### PR TITLE
Allow dev Mill and Herald to run on GKE Spot VMs.

### DIFF
--- a/docs/gke/duchy-deployment.md
+++ b/docs/gke/duchy-deployment.md
@@ -149,14 +149,15 @@ gcloud container clusters create worker1-duchy \
   --enable-network-policy --workload-pool=halo-worker1-demo.svc.id.goog \
   --service-account="gke-cluster@halo-worker1-demo.iam.gserviceaccount.com" \
   --database-encryption-key=projects/halo-worker1-demo/locations/us-central1/keyRings/test-key-ring/cryptoKeys/k8s-secret \
-  --num-nodes=3 --enable-autoscaling --min-nodes=2 --max-nodes=5 \
+  --num-nodes=2 --enable-autoscaling --min-nodes=2 --max-nodes=4 \
   --machine-type=e2-standard-2 -cluster-version=1.24.2-gke.1900
 ```
 
-Adjust the node pool based on your expected usage. Due to the differences in CPU
-vs. memory requirements for each pod, it may be more efficient to have multiple
-node pools with different machine types and/or to use GKE's auto-scaling and
-provisioning features.
+Adjust the node pools based on your expected usage. You may wish to use GKE
+features such as autoscaling or multiple node pools with different
+machine/scheduling types. The default Mill and Herald configuration include a
+toleration for running on
+[Spot VMs](https://cloud.google.com/kubernetes-engine/docs/how-to/spot-vms#use_taints_and_tolerations_for).
 
 The GKE version should be no older than `1.24.0` in order to support built-in
 gRPC health probe.

--- a/docs/gke/kingdom-deployment.md
+++ b/docs/gke/kingdom-deployment.md
@@ -163,10 +163,10 @@ the Kingdom, running under the `gke-cluster` service account in the
 ```shell
 gcloud container clusters create halo-cmm-kingdom-demo-cluster \
   --enable-network-policy --workload-pool=halo-kingdom-demo.svc.id.goog \
-  --service-account="gke-cluster@halo-kingdom-demo.iam.gserviceaccount.com" \
+  --service-account='gke-cluster@halo-kingdom-demo.iam.gserviceaccount.com' \
   --database-encryption-key=projects/halo-cmm-dev/locations/us-central1/keyRings/test-key-ring/cryptoKeys/k8s-secret \
-  --num-nodes=2 --enable-autoscaling --min-nodes=1 --max-nodes=5 \
-  --machine-type=e2-highcpu-2 --cluster-version=1.24.2-gke.1900
+  --num-nodes=3 --enable-autoscaling --min-nodes=3 --max-nodes=6 \
+  --machine-type=e2-highcpu-2 --cluster-version='1.24.2-gke.1900'
 ```
 
 Adjust the number of nodes and machine type according to your expected usage.

--- a/src/main/k8s/base.cue
+++ b/src/main/k8s/base.cue
@@ -272,6 +272,15 @@ objects: [ for objectSet in objectSets for object in objectSet {object}]
 	}
 }
 
+// K8s Toleration.
+#Toleration: {
+	key:                string
+	operator?:          "Equal" | "Exists"
+	value?:             string
+	effect?:            "NoSchedule" | "PreferNoSchedule" | "NoExecute"
+	tolerationSeconds?: int64
+}
+
 // K8s PodSpec.
 #PodSpec: {
 	_mounts: [Name=string]:     #Mount & {name:  Name}
@@ -282,6 +291,9 @@ objects: [ for objectSet in objectSets for object in objectSet {object}]
 	}
 	_initContainers: [Name=string]: #Container & {
 		name: Name
+	}
+	_tolerations: [Key=string]: #Toleration & {
+		key: Key
 	}
 	_dependencies: [...string]
 
@@ -303,6 +315,7 @@ objects: [ for objectSet in objectSets for object in objectSet {object}]
 	serviceAccountName?: string
 	nodeSelector?: [_=string]: string
 	initContainers: [ for _, initContainer in _initContainers {initContainer}]
+	tolerations: [ for _, toleration in _tolerations {toleration}]
 }
 
 // K8s Pod.

--- a/src/main/k8s/dev/base_gke.cue
+++ b/src/main/k8s/dev/base_gke.cue
@@ -47,3 +47,13 @@ package k8s
 		"iam.gke.io/gke-metadata-server-enabled": "true"
 	}
 }
+
+#SpotVmPodSpec: {
+	#PodSpec
+
+	_tolerations: "cloud.google.com/gke-spot": {
+		operator: "Equal"
+		value:    "true"
+		effect:   "NoSchedule"
+	}
+}

--- a/src/main/k8s/dev/duchy_gke.cue
+++ b/src/main/k8s/dev/duchy_gke.cue
@@ -26,7 +26,8 @@ _duchy_cert_name: "duchies/\(_duchy_name)/certificates/\(_certificateId)"
 #InternalServerServiceAccount: "internal-server"
 #StorageServiceAccount:        "storage"
 #MillResourceRequirements:     #ResourceRequirements & {
-	limits: memory: "4Gi"
+	requests: cpu:  "800m"
+	limits: memory: "2Gi"
 }
 #SpannerComputationsResourceRequirements: #ResourceRequirements & {
 	limits: memory: "384Mi"
@@ -90,6 +91,9 @@ duchy: #Duchy & {
 				serviceAccountName: #InternalServerServiceAccount
 			}
 		}
+		"herald-daemon-deployment": {
+			spec: template: spec: #SpotVmPodSpec
+		}
 		"liquid-legions-v2-mill-daemon-deployment": {
 			_container: {
 				_javaOptions: maxRamPercentage: 50.0
@@ -97,7 +101,7 @@ duchy: #Duchy & {
 			}
 			spec: {
 				replicas: #MillReplicas
-				template: spec: #ServiceAccountPodSpec & {
+				template: spec: #ServiceAccountPodSpec & #SpotVmPodSpec & {
 					serviceAccountName: #StorageServiceAccount
 				}
 			}

--- a/src/main/k8s/local/edp_simulators.cue
+++ b/src/main/k8s/local/edp_simulators.cue
@@ -56,6 +56,13 @@ edpSimulators: {
 			]
 			_edp_simulator_image:         "bazel/src/main/kotlin/org/wfanet/measurement/loadtest/dataprovider:forwarded_storage_edp_simulator_runner_image"
 			_simulator_image_pull_policy: "Never"
+
+			deployment: spec: template: spec: {
+				_dependencies: [
+					"v2alpha-public-api-server",
+					"worker1-requisition-fulfillment-server",
+				]
+			}
 		}
 	}
 }


### PR DESCRIPTION
This configures those Deployments to tolerate node pools with a `NoSchedule` taint for `cloud.google.com/gke-spot`.

See http://cloud/kubernetes-engine/docs/how-to/spot-vms#use_taints_and_tolerations_for

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/world-federation-of-advertisers/cross-media-measurement/725)
<!-- Reviewable:end -->
