### PR TITLE
Update cross-media-measurement-api version.

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -272,9 +272,9 @@ load("//build/wfa:repositories.bzl", "wfa_repo_archive")
 
 wfa_repo_archive(
     name = "wfa_measurement_proto",
-    commit = "f056bffb50e0ff4383d49b2570978aae92682895",
+    commit = "ab647fffd78f29769611f05ef131ec1f1feed820",
     repo = "cross-media-measurement-api",
-    sha256 = "a6dbe65abcdc25c78fa92725df4a4e3d25bf63cdfe9b66bc009cfa74252f2955"
+    sha256 = "c7d87a438a446ebeacdcae8bcfed270c513ae5c5d26bccd36fb179d47e7d3365",
 )
 
 wfa_repo_archive(

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/service/api/v2alpha/ExchangeStepAttemptsService.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/service/api/v2alpha/ExchangeStepAttemptsService.kt
@@ -18,7 +18,6 @@ import com.google.type.Date
 import io.grpc.Status
 import java.time.LocalDate
 import org.wfanet.measurement.api.v2alpha.AppendLogEntryRequest
-import org.wfanet.measurement.api.v2alpha.CreateExchangeStepAttemptRequest
 import org.wfanet.measurement.api.v2alpha.ExchangeStepAttempt
 import org.wfanet.measurement.api.v2alpha.ExchangeStepAttemptsGrpcKt.ExchangeStepAttemptsCoroutineImplBase
 import org.wfanet.measurement.api.v2alpha.FinishExchangeStepAttemptRequest
@@ -29,7 +28,6 @@ import org.wfanet.measurement.common.grpc.failGrpc
 import org.wfanet.measurement.common.identity.apiIdToExternalId
 import org.wfanet.measurement.common.identity.externalIdToApiId
 import org.wfanet.measurement.internal.kingdom.AppendLogEntryRequest as InternalAppendLogEntryRequest
-import org.wfanet.measurement.internal.kingdom.CreateExchangeStepAttemptRequest as InternalCreateExchangeStepAttemptRequest
 import org.wfanet.measurement.internal.kingdom.ExchangeStepAttempt as InternalExchangeStepAttempt
 import org.wfanet.measurement.internal.kingdom.ExchangeStepAttemptDetails
 import org.wfanet.measurement.internal.kingdom.ExchangeStepAttemptsGrpcKt.ExchangeStepAttemptsCoroutineStub as InternalExchangeStepAttemptsCoroutineStub
@@ -55,30 +53,6 @@ class ExchangeStepAttemptsService(
         }
         .build()
     val response = internalExchangeStepAttempts.appendLogEntry(internalRequest)
-    return response.toV2Alpha()
-  }
-
-  override suspend fun createExchangeStepAttempt(
-    request: CreateExchangeStepAttemptRequest
-  ): ExchangeStepAttempt {
-    val sanitizedExchangeStepAttempt =
-      request
-        .exchangeStepAttempt
-        .toBuilder()
-        .apply {
-          keyBuilder.clearExchangeStepAttemptId()
-          clearAttemptNumber()
-          state = ExchangeStepAttempt.State.ACTIVE
-          clearStartTime()
-          clearUpdateTime()
-        }
-        .build()
-
-    val internalRequest =
-      InternalCreateExchangeStepAttemptRequest.newBuilder()
-        .setExchangeStepAttempt(sanitizedExchangeStepAttempt.toInternal())
-        .build()
-    val response = internalExchangeStepAttempts.createExchangeStepAttempt(internalRequest)
     return response.toV2Alpha()
   }
 

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/service/api/v2alpha/ExchangeStepsService.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/service/api/v2alpha/ExchangeStepsService.kt
@@ -14,20 +14,20 @@
 
 package org.wfanet.measurement.kingdom.service.api.v2alpha
 
+import org.wfanet.measurement.api.v2alpha.ClaimReadyExchangeStepRequest
+import org.wfanet.measurement.api.v2alpha.ClaimReadyExchangeStepResponse
 import org.wfanet.measurement.api.v2alpha.ExchangeStep
 import org.wfanet.measurement.api.v2alpha.ExchangeStepsGrpcKt.ExchangeStepsCoroutineImplBase
-import org.wfanet.measurement.api.v2alpha.FindReadyExchangeStepRequest
-import org.wfanet.measurement.api.v2alpha.FindReadyExchangeStepResponse
 import org.wfanet.measurement.api.v2alpha.GetExchangeStepRequest
 
 class ExchangeStepsService : ExchangeStepsCoroutineImplBase() {
-  override suspend fun getExchangeStep(request: GetExchangeStepRequest): ExchangeStep {
+  override suspend fun claimReadyExchangeStep(
+    request: ClaimReadyExchangeStepRequest
+  ): ClaimReadyExchangeStepResponse {
     TODO("world-federation-of-advertisers/cross-media-measurement#3: implement this")
   }
 
-  override suspend fun findReadyExchangeStep(
-    request: FindReadyExchangeStepRequest
-  ): FindReadyExchangeStepResponse {
+  override suspend fun getExchangeStep(request: GetExchangeStepRequest): ExchangeStep {
     TODO("world-federation-of-advertisers/cross-media-measurement#3: implement this")
   }
 }

--- a/src/main/proto/wfa/measurement/internal/kingdom/exchange_step_attempts_service.proto
+++ b/src/main/proto/wfa/measurement/internal/kingdom/exchange_step_attempts_service.proto
@@ -25,12 +25,6 @@ option java_multiple_files = true;
 
 // Internal service for managing `ExchangeStepAttempt` resources.
 service ExchangeStepAttempts {
-  // Creates an `ExchangeStepAttempt`.
-  //
-  // This should not specify the attempt number.
-  rpc CreateExchangeStepAttempt(CreateExchangeStepAttemptRequest)
-      returns (ExchangeStepAttempt);
-
   // Streams `ExchangeStepAttempt`s.
   rpc StreamExchangeStepAttempts(StreamExchangeStepAttemptsRequest)
       returns (stream ExchangeStepAttempt);

--- a/src/test/kotlin/org/wfanet/measurement/kingdom/service/api/v2alpha/ExchangeStepAttemptsServiceTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/kingdom/service/api/v2alpha/ExchangeStepAttemptsServiceTest.kt
@@ -27,14 +27,12 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 import org.wfanet.measurement.api.v2alpha.AppendLogEntryRequest
-import org.wfanet.measurement.api.v2alpha.CreateExchangeStepAttemptRequest
 import org.wfanet.measurement.api.v2alpha.ExchangeStepAttempt
 import org.wfanet.measurement.api.v2alpha.FinishExchangeStepAttemptRequest
 import org.wfanet.measurement.common.grpc.testing.GrpcTestServerRule
 import org.wfanet.measurement.common.identity.externalIdToApiId
 import org.wfanet.measurement.common.testing.verifyProtoArgument
 import org.wfanet.measurement.internal.kingdom.AppendLogEntryRequest as InternalAppendLogEntryRequest
-import org.wfanet.measurement.internal.kingdom.CreateExchangeStepAttemptRequest as InternalCreateExchangeStepAttemptRequest
 import org.wfanet.measurement.internal.kingdom.ExchangeStepAttempt as InternalExchangeStepAttempt
 import org.wfanet.measurement.internal.kingdom.ExchangeStepAttemptsGrpcKt.ExchangeStepAttemptsCoroutineImplBase as InternalExchangeStepAttempts
 import org.wfanet.measurement.internal.kingdom.ExchangeStepAttemptsGrpcKt.ExchangeStepAttemptsCoroutineStub
@@ -107,7 +105,6 @@ class ExchangeStepAttemptsServiceTest {
   private val internalService: InternalExchangeStepAttempts =
     mock(useConstructor = UseConstructor.parameterless()) {
       onBlocking { appendLogEntry(any()) }.thenReturn(INTERNAL_EXCHANGE_STEP_ATTEMPT)
-      onBlocking { createExchangeStepAttempt(any()) }.thenReturn(INTERNAL_EXCHANGE_STEP_ATTEMPT)
       onBlocking { finishExchangeStepAttempt(any()) }.thenReturn(INTERNAL_EXCHANGE_STEP_ATTEMPT)
     }
 
@@ -137,68 +134,6 @@ class ExchangeStepAttemptsServiceTest {
             stepIndex = STEP_INDEX
             attemptNumber = ATTEMPT_NUMBER
             addAllDebugLogEntries(INTERNAL_EXCHANGE_STEP_ATTEMPT.details.debugLogEntriesList)
-          }
-          .build()
-      )
-  }
-
-  @Test
-  fun `createExchangeStepAttempt with minimal request`() {
-    val request =
-      CreateExchangeStepAttemptRequest.newBuilder()
-        .apply { exchangeStepAttemptBuilder.apply { key = EXCHANGE_STEP_ATTEMPT.key } }
-        .build()
-
-    assertThat(runBlocking { service.createExchangeStepAttempt(request) })
-      .isEqualTo(EXCHANGE_STEP_ATTEMPT)
-
-    verifyProtoArgument(internalService, InternalExchangeStepAttempts::createExchangeStepAttempt)
-      .ignoringFieldAbsence()
-      .isEqualTo(
-        InternalCreateExchangeStepAttemptRequest.newBuilder()
-          .apply {
-            exchangeStepAttemptBuilder.apply {
-              externalRecurringExchangeId = RECURRING_EXCHANGE_ID
-              date = INTERNAL_EXCHANGE_STEP_ATTEMPT.date
-              stepIndex = STEP_INDEX
-              state = InternalExchangeStepAttempt.State.ACTIVE
-            }
-          }
-          .build()
-      )
-  }
-
-  @Test
-  fun `createExchangeStepAttempt with extra fields set`() {
-    val request =
-      CreateExchangeStepAttemptRequest.newBuilder()
-        .apply {
-          exchangeStepAttemptBuilder.apply {
-            key = EXCHANGE_STEP_ATTEMPT.key
-            state = ExchangeStepAttempt.State.FAILED
-            attemptNumber = 12345
-            addAllDebugLogEntries(EXCHANGE_STEP_ATTEMPT.debugLogEntriesList)
-          }
-        }
-        .build()
-
-    assertThat(runBlocking { service.createExchangeStepAttempt(request) })
-      .isEqualTo(EXCHANGE_STEP_ATTEMPT)
-
-    verifyProtoArgument(internalService, InternalExchangeStepAttempts::createExchangeStepAttempt)
-      .ignoringFieldAbsence()
-      .isEqualTo(
-        InternalCreateExchangeStepAttemptRequest.newBuilder()
-          .apply {
-            exchangeStepAttemptBuilder.apply {
-              externalRecurringExchangeId = RECURRING_EXCHANGE_ID
-              date = INTERNAL_EXCHANGE_STEP_ATTEMPT.date
-              stepIndex = STEP_INDEX
-              state = InternalExchangeStepAttempt.State.ACTIVE
-              detailsBuilder.addAllDebugLogEntries(
-                INTERNAL_EXCHANGE_STEP_ATTEMPT.details.debugLogEntriesList
-              )
-            }
           }
           .build()
       )

--- a/src/test/kotlin/org/wfanet/measurement/kingdom/service/api/v2alpha/ExchangeStepsServiceTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/kingdom/service/api/v2alpha/ExchangeStepsServiceTest.kt
@@ -19,7 +19,7 @@ import kotlinx.coroutines.runBlocking
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
-import org.wfanet.measurement.api.v2alpha.FindReadyExchangeStepRequest
+import org.wfanet.measurement.api.v2alpha.ClaimReadyExchangeStepRequest
 import org.wfanet.measurement.api.v2alpha.GetExchangeStepRequest
 
 @RunWith(JUnit4::class)
@@ -36,10 +36,10 @@ class ExchangeStepsServiceTest {
     }
 
   @Test
-  fun findReadyExchangeStep() =
+  fun claimReadyExchangeStep() =
     runBlocking<Unit> {
       assertFailsWith(NotImplementedError::class) {
-        service.findReadyExchangeStep(FindReadyExchangeStepRequest.getDefaultInstance())
+        service.claimReadyExchangeStep(ClaimReadyExchangeStepRequest.getDefaultInstance())
       }
     }
 }


### PR DESCRIPTION
This also moves the internal ExchangeStepAttempts service to be in
parity with the public API version.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/world-federation-of-advertisers/cross-media-measurement/51)
<!-- Reviewable:end -->
