### PR TITLE
Remove unnecessary fields from Kingdom internal API.

### DIFF
--- a/src/main/kotlin/org/wfanet/measurement/kingdom/service/api/v2alpha/MeasurementsService.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/service/api/v2alpha/MeasurementsService.kt
@@ -44,7 +44,6 @@ import org.wfanet.measurement.common.grpc.grpcRequire
 import org.wfanet.measurement.common.grpc.grpcRequireNotNull
 import org.wfanet.measurement.common.identity.apiIdToExternalId
 import org.wfanet.measurement.common.identity.externalIdToApiId
-import org.wfanet.measurement.common.toJson
 import org.wfanet.measurement.internal.kingdom.CancelMeasurementRequest as InternalCancelMeasurementRequest
 import org.wfanet.measurement.internal.kingdom.GetMeasurementRequest as InternalGetMeasurementRequest
 import org.wfanet.measurement.internal.kingdom.Measurement as InternalMeasurement
@@ -341,7 +340,6 @@ private fun Measurement.toInternal(
       dataProviderList = this@toInternal.serializedDataProviderList
       dataProviderListSalt = this@toInternal.dataProviderListSalt
     }
-    detailsJson = details.toJson()
   }
 }
 

--- a/src/main/proto/wfa/measurement/internal/kingdom/computation_participant.proto
+++ b/src/main/proto/wfa/measurement/internal/kingdom/computation_participant.proto
@@ -31,8 +31,7 @@ message ComputationParticipant {
 
   fixed64 external_duchy_certificate_id = 5;
 
-  google.protobuf.Timestamp create_time = 6;
-  google.protobuf.Timestamp update_time = 7;
+  google.protobuf.Timestamp update_time = 6;
 
   enum State {
     STATE_UNSPECIFIED = 0;
@@ -53,7 +52,7 @@ message ComputationParticipant {
     // The parent `Measurement` will be in the `FAILED` state.
     FAILED = 4;
   }
-  State state = 8;
+  State state = 7;
 
   message LiquidLegionsV2Details {
     // Serialized `ElGamalPublicKey` message from public API.
@@ -66,13 +65,12 @@ message ComputationParticipant {
       LiquidLegionsV2Details liquid_legions_v2 = 1;
     }
   }
-  Details details = 9;
-  string details_json = 10;
+  Details details = 8;
 
-  DuchyMeasurementLogEntry failure_log_entry = 11;
+  DuchyMeasurementLogEntry failure_log_entry = 9;
 
   // Version of the public API for serialized message definitions as well as
   // resource names, which is denormalized from the parent Measurement.
   // Output-only.
-  string api_version = 12;
+  string api_version = 10;
 }

--- a/src/main/proto/wfa/measurement/internal/kingdom/measurement.proto
+++ b/src/main/proto/wfa/measurement/internal/kingdom/measurement.proto
@@ -115,16 +115,15 @@ message Measurement {
     bytes encrypted_result = 9;
   }
   Details details = 11;
-  string details_json = 12;
 
   // Child Requisitions of this Measurement, using Requisition.View.NORMALIZED.
   // Output-only.
   //
   // Only set for COMPUTATION view.
-  repeated Requisition requisitions = 13;
+  repeated Requisition requisitions = 12;
 
   // Child ComputationParticipants of this Measurement. Output-only.
   //
   // Only set for COMPUTATION view.
-  repeated ComputationParticipant computation_participants = 14;
+  repeated ComputationParticipant computation_participants = 13;
 }

--- a/src/main/proto/wfa/measurement/internal/kingdom/requisition.proto
+++ b/src/main/proto/wfa/measurement/internal/kingdom/requisition.proto
@@ -123,7 +123,6 @@ message Requisition {
     Refusal refusal = 5;
   }
   Details details = 11;
-  string details_json = 12;
 
   message ParentMeasurement {
     // Version of the public API for serialized message definitions as well as
@@ -141,5 +140,5 @@ message Requisition {
   // Denormalized fields from the parent Measurement. Output-only.
   //
   // Only set for FULL view.
-  ParentMeasurement parent_measurement = 13;
+  ParentMeasurement parent_measurement = 12;
 }

--- a/src/main/proto/wfa/measurement/internal/kingdom/requisitions_service.proto
+++ b/src/main/proto/wfa/measurement/internal/kingdom/requisitions_service.proto
@@ -84,8 +84,3 @@ message RefuseRequisitionRequest {
 
   Requisition.Refusal refusal = 3;
 }
-
-message PageToken {
-  google.protobuf.Timestamp created_after = 1;
-  StreamRequisitionsRequest.Filter filter = 2;
-}

--- a/src/test/kotlin/org/wfanet/measurement/kingdom/service/api/v2alpha/MeasurementsServiceTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/kingdom/service/api/v2alpha/MeasurementsServiceTest.kt
@@ -54,7 +54,6 @@ import org.wfanet.measurement.common.grpc.testing.GrpcTestServerRule
 import org.wfanet.measurement.common.identity.apiIdToExternalId
 import org.wfanet.measurement.common.testing.captureFirst
 import org.wfanet.measurement.common.testing.verifyProtoArgument
-import org.wfanet.measurement.common.toJson
 import org.wfanet.measurement.common.toProtoTime
 import org.wfanet.measurement.internal.kingdom.CancelMeasurementRequest as InternalCancelMeasurementRequest
 import org.wfanet.measurement.internal.kingdom.GetMeasurementRequest as InternalGetMeasurementRequest
@@ -690,7 +689,6 @@ private val INTERNAL_MEASUREMENT: InternalMeasurement = buildInternalMeasurement
     dataProviderList = MEASUREMENT.serializedDataProviderList
     dataProviderListSalt = MEASUREMENT.dataProviderListSalt
   }
-  detailsJson = details.toJson()
 }
 
 private inline fun MeasurementSpec.rebuild(fill: (@Builder MeasurementSpec.Builder).() -> Unit) =


### PR DESCRIPTION
* The `details_json` fields were added unintentionally to the protobuf API. JSON serialization of Details columns is purely for DB debugging.
* `ComputationParticipant` doesn't need a `create_time` field as its created as part of the parent `Measurement`, and the field isn't used for anything.
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/world-federation-of-advertisers/cross-media-measurement/206)
<!-- Reviewable:end -->
