### PR TITLE
Update setMeasurementResult calls to be sequential

### DIFF
--- a/src/main/kotlin/org/wfanet/measurement/reporting/service/api/v1alpha/ReportsService.kt
+++ b/src/main/kotlin/org/wfanet/measurement/reporting/service/api/v1alpha/ReportsService.kt
@@ -796,14 +796,11 @@ class ReportsService(
     for ((measurementReferenceId, internalMeasurement) in measurementsMap) {
       // Measurement with SUCCEEDED state is already synced
       if (internalMeasurement.state == InternalMeasurement.State.SUCCEEDED) continue
-
-      launch {
-        syncMeasurement(
-          measurementReferenceId,
-          measurementConsumerReferenceId,
-          apiAuthenticationKey,
-        )
-      }
+      syncMeasurement(
+        measurementReferenceId,
+        measurementConsumerReferenceId,
+        apiAuthenticationKey,
+      )
     }
   }
 

--- a/src/main/proto/wfa/measurement/internal/reporting/measurements_service.proto
+++ b/src/main/proto/wfa/measurement/internal/reporting/measurements_service.proto
@@ -39,6 +39,7 @@ message GetMeasurementRequest {
   string measurement_reference_id = 2;
 }
 
+// TODO(tristanvuong2021): Modify to take a list of measurement results
 message SetMeasurementResultRequest {
   // `MeasurementConsumer` ID from the CMMS public API.
   string measurement_consumer_reference_id = 1;

--- a/src/main/proto/wfa/measurement/internal/reporting/measurements_service.proto
+++ b/src/main/proto/wfa/measurement/internal/reporting/measurements_service.proto
@@ -39,7 +39,6 @@ message GetMeasurementRequest {
   string measurement_reference_id = 2;
 }
 
-// TODO(tristanvuong2021): Modify to take a list of measurement results
 message SetMeasurementResultRequest {
   // `MeasurementConsumer` ID from the CMMS public API.
   string measurement_consumer_reference_id = 1;


### PR DESCRIPTION
The calls cannot actually be async due to what setMeasurementResult does. Errors occur due to transaction conflicts. Added a TODO to make setMeasurementResult a method that takes in a list in order to do asynchrous inserts there.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/world-federation-of-advertisers/cross-media-measurement/663)
<!-- Reviewable:end -->
