### PR TITLE
Define Certificate message type for Kingdom internal services.

### DIFF
--- a/src/main/proto/wfa/measurement/internal/kingdom/BUILD.bazel
+++ b/src/main/proto/wfa/measurement/internal/kingdom/BUILD.bazel
@@ -26,6 +26,13 @@ proto_and_java_proto_library(
 )
 
 proto_and_java_proto_library(
+    name = "certificate",
+    deps = [
+        "@com_google_protobuf//:timestamp_proto",
+    ],
+)
+
+proto_and_java_proto_library(
     name = "crypto",
 )
 

--- a/src/main/proto/wfa/measurement/internal/kingdom/certificate.proto
+++ b/src/main/proto/wfa/measurement/internal/kingdom/certificate.proto
@@ -1,0 +1,61 @@
+// Copyright 2021 The Cross-Media Measurement Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package wfa.measurement.internal.kingdom;
+
+import "google/protobuf/timestamp.proto";
+
+option java_package = "org.wfanet.measurement.internal.kingdom";
+option java_multiple_files = true;
+
+message Certificate {
+  oneof parent {
+    fixed64 data_provider_external_id = 1;
+    fixed64 measurement_consumer_external_id = 2;
+    string duchy_external_id = 3;
+  }
+  fixed64 certificate_external_id = 4;
+
+  // X.509 v3 subject key identifier.
+  bytes subject_key_identifier = 5;
+
+  // The beginning of the X.509 validity period, inclusive.
+  google.protobuf.Timestamp not_valid_before = 6;
+
+  // The end of the X.509 validity period, inclusive.
+  google.protobuf.Timestamp not_valid_after = 7;
+
+  // RFC 5280 revocation state.
+  enum RevocationState {
+    REVOCATION_STATE_UNSPECIFIED = 0;
+
+    // Certificate is on hold and therefore invalid, possibly temporarily.
+    HOLD = 1;
+
+    // Certificate has been revoked. Terminal state.
+    REVOKED = 2;
+  }
+  // Revocation state of the certificate reported by an API caller.
+  //
+  // Note that this is not guaranteed to reflect the actual revocation state
+  // determined by the issuing certificate authority.
+  RevocationState revocation_state = 8;
+
+  message Details {
+    // X.509 certificate in DER format.
+    bytes x509_der = 1;
+  }
+}


### PR DESCRIPTION
This includes some fields denormalized from the X.509 certificate so they can be queried.

For issue #52.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/world-federation-of-advertisers/cross-media-measurement/78)
<!-- Reviewable:end -->
