### PR TITLE
Make mergePreviousTransaction increase repetition count

### DIFF
--- a/src/main/kotlin/org/wfanet/measurement/eventdataprovider/privacybudgetmanagement/PrivacyBudgetLedgerBackingStore.kt
+++ b/src/main/kotlin/org/wfanet/measurement/eventdataprovider/privacybudgetmanagement/PrivacyBudgetLedgerBackingStore.kt
@@ -28,7 +28,10 @@ data class PrivacyBudgetLedgerEntry(
   val privacyBucketGroup: PrivacyBucketGroup,
   val privacyCharge: PrivacyCharge,
   val repetitionCount: Int
-)
+) {
+  fun canBeMergedWith(otherEntry: PrivacyBudgetLedgerEntry): Boolean =
+    privacyCharge == otherEntry.privacyCharge && privacyBucketGroup == otherEntry.privacyBucketGroup
+}
 
 /** Manages the persistence of privacy budget data. */
 interface PrivacyBudgetLedgerBackingStore : Closeable {
@@ -77,7 +80,7 @@ interface PrivacyBudgetLedgerTransactionContext : Closeable {
    *
    * One possible implementation is to represent the permanently merged privacy budget charges using
    * a special transaction ID (for example, 0). When merging a row, if there is an existing row with
-   * the special transaction ID that has the same privacy charge, then the repetition count can be
+   * the special transaction ID that has the same privacy charge, then the repetition count shall be
    * increased and the merged row can be deleted. Otherwise, the transaction ID for the merged row
    * can be set to the special transaction ID.
    */

--- a/src/test/kotlin/org/wfanet/measurement/eventdataprovider/privacybudgetmanagement/AbstractPrivacyBudgetLedgerStoreTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/eventdataprovider/privacybudgetmanagement/AbstractPrivacyBudgetLedgerStoreTest.kt
@@ -15,6 +15,7 @@ package org.wfanet.measurement.eventdataprovider.privacybudgetmanagement
 
 import java.time.LocalDate
 import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
 import org.junit.Test
 
 abstract class AbstractPrivacyBudgetLedgerStoreTest {
@@ -146,12 +147,156 @@ abstract class AbstractPrivacyBudgetLedgerStoreTest {
 
       backingStore.startTransaction().use { newTxContext: PrivacyBudgetLedgerTransactionContext ->
         val matchingLedgerEntries = newTxContext.findIntersectingLedgerEntries(bucket1)
-        assertEquals(matchingLedgerEntries.size, 1)
-        assertEquals(matchingLedgerEntries[0].transactionId, txId)
+        assertEquals(1, matchingLedgerEntries.size)
+        assertEquals(txId, matchingLedgerEntries[0].transactionId)
         newTxContext.mergePreviousTransaction(txId)
         val newMatchingLedgerEntries = newTxContext.findIntersectingLedgerEntries(bucket1)
-        assertEquals(newMatchingLedgerEntries.size, 1)
-        assertEquals(newMatchingLedgerEntries[0].transactionId, 0)
+        assertEquals(1, newMatchingLedgerEntries.size)
+        assertEquals(0, newMatchingLedgerEntries[0].transactionId)
+      }
+    }
+  }
+
+  private val targetBucketGroup =
+    PrivacyBucketGroup(
+      "ACME",
+      LocalDate.parse("2021-07-01"),
+      LocalDate.parse("2021-07-01"),
+      AgeGroup.RANGE_35_54,
+      Gender.MALE,
+      0.3f,
+      0.1f
+    )
+  // Each sample bucket group are a modification of targetBucketGroup with a change in a single
+  // dimension
+  // to allow tests to check if the backing stores are updating only the target entry
+  private val sampleBucketGroups =
+    listOf(
+      // Different consumer ID
+      PrivacyBucketGroup(
+        "COMPANY",
+        LocalDate.parse("2021-07-01"),
+        LocalDate.parse("2021-07-01"),
+        AgeGroup.RANGE_35_54,
+        Gender.MALE,
+        0.5f,
+        0.1f
+      ),
+      // Different Date
+      PrivacyBucketGroup(
+        "ACME",
+        LocalDate.parse("2021-07-02"),
+        LocalDate.parse("2021-07-02"),
+        AgeGroup.RANGE_35_54,
+        Gender.MALE,
+        0.3f,
+        0.1f
+      ),
+      // Different AgeGroup
+      PrivacyBucketGroup(
+        "ACME",
+        LocalDate.parse("2021-07-01"),
+        LocalDate.parse("2021-07-01"),
+        AgeGroup.RANGE_18_34,
+        Gender.MALE,
+        0.3f,
+        0.1f
+      ),
+      // Different Gender
+      PrivacyBucketGroup(
+        "ACME",
+        LocalDate.parse("2021-07-01"),
+        LocalDate.parse("2021-07-01"),
+        AgeGroup.RANGE_35_54,
+        Gender.FEMALE,
+        0.3f,
+        0.1f
+      ),
+      // Different Vid start
+      PrivacyBucketGroup(
+        "ACME",
+        LocalDate.parse("2021-07-01"),
+        LocalDate.parse("2021-07-01"),
+        AgeGroup.RANGE_35_54,
+        Gender.MALE,
+        0.5f,
+        0.1f
+      ),
+    )
+
+  @Test(timeout = 15000)
+  fun `mergePreviousTransaction updates repetition count of matching entry`() {
+    val charge = PrivacyCharge(0.01f, 0.0001f)
+    createBackingStore(true).use { backingStore: PrivacyBudgetLedgerBackingStore ->
+      // Add target bucket entry and merge it.
+      // Add sample bucket groups.
+      backingStore.startTransaction().use { txContext: PrivacyBudgetLedgerTransactionContext ->
+        txContext.addLedgerEntry(targetBucketGroup, charge)
+        sampleBucketGroups.forEach { txContext.addLedgerEntry(it, charge) }
+        txContext.mergePreviousTransaction(txContext.transactionId)
+        txContext.commit()
+      }
+      // Add the same entry again as a new transaction
+      var txId: Long
+      backingStore.startTransaction().use { txContext: PrivacyBudgetLedgerTransactionContext ->
+        txId = txContext.transactionId
+        txContext.addLedgerEntry(targetBucketGroup, charge)
+        txContext.commit()
+      }
+
+      backingStore.startTransaction().use { newTxContext: PrivacyBudgetLedgerTransactionContext ->
+        val matchingLedgerEntries = newTxContext.findIntersectingLedgerEntries(targetBucketGroup)
+        assertEquals(2, matchingLedgerEntries.size)
+        val hasMergedEntry =
+          matchingLedgerEntries[0].transactionId == 0L ||
+            matchingLedgerEntries[1].transactionId == 0L
+        val hasNonMergedEntry =
+          matchingLedgerEntries[0].transactionId == txId ||
+            matchingLedgerEntries[1].transactionId == txId
+        assert(hasMergedEntry && hasNonMergedEntry)
+        newTxContext.mergePreviousTransaction(txId)
+        val newMatchingLedgerEntries = newTxContext.findIntersectingLedgerEntries(targetBucketGroup)
+        assertEquals(1, newMatchingLedgerEntries.size)
+        assertEquals(0, newMatchingLedgerEntries[0].transactionId)
+        assertEquals(2, newMatchingLedgerEntries[0].repetitionCount)
+        // Sanity check - check the unrelated sample bucket groups are unchanged
+        sampleBucketGroups.forEach { bucket ->
+          val unchangedLedgerEntries = newTxContext.findIntersectingLedgerEntries(bucket)
+          assertEquals(1, unchangedLedgerEntries.size)
+          assertEquals(1, unchangedLedgerEntries[0].repetitionCount)
+        }
+      }
+    }
+  }
+
+  fun `mergePreviousTransaction only merges the right transaction`() {
+    val charge = PrivacyCharge(0.01f, 0.0001f)
+    createBackingStore(true).use { backingStore: PrivacyBudgetLedgerBackingStore ->
+      backingStore.startTransaction().use { txContext: PrivacyBudgetLedgerTransactionContext ->
+        txContext.addLedgerEntry(targetBucketGroup, charge)
+        txContext.mergePreviousTransaction(txContext.transactionId)
+        txContext.commit()
+      }
+      var notToMergeTransactionId: Long
+      backingStore.startTransaction().use { txContext: PrivacyBudgetLedgerTransactionContext ->
+        notToMergeTransactionId = txContext.transactionId
+        txContext.addLedgerEntry(targetBucketGroup, charge)
+        txContext.commit()
+      }
+      backingStore.startTransaction().use { txContext: PrivacyBudgetLedgerTransactionContext ->
+        val txId = txContext.transactionId
+        txContext.addLedgerEntry(targetBucketGroup, charge)
+        txContext.mergePreviousTransaction(txId)
+        txContext.commit()
+      }
+      backingStore.startTransaction().use { txContext: PrivacyBudgetLedgerTransactionContext ->
+        val matchingEntries = txContext.findIntersectingLedgerEntries(targetBucketGroup)
+        assertEquals(2, matchingEntries.size)
+        val mergedEntry = assertNotNull(matchingEntries.find { it.transactionId == 0L })
+        val notToMergeEntry =
+          assertNotNull(matchingEntries.find { it.transactionId == notToMergeTransactionId })
+        assertEquals(2, mergedEntry.repetitionCount)
+        assertEquals(1, notToMergeEntry.repetitionCount)
       }
     }
   }


### PR DESCRIPTION
Before this, `mergePreviousTransaction()` was just adding new entries if there were matches within the merged ledger entries.
This changes the language to say that the behavior of merging matched entries by increasing repetition count is mandatory.
Also introduces new test to exercise this new expected behavior.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/world-federation-of-advertisers/cross-media-measurement/538)
<!-- Reviewable:end -->
