### PR TITLE
Update llv2 mill implementation for all execution phases.

### DIFF
--- a/src/main/cc/wfa/measurement/internal/duchy/protocol/liquid_legions_v2/noise_parameters_computation.h
+++ b/src/main/cc/wfa/measurement/internal/duchy/protocol/liquid_legions_v2/noise_parameters_computation.h
@@ -37,10 +37,6 @@ math::DistributedGeometricRandomComponentOptions GetFrequencyNoiseOptions(
     const wfa::measurement::internal::duchy::DifferentialPrivacyParams& params,
     int uncorrupted_party_count);
 
-math::TruncatedDiscreteLaplaceDistributedOptions GetPublisherNoiseOptions(
-    const wfa::measurement::internal::duchy::DifferentialPrivacyParams& params,
-    int publisher_count);
-
 }  // namespace wfa::measurement::internal::duchy::protocol::liquid_legions_v2
 
 #endif  // SRC_MAIN_CC_WFA_MEASUREMENT_INTERNAL_DUCHY_PROTOCOL_LIQUID_LEGIONS_V2_NOISE_PARAMETERS_COMPUTATION_H_

--- a/src/main/kotlin/org/wfanet/measurement/duchy/db/computation/ComputationDataClients.kt
+++ b/src/main/kotlin/org/wfanet/measurement/duchy/db/computation/ComputationDataClients.kt
@@ -122,7 +122,20 @@ private constructor(
     return response.token
   }
 
-  /** Returns a map of [BlobRef]s to the actual bytes of the BLOB for all inputs to the stage. */
+  /** Reads and combines all requisition blobs fulfilled at this duchy. */
+  suspend fun readAllRequisitionBlobs(token: ComputationToken, duchyId: String): ByteString {
+    return token
+      .requisitionsList
+      .filter { it.details.externalFulfillingDuchyId == duchyId }
+      .map {
+        checkNotNull(computationStore.get(it.path)) { "Blob with key ${it.path} not found" }
+          .read()
+          .flatten()
+      }
+      .flatten()
+  }
+
+  /** Returns a map of [BlobRef]s to the actual bytes of the blob for all inputs to the stage. */
   suspend fun readInputBlobs(token: ComputationToken): Map<BlobRef, ByteString> {
     return token
       .blobsList

--- a/src/main/kotlin/org/wfanet/measurement/duchy/deploy/common/daemon/mill/liquidlegionsv2/LiquidLegionsV2MillFlags.kt
+++ b/src/main/kotlin/org/wfanet/measurement/duchy/deploy/common/daemon/mill/liquidlegionsv2/LiquidLegionsV2MillFlags.kt
@@ -16,27 +16,12 @@ package org.wfanet.measurement.duchy.deploy.common.daemon.mill.liquidlegionsv2
 
 import java.time.Duration
 import kotlin.properties.Delegates
-import org.wfanet.measurement.duchy.DuchyPublicKeys
 import org.wfanet.measurement.duchy.deploy.common.CommonDuchyFlags
 import picocli.CommandLine
 
 class LiquidLegionsV2MillFlags {
   @CommandLine.Mixin
   lateinit var duchy: CommonDuchyFlags
-    private set
-
-  @CommandLine.Mixin
-  lateinit var duchyPublicKeys: DuchyPublicKeys.Flags
-    private set
-
-  // TODO: Switch to a more secure option such as a keystore prior to initial
-  // production deployment.
-  @CommandLine.Option(
-    names = ["--duchy-secret-key"],
-    description = ["This Duchy's secret key component of its ElGamal key pair."],
-    required = true
-  )
-  lateinit var duchySecretKey: String
     private set
 
   @CommandLine.Option(
@@ -106,51 +91,11 @@ class LiquidLegionsV2MillFlags {
   lateinit var millId: String
     private set
 
-  @CommandLine.Option(
-    names = ["--aggregator-id"],
-    description = ["The Identifier of the aggregator duchy."],
-    required = true
-  )
-  lateinit var aggregatorId: String
-    private set
-
   @set:CommandLine.Option(
     names = ["--bytes-per-chunk"],
     description = ["The number of bytes in a chunk when sending rpc result to other duchy."],
     defaultValue = "32768" // 32 KiB. See https://github.com/grpc/grpc.github.io/issues/371.
   )
   var requestChunkSizeBytes by Delegates.notNull<Int>()
-    private set
-
-  @set:CommandLine.Option(
-    names = ["--liquid-legions-decay-rate"],
-    description = ["The decay rate of liquid legions sketch."],
-    defaultValue = "12.0"
-  )
-  var liquidLegionsDecayRate by Delegates.notNull<Double>()
-    private set
-
-  @set:CommandLine.Option(
-    names = ["--liquid-legions-size"],
-    description = ["The maximum size of liquid legions sketch."],
-    defaultValue = "100000"
-  )
-  var liquidLegionsSize by Delegates.notNull<Long>()
-    private set
-
-  @set:CommandLine.Option(
-    names = ["--sketch-max-frequency"],
-    description = ["The maximum frequency to reveal in the histogram."],
-    defaultValue = "10"
-  )
-  var sketchMaxFrequency by Delegates.notNull<Int>()
-    private set
-
-  @CommandLine.Option(
-    names = ["--noise-config"],
-    description = ["LiquidLegionsV2NoiseConfig proto message in text format."],
-    required = true
-  )
-  lateinit var noiseConfig: String
     private set
 }

--- a/src/main/proto/wfa/measurement/internal/duchy/protocol/liquid_legions_sketch_aggregation_v2.proto
+++ b/src/main/proto/wfa/measurement/internal/duchy/protocol/liquid_legions_sketch_aggregation_v2.proto
@@ -157,22 +157,17 @@ message LiquidLegionsSketchAggregationV2 {
     // computation.
     ReachEstimate reach_estimate = 4;
 
-    // Total number of MetricRequisitions across all duchies used in this
-    // computation.
-    // TODO(wangyaopw): delete after v2alpha is done
-    int32 total_requisition_count = 5;
+    // The Elgamal public key combined from all duchy participants' public keys.
+    ElGamalPublicKey combined_public_key = 5;
+
+    // The Elgamal public key combined from the public keys of the duchies after
+    // this duchy in the ring and the aggregator duchy.
+    ElGamalPublicKey partially_combined_public_key = 6;
 
     // The local elgamal key used in this computation.
     // TODO(wangyaopw): delete this field when we switch to use a secure key
     //  store for duchy private keys.
-    ElGamalKeyPair local_elgamal_key = 6;
-
-    // The Elgamal public key combined from all duchy participants' public keys.
-    ElGamalPublicKey combined_public_key = 7;
-
-    // The Elgamal public key combined from the public keys of the duchies after
-    // this duchy in the ring and the aggregator duchy.
-    ElGamalPublicKey partially_combined_public_key = 8;
+    ElGamalKeyPair local_elgamal_key = 7;
   }
 
   // Details about a particular attempt of running a stage of the LiquidLegionV2


### PR DESCRIPTION
Two key changes:
1. In the setup phase, the data is now read from the
requisitionBlobs instead of from the stage input blob.
2. The parameters of all crypto library calls now come from
the computationDetails instead of from the mill's configuration.
In other words, no shared parameters for all computations anymore.

Also updated the test to use kotlin style apply{} for all proto
messages.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/world-federation-of-advertisers/cross-media-measurement/105)
<!-- Reviewable:end -->
