### PR TITLE
Remove most usages of KingdomRelationalDatabase.

### DIFF
--- a/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/common/server/KingdomDataServer.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/common/server/KingdomDataServer.kt
@@ -32,7 +32,7 @@ abstract class KingdomDataServer : Runnable {
   protected suspend fun run(database: KingdomRelationalDatabase) {
     DuchyIds.setDuchyIdsFromFlags(duchyIdFlags)
 
-    val services = buildDataServices(database)
+    val services = buildDataServices(database, database, database)
     val server = CommonServer.fromFlags(serverFlags, this::class.simpleName!!, services)
 
     runInterruptible { server.start().blockUntilShutdown() }

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/service/internal/DataServices.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/service/internal/DataServices.kt
@@ -15,15 +15,21 @@
 package org.wfanet.measurement.kingdom.service.internal
 
 import io.grpc.BindableService
-import org.wfanet.measurement.kingdom.db.KingdomRelationalDatabase
+import org.wfanet.measurement.kingdom.db.LegacySchedulingDatabase
+import org.wfanet.measurement.kingdom.db.ReportDatabase
+import org.wfanet.measurement.kingdom.db.RequisitionDatabase
 
 /** Builds a list of all the Kingdom's internal data-layer services. */
-fun buildDataServices(relationalDatabase: KingdomRelationalDatabase): List<BindableService> {
+fun buildDataServices(
+  legacySchedulingDatabase: LegacySchedulingDatabase,
+  reportDatabase: ReportDatabase,
+  requisitionDatabase: RequisitionDatabase
+): List<BindableService> {
   return listOf(
-    ReportConfigSchedulesService(relationalDatabase),
-    ReportConfigsService(relationalDatabase),
-    ReportsService(relationalDatabase),
-    ReportLogEntriesService(relationalDatabase),
-    RequisitionsService(relationalDatabase)
+    ReportConfigSchedulesService(legacySchedulingDatabase),
+    ReportConfigsService(legacySchedulingDatabase),
+    ReportsService(reportDatabase),
+    ReportLogEntriesService(reportDatabase),
+    RequisitionsService(requisitionDatabase)
   )
 }

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/service/internal/ReportConfigSchedulesService.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/service/internal/ReportConfigSchedulesService.kt
@@ -18,14 +18,15 @@ import kotlinx.coroutines.flow.Flow
 import org.wfanet.measurement.internal.kingdom.ReportConfigSchedule
 import org.wfanet.measurement.internal.kingdom.ReportConfigSchedulesGrpcKt.ReportConfigSchedulesCoroutineImplBase
 import org.wfanet.measurement.internal.kingdom.StreamReadyReportConfigSchedulesRequest
-import org.wfanet.measurement.kingdom.db.KingdomRelationalDatabase
+import org.wfanet.measurement.kingdom.db.LegacySchedulingDatabase
 
 class ReportConfigSchedulesService(
-  private val kingdomRelationalDatabase: KingdomRelationalDatabase
+  private val legacySchedulingDatabase: LegacySchedulingDatabase
 ) : ReportConfigSchedulesCoroutineImplBase() {
 
   override fun streamReadyReportConfigSchedules(
     request: StreamReadyReportConfigSchedulesRequest
-  ): Flow<ReportConfigSchedule> =
-    kingdomRelationalDatabase.streamReadySchedules(request.limit)
+  ): Flow<ReportConfigSchedule> {
+    return legacySchedulingDatabase.streamReadySchedules(request.limit)
+  }
 }

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/service/internal/ReportConfigsService.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/service/internal/ReportConfigsService.kt
@@ -19,17 +19,17 @@ import org.wfanet.measurement.common.identity.ExternalId
 import org.wfanet.measurement.internal.kingdom.ListRequisitionTemplatesRequest
 import org.wfanet.measurement.internal.kingdom.ListRequisitionTemplatesResponse
 import org.wfanet.measurement.internal.kingdom.ReportConfigsGrpcKt.ReportConfigsCoroutineImplBase
-import org.wfanet.measurement.kingdom.db.KingdomRelationalDatabase
+import org.wfanet.measurement.kingdom.db.LegacySchedulingDatabase
 
 class ReportConfigsService(
-  private val kingdomRelationalDatabase: KingdomRelationalDatabase
+  private val legacySchedulingDatabase: LegacySchedulingDatabase
 ) : ReportConfigsCoroutineImplBase() {
 
   override suspend fun listRequisitionTemplates(
     request: ListRequisitionTemplatesRequest
   ): ListRequisitionTemplatesResponse {
     val id = ExternalId(request.externalReportConfigId)
-    val requisitionTemplates = kingdomRelationalDatabase.listRequisitionTemplates(id)
+    val requisitionTemplates = legacySchedulingDatabase.listRequisitionTemplates(id)
     return ListRequisitionTemplatesResponse.newBuilder()
       .addAllRequisitionTemplates(requisitionTemplates.toList())
       .build()

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/service/internal/ReportLogEntriesService.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/service/internal/ReportLogEntriesService.kt
@@ -16,12 +16,12 @@ package org.wfanet.measurement.kingdom.service.internal
 
 import org.wfanet.measurement.internal.kingdom.ReportLogEntriesGrpcKt.ReportLogEntriesCoroutineImplBase
 import org.wfanet.measurement.internal.kingdom.ReportLogEntry
-import org.wfanet.measurement.kingdom.db.KingdomRelationalDatabase
+import org.wfanet.measurement.kingdom.db.ReportDatabase
 
 class ReportLogEntriesService(
-  private val kingdomRelationalDatabase: KingdomRelationalDatabase
+  private val reportDatabase: ReportDatabase
 ) : ReportLogEntriesCoroutineImplBase() {
   override suspend fun createReportLogEntry(request: ReportLogEntry): ReportLogEntry {
-    return kingdomRelationalDatabase.addReportLogEntry(request)
+    return reportDatabase.addReportLogEntry(request)
   }
 }

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/service/internal/ReportsService.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/service/internal/ReportsService.kt
@@ -28,25 +28,25 @@ import org.wfanet.measurement.internal.kingdom.ReportsGrpcKt.ReportsCoroutineImp
 import org.wfanet.measurement.internal.kingdom.StreamReadyReportsRequest
 import org.wfanet.measurement.internal.kingdom.StreamReportsRequest
 import org.wfanet.measurement.internal.kingdom.UpdateReportStateRequest
-import org.wfanet.measurement.kingdom.db.KingdomRelationalDatabase
+import org.wfanet.measurement.kingdom.db.ReportDatabase
 import org.wfanet.measurement.kingdom.db.streamReportsFilter
 
 class ReportsService(
-  private val kingdomRelationalDatabase: KingdomRelationalDatabase
+  private val reportDatabase: ReportDatabase
 ) : ReportsCoroutineImplBase() {
   override suspend fun getReport(request: GetReportRequest): Report {
-    return kingdomRelationalDatabase.getReport(ExternalId(request.externalReportId))
+    return reportDatabase.getReport(ExternalId(request.externalReportId))
   }
 
   override suspend fun createNextReport(request: CreateNextReportRequest): Report {
-    return kingdomRelationalDatabase.createNextReport(
+    return reportDatabase.createNextReport(
       ExternalId(request.externalScheduleId),
       request.combinedPublicKeyResourceId
     )
   }
 
   override fun streamReports(request: StreamReportsRequest): Flow<Report> {
-    return kingdomRelationalDatabase.streamReports(
+    return reportDatabase.streamReports(
       streamReportsFilter(
         externalAdvertiserIds = request.filter.externalAdvertiserIdsList.map(::ExternalId),
         externalReportConfigIds = request.filter.externalReportConfigIdsList.map(::ExternalId),
@@ -59,11 +59,11 @@ class ReportsService(
   }
 
   override fun streamReadyReports(request: StreamReadyReportsRequest): Flow<Report> {
-    return kingdomRelationalDatabase.streamReadyReports(request.limit)
+    return reportDatabase.streamReadyReports(request.limit)
   }
 
   override suspend fun updateReportState(request: UpdateReportStateRequest): Report {
-    return kingdomRelationalDatabase.updateReportState(
+    return reportDatabase.updateReportState(
       ExternalId(request.externalReportId),
       request.state
     )
@@ -72,7 +72,7 @@ class ReportsService(
   override suspend fun associateRequisition(
     request: AssociateRequisitionRequest
   ): AssociateRequisitionResponse {
-    kingdomRelationalDatabase.associateRequisitionToReport(
+    reportDatabase.associateRequisitionToReport(
       externalRequisitionId = ExternalId(request.externalRequisitionId),
       externalReportId = ExternalId(request.externalReportId)
     )
@@ -82,7 +82,7 @@ class ReportsService(
   override suspend fun confirmDuchyReadiness(
     request: ConfirmDuchyReadinessRequest
   ): Report {
-    return kingdomRelationalDatabase.confirmDuchyReadiness(
+    return reportDatabase.confirmDuchyReadiness(
       ExternalId(request.externalReportId),
       request.duchyId,
       request.externalRequisitionIdsList.map(::ExternalId).toSet()
@@ -90,7 +90,7 @@ class ReportsService(
   }
 
   override suspend fun finishReport(request: FinishReportRequest): Report {
-    return kingdomRelationalDatabase.finishReport(
+    return reportDatabase.finishReport(
       ExternalId(request.externalReportId),
       request.result
     )

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/service/internal/RequisitionsService.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/service/internal/RequisitionsService.kt
@@ -24,11 +24,11 @@ import org.wfanet.measurement.internal.kingdom.Requisition
 import org.wfanet.measurement.internal.kingdom.Requisition.RequisitionState
 import org.wfanet.measurement.internal.kingdom.RequisitionsGrpcKt.RequisitionsCoroutineImplBase
 import org.wfanet.measurement.internal.kingdom.StreamRequisitionsRequest
-import org.wfanet.measurement.kingdom.db.KingdomRelationalDatabase
+import org.wfanet.measurement.kingdom.db.RequisitionDatabase
 import org.wfanet.measurement.kingdom.db.streamRequisitionsFilter
 
 class RequisitionsService(
-  private val kingdomRelationalDatabase: KingdomRelationalDatabase
+  private val requisitionDatabase: RequisitionDatabase
 ) : RequisitionsCoroutineImplBase() {
   override suspend fun createRequisition(request: Requisition): Requisition {
     require(request.externalRequisitionId == 0L) {
@@ -37,11 +37,11 @@ class RequisitionsService(
     require(request.state == RequisitionState.UNFULFILLED) {
       "Initial requisitions must be unfulfilled: $request"
     }
-    return kingdomRelationalDatabase.createRequisition(request)
+    return requisitionDatabase.createRequisition(request)
   }
 
   override suspend fun fulfillRequisition(request: FulfillRequisitionRequest): Requisition {
-    val transition = kingdomRelationalDatabase.fulfillRequisition(
+    val transition = requisitionDatabase.fulfillRequisition(
       ExternalId(request.externalRequisitionId),
       request.duchyId
     )
@@ -61,6 +61,6 @@ class RequisitionsService(
       states = filter.statesList,
       createdAfter = filter.createdAfter.toInstant()
     )
-    return kingdomRelationalDatabase.streamRequisitions(internalFilter, request.limit)
+    return requisitionDatabase.streamRequisitions(internalFilter, request.limit)
   }
 }

--- a/src/main/kotlin/org/wfanet/measurement/loadtest/CorrectnessImpl.kt
+++ b/src/main/kotlin/org/wfanet/measurement/loadtest/CorrectnessImpl.kt
@@ -66,6 +66,7 @@ import org.wfanet.measurement.internal.kingdom.ReportDetails
 import org.wfanet.measurement.internal.kingdom.TimePeriod
 import org.wfanet.measurement.internal.loadtest.TestResult
 import org.wfanet.measurement.kingdom.db.KingdomRelationalDatabase
+import org.wfanet.measurement.kingdom.db.ReportDatabase
 import org.wfanet.measurement.kingdom.db.streamReportsFilter
 import org.wfanet.measurement.kingdom.db.testing.DatabaseTestHelper
 import org.wfanet.measurement.storage.StorageClient
@@ -152,7 +153,7 @@ class CorrectnessImpl(
     logger.info("Correctness Test passes with manifest: $blobKey.")
   }
 
-  private suspend fun KingdomRelationalDatabase.getFinishedReport(
+  private suspend fun ReportDatabase.getFinishedReport(
     externalReportConfigId: ExternalId,
     externalScheduleId: ExternalId
   ): Report {

--- a/src/test/kotlin/org/wfanet/measurement/integration/common/InProcessKingdom.kt
+++ b/src/test/kotlin/org/wfanet/measurement/integration/common/InProcessKingdom.kt
@@ -76,7 +76,13 @@ class InProcessKingdom(
 
   private val databaseServices = GrpcTestServerRule(logAllRequests = verboseGrpcLogging) {
     logger.info("Building Kingdom's internal services")
-    for (service in buildDataServices(kingdomRelationalDatabase)) {
+    val services =
+      buildDataServices(
+        kingdomRelationalDatabase,
+        kingdomRelationalDatabase,
+        kingdomRelationalDatabase
+      )
+    for (service in services) {
       addService(service.withVerboseLogging(verboseGrpcLogging))
     }
   }

--- a/src/test/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/server/GcpKingdomDataServerTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/server/GcpKingdomDataServerTest.kt
@@ -113,14 +113,14 @@ private val REPETITION_SPEC: RepetitionSpec = RepetitionSpec.newBuilder().apply 
 class GcpKingdomDataServerTest : KingdomDatabaseTestBase() {
   @get:Rule
   val grpcTestServer = GrpcTestServerRule(logAllRequests = true) {
-    val relationalDatabase =
+    val database =
       SpannerKingdomRelationalDatabase(
         Clock.systemUTC(),
         RandomIdGenerator(Clock.systemUTC()),
         databaseClient
       )
 
-    buildDataServices(relationalDatabase)
+    buildDataServices(database, database, database)
       .forEach(this::addService)
   }
 


### PR DESCRIPTION
This replaces the usages with the super-interfaces introduced in
commit 556ba60.

The next step will be to split apart the implementation of
KingdomRelationalDatabase, SpannerKingdomRelationalDatabase, into
implementations of the super-interfaces. After that,
KingdomRelationalDatabase can finally be removed.