### PR TITLE
Increase timeout for GCloudInProcessLifeOfAMeasurementIntegrationTest.

### DIFF
--- a/src/test/kotlin/org/wfanet/measurement/integration/gcloud/BUILD.bazel
+++ b/src/test/kotlin/org/wfanet/measurement/integration/gcloud/BUILD.bazel
@@ -26,6 +26,7 @@ spanner_emulator_test(
     name = "GCloudInProcessLifeOfAMeasurementIntegrationTest",
     size = "large",
     srcs = ["GCloudInProcessLifeOfAMeasurementIntegrationTest.kt"],
+    tags = ["cpu:2"],
     test_class = "org.wfanet.measurement.integration.gcloud.GCloudInProcessLifeOfAMeasurementIntegrationTest",
     deps = [
         ":gcloud",

--- a/src/test/kotlin/org/wfanet/measurement/integration/gcloud/GCloudInProcessLifeOfAMeasurementIntegrationTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/integration/gcloud/GCloudInProcessLifeOfAMeasurementIntegrationTest.kt
@@ -29,7 +29,7 @@ import org.wfanet.measurement.storage.StorageClient
 class GCloudInProcessLifeOfAMeasurementIntegrationTest :
   InProcessLifeOfAMeasurementIntegrationTest() {
 
-  @get:Rule val timeout = CoroutinesTimeout.seconds(60)
+  @get:Rule val timeout = CoroutinesTimeout.seconds(90)
 
   override val kingdomDataServicesRule by lazy { KingdomDataServicesProviderRule() }
   override val duchyDependenciesRule by lazy { DuchyDependencyProviderRule(ALL_DUCHY_NAMES) }


### PR DESCRIPTION
This avoids false failures in low-CPU environments such as GitHub Actions.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/world-federation-of-advertisers/cross-media-measurement/720)
<!-- Reviewable:end -->
