### PR TITLE
Add missing fields to internal Measurement/Requisition.

### DIFF
--- a/src/main/kotlin/org/wfanet/measurement/kingdom/service/system/v1alpha/ProtoConversions.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/service/system/v1alpha/ProtoConversions.kt
@@ -39,7 +39,7 @@ import org.wfanet.measurement.system.v1alpha.RequisitionKey
 import org.wfanet.measurement.system.v1alpha.StageAttempt
 
 /** Converts a kingdom internal Requisition to system Api Requisition. */
-fun InternalRequisition.toSystemRequisition(): Requisition {
+fun InternalRequisition.toSystemRequisition(publicApiVersion: Version): Requisition {
   return Requisition.newBuilder()
     .also {
       it.name =
@@ -49,7 +49,7 @@ fun InternalRequisition.toSystemRequisition(): Requisition {
           )
           .toName()
       it.dataProvider =
-        when (Version.fromString(apiVersion)) {
+        when (publicApiVersion) {
           Version.V2_ALPHA -> DataProviderKey(externalIdToApiId(externalDataProviderId)).toName()
           Version.VERSION_UNSPECIFIED -> error("Public api version is invalid or unspecified.")
         }
@@ -180,7 +180,9 @@ fun InternalMeasurement.toSystemComputation(): Computation {
         }
       )
       it.addAllRequisitions(
-        requisitionsList.map { requisition -> requisition.toSystemRequisition() }
+        requisitionsList.map { requisition ->
+          requisition.toSystemRequisition(Version.fromString(details.apiVersion))
+        }
       )
       it.duchyProtocolConfig = details.duchyProtocolConfig.toSystemDuchyProtocolConfig()
     }

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/service/system/v1alpha/RequisitionsService.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/service/system/v1alpha/RequisitionsService.kt
@@ -14,6 +14,7 @@
 
 package org.wfanet.measurement.kingdom.service.system.v1alpha
 
+import org.wfanet.measurement.api.Version
 import org.wfanet.measurement.common.grpc.grpcRequire
 import org.wfanet.measurement.common.grpc.grpcRequireNotNull
 import org.wfanet.measurement.common.identity.DuchyIdentity
@@ -49,6 +50,9 @@ class RequisitionsService(
           dataProviderParticipationSignature = request.dataProviderParticipationSignature
         }
         .build()
-    return internalRequisitionsClient.fulfillRequisition(internalRequest).toSystemRequisition()
+    val internalResponse = internalRequisitionsClient.fulfillRequisition(internalRequest)
+    return internalResponse.toSystemRequisition(
+      Version.fromString(internalResponse.parentMeasurement.apiVersion)
+    )
   }
 }

--- a/src/main/proto/wfa/measurement/internal/kingdom/BUILD.bazel
+++ b/src/main/proto/wfa/measurement/internal/kingdom/BUILD.bazel
@@ -396,6 +396,7 @@ proto_and_java_proto_library(
 proto_and_java_proto_library(
     name = "requisition",
     deps = [
+        ":computation_participant_proto",
         "@com_google_protobuf//:timestamp_proto",
     ],
 )

--- a/src/main/proto/wfa/measurement/internal/kingdom/measurement.proto
+++ b/src/main/proto/wfa/measurement/internal/kingdom/measurement.proto
@@ -83,6 +83,20 @@ message Measurement {
   }
   State state = 9;
 
+  message DataProviderValue {
+    fixed64 external_data_provider_certificate_id = 1;
+
+    // Serialized `EncryptionPublicKey` message from the public API.
+    bytes data_provider_public_key = 2;
+    bytes data_provider_public_key_signature = 3;
+
+    bytes encrypted_requisition_spec = 4;
+  }
+  // Map of external DataProvider ID to DataProviderValue.
+  //
+  // Only set for DEFAULT view.
+  map<fixed64, DataProviderValue> data_providers = 10;
+
   message Details {
     // Version the public API for serialized message definitions.
     string api_version = 1;
@@ -100,16 +114,17 @@ message Measurement {
     bytes result_public_key = 8;
     bytes encrypted_result = 9;
   }
-  Details details = 10;
-  string details_json = 11;
+  Details details = 11;
+  string details_json = 12;
 
-  // Child Requisitions of this Measurement. Output-only.
+  // Child Requisitions of this Measurement, using Requisition.View.NORMALIZED.
+  // Output-only.
   //
   // Only set for COMPUTATION view.
-  repeated Requisition requisitions = 12;
+  repeated Requisition requisitions = 13;
 
   // Child ComputationParticipants of this Measurement. Output-only.
   //
   // Only set for COMPUTATION view.
-  repeated ComputationParticipant computation_participants = 13;
+  repeated ComputationParticipant computation_participants = 14;
 }

--- a/src/main/proto/wfa/measurement/internal/kingdom/requisition.proto
+++ b/src/main/proto/wfa/measurement/internal/kingdom/requisition.proto
@@ -17,11 +17,19 @@ syntax = "proto3";
 package wfa.measurement.internal.kingdom;
 
 import "google/protobuf/timestamp.proto";
+import "wfa/measurement/internal/kingdom/computation_participant.proto";
 
 option java_package = "org.wfanet.measurement.internal.kingdom";
 option java_multiple_files = true;
 
 message Requisition {
+  enum View {
+    // Default view, which includes all fields.
+    FULL = 0;
+
+    // Normalized view, which excludes fields from other entities.
+    NORMALIZED = 1;
+  }
   fixed64 external_measurement_consumer_id = 1;
   fixed64 external_measurement_id = 2;
   fixed64 external_requisition_id = 3;
@@ -92,20 +100,46 @@ message Requisition {
     string message = 2;
   }
 
+  message DuchyValue {
+    // External ID of Certificate used to verify signatures in protocol field.
+    fixed64 external_duchy_certificate_id = 1;
+
+    oneof protocol {
+      ComputationParticipant.LiquidLegionsV2Details liquid_legions_v2 = 2;
+    }
+  }
+  // Map of external Duchy ID to DuchyValue.
+  map<string, DuchyValue> duchies = 10;
+
   message Details {
     // Serialized `EncryptionPublicKey` message from the public API.
     bytes data_provider_public_key = 1;
     bytes data_provider_public_key_signature = 2;
 
-    bytes data_provider_participation_signature = 3;
+    bytes encrypted_requisition_spec = 3;
 
-    Refusal refusal = 4;
+    bytes data_provider_participation_signature = 4;
+
+    Refusal refusal = 5;
   }
-  Details details = 10;
-  string details_json = 11;
+  Details details = 11;
+  string details_json = 12;
 
-  // Version of the public API for serialized message definitions as well as
-  // resource names, which is denormalized from the parent Measurement.
-  // Output-only.
-  string api_version = 12;
+  message ParentMeasurement {
+    // Version of the public API for serialized message definitions as well as
+    // resource names.
+    string api_version = 1;
+
+    fixed64 external_measurement_consumer_certificate_id = 2;
+
+    // Serialized `MeasurementSpec` from public API.
+    bytes measurement_spec = 3;
+    bytes measurement_spec_signature = 4;
+
+    string external_protocol_config_id = 5;
+  }
+  // Denormalized fields from the parent Measurement. Output-only.
+  //
+  // Only set for FULL view.
+  ParentMeasurement parent_measurement = 13;
 }

--- a/src/test/kotlin/org/wfanet/measurement/kingdom/service/system/v1alpha/ComputationsServiceTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/kingdom/service/system/v1alpha/ComputationsServiceTest.kt
@@ -101,9 +101,7 @@ private val INTERNAL_REQUISITION =
       externalDataProviderId = EXTERNAL_DATA_PROVIDER_ID
       externalFulfillingDuchyId = DUCHY_ID
       state = InternalRequisition.State.FULFILLED
-      apiVersion = PUBLIC_API_VERSION
       detailsBuilder.apply {
-        apiVersion = PUBLIC_API_VERSION
         dataProviderParticipationSignature = DATA_PROVIDER_PARTICIPATION_SIGNATURE
       }
     }

--- a/src/test/kotlin/org/wfanet/measurement/kingdom/service/system/v1alpha/RequisitionsServiceTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/kingdom/service/system/v1alpha/RequisitionsServiceTest.kt
@@ -64,9 +64,9 @@ private val INTERNAL_REQUISITION =
       externalFulfillingDuchyId = DUCHY_ID
       state = InternalRequisition.State.FULFILLED
       detailsBuilder.apply {
-        apiVersion = PUBLIC_API_VERSION
         dataProviderParticipationSignature = DATA_PROVIDER_PARTICIPATION_SIGNATURE
       }
+      parentMeasurementBuilder.apply { apiVersion = PUBLIC_API_VERSION }
     }
     .build()
 


### PR DESCRIPTION
These were needed to populate the matching public API messages. The Requistion fields that are denormalized from the parent Measurement are now not populated for the NORMALIZED Requisition view.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/world-federation-of-advertisers/cross-media-measurement/170)
<!-- Reviewable:end -->
