### PR TITLE
Add TLS support for gRPC servers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 # Bazel convenience symlinks.
-/bazel-*/
+bazel-*
 
 # Bazel IntelliJ projects.
 .ijwb
@@ -7,8 +7,3 @@
 # IntelliJ projects.
 .idea/
 *.iml
-
-.DS_Store
-cddignore
-lib/
-bazel-*

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,8 @@
 # IntelliJ projects.
 .idea/
 *.iml
+
+.DS_Store
+cddignore
+lib/
+bazel-*

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 # Bazel convenience symlinks.
-bazel-*
+/bazel-*
 
 # Bazel IntelliJ projects.
 .ijwb

--- a/AUTHORS
+++ b/AUTHORS
@@ -7,3 +7,4 @@
 
 Google LLC
 Facebook, Inc.
+Amazon.com Services LLC

--- a/src/main/kotlin/org/wfanet/measurement/common/grpc/BUILD.bazel
+++ b/src/main/kotlin/org/wfanet/measurement/common/grpc/BUILD.bazel
@@ -6,9 +6,11 @@ kt_jvm_library(
     name = "grpc",
     srcs = glob(["*.kt"]),
     deps = [
+        "//imports/java/com/google/protobuf",
         "//imports/java/io/grpc:api",
         "//imports/java/io/grpc/netty",
         "//imports/java/io/grpc/services:health",
+        "//imports/java/picocli",
         "//src/main/kotlin/org/wfanet/measurement/common",
         "//src/main/kotlin/org/wfanet/measurement/common/crypto:signing_certs",
         "//src/main/kotlin/org/wfanet/measurement/common/throttler",

--- a/src/main/kotlin/org/wfanet/measurement/common/grpc/Channel.kt
+++ b/src/main/kotlin/org/wfanet/measurement/common/grpc/Channel.kt
@@ -30,6 +30,10 @@ fun buildChannel(target: String): ManagedChannel {
     .build()
 }
 
+fun buildTlsChannel(target: String): ManagedChannel {
+  return ManagedChannelBuilder.forTarget(target).build()
+}
+
 /**
  * Builds a [ManagedChannel] for the specified target.
  *

--- a/src/main/kotlin/org/wfanet/measurement/common/grpc/Channel.kt
+++ b/src/main/kotlin/org/wfanet/measurement/common/grpc/Channel.kt
@@ -23,14 +23,14 @@ import java.time.Duration
  *
  * @param target the URI or authority string for the target server
  */
-fun buildChannel(target: String): ManagedChannel {
+fun buildPlaintextChannel(target: String): ManagedChannel {
   return ManagedChannelBuilder.forTarget(target)
-    // TODO: Remove this once TLS has been configured for our servers.
+    // TODO: Add assertion to ensure it's never called in a prod env
     .usePlaintext()
     .build()
 }
 
-fun buildTlsChannel(target: String): ManagedChannel {
+fun buildChannel(target: String): ManagedChannel {
   return ManagedChannelBuilder.forTarget(target).build()
 }
 

--- a/src/main/kotlin/org/wfanet/measurement/common/grpc/CommonServer.kt
+++ b/src/main/kotlin/org/wfanet/measurement/common/grpc/CommonServer.kt
@@ -89,7 +89,7 @@ private constructor(
     var port by Delegates.notNull<Int>()
       private set
 
-    @set:CommandLine.Option(
+    @CommandLine.Option(
       names = ["--tls-cert-file"],
       description = ["TLS cert file."],
       defaultValue = ""
@@ -97,7 +97,7 @@ private constructor(
     lateinit var certFile: File
       private set
 
-    @set:CommandLine.Option(
+    @CommandLine.Option(
       names = ["--tls-key-file"],
       description = ["TLS key file."],
       defaultValue = ""
@@ -105,9 +105,9 @@ private constructor(
     lateinit var privateKeyFile: File
       private set
 
-    @set:CommandLine.Option(
+    @CommandLine.Option(
       names = ["--cert-collection-file"],
-      description = ["cert collection file."],
+      description = ["Cert collection file."],
       defaultValue = ""
     )
     lateinit var certCollectionFile: File
@@ -115,7 +115,7 @@ private constructor(
 
     @set:CommandLine.Option(
       names = ["--require-client-auth"],
-      description = ["require client auth"],
+      description = ["Require client auth"],
       defaultValue = "true"
     )
     var clientAuthRequired by Delegates.notNull<Boolean>()
@@ -173,8 +173,7 @@ private constructor(
       nameForLogging: String,
       services: Iterable<ServerServiceDefinition>
     ): CommonServer {
-      var certs: SigningCerts? = null
-      certs =
+      val certs =
         SigningCerts.fromPemFiles(
           certificateFile = flags.certFile,
           privateKeyFile = flags.privateKeyFile,

--- a/src/main/kotlin/org/wfanet/measurement/common/grpc/CommonServer.kt
+++ b/src/main/kotlin/org/wfanet/measurement/common/grpc/CommonServer.kt
@@ -94,7 +94,7 @@ private constructor(
       description = ["TLS cert file."],
       defaultValue = ""
     )
-    var certFile by Delegates.notNull<File>()
+    lateinit var certFile: File
       private set
 
     @set:CommandLine.Option(
@@ -102,7 +102,7 @@ private constructor(
       description = ["TLS key file."],
       defaultValue = ""
     )
-    var privateKeyFile by Delegates.notNull<File>()
+    lateinit var privateKeyFile: File
       private set
 
     @set:CommandLine.Option(
@@ -110,13 +110,13 @@ private constructor(
       description = ["cert collection file."],
       defaultValue = ""
     )
-    var certCollectionFile by Delegates.notNull<File>()
+    lateinit var certCollectionFile: File
       private set
 
     @set:CommandLine.Option(
       names = ["--require-client-auth"],
       description = ["require client auth"],
-      defaultValue = "false"
+      defaultValue = "true"
     )
     var clientAuthRequired by Delegates.notNull<Boolean>()
       private set
@@ -136,7 +136,7 @@ private constructor(
     /** Constructs a [CommonServer] from parameters. */
     fun fromParameters(
       port: Int,
-      debugVerboseGrpcLogging: Boolean,
+      verboseGrpcLogging: Boolean,
       certs: SigningCerts?,
       clientAuth: ClientAuth,
       nameForLogging: String,
@@ -145,7 +145,7 @@ private constructor(
       return CommonServer(
         nameForLogging,
         port,
-        services.run { if (debugVerboseGrpcLogging) map { it.withVerboseLogging() } else this },
+        services.run { if (verboseGrpcLogging) map { it.withVerboseLogging() } else this },
         certs?.toServerTlsContext(clientAuth)
       )
     }
@@ -174,17 +174,12 @@ private constructor(
       services: Iterable<ServerServiceDefinition>
     ): CommonServer {
       var certs: SigningCerts? = null
-      if (flags.certFile.exists() &&
-          flags.privateKeyFile.exists() &&
-          flags.certCollectionFile.exists()
-      ) {
-        certs =
-          SigningCerts.fromPemFiles(
-            certificateFile = flags.certFile,
-            privateKeyFile = flags.privateKeyFile,
-            trustedCertCollectionFile = flags.certCollectionFile
-          )
-      }
+      certs =
+        SigningCerts.fromPemFiles(
+          certificateFile = flags.certFile,
+          privateKeyFile = flags.privateKeyFile,
+          trustedCertCollectionFile = flags.certCollectionFile
+        )
 
       return fromParameters(
         flags.port,

--- a/src/main/kotlin/org/wfanet/measurement/common/grpc/CommonServer.kt
+++ b/src/main/kotlin/org/wfanet/measurement/common/grpc/CommonServer.kt
@@ -150,23 +150,6 @@ private constructor(
       )
     }
 
-    fun fromParameters(
-      port: Int,
-      debugVerboseGrpcLogging: Boolean,
-      certs: SigningCerts?,
-      clientAuth: ClientAuth,
-      nameForLogging: String,
-      vararg services: ServerServiceDefinition
-    ): CommonServer =
-      fromParameters(
-        port,
-        debugVerboseGrpcLogging,
-        certs,
-        clientAuth,
-        nameForLogging,
-        services.asIterable()
-      )
-
     @JvmName("fromFlagsServiceDefinition")
     fun fromFlags(
       flags: Flags,

--- a/src/main/kotlin/org/wfanet/measurement/common/identity/BUILD.bazel
+++ b/src/main/kotlin/org/wfanet/measurement/common/identity/BUILD.bazel
@@ -13,5 +13,6 @@ kt_jvm_library(
         "//imports/java/io/grpc/stub",
         "//imports/java/picocli",
         "//src/main/kotlin/org/wfanet/measurement/common",
+        "//src/main/kotlin/org/wfanet/measurement/common/grpc",
     ],
 )

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/common/server/KingdomApiServer.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/common/server/KingdomApiServer.kt
@@ -18,7 +18,7 @@ import io.grpc.BindableService
 import io.grpc.Channel
 import kotlin.properties.Delegates
 import org.wfanet.measurement.common.grpc.CommonServer
-import org.wfanet.measurement.common.grpc.buildChannel
+import org.wfanet.measurement.common.grpc.buildTlsChannel
 import org.wfanet.measurement.common.grpc.withVerboseLogging
 import org.wfanet.measurement.common.identity.DuchyIdFlags
 import org.wfanet.measurement.common.identity.DuchyIds
@@ -51,7 +51,7 @@ fun runKingdomApiServer(
   DuchyIds.setDuchyIdsFromFlags(duchyIdFlags)
 
   val channel: Channel =
-    buildChannel(kingdomApiServerFlags.internalApiTarget)
+    buildTlsChannel(kingdomApiServerFlags.internalApiTarget)
       .withVerboseLogging(kingdomApiServerFlags.debugVerboseGrpcClientLogging)
 
   val service = serviceFactory(channel).withDuchyIdentities()

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/common/server/KingdomApiServer.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/common/server/KingdomApiServer.kt
@@ -18,7 +18,7 @@ import io.grpc.BindableService
 import io.grpc.Channel
 import kotlin.properties.Delegates
 import org.wfanet.measurement.common.grpc.CommonServer
-import org.wfanet.measurement.common.grpc.buildTlsChannel
+import org.wfanet.measurement.common.grpc.buildChannel
 import org.wfanet.measurement.common.grpc.withVerboseLogging
 import org.wfanet.measurement.common.identity.DuchyIdFlags
 import org.wfanet.measurement.common.identity.DuchyIds
@@ -51,7 +51,7 @@ fun runKingdomApiServer(
   DuchyIds.setDuchyIdsFromFlags(duchyIdFlags)
 
   val channel: Channel =
-    buildTlsChannel(kingdomApiServerFlags.internalApiTarget)
+    buildChannel(kingdomApiServerFlags.internalApiTarget)
       .withVerboseLogging(kingdomApiServerFlags.debugVerboseGrpcClientLogging)
 
   val service = serviceFactory(channel).withDuchyIdentities()

--- a/src/test/kotlin/org/wfanet/measurement/common/grpc/TransportSecurityTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/common/grpc/TransportSecurityTest.kt
@@ -20,7 +20,6 @@ import io.grpc.health.v1.HealthCheckRequest
 import io.grpc.health.v1.HealthCheckResponse
 import io.grpc.health.v1.HealthGrpcKt.HealthCoroutineStub
 import io.grpc.netty.NettyChannelBuilder
-import io.grpc.netty.NettyServerBuilder
 import io.grpc.services.HealthStatusManager
 import io.grpc.testing.GrpcCleanupRule
 import io.netty.handler.ssl.ClientAuth
@@ -41,6 +40,7 @@ private const val ALGORITHM = "ec"
 private const val CURVE = "prime256v1"
 private const val SERVICE = "DummyService"
 private const val HOSTNAME = "localhost"
+private const val PORT = 8080
 private const val SUBJECT_ALT_NAME_EXT = "subjectAltName=DNS:$HOSTNAME,IP:127.0.0.1"
 
 @RunWith(JUnit4::class)
@@ -64,24 +64,30 @@ class TransportSecurityTest {
 
   @get:Rule val grpcCleanup = GrpcCleanupRule()
 
-  private fun startServer(clientAuth: ClientAuth): Server {
+  private fun startCommonServer(clientAuth: ClientAuth): Server {
+
     val server =
-      grpcCleanup
-        .register(
-          NettyServerBuilder.forPort(0)
-            .sslContext(serverCerts.toServerTlsContext(clientAuth))
-            .addService(healthStatusManager.healthService.withVerboseLogging())
-            .build()
+      CommonServer.fromParameters(
+          PORT,
+          true,
+          tempDir.resolve("server.pem").toString(),
+          tempDir.resolve("server.key").toString(),
+          tempDir.resolve("client-root.pem").toString(),
+          clientAuth,
+          "test",
+          healthStatusManager.healthService.withVerboseLogging()
         )
         .start()
     healthStatusManager.setStatus(SERVICE, HealthCheckResponse.ServingStatus.SERVING)
 
-    return server
+    grpcCleanup.register(server.server)
+
+    return server.server
   }
 
   @Test
   fun `TLS server valid`() {
-    val server = startServer(ClientAuth.NONE)
+    startCommonServer(ClientAuth.NONE)
 
     // Verify server using openssl s_client.
     runBlocking {
@@ -89,7 +95,7 @@ class TransportSecurityTest {
         "openssl",
         "s_client",
         "-connect",
-        "$HOSTNAME:${server.port}",
+        "$HOSTNAME:$PORT",
         "-verify_return_error",
         "-CAfile",
         "server-root.pem",
@@ -102,7 +108,7 @@ class TransportSecurityTest {
 
   @Test
   fun `mTLS server valid`() {
-    val server = startServer(ClientAuth.REQUIRE)
+    startCommonServer(ClientAuth.REQUIRE)
 
     // Verify server using openssl s_client.
     runBlocking {
@@ -110,7 +116,7 @@ class TransportSecurityTest {
         "openssl",
         "s_client",
         "-connect",
-        "$HOSTNAME:${server.port}",
+        "$HOSTNAME:$PORT",
         "-verify_return_error",
         "-cert",
         "client.pem",
@@ -127,10 +133,12 @@ class TransportSecurityTest {
 
   @Test
   fun `TLS RPC succeeds`() {
-    val server = startServer(ClientAuth.NONE)
+
+    startCommonServer(ClientAuth.NONE)
+
     val channel =
       grpcCleanup.register(
-        NettyChannelBuilder.forAddress(HOSTNAME, server.port)
+        NettyChannelBuilder.forAddress(HOSTNAME, PORT)
           .sslContext(clientCerts.toClientTlsContext())
           .build()
       )
@@ -145,10 +153,10 @@ class TransportSecurityTest {
 
   @Test
   fun `mTLS RPC succeeds`() {
-    val server = startServer(ClientAuth.REQUIRE)
+    startCommonServer(ClientAuth.REQUIRE)
     val channel =
       grpcCleanup.register(
-        NettyChannelBuilder.forAddress(HOSTNAME, server.port)
+        NettyChannelBuilder.forAddress(HOSTNAME, PORT)
           .sslContext(clientCerts.toClientTlsContext())
           .build()
       )

--- a/src/test/kotlin/org/wfanet/measurement/common/grpc/TransportSecurityTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/common/grpc/TransportSecurityTest.kt
@@ -73,7 +73,7 @@ class TransportSecurityTest {
           serverCerts,
           clientAuth,
           "test",
-          healthStatusManager.healthService.withVerboseLogging()
+          listOf(healthStatusManager.healthService.withVerboseLogging())
         )
         .start()
     healthStatusManager.setStatus(SERVICE, HealthCheckResponse.ServingStatus.SERVING)

--- a/src/test/kotlin/org/wfanet/measurement/common/grpc/TransportSecurityTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/common/grpc/TransportSecurityTest.kt
@@ -70,9 +70,7 @@ class TransportSecurityTest {
       CommonServer.fromParameters(
           PORT,
           true,
-          tempDir.resolve("server.pem").toString(),
-          tempDir.resolve("server.key").toString(),
-          tempDir.resolve("client-root.pem").toString(),
+          serverCerts,
           clientAuth,
           "test",
           healthStatusManager.healthService.withVerboseLogging()


### PR DESCRIPTION
Added support for TLS for the gRPC servers by providing command line flags for configuring cert & key files.


<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/world-federation-of-advertisers/cross-media-measurement/77)
<!-- Reviewable:end -->
