### PR TITLE
Use bazel rather than containerized scripts in deployment commands.

### DIFF
--- a/docs/building.md
+++ b/docs/building.md
@@ -7,12 +7,12 @@ resulting container images are intended to run in
 ## Requirements
 
 In order to build the primary system executables and run the corresponding
-tests, your build environment must meet the following:
+tests, your build environment must have the following:
 
 *   Bazel
     *   See [`.bazelversion`](../.bazelversion)
 *   GNU/Linux OS with x86-64 architecture
-    *   Some image targets require glibc <= 2.31
+    *   Some image targets require building with glibc <= 2.31
     *   Known to work on Debian Bullseye and Ubuntu 18.04
 *   [Clang](https://clang.llvm.org/)
 *   [SWIG](http://swig.org/)
@@ -26,6 +26,17 @@ The entire suite of tests can be run using the following command:
 ```shell
 bazel test //src/test/...
 ```
+
+### Specifying Host Platform
+
+As stated above, some targets require building with glibc <= 2.31. Bazel cannot
+detect the glibc version used by the local C++ toolchain, so we rely on the host
+platform being explicitly specified using the `--host_platform` option. Known
+compatible platforms are defined in the
+[//build/platforms package](../build/platforms/BUILD.bazel).
+
+For example, if your host machine is running Ubuntu 20.04, you would specify
+`--host_platform=//build/platforms:ubuntu_20_04`.
 
 ## Make Variables
 
@@ -76,10 +87,11 @@ example:
 tools/bazel-container test //src/test/...
 ```
 
-Note that if you want to develop on the host machine rather than just building,
-it may be simpler to use the Bash shell (`/bin/bash`) as your entry point and
-run your `bazel` commands from there. This way you can install an IDE inside the
-container and use it using X11 forwarding.
+Note that if you don't need to interact with the code on your host machine, it
+may be simpler to use the Bash shell (`/bin/bash`) as your entry point and run
+all of your commands from inside the container. You may even want to install
+IntelliJ inside the container and then use X11 forwarding to use it from your
+host machine.
 
 ### Hybrid Development
 
@@ -88,6 +100,9 @@ requirements, you can do most of your development on the host machine and just
 use the container for building/deploying image targets using the
 `tools/bazel-container` script. You can even run targets built inside the
 container on your host machine.
+
+Note: This script specifies the appropriate host platform to Bazel, so you
+should not use the `--host_platform` option when using it.
 
 The `tools/bazel-container` script uses a Docker volume for Bazel output. The
 script prints the volume name to `STDERR` when it's run. You can use this to
@@ -116,14 +131,5 @@ bazel-container-output/mill-daemon
 ## Local Kubernetes
 
 You can bring up a minimal testing environment in a local Kubernetes environment
-using either [Usernetes](https://github.com/rootless-containers/usernetes) (U7s)
-with containerd or [kind](https://kind.sigs.k8s.io/). Use one of the following
-commands:
-
-```shell
-bazel run //src/main/k8s:kingdom_and_three_duchies_u7s
-```
-
-```shell
-bazel run //src/main/k8s:kingdom_and_three_duchies_kind
-```
+using [KiND](https://kind.sigs.k8s.io/). See
+[instructions](../src/main/k8s/local/README.md).

--- a/docs/gke/correctness-test.md
+++ b/docs/gke/correctness-test.md
@@ -64,39 +64,7 @@ sure you have a domain you can config.***
 
 ## Step 0. Before You Start
 
-Install the following software on your machine.
-
--   [Kubectl](https://kubernetes.io/docs/tasks/tools/)
--   [Bazel](https://docs.bazel.build/versions/main/install.html)
--   [Cloud SDK](https://cloud.google.com/sdk/docs/install)
-
-Clone the halo
-[cross-media-measurement](https://github.com/world-federation-of-advertisers/cross-media-measurement)
-git repository locally, and check out the targeted commit (likely the one
-mentioned in the beginning of the doc).
-
-```shell
-git clone https://github.com/world-federation-of-advertisers/cross-media-measurement.git
-git checkout the-expected-commit-number
-```
-
-Run the following command in the root directory and make sure it passes
-
-```shell
-bazel test src/...
-```
-
-or
-
-```shell
-tools/bazel-container test src/...
-```
-
-depending on your machine OS.
-
-Read this
-[page](https://github.com/world-federation-of-advertisers/cross-media-measurement/blob/main/docs/building.md)
-for more details if you have trouble building/testing the codes.
+See [Machine Setup](machine-setup.md).
 
 # Step 1. Create and setup the GCP Project
 
@@ -203,17 +171,18 @@ haven't done it. If you use other repositories, adjust the commands accordingly.
 2.  Build and push the binaries to gcr.io by running the following commands
 
     ```shell
-    $bazel query 'kind("container_push", //src/main/docker:all)' | xargs -n 1 -o \
-    tools/bazel-container-run -c opt --define container_registry=gcr.io --define \
-    image_repo_prefix=halo-cmm-demo
+    bazel query 'kind("container_push", //src/main/docker:all)' | xargs -n 1 -o \
+      bazel run -c opt --define container_registry=gcr.io --define \
+      image_repo_prefix=halo-cmm-demo
     ```
+
+    Tip: If you're using [Hybrid Development](../building.md#hybrid-development)
+    for containerized builds, replace `bazel run` with
+    `tools/bazel-container-run`.
 
     The above command builds and pushes all halo binaries one by one. You should
     see logs like "Successfully pushed Docker image to gcr.io/halo-cmm-
     demo/something" multiple times.
-
-    If you see errors using `tools/bazel-contain-run`, check the
-    [Hybrid Development approach](https://github.com/world-federation-of-advertisers/cross-media-measurement/blob/main/docs/building.md#hybrid-development).
 
     If you see an `UNAUTHORIZED` error, run the following command and retry.
 
@@ -352,10 +321,13 @@ halo-cmm-worker2-demo-cluster      us-central1-c  1.21.5-gke.1302  34.68.24.213 
     values)
 
     ```shell
-    tools/bazel-container-run src/main/kotlin/org/wfanet/measurement/tools:deploy_kingdom_to_gke \
-        --define=k8s_kingdom_secret_name=certs-and-configs-gb46dm7468 \
-        -- --yaml-file=kingdom_gke.yaml --cluster-name=halo-cmm-kingdom-demo-cluster \
-        --environment=dev
+    bazel run \
+      //src/main/kotlin/org/wfanet/measurement/tools:deploy_kingdom_to_gke \
+      --define=k8s_kingdom_secret_name=certs-and-configs-gb46dm7468 \
+      -- \
+      --yaml-file=kingdom_gke.yaml \
+      --cluster-name=halo-cmm-kingdom-demo-cluster \
+      --environment=dev
     ```
 
 6.  Verify everything is fine by run:
@@ -566,13 +538,16 @@ _computation_control_targets: {
     command)
 
     ```shell
-    tools/bazel-container-run src/main/kotlin/org/wfanet/measurement/tools:deploy_duchy_to_gke \
-        --define=k8s_duchy_secret_name=certs-and-configs-gb46dm7468 \
-        --define=duchy_name=aggregator \
-        --define=duchy_cert_name=duchies/aggregator/certificates/DTDmi5he1do \
-        --define=duchy_protocols_setup_config=aggregator_protocols_setup_config.textproto \
-        -- --yaml-file=duchy_gke.yaml --cluster-name=halo-cmm-aggregator-demo-cluster \
-        --environment=dev
+    bazel run \
+      //src/main/kotlin/org/wfanet/measurement/tools:deploy_duchy_to_gke \
+      --define=k8s_duchy_secret_name=certs-and-configs-gb46dm7468 \
+      --define=duchy_name=aggregator \
+      --define=duchy_cert_name=duchies/aggregator/certificates/DTDmi5he1do \
+      --define=duchy_protocols_setup_config=aggregator_protocols_setup_config.textproto \
+      -- \
+      --yaml-file=duchy_gke.yaml \
+      --cluster-name=halo-cmm-aggregator-demo-cluster \
+      --environment=dev
     ```
 
 4.  Update the DNS records for the aggregator's public and system APIs
@@ -612,13 +587,14 @@ _computation_control_targets: {
     the command)
 
     ```shell
-    tools/bazel-container-run src/main/kotlin/org/wfanet/measurement/tools:deploy_duchy_to_gke \
-        --define=k8s_duchy_secret_name=certs-and-configs-gb46dm7468 \
-        --define=duchy_name=worker1 \
-        --define=duchy_cert_name=duchies/worker1/certificates/Vr9cWmehKZM \
-        --define=duchy_protocols_setup_config=non_aggregator_protocols_setup_config.textproto \
-        -- --yaml-file=duchy_gke.yaml --cluster-name=halo-cmm-worker1-demo-cluster \
-        --environment=dev
+    bazel run src/main/kotlin/org/wfanet/measurement/tools:deploy_duchy_to_gke \
+      --define=k8s_duchy_secret_name=certs-and-configs-gb46dm7468 \
+      --define=duchy_name=worker1 \
+      --define=duchy_cert_name=duchies/worker1/certificates/Vr9cWmehKZM \
+      --define=duchy_protocols_setup_config=non_aggregator_protocols_setup_config.textproto \
+      -- \
+      --yaml-file=duchy_gke.yaml --cluster-name=halo-cmm-worker1-demo-cluster \
+      --environment=dev
     ```
 
 4.  Update the DNS records for the worker1's public and system APIs
@@ -658,13 +634,15 @@ _computation_control_targets: {
     the command)
 
     ```shell
-    tools/bazel-container-run src/main/kotlin/org/wfanet/measurement/tools:deploy_duchy_to_gke \
-     --define=k8s_duchy_secret_name=certs-and-configs-gb46dm7468 \
-     --define=duchy_name=worker2 \
-     --define=duchy_cert_name=duchies/worker2/certificates/QBC5Lphe1p0 \
-     --define=duchy_protocols_setup_config=non_aggregator_protocols_setup_config.textproto \
-    -- --yaml-file=duchy_gke.yaml --cluster-name=halo-cmm-worker2-demo-cluster \\
-     --environment=dev
+    bazel run \
+      //src/main/kotlin/org/wfanet/measurement/tools:deploy_duchy_to_gke \
+      --define=k8s_duchy_secret_name=certs-and-configs-gb46dm7468 \
+      --define=duchy_name=worker2 \
+      --define=duchy_cert_name=duchies/worker2/certificates/QBC5Lphe1p0 \
+      --define=duchy_protocols_setup_config=non_aggregator_protocols_setup_config.textproto \
+      -- \
+      --yaml-file=duchy_gke.yaml --cluster-name=halo-cmm-worker2-demo-cluster \
+      --environment=dev
     ```
 
 4.  Update the DNS records for the worker2's public and system APIs
@@ -757,17 +735,19 @@ acts as one of the 6 different EDPs.
 4.  Deploy all 6 EDP simulators by running
 
     ```shell
-    tools/bazel-container-run src/main/kotlin/org/wfanet/measurement/tools:deploy_edp_simulator_to_gke \
-    --define=k8s_simulator_secret_name=certs-and-configs-gb46dm7468 \
-    --define=mc_name=measurementConsumers/TGWOaWehLQ8 \
-    --define=edp1_name=dataProviders/HRL1wWehTSM \
-    --define=edp2_name=dataProviders/djQdz2ehSSE \
-    --define=edp3_name=dataProviders/SQ99TmehSA8 \
-    --define=edp4_name=dataProviders/TBZkB5heuL0 \
-    --define=edp5_name=dataProviders/HOCBxZheuS8 \
-    --define=edp6_name=dataProviders/VGExFmehRhY \
-    -- --yaml-file=edp_simulator_gke.yaml \
-    --cluster-name=halo-cmm-simulator-demo-cluster --environment=dev
+    bazel run \
+      //src/main/kotlin/org/wfanet/measurement/tools:deploy_edp_simulator_to_gke \
+      --define=k8s_simulator_secret_name=certs-and-configs-gb46dm7468 \
+      --define=mc_name=measurementConsumers/TGWOaWehLQ8 \
+      --define=edp1_name=dataProviders/HRL1wWehTSM \
+      --define=edp2_name=dataProviders/djQdz2ehSSE \
+      --define=edp3_name=dataProviders/SQ99TmehSA8 \
+      --define=edp4_name=dataProviders/TBZkB5heuL0 \
+      --define=edp5_name=dataProviders/HOCBxZheuS8 \
+      --define=edp6_name=dataProviders/VGExFmehRhY \
+      -- \
+      --yaml-file=edp_simulator_gke.yaml \
+      --cluster-name=halo-cmm-simulator-demo-cluster --environment=dev
     ```
 
 5.  Verify everything is fine.
@@ -828,12 +808,14 @@ a measurement. Then, the frontendSimulator will
     first)
 
     ```shell
-    tools/bazel-container-run src/main/kotlin/org/wfanet/measurement/tools:deploy_frontend_simulator_to_gke \
-    --define=k8s_simulator_secret_name=certs-and-configs-gb46dm7468 \
-    --define=mc_name=measurementConsumers/TGWOaWehLQ8 \
-    --define=mc_api_key=ZEhkVZhe1Q0 \
-     -- --yaml-file=frontend_simulator_gke.yaml \
-    --cluster-name=halo-cmm-simulator-demo-cluster --environment=dev
+    bazel run \
+      //src/main/kotlin/org/wfanet/measurement/tools:deploy_frontend_simulator_to_gke \
+      --define=k8s_simulator_secret_name=certs-and-configs-gb46dm7468 \
+      --define=mc_name=measurementConsumers/TGWOaWehLQ8 \
+      --define=mc_api_key=ZEhkVZhe1Q0 \
+      -- \
+      --yaml-file=frontend_simulator_gke.yaml \
+      --cluster-name=halo-cmm-simulator-demo-cluster --environment=dev
     ```
 
 The frontend simulator job takes about 6 minutes to complete, since that is how

--- a/docs/gke/machine-setup.md
+++ b/docs/gke/machine-setup.md
@@ -1,0 +1,42 @@
+# Machine Setup for GKE Deployment
+
+## Bazel
+
+Read through [Building](../building.md) and make sure that your build
+environment meets the stated requirements. You may need to adjust some of the
+`bazel` commands below depending on your machine configuration.
+
+We recommend
+[installing Bazel using Bazelisk](https://docs.bazel.build/versions/4.2.2/install-bazelisk.html),
+where the `bazel` command in your path points to the Bazelisk executable.
+
+## SDKs
+
+Ensure the following additional software is installed on your machine.
+
+*   [Kubectl](https://kubernetes.io/docs/tasks/tools/)
+*   [Cloud SDK](https://cloud.google.com/sdk/docs/install)
+
+If you are doing a GKE deployment, it is assumed that you have some familiarity
+with using these.
+
+## Clone the Repository
+
+```shell
+git clone https://github.com/world-federation-of-advertisers/cross-media-measurement.git
+```
+
+You may want to pick a known working revision and switch to that.
+
+```shell
+git checkout 7fab61049e425bb0edd5fa2802290bf1722254e7
+```
+
+You can run all of the tests as a sanity check to make sure everything passes.
+Note that all of the tests must pass as a precondition for merging a pull
+request, so if this fails it is most likely something specific to your
+development environment.
+
+```shell
+bazel test //src/...
+```


### PR DESCRIPTION
Use of the scripts for containerized builds are very dependent on the build environment. This adds references to the building doc instead, and indicates that the reader may need to adjust their commands.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/world-federation-of-advertisers/cross-media-measurement/439)
<!-- Reviewable:end -->
https://rally1.rallydev.com/#/?detail=/task/626955042001&fdp=true