### PR TITLE
Add AIP annotations and comments.

### DIFF
--- a/src/main/proto/wfa/measurement/reporting/v1alpha/metric.proto
+++ b/src/main/proto/wfa/measurement/reporting/v1alpha/metric.proto
@@ -43,7 +43,10 @@ message Metric {
   oneof metric_type {
     // The count of unique audiences reached given a set of event groups.
     ReachParams reach = 1;
-    // The reach frequency histogram given a set of event groups.
+    // The reach frequency histogram given a set of event groups. Currently, we
+    // only support union operations for frequency histograms. Any other
+    // operations on frequency histograms won't guarantee the result is a
+    // frequency histogram.
     FrequencyHistogramParams frequency_histogram = 2;
     // The impression count given a set of event groups.
     ImpressionCountParams impression_count = 3;
@@ -101,5 +104,6 @@ message Metric {
   }
 
   // A list of named `SetOperations` on which the same metric will be applied.
-  repeated NamedSetOperation set_operations = 7;
+  repeated NamedSetOperation set_operations = 7
+      [(google.api.field_behavior) = REQUIRED];
 }

--- a/src/main/proto/wfa/measurement/reporting/v1alpha/report.proto
+++ b/src/main/proto/wfa/measurement/reporting/v1alpha/report.proto
@@ -36,9 +36,12 @@ message Report {
   string name = 1;
 
   // Representation of a Measurement Consumer entity.
-  string measurement_consumer = 2 [(google.api.resource_reference) = {
-    type: "halo.wfanet.org/MeasurementConsumer"
-  }];
+  string measurement_consumer = 2 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference) = {
+      type: "halo.wfanet.org/MeasurementConsumer"
+    }
+  ];
 
   // Map entry of `EventGroup` to filter predicate.
   message EventGroupFilter {
@@ -59,6 +62,7 @@ message Report {
       [(google.api.field_behavior) = REQUIRED];
 
   // Types of time intervals for metric aggregation.
+  // REQUIRED
   oneof time {
     // A list of time intervals with different start times and end times.
     TimeIntervals time_intervals = 4;


### PR DESCRIPTION
Note that field behavior is not supported for `oneof`

```
oneof time {
  option (google.api.field_behavior) = REQUIRED;
  …
}
```

AIP linter will complain about the code above with message

```
option (google.api.field_behavior): extension google.api.field_behavior should extend 
google.protobuf.OneofOptions but instead extends google.protobuf.FieldOptions
```