### PR TITLE
Don't generate internal protocolConfig for direct reach and frequency measurement

### DIFF
--- a/build/repositories.bzl
+++ b/build/repositories.bzl
@@ -24,8 +24,8 @@ def wfa_measurement_system_repositories():
     wfa_repo_archive(
         name = "wfa_common_jvm",
         repo = "common-jvm",
-        sha256 = "fdf895c9fc11233f7b152a8f16ff462b64e41ced0dcc2429ce2c13c3aa90d4f0",
-        version = "0.39.0",
+        sha256 = "c435f27922f95ef117d863938d1b79d3bd4d25505e795fbf7fd39653dceeb5ab",
+        version = "0.40.0",
     )
 
     wfa_repo_archive(

--- a/src/main/kotlin/org/wfanet/measurement/integration/common/Configs.kt
+++ b/src/main/kotlin/org/wfanet/measurement/integration/common/Configs.kt
@@ -63,7 +63,8 @@ val LLV2_AGGREGATOR_NAME =
   AGGREGATOR_PROTOCOLS_SETUP_CONFIG.liquidLegionsV2.externalAggregatorDuchyId!!
 
 val ALL_DUCHY_NAMES = DUCHY_ID_CONFIG.duchiesList.map { it.externalDuchyId }
-val ALL_EDP_DISPLAY_NAMES = listOf("edp1", "edp2", "edp3")
+val ALL_EDP_DISPLAY_NAMES = listOf("edp1")
+// val ALL_EDP_DISPLAY_NAMES = listOf("edp1", "edp2", "edp3")
 
 /**
  * Values of this map are anded to create the event filter to be sent to the EDPs.

--- a/src/main/kotlin/org/wfanet/measurement/integration/common/Configs.kt
+++ b/src/main/kotlin/org/wfanet/measurement/integration/common/Configs.kt
@@ -63,8 +63,7 @@ val LLV2_AGGREGATOR_NAME =
   AGGREGATOR_PROTOCOLS_SETUP_CONFIG.liquidLegionsV2.externalAggregatorDuchyId!!
 
 val ALL_DUCHY_NAMES = DUCHY_ID_CONFIG.duchiesList.map { it.externalDuchyId }
-val ALL_EDP_DISPLAY_NAMES = listOf("edp1")
-// val ALL_EDP_DISPLAY_NAMES = listOf("edp1", "edp2", "edp3")
+val ALL_EDP_DISPLAY_NAMES = listOf("edp1", "edp2", "edp3")
 
 /**
  * Values of this map are anded to create the event filter to be sent to the EDPs.

--- a/src/main/kotlin/org/wfanet/measurement/integration/common/InProcessLifeOfAMeasurementIntegrationTest.kt
+++ b/src/main/kotlin/org/wfanet/measurement/integration/common/InProcessLifeOfAMeasurementIntegrationTest.kt
@@ -219,6 +219,17 @@ abstract class InProcessLifeOfAMeasurementIntegrationTest {
     }
 
   @Test
+  fun `create a direct RF measurement and check the result is equal to the expected result`() =
+    runBlocking {
+      // Wait until all EDPs finish creating eventGroups before the test starts.
+      val eventGroupList = pollForEventGroups()
+      assertThat(eventGroupList).isNotNull()
+
+      // Use frontend simulator to create a reach and frequency measurement and verify its result.
+      frontendSimulator.executeDirectReachAndFrequency("1234")
+    }
+
+  @Test
   fun `create an impression measurement and check the result is equal to the expected result`() =
     runBlocking {
       // Wait until all EDPs finish creating eventGroups before the test starts.

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/service/api/v2alpha/ProtoConversions.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/service/api/v2alpha/ProtoConversions.kt
@@ -275,6 +275,7 @@ fun Measurement.toInternal(
       @Suppress("WHEN_ENUM_CAN_BE_NULL_IN_JAVA") // Proto enum fields are never null.
       when (measurementSpecProto.measurementTypeCase) {
         MeasurementSpec.MeasurementTypeCase.REACH_AND_FREQUENCY -> {
+          // For single EDP direct R/F measurement, don't generate internal protocolConfig
           if (dataProvidersCount > 1) {
             protocolConfig = internalProtocolConfig {
               externalProtocolConfigId = Llv2ProtocolConfig.name

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/service/api/v2alpha/ProtoConversions.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/service/api/v2alpha/ProtoConversions.kt
@@ -275,13 +275,15 @@ fun Measurement.toInternal(
       @Suppress("WHEN_ENUM_CAN_BE_NULL_IN_JAVA") // Proto enum fields are never null.
       when (measurementSpecProto.measurementTypeCase) {
         MeasurementSpec.MeasurementTypeCase.REACH_AND_FREQUENCY -> {
-          protocolConfig = internalProtocolConfig {
-            externalProtocolConfigId = Llv2ProtocolConfig.name
-            measurementType = InternalProtocolConfig.MeasurementType.REACH_AND_FREQUENCY
-            liquidLegionsV2 = Llv2ProtocolConfig.protocolConfig
-          }
-          duchyProtocolConfig = duchyProtocolConfig {
-            liquidLegionsV2 = Llv2ProtocolConfig.duchyProtocolConfig
+          if (dataProvidersCount > 1) {
+            protocolConfig = internalProtocolConfig {
+              externalProtocolConfigId = Llv2ProtocolConfig.name
+              measurementType = InternalProtocolConfig.MeasurementType.REACH_AND_FREQUENCY
+              liquidLegionsV2 = Llv2ProtocolConfig.protocolConfig
+            }
+            duchyProtocolConfig = duchyProtocolConfig {
+              liquidLegionsV2 = Llv2ProtocolConfig.duchyProtocolConfig
+            }
           }
         }
         // No protocol for impression or duration type.

--- a/src/main/kotlin/org/wfanet/measurement/loadtest/dataprovider/BUILD.bazel
+++ b/src/main/kotlin/org/wfanet/measurement/loadtest/dataprovider/BUILD.bazel
@@ -53,6 +53,7 @@ kt_jvm_library(
         "@any_sketch_java//src/main/java/org/wfanet/anysketch/crypto:sketch_encrypter_adapter",
         "@any_sketch_java//src/main/java/org/wfanet/sampling:vid_sampler",
         "@wfa_common_jvm//imports/java/com/google/cloud/bigquery",
+        "@wfa_common_jvm//imports/java/org/apache/commons:math3",
         "@wfa_common_jvm//imports/kotlin/kotlinx/coroutines:core",
         "@wfa_common_jvm//src/main/kotlin/org/wfanet/measurement/common",
         "@wfa_common_jvm//src/main/kotlin/org/wfanet/measurement/common/crypto:key_storage",

--- a/src/main/kotlin/org/wfanet/measurement/loadtest/dataprovider/EdpSimulator.kt
+++ b/src/main/kotlin/org/wfanet/measurement/loadtest/dataprovider/EdpSimulator.kt
@@ -210,9 +210,7 @@ class EdpSimulator(
         )
       }
 
-      if (
-        requisition.protocolConfig.protocolCase != ProtocolConfig.ProtocolCase.LIQUID_LEGIONS_V2
-      ) {
+      if (!requisition.hasProtocolConfig()) {
         when (measurementSpec.measurementTypeCase) {
           MeasurementSpec.MeasurementTypeCase.REACH_AND_FREQUENCY ->
             fulfillDirectReachAndFrequencyMeasurement(requisition, requisitionSpec, measurementSpec)

--- a/src/main/kotlin/org/wfanet/measurement/loadtest/dataprovider/EdpSimulator.kt
+++ b/src/main/kotlin/org/wfanet/measurement/loadtest/dataprovider/EdpSimulator.kt
@@ -212,8 +212,10 @@ class EdpSimulator(
 
       if (!requisition.hasProtocolConfig()) {
         when (measurementSpec.measurementTypeCase) {
-          MeasurementSpec.MeasurementTypeCase.REACH_AND_FREQUENCY ->
+          MeasurementSpec.MeasurementTypeCase.REACH_AND_FREQUENCY -> {
+            // Direct R/F measurement(single EDP) will not have protocolConfig
             fulfillDirectReachAndFrequencyMeasurement(requisition, requisitionSpec, measurementSpec)
+          }
           MeasurementSpec.MeasurementTypeCase.IMPRESSION ->
             fulfillImpressionMeasurement(requisition, requisitionSpec, measurementSpec)
           MeasurementSpec.MeasurementTypeCase.DURATION ->

--- a/src/main/kotlin/org/wfanet/measurement/loadtest/frontend/BUILD.bazel
+++ b/src/main/kotlin/org/wfanet/measurement/loadtest/frontend/BUILD.bazel
@@ -45,6 +45,7 @@ kt_jvm_library(
         "@any_sketch_java//src/main/java/org/wfanet/estimation:estimators",
         "@any_sketch_java//src/main/java/org/wfanet/estimation:value_histogram",
         "@wfa_common_jvm//imports/java/com/google/common/truth/extensions/proto",
+        "@wfa_common_jvm//imports/java/org/apache/commons:math3",
         "@wfa_common_jvm//src/main/kotlin/org/wfanet/measurement/common/crypto:hashing",
         "@wfa_consent_signaling_client//src/main/kotlin/org/wfanet/measurement/consent/client/measurementconsumer",
     ],

--- a/src/main/kotlin/org/wfanet/measurement/loadtest/frontend/FrontendSimulator.kt
+++ b/src/main/kotlin/org/wfanet/measurement/loadtest/frontend/FrontendSimulator.kt
@@ -153,7 +153,8 @@ class FrontendSimulator(
 
       assertThat(reachAndFrequencyResult.reach.value).isEqualTo(expectedResult)
       logger.info(
-        "Direct reach and frequency result is equal to the expected result. Correctness Test passes."
+        "Direct reach and frequency result is equal to the expected result. " +
+          "Correctness Test passes."
       )
 
       return

--- a/src/test/kotlin/org/wfanet/measurement/kingdom/service/api/v2alpha/MeasurementsServiceTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/kingdom/service/api/v2alpha/MeasurementsServiceTest.kt
@@ -462,7 +462,7 @@ class MeasurementsServiceTest {
   }
 
   @Test
-  fun `createMeasurement throws INVALID_ARGUMENT when reach privacy params are missing`() {
+  fun `createMeasurement throws INVALID_ARGUMENT when RF reach privacy params are missing`() {
     val exception =
       assertFailsWith<StatusRuntimeException> {
         withMeasurementConsumerPrincipal(MEASUREMENT_CONSUMER_NAME) {
@@ -496,7 +496,7 @@ class MeasurementsServiceTest {
   }
 
   @Test
-  fun `createMeasurement throws INVALID_ARGUMENT when frequency privacy params are missing`() {
+  fun `createMeasurement throws INVALID_ARGUMENT when RF frequency privacy params are missing`() {
     val exception =
       assertFailsWith<StatusRuntimeException> {
         withMeasurementConsumerPrincipal(MEASUREMENT_CONSUMER_NAME) {

--- a/src/test/kotlin/org/wfanet/measurement/kingdom/service/api/v2alpha/MeasurementsServiceTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/kingdom/service/api/v2alpha/MeasurementsServiceTest.kt
@@ -128,7 +128,7 @@ private val UPDATE_TIME: Timestamp = Instant.ofEpochSecond(123).toProtoTime()
 @RunWith(JUnit4::class)
 class MeasurementsServiceTest {
   private val internalMeasurementsMock: MeasurementsGrpcKt.MeasurementsCoroutineImplBase =
-    mockService() {
+    mockService {
       onBlocking { createMeasurement(any()) }.thenReturn(INTERNAL_MEASUREMENT)
       onBlocking { getMeasurement(any()) }.thenReturn(INTERNAL_MEASUREMENT)
       onBlocking { streamMeasurements(any()) }
@@ -230,14 +230,12 @@ class MeasurementsServiceTest {
   }
 
   @Test
-  fun `createMeasurement with RF type returns measurement with resource name set`() {
+  fun `createMeasurement with RF type single EDP returns measurement with resource name set`() {
     val request = createMeasurementRequest { measurement = MEASUREMENT }
-
     val result =
       withMeasurementConsumerPrincipal(MEASUREMENT_CONSUMER_NAME) {
         runBlocking { service.createMeasurement(request) }
       }
-
     val expected = MEASUREMENT
 
     verifyProtoArgument(
@@ -248,15 +246,93 @@ class MeasurementsServiceTest {
         INTERNAL_MEASUREMENT.copy {
           clearUpdateTime()
           clearExternalMeasurementId()
-
           details =
             details.copy {
               clearFailure()
-              if (request.measurement.dataProvidersCount == 1) {
-                clearProtocolConfig()
-                clearDuchyProtocolConfig()
-              }
+              clearProtocolConfig()
+              clearDuchyProtocolConfig()
             }
+          results.clear()
+        }
+      )
+
+    assertThat(result).ignoringRepeatedFieldOrder().isEqualTo(expected)
+  }
+
+  @Test
+  fun `createMeasurement with RF type two EDP returns measurement with resource name set`() {
+    var measurementWithTwoEdp =
+      MEASUREMENT.copy {
+        dataProviders += dataProviderEntry {
+          key = makeDataProvider(456L)
+          value = value {
+            dataProviderCertificate = "dataProviders/AAAAAAAAAcg/certificates/AAAAAAAAAcg"
+            dataProviderPublicKey = signedData {
+              data = UPDATE_TIME.toByteString()
+              signature = UPDATE_TIME.toByteString()
+            }
+            encryptedRequisitionSpec = UPDATE_TIME.toByteString()
+            nonceHash = DATA_PROVIDER_NONCE_HASH
+          }
+        }
+        measurementSpec = signedData {
+          data =
+            MEASUREMENT_SPEC.copy { nonceHashes += ByteString.copyFromUtf8("bar") }.toByteString()
+          signature = UPDATE_TIME.toByteString()
+        }
+      }
+
+    val dataProviderMap =
+      measurementWithTwoEdp.dataProvidersList.associateBy(
+        { apiIdToExternalId(DataProviderKey.fromName(it.key)!!.dataProviderId) },
+        {
+          InternalMeasurementKt.dataProviderValue {
+            externalDataProviderCertificateId =
+              apiIdToExternalId(
+                DataProviderCertificateKey.fromName(it.value.dataProviderCertificate)!!
+                  .certificateId
+              )
+            dataProviderPublicKey = it.value.dataProviderPublicKey.data
+            dataProviderPublicKeySignature = it.value.dataProviderPublicKey.signature
+            encryptedRequisitionSpec = it.value.encryptedRequisitionSpec
+            nonceHash = it.value.nonceHash
+          }
+        }
+      )
+    runBlocking {
+      whenever(internalMeasurementsMock.createMeasurement(any()))
+        .thenReturn(
+          INTERNAL_MEASUREMENT.copy {
+            dataProviders.clear()
+            dataProviders.putAll(dataProviderMap)
+            details = details.copy { measurementSpec = measurementWithTwoEdp.measurementSpec.data }
+          }
+        )
+    }
+
+    val request = createMeasurementRequest { measurement = measurementWithTwoEdp }
+    val result =
+      withMeasurementConsumerPrincipal(MEASUREMENT_CONSUMER_NAME) {
+        runBlocking { service.createMeasurement(request) }
+      }
+    val expected = measurementWithTwoEdp
+
+    verifyProtoArgument(
+        internalMeasurementsMock,
+        MeasurementsGrpcKt.MeasurementsCoroutineImplBase::createMeasurement
+      )
+      .isEqualTo(
+        INTERNAL_MEASUREMENT.copy {
+          clearUpdateTime()
+          clearExternalMeasurementId()
+          dataProviders.clear()
+          dataProviders.putAll(dataProviderMap)
+          details =
+            details.copy {
+              clearFailure()
+              measurementSpec = measurementWithTwoEdp.measurementSpec.data
+            }
+
           results.clear()
         }
       )

--- a/src/test/kotlin/org/wfanet/measurement/kingdom/service/api/v2alpha/MeasurementsServiceTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/kingdom/service/api/v2alpha/MeasurementsServiceTest.kt
@@ -248,7 +248,15 @@ class MeasurementsServiceTest {
         INTERNAL_MEASUREMENT.copy {
           clearUpdateTime()
           clearExternalMeasurementId()
-          details = details.copy { clearFailure() }
+
+          details =
+            details.copy {
+              clearFailure()
+              if (request.measurement.dataProvidersCount == 1) {
+                clearProtocolConfig()
+                clearDuchyProtocolConfig()
+              }
+            }
           results.clear()
         }
       )


### PR DESCRIPTION
Don't generate protocolConfig for direct reach and frequency measurement(count of dataProvider is equal to 1) so MPC computation will not be triggered

Add Laplace noise to reach and frequency result in direct measurement in EDP simulator
<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/world-federation-of-advertisers/cross-media-measurement/619)
<!-- Reviewable:end -->
