### PR TITLE
Add IntelliJ instructions

### DIFF
--- a/docs/building.md
+++ b/docs/building.md
@@ -31,13 +31,19 @@ bazel test //src/test/...
 To build on MacOS you need to run the bazel build/test in a docker container using
 `tools/bazel-container build "//..."`
 
-As of early June 2021, these steps work to get code completion working for Intellij on MacOS:
+fyi, currently using the docker build clashes with running the bazel build locally on your computer.
+
+
+### IntelliJ Setup
+
+As of early June 2021, these steps work to get code completion working for Intellij:
 - use IntelliJ 2021.1.2 and the beta build of the Bazel Plugin
     - Add `https://plugins.jetbrains.com/plugins/list?channel=beta` to your list of plugin repos ([source](https://github.com/bazelbuild/intellij/issues/2406))
 - Start a new project from scratch in IntelliJ by selecting "Import Bazel Project" and open the base dir of the cross-media-measurement repo
     - Uncomment "Kotlin" when creating the .bazelproject file
 - Once the new projected is created, the Bazel plugin will kick off a sync and, after a while, IntelliJ should start detecting all dependencies and index them. Ignore the Bazel output errors, they happen because e.g. the Spanner Emulator can only be build on Linux.
-- You can run most Kotlin tests (with some exceptions, e.g. TransportSecurityTest.kt doesn't work because of openssl incompatibilities) by directly invoking a particular test: `bazel test "//src/test/kotlin/org/wfanet/measurement/common/identity/..."` or similar.
+
+On MacOS not all targets are supported for building but you can run most Kotlin tests (with some exceptions, e.g. TransportSecurityTest.kt doesn't work because of openssl incompatibilities) by directly invoking a particular test: `bazel test "//src/test/kotlin/org/wfanet/measurement/common/identity/..."` or similar.
 
 
 ### Local Kubernetes

--- a/docs/building.md
+++ b/docs/building.md
@@ -31,6 +31,14 @@ bazel test //src/test/...
 To build on MacOS you need to run the bazel build/test in a docker container using
 `tools/bazel-container build "//..."`
 
+As of early June 2021, these steps work to get code completion working for Intellij on MacOS:
+- use IntelliJ 2021.1.2 and the beta build of the Bazel Plugin
+    - Add `https://plugins.jetbrains.com/plugins/list?channel=beta` to your list of plugin repos ([source](https://github.com/bazelbuild/intellij/issues/2406))
+- Start a new project from scratch in IntelliJ by selecting "Import Bazel Project" and open the base dir of the cross-media-measurement repo
+    - Uncomment "Kotlin" when creating the .bazelproject file
+- Once the new projected is created, the Bazel plugin will kick off a sync and, after a while, IntelliJ should start detecting all dependencies and index them. Ignore the Bazel output errors, they happen because e.g. the Spanner Emulator can only be build on Linux.
+- You can run most Kotlin tests (with some exceptions, e.g. TransportSecurityTest.kt doesn't work because of openssl incompatibilities) by directly invoking a particular test: `bazel test "//src/test/kotlin/org/wfanet/measurement/common/identity/..."` or similar.
+
 
 ### Local Kubernetes
 


### PR DESCRIPTION
As per our discussion yesterday, adding a few instructions to the doc so they're not getting lost before the next person onboards.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/world-federation-of-advertisers/cross-media-measurement/101)
<!-- Reviewable:end -->
