### PR TITLE
Copy util matchers from Any Sketch repo.

### DIFF
--- a/src/test/cc/testutil/BUILD.bazel
+++ b/src/test/cc/testutil/BUILD.bazel
@@ -17,6 +17,8 @@ cc_library(
     testonly = True,
     hdrs = ["matchers.h"],
     deps = [
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/status:statusor",
         "@com_google_protobuf//:protobuf",
         "@googletest//:gtest",
     ],

--- a/src/test/cc/testutil/matchers.h
+++ b/src/test/cc/testutil/matchers.h
@@ -15,11 +15,33 @@
 #ifndef SRC_TEST_CC_TESTUTIL_MATCHERS_H_
 #define SRC_TEST_CC_TESTUTIL_MATCHERS_H_
 
+#include "absl/status/status.h"
+#include "absl/status/statusor.h"
 #include "gmock/gmock.h"
 #include "google/protobuf/util/message_differencer.h"
 #include "gtest/gtest.h"
 
 namespace wfa {
+
+MATCHER(IsOk, "") {
+  return testing::ExplainMatchResult(true, arg.ok(), result_listener);
+}
+
+MATCHER(IsNotOk, "") {
+  return testing::ExplainMatchResult(testing::Not(IsOk()), arg,
+                                     result_listener);
+}
+
+MATCHER_P(IsOkAndHolds, value, "") {
+  if (arg.ok()) {
+    return testing::ExplainMatchResult(value, arg.value(), result_listener);
+  }
+
+  *result_listener << "expected OK status instead of error code "
+                   << absl::StatusCodeToString(arg.status().code())
+                   << " and message " << arg.status();
+  return false;
+}
 
 MATCHER_P2(StatusIs, code, message, "") {
   if (arg.code() != code) {


### PR DESCRIPTION
Source: https://github.com/world-federation-of-advertisers/any-sketch/blob/main/src/test/cc/testutil/matchers.h.
VID code requires util matchers in both cross-media-measurement and
any-sketch repos, but the file names conflict. For short term solution, we
will have all the required util matchers for VID in cross-media-measurement repo.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/world-federation-of-advertisers/cross-media-measurement/67)
<!-- Reviewable:end -->
