### PR TITLE
Add cue_library rule.

### DIFF
--- a/src/main/k8s/BUILD.bazel
+++ b/src/main/k8s/BUILD.bazel
@@ -1,27 +1,64 @@
 load("//build/k8s:defs.bzl", "k8s_apply", "k8s_import")
 load("//build:variables.bzl", "IMAGE_REPOSITORY_SETTINGS", "TEST_GOOGLE_CLOUD_SETTINGS")
 load("//src/main/docker:images.bzl", "ALL_LOCAL_IMAGES")
+load("//build/cue:defs.bzl", "cue_library")
 load(":macros.bzl", "cue_dump")
 
 package(default_visibility = ["//src/main/k8s:__subpackages__"])
 
+cue_library(
+    name = "base",
+    srcs = ["base.cue"],
+)
+
+cue_library(
+    name = "resource_setup",
+    srcs = ["resource_setup.cue"],
+    deps = [":base"],
+)
+
+cue_library(
+    name = "kingdom",
+    srcs = ["kingdom.cue"],
+    deps = [":base"],
+)
+
+cue_library(
+    name = "duchy",
+    srcs = ["duchy.cue"],
+    deps = [":base"],
+)
+
+cue_library(
+    name = "frontend_simulator",
+    srcs = ["frontend_simulator.cue"],
+    deps = [":base"],
+)
+
+cue_library(
+    name = "edp_simulator",
+    srcs = ["edp_simulator.cue"],
+    deps = [":base"],
+)
+
 CUE_LIBRARIES = [
-    "base.cue",
-    "duchy.cue",
-    "kingdom.cue",
-    "frontend_simulator.cue",
-    "edp_simulator.cue",
-    "resource_setup.cue",
+    ":base",
+    ":duchy",
+    ":edp_simulator",
+    ":frontend_simulator",
+    ":kingdom",
+    ":resource_setup",
 ]
 
 cue_dump(
     name = "kingdom_and_three_duchies_from_cue_local",
-    srcs = CUE_LIBRARIES + ["kingdom_and_three_duchies_local.cue"],
+    srcs = ["kingdom_and_three_duchies_local.cue"],
+    deps = CUE_LIBRARIES,
 )
 
 cue_dump(
     name = "kingdom_and_three_duchies_from_cue_gke",
-    srcs = CUE_LIBRARIES + ["kingdom_and_three_duchies_gke.cue"],
+    srcs = ["kingdom_and_three_duchies_gke.cue"],
     cue_tags = {
         "cloud_storage_bucket": TEST_GOOGLE_CLOUD_SETTINGS.cloud_storage_bucket,
         "cloud_storage_project": TEST_GOOGLE_CLOUD_SETTINGS.cloud_storage_project,
@@ -31,6 +68,7 @@ cue_dump(
         "spanner_project": TEST_GOOGLE_CLOUD_SETTINGS.spanner_project,
     },
     tags = ["manual"],
+    deps = CUE_LIBRARIES,
 )
 
 ALL_LOCAL_IMAGE_ARCHIVES = [

--- a/src/main/k8s/dev/BUILD.bazel
+++ b/src/main/k8s/dev/BUILD.bazel
@@ -2,25 +2,21 @@ load("//src/main/k8s:macros.bzl", "cue_dump")
 
 cue_dump(
     name = "kingdom_gke",
-    srcs = [
-        "kingdom_gke.cue",
-        "//src/main/k8s:base.cue",
-        "//src/main/k8s:kingdom.cue",
-        "//src/main/k8s:resource_setup.cue",
-    ],
+    srcs = ["kingdom_gke.cue"],
     cue_tags = {
         "environment": "dev",
         "secret_name": "TBD",
     },
+    deps = [
+        "//src/main/k8s:base",
+        "//src/main/k8s:kingdom",
+        "//src/main/k8s:resource_setup",
+    ],
 )
 
 cue_dump(
     name = "aggregator_gke",
-    srcs = [
-        "duchy_gke.cue",
-        "//src/main/k8s:base.cue",
-        "//src/main/k8s:duchy.cue",
-    ],
+    srcs = ["duchy_gke.cue"],
     cue_tags = {
         "duchy_name": "aggregator",
         "duchy_cert_name": "TBD",
@@ -28,15 +24,15 @@ cue_dump(
         "environment": "dev",
         "secret_name": "TBD",
     },
+    deps = [
+        "//src/main/k8s:base",
+        "//src/main/k8s:duchy",
+    ],
 )
 
 cue_dump(
     name = "worker1_gke",
-    srcs = [
-        "duchy_gke.cue",
-        "//src/main/k8s:base.cue",
-        "//src/main/k8s:duchy.cue",
-    ],
+    srcs = ["duchy_gke.cue"],
     cue_tags = {
         "duchy_name": "worker1",
         "duchy_cert_name": "TBD",
@@ -44,15 +40,15 @@ cue_dump(
         "environment": "dev",
         "secret_name": "TBD",
     },
+    deps = [
+        "//src/main/k8s:base",
+        "//src/main/k8s:duchy",
+    ],
 )
 
 cue_dump(
     name = "worker2_gke",
-    srcs = [
-        "duchy_gke.cue",
-        "//src/main/k8s:base.cue",
-        "//src/main/k8s:duchy.cue",
-    ],
+    srcs = ["duchy_gke.cue"],
     cue_tags = {
         "duchy_name": "worker2",
         "duchy_cert_name": "TBD",
@@ -60,15 +56,15 @@ cue_dump(
         "environment": "dev",
         "secret_name": "TBD",
     },
+    deps = [
+        "//src/main/k8s:base",
+        "//src/main/k8s:duchy",
+    ],
 )
 
 cue_dump(
     name = "edp_simulator_gke",
-    srcs = [
-        "edp_simulator_gke.cue",
-        "//src/main/k8s:base.cue",
-        "//src/main/k8s:edp_simulator.cue",
-    ],
+    srcs = ["edp_simulator_gke.cue"],
     cue_tags = {
         "mc_name": "TBD",
         "edp1_name": "TBD",
@@ -79,19 +75,23 @@ cue_dump(
         "edp6_name": "TBD",
         "secret_name": "TBD",
     },
+    deps = [
+        "//src/main/k8s:base",
+        "//src/main/k8s:edp_simulator",
+    ],
 )
 
 cue_dump(
     name = "frontend_simulator_gke",
-    srcs = [
-        "frontend_simulator_gke.cue",
-        "//src/main/k8s:base.cue",
-        "//src/main/k8s:frontend_simulator.cue",
-    ],
+    srcs = ["frontend_simulator_gke.cue"],
     cue_tags = {
         "mc_name": "TBD",
         "secret_name": "TBD",
     },
+    deps = [
+        "//src/main/k8s:base",
+        "//src/main/k8s:frontend_simulator",
+    ],
 )
 
 filegroup(

--- a/src/main/k8s/macros.bzl
+++ b/src/main/k8s/macros.bzl
@@ -16,11 +16,12 @@
 
 load("//build/cue:defs.bzl", "cue_export")
 
-def cue_dump(name, srcs, cue_tags = None, **kwargs):
+def cue_dump(name, srcs, deps = None, cue_tags = None, **kwargs):
     outfile = name + ".yaml"
     cue_export(
         name = name,
         srcs = srcs,
+        deps = deps,
         outfile = outfile,
         filetype = "yaml",
         expression = "listObject",


### PR DESCRIPTION
This allows sharing of CUE libraries without depending on source files from other Bazel packages, which is against best practices.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/world-federation-of-advertisers/cross-media-measurement/415)
<!-- Reviewable:end -->
