### PR TITLE
Simplify and split apart Kingdom filter implementations.

### DIFF
--- a/src/main/kotlin/org/wfanet/measurement/common/Filters.kt
+++ b/src/main/kotlin/org/wfanet/measurement/common/Filters.kt
@@ -31,10 +31,6 @@ data class AllOfClause<V : TerminalClause>(val clauses: Iterable<V>) {
 
 interface TerminalClause
 
-interface AnyOfClause : TerminalClause
-
-interface GreaterThanClause : TerminalClause
-
 fun <V : TerminalClause> allOf(clauses: Iterable<V>): AllOfClause<V> = AllOfClause(clauses)
 
 fun <V : TerminalClause> allOf(vararg clauses: V): AllOfClause<V> =

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/db/ReportFilters.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/db/ReportFilters.kt
@@ -1,4 +1,4 @@
-// Copyright 2020 The Cross-Media Measurement Authors
+// Copyright 2021 The Cross-Media Measurement Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -16,50 +16,13 @@ package org.wfanet.measurement.kingdom.db
 
 import java.time.Instant
 import org.wfanet.measurement.common.AllOfClause
-import org.wfanet.measurement.common.AnyOfClause
-import org.wfanet.measurement.common.GreaterThanClause
 import org.wfanet.measurement.common.TerminalClause
 import org.wfanet.measurement.common.allOf
 import org.wfanet.measurement.common.identity.ExternalId
 import org.wfanet.measurement.internal.kingdom.Report.ReportState
-import org.wfanet.measurement.internal.kingdom.Requisition.RequisitionState
 
-typealias StreamRequisitionsFilter = AllOfClause<StreamRequisitionsClause>
-
+/** Filter type for Reports. */
 typealias StreamReportsFilter = AllOfClause<StreamReportsClause>
-
-/**
- * Creates a filter for Requisitions.
- *
- * The list inputs are treated as disjunctions, and all non-null inputs are conjoined.
- *
- * For example,
- *
- * streamRequisitionsFilter(externalDataProviderIds = listOf(ID1, ID2), createdAfter = SOME_TIME)
- *
- * would match each Requisition that matches both these criteria:
- * - it is associated with either ID1 or ID2, and
- * - it was created after SOME_TIME.
- *
- * @param externalDataProviderIds a list of Data Providers
- * @param externalCampaignIds a list of Campaigns
- * @param states a list of [RequisitionState]s
- * @param createdAfter a time after which Requisitions must be created
- */
-fun streamRequisitionsFilter(
-  externalDataProviderIds: List<ExternalId>? = null,
-  externalCampaignIds: List<ExternalId>? = null,
-  states: List<RequisitionState>? = null,
-  createdAfter: Instant? = null
-): StreamRequisitionsFilter =
-  allOf(
-    listOfNotNull(
-      externalDataProviderIds.ifNotNullOrEmpty(StreamRequisitionsClause::ExternalDataProviderId),
-      externalCampaignIds.ifNotNullOrEmpty(StreamRequisitionsClause::ExternalCampaignId),
-      states.ifNotNullOrEmpty(StreamRequisitionsClause::State),
-      createdAfter?.let(StreamRequisitionsClause::CreatedAfter)
-    )
-  )
 
 /**
  * Creates a filter for Reports.
@@ -97,57 +60,29 @@ fun streamReportsFilter(
     )
   )
 
-/** Base class for Requisition filters. Never directly instantiated. */
-sealed class StreamRequisitionsClause : TerminalClause {
-
-  /** Matching Requisitions must belong to a Data Provider with an external id in [values]. */
-  data class ExternalDataProviderId internal constructor(val values: List<ExternalId>) :
-    StreamRequisitionsClause(), AnyOfClause
-
-  /** Matching Requisitions must belong to a Campaign with an external id in [values]. */
-  data class ExternalCampaignId internal constructor(val values: List<ExternalId>) :
-    StreamRequisitionsClause(), AnyOfClause
-
-  /** Matching Requisitions must have a state among those in [values]. */
-  data class State internal constructor(val values: List<RequisitionState>) :
-    StreamRequisitionsClause(), AnyOfClause
-
-  /** Matching Requisitions must have been created after [value]. */
-  data class CreatedAfter internal constructor(val value: Instant) :
-    StreamRequisitionsClause(), GreaterThanClause
-}
-
 /** Base class for filtering Report streams. Never directly instantiated. */
 sealed class StreamReportsClause : TerminalClause {
 
   /** Matching Reports must belong to an Advertiser with an external id in [values]. */
   data class ExternalAdvertiserId internal constructor(val values: List<ExternalId>) :
-    StreamReportsClause(), AnyOfClause
+    StreamReportsClause()
 
   /** Matching Reports must belong to a ReportConfig with an external id in [values]. */
   data class ExternalReportConfigId internal constructor(val values: List<ExternalId>) :
-    StreamReportsClause(), AnyOfClause
+    StreamReportsClause()
 
   /** Matching Reports must belong to ReportConfigSchedule with an external id in [values]. */
   data class ExternalScheduleId internal constructor(val values: List<ExternalId>) :
-    StreamReportsClause(), AnyOfClause
+    StreamReportsClause()
 
   /** Matching Reports must have a state among those in [values]. */
-  data class State internal constructor(val values: List<ReportState>) :
-    StreamReportsClause(), AnyOfClause
+  data class State internal constructor(val values: List<ReportState>) : StreamReportsClause()
 
   /** Matching Reports must have been updated after [value]. */
-  data class UpdatedAfter internal constructor(val value: Instant) :
-    StreamReportsClause(), GreaterThanClause
+  data class UpdatedAfter internal constructor(val value: Instant) : StreamReportsClause()
 }
 
 /** Returns whether the filter acts on a Report's state. This is useful for forcing indexes. */
 fun StreamReportsFilter.hasStateFilter(): Boolean {
   return clauses.any { it is StreamReportsClause.State }
 }
-
-private fun <T, V> List<T>?.ifNotNullOrEmpty(block: (List<T>) -> V): V? =
-  this?.ifEmpty { null }?.let(block)
-
-private fun <V> Instant?.ifNotNullOrEpoch(block: (Instant) -> V): V? =
-  this?.let { if (it == Instant.EPOCH) null else block(it) }

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/db/RequisitionFilters.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/db/RequisitionFilters.kt
@@ -1,0 +1,77 @@
+// Copyright 2021 The Cross-Media Measurement Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.wfanet.measurement.kingdom.db
+
+import java.time.Instant
+import org.wfanet.measurement.common.AllOfClause
+import org.wfanet.measurement.common.TerminalClause
+import org.wfanet.measurement.common.allOf
+import org.wfanet.measurement.common.identity.ExternalId
+import org.wfanet.measurement.internal.kingdom.Requisition.RequisitionState
+
+/** Filter type for Requisitions. */
+typealias StreamRequisitionsFilter = AllOfClause<StreamRequisitionsClause>
+
+/**
+ * Creates a filter for Requisitions.
+ *
+ * The list inputs are treated as disjunctions, and all non-null inputs are conjoined.
+ *
+ * For example,
+ *
+ * streamRequisitionsFilter(externalDataProviderIds = listOf(ID1, ID2), createdAfter = SOME_TIME)
+ *
+ * would match each Requisition that matches both these criteria:
+ * - it is associated with either ID1 or ID2, and
+ * - it was created after SOME_TIME.
+ *
+ * @param externalDataProviderIds a list of Data Providers
+ * @param externalCampaignIds a list of Campaigns
+ * @param states a list of [RequisitionState]s
+ * @param createdAfter a time after which Requisitions must be created
+ */
+fun streamRequisitionsFilter(
+  externalDataProviderIds: List<ExternalId>? = null,
+  externalCampaignIds: List<ExternalId>? = null,
+  states: List<RequisitionState>? = null,
+  createdAfter: Instant? = null
+): StreamRequisitionsFilter {
+  return allOf(
+    listOfNotNull(
+      externalDataProviderIds.ifNotNullOrEmpty(StreamRequisitionsClause::ExternalDataProviderId),
+      externalCampaignIds.ifNotNullOrEmpty(StreamRequisitionsClause::ExternalCampaignId),
+      states.ifNotNullOrEmpty(StreamRequisitionsClause::State),
+      createdAfter?.let(StreamRequisitionsClause::CreatedAfter)
+    )
+  )
+}
+
+/** Base class for Requisition filters. Never directly instantiated. */
+sealed class StreamRequisitionsClause : TerminalClause {
+  /** Matching Requisitions must belong to a Data Provider with an external id in [values]. */
+  data class ExternalDataProviderId internal constructor(val values: List<ExternalId>) :
+    StreamRequisitionsClause()
+
+  /** Matching Requisitions must belong to a Campaign with an external id in [values]. */
+  data class ExternalCampaignId internal constructor(val values: List<ExternalId>) :
+    StreamRequisitionsClause()
+
+  /** Matching Requisitions must have a state among those in [values]. */
+  data class State internal constructor(val values: List<RequisitionState>) :
+    StreamRequisitionsClause()
+
+  /** Matching Requisitions must have been created after [value]. */
+  data class CreatedAfter internal constructor(val value: Instant) : StreamRequisitionsClause()
+}

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/db/Util.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/db/Util.kt
@@ -1,0 +1,23 @@
+// Copyright 2020 The Cross-Media Measurement Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.wfanet.measurement.kingdom.db
+
+import java.time.Instant
+
+internal fun <T, V> List<T>?.ifNotNullOrEmpty(block: (List<T>) -> V): V? =
+  this?.ifEmpty { null }?.let(block)
+
+internal fun <V> Instant?.ifNotNullOrEpoch(block: (Instant) -> V): V? =
+  this?.let { if (it == Instant.EPOCH) null else block(it) }

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/common/Filters.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/common/Filters.kt
@@ -19,8 +19,6 @@ import com.google.cloud.spanner.Value
 import com.google.protobuf.ProtocolMessageEnum
 import java.time.Instant
 import org.wfanet.measurement.common.AllOfClause
-import org.wfanet.measurement.common.AnyOfClause
-import org.wfanet.measurement.common.GreaterThanClause
 import org.wfanet.measurement.common.TerminalClause
 import org.wfanet.measurement.common.identity.ExternalId
 import org.wfanet.measurement.common.numberAsLong
@@ -28,13 +26,36 @@ import org.wfanet.measurement.gcloud.common.toGcloudTimestamp
 import org.wfanet.measurement.gcloud.spanner.appendClause
 import org.wfanet.measurement.kingdom.db.StreamReportsClause
 import org.wfanet.measurement.kingdom.db.StreamRequisitionsClause
-import org.wfanet.measurement.kingdom.deploy.gcloud.spanner.common.SqlConverter.SqlData
+import org.wfanet.measurement.kingdom.deploy.gcloud.spanner.common.SqlData.ClauseType.ANY_OF
+import org.wfanet.measurement.kingdom.deploy.gcloud.spanner.common.SqlData.ClauseType.GREATER_THAN
 
+/** Represents the information necessary to build a standard WHERE-clause predicate. */
+data class SqlData(
+  val column: String,
+  val clauseType: ClauseType,
+  val spannerValue: Value,
+  val bindName: String = column.replace(".", "_")
+) {
+  enum class ClauseType {
+    ANY_OF,
+    GREATER_THAN
+  }
+}
+
+infix fun String.containedIn(spannerValue: Value): SqlData {
+  return SqlData(this, ANY_OF, spannerValue)
+}
+
+infix fun String.greaterThan(spannerValue: Value): SqlData {
+  return SqlData(this, GREATER_THAN, spannerValue)
+}
+
+/** Converts [V] into SQL. */
 interface SqlConverter<V> {
-  data class SqlData(val fieldName: String, val bindingName: String, val spannerValue: Value)
   fun sqlData(v: V): SqlData
 }
 
+/** Converts an [AllOfClause] to Spanner-compliant SQL. */
 fun <V : TerminalClause> AllOfClause<V>.toSql(
   query: Statement.Builder,
   sqlConverter: SqlConverter<V>
@@ -42,11 +63,11 @@ fun <V : TerminalClause> AllOfClause<V>.toSql(
   for ((i, clause) in clauses.withIndex()) {
     if (i > 0) query.appendClause("  AND")
     val sqlData = sqlConverter.sqlData(clause)
-    val fieldName = sqlData.fieldName
-    val bindName = sqlData.bindingName
-    when (clause) {
-      is AnyOfClause -> query.append("($fieldName IN UNNEST(@$bindName))")
-      is GreaterThanClause -> query.append("($fieldName > @$bindName)")
+    val fieldName = sqlData.column
+    val bindName = sqlData.bindName
+    when (sqlData.clauseType) {
+      ANY_OF -> query.append("($fieldName IN UNNEST(@$bindName))")
+      GREATER_THAN -> query.append("($fieldName > @$bindName)")
     }
     query.bind(bindName).to(sqlData.spannerValue)
   }
@@ -56,21 +77,12 @@ object StreamRequisitionsFilterSqlConverter : SqlConverter<StreamRequisitionsCla
   override fun sqlData(v: StreamRequisitionsClause): SqlData =
     when (v) {
       is StreamRequisitionsClause.ExternalDataProviderId ->
-        SqlData(
-          "DataProviders.ExternalDataProviderId",
-          "external_data_provider_id",
-          externalIdValueArray(v.values)
-        )
+        "DataProviders.ExternalDataProviderId" containedIn externalIdValueArray(v.values)
       is StreamRequisitionsClause.ExternalCampaignId ->
-        SqlData(
-          "Campaigns.ExternalCampaignId",
-          "external_campaignId",
-          externalIdValueArray(v.values)
-        )
+        "Campaigns.ExternalCampaignId" containedIn externalIdValueArray(v.values)
       is StreamRequisitionsClause.CreatedAfter ->
-        SqlData("Requisitions.CreateTime", "create_time", timestampValue(v.value))
-      is StreamRequisitionsClause.State ->
-        SqlData("Requisitions.State", "state", enumValueArray(v.values))
+        "Requisitions.CreateTime" greaterThan timestampValue(v.value)
+      is StreamRequisitionsClause.State -> "Requisitions.State" containedIn enumValueArray(v.values)
     }
 }
 
@@ -78,33 +90,25 @@ object StreamReportsFilterSqlConverter : SqlConverter<StreamReportsClause> {
   override fun sqlData(v: StreamReportsClause): SqlData =
     when (v) {
       is StreamReportsClause.ExternalAdvertiserId ->
-        SqlData(
-          "Advertisers.ExternalAdvertiserId",
-          "external_advertiser_id",
-          externalIdValueArray(v.values)
-        )
+        "Advertisers.ExternalAdvertiserId" containedIn externalIdValueArray(v.values)
       is StreamReportsClause.ExternalReportConfigId ->
-        SqlData(
-          "ReportConfigs.ExternalReportConfigId",
-          "external_report_config_id",
-          externalIdValueArray(v.values)
-        )
+        "ReportConfigs.ExternalReportConfigId" containedIn externalIdValueArray(v.values)
       is StreamReportsClause.ExternalScheduleId ->
-        SqlData(
-          "ReportConfigSchedules.ExternalScheduleId",
-          "external_schedule_id",
-          externalIdValueArray(v.values)
-        )
-      is StreamReportsClause.State -> SqlData("Reports.State", "state", enumValueArray(v.values))
+        "ReportConfigSchedules.ExternalScheduleId" containedIn externalIdValueArray(v.values)
+      is StreamReportsClause.State -> "Reports.State" containedIn enumValueArray(v.values)
       is StreamReportsClause.UpdatedAfter ->
-        SqlData("Reports.UpdateTime", "update_time", timestampValue(v.value))
+        "Reports.UpdateTime" greaterThan timestampValue(v.value)
     }
 }
 
-private fun externalIdValueArray(ids: Iterable<ExternalId>): Value =
-  Value.int64Array(ids.map(ExternalId::value))
+private fun externalIdValueArray(ids: Iterable<ExternalId>): Value {
+  return Value.int64Array(ids.map { it.value })
+}
 
-private fun enumValueArray(enums: Iterable<ProtocolMessageEnum>): Value =
-  Value.int64Array(enums.map { it.numberAsLong })
+private fun enumValueArray(enums: Iterable<ProtocolMessageEnum>): Value {
+  return Value.int64Array(enums.map { it.numberAsLong })
+}
 
-private fun timestampValue(time: Instant): Value = Value.timestamp(time.toGcloudTimestamp())
+private fun timestampValue(time: Instant): Value {
+  return Value.timestamp(time.toGcloudTimestamp())
+}


### PR DESCRIPTION
This is in advance of adding the data layer for Panel Match entities.

- Moves generic filter definitions to their own files
- Gets rid of the generic concept of AnyOf and GreaterThan filters
- Adds a bit of syntactic sugar to make things easier to read

See issue #3.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/world-federation-of-advertisers/cross-media-measurement/47)
<!-- Reviewable:end -->
