### PR TITLE
Add event filtering

### DIFF
--- a/src/main/kotlin/org/wfanet/measurement/eventdataprovider/eventfiltration/BUILD.bazel
+++ b/src/main/kotlin/org/wfanet/measurement/eventdataprovider/eventfiltration/BUILD.bazel
@@ -1,0 +1,16 @@
+load("@io_bazel_rules_kotlin//kotlin:jvm.bzl", "kt_jvm_library")
+
+package(default_visibility = ["//visibility:public"])
+
+kt_jvm_library(
+    name = "event_filters",
+    srcs = [
+        "EventFilterException.kt",
+        "EventFilters.kt",
+    ],
+    deps = [
+        "//imports/java/org/projectnessie/cel:core",
+        "//imports/java/org/projectnessie/cel/tools",
+        "//src/main/kotlin/org/wfanet/measurement/eventdataprovider/eventfiltration/validation",
+    ],
+)

--- a/src/main/kotlin/org/wfanet/measurement/eventdataprovider/eventfiltration/EventFilterException.kt
+++ b/src/main/kotlin/org/wfanet/measurement/eventdataprovider/eventfiltration/EventFilterException.kt
@@ -1,0 +1,26 @@
+// Copyright 2022 The Cross-Media Measurement Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.wfanet.measurement.eventdataprovider.eventfiltration
+
+class EventFilterException(val code: Code, message: String? = null) : Exception(message) {
+
+  enum class Code {
+    /** Filter evaluation result is an error */
+    EVALUATION_ERROR,
+
+    /** Filter expression does not evaluate to a boolean */
+    INVALID_RESULT,
+  }
+}

--- a/src/main/kotlin/org/wfanet/measurement/eventdataprovider/eventfiltration/EventFilters.kt
+++ b/src/main/kotlin/org/wfanet/measurement/eventdataprovider/eventfiltration/EventFilters.kt
@@ -1,0 +1,82 @@
+// Copyright 2022 The Cross-Media Measurement Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.wfanet.measurement.eventdataprovider.eventfiltration
+
+import com.google.protobuf.Message
+import org.projectnessie.cel.Ast
+import org.projectnessie.cel.Env
+import org.projectnessie.cel.Program
+import org.projectnessie.cel.common.types.BoolT
+import org.projectnessie.cel.common.types.Err
+import org.projectnessie.cel.common.types.ref.Val
+import org.wfanet.measurement.eventdataprovider.eventfiltration.validation.EventFilterValidationException
+import org.wfanet.measurement.eventdataprovider.eventfiltration.validation.EventFilterValidator
+
+object EventFilters {
+  /**
+   * Compiles a [Program] that should be fed into [matches] function to indicate if an [Event]
+   * should be filtered or not, based on the filtering CEL expression.
+   *
+   * @param defaultEventMessage is a protobuf Message default instance for a message that contains
+   * each type of event template as fields. See `event_annotations.proto`.
+   *
+   * Throws a [EventFilterValidationException].
+   */
+  fun compileProgram(celExpr: String, defaultEventMessage: Message): Program =
+    EventFilterValidator.compileProgramWithEventMessage(celExpr, defaultEventMessage)
+
+  /**
+   * Validates an Event Filtering CEL expression according to Halo rules.
+   *
+   * Throws a [EventFilterValidationException] on [compile] with the following codes:
+   * * [EventFilterValidationException.Code.INVALID_CEL_EXPRESSION]
+   * * [EventFilterValidationException.Code.INVALID_VALUE_TYPE]
+   * * [EventFilterValidationException.Code.UNSUPPORTED_OPERATION]
+   * * [EventFilterValidationException.Code.EXPRESSION_IS_NOT_CONDITIONAL]
+   * * [EventFilterValidationException.Code.INVALID_OPERATION_OUTSIDE_LEAF]
+   * * [EventFilterValidationException.Code.FIELD_COMPARISON_OUTSIDE_LEAF]
+   */
+  fun compile(celExpr: String, env: Env): Ast = EventFilterValidator.compile(celExpr, env)
+
+  /**
+   * Indicates if an Event should be filtered or not, based on a Program previously compiled with
+   * [compileProgram] function.
+   *
+   * @param event is a protobuf Message that contains each type of event template as fields. See
+   * `event_annotations.proto`.
+   *
+   * Throws a [EventFilterException] with the following codes:
+   * * [EventFilterException.Code.EVALUATION_ERROR]
+   * * [EventFilterException.Code.INVALID_RESULT]
+   */
+  fun matches(event: Message, program: Program): Boolean {
+    val variables: Map<String, Any> = event.allFields.entries.associate { it.key.name to it.value }
+    val result: Program.EvalResult = program.eval(variables)
+    val value: Val = result.`val`
+    if (value is Err) {
+      throw EventFilterException(
+        EventFilterException.Code.EVALUATION_ERROR,
+        value.toString(),
+      )
+    }
+    if (value !is BoolT) {
+      throw EventFilterException(
+        EventFilterException.Code.INVALID_RESULT,
+        "Evaluation of CEL expression should result in a boolean value",
+      )
+    }
+    return value.booleanValue()
+  }
+}

--- a/src/main/kotlin/org/wfanet/measurement/eventdataprovider/eventfiltration/validation/BUILD.bazel
+++ b/src/main/kotlin/org/wfanet/measurement/eventdataprovider/eventfiltration/validation/BUILD.bazel
@@ -1,12 +1,16 @@
 load("@io_bazel_rules_kotlin//kotlin:jvm.bzl", "kt_jvm_library")
 
-package(default_visibility = ["//visibility:public"])
+package(default_visibility = ["//visibility:private"])
 
 kt_jvm_library(
     name = "validation",
     srcs = [
         "EventFilterValidationException.kt",
         "EventFilterValidator.kt",
+    ],
+    visibility = [
+        "//src/main/kotlin/org/wfanet/measurement/eventdataprovider/eventfiltration:__pkg__",
+        "//src/test/kotlin/org/wfanet/measurement/eventdataprovider/eventfiltration/validation:__pkg__",
     ],
     deps = [
         "//imports/java/com/google:cel-generated-pb",

--- a/src/main/kotlin/org/wfanet/measurement/loadtest/dataprovider/BUILD.bazel
+++ b/src/main/kotlin/org/wfanet/measurement/loadtest/dataprovider/BUILD.bazel
@@ -29,7 +29,7 @@ kt_jvm_library(
         "//imports/java/org/projectnessie/cel/tools",
         "//src/main/kotlin/org/wfanet/measurement/api/v2alpha:event_data_classes",
         "//src/main/kotlin/org/wfanet/measurement/api/v2alpha:event_templates",
-        "//src/main/kotlin/org/wfanet/measurement/eventdataprovider/eventfiltration/validation",
+        "//src/main/kotlin/org/wfanet/measurement/eventdataprovider/eventfiltration:event_filters",
         "//src/main/kotlin/org/wfanet/measurement/loadtest:service_flags",
         "//src/main/kotlin/org/wfanet/measurement/loadtest/config:event_filters",
         "//src/main/kotlin/org/wfanet/measurement/loadtest/storage",

--- a/src/main/kotlin/org/wfanet/measurement/loadtest/dataprovider/EdpSimulator.kt
+++ b/src/main/kotlin/org/wfanet/measurement/loadtest/dataprovider/EdpSimulator.kt
@@ -14,6 +14,7 @@
 
 package org.wfanet.measurement.loadtest.dataprovider
 
+import com.google.api.expr.v1alpha1.Decl
 import com.google.common.hash.Hashing
 import com.google.protobuf.ByteString
 import java.nio.file.Paths
@@ -82,8 +83,8 @@ import org.wfanet.measurement.consent.client.dataprovider.computeRequisitionFing
 import org.wfanet.measurement.consent.client.dataprovider.decryptRequisitionSpec
 import org.wfanet.measurement.consent.client.dataprovider.verifyMeasurementSpec
 import org.wfanet.measurement.consent.client.dataprovider.verifyRequisitionSpec
+import org.wfanet.measurement.eventdataprovider.eventfiltration.EventFilters
 import org.wfanet.measurement.eventdataprovider.eventfiltration.validation.EventFilterValidationException
-import org.wfanet.measurement.eventdataprovider.eventfiltration.validation.EventFilterValidator
 import org.wfanet.measurement.loadtest.storage.SketchStore
 
 private const val EVENT_TEMPLATE_CLASS_NAME =
@@ -326,7 +327,7 @@ class EdpSimulator(
   }
 
   private fun validateEventFilter(eventFilter: EventFilter) {
-    val decls =
+    val declarations: List<Decl> =
       eventTemplateNames.map {
         Decls.newVar(
           EventTemplates.getEventTemplateForType(it)!!.name,
@@ -338,10 +339,10 @@ class EdpSimulator(
       Env.newEnv(
         EnvOption.customTypeAdapter(celProtoTypeRegistry),
         EnvOption.customTypeProvider(celProtoTypeRegistry),
-        EnvOption.declarations(decls),
+        EnvOption.declarations(declarations),
       )
 
-    EventFilterValidator.validate(eventFilter.expression, env)
+    EventFilters.compile(eventFilter.expression, env)
   }
 
   private suspend fun fulfillRequisition(

--- a/src/main/kotlin/org/wfanet/measurement/loadtest/frontend/FrontendSimulator.kt
+++ b/src/main/kotlin/org/wfanet/measurement/loadtest/frontend/FrontendSimulator.kt
@@ -397,7 +397,7 @@ class FrontendSimulator(
    * Creates a CEL filter using Event Templates names to qualify each variable in expression.
    *
    * @param registeredEventTemplates Fully-qualified protobuf message types (e.g.
-   * org.wfa.measurement.api.v2alpha.event_templates.testing.TestVideoTemplate)
+   * wfa.measurement.api.v2alpha.event_templates.testing.TestVideoTemplate)
    */
   private fun createFilterExpression(registeredEventTemplates: Iterable<String>): String {
     val eventGroupTemplateNameMap: Map<String, String> =

--- a/src/main/proto/wfa/measurement/api/v2alpha/event_templates/testing/BUILD.bazel
+++ b/src/main/proto/wfa/measurement/api/v2alpha/event_templates/testing/BUILD.bazel
@@ -7,9 +7,12 @@ package(
     default_visibility = ["//visibility:public"],
 )
 
+IMPORT_PREFIX = "/src/main/proto"
+
 proto_library(
     name = "event_templates_proto",
-    srcs = glob(["*_template.proto"]),
+    srcs = glob(["*template.proto"]),
+    strip_import_prefix = IMPORT_PREFIX,
     deps = [
         "@com_google_protobuf//:descriptor_proto",
         "@com_google_protobuf//:duration_proto",
@@ -26,4 +29,22 @@ kt_jvm_proto_library(
     name = "event_templates_kt_jvm_proto",
     srcs = [":event_templates_proto"],
     deps = [":event_templates_java_proto"],
+)
+
+proto_library(
+    name = "event_proto",
+    srcs = ["test_event.proto"],
+    strip_import_prefix = IMPORT_PREFIX,
+    deps = [":event_templates_proto"],
+)
+
+java_proto_library(
+    name = "event_java_proto",
+    deps = [":event_proto"],
+)
+
+kt_jvm_proto_library(
+    name = "event_kt_jvm_proto",
+    srcs = [":event_proto"],
+    deps = [":event_java_proto"],
 )

--- a/src/main/proto/wfa/measurement/api/v2alpha/event_templates/testing/test_event.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/event_templates/testing/test_event.proto
@@ -1,0 +1,28 @@
+// Copyright 2022 The Cross-Media Measurement Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package wfa.measurement.api.v2alpha.event_templates.testing;
+
+import "wfa/measurement/api/v2alpha/event_templates/testing/test_banner_template.proto";
+import "wfa/measurement/api/v2alpha/event_templates/testing/test_video_template.proto";
+
+option java_package = "org.wfanet.measurement.api.v2alpha.event_templates.testing";
+option java_multiple_files = true;
+
+message TestEvent {
+  optional TestVideoTemplate video_ad = 1;
+  optional TestBannerTemplate banner_ad = 2;
+}

--- a/src/test/kotlin/org/wfanet/measurement/eventdataprovider/eventfiltration/BUILD.bazel
+++ b/src/test/kotlin/org/wfanet/measurement/eventdataprovider/eventfiltration/BUILD.bazel
@@ -1,0 +1,18 @@
+load("@io_bazel_rules_kotlin//kotlin:jvm.bzl", "kt_jvm_test")
+
+kt_jvm_test(
+    name = "EventFiltersTest",
+    srcs = ["EventFiltersTest.kt"],
+    test_class = "org.wfanet.measurement.eventdataprovider.eventfiltration.EventFiltersTest",
+    deps = [
+        "//imports/java/org/projectnessie/cel:core",
+        "//imports/java/org/projectnessie/cel/tools",
+        "//src/main/kotlin/org/wfanet/measurement/eventdataprovider/eventfiltration:event_filters",
+        "//src/main/proto/wfa/measurement/api/v2alpha/event_templates/testing:event_kt_jvm_proto",
+        "//src/main/proto/wfa/measurement/api/v2alpha/event_templates/testing:event_templates_kt_jvm_proto",
+        "@wfa_common_jvm//imports/java/com/google/common/truth",
+        "@wfa_common_jvm//imports/java/org/junit",
+        "@wfa_common_jvm//imports/kotlin/kotlin/test",
+        "@wfa_common_jvm//src/main/kotlin/org/wfanet/measurement/common",
+    ],
+)

--- a/src/test/kotlin/org/wfanet/measurement/eventdataprovider/eventfiltration/EventFiltersTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/eventdataprovider/eventfiltration/EventFiltersTest.kt
@@ -1,0 +1,89 @@
+// Copyright 2022 The Cross-Media Measurement Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.wfanet.measurement.eventdataprovider.eventfiltration
+
+import com.google.common.truth.Truth.assertThat
+import com.google.protobuf.Message
+import kotlin.test.assertFailsWith
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+import org.wfanet.measurement.api.v2alpha.event_templates.testing.AgeRange
+import org.wfanet.measurement.api.v2alpha.event_templates.testing.TestEvent
+import org.wfanet.measurement.api.v2alpha.event_templates.testing.ageRange
+import org.wfanet.measurement.api.v2alpha.event_templates.testing.testEvent
+import org.wfanet.measurement.api.v2alpha.event_templates.testing.testVideoTemplate
+import org.wfanet.measurement.eventdataprovider.eventfiltration.validation.EventFilterValidationException
+
+@RunWith(JUnit4::class)
+class EventFiltersTest {
+  private fun exampleEventWithAge(): Message {
+    return testEvent {
+      videoAd = testVideoTemplate { age = ageRange { value = AgeRange.Value.AGE_18_TO_24 } }
+    }
+  }
+
+  @Test
+  fun `keeps event when condition matches`() {
+    val program =
+      EventFilters.compileProgram(
+        " video_ad.age.value == 1",
+        testEvent {},
+      )
+    val event = exampleEventWithAge()
+    assert(EventFilters.matches(event, program))
+  }
+
+  @Test
+  fun `filters even when condition does not match`() {
+    val program =
+      EventFilters.compileProgram(" video_ad.age.value != 1", TestEvent.getDefaultInstance())
+    val event = exampleEventWithAge()
+    assert(!EventFilters.matches(event, program))
+  }
+
+  private inline fun assertFailsWithCode(
+    code: EventFilterException.Code,
+    block: () -> Unit,
+  ) {
+    val e = assertFailsWith(EventFilterException::class, block)
+    assertThat(e.code).isEqualTo(code)
+  }
+
+  @Test
+  fun `throws error when field is not filled`() {
+    val program =
+      EventFilters.compileProgram(
+        " video_ad.age.value == 1",
+        testEvent {},
+      )
+    val event = testEvent {}
+    assertFailsWithCode(EventFilterException.Code.EVALUATION_ERROR) {
+      EventFilters.matches(event, program)
+    }
+  }
+
+  @Test
+  fun `throws error when result is not boolean`() {
+    val e =
+      assertFailsWith(EventFilterValidationException::class) {
+        EventFilters.compileProgram(
+          "video_ad.age.value",
+          testEvent {},
+        )
+      }
+    assertThat(e.code).isEqualTo(EventFilterValidationException.Code.EXPRESSION_IS_NOT_CONDITIONAL)
+  }
+}

--- a/src/test/kotlin/org/wfanet/measurement/eventdataprovider/eventfiltration/validation/EventFilterValidatorTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/eventdataprovider/eventfiltration/validation/EventFilterValidatorTest.kt
@@ -64,22 +64,27 @@ class EventFilterValidatorTest {
     )
   }
 
-  private fun assertThatFailsWithCode(celExpression: String, code: Code, env: Env = Env.newEnv()) {
+  private fun assertFailsWithCode(celExpression: String, code: Code, env: Env = Env.newEnv()) {
     val e =
       assertFailsWith(EventFilterValidationException::class) {
-        EventFilterValidator.validate(celExpression, env)
+        EventFilterValidator.compile(celExpression, env)
       }
     assertThat(e.code).isEqualTo(code)
   }
 
   @Test
   fun `fails on invalid operation`() {
-    assertThatFailsWithCode("1 + 1", Code.UNSUPPORTED_OPERATION)
+    assertFailsWithCode("1 + 1", Code.UNSUPPORTED_OPERATION)
+  }
+
+  @Test
+  fun `fails on invalid expression`() {
+    assertFailsWithCode("+", Code.INVALID_CEL_EXPRESSION)
   }
 
   @Test
   fun `works on supported operation`() {
-    EventFilterValidator.validate(
+    EventFilterValidator.compile(
       "age > 30",
       env(intVar("age")),
     )
@@ -87,7 +92,7 @@ class EventFilterValidatorTest {
 
   @Test
   fun `fails on comparing string to int`() {
-    assertThatFailsWithCode(
+    assertFailsWithCode(
       "age > 30",
       Code.INVALID_CEL_EXPRESSION,
       env(stringVar("age")),
@@ -96,7 +101,7 @@ class EventFilterValidatorTest {
 
   @Test
   fun `fails on comparing int to boolean conditional`() {
-    assertThatFailsWithCode(
+    assertFailsWithCode(
       "age && (date > 10)",
       Code.INVALID_CEL_EXPRESSION,
       env(
@@ -108,7 +113,7 @@ class EventFilterValidatorTest {
 
   @Test
   fun `comparing field to a list of constants is valid`() {
-    EventFilterValidator.validate(
+    EventFilterValidator.compile(
       "age in [10, 20, 30]",
       env(intVar("age")),
     )
@@ -116,7 +121,7 @@ class EventFilterValidatorTest {
 
   @Test
   fun `comparing field to a list of constants fails if types don't match`() {
-    assertThatFailsWithCode(
+    assertFailsWithCode(
       "age in [10, 20, 30]",
       Code.INVALID_CEL_EXPRESSION,
       env(stringVar("age")),
@@ -125,7 +130,7 @@ class EventFilterValidatorTest {
 
   @Test
   fun `variable is invalid within a list`() {
-    assertThatFailsWithCode(
+    assertFailsWithCode(
       "age in [a, b, c]",
       Code.INVALID_VALUE_TYPE,
       env(
@@ -139,22 +144,22 @@ class EventFilterValidatorTest {
 
   @Test
   fun `constant is invalid at the left side of IN operator`() {
-    assertThatFailsWithCode("10 in [10, 20, 30]", Code.INVALID_VALUE_TYPE)
+    assertFailsWithCode("10 in [10, 20, 30]", Code.INVALID_VALUE_TYPE)
   }
 
   @Test
   fun `a single expression is invalid`() {
-    assertThatFailsWithCode("age", Code.EXPRESSION_IS_NOT_CONDITIONAL, env(stringVar("age")))
+    assertFailsWithCode("age", Code.EXPRESSION_IS_NOT_CONDITIONAL, env(stringVar("age")))
   }
 
   @Test
   fun `list is not valid outside @in operator`() {
-    assertThatFailsWithCode("[1, 2, 3] == [1, 2, 3]", Code.INVALID_VALUE_TYPE)
+    assertFailsWithCode("[1, 2, 3] == [1, 2, 3]", Code.INVALID_VALUE_TYPE)
   }
 
   @Test
   fun `fields should be compared only at leafs`() {
-    assertThatFailsWithCode(
+    assertFailsWithCode(
       "field1 == (field2 != field3)",
       Code.FIELD_COMPARISON_OUTSIDE_LEAF,
       env(
@@ -167,7 +172,7 @@ class EventFilterValidatorTest {
 
   @Test
   fun `a complex comparison works`() {
-    EventFilterValidator.validate(
+    EventFilterValidator.compile(
       "age < 20 || age > 50",
       env(intVar("age")),
     )
@@ -175,7 +180,7 @@ class EventFilterValidatorTest {
 
   @Test
   fun `it disallows operator outside leafs`() {
-    assertThatFailsWithCode(
+    assertFailsWithCode(
       "(a == b) <= (field2 < field3)",
       Code.INVALID_OPERATION_OUTSIDE_LEAF,
       env(
@@ -189,7 +194,7 @@ class EventFilterValidatorTest {
 
   @Test
   fun `fields can be compared between each other`() {
-    EventFilterValidator.validate(
+    EventFilterValidator.compile(
       "field1 == field2",
       env(
         intVar("field1"),
@@ -200,7 +205,7 @@ class EventFilterValidatorTest {
 
   @Test
   fun `fails on inexistant template field`() {
-    assertThatFailsWithCode(
+    assertFailsWithCode(
       "vt.date == 10",
       Code.INVALID_CEL_EXPRESSION,
       envWithTestTemplateVars(videoTemplateVar("vt"))
@@ -209,7 +214,7 @@ class EventFilterValidatorTest {
 
   @Test
   fun `can use valid template fields on comparison`() {
-    EventFilterValidator.validate(
+    EventFilterValidator.compile(
       "bt.gender.value == 2 && vt.age.value == 1",
       envWithTestTemplateVars(
         bannerTemplateVar("bt"),
@@ -220,7 +225,7 @@ class EventFilterValidatorTest {
 
   @Test
   fun `can use template with IN operator`() {
-    EventFilterValidator.validate(
+    EventFilterValidator.compile(
       "vt.age.value in [0, 1]",
       envWithTestTemplateVars(videoTemplateVar("vt"))
     )


### PR DESCRIPTION
Creates an event filtering library that will match a CEL expression to an event Message
* Event Message's are defined as proto's that have all valid event templates as optional fields
* The name of the template field, within the event message, is used for reference by variables in the CEL expression
* The EventFilter only needs a default Event Message to initialize the CEL environment, and compile the expression

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/world-federation-of-advertisers/cross-media-measurement/491)
<!-- Reviewable:end -->
