### PR TITLE
Fix inefficient Spanner query joins.

### DIFF
--- a/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/readers/ComputationParticipantReader.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/readers/ComputationParticipantReader.kt
@@ -68,7 +68,10 @@ private val BASE_SQL =
       FROM
         DuchyMeasurementLogEntries
         JOIN MeasurementLogEntries USING (MeasurementConsumerId, MeasurementId, CreateTime)
-      WHERE DuchyMeasurementLogEntries.DuchyId = ComputationParticipants.DuchyId
+      WHERE
+        DuchyMeasurementLogEntries.DuchyId = ComputationParticipants.DuchyId
+        AND DuchyMeasurementLogEntries.MeasurementConsumerId = ComputationParticipants.MeasurementConsumerId
+        AND DuchyMeasurementLogEntries.MeasurementId = ComputationParticipants.MeasurementId
       ORDER BY MeasurementLogEntries.CreateTime DESC
     ) AS DuchyMeasurementLogEntries
   FROM

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/readers/MeasurementReader.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/readers/MeasurementReader.kt
@@ -138,13 +138,12 @@ class MeasurementReader(private val view: Measurement.View) :
           ExternalDuchyCertificateId,
           EncryptedResult
         FROM
-          Measurements as _Measurements
-          JOIN DuchyMeasurementResults USING(MeasurementConsumerId, MeasurementId)
+          DuchyMeasurementResults
           JOIN DuchyCertificates
             ON (DuchyCertificates.CertificateId = DuchyMeasurementResults.CertificateId)
         WHERE
-          Measurements.MeasurementConsumerId = DuchyMeasurementResults.MeasurementConsumerId
-          AND Measurements.MeasurementId = DuchyMeasurementResults.MeasurementId
+          DuchyMeasurementResults.MeasurementConsumerId = Measurements.MeasurementConsumerId
+          AND DuchyMeasurementResults.MeasurementId = Measurements.MeasurementId
       ) AS DuchyResults
     FROM
       Measurements
@@ -228,10 +227,8 @@ class MeasurementReader(private val view: Measurement.View) :
           ExternalDuchyCertificateId,
           EncryptedResult
         FROM
-          Measurements as _Measurements
-          JOIN DuchyMeasurementResults USING(MeasurementConsumerId, MeasurementId)
-          JOIN DuchyCertificates
-            ON (DuchyCertificates.CertificateId = DuchyMeasurementResults.CertificateId)
+          DuchyMeasurementResults
+          JOIN DuchyCertificates USING (CertificateId)
         WHERE
           Measurements.MeasurementConsumerId = DuchyMeasurementResults.MeasurementConsumerId
           AND Measurements.MeasurementId = DuchyMeasurementResults.MeasurementId


### PR DESCRIPTION
Spanner monitoring showed that these queries were consuming significant CPU, scanning orders of magnitude more rows than necessary and having >1s average latency.

Sample avg latency reduction:
ComputationParticipant by Computation ID 5491ms -> 544ms

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/world-federation-of-advertisers/cross-media-measurement/688)
<!-- Reviewable:end -->
