### PR TITLE
Use bind mount on Linux hosts for containerized builds.

### DIFF
--- a/docs/building.md
+++ b/docs/building.md
@@ -87,6 +87,9 @@ example:
 tools/bazel-container test //src/test/...
 ```
 
+Note: This script specifies the appropriate host platform to Bazel, so you
+should not use the `--host_platform` option when using it.
+
 Note that if you don't need to interact with the code on your host machine, it
 may be simpler to use the Bash shell (`/bin/bash`) as your entry point and run
 all of your commands from inside the container. You may even want to install
@@ -114,32 +117,11 @@ use the container for building/deploying image targets using the
 `tools/bazel-container` script. You can even run targets built inside the
 container on your host machine.
 
-Note: This script specifies the appropriate host platform to Bazel, so you
-should not use the `--host_platform` option when using it.
-
-The `tools/bazel-container` script uses a Docker volume for Bazel output. The
-script prints the volume name to `STDERR` when it's run. You can use this to
-determine the mount point of the volume and create a symlink to it within
-workspace directory.
-
-Suppose the script indicates that it's using a volume named
-`bazel-output-b471b3a2d1215b70045d7f5bfa478e3e`. We can create a
-`bazel-container-output` symlink to point to the volume's mount point:
-
-```shell
-ln -s $(docker volume inspect bazel-output-b471b3a2d1215b70045d7f5bfa478e3e --format '{{.Mountpoint}}') bazel-container-output
-```
-
-We can then use the `--script_path` option to the `run` subcommand to output a
-script that we can run from the host machine. For example, we can build and run
-the target
-`//src/main/kotlin/org/wfanet/measurement/duchy/deploy/common/daemon/mill/liquidlegionsv2:ForwardedStorageLiquidLegionsV2MillDaemon`
-as follows:
-
-```shell
-tools/bazel-container run --script_path="$PWD/bazel-container-output/mill-daemon" //src/main/kotlin/org/wfanet/measurement/duchy/deploy/common/daemon/mill/liquidlegionsv2:ForwardedStorageLiquidLegionsV2MillDaemon && \
-bazel-container-output/mill-daemon
-```
+When running on Linux, the script will write its output to the
+`bazel-container-output` directory inside of your working directory. We can use
+the `--script_path` option to the `run` subcommand to output a script that we
+can run from the host machine. The `tools/bazel-container-run` script will do
+this for you, so you can use it in place of `bazel run`.
 
 ## Local Kubernetes
 

--- a/tools/bazel-container
+++ b/tools/bazel-container
@@ -118,10 +118,6 @@ main() {
   host_bazelisk_cache_dir="$(ensure_host_bazelisk_cache_dir)"
   readonly host_bazelisk_cache_dir
 
-  local output_volume
-  output_volume="$(get_output_volume)"
-  readonly output_volume
-
   mkdir -p "${OUTPUT_BASE}"
 
   local -a docker_options=(
@@ -141,8 +137,6 @@ main() {
       "type=bind,source=${host_output_user_root},target=${OUTPUT_USER_ROOT}"
     '--mount'
       "type=bind,source=${host_bazelisk_cache_dir},target=${BAZELISK_HOME}"
-    '--mount'
-      "type=volume,source=${output_volume},target=${OUTPUT_BASE}"
     '--mount'
       "type=bind,source=${docker_socket},target=/var/run/docker.sock"
     "--workdir=${PWD}"
@@ -166,14 +160,27 @@ main() {
     )
   fi
 
+  if [[ "${OSTYPE}" == 'linux'* ]]; then
+    docker_options+=(
+      '--mount'
+        "type=bind,source=${OUTPUT_BASE},target=${OUTPUT_BASE}"
+    )
+  else
+    # Mount OUTPUT_BASE as a named volume to avoid potential filesystem
+    # incompatibilities.
+
+    local output_volume
+    output_volume="$(get_output_volume)"
+    readonly output_volume
+
+    docker_options+=(
+      '--mount'
+        "type=volume,source=${output_volume},target=${OUTPUT_BASE}"
+    )
+  fi
+
   if ! is_rootless; then
     local -r owner="${EUID}:${GROUPS[0]}"
-
-    # Set volume ownership.
-    ${DOCKER} run --rm \
-      --mount type=volume,source="${output_volume}",target="${OUTPUT_BASE}" \
-      --entrypoint=/bin/sh "${IMAGE}" \
-      -c "touch ${OUTPUT_BASE}/.initialized && chown ${owner} ${OUTPUT_BASE}"
 
     docker_options+=(
       "--user=${owner}"
@@ -208,8 +215,7 @@ main() {
     "${DOCKER}" cp "$HOME/.bazelrc" "${container_id}:${CONTAINER_HOME}/"
   fi
 
-  echo "Running in Bazel container with output volume ${output_volume}:" \
-    "${command} $*" >&2
+  echo "Running in Bazel container: ${command} $*" >&2
   exec "${DOCKER}" start --attach --interactive "${container_id}"
 }
 


### PR DESCRIPTION
This avoids volume permissions issues when doing hybrid development.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/world-federation-of-advertisers/cross-media-measurement/565)
<!-- Reviewable:end -->
