### PR TITLE
Fixed com_github_google_go_containerregistry

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -165,8 +165,8 @@ load("//build/io_bazel_rules_docker:repo.bzl", "rules_docker_repo")
 
 rules_docker_repo(
     name = "io_bazel_rules_docker",
-    commit = "7da0de3d094aae5601c45ae0855b64fb2771cd72",
-    sha256 = "c15ef66698f5d2122a3e875c327d9ecd34a231a9dc4753b9500e70518464cc21",
+    commit = "f929d80c5a4363994968248d87a892b1c2ef61d4",
+    sha256 = "efda18e39a63ee3c1b187b1349f61c48c31322bf84227d319b5dece994380bb6",
 )
 
 load(


### PR DESCRIPTION
There is a build failure/

```
ERROR: /home/runner/.cache/bazel/_bazel_runner/5efb41e3bf38a44ce0efecb45b2f3782/external/io_bazel_rules_docker/container/go/cmd/extract_config/BUILD:19:11: @io_bazel_rules_docker//container/go/cmd/extract_config:go_default_library depends on @com_github_google_go_containerregistry//pkg/v1/tarball:go_default_library in repository @com_github_google_go_containerregistry which failed to fetch. no such package '@com_github_google_go_containerregistry//pkg/v1/tarball': java.io.IOException: Error downloading [https://api.github.com/repos/google/go-containerregistry/tarball/8a2841911ffee4f6892ca0083e89752fb46c48dd] to /home/runner/.cache/bazel/_bazel_runner/5efb41e3bf38a44ce0efecb45b2f3782/external/com_github_google_go_containerregistry/temp16100567993540712573/8a2841911ffee4f6892ca0083e89752fb46c48dd.tar.gz: Checksum was cadb09cb5bcbe00688c73d716d1c9e774d6e4959abec4c425a1b995faf33e964 but wanted 60b9a600affa5667bd444019a4e218b7752d8500cfa923c1ac54ce2f88f773e2
```