### PR TITLE
Implement skeletons of Panel Match public APIs.

### DIFF
--- a/src/main/kotlin/org/wfanet/measurement/kingdom/service/api/v2alpha/BUILD.bazel
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/service/api/v2alpha/BUILD.bazel
@@ -1,0 +1,51 @@
+load("//build:defs.bzl", "test_target")
+load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kt_jvm_library")
+
+package(default_visibility = [
+    test_target("__pkg__"),
+    "//src/main/kotlin/org/wfanet/measurement/kingdom/deploy:__subpackages__",
+    "//src/test/kotlin/org/wfanet/measurement/integration/common:__pkg__",
+])
+
+kt_jvm_library(
+    name = "recurring_exchanges_service",
+    srcs = ["RecurringExchangesService.kt"],
+    deps = [
+        "//imports/kotlin/kotlin/test",
+        "//imports/kotlin/kotlinx/coroutines:core",
+        "//src/main/kotlin/org/wfanet/measurement/common",
+        "//src/main/kotlin/org/wfanet/measurement/common/grpc",
+        "//src/main/kotlin/org/wfanet/measurement/common/identity",
+        "//src/main/proto/wfa/measurement/api/v2alpha:recurring_exchange_java_proto",
+        "//src/main/proto/wfa/measurement/api/v2alpha:recurring_exchanges_service_kt_jvm_grpc",
+    ],
+)
+
+kt_jvm_library(
+    name = "exchanges_service",
+    srcs = ["ExchangesService.kt"],
+    deps = [
+        "//imports/kotlin/kotlin/test",
+        "//imports/kotlin/kotlinx/coroutines:core",
+        "//src/main/kotlin/org/wfanet/measurement/common",
+        "//src/main/kotlin/org/wfanet/measurement/common/grpc",
+        "//src/main/kotlin/org/wfanet/measurement/common/identity",
+        "//src/main/proto/wfa/measurement/api/v2alpha:exchange_java_proto",
+        "//src/main/proto/wfa/measurement/api/v2alpha:exchanges_service_kt_jvm_grpc",
+    ],
+)
+
+kt_jvm_library(
+    name = "exchange_step_attempts_service",
+    srcs = ["ExchangeStepAttemptsService.kt"],
+    deps = [
+        "//imports/kotlin/kotlin/test",
+        "//imports/kotlin/kotlinx/coroutines:core",
+        "//src/main/kotlin/org/wfanet/measurement/common",
+        "//src/main/kotlin/org/wfanet/measurement/common/grpc",
+        "//src/main/kotlin/org/wfanet/measurement/common/identity",
+        "//src/main/proto/wfa/measurement/api/v2alpha:exchange_step_attempt_java_proto",
+        "//src/main/proto/wfa/measurement/api/v2alpha:exchange_step_attempts_service_kt_jvm_grpc",
+        "//src/main/proto/wfa/measurement/api/v2alpha:exchange_step_java_proto",
+    ],
+)

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/service/api/v2alpha/ExchangeStepAttemptsService.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/service/api/v2alpha/ExchangeStepAttemptsService.kt
@@ -1,0 +1,54 @@
+// Copyright 2021 The Cross-Media Measurement Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.wfanet.measurement.kingdom.service.api.v2alpha
+
+import org.wfanet.measurement.api.v2alpha.AppendLogEntryRequest
+import org.wfanet.measurement.api.v2alpha.CreateExchangeStepAttemptRequest
+import org.wfanet.measurement.api.v2alpha.ExchangeStepAttempt
+import org.wfanet.measurement.api.v2alpha.ExchangeStepAttemptsGrpcKt.ExchangeStepAttemptsCoroutineImplBase
+import org.wfanet.measurement.api.v2alpha.FinishExchangeStepAttemptRequest
+import org.wfanet.measurement.api.v2alpha.GetExchangeStepAttemptRequest
+import org.wfanet.measurement.api.v2alpha.ListExchangeStepAttemptsRequest
+import org.wfanet.measurement.api.v2alpha.ListExchangeStepAttemptsResponse
+
+class ExchangeStepAttemptsService : ExchangeStepAttemptsCoroutineImplBase() {
+  override suspend fun appendLogEntry(request: AppendLogEntryRequest): ExchangeStepAttempt {
+    TODO("world-federation-of-advertisers/cross-media-measurement#3: implement this")
+  }
+
+  override suspend fun createExchangeStepAttempt(
+    request: CreateExchangeStepAttemptRequest
+  ): ExchangeStepAttempt {
+    TODO("world-federation-of-advertisers/cross-media-measurement#3: implement this")
+  }
+
+  override suspend fun finishExchangeStepAttempt(
+    request: FinishExchangeStepAttemptRequest
+  ): ExchangeStepAttempt {
+    TODO("world-federation-of-advertisers/cross-media-measurement#3: implement this")
+  }
+
+  override suspend fun getExchangeStepAttempt(
+    request: GetExchangeStepAttemptRequest
+  ): ExchangeStepAttempt {
+    TODO("world-federation-of-advertisers/cross-media-measurement#3: implement this")
+  }
+
+  override suspend fun listExchangeStepAttempts(
+    request: ListExchangeStepAttemptsRequest
+  ): ListExchangeStepAttemptsResponse {
+    TODO("world-federation-of-advertisers/cross-media-measurement#3: implement this")
+  }
+}

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/service/api/v2alpha/ExchangesService.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/service/api/v2alpha/ExchangesService.kt
@@ -1,0 +1,37 @@
+// Copyright 2021 The Cross-Media Measurement Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.wfanet.measurement.kingdom.service.api.v2alpha
+
+import kotlinx.coroutines.flow.Flow
+import org.wfanet.measurement.api.v2alpha.Exchange
+import org.wfanet.measurement.api.v2alpha.ExchangesGrpcKt.ExchangesCoroutineImplBase
+import org.wfanet.measurement.api.v2alpha.GetExchangeRequest
+import org.wfanet.measurement.api.v2alpha.ListExchangesRequest
+import org.wfanet.measurement.api.v2alpha.ListExchangesResponse
+import org.wfanet.measurement.api.v2alpha.UploadAuditTrailRequest
+
+class ExchangesService : ExchangesCoroutineImplBase() {
+  override suspend fun getExchange(request: GetExchangeRequest): Exchange {
+    TODO("world-federation-of-advertisers/cross-media-measurement#3: implement this")
+  }
+
+  override suspend fun listExchanges(request: ListExchangesRequest): ListExchangesResponse {
+    TODO("world-federation-of-advertisers/cross-media-measurement#3: implement this")
+  }
+
+  override suspend fun uploadAuditTrail(requests: Flow<UploadAuditTrailRequest>): Exchange {
+    TODO("world-federation-of-advertisers/cross-media-measurement#3: implement this")
+  }
+}

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/service/api/v2alpha/RecurringExchangesService.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/service/api/v2alpha/RecurringExchangesService.kt
@@ -1,0 +1,46 @@
+// Copyright 2021 The Cross-Media Measurement Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.wfanet.measurement.kingdom.service.api.v2alpha
+
+import org.wfanet.measurement.api.v2alpha.CreateRecurringExchangeRequest
+import org.wfanet.measurement.api.v2alpha.GetRecurringExchangeRequest
+import org.wfanet.measurement.api.v2alpha.ListRecurringExchangesRequest
+import org.wfanet.measurement.api.v2alpha.ListRecurringExchangesResponse
+import org.wfanet.measurement.api.v2alpha.RecurringExchange
+import org.wfanet.measurement.api.v2alpha.RecurringExchangesGrpcKt.RecurringExchangesCoroutineImplBase
+
+class RecurringExchangesService : RecurringExchangesCoroutineImplBase() {
+  override suspend fun createRecurringExchange(
+    request: CreateRecurringExchangeRequest
+  ): RecurringExchange {
+    TODO("world-federation-of-advertisers/cross-media-measurement#3: implement this")
+  }
+
+  override suspend fun getRecurringExchange(
+    request: GetRecurringExchangeRequest
+  ): RecurringExchange {
+    TODO("world-federation-of-advertisers/cross-media-measurement#3: implement this")
+  }
+
+  override suspend fun listRecurringExchanges(
+    request: ListRecurringExchangesRequest
+  ): ListRecurringExchangesResponse {
+    TODO("world-federation-of-advertisers/cross-media-measurement#3: implement this")
+  }
+
+  override suspend fun updateRecurringExchange(request: RecurringExchange): RecurringExchange {
+    TODO("world-federation-of-advertisers/cross-media-measurement#3: implement this")
+  }
+}

--- a/src/test/kotlin/org/wfanet/measurement/kingdom/service/api/v2alpha/BUILD.bazel
+++ b/src/test/kotlin/org/wfanet/measurement/kingdom/service/api/v2alpha/BUILD.bazel
@@ -1,0 +1,55 @@
+load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kt_jvm_test")
+
+kt_jvm_test(
+    name = "ExchangesServiceTest",
+    srcs = ["ExchangesServiceTest.kt"],
+    test_class = "org.wfanet.measurement.kingdom.service.api.v2alpha.ExchangesServiceTest",
+    deps = [
+        "//imports/java/com/google/common/truth",
+        "//imports/java/com/google/common/truth/extensions/proto",
+        "//imports/java/com/google/protobuf",
+        "//imports/kotlin/com/nhaarman/mockitokotlin2",
+        "//imports/kotlin/kotlinx/coroutines:core",
+        "//src/main/kotlin/org/wfanet/measurement/common",
+        "//src/main/kotlin/org/wfanet/measurement/common/grpc/testing",
+        "//src/main/kotlin/org/wfanet/measurement/kingdom/service/api/v2alpha:exchanges_service",
+        "//src/main/proto/wfa/measurement/api/v2alpha:exchange_java_proto",
+        "//src/main/proto/wfa/measurement/api/v2alpha:exchanges_service_kt_jvm_grpc",
+    ],
+)
+
+kt_jvm_test(
+    name = "ExchangeStepAttemptsServiceTest",
+    srcs = ["ExchangeStepAttemptsServiceTest.kt"],
+    test_class = "org.wfanet.measurement.kingdom.service.api.v2alpha.ExchangeStepAttemptsServiceTest",
+    deps = [
+        "//imports/java/com/google/common/truth",
+        "//imports/java/com/google/common/truth/extensions/proto",
+        "//imports/java/com/google/protobuf",
+        "//imports/kotlin/com/nhaarman/mockitokotlin2",
+        "//imports/kotlin/kotlinx/coroutines:core",
+        "//src/main/kotlin/org/wfanet/measurement/common",
+        "//src/main/kotlin/org/wfanet/measurement/common/grpc/testing",
+        "//src/main/kotlin/org/wfanet/measurement/kingdom/service/api/v2alpha:exchange_step_attempts_service",
+        "//src/main/proto/wfa/measurement/api/v2alpha:exchange_step_attempts_service_kt_jvm_grpc",
+        "//src/main/proto/wfa/measurement/api/v2alpha:exchange_step_java_proto",
+    ],
+)
+
+kt_jvm_test(
+    name = "RecurringExchangesServiceTest",
+    srcs = ["RecurringExchangesServiceTest.kt"],
+    test_class = "org.wfanet.measurement.kingdom.service.api.v2alpha.RecurringExchangesServiceTest",
+    deps = [
+        "//imports/java/com/google/common/truth",
+        "//imports/java/com/google/common/truth/extensions/proto",
+        "//imports/java/com/google/protobuf",
+        "//imports/kotlin/com/nhaarman/mockitokotlin2",
+        "//imports/kotlin/kotlinx/coroutines:core",
+        "//src/main/kotlin/org/wfanet/measurement/common",
+        "//src/main/kotlin/org/wfanet/measurement/common/grpc/testing",
+        "//src/main/kotlin/org/wfanet/measurement/kingdom/service/api/v2alpha:recurring_exchanges_service",
+        "//src/main/proto/wfa/measurement/api/v2alpha:recurring_exchange_java_proto",
+        "//src/main/proto/wfa/measurement/api/v2alpha:recurring_exchanges_service_kt_jvm_grpc",
+    ],
+)

--- a/src/test/kotlin/org/wfanet/measurement/kingdom/service/api/v2alpha/ExchangeStepAttemptsServiceTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/kingdom/service/api/v2alpha/ExchangeStepAttemptsServiceTest.kt
@@ -1,0 +1,51 @@
+// Copyright 2021 The Cross-Media Measurement Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.wfanet.measurement.kingdom.service.api.v2alpha
+
+import kotlin.test.assertFailsWith
+import kotlinx.coroutines.runBlocking
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+import org.wfanet.measurement.api.v2alpha.AppendLogEntryRequest
+import org.wfanet.measurement.api.v2alpha.CreateExchangeStepAttemptRequest
+import org.wfanet.measurement.api.v2alpha.FinishExchangeStepAttemptRequest
+
+@RunWith(JUnit4::class)
+class ExchangeStepAttemptsServiceTest {
+
+  private val service = ExchangeStepAttemptsService()
+
+  @Test
+  fun appendLogEntry() = runBlocking<Unit> {
+    assertFailsWith(NotImplementedError::class) {
+      service.appendLogEntry(AppendLogEntryRequest.getDefaultInstance())
+    }
+  }
+
+  @Test
+  fun createExchangeStepAttempt() = runBlocking<Unit> {
+    assertFailsWith(NotImplementedError::class) {
+      service.createExchangeStepAttempt(CreateExchangeStepAttemptRequest.getDefaultInstance())
+    }
+  }
+
+  @Test
+  fun finishExchangeStepAttempt() = runBlocking<Unit> {
+    assertFailsWith(NotImplementedError::class) {
+      service.finishExchangeStepAttempt(FinishExchangeStepAttemptRequest.getDefaultInstance())
+    }
+  }
+}

--- a/src/test/kotlin/org/wfanet/measurement/kingdom/service/api/v2alpha/ExchangesServiceTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/kingdom/service/api/v2alpha/ExchangesServiceTest.kt
@@ -1,0 +1,51 @@
+// Copyright 2021 The Cross-Media Measurement Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.wfanet.measurement.kingdom.service.api.v2alpha
+
+import kotlin.test.assertFailsWith
+import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.runBlocking
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+import org.wfanet.measurement.api.v2alpha.GetExchangeRequest
+import org.wfanet.measurement.api.v2alpha.ListExchangesRequest
+
+@RunWith(JUnit4::class)
+class ExchangesServiceTest {
+
+  private val service = ExchangesService()
+
+  @Test
+  fun getExchange() = runBlocking<Unit> {
+    assertFailsWith(NotImplementedError::class) {
+      service.getExchange(GetExchangeRequest.getDefaultInstance())
+    }
+  }
+
+  @Test
+  fun listExchanges() = runBlocking<Unit> {
+    assertFailsWith(NotImplementedError::class) {
+      service.listExchanges(ListExchangesRequest.getDefaultInstance())
+    }
+  }
+
+  @Test
+  fun uploadAuditTrail() = runBlocking<Unit> {
+    assertFailsWith(NotImplementedError::class) {
+      service.uploadAuditTrail(emptyFlow())
+    }
+  }
+}

--- a/src/test/kotlin/org/wfanet/measurement/kingdom/service/api/v2alpha/RecurringExchangesServiceTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/kingdom/service/api/v2alpha/RecurringExchangesServiceTest.kt
@@ -1,0 +1,59 @@
+// Copyright 2021 The Cross-Media Measurement Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.wfanet.measurement.kingdom.service.api.v2alpha
+
+import kotlin.test.assertFailsWith
+import kotlinx.coroutines.runBlocking
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+import org.wfanet.measurement.api.v2alpha.CreateRecurringExchangeRequest
+import org.wfanet.measurement.api.v2alpha.GetRecurringExchangeRequest
+import org.wfanet.measurement.api.v2alpha.ListRecurringExchangesRequest
+import org.wfanet.measurement.api.v2alpha.RecurringExchange
+
+@RunWith(JUnit4::class)
+class RecurringExchangesServiceTest {
+
+  val service = RecurringExchangesService()
+
+  @Test
+  fun createRecurringExchange() = runBlocking<Unit> {
+    assertFailsWith(NotImplementedError::class) {
+      service.createRecurringExchange(CreateRecurringExchangeRequest.getDefaultInstance())
+    }
+  }
+
+  @Test
+  fun getRecurringExchange() = runBlocking<Unit> {
+    assertFailsWith(NotImplementedError::class) {
+      service.getRecurringExchange(GetRecurringExchangeRequest.getDefaultInstance())
+    }
+  }
+
+  @Test
+  fun listRecurringExchanges() = runBlocking<Unit> {
+    assertFailsWith(NotImplementedError::class) {
+      service.listRecurringExchanges(ListRecurringExchangesRequest.getDefaultInstance())
+    }
+  }
+
+  @Test
+  fun updateRecurringExchange() = runBlocking<Unit> {
+    assertFailsWith(NotImplementedError::class) {
+      service.updateRecurringExchange(RecurringExchange.getDefaultInstance())
+    }
+  }
+}


### PR DESCRIPTION
This just adds the basic Kotlin classes and some tests that expect the
services to throw NotImplementedErrors. Future commits will fill in the
logic.

See issue world-federation-of-advertisers/cross-media-measurement#3.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/world-federation-of-advertisers/cross-media-measurement/5)
<!-- Reviewable:end -->
