### PR TITLE
Add a oneof protocol field to the ReportDetails.

### DIFF
--- a/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/writers/UpdateReportState.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/writers/UpdateReportState.kt
@@ -67,6 +67,7 @@ internal fun SpannerWriter.TransactionScope.updateReportState(
 
 private val ReportState.isTerminal: Boolean
   get() = when (this) {
+    ReportState.AWAITING_DUCHY_INITIALIZATION -> error("not implemented")
     ReportState.AWAITING_REQUISITION_CREATION,
     ReportState.AWAITING_DUCHY_CONFIRMATION,
     ReportState.IN_PROGRESS -> false

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/service/system/v1alpha/GlobalComputationService.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/service/system/v1alpha/GlobalComputationService.kt
@@ -211,6 +211,7 @@ private object ContinuationTokenConverter {
 
 private fun translateState(reportState: ReportState): State =
   when (reportState) {
+    ReportState.AWAITING_DUCHY_INITIALIZATION -> error("not implemented")
     ReportState.AWAITING_REQUISITION_CREATION -> State.CREATED
     ReportState.AWAITING_DUCHY_CONFIRMATION -> State.CONFIRMING
     ReportState.IN_PROGRESS -> State.RUNNING
@@ -224,6 +225,7 @@ private fun translateState(reportState: ReportState): State =
 private enum class StateType { TERMINAL, INTERMEDIATE, INVALID }
 private fun getStateType(reportState: ReportState): StateType =
   when (reportState) {
+    ReportState.AWAITING_DUCHY_INITIALIZATION -> error("not implemented")
     ReportState.AWAITING_REQUISITION_CREATION,
     ReportState.AWAITING_DUCHY_CONFIRMATION,
     ReportState.IN_PROGRESS -> StateType.INTERMEDIATE

--- a/src/main/proto/wfa/measurement/internal/kingdom/BUILD.bazel
+++ b/src/main/proto/wfa/measurement/internal/kingdom/BUILD.bazel
@@ -17,6 +17,14 @@ proto_and_java_proto_library(
 )
 
 proto_and_java_proto_library(
+    name = "protocol_data",
+    deps = [
+        "@any_sketch//src/main/proto/wfa/common:el_gamal_key_proto",
+        "@any_sketch//src/main/proto/wfa/common:noise_parameters_proto",
+    ],
+)
+
+proto_and_java_proto_library(
     name = "exchange",
     deps = [
         ":exchange_details_proto",
@@ -140,6 +148,9 @@ kt_jvm_grpc_and_java_proto_library(
 
 proto_and_java_proto_library(
     name = "report_details",
+    deps = [
+        ":protocol_data_proto",
+    ],
 )
 
 proto_and_java_proto_library(

--- a/src/main/proto/wfa/measurement/internal/kingdom/protocol_data.proto
+++ b/src/main/proto/wfa/measurement/internal/kingdom/protocol_data.proto
@@ -1,0 +1,81 @@
+// Copyright 2021 The Cross-Media Measurement Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package wfa.measurement.internal.kingdom;
+
+import "wfa/common/el_gamal_key.proto";
+import "wfa/common/noise_parameters.proto";
+
+option java_package = "org.wfanet.measurement.internal.kingdom";
+option java_multiple_files = true;
+
+// Protocol-specific configuration and parameters for the Liquid Legions V2
+// Protocol.
+message LiquidLegionsV2Data {
+  // Initial configurations
+  LiquidLegionsV2Config config = 1;
+  // ElGamal keys used for a certain report.
+  map<string, wfa.common.ElGamalPublicKey> duchy_keys = 2;
+}
+
+// Protocol-specific configuration for the Liquid Legions V2 Protocol.
+// Used internally in the report details. The fields should be set when a report
+// is created and then immutable.
+message LiquidLegionsV2Config {
+  // The decay rate of the Liquid Legions sketch.
+  double decay_rate = 1;
+
+  // The maximum size of the Liquid Legions sketch.
+  int64 size = 2;
+
+  // The maximum frequency to reveal in the histogram.
+  int32 maximum_frequency = 3;
+
+  // Noise parameters selected for the LiquidLegionV2 MPC protocol.
+  // Only used as the configuration file consumed by the LiquidLegionV2Mill.
+  message NoiseConfig {
+    message ReachNoiseConfig {
+      // DP params for the publisher noise registers.
+      // Each of these registers contains a well-known constant register id, and
+      // arbitrary key and count values.
+      wfa.common.DifferentialPrivacyParams publisher_noise = 1;
+      // DP params for the blind histogram noise register.
+      // Each of these registers contains a random register id, the same
+      // constant key indicating that the register is destroyed, and an
+      // arbitrary count value.
+      wfa.common.DifferentialPrivacyParams blind_histogram_noise = 2;
+      // DP params for the noise for the publisher noise registers.
+      // Each of these registers contains a well-known constant register id, and
+      // arbitrary key and count values.
+      wfa.common.DifferentialPrivacyParams noise_for_publisher_noise = 3;
+      // DP params for the global reach DP noise registers.
+      // Each of these registers contains a random register id which is out of
+      // bounds of the normal id space, the same constant key indicating that
+      // the register is destroyed, and an arbitrary count value.
+      wfa.common.DifferentialPrivacyParams global_reach_dp_noise = 4;
+    }
+    ReachNoiseConfig reach_noise_config = 1;
+
+    // Differential privacy parameters for noise tuples.
+    // Same value is used for both (0, R, R) and (R, R, R) tuples.
+    wfa.common.DifferentialPrivacyParams frequency_noise_config = 2;
+  }
+  NoiseConfig noise_config = 4;
+
+  // ID of the OpenSSL built-in elliptic curve. For example, 415 for the
+  // prime256v1 curve.
+  int32 elliptic_curve_id = 5;
+}

--- a/src/main/proto/wfa/measurement/internal/kingdom/report.proto
+++ b/src/main/proto/wfa/measurement/internal/kingdom/report.proto
@@ -27,21 +27,28 @@ message Report {
   enum ReportState {
     REPORT_STATE_UNKNOWN = 0;
 
+    // A Report is created. Each duchy needs to initialize locally for this
+    // computation. The actual work done during initialization depends on the
+    // protocol running for this report. For example, in the LLV2 protocol, each
+    // duchy needs to send back a newly created ElGamal public key to be
+    // used specifically for this report.
+    AWAITING_DUCHY_INITIALIZATION = 1;
+
     // For new Reports, while Requisitions are being created, associated, and
     // fulfilled.
-    AWAITING_REQUISITION_CREATION = 1;
+    AWAITING_REQUISITION_CREATION = 2;
 
     // All Requisitions are associated and fulfilled. Duchies must confirm that
     // they are ready to start.
-    AWAITING_DUCHY_CONFIRMATION = 2;
+    AWAITING_DUCHY_CONFIRMATION = 3;
 
     // Duchies may proceed with the computation.
-    IN_PROGRESS = 3;
+    IN_PROGRESS = 4;
 
     // Terminal states
-    SUCCEEDED = 4;
-    FAILED = 5;
-    CANCELLED = 6;
+    SUCCEEDED = 5;
+    FAILED = 6;
+    CANCELLED = 7;
   }
 
   fixed64 external_advertiser_id = 1;

--- a/src/main/proto/wfa/measurement/internal/kingdom/report_details.proto
+++ b/src/main/proto/wfa/measurement/internal/kingdom/report_details.proto
@@ -16,6 +16,8 @@ syntax = "proto3";
 
 package wfa.measurement.internal.kingdom;
 
+import "src/main/proto/wfa/measurement/internal/kingdom/protocol_data.proto";
+
 option java_package = "org.wfanet.measurement.internal.kingdom";
 option java_multiple_files = true;
 
@@ -45,7 +47,10 @@ message ReportDetails {
   }
   repeated ExternalRequisitionKey requisitions = 3;
 
-  // ID of the CombinedPublicKey resource for the encryption key used to encrypt
-  // all metric values for this report.
+  oneof protocol {
+    LiquidLegionsV2Data liquid_legions_v2 = 4;
+  }
+
+  // TODO(wangyaopw): delete combined_public_key_resource_id and its usage.
   string combined_public_key_resource_id = 5;
 }


### PR DESCRIPTION
This field contains the source of truth configurations and parameters used for a particular report.

* Configrations are determined at report creation time.
* Parameters can be updated during the computation, e.g., the LiquidLegionsV2Data.duchyKeys are set after the duchies send their respective keys back the to kingdom.