### PR TITLE
Refactor resource configuration for K8s.

### DIFF
--- a/build/repositories.bzl
+++ b/build/repositories.bzl
@@ -73,6 +73,6 @@ def wfa_measurement_system_repositories():
     wfa_repo_archive(
         name = "wfa_rules_cue",
         repo = "rules_cue",
-        sha256 = "62def6a4dc401fd1549e44e2a4e2ae73cf75e6870025329bc78a0150d9a2594a",
-        version = "0.1.0",
+        sha256 = "86c699afae3bbe44d36ff8f5fad9c13b22aab35219b3002287402fb9a5cdb5d5",
+        version = "0.1.1",
     )

--- a/docs/gke/cluster-config.md
+++ b/docs/gke/cluster-config.md
@@ -108,6 +108,16 @@ using the `gcloud` CLI. See
 [Encrypt secrets at the application layer](https://cloud.google.com/kubernetes-engine/docs/how-to/encrypting-secrets)
 for more information.
 
+## Setting Default Resource Requirements
+
+It's a good idea to set default resource requirements for your cluster namespace
+using a `LimitRange`. See the corresponding
+[guide](https://kubernetes.io/docs/tasks/administer-cluster/manage-resources/memory-default-namespace/)
+for more information.
+
+For the `dev` environment, we use
+[resource_requirements.yaml](../../src/main/k8s/testing/secretfiles/resource_requirements.yaml)
+
 ## Reserving External IPs
 
 If you already have an IP that was assigned to a `LoadBalancer` service, you can

--- a/src/main/k8s/README.md
+++ b/src/main/k8s/README.md
@@ -3,6 +3,10 @@
 This package contains targets that generate Kubernetes manifests for deploying
 CMMS components using [CUE](https://cuelang.org/).
 
+See the
+[Kubernetes API Reference](https://kubernetes.io/docs/reference/kubernetes-api/)
+for background.
+
 ## Useful Labels
 
 All resources defined in these manifests should have the

--- a/src/main/k8s/dev/base_gke.cue
+++ b/src/main/k8s/dev/base_gke.cue
@@ -34,17 +34,3 @@ package k8s
 		"iam.gke.io/gke-metadata-server-enabled": "true"
 	}
 }
-
-#DefaultResourceConfig: #ResourceConfig & {
-	replicas: replicas | *1
-	resources: {
-		requests: {
-			cpu: cpu | *"100m"
-		}
-		limits: {
-			cpu:    cpu | *"400m"
-			memory: memory | *"512Mi"
-		}
-	}
-	jvmHeapSize: jvmHeapSize | *"400m"
-}

--- a/src/main/k8s/dev/config.cue
+++ b/src/main/k8s/dev/config.cue
@@ -25,8 +25,9 @@ import "strings"
 }
 
 #SpannerConfig: {
-	project:  #GCloudProject
-	instance: #SpannerInstance
+	project:      #GCloudProject
+	instance:     #SpannerInstance
+	readyTimeout: "30s"
 }
 
 #CloudStorageConfig: Config={

--- a/src/main/k8s/dev/duchy_gke.cue
+++ b/src/main/k8s/dev/duchy_gke.cue
@@ -25,24 +25,21 @@ _duchy_cert_name: "duchies/\(_duchy_name)/certificates/\(_certificateId)"
 #KingdomSystemApiTarget:       "system.kingdom.dev.halo-cmm.org:8443"
 #InternalServerServiceAccount: "internal-server"
 #StorageServiceAccount:        "storage"
-#DuchyServerResourceConfig:    #DefaultResourceConfig & {
-}
-#MillResourceConfig: #DefaultResourceConfig & {
-	replicas: 1
-	resources: {
-		requests: {
-			cpu: "200m"
-		}
-		limits: {
-			cpu:    "800m"
-			memory: "4Gi"
-		}
+#MillResourceRequirements:     #ResourceRequirements & {
+	requests: cpu: "200m"
+	limits: {
+		cpu:    "800m"
+		memory: "4Gi"
 	}
-	jvmHeapSize: "3584m"
 }
-#HeraldResourceConfig: #DefaultResourceConfig & {
-	replicas: 1 // We should have 1 and only 1 herald.
+#SpannerComputationsResourceRequirements: #ResourceRequirements & {
+	requests: cpu: "50m"
+	limits: {
+		cpu:    "200m"
+		memory: "384Mi"
+	}
 }
+#MillReplicas: 1
 
 objectSets: [
 	default_deny_ingress_and_egress,
@@ -91,35 +88,35 @@ duchy: #Duchy & {
 			"\(name)": config.image
 		}
 	}
-	_resource_configs: {
-		"async-computation-control-server": #DuchyServerResourceConfig
-		"computation-control-server":       #DuchyServerResourceConfig
-		"herald-daemon":                    #HeraldResourceConfig
-		"liquid-legions-v2-mill-daemon":    #MillResourceConfig
-		"requisition-fulfillment-server":   #DuchyServerResourceConfig
-		"spanner-computations-server":      #DuchyServerResourceConfig
-	}
 	_duchy_image_pull_policy: "Always"
 	_verbose_grpc_logging:    "false"
 
 	deployments: {
 		"spanner-computations-server-deployment": {
-			_podSpec: #ServiceAccountPodSpec & {
+			_container: resources: #SpannerComputationsResourceRequirements
+			spec: template: spec: #ServiceAccountPodSpec & {
 				serviceAccountName: #InternalServerServiceAccount
 			}
 		}
 		"liquid-legions-v2-mill-daemon-deployment": {
-			_podSpec: #ServiceAccountPodSpec & {
-				serviceAccountName: #StorageServiceAccount
+			_container: {
+				_javaOptions: maxRamPercentage: 50.0
+				resources: #MillResourceRequirements
+			}
+			spec: {
+				replicas: #MillReplicas
+				template: spec: #ServiceAccountPodSpec & {
+					serviceAccountName: #StorageServiceAccount
+				}
 			}
 		}
 		"computation-control-server-deployment": {
-			_podSpec: #ServiceAccountPodSpec & {
+			spec: template: spec: #ServiceAccountPodSpec & {
 				serviceAccountName: #StorageServiceAccount
 			}
 		}
 		"requisition-fulfillment-server-deployment": {
-			_podSpec: #ServiceAccountPodSpec & {
+			spec: template: spec: #ServiceAccountPodSpec & {
 				serviceAccountName: #StorageServiceAccount
 			}
 		}

--- a/src/main/k8s/dev/edp_simulator_gke.cue
+++ b/src/main/k8s/dev/edp_simulator_gke.cue
@@ -79,7 +79,6 @@ edp_simulators: {
 			_edp_simulator_image:         _imageConfig.image
 			_simulator_image_pull_policy: "Always"
 			_additional_args:             _bigQueryConfig.flags
-			_resourceConfig:              #DefaultResourceConfig
 		}
 	}
 }

--- a/src/main/k8s/dev/frontend_simulator_gke.cue
+++ b/src/main/k8s/dev/frontend_simulator_gke.cue
@@ -37,5 +37,4 @@ frontend_simulator: #FrontendSimulator & {
 	_kingdom_public_api_target: #KingdomPublicApiTarget
 	_simulator_image:           _imageConfig.image
 	_blob_storage_flags:        _cloudStorageConfig.flags
-	_resourceConfig:            #DefaultResourceConfig
 }

--- a/src/main/k8s/dev/panel_match_resource_setup_gke.cue
+++ b/src/main/k8s/dev/panel_match_resource_setup_gke.cue
@@ -28,6 +28,5 @@ panel_match_resource_setup_job: #PanelMatchResourceSetup & {
 	_edp_display_name:           "edp1"
 	_mp_display_name:            "mp1"
 	_job_image:                  #ContainerRegistryPrefix + "/loadtest/panel-match-resource-setup"
-	_resourceConfig:             #DefaultResourceConfig
 	_resource_setup_secret_name: _secret_name
 }

--- a/src/main/k8s/dev/reporting_gke.cue
+++ b/src/main/k8s/dev/reporting_gke.cue
@@ -17,9 +17,6 @@ package k8s
 _reportingSecretName:         string @tag("secret_name")
 _reportingMcConfigSecretName: string @tag("mc_config_secret_name")
 
-#ReportingServerResourceConfig: #DefaultResourceConfig & {
-}
-
 #KingdomApiTarget: #GrpcTarget & {
 	host: "public.kingdom.dev.halo-cmm.org"
 	port: 8443
@@ -65,16 +62,12 @@ reporting: #Reporting & {
 		}
 	}
 
-	_resourceConfigs: {
-		"postgres-reporting-data-server": #ReportingServerResourceConfig
-		"v1alpha-public-api-server":      #ReportingServerResourceConfig
-	}
 	_imagePullPolicy:          "Always"
 	_verboseGrpcServerLogging: true
 
 	deployments: {
 		"postgres-reporting-data-server": {
-			_podSpec: #ServiceAccountPodSpec & {
+			spec: template: spec: #ServiceAccountPodSpec & {
 				serviceAccountName: #InternalServerServiceAccount
 			}
 		}

--- a/src/main/k8s/dev/resource_setup_gke.cue
+++ b/src/main/k8s/dev/resource_setup_gke.cue
@@ -16,19 +16,6 @@ package k8s
 
 _secret_name: string @tag("secret_name")
 
-_resourceConfig: #ResourceConfig: {
-	resources: {
-		requests: {
-			cpu: "100m"
-		}
-		limits: {
-			cpu:    "400m"
-			memory: "512Mi"
-		}
-	}
-	jvmHeapSize: "400m"
-}
-
 objectSets: [resourceSetup]
 
 _imageConfig: #ImageConfig & {
@@ -41,5 +28,4 @@ resourceSetup: #ResourceSetup & {
 	_job_image:                  _imageConfig.image
 	_resource_setup_secret_name: _secret_name
 	_dependencies: ["gcp-kingdom-data-server"]
-	_resourceConfig: #DefaultResourceConfig
 }

--- a/src/main/k8s/duchy.cue
+++ b/src/main/k8s/duchy.cue
@@ -41,8 +41,6 @@ import ("strings")
 	_images: [Name=_]: string
 	_duchy_image_pull_policy: string
 
-	_resource_configs: [Name=_]: #ResourceConfig
-
 	_akid_to_principal_map_file_flag:                   "--authority-key-identifier-to-principal-map-file=/etc/\(#AppName)/config-files/authority_key_identifier_to_principal_map.textproto"
 	_async_computations_control_service_target_flag:    "--async-computation-control-service-target=" + (#Target & {name: "\(_name)-async-computation-control-server"}).target
 	_async_computations_control_service_cert_host_flag: "--async-computation-control-service-cert-host=localhost"
@@ -79,14 +77,15 @@ import ("strings")
 		_name:            _object_prefix + _unprefixed_name
 		_secretName:      _duchy_secret_name
 		_system:          "duchy"
-		_image:           _images[_unprefixed_name]
-		_imagePullPolicy: _duchy_image_pull_policy
-		_resourceConfig:  _resource_configs[_unprefixed_name]
+		_container: {
+			image:           _images[_unprefixed_name]
+			imagePullPolicy: _duchy_image_pull_policy
+		}
 	}
 
 	deployments: {
-		"herald-daemon-deployment": #Deployment & {
-			_args: [
+		"herald-daemon-deployment": {
+			_container: args: [
 				_computations_service_target_flag,
 				_computations_service_cert_host_flag,
 				_duchy_name_flag,
@@ -100,28 +99,29 @@ import ("strings")
 				"--polling-interval=1m",
 			]
 		}
-		"liquid-legions-v2-mill-daemon-deployment": #Deployment & {
-			_args: [
-				_computations_service_target_flag,
-				_computations_service_cert_host_flag,
-				_duchy_name_flag,
-				_duchy_info_config_flag,
-				_duchy_tls_cert_file_flag,
-				_duchy_tls_key_file_flag,
-				_duchy_cert_collection_file_flag,
-				_duchy_cs_cert_file_flag,
-				_duchy_cs_key_file_flag,
-				_duchy_cs_cert_rename_name_flag,
-				_kingdom_system_api_target_flag,
-				_kingdom_system_api_cert_host_flag,
-				"--channel-shutdown-timeout=3s",
-				"--polling-interval=1s",
+		"liquid-legions-v2-mill-daemon-deployment": {
+			_container: args: [
+						_computations_service_target_flag,
+						_computations_service_cert_host_flag,
+						_duchy_name_flag,
+						_duchy_info_config_flag,
+						_duchy_tls_cert_file_flag,
+						_duchy_tls_key_file_flag,
+						_duchy_cert_collection_file_flag,
+						_duchy_cs_cert_file_flag,
+						_duchy_cs_key_file_flag,
+						_duchy_cs_cert_rename_name_flag,
+						_kingdom_system_api_target_flag,
+						_kingdom_system_api_cert_host_flag,
+						"--channel-shutdown-timeout=3s",
+						"--polling-interval=1s",
 			] + _blob_storage_flags + _computation_control_target_flags
-			_jvm_flags: "-Xmx4g -Xms256m"
-			_dependencies: ["\(_name)-spanner-computations-server", "\(_name)-computation-control-server"]
+			spec: template: spec: _dependencies: [
+				"\(_name)-spanner-computations-server", "\(_name)-computation-control-server",
+			]
 		}
 		"async-computation-control-server-deployment": #ServerDeployment & {
-			_args: [
+			_container: args: [
 				_computations_service_target_flag,
 				_computations_service_cert_host_flag,
 				_duchy_name_flag,
@@ -135,61 +135,63 @@ import ("strings")
 			]
 		}
 		"computation-control-server-deployment": #ServerDeployment & {
-			_args: [
-				_async_computations_control_service_target_flag,
-				_async_computations_control_service_cert_host_flag,
-				_duchy_name_flag,
-				_duchy_info_config_flag,
-				_duchy_tls_cert_file_flag,
-				_duchy_tls_key_file_flag,
-				_duchy_cert_collection_file_flag,
-				_debug_verbose_grpc_server_logging_flag,
-				"--port=8443",
-				"--health-port=8080",
+			_container: args: [
+						_async_computations_control_service_target_flag,
+						_async_computations_control_service_cert_host_flag,
+						_duchy_name_flag,
+						_duchy_info_config_flag,
+						_duchy_tls_cert_file_flag,
+						_duchy_tls_key_file_flag,
+						_duchy_cert_collection_file_flag,
+						_debug_verbose_grpc_server_logging_flag,
+						"--port=8443",
+						"--health-port=8080",
 			] + _blob_storage_flags
 		}
-		"spanner-computations-server-deployment": Deployment=#ServerDeployment & {
-			_args: [
-				_debug_verbose_grpc_server_logging_flag,
-				_duchy_name_flag,
-				_duchy_info_config_flag,
-				_duchy_tls_cert_file_flag,
-				_duchy_tls_key_file_flag,
-				_duchy_cert_collection_file_flag,
-				_kingdom_system_api_target_flag,
-				_kingdom_system_api_cert_host_flag,
-				"--channel-shutdown-timeout=3s",
-				"--port=8443",
-				"--health-port=8080",
+		"spanner-computations-server-deployment": #ServerDeployment & {
+			_container: args: [
+						_debug_verbose_grpc_server_logging_flag,
+						_duchy_name_flag,
+						_duchy_info_config_flag,
+						_duchy_tls_cert_file_flag,
+						_duchy_tls_key_file_flag,
+						_duchy_cert_collection_file_flag,
+						_kingdom_system_api_target_flag,
+						_kingdom_system_api_cert_host_flag,
+						"--channel-shutdown-timeout=3s",
+						"--port=8443",
+						"--health-port=8080",
 			] + _spannerConfig.flags
-
-			_podSpec: _initContainers: {
-				"\(_object_prefix)update-duchy-schema": {
-					image:           _images["update-duchy-schema"]
-					imagePullPolicy: Deployment._imagePullPolicy
-					args:            _spannerConfig.flags
+			_updateSchemaContainer: #Container & {
+				image:           _images["update-duchy-schema"]
+				imagePullPolicy: _container.imagePullPolicy
+				args:            _spannerConfig.flags
+			}
+			spec: template: spec: {
+				_initContainers: {
+					"\(_object_prefix)update-duchy-schema": _updateSchemaContainer
 				}
 			}
 		}
 		"requisition-fulfillment-server-deployment": #ServerDeployment & {
-			_configMapMounts: [{
-				name: "config-files"
-			}]
-			_args: [
-				_debug_verbose_grpc_server_logging_flag,
-				_akid_to_principal_map_file_flag,
-				_duchy_name_flag,
-				_duchy_tls_cert_file_flag,
-				_duchy_tls_key_file_flag,
-				_duchy_cert_collection_file_flag,
-				_computations_service_target_flag,
-				_computations_service_cert_host_flag,
-				_kingdom_system_api_target_flag,
-				_kingdom_system_api_cert_host_flag,
-				"--port=8443",
-				"--health-port=8080",
+			_container: args: [
+						_debug_verbose_grpc_server_logging_flag,
+						_akid_to_principal_map_file_flag,
+						_duchy_name_flag,
+						_duchy_tls_cert_file_flag,
+						_duchy_tls_key_file_flag,
+						_duchy_cert_collection_file_flag,
+						_computations_service_target_flag,
+						_computations_service_cert_host_flag,
+						_kingdom_system_api_target_flag,
+						_kingdom_system_api_cert_host_flag,
+						"--port=8443",
+						"--health-port=8080",
 			] + _blob_storage_flags
-			_dependencies: ["\(_name)-spanner-computations-server"]
+			spec: template: spec: {
+				_projectionMounts: "config-files": #ConfigMapMount
+				_dependencies: ["\(_name)-spanner-computations-server"]
+			}
 		}
 	}
 
@@ -217,7 +219,7 @@ import ("strings")
 				// External API server; allow ingress from anywhere to service port.
 				gRpc: {
 					ports: [{
-						port: #GrpcServicePort
+						port: #GrpcPort
 					}]
 				}
 			}
@@ -241,7 +243,7 @@ import ("strings")
 				// External API server; allow ingress from anywhere to service port.
 				gRpc: {
 					ports: [{
-						port: #GrpcServicePort
+						port: #GrpcPort
 					}]
 				}
 			}

--- a/src/main/k8s/edp_simulator.cue
+++ b/src/main/k8s/edp_simulator.cue
@@ -14,13 +14,12 @@
 
 package k8s
 
-#EdpSimulator: EdpSimulator={
+#EdpSimulator: {
 	_edp: {display_name: string, resource_name: string}
 	_mc_resource_name:          string
 	_edp_secret_name:           string
 	_duchy_public_api_target:   string
 	_kingdom_public_api_target: string
-	_resourceConfig:            #ResourceConfig
 
 	_edp_display_name:  _edp.display_name
 	_edp_resource_name: _edp.resource_name
@@ -31,28 +30,28 @@ package k8s
 
 	_additional_args: [...string]
 
-	edp_simulator_deployment: #Deployment & {
-		_name:            _edp_display_name + "-simulator"
-		_secretName:      _edp_secret_name
-		_system:          "simulator"
-		_image:           _edp_simulator_image
-		_imagePullPolicy: _simulator_image_pull_policy
-		_resourceConfig:  EdpSimulator._resourceConfig
-
-		_args: [
-			"--tls-cert-file=/var/run/secrets/files/\(_edp_display_name)_tls.pem",
-			"--tls-key-file=/var/run/secrets/files/\(_edp_display_name)_tls.key",
-			"--cert-collection-file=/var/run/secrets/files/all_root_certs.pem",
-			"--data-provider-resource-name=\(_edp_resource_name)",
-			"--data-provider-display-name=\(_edp_display_name)",
-			"--data-provider-encryption-private-keyset=/var/run/secrets/files/\(_edp_display_name)_enc_private.tink",
-			"--data-provider-consent-signaling-private-key-der-file=/var/run/secrets/files/\(_edp_display_name)_cs_private.der",
-			"--data-provider-consent-signaling-certificate-der-file=/var/run/secrets/files/\(_edp_display_name)_cs_cert.der",
-			"--mc-resource-name=\(_mc_resource_name)",
-			"--kingdom-public-api-target=\(_kingdom_public_api_target)",
-			"--kingdom-public-api-cert-host=localhost",
-			"--requisition-fulfillment-service-target=\(_duchy_public_api_target)",
-			"--requisition-fulfillment-service-cert-host=localhost",
-		] + _blob_storage_flags + _additional_args
+	deployment: #Deployment & {
+		_name:       _edp_display_name + "-simulator"
+		_secretName: _edp_secret_name
+		_system:     "simulator"
+		_container: {
+			image:           _edp_simulator_image
+			imagePullPolicy: _simulator_image_pull_policy
+			args:            [
+						"--tls-cert-file=/var/run/secrets/files/\(_edp_display_name)_tls.pem",
+						"--tls-key-file=/var/run/secrets/files/\(_edp_display_name)_tls.key",
+						"--cert-collection-file=/var/run/secrets/files/all_root_certs.pem",
+						"--data-provider-resource-name=\(_edp_resource_name)",
+						"--data-provider-display-name=\(_edp_display_name)",
+						"--data-provider-encryption-private-keyset=/var/run/secrets/files/\(_edp_display_name)_enc_private.tink",
+						"--data-provider-consent-signaling-private-key-der-file=/var/run/secrets/files/\(_edp_display_name)_cs_private.der",
+						"--data-provider-consent-signaling-certificate-der-file=/var/run/secrets/files/\(_edp_display_name)_cs_cert.der",
+						"--mc-resource-name=\(_mc_resource_name)",
+						"--kingdom-public-api-target=\(_kingdom_public_api_target)",
+						"--kingdom-public-api-cert-host=localhost",
+						"--requisition-fulfillment-service-target=\(_duchy_public_api_target)",
+						"--requisition-fulfillment-service-cert-host=localhost",
+			] + _blob_storage_flags + _additional_args
+		}
 	}
 }

--- a/src/main/k8s/frontend_simulator.cue
+++ b/src/main/k8s/frontend_simulator.cue
@@ -22,28 +22,27 @@ package k8s
 	_simulator_image_pull_policy: string | *"Always"
 	_kingdom_public_api_target:   string
 	_blob_storage_flags: [...string]
-	_resourceConfig: #ResourceConfig
 
 	frontend_simulator_job: #Job & {
-		_name:            "frontend-simulator"
-		_secretName:      _mc_secret_name
-		_image:           _simulator_image
-		_imagePullPolicy: _simulator_image_pull_policy
-		_resources:       _resourceConfig.resources
-		_jvmHeapSize:     _resourceConfig.jvmHeapSize
-		_args:            [
-					"--tls-cert-file=/var/run/secrets/files/mc_tls.pem",
-					"--tls-key-file=/var/run/secrets/files/mc_tls.key",
-					"--cert-collection-file=/var/run/secrets/files/all_root_certs.pem",
-					"--kingdom-public-api-target=\(_kingdom_public_api_target)",
-					"--kingdom-public-api-cert-host=localhost",
-					"--mc-resource-name=\(_mc_resource_name)",
-					"--api-authentication-key=\(_mc_api_authentication_key)",
-					"--mc-consent-signaling-cert-der-file=/var/run/secrets/files/mc_cs_cert.der",
-					"--mc-consent-signaling-key-der-file=/var/run/secrets/files/mc_cs_private.der",
-					"--mc-encryption-private-keyset=/var/run/secrets/files/mc_enc_private.tink",
-					"--output-differential-privacy-epsilon=0.1",
-					"--output-differential-privacy-delta=0.000001",
-		] + _blob_storage_flags
+		_name:       "frontend-simulator"
+		_secretName: _mc_secret_name
+		_container: {
+			image:           _simulator_image
+			imagePullPolicy: _simulator_image_pull_policy
+			args:            [
+						"--tls-cert-file=/var/run/secrets/files/mc_tls.pem",
+						"--tls-key-file=/var/run/secrets/files/mc_tls.key",
+						"--cert-collection-file=/var/run/secrets/files/all_root_certs.pem",
+						"--kingdom-public-api-target=\(_kingdom_public_api_target)",
+						"--kingdom-public-api-cert-host=localhost",
+						"--mc-resource-name=\(_mc_resource_name)",
+						"--api-authentication-key=\(_mc_api_authentication_key)",
+						"--mc-consent-signaling-cert-der-file=/var/run/secrets/files/mc_cs_cert.der",
+						"--mc-consent-signaling-key-der-file=/var/run/secrets/files/mc_cs_private.der",
+						"--mc-encryption-private-keyset=/var/run/secrets/files/mc_enc_private.tink",
+						"--output-differential-privacy-epsilon=0.1",
+						"--output-differential-privacy-delta=0.000001",
+			] + _blob_storage_flags
+		}
 	}
 }

--- a/src/main/k8s/local/README.md
+++ b/src/main/k8s/local/README.md
@@ -8,18 +8,25 @@ local KiND cluster. You should have some familiarity with Kubernetes and
 `kubectl`.
 
 Minimum Version Required:
-- KiND: v0.13.0
-- kubernetes server: v1.24.0
-- kubectl: compatible with kubernetes server
 
-Use the default `kind` as the KiND cluster name. The corresponding k8s cluster name is 
-`kind-kind`.
+-   KiND: v0.13.0
+-   kubernetes server: v1.24.0
+-   kubectl: compatible with kubernetes server
+
+Use the default `kind` as the KiND cluster name. The corresponding k8s cluster
+name is `kind-kind`.
 
 Note that some of the targets listed below -- namely, the Duchies and
 simulators -- have requirements regarding the version of glibc in the build
 environment. See [Building](../../../../docs/building.md).
 
 ## Initial Setup
+
+### Set Default Resource Requirements
+
+```shell
+kubectl apply -f src/main/k8s/testing/secretfiles/resource_requirements.yaml
+```
 
 ### Create Secret
 

--- a/src/main/k8s/local/config.cue
+++ b/src/main/k8s/local/config.cue
@@ -15,21 +15,9 @@
 package k8s
 
 #SpannerConfig: {
-	project:      "cross-media-measurement-system"
-	instance:     "emulator-instance"
-	emulatorHost: (#Target & {name: "spanner-emulator"}).target
-}
+	project:  "cross-media-measurement-system"
+	instance: "emulator-instance"
 
-#DefaultResourceConfig: #ResourceConfig & {
-	replicas: replicas | *1
-	resources: {
-		requests: {
-			cpu: cpu | *"100m"
-		}
-		limits: {
-			cpu:    cpu | *"400m"
-			memory: memory | *"512Mi"
-		}
-	}
-	jvmHeapSize: jvmHeapSize | *"400m"
+	let EmulatorTarget = #ServiceTarget & {serviceName: "spanner-emulator"}
+	emulatorHost: EmulatorTarget.target
 }

--- a/src/main/k8s/local/edp_simulators.cue
+++ b/src/main/k8s/local/edp_simulators.cue
@@ -73,7 +73,6 @@ edpSimulators: {
 			]
 			_edp_simulator_image:         "bazel/src/main/kotlin/org/wfanet/measurement/loadtest/dataprovider:forwarded_storage_edp_simulator_runner_image"
 			_simulator_image_pull_policy: "Never"
-			_resourceConfig:              #DefaultResourceConfig
 		}
 	}
 }

--- a/src/main/k8s/local/frontend_simulator.cue
+++ b/src/main/k8s/local/frontend_simulator.cue
@@ -33,5 +33,4 @@ frontendSimulator: #FrontendSimulator & {
 		"--forwarded-storage-service-target=" + (#Target & {name: "fake-storage-server"}).target,
 		"--forwarded-storage-cert-host=localhost",
 	]
-	_resourceConfig: #DefaultResourceConfig
 }

--- a/src/main/k8s/local/kingdom.cue
+++ b/src/main/k8s/local/kingdom.cue
@@ -16,7 +16,12 @@ package k8s
 
 _secret_name: string @tag("secret_name")
 
-#KingdomServerResourceConfig: #DefaultResourceConfig & {
+#DataServerResourceRequirements: #ResourceRequirements & {
+	requests: cpu: "50m"
+	limits: {
+		cpu:    "200m"
+		memory: "384Mi"
+	}
 }
 
 objectSets: [ for objectSet in kingdom {objectSet}]
@@ -30,12 +35,13 @@ kingdom: #Kingdom & {
 		"system-api-server":         "bazel/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/common/server:system_api_server_image"
 		"v2alpha-public-api-server": "bazel/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/common/server:v2alpha_public_api_server_image"
 	}
-	_resource_configs: {
-		"gcp-kingdom-data-server":   #KingdomServerResourceConfig
-		"system-api-server":         #KingdomServerResourceConfig
-		"v2alpha-public-api-server": #KingdomServerResourceConfig
-	}
 	_kingdom_image_pull_policy: "Never"
 	_verboseGrpcServerLogging:  true
 	_verboseGrpcClientLogging:  true
+
+	deployments: {
+		"gcp-kingdom-data-server": {
+			_container: resources: #DataServerResourceRequirements
+		}
+	}
 }

--- a/src/main/k8s/local/postgres_database.cue
+++ b/src/main/k8s/local/postgres_database.cue
@@ -16,64 +16,54 @@ package k8s
 
 _dbSecretName: string @tag("db_secret_name")
 
+#ComponentName: "testing"
+
 objectSets: [
 	services,
 	pods,
 ]
 
+services: [Name=string]: #Service & {
+	metadata: {
+		_component: #ComponentName
+		name:       Name
+	}
+}
 services: {
 	"postgres": {
-		apiVersion: "v1"
-		kind:       "Service"
-		metadata: {
-			name: "postgres"
-			labels: {
-				"app.kubernetes.io/part-of":   #AppName
-				"app.kubernetes.io/component": "testing"
-			}
-		}
 		spec: {
-			selector: app: "postgres-app"
 			ports: [{
-				name:       "postgresql"
-				port:       5432
-				protocol:   "TCP"
-				targetPort: 5432
+				name: "postgresql"
+				port: 5432
 			}]
 		}
 	}
 }
 
+pods: [Name=string]: #Pod & {
+	metadata: {
+		_component: #ComponentName
+		name:       Name
+	}
+}
 pods: {
-	"postgres-pod": {
-		apiVersion: "v1"
-		kind:       "Pod"
-		metadata: {
-			name: "postgres-pod"
-			labels: {
-				app:                           "postgres-app"
-				"app.kubernetes.io/part-of":   #AppName
-				"app.kubernetes.io/component": "testing"
-			}
-		}
-		spec: containers: [{
-			name:  "postgres"
-			image: "docker.io/postgres:14.4-alpine"
-			env: [{
-				name: "POSTGRES_USER"
-				valueFrom:
-					secretKeyRef: {
+	"postgres": {
+		spec: _containers: "postgres": {
+			_envVars: {
+				"POSTGRES_USER": {
+					valueFrom: secretKeyRef: {
 						name: _dbSecretName
 						key:  "username"
 					}
-			}, {
-				name: "POSTGRES_PASSWORD"
-				valueFrom:
-					secretKeyRef: {
+				}
+				"POSTGRES_PASSWORD": {
+					valueFrom: secretKeyRef: {
 						name: _dbSecretName
 						key:  "password"
 					}
-			}]
-	}]
-}
+				}
+			}
+			image: "docker.io/postgres:14.4-alpine"
+		}
+	}
 }

--- a/src/main/k8s/local/resource_setup.cue
+++ b/src/main/k8s/local/resource_setup.cue
@@ -25,5 +25,4 @@ resourceSetup: #ResourceSetup & {
 	_job_image_pull_policy:      "Never"
 	_resource_setup_secret_name: _secret_name
 	_dependencies: ["gcp-kingdom-data-server"]
-	_resourceConfig: #DefaultResourceConfig
 }

--- a/src/main/k8s/panel_match_resource_setup.cue
+++ b/src/main/k8s/panel_match_resource_setup.cue
@@ -20,7 +20,6 @@ package k8s
 	_resource_setup_secret_name: string
 	_job_image:                  string
 	_job_image_pull_policy:      string | *"Always"
-	_resourceConfig:             #ResourceConfig
 	_tls_cert_key_files_flags: [
 		"--tls-cert-file=/var/run/secrets/files/mc_tls.pem",
 		"--tls-key-file=/var/run/secrets/files/mc_tls.key",
@@ -47,17 +46,17 @@ package k8s
 	]
 
 	resource_setup_job: #Job & {
-		_name:            "resource-setup"
-		_secretName:      _resource_setup_secret_name
-		_image:           _job_image
-		_imagePullPolicy: _job_image_pull_policy
-		_resources:       _resourceConfig.resources
-		_jvmHeapSize:     _resourceConfig.jvmHeapSize
-		_args:
-			_tls_cert_key_files_flags +
-			_kingdom_internal_api_flags +
-			_edp_cert_key_files_flags +
-			_mp_cert_key_files_flags +
-			_exchange_workflow_flag
+		_name:       "resource-setup"
+		_secretName: _resource_setup_secret_name
+		_container: {
+			image:           _job_image
+			imagePullPolicy: _job_image_pull_policy
+			args:
+				_tls_cert_key_files_flags +
+				_kingdom_internal_api_flags +
+				_edp_cert_key_files_flags +
+				_mp_cert_key_files_flags +
+				_exchange_workflow_flag
+		}
 	}
 }

--- a/src/main/k8s/resource_setup.cue
+++ b/src/main/k8s/resource_setup.cue
@@ -21,7 +21,6 @@ package k8s
 	_job_image:                  string
 	_job_image_pull_policy:      string | *"Always"
 	_dependencies: [...string]
-	_resourceConfig: #ResourceConfig
 	_edp_cert_key_files_flags:
 		[
 			for d in _edp_display_names {
@@ -61,25 +60,26 @@ package k8s
 	]
 
 	resource_setup_job: #Job & {
-		_name:            "resource-setup"
-		_secretName:      _resource_setup_secret_name
-		_image:           _job_image
-		_imagePullPolicy: _job_image_pull_policy
-		_dependencies:    ResourceSetup._dependencies
-		_resources:       _resourceConfig.resources
-		_jvmHeapSize:     _resourceConfig.jvmHeapSize
-		_args:
-			_edp_cert_key_files_flags +
-			_mc_cert_key_files_flags +
-			_tls_cert_key_files_flags +
-			_duchy_cs_cert_files_flags +
-			_kingdom_public_api_flags +
-			_kingdom_internal_api_flags
-		_jobSpec: {
-			backoffLimit: 0 // Don't retry.
+		_name:       "resource-setup"
+		_secretName: _resource_setup_secret_name
+		_container: {
+			image:           _job_image
+			imagePullPolicy: _job_image_pull_policy
+			args:
+				_edp_cert_key_files_flags +
+				_mc_cert_key_files_flags +
+				_tls_cert_key_files_flags +
+				_duchy_cs_cert_files_flags +
+				_kingdom_public_api_flags +
+				_kingdom_internal_api_flags
 		}
-		_podSpec: {
-			restartPolicy: "Never"
+
+		spec: {
+			backoffLimit: 0 // Don't retry.
+			template: spec: {
+				_dependencies: ResourceSetup._dependencies
+				restartPolicy: "Never"
+			}
 		}
 	}
 }

--- a/src/main/k8s/spanner.cue
+++ b/src/main/k8s/spanner.cue
@@ -18,12 +18,14 @@ package k8s
 	project:       string
 	instance:      string
 	database:      string
+	readyTimeout?: string
 	emulatorHost?: string
 
 	flags: [
 		"--spanner-project=\(project)",
 		"--spanner-instance=\(instance)",
 		"--spanner-database=\(database)",
+		if readyTimeout != _|_ {"--spanner-ready-timeout=\(readyTimeout)"},
 		if emulatorHost != _|_ {"--spanner-emulator-host=\(emulatorHost)"},
 	]
 }

--- a/src/main/k8s/testing/secretfiles/resource_requirements.yaml
+++ b/src/main/k8s/testing/secretfiles/resource_requirements.yaml
@@ -1,0 +1,26 @@
+# Copyright 2022 The Cross-Media Measurement Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: LimitRange
+metadata:
+  name: resource-requirements
+spec:
+  limits:
+  - type: Container
+    defaultRequest:
+      cpu: 20m
+    default:
+      cpu: 100m
+      memory: 256Mi


### PR DESCRIPTION
* Specify defaults at the cluster namespace level.
* Refactor definitions to be closer to K8s API.
* Rely on JVM container support for heap sizing (`XX:UseContainerSupport`).
* Adjust resource requirements based upon observed usage during correctness test (will likely need further tweaking).

This also avoids an observed issue with Spanner servers by increasing the ready timeout.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/world-federation-of-advertisers/cross-media-measurement/659)
<!-- Reviewable:end -->
