### PR TITLE
Fix inaccurate test method names in ComputationParticipantsServiceTest.

### DIFF
--- a/src/main/kotlin/org/wfanet/measurement/kingdom/service/internal/testing/ComputationParticipantsServiceTest.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/service/internal/testing/ComputationParticipantsServiceTest.kt
@@ -102,7 +102,7 @@ abstract class ComputationParticipantsServiceTest<T : ComputationParticipantsCor
   }
 
   @Test
-  fun `confirmComputationParticipant fails for wrong externalDuchyId`() = runBlocking {
+  fun `setParticipantRequisitionParams fails for wrong externalDuchyId`() = runBlocking {
     val measurementConsumer = population.createMeasurementConsumer(measurementConsumersService)
     val dataProvider = population.createDataProvider(dataProvidersService)
 
@@ -136,7 +136,7 @@ abstract class ComputationParticipantsServiceTest<T : ComputationParticipantsCor
   }
 
   @Test
-  fun `confirmComputationParticipant fails for wrong externalComputationId`() = runBlocking {
+  fun `setParticipantRequisitionParams fails for wrong externalComputationId`() = runBlocking {
     val measurementConsumer = population.createMeasurementConsumer(measurementConsumersService)
     measurementConsumer.certificate.externalCertificateId
     val dataProvider = population.createDataProvider(dataProvidersService)
@@ -170,7 +170,7 @@ abstract class ComputationParticipantsServiceTest<T : ComputationParticipantsCor
   }
 
   @Test
-  fun `confirmComputationParticipant fails for wrong certificate for computationParticipant`() =
+  fun `setParticipantRequisitionParams fails for wrong certificate for computationParticipant`() =
       runBlocking {
     val measurementConsumer = population.createMeasurementConsumer(measurementConsumersService)
     val dataProvider = population.createDataProvider(dataProvidersService)


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/world-federation-of-advertisers/cross-media-measurement/252)
<!-- Reviewable:end -->
