### PR TITLE
Event filter CEL expression validation

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -34,7 +34,9 @@ ADDITIONAL_MAVEN_ARTIFACTS = artifacts.dict_to_list({
     "com.opentable.components:otj-pg-embedded": "0.13.4",
     "software.aws.rds:aws-postgresql-jdbc": "0.1.0",
     "org.reflections:reflections": "0.10.2",
-    "org.projectnessie.cel:cel-tools" : "0.2.4",
+    "org.projectnessie.cel:cel-core": "0.2.4",
+    "org.projectnessie.cel:cel-tools": "0.2.4",
+    "org.projectnessie.cel:cel-generated-pb": "0.2.4",
 })
 
 maven_install(

--- a/imports/java/org/projectnessie/cel/BUILD.bazel
+++ b/imports/java/org/projectnessie/cel/BUILD.bazel
@@ -1,0 +1,16 @@
+package(default_visibility = ["//visibility:public"])
+
+alias(
+    name = "cel-tools",
+    actual = "@maven//:org_projectnessie_cel_cel_tools",
+)
+
+alias(
+    name = "cel-core",
+    actual = "@maven//:org_projectnessie_cel_cel_core",
+)
+
+alias(
+    name = "cel-generated-pb",
+    actual = "@maven//:org_projectnessie_cel_cel_generated_pb",
+)

--- a/src/main/kotlin/org/wfanet/measurement/eventDataProvider/eventFiltration/validation/BUILD.bazel
+++ b/src/main/kotlin/org/wfanet/measurement/eventDataProvider/eventFiltration/validation/BUILD.bazel
@@ -1,0 +1,16 @@
+load("@io_bazel_rules_kotlin//kotlin:jvm.bzl", "kt_jvm_library")
+
+package(default_visibility = ["//visibility:public"])
+
+kt_jvm_library(
+    name = "event_filter_validator",
+    srcs = [
+        "EventFilterValidationException.kt",
+        "EventFilterValidator.kt",
+    ],
+    deps = [
+        "//imports/java/org/projectnessie/cel:cel-core",
+        "//imports/java/org/projectnessie/cel:cel-generated-pb",
+        "//imports/java/org/projectnessie/cel:cel-tools",
+    ],
+)

--- a/src/main/kotlin/org/wfanet/measurement/eventDataProvider/eventFiltration/validation/EventFilterValidationException.kt
+++ b/src/main/kotlin/org/wfanet/measurement/eventDataProvider/eventFiltration/validation/EventFilterValidationException.kt
@@ -1,0 +1,38 @@
+// Copyright 2022 The Cross-Media Measurement Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.wfanet.measurement.eventDataProvider.eventFiltration.validation
+
+class EventFilterValidationException(val code: Code, message: String) : Exception(message) {
+
+  enum class Code {
+    /** An expression that cannot be interpreted as a valid CEL due to syntax or typing. */
+    INVALID_CEL_EXPRESSION,
+
+    /** Expression uses a CEL operation that currently is not supported for Halo. */
+    UNSUPPORTED_OPERATION,
+
+    /** A CEL value has a type that is invalid for Halo. */
+    INVALID_VALUE_TYPE,
+
+    /** Field comparison is not done within a leaf node. */
+    FIELD_COMPARISON_OUTSIDE_LEAF,
+
+    /** The expression is a single value, not a condition. */
+    EXPRESSION_IS_NOT_CONDITIONAL,
+
+    /** Leaf-only operator used outside leaf. */
+    INVALID_OPERATION_OUTSIDE_LEAF,
+  }
+}

--- a/src/main/kotlin/org/wfanet/measurement/eventDataProvider/eventFiltration/validation/EventFilterValidator.kt
+++ b/src/main/kotlin/org/wfanet/measurement/eventDataProvider/eventFiltration/validation/EventFilterValidator.kt
@@ -1,0 +1,162 @@
+// Copyright 2022 The Cross-Media Measurement Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.wfanet.measurement.eventDataProvider.eventFiltration.validation
+
+import com.google.api.expr.v1alpha1.Expr
+import org.projectnessie.cel.Env
+import org.projectnessie.cel.Issues
+
+/**
+ * Validates an Event Filtering CEL expression according to Halo rules.
+ *
+ * Throws a [EventFilterValidationException] on [validate] with the following codes:
+ * * [EventFilterValidationException.Code.INVALID_CEL_EXPRESSION]
+ * * [EventFilterValidationException.Code.INVALID_VALUE_TYPE]
+ * * [EventFilterValidationException.Code.UNSUPPORTED_OPERATION]
+ * * [EventFilterValidationException.Code.EXPRESSION_IS_NOT_CONDITIONAL]
+ * * [EventFilterValidationException.Code.INVALID_OPERATION_OUTSIDE_LEAF]
+ * * [EventFilterValidationException.Code.FIELD_COMPARISON_OUTSIDE_LEAF]
+ */
+object EventFilterValidator {
+
+  private val hasIndent = { args: List<Expr> -> args.find { it.hasIdentExpr() } != null }
+  private val hasCallExpr = { args: List<Expr> -> args.find { it.hasCallExpr() } != null }
+
+  private fun validateInOperator(callExpr: Expr.Call) {
+    val left = callExpr.argsList[0]
+    val right = callExpr.argsList[1]
+    if (!left.hasIdentExpr() && !left.hasSelectExpr()) {
+      throw EventFilterValidationException(
+        EventFilterValidationException.Code.INVALID_VALUE_TYPE,
+        "Operator @in left argument should be a variable",
+      )
+    }
+    if (!right.hasListExpr()) {
+      throw EventFilterValidationException(
+        EventFilterValidationException.Code.INVALID_VALUE_TYPE,
+        "Operator @in right argument should be a list",
+      )
+    }
+    if (right.hasListExpr()) {
+      for (element in right.listExpr.elementsList) {
+        if (!element.hasConstExpr()) {
+          throw EventFilterValidationException(
+            EventFilterValidationException.Code.INVALID_VALUE_TYPE,
+            "Operator @in right argument should be a list of constants or a variable",
+          )
+        }
+      }
+    }
+  }
+
+  fun failOnInvalidExpression(issues: Issues) {
+    if (issues.hasIssues()) {
+      throw EventFilterValidationException(
+        EventFilterValidationException.Code.INVALID_CEL_EXPRESSION,
+        issues.toString(),
+      )
+    }
+  }
+
+  private fun failOnListOutsideInOperator(expr: Expr) {
+    if (expr.hasListExpr()) {
+      throw EventFilterValidationException(
+        EventFilterValidationException.Code.INVALID_VALUE_TYPE,
+        "Lists are only allowed on the right side of a @in operator",
+      )
+    }
+  }
+
+  private fun failOnSingleToplevelValue() {
+    throw EventFilterValidationException(
+      EventFilterValidationException.Code.EXPRESSION_IS_NOT_CONDITIONAL,
+      "Expression cannot be a single value, should be a conditional",
+    )
+  }
+
+  private fun failOnVariableOutsideLeaf(args: List<Expr>) {
+    if (hasIndent(args) && hasCallExpr(args)) {
+      throw EventFilterValidationException(
+        EventFilterValidationException.Code.FIELD_COMPARISON_OUTSIDE_LEAF,
+        "Field comparison should be done only on the leaf expressions",
+      )
+    }
+  }
+
+  private fun failOnInvalidOperationOutsideLeaf(callExpr: Expr.Call) {
+    val operator = callExpr.function
+    if (LEAF_ONLY_OPERATORS.contains(operator) && hasCallExpr(callExpr.argsList)) {
+      throw EventFilterValidationException(
+        EventFilterValidationException.Code.INVALID_OPERATION_OUTSIDE_LEAF,
+        "Operator $operator should only be used on leaf expressions",
+      )
+    }
+  }
+
+  private fun failOnNotAllowedOperator(operator: String?) {
+    if (!ALLOWED_OPERATORS.contains(operator)) {
+      throw EventFilterValidationException(
+        EventFilterValidationException.Code.UNSUPPORTED_OPERATION,
+        "Operator $operator is not allowed",
+      )
+    }
+  }
+
+  private fun validateExpr(expr: Expr) {
+    if (!expr.hasCallExpr()) {
+      failOnListOutsideInOperator(expr)
+      return
+    }
+    val callExpr: Expr.Call = expr.callExpr
+    val operator = callExpr.function
+    failOnNotAllowedOperator(operator)
+    if (operator == "@in") {
+      validateInOperator(callExpr)
+      return
+    }
+    failOnVariableOutsideLeaf(callExpr.argsList)
+    failOnInvalidOperationOutsideLeaf(callExpr)
+    for (arg in callExpr.argsList) {
+      validateExpr(arg)
+    }
+  }
+
+  fun validate(celExpression: String, env: Env) {
+    val astAndIssues = env.compile(celExpression)
+    failOnInvalidExpression(astAndIssues.issues)
+    val expr = astAndIssues.ast.expr
+    if (!expr.hasCallExpr()) {
+      failOnSingleToplevelValue()
+    }
+    validateExpr(expr)
+  }
+}
+
+private val LEAF_ONLY_OPERATORS =
+  listOf(
+    "_>_",
+    "_<_",
+    "_!=_",
+    "_==_",
+    "_<=_",
+    "@in",
+  )
+private val BOOLEAN_OPERATORS =
+  listOf(
+    "!_",
+    "_&&_",
+    "_||_",
+  )
+private val ALLOWED_OPERATORS = LEAF_ONLY_OPERATORS + BOOLEAN_OPERATORS

--- a/src/test/kotlin/org/wfanet/measurement/eventDataProvider/eventFiltration/validation/BUILD.bazel
+++ b/src/test/kotlin/org/wfanet/measurement/eventDataProvider/eventFiltration/validation/BUILD.bazel
@@ -1,0 +1,17 @@
+load("@io_bazel_rules_kotlin//kotlin:jvm.bzl", "kt_jvm_test")
+
+kt_jvm_test(
+    name = "EventFilterValidatorTest",
+    srcs = ["EventFilterValidatorTest.kt"],
+    test_class = "org.wfanet.measurement.eventDataProvider.eventFiltration.validation.EventFilterValidatorTest",
+    deps = [
+        "//imports/java/org/projectnessie/cel:cel-core",
+        "//imports/java/org/projectnessie/cel:cel-generated-pb",
+        "//imports/java/org/projectnessie/cel:cel-tools",
+        "//src/main/kotlin/org/wfanet/measurement/eventDataProvider/eventFiltration/validation:event_filter_validator",
+        "//src/main/proto/wfa/measurement/api/v2alpha/event_templates/testing:event_templates_java_proto",
+        "@wfa_common_jvm//imports/java/com/google/common/truth",
+        "@wfa_common_jvm//imports/java/org/junit",
+        "@wfa_common_jvm//imports/kotlin/kotlin/test",
+    ],
+)

--- a/src/test/kotlin/org/wfanet/measurement/eventDataProvider/eventFiltration/validation/EventFilterValidatorTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/eventDataProvider/eventFiltration/validation/EventFilterValidatorTest.kt
@@ -1,0 +1,217 @@
+// Copyright 2022 The Cross-Media Measurement Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.wfanet.measurement.eventDataProvider.eventFiltration.validation
+
+import com.google.api.expr.v1alpha1.Decl
+import com.google.common.truth.Truth.assertThat
+import kotlin.test.assertFailsWith
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+import org.projectnessie.cel.Env
+import org.projectnessie.cel.EnvOption
+import org.projectnessie.cel.checker.Decls
+import org.projectnessie.cel.common.types.pb.ProtoTypeRegistry
+import org.wfanet.measurement.api.v2alpha.event_templates.testing.TestVideoTemplate
+import org.wfanet.measurement.eventDataProvider.eventFiltration.validation.EventFilterValidationException.Code as Code
+
+private const val TEMPLATE_PREFIX = "org.wfa.measurement.api.v2alpha.event_templates.testing"
+
+@RunWith(JUnit4::class)
+class EventFilterValidatorTest {
+  private fun env(vararg vars: Decl): Env {
+    return Env.newEnv(EnvOption.declarations(*vars))
+  }
+  private val booleanVar = { name: String -> Decls.newVar(name, Decls.Bool) }
+  private val intVar = { name: String -> Decls.newVar(name, Decls.Int) }
+  private val stringVar = { name: String -> Decls.newVar(name, Decls.String) }
+  private fun videoTemplateVar(name: String): Decl {
+    return Decls.newVar(
+      name,
+      Decls.newObjectType("$TEMPLATE_PREFIX.TestVideoTemplate"),
+    )
+  }
+
+  private fun envWithTestVideoTemplate(vararg vars: Decl): Env {
+    var typeRegistry: ProtoTypeRegistry =
+      ProtoTypeRegistry.newRegistry(
+        TestVideoTemplate.getDefaultInstance(),
+      )
+    return Env.newEnv(
+      EnvOption.customTypeAdapter(typeRegistry),
+      EnvOption.customTypeProvider(typeRegistry),
+      EnvOption.declarations(*vars),
+    )
+  }
+
+  private fun assertThatFailsWithCode(celExpression: String, code: Code, env: Env = Env.newEnv()) {
+    val e =
+      assertFailsWith(EventFilterValidationException::class) {
+        EventFilterValidator.validate(celExpression, env)
+      }
+    assertThat(e.code).isEqualTo(code)
+  }
+
+  @Test
+  fun `fails on invalid operation`() {
+    assertThatFailsWithCode("1 + 1", Code.UNSUPPORTED_OPERATION)
+  }
+
+  @Test
+  fun `works on supported operation`() {
+    EventFilterValidator.validate(
+      "age > 30",
+      env(intVar("age")),
+    )
+  }
+
+  @Test
+  fun `fails on comparing string to int`() {
+    assertThatFailsWithCode(
+      "age > 30",
+      Code.INVALID_CEL_EXPRESSION,
+      env(stringVar("age")),
+    )
+  }
+
+  @Test
+  fun `fails on comparing int to boolean conditional`() {
+    assertThatFailsWithCode(
+      "age && (date > 10)",
+      Code.INVALID_CEL_EXPRESSION,
+      env(
+        intVar("age"),
+        intVar("date"),
+      )
+    )
+  }
+
+  @Test
+  fun `comparing field to a list of constants is valid`() {
+    EventFilterValidator.validate(
+      "age in [10, 20, 30]",
+      env(intVar("age")),
+    )
+  }
+
+  @Test
+  fun `comparing field to a list of constants fails if types don't match`() {
+    assertThatFailsWithCode(
+      "age in [10, 20, 30]",
+      Code.INVALID_CEL_EXPRESSION,
+      env(stringVar("age")),
+    )
+  }
+
+  @Test
+  fun `variable is invalid within a list`() {
+    assertThatFailsWithCode(
+      "age in [a, b, c]",
+      Code.INVALID_VALUE_TYPE,
+      env(
+        intVar("age"),
+        intVar("a"),
+        intVar("b"),
+        intVar("c"),
+      )
+    )
+  }
+
+  @Test
+  fun `constant is invalid at the left side of IN operator`() {
+    assertThatFailsWithCode("10 in [10, 20, 30]", Code.INVALID_VALUE_TYPE)
+  }
+
+  @Test
+  fun `a single expression is invalid`() {
+    assertThatFailsWithCode("age", Code.EXPRESSION_IS_NOT_CONDITIONAL, env(stringVar("age")))
+  }
+
+  @Test
+  fun `list is not valid outside @in operator`() {
+    assertThatFailsWithCode("[1, 2, 3] == [1, 2, 3]", Code.INVALID_VALUE_TYPE)
+  }
+
+  @Test
+  fun `fields should be compared only at leafs`() {
+    assertThatFailsWithCode(
+      "field1 == (field2 != field3)",
+      Code.FIELD_COMPARISON_OUTSIDE_LEAF,
+      env(
+        booleanVar("field1"),
+        stringVar("field2"),
+        stringVar("field3"),
+      ),
+    )
+  }
+
+  @Test
+  fun `a complex comparison works`() {
+    EventFilterValidator.validate(
+      "age < 20 || age > 50",
+      env(intVar("age")),
+    )
+  }
+
+  @Test
+  fun `it disallows operator outside leafs`() {
+    assertThatFailsWithCode(
+      "(a == b) <= (field2 < field3)",
+      Code.INVALID_OPERATION_OUTSIDE_LEAF,
+      env(
+        intVar("a"),
+        intVar("b"),
+        stringVar("field2"),
+        stringVar("field3"),
+      ),
+    )
+  }
+
+  @Test
+  fun `fields can be compared between each other`() {
+    EventFilterValidator.validate(
+      "field1 == field2",
+      env(
+        intVar("field1"),
+        intVar("field2"),
+      ),
+    )
+  }
+
+  @Test
+  fun `fails on inexistant template field`() {
+    assertThatFailsWithCode(
+      "vt.date == 10",
+      Code.INVALID_CEL_EXPRESSION,
+      envWithTestVideoTemplate(videoTemplateVar("vt"))
+    )
+  }
+
+  @Test
+  fun `can use valid template fields on comparison`() {
+    EventFilterValidator.validate(
+      "vt.age.value == 1",
+      envWithTestVideoTemplate(videoTemplateVar("vt"))
+    )
+  }
+
+  @Test
+  fun `can use template with IN operator`() {
+    EventFilterValidator.validate(
+      "vt.age.value in [0, 1]",
+      envWithTestVideoTemplate(videoTemplateVar("vt"))
+    )
+  }
+}


### PR DESCRIPTION
Adds a validator of Event Filtering expressions that will use the Common Expression Language.
It validates that the expression fits Halo's limitations in terms of structure and operators that are allowed.
(type validation will be in the next component, an Evaluator, that will interpret the fields referenced in the expression).

Note: this is on top of @uakyol's PR, so we can have feedback on how both workflows work together

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/world-federation-of-advertisers/cross-media-measurement/451)
<!-- Reviewable:end -->
