### PR TITLE
Don't use runIfTokenFromlastUpdate for writeRequisitionBlobPath().

### DIFF
--- a/src/main/kotlin/org/wfanet/measurement/duchy/deploy/gcloud/spanner/computation/GcpSpannerComputationsDatabaseTransactor.kt
+++ b/src/main/kotlin/org/wfanet/measurement/duchy/deploy/gcloud/spanner/computation/GcpSpannerComputationsDatabaseTransactor.kt
@@ -611,7 +611,7 @@ class GcpSpannerComputationsDatabaseTransactor<
     pathToBlob: String
   ) {
     require(pathToBlob.isNotBlank()) { "Cannot insert blank path to blob. $externalRequisitionKey" }
-    runIfTokenFromLastUpdate(token) { ctx ->
+    databaseClient.readWriteTransaction().execute { ctx ->
       val row =
         ctx.readRowUsingIndex(
           "Requisitions",


### PR DESCRIPTION
It is causing an issue when multiple EDPs are fulfilling their
requisitions at the same time.

There is no need to require the caller of writeRequisitionBlobPath() to own
the most recent token. writeRequisitionBlobPath() is called by the
requsitionFulfillmentService, which doesn't claim the lock of a computation
before updating it.

https://rally1.rallydev.com/#/604612930531d/userstories?detail=%2Ftask%2F609964597029&view=2c2927c0-626b-4740-8620-af2a93b7d623

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/world-federation-of-advertisers/cross-media-measurement/289)
<!-- Reviewable:end -->
