### PR TITLE
Revert "Migrate testutil dependency to common_cpp"

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -304,15 +304,3 @@ switched_rules_by_language(
     name = "com_google_googleapis_imports",
     java = True,
 )
-
-# Common-cpp
-http_archive(
-    name = "wfa_common_cpp",
-    sha256 = "e0e1f5eed832ef396109354a64c6c1306bf0fb5ea0b449ce6ee1e8edc6fe279d",
-    strip_prefix = "common-cpp-43c75acc3394e19bcfd2cfe8e8e2454365d26d60",
-    url = "https://github.com/world-federation-of-advertisers/common-cpp/archive/43c75acc3394e19bcfd2cfe8e8e2454365d26d60.tar.gz",
-)
-
-load("@wfa_common_cpp//build:deps.bzl", "common_cpp_deps")
-
-common_cpp_deps()

--- a/src/test/cc/testutil/BUILD.bazel
+++ b/src/test/cc/testutil/BUILD.bazel
@@ -1,0 +1,25 @@
+load("@rules_cc//cc:defs.bzl", "cc_library")
+
+package(
+    default_visibility = [
+        "//visibility:public",
+    ],
+)
+
+cc_library(
+    name = "status_macros",
+    testonly = True,
+    hdrs = ["status_macros.h"],
+)
+
+cc_library(
+    name = "matchers",
+    testonly = True,
+    hdrs = ["matchers.h"],
+    deps = [
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/status:statusor",
+        "@com_google_protobuf//:protobuf",
+        "@googletest//:gtest",
+    ],
+)

--- a/src/test/cc/testutil/matchers.h
+++ b/src/test/cc/testutil/matchers.h
@@ -1,0 +1,81 @@
+// Copyright 2020 The Cross-Media Measurement Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef SRC_TEST_CC_TESTUTIL_MATCHERS_H_
+#define SRC_TEST_CC_TESTUTIL_MATCHERS_H_
+
+#include <string>
+
+#include "absl/status/status.h"
+#include "absl/status/statusor.h"
+#include "gmock/gmock.h"
+#include "google/protobuf/util/message_differencer.h"
+#include "gtest/gtest.h"
+
+namespace wfa {
+
+MATCHER(IsOk, "") {
+  return testing::ExplainMatchResult(true, arg.ok(), result_listener);
+}
+
+MATCHER(IsNotOk, "") {
+  return testing::ExplainMatchResult(testing::Not(IsOk()), arg,
+                                     result_listener);
+}
+
+MATCHER_P(IsOkAndHolds, value, "") {
+  if (arg.ok()) {
+    return testing::ExplainMatchResult(value, arg.value(), result_listener);
+  }
+
+  *result_listener << "expected OK status instead of error code "
+                   << absl::StatusCodeToString(arg.status().code())
+                   << " and message " << arg.status();
+  return false;
+}
+
+MATCHER_P2(StatusIs, code, message, "") {
+  if (arg.code() != code) {
+    *result_listener << "Expected code: " << code << " but got code "
+                     << arg.code();
+    return false;
+  }
+  return testing::ExplainMatchResult(
+      testing::HasSubstr(message), std::string(arg.message()), result_listener);
+}
+
+MATCHER_P(IsBlockSorted, block_size, "") {
+  if (arg.length() % block_size != 0) {
+    return false;
+  }
+  for (size_t i = block_size; i < arg.length(); i += block_size) {
+    if (arg.substr(i, block_size) < arg.substr(i - block_size, block_size)) {
+      return false;
+    }
+  }
+  return true;
+}
+
+// Returns true if two proto messages are equal when ignoring the order of
+// repeated fields.
+MATCHER_P(EqualsProto, expected, "") {
+  ::google::protobuf::util::MessageDifferencer differencer;
+  differencer.set_repeated_field_comparison(
+      ::google::protobuf::util::MessageDifferencer::AS_SET);
+  return differencer.Compare(arg, expected);
+}
+
+}  // namespace wfa
+
+#endif  // SRC_TEST_CC_TESTUTIL_MATCHERS_H_

--- a/src/test/cc/testutil/status_macros.h
+++ b/src/test/cc/testutil/status_macros.h
@@ -1,0 +1,31 @@
+// Copyright 2020 The Cross-Media Measurement Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef SRC_TEST_CC_TESTUTIL_STATUS_MACROS_H_H_
+#define SRC_TEST_CC_TESTUTIL_STATUS_MACROS_H_H_
+
+#define ASSERT_OK_AND_ASSIGN(lhs, rexpr) \
+  ASSERT_OK_AND_ASSIGN_IMPL(             \
+      STATUS_MACROS_CONCAT_NAME(_status_or_value, __COUNTER__), lhs, rexpr)
+
+#define ASSERT_OK_AND_ASSIGN_IMPL(statusor, lhs, rexpr) \
+  auto statusor = (rexpr);                              \
+  ASSERT_TRUE(statusor.ok());                           \
+  lhs = std::move(statusor).value()
+
+#define STATUS_MACROS_CONCAT_NAME(x, y) STATUS_MACROS_CONCAT_IMPL(x, y)
+
+#define STATUS_MACROS_CONCAT_IMPL(x, y) x##y
+
+#endif  // SRC_TEST_CC_TESTUTIL_STATUS_MACROS_H_H_

--- a/src/test/cc/wfa/measurement/internal/duchy/protocol/liquid_legions_v2/BUILD.bazel
+++ b/src/test/cc/wfa/measurement/internal/duchy/protocol/liquid_legions_v2/BUILD.bazel
@@ -9,12 +9,13 @@ cc_test(
     ],
     deps = [
         "//src/main/cc/wfa/measurement/internal/duchy/protocol/liquid_legions_v2:liquid_legions_v2_encryption_utility",
+        "//src/test/cc/testutil:matchers",
+        "//src/test/cc/testutil:status_macros",
         "@any_sketch//src/main/cc/any_sketch/crypto:sketch_encrypter",
         "@any_sketch//src/main/cc/estimation:estimators",
         "@any_sketch//src/main/proto/wfa/any_sketch:sketch_cc_proto",
         "@googletest//:gtest",
         "@googletest//:gtest_main",
-        "@wfa_common_cpp//src/main/cc/common_cpp/testing:status",
     ],
 )
 

--- a/src/test/cc/wfa/measurement/internal/duchy/protocol/liquid_legions_v2/liquid_legions_v2_encryption_utility_test.cc
+++ b/src/test/cc/wfa/measurement/internal/duchy/protocol/liquid_legions_v2/liquid_legions_v2_encryption_utility_test.cc
@@ -24,9 +24,9 @@
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 #include "src/main/cc/any_sketch/crypto/sketch_encrypter.h"
-#include "src/main/cc/common_cpp/testing/status_macros.h"
-#include "src/main/cc/common_cpp/testing/status_matchers.h"
 #include "src/main/cc/estimation/estimators.h"
+#include "src/test/cc/testutil/matchers.h"
+#include "src/test/cc/testutil/status_macros.h"
 #include "wfa/any_sketch/sketch.pb.h"
 #include "wfa/measurement/common/crypto/constants.h"
 #include "wfa/measurement/common/crypto/ec_point_util.h"
@@ -243,18 +243,6 @@ absl::StatusOr<bool> IsPaddingFrequencyNoiseTuples(
                    GetFlagsFromFourTuples(cipher, four_tuples_bytes));
   // (0, 0, R)
   return !flags[0] && !flags[1] && flags[2];
-}
-
-MATCHER_P(IsBlockSorted, block_size, "") {
-  if (arg.length() % block_size != 0) {
-    return false;
-  }
-  for (size_t i = block_size; i < arg.length(); i += block_size) {
-    if (arg.substr(i, block_size) < arg.substr(i - block_size, block_size)) {
-      return false;
-    }
-  }
-  return true;
 }
 
 // The TestData generates cipher keys for 3 duchies, and the combined public


### PR DESCRIPTION
Reverts world-federation-of-advertisers/cross-media-measurement#162

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/world-federation-of-advertisers/cross-media-measurement/163)
<!-- Reviewable:end -->
