### PR TITLE
Fix local correctness test by passing in Event Templates to Simulators

### DIFF
--- a/src/main/kotlin/org/wfanet/measurement/loadtest/config/BUILD.bazel
+++ b/src/main/kotlin/org/wfanet/measurement/loadtest/config/BUILD.bazel
@@ -1,3 +1,5 @@
+load("@io_bazel_rules_kotlin//kotlin:jvm.bzl", "kt_jvm_library")
+
 filegroup(
     name = "config",
     srcs = [
@@ -8,5 +10,13 @@ filegroup(
         "//src/test/kotlin/org/wfanet/measurement/e2e:__subpackages__",
         "//src/test/kotlin/org/wfanet/measurement/integration/common:__pkg__",
         "//src/test/kotlin/org/wfanet/measurement/loadtest:__pkg__",
+    ],
+)
+
+kt_jvm_library(
+    name = "event_filters",
+    srcs = ["EventFilters.kt"],
+    visibility = [
+        "//src/main/kotlin/org/wfanet/measurement/loadtest:__subpackages__",
     ],
 )

--- a/src/main/kotlin/org/wfanet/measurement/loadtest/config/EventFilters.kt
+++ b/src/main/kotlin/org/wfanet/measurement/loadtest/config/EventFilters.kt
@@ -16,12 +16,16 @@ package org.wfanet.measurement.loadtest.config
 
 private const val TEMPLATE_PREFIX = "org.wfa.measurement.api.v2alpha.event_templates.testing"
 
-/**
- * Values of this map are anded to create the event filter to be sent to the EDPs.
- *
- * For purposes of this simulation, all of the EDPs register the same templates and receive the same
- * filter from the MC.
- *
- * TODO(@uakyol): Add [date], [socialGrade], [gender] fields once filtration is implemented.
- */
-val EVENT_TEMPLATES_TO_FILTERS_MAP = mapOf("$TEMPLATE_PREFIX.TestVideoTemplate" to "age.value == 1")
+object EventFilters {
+
+  /**
+   * Values of this map are anded to create the event filter to be sent to the EDPs.
+   *
+   * For purposes of this simulation, all of the EDPs register the same templates and receive the
+   * same filter from the MC.
+   *
+   * TODO(@uakyol): Add [date], [socialGrade], [gender] fields once filtration is implemented.
+   */
+  val EVENT_TEMPLATES_TO_FILTERS_MAP =
+    mapOf("$TEMPLATE_PREFIX.TestVideoTemplate" to "age.value == 1")
+}

--- a/src/main/kotlin/org/wfanet/measurement/loadtest/config/EventFilters.kt
+++ b/src/main/kotlin/org/wfanet/measurement/loadtest/config/EventFilters.kt
@@ -1,0 +1,27 @@
+// Copyright 2022 The Cross-Media Measurement Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.wfanet.measurement.loadtest.config
+
+private const val TEMPLATE_PREFIX = "org.wfa.measurement.api.v2alpha.event_templates.testing"
+
+/**
+ * Values of this map are anded to create the event filter to be sent to the EDPs.
+ *
+ * For purposes of this simulation, all of the EDPs register the same templates and receive the same
+ * filter from the MC.
+ *
+ * TODO(@uakyol): Add [date], [socialGrade], [gender] fields once filtration is implemented.
+ */
+val EVENT_TEMPLATES_TO_FILTERS_MAP = mapOf("$TEMPLATE_PREFIX.TestVideoTemplate" to "age.value == 1")

--- a/src/main/kotlin/org/wfanet/measurement/loadtest/dataprovider/BUILD.bazel
+++ b/src/main/kotlin/org/wfanet/measurement/loadtest/dataprovider/BUILD.bazel
@@ -31,6 +31,7 @@ kt_jvm_library(
         "//src/main/kotlin/org/wfanet/measurement/api/v2alpha:event_template_type_registry",
         "//src/main/kotlin/org/wfanet/measurement/eventdataprovider/eventfiltration/validation",
         "//src/main/kotlin/org/wfanet/measurement/loadtest:service_flags",
+        "//src/main/kotlin/org/wfanet/measurement/loadtest/config:event_filters",
         "//src/main/kotlin/org/wfanet/measurement/loadtest/storage",
         "//src/main/proto/wfa/any_sketch:sketch_kt_jvm_proto",
         "//src/main/proto/wfa/any_sketch/crypto:sketch_encryption_methods_kt_jvm_proto",

--- a/src/main/kotlin/org/wfanet/measurement/loadtest/dataprovider/EdpSimulatorRunner.kt
+++ b/src/main/kotlin/org/wfanet/measurement/loadtest/dataprovider/EdpSimulatorRunner.kt
@@ -26,6 +26,7 @@ import org.wfanet.measurement.common.crypto.testing.loadSigningKey
 import org.wfanet.measurement.common.crypto.tink.testing.loadPrivateKey
 import org.wfanet.measurement.common.grpc.buildMutualTlsChannel
 import org.wfanet.measurement.common.throttler.MinimumIntervalThrottler
+import org.wfanet.measurement.loadtest.config.EVENT_TEMPLATES_TO_FILTERS_MAP
 import org.wfanet.measurement.loadtest.storage.SketchStore
 import org.wfanet.measurement.storage.StorageClient
 import picocli.CommandLine
@@ -80,7 +81,8 @@ abstract class EdpSimulatorRunner : Runnable {
           requisitionFulfillmentStub,
           SketchStore(storageClient),
           eventQuery,
-          MinimumIntervalThrottler(Clock.systemUTC(), flags.throttlerMinimumInterval)
+          MinimumIntervalThrottler(Clock.systemUTC(), flags.throttlerMinimumInterval),
+          eventTemplateNames = EVENT_TEMPLATES_TO_FILTERS_MAP.keys.toList()
         )
         .process()
     }

--- a/src/main/kotlin/org/wfanet/measurement/loadtest/dataprovider/EdpSimulatorRunner.kt
+++ b/src/main/kotlin/org/wfanet/measurement/loadtest/dataprovider/EdpSimulatorRunner.kt
@@ -26,7 +26,7 @@ import org.wfanet.measurement.common.crypto.testing.loadSigningKey
 import org.wfanet.measurement.common.crypto.tink.testing.loadPrivateKey
 import org.wfanet.measurement.common.grpc.buildMutualTlsChannel
 import org.wfanet.measurement.common.throttler.MinimumIntervalThrottler
-import org.wfanet.measurement.loadtest.config.EVENT_TEMPLATES_TO_FILTERS_MAP
+import org.wfanet.measurement.loadtest.config.EventFilters.EVENT_TEMPLATES_TO_FILTERS_MAP
 import org.wfanet.measurement.loadtest.storage.SketchStore
 import org.wfanet.measurement.storage.StorageClient
 import picocli.CommandLine

--- a/src/main/kotlin/org/wfanet/measurement/loadtest/frontend/BUILD.bazel
+++ b/src/main/kotlin/org/wfanet/measurement/loadtest/frontend/BUILD.bazel
@@ -58,6 +58,7 @@ kt_jvm_library(
         ":frontend_simulator",
         "//src/main/kotlin/org/wfanet/measurement/kingdom/deploy/common:flags",
         "//src/main/kotlin/org/wfanet/measurement/loadtest:service_flags",
+        "//src/main/kotlin/org/wfanet/measurement/loadtest/config:event_filters",
         "//src/main/proto/wfa/measurement/api/v2alpha:event_groups_service_kt_jvm_grpc_proto",
         "//src/main/proto/wfa/measurement/api/v2alpha:measurements_service_kt_jvm_grpc_proto",
         "@wfa_common_jvm//imports/java/io/grpc:api",

--- a/src/main/kotlin/org/wfanet/measurement/loadtest/frontend/FrontendSimulatorRunner.kt
+++ b/src/main/kotlin/org/wfanet/measurement/loadtest/frontend/FrontendSimulatorRunner.kt
@@ -27,6 +27,7 @@ import org.wfanet.measurement.common.crypto.testing.SigningCertsTesting
 import org.wfanet.measurement.common.crypto.testing.loadSigningKey
 import org.wfanet.measurement.common.crypto.tink.testing.loadPrivateKey
 import org.wfanet.measurement.common.grpc.buildMutualTlsChannel
+import org.wfanet.measurement.loadtest.config.EVENT_TEMPLATES_TO_FILTERS_MAP
 import org.wfanet.measurement.loadtest.storage.SketchStore
 import org.wfanet.measurement.storage.StorageClient
 import picocli.CommandLine
@@ -84,7 +85,8 @@ abstract class FrontendSimulatorRunner : Runnable {
           measurementsStub,
           requisitionsStub,
           measurementConsumersStub,
-          SketchStore(storageClient)
+          SketchStore(storageClient),
+          EVENT_TEMPLATES_TO_FILTERS_MAP
         )
 
       launch { frontendSimulator.executeReachAndFrequency(flags.runId + "-reach_frequency") }

--- a/src/main/kotlin/org/wfanet/measurement/loadtest/frontend/FrontendSimulatorRunner.kt
+++ b/src/main/kotlin/org/wfanet/measurement/loadtest/frontend/FrontendSimulatorRunner.kt
@@ -27,7 +27,7 @@ import org.wfanet.measurement.common.crypto.testing.SigningCertsTesting
 import org.wfanet.measurement.common.crypto.testing.loadSigningKey
 import org.wfanet.measurement.common.crypto.tink.testing.loadPrivateKey
 import org.wfanet.measurement.common.grpc.buildMutualTlsChannel
-import org.wfanet.measurement.loadtest.config.EVENT_TEMPLATES_TO_FILTERS_MAP
+import org.wfanet.measurement.loadtest.config.EventFilters.EVENT_TEMPLATES_TO_FILTERS_MAP
 import org.wfanet.measurement.loadtest.storage.SketchStore
 import org.wfanet.measurement.storage.StorageClient
 import picocli.CommandLine


### PR DESCRIPTION
Fixes the local correctness test by adding EventFilters to Frontend simulator runner and the EDPSimulator runner
Tested with instructions from https://github.com/world-federation-of-advertisers/cross-media-measurement/blob/main/src/main/k8s/local/README.md#local-kubernetes-deployment and verified the correctness 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/world-federation-of-advertisers/cross-media-measurement/508)
<!-- Reviewable:end -->
