### PR TITLE
Validate measurementSpec.nounceHashes when creating new measurement.

### DIFF
--- a/src/test/kotlin/org/wfanet/measurement/kingdom/service/api/v2alpha/MeasurementsServiceTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/kingdom/service/api/v2alpha/MeasurementsServiceTest.kt
@@ -159,6 +159,7 @@ private val MEASUREMENT_SPEC = measurementSpec {
           delta = 1.0
         }
     }
+  nonceHashes += ByteString.copyFromUtf8("foo")
 }
 private val MEASUREMENT = measurement {
   name = MEASUREMENT_NAME


### PR DESCRIPTION
Also fixed a bug in the frontendSimulator that all EDPs use the same
nouce.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/world-federation-of-advertisers/cross-media-measurement/380)
<!-- Reviewable:end -->
