### PR TITLE
Mark Distroless Java as being compatible with glibc 3.31.

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -10,6 +10,10 @@ build --javabase=@bazel_tools//tools/jdk:remote_jdk11
 # Target Java 8.
 build --java_toolchain=@bazel_tools//tools/jdk:toolchain_java8
 
+# Convenience platform configurations.
+build:debian-bullseye --platforms=//build/platforms:debian_bullseye
+build:ubuntu-bionic --platforms=//build/platforms:ubuntu_bionic
+
 import %workspace%/container.bazelrc
 import %workspace%/remote.bazelrc
 import %workspace%/results.bazelrc

--- a/build/platforms/BUILD.bazel
+++ b/build/platforms/BUILD.bazel
@@ -43,7 +43,7 @@ platform(
 
 alias(
     name = "distroless",
-    actual = ":debian_buster",
+    actual = ":debian_bullseye",
 )
 
 platform(

--- a/build/platforms/constraints.bzl
+++ b/build/platforms/constraints.bzl
@@ -21,5 +21,6 @@ DISTROLESS_JAVA = [
     "@wfa_measurement_system//build/platforms:glibc_2_23": [],
     "@wfa_measurement_system//build/platforms:glibc_2_27": [],
     "@wfa_measurement_system//build/platforms:glibc_2_28": [],
+    "@wfa_measurement_system//build/platforms:glibc_2_31": [],
     "//conditions:default": ["@platforms//:incompatible"],
 })

--- a/build/repositories.bzl
+++ b/build/repositories.bzl
@@ -24,8 +24,8 @@ def wfa_measurement_system_repositories():
     wfa_repo_archive(
         name = "wfa_common_jvm",
         repo = "common-jvm",
-        sha256 = "f9b2be33d3515a66e28feff14ca7405a73b4853f28912f69175bddc183805b92",
-        version = "0.13.0",
+        sha256 = "9c4e6d87b98d48c4e62c7ad19b56ab0e4bef527152a4816a962d10e461b2776d",
+        version = "0.15.0",
     )
 
     wfa_repo_archive(


### PR DESCRIPTION
common-jvm v0.15.0 specifies new Distroless Java images based on Debian 11 (Bullseye), which have glibc 3.31.

This also adds convenience platform configurations for local .bazelrc. For example, if your platform is Debian Bullseye then you can add `build --config=debian-bullseye` to your local .bazelrc.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/world-federation-of-advertisers/cross-media-measurement/304)
<!-- Reviewable:end -->
