### PR TITLE
Change ExchangeStepAttemptDetails inputs/outputs

### DIFF
--- a/src/main/proto/wfa/measurement/internal/kingdom/exchange_step_attempt_details.proto
+++ b/src/main/proto/wfa/measurement/internal/kingdom/exchange_step_attempt_details.proto
@@ -33,10 +33,13 @@ message ExchangeStepAttemptDetails {
   // Warnings, errors, and other messages for debugging purposes. Append-only.
   repeated DebugLog debug_log_entries = 4;
 
-  // Paths, tables, etc. accessible to the other party.
-  // Each of these is an encrypted SignedData. Each SignedData holds a
-  // serialized SharedOutput protocol buffer from the public API.
-  repeated bytes shared_outputs = 5;
+  // Signed URL containing paths, tables, etc. accessible to the other party.
+  // Each of these point to remote cloud blob storage services.
+  // Initially these will only support GCS urls.
+  // Outputs point to encrypted data.
+  repeated string shared_outputs = 5;
+  // Inputs point to a bucket location to push encrypted data to.
+  repeated string shared_inputs = 8;
 
   // When the ExchangeStepAttempt was created.
   google.protobuf.Timestamp start_time = 6;


### PR DESCRIPTION
Changes the ExchangeStepAttemptDetails proto to have both a shared inputs and
shared outputs field. Changes field type from bytes (blob) to string
with the expectation that the storage step will pass signed cloud
storage urls containing the exchange data blob rather than the actual blob
itself. These blobs would likely be quite large and not work as part of
an API reponse directly. As this proto is not yet used it does not seem
necessary to reserve the existing shared_ouputs and use a new field
name despite the change in field type.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/world-federation-of-advertisers/cross-media-measurement/136)
<!-- Reviewable:end -->
