### PR TITLE
Add postgres schema and test for privacy budget ledger

### DIFF
--- a/src/main/kotlin/org/wfanet/measurement/integration/deploy/postgres/BUILD.bazel
+++ b/src/main/kotlin/org/wfanet/measurement/integration/deploy/postgres/BUILD.bazel
@@ -1,0 +1,15 @@
+load("@io_bazel_rules_kotlin//kotlin:jvm.bzl", "kt_jvm_library")
+
+package(default_visibility = ["//visibility:public"])
+
+kt_jvm_library(
+    name = "schemata",
+    srcs = [
+        "Schemata.kt",
+    ],
+    deps = [
+        "@wfa_common_jvm//src/main/kotlin/org/wfanet/measurement/common",
+    ],
+)
+
+exports_files(["ledger.sql"])

--- a/src/main/kotlin/org/wfanet/measurement/integration/deploy/postgres/Schemata.kt
+++ b/src/main/kotlin/org/wfanet/measurement/integration/deploy/postgres/Schemata.kt
@@ -1,0 +1,36 @@
+// Copyright 2022 The Cross-Media Measurement Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package src.main.kotlin.org.wfanet.measurement.integration.deploy.postgres
+
+import java.io.File
+import java.nio.file.Paths
+import org.wfanet.measurement.common.getRuntimePath
+
+private val SCHEMA_DIR =
+  Paths.get(
+    "wfa_measurement_system",
+    "src",
+    "main",
+    "kotlin",
+    "org",
+    "wfanet",
+    "measurement",
+    "integration",
+    "deploy",
+    "postgres",
+  )
+
+val POSTGRES_LEDGER_SCHEMA_FILE: File =
+  checkNotNull(getRuntimePath(SCHEMA_DIR.resolve("ledger.sql"))).toFile()

--- a/src/main/kotlin/org/wfanet/measurement/integration/deploy/postgres/ledger.sql
+++ b/src/main/kotlin/org/wfanet/measurement/integration/deploy/postgres/ledger.sql
@@ -1,0 +1,51 @@
+-- Copyright 2022 The Cross-Media Measurement Authors
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--      http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+CREATE TYPE Gender AS ENUM ('M', 'F');
+CREATE TYPE AgeGroup AS ENUM ('18_34', '35_54', '55+');
+
+-- This sequence will be referenced as `TransactionId` field at `LedgerEntries` table
+-- being incremented only at the start of any transaction.
+-- This will allow for transaction rollback functionality after a commit.
+-- The special value of 0 is reserved for merged transactions.
+CREATE SEQUENCE LedgerEntriesTransactionIdSeq AS bigint START WITH 100;
+
+CREATE TABLE LedgerEntries (
+    -- A unique key associated with this row to allow for subsequent updates and deletions.
+    LedgerEntryId bigserial PRIMARY KEY,
+    -- Which Measurement Consumer this PrivacyBucket belongs to.
+    MeasurementConsumerId text NOT NULL,
+    -- ID for the transaction this entry belongs to.
+    TransactionId bigint NOT NULL,
+    -- Day for this PrivacyBucket. DD-MM-YYYY.
+    Date Date NOT NULL,
+    -- Age for this PrivacyBucket.
+    AgeGroup AgeGroup NOT NULL,
+    -- Gender for this PrivacyBucket.
+    Gender Gender NOT NULL,
+    -- Start of the Vid range for this PrivacyBucket. Bucket vid's ranges from VidStart to VidStart + 0.1.
+    VidStart real NOT NULL,
+    -- Delta for the charge of this ledger entry.
+    Delta real NOT NULL,
+    -- Epsilon for the charge of this ledger entry.
+    Epsilon real NOT NULL,
+    -- How many times this charge is applied to this Privacy Bucket.
+    RepetitionCount integer NOT NULL
+);
+-- Used to query entries efficiently to update RepetitionCount
+CREATE INDEX LedgerEntriesByCharge
+  ON LedgerEntries
+  (MeasurementConsumerId, Date, AgeGroup, Gender, VidStart, Delta, Epsilon);
+-- Used to rollback transactions
+CREATE INDEX LedgerEntriesByTransaction ON LedgerEntries (TransactionId);

--- a/src/test/kotlin/org/wfanet/measurement/integration/postgres/BUILD.bazel
+++ b/src/test/kotlin/org/wfanet/measurement/integration/postgres/BUILD.bazel
@@ -1,0 +1,19 @@
+load("@io_bazel_rules_kotlin//kotlin:jvm.bzl", "kt_jvm_test")
+
+kt_jvm_test(
+    name = "PrivacyBudgetPostgresSchemaTest",
+    srcs = [
+        "PrivacyBudgetPostgresSchemaTest.kt",
+    ],
+    data = [
+        "//src/main/kotlin/org/wfanet/measurement/integration/deploy/postgres:ledger.sql",
+    ],
+    test_class = "org.wfanet.measurement.integration.postgres.PrivacyBudgetPostgresSchemaTest",
+    deps = [
+        "//imports/java/com/opentable/db/postgres:otj_pg_embedded",
+        "//src/main/kotlin/org/wfanet/measurement/integration/deploy/postgres:schemata",
+        "@wfa_common_jvm//imports/java/org/junit",
+        "@wfa_common_jvm//imports/kotlin/kotlin/test",
+        "@wfa_common_jvm//src/main/kotlin/org/wfanet/measurement/common",
+    ],
+)

--- a/src/test/kotlin/org/wfanet/measurement/integration/postgres/PrivacyBudgetPostgresSchemaTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/integration/postgres/PrivacyBudgetPostgresSchemaTest.kt
@@ -1,0 +1,80 @@
+// Copyright 2022 The Cross-Media Measurement Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.wfanet.measurement.integration.postgres
+
+import com.opentable.db.postgres.junit.EmbeddedPostgresRules
+import com.opentable.db.postgres.junit.SingleInstancePostgresRule
+import java.sql.Connection
+import java.sql.ResultSet
+import java.sql.Statement
+import kotlin.test.assertEquals
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+import src.main.kotlin.org.wfanet.measurement.integration.deploy.postgres.POSTGRES_LEDGER_SCHEMA_FILE
+
+@RunWith(JUnit4::class)
+class PrivacyBudgetPostgresSchemaTest {
+  val schema = POSTGRES_LEDGER_SCHEMA_FILE.readText()
+
+  @get:Rule val pg: SingleInstancePostgresRule = EmbeddedPostgresRules.singleInstance()
+
+  @Test
+  fun `privacy budget ledger sql file is valid for postgres`() {
+    val connection: Connection = pg.embeddedPostgres.postgresDatabase.connection
+    val statement: Statement = connection.createStatement()
+    statement.execute(schema)
+  }
+
+  @Test
+  fun `privacy budget ledger can be written and read`() {
+    val connection: Connection = pg.embeddedPostgres.postgresDatabase.connection
+    val statement = connection.createStatement()
+    val insertSql =
+      """
+      INSERT INTO LedgerEntries (
+        TransactionId,
+        MeasurementConsumerId,
+        Date,
+        AgeGroup,
+        Gender,
+        VidStart,
+        Delta,
+        Epsilon,
+        RepetitionCount
+      ) VALUES (
+        nextval('LedgerEntriesTransactionIdSeq'),
+        1,
+        '2022-01-01',
+        '18_34',
+        'F',
+        100,
+        0.1,
+        0.01,
+        10
+      );
+      """
+    val selectSql = """
+      SELECT Gender, Delta from LedgerEntries
+      """
+    statement.execute(schema)
+    statement.execute(insertSql)
+    val result: ResultSet = statement.executeQuery(selectSql)
+    result.next()
+    assertEquals("F", result.getString("gender"))
+    assertEquals(0.1f, result.getFloat("delta"))
+  }
+}


### PR DESCRIPTION
* Creates a schema for the Privacy Bucket Ledger backing store using postgresql notation
* Run the schema and a basic write/read as a basic test, under a postgres docker test harness already implemented in the project

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/world-federation-of-advertisers/cross-media-measurement/520)
<!-- Reviewable:end -->
