### PR TITLE
Use default output rather than predeclared output for cue_export

### DIFF
--- a/build/cue/defs.bzl
+++ b/build/cue/defs.bzl
@@ -109,14 +109,15 @@ cue_library = rule(
 )
 
 def _cue_export_impl(ctx):
-    outfile = ctx.outputs.outfile
+    outfile = ctx.actions.declare_file(
+        ".".join((ctx.label.name, ctx.attr.filetype)),
+    )
     transitive_sources = _get_transitive_sources(ctx.files.srcs, ctx.attr.deps)
 
     args = ctx.actions.args()
     args.add("export")
     args.add("--outfile", outfile)
-    if ctx.attr.filetype:
-        args.add("--out", ctx.attr.filetype)
+    args.add("--out", ctx.attr.filetype)
     if ctx.attr.expression:
         args.add("--expression", ctx.attr.expression)
     args.add_all(transitive_sources)
@@ -136,6 +137,8 @@ def _cue_export_impl(ctx):
         arguments = [args],
     )
 
+    return [DefaultInfo(files = depset([outfile]))]
+
 cue_export = rule(
     implementation = _cue_export_impl,
     attrs = {
@@ -150,10 +153,7 @@ cue_export = rule(
         "filetype": attr.string(
             doc = "Output filetype.",
             default = "yaml",
-        ),
-        "outfile": attr.output(
-            doc = "Output file.",
-            mandatory = True,
+            values = ["yaml", "json"],
         ),
         "expression": attr.string(),
         "cue_tags": attr.string_dict(

--- a/src/main/k8s/dev/BUILD.bazel
+++ b/src/main/k8s/dev/BUILD.bazel
@@ -78,8 +78,8 @@ cue_dump(
 filegroup(
     name = "k8s_kingdom_deployment_config",
     srcs = [
-        ":kingdom_gke.yaml",
-        ":resource_setup_gke.yaml",
+        ":kingdom_gke",
+        ":resource_setup_gke",
     ],
     tags = ["manual"],
     visibility = [
@@ -90,7 +90,7 @@ filegroup(
 filegroup(
     name = "k8s_duchy_deployment_config",
     srcs = [
-        ":duchy_gke.yaml",
+        ":duchy_gke",
     ],
     tags = ["manual"],
     visibility = [
@@ -101,7 +101,7 @@ filegroup(
 filegroup(
     name = "k8s_edp_simulator_deployment_config",
     srcs = [
-        ":edp_simulator_gke.yaml",
+        ":edp_simulator_gke",
     ],
     tags = ["manual"],
     visibility = [
@@ -112,7 +112,7 @@ filegroup(
 filegroup(
     name = "k8s_frontend_simulator_deployment_config",
     srcs = [
-        ":frontend_simulator_gke.yaml",
+        ":frontend_simulator_gke",
     ],
     tags = ["manual"],
     visibility = [

--- a/src/main/k8s/local/BUILD.bazel
+++ b/src/main/k8s/local/BUILD.bazel
@@ -92,7 +92,7 @@ EMULATOR_IMAGE_NAMES = [
 
 k8s_apply(
     name = "emulators_kind",
-    src = ":emulators.yaml",
+    src = ":emulators",
     # Deploying emulators should bring down everything else since DB and storage
     # get recreated.
     delete_selector = "app.kubernetes.io/part-of=halo-cmms",
@@ -109,7 +109,7 @@ RESOURCE_SETUP_IMAGE_NAMES = [
 
 k8s_apply(
     name = "resource_setup_kind",
-    src = ":resource_setup.yaml",
+    src = ":resource_setup",
     imports = [
         "//src/main/k8s:import_" + image_name + "_kind"
         for image_name in RESOURCE_SETUP_IMAGE_NAMES
@@ -126,7 +126,7 @@ KINGDOM_IMAGE_NAMES = [
 
 k8s_apply(
     name = "kingdom_kind",
-    src = ":kingdom.yaml",
+    src = ":kingdom",
     delete_selector = "app.kubernetes.io/part-of=halo-cmms,app.kubernetes.io/component=kingdom",
     imports = [
         "//src/main/k8s:import_" + image_name + "_kind"
@@ -147,7 +147,7 @@ DUCHY_IMAGE_NAMES = [
 
 k8s_apply(
     name = "duchies_kind",
-    src = ":duchies.yaml",
+    src = ":duchies",
     delete_selector = "app.kubernetes.io/part-of=halo-cmms,app.kubernetes.io/component=duchy",
     imports = [
         "//src/main/k8s:import_" + image_name + "_kind"
@@ -162,7 +162,7 @@ EDP_SIMULATOR_IMAGE_NAMES = [
 
 k8s_apply(
     name = "edp_simulators_kind",
-    src = ":edp_simulators.yaml",
+    src = ":edp_simulators",
     delete_selector = "app.kubernetes.io/part-of=halo-cmms,app.kubernetes.io/component=simulator",
     imports = [
         "//src/main/k8s:import_" + image_name + "_kind"
@@ -177,7 +177,7 @@ FRONTEND_SIMULATOR_IMAGE_NAMES = [
 
 k8s_apply(
     name = "mc_frontend_simulator_kind",
-    src = ":mc_frontend_simulator.yaml",
+    src = ":mc_frontend_simulator",
     imports = [
         "//src/main/k8s:import_" + image_name + "_kind"
         for image_name in FRONTEND_SIMULATOR_IMAGE_NAMES

--- a/src/main/k8s/macros.bzl
+++ b/src/main/k8s/macros.bzl
@@ -17,12 +17,10 @@
 load("//build/cue:defs.bzl", "cue_export")
 
 def cue_dump(name, srcs, deps = None, cue_tags = None, **kwargs):
-    outfile = name + ".yaml"
     cue_export(
         name = name,
         srcs = srcs,
         deps = deps,
-        outfile = outfile,
         filetype = "yaml",
         expression = "listObject",
         cue_tags = cue_tags,


### PR DESCRIPTION
From https://docs.bazel.build/versions/4.2.2/skylark/rules.html#outputs:
> Prefer using non-predeclared outputs and explicitly adding outputs to DefaultInfo.files. Use the rule target’s label as input for rules which consume the output instead of a predeclared output’s label.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/world-federation-of-advertisers/cross-media-measurement/428)
<!-- Reviewable:end -->
