### PR TITLE
Add missing direct dependencies in build files

### DIFF
--- a/src/main/kotlin/org/wfanet/measurement/api/v2alpha/BUILD.bazel
+++ b/src/main/kotlin/org/wfanet/measurement/api/v2alpha/BUILD.bazel
@@ -53,7 +53,12 @@ kt_jvm_library(
     srcs = ["Providers.kt"],
     deps = [
         ":principal_server_interceptor",
+        "//src/main/kotlin/org/wfanet/measurement/api/v2alpha:principal",
+        "//src/main/kotlin/org/wfanet/measurement/api/v2alpha:resource_key",
         "//src/main/proto/wfa/measurement/internal/common:provider_java_proto",
         "//src/main/proto/wfa/measurement/internal/common:provider_kt_jvm_proto",
+        "@wfa_common_jvm//imports/java/io/grpc:api",
+        "@wfa_common_jvm//imports/java/io/grpc:context",
+        "@wfa_common_jvm//src/main/kotlin/org/wfanet/measurement/common/identity",
     ],
 )

--- a/src/main/kotlin/org/wfanet/measurement/api/v2alpha/testing/BUILD.bazel
+++ b/src/main/kotlin/org/wfanet/measurement/api/v2alpha/testing/BUILD.bazel
@@ -12,8 +12,12 @@ kt_jvm_library(
     name = "testing",
     srcs = glob(["*.kt"]),
     deps = [
+        "//src/main/kotlin/org/wfanet/measurement/api/v2alpha:principal",
         "//src/main/kotlin/org/wfanet/measurement/api/v2alpha:principal_server_interceptor",
+        "//src/main/kotlin/org/wfanet/measurement/api/v2alpha:resource_key",
         "//src/main/kotlin/org/wfanet/measurement/common/identity",
+        "@wfa_common_jvm//imports/java/io/grpc:api",
+        "@wfa_common_jvm//imports/java/io/grpc:context",
         "@wfa_common_jvm//imports/java/org/junit",
         "@wfa_common_jvm//imports/kotlin/kotlinx/coroutines:core",
         "@wfa_common_jvm//src/main/kotlin/org/wfanet/measurement/common/identity",

--- a/src/main/kotlin/org/wfanet/measurement/common/identity/BUILD.bazel
+++ b/src/main/kotlin/org/wfanet/measurement/common/identity/BUILD.bazel
@@ -14,10 +14,13 @@ kt_jvm_library(
     ],
     deps = [
         "//src/main/proto/wfa/measurement/config:duchy_rpc_config_kt_jvm_proto",
+        "@wfa_common_jvm//imports/java/com/google/protobuf",
         "@wfa_common_jvm//imports/java/io/grpc:api",
+        "@wfa_common_jvm//imports/java/io/grpc:context",
         "@wfa_common_jvm//imports/java/io/grpc/stub",
         "@wfa_common_jvm//imports/java/picocli",
         "@wfa_common_jvm//src/main/kotlin/org/wfanet/measurement/common",
+        "@wfa_common_jvm//src/main/kotlin/org/wfanet/measurement/common/crypto:security_provider",
         "@wfa_common_jvm//src/main/kotlin/org/wfanet/measurement/common/grpc",
     ],
 )

--- a/src/main/kotlin/org/wfanet/measurement/common/identity/testing/BUILD.bazel
+++ b/src/main/kotlin/org/wfanet/measurement/common/identity/testing/BUILD.bazel
@@ -10,6 +10,8 @@ kt_jvm_library(
     srcs = glob(["*.kt"]),
     deps = [
         "//src/main/kotlin/org/wfanet/measurement/common/identity",
+        "@wfa_common_jvm//imports/java/io/grpc:api",
+        "@wfa_common_jvm//imports/java/io/grpc:context",
         "@wfa_common_jvm//imports/java/org/junit",
         "@wfa_common_jvm//imports/kotlin/kotlinx/coroutines:core",
         "@wfa_common_jvm//src/main/kotlin/org/wfanet/measurement/common/identity",


### PR DESCRIPTION
This is just to add missing dependencies that are used via indirect dependencies. It is a no-op, only to prevent issues where something like dependency import order might cause unexpected behaviours.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/world-federation-of-advertisers/cross-media-measurement/401)
<!-- Reviewable:end -->
