### PR TITLE
Add pg-embedded to test a minimal postgres schema validation

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -27,6 +27,8 @@ load("@wfa_common_jvm//build/maven:artifacts.bzl", "artifacts")
 
 ADDITIONAL_MAVEN_ARTIFACTS = artifacts.dict_to_list({
     "com.google.crypto.tink:tink": "1.6.0",
+    "com.opentable.components:otj-pg-embedded": "0.13.4",
+    "software.aws.rds:aws-postgresql-jdbc": "0.1.0",
 })
 
 maven_install(

--- a/imports/java/com/opentable/db/postgres/BUILD.bazel
+++ b/imports/java/com/opentable/db/postgres/BUILD.bazel
@@ -1,0 +1,6 @@
+package(default_visibility = ["//visibility:public"])
+
+alias(
+    name = "otj_pg_embedded",
+    actual = "@maven//:com_opentable_components_otj_pg_embedded",
+)

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/aws/postgres/testing/BUILD.bazel
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/aws/postgres/testing/BUILD.bazel
@@ -1,0 +1,23 @@
+load("@io_bazel_rules_kotlin//kotlin:jvm.bzl", "kt_jvm_library")
+
+package(default_visibility = ["//visibility:public"])
+
+kt_jvm_library(
+    name = "schemata",
+    srcs = [
+        "Schemata.kt",
+    ],
+    deps = [
+        "@wfa_common_jvm//src/main/kotlin/org/wfanet/measurement/common",
+    ],
+)
+
+genrule(
+    name = "concat_kingdom",
+    srcs = [
+        "exchange.sql",
+    ],
+    outs = ["kingdom.sql"],
+    cmd = "cat $(SRCS) > $@",
+    visibility = ["//visibility:public"],
+)

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/aws/postgres/testing/Schemata.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/aws/postgres/testing/Schemata.kt
@@ -1,0 +1,38 @@
+// Copyright 2020 The Cross-Media Measurement Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.wfanet.measurement.kingdom.deploy.aws.postgres
+
+import java.io.File
+import java.nio.file.Paths
+import org.wfanet.measurement.common.getRuntimePath
+
+private val SCHEMA_DIR =
+  Paths.get(
+    "wfa_measurement_system",
+    "src",
+    "main",
+    "kotlin",
+    "org",
+    "wfanet",
+    "measurement",
+    "kingdom",
+    "deploy",
+    "aws",
+    "postgres",
+    "testing",
+  )
+
+val AWS_KINGDOM_SCHEMA_FILE: File =
+  checkNotNull(getRuntimePath(SCHEMA_DIR.resolve("kingdom.sql"))).toFile()

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/aws/postgres/testing/exchange.sql
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/aws/postgres/testing/exchange.sql
@@ -1,0 +1,27 @@
+-- Copyright 2020 The Cross-Media Measurement Authors
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--      http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+
+-- minimal port of a table from `src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/exchange.sdl`
+-- for use in testing
+
+CREATE TABLE ModelProviders (
+  PRIMARY KEY (ModelProviderId),
+  ModelProviderId BIGINT NOT NULL,
+
+  ExternalModelProviderId BIGINT NOT NULL
+);
+
+CREATE UNIQUE INDEX ModelProvidersByExternalId
+  ON ModelProviders(ExternalModelProviderId);

--- a/src/test/kotlin/org/wfanet/measurement/kingdom/deploy/aws/postgres/AwsKingdomSchemaTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/kingdom/deploy/aws/postgres/AwsKingdomSchemaTest.kt
@@ -1,0 +1,35 @@
+// Copyright 2020 The Cross-Media Measurement Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.wfanet.measurement.kingdom.deploy.aws.postgres
+
+import com.opentable.db.postgres.junit.EmbeddedPostgresRules
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+
+@RunWith(JUnit4::class)
+class AwsKingdomSchemaTest {
+  val schema = AWS_KINGDOM_SCHEMA_FILE.readText()
+
+  @get:Rule val pg = EmbeddedPostgresRules.singleInstance()
+
+  @Test
+  fun `kingdom schema is valid sql for postgres`() {
+    val conn = pg.embeddedPostgres.postgresDatabase.connection
+    val statement = conn.createStatement()
+    statement.execute(schema)
+  }
+}

--- a/src/test/kotlin/org/wfanet/measurement/kingdom/deploy/aws/postgres/BUILD.bazel
+++ b/src/test/kotlin/org/wfanet/measurement/kingdom/deploy/aws/postgres/BUILD.bazel
@@ -1,0 +1,19 @@
+load("@io_bazel_rules_kotlin//kotlin:jvm.bzl", "kt_jvm_test")
+
+kt_jvm_test(
+    name = "AwsKingdomSchemaTest",
+    srcs = [
+        "AwsKingdomSchemaTest.kt",
+    ],
+    data = [
+        "//src/main/kotlin/org/wfanet/measurement/kingdom/deploy/aws/postgres/testing:kingdom.sql",
+    ],
+    test_class = "org.wfanet.measurement.kingdom.deploy.aws.postgres.AwsKingdomSchemaTest",
+    deps = [
+        "//imports/java/com/opentable/db/postgres:otj_pg_embedded",
+        "//src/main/kotlin/org/wfanet/measurement/kingdom/deploy/aws/postgres/testing:schemata",
+        "@wfa_common_jvm//imports/java/org/junit",
+        "@wfa_common_jvm//imports/kotlin/kotlin/test",
+        "@wfa_common_jvm//src/main/kotlin/org/wfanet/measurement/common",
+    ],
+)


### PR DESCRIPTION
This is more of a request for comments and to:
* Make sure github's CI will be able to run embedded postgres in testing
* Help decide if we want to go the route of using embedded postgres for unit testing
* Find a simple way for testing schema migration from Spanner to Postgres

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/world-federation-of-advertisers/cross-media-measurement/354)
<!-- Reviewable:end -->
