### PR TITLE
Reject zero values of delta

### DIFF
--- a/src/main/kotlin/org/wfanet/measurement/duchy/daemon/herald/LiquidLegionsV2Starter.kt
+++ b/src/main/kotlin/org/wfanet/measurement/duchy/daemon/herald/LiquidLegionsV2Starter.kt
@@ -101,15 +101,13 @@ object LiquidLegionsV2Starter {
     aggregatorId: String
   ) {
     val updatedDetails =
-      token
-        .computationDetails
+      token.computationDetails
         .toBuilder()
         .apply {
           liquidLegionsV2Builder
             .clearParticipant()
             .addAllParticipant(
-              systemComputation
-                .computationParticipantsList
+              systemComputation.computationParticipantsList
                 .map { it.toDuchyComputationParticipant(systemComputation.publicApiVersion) }
                 .orderByRoles(token.globalComputationId, aggregatorId)
             )
@@ -299,6 +297,12 @@ object LiquidLegionsV2Starter {
                 "Missing ReachAndFrequency in the measurementSpec."
               }
               val reachAndFrequency = measurementSpec.reachAndFrequency
+              require(reachAndFrequency.reachPrivacyParams.delta > 0) {
+                "LLv2 requires that reach_privacy_params.delta be greater than 0"
+              }
+              require(reachAndFrequency.frequencyPrivacyParams.delta > 0) {
+                "LLv2 requires that frequency_privacy_params.delta be greater than 0"
+              }
               reachNoiseConfigBuilder.globalReachDpNoise =
                 reachAndFrequency.reachPrivacyParams.toDuchyDifferentialPrivacyParams()
               frequencyNoiseConfig =


### PR DESCRIPTION
The differential privacy protocols currently in use for Liquid Legions v2 require that delta > 0.  If a 0 value of delta was supplied, the C++ code for sketch creation and noising would generate an exception, causing the duchy to crash.  This patch causes the herald to check for a non-zero value of delta before further processing is allowed.  If a zero value is found, then the Herald generates an exception.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/world-federation-of-advertisers/cross-media-measurement/607)
<!-- Reviewable:end -->
