### PR TITLE
Update the confirmationPhase processor in the llv2 mill.

### DIFF
--- a/src/main/kotlin/org/wfanet/measurement/duchy/daemon/mill/liquidlegionsv2/crypto/BUILD.bazel
+++ b/src/main/kotlin/org/wfanet/measurement/duchy/daemon/mill/liquidlegionsv2/crypto/BUILD.bazel
@@ -10,5 +10,7 @@ kt_jvm_library(
         "//src/main/kotlin/org/wfanet/measurement/common",
         "//src/main/proto/wfa/measurement/internal/duchy/protocol:liquid_legions_v2_encryption_methods_java_proto",
         "//src/main/swig/protocol/liquidlegionsv2:liquid_legions_v2_encryption_utility",
+        "@any_sketch_java//src/main/java/org/wfanet/anysketch/crypto:sketch_encrypter_adapter",
+        "@any_sketch_java//src/main/proto/wfa/any_sketch/crypto:sketch_encryption_methods_java_proto",
     ],
 )

--- a/src/main/kotlin/org/wfanet/measurement/duchy/daemon/mill/liquidlegionsv2/crypto/JniLiquidLegionsV2Encryption.kt
+++ b/src/main/kotlin/org/wfanet/measurement/duchy/daemon/mill/liquidlegionsv2/crypto/JniLiquidLegionsV2Encryption.kt
@@ -15,6 +15,9 @@
 package org.wfanet.measurement.duchy.daemon.mill.liquidlegionsv2.crypto
 
 import java.nio.file.Paths
+import org.wfanet.anysketch.crypto.CombineElGamalPublicKeysRequest
+import org.wfanet.anysketch.crypto.CombineElGamalPublicKeysResponse
+import org.wfanet.anysketch.crypto.SketchEncrypterAdapter
 import org.wfanet.measurement.common.loadLibrary
 import org.wfanet.measurement.internal.duchy.protocol.CompleteExecutionPhaseOneAtAggregatorRequest
 import org.wfanet.measurement.internal.duchy.protocol.CompleteExecutionPhaseOneAtAggregatorResponse
@@ -103,11 +106,23 @@ class JniLiquidLegionsV2Encryption : LiquidLegionsV2Encryption {
     )
   }
 
+  override fun combineElGamalPublicKeys(
+    request: CombineElGamalPublicKeysRequest
+  ): CombineElGamalPublicKeysResponse {
+    return CombineElGamalPublicKeysResponse.parseFrom(
+      SketchEncrypterAdapter.CombineElGamalPublicKeys(request.toByteArray())
+    )
+  }
+
   companion object {
     init {
       loadLibrary(
         name = "liquid_legions_v2_encryption_utility",
         directoryPath = Paths.get("wfa_measurement_system/src/main/swig/protocol/liquidlegionsv2")
+      )
+      loadLibrary(
+        name = "sketch_encrypter_adapter",
+        directoryPath = Paths.get("any_sketch_java/src/main/java/org/wfanet/anysketch/crypto")
       )
     }
   }

--- a/src/main/kotlin/org/wfanet/measurement/duchy/daemon/mill/liquidlegionsv2/crypto/LiquidLegionsV2Encryption.kt
+++ b/src/main/kotlin/org/wfanet/measurement/duchy/daemon/mill/liquidlegionsv2/crypto/LiquidLegionsV2Encryption.kt
@@ -14,6 +14,8 @@
 
 package org.wfanet.measurement.duchy.daemon.mill.liquidlegionsv2.crypto
 
+import org.wfanet.anysketch.crypto.CombineElGamalPublicKeysRequest
+import org.wfanet.anysketch.crypto.CombineElGamalPublicKeysResponse
 import org.wfanet.measurement.internal.duchy.protocol.CompleteExecutionPhaseOneAtAggregatorRequest
 import org.wfanet.measurement.internal.duchy.protocol.CompleteExecutionPhaseOneAtAggregatorResponse
 import org.wfanet.measurement.internal.duchy.protocol.CompleteExecutionPhaseOneRequest
@@ -67,4 +69,8 @@ interface LiquidLegionsV2Encryption {
   fun completeExecutionPhaseThreeAtAggregator(
     request: CompleteExecutionPhaseThreeAtAggregatorRequest
   ): CompleteExecutionPhaseThreeAtAggregatorResponse
+
+  fun combineElGamalPublicKeys(
+    request: CombineElGamalPublicKeysRequest
+  ): CombineElGamalPublicKeysResponse
 }

--- a/src/main/kotlin/org/wfanet/measurement/duchy/db/computation/ComputationProtocolStageDetails.kt
+++ b/src/main/kotlin/org/wfanet/measurement/duchy/db/computation/ComputationProtocolStageDetails.kt
@@ -81,18 +81,17 @@ class ComputationProtocolStageDetails(val otherDuchies: List<String>) :
     details: ComputationDetails,
     reason: EndComputationReason
   ): ComputationDetails {
-    return details
-      .toBuilder()
-      .setEndingState(
-        when (reason) {
-          EndComputationReason.SUCCEEDED -> ComputationDetails.CompletedReason.SUCCEEDED
-          EndComputationReason.FAILED -> ComputationDetails.CompletedReason.FAILED
-          EndComputationReason.CANCELED -> ComputationDetails.CompletedReason.CANCELED
-        }
-      )
-      .build()
+    return details.toBuilder().setEndingState(reason.toCompletedReason()).build()
   }
 
   override fun parseComputationDetails(bytes: ByteArray): ComputationDetails =
     ComputationDetails.parseFrom(bytes)
+}
+
+fun EndComputationReason.toCompletedReason(): ComputationDetails.CompletedReason {
+  return when (this) {
+    EndComputationReason.SUCCEEDED -> ComputationDetails.CompletedReason.SUCCEEDED
+    EndComputationReason.FAILED -> ComputationDetails.CompletedReason.FAILED
+    EndComputationReason.CANCELED -> ComputationDetails.CompletedReason.CANCELED
+  }
 }

--- a/src/main/kotlin/org/wfanet/measurement/duchy/db/computation/LiquidLegionsSketchAggregationV2Protocol.kt
+++ b/src/main/kotlin/org/wfanet/measurement/duchy/db/computation/LiquidLegionsSketchAggregationV2Protocol.kt
@@ -158,11 +158,8 @@ object LiquidLegionsSketchAggregationV2Protocol {
             ComputationStageDetails.newBuilder()
               .apply {
                 liquidLegionsV2Builder.waitSetupPhaseInputsDetailsBuilder.apply {
-                  // The WAIT_SKETCHES stage has exactly one input which is the noised sketches from
-                  // the primary duchy running the wait operation. It is not an output of the stage
-                  // because it is a result of a locally running stage.
                   putAllExternalDuchyLocalBlobId(
-                    otherDuchies.mapIndexed { idx, duchy -> duchy to (idx + 1).toLong() }.toMap()
+                    otherDuchies.mapIndexed { idx, duchy -> duchy to idx.toLong() }.toMap()
                   )
                 }
               }

--- a/src/main/proto/wfa/measurement/internal/duchy/protocol/liquid_legions_sketch_aggregation_v2.proto
+++ b/src/main/proto/wfa/measurement/internal/duchy/protocol/liquid_legions_sketch_aggregation_v2.proto
@@ -166,6 +166,13 @@ message LiquidLegionsSketchAggregationV2 {
     // TODO(wangyaopw): delete this field when we switch to use a secure key
     //  store for duchy private keys.
     ElGamalKeyPair local_elgamal_key = 6;
+
+    // The Elgamal public key combined from all duchy participants' public keys.
+    ElGamalPublicKey combined_public_key = 7;
+
+    // The Elgamal public key combined from the public keys of the duchies after
+    // this duchy in the ring and the aggregator duchy.
+    ElGamalPublicKey partially_combined_public_key = 8;
   }
 
   // Details about a particular attempt of running a stage of the LiquidLegionV2
@@ -174,10 +181,6 @@ message LiquidLegionsSketchAggregationV2 {
     oneof detail {
       // Details specific to the WAIT_SETUP_PHASE_INPUTS stage.
       WaitSetupPhaseInputsDetails wait_setup_phase_inputs_details = 1;
-      // TODO(wangyaopw): delete after v2alpha is done.
-      // Details specific to the TO_CONFIRM_REQUISITIONS stage.
-      ToConfirmRequisitionsStageDetails to_confirm_requisitions_stage_details =
-          2;
     }
   }
 
@@ -193,12 +196,5 @@ message LiquidLegionsSketchAggregationV2 {
     // the output references have a path the worker can move onto the next
     // stage.
     map<string, int64> external_duchy_local_blob_id = 1;
-  }
-
-  // TODO(wangyaopw): delete after v2alpha is done
-  // The details used to run a TO_CONFIRM_REQUISITIONS stage.
-  message ToConfirmRequisitionsStageDetails {
-    // list of local requisitions that are required for this computation.
-    repeated RequisitionKey keys = 1;
   }
 }

--- a/src/test/kotlin/org/wfanet/measurement/duchy/daemon/herald/HeraldTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/duchy/daemon/herald/HeraldTest.kt
@@ -37,7 +37,6 @@ import org.wfanet.measurement.api.v2alpha.ProtocolConfig
 import org.wfanet.measurement.common.grpc.testing.GrpcTestServerRule
 import org.wfanet.measurement.common.testing.pollFor
 import org.wfanet.measurement.common.throttler.testing.FakeThrottler
-import org.wfanet.measurement.duchy.db.computation.ExternalRequisitionKey
 import org.wfanet.measurement.duchy.db.computation.testing.FakeComputationsDatabase
 import org.wfanet.measurement.duchy.service.internal.computation.ComputationsService
 import org.wfanet.measurement.duchy.service.internal.computation.newEmptyOutputBlobMetadata
@@ -476,7 +475,21 @@ class HeraldTest {
         globalId = globalId,
         stage = WAIT_REQUISITIONS_AND_KEY_SET.toProtocolStage(),
         computationDetails = NON_AGGREGATOR_COMPUTATION_DETAILS,
-        requisitions = listOf(ExternalRequisitionKey("A", "1"), ExternalRequisitionKey("B", "2"))
+        requisitions =
+          listOf(
+            RequisitionMetadata.newBuilder()
+              .apply {
+                externalDataProviderId = "A"
+                externalRequisitionId = "1"
+              }
+              .build(),
+            RequisitionMetadata.newBuilder()
+              .apply {
+                externalDataProviderId = "B"
+                externalRequisitionId = "2"
+              }
+              .build()
+          )
       )
 
       assertThat(aggregatorHerald.syncStatuses(EMPTY_TOKEN))

--- a/src/test/kotlin/org/wfanet/measurement/duchy/daemon/mill/liquidlegionsv2/LiquidLegionsV2MillTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/duchy/daemon/mill/liquidlegionsv2/LiquidLegionsV2MillTest.kt
@@ -34,14 +34,11 @@ import com.nhaarman.mockitokotlin2.argumentCaptor
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.times
 import com.nhaarman.mockitokotlin2.verifyBlocking
-import com.nhaarman.mockitokotlin2.verifyZeroInteractions
 import com.nhaarman.mockitokotlin2.whenever
-import io.grpc.Status
 import java.time.Clock
 import java.time.Duration
 import java.util.concurrent.atomic.AtomicInteger
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.runBlocking
 import org.junit.Before
@@ -50,6 +47,9 @@ import org.junit.Test
 import org.junit.rules.TemporaryFolder
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
+import org.wfanet.anysketch.crypto.CombineElGamalPublicKeysRequest
+import org.wfanet.anysketch.crypto.CombineElGamalPublicKeysResponse
+import org.wfanet.anysketch.crypto.ElGamalPublicKey
 import org.wfanet.measurement.api.v2alpha.ElGamalPublicKey as V2AlphaElGamalPublicKey
 import org.wfanet.measurement.common.flatten
 import org.wfanet.measurement.common.grpc.testing.GrpcTestServerRule
@@ -68,11 +68,11 @@ import org.wfanet.measurement.duchy.service.internal.computation.ComputationsSer
 import org.wfanet.measurement.duchy.service.internal.computation.newEmptyOutputBlobMetadata
 import org.wfanet.measurement.duchy.service.internal.computation.newInputBlobMetadata
 import org.wfanet.measurement.duchy.service.internal.computation.newOutputBlobMetadata
-import org.wfanet.measurement.duchy.service.internal.computation.newPassThroughBlobMetadata
 import org.wfanet.measurement.duchy.storage.ComputationStore
 import org.wfanet.measurement.duchy.toProtocolStage
 import org.wfanet.measurement.internal.duchy.ComputationBlobDependency
 import org.wfanet.measurement.internal.duchy.ComputationDetails
+import org.wfanet.measurement.internal.duchy.ComputationDetails.CompletedReason
 import org.wfanet.measurement.internal.duchy.ComputationStageBlobMetadata
 import org.wfanet.measurement.internal.duchy.ComputationStageDetails
 import org.wfanet.measurement.internal.duchy.ComputationStatsGrpcKt.ComputationStatsCoroutineImplBase
@@ -82,7 +82,7 @@ import org.wfanet.measurement.internal.duchy.ComputationsGrpcKt.ComputationsCoro
 import org.wfanet.measurement.internal.duchy.MetricValue
 import org.wfanet.measurement.internal.duchy.MetricValuesGrpcKt.MetricValuesCoroutineImplBase
 import org.wfanet.measurement.internal.duchy.MetricValuesGrpcKt.MetricValuesCoroutineStub
-import org.wfanet.measurement.internal.duchy.StreamMetricValueRequest
+import org.wfanet.measurement.internal.duchy.RequisitionMetadata
 import org.wfanet.measurement.internal.duchy.StreamMetricValueResponse
 import org.wfanet.measurement.internal.duchy.config.LiquidLegionsV2SetupConfig.RoleInComputation
 import org.wfanet.measurement.internal.duchy.protocol.CompleteExecutionPhaseOneAtAggregatorRequest
@@ -101,6 +101,7 @@ import org.wfanet.measurement.internal.duchy.protocol.CompleteInitializationPhas
 import org.wfanet.measurement.internal.duchy.protocol.CompleteInitializationPhaseResponse
 import org.wfanet.measurement.internal.duchy.protocol.CompleteSetupPhaseRequest
 import org.wfanet.measurement.internal.duchy.protocol.CompleteSetupPhaseResponse
+import org.wfanet.measurement.internal.duchy.protocol.LiquidLegionsSketchAggregationV2.ComputationDetails.ComputationParticipant
 import org.wfanet.measurement.internal.duchy.protocol.LiquidLegionsSketchAggregationV2.Stage.COMPLETE
 import org.wfanet.measurement.internal.duchy.protocol.LiquidLegionsSketchAggregationV2.Stage.CONFIRMATION_PHASE
 import org.wfanet.measurement.internal.duchy.protocol.LiquidLegionsSketchAggregationV2.Stage.EXECUTION_PHASE_ONE
@@ -124,7 +125,7 @@ import org.wfanet.measurement.system.v1alpha.ComputationControlGrpcKt.Computatio
 import org.wfanet.measurement.system.v1alpha.ComputationControlGrpcKt.ComputationControlCoroutineStub
 import org.wfanet.measurement.system.v1alpha.ComputationParticipantsGrpcKt.ComputationParticipantsCoroutineImplBase
 import org.wfanet.measurement.system.v1alpha.ComputationParticipantsGrpcKt.ComputationParticipantsCoroutineStub
-import org.wfanet.measurement.system.v1alpha.ConfirmGlobalComputationRequest
+import org.wfanet.measurement.system.v1alpha.ConfirmComputationParticipantRequest
 import org.wfanet.measurement.system.v1alpha.CreateGlobalComputationStatusUpdateRequest
 import org.wfanet.measurement.system.v1alpha.FinishGlobalComputationRequest
 import org.wfanet.measurement.system.v1alpha.GlobalComputation
@@ -365,6 +366,30 @@ class LiquidLegionsV2MillTest {
         computationControlRequests = runBlocking { request.toList() }
         AdvanceComputationResponse.getDefaultInstance()
       }
+
+    whenever(mockCryptoWorker.combineElGamalPublicKeys(any())).thenAnswer {
+      val cryptoRequest: CombineElGamalPublicKeysRequest = it.getArgument(0)
+      CombineElGamalPublicKeysResponse.newBuilder()
+        .setElGamalKeys(
+          ElGamalPublicKey.newBuilder().apply {
+            generator =
+              ByteString.copyFromUtf8(
+                cryptoRequest
+                  .elGamalKeysList
+                  .map { key -> key.generator.toStringUtf8() }
+                  .joinToString(separator = "_")
+              )
+            element =
+              ByteString.copyFromUtf8(
+                cryptoRequest
+                  .elGamalKeysList
+                  .map { key -> key.element.toStringUtf8() }
+                  .joinToString(separator = "_")
+              )
+          }
+        )
+        .build()
+    }
   }
 
   @Test
@@ -473,185 +498,36 @@ class LiquidLegionsV2MillTest {
   }
 
   @Test
-  fun `confirm requisition, no local requisitions required at aggregator`() = runBlocking {
-    // Stage 0. preparing the storage and set up mock
-    fakeComputationDb.addComputation(
-      globalId = GLOBAL_ID,
-      stage = CONFIRMATION_PHASE.toProtocolStage(),
-      computationDetails = aggregatorComputationDetails,
-      blobs = listOf(newEmptyOutputBlobMetadata(0L))
-    )
-
-    // Stage 1. Process the above computation
-    aggregatorMill.pollAndProcessNextComputation()
-
-    // Stage 2. Check the status of the computation
-    val blobKey = generatedBlobKeys.last()
-    assertThat(fakeComputationDb[LOCAL_ID])
-      .isEqualTo(
-        ComputationToken.newBuilder()
-          .setGlobalComputationId(GLOBAL_ID)
-          .setLocalComputationId(LOCAL_ID)
-          .setAttempt(1)
-          .setComputationStage(WAIT_SETUP_PHASE_INPUTS.toProtocolStage())
-          .addAllBlobs(
-            listOf(
-              newPassThroughBlobMetadata(0, blobKey),
-              newEmptyOutputBlobMetadata(1),
-              newEmptyOutputBlobMetadata(2)
-            )
-          )
-          .setStageSpecificDetails(
-            ComputationStageDetails.newBuilder().apply {
-              liquidLegionsV2Builder.waitSetupPhaseInputsDetailsBuilder.apply {
-                putExternalDuchyLocalBlobId("DUCHY_TWO", 1L)
-                putExternalDuchyLocalBlobId("DUCHY_THREE", 2L)
-              }
-            }
-          )
-          .setComputationDetails(aggregatorComputationDetails)
-          .setVersion(3) // CreateComputation + write blob + transitionStage
-          .build()
-      )
-    assertThat(computationStore.get(blobKey)?.readToString()).isEmpty()
-
-    verifyZeroInteractions(mockMetricValues)
-    verifyProtoArgument(
-        mockGlobalComputations,
-        GlobalComputationsCoroutineImplBase::confirmGlobalComputation
-      )
-      .isEqualTo(
-        ConfirmGlobalComputationRequest.newBuilder()
-          .setKey(GlobalComputation.Key.newBuilder().setGlobalComputationId(GLOBAL_ID))
-          .build()
-      )
-  }
-
-  @Test
-  fun `confirm requisition, all local requisitions available non-aggregator`() = runBlocking {
-    // Stage 0. preparing the storage and set up mock
-    fakeComputationDb.addComputation(
-      globalId = GLOBAL_ID,
-      stage = CONFIRMATION_PHASE.toProtocolStage(),
-      computationDetails = nonAggregatorComputationDetails,
-      blobs = listOf(newEmptyOutputBlobMetadata(0L)),
-      stageDetails =
-        ComputationStageDetails.newBuilder()
-          .apply {
-            liquidLegionsV2Builder.toConfirmRequisitionsStageDetailsBuilder.apply {
-              addKeys("1".toRequisitionKey())
-              addKeys("2".toRequisitionKey())
-            }
-          }
-          .build()
-    )
-
-    lateinit var metricValuesRequest1: StreamMetricValueRequest
-    lateinit var metricValuesRequest2: StreamMetricValueRequest
-    whenever(mockMetricValues.streamMetricValue(any()))
-      .thenAnswer {
-        metricValuesRequest1 = it.getArgument(0)
-        flowOf(
-          StreamMetricValueResponse.newBuilder()
-            .setHeader(StreamMetricValueResponse.Header.getDefaultInstance())
-            .build(),
-          // Add a header to test filtering
-          "A_chunk_1_".toMetricChunkResponse(),
-          "A_chunk_2_".toMetricChunkResponse(),
-          "A_chunk_3_".toMetricChunkResponse()
-        )
-      }
-      .thenAnswer {
-        metricValuesRequest2 = it.getArgument(0)
-        flowOf("B_chunk_1_".toMetricChunkResponse(), "B_chunk_2_".toMetricChunkResponse())
-      }
-
-    // Stage 1. Process the above computation
-    nonAggregatorMill.pollAndProcessNextComputation()
-
-    // Stage 2. Check the status of the computation
-    val blobKey = generatedBlobKeys.last()
-    assertThat(fakeComputationDb[LOCAL_ID])
-      .isEqualTo(
-        ComputationToken.newBuilder()
-          .setGlobalComputationId(GLOBAL_ID)
-          .setLocalComputationId(LOCAL_ID)
-          .setAttempt(1)
-          .setComputationStage(WAIT_TO_START.toProtocolStage())
-          .addBlobs(newPassThroughBlobMetadata(0, blobKey))
-          .setVersion(3) // CreateComputation + write blob + transitionStage
-          .setComputationDetails(nonAggregatorComputationDetails)
-          .build()
-      )
-    assertThat(computationStore.get(blobKey)?.readToString())
-      .isEqualTo("A_chunk_1_A_chunk_2_A_chunk_3_B_chunk_1_B_chunk_2_")
-
-    assertThat(metricValuesRequest1)
-      .isEqualTo(
-        StreamMetricValueRequest.newBuilder().setResourceKey("1".toMetricValueResourceKey()).build()
-      )
-    assertThat(metricValuesRequest2)
-      .isEqualTo(
-        StreamMetricValueRequest.newBuilder().setResourceKey("2".toMetricValueResourceKey()).build()
-      )
-    verifyProtoArgument(
-        mockGlobalComputations,
-        GlobalComputationsCoroutineImplBase::confirmGlobalComputation
-      )
-      .isEqualTo(
-        ConfirmGlobalComputationRequest.newBuilder()
-          .setKey(GlobalComputation.Key.newBuilder().setGlobalComputationId(GLOBAL_ID))
-          .addReadyRequisitions("1".toMetricRequisitionKey())
-          .addReadyRequisitions("2".toMetricRequisitionKey())
-          .build()
-      )
-  }
-
-  @Test
-  fun `confirm requisition, missing requisition at aggregator`() =
+  fun `confirm requisition, failed due to missing local requisition`() =
     runBlocking<Unit> {
       // Stage 0. preparing the storage and set up mock
-      val requisition1 = "1"
-      val requisition2 = "2"
+      val requisition1 =
+        RequisitionMetadata.newBuilder()
+          .apply {
+            externalDataProviderId = "A"
+            externalRequisitionId = "111"
+            path = "foo/123"
+            detailsBuilder.externalFulfillingDuchyId = DUCHY_ONE_NAME
+          }
+          .build()
+      val requisition2 =
+        RequisitionMetadata.newBuilder()
+          .apply {
+            externalDataProviderId = "B"
+            externalRequisitionId = "222"
+            clearPath() // Path is missing for this requisition
+            detailsBuilder.externalFulfillingDuchyId = DUCHY_ONE_NAME
+          }
+          .build()
       fakeComputationDb.addComputation(
         globalId = GLOBAL_ID,
         stage = CONFIRMATION_PHASE.toProtocolStage(),
-        computationDetails = nonAggregatorComputationDetails,
-        blobs = listOf(newEmptyOutputBlobMetadata(0L)),
-        stageDetails =
-          ComputationStageDetails.newBuilder()
-            .apply {
-              liquidLegionsV2Builder.toConfirmRequisitionsStageDetailsBuilder.apply {
-                addKeys(requisition1.toRequisitionKey())
-                addKeys(requisition2.toRequisitionKey())
-              }
-            }
-            .build()
+        computationDetails = aggregatorComputationDetails,
+        requisitions = listOf(requisition1, requisition2)
       )
 
-      val metricValue =
-        MetricValue.newBuilder().setResourceKey(requisition1.toMetricValueResourceKey()).build()
-      val content = ByteString.copyFromUtf8("chunk")
-      whenever(mockMetricValues.getMetricValue(any()))
-        .thenReturn(metricValue)
-        .thenThrow(Status.NOT_FOUND.asRuntimeException())
-      whenever(mockMetricValues.streamMetricValue(any()))
-        .thenReturn(
-          flowOf(
-            StreamMetricValueResponse.newBuilder()
-              .apply {
-                headerBuilder.metricValue = metricValue
-                headerBuilder.dataSizeBytes = content.size.toLong()
-              }
-              .build(),
-            content.toMetricChunkResponse()
-          )
-        )
-        .thenThrow(Status.NOT_FOUND.asRuntimeException())
       whenever(mockGlobalComputations.createGlobalComputationStatusUpdate(any()))
         .thenReturn(GlobalComputationStatusUpdate.getDefaultInstance())
-      whenever(mockGlobalComputations.confirmGlobalComputation(any()))
-        .thenReturn(GlobalComputation.getDefaultInstance())
 
       // Stage 1. Process the above computation
       aggregatorMill.pollAndProcessNextComputation()
@@ -665,21 +541,14 @@ class LiquidLegionsV2MillTest {
             .setAttempt(1)
             .setComputationStage(COMPLETE.toProtocolStage())
             .setVersion(2) // CreateComputation + transitionStage
-            .setComputationDetails(nonAggregatorComputationDetails)
+            .setComputationDetails(
+              aggregatorComputationDetails.toBuilder().setEndingState(CompletedReason.FAILED)
+            )
+            .addAllRequisitions(listOf(requisition1, requisition2))
             .build()
         )
 
-      // Only one requisition is confirmed
-      verifyProtoArgument(
-          mockGlobalComputations,
-          GlobalComputationsCoroutineImplBase::confirmGlobalComputation
-        )
-        .isEqualTo(
-          ConfirmGlobalComputationRequest.newBuilder()
-            .setKey(GlobalComputation.Key.newBuilder().setGlobalComputationId(GLOBAL_ID))
-            .addReadyRequisitions("1".toMetricRequisitionKey())
-            .build()
-        )
+      // TODO: assert FailComputationParticipant call
 
       argumentCaptor<CreateGlobalComputationStatusUpdateRequest> {
         verifyBlocking(mockGlobalComputations, times(3)) {
@@ -707,6 +576,250 @@ class LiquidLegionsV2MillTest {
               .build()
           )
       }
+    }
+
+  @Test
+  fun `confirm requisition, passed at non-aggregator`() =
+    runBlocking<Unit> {
+      // Stage 0. preparing the storage and set up mock
+      val requisition1 =
+        RequisitionMetadata.newBuilder()
+          .apply {
+            externalDataProviderId = "A"
+            externalRequisitionId = "111"
+            path = "foo/123"
+            detailsBuilder.externalFulfillingDuchyId = DUCHY_ONE_NAME
+          }
+          .build()
+      val requisition2 =
+        RequisitionMetadata.newBuilder()
+          .apply {
+            externalDataProviderId = "B"
+            externalRequisitionId = "222"
+            clearPath() // Path is empty since it is fulfilled at another duchy.
+            detailsBuilder.externalFulfillingDuchyId = DUCHY_TWO_NAME
+          }
+          .build()
+      val computationParticipant1 =
+        ComputationParticipant.newBuilder()
+          .apply {
+            duchyId = DUCHY_ONE_NAME
+            publicKeyBuilder.apply {
+              generator = ByteString.copyFromUtf8("generator_1")
+              element = ByteString.copyFromUtf8("element_1")
+            }
+          }
+          .build()
+      val computationParticipant2 =
+        ComputationParticipant.newBuilder()
+          .apply {
+            duchyId = DUCHY_TWO_NAME
+            publicKeyBuilder.apply {
+              generator = ByteString.copyFromUtf8("generator_2")
+              element = ByteString.copyFromUtf8("element_2")
+            }
+          }
+          .build()
+      val computationParticipant3 =
+        ComputationParticipant.newBuilder()
+          .apply {
+            duchyId = DUCHY_THREE_NAME
+            publicKeyBuilder.apply {
+              generator = ByteString.copyFromUtf8("generator_3")
+              element = ByteString.copyFromUtf8("element_3")
+            }
+          }
+          .build()
+      val computationDetailsWithDuchyParticipants =
+        nonAggregatorComputationDetails
+          .toBuilder()
+          .apply {
+            liquidLegionsV2Builder.addAllParticipant(
+              listOf(computationParticipant1, computationParticipant2, computationParticipant3)
+            )
+          }
+          .build()
+
+      fakeComputationDb.addComputation(
+        globalId = GLOBAL_ID,
+        stage = CONFIRMATION_PHASE.toProtocolStage(),
+        computationDetails = computationDetailsWithDuchyParticipants,
+        requisitions = listOf(requisition1, requisition2)
+      )
+
+      whenever(mockGlobalComputations.createGlobalComputationStatusUpdate(any()))
+        .thenReturn(GlobalComputationStatusUpdate.getDefaultInstance())
+
+      // Stage 1. Process the above computation
+      aggregatorMill.pollAndProcessNextComputation()
+
+      // Stage 2. Check the status of the computation
+      assertThat(fakeComputationDb[LOCAL_ID]!!)
+        .isEqualTo(
+          ComputationToken.newBuilder()
+            .setGlobalComputationId(GLOBAL_ID)
+            .setLocalComputationId(LOCAL_ID)
+            .setAttempt(1)
+            .setComputationStage(WAIT_TO_START.toProtocolStage())
+            .setVersion(3) // CreateComputation + updateComputationDetail + transitionStage
+            .setComputationDetails(
+              computationDetailsWithDuchyParticipants.toBuilder().apply {
+                liquidLegionsV2Builder.apply {
+                  combinedPublicKeyBuilder.apply {
+                    generator = ByteString.copyFromUtf8("generator_1_generator_2_generator_3")
+                    element = ByteString.copyFromUtf8("element_1_element_2_element_3")
+                  }
+                  partiallyCombinedPublicKeyBuilder.apply {
+                    generator = ByteString.copyFromUtf8("generator_2_generator_3")
+                    element = ByteString.copyFromUtf8("element_2_element_3")
+                  }
+                }
+              }
+            )
+            .addAllRequisitions(listOf(requisition1, requisition2))
+            .build()
+        )
+
+      verifyProtoArgument(
+          mockComputationParticipants,
+          ComputationParticipantsCoroutineImplBase::confirmComputationParticipant
+        )
+        .isEqualTo(
+          ConfirmComputationParticipantRequest.newBuilder()
+            .apply {
+              keyBuilder.apply {
+                computationId = GLOBAL_ID
+                duchyId = DUCHY_ONE_NAME
+              }
+            }
+            .build()
+        )
+    }
+
+  @Test
+  fun `confirm requisition, passed at aggregator`() =
+    runBlocking<Unit> {
+      // Stage 0. preparing the storage and set up mock
+      val requisition1 =
+        RequisitionMetadata.newBuilder()
+          .apply {
+            externalDataProviderId = "A"
+            externalRequisitionId = "111"
+            path = "foo/123"
+            detailsBuilder.externalFulfillingDuchyId = DUCHY_ONE_NAME
+          }
+          .build()
+      val requisition2 =
+        RequisitionMetadata.newBuilder()
+          .apply {
+            externalDataProviderId = "B"
+            externalRequisitionId = "222"
+            clearPath() // Path is empty since it is fulfilled at another duchy.
+            detailsBuilder.externalFulfillingDuchyId = DUCHY_TWO_NAME
+          }
+          .build()
+      val computationParticipant1 =
+        ComputationParticipant.newBuilder()
+          .apply {
+            duchyId = DUCHY_ONE_NAME
+            publicKeyBuilder.apply {
+              generator = ByteString.copyFromUtf8("generator_1")
+              element = ByteString.copyFromUtf8("element_1")
+            }
+          }
+          .build()
+      val computationParticipant2 =
+        ComputationParticipant.newBuilder()
+          .apply {
+            duchyId = DUCHY_TWO_NAME
+            publicKeyBuilder.apply {
+              generator = ByteString.copyFromUtf8("generator_2")
+              element = ByteString.copyFromUtf8("element_2")
+            }
+          }
+          .build()
+      val computationParticipant3 =
+        ComputationParticipant.newBuilder()
+          .apply {
+            duchyId = DUCHY_THREE_NAME
+            publicKeyBuilder.apply {
+              generator = ByteString.copyFromUtf8("generator_3")
+              element = ByteString.copyFromUtf8("element_3")
+            }
+          }
+          .build()
+      val computationDetailsWithDuchyParticipants =
+        aggregatorComputationDetails
+          .toBuilder()
+          .apply {
+            liquidLegionsV2Builder.addAllParticipant(
+              listOf(computationParticipant1, computationParticipant2, computationParticipant3)
+            )
+          }
+          .build()
+      fakeComputationDb.addComputation(
+        globalId = GLOBAL_ID,
+        stage = CONFIRMATION_PHASE.toProtocolStage(),
+        computationDetails = computationDetailsWithDuchyParticipants,
+        requisitions = listOf(requisition1, requisition2)
+      )
+
+      whenever(mockGlobalComputations.createGlobalComputationStatusUpdate(any()))
+        .thenReturn(GlobalComputationStatusUpdate.getDefaultInstance())
+
+      // Stage 1. Process the above computation
+      aggregatorMill.pollAndProcessNextComputation()
+
+      // Stage 2. Check the status of the computation
+      assertThat(fakeComputationDb[LOCAL_ID]!!)
+        .isEqualTo(
+          ComputationToken.newBuilder()
+            .setGlobalComputationId(GLOBAL_ID)
+            .setLocalComputationId(LOCAL_ID)
+            .setAttempt(1)
+            .setComputationStage(WAIT_SETUP_PHASE_INPUTS.toProtocolStage())
+            .setVersion(3) // CreateComputation + updateComputationDetails + transitionStage
+            .addAllBlobs(listOf(newEmptyOutputBlobMetadata(0), newEmptyOutputBlobMetadata(1)))
+            .setStageSpecificDetails(
+              ComputationStageDetails.newBuilder().apply {
+                liquidLegionsV2Builder.waitSetupPhaseInputsDetailsBuilder.apply {
+                  putExternalDuchyLocalBlobId("DUCHY_TWO", 0L)
+                  putExternalDuchyLocalBlobId("DUCHY_THREE", 1L)
+                }
+              }
+            )
+            .setComputationDetails(
+              computationDetailsWithDuchyParticipants.toBuilder().apply {
+                liquidLegionsV2Builder.apply {
+                  combinedPublicKeyBuilder.apply {
+                    generator = ByteString.copyFromUtf8("generator_1_generator_2_generator_3")
+                    element = ByteString.copyFromUtf8("element_1_element_2_element_3")
+                  }
+                  partiallyCombinedPublicKeyBuilder.apply {
+                    generator = ByteString.copyFromUtf8("generator_1_generator_2_generator_3")
+                    element = ByteString.copyFromUtf8("element_1_element_2_element_3")
+                  }
+                }
+              }
+            )
+            .addAllRequisitions(listOf(requisition1, requisition2))
+            .build()
+        )
+
+      verifyProtoArgument(
+          mockComputationParticipants,
+          ComputationParticipantsCoroutineImplBase::confirmComputationParticipant
+        )
+        .isEqualTo(
+          ConfirmComputationParticipantRequest.newBuilder()
+            .apply {
+              keyBuilder.apply {
+                computationId = GLOBAL_ID
+                duchyId = DUCHY_ONE_NAME
+              }
+            }
+            .build()
+        )
     }
 
   @Test
@@ -1353,7 +1466,9 @@ class LiquidLegionsV2MillTest {
           .setAttempt(1)
           .setComputationStage(COMPLETE.toProtocolStage())
           .setVersion(3) // CreateComputation + writeOutputBlob + transitionStage
-          .setComputationDetails(nonAggregatorComputationDetails)
+          .setComputationDetails(
+            nonAggregatorComputationDetails.toBuilder().setEndingState(CompletedReason.SUCCEEDED)
+          )
           .build()
       )
     assertThat(computationStore.get(blobKey)?.readToString())
@@ -1426,7 +1541,9 @@ class LiquidLegionsV2MillTest {
           .setAttempt(1)
           .setComputationStage(COMPLETE.toProtocolStage())
           .setVersion(3) // CreateComputation + writeOutputBlob + transitionStage
-          .setComputationDetails(computationDetailsWithReach)
+          .setComputationDetails(
+            computationDetailsWithReach.toBuilder().setEndingState(CompletedReason.SUCCEEDED)
+          )
           .build()
       )
     assertThat(computationStore.get(blobKey)?.readToString()).isNotEmpty()

--- a/src/test/kotlin/org/wfanet/measurement/duchy/daemon/mill/liquidlegionsv2/crypto/JniLiquidLegionsV2EncryptionTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/duchy/daemon/mill/liquidlegionsv2/crypto/JniLiquidLegionsV2EncryptionTest.kt
@@ -17,6 +17,7 @@ package org.wfanet.measurement.duchy.daemon.mill.liquidlegionsv2.crypto
 import com.google.common.truth.Truth.assertThat
 import kotlin.test.assertFailsWith
 import org.junit.Test
+import org.wfanet.anysketch.crypto.CombineElGamalPublicKeysRequest
 import org.wfanet.measurement.internal.duchy.protocol.CompleteExecutionPhaseTwoRequest
 
 class JniLiquidLegionsV2EncryptionTest {
@@ -24,11 +25,19 @@ class JniLiquidLegionsV2EncryptionTest {
   @Test
   fun `check JNI lib is loaded successfully`() {
     // Send an invalid request and check if we can get the error thrown inside JNI.
-    val e =
+    val e1 =
       assertFailsWith(RuntimeException::class) {
         JniLiquidLegionsV2Encryption()
           .completeExecutionPhaseTwo(CompleteExecutionPhaseTwoRequest.getDefaultInstance())
       }
-    assertThat(e.message).contains("Failed to create the protocol cipher")
+    assertThat(e1.message).contains("Failed to create the protocol cipher")
+
+    // Send an invalid request and check if we can get the error thrown inside JNI.
+    val e2 =
+      assertFailsWith(RuntimeException::class) {
+        JniLiquidLegionsV2Encryption()
+          .combineElGamalPublicKeys(CombineElGamalPublicKeysRequest.getDefaultInstance())
+      }
+    assertThat(e2.message).contains("Keys cannot be empty")
   }
 }

--- a/src/test/kotlin/org/wfanet/measurement/duchy/db/computation/LiquidLegionsSketchAggregationV2ProtocolEnumStagesDetailsTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/duchy/db/computation/LiquidLegionsSketchAggregationV2ProtocolEnumStagesDetailsTest.kt
@@ -34,9 +34,9 @@ class LiquidLegionsSketchAggregationV2ProtocolEnumStagesDetailsTest {
             ComputationStageDetails.newBuilder()
               .apply {
                 liquidLegionsV2Builder.waitSetupPhaseInputsDetailsBuilder.apply {
-                  putExternalDuchyLocalBlobId("A", 1L)
-                  putExternalDuchyLocalBlobId("B", 2L)
-                  putExternalDuchyLocalBlobId("C", 3L)
+                  putExternalDuchyLocalBlobId("A", 0L)
+                  putExternalDuchyLocalBlobId("B", 1L)
+                  putExternalDuchyLocalBlobId("C", 2L)
                 }
               }
               .build()

--- a/src/test/kotlin/org/wfanet/measurement/duchy/service/internal/computation/ComputationsServiceTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/duchy/service/internal/computation/ComputationsServiceTest.kt
@@ -26,7 +26,6 @@ import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 import org.wfanet.measurement.common.grpc.testing.GrpcTestServerRule
 import org.wfanet.measurement.common.testing.verifyProtoArgument
-import org.wfanet.measurement.duchy.db.computation.ExternalRequisitionKey
 import org.wfanet.measurement.duchy.db.computation.testing.FakeComputationsDatabase
 import org.wfanet.measurement.duchy.toProtocolStage
 import org.wfanet.measurement.internal.duchy.AdvanceComputationStageRequest
@@ -40,6 +39,7 @@ import org.wfanet.measurement.internal.duchy.GetComputationIdsResponse
 import org.wfanet.measurement.internal.duchy.RecordOutputBlobPathRequest
 import org.wfanet.measurement.internal.duchy.RecordRequisitionBlobPathRequest
 import org.wfanet.measurement.internal.duchy.RequisitionDetails
+import org.wfanet.measurement.internal.duchy.RequisitionMetadata
 import org.wfanet.measurement.internal.duchy.UpdateComputationDetailsRequest
 import org.wfanet.measurement.internal.duchy.config.LiquidLegionsV2SetupConfig.RoleInComputation
 import org.wfanet.measurement.internal.duchy.protocol.LiquidLegionsSketchAggregationV2
@@ -86,7 +86,15 @@ class ComputationsServiceTest {
       globalId = id,
       stage = LiquidLegionsSketchAggregationV2.Stage.EXECUTION_PHASE_ONE.toProtocolStage(),
       computationDetails = aggregatorComputationDetails,
-      requisitions = listOf(ExternalRequisitionKey("edp1", "1234"))
+      requisitions =
+        listOf(
+          RequisitionMetadata.newBuilder()
+            .apply {
+              externalDataProviderId = "edp1"
+              externalRequisitionId = "1234"
+            }
+            .build()
+        )
     )
 
     val expectedToken =
@@ -153,7 +161,20 @@ class ComputationsServiceTest {
       stage = LiquidLegionsSketchAggregationV2.Stage.EXECUTION_PHASE_ONE.toProtocolStage(),
       computationDetails = aggregatorComputationDetails,
       requisitions =
-        listOf(ExternalRequisitionKey("edp1", "1234"), ExternalRequisitionKey("edp2", "5678"))
+        listOf(
+          RequisitionMetadata.newBuilder()
+            .apply {
+              externalDataProviderId = "edp1"
+              externalRequisitionId = "1234"
+            }
+            .build(),
+          RequisitionMetadata.newBuilder()
+            .apply {
+              externalDataProviderId = "edp2"
+              externalRequisitionId = "5678"
+            }
+            .build()
+        )
     )
     val tokenAtStart = fakeService.getComputationToken(id.toGetTokenRequest()).token
     val newComputationDetails =
@@ -233,6 +254,7 @@ class ComputationsServiceTest {
           .apply {
             version = 1
             computationStage = LiquidLegionsSketchAggregationV2.Stage.COMPLETE.toProtocolStage()
+            computationDetailsBuilder.endingState = ComputationDetails.CompletedReason.FAILED
           }
           .build()
           .toFinishComputationResponse()
@@ -452,7 +474,15 @@ class ComputationsServiceTest {
       globalId = id,
       stage = LiquidLegionsSketchAggregationV2.Stage.EXECUTION_PHASE_ONE.toProtocolStage(),
       computationDetails = aggregatorComputationDetails,
-      requisitions = listOf(ExternalRequisitionKey("edp1", "1234"))
+      requisitions =
+        listOf(
+          RequisitionMetadata.newBuilder()
+            .apply {
+              externalDataProviderId = "edp1"
+              externalRequisitionId = "1234"
+            }
+            .build()
+        )
     )
 
     val tokenAtStart = fakeService.getComputationToken(id.toGetTokenRequest()).token


### PR DESCRIPTION
Behavior change:
previously, the mill would fetch all local requisitions from the
metricValueService and store the combined sketch locally for the future
processing.
Now, the mill just verify requistions status based on the database information,
no blob read/write is done.

so the output blob number of the INITIALIZATION_PHASE changes from 1 to
0. And there is no input blob for the WAIT_TO_START and
WAIT_SETUP_PHASE_INPUT stages any more.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/world-federation-of-advertisers/cross-media-measurement/98)
<!-- Reviewable:end -->
