### PR TITLE
Specify BAZELISK_HOME in bazel-container.

### DIFF
--- a/tools/bazel-container
+++ b/tools/bazel-container
@@ -6,7 +6,7 @@ readonly IMAGE='docker.io/wfameasurement/bazel@sha256:1f6d2be8e8abbb96d49bf77fde
 readonly DOCKER="${DOCKER:-docker}"
 readonly USERNAME="$(id -un)"
 readonly OUTPUT_USER_ROOT="${HOME}/.cache/bazel/_bazel_${USERNAME}"
-readonly BAZELISK_CACHE_DIR='/root/.cache/bazelisk'
+readonly BAZELISK_HOME="${HOME}/.cache/bazelisk"
 
 is_podman() {
   [[ "$($DOCKER -v)" == *podman* ]]
@@ -43,11 +43,11 @@ get_host_output_user_root() {
 
 get_host_cache_dir() {
   if [[ -v XDG_CACHE_HOME ]]; then
-    echo "$XDG_CACHE_HOME"
-  elif [[ "$OSTYPE" == 'darwin'* ]]; then
-    echo "$HOME/Library/Caches"
+    echo "${XDG_CACHE_HOME}"
+  elif [[ "${OSTYPE}" == 'darwin'* ]]; then
+    echo "${HOME}/Library/Caches"
   else
-    echo "$HOME/.cache"
+    echo "${HOME}/.cache"
   fi
 }
 
@@ -76,12 +76,14 @@ main() {
     '--rm'
     '--network=host'
     '--entrypoint=/usr/bin/bazel'
+    '--env'
+      "BAZELISK_HOME=${BAZELISK_HOME}"
     '--mount'
       "type=bind,source=${PWD},target=${PWD}"
     '--mount'
       "type=bind,source=${host_output_user_root},target=${OUTPUT_USER_ROOT}"
     '--mount'
-      "type=bind,source=${host_bazelisk_cache_dir},target=${BAZELISK_CACHE_DIR}"
+      "type=bind,source=${host_bazelisk_cache_dir},target=${BAZELISK_HOME}"
     "--workdir=${PWD}"
   )
 


### PR DESCRIPTION
This fixes an issue introduced in #307 where the Bazelisk cache dir inside the container would be incorrect unless Docker were being run in rootless mode.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/world-federation-of-advertisers/cross-media-measurement/309)
<!-- Reviewable:end -->
