### PR TITLE
Drop CPU limits from K8s resource requirements.

### DIFF
--- a/docs/gke/kingdom-deployment.md
+++ b/docs/gke/kingdom-deployment.md
@@ -165,15 +165,14 @@ gcloud container clusters create halo-cmm-kingdom-demo-cluster \
   --enable-network-policy --workload-pool=halo-kingdom-demo.svc.id.goog \
   --service-account="gke-cluster@halo-kingdom-demo.iam.gserviceaccount.com" \
   --database-encryption-key=projects/halo-cmm-dev/locations/us-central1/keyRings/test-key-ring/cryptoKeys/k8s-secret \
-  --num-nodes=3 --enable-autoscaling --min-nodes=1 --max-nodes=5 \
-  --machine-type=e2-small --cluster-version=1.24.2-gke.1900
+  --num-nodes=2 --enable-autoscaling --min-nodes=1 --max-nodes=5 \
+  --machine-type=e2-highcpu-2 --cluster-version=1.24.2-gke.1900
 ```
 
-Note: ~3 nodes with the `e2-small` machine type should be enough to run the
-Kingdom servers initially, but should be adjusted depending on expected load.
+Adjust the number of nodes and machine type according to your expected usage.
 
-The GKE version should be no older than `1.24.0` in order to support built-in gRPC 
-health probe.
+The GKE version should be no older than `1.24.0` in order to support built-in
+gRPC health probe.
 
 After creating the cluster, we can configure `kubectl` to be able to access it
 

--- a/src/main/k8s/dev/duchy_gke.cue
+++ b/src/main/k8s/dev/duchy_gke.cue
@@ -26,18 +26,10 @@ _duchy_cert_name: "duchies/\(_duchy_name)/certificates/\(_certificateId)"
 #InternalServerServiceAccount: "internal-server"
 #StorageServiceAccount:        "storage"
 #MillResourceRequirements:     #ResourceRequirements & {
-	requests: cpu: "200m"
-	limits: {
-		cpu:    "800m"
-		memory: "4Gi"
-	}
+	limits: memory: "4Gi"
 }
 #SpannerComputationsResourceRequirements: #ResourceRequirements & {
-	requests: cpu: "50m"
-	limits: {
-		cpu:    "200m"
-		memory: "384Mi"
-	}
+	limits: memory: "384Mi"
 }
 #MillReplicas: 1
 

--- a/src/main/k8s/dev/kingdom_gke.cue
+++ b/src/main/k8s/dev/kingdom_gke.cue
@@ -20,11 +20,7 @@ _secret_name: string @tag("secret_name")
 #InternalServerServiceAccount: "internal-server"
 
 #DataServerResourceRequirements: #ResourceRequirements & {
-	requests: cpu: "50m"
-	limits: {
-		cpu:    "200m"
-		memory: "384Mi"
-	}
+	limits: memory: "512Mi"
 }
 
 objectSets: [
@@ -64,6 +60,7 @@ kingdom: #Kingdom & {
 	deployments: {
 		"gcp-kingdom-data-server": {
 			_container: {
+				_javaOptions: maxRamPercentage: 40.0
 				resources: #DataServerResourceRequirements
 			}
 			spec: template: spec: #ServiceAccountPodSpec & {

--- a/src/main/k8s/local/duchies.cue
+++ b/src/main/k8s/local/duchies.cue
@@ -22,20 +22,10 @@ _worker2_cert_name:    string @tag("worker2_cert_name")
 #KingdomSystemApiTarget:   (#Target & {name: "system-api-server"}).target
 #SpannerEmulatorHost:      (#Target & {name: "spanner-emulator"}).target
 #MillResourceRequirements: #ResourceRequirements & {
-	requests: {
-		cpu: "200m"
-	}
-	limits: {
-		cpu:    "800m"
-		memory: "4Gi"
-	}
+	limits: memory: "4Gi"
 }
 #SpannerComputationsResourceRequirements: #ResourceRequirements & {
-	requests: cpu: "50m"
-	limits: {
-		cpu:    "200m"
-		memory: "384Mi"
-	}
+	limits: memory: "384Mi"
 }
 #DuchyConfig: {
 	let duchyName = name

--- a/src/main/k8s/local/kingdom.cue
+++ b/src/main/k8s/local/kingdom.cue
@@ -17,11 +17,7 @@ package k8s
 _secret_name: string @tag("secret_name")
 
 #DataServerResourceRequirements: #ResourceRequirements & {
-	requests: cpu: "50m"
-	limits: {
-		cpu:    "200m"
-		memory: "384Mi"
-	}
+	limits: memory: "512Mi"
 }
 
 objectSets: [ for objectSet in kingdom {objectSet}]
@@ -41,7 +37,10 @@ kingdom: #Kingdom & {
 
 	deployments: {
 		"gcp-kingdom-data-server": {
-			_container: resources: #DataServerResourceRequirements
+			_container: {
+				_javaOptions: maxRamPercentage: 40.0
+				resources: #DataServerResourceRequirements
+			}
 		}
 	}
 }

--- a/src/main/k8s/testing/secretfiles/resource_requirements.yaml
+++ b/src/main/k8s/testing/secretfiles/resource_requirements.yaml
@@ -19,8 +19,5 @@ metadata:
 spec:
   limits:
   - type: Container
-    defaultRequest:
-      cpu: 20m
     default:
-      cpu: 100m
       memory: 256Mi


### PR DESCRIPTION
It appears that these limits were too low (e.g. resulting in Spanner transactions taking tens of seconds). This allows containers to utilize unclaimed CPU. The amount of CPU available to utilize will depend on the node pool configuration.

We may wish to specify CPU requests to ensure that containers don't get starved for resources.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/world-federation-of-advertisers/cross-media-measurement/687)
<!-- Reviewable:end -->
