### PR TITLE
Add Kingdom-internal Panel Match data-layer gRPC service definitions.

### DIFF
--- a/src/main/proto/wfa/measurement/internal/kingdom/BUILD.bazel
+++ b/src/main/proto/wfa/measurement/internal/kingdom/BUILD.bazel
@@ -28,6 +28,19 @@ proto_and_java_proto_library(
     name = "exchange_details",
 )
 
+proto_library(
+    name = "exchanges_service_proto",
+    srcs = ["exchanges_service.proto"],
+    deps = [
+        ":exchange_proto",
+    ],
+)
+
+kt_jvm_grpc_and_java_proto_library(
+    name = "exchanges_service_kt_jvm_grpc",
+    srcs = [":exchanges_service_proto"],
+)
+
 proto_and_java_proto_library(
     name = "exchange_step_attempt",
     deps = [
@@ -43,6 +56,21 @@ proto_and_java_proto_library(
     ],
 )
 
+proto_library(
+    name = "exchange_step_attempts_service_proto",
+    srcs = ["exchange_step_attempts_service.proto"],
+    deps = [
+        ":exchange_step_attempt_details_proto",
+        ":exchange_step_attempt_proto",
+        "@com_google_googleapis//google/type:date_proto",
+    ],
+)
+
+kt_jvm_grpc_and_java_proto_library(
+    name = "exchange_step_attempts_service_kt_jvm_grpc",
+    srcs = [":exchange_step_attempts_service_proto"],
+)
+
 proto_and_java_proto_library(
     name = "recurring_exchange",
     deps = [
@@ -52,6 +80,17 @@ proto_and_java_proto_library(
 
 proto_and_java_proto_library(
     name = "recurring_exchange_details",
+)
+
+proto_library(
+    name = "recurring_exchanges_service_proto",
+    srcs = ["recurring_exchanges_service.proto"],
+    deps = [":recurring_exchange_proto"],
+)
+
+kt_jvm_grpc_and_java_proto_library(
+    name = "recurring_exchanges_service_kt_jvm_grpc",
+    srcs = [":recurring_exchanges_service_proto"],
 )
 
 proto_and_java_proto_library(

--- a/src/main/proto/wfa/measurement/internal/kingdom/exchange_step_attempt.proto
+++ b/src/main/proto/wfa/measurement/internal/kingdom/exchange_step_attempt.proto
@@ -38,8 +38,30 @@ message ExchangeStepAttempt {
 
   // Which attempt this is. The first attempt should have index 1 and each
   // subsequent attempt should increase the last `attempt_number` by 1.
+  // Output-only.
   int32 attempt_number = 5;
 
   // Additional metadata about the ExchangeStepAttempt.
   ExchangeStepAttemptDetails details = 6;
+
+  enum State {
+    STATE_UNSPECIFIED = 0;
+
+    // The attempt has not yet reached a terminal state.
+    ACTIVE = 2;
+
+    // The attempt has succeeded. There cannot be more attempts for the step.
+    // Terminal state.
+    SUCCEEDED = 3;
+
+    // The attempt has failed. The step should be retried. Terminal state.
+    FAILED = 4;
+  }
+
+  // State of the ExchangeStepAttempt.
+  State state = 7;
+
+  // Serialized ExchangeWorkflow message denormalized from the ancestor
+  // `RecurringExchange`'s `RecurringExchangeDetails`. Output-only.
+  bytes serialized_recurring_exchange = 8;
 }

--- a/src/main/proto/wfa/measurement/internal/kingdom/exchange_step_attempt_details.proto
+++ b/src/main/proto/wfa/measurement/internal/kingdom/exchange_step_attempt_details.proto
@@ -23,23 +23,6 @@ option java_multiple_files = true;
 
 // Stores metadata about an ExchangeStepAttempt.
 message ExchangeStepAttemptDetails {
-  enum State {
-    STATE_UNSPECIFIED = 0;
-
-    // The attempt is has not yet reached a terminal state.
-    ACTIVE = 2;
-
-    // The attempt has succeeded. There cannot be more attempts for the step.
-    // Terminal state.
-    SUCCEEDED = 3;
-
-    // The attempt has failed. The step should be retried. Terminal state.
-    FAILED = 4;
-  }
-
-  // State of the ExchangeStepAttempt.
-  State state = 3;
-
   message DebugLog {
     // When the log entry was made.
     google.protobuf.Timestamp time = 1;

--- a/src/main/proto/wfa/measurement/internal/kingdom/exchange_step_attempts_service.proto
+++ b/src/main/proto/wfa/measurement/internal/kingdom/exchange_step_attempts_service.proto
@@ -1,0 +1,93 @@
+// Copyright 2021 The Cross-Media Measurement Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package wfa.measurement.internal.kingdom;
+
+import "google/type/date.proto";
+import "src/main/proto/wfa/measurement/internal/kingdom/exchange_step_attempt.proto";
+import "src/main/proto/wfa/measurement/internal/kingdom/exchange_step_attempt_details.proto";
+
+option java_package = "org.wfanet.measurement.internal.kingdom";
+option java_multiple_files = true;
+
+// Internal service for managing `ExchangeStepAttempt` resources.
+service ExchangeStepAttempts {
+  // Creates an `ExchangeStepAttempt`.
+  //
+  // This should not specify the attempt number.
+  rpc CreateExchangeStepAttempt(CreateExchangeStepAttemptRequest)
+      returns (ExchangeStepAttempt);
+
+  // Streams `ExchangeStepAttempt`s.
+  rpc StreamExchangeStepAttempts(StreamExchangeStepAttemptsRequest)
+      returns (stream ExchangeStepAttempt);
+
+  // Appends an `ExchangeStepAttemptDetails.DebugLog` to an
+  // `ExchangeStepAttempt`.
+  rpc AppendLogEntry(AppendLogEntryRequest) returns (ExchangeStepAttempt);
+
+  // Updates the state of an ExchangeStepAttempt to a terminal state.
+  rpc FinishExchangeStepAttempt(FinishExchangeStepAttemptRequest)
+      returns (ExchangeStepAttempt);
+}
+
+// Request message for "/ExchangeStepAttempts.CreateExchangeStepAttempt".
+message CreateExchangeStepAttemptRequest {
+  ExchangeStepAttempt exchange_step_attempt = 1;
+}
+
+// Request message for "/ExchangeStepAttempts.StreamExchangeStepAttempts".
+message StreamExchangeStepAttemptsRequest {
+  int32 limit = 1;
+
+  // Restricts results to those matching all of the given criteria. Repeated
+  // fields are treated as disjunctions.
+  message Filter {
+    repeated fixed64 external_recurring_exchange_ids = 1;
+    repeated google.type.Date dates = 2;
+    repeated int32 step_indices = 3;
+    repeated ExchangeStepAttempt.State states = 4;
+  }
+  Filter filter = 2;
+}
+
+// Request message for "/ExchangeStepAttempts.AppendLogEntry".
+message AppendLogEntryRequest {
+  // Primary key of the `ExchangeStepAttempt`.
+  // If the `attempt_number` is omitted, appends to the entry with highest
+  // `attempt_number`.
+  fixed64 external_recurring_exchange_id = 1;
+  google.type.Date date = 2;
+  int32 step_index = 3;
+  int32 attempt_number = 4;
+
+  // Log entry to append.
+  repeated ExchangeStepAttemptDetails.DebugLog log_entries = 5;
+}
+
+// Request message for "/ExchangeStepAttempts.FinishExchangeStepAttempt".
+message FinishExchangeStepAttemptRequest {
+  // Primary key of the `ExchangeStepAttempt`.
+  // If the `attempt_number` is omitted, it assumes the `ExchangeStepAttempt`
+  // with the highest `attempt_number`.
+  fixed64 external_recurring_exchange_id = 1;
+  google.type.Date date = 2;
+  int32 step_index = 3;
+  int32 attempt_number = 4;
+
+  // Final state for the `ExchangeStepAttempt`.
+  ExchangeStepAttempt.State state = 5;
+}

--- a/src/main/proto/wfa/measurement/internal/kingdom/exchanges_service.proto
+++ b/src/main/proto/wfa/measurement/internal/kingdom/exchanges_service.proto
@@ -16,26 +16,22 @@ syntax = "proto3";
 
 package wfa.measurement.internal.kingdom;
 
-import "google/type/date.proto";
-import "src/main/proto/wfa/measurement/internal/kingdom/exchange_details.proto";
+import "src/main/proto/wfa/measurement/internal/kingdom/exchange.proto";
 
 option java_package = "org.wfanet.measurement.internal.kingdom";
 option java_multiple_files = true;
 
-// An `Exchange` is a `RecurringExchange` on a particular date.
-message Exchange {
-  // Internal identifier of the parent `RecurringExchange`.
-  fixed64 external_recurring_exchange_id = 1;
+// Internal service for managing `Exchange` resources.
+service Exchanges {
+  // Creates an `Exchange`.
+  //
+  // If there is already an Exchange for the same date for the given
+  // `RecurringExchange`, this will do nothing and return that instead.
+  rpc CreateExchange(CreateExchangeRequest) returns (Exchange);
+}
 
-  // The date that the `Exchange` is supposed to occur. There can be at most one
-  // `Exchange` for a `RecurringExchange` on any given date -- this is a part of
-  // the `Exchange`'s primary key.
-  google.type.Date date = 2;
-
-  // Additional metadata about the Exchange.
-  ExchangeDetails details = 3;
-
-  // Serialized ExchangeWorkflow message denormalized from the parent
-  // `RecurringExchange`'s `RecurringExchangeDetails`.
-  bytes serialized_recurring_exchange = 4;
+// Request for `/Exchanges.CreateExchange`.
+message CreateExchangeRequest {
+  // The `Exchange` to create.
+  Exchange exchange = 1;
 }

--- a/src/main/proto/wfa/measurement/internal/kingdom/recurring_exchanges_service.proto
+++ b/src/main/proto/wfa/measurement/internal/kingdom/recurring_exchanges_service.proto
@@ -16,26 +16,28 @@ syntax = "proto3";
 
 package wfa.measurement.internal.kingdom;
 
-import "google/type/date.proto";
-import "src/main/proto/wfa/measurement/internal/kingdom/exchange_details.proto";
+import "src/main/proto/wfa/measurement/internal/kingdom/recurring_exchange.proto";
 
 option java_package = "org.wfanet.measurement.internal.kingdom";
 option java_multiple_files = true;
 
-// An `Exchange` is a `RecurringExchange` on a particular date.
-message Exchange {
-  // Internal identifier of the parent `RecurringExchange`.
+// Internal service for managing `RecurringExchange` resources.
+service RecurringExchanges {
+  // Gets an existing `RecurringExchange`.
+  rpc GetRecurringExchange(GetRecurringExchangeRequest)
+      returns (RecurringExchange);
+
+  // Creates a `RecurringExchange`.
+  rpc CreateRecurringExchange(CreateRecurringExchangeRequest)
+      returns (RecurringExchange);
+}
+
+// Request message for "/RecurringExchanges.GetRecurringExchange".
+message GetRecurringExchangeRequest {
   fixed64 external_recurring_exchange_id = 1;
+}
 
-  // The date that the `Exchange` is supposed to occur. There can be at most one
-  // `Exchange` for a `RecurringExchange` on any given date -- this is a part of
-  // the `Exchange`'s primary key.
-  google.type.Date date = 2;
-
-  // Additional metadata about the Exchange.
-  ExchangeDetails details = 3;
-
-  // Serialized ExchangeWorkflow message denormalized from the parent
-  // `RecurringExchange`'s `RecurringExchangeDetails`.
-  bytes serialized_recurring_exchange = 4;
+// Request message for "/RecurringExchanges.CreateRecurringExchange".
+message CreateRecurringExchangeRequest {
+  RecurringExchange recurring_exchange = 1;
 }


### PR DESCRIPTION
For now, this adds a minimal set of methods required to implement most
of the functionality of the public facing APIs.

As more functionality is required, these will need to be expanded.
Building them incrementally has the advantage of not needing to
implement methods that are later determined to be unnecessary.

See world-federation-of-advertisers/cross-media-measurement#3.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/world-federation-of-advertisers/cross-media-measurement/10)
<!-- Reviewable:end -->
