### PR TITLE
Qualify bazel references with workspace name in /build.

### DIFF
--- a/build/cloud_spanner_emulator/defs.bzl
+++ b/build/cloud_spanner_emulator/defs.bzl
@@ -24,7 +24,11 @@ def _cloud_spanner_emulator_impl(rctx):
         url = url,
         sha256 = sha256,
     )
-    rctx.template("BUILD.bazel", Label("//build/cloud_spanner_emulator:BUILD.external"), executable = False)
+    rctx.template(
+        "BUILD.bazel",
+        Label("@wfa_measurement_system//build/cloud_spanner_emulator:BUILD.external"),
+        executable = False,
+    )
 
 cloud_spanner_emulator_binaries = repository_rule(
     implementation = _cloud_spanner_emulator_impl,

--- a/build/cue/defs.bzl
+++ b/build/cue/defs.bzl
@@ -75,7 +75,7 @@ def cue_string_field(name, src, identifier, package = None, **kwargs):
         identifier = identifier,
         package = package,
         output = name + ".cue",
-        tool = "//build/cue:gen-cue-string-field",
+        tool = "@wfa_measurement_system//build/cue:gen-cue-string-field",
         **kwargs
     )
 

--- a/build/cue/repo.bzl
+++ b/build/cue/repo.bzl
@@ -24,7 +24,11 @@ def _cue_binaries_impl(rctx):
         url = url,
         sha256 = sha256,
     )
-    rctx.template("BUILD.bazel", Label("//build/cue:BUILD.external"), executable = False)
+    rctx.template(
+        "BUILD.bazel",
+        Label("@wfa_measurement_system//build/cue:BUILD.external"),
+        executable = False,
+    )
 
 cue_binaries = repository_rule(
     implementation = _cue_binaries_impl,

--- a/build/macros.bzl
+++ b/build/macros.bzl
@@ -58,7 +58,7 @@ def kt_jvm_grpc_library(
         name = name,
         exports = [
             internal_name,
-            "//imports/java/io/grpc/stub",
+            "@wfa_measurement_system//imports/java/io/grpc/stub",
         ] + deps,
         visibility = visibility,
         **kwargs

--- a/build/platforms/BUILD.bazel
+++ b/build/platforms/BUILD.bazel
@@ -85,7 +85,9 @@ platform(
     constraint_values = [
         ":glibc_2_27",
     ],
-    parents = ["//third_party/rbe_configs/config:platform"],
+    parents = [
+        "@wfa_measurement_system//third_party/rbe_configs/config:platform",
+    ],
 )
 
 platform(

--- a/build/platforms/constraints.bzl
+++ b/build/platforms/constraints.bzl
@@ -18,8 +18,8 @@ DISTROLESS_JAVA = [
     "@platforms//os:linux",
     "@platforms//cpu:x86_64",
 ] + select({
-    "//build/platforms:glibc_2_23": [],
-    "//build/platforms:glibc_2_27": [],
-    "//build/platforms:glibc_2_28": [],
+    "@wfa_measurement_system//build/platforms:glibc_2_23": [],
+    "@wfa_measurement_system//build/platforms:glibc_2_27": [],
+    "@wfa_measurement_system//build/platforms:glibc_2_28": [],
     "//conditions:default": ["@platforms//:incompatible"],
 })


### PR DESCRIPTION
This allows other repositories to take a dependency on
cross-media-measurement without needing to clone parts of /build.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/world-federation-of-advertisers/cross-media-measurement/46)
<!-- Reviewable:end -->
