### PR TITLE
Add EDP libraries for Requisition fulfillment

### DIFF
--- a/src/main/kotlin/org/wfanet/measurement/dataprovider/common/BUILD.bazel
+++ b/src/main/kotlin/org/wfanet/measurement/dataprovider/common/BUILD.bazel
@@ -1,0 +1,29 @@
+load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kt_jvm_library")
+
+package(default_visibility = [
+    "//src/main/kotlin/org/wfanet/measurement:__subpackages__",
+    "//src/test/kotlin/org/wfanet/measurement:__subpackages__",
+])
+
+kt_jvm_library(
+    name = "common",
+    srcs = glob(["*.kt"]),
+    deps = [
+        "//imports/kotlin/kotlinx/coroutines:core",
+        "//src/main/kotlin/org/wfanet/measurement/common",
+        "//src/main/kotlin/org/wfanet/measurement/common/identity",
+        "//src/main/proto/wfa/measurement/api/v1alpha:crypto_java_proto",
+        "//src/main/proto/wfa/measurement/api/v1alpha:sketch_java_proto",
+        "//src/main/proto/wfa/measurement/api/v2alpha:combined_public_keys_service_kt_jvm_grpc",
+        "//src/main/proto/wfa/measurement/api/v2alpha:crypto_java_proto",
+        "//src/main/proto/wfa/measurement/api/v2alpha:requisition_fulfillment_service_kt_jvm_grpc",
+        "//src/main/proto/wfa/measurement/api/v2alpha:requisition_java_proto",
+        "//src/main/proto/wfa/measurement/api/v2alpha:requisition_spec_java_proto",
+        "//src/main/proto/wfa/measurement/api/v2alpha:requisitions_service_kt_jvm_grpc",
+        "//src/main/proto/wfa/measurement/api/v2alpha:sketch_configs_service_kt_jvm_grpc",
+        "//src/main/proto/wfa/measurement/api/v2alpha:sketch_java_proto",
+        "@any_sketch_java//src/main/java/org/wfanet/anysketch:sketch_proto_converter",
+        "@any_sketch_java//src/main/java/org/wfanet/anysketch/crypto:sketch_encrypter_adapter",
+        "@any_sketch_java//src/main/proto/wfa/any_sketch/crypto:sketch_encryption_methods_java_proto",
+    ],
+)

--- a/src/main/kotlin/org/wfanet/measurement/dataprovider/common/DefaultEncryptedSketchGenerator.kt
+++ b/src/main/kotlin/org/wfanet/measurement/dataprovider/common/DefaultEncryptedSketchGenerator.kt
@@ -1,0 +1,38 @@
+// Copyright 2021 The Cross-Media Measurement Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.wfanet.measurement.dataprovider.common
+
+import com.google.protobuf.ByteString
+import kotlinx.coroutines.flow.Flow
+import org.wfanet.measurement.api.v2alpha.ElGamalPublicKey
+import org.wfanet.measurement.api.v2alpha.MeasurementSpec
+import org.wfanet.measurement.api.v2alpha.RequisitionSpec
+import org.wfanet.measurement.api.v2alpha.SketchConfig
+
+/** [EncryptedSketchGenerator] that delegates to helpers. */
+class DefaultEncryptedSketchGenerator(
+  private val elGamalPublicKeyStore: ElGamalPublicKeyStore,
+  private val sketchConfigStore: SketchConfigStore,
+  private val generateSketch: (RequisitionSpec, ElGamalPublicKey, SketchConfig) -> Flow<ByteString>
+) : EncryptedSketchGenerator {
+  override suspend fun generate(
+    requisitionSpec: RequisitionSpec,
+    encryptedSketch: MeasurementSpec.EncryptedSketch
+  ): Flow<ByteString> {
+    val publicKey = elGamalPublicKeyStore.get(encryptedSketch.combinedPublicKey)
+    val sketchConfig = sketchConfigStore.get(encryptedSketch.sketchConfig)
+    return generateSketch(requisitionSpec, publicKey, sketchConfig)
+  }
+}

--- a/src/main/kotlin/org/wfanet/measurement/dataprovider/common/ElGamalPublicKeyStore.kt
+++ b/src/main/kotlin/org/wfanet/measurement/dataprovider/common/ElGamalPublicKeyStore.kt
@@ -1,0 +1,26 @@
+// Copyright 2021 The Cross-Media Measurement Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.wfanet.measurement.dataprovider.common
+
+import org.wfanet.measurement.api.v2alpha.CombinedPublicKey
+import org.wfanet.measurement.api.v2alpha.ElGamalPublicKey
+
+/**
+ * Interface for depencency-injecting a way to get [ElGamalPublicKey]s from [CombinedPublicKey]s.
+ */
+interface ElGamalPublicKeyStore {
+  /** Looks up an [ElGamalPublicKey]. */
+  suspend fun get(key: CombinedPublicKey.Key): ElGamalPublicKey
+}

--- a/src/main/kotlin/org/wfanet/measurement/dataprovider/common/EncryptedSketchGenerator.kt
+++ b/src/main/kotlin/org/wfanet/measurement/dataprovider/common/EncryptedSketchGenerator.kt
@@ -1,0 +1,35 @@
+// Copyright 2021 The Cross-Media Measurement Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.wfanet.measurement.dataprovider.common
+
+import com.google.protobuf.ByteString
+import kotlinx.coroutines.flow.Flow
+import org.wfanet.measurement.api.v2alpha.MeasurementSpec.EncryptedSketch
+import org.wfanet.measurement.api.v2alpha.RequisitionSpec
+
+/**
+ * Interface for handling Requisitions with an [EncryptedSketch]-typed MeasurementSpec.
+ */
+interface EncryptedSketchGenerator {
+  /**
+   * Generates an encrypted sketch as a flow of ByteStrings.
+   *
+   * Each ByteString's size should be optimized for gRPC network transmission (several KiB).
+   */
+  suspend fun generate(
+    requisitionSpec: RequisitionSpec,
+    encryptedSketch: EncryptedSketch
+  ): Flow<ByteString>
+}

--- a/src/main/kotlin/org/wfanet/measurement/dataprovider/common/GrpcElGamalPublicKeyCache.kt
+++ b/src/main/kotlin/org/wfanet/measurement/dataprovider/common/GrpcElGamalPublicKeyCache.kt
@@ -1,0 +1,41 @@
+// Copyright 2021 The Cross-Media Measurement Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.wfanet.measurement.dataprovider.common
+
+import org.wfanet.measurement.api.v2alpha.CombinedPublicKey
+import org.wfanet.measurement.api.v2alpha.CombinedPublicKeysGrpcKt.CombinedPublicKeysCoroutineStub
+import org.wfanet.measurement.api.v2alpha.ElGamalPublicKey
+import org.wfanet.measurement.api.v2alpha.GetCombinedPublicKeyRequest
+
+/**
+ * Implementation of [ElGamalPublicKey] that caches results obtained from gRPC calls.
+ */
+class GrpcElGamalPublicKeyCache(
+  private val combinedPublicKeys: CombinedPublicKeysCoroutineStub
+) : ElGamalPublicKeyStore {
+  private val cache = mutableMapOf<CombinedPublicKey.Key, ElGamalPublicKey>()
+
+  override suspend fun get(key: CombinedPublicKey.Key): ElGamalPublicKey {
+    return cache.getOrPut(key) { getFromGrpc(key) }
+  }
+
+  private suspend fun getFromGrpc(key: CombinedPublicKey.Key): ElGamalPublicKey {
+    val request = GetCombinedPublicKeyRequest.newBuilder().also {
+      it.key = key
+    }.build()
+
+    return combinedPublicKeys.getCombinedPublicKey(request).encryptionKey
+  }
+}

--- a/src/main/kotlin/org/wfanet/measurement/dataprovider/common/GrpcRequisitionFulfiller.kt
+++ b/src/main/kotlin/org/wfanet/measurement/dataprovider/common/GrpcRequisitionFulfiller.kt
@@ -1,0 +1,52 @@
+// Copyright 2021 The Cross-Media Measurement Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.wfanet.measurement.dataprovider.common
+
+import com.google.protobuf.ByteString
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.emitAll
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.map
+import org.wfanet.measurement.api.v2alpha.FulfillRequisitionRequest
+import org.wfanet.measurement.api.v2alpha.Requisition
+import org.wfanet.measurement.api.v2alpha.RequisitionFulfillmentGrpcKt.RequisitionFulfillmentCoroutineStub
+
+/**
+ * Implementation of [RequisitionFulfiller] for gRPC.
+ */
+class GrpcRequisitionFulfiller(
+  private val stub: RequisitionFulfillmentCoroutineStub
+) : RequisitionFulfiller {
+  override suspend fun fulfillRequisition(key: Requisition.Key, data: Flow<ByteString>) {
+    stub.fulfillRequisition(
+      flow {
+        emit(makeFulfillRequisitionHeader(key))
+        emitAll(data.map { makeFulfillRequisitionBody(it) })
+      }
+    )
+  }
+
+  private fun makeFulfillRequisitionHeader(key: Requisition.Key): FulfillRequisitionRequest {
+    return FulfillRequisitionRequest.newBuilder().apply {
+      headerBuilder.key = key
+    }.build()
+  }
+
+  private fun makeFulfillRequisitionBody(bytes: ByteString): FulfillRequisitionRequest {
+    return FulfillRequisitionRequest.newBuilder().apply {
+      bodyChunkBuilder.data = bytes
+    }.build()
+  }
+}

--- a/src/main/kotlin/org/wfanet/measurement/dataprovider/common/GrpcSketchConfigCache.kt
+++ b/src/main/kotlin/org/wfanet/measurement/dataprovider/common/GrpcSketchConfigCache.kt
@@ -1,0 +1,40 @@
+// Copyright 2021 The Cross-Media Measurement Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.wfanet.measurement.dataprovider.common
+
+import org.wfanet.measurement.api.v2alpha.GetSketchConfigRequest
+import org.wfanet.measurement.api.v2alpha.SketchConfig
+import org.wfanet.measurement.api.v2alpha.SketchConfigsGrpcKt.SketchConfigsCoroutineStub
+
+/**
+ * Implementation of [SketchConfigStore] that caches [SketchConfig]s obtained via gRPC.
+ */
+class GrpcSketchConfigCache(
+  val sketchConfigs: SketchConfigsCoroutineStub
+) : SketchConfigStore {
+  private val cache = mutableMapOf<SketchConfig.Key, SketchConfig>()
+
+  override suspend fun get(key: SketchConfig.Key): SketchConfig {
+    return cache.getOrPut(key) { getFromGrpc(key) }
+  }
+
+  private suspend fun getFromGrpc(key: SketchConfig.Key): SketchConfig {
+    return sketchConfigs.getSketchConfig(
+      GetSketchConfigRequest.newBuilder().also {
+        it.key = key
+      }.build()
+    )
+  }
+}

--- a/src/main/kotlin/org/wfanet/measurement/dataprovider/common/GrpcUnfulfilledRequisitionProvider.kt
+++ b/src/main/kotlin/org/wfanet/measurement/dataprovider/common/GrpcUnfulfilledRequisitionProvider.kt
@@ -1,0 +1,56 @@
+// Copyright 2021 The Cross-Media Measurement Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.wfanet.measurement.dataprovider.common
+
+import java.util.ArrayDeque
+import org.wfanet.measurement.api.v2alpha.ListRequisitionsRequest
+import org.wfanet.measurement.api.v2alpha.Requisition
+import org.wfanet.measurement.api.v2alpha.RequisitionsGrpcKt.RequisitionsCoroutineStub
+import org.wfanet.measurement.common.identity.ExternalId
+
+/**
+ * Implementation of [UnfulfilledRequisitionProvider] that loads pages of unfulfilled [Requisition]s
+ * via gRPC and caches them until needed.
+ */
+class GrpcUnfulfilledRequisitionProvider(
+  externalDataProviderId: ExternalId,
+  private val requisitions: RequisitionsCoroutineStub
+) : UnfulfilledRequisitionProvider {
+  private val requestTemplate =
+    ListRequisitionsRequest.newBuilder().apply {
+      parentBuilder.dataProviderId = externalDataProviderId.apiId.value
+      filterBuilder.addStates(Requisition.State.UNFULFILLED)
+    }.build()
+
+  private val buffer = ArrayDeque<Requisition>()
+  private var pageToken = ""
+
+  override suspend fun get(): Requisition? {
+    if (buffer.isEmpty()) {
+      refillBuffer()
+    }
+    return buffer.pollFirst()
+  }
+
+  suspend fun refillBuffer() {
+    val request =
+      requestTemplate.toBuilder()
+        .setPageToken(pageToken)
+        .build()
+    val response = requisitions.listRequisitions(request)
+    pageToken = response.nextPageToken
+    buffer.addAll(response.requisitionsList)
+  }
+}

--- a/src/main/kotlin/org/wfanet/measurement/dataprovider/common/JniSketchEncrypter.kt
+++ b/src/main/kotlin/org/wfanet/measurement/dataprovider/common/JniSketchEncrypter.kt
@@ -1,0 +1,66 @@
+// Copyright 2021 The Cross-Media Measurement Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.wfanet.measurement.dataprovider.common
+
+import com.google.protobuf.ByteString
+import java.nio.file.Paths
+import org.wfanet.anysketch.crypto.EncryptSketchRequest
+import org.wfanet.anysketch.crypto.EncryptSketchRequest.DestroyedRegisterStrategy
+import org.wfanet.anysketch.crypto.EncryptSketchResponse
+import org.wfanet.anysketch.crypto.SketchEncrypterAdapter
+import org.wfanet.measurement.api.v1alpha.Sketch as LegacySketch
+import org.wfanet.measurement.api.v2alpha.ElGamalPublicKey
+import org.wfanet.measurement.api.v2alpha.Sketch
+import org.wfanet.measurement.common.loadLibrary
+
+/**
+ * Utility to encrypt [Sketch]es by wrapping JNIed C++ libraries.
+ */
+class JniSketchEncrypter(
+  private val maximumValue: Int,
+  private val destroyedRegisterStrategy: DestroyedRegisterStrategy
+) {
+  fun encrypt(
+    sketch: Sketch,
+    key: ElGamalPublicKey
+  ): ByteString {
+    val request = EncryptSketchRequest.newBuilder().also {
+      // TODO: Update the underlying library to use v2alpha?
+      it.sketch = LegacySketch.parseFrom(sketch.toByteString())
+      it.curveId = key.ellipticCurveId.toLong()
+      it.maximumValue = maximumValue
+      it.elGamalKeysBuilder.apply {
+        generator = key.generator
+        element = key.element
+      }
+      it.destroyedRegisterStrategy = destroyedRegisterStrategy
+    }.build()
+
+    val response = EncryptSketchResponse.parseFrom(
+      SketchEncrypterAdapter.EncryptSketch(request.toByteArray())
+    )
+
+    return response.encryptedSketch
+  }
+
+  companion object {
+    init {
+      loadLibrary(
+        name = "sketch_encrypter_adapter",
+        directoryPath = Paths.get("any_sketch_java/src/main/java/org/wfanet/anysketch/crypto")
+      )
+    }
+  }
+}

--- a/src/main/kotlin/org/wfanet/measurement/dataprovider/common/RequisitionDecoder.kt
+++ b/src/main/kotlin/org/wfanet/measurement/dataprovider/common/RequisitionDecoder.kt
@@ -1,0 +1,31 @@
+// Copyright 2021 The Cross-Media Measurement Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.wfanet.measurement.dataprovider.common
+
+import org.wfanet.measurement.api.v2alpha.MeasurementSpec
+import org.wfanet.measurement.api.v2alpha.Requisition
+import org.wfanet.measurement.api.v2alpha.RequisitionSpec
+
+/** Interface for [Requisition] signature validation and decryption. */
+interface RequisitionDecoder {
+  fun decodeMeasurementSpec(requisition: Requisition): MeasurementSpec
+  fun decodeRequisitionSpec(requisition: Requisition): RequisitionSpec
+}
+
+/** Indicates an invalid cryptographic signature. */
+class InvalidSignatureException(override val message: String) : Exception()
+
+/** Indicates a failure to decrypt. */
+class DecryptionException(override val message: String) : Exception()

--- a/src/main/kotlin/org/wfanet/measurement/dataprovider/common/RequisitionFulfiller.kt
+++ b/src/main/kotlin/org/wfanet/measurement/dataprovider/common/RequisitionFulfiller.kt
@@ -1,0 +1,26 @@
+// Copyright 2021 The Cross-Media Measurement Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.wfanet.measurement.dataprovider.common
+
+import com.google.protobuf.ByteString
+import kotlinx.coroutines.flow.Flow
+import org.wfanet.measurement.api.v2alpha.Requisition
+
+/**
+ * Interface for Dependency Injection of [Requisition] fulfillment responsibility.
+ */
+interface RequisitionFulfiller {
+  suspend fun fulfillRequisition(key: Requisition.Key, data: Flow<ByteString>)
+}

--- a/src/main/kotlin/org/wfanet/measurement/dataprovider/common/SketchConfigStore.kt
+++ b/src/main/kotlin/org/wfanet/measurement/dataprovider/common/SketchConfigStore.kt
@@ -1,0 +1,22 @@
+// Copyright 2021 The Cross-Media Measurement Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.wfanet.measurement.dataprovider.common
+
+import org.wfanet.measurement.api.v2alpha.SketchConfig
+
+/** Interface for Dependency Injection of loading [SketchConfig]s. */
+interface SketchConfigStore {
+  suspend fun get(key: SketchConfig.Key): SketchConfig
+}

--- a/src/main/kotlin/org/wfanet/measurement/dataprovider/common/UnfulfilledRequisitionProvider.kt
+++ b/src/main/kotlin/org/wfanet/measurement/dataprovider/common/UnfulfilledRequisitionProvider.kt
@@ -1,0 +1,22 @@
+// Copyright 2021 The Cross-Media Measurement Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.wfanet.measurement.dataprovider.common
+
+import org.wfanet.measurement.api.v2alpha.Requisition
+
+/** Interface for Dependency Injection of loading unfulfilled [Requisition]s. */
+interface UnfulfilledRequisitionProvider {
+  suspend fun get(): Requisition?
+}

--- a/src/main/kotlin/org/wfanet/measurement/dataprovider/daemon/BUILD.bazel
+++ b/src/main/kotlin/org/wfanet/measurement/dataprovider/daemon/BUILD.bazel
@@ -1,0 +1,23 @@
+load("//build:defs.bzl", "test_target")
+load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kt_jvm_library")
+
+package(default_visibility = [
+    "//src/main/kotlin/org/wfanet/measurement/dataprovider:__subpackages__",
+    test_target(":__subpackages__"),
+    "//src/test/kotlin/org/wfanet/measurement/e2e:__subpackages__",
+])
+
+kt_jvm_library(
+    name = "daemon",
+    srcs = glob(["*.kt"]),
+    deps = [
+        "//imports/java/com/google/protobuf",
+        "//imports/kotlin/kotlinx/coroutines:core",
+        "//src/main/kotlin/org/wfanet/measurement/common",
+        "//src/main/kotlin/org/wfanet/measurement/common/identity",
+        "//src/main/kotlin/org/wfanet/measurement/common/throttler",
+        "//src/main/kotlin/org/wfanet/measurement/dataprovider/common",
+        "//src/main/proto/wfa/measurement/api/v2alpha:measurement_java_proto",
+        "//src/main/proto/wfa/measurement/api/v2alpha:requisition_java_proto",
+    ],
+)

--- a/src/main/kotlin/org/wfanet/measurement/dataprovider/daemon/DaemonLoop.kt
+++ b/src/main/kotlin/org/wfanet/measurement/dataprovider/daemon/DaemonLoop.kt
@@ -1,0 +1,33 @@
+// Copyright 2021 The Cross-Media Measurement Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.wfanet.measurement.dataprovider.daemon
+
+import kotlinx.coroutines.yield
+import org.wfanet.measurement.common.logAndSuppressExceptionSuspend
+import org.wfanet.measurement.common.throttler.Throttler
+
+/**
+ * Runs [block] indefinitely, logging and suppressing exceptions that it throws.
+ *
+ * The only way to terminate this is to cancel the coroutine running it.
+ */
+suspend fun Throttler.loopOnReadySuppressingExceptions(block: suspend () -> Unit) {
+  while (true) {
+    logAndSuppressExceptionSuspend {
+      onReady(block)
+    }
+    yield()
+  }
+}

--- a/src/main/kotlin/org/wfanet/measurement/dataprovider/daemon/RequisitionFulfillmentWorkflow.kt
+++ b/src/main/kotlin/org/wfanet/measurement/dataprovider/daemon/RequisitionFulfillmentWorkflow.kt
@@ -1,0 +1,55 @@
+// Copyright 2021 The Cross-Media Measurement Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.wfanet.measurement.dataprovider.daemon
+
+import com.google.protobuf.ByteString
+import kotlinx.coroutines.flow.Flow
+import org.wfanet.measurement.api.v2alpha.MeasurementSpec
+import org.wfanet.measurement.api.v2alpha.Requisition
+import org.wfanet.measurement.dataprovider.common.EncryptedSketchGenerator
+import org.wfanet.measurement.dataprovider.common.RequisitionDecoder
+import org.wfanet.measurement.dataprovider.common.RequisitionFulfiller
+import org.wfanet.measurement.dataprovider.common.UnfulfilledRequisitionProvider
+
+/**
+ * Combines the constructor parameters together into a workflow to find and fulfill a [Requisition].
+ *
+ * @property unfulfilledRequisitionProvider helper to fetch unfulfilled [Requisition]s
+ * @property requisitionDecoder helper for cryptographic operations on [Requisition]s
+ * @property requisitionFulfiller helper to upload encrypted sketches
+ * @property sketchGenerator helper to build encrypted sketches
+ */
+class RequisitionFulfillmentWorkflow(
+  private val unfulfilledRequisitionProvider: UnfulfilledRequisitionProvider,
+  private val requisitionDecoder: RequisitionDecoder,
+  private val sketchGenerator: EncryptedSketchGenerator,
+  private val requisitionFulfiller: RequisitionFulfiller
+) {
+  suspend fun execute() {
+    val requisition: Requisition = unfulfilledRequisitionProvider.get() ?: return
+
+    val measurementSpec = requisitionDecoder.decodeMeasurementSpec(requisition)
+    val requisitionSpec = requisitionDecoder.decodeRequisitionSpec(requisition)
+
+    val sketchChunks: Flow<ByteString> = when (measurementSpec.forCase) {
+      MeasurementSpec.ForCase.ENCRYPTED_SKETCH ->
+        sketchGenerator.generate(requisitionSpec, measurementSpec.encryptedSketch)
+      else ->
+        throw IllegalArgumentException("Case ${measurementSpec.forCase} unsupported.")
+    }
+
+    requisitionFulfiller.fulfillRequisition(requisition.key, sketchChunks)
+  }
+}

--- a/src/main/kotlin/org/wfanet/measurement/dataprovider/deploy/fake/BUILD.bazel
+++ b/src/main/kotlin/org/wfanet/measurement/dataprovider/deploy/fake/BUILD.bazel
@@ -1,0 +1,41 @@
+load("@rules_java//java:defs.bzl", "java_binary")
+load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kt_jvm_library")
+load("@io_bazel_rules_docker//java:image.bzl", "java_image")
+
+package(default_visibility = [
+    "//src/main/kotlin/org/wfanet/measurement:__subpackages__",
+    "//src/test/kotlin/org/wfanet/measurement:__subpackages__",
+])
+
+kt_jvm_library(
+    name = "fake_requisition_fulfillment_daemon",
+    srcs = ["FakeRequisitionFulfillmentDaemonMain.kt"],
+    deps = [
+        "//src/main/kotlin/org/wfanet/measurement/common",
+        "//src/main/kotlin/org/wfanet/measurement/common/grpc",
+        "//src/main/kotlin/org/wfanet/measurement/common/identity",
+        "//src/main/kotlin/org/wfanet/measurement/dataprovider/common",
+        "//src/main/kotlin/org/wfanet/measurement/dataprovider/daemon",
+        "//src/main/kotlin/org/wfanet/measurement/dataprovider/fake",
+        "//src/main/proto/wfa/measurement/api/v2alpha:combined_public_keys_service_kt_jvm_grpc",
+        "//src/main/proto/wfa/measurement/api/v2alpha:crypto_java_proto",
+        "//src/main/proto/wfa/measurement/api/v2alpha:measurements_service_kt_jvm_grpc",
+        "//src/main/proto/wfa/measurement/api/v2alpha:requisition_fulfillment_service_kt_jvm_grpc",
+        "//src/main/proto/wfa/measurement/api/v2alpha:requisitions_service_kt_jvm_grpc",
+        "//src/main/proto/wfa/measurement/api/v2alpha:sketch_configs_service_kt_jvm_grpc",
+        "//src/main/proto/wfa/measurement/api/v2alpha:sketch_java_proto",
+    ],
+)
+
+java_binary(
+    name = "FakeRequisitionFulfillmentDaemon",
+    main_class = "org.wfanet.measurement.dataprovider.deploy.common.FakeRequisitionFulfillmentDaemonMainKt",
+    runtime_deps = [":fake_requisition_fulfillment_daemon"],
+)
+
+java_image(
+    name = "fake_requisition_fulfillment_image",
+    main_class = "org.wfanet.measurement.dataprovider.deploy.common.FakeRequisitionFulfillmentDaemonMainKt",
+    visibility = ["//src:docker_image_deployment"],
+    runtime_deps = [":fake_requisition_fulfillment_daemon"],
+)

--- a/src/main/kotlin/org/wfanet/measurement/dataprovider/deploy/fake/FakeRequisitionFulfillmentDaemonMain.kt
+++ b/src/main/kotlin/org/wfanet/measurement/dataprovider/deploy/fake/FakeRequisitionFulfillmentDaemonMain.kt
@@ -1,0 +1,177 @@
+// Copyright 2021 The Cross-Media Measurement Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.wfanet.measurement.dataprovider.deploy.fake
+
+import com.google.protobuf.ByteString
+import java.time.Clock
+import java.time.Duration
+import kotlin.properties.Delegates
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.runBlocking
+import org.wfanet.anysketch.crypto.EncryptSketchRequest.DestroyedRegisterStrategy.FLAGGED_KEY
+import org.wfanet.measurement.api.v2alpha.CombinedPublicKeysGrpcKt.CombinedPublicKeysCoroutineStub
+import org.wfanet.measurement.api.v2alpha.ElGamalPublicKey
+import org.wfanet.measurement.api.v2alpha.RequisitionFulfillmentGrpcKt.RequisitionFulfillmentCoroutineStub
+import org.wfanet.measurement.api.v2alpha.RequisitionSpec
+import org.wfanet.measurement.api.v2alpha.RequisitionsGrpcKt.RequisitionsCoroutineStub
+import org.wfanet.measurement.api.v2alpha.Sketch
+import org.wfanet.measurement.api.v2alpha.SketchConfig
+import org.wfanet.measurement.api.v2alpha.SketchConfigsGrpcKt.SketchConfigsCoroutineStub
+import org.wfanet.measurement.common.asBufferedFlow
+import org.wfanet.measurement.common.commandLineMain
+import org.wfanet.measurement.common.grpc.buildChannel
+import org.wfanet.measurement.common.grpc.withVerboseLogging
+import org.wfanet.measurement.common.identity.ApiId
+import org.wfanet.measurement.common.throttler.MinimumIntervalThrottler
+import org.wfanet.measurement.dataprovider.common.DefaultEncryptedSketchGenerator
+import org.wfanet.measurement.dataprovider.common.GrpcElGamalPublicKeyCache
+import org.wfanet.measurement.dataprovider.common.GrpcRequisitionFulfiller
+import org.wfanet.measurement.dataprovider.common.GrpcSketchConfigCache
+import org.wfanet.measurement.dataprovider.common.GrpcUnfulfilledRequisitionProvider
+import org.wfanet.measurement.dataprovider.common.JniSketchEncrypter
+import org.wfanet.measurement.dataprovider.daemon.RequisitionFulfillmentWorkflow
+import org.wfanet.measurement.dataprovider.daemon.loopOnReadySuppressingExceptions
+import org.wfanet.measurement.dataprovider.fake.FakeRequisitionDecoder
+import picocli.CommandLine
+
+class Flags {
+  @CommandLine.Option(
+    names = ["--external-data-provider-id"],
+    required = true
+  )
+  lateinit var externalDataProviderId: String
+    private set
+
+  @CommandLine.Option(
+    names = ["--combined-public-keys-service-target"],
+    required = true
+  )
+  lateinit var combinedPublicKeysServiceTarget: String
+    private set
+
+  val combinedPublicKeysStub by lazy {
+    CombinedPublicKeysCoroutineStub(
+      buildChannel(combinedPublicKeysServiceTarget)
+        .withVerboseLogging(debugVerboseGrpcClientLogging)
+    )
+  }
+
+  @CommandLine.Option(
+    names = ["--requisitions-service-target"],
+    required = true
+  )
+  lateinit var requisitionsServiceTarget: String
+    private set
+
+  val requisitionsStub by lazy {
+    RequisitionsCoroutineStub(
+      buildChannel(requisitionsServiceTarget)
+        .withVerboseLogging(debugVerboseGrpcClientLogging)
+    )
+  }
+
+  @CommandLine.Option(
+    names = ["--requisition-fulfillment-service-target"],
+    required = true
+  )
+  lateinit var requisitionFulfillmentServiceTarget: String
+    private set
+
+  val requisitionFulfillmentStub by lazy {
+    RequisitionFulfillmentCoroutineStub(
+      buildChannel(requisitionFulfillmentServiceTarget)
+        .withVerboseLogging(debugVerboseGrpcClientLogging)
+    )
+  }
+
+  @CommandLine.Option(
+    names = ["--sketch-configs-service-target"],
+    required = true
+  )
+  lateinit var sketchConfigsServiceTarget: String
+    private set
+
+  val sketchConfigsStub by lazy {
+    SketchConfigsCoroutineStub(
+      buildChannel(sketchConfigsServiceTarget)
+        .withVerboseLogging(debugVerboseGrpcClientLogging)
+    )
+  }
+
+  @CommandLine.Option(
+    names = ["--throttler-minimum-interval"],
+    defaultValue = "1s"
+  )
+  lateinit var throttlerMinimumInterval: Duration
+    private set
+
+  @set:CommandLine.Option(
+    names = ["--debug-verbose-grpc-client-logging"],
+    description = ["Enables full gRPC request and response logging for outgoing gRPCs"],
+    defaultValue = "false"
+  )
+  var debugVerboseGrpcClientLogging by Delegates.notNull<Boolean>()
+    private set
+}
+
+object EmptySketchGenerator {
+  private val sketchEncrypter =
+    JniSketchEncrypter(maximumValue = 10, destroyedRegisterStrategy = FLAGGED_KEY)
+
+  @Suppress("UNUSED_PARAMETER")
+  fun generate(
+    requisitionSpec: RequisitionSpec,
+    encryptionKey: ElGamalPublicKey,
+    sketchConfig: SketchConfig
+  ): Flow<ByteString> {
+    // TODO: replace this with a more interesting sketch generator, configurable from flags.
+    val sketch = Sketch.newBuilder().apply {
+      config = sketchConfig
+    }.build()
+
+    return sketchEncrypter.encrypt(sketch, encryptionKey).asBufferedFlow(1024)
+  }
+}
+
+@CommandLine.Command(
+  name = "fake_requisition_fulfillment_daemon",
+  mixinStandardHelpOptions = true,
+  showDefaultValues = true
+)
+private fun run(@CommandLine.Mixin flags: Flags) {
+  val throttler = MinimumIntervalThrottler(Clock.systemUTC(), flags.throttlerMinimumInterval)
+
+  val workflow = RequisitionFulfillmentWorkflow(
+    GrpcUnfulfilledRequisitionProvider(
+      ApiId(flags.externalDataProviderId).externalId,
+      flags.requisitionsStub
+    ),
+    FakeRequisitionDecoder(),
+    DefaultEncryptedSketchGenerator(
+      GrpcElGamalPublicKeyCache(flags.combinedPublicKeysStub),
+      GrpcSketchConfigCache(flags.sketchConfigsStub),
+      EmptySketchGenerator::generate
+    ),
+    GrpcRequisitionFulfiller(flags.requisitionFulfillmentStub)
+  )
+
+  runBlocking {
+    throttler.loopOnReadySuppressingExceptions {
+      workflow.execute()
+    }
+  }
+}
+
+fun main(args: Array<String>) = commandLineMain(::run, args)

--- a/src/main/kotlin/org/wfanet/measurement/dataprovider/fake/BUILD.bazel
+++ b/src/main/kotlin/org/wfanet/measurement/dataprovider/fake/BUILD.bazel
@@ -1,0 +1,25 @@
+load("//build:defs.bzl", "test_target")
+load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kt_jvm_library")
+
+package(default_visibility = [
+    "//src/main/kotlin/org/wfanet/measurement/dataprovider:__subpackages__",
+    test_target(":__subpackages__"),
+    "//src/test/kotlin/org/wfanet/measurement/e2e:__subpackages__",
+])
+
+kt_jvm_library(
+    name = "fake",
+    srcs = glob(["*.kt"]),
+    deps = [
+        "//imports/java/com/google/protobuf",
+        "//src/main/kotlin/org/wfanet/measurement/common",
+        "//src/main/kotlin/org/wfanet/measurement/common/identity",
+        "//src/main/kotlin/org/wfanet/measurement/dataprovider/common",
+        "//src/main/proto/wfa/measurement/api/v2alpha:crypto_java_proto",
+        "//src/main/proto/wfa/measurement/api/v2alpha:data_provider_java_proto",
+        "//src/main/proto/wfa/measurement/api/v2alpha:measurement_java_proto",
+        "//src/main/proto/wfa/measurement/api/v2alpha:requisition_java_proto",
+        "//src/main/proto/wfa/measurement/api/v2alpha:requisition_spec_java_proto",
+        "//src/main/proto/wfa/measurement/api/v2alpha:sketch_java_proto",
+    ],
+)

--- a/src/main/kotlin/org/wfanet/measurement/dataprovider/fake/FakeRequisitionDecoder.kt
+++ b/src/main/kotlin/org/wfanet/measurement/dataprovider/fake/FakeRequisitionDecoder.kt
@@ -1,0 +1,40 @@
+// Copyright 2021 The Cross-Media Measurement Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.wfanet.measurement.dataprovider.fake
+
+import org.wfanet.measurement.api.v2alpha.MeasurementSpec
+import org.wfanet.measurement.api.v2alpha.Requisition
+import org.wfanet.measurement.api.v2alpha.RequisitionSpec
+import org.wfanet.measurement.api.v2alpha.SignedData
+import org.wfanet.measurement.dataprovider.common.RequisitionDecoder
+
+/**
+ * [RequisitionDecoder] that makes no attempt to perform any cryptography.
+ *
+ * It assumes that there is no encryption and does not attempt to validate signatures.
+ *
+ * DO NOT use this in production.
+ */
+class FakeRequisitionDecoder : RequisitionDecoder {
+  override fun decodeMeasurementSpec(requisition: Requisition): MeasurementSpec {
+    val serializedMeasurementSpec = requisition.measurementSpec
+    return MeasurementSpec.parseFrom(serializedMeasurementSpec.data)
+  }
+
+  override fun decodeRequisitionSpec(requisition: Requisition): RequisitionSpec {
+    val signedData = SignedData.parseFrom(requisition.encryptedRequisitionSpec)
+    return RequisitionSpec.parseFrom(signedData.data)
+  }
+}

--- a/src/main/kotlin/org/wfanet/measurement/loadtest/CorrectnessImpl.kt
+++ b/src/main/kotlin/org/wfanet/measurement/loadtest/CorrectnessImpl.kt
@@ -121,6 +121,7 @@ class CorrectnessImpl(
     coroutineScope {
       generatedCampaigns.forEach {
         launch {
+          // TODO: replace this with FakeDataProvider.
           encryptAndSend(it, testResult)
         }
       }

--- a/src/test/kotlin/org/wfanet/measurement/dataprovider/daemon/BUILD.bazel
+++ b/src/test/kotlin/org/wfanet/measurement/dataprovider/daemon/BUILD.bazel
@@ -1,0 +1,26 @@
+load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kt_jvm_test")
+
+kt_jvm_test(
+    name = "RequistionFulfillmentWorkflowTest",
+    srcs = ["RequistionFulfillmentWorkflowTest.kt"],
+    test_class = "org.wfanet.measurement.dataprovider.daemon.RequistionFulfillmentWorkflowTest",
+    deps = [
+        "//imports/java/com/google/common/truth",
+        "//imports/java/com/google/common/truth/extensions/proto",
+        "//imports/java/com/google/protobuf",
+        "//imports/java/org/mockito",
+        "//imports/kotlin/com/nhaarman/mockitokotlin2",
+        "//imports/kotlin/kotlinx/coroutines:core",
+        "//src/main/kotlin/org/wfanet/measurement/common",
+        "//src/main/kotlin/org/wfanet/measurement/common/identity",
+        "//src/main/kotlin/org/wfanet/measurement/common/identity/testing",
+        "//src/main/kotlin/org/wfanet/measurement/dataprovider/common",
+        "//src/main/kotlin/org/wfanet/measurement/dataprovider/daemon",
+        "//src/main/proto/wfa/measurement/api/v1alpha:crypto_java_proto",
+        "//src/main/proto/wfa/measurement/api/v1alpha:sketch_java_proto",
+        "//src/main/proto/wfa/measurement/api/v2alpha:crypto_java_proto",
+        "//src/main/proto/wfa/measurement/api/v2alpha:requisition_java_proto",
+        "//src/main/proto/wfa/measurement/api/v2alpha:requisition_spec_java_proto",
+        "//src/main/proto/wfa/measurement/api/v2alpha:sketch_java_proto",
+    ],
+)

--- a/src/test/kotlin/org/wfanet/measurement/dataprovider/daemon/RequistionFulfillmentWorkflowTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/dataprovider/daemon/RequistionFulfillmentWorkflowTest.kt
@@ -1,0 +1,172 @@
+// Copyright 2021 The Cross-Media Measurement Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.wfanet.measurement.dataprovider.daemon
+
+import com.google.common.truth.Truth.assertThat
+import com.google.common.truth.extensions.proto.ProtoTruth.assertThat
+import com.google.protobuf.ByteString
+import com.nhaarman.mockitokotlin2.any
+import com.nhaarman.mockitokotlin2.argumentCaptor
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.verifyBlocking
+import com.nhaarman.mockitokotlin2.verifyZeroInteractions
+import com.nhaarman.mockitokotlin2.whenever
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.runBlocking
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+import org.wfanet.measurement.api.v2alpha.CombinedPublicKey
+import org.wfanet.measurement.api.v2alpha.ElGamalPublicKey
+import org.wfanet.measurement.api.v2alpha.MeasurementSpec
+import org.wfanet.measurement.api.v2alpha.MeasurementSpec.EncryptedSketch
+import org.wfanet.measurement.api.v2alpha.Requisition
+import org.wfanet.measurement.api.v2alpha.RequisitionSpec
+import org.wfanet.measurement.api.v2alpha.SignedData
+import org.wfanet.measurement.api.v2alpha.SketchConfig
+import org.wfanet.measurement.common.byteStringOf
+import org.wfanet.measurement.dataprovider.common.EncryptedSketchGenerator
+import org.wfanet.measurement.dataprovider.common.RequisitionDecoder
+import org.wfanet.measurement.dataprovider.common.RequisitionFulfiller
+import org.wfanet.measurement.dataprovider.common.UnfulfilledRequisitionProvider
+
+private val COMBINED_PUBLIC_KEY_KEY: CombinedPublicKey.Key =
+  CombinedPublicKey.Key.newBuilder().apply {
+    combinedPublicKeyId = "some-combined-public-key-id"
+  }.build()
+
+private val ENCRYPTION_KEY: ElGamalPublicKey =
+  ElGamalPublicKey.newBuilder().apply {
+    ellipticCurveId = 123456789
+    generator = byteStringOf(0xAB, 0xCD)
+    element = byteStringOf(0xEF, 0x89)
+  }.build()
+
+private val SKETCH_CONFIG = SketchConfig.newBuilder().apply {
+  keyBuilder.sketchConfigId = "some-sketch-config-id"
+}.build()
+
+private val REQUISITION_SPEC = RequisitionSpec.newBuilder().apply {
+  // Add some nonsense to differentiate from the default instance.
+  addEventGroupEntriesBuilder().eventGroupBuilder.eventGroupId = "some-event-group-id"
+}.build()
+
+private val ENCRYPTED_SKETCH = EncryptedSketch.newBuilder().apply {
+  sketchConfig = SKETCH_CONFIG.key
+  combinedPublicKey = COMBINED_PUBLIC_KEY_KEY
+}.build()
+
+private val MEASUREMENT_SPEC = MeasurementSpec.newBuilder().apply {
+  encryptedSketch = ENCRYPTED_SKETCH
+}.build()
+
+private val REQUISITION = Requisition.newBuilder().apply {
+  measurementSpecBuilder.data = MEASUREMENT_SPEC.toByteString()
+  encryptedRequisitionSpec =
+    SignedData.newBuilder().apply {
+      data = REQUISITION_SPEC.toByteString()
+    }
+      .build()
+      .toByteString()
+}.build()
+
+@RunWith(JUnit4::class)
+class RequistionFulfillmentWorkflowTest {
+  private val unfulfilledRequisitionProvider = mock<UnfulfilledRequisitionProvider>()
+  private val requisitionDecoder = mock<RequisitionDecoder>()
+  private val sketchGenerator = mock<EncryptedSketchGenerator>()
+  private val requisitionFulfiller = mock<RequisitionFulfiller>()
+  private val requisitionFulfillmentWorkflow =
+    RequisitionFulfillmentWorkflow(
+      unfulfilledRequisitionProvider,
+      requisitionDecoder,
+      sketchGenerator,
+      requisitionFulfiller
+    )
+
+  @Test
+  fun noRequisition() = runBlocking {
+    whenever(unfulfilledRequisitionProvider.get())
+      .thenReturn(null as Requisition?)
+
+    requisitionFulfillmentWorkflow.execute()
+
+    verifyZeroInteractions(
+      requisitionDecoder,
+      sketchGenerator,
+      requisitionFulfiller
+    )
+  }
+
+  @Test
+  fun withRequisition() = runBlocking<Unit> {
+    whenever(unfulfilledRequisitionProvider.get())
+      .thenReturn(REQUISITION)
+
+    whenever(requisitionDecoder.decodeMeasurementSpec(any()))
+      .thenReturn(MEASUREMENT_SPEC)
+
+    whenever(requisitionDecoder.decodeRequisitionSpec(any()))
+      .thenReturn(REQUISITION_SPEC)
+
+    whenever(sketchGenerator.generate(any(), any()))
+      .thenReturn(flowOf(byteStringOf(0x01), byteStringOf(0x02)))
+
+    lateinit var observedFulfilledRequisitionKey: Requisition.Key
+    lateinit var observedFulfilledRequisitionBytes: List<ByteString>
+    whenever(requisitionFulfiller.fulfillRequisition(any(), any()))
+      .thenAnswer {
+        runBlocking {
+          observedFulfilledRequisitionKey = it.getArgument<Requisition.Key>(0)
+          observedFulfilledRequisitionBytes = it.getArgument<Flow<ByteString>>(1).toList()
+        }
+      }
+
+    requisitionFulfillmentWorkflow.execute()
+
+    argumentCaptor<Requisition> {
+      verifyBlocking(requisitionDecoder) {
+        decodeMeasurementSpec(capture())
+      }
+      assertThat(firstValue).isEqualTo(REQUISITION)
+    }
+
+    argumentCaptor<Requisition> {
+      verifyBlocking(requisitionDecoder) {
+        decodeRequisitionSpec(capture())
+      }
+      assertThat(firstValue).isEqualTo(REQUISITION)
+    }
+
+    val requisitionSpecCaptor = argumentCaptor<RequisitionSpec>()
+    val encryptedSketchCaptor = argumentCaptor<EncryptedSketch>()
+
+    verifyBlocking(sketchGenerator) {
+      generate(requisitionSpecCaptor.capture(), encryptedSketchCaptor.capture())
+    }
+    assertThat(requisitionSpecCaptor.firstValue)
+      .isEqualTo(REQUISITION_SPEC)
+    assertThat(encryptedSketchCaptor.firstValue)
+      .isEqualTo(ENCRYPTED_SKETCH)
+
+    assertThat(observedFulfilledRequisitionKey)
+      .isEqualTo(REQUISITION.key)
+
+    assertThat(observedFulfilledRequisitionBytes)
+      .containsExactly(byteStringOf(0x01), byteStringOf(0x02))
+  }
+}

--- a/src/test/kotlin/org/wfanet/measurement/integration/common/FakeDataProviderRule.kt
+++ b/src/test/kotlin/org/wfanet/measurement/integration/common/FakeDataProviderRule.kt
@@ -65,6 +65,7 @@ class FakeDataProviderRule : TestRule {
     )
   }
 
+  // TODO: replace this with FakeDataProvider.
   private suspend fun runDataProvider(
     externalDataProviderId: ExternalId,
     externalCampaignId: ExternalId,


### PR DESCRIPTION
This introduces a number of interfaces in ../dataprovider/common to
provide the functionality necessary to obtain and fulfill Requisitions
in the v2alpha API.

It also adds a fully-functional fake Requisition fulfillment daemon.

Future commits should:
  - Integrate this into existing test infrastructure.
  - Implement the cryptographic operations for consent signals.


<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/world-federation-of-advertisers/cross-media-measurement/6)
<!-- Reviewable:end -->
