### PR TITLE
Catch more RPC exceptions.

### DIFF
--- a/src/main/kotlin/org/wfanet/measurement/duchy/daemon/herald/Herald.kt
+++ b/src/main/kotlin/org/wfanet/measurement/duchy/daemon/herald/Herald.kt
@@ -283,7 +283,7 @@ class Herald(
             systemComputation,
             protocolsSetupConfig.liquidLegionsV2.externalAggregatorDuchyId
           )
-        else -> error { "Unknown or unsupported protocol." }
+        else -> error("Unknown or unsupported protocol.")
       }
       logger.info("[id=$globalId]: Confirmed Computation")
     }
@@ -298,7 +298,7 @@ class Herald(
       when (token.computationDetails.protocolCase) {
         ComputationDetails.ProtocolCase.LIQUID_LEGIONS_V2 ->
           LiquidLegionsV2Starter.startComputation(token, internalComputationsClient)
-        else -> error { "Unknown or unsupported protocol." }
+        else -> error("Unknown or unsupported protocol.")
       }
       logger.info("[id=$globalId]: Started Computation")
     }

--- a/src/main/kotlin/org/wfanet/measurement/duchy/daemon/mill/MillBase.kt
+++ b/src/main/kotlin/org/wfanet/measurement/duchy/daemon/mill/MillBase.kt
@@ -136,7 +136,7 @@ abstract class MillBase(
           logger.info("ComputationServer not ready")
           return
         }
-        throw ex
+        throw Exception("Error claiming work", ex)
       }
     computationsServerReady = true
 

--- a/src/main/kotlin/org/wfanet/measurement/duchy/deploy/gcloud/spanner/computation/GcpSpannerComputationsDatabaseTransactor.kt
+++ b/src/main/kotlin/org/wfanet/measurement/duchy/deploy/gcloud/spanner/computation/GcpSpannerComputationsDatabaseTransactor.kt
@@ -687,14 +687,14 @@ class GcpSpannerComputationsDatabaseTransactor<
         readWriteTransactionBlock(ctx)
       } else {
         val tokenTime = Instant.ofEpochMilli(tokenTimeMillis)
-        error {
+        error(
           """
           Failed to update because of editVersion mismatch.
             Token's editVersion: $tokenTimeMillis ($tokenTime)
             Computations table's UpdateTime: $updateTimeMillis ($updateTime)
             Difference: ${Duration.between(tokenTime, updateTime)}
           """.trimIndent()
-        }
+        )
       }
     }
   }

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/common/server/SystemApiServer.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/common/server/SystemApiServer.kt
@@ -30,7 +30,7 @@ import picocli.CommandLine
 private const val SERVER_NAME = "SystemApiServer"
 
 @CommandLine.Command(
-  name = "SystemApiServer",
+  name = SERVER_NAME,
   description = ["Server daemon for Kingdom system API services."],
   mixinStandardHelpOptions = true,
   showDefaultValues = true

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/service/system/v1alpha/ComputationsService.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/service/system/v1alpha/ComputationsService.kt
@@ -69,7 +69,17 @@ class ComputationsService(
       GetMeasurementByComputationIdRequest.newBuilder()
         .apply { externalComputationId = apiIdToExternalId(computationKey.computationId) }
         .build()
-    return measurementsClient.getMeasurementByComputationId(internalRequest).toSystemComputation()
+    try {
+      return measurementsClient.getMeasurementByComputationId(internalRequest).toSystemComputation()
+    } catch (e: StatusException) {
+      throw when (e.status.code) {
+          Status.Code.DEADLINE_EXCEEDED -> Status.DEADLINE_EXCEEDED
+          Status.Code.CANCELLED -> Status.CANCELLED
+          else -> Status.UNKNOWN
+        }
+        .withCause(e)
+        .asRuntimeException()
+    }
   }
 
   override fun streamActiveComputations(
@@ -139,7 +149,17 @@ class ComputationsService(
       externalAggregatorCertificateId = apiIdToExternalId(aggregatorCertificateKey.certificateId)
       encryptedResult = request.encryptedResult
     }
-    return measurementsClient.setMeasurementResult(internalRequest).toSystemComputation()
+    try {
+      return measurementsClient.setMeasurementResult(internalRequest).toSystemComputation()
+    } catch (e: StatusException) {
+      throw when (e.status.code) {
+          Status.Code.DEADLINE_EXCEEDED -> Status.DEADLINE_EXCEEDED
+          Status.Code.CANCELLED -> Status.CANCELLED
+          else -> Status.UNKNOWN
+        }
+        .withCause(e)
+        .asRuntimeException()
+    }
   }
 
   private fun streamMeasurements(
@@ -154,7 +174,17 @@ class ComputationsService(
       }
       measurementView = Measurement.View.COMPUTATION
     }
-    return measurementsClient.streamMeasurements(request)
+    try {
+      return measurementsClient.streamMeasurements(request)
+    } catch (e: StatusException) {
+      throw when (e.status.code) {
+          Status.Code.DEADLINE_EXCEEDED -> Status.DEADLINE_EXCEEDED
+          Status.Code.CANCELLED -> Status.CANCELLED
+          else -> Status.UNKNOWN
+        }
+        .withCause(e)
+        .asRuntimeException()
+    }
   }
 
   companion object {


### PR DESCRIPTION
StatusException should be caught at the lowest level, i.e. the call site of the RPC. This is because how a given error should be handled depends on which method was being called. If it needs to be handled at a higher level, it should be wrapped in another exception type to make that explicit to calling code.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/world-federation-of-advertisers/cross-media-measurement/714)
<!-- Reviewable:end -->
