### PR TITLE
Avoid inconsistent results in the unit test.

### DIFF
--- a/src/main/kotlin/org/wfanet/measurement/reporting/service/api/v1alpha/ReportsService.kt
+++ b/src/main/kotlin/org/wfanet/measurement/reporting/service/api/v1alpha/ReportsService.kt
@@ -1271,7 +1271,7 @@ class ReportsService(
             throw Exception("Unable to retrieve the data provider [$dataProviderName].", e)
           }
 
-        key = dataProviderName
+        key = dataProvider.name
         value = dataProviderEntryValue {
           dataProviderCertificate = dataProvider.certificate
           dataProviderPublicKey = dataProvider.publicKey


### PR DESCRIPTION
Due to the randomness from Kotlin Coroutine, the names of the dataProviders in the input list could be different from the output of the mock dataProvidersStub, which sometime causes a test failure. To avoid that, we use `dataProvider.name` instead.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/world-federation-of-advertisers/cross-media-measurement/715)
<!-- Reviewable:end -->
