### PR TITLE
Update common-jvm to 0.45.1.

### DIFF
--- a/build/repositories.bzl
+++ b/build/repositories.bzl
@@ -24,8 +24,8 @@ def wfa_measurement_system_repositories():
     wfa_repo_archive(
         name = "wfa_common_jvm",
         repo = "common-jvm",
-        sha256 = "2c08c2fbfa076df788b6f82d5441d0eb7e76b40d459937a9709138ec99352885",
-        version = "0.43.3",
+        sha256 = "d1566e77a6cab9cbf36248b52f3d8bafa5ac28a2a9a947f4c83d4769acf319d8",
+        version = "0.45.1",
     )
 
     wfa_repo_archive(

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/common/BUILD.bazel
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/common/BUILD.bazel
@@ -18,6 +18,7 @@ kt_jvm_library(
         "//src/main/proto/wfa/measurement/internal/kingdom:measurement_kt_jvm_proto",
         "@wfa_common_jvm//imports/java/com/google/cloud/spanner",
         "@wfa_common_jvm//imports/java/com/google/protobuf",
+        "@wfa_common_jvm//imports/java/com/google/type:type_java_proto",
         "@wfa_common_jvm//imports/java/io/grpc/protobuf",
         "@wfa_common_jvm//src/main/kotlin/org/wfanet/measurement/common",
         "@wfa_common_jvm//src/main/kotlin/org/wfanet/measurement/gcloud/common",

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/service/internal/testing/Population.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/service/internal/testing/Population.kt
@@ -16,6 +16,9 @@ package org.wfanet.measurement.kingdom.service.internal.testing
 
 import com.google.gson.JsonParser
 import com.google.protobuf.kotlin.toByteStringUtf8
+import com.google.rpc.ErrorInfo
+import io.grpc.StatusRuntimeException
+import io.grpc.protobuf.ProtoUtils
 import java.time.Clock
 import java.time.Instant
 import java.time.temporal.ChronoUnit
@@ -347,3 +350,14 @@ fun DataProvider.toDataProviderValue(nonce: Long = Random.Default.nextLong()) = 
   encryptedRequisitionSpec = "Encrypted RequisitionSpec $nonce".toByteStringUtf8()
   nonceHash = hashSha256(nonce)
 }
+
+/**
+ * [ErrorInfo] from [trailers][StatusRuntimeException.getTrailers].
+ *
+ * TODO(@SanjayVas): Move this to common.grpc.
+ */
+val StatusRuntimeException.errorInfo: ErrorInfo?
+  get() {
+    val key = ProtoUtils.keyForProto(ErrorInfo.getDefaultInstance())
+    return trailers?.get(key)
+  }

--- a/src/main/proto/wfa/measurement/internal/kingdom/error_code.proto
+++ b/src/main/proto/wfa/measurement/internal/kingdom/error_code.proto
@@ -68,4 +68,10 @@ enum ErrorCode {
   EVENT_GROUP_INVALID_ARGS = 21;
   /** EventGroupMetadataDescriptor could not be found. */
   EVENT_GROUP_METADATA_DESCRIPTOR_NOT_FOUND = 22;
+  /** RecurringExchange could not be found. */
+  RECURRING_EXCHANGE_NOT_FOUND = 23;
+  /** ExchangeStepAttempt could not be found. */
+  EXCHANGE_STEP_ATTEMPT_NOT_FOUND = 24;
+  /** ExchangeStep could not be found. */
+  EXCHANGE_STEP_NOT_FOUND = 25;
 }


### PR DESCRIPTION
This fixes StatusRuntimeExceptions being thrown from Spanner transaction executors, which breaks exception handling in the Spanner API client.
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/world-federation-of-advertisers/cross-media-measurement/673)
<!-- Reviewable:end -->
