### PR TITLE
Memoization for advanced composition theorem

### DIFF
--- a/src/main/kotlin/org/wfanet/measurement/eventdataprovider/privacybudgetmanagement/AdvancedComposition.kt
+++ b/src/main/kotlin/org/wfanet/measurement/eventdataprovider/privacybudgetmanagement/AdvancedComposition.kt
@@ -36,7 +36,7 @@ object AdvancedComposition {
    * @return The number of distinct ways to draw k items from a set of size n. Alternatively, the
    * coefficient of x^k in the expansion of (1 + x)^n.
    */
-  fun coeff(n: Int, k: Int): Float {
+  private fun coeff(n: Int, k: Int): Float {
     return if ((n < 0) || (k < 0) || (n < k)) {
       0.0f
     } else if ((k == 0) || (n == k)) {

--- a/src/main/kotlin/org/wfanet/measurement/eventdataprovider/privacybudgetmanagement/AdvancedComposition.kt
+++ b/src/main/kotlin/org/wfanet/measurement/eventdataprovider/privacybudgetmanagement/AdvancedComposition.kt
@@ -17,9 +17,16 @@ import java.util.concurrent.ConcurrentHashMap
 import kotlin.math.exp
 import kotlin.math.pow
 
+data class AdvancedCompositionKey(
+  val charge: PrivacyCharge,
+  val repetitionCount: Int,
+  val totalDelta: Float
+)
+
 /** Memoized computation of binomial coefficients. */
-object Binom {
+object AdvancedComposition {
   private val memoizedCoeffs = ConcurrentHashMap<Pair<Int, Int>, Float>()
+  private val memoizedResults = HashMap<AdvancedCompositionKey, Float?>()
 
   /**
    * Computes the number of distinct ways to choose k items from a set of n.
@@ -40,52 +47,57 @@ object Binom {
       memoizedCoeffs.getOrPut(n to k) { coeff(n - 1, k - 1) + coeff(n - 1, k) }
     }
   }
-}
 
-/**
- * Computes total DP parameters after applying an algorithm with given privacy parameters multiple
- * times.
- *
- * Using the optimal advanced composition theorem, Theorem 3.3 from the paper Kairouz, Oh,
- * Viswanath. "The Composition Theorem for Differential Privacy", to compute the total DP parameters
- * given that we are applying an algorithm with a given privacy parameters for a given number of
- * times.
- *
- * This code is a Kotlin implementation of the advanced_composition() function in the Google
- * differential privacy accounting library, located at
- * https://github.com/google/differential-privacy.git
- *
- * @param privacyParameters The privacy guarantee of a single query.
- * @param numQueries Number of times the algorithm is invoked.
- * @param totalDelta The target value of total delta of the privacy parameters for the multiple runs
- * of the algorithm.
- *
- * @return totalEpsilon such that, when applying the algorithm the given number of times, the result
- * is still (totalEpsilon, totalDelta)-DP. None when the total_delta is less than 1 - (1 -
- * delta)^repetitionCount, for which no guarantee of (totalEpsilon, totalDelta)-DP is possible for
- * any value of totalEpsilon.
- */
-fun totalPrivacyBudgetUsageUnderAdvancedComposition(
-  charge: PrivacyCharge,
-  repetitionCount: Int,
-  totalDelta: Float
-): Float? {
-  val epsilon = charge.epsilon
-  val delta = charge.delta
-  val k = repetitionCount
+  /**
+   * Computes total DP parameters after applying an algorithm with given privacy parameters multiple
+   * times.
+   *
+   * Using the optimal advanced composition theorem, Theorem 3.3 from the paper Kairouz, Oh,
+   * Viswanath. "The Composition Theorem for Differential Privacy", to compute the total DP
+   * parameters given that we are applying an algorithm with a given privacy parameters for a given
+   * number of times.
+   *
+   * This code is a Kotlin implementation of the advanced_composition() function in the Google
+   * differential privacy accounting library, located at
+   * https://github.com/google/differential-privacy.git
+   *
+   * @param charge The privacy charge of a single query.
+   * @param repetitionCount Number of times the algorithm is invoked.
+   * @param totalDelta The target value of total delta of the privacy parameters for the multiple
+   * runs of the algorithm.
+   *
+   * @return totalEpsilon such that, when applying the algorithm the given number of times, the
+   * result is still (totalEpsilon, totalDelta)-DP. None when the total_delta is less than 1 - (1 -
+   * delta)^repetitionCount, for which no guarantee of (totalEpsilon, totalDelta)-DP is possible for
+   * any value of totalEpsilon.
+   */
+  fun totalPrivacyBudgetUsageUnderAdvancedComposition(
+    charge: PrivacyCharge,
+    repetitionCount: Int,
+    totalDelta: Float
+  ): Float? {
+    val advancedCompositionKey: AdvancedCompositionKey =
+      AdvancedCompositionKey(charge, repetitionCount, totalDelta)
+    return memoizedResults.getOrPut(advancedCompositionKey) {
+      val epsilon = advancedCompositionKey.charge.epsilon
+      val delta = advancedCompositionKey.charge.delta
+      val k = advancedCompositionKey.repetitionCount
 
-  // The calculation follows Theorem 3.3 of https://arxiv.org/pdf/1311.0776.pdf
-  for (i in k / 2 downTo 0) {
-    var deltaI = 0.0f
-    for (l in 0..i - 1) {
-      deltaI +=
-        Binom.coeff(k, l) *
-          (exp(epsilon * (k - l).toFloat()) - exp(epsilon * (k - 2 * i + l).toFloat()))
-    }
-    deltaI /= (1.0f + exp(epsilon)).pow(k)
-    if (1.0f - (1 - delta).pow(k) * (1.0f - deltaI) <= totalDelta) {
-      return epsilon * (k - 2 * i).toFloat()
+      // The calculation follows Theorem 3.3 of https://arxiv.org/pdf/1311.0776.pdf
+      for (i in k / 2 downTo 0) {
+        var deltaI = 0.0f
+        for (l in 0..i - 1) {
+          deltaI +=
+            coeff(k, l) *
+              (exp(epsilon * (k - l).toFloat()) - exp(epsilon * (k - 2 * i + l).toFloat()))
+        }
+        deltaI /= (1.0f + exp(epsilon)).pow(k)
+        if (1.0f - (1 - delta).pow(k) * (1.0f - deltaI) <= advancedCompositionKey.totalDelta) {
+          memoizedResults.put(advancedCompositionKey, epsilon * (k - 2 * i).toFloat())
+          return memoizedResults.get(advancedCompositionKey)
+        }
+      }
+      return null
     }
   }
-  return null
 }

--- a/src/main/kotlin/org/wfanet/measurement/eventdataprovider/privacybudgetmanagement/AdvancedComposition.kt
+++ b/src/main/kotlin/org/wfanet/measurement/eventdataprovider/privacybudgetmanagement/AdvancedComposition.kt
@@ -99,10 +99,8 @@ object AdvancedComposition {
     charge: PrivacyCharge,
     repetitionCount: Int,
     totalDelta: Float
-  ): Float? {
-
-    return memoizedResults.getOrPut(AdvancedCompositionKey(charge, repetitionCount, totalDelta)) {
+  ): Float? =
+    memoizedResults.getOrPut(AdvancedCompositionKey(charge, repetitionCount, totalDelta)) {
       calculateAdvnacedComposition(charge, repetitionCount, totalDelta)
     }
-  }
 }

--- a/src/main/kotlin/org/wfanet/measurement/eventdataprovider/privacybudgetmanagement/AdvancedComposition.kt
+++ b/src/main/kotlin/org/wfanet/measurement/eventdataprovider/privacybudgetmanagement/AdvancedComposition.kt
@@ -48,7 +48,7 @@ object AdvancedComposition {
     }
   }
 
-  private fun calculateAdvnacedComposition(
+  private fun calculateAdvancedComposition(
     charge: PrivacyCharge,
     repetitionCount: Int,
     totalDelta: Float
@@ -101,6 +101,6 @@ object AdvancedComposition {
     totalDelta: Float
   ): Float? =
     memoizedResults.getOrPut(AdvancedCompositionKey(charge, repetitionCount, totalDelta)) {
-      calculateAdvnacedComposition(charge, repetitionCount, totalDelta)
+      calculateAdvancedComposition(charge, repetitionCount, totalDelta)
     }
 }

--- a/src/main/kotlin/org/wfanet/measurement/eventdataprovider/privacybudgetmanagement/PrivacyBudgetLedger.kt
+++ b/src/main/kotlin/org/wfanet/measurement/eventdataprovider/privacybudgetmanagement/PrivacyBudgetLedger.kt
@@ -144,7 +144,7 @@ class PrivacyBudgetLedger(
     if (allChargesEquivalent) {
       val nCharges = nonUniqueCharges.sumOf { it.count }
       val advancedCompositionEpsilon =
-        totalPrivacyBudgetUsageUnderAdvancedComposition(
+        AdvancedComposition.totalPrivacyBudgetUsageUnderAdvancedComposition(
           PrivacyCharge(nonUniqueCharges[0].epsilon, nonUniqueCharges[0].delta),
           nCharges,
           maximumTotalDelta

--- a/src/test/kotlin/org/wfanet/measurement/eventdataprovider/privacybudgetmanagement/AdvancedCompositionTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/eventdataprovider/privacybudgetmanagement/AdvancedCompositionTest.kt
@@ -18,22 +18,7 @@ import org.junit.Test
 
 class AdvancedCompositionTest {
   @Test
-  fun `binomial coefficients compute as expected`() {
-    assertThat(AdvancedComposition.coeff(0, 0)).isEqualTo(1.0f)
-    assertThat(AdvancedComposition.coeff(1, 0)).isEqualTo(1.0f)
-    assertThat(AdvancedComposition.coeff(1, 1)).isEqualTo(1.0f)
-    assertThat(AdvancedComposition.coeff(2, 0)).isEqualTo(1.0f)
-    assertThat(AdvancedComposition.coeff(2, 1)).isEqualTo(2.0f)
-    assertThat(AdvancedComposition.coeff(2, 2)).isEqualTo(1.0f)
-    assertThat(AdvancedComposition.coeff(3, 0)).isEqualTo(1.0f)
-    assertThat(AdvancedComposition.coeff(3, 1)).isEqualTo(3.0f)
-    assertThat(AdvancedComposition.coeff(3, 2)).isEqualTo(3.0f)
-    assertThat(AdvancedComposition.coeff(3, 3)).isEqualTo(1.0f)
-    assertThat(AdvancedComposition.coeff(20, 10)).isEqualTo(184756.0f)
-  }
-
-  @Test
-  fun `advanced composition`() {
+  fun `advanced composition computation works as expected`() {
     assertThat(
         AdvancedComposition.totalPrivacyBudgetUsageUnderAdvancedComposition(
           PrivacyCharge(1.0f, 0.0f),

--- a/src/test/kotlin/org/wfanet/measurement/eventdataprovider/privacybudgetmanagement/AdvancedCompositionTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/eventdataprovider/privacybudgetmanagement/AdvancedCompositionTest.kt
@@ -19,35 +19,47 @@ import org.junit.Test
 class AdvancedCompositionTest {
   @Test
   fun `binomial coefficients compute as expected`() {
-    assertThat(Binom.coeff(0, 0)).isEqualTo(1.0f)
-    assertThat(Binom.coeff(1, 0)).isEqualTo(1.0f)
-    assertThat(Binom.coeff(1, 1)).isEqualTo(1.0f)
-    assertThat(Binom.coeff(2, 0)).isEqualTo(1.0f)
-    assertThat(Binom.coeff(2, 1)).isEqualTo(2.0f)
-    assertThat(Binom.coeff(2, 2)).isEqualTo(1.0f)
-    assertThat(Binom.coeff(3, 0)).isEqualTo(1.0f)
-    assertThat(Binom.coeff(3, 1)).isEqualTo(3.0f)
-    assertThat(Binom.coeff(3, 2)).isEqualTo(3.0f)
-    assertThat(Binom.coeff(3, 3)).isEqualTo(1.0f)
-    assertThat(Binom.coeff(20, 10)).isEqualTo(184756.0f)
+    assertThat(AdvancedComposition.coeff(0, 0)).isEqualTo(1.0f)
+    assertThat(AdvancedComposition.coeff(1, 0)).isEqualTo(1.0f)
+    assertThat(AdvancedComposition.coeff(1, 1)).isEqualTo(1.0f)
+    assertThat(AdvancedComposition.coeff(2, 0)).isEqualTo(1.0f)
+    assertThat(AdvancedComposition.coeff(2, 1)).isEqualTo(2.0f)
+    assertThat(AdvancedComposition.coeff(2, 2)).isEqualTo(1.0f)
+    assertThat(AdvancedComposition.coeff(3, 0)).isEqualTo(1.0f)
+    assertThat(AdvancedComposition.coeff(3, 1)).isEqualTo(3.0f)
+    assertThat(AdvancedComposition.coeff(3, 2)).isEqualTo(3.0f)
+    assertThat(AdvancedComposition.coeff(3, 3)).isEqualTo(1.0f)
+    assertThat(AdvancedComposition.coeff(20, 10)).isEqualTo(184756.0f)
   }
 
   @Test
   fun `advanced composition`() {
-    assertThat(totalPrivacyBudgetUsageUnderAdvancedComposition(PrivacyCharge(1.0f, 0.0f), 30, 0.0f))
+    assertThat(AdvancedComposition.totalPrivacyBudgetUsageUnderAdvancedComposition(PrivacyCharge(1.0f, 0.0f), 30, 0.0f))
       .isEqualTo(30.0f)
     assertThat(
-        totalPrivacyBudgetUsageUnderAdvancedComposition(PrivacyCharge(1.0f, 0.001f), 30, 0.06f)
+        AdvancedComposition.totalPrivacyBudgetUsageUnderAdvancedComposition(
+          PrivacyCharge(1.0f, 0.001f),
+          30,
+          0.06f
+        )
       )
       .isEqualTo(22.0f)
     assertThat(
-        totalPrivacyBudgetUsageUnderAdvancedComposition(PrivacyCharge(1.0f, 0.001f), 30, 0.1f)
+        AdvancedComposition.totalPrivacyBudgetUsageUnderAdvancedComposition(
+          PrivacyCharge(1.0f, 0.001f),
+          30,
+          0.1f
+        )
       )
       .isEqualTo(20.0f)
-    assertThat(totalPrivacyBudgetUsageUnderAdvancedComposition(PrivacyCharge(1.0f, 0.2f), 1, 0.1f))
+    assertThat(AdvancedComposition.totalPrivacyBudgetUsageUnderAdvancedComposition(PrivacyCharge(1.0f, 0.2f), 1, 0.1f))
       .isEqualTo(null)
     assertThat(
-        totalPrivacyBudgetUsageUnderAdvancedComposition(PrivacyCharge(1.0f, 0.01f), 30, 0.26f)
+        AdvancedComposition.totalPrivacyBudgetUsageUnderAdvancedComposition(
+          PrivacyCharge(1.0f, 0.01f),
+          30,
+          0.26f
+        )
       )
       .isEqualTo(null)
   }

--- a/src/test/kotlin/org/wfanet/measurement/eventdataprovider/privacybudgetmanagement/AdvancedCompositionTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/eventdataprovider/privacybudgetmanagement/AdvancedCompositionTest.kt
@@ -34,7 +34,13 @@ class AdvancedCompositionTest {
 
   @Test
   fun `advanced composition`() {
-    assertThat(AdvancedComposition.totalPrivacyBudgetUsageUnderAdvancedComposition(PrivacyCharge(1.0f, 0.0f), 30, 0.0f))
+    assertThat(
+        AdvancedComposition.totalPrivacyBudgetUsageUnderAdvancedComposition(
+          PrivacyCharge(1.0f, 0.0f),
+          30,
+          0.0f
+        )
+      )
       .isEqualTo(30.0f)
     assertThat(
         AdvancedComposition.totalPrivacyBudgetUsageUnderAdvancedComposition(
@@ -52,7 +58,13 @@ class AdvancedCompositionTest {
         )
       )
       .isEqualTo(20.0f)
-    assertThat(AdvancedComposition.totalPrivacyBudgetUsageUnderAdvancedComposition(PrivacyCharge(1.0f, 0.2f), 1, 0.1f))
+    assertThat(
+        AdvancedComposition.totalPrivacyBudgetUsageUnderAdvancedComposition(
+          PrivacyCharge(1.0f, 0.2f),
+          1,
+          0.1f
+        )
+      )
       .isEqualTo(null)
     assertThat(
         AdvancedComposition.totalPrivacyBudgetUsageUnderAdvancedComposition(


### PR DESCRIPTION
This increases the performance of this lookup significantly.  

totalPrivacyBudgetUsageUnderAdvancedComposition works in O(repetition_count^2) and it runs this unnecessarily for all PrivacyBucketGroups that have the same charge.

It will now run O(1) for all PrivacyBucketGroups after the first calculation

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/world-federation-of-advertisers/cross-media-measurement/551)
<!-- Reviewable:end -->
