### PR TITLE
Delete an outdated TODO.

### DIFF
--- a/src/main/kotlin/org/wfanet/measurement/duchy/daemon/mill/MillBase.kt
+++ b/src/main/kotlin/org/wfanet/measurement/duchy/daemon/mill/MillBase.kt
@@ -220,7 +220,6 @@ abstract class MillBase(
   ) {
     val request = setComputationResultRequest {
       name = ComputationKey(globalId).toName()
-      // TODO(wangyaopw): set the cert resourceName when it is added to the protos.
       aggregatorCertificate = ByteString.copyFrom(certificate.encoded)
       this.resultPublicKey = resultPublicKey
       this.encryptedResult = encryptedResult


### PR DESCRIPTION
The aggregatorCertificateId is not included in the public API
measurement proto. There is no need to attach it to the result.

The aggregator should guarantee that the certificate used to
sign the result is still valid.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/world-federation-of-advertisers/cross-media-measurement/325)
<!-- Reviewable:end -->
