### PR TITLE
Mark v2alpha Builder annotation as internal.

### DIFF
--- a/src/main/kotlin/org/wfanet/measurement/kingdom/service/api/v2alpha/BUILD.bazel
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/service/api/v2alpha/BUILD.bazel
@@ -16,9 +16,9 @@ kt_jvm_library(
 kt_jvm_library(
     name = "certificates",
     srcs = ["Certificates.kt"],
+    associates = [":builder"],
     visibility = [test_target("__pkg__")],
     deps = [
-        ":builder",
         "//src/main/proto/wfa/measurement/internal/kingdom:certificate_java_proto",
         "@wfa_common_jvm//src/main/kotlin/org/wfanet/measurement/common/crypto:security_provider",
         "@wfa_common_jvm//src/main/kotlin/org/wfanet/measurement/common/grpc",
@@ -28,8 +28,8 @@ kt_jvm_library(
 kt_jvm_library(
     name = "data_providers_service",
     srcs = ["DataProvidersService.kt"],
+    associates = [":builder"],
     deps = [
-        ":builder",
         ":certificates",
         "//src/main/kotlin/org/wfanet/measurement/api:public_api_version",
         "//src/main/kotlin/org/wfanet/measurement/api/v2alpha:resource_key",
@@ -45,6 +45,7 @@ kt_jvm_library(
 kt_jvm_library(
     name = "recurring_exchanges_service",
     srcs = ["RecurringExchangesService.kt"],
+    associates = [":builder"],
     deps = [
         "//src/main/kotlin/org/wfanet/measurement/common/identity",
         "//src/main/proto/wfa/measurement/api/v2alpha:recurring_exchange_java_proto",
@@ -112,8 +113,8 @@ kt_jvm_library(
 kt_jvm_library(
     name = "measurement_consumers_service",
     srcs = ["MeasurementConsumersService.kt"],
+    associates = [":builder"],
     deps = [
-        ":builder",
         ":certificates",
         "//src/main/kotlin/org/wfanet/measurement/api:public_api_version",
         "//src/main/kotlin/org/wfanet/measurement/api/v2alpha:resource_key",
@@ -129,8 +130,8 @@ kt_jvm_library(
 kt_jvm_library(
     name = "requisitions_service",
     srcs = ["RequisitionsService.kt"],
+    associates = [":builder"],
     deps = [
-        ":builder",
         "//src/main/kotlin/org/wfanet/measurement/api:public_api_version",
         "//src/main/kotlin/org/wfanet/measurement/api/v2alpha:resource_key",
         "//src/main/proto/wfa/measurement/api/v2alpha:requisitions_service_kt_jvm_grpc",

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/service/api/v2alpha/Builder.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/service/api/v2alpha/Builder.kt
@@ -14,4 +14,4 @@
 
 package org.wfanet.measurement.kingdom.service.api.v2alpha
 
-@DslMarker @Target(AnnotationTarget.CLASS, AnnotationTarget.TYPE) annotation class Builder
+@DslMarker @Target(AnnotationTarget.CLASS, AnnotationTarget.TYPE) internal annotation class Builder

--- a/src/test/kotlin/org/wfanet/measurement/kingdom/service/api/v2alpha/BUILD.bazel
+++ b/src/test/kotlin/org/wfanet/measurement/kingdom/service/api/v2alpha/BUILD.bazel
@@ -5,11 +5,11 @@ kt_jvm_test(
     srcs = ["DataProvidersServiceTest.kt"],
     associates = [
         "//src/main/kotlin/org/wfanet/measurement/kingdom/service/api/v2alpha:data_providers_service",
+        "//src/main/kotlin/org/wfanet/measurement/kingdom/service/api/v2alpha:builder",
     ],
     data = ["@wfa_common_jvm//src/main/kotlin/org/wfanet/measurement/common/crypto/testing/testdata:static_certs"],
     test_class = "org.wfanet.measurement.kingdom.service.api.v2alpha.DataProvidersServiceTest",
     deps = [
-        "//src/main/kotlin/org/wfanet/measurement/kingdom/service/api/v2alpha:builder",
         "//src/main/proto/wfa/measurement/internal/kingdom:data_providers_service_kt_jvm_grpc",
         "@wfa_common_jvm//imports/java/com/google/common/truth",
         "@wfa_common_jvm//imports/java/com/google/common/truth/extensions/proto",
@@ -103,11 +103,11 @@ kt_jvm_test(
     srcs = ["MeasurementConsumersServiceTest.kt"],
     associates = [
         "//src/main/kotlin/org/wfanet/measurement/kingdom/service/api/v2alpha:measurement_consumers_service",
+        "//src/main/kotlin/org/wfanet/measurement/kingdom/service/api/v2alpha:builder",
     ],
     data = ["@wfa_common_jvm//src/main/kotlin/org/wfanet/measurement/common/crypto/testing/testdata:static_certs"],
     test_class = "org.wfanet.measurement.kingdom.service.api.v2alpha.MeasurementConsumersServiceTest",
     deps = [
-        "//src/main/kotlin/org/wfanet/measurement/kingdom/service/api/v2alpha:builder",
         "//src/main/proto/wfa/measurement/internal/kingdom:measurement_consumers_service_kt_jvm_grpc",
         "@wfa_common_jvm//imports/java/com/google/common/truth",
         "@wfa_common_jvm//imports/java/com/google/common/truth/extensions/proto",
@@ -126,6 +126,7 @@ kt_jvm_test(
     srcs = ["RequisitionsServiceTest.kt"],
     associates = [
         "//src/main/kotlin/org/wfanet/measurement/kingdom/service/api/v2alpha:requisitions_service",
+        "//src/main/kotlin/org/wfanet/measurement/kingdom/service/api/v2alpha:builder",
     ],
     test_class = "org.wfanet.measurement.kingdom.service.api.v2alpha.RequisitionServiceTest",
     deps = [


### PR DESCRIPTION
This uses the `associates` attribute of `kt_jvm_library` to combine multiple targets in the same Kotlin package into a single Kotlin module. This allows us to treat Kotlin's internal visibility more like Java's default/package-private visibility, without having to use a single Bazel target.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/world-federation-of-advertisers/cross-media-measurement/188)
<!-- Reviewable:end -->
