### PR TITLE
Order the computationParticipants by their order in the MPC ring.

### DIFF
--- a/src/main/kotlin/org/wfanet/measurement/duchy/daemon/herald/BUILD.bazel
+++ b/src/main/kotlin/org/wfanet/measurement/duchy/daemon/herald/BUILD.bazel
@@ -15,6 +15,7 @@ kt_jvm_library(
         "//src/main/kotlin/org/wfanet/measurement/common/grpc",
         "//src/main/kotlin/org/wfanet/measurement/duchy:computation_stage",
         "//src/main/kotlin/org/wfanet/measurement/duchy/daemon/utils:computation_conversions",
+        "//src/main/kotlin/org/wfanet/measurement/duchy/daemon/utils:duchy_order",
         "//src/main/kotlin/org/wfanet/measurement/duchy/daemon/utils:public_api_version",
         "//src/main/kotlin/org/wfanet/measurement/duchy/db/computation",
         "//src/main/proto/wfa/measurement/api/v2alpha:crypto_java_proto",

--- a/src/main/kotlin/org/wfanet/measurement/duchy/daemon/herald/Herald.kt
+++ b/src/main/kotlin/org/wfanet/measurement/duchy/daemon/herald/Herald.kt
@@ -27,6 +27,8 @@ import org.wfanet.measurement.api.v2alpha.ProtocolConfig
 import org.wfanet.measurement.common.grpc.grpcStatusCode
 import org.wfanet.measurement.common.throttler.Throttler
 import org.wfanet.measurement.common.withRetriesOnEach
+import org.wfanet.measurement.duchy.daemon.utils.MeasurementType
+import org.wfanet.measurement.duchy.daemon.utils.toMeasurementType
 import org.wfanet.measurement.duchy.db.computation.ComputationProtocolStageDetails
 import org.wfanet.measurement.duchy.service.internal.computation.toGetTokenRequest
 import org.wfanet.measurement.internal.duchy.ComputationDetails
@@ -34,7 +36,7 @@ import org.wfanet.measurement.internal.duchy.ComputationsGrpcKt.ComputationsCoro
 import org.wfanet.measurement.internal.duchy.config.ProtocolsSetupConfig
 import org.wfanet.measurement.system.v1alpha.Computation
 import org.wfanet.measurement.system.v1alpha.Computation.State
-import org.wfanet.measurement.system.v1alpha.ComputationsGrpcKt.ComputationsCoroutineStub as GlobalComputationsCoroutineStub
+import org.wfanet.measurement.system.v1alpha.ComputationsGrpcKt.ComputationsCoroutineStub as SystemComputationsCoroutineStub
 import org.wfanet.measurement.system.v1alpha.StreamActiveComputationsRequest
 import org.wfanet.measurement.system.v1alpha.StreamActiveComputationsResponse
 
@@ -46,7 +48,7 @@ import org.wfanet.measurement.system.v1alpha.StreamActiveComputationsResponse
  * they are able to start the computation.
  *
  * @param computationStorageClient manages interactions with computations storage service.
- * @param globalComputationsClient stub for communicating with the Kingdom's system Computations
+ * @param systemComputationsClient stub for communicating with the Kingdom's system Computations
  * Service.
  * @param protocolsSetupConfig duchy's local protocolsSetupConfig
  * @param configMaps a map of public Api ProtocolConfigIds to the configs.
@@ -56,7 +58,7 @@ import org.wfanet.measurement.system.v1alpha.StreamActiveComputationsResponse
 class Herald(
   otherDuchiesInComputation: List<String>,
   private val computationStorageClient: ComputationsCoroutineStub,
-  private val globalComputationsClient: GlobalComputationsCoroutineStub,
+  private val systemComputationsClient: SystemComputationsCoroutineStub,
   private val protocolsSetupConfig: ProtocolsSetupConfig,
   private val configMaps: Map<String, ProtocolConfig>,
   private val blobStorageBucket: String = "computation-blob-storage",
@@ -92,13 +94,13 @@ class Herald(
   }
 
   /**
-   * Syncs the status of computations stored at the kingdom, via the global computation service,
+   * Syncs the status of computations stored at the kingdom, via the system computation service,
    * with those stored locally.
    *
    * @param continuationToken the continuation token of the last computation in the stream which was
    * processed by the herald.
    * @return the continuation token of the last computation processed in that stream of active
-   * computations from the global computation service.
+   * computations from the system computation service.
    */
   suspend fun syncStatuses(continuationToken: String): String {
     if (this::attemptException.isInitialized) {
@@ -107,12 +109,12 @@ class Herald(
 
     var lastProcessedContinuationToken = continuationToken
     logger.info("Reading stream of active computations since $continuationToken.")
-    globalComputationsClient
+    systemComputationsClient
       .streamActiveComputations(
         StreamActiveComputationsRequest.newBuilder().setContinuationToken(continuationToken).build()
       )
       .withRetriesOnEach(maxAttempts = 3, retryPredicate = ::mayBeTransientGrpcError) { response ->
-        processGlobalComputationChange(response)
+        processSystemComputationChange(response)
         lastProcessedContinuationToken = response.continuationToken
       }
       // Cancel the flow on the first error, but don't actually throw the error. This will keep
@@ -124,8 +126,7 @@ class Herald(
     return lastProcessedContinuationToken
   }
 
-  private suspend fun processGlobalComputationChange(response: StreamActiveComputationsResponse) {
-    // TODO: create computation according to the protocol specified by the kingdom.
+  private suspend fun processSystemComputationChange(response: StreamActiveComputationsResponse) {
     val globalId: String = checkNotNull(response.computation.key?.computationId)
     logger.info("[id=$globalId]: Processing updated GlobalComputation")
     when (val state = response.computation.state) {
@@ -140,19 +141,21 @@ class Herald(
   }
 
   /** Creates a new computation. */
-  // TODO: create Computation of type mapping the protocol specified by the kingdom.
-  private suspend fun create(globalComputation: Computation) {
-    val globalId: String = checkNotNull(globalComputation.key?.computationId)
+  private suspend fun create(systemComputation: Computation) {
+    val globalId: String = checkNotNull(systemComputation.key?.computationId)
     logger.info("[id=$globalId] Creating Computation")
     try {
-      // TODO: get the protocol from the kingdom's response and create a corresponding computation.
-      LiquidLegionsV2Starter.createComputation(
-        computationStorageClient,
-        globalComputation,
-        protocolsSetupConfig.liquidLegionsV2,
-        configMaps,
-        blobStorageBucket
-      )
+      when (systemComputation.toMeasurementType()) {
+        MeasurementType.REACH_AND_FREQUENCY -> {
+          LiquidLegionsV2Starter.createComputation(
+            computationStorageClient,
+            systemComputation,
+            protocolsSetupConfig.liquidLegionsV2,
+            configMaps,
+            blobStorageBucket
+          )
+        }
+      }
       logger.info("[id=$globalId]: Created Computation")
     } catch (e: Exception) {
       if (e.grpcStatusCode() == Status.Code.ALREADY_EXISTS) {
@@ -166,14 +169,14 @@ class Herald(
   /**
    * Attempts the block once and if that fails, launches a coroutine to continue retrying in the
    * background. Retrying is necessary since there is a race condition between the mill updating
-   * local computation state and the herald retrieving a globalComputation update from the kingdom.
+   * local computation state and the herald retrieving a systemComputation update from the kingdom.
    */
   private suspend fun runWithRetry(
-    globalComputation: Computation,
-    block: suspend (globalComputation: Computation) -> Unit
+    systemComputation: Computation,
+    block: suspend (systemComputation: Computation) -> Unit
   ) {
-    val globalId = globalComputation.key.computationId
-    val attempt: suspend () -> Boolean = { runCatching { block(globalComputation) }.isSuccess }
+    val globalId = systemComputation.key.computationId
+    val attempt: suspend () -> Boolean = { runCatching { block(systemComputation) }.isSuccess }
     if (!attempt()) {
       // TODO: use another scope other than the GlobalScope.
       GlobalScope.launch(Dispatchers.IO) {
@@ -192,9 +195,9 @@ class Herald(
   }
 
   /** Attempts to update a new computation from duchy confirmation. */
-  private suspend fun update(globalComputation: Computation) {
-    val globalId = globalComputation.key.computationId
-    runWithRetry(globalComputation) {
+  private suspend fun update(systemComputation: Computation) {
+    val globalId = systemComputation.key.computationId
+    runWithRetry(systemComputation) {
       logger.info("[id=$globalId]: Updating Computation")
       val token = computationStorageClient.getComputationToken(globalId.toGetTokenRequest()).token
       when (token.computationDetails.protocolCase) {
@@ -203,7 +206,8 @@ class Herald(
             token,
             computationStorageClient,
             computationProtocolStageDetails,
-            globalComputation,
+            systemComputation,
+            protocolsSetupConfig.liquidLegionsV2.externalAggregatorDuchyId,
             logger
           )
         else -> error { "Unknown or unsupported protocol." }
@@ -212,9 +216,9 @@ class Herald(
   }
 
   /** Attempts to start a computation that is in WAIT_TO_START. */
-  private suspend fun start(globalComputation: Computation) {
-    val globalId = globalComputation.key.computationId
-    runWithRetry(globalComputation) {
+  private suspend fun start(systemComputation: Computation) {
+    val globalId = systemComputation.key.computationId
+    runWithRetry(systemComputation) {
       logger.info("[id=$globalId]: Starting Computation")
       val token = computationStorageClient.getComputationToken(globalId.toGetTokenRequest()).token
       when (token.computationDetails.protocolCase) {

--- a/src/main/kotlin/org/wfanet/measurement/duchy/daemon/utils/ComputationConversions.kt
+++ b/src/main/kotlin/org/wfanet/measurement/duchy/daemon/utils/ComputationConversions.kt
@@ -20,6 +20,7 @@ import org.wfanet.measurement.api.v2alpha.ElGamalPublicKey as V2AlphaElGamalPubl
 import org.wfanet.measurement.api.v2alpha.EncryptionPublicKey as V2AlphaEncryptionPublicKey
 import org.wfanet.measurement.api.v2alpha.HybridCipherSuite as V2AlphaHybridCipherSuite
 import org.wfanet.measurement.api.v2alpha.MeasurementSpec
+import org.wfanet.measurement.api.v2alpha.MeasurementSpec.MeasurementTypeCase
 import org.wfanet.measurement.internal.duchy.ComputationDetails.KingdomComputationDetails
 import org.wfanet.measurement.internal.duchy.DifferentialPrivacyParams
 import org.wfanet.measurement.internal.duchy.ElGamalPublicKey
@@ -29,6 +30,25 @@ import org.wfanet.measurement.internal.duchy.RequisitionDetails
 import org.wfanet.measurement.system.v1alpha.Computation as SystemComputation
 import org.wfanet.measurement.system.v1alpha.DifferentialPrivacyParams as SystemDifferentialPrivacyParams
 import org.wfanet.measurement.system.v1alpha.Requisition as SystemRequisition
+
+/** Supported measurement types in the duchy. */
+enum class MeasurementType {
+  REACH_AND_FREQUENCY
+}
+
+/** Gets the measurement type from the system computation. */
+fun SystemComputation.toMeasurementType(): MeasurementType {
+  return when (publicApiVersion.toPublicApiVersion()) {
+    PublicApiVersion.V2_ALPHA -> {
+      val v2AlphaMeasurementSpec = MeasurementSpec.parseFrom(measurementSpec)
+      @Suppress("WHEN_ENUM_CAN_BE_NULL_IN_JAVA") // Proto enum fields are never null.
+      when (v2AlphaMeasurementSpec.measurementTypeCase) {
+        MeasurementTypeCase.REACH_AND_FREQUENCY -> MeasurementType.REACH_AND_FREQUENCY
+        MeasurementTypeCase.MEASUREMENTTYPE_NOT_SET -> error("Measurement type not set.")
+      }
+    }
+  }
+}
 
 /** Creates a KingdomComputationDetails from the kingdom system API Computation. */
 fun SystemComputation.toKingdomComputationDetails(): KingdomComputationDetails {

--- a/src/main/kotlin/org/wfanet/measurement/duchy/deploy/common/daemon/herald/HeraldDaemon.kt
+++ b/src/main/kotlin/org/wfanet/measurement/duchy/deploy/common/daemon/herald/HeraldDaemon.kt
@@ -60,11 +60,11 @@ private class Flags {
     private set
 
   @CommandLine.Option(
-    names = ["--global-computation-service-target"],
+    names = ["--system-computation-service-target"],
     description = ["Address and port of the kingdom system Computations Service"],
     required = true
   )
-  lateinit var globalComputationsServiceTarget: String
+  lateinit var systemComputationsServiceTarget: String
     private set
 
   @CommandLine.Option(
@@ -105,9 +105,9 @@ private fun run(@CommandLine.Mixin flags: Flags) {
   }
   val otherDuchyNames = latestDuchyPublicKeys.keys.filter { it != duchyName }
 
-  val globalComputationServiceChannel = buildChannel(flags.globalComputationsServiceTarget)
-  val globalComputationsClient =
-    SystemComputationsCoroutineStub(globalComputationServiceChannel)
+  val systemComputationServiceChannel = buildChannel(flags.systemComputationsServiceTarget)
+  val systemComputationsClient =
+    SystemComputationsCoroutineStub(systemComputationServiceChannel)
       .withDuchyId(flags.duchy.duchyName)
 
   val storageChannel = buildChannel(flags.computationsServiceTarget)
@@ -115,7 +115,7 @@ private fun run(@CommandLine.Mixin flags: Flags) {
   addChannelShutdownHooks(
     Runtime.getRuntime(),
     flags.channelShutdownTimeout,
-    globalComputationServiceChannel,
+    systemComputationServiceChannel,
     storageChannel
   )
 
@@ -123,7 +123,7 @@ private fun run(@CommandLine.Mixin flags: Flags) {
     Herald(
       otherDuchiesInComputation = otherDuchyNames,
       computationStorageClient = ComputationsCoroutineStub(storageChannel),
-      globalComputationsClient = globalComputationsClient,
+      systemComputationsClient = systemComputationsClient,
       protocolsSetupConfig =
         flags.protocolsSetupConfig.reader().use {
           parseTextProto(it, ProtocolsSetupConfig.getDefaultInstance())

--- a/src/main/proto/wfa/measurement/internal/duchy/config/protocols_setup_config.proto
+++ b/src/main/proto/wfa/measurement/internal/duchy/config/protocols_setup_config.proto
@@ -41,4 +41,7 @@ message LiquidLegionsV2SetupConfig {
     NON_AGGREGATOR = 2;
   }
   RoleInComputation role = 1;
+
+  // The external id of the aggregator duchy.
+  string external_aggregator_duchy_id = 2;
 }


### PR DESCRIPTION
The mill will use this order of the computationParticipants list as
the source of truth of the mpc ring structure.

Also renamed GlobalComputationService to SystemComputationService in the herald.
However, the kingdom's computation id is still called GlobalId or
GlobalComputationId, since word "Global" is already used in the database
column.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/world-federation-of-advertisers/cross-media-measurement/97)
<!-- Reviewable:end -->
