### PR TITLE
Revert back Certificate for ModelProvider

### DIFF
--- a/build/repositories.bzl
+++ b/build/repositories.bzl
@@ -39,8 +39,8 @@ def wfa_measurement_system_repositories():
     wfa_repo_archive(
         name = "wfa_measurement_proto",
         repo = "cross-media-measurement-api",
-        sha256 = "b13ee5bb927f3eaddd380cfadffb3ce92decda74e8d55dc2910f285c92f4bed4",
-        version = "0.22.1",
+        sha256 = "da28ccac88a12b3b75b974b92604b8e332b8bc91cd276afab1ee41415fa320a3",
+        version = "0.22.2",
     )
 
     wfa_repo_archive(

--- a/src/main/kotlin/org/wfanet/measurement/api/v2alpha/ModelProviderCertificateKey.kt
+++ b/src/main/kotlin/org/wfanet/measurement/api/v2alpha/ModelProviderCertificateKey.kt
@@ -1,0 +1,49 @@
+// Copyright 2021 The Cross-Media Measurement Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.wfanet.measurement.api.v2alpha
+
+import org.wfanet.measurement.common.ResourceNameParser
+
+private val parser =
+  ResourceNameParser("modelProviders/{model_provider}/certificates/{certificate}")
+
+/** [ResourceKey] of a ModelProvider Certificate. */
+data class ModelProviderCertificateKey(
+  val modelProviderId: String,
+  override val certificateId: String
+) : CertificateParentKey {
+  override fun toName(): String {
+    return parser.assembleName(
+      mapOf(IdVariable.MODEL_PROVIDER to modelProviderId, IdVariable.CERTIFICATE to certificateId)
+    )
+  }
+
+  companion object {
+    val defaultValue = ModelProviderCertificateKey("", "")
+
+    fun fromName(resourceName: String): ModelProviderCertificateKey? {
+      return parser.parseIdVars(resourceName)?.let {
+        ModelProviderCertificateKey(
+          it.getValue(IdVariable.MODEL_PROVIDER),
+          it.getValue(IdVariable.CERTIFICATE)
+        )
+      }
+    }
+  }
+}
+
+fun makeModelProviderCertificateName(modelProviderId: String, certificateId: String): String {
+  return ModelProviderCertificateKey(modelProviderId, certificateId).toName()
+}

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/SpannerCertificatesService.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/SpannerCertificatesService.kt
@@ -108,6 +108,9 @@ class SpannerCertificatesService(
           CertificateReader(CertificateReader.ParentType.DUCHY)
             .bindWhereClause(duchyId, externalCertificateId)
         }
+        GetCertificateRequest.ParentCase.EXTERNAL_MODEL_PROVIDER_ID ->
+          CertificateReader(CertificateReader.ParentType.MODEL_PROVIDER)
+            .bindWhereClause(ExternalId(request.externalModelProviderId), externalCertificateId)
         GetCertificateRequest.ParentCase.PARENT_NOT_SET ->
           throw Status.INVALID_ARGUMENT.withDescription("parent not specified").asRuntimeException()
       }

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/common/KingdomInternalException.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/common/KingdomInternalException.kt
@@ -194,6 +194,19 @@ class DuchyCertificateNotFoundException(
       )
 }
 
+class ModelProviderCertificateNotFoundException(
+  val externalModelProviderId: ExternalId,
+  externalCertificateId: ExternalId,
+  provideDescription: () -> String = { "ModelProvider's Certificate not found" }
+) : CertificateNotFoundException(externalCertificateId, provideDescription) {
+  override val context
+    get() =
+      mapOf(
+        "external_model_provider_id" to externalModelProviderId.toString(),
+        "external_certificate_id" to externalCertificateId.toString()
+      )
+}
+
 class CertificateRevocationStateIllegalException(
   val externalCertificateId: ExternalId,
   val state: Certificate.RevocationState,

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/readers/CertificateReader.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/readers/CertificateReader.kt
@@ -44,7 +44,8 @@ class CertificateReader(private val parentType: ParentType) :
   enum class ParentType(private val prefix: String) {
     DATA_PROVIDER("DataProvider"),
     MEASUREMENT_CONSUMER("MeasurementConsumer"),
-    DUCHY("Duchy");
+    DUCHY("Duchy"),
+    MODEL_PROVIDER("ModelProvider");
 
     val idColumnName: String = "${prefix}Id"
     val externalCertificateIdColumnName: String = "External${prefix}CertificateId"
@@ -53,14 +54,14 @@ class CertificateReader(private val parentType: ParentType) :
     val externalIdColumnName: String?
       get() =
         when (this) {
-          DATA_PROVIDER, MEASUREMENT_CONSUMER -> "External${prefix}Id"
+          DATA_PROVIDER, MEASUREMENT_CONSUMER, MODEL_PROVIDER -> "External${prefix}Id"
           DUCHY -> null
         }
 
     val tableName: String?
       get() =
         when (this) {
-          DATA_PROVIDER, MEASUREMENT_CONSUMER -> "${prefix}s"
+          DATA_PROVIDER, MEASUREMENT_CONSUMER, MODEL_PROVIDER -> "${prefix}s"
           DUCHY -> null
         }
   }
@@ -140,6 +141,14 @@ class CertificateReader(private val parentType: ParentType) :
           isValid
         )
       }
+      ParentType.MODEL_PROVIDER ->
+        Result(
+          buildModelProviderCertificate(struct),
+          certificateId,
+          isNotYetActive,
+          isExpired,
+          isValid
+        )
     }
   }
 
@@ -176,7 +185,8 @@ class CertificateReader(private val parentType: ParentType) :
   companion object {
     private fun buildBaseSql(parentType: ParentType): String {
       return when (parentType) {
-        ParentType.DATA_PROVIDER, ParentType.MEASUREMENT_CONSUMER -> buildExternalIdSql(parentType)
+        ParentType.DATA_PROVIDER, ParentType.MEASUREMENT_CONSUMER, ParentType.MODEL_PROVIDER ->
+          buildExternalIdSql(parentType)
         ParentType.DUCHY -> buildInternalIdSql(parentType)
       }
     }
@@ -227,6 +237,14 @@ class CertificateReader(private val parentType: ParentType) :
 
       val parentType = ParentType.DATA_PROVIDER
       externalDataProviderId = struct.getLong(parentType.externalIdColumnName)
+      externalCertificateId = struct.getLong(parentType.externalCertificateIdColumnName)
+    }
+
+    private fun buildModelProviderCertificate(struct: Struct) = certificate {
+      fillCommon(struct)
+
+      val parentType = ParentType.MODEL_PROVIDER
+      externalModelProviderId = struct.getLong(parentType.externalIdColumnName)
       externalCertificateId = struct.getLong(parentType.externalCertificateIdColumnName)
     }
 

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/writers/CreateCertificate.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/writers/CreateCertificate.kt
@@ -32,8 +32,10 @@ import org.wfanet.measurement.kingdom.deploy.gcloud.spanner.common.CertSubjectKe
 import org.wfanet.measurement.kingdom.deploy.gcloud.spanner.common.DataProviderNotFoundException
 import org.wfanet.measurement.kingdom.deploy.gcloud.spanner.common.DuchyNotFoundException
 import org.wfanet.measurement.kingdom.deploy.gcloud.spanner.common.MeasurementConsumerNotFoundException
+import org.wfanet.measurement.kingdom.deploy.gcloud.spanner.common.ModelProviderNotFoundException
 import org.wfanet.measurement.kingdom.deploy.gcloud.spanner.readers.DataProviderReader
 import org.wfanet.measurement.kingdom.deploy.gcloud.spanner.readers.MeasurementConsumerReader
+import org.wfanet.measurement.kingdom.deploy.gcloud.spanner.readers.ModelProviderReader
 
 /**
  * Creates a certificate in the database.
@@ -50,6 +52,7 @@ class CreateCertificate(private val certificate: Certificate) :
       Certificate.ParentCase.EXTERNAL_DATA_PROVIDER_ID -> "DataProvider"
       Certificate.ParentCase.EXTERNAL_MEASUREMENT_CONSUMER_ID -> "MeasurementConsumer"
       Certificate.ParentCase.EXTERNAL_DUCHY_ID -> "Duchy"
+      Certificate.ParentCase.EXTERNAL_MODEL_PROVIDER_ID -> "ModelProvider"
       Certificate.ParentCase.PARENT_NOT_SET ->
         throw IllegalArgumentException("Parent field of Certificate is not set")
     }
@@ -94,6 +97,13 @@ class CreateCertificate(private val certificate: Certificate) :
       Certificate.ParentCase.EXTERNAL_DUCHY_ID ->
         DuchyIds.getInternalId(certificate.externalDuchyId)
           ?: throw DuchyNotFoundException(certificate.externalDuchyId)
+      Certificate.ParentCase.EXTERNAL_MODEL_PROVIDER_ID -> {
+        val externalModelProviderId = ExternalId(certificate.externalModelProviderId)
+        ModelProviderReader()
+          .readByExternalModelProviderId(transactionContext, externalModelProviderId)
+          ?.modelProviderId
+          ?: throw ModelProviderNotFoundException(externalModelProviderId)
+      }
       Certificate.ParentCase.PARENT_NOT_SET ->
         throw IllegalArgumentException("Parent field of Certificate is not set")
     }

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/writers/ReleaseCertificateHold.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/writers/ReleaseCertificateHold.kt
@@ -32,6 +32,7 @@ import org.wfanet.measurement.kingdom.deploy.gcloud.spanner.common.DuchyCertific
 import org.wfanet.measurement.kingdom.deploy.gcloud.spanner.common.DuchyNotFoundException
 import org.wfanet.measurement.kingdom.deploy.gcloud.spanner.common.KingdomInternalException
 import org.wfanet.measurement.kingdom.deploy.gcloud.spanner.common.MeasurementConsumerCertificateNotFoundException
+import org.wfanet.measurement.kingdom.deploy.gcloud.spanner.common.ModelProviderCertificateNotFoundException
 import org.wfanet.measurement.kingdom.deploy.gcloud.spanner.readers.CertificateReader
 
 /**
@@ -52,25 +53,35 @@ class ReleaseCertificateHold(private val request: ReleaseCertificateHoldRequest)
     val certificateResult =
       when (request.parentCase) {
         ReleaseCertificateHoldRequest.ParentCase.EXTERNAL_DATA_PROVIDER_ID -> {
+          val externalDataProviderId = ExternalId(request.externalDataProviderId)
           val reader =
             CertificateReader(CertificateReader.ParentType.DATA_PROVIDER)
-              .bindWhereClause(ExternalId(request.externalDataProviderId), externalCertificateId)
+              .bindWhereClause(externalDataProviderId, externalCertificateId)
           reader.execute(transactionContext).singleOrNull()
             ?: throw DataProviderCertificateNotFoundException(
-              ExternalId(request.externalDataProviderId),
+              externalDataProviderId,
               externalCertificateId
             )
         }
         ReleaseCertificateHoldRequest.ParentCase.EXTERNAL_MEASUREMENT_CONSUMER_ID -> {
+          val externalMeasurementConsumerId = ExternalId(request.externalMeasurementConsumerId)
           val reader =
             CertificateReader(CertificateReader.ParentType.MEASUREMENT_CONSUMER)
-              .bindWhereClause(
-                ExternalId(request.externalMeasurementConsumerId),
-                externalCertificateId
-              )
+              .bindWhereClause(externalMeasurementConsumerId, externalCertificateId)
           reader.execute(transactionContext).singleOrNull()
             ?: throw MeasurementConsumerCertificateNotFoundException(
-              ExternalId(request.externalMeasurementConsumerId),
+              externalMeasurementConsumerId,
+              externalCertificateId
+            ) { "Certificate not found." }
+        }
+        ReleaseCertificateHoldRequest.ParentCase.EXTERNAL_MODEL_PROVIDER_ID -> {
+          val externalModelProviderId = ExternalId(request.externalModelProviderId)
+          val reader =
+            CertificateReader(CertificateReader.ParentType.MODEL_PROVIDER)
+              .bindWhereClause(externalModelProviderId, externalCertificateId)
+          reader.execute(transactionContext).singleOrNull()
+            ?: throw ModelProviderCertificateNotFoundException(
+              externalModelProviderId,
               externalCertificateId
             ) { "Certificate not found." }
         }

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/writers/RevokeCertificate.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/writers/RevokeCertificate.kt
@@ -34,6 +34,7 @@ import org.wfanet.measurement.kingdom.deploy.gcloud.spanner.common.DuchyCertific
 import org.wfanet.measurement.kingdom.deploy.gcloud.spanner.common.DuchyNotFoundException
 import org.wfanet.measurement.kingdom.deploy.gcloud.spanner.common.KingdomInternalException
 import org.wfanet.measurement.kingdom.deploy.gcloud.spanner.common.MeasurementConsumerCertificateNotFoundException
+import org.wfanet.measurement.kingdom.deploy.gcloud.spanner.common.ModelProviderCertificateNotFoundException
 import org.wfanet.measurement.kingdom.deploy.gcloud.spanner.queries.StreamMeasurements
 import org.wfanet.measurement.kingdom.deploy.gcloud.spanner.queries.StreamMeasurementsByDataProviderCertificate
 import org.wfanet.measurement.kingdom.deploy.gcloud.spanner.queries.StreamMeasurementsByDuchyCertificate
@@ -63,25 +64,35 @@ class RevokeCertificate(private val request: RevokeCertificateRequest) :
     val certificateResult =
       when (request.parentCase) {
         RevokeCertificateRequest.ParentCase.EXTERNAL_DATA_PROVIDER_ID -> {
+          val externalDataProviderId = ExternalId(request.externalDataProviderId)
           val reader =
             CertificateReader(CertificateReader.ParentType.DATA_PROVIDER)
-              .bindWhereClause(ExternalId(request.externalDataProviderId), externalCertificateId)
+              .bindWhereClause(externalDataProviderId, externalCertificateId)
           reader.execute(transactionContext).singleOrNull()
             ?: throw DataProviderCertificateNotFoundException(
-              ExternalId(request.externalDataProviderId),
+              externalDataProviderId,
               externalCertificateId
             ) { "Certificate not found." }
         }
         RevokeCertificateRequest.ParentCase.EXTERNAL_MEASUREMENT_CONSUMER_ID -> {
+          val externalMeasurementConsumerId = ExternalId(request.externalMeasurementConsumerId)
           val reader =
             CertificateReader(CertificateReader.ParentType.MEASUREMENT_CONSUMER)
-              .bindWhereClause(
-                ExternalId(request.externalMeasurementConsumerId),
-                externalCertificateId
-              )
+              .bindWhereClause(externalMeasurementConsumerId, externalCertificateId)
           reader.execute(transactionContext).singleOrNull()
             ?: throw MeasurementConsumerCertificateNotFoundException(
-              ExternalId(request.externalMeasurementConsumerId),
+              externalMeasurementConsumerId,
+              externalCertificateId
+            ) { "Certificate not found." }
+        }
+        RevokeCertificateRequest.ParentCase.EXTERNAL_MODEL_PROVIDER_ID -> {
+          val externalModelProviderId = ExternalId(request.externalModelProviderId)
+          val reader =
+            CertificateReader(CertificateReader.ParentType.MODEL_PROVIDER)
+              .bindWhereClause(externalModelProviderId, externalCertificateId)
+          reader.execute(transactionContext).singleOrNull()
+            ?: throw ModelProviderCertificateNotFoundException(
+              externalModelProviderId,
               externalCertificateId
             ) { "Certificate not found." }
         }

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/service/internal/testing/CertificatesServiceTest.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/service/internal/testing/CertificatesServiceTest.kt
@@ -171,6 +171,10 @@ abstract class CertificatesServiceTest<T : CertificatesCoroutineImplBase> {
       population.createMeasurementConsumer(measurementConsumersService, accountsService)
         .externalMeasurementConsumerId
     assertGetFailsWithMissingCertificate { externalMeasurementConsumerId = measurementConsumerId }
+
+    val modelProviderId =
+      population.createModelProvider(modelProvidersService).externalModelProviderId
+    assertGetFailsWithMissingCertificate { externalModelProviderId = modelProviderId }
   }
 
   private fun assertCreateFailsWithMissingOwner(
@@ -195,6 +199,9 @@ abstract class CertificatesServiceTest<T : CertificatesCoroutineImplBase> {
     }
     assertCreateFailsWithMissingOwner("MeasurementConsumer not found") {
       externalMeasurementConsumerId = NOT_AN_ID
+    }
+    assertCreateFailsWithMissingOwner("ModelProvider not found") {
+      externalModelProviderId = NOT_AN_ID
     }
   }
 
@@ -224,6 +231,10 @@ abstract class CertificatesServiceTest<T : CertificatesCoroutineImplBase> {
       population.createMeasurementConsumer(measurementConsumersService, accountsService)
         .externalMeasurementConsumerId
     assertCreateCertificateSucceeds { externalMeasurementConsumerId = measurementConsumerId }
+
+    val modelProviderId =
+      population.createModelProvider(modelProvidersService).externalModelProviderId
+    assertCreateCertificateSucceeds { externalModelProviderId = modelProviderId }
   }
 
   private fun assertGetCertificateSucceeds(init: CertificateKt.Dsl.() -> Unit) = runBlocking {
@@ -244,6 +255,8 @@ abstract class CertificatesServiceTest<T : CertificatesCoroutineImplBase> {
           externalMeasurementConsumerId = requestCertificate.externalMeasurementConsumerId
         Certificate.ParentCase.EXTERNAL_DUCHY_ID ->
           externalDuchyId = requestCertificate.externalDuchyId
+        Certificate.ParentCase.EXTERNAL_MODEL_PROVIDER_ID ->
+          externalModelProviderId = requestCertificate.externalModelProviderId
         Certificate.ParentCase.PARENT_NOT_SET -> error("Invalid parentCase")
       }
     }
@@ -262,6 +275,10 @@ abstract class CertificatesServiceTest<T : CertificatesCoroutineImplBase> {
       population.createMeasurementConsumer(measurementConsumersService, accountsService)
         .externalMeasurementConsumerId
     assertGetCertificateSucceeds { externalMeasurementConsumerId = measurementConsumerId }
+
+    val modelProviderId =
+      population.createModelProvider(modelProvidersService).externalModelProviderId
+    assertGetCertificateSucceeds { externalModelProviderId = modelProviderId }
   }
 
   @Test

--- a/src/main/proto/wfa/measurement/internal/kingdom/BUILD.bazel
+++ b/src/main/proto/wfa/measurement/internal/kingdom/BUILD.bazel
@@ -59,6 +59,7 @@ proto_and_java_proto_library(
 
 proto_and_java_proto_library(
     name = "model_provider",
+    deps = [":certificate_proto"],
 )
 
 proto_library(

--- a/src/main/proto/wfa/measurement/internal/kingdom/certificate.proto
+++ b/src/main/proto/wfa/measurement/internal/kingdom/certificate.proto
@@ -26,17 +26,18 @@ message Certificate {
     fixed64 external_data_provider_id = 1;
     fixed64 external_measurement_consumer_id = 2;
     string external_duchy_id = 3;
+    fixed64 external_model_provider_id = 4;
   }
-  fixed64 external_certificate_id = 4;
+  fixed64 external_certificate_id = 5;
 
   // X.509 v3 subject key identifier.
-  bytes subject_key_identifier = 5;
+  bytes subject_key_identifier = 6;
 
   // The beginning of the X.509 validity period, inclusive.
-  google.protobuf.Timestamp not_valid_before = 6;
+  google.protobuf.Timestamp not_valid_before = 7;
 
   // The end of the X.509 validity period, inclusive.
-  google.protobuf.Timestamp not_valid_after = 7;
+  google.protobuf.Timestamp not_valid_after = 8;
 
   // RFC 5280 revocation state.
   enum RevocationState {
@@ -52,11 +53,11 @@ message Certificate {
   //
   // Note that this is not guaranteed to reflect the actual revocation state
   // determined by the issuing certificate authority.
-  RevocationState revocation_state = 8;
+  RevocationState revocation_state = 9;
 
   message Details {
     // X.509 certificate in DER format.
     bytes x509_der = 1;
   }
-  Details details = 9;
+  Details details = 10;
 }

--- a/src/main/proto/wfa/measurement/internal/kingdom/certificates_service.proto
+++ b/src/main/proto/wfa/measurement/internal/kingdom/certificates_service.proto
@@ -41,8 +41,9 @@ message GetCertificateRequest {
     fixed64 external_data_provider_id = 1;
     fixed64 external_measurement_consumer_id = 2;
     string external_duchy_id = 3;
+    fixed64 external_model_provider_id = 4;
   }
-  fixed64 external_certificate_id = 4;
+  fixed64 external_certificate_id = 5;
 }
 
 message RevokeCertificateRequest {
@@ -50,10 +51,11 @@ message RevokeCertificateRequest {
     fixed64 external_data_provider_id = 1;
     fixed64 external_measurement_consumer_id = 2;
     string external_duchy_id = 3;
+    fixed64 external_model_provider_id = 4;
   }
-  fixed64 external_certificate_id = 4;
+  fixed64 external_certificate_id = 5;
 
-  Certificate.RevocationState revocation_state = 5;
+  Certificate.RevocationState revocation_state = 6;
 }
 
 message ReleaseCertificateHoldRequest {
@@ -61,6 +63,7 @@ message ReleaseCertificateHoldRequest {
     fixed64 external_data_provider_id = 1;
     fixed64 external_measurement_consumer_id = 2;
     string external_duchy_id = 3;
+    fixed64 external_model_provider_id = 4;
   }
-  fixed64 external_certificate_id = 4;
+  fixed64 external_certificate_id = 5;
 }


### PR DESCRIPTION
Revert [PR #522](https://github.com/world-federation-of-advertisers/cross-media-measurement/pull/522).
CertificateService will keep taking care of certificate for ModelProvider. But ModelProvider itself won't have concepts of certificate or public_key.


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/world-federation-of-advertisers/cross-media-measurement/556)
<!-- Reviewable:end -->
