### PR TITLE
Fix the blobpath.

### DIFF
--- a/src/main/kotlin/org/wfanet/measurement/duchy/storage/ComputationStore.kt
+++ b/src/main/kotlin/org/wfanet/measurement/duchy/storage/ComputationStore.kt
@@ -21,7 +21,7 @@ import org.wfanet.measurement.storage.BlobKeyGenerator
 import org.wfanet.measurement.storage.StorageClient
 import org.wfanet.measurement.storage.Store
 
-private const val BLOB_KEY_PREFIX = "/computations"
+private const val BLOB_KEY_PREFIX = "computations"
 
 /** A [Store] instance for managing Blobs associated with computations in the Duchy. */
 class ComputationStore
@@ -49,5 +49,5 @@ data class ComputationBlobContext(
 
 /** Generates a Blob key using the [ComputationBlobContext]. */
 private fun generateBlobKey(context: ComputationBlobContext): String {
-  return "/${context.externalComputationId}/${context.computationStage.name}/${UUID.randomUUID()}"
+  return "${context.externalComputationId}/${context.computationStage.name}/${UUID.randomUUID()}"
 }

--- a/src/main/kotlin/org/wfanet/measurement/duchy/storage/RequisitionStore.kt
+++ b/src/main/kotlin/org/wfanet/measurement/duchy/storage/RequisitionStore.kt
@@ -19,7 +19,7 @@ import org.wfanet.measurement.storage.BlobKeyGenerator
 import org.wfanet.measurement.storage.StorageClient
 import org.wfanet.measurement.storage.Store
 
-private const val BLOB_KEY_PREFIX = "/requisitions"
+private const val BLOB_KEY_PREFIX = "requisitions"
 
 /** A [Store] instance for managing Blobs associated with requisitions in the Duchy. */
 class RequisitionStore
@@ -47,5 +47,5 @@ data class RequisitionBlobContext(
 
 /** Generates a Blob key using the [RequisitionBlobContext]. */
 private fun generateBlobKey(context: RequisitionBlobContext): String {
-  return "/${context.externalDataProviderId}/${context.externalRequisitionId}/${UUID.randomUUID()}"
+  return "${context.externalDataProviderId}/${context.externalRequisitionId}/${UUID.randomUUID()}"
 }

--- a/src/main/kotlin/org/wfanet/measurement/loadtest/frontend/FrontendSimulator.kt
+++ b/src/main/kotlin/org/wfanet/measurement/loadtest/frontend/FrontendSimulator.kt
@@ -105,7 +105,7 @@ class FrontendSimulator(
   private val measurementsClient: MeasurementsCoroutineStub,
   private val requisitionsClient: RequisitionsCoroutineStub,
   private val measurementConsumersClient: MeasurementConsumersCoroutineStub,
-  private val storageClient: SketchStore,
+  private val sketchStore: SketchStore,
   private val runId: String
 ) {
 
@@ -212,7 +212,7 @@ class FrontendSimulator(
     val anySketches =
       requisitions.map {
         val storedSketch =
-          storageClient.get(it.name)?.read(DEFAULT_BUFFER_SIZE_BYTES)?.flatten()
+          sketchStore.get(it.name)?.read(DEFAULT_BUFFER_SIZE_BYTES)?.flatten()
             ?: error("Sketch blob not found for ${it.name}.")
         SketchProtos.toAnySketch(Sketch.parseFrom(storedSketch))
       }

--- a/src/main/kotlin/org/wfanet/measurement/loadtest/storage/SketchStore.kt
+++ b/src/main/kotlin/org/wfanet/measurement/loadtest/storage/SketchStore.kt
@@ -18,7 +18,7 @@ import org.wfanet.measurement.storage.BlobKeyGenerator
 import org.wfanet.measurement.storage.StorageClient
 import org.wfanet.measurement.storage.Store
 
-private const val BLOB_KEY_PREFIX = "/sketches"
+private const val BLOB_KEY_PREFIX = "sketches"
 
 /** A [Store] instance for managing Blobs associated with sketches (for test purpose only). */
 class SketchStore


### PR DESCRIPTION
The `/` in the prefix results in an additional folder with empty name.
The `SketchStore` is missing a `/` in front of the blobKey.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/world-federation-of-advertisers/cross-media-measurement/340)
<!-- Reviewable:end -->
