### PR TITLE
Fix the GKE correctnessTest deployment.

### DIFF
--- a/build/variables.bzl
+++ b/build/variables.bzl
@@ -38,10 +38,43 @@ TEST_K8S_SETTINGS = struct(
     # Resource name of the 2nd worker Duchy's Certificate.
     worker2_cert_name = "$(worker2_cert_name)",
     mc_name = "$(mc_name)",
+    mc_api_key = "$(mc_api_key)",
     edp1_name = "$(edp1_name)",
     edp2_name = "$(edp2_name)",
     edp3_name = "$(edp3_name)",
     edp4_name = "$(edp4_name)",
     edp5_name = "$(edp5_name)",
     edp6_name = "$(edp6_name)",
+)
+
+# Settings for Kingdom Kubernetes deployments.
+KINGDOM_K8S_SETTINGS = struct(
+    secret_name = "$(k8s_kingdom_secret_name)",
+)
+
+# Settings for Duchy Kubernetes deployments.
+DUCHY_K8S_SETTINGS = struct(
+    secret_name = "$(k8s_duchy_secret_name)",
+    duchy_name = "$(duchy_name)",
+    duchy_cert_name = "$(duchy_cert_name)",
+    duchy_protocols_setup_config = "$(duchy_protocols_setup_config)",
+)
+
+# Settings for EDP simulator Kubernetes deployments.
+EDP_SIMULATOR_K8S_SETTINGS = struct(
+    secret_name = "$(k8s_simulator_secret_name)",
+    mc_name = "$(mc_name)",
+    edp1_name = "$(edp1_name)",
+    edp2_name = "$(edp2_name)",
+    edp3_name = "$(edp3_name)",
+    edp4_name = "$(edp4_name)",
+    edp5_name = "$(edp5_name)",
+    edp6_name = "$(edp6_name)",
+)
+
+# Settings for Frontend simulator Kubernetes deployments.
+FRONTEND_SIMULATOR_K8S_SETTINGS = struct(
+    secret_name = "$(k8s_simulator_secret_name)",
+    mc_name = "$(mc_name)",
+    mc_api_key = "$(mc_api_key)",
 )

--- a/src/main/k8s/base.cue
+++ b/src/main/k8s/base.cue
@@ -304,10 +304,11 @@ objects: [ for objectSet in objectSets for object in objectSet {object}]
 default_deny_ingress_and_egress: [{
 	apiVersion: "networking.k8s.io/v1"
 	kind:       "NetworkPolicy"
-	metadata:
+	metadata: {
 		name: "default-deny-ingress-and-egress"
-	labels: {
-		"app.kubernetes.io/part-of": #AppName
+		labels: {
+			"app.kubernetes.io/part-of": #AppName
+		}
 	}
 	spec: {
 		podSelector: {}

--- a/src/main/k8s/dev/BUILD.bazel
+++ b/src/main/k8s/dev/BUILD.bazel
@@ -1,57 +1,40 @@
+load("//build:variables.bzl", "DUCHY_K8S_SETTINGS", "EDP_SIMULATOR_K8S_SETTINGS", "FRONTEND_SIMULATOR_K8S_SETTINGS", "KINGDOM_K8S_SETTINGS")
 load("//src/main/k8s:macros.bzl", "cue_dump")
 
 cue_dump(
     name = "kingdom_gke",
     srcs = ["kingdom_gke.cue"],
     cue_tags = {
-        "secret_name": "TBD",
+        "secret_name": KINGDOM_K8S_SETTINGS.secret_name,
     },
+    tags = ["manual"],
     deps = [
-        "//src/main/k8s:base",
         "//src/main/k8s:kingdom",
+    ],
+)
+
+cue_dump(
+    name = "resource_setup_gke",
+    srcs = ["resource_setup_gke.cue"],
+    cue_tags = {
+        "secret_name": KINGDOM_K8S_SETTINGS.secret_name,
+    },
+    tags = ["manual"],
+    deps = [
         "//src/main/k8s:resource_setup",
     ],
 )
 
 cue_dump(
-    name = "aggregator_gke",
+    name = "duchy_gke",
     srcs = ["duchy_gke.cue"],
     cue_tags = {
-        "duchy_name": "aggregator",
-        "duchy_cert_name": "TBD",
-        "duchy_protocols_setup_config": "aggregator_protocols_setup_config.textproto",
-        "secret_name": "TBD",
+        "duchy_name": DUCHY_K8S_SETTINGS.duchy_name,
+        "duchy_cert_name": DUCHY_K8S_SETTINGS.duchy_cert_name,
+        "duchy_protocols_setup_config": DUCHY_K8S_SETTINGS.duchy_protocols_setup_config,
+        "secret_name": DUCHY_K8S_SETTINGS.secret_name,
     },
-    deps = [
-        "//src/main/k8s:base",
-        "//src/main/k8s:duchy",
-    ],
-)
-
-cue_dump(
-    name = "worker1_gke",
-    srcs = ["duchy_gke.cue"],
-    cue_tags = {
-        "duchy_name": "worker1",
-        "duchy_cert_name": "TBD",
-        "duchy_protocols_setup_config": "non_aggregator_protocols_setup_config.textproto",
-        "secret_name": "TBD",
-    },
-    deps = [
-        "//src/main/k8s:base",
-        "//src/main/k8s:duchy",
-    ],
-)
-
-cue_dump(
-    name = "worker2_gke",
-    srcs = ["duchy_gke.cue"],
-    cue_tags = {
-        "duchy_name": "worker2",
-        "duchy_cert_name": "TBD",
-        "duchy_protocols_setup_config": "non_aggregator_protocols_setup_config.textproto",
-        "secret_name": "TBD",
-    },
+    tags = ["manual"],
     deps = [
         "//src/main/k8s:base",
         "//src/main/k8s:duchy",
@@ -62,17 +45,17 @@ cue_dump(
     name = "edp_simulator_gke",
     srcs = ["edp_simulator_gke.cue"],
     cue_tags = {
-        "mc_name": "TBD",
-        "edp1_name": "TBD",
-        "edp2_name": "TBD",
-        "edp3_name": "TBD",
-        "edp4_name": "TBD",
-        "edp5_name": "TBD",
-        "edp6_name": "TBD",
-        "secret_name": "TBD",
+        "mc_name": EDP_SIMULATOR_K8S_SETTINGS.mc_name,
+        "edp1_name": EDP_SIMULATOR_K8S_SETTINGS.edp1_name,
+        "edp2_name": EDP_SIMULATOR_K8S_SETTINGS.edp2_name,
+        "edp3_name": EDP_SIMULATOR_K8S_SETTINGS.edp3_name,
+        "edp4_name": EDP_SIMULATOR_K8S_SETTINGS.edp4_name,
+        "edp5_name": EDP_SIMULATOR_K8S_SETTINGS.edp5_name,
+        "edp6_name": EDP_SIMULATOR_K8S_SETTINGS.edp6_name,
+        "secret_name": EDP_SIMULATOR_K8S_SETTINGS.secret_name,
     },
+    tags = ["manual"],
     deps = [
-        "//src/main/k8s:base",
         "//src/main/k8s:edp_simulator",
     ],
 )
@@ -81,9 +64,11 @@ cue_dump(
     name = "frontend_simulator_gke",
     srcs = ["frontend_simulator_gke.cue"],
     cue_tags = {
-        "mc_name": "TBD",
-        "secret_name": "TBD",
+        "mc_name": FRONTEND_SIMULATOR_K8S_SETTINGS.mc_name,
+        "mc_api_key": FRONTEND_SIMULATOR_K8S_SETTINGS.mc_api_key,
+        "secret_name": FRONTEND_SIMULATOR_K8S_SETTINGS.secret_name,
     },
+    tags = ["manual"],
     deps = [
         "//src/main/k8s:base",
         "//src/main/k8s:frontend_simulator",
@@ -91,14 +76,43 @@ cue_dump(
 )
 
 filegroup(
-    name = "k8s_deployment_config",
+    name = "k8s_kingdom_deployment_config",
     srcs = [
-        ":aggregator_gke.yaml",
-        ":edp_simulator_gke.yaml",
-        ":frontend_simulator_gke.yaml",
         ":kingdom_gke.yaml",
-        ":worker1_gke.yaml",
-        ":worker2_gke.yaml",
+        ":resource_setup_gke.yaml",
+    ],
+    tags = ["manual"],
+    visibility = [
+        "//src/main/kotlin/org/wfanet/measurement/tools:__subpackages__",
+    ],
+)
+
+filegroup(
+    name = "k8s_duchy_deployment_config",
+    srcs = [
+        ":duchy_gke.yaml",
+    ],
+    tags = ["manual"],
+    visibility = [
+        "//src/main/kotlin/org/wfanet/measurement/tools:__subpackages__",
+    ],
+)
+
+filegroup(
+    name = "k8s_edp_simulator_deployment_config",
+    srcs = [
+        ":edp_simulator_gke.yaml",
+    ],
+    tags = ["manual"],
+    visibility = [
+        "//src/main/kotlin/org/wfanet/measurement/tools:__subpackages__",
+    ],
+)
+
+filegroup(
+    name = "k8s_frontend_simulator_deployment_config",
+    srcs = [
+        ":frontend_simulator_gke.yaml",
     ],
     tags = ["manual"],
     visibility = [

--- a/src/main/k8s/dev/frontend_simulator_gke.cue
+++ b/src/main/k8s/dev/frontend_simulator_gke.cue
@@ -15,6 +15,7 @@
 package k8s
 
 _mc_name:     string @tag("mc_name")
+_mc_api_key:  string @tag("mc_api_key")
 _secret_name: string @tag("secret_name")
 
 #KingdomPublicApiTarget:  "public.kingdom.dev.halo-cmm.org:8443"
@@ -27,6 +28,7 @@ objectSets: [frontend_simulator]
 
 frontend_simulator: #FrontendSimulator & {
 	_mc_resource_name:          _mc_name
+	_mc_api_authentication_key: _mc_api_key
 	_mc_secret_name:            _secret_name
 	_kingdom_public_api_target: #KingdomPublicApiTarget
 	_simulator_image:           #ContainerRegistryPrefix + "/loadtest/frontend-simulator"

--- a/src/main/k8s/dev/kingdom_gke.cue
+++ b/src/main/k8s/dev/kingdom_gke.cue
@@ -29,7 +29,6 @@ _secret_name: string @tag("secret_name")
 }
 
 objectSets: [
-		// resource_setup_job, Only deploy if the kingdom database is reset.
 		default_deny_ingress_and_egress,
 ] + [ for k in kingdom {k}]
 
@@ -58,11 +57,4 @@ kingdom: #Kingdom & {
 	}
 	_kingdom_image_pull_policy: "Always"
 	_verbose_grpc_logging:      "false"
-}
-
-resource_setup_job: #ResourceSetup & {
-	_edp_display_names: ["edp1", "edp2", "edp3", "edp4", "edp5", "edp6"]
-	_duchy_ids: ["aggregator", "worker1", "worker2"]
-	_job_image:                  #ContainerRegistryPrefix + "/loadtest/resource-setup"
-	_resource_setup_secret_name: _secret_name
 }

--- a/src/main/k8s/dev/resource_setup_gke.cue
+++ b/src/main/k8s/dev/resource_setup_gke.cue
@@ -1,0 +1,40 @@
+// Copyright 2021 The Cross-Media Measurement Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package k8s
+
+_secret_name: string @tag("secret_name")
+
+#GloudProject:            "halo-cmm-dev"
+#ContainerRegistry:       "gcr.io"
+#ContainerRegistryPrefix: #ContainerRegistry + "/" + #GloudProject
+#DefaultResourceConfig: {
+	replicas:              1
+	resourceRequestCpu:    "100m"
+	resourceLimitCpu:      "200m"
+	resourceRequestMemory: "256Mi"
+	resourceLimitMemory:   "512Mi"
+}
+
+objectSets: [
+	resource_setup_job,
+]
+
+resource_setup_job: #ResourceSetup & {
+	_edp_display_names: ["edp1", "edp2", "edp3", "edp4", "edp5", "edp6"]
+	_duchy_ids: ["aggregator", "worker1", "worker2"]
+	_job_image:                  #ContainerRegistryPrefix + "/loadtest/resource-setup"
+	_resource_configs:           #DefaultResourceConfig
+	_resource_setup_secret_name: _secret_name
+}

--- a/src/main/k8s/duchy.cue
+++ b/src/main/k8s/duchy.cue
@@ -235,7 +235,7 @@ import ("strings")
 			_destinationMatchLabels: [] // Herald is allowed to send traffic externally.
 		}
 		"push-spanner-schema-job": #NetworkPolicy & {
-			_app_label: _object_prefix + "push-spanner-schema-job"
+			_app_label: _object_prefix + "push-spanner-schema-app"
 			_sourceMatchLabels: ["NA"] // Use "NA" to reject all ingress traffic.
 			_destinationMatchLabels: [] // Need to send external traffic to spanner.
 		}

--- a/src/main/k8s/frontend_simulator.cue
+++ b/src/main/k8s/frontend_simulator.cue
@@ -17,6 +17,7 @@ package k8s
 #FrontendSimulator: {
 	_mc_resource_name:            string
 	_mc_secret_name:              string
+	_mc_api_authentication_key:   string
 	_simulator_image:             string
 	_simulator_image_pull_policy: string | *"Always"
 	_kingdom_public_api_target:   string
@@ -34,6 +35,7 @@ package k8s
 					"--kingdom-public-api-target=\(_kingdom_public_api_target)",
 					"--kingdom-public-api-cert-host=localhost",
 					"--mc-resource-name=\(_mc_resource_name)",
+					"--api-authentication-key=\(_mc_api_authentication_key)",
 					"--mc-consent-signaling-cert-der-file=/var/run/secrets/files/mc_cs_cert.der",
 					"--mc-consent-signaling-key-der-file=/var/run/secrets/files/mc_cs_private.der",
 					"--mc-encryption-private-keyset=/var/run/secrets/files/mc_enc_private.tink",

--- a/src/main/k8s/kingdom.cue
+++ b/src/main/k8s/kingdom.cue
@@ -158,7 +158,7 @@ import ("strings")
 			]
 		}
 		"push-spanner-schema-job": #NetworkPolicy & {
-			_app_label: "kingdom-push-spanner-schema-job"
+			_app_label: "kingdom-push-spanner-schema-app"
 			_sourceMatchLabels: ["NA"] // Use "NA" to reject all ingress traffic.
 			_destinationMatchLabels: [] // Need to send external traffic to spanner.
 		}

--- a/src/main/k8s/local/BUILD.bazel
+++ b/src/main/k8s/local/BUILD.bazel
@@ -78,6 +78,7 @@ cue_dump(
     cue_tags = {
         "secret_name": TEST_K8S_SETTINGS.secret_name,
         "mc_name": TEST_K8S_SETTINGS.mc_name,
+        "mc_api_key": TEST_K8S_SETTINGS.mc_api_key,
     },
     tags = ["manual"],
     deps = [

--- a/src/main/k8s/local/frontend_simulator.cue
+++ b/src/main/k8s/local/frontend_simulator.cue
@@ -15,6 +15,7 @@
 package k8s
 
 _mc_name:     string @tag("mc_name")
+_mc_api_key:  string @tag("mc_api_key")
 _secret_name: string @tag("secret_name")
 
 #KingdomPublicApiTarget: (#Target & {name: "v2alpha-public-api-server"}).target
@@ -24,6 +25,7 @@ objectSets: [frontendSimulator]
 frontendSimulator: #FrontendSimulator & {
 	_mc_resource_name:            _mc_name
 	_mc_secret_name:              _secret_name
+	_mc_api_authentication_key:   _mc_api_key
 	_kingdom_public_api_target:   #KingdomPublicApiTarget
 	_simulator_image:             "bazel/src/main/kotlin/org/wfanet/measurement/loadtest/frontend:forwarded_storage_frontend_simulator_runner_image"
 	_simulator_image_pull_policy: "Never"

--- a/src/main/kotlin/org/wfanet/measurement/loadtest/resourcesetup/ResourceSetup.kt
+++ b/src/main/kotlin/org/wfanet/measurement/loadtest/resourcesetup/ResourceSetup.kt
@@ -76,19 +76,19 @@ class ResourceSetup(
   ) {
     logger.info("Starting with RunID: $runId ...")
 
-    // Step 1: Create the EDPs.
-    dataProviderContents.forEach {
-      val dataProviderName = createInternalDataProvider(it)
-      logger.info("Successfully created data provider: $dataProviderName")
-    }
-
-    // Step 2: Create the MC.
+    // Step 1: Create the MC.
     val (measurementConsumer, apiAuthenticationKey) =
       createMeasurementConsumer(measurementConsumerContent)
     logger.info("Successfully created measurement consumer: ${measurementConsumer.name}")
     logger.info(
       "API key for measurement consumer ${measurementConsumer.name}: $apiAuthenticationKey"
     )
+
+    // Step 2: Create the EDPs.
+    dataProviderContents.forEach {
+      val dataProviderName = createInternalDataProvider(it)
+      logger.info("Successfully created data provider: $dataProviderName")
+    }
 
     // Step 3: Create certificate for each duchy.
     duchyCerts.forEach {

--- a/src/main/kotlin/org/wfanet/measurement/tools/BUILD.bazel
+++ b/src/main/kotlin/org/wfanet/measurement/tools/BUILD.bazel
@@ -27,14 +27,9 @@ kt_jvm_library(
 )
 
 java_binary(
-    name = "deploy_kingdom_dev_to_gke",
-    args = [
-        "--yaml-file=kingdom_gke.yaml",
-        "--cluster-name=halo-cmm-kingdom-dev-cluster",
-        "--environment=dev",
-    ],
+    name = "deploy_kingdom_to_gke",
     data = [
-        "//src/main/k8s/dev:k8s_deployment_config",
+        "//src/main/k8s/dev:k8s_kingdom_deployment_config",
     ],
     main_class = "org.wfanet.measurement.tools.DeployToGkeKt",
     tags = ["manual"],
@@ -42,14 +37,9 @@ java_binary(
 )
 
 java_binary(
-    name = "deploy_edp_simulator_dev_to_gke",
-    args = [
-        "--yaml-file=edp_simulator_gke.yaml",
-        "--cluster-name=halo-cmm-simulator-dev-cluster",
-        "--environment=dev",
-    ],
+    name = "deploy_duchy_to_gke",
     data = [
-        "//src/main/k8s/dev:k8s_deployment_config",
+        "//src/main/k8s/dev:k8s_duchy_deployment_config",
     ],
     main_class = "org.wfanet.measurement.tools.DeployToGkeKt",
     tags = ["manual"],
@@ -57,14 +47,9 @@ java_binary(
 )
 
 java_binary(
-    name = "deploy_aggregator_dev_to_gke",
-    args = [
-        "--yaml-file=aggregator_gke.yaml",
-        "--cluster-name=halo-cmm-aggregator-dev-cluster",
-        "--environment=dev",
-    ],
+    name = "deploy_edp_simulator_to_gke",
     data = [
-        "//src/main/k8s/dev:k8s_deployment_config",
+        "//src/main/k8s/dev:k8s_edp_simulator_deployment_config",
     ],
     main_class = "org.wfanet.measurement.tools.DeployToGkeKt",
     tags = ["manual"],
@@ -72,44 +57,9 @@ java_binary(
 )
 
 java_binary(
-    name = "deploy_worker1_dev_to_gke",
-    args = [
-        "--yaml-file=worker1_gke.yaml",
-        "--cluster-name=halo-cmm-worker1-dev-cluster",
-        "--environment=dev",
-    ],
+    name = "deploy_frontend_simulator_to_gke",
     data = [
-        "//src/main/k8s/dev:k8s_deployment_config",
-    ],
-    main_class = "org.wfanet.measurement.tools.DeployToGkeKt",
-    tags = ["manual"],
-    runtime_deps = ["deploy_to_gke_impl"],
-)
-
-java_binary(
-    name = "deploy_worker2_dev_to_gke",
-    args = [
-        "--yaml-file=worker2_gke.yaml",
-        "--cluster-name=halo-cmm-worker2-dev-cluster",
-        "--environment=dev",
-    ],
-    data = [
-        "//src/main/k8s/dev:k8s_deployment_config",
-    ],
-    main_class = "org.wfanet.measurement.tools.DeployToGkeKt",
-    tags = ["manual"],
-    runtime_deps = ["deploy_to_gke_impl"],
-)
-
-java_binary(
-    name = "deploy_mc_simulator_dev_to_gke",
-    args = [
-        "--yaml-file=frontend_simulator_gke.yaml",
-        "--cluster-name=halo-cmm-simulator-dev-cluster",
-        "--environment=dev",
-    ],
-    data = [
-        "//src/main/k8s/dev:k8s_deployment_config",
+        "//src/main/k8s/dev:k8s_frontend_simulator_deployment_config",
     ],
     main_class = "org.wfanet.measurement.tools.DeployToGkeKt",
     tags = ["manual"],


### PR DESCRIPTION
The test was broken since we have made plenty changes to the system.
For example, principal authority and mark variables related changes.

The PR also
1. uploaded a synthetic-labelled-events.csv for completing correctnessTest
on GKE
2. switched the order of EDP and MC creation in the resourceSetupJob to
make sure we call the kingdom public API first. Otherwise, the job may
call the internal kingdom API successfully and fail later when calling
the public API. If this happens, the retry would fail constantly since
the EDPs are already created.
3. Deleted the labels in the NetworkPolicy, since NetworkPolicy doesn't
supoort labels.


https://rally1.rallydev.com/#/604612930531d/userstories?detail=%2Fuserstory%2F619653855975


<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/world-federation-of-advertisers/cross-media-measurement/426)
<!-- Reviewable:end -->
