### PR TITLE
Check if there are duplicated dataProvider entries in the measurement.

### DIFF
--- a/src/main/kotlin/org/wfanet/measurement/kingdom/service/api/v2alpha/MeasurementsService.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/service/api/v2alpha/MeasurementsService.kt
@@ -110,7 +110,12 @@ class MeasurementsService(private val internalMeasurementsStub: MeasurementsCoro
     grpcRequire(measurement.dataProvidersList.isNotEmpty()) { "Data Providers list is empty" }
     val dataProvidersMap = mutableMapOf<Long, DataProviderValue>()
     measurement.dataProvidersList.forEach {
-      with(it.validateAndMap()) { dataProvidersMap[key] = value }
+      with(it.validateAndMap()) {
+        grpcRequire(!dataProvidersMap.containsKey(key)) {
+          "Duplicated keys found in the data_providers."
+        }
+        dataProvidersMap[key] = value
+      }
     }
 
     val internalMeasurement =

--- a/src/test/kotlin/org/wfanet/measurement/kingdom/service/api/v2alpha/MeasurementsServiceTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/kingdom/service/api/v2alpha/MeasurementsServiceTest.kt
@@ -745,6 +745,22 @@ class MeasurementsServiceTest {
       .isEqualTo("Resource name is either unspecified or invalid")
   }
 
+  @Test
+  fun `createMeasurement throws INVALID_ARGUMENT when dataProviderList has duplicated keys`() {
+    val exception =
+      assertFailsWith<StatusRuntimeException> {
+        runBlocking {
+          service.createMeasurement(
+            createMeasurementRequest {
+              measurement = MEASUREMENT.copy { dataProviders += dataProviders }
+            }
+          )
+        }
+      }
+    assertThat(exception.status.code).isEqualTo(Status.Code.INVALID_ARGUMENT)
+    assertThat(exception.status.description).contains("Duplicated keys")
+  }
+
   companion object {
     @BeforeClass
     @JvmStatic


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/world-federation-of-advertisers/cross-media-measurement/276)
<!-- Reviewable:end -->
