### PR TITLE
Replace the RefuseComputationParticipant method with FailComputationParticipant.

### DIFF
--- a/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/measurement.sdl
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/measurement.sdl
@@ -292,20 +292,37 @@ CREATE TABLE ComputationParticipants (
 -- This is used to give a bird's eye view of the state of the computations to
 -- help debug and track progress.
 CREATE TABLE MeasurementLogEntries (
-  MeasurementConsumerId           INT64 NOT NULL,
-  MeasurementId                   INT64 NOT NULL,
+  MeasurementConsumerId INT64 NOT NULL,
+  MeasurementId INT64 NOT NULL,
+  CreateTime TIMESTAMP NOT NULL OPTIONS (allow_commit_timestamp = true),
 
-  ExternalComputationLogEntryId   INT64,
-  DuchyId                         INT64,
-
-  CreateTime                      TIMESTAMP NOT NULL
-                                  OPTIONS (allow_commit_timestamp = true),
-
-  -- MeasurementLogDetails serialized proto.
+  -- Serialized
+  -- org.wfanet.measurement.internal.kingdom.MeasurementLogEntry.Details
+  -- protobuf message.
   MeasurementLogDetails      BYTES(MAX) NOT NULL,
   MeasurementLogDetailsJson  STRING(MAX) NOT NULL,
 ) PRIMARY KEY (MeasurementConsumerId, MeasurementId, CreateTime),
   INTERLEAVE IN PARENT Measurements ON DELETE CASCADE;
 
-CREATE UNIQUE NULL_FILTERED  INDEX MeasurementLogEntriesByExternalId
-  ON MeasurementLogEntries(DuchyId, ExternalComputationLogEntryId);
+-- Duchy-specific information for a Measurement log entry. There should be a row
+-- in this table for every row in MeasurementLogEntries where the source of the
+-- log event is a Duchy.
+CREATE TABLE DuchyMeasurementLogEntries (
+  MeasurementConsumerId INT64 NOT NULL,
+  MeasurementId INT64 NOT NULL,
+  CreateTime TIMESTAMP NOT NULL OPTIONS (allow_commit_timestamp = true),
+
+  DuchyId INT64 NOT NULL,
+
+  ExternalComputationLogEntryId INT64 NOT NULL,
+
+  -- Serialized
+  -- org.wfanet.measurement.internal.kingdom.DuchyMeasurementLogEntry.Details
+  -- protobuf message.
+  DuchyMeasurementLogDetails BYTES(MAX) NOT NULL,
+  DuchyMeasurementLogDetailsJson STRING(MAX) NOT NULL,
+) PRIMARY KEY (MeasurementConsumerId, MeasurementId, CreateTime),
+  INTERLEAVE IN PARENT MeasurementLogEntries ON DELETE CASCADE;
+
+CREATE UNIQUE INDEX DuchyMeasurementLogEntriesByExternalId
+  ON DuchyMeasurementLogEntries(DuchyId, ExternalComputationLogEntryId);

--- a/src/main/proto/wfa/measurement/internal/kingdom/measurement_log_entry.proto
+++ b/src/main/proto/wfa/measurement/internal/kingdom/measurement_log_entry.proto
@@ -43,44 +43,51 @@ message MeasurementLogEntry {
 
     // Time that the error occurred.
     google.protobuf.Timestamp error_time = 2;
-
-    // Human-readable error message. This should not include any sensitive info.
-    string error_message = 3;
   }
 
-  message DuchyDetails {
-    string external_duchy_id = 1;
-    // External ID for the entry in the system API.
-    fixed64 external_computation_log_entry_id = 2;
+  message Details {
+    // Human-readable error message. This should not include any sensitive info.
+    string log_message = 1;
 
+    // Details about an error. Only set if the log entry is for an error event.
+    ErrorDetails error = 2;
+  }
+  Details details = 4;
+}
+
+message DuchyMeasurementLogEntry {
+  MeasurementLogEntry log_entry = 1;
+  string external_duchy_id = 2;
+
+  string external_computation_log_entry_id = 3;
+
+  message StageAttempt {
     // Tag number of the stage enum value from an external system.
-    int32 stage = 3;
+    int32 stage = 1;
 
     // Name of the stage enum value from an external system.
     //
     // This is for human readability only.
-    string stage_name = 4;
+    string stage_name = 2;
 
     // Time the stage started.
-    google.protobuf.Timestamp stage_start_time = 5;
+    google.protobuf.Timestamp stage_start_time = 3;
 
     // The attempt number for this stage, with 1 being the first attempt.
     //
     // This value should be strictly monotonically increasing for each
     // subsequent log entry for a Duchy with the same stage.
-    int64 attempt_number = 6;
+    int64 attempt_number = 4;
   }
-
   message Details {
-    // Human-readable log message.
-    string log_message = 1;
+    // ID of some child of the Duchy from an external system.
+    //
+    // For example, this may identify a specific job or task.
+    string duchy_child_reference_id = 1;
 
-    // Details about an error. Only set if the log entry is for an error event.
-    ErrorDetails error = 2;
-
-    oneof source {
-      DuchyDetails duchy = 3;
-    }
+    // Details about the computation stage that the log event occurred during.
+    // Only set if the event happened during computation.
+    StageAttempt stage_attempt = 2;
   }
   Details details = 4;
 }

--- a/src/main/proto/wfa/measurement/system/v1alpha/BUILD.bazel
+++ b/src/main/proto/wfa/measurement/system/v1alpha/BUILD.bazel
@@ -24,10 +24,26 @@ java_proto_library(
 )
 
 proto_library(
+    name = "stage_attempt_proto",
+    srcs = ["stage_attempt.proto"],
+    strip_import_prefix = IMPORT_PREFIX,
+    deps = [
+        "@com_google_protobuf//:timestamp_proto",
+    ],
+)
+
+java_proto_library(
+    name = "stage_attempt_jave_proto",
+    visibility = ["//visibility:public"],
+    deps = [":stage_attempt_proto"],
+)
+
+proto_library(
     name = "computation_participant_proto",
     srcs = ["computation_participant.proto"],
     strip_import_prefix = IMPORT_PREFIX,
     deps = [
+        ":stage_attempt_proto",
         "@com_google_protobuf//:timestamp_proto",
     ],
 )
@@ -55,6 +71,7 @@ proto_library(
     srcs = ["computation_log_entry.proto"],
     strip_import_prefix = IMPORT_PREFIX,
     deps = [
+        ":stage_attempt_proto",
         "@com_google_protobuf//:timestamp_proto",
     ],
 )

--- a/src/main/proto/wfa/measurement/system/v1alpha/computation_log_entries_service.proto
+++ b/src/main/proto/wfa/measurement/system/v1alpha/computation_log_entries_service.proto
@@ -27,6 +27,9 @@ option java_outer_classname = "ComputationLogEntriesServiceProto";
 // resources.
 service ComputationLogEntries {
   // Creates a new `ComputationLogEntry`.
+  //
+  // Note that this cannot be used to log permanent errors. Instead, the
+  // `FailComputationParticipant` method should be used to indicate a failure.
   rpc CreateComputationLogEntry(CreateComputationLogEntryRequest)
       returns (ComputationLogEntry);
 }

--- a/src/main/proto/wfa/measurement/system/v1alpha/computation_log_entry.proto
+++ b/src/main/proto/wfa/measurement/system/v1alpha/computation_log_entry.proto
@@ -17,6 +17,7 @@ syntax = "proto3";
 package wfa.measurement.system.v1alpha;
 
 import "google/protobuf/timestamp.proto";
+import "wfa/measurement/system/v1alpha/stage_attempt.proto";
 
 option java_package = "org.wfanet.measurement.system.v1alpha";
 option java_multiple_files = true;
@@ -37,29 +38,12 @@ message ComputationLogEntry {
   // For example, this may identify a specific job or task.
   string participant_child_reference_id = 2;
 
-  // Free-form human-readable log message.
+  // Free-form human-readable log message. This should not include any sensitive
+  // info.
   string log_message = 3;
 
-  message StageAttempt {
-    // Tag number of the stage enum value from an external system. Required.
-    int32 stage = 1;
-
-    // Name of the stage enum value from an external system.
-    //
-    // This is for human readability only.
-    string stage_name = 2;
-
-    // Time the stage started.
-    google.protobuf.Timestamp stage_start_time = 3;
-
-    // The attempt number for this stage, with 1 being the first attempt.
-    //
-    // This value should be strictly monotonically increasing for each
-    // subsequent `ComputationLogEntry` for a `ComputationParticipant` with the
-    // same `stage`.
-    int64 attempt_number = 4;
-  }
-  // Information about the stage attempt.
+  // Information about the stage attempt. Set if the log event occurred during
+  // stage processing.
   StageAttempt stage_attempt = 4;
 
   message ErrorDetails {
@@ -73,7 +57,7 @@ message ComputationLogEntry {
       // may be reattempted.
       TRANSIENT = 1;
 
-      // Permanent error.
+      // Permanent error. Output-only.
       //
       // The parent `Computation` will be in the `FAILED` state.
       PERMANENT = 2;
@@ -83,9 +67,6 @@ message ComputationLogEntry {
 
     // Time that the error occurred.
     google.protobuf.Timestamp error_time = 2;
-
-    // Human-readable error message. This should not include any sensitive info.
-    string error_message = 3;
   }
   // Details for a computation error. Only set if this `ComputationLogEntry` is
   // for an error event.

--- a/src/main/proto/wfa/measurement/system/v1alpha/computation_participant.proto
+++ b/src/main/proto/wfa/measurement/system/v1alpha/computation_participant.proto
@@ -17,6 +17,7 @@ syntax = "proto3";
 package wfa.measurement.system.v1alpha;
 
 import "google/protobuf/timestamp.proto";
+import "wfa/measurement/system/v1alpha/stage_attempt.proto";
 
 option java_package = "org.wfanet.measurement.system.v1alpha";
 option java_multiple_files = true;
@@ -41,13 +42,14 @@ message ComputationParticipant {
     // not yet ready to participate.
     REQUISITION_PARAMS_SET = 2;
 
-    // The `ComputationParticipant` is ready to participate. Terminal state.
+    // The `ComputationParticipant` is ready to participate.
     READY = 3;
 
-    // The `ComputationParticipant` has refused to participate. Terminal state.
+    // A permanent error occurred in the `ComputationParticipant`. Terminal
+    // state.
     //
     // The parent `Computation` will be in the `FAILED` state.
-    REFUSED = 4;
+    FAILED = 4;
   }
   // State of this `ComputationParticipant`. Output-only.
   State state = 2;
@@ -78,4 +80,23 @@ message ComputationParticipant {
   }
   // Parameters needed for `Requisition` to be made available in public API.
   RequisitionParams requisition_params = 4;
+
+  message Failure {
+    // ID of some child of the `ComputationParticipant` from an external system.
+    //
+    // For example, this may identify a specific job or task.
+    string participant_child_reference_id = 1;
+
+    // Human-readable error message. This should not include any sensitive info.
+    string error_message = 2;
+
+    // Time that the error occurred.
+    google.protobuf.Timestamp error_time = 3;
+
+    // Information about the stage attempt. Set if the error occurred during
+    // stage processing.
+    StageAttempt stage_attempt = 4;
+  }
+  // Information about a failure. Set when state is `FAILED`.
+  Failure failure = 5;
 }

--- a/src/main/proto/wfa/measurement/system/v1alpha/computation_participants_service.proto
+++ b/src/main/proto/wfa/measurement/system/v1alpha/computation_participants_service.proto
@@ -33,10 +33,10 @@ service ComputationParticipants {
   rpc SetParticipantRequisitionParams(SetParticipantRequisitionParamsRequest)
       returns (ComputationParticipant);
 
-  // Transitions a `ComputationParticipant` to the `REFUSED` state.
+  // Transitions a `ComputationParticipant` to the `FAILED` state.
   //
   // This is a [state transition method](https://google.aip.dev/216).
-  rpc RefuseComputationParticipant(RefuseComputationParticipantRequest)
+  rpc FailComputationParticipant(FailComputationParticipantRequest)
       returns (ComputationParticipant);
 
   // Transitions a `ComputationParticipant` to the `READY` state.
@@ -55,10 +55,13 @@ message SetParticipantRequisitionParamsRequest {
   ComputationParticipant.RequisitionParams requisition_params = 2;
 }
 
-// Request message for the `RefuseComputationParticipant` method.
-message RefuseComputationParticipantRequest {
+// Request message for the `FailComputationParticipant` method.
+message FailComputationParticipantRequest {
   // Resource key of the `ComputationParticipant`. Required.
   ComputationParticipant.Key key = 1;
+
+  // Failure information. Required.
+  ComputationParticipant.Failure failure = 2;
 }
 
 // Request message for the `ConfirmComputationParticipant` method.

--- a/src/main/proto/wfa/measurement/system/v1alpha/stage_attempt.proto
+++ b/src/main/proto/wfa/measurement/system/v1alpha/stage_attempt.proto
@@ -1,0 +1,43 @@
+// Copyright 2021 The Cross-Media Measurement Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package wfa.measurement.system.v1alpha;
+
+import "google/protobuf/timestamp.proto";
+
+option java_package = "org.wfanet.measurement.system.v1alpha";
+option java_multiple_files = true;
+option java_outer_classname = "StageAttemptProto";
+
+message StageAttempt {
+  // Tag number of the stage enum value from an external system. Required.
+  int32 stage = 1;
+
+  // Name of the stage enum value from an external system.
+  //
+  // This is for human readability only.
+  string stage_name = 2;
+
+  // Time the stage started.
+  google.protobuf.Timestamp stage_start_time = 3;
+
+  // The attempt number for this stage, with 1 being the first attempt.
+  //
+  // This value should be strictly monotonically increasing for each
+  // subsequent `ComputationLogEntry` for a `ComputationParticipant` with the
+  // same `stage`.
+  int64 attempt_number = 4;
+}


### PR DESCRIPTION
This can be used by a Duchy to indicate a permanent error, transitioning the parent Computation to the FAILED state.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/world-federation-of-advertisers/cross-media-measurement/91)
<!-- Reviewable:end -->
