### PR TITLE
Update common-jvm to 0.36.0.

### DIFF
--- a/build/repositories.bzl
+++ b/build/repositories.bzl
@@ -24,8 +24,8 @@ def wfa_measurement_system_repositories():
     wfa_repo_archive(
         name = "wfa_common_jvm",
         repo = "common-jvm",
-        sha256 = "9505024528afc9e7a9e126a297458fa4503a33ff21c55bac58e5184385f492e2",
-        version = "0.35.0",
+        sha256 = "4a8ed583bef38668f084e45fc486aeb27808d4dbe6d3ed5ba85924fdf0c3fd84",
+        version = "0.36.0",
     )
 
     wfa_repo_archive(

--- a/src/main/kotlin/org/wfanet/measurement/loadtest/dataprovider/EdpSimulatorRunner.kt
+++ b/src/main/kotlin/org/wfanet/measurement/loadtest/dataprovider/EdpSimulatorRunner.kt
@@ -21,7 +21,7 @@ import org.wfanet.measurement.api.v2alpha.CertificatesGrpcKt.CertificatesCorouti
 import org.wfanet.measurement.api.v2alpha.EventGroupsGrpcKt.EventGroupsCoroutineStub
 import org.wfanet.measurement.api.v2alpha.RequisitionFulfillmentGrpcKt.RequisitionFulfillmentCoroutineStub
 import org.wfanet.measurement.api.v2alpha.RequisitionsGrpcKt.RequisitionsCoroutineStub
-import org.wfanet.measurement.common.crypto.testing.SigningCertsTesting
+import org.wfanet.measurement.common.crypto.SigningCerts
 import org.wfanet.measurement.common.crypto.testing.loadSigningKey
 import org.wfanet.measurement.common.crypto.tink.testing.loadPrivateKey
 import org.wfanet.measurement.common.grpc.buildMutualTlsChannel
@@ -40,7 +40,7 @@ abstract class EdpSimulatorRunner : Runnable {
 
   protected fun run(storageClient: StorageClient, eventQuery: EventQuery) {
     val clientCerts =
-      SigningCertsTesting.fromPemFiles(
+      SigningCerts.fromPemFiles(
         certificateFile = flags.tlsFlags.certFile,
         privateKeyFile = flags.tlsFlags.privateKeyFile,
         trustedCertCollectionFile = flags.tlsFlags.certCollectionFile

--- a/src/main/kotlin/org/wfanet/measurement/loadtest/frontend/FrontendSimulatorRunner.kt
+++ b/src/main/kotlin/org/wfanet/measurement/loadtest/frontend/FrontendSimulatorRunner.kt
@@ -24,7 +24,7 @@ import org.wfanet.measurement.api.v2alpha.EventGroupsGrpcKt.EventGroupsCoroutine
 import org.wfanet.measurement.api.v2alpha.MeasurementConsumersGrpcKt.MeasurementConsumersCoroutineStub
 import org.wfanet.measurement.api.v2alpha.MeasurementsGrpcKt.MeasurementsCoroutineStub
 import org.wfanet.measurement.api.v2alpha.RequisitionsGrpcKt.RequisitionsCoroutineStub
-import org.wfanet.measurement.common.crypto.testing.SigningCertsTesting
+import org.wfanet.measurement.common.crypto.SigningCerts
 import org.wfanet.measurement.common.crypto.testing.loadSigningKey
 import org.wfanet.measurement.common.crypto.tink.testing.loadPrivateKey
 import org.wfanet.measurement.common.grpc.buildMutualTlsChannel
@@ -41,7 +41,7 @@ abstract class FrontendSimulatorRunner : Runnable {
 
   protected fun run(storageClient: StorageClient) {
     val clientCerts =
-      SigningCertsTesting.fromPemFiles(
+      SigningCerts.fromPemFiles(
         certificateFile = flags.tlsFlags.certFile,
         privateKeyFile = flags.tlsFlags.privateKeyFile,
         trustedCertCollectionFile = flags.tlsFlags.certCollectionFile

--- a/src/main/kotlin/org/wfanet/measurement/loadtest/panelmatchresourcesetup/PanelMatchResourceSetupRunner.kt
+++ b/src/main/kotlin/org/wfanet/measurement/loadtest/panelmatchresourcesetup/PanelMatchResourceSetupRunner.kt
@@ -21,7 +21,7 @@ import org.wfanet.measurement.api.v2alpha.ExchangeWorkflow
 import org.wfanet.measurement.api.v2alpha.copy
 import org.wfanet.measurement.api.v2alpha.exchangeWorkflow
 import org.wfanet.measurement.common.commandLineMain
-import org.wfanet.measurement.common.crypto.testing.SigningCertsTesting
+import org.wfanet.measurement.common.crypto.SigningCerts
 import org.wfanet.measurement.common.crypto.testing.loadSigningKey
 import org.wfanet.measurement.common.crypto.tink.testing.loadPublicKey
 import org.wfanet.measurement.common.grpc.buildMutualTlsChannel
@@ -42,7 +42,7 @@ private const val SCHEDULE = "@daily"
 )
 private fun run(@CommandLine.Mixin flags: PanelMatchResourceSetupFlags) {
   val clientCerts =
-    SigningCertsTesting.fromPemFiles(
+    SigningCerts.fromPemFiles(
       certificateFile = flags.tlsFlags.certFile,
       privateKeyFile = flags.tlsFlags.privateKeyFile,
       trustedCertCollectionFile = flags.tlsFlags.certCollectionFile

--- a/src/main/kotlin/org/wfanet/measurement/loadtest/resourcesetup/ResourceSetupRunner.kt
+++ b/src/main/kotlin/org/wfanet/measurement/loadtest/resourcesetup/ResourceSetupRunner.kt
@@ -20,7 +20,7 @@ import org.wfanet.measurement.api.v2alpha.AccountsGrpcKt.AccountsCoroutineStub
 import org.wfanet.measurement.api.v2alpha.ApiKeysGrpcKt.ApiKeysCoroutineStub
 import org.wfanet.measurement.api.v2alpha.MeasurementConsumersGrpcKt.MeasurementConsumersCoroutineStub
 import org.wfanet.measurement.common.commandLineMain
-import org.wfanet.measurement.common.crypto.testing.SigningCertsTesting
+import org.wfanet.measurement.common.crypto.SigningCerts
 import org.wfanet.measurement.common.crypto.testing.loadSigningKey
 import org.wfanet.measurement.common.crypto.tink.testing.loadPublicKey
 import org.wfanet.measurement.common.grpc.buildMutualTlsChannel
@@ -38,7 +38,7 @@ import picocli.CommandLine
 )
 private fun run(@CommandLine.Mixin flags: ResourceSetupFlags) {
   val clientCerts =
-    SigningCertsTesting.fromPemFiles(
+    SigningCerts.fromPemFiles(
       certificateFile = flags.tlsFlags.certFile,
       privateKeyFile = flags.tlsFlags.privateKeyFile,
       trustedCertCollectionFile = flags.tlsFlags.certCollectionFile

--- a/src/main/kotlin/org/wfanet/measurement/system/v1alpha/IdVariable.kt
+++ b/src/main/kotlin/org/wfanet/measurement/system/v1alpha/IdVariable.kt
@@ -24,9 +24,9 @@ internal enum class IdVariable {
 }
 
 internal fun ResourceNameParser.assembleName(idMap: Map<IdVariable, String>): String {
-  return assembleName(idMap.mapKeys { it.key.name.toLowerCase() })
+  return assembleName(idMap.mapKeys { it.key.name.lowercase() })
 }
 
 internal fun ResourceNameParser.parseIdVars(resourceName: String): Map<IdVariable, String>? {
-  return parseIdSegments(resourceName)?.mapKeys { IdVariable.valueOf(it.key.toUpperCase()) }
+  return parseIdSegments(resourceName)?.mapKeys { IdVariable.valueOf(it.key.uppercase()) }
 }


### PR DESCRIPTION
This fixes appropriate warnings/errors for upgrading to Kotlin language 1.5 and kotlinx-coroutines 1.6. In particular, it drops the usage of GlobalScope which is now marked as a delicate API.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/world-federation-of-advertisers/cross-media-measurement/582)
<!-- Reviewable:end -->
