### PR TITLE
Change data type of external_duchy_id to string.

### DIFF
--- a/src/main/proto/wfa/measurement/internal/kingdom/computation_participant.proto
+++ b/src/main/proto/wfa/measurement/internal/kingdom/computation_participant.proto
@@ -24,7 +24,7 @@ option java_multiple_files = true;
 message ComputationParticipant {
   fixed64 external_measurement_consumer_id = 1;
   fixed64 external_measurement_id = 2;
-  fixed64 external_duchy_id = 3;
+  string external_duchy_id = 3;
 
   fixed64 external_duchy_certificate_id = 4;
 

--- a/src/main/proto/wfa/measurement/internal/kingdom/measurement_log_entry.proto
+++ b/src/main/proto/wfa/measurement/internal/kingdom/measurement_log_entry.proto
@@ -49,7 +49,7 @@ message MeasurementLogEntry {
   }
 
   message DuchyDetails {
-    fixed64 external_duchy_id = 1;
+    string external_duchy_id = 1;
     // External ID for the entry in the system API.
     fixed64 external_computation_log_entry_id = 2;
 


### PR DESCRIPTION
We expect a small set of well-known Duchies, so we can use human-readable strings for their external IDs.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/world-federation-of-advertisers/cross-media-measurement/62)
<!-- Reviewable:end -->
