### PR TITLE
Separate key pairs in EncryptionKeyPairStore by principal

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@
 
 # VIM swap files
 *.swp
+# VIM undo files
+*.un~

--- a/src/main/k8s/local/README.md
+++ b/src/main/k8s/local/README.md
@@ -262,14 +262,33 @@ entries {
 ```
 
 The ConfigMap also needs an additional file named
-`encryption_key_pair_config.textproto`:
+`encryption_key_pair_config.textproto` listing key pairs
+by `MeasurementConsumer`:
 
 ```prototext
 # proto-file: wfa/measurement/config/reporting/encryption_key_pair_config.proto
 # proto-message: EncryptionKeyPairConfig
-key_pairs {
-  key: "mc_enc_public.tink"
-  value: "mc_enc_private.tink"
+principal_key_pairs {
+  principal: "measurement_consumer1"
+  key_pairs {
+    public_key_file: "mc_enc_public.tink"
+    private_key_file: "mc_enc_private.tink"
+  }
+  key_pairs {
+    public_key_file: "edp1_enc_public.tink"
+    private_key_file: "edp1_enc_private.tink"
+  }
+}
+principal_key_pairs {
+  principal: "measurement_consumer2"
+  key_pairs {
+    public_key_file: "edp2_enc_public.tink"
+    private_key_file: "edp2_enc_private.tink"
+  }
+  key_pairs {
+    public_key_file: "edp3_enc_public.tink"
+    private_key_file: "edp3_enc_private.tink"
+  }
 }
 ```
 

--- a/src/main/kotlin/org/wfanet/measurement/reporting/service/api/v1alpha/EventGroupsService.kt
+++ b/src/main/kotlin/org/wfanet/measurement/reporting/service/api/v1alpha/EventGroupsService.kt
@@ -54,6 +54,7 @@ class EventGroupsService(
         "Cannot list event groups with entities other than measurement consumer."
       }
     }
+    val principalName = principal.resourceKey.toName()
     val apiAuthenticationKey: String = principal.config.apiKey
     val dataProviderName =
       CmmsDataProviderKey(
@@ -78,7 +79,10 @@ class EventGroupsService(
     val parsedEventGroupMetadataMap: Map<String, CmmsEventGroup.Metadata> =
       cmmsEventGroups.associate {
         val measurementConsumerPrivateKey =
-          encryptionKeyPairStore.getPrivateKeyHandle(it.measurementConsumerPublicKey.data)
+          encryptionKeyPairStore.getPrivateKeyHandle(
+            principalName,
+            it.measurementConsumerPublicKey.data
+          )
             ?: failGrpc(Status.FAILED_PRECONDITION) {
               "Public key does not have corresponding private key"
             }

--- a/src/main/proto/wfa/measurement/config/reporting/encryption_key_pair_config.proto
+++ b/src/main/proto/wfa/measurement/config/reporting/encryption_key_pair_config.proto
@@ -20,7 +20,15 @@ option java_package = "org.wfanet.measurement.config.reporting";
 option java_multiple_files = true;
 
 message EncryptionKeyPairConfig {
-  // Path to the public key as the map key. Path to the private key as the map
-  // value.
-  map<string, string> key_pairs = 1;
+  // Files for a pair of public / private key.
+  message KeyPair {
+    string public_key_file = 1;
+    string private_key_file = 2;
+  }
+  // The list of key pairs for a principal.
+  message PrincipalKeyPairs {
+    string principal = 1;
+    repeated KeyPair key_pairs = 2;
+  }
+  repeated PrincipalKeyPairs principal_key_pairs = 1;
 }

--- a/src/test/kotlin/org/wfanet/measurement/reporting/deploy/common/key_pair_map.textproto
+++ b/src/test/kotlin/org/wfanet/measurement/reporting/deploy/common/key_pair_map.textproto
@@ -1,12 +1,26 @@
-# proto-file: src/main/proto/wfa/measurement/config/reporting/encryption_key_pair_config.proto
+# proto-file:
+# src/main/proto/wfa/measurement/config/reporting/encryption_key_pair_config.proto
 # proto-message: EncryptionKeyPairConfig
 
-key_pairs {
-  key: "mc_enc_public.tink"
-  value: "mc_enc_private.tink"
+principal_key_pairs {
+  principal: "measurement_consumer1"
+  key_pairs {
+    public_key_file: "mc_enc_public.tink"
+    private_key_file: "mc_enc_private.tink"
+  }
+  key_pairs {
+    public_key_file: "edp1_enc_public.tink"
+    private_key_file: "edp1_enc_private.tink"
+  }
 }
-key_pairs {
-  key: "edp1_enc_public.tink"
-  value: "edp1_enc_private.tink"
+principal_key_pairs {
+  principal: "measurement_consumer2"
+  key_pairs {
+    public_key_file: "edp2_enc_public.tink"
+    private_key_file: "edp2_enc_private.tink"
+  }
+  key_pairs {
+    public_key_file: "edp3_enc_public.tink"
+    private_key_file: "edp3_enc_private.tink"
+  }
 }
-

--- a/src/test/kotlin/org/wfanet/measurement/reporting/service/api/v1alpha/EventGroupsServiceTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/reporting/service/api/v1alpha/EventGroupsServiceTest.kt
@@ -81,14 +81,17 @@ private val SECRET_FILES_PATH: Path =
   )
 private val ENCRYPTION_PRIVATE_KEY = loadEncryptionPrivateKey("mc_enc_private.tink")
 private val ENCRYPTION_PUBLIC_KEY = loadEncryptionPublicKey("mc_enc_public.tink")
-private val ENCRYPTION_KEY_PAIR_STORE =
-  InMemoryEncryptionKeyPairStore(
-    mapOf(ENCRYPTION_PUBLIC_KEY.toByteString() to ENCRYPTION_PRIVATE_KEY)
-  )
 private val EDP_SIGNING_KEY = loadSigningKey("edp1_cs_cert.der", "edp1_cs_private.der")
 private const val MEASUREMENT_CONSUMER_REFERENCE_ID = "measurementConsumerRefId"
 private val MEASUREMENT_CONSUMER_NAME =
   MeasurementConsumerKey(MEASUREMENT_CONSUMER_REFERENCE_ID).toName()
+private val ENCRYPTION_KEY_PAIR_STORE =
+  InMemoryEncryptionKeyPairStore(
+    mapOf(
+      MEASUREMENT_CONSUMER_NAME to
+        listOf(ENCRYPTION_PUBLIC_KEY.toByteString() to ENCRYPTION_PRIVATE_KEY)
+    )
+  )
 private val TEST_MESSAGE = testMetadataMessage {
   name = name { value = "Bob" }
   age = age { value = 15 }

--- a/src/test/kotlin/org/wfanet/measurement/reporting/service/api/v1alpha/ReportsServiceTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/reporting/service/api/v1alpha/ReportsServiceTest.kt
@@ -303,18 +303,21 @@ private val MEASUREMENT_CONSUMER_PRIVATE_KEY_DATA = SECRETS_DIR.resolve("mc_enc_
 private val MEASUREMENT_CONSUMER_PRIVATE_KEY_HANDLE: PrivateKeyHandle =
   loadPrivateKey(MEASUREMENT_CONSUMER_PRIVATE_KEY_DATA)
 
-// InMemoryEncryptionKeyPairStore
-private val ENCRYPTION_KEY_PAIR_STORE =
-  InMemoryEncryptionKeyPairStore(
-    mapOf(MEASUREMENT_PUBLIC_KEY_DATA to MEASUREMENT_CONSUMER_PRIVATE_KEY_HANDLE)
-  )
-
 // Measurement consumer IDs and names
 private val MEASUREMENT_CONSUMER_EXTERNAL_IDS = listOf(111L, 112L)
 private val MEASUREMENT_CONSUMER_REFERENCE_IDS =
   MEASUREMENT_CONSUMER_EXTERNAL_IDS.map { externalIdToApiId(it) }
 private val MEASUREMENT_CONSUMER_NAMES =
   MEASUREMENT_CONSUMER_REFERENCE_IDS.map { MeasurementConsumerKey(it).toName() }
+
+// InMemoryEncryptionKeyPairStore
+private val ENCRYPTION_KEY_PAIR_STORE =
+  InMemoryEncryptionKeyPairStore(
+    mapOf(
+      MEASUREMENT_CONSUMER_NAMES[0] to
+        listOf(MEASUREMENT_PUBLIC_KEY_DATA to MEASUREMENT_CONSUMER_PRIVATE_KEY_HANDLE)
+    )
+  )
 
 // Measurement consumer certificate IDs
 private const val MEASUREMENT_CONSUMER_CERTIFICATE_EXTERNAL_ID = 121L


### PR DESCRIPTION
Enable multi tenancy for the reporting server by making `EncryptionKeyPairStore` handles private key pairs by principal.
* Consumers of the key pair store now pass the principal along with the public key in order to retrieve the private key
* Configuration using textproto for `EncryptionKeyPairConfig` message is updated to define key pairs by principal 
* Doesn't change the current way of obtaining the key pairs by by loading from each key file path

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/world-federation-of-advertisers/cross-media-measurement/700)
<!-- Reviewable:end -->
