### PR TITLE
Kingdom supports repeated protocols in public protocol_config

### DIFF
--- a/build/repositories.bzl
+++ b/build/repositories.bzl
@@ -39,7 +39,7 @@ def wfa_measurement_system_repositories():
     wfa_repo_archive(
         name = "wfa_measurement_proto",
         repo = "cross-media-measurement-api",
-        commit = "9064af16be7521eac562139145e0456351f76361",
+        commit = "595462a63840d8a77f696b960e00906ecdf10028",
         sha256 = None,
         #        sha256 = "69ee69cbfa11ba90ca172d3141a9465a4408883e1aa559d56ef740bd01d474ff",
         #        version = "0.23.0",

--- a/build/repositories.bzl
+++ b/build/repositories.bzl
@@ -35,11 +35,14 @@ def wfa_measurement_system_repositories():
         version = "0.8.0",
     )
 
+    # DO_NOT_SUBMIT(world-federation-of-advertisers/cross-media-measurement-api PR): Replace with version once released from main.
     wfa_repo_archive(
         name = "wfa_measurement_proto",
         repo = "cross-media-measurement-api",
-        sha256 = "69ee69cbfa11ba90ca172d3141a9465a4408883e1aa559d56ef740bd01d474ff",
-        version = "0.23.0",
+        commit = "9064af16be7521eac562139145e0456351f76361",
+        sha256 = None,
+        #        sha256 = "69ee69cbfa11ba90ca172d3141a9465a4408883e1aa559d56ef740bd01d474ff",
+        #        version = "0.23.0",
     )
 
     wfa_repo_archive(

--- a/build/repositories.bzl
+++ b/build/repositories.bzl
@@ -35,14 +35,12 @@ def wfa_measurement_system_repositories():
         version = "0.8.0",
     )
 
-    # DO_NOT_SUBMIT(world-federation-of-advertisers/cross-media-measurement-api PR): Replace with version once released from main.
     wfa_repo_archive(
         name = "wfa_measurement_proto",
         repo = "cross-media-measurement-api",
         commit = "595462a63840d8a77f696b960e00906ecdf10028",
-        sha256 = None,
-        #        sha256 = "69ee69cbfa11ba90ca172d3141a9465a4408883e1aa559d56ef740bd01d474ff",
-        #        version = "0.23.0",
+        sha256 = "8412e478f15119b624e6696b578ca308b55f61a240e83ea2f72444692118d1ff",
+        version = "0.24.0",
     )
 
     wfa_repo_archive(

--- a/build/repositories.bzl
+++ b/build/repositories.bzl
@@ -38,7 +38,6 @@ def wfa_measurement_system_repositories():
     wfa_repo_archive(
         name = "wfa_measurement_proto",
         repo = "cross-media-measurement-api",
-        commit = "595462a63840d8a77f696b960e00906ecdf10028",
         sha256 = "8412e478f15119b624e6696b578ca308b55f61a240e83ea2f72444692118d1ff",
         version = "0.24.0",
     )

--- a/src/main/kotlin/org/wfanet/measurement/integration/common/InProcessKingdom.kt
+++ b/src/main/kotlin/org/wfanet/measurement/integration/common/InProcessKingdom.kt
@@ -14,6 +14,17 @@
 
 package org.wfanet.measurement.integration.common
 
+import io.grpc.Channel
+import java.util.concurrent.TimeUnit
+import java.util.logging.Logger
+import org.junit.rules.TestRule
+import org.junit.runner.Description
+import org.junit.runners.model.Statement
+import org.wfanet.measurement.api.v2alpha.testing.withMetadataPrincipalIdentities
+import org.wfanet.measurement.common.grpc.testing.GrpcTestServerRule
+import org.wfanet.measurement.common.grpc.withDefaultDeadline
+import org.wfanet.measurement.common.identity.testing.withMetadataDuchyIdentities
+import org.wfanet.measurement.common.testing.chainRulesSequentially
 import org.wfanet.measurement.internal.kingdom.AccountsGrpcKt.AccountsCoroutineStub as InternalAccountsCoroutineStub
 import org.wfanet.measurement.internal.kingdom.ApiKeysGrpcKt.ApiKeysCoroutineStub as InternalApiKeysCoroutineStub
 import org.wfanet.measurement.internal.kingdom.CertificatesGrpcKt.CertificatesCoroutineStub as InternalCertificatesCoroutineStub
@@ -28,21 +39,6 @@ import org.wfanet.measurement.internal.kingdom.MeasurementLogEntriesGrpcKt.Measu
 import org.wfanet.measurement.internal.kingdom.MeasurementsGrpcKt.MeasurementsCoroutineStub as InternalMeasurementsCoroutineStub
 import org.wfanet.measurement.internal.kingdom.PublicKeysGrpcKt.PublicKeysCoroutineStub as InternalPublicKeysCoroutineStub
 import org.wfanet.measurement.internal.kingdom.RequisitionsGrpcKt.RequisitionsCoroutineStub as InternalRequisitionsCoroutineStub
-import org.wfanet.measurement.kingdom.service.system.v1alpha.ComputationLogEntriesService as systemComputationLogEntriesService
-import org.wfanet.measurement.kingdom.service.system.v1alpha.ComputationParticipantsService as systemComputationParticipantsService
-import org.wfanet.measurement.kingdom.service.system.v1alpha.ComputationsService as systemComputationsService
-import org.wfanet.measurement.kingdom.service.system.v1alpha.RequisitionsService as systemRequisitionsService
-import io.grpc.Channel
-import java.util.concurrent.TimeUnit
-import java.util.logging.Logger
-import org.junit.rules.TestRule
-import org.junit.runner.Description
-import org.junit.runners.model.Statement
-import org.wfanet.measurement.api.v2alpha.testing.withMetadataPrincipalIdentities
-import org.wfanet.measurement.common.grpc.testing.GrpcTestServerRule
-import org.wfanet.measurement.common.grpc.withDefaultDeadline
-import org.wfanet.measurement.common.identity.testing.withMetadataDuchyIdentities
-import org.wfanet.measurement.common.testing.chainRulesSequentially
 import org.wfanet.measurement.kingdom.deploy.common.service.DataServices
 import org.wfanet.measurement.kingdom.deploy.common.service.toList
 import org.wfanet.measurement.kingdom.service.api.v2alpha.AccountsService
@@ -59,6 +55,10 @@ import org.wfanet.measurement.kingdom.service.api.v2alpha.PublicKeysService
 import org.wfanet.measurement.kingdom.service.api.v2alpha.RequisitionsService
 import org.wfanet.measurement.kingdom.service.api.v2alpha.withAccountAuthenticationServerInterceptor
 import org.wfanet.measurement.kingdom.service.api.v2alpha.withApiKeyAuthenticationServerInterceptor
+import org.wfanet.measurement.kingdom.service.system.v1alpha.ComputationLogEntriesService as systemComputationLogEntriesService
+import org.wfanet.measurement.kingdom.service.system.v1alpha.ComputationParticipantsService as systemComputationParticipantsService
+import org.wfanet.measurement.kingdom.service.system.v1alpha.ComputationsService as systemComputationsService
+import org.wfanet.measurement.kingdom.service.system.v1alpha.RequisitionsService as systemRequisitionsService
 
 /** TestRule that starts and stops all Kingdom gRPC services. */
 class InProcessKingdom(
@@ -127,29 +127,29 @@ class InProcessKingdom(
       logger.info("Building Kingdom's public API services")
 
       listOf(
-        ApiKeysService(internalApiKeysClient)
+          ApiKeysService(internalApiKeysClient)
             .withAccountAuthenticationServerInterceptor(internalAccountsClient, redirectUri),
-        CertificatesService(internalCertificatesClient)
+          CertificatesService(internalCertificatesClient)
             .withMetadataPrincipalIdentities()
             .withApiKeyAuthenticationServerInterceptor(internalApiKeysClient),
-        DataProvidersService(internalDataProvidersClient)
+          DataProvidersService(internalDataProvidersClient)
             .withMetadataPrincipalIdentities()
             .withApiKeyAuthenticationServerInterceptor(internalApiKeysClient),
-        EventGroupsService(internalEventGroupsClient)
+          EventGroupsService(internalEventGroupsClient)
             .withMetadataPrincipalIdentities()
             .withApiKeyAuthenticationServerInterceptor(internalApiKeysClient),
-        MeasurementsService(internalMeasurementsClient, allowMpcProtocolsForSingleDataProvider)
+          MeasurementsService(internalMeasurementsClient, allowMpcProtocolsForSingleDataProvider)
             .withMetadataPrincipalIdentities()
             .withApiKeyAuthenticationServerInterceptor(internalApiKeysClient),
-        PublicKeysService(internalPublicKeysClient)
+          PublicKeysService(internalPublicKeysClient)
             .withMetadataPrincipalIdentities()
             .withApiKeyAuthenticationServerInterceptor(internalApiKeysClient),
-        RequisitionsService(allowMpcProtocolsForSingleDataProvider, internalRequisitionsClient)
+          RequisitionsService(allowMpcProtocolsForSingleDataProvider, internalRequisitionsClient)
             .withMetadataPrincipalIdentities()
             .withApiKeyAuthenticationServerInterceptor(internalApiKeysClient),
-        AccountsService(internalAccountsClient, redirectUri)
+          AccountsService(internalAccountsClient, redirectUri)
             .withAccountAuthenticationServerInterceptor(internalAccountsClient, redirectUri),
-        MeasurementConsumersService(internalMeasurementConsumersClient)
+          MeasurementConsumersService(internalMeasurementConsumersClient)
             .withMetadataPrincipalIdentities()
             .withAccountAuthenticationServerInterceptor(internalAccountsClient, redirectUri)
             .withApiKeyAuthenticationServerInterceptor(internalApiKeysClient)

--- a/src/main/kotlin/org/wfanet/measurement/integration/common/InProcessKingdom.kt
+++ b/src/main/kotlin/org/wfanet/measurement/integration/common/InProcessKingdom.kt
@@ -14,17 +14,6 @@
 
 package org.wfanet.measurement.integration.common
 
-import io.grpc.Channel
-import java.util.concurrent.TimeUnit
-import java.util.logging.Logger
-import org.junit.rules.TestRule
-import org.junit.runner.Description
-import org.junit.runners.model.Statement
-import org.wfanet.measurement.api.v2alpha.testing.withMetadataPrincipalIdentities
-import org.wfanet.measurement.common.grpc.testing.GrpcTestServerRule
-import org.wfanet.measurement.common.grpc.withDefaultDeadline
-import org.wfanet.measurement.common.identity.testing.withMetadataDuchyIdentities
-import org.wfanet.measurement.common.testing.chainRulesSequentially
 import org.wfanet.measurement.internal.kingdom.AccountsGrpcKt.AccountsCoroutineStub as InternalAccountsCoroutineStub
 import org.wfanet.measurement.internal.kingdom.ApiKeysGrpcKt.ApiKeysCoroutineStub as InternalApiKeysCoroutineStub
 import org.wfanet.measurement.internal.kingdom.CertificatesGrpcKt.CertificatesCoroutineStub as InternalCertificatesCoroutineStub
@@ -39,6 +28,21 @@ import org.wfanet.measurement.internal.kingdom.MeasurementLogEntriesGrpcKt.Measu
 import org.wfanet.measurement.internal.kingdom.MeasurementsGrpcKt.MeasurementsCoroutineStub as InternalMeasurementsCoroutineStub
 import org.wfanet.measurement.internal.kingdom.PublicKeysGrpcKt.PublicKeysCoroutineStub as InternalPublicKeysCoroutineStub
 import org.wfanet.measurement.internal.kingdom.RequisitionsGrpcKt.RequisitionsCoroutineStub as InternalRequisitionsCoroutineStub
+import org.wfanet.measurement.kingdom.service.system.v1alpha.ComputationLogEntriesService as systemComputationLogEntriesService
+import org.wfanet.measurement.kingdom.service.system.v1alpha.ComputationParticipantsService as systemComputationParticipantsService
+import org.wfanet.measurement.kingdom.service.system.v1alpha.ComputationsService as systemComputationsService
+import org.wfanet.measurement.kingdom.service.system.v1alpha.RequisitionsService as systemRequisitionsService
+import io.grpc.Channel
+import java.util.concurrent.TimeUnit
+import java.util.logging.Logger
+import org.junit.rules.TestRule
+import org.junit.runner.Description
+import org.junit.runners.model.Statement
+import org.wfanet.measurement.api.v2alpha.testing.withMetadataPrincipalIdentities
+import org.wfanet.measurement.common.grpc.testing.GrpcTestServerRule
+import org.wfanet.measurement.common.grpc.withDefaultDeadline
+import org.wfanet.measurement.common.identity.testing.withMetadataDuchyIdentities
+import org.wfanet.measurement.common.testing.chainRulesSequentially
 import org.wfanet.measurement.kingdom.deploy.common.service.DataServices
 import org.wfanet.measurement.kingdom.deploy.common.service.toList
 import org.wfanet.measurement.kingdom.service.api.v2alpha.AccountsService
@@ -55,10 +59,6 @@ import org.wfanet.measurement.kingdom.service.api.v2alpha.PublicKeysService
 import org.wfanet.measurement.kingdom.service.api.v2alpha.RequisitionsService
 import org.wfanet.measurement.kingdom.service.api.v2alpha.withAccountAuthenticationServerInterceptor
 import org.wfanet.measurement.kingdom.service.api.v2alpha.withApiKeyAuthenticationServerInterceptor
-import org.wfanet.measurement.kingdom.service.system.v1alpha.ComputationLogEntriesService as systemComputationLogEntriesService
-import org.wfanet.measurement.kingdom.service.system.v1alpha.ComputationParticipantsService as systemComputationParticipantsService
-import org.wfanet.measurement.kingdom.service.system.v1alpha.ComputationsService as systemComputationsService
-import org.wfanet.measurement.kingdom.service.system.v1alpha.RequisitionsService as systemRequisitionsService
 
 /** TestRule that starts and stops all Kingdom gRPC services. */
 class InProcessKingdom(
@@ -66,6 +66,7 @@ class InProcessKingdom(
   val verboseGrpcLogging: Boolean = true,
   /** The open id client redirect uri when creating the authentication uri. */
   private val redirectUri: String,
+  private val allowMpcProtocolsForSingleDataProvider: Boolean,
 ) : TestRule {
   private val kingdomDataServices by lazy { dataServicesProvider() }
 
@@ -126,29 +127,29 @@ class InProcessKingdom(
       logger.info("Building Kingdom's public API services")
 
       listOf(
-          ApiKeysService(internalApiKeysClient)
+        ApiKeysService(internalApiKeysClient)
             .withAccountAuthenticationServerInterceptor(internalAccountsClient, redirectUri),
-          CertificatesService(internalCertificatesClient)
+        CertificatesService(internalCertificatesClient)
             .withMetadataPrincipalIdentities()
             .withApiKeyAuthenticationServerInterceptor(internalApiKeysClient),
-          DataProvidersService(internalDataProvidersClient)
+        DataProvidersService(internalDataProvidersClient)
             .withMetadataPrincipalIdentities()
             .withApiKeyAuthenticationServerInterceptor(internalApiKeysClient),
-          EventGroupsService(internalEventGroupsClient)
+        EventGroupsService(internalEventGroupsClient)
             .withMetadataPrincipalIdentities()
             .withApiKeyAuthenticationServerInterceptor(internalApiKeysClient),
-          MeasurementsService(internalMeasurementsClient)
+        MeasurementsService(internalMeasurementsClient, allowMpcProtocolsForSingleDataProvider)
             .withMetadataPrincipalIdentities()
             .withApiKeyAuthenticationServerInterceptor(internalApiKeysClient),
-          PublicKeysService(internalPublicKeysClient)
+        PublicKeysService(internalPublicKeysClient)
             .withMetadataPrincipalIdentities()
             .withApiKeyAuthenticationServerInterceptor(internalApiKeysClient),
-          RequisitionsService(internalRequisitionsClient)
+        RequisitionsService(allowMpcProtocolsForSingleDataProvider, internalRequisitionsClient)
             .withMetadataPrincipalIdentities()
             .withApiKeyAuthenticationServerInterceptor(internalApiKeysClient),
-          AccountsService(internalAccountsClient, redirectUri)
+        AccountsService(internalAccountsClient, redirectUri)
             .withAccountAuthenticationServerInterceptor(internalAccountsClient, redirectUri),
-          MeasurementConsumersService(internalMeasurementConsumersClient)
+        MeasurementConsumersService(internalMeasurementConsumersClient)
             .withMetadataPrincipalIdentities()
             .withAccountAuthenticationServerInterceptor(internalAccountsClient, redirectUri)
             .withApiKeyAuthenticationServerInterceptor(internalApiKeysClient)

--- a/src/main/kotlin/org/wfanet/measurement/integration/common/InProcessLifeOfAMeasurementIntegrationTest.kt
+++ b/src/main/kotlin/org/wfanet/measurement/integration/common/InProcessLifeOfAMeasurementIntegrationTest.kt
@@ -14,6 +14,14 @@
 
 package org.wfanet.measurement.integration.common
 
+import org.wfanet.measurement.api.v2alpha.AccountsGrpcKt.AccountsCoroutineStub as PublicAccountsCoroutineStub
+import org.wfanet.measurement.api.v2alpha.ApiKeysGrpcKt.ApiKeysCoroutineStub as PublicApiKeysCoroutineStub
+import org.wfanet.measurement.api.v2alpha.CertificatesGrpcKt.CertificatesCoroutineStub as PublicCertificatesCoroutineStub
+import org.wfanet.measurement.api.v2alpha.DataProvidersGrpcKt.DataProvidersCoroutineStub as PublicDataProvidersCoroutineStub
+import org.wfanet.measurement.api.v2alpha.EventGroupsGrpcKt.EventGroupsCoroutineStub as PublicEventGroupsCoroutineStub
+import org.wfanet.measurement.api.v2alpha.MeasurementConsumersGrpcKt.MeasurementConsumersCoroutineStub as PublicMeasurementConsumersCoroutineStub
+import org.wfanet.measurement.api.v2alpha.MeasurementsGrpcKt.MeasurementsCoroutineStub as PublicMeasurementsCoroutineStub
+import org.wfanet.measurement.api.v2alpha.RequisitionsGrpcKt.RequisitionsCoroutineStub as PublicRequisitionsCoroutineStub
 import java.time.Duration
 import kotlinx.coroutines.runBlocking
 import org.junit.After
@@ -22,15 +30,7 @@ import org.junit.BeforeClass
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TestRule
-import org.wfanet.measurement.api.v2alpha.AccountsGrpcKt.AccountsCoroutineStub as PublicAccountsCoroutineStub
-import org.wfanet.measurement.api.v2alpha.ApiKeysGrpcKt.ApiKeysCoroutineStub as PublicApiKeysCoroutineStub
-import org.wfanet.measurement.api.v2alpha.CertificatesGrpcKt.CertificatesCoroutineStub as PublicCertificatesCoroutineStub
-import org.wfanet.measurement.api.v2alpha.DataProvidersGrpcKt.DataProvidersCoroutineStub as PublicDataProvidersCoroutineStub
 import org.wfanet.measurement.api.v2alpha.EventGroup
-import org.wfanet.measurement.api.v2alpha.EventGroupsGrpcKt.EventGroupsCoroutineStub as PublicEventGroupsCoroutineStub
-import org.wfanet.measurement.api.v2alpha.MeasurementConsumersGrpcKt.MeasurementConsumersCoroutineStub as PublicMeasurementConsumersCoroutineStub
-import org.wfanet.measurement.api.v2alpha.MeasurementsGrpcKt.MeasurementsCoroutineStub as PublicMeasurementsCoroutineStub
-import org.wfanet.measurement.api.v2alpha.RequisitionsGrpcKt.RequisitionsCoroutineStub as PublicRequisitionsCoroutineStub
 import org.wfanet.measurement.api.v2alpha.differentialPrivacyParams
 import org.wfanet.measurement.common.identity.DuchyInfo
 import org.wfanet.measurement.common.testing.ProviderRule
@@ -52,6 +52,7 @@ private val OUTPUT_DP_PARAMS = differentialPrivacyParams {
 }
 private const val REDIRECT_URI = "https://localhost:2048"
 private val RESULT_POLLING_DELAY = Duration.ofSeconds(10)
+private const val ALLOW_MPC_PROTOCOLS_FOR_SINGLE_DATA_PROVIDER = true
 
 /**
  * Test that everything is wired up properly.
@@ -74,7 +75,8 @@ abstract class InProcessLifeOfAMeasurementIntegrationTest {
     InProcessKingdom(
       dataServicesProvider = { kingdomDataServices },
       verboseGrpcLogging = false,
-      REDIRECT_URI
+      REDIRECT_URI,
+      ALLOW_MPC_PROTOCOLS_FOR_SINGLE_DATA_PROVIDER
     )
 
   private val duchies: List<InProcessDuchy> by lazy {

--- a/src/main/kotlin/org/wfanet/measurement/integration/common/InProcessLifeOfAMeasurementIntegrationTest.kt
+++ b/src/main/kotlin/org/wfanet/measurement/integration/common/InProcessLifeOfAMeasurementIntegrationTest.kt
@@ -14,14 +14,6 @@
 
 package org.wfanet.measurement.integration.common
 
-import org.wfanet.measurement.api.v2alpha.AccountsGrpcKt.AccountsCoroutineStub as PublicAccountsCoroutineStub
-import org.wfanet.measurement.api.v2alpha.ApiKeysGrpcKt.ApiKeysCoroutineStub as PublicApiKeysCoroutineStub
-import org.wfanet.measurement.api.v2alpha.CertificatesGrpcKt.CertificatesCoroutineStub as PublicCertificatesCoroutineStub
-import org.wfanet.measurement.api.v2alpha.DataProvidersGrpcKt.DataProvidersCoroutineStub as PublicDataProvidersCoroutineStub
-import org.wfanet.measurement.api.v2alpha.EventGroupsGrpcKt.EventGroupsCoroutineStub as PublicEventGroupsCoroutineStub
-import org.wfanet.measurement.api.v2alpha.MeasurementConsumersGrpcKt.MeasurementConsumersCoroutineStub as PublicMeasurementConsumersCoroutineStub
-import org.wfanet.measurement.api.v2alpha.MeasurementsGrpcKt.MeasurementsCoroutineStub as PublicMeasurementsCoroutineStub
-import org.wfanet.measurement.api.v2alpha.RequisitionsGrpcKt.RequisitionsCoroutineStub as PublicRequisitionsCoroutineStub
 import java.time.Duration
 import kotlinx.coroutines.runBlocking
 import org.junit.After
@@ -30,7 +22,15 @@ import org.junit.BeforeClass
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TestRule
+import org.wfanet.measurement.api.v2alpha.AccountsGrpcKt.AccountsCoroutineStub as PublicAccountsCoroutineStub
+import org.wfanet.measurement.api.v2alpha.ApiKeysGrpcKt.ApiKeysCoroutineStub as PublicApiKeysCoroutineStub
+import org.wfanet.measurement.api.v2alpha.CertificatesGrpcKt.CertificatesCoroutineStub as PublicCertificatesCoroutineStub
+import org.wfanet.measurement.api.v2alpha.DataProvidersGrpcKt.DataProvidersCoroutineStub as PublicDataProvidersCoroutineStub
 import org.wfanet.measurement.api.v2alpha.EventGroup
+import org.wfanet.measurement.api.v2alpha.EventGroupsGrpcKt.EventGroupsCoroutineStub as PublicEventGroupsCoroutineStub
+import org.wfanet.measurement.api.v2alpha.MeasurementConsumersGrpcKt.MeasurementConsumersCoroutineStub as PublicMeasurementConsumersCoroutineStub
+import org.wfanet.measurement.api.v2alpha.MeasurementsGrpcKt.MeasurementsCoroutineStub as PublicMeasurementsCoroutineStub
+import org.wfanet.measurement.api.v2alpha.RequisitionsGrpcKt.RequisitionsCoroutineStub as PublicRequisitionsCoroutineStub
 import org.wfanet.measurement.api.v2alpha.differentialPrivacyParams
 import org.wfanet.measurement.common.identity.DuchyInfo
 import org.wfanet.measurement.common.testing.ProviderRule

--- a/src/main/kotlin/org/wfanet/measurement/integration/deploy/gcloud/InProcessKingdom.kt
+++ b/src/main/kotlin/org/wfanet/measurement/integration/deploy/gcloud/InProcessKingdom.kt
@@ -22,6 +22,7 @@ import org.wfanet.measurement.kingdom.deploy.gcloud.spanner.SpannerDataServices
 import org.wfanet.measurement.kingdom.deploy.gcloud.spanner.testing.Schemata
 
 private const val REDIRECT_URI = "https://localhost:2048"
+private const val ALLOW_MPC_PROTOCOLS_FOR_SINGLE_DATA_PROVIDER = true
 
 fun buildKingdomSpannerEmulatorDatabaseRule(): SpannerEmulatorDatabaseRule {
   return SpannerEmulatorDatabaseRule(Schemata.KINGDOM_CHANGELOG_PATH)
@@ -37,6 +38,7 @@ fun buildSpannerInProcessKingdom(
       SpannerDataServices(clock, RandomIdGenerator(clock), databaseRule.databaseClient)
     },
     verboseGrpcLogging = verboseGrpcLogging,
-    REDIRECT_URI
+    REDIRECT_URI,
+    ALLOW_MPC_PROTOCOLS_FOR_SINGLE_DATA_PROVIDER
   )
 }

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/common/server/V2alphaPublicApiServer.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/common/server/V2alphaPublicApiServer.kt
@@ -14,6 +14,17 @@
 
 package org.wfanet.measurement.kingdom.deploy.common.server
 
+import io.grpc.ServerServiceDefinition
+import java.io.File
+import kotlin.properties.Delegates
+import org.wfanet.measurement.api.v2alpha.AkidPrincipalLookup
+import org.wfanet.measurement.api.v2alpha.withPrincipalsFromX509AuthorityKeyIdentifiers
+import org.wfanet.measurement.common.commandLineMain
+import org.wfanet.measurement.common.crypto.SigningCerts
+import org.wfanet.measurement.common.grpc.CommonServer
+import org.wfanet.measurement.common.grpc.buildMutualTlsChannel
+import org.wfanet.measurement.common.grpc.withDefaultDeadline
+import org.wfanet.measurement.common.grpc.withVerboseLogging
 import org.wfanet.measurement.internal.kingdom.AccountsGrpcKt.AccountsCoroutineStub as InternalAccountsCoroutineStub
 import org.wfanet.measurement.internal.kingdom.ApiKeysGrpcKt.ApiKeysCoroutineStub as InternalApiKeysCoroutineStub
 import org.wfanet.measurement.internal.kingdom.CertificatesGrpcKt.CertificatesCoroutineStub as InternalCertificatesCoroutineStub
@@ -26,17 +37,6 @@ import org.wfanet.measurement.internal.kingdom.MeasurementConsumersGrpcKt.Measur
 import org.wfanet.measurement.internal.kingdom.MeasurementsGrpcKt.MeasurementsCoroutineStub as InternalMeasurementsCoroutineStub
 import org.wfanet.measurement.internal.kingdom.PublicKeysGrpcKt.PublicKeysCoroutineStub as InternalPublicKeysCoroutineStub
 import org.wfanet.measurement.internal.kingdom.RequisitionsGrpcKt.RequisitionsCoroutineStub as InternalRequisitionsCoroutineStub
-import io.grpc.ServerServiceDefinition
-import java.io.File
-import kotlin.properties.Delegates
-import org.wfanet.measurement.api.v2alpha.AkidPrincipalLookup
-import org.wfanet.measurement.api.v2alpha.withPrincipalsFromX509AuthorityKeyIdentifiers
-import org.wfanet.measurement.common.commandLineMain
-import org.wfanet.measurement.common.crypto.SigningCerts
-import org.wfanet.measurement.common.grpc.CommonServer
-import org.wfanet.measurement.common.grpc.buildMutualTlsChannel
-import org.wfanet.measurement.common.grpc.withDefaultDeadline
-import org.wfanet.measurement.common.grpc.withVerboseLogging
 import org.wfanet.measurement.kingdom.deploy.common.Llv2ProtocolConfig
 import org.wfanet.measurement.kingdom.deploy.common.Llv2ProtocolConfigFlags
 import org.wfanet.measurement.kingdom.service.api.v2alpha.AccountsService
@@ -116,20 +116,20 @@ private fun run(
         .withApiKeyAuthenticationServerInterceptor(internalApiKeysCoroutineStub),
       EventGroupMetadataDescriptorsService(
           InternalEventGroupMetadataDescriptorsCoroutineStub(channel)
-      )
+        )
         .withPrincipalsFromX509AuthorityKeyIdentifiers(principalLookup)
         .withApiKeyAuthenticationServerInterceptor(internalApiKeysCoroutineStub),
       ExchangeStepAttemptsService(
-        InternalExchangeStepAttemptsCoroutineStub(channel),
-        internalExchangeStepsCoroutineStub
-      )
+          InternalExchangeStepAttemptsCoroutineStub(channel),
+          internalExchangeStepsCoroutineStub
+        )
         .withPrincipalsFromX509AuthorityKeyIdentifiers(principalLookup),
       ExchangeStepsService(internalExchangeStepsCoroutineStub)
         .withPrincipalsFromX509AuthorityKeyIdentifiers(principalLookup),
       MeasurementsService(
-        InternalMeasurementsCoroutineStub(channel),
-        v2alphaFlags.allowMpcProtocolsForSingleDataProvider
-      )
+          InternalMeasurementsCoroutineStub(channel),
+          v2alphaFlags.allowMpcProtocolsForSingleDataProvider
+        )
         .withPrincipalsFromX509AuthorityKeyIdentifiers(principalLookup)
         .withApiKeyAuthenticationServerInterceptor(internalApiKeysCoroutineStub),
       MeasurementConsumersService(InternalMeasurementConsumersCoroutineStub(channel))
@@ -143,9 +143,9 @@ private fun run(
         .withPrincipalsFromX509AuthorityKeyIdentifiers(principalLookup)
         .withApiKeyAuthenticationServerInterceptor(internalApiKeysCoroutineStub),
       RequisitionsService(
-        v2alphaFlags.allowMpcProtocolsForSingleDataProvider,
-        InternalRequisitionsCoroutineStub(channel)
-      )
+          v2alphaFlags.allowMpcProtocolsForSingleDataProvider,
+          InternalRequisitionsCoroutineStub(channel)
+        )
         .withPrincipalsFromX509AuthorityKeyIdentifiers(principalLookup)
         .withApiKeyAuthenticationServerInterceptor(internalApiKeysCoroutineStub)
     )

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/common/server/V2alphaPublicApiServer.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/common/server/V2alphaPublicApiServer.kt
@@ -14,16 +14,6 @@
 
 package org.wfanet.measurement.kingdom.deploy.common.server
 
-import io.grpc.ServerServiceDefinition
-import java.io.File
-import org.wfanet.measurement.api.v2alpha.AkidPrincipalLookup
-import org.wfanet.measurement.api.v2alpha.withPrincipalsFromX509AuthorityKeyIdentifiers
-import org.wfanet.measurement.common.commandLineMain
-import org.wfanet.measurement.common.crypto.SigningCerts
-import org.wfanet.measurement.common.grpc.CommonServer
-import org.wfanet.measurement.common.grpc.buildMutualTlsChannel
-import org.wfanet.measurement.common.grpc.withDefaultDeadline
-import org.wfanet.measurement.common.grpc.withVerboseLogging
 import org.wfanet.measurement.internal.kingdom.AccountsGrpcKt.AccountsCoroutineStub as InternalAccountsCoroutineStub
 import org.wfanet.measurement.internal.kingdom.ApiKeysGrpcKt.ApiKeysCoroutineStub as InternalApiKeysCoroutineStub
 import org.wfanet.measurement.internal.kingdom.CertificatesGrpcKt.CertificatesCoroutineStub as InternalCertificatesCoroutineStub
@@ -36,6 +26,17 @@ import org.wfanet.measurement.internal.kingdom.MeasurementConsumersGrpcKt.Measur
 import org.wfanet.measurement.internal.kingdom.MeasurementsGrpcKt.MeasurementsCoroutineStub as InternalMeasurementsCoroutineStub
 import org.wfanet.measurement.internal.kingdom.PublicKeysGrpcKt.PublicKeysCoroutineStub as InternalPublicKeysCoroutineStub
 import org.wfanet.measurement.internal.kingdom.RequisitionsGrpcKt.RequisitionsCoroutineStub as InternalRequisitionsCoroutineStub
+import io.grpc.ServerServiceDefinition
+import java.io.File
+import kotlin.properties.Delegates
+import org.wfanet.measurement.api.v2alpha.AkidPrincipalLookup
+import org.wfanet.measurement.api.v2alpha.withPrincipalsFromX509AuthorityKeyIdentifiers
+import org.wfanet.measurement.common.commandLineMain
+import org.wfanet.measurement.common.crypto.SigningCerts
+import org.wfanet.measurement.common.grpc.CommonServer
+import org.wfanet.measurement.common.grpc.buildMutualTlsChannel
+import org.wfanet.measurement.common.grpc.withDefaultDeadline
+import org.wfanet.measurement.common.grpc.withVerboseLogging
 import org.wfanet.measurement.kingdom.deploy.common.Llv2ProtocolConfig
 import org.wfanet.measurement.kingdom.deploy.common.Llv2ProtocolConfigFlags
 import org.wfanet.measurement.kingdom.service.api.v2alpha.AccountsService
@@ -115,17 +116,20 @@ private fun run(
         .withApiKeyAuthenticationServerInterceptor(internalApiKeysCoroutineStub),
       EventGroupMetadataDescriptorsService(
           InternalEventGroupMetadataDescriptorsCoroutineStub(channel)
-        )
+      )
         .withPrincipalsFromX509AuthorityKeyIdentifiers(principalLookup)
         .withApiKeyAuthenticationServerInterceptor(internalApiKeysCoroutineStub),
       ExchangeStepAttemptsService(
-          InternalExchangeStepAttemptsCoroutineStub(channel),
-          internalExchangeStepsCoroutineStub
-        )
+        InternalExchangeStepAttemptsCoroutineStub(channel),
+        internalExchangeStepsCoroutineStub
+      )
         .withPrincipalsFromX509AuthorityKeyIdentifiers(principalLookup),
       ExchangeStepsService(internalExchangeStepsCoroutineStub)
         .withPrincipalsFromX509AuthorityKeyIdentifiers(principalLookup),
-      MeasurementsService(InternalMeasurementsCoroutineStub(channel))
+      MeasurementsService(
+        InternalMeasurementsCoroutineStub(channel),
+        v2alphaFlags.allowMpcProtocolsForSingleDataProvider
+      )
         .withPrincipalsFromX509AuthorityKeyIdentifiers(principalLookup)
         .withApiKeyAuthenticationServerInterceptor(internalApiKeysCoroutineStub),
       MeasurementConsumersService(InternalMeasurementConsumersCoroutineStub(channel))
@@ -138,7 +142,10 @@ private fun run(
       PublicKeysService(InternalPublicKeysCoroutineStub(channel))
         .withPrincipalsFromX509AuthorityKeyIdentifiers(principalLookup)
         .withApiKeyAuthenticationServerInterceptor(internalApiKeysCoroutineStub),
-      RequisitionsService(InternalRequisitionsCoroutineStub(channel))
+      RequisitionsService(
+        v2alphaFlags.allowMpcProtocolsForSingleDataProvider,
+        InternalRequisitionsCoroutineStub(channel)
+      )
         .withPrincipalsFromX509AuthorityKeyIdentifiers(principalLookup)
         .withApiKeyAuthenticationServerInterceptor(internalApiKeysCoroutineStub)
     )
@@ -163,5 +170,13 @@ private class V2alphaFlags {
     required = true
   )
   lateinit var redirectUri: String
+    private set
+
+  @set:CommandLine.Option(
+    names = ["--allow-mpc-protocols-for-single-data-provider"],
+    description = ["Enable mpc-based reach and frequency calculation for single-EDP measurement"],
+    defaultValue = "true"
+  )
+  var allowMpcProtocolsForSingleDataProvider by Delegates.notNull<Boolean>()
     private set
 }

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/readers/MeasurementReader.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/readers/MeasurementReader.kt
@@ -150,7 +150,8 @@ class MeasurementReader(private val view: Measurement.View) :
       Measurements
       JOIN MeasurementConsumers USING (MeasurementConsumerId)
       JOIN MeasurementConsumerCertificates USING(MeasurementConsumerId, CertificateId)
-    """.trimIndent()
+    """
+        .trimIndent()
 
     private val computationViewBaseSql =
       """
@@ -243,7 +244,8 @@ class MeasurementReader(private val view: Measurement.View) :
       Measurements
       JOIN MeasurementConsumers USING (MeasurementConsumerId)
       JOIN MeasurementConsumerCertificates USING(MeasurementConsumerId, CertificateId)
-    """.trimIndent()
+    """
+        .trimIndent()
   }
 }
 
@@ -306,10 +308,13 @@ private fun MeasurementKt.Dsl.fillDefaultView(struct: Struct) {
 
 private fun MeasurementKt.Dsl.fillComputationView(struct: Struct) {
   fillMeasurementCommon(struct)
+  val requisitionsStructs = struct.getStructList("Requisitions")
+  val dataProvidersCount = requisitionsStructs.size
 
   if (struct.isNull("ExternalComputationId")) {
-    for (requisitionStruct in struct.getStructList("Requisitions")) {
-      requisitions += RequisitionReader.buildRequisition(struct, requisitionStruct, mapOf())
+    for (requisitionStruct in requisitionsStructs) {
+      requisitions +=
+        RequisitionReader.buildRequisition(struct, requisitionStruct, mapOf(), dataProvidersCount)
     }
     return
   }
@@ -337,8 +342,13 @@ private fun MeasurementKt.Dsl.fillComputationView(struct: Struct) {
       )
   }
 
-  for (requisitionStruct in struct.getStructList("Requisitions")) {
+  for (requisitionStruct in requisitionsStructs) {
     requisitions +=
-      RequisitionReader.buildRequisition(struct, requisitionStruct, participantStructs)
+      RequisitionReader.buildRequisition(
+        struct,
+        requisitionStruct,
+        participantStructs,
+        dataProvidersCount
+      )
   }
 }

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/readers/RequisitionReader.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/readers/RequisitionReader.kt
@@ -60,15 +60,10 @@ private val BASE_SQL =
         count(ExternalDataProviderId),
       FROM
         Requisitions
-        JOIN DataProviders USING (DataProviderId)
-        JOIN DataProviderCertificates ON (
-          DataProviderCertificates.DataProviderId = Requisitions.DataProviderId
-          AND DataProviderCertificates.CertificateId = Requisitions.DataProviderCertificateId
-        )
       WHERE
         Requisitions.MeasurementConsumerId = Measurements.MeasurementConsumerId
         AND Requisitions.MeasurementId = Measurements.MeasurementId
-    ) AS DataProvidersCount,
+    ) AS MeasurementRequisitionCount,
     ARRAY(
       SELECT AS STRUCT
         ComputationParticipants.DuchyId,
@@ -181,7 +176,7 @@ class RequisitionReader : BaseSpannerReader<RequisitionReader.Result>() {
             "Duchy with internal ID $duchyId not found"
           }
         }
-      val dataProvidersCount = struct.getLong("DataProvidersCount")
+      val dataProvidersCount = struct.getLong("MeasurementRequisitionCount")
 
       return buildRequisition(struct, struct, participantStructs, dataProvidersCount.toInt())
     }

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/service/api/v2alpha/MeasurementsService.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/service/api/v2alpha/MeasurementsService.kt
@@ -65,8 +65,10 @@ private const val MAX_PAGE_SIZE = 1000
 
 private const val MISSING_RESOURCE_NAME_ERROR = "Resource name is either unspecified or invalid"
 
-class MeasurementsService(private val internalMeasurementsStub: MeasurementsCoroutineStub) :
-  MeasurementsCoroutineImplBase() {
+class MeasurementsService(
+  private val internalMeasurementsStub: MeasurementsCoroutineStub,
+  private val allowMpcProtocolsForSingleDataProvider: Boolean,
+) : MeasurementsCoroutineImplBase() {
 
   override suspend fun getMeasurement(request: GetMeasurementRequest): Measurement {
     val authenticatedMeasurementConsumerKey = getAuthenticatedMeasurementConsumerKey()
@@ -95,7 +97,7 @@ class MeasurementsService(private val internalMeasurementsStub: MeasurementsCoro
         }
       }
 
-    return internalMeasurement.toMeasurement()
+    return internalMeasurement.toMeasurement(allowMpcProtocolsForSingleDataProvider)
   }
 
   override suspend fun createMeasurement(request: CreateMeasurementRequest): Measurement {
@@ -168,7 +170,7 @@ class MeasurementsService(private val internalMeasurementsStub: MeasurementsCoro
         }
       }
 
-    return internalMeasurement.toMeasurement()
+    return internalMeasurement.toMeasurement(allowMpcProtocolsForSingleDataProvider)
   }
 
   override suspend fun listMeasurements(
@@ -198,9 +200,10 @@ class MeasurementsService(private val internalMeasurementsStub: MeasurementsCoro
 
     return listMeasurementsResponse {
       measurement +=
-        results
-          .subList(0, min(results.size, listMeasurementsPageToken.pageSize))
-          .map(InternalMeasurement::toMeasurement)
+        results.subList(0, min(results.size, listMeasurementsPageToken.pageSize))
+          .map { internalMeasurement ->
+            internalMeasurement.toMeasurement(allowMpcProtocolsForSingleDataProvider)
+          }
       if (results.size > listMeasurementsPageToken.pageSize) {
         val pageToken =
           listMeasurementsPageToken.copy {
@@ -244,7 +247,7 @@ class MeasurementsService(private val internalMeasurementsStub: MeasurementsCoro
         }
       }
 
-    return internalMeasurement.toMeasurement()
+    return internalMeasurement.toMeasurement(allowMpcProtocolsForSingleDataProvider)
   }
 }
 

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/service/api/v2alpha/MeasurementsService.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/service/api/v2alpha/MeasurementsService.kt
@@ -14,8 +14,6 @@
 
 package org.wfanet.measurement.kingdom.service.api.v2alpha
 
-import org.wfanet.measurement.internal.kingdom.Measurement as InternalMeasurement
-import org.wfanet.measurement.internal.kingdom.Measurement.View as InternalMeasurementView
 import com.google.protobuf.InvalidProtocolBufferException
 import io.grpc.Status
 import io.grpc.StatusException
@@ -51,7 +49,9 @@ import org.wfanet.measurement.common.grpc.failGrpc
 import org.wfanet.measurement.common.grpc.grpcRequire
 import org.wfanet.measurement.common.grpc.grpcRequireNotNull
 import org.wfanet.measurement.common.identity.apiIdToExternalId
+import org.wfanet.measurement.internal.kingdom.Measurement as InternalMeasurement
 import org.wfanet.measurement.internal.kingdom.Measurement.DataProviderValue
+import org.wfanet.measurement.internal.kingdom.Measurement.View as InternalMeasurementView
 import org.wfanet.measurement.internal.kingdom.MeasurementKt.dataProviderValue
 import org.wfanet.measurement.internal.kingdom.MeasurementsGrpcKt.MeasurementsCoroutineStub
 import org.wfanet.measurement.internal.kingdom.StreamMeasurementsRequest
@@ -200,10 +200,10 @@ class MeasurementsService(
 
     return listMeasurementsResponse {
       measurement +=
-        results.subList(0, min(results.size, listMeasurementsPageToken.pageSize))
-          .map { internalMeasurement ->
-            internalMeasurement.toMeasurement(allowMpcProtocolsForSingleDataProvider)
-          }
+        results.subList(0, min(results.size, listMeasurementsPageToken.pageSize)).map {
+          internalMeasurement ->
+          internalMeasurement.toMeasurement(allowMpcProtocolsForSingleDataProvider)
+        }
       if (results.size > listMeasurementsPageToken.pageSize) {
         val pageToken =
           listMeasurementsPageToken.copy {

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/service/api/v2alpha/MeasurementsService.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/service/api/v2alpha/MeasurementsService.kt
@@ -14,6 +14,8 @@
 
 package org.wfanet.measurement.kingdom.service.api.v2alpha
 
+import org.wfanet.measurement.internal.kingdom.Measurement as InternalMeasurement
+import org.wfanet.measurement.internal.kingdom.Measurement.View as InternalMeasurementView
 import com.google.protobuf.InvalidProtocolBufferException
 import io.grpc.Status
 import io.grpc.StatusException
@@ -49,9 +51,7 @@ import org.wfanet.measurement.common.grpc.failGrpc
 import org.wfanet.measurement.common.grpc.grpcRequire
 import org.wfanet.measurement.common.grpc.grpcRequireNotNull
 import org.wfanet.measurement.common.identity.apiIdToExternalId
-import org.wfanet.measurement.internal.kingdom.Measurement as InternalMeasurement
 import org.wfanet.measurement.internal.kingdom.Measurement.DataProviderValue
-import org.wfanet.measurement.internal.kingdom.Measurement.View as InternalMeasurementView
 import org.wfanet.measurement.internal.kingdom.MeasurementKt.dataProviderValue
 import org.wfanet.measurement.internal.kingdom.MeasurementsGrpcKt.MeasurementsCoroutineStub
 import org.wfanet.measurement.internal.kingdom.StreamMeasurementsRequest
@@ -106,7 +106,9 @@ class MeasurementsService(private val internalMeasurementsStub: MeasurementsCoro
     val measurementConsumerCertificateKey =
       grpcRequireNotNull(
         MeasurementConsumerCertificateKey.fromName(measurement.measurementConsumerCertificate)
-      ) { "Measurement Consumer Certificate resource name is either unspecified or invalid" }
+      ) {
+        "Measurement Consumer Certificate resource name is either unspecified or invalid"
+      }
 
     if (
       authenticatedMeasurementConsumerKey.measurementConsumerId !=
@@ -353,7 +355,9 @@ private fun ListMeasurementsRequest.toListMeasurementsPageToken(): ListMeasureme
 
       grpcRequire(
         measurementStatesList.containsAll(states) && states.containsAll(measurementStatesList)
-      ) { "Arguments must be kept the same when using a page token" }
+      ) {
+        "Arguments must be kept the same when using a page token"
+      }
 
       if (source.pageSize in 1..MAX_PAGE_SIZE) {
         pageSize = source.pageSize

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/service/api/v2alpha/RequisitionsService.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/service/api/v2alpha/RequisitionsService.kt
@@ -14,6 +14,10 @@
 
 package org.wfanet.measurement.kingdom.service.api.v2alpha
 
+import org.wfanet.measurement.internal.kingdom.Requisition as InternalRequisition
+import org.wfanet.measurement.internal.kingdom.Requisition.Refusal as InternalRefusal
+import org.wfanet.measurement.internal.kingdom.Requisition.State as InternalState
+import org.wfanet.measurement.internal.kingdom.RequisitionKt as InternalRequisitionKt
 import io.grpc.Status
 import io.grpc.StatusException
 import kotlin.math.min
@@ -60,12 +64,7 @@ import org.wfanet.measurement.common.identity.apiIdToExternalId
 import org.wfanet.measurement.common.identity.externalIdToApiId
 import org.wfanet.measurement.internal.common.Provider
 import org.wfanet.measurement.internal.kingdom.FulfillRequisitionRequestKt.directRequisitionParams
-import org.wfanet.measurement.internal.kingdom.ProtocolConfig
-import org.wfanet.measurement.internal.kingdom.Requisition as InternalRequisition
 import org.wfanet.measurement.internal.kingdom.Requisition.DuchyValue
-import org.wfanet.measurement.internal.kingdom.Requisition.Refusal as InternalRefusal
-import org.wfanet.measurement.internal.kingdom.Requisition.State as InternalState
-import org.wfanet.measurement.internal.kingdom.RequisitionKt as InternalRequisitionKt
 import org.wfanet.measurement.internal.kingdom.RequisitionsGrpcKt.RequisitionsCoroutineStub
 import org.wfanet.measurement.internal.kingdom.StreamRequisitionsRequest
 import org.wfanet.measurement.internal.kingdom.StreamRequisitionsRequestKt
@@ -307,9 +306,7 @@ private fun InternalRequisition.toRequisition(): Requisition {
       data = parentMeasurement.measurementSpec
       signature = parentMeasurement.measurementSpecSignature
     }
-    if (
-      parentMeasurement.protocolConfig.protocolCase != ProtocolConfig.ProtocolCase.PROTOCOL_NOT_SET
-    ) {
+    if (parentMeasurement.hasProtocolConfig()) {
       protocolConfig =
         try {
           parentMeasurement.protocolConfig.toProtocolConfig()
@@ -470,12 +467,16 @@ private fun ListRequisitionsRequest.toListRequisitionsPageToken(): ListRequisiti
 
       grpcRequire(
         states.containsAll(requisitionsStatesList) && requisitionsStatesList.containsAll(states)
-      ) { "Arguments must be kept the same when using a page token" }
+      ) {
+        "Arguments must be kept the same when using a page token"
+      }
 
       grpcRequire(
         measurementStates.containsAll(measurementsStatesList) &&
           measurementsStatesList.containsAll(measurementStates)
-      ) { "Arguments must be kept the same when using a page token" }
+      ) {
+        "Arguments must be kept the same when using a page token"
+      }
 
       if (source.pageSize in MIN_PAGE_SIZE..MAX_PAGE_SIZE) {
         pageSize = source.pageSize

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/service/api/v2alpha/RequisitionsService.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/service/api/v2alpha/RequisitionsService.kt
@@ -14,10 +14,6 @@
 
 package org.wfanet.measurement.kingdom.service.api.v2alpha
 
-import org.wfanet.measurement.internal.kingdom.Requisition as InternalRequisition
-import org.wfanet.measurement.internal.kingdom.Requisition.Refusal as InternalRefusal
-import org.wfanet.measurement.internal.kingdom.Requisition.State as InternalState
-import org.wfanet.measurement.internal.kingdom.RequisitionKt as InternalRequisitionKt
 import io.grpc.Status
 import io.grpc.StatusException
 import kotlin.math.min
@@ -65,7 +61,11 @@ import org.wfanet.measurement.common.identity.apiIdToExternalId
 import org.wfanet.measurement.common.identity.externalIdToApiId
 import org.wfanet.measurement.internal.common.Provider
 import org.wfanet.measurement.internal.kingdom.FulfillRequisitionRequestKt.directRequisitionParams
+import org.wfanet.measurement.internal.kingdom.Requisition as InternalRequisition
 import org.wfanet.measurement.internal.kingdom.Requisition.DuchyValue
+import org.wfanet.measurement.internal.kingdom.Requisition.Refusal as InternalRefusal
+import org.wfanet.measurement.internal.kingdom.Requisition.State as InternalState
+import org.wfanet.measurement.internal.kingdom.RequisitionKt as InternalRequisitionKt
 import org.wfanet.measurement.internal.kingdom.RequisitionsGrpcKt.RequisitionsCoroutineStub
 import org.wfanet.measurement.internal.kingdom.StreamRequisitionsRequest
 import org.wfanet.measurement.internal.kingdom.StreamRequisitionsRequestKt
@@ -160,10 +160,10 @@ class RequisitionsService(
 
     return listRequisitionsResponse {
       requisitions +=
-        results.subList(0, min(results.size, listRequisitionsPageToken.pageSize))
-          .map { internalRequisition ->
-            internalRequisition.toRequisition(allowMpcProtocolsForSingleDataProvider)
-          }
+        results.subList(0, min(results.size, listRequisitionsPageToken.pageSize)).map {
+          internalRequisition ->
+          internalRequisition.toRequisition(allowMpcProtocolsForSingleDataProvider)
+        }
 
       if (results.size > listRequisitionsPageToken.pageSize) {
         val pageToken =
@@ -291,9 +291,9 @@ private fun InternalRequisition.toRequisition(
   return requisition {
     name =
       RequisitionKey(
-        externalIdToApiId(externalDataProviderId),
-        externalIdToApiId(externalRequisitionId)
-      )
+          externalIdToApiId(externalDataProviderId),
+          externalIdToApiId(externalRequisitionId)
+        )
         .toName()
 
     measurement =
@@ -304,20 +304,21 @@ private fun InternalRequisition.toRequisition(
         .toName()
     measurementConsumerCertificate =
       MeasurementConsumerCertificateKey(
-        externalIdToApiId(externalMeasurementConsumerId),
-        externalIdToApiId(parentMeasurement.externalMeasurementConsumerCertificateId)
-      )
+          externalIdToApiId(externalMeasurementConsumerId),
+          externalIdToApiId(parentMeasurement.externalMeasurementConsumerCertificateId)
+        )
         .toName()
     measurementSpec = signedData {
       data = parentMeasurement.measurementSpec
       signature = parentMeasurement.measurementSpecSignature
     }
 
-    val parsedMeasurementSpec = MeasurementSpec.parseFrom(parentMeasurement.measurementSpec)
+    val measurementTypeCase =
+      MeasurementSpec.parseFrom(parentMeasurement.measurementSpec).measurementTypeCase
     protocolConfig =
       try {
         parentMeasurement.protocolConfig.toProtocolConfig(
-          parsedMeasurementSpec,
+          measurementTypeCase,
           parentMeasurement.dataProvidersCount,
           allowMpcProtocolsForSingleDataProvider
         )
@@ -329,9 +330,9 @@ private fun InternalRequisition.toRequisition(
 
     dataProviderCertificate =
       DataProviderCertificateKey(
-        externalIdToApiId(externalDataProviderId),
-        externalIdToApiId(this@toRequisition.dataProviderCertificate.externalCertificateId)
-      )
+          externalIdToApiId(externalDataProviderId),
+          externalIdToApiId(this@toRequisition.dataProviderCertificate.externalCertificateId)
+        )
         .toName()
     dataProviderPublicKey = signedData {
       data = details.dataProviderPublicKey

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/service/internal/testing/MeasurementsServiceTest.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/service/internal/testing/MeasurementsServiceTest.kt
@@ -713,7 +713,6 @@ abstract class MeasurementsServiceTest<T : MeasurementsCoroutineImplBase> {
               measurementSpecSignature = createdMeasurement.details.measurementSpecSignature
               protocolConfig = protocolConfig {
                 liquidLegionsV2 = ProtocolConfig.LiquidLegionsV2.getDefaultInstance()
-                measurementType = ProtocolConfig.MeasurementType.MEASUREMENT_TYPE_UNSPECIFIED
               }
               dataProvidersCount = 1
             }

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/service/internal/testing/MeasurementsServiceTest.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/service/internal/testing/MeasurementsServiceTest.kt
@@ -715,6 +715,7 @@ abstract class MeasurementsServiceTest<T : MeasurementsCoroutineImplBase> {
                 liquidLegionsV2 = ProtocolConfig.LiquidLegionsV2.getDefaultInstance()
                 measurementType = ProtocolConfig.MeasurementType.MEASUREMENT_TYPE_UNSPECIFIED
               }
+              dataProvidersCount = 1
             }
             details = details {
               dataProviderPublicKey = dataProviderValue.dataProviderPublicKey

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/service/internal/testing/RequisitionsServiceTest.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/service/internal/testing/RequisitionsServiceTest.kt
@@ -14,6 +14,13 @@
 
 package org.wfanet.measurement.kingdom.service.internal.testing
 
+import org.wfanet.measurement.internal.kingdom.AccountsGrpcKt.AccountsCoroutineImplBase as AccountsCoroutineService
+import org.wfanet.measurement.internal.kingdom.CertificatesGrpcKt.CertificatesCoroutineImplBase as CertificatesCoroutineService
+import org.wfanet.measurement.internal.kingdom.ComputationParticipantsGrpcKt.ComputationParticipantsCoroutineImplBase as ComputationParticipantsCoroutineService
+import org.wfanet.measurement.internal.kingdom.DataProvidersGrpcKt.DataProvidersCoroutineImplBase as DataProvidersCoroutineService
+import org.wfanet.measurement.internal.kingdom.MeasurementConsumersGrpcKt.MeasurementConsumersCoroutineImplBase as MeasurementConsumersCoroutineService
+import org.wfanet.measurement.internal.kingdom.MeasurementsGrpcKt.MeasurementsCoroutineImplBase as MeasurementsCoroutineService
+import org.wfanet.measurement.internal.kingdom.RequisitionsGrpcKt.RequisitionsCoroutineImplBase as RequisitionsCoroutineService
 import com.google.common.truth.Truth.assertThat
 import com.google.common.truth.extensions.proto.ProtoTruth.assertThat
 import com.google.protobuf.kotlin.toByteStringUtf8
@@ -33,23 +40,16 @@ import org.junit.runners.JUnit4
 import org.wfanet.measurement.common.identity.IdGenerator
 import org.wfanet.measurement.common.identity.RandomIdGenerator
 import org.wfanet.measurement.common.toInstant
-import org.wfanet.measurement.internal.kingdom.AccountsGrpcKt.AccountsCoroutineImplBase as AccountsCoroutineService
 import org.wfanet.measurement.internal.kingdom.Certificate
-import org.wfanet.measurement.internal.kingdom.CertificatesGrpcKt.CertificatesCoroutineImplBase as CertificatesCoroutineService
-import org.wfanet.measurement.internal.kingdom.ComputationParticipantsGrpcKt.ComputationParticipantsCoroutineImplBase as ComputationParticipantsCoroutineService
-import org.wfanet.measurement.internal.kingdom.DataProvidersGrpcKt.DataProvidersCoroutineImplBase as DataProvidersCoroutineService
 import org.wfanet.measurement.internal.kingdom.FulfillRequisitionRequestKt.computedRequisitionParams
 import org.wfanet.measurement.internal.kingdom.FulfillRequisitionRequestKt.directRequisitionParams
 import org.wfanet.measurement.internal.kingdom.Measurement
-import org.wfanet.measurement.internal.kingdom.MeasurementConsumersGrpcKt.MeasurementConsumersCoroutineImplBase as MeasurementConsumersCoroutineService
 import org.wfanet.measurement.internal.kingdom.MeasurementKt.resultInfo
-import org.wfanet.measurement.internal.kingdom.MeasurementsGrpcKt.MeasurementsCoroutineImplBase as MeasurementsCoroutineService
 import org.wfanet.measurement.internal.kingdom.ProtocolConfig
 import org.wfanet.measurement.internal.kingdom.Requisition
 import org.wfanet.measurement.internal.kingdom.RequisitionKt
 import org.wfanet.measurement.internal.kingdom.RequisitionKt.parentMeasurement
 import org.wfanet.measurement.internal.kingdom.RequisitionKt.refusal
-import org.wfanet.measurement.internal.kingdom.RequisitionsGrpcKt.RequisitionsCoroutineImplBase as RequisitionsCoroutineService
 import org.wfanet.measurement.internal.kingdom.StreamRequisitionsRequestKt.filter
 import org.wfanet.measurement.internal.kingdom.cancelMeasurementRequest
 import org.wfanet.measurement.internal.kingdom.fulfillRequisitionRequest
@@ -575,6 +575,7 @@ abstract class RequisitionsServiceTest<T : RequisitionsCoroutineService> {
         protocolConfig = protocolConfig {
           liquidLegionsV2 = ProtocolConfig.LiquidLegionsV2.getDefaultInstance()
         }
+        dataProvidersCount = 1
       }
     }
     assertThat(requisition)
@@ -649,6 +650,7 @@ abstract class RequisitionsServiceTest<T : RequisitionsCoroutineService> {
         measurementSpecSignature = measurement.details.measurementSpecSignature
         state = Measurement.State.PENDING_REQUISITION_FULFILLMENT
         protocolConfig = protocolConfig {}
+        dataProvidersCount = 1
       }
     }
     assertThat(requisition)

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/service/internal/testing/RequisitionsServiceTest.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/service/internal/testing/RequisitionsServiceTest.kt
@@ -14,13 +14,6 @@
 
 package org.wfanet.measurement.kingdom.service.internal.testing
 
-import org.wfanet.measurement.internal.kingdom.AccountsGrpcKt.AccountsCoroutineImplBase as AccountsCoroutineService
-import org.wfanet.measurement.internal.kingdom.CertificatesGrpcKt.CertificatesCoroutineImplBase as CertificatesCoroutineService
-import org.wfanet.measurement.internal.kingdom.ComputationParticipantsGrpcKt.ComputationParticipantsCoroutineImplBase as ComputationParticipantsCoroutineService
-import org.wfanet.measurement.internal.kingdom.DataProvidersGrpcKt.DataProvidersCoroutineImplBase as DataProvidersCoroutineService
-import org.wfanet.measurement.internal.kingdom.MeasurementConsumersGrpcKt.MeasurementConsumersCoroutineImplBase as MeasurementConsumersCoroutineService
-import org.wfanet.measurement.internal.kingdom.MeasurementsGrpcKt.MeasurementsCoroutineImplBase as MeasurementsCoroutineService
-import org.wfanet.measurement.internal.kingdom.RequisitionsGrpcKt.RequisitionsCoroutineImplBase as RequisitionsCoroutineService
 import com.google.common.truth.Truth.assertThat
 import com.google.common.truth.extensions.proto.ProtoTruth.assertThat
 import com.google.protobuf.kotlin.toByteStringUtf8
@@ -40,16 +33,23 @@ import org.junit.runners.JUnit4
 import org.wfanet.measurement.common.identity.IdGenerator
 import org.wfanet.measurement.common.identity.RandomIdGenerator
 import org.wfanet.measurement.common.toInstant
+import org.wfanet.measurement.internal.kingdom.AccountsGrpcKt.AccountsCoroutineImplBase as AccountsCoroutineService
 import org.wfanet.measurement.internal.kingdom.Certificate
+import org.wfanet.measurement.internal.kingdom.CertificatesGrpcKt.CertificatesCoroutineImplBase as CertificatesCoroutineService
+import org.wfanet.measurement.internal.kingdom.ComputationParticipantsGrpcKt.ComputationParticipantsCoroutineImplBase as ComputationParticipantsCoroutineService
+import org.wfanet.measurement.internal.kingdom.DataProvidersGrpcKt.DataProvidersCoroutineImplBase as DataProvidersCoroutineService
 import org.wfanet.measurement.internal.kingdom.FulfillRequisitionRequestKt.computedRequisitionParams
 import org.wfanet.measurement.internal.kingdom.FulfillRequisitionRequestKt.directRequisitionParams
 import org.wfanet.measurement.internal.kingdom.Measurement
+import org.wfanet.measurement.internal.kingdom.MeasurementConsumersGrpcKt.MeasurementConsumersCoroutineImplBase as MeasurementConsumersCoroutineService
 import org.wfanet.measurement.internal.kingdom.MeasurementKt.resultInfo
+import org.wfanet.measurement.internal.kingdom.MeasurementsGrpcKt.MeasurementsCoroutineImplBase as MeasurementsCoroutineService
 import org.wfanet.measurement.internal.kingdom.ProtocolConfig
 import org.wfanet.measurement.internal.kingdom.Requisition
 import org.wfanet.measurement.internal.kingdom.RequisitionKt
 import org.wfanet.measurement.internal.kingdom.RequisitionKt.parentMeasurement
 import org.wfanet.measurement.internal.kingdom.RequisitionKt.refusal
+import org.wfanet.measurement.internal.kingdom.RequisitionsGrpcKt.RequisitionsCoroutineImplBase as RequisitionsCoroutineService
 import org.wfanet.measurement.internal.kingdom.StreamRequisitionsRequestKt.filter
 import org.wfanet.measurement.internal.kingdom.cancelMeasurementRequest
 import org.wfanet.measurement.internal.kingdom.fulfillRequisitionRequest

--- a/src/main/kotlin/org/wfanet/measurement/loadtest/dataprovider/EdpSimulator.kt
+++ b/src/main/kotlin/org/wfanet/measurement/loadtest/dataprovider/EdpSimulator.kt
@@ -14,7 +14,6 @@
 
 package org.wfanet.measurement.loadtest.dataprovider
 
-import org.wfanet.anysketch.crypto.ElGamalPublicKey as AnySketchElGamalPublicKey
 import com.google.protobuf.ByteString
 import com.google.protobuf.duration
 import io.grpc.StatusException
@@ -34,6 +33,7 @@ import org.wfanet.anysketch.SketchConfigKt.valueSpec
 import org.wfanet.anysketch.SketchProtos
 import org.wfanet.anysketch.crypto.CombineElGamalPublicKeysRequest
 import org.wfanet.anysketch.crypto.CombineElGamalPublicKeysResponse
+import org.wfanet.anysketch.crypto.ElGamalPublicKey as AnySketchElGamalPublicKey
 import org.wfanet.anysketch.crypto.EncryptSketchRequest
 import org.wfanet.anysketch.crypto.EncryptSketchResponse
 import org.wfanet.anysketch.crypto.SketchEncrypterAdapter
@@ -206,7 +206,7 @@ class EdpSimulator(
         )
       }
 
-      if (requisition.protocolConfig.protocolsList.last().hasDirect()) {
+      if (requisition.protocolConfig.protocolsList.any { protocol -> protocol.hasDirect() }) {
         when (measurementSpec.measurementTypeCase) {
           MeasurementSpec.MeasurementTypeCase.REACH_AND_FREQUENCY -> {
             fulfillDirectReachAndFrequencyMeasurement(requisition, requisitionSpec, measurementSpec)

--- a/src/main/kotlin/org/wfanet/measurement/loadtest/dataprovider/EdpSimulator.kt
+++ b/src/main/kotlin/org/wfanet/measurement/loadtest/dataprovider/EdpSimulator.kt
@@ -206,10 +206,7 @@ class EdpSimulator(
         )
       }
 
-      if (
-        !requisition.hasProtocolConfig() ||
-          requisition.protocolConfig.protocolsList.any { protocol -> protocol.hasDirect() }
-      ) {
+      if (requisition.protocolConfig.protocolsList.any { protocol -> protocol.hasDirect() }) {
         when (measurementSpec.measurementTypeCase) {
           MeasurementSpec.MeasurementTypeCase.REACH_AND_FREQUENCY -> {
             fulfillDirectReachAndFrequencyMeasurement(requisition, requisitionSpec, measurementSpec)
@@ -352,10 +349,13 @@ class EdpSimulator(
     requisitionFingerprint: ByteString,
     requisitionSpec: RequisitionSpec
   ) {
-    val liquidLegionsV2: ProtocolConfig.LiquidLegionsV2 =
-      requisition.protocolConfig.protocolsList
-        .find { protocol -> protocol.hasLiquidLegionsV2() }!!
-        .liquidLegionsV2
+    val llv2Protocol: ProtocolConfig.Protocol =
+      requireNotNull(
+        requisition.protocolConfig.protocolsList.find { protocol -> protocol.hasLiquidLegionsV2() }
+      ) {
+        "Protocol with LiquidLegionsV2 is missing"
+      }
+    val liquidLegionsV2: ProtocolConfig.LiquidLegionsV2 = llv2Protocol.liquidLegionsV2
     val combinedPublicKey = requisition.getCombinedPublicKey(liquidLegionsV2.ellipticCurveId)
     val sketchConfig = liquidLegionsV2.sketchParams.toSketchConfig()
 

--- a/src/main/kotlin/org/wfanet/measurement/loadtest/dataprovider/EdpSimulator.kt
+++ b/src/main/kotlin/org/wfanet/measurement/loadtest/dataprovider/EdpSimulator.kt
@@ -14,6 +14,7 @@
 
 package org.wfanet.measurement.loadtest.dataprovider
 
+import org.wfanet.anysketch.crypto.ElGamalPublicKey as AnySketchElGamalPublicKey
 import com.google.protobuf.ByteString
 import com.google.protobuf.duration
 import io.grpc.StatusException
@@ -33,7 +34,6 @@ import org.wfanet.anysketch.SketchConfigKt.valueSpec
 import org.wfanet.anysketch.SketchProtos
 import org.wfanet.anysketch.crypto.CombineElGamalPublicKeysRequest
 import org.wfanet.anysketch.crypto.CombineElGamalPublicKeysResponse
-import org.wfanet.anysketch.crypto.ElGamalPublicKey as AnySketchElGamalPublicKey
 import org.wfanet.anysketch.crypto.EncryptSketchRequest
 import org.wfanet.anysketch.crypto.EncryptSketchResponse
 import org.wfanet.anysketch.crypto.SketchEncrypterAdapter
@@ -206,10 +206,12 @@ class EdpSimulator(
         )
       }
 
-      if (!requisition.hasProtocolConfig()) {
+      if (
+        !requisition.hasProtocolConfig() ||
+          requisition.protocolConfig.protocolsList.last().hasDirect()
+      ) {
         when (measurementSpec.measurementTypeCase) {
           MeasurementSpec.MeasurementTypeCase.REACH_AND_FREQUENCY -> {
-            // Direct R/F measurement(single EDP) will not have protocolConfig
             fulfillDirectReachAndFrequencyMeasurement(requisition, requisitionSpec, measurementSpec)
           }
           MeasurementSpec.MeasurementTypeCase.IMPRESSION ->

--- a/src/main/kotlin/org/wfanet/measurement/loadtest/dataprovider/EdpSimulator.kt
+++ b/src/main/kotlin/org/wfanet/measurement/loadtest/dataprovider/EdpSimulator.kt
@@ -206,10 +206,7 @@ class EdpSimulator(
         )
       }
 
-      if (
-        !requisition.hasProtocolConfig() ||
-          requisition.protocolConfig.protocolsList.last().hasDirect()
-      ) {
+      if (requisition.protocolConfig.protocolsList.last().hasDirect()) {
         when (measurementSpec.measurementTypeCase) {
           MeasurementSpec.MeasurementTypeCase.REACH_AND_FREQUENCY -> {
             fulfillDirectReachAndFrequencyMeasurement(requisition, requisitionSpec, measurementSpec)

--- a/src/main/kotlin/org/wfanet/measurement/loadtest/dataprovider/EdpSimulator.kt
+++ b/src/main/kotlin/org/wfanet/measurement/loadtest/dataprovider/EdpSimulator.kt
@@ -14,7 +14,6 @@
 
 package org.wfanet.measurement.loadtest.dataprovider
 
-import org.wfanet.anysketch.crypto.ElGamalPublicKey as AnySketchElGamalPublicKey
 import com.google.protobuf.ByteString
 import com.google.protobuf.duration
 import io.grpc.StatusException
@@ -34,6 +33,7 @@ import org.wfanet.anysketch.SketchConfigKt.valueSpec
 import org.wfanet.anysketch.SketchProtos
 import org.wfanet.anysketch.crypto.CombineElGamalPublicKeysRequest
 import org.wfanet.anysketch.crypto.CombineElGamalPublicKeysResponse
+import org.wfanet.anysketch.crypto.ElGamalPublicKey as AnySketchElGamalPublicKey
 import org.wfanet.anysketch.crypto.EncryptSketchRequest
 import org.wfanet.anysketch.crypto.EncryptSketchResponse
 import org.wfanet.anysketch.crypto.SketchEncrypterAdapter

--- a/src/main/proto/wfa/measurement/internal/kingdom/measurement.proto
+++ b/src/main/proto/wfa/measurement/internal/kingdom/measurement.proto
@@ -278,6 +278,8 @@ message Requisition {
     ProtocolConfig protocol_config = 5;
 
     Measurement.State state = 6;
+
+    int32 data_providers_count = 7;
   }
   // Denormalized fields from the parent Measurement. Output-only.
   ParentMeasurement parent_measurement = 12;

--- a/src/main/proto/wfa/measurement/internal/kingdom/protocol_config.proto
+++ b/src/main/proto/wfa/measurement/internal/kingdom/protocol_config.proto
@@ -53,13 +53,31 @@ message ProtocolConfig {
     int32 maximum_frequency = 4;
   }
 
-  // Configuration for the specific protocol.
+  // Protocol for direct measurement
+  message Direct {}
+
+  message Protocol {
+    // Configuration for the specific protocol.
+    oneof protocol {
+      // Liquid Legions v2 config.
+      //
+      // May only be set when the measurement type is REACH_AND_FREQUENCY.
+      LiquidLegionsV2 liquid_legions_v2 = 1;
+
+      Direct direct = 2;
+    }
+  }
+
+  // Configuration for the specific protocol. Required. Immutable.
   oneof protocol {
     // Liquid Legions v2 config.
     //
-    // May only be set when the measurement type is REACH_AND_FREQUENCY.
-    LiquidLegionsV2 liquid_legions_v2 = 3;
+    // May only be set when `measurement_type` is `REACH_AND_FREQUENCY`.
+    LiquidLegionsV2 liquid_legions_v2 = 3 [deprecated = true];
   }
+
+  // List of protocols the EDP may use
+  repeated Protocol protocols = 4;
 }
 
 // Parameters for a Liquid Legions sketch.

--- a/src/main/proto/wfa/measurement/internal/kingdom/protocol_config.proto
+++ b/src/main/proto/wfa/measurement/internal/kingdom/protocol_config.proto
@@ -75,6 +75,8 @@ message ProtocolConfig {
     // Liquid Legions v2 config.
     //
     // May only be set when `measurement_type` is `REACH_AND_FREQUENCY`.
+    //
+    // Deprecated and replace with protocols.
     LiquidLegionsV2 liquid_legions_v2 = 3 [deprecated = true];
   }
 

--- a/src/main/proto/wfa/measurement/internal/kingdom/protocol_config.proto
+++ b/src/main/proto/wfa/measurement/internal/kingdom/protocol_config.proto
@@ -30,8 +30,6 @@ message ProtocolConfig {
   enum MeasurementType {
     MEASUREMENT_TYPE_UNSPECIFIED = 0;
     REACH_AND_FREQUENCY = 1;
-    IMPRESSION = 2;
-    DURATION = 3;
   }
   // The type of measurement that this protocol computes.
   MeasurementType measurement_type = 2;
@@ -55,33 +53,13 @@ message ProtocolConfig {
     int32 maximum_frequency = 4;
   }
 
-  // Protocol for direct measurement
-  message Direct {}
-
-  message Protocol {
-    // Configuration for the specific protocol.
-    oneof protocol {
-      // Liquid Legions v2 config.
-      //
-      // May only be set when the measurement type is REACH_AND_FREQUENCY.
-      LiquidLegionsV2 liquid_legions_v2 = 1;
-
-      Direct direct = 2;
-    }
-  }
-
-  // Configuration for the specific protocol. Required. Immutable.
+  // Configuration for the specific protocol.
   oneof protocol {
     // Liquid Legions v2 config.
     //
-    // May only be set when `measurement_type` is `REACH_AND_FREQUENCY`.
-    //
-    // Deprecated and replace with protocols.
-    LiquidLegionsV2 liquid_legions_v2 = 3 [deprecated = true];
+    // May only be set when the measurement type is REACH_AND_FREQUENCY.
+    LiquidLegionsV2 liquid_legions_v2 = 3;
   }
-
-  // List of protocols the EDP may use
-  repeated Protocol protocols = 4;
 }
 
 // Parameters for a Liquid Legions sketch.

--- a/src/main/proto/wfa/measurement/internal/kingdom/protocol_config.proto
+++ b/src/main/proto/wfa/measurement/internal/kingdom/protocol_config.proto
@@ -22,17 +22,12 @@ option java_package = "org.wfanet.measurement.internal.kingdom";
 option java_multiple_files = true;
 
 message ProtocolConfig {
+  reserved 2;
+
   // The ID is reserved for future potential usage.
   // Currently, we directly embed the protocolConfig into `Requisition` and
   // `Measurement`.
   string external_protocol_config_id = 1;
-
-  enum MeasurementType {
-    MEASUREMENT_TYPE_UNSPECIFIED = 0;
-    REACH_AND_FREQUENCY = 1;
-  }
-  // The type of measurement that this protocol computes.
-  MeasurementType measurement_type = 2;
 
   // Configuration for the Liquid Legions v2 R/F protocol.
   message LiquidLegionsV2 {

--- a/src/main/proto/wfa/measurement/internal/kingdom/protocol_config.proto
+++ b/src/main/proto/wfa/measurement/internal/kingdom/protocol_config.proto
@@ -30,6 +30,8 @@ message ProtocolConfig {
   enum MeasurementType {
     MEASUREMENT_TYPE_UNSPECIFIED = 0;
     REACH_AND_FREQUENCY = 1;
+    IMPRESSION = 2;
+    DURATION = 3;
   }
   // The type of measurement that this protocol computes.
   MeasurementType measurement_type = 2;

--- a/src/test/kotlin/org/wfanet/measurement/kingdom/service/api/v2alpha/MeasurementsServiceTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/kingdom/service/api/v2alpha/MeasurementsServiceTest.kt
@@ -392,9 +392,14 @@ class MeasurementsServiceTest {
           details =
             details.copy {
               clearFailure()
-              clearProtocolConfig()
               clearDuchyProtocolConfig()
               measurementSpec = request.measurement.measurementSpec.data
+              protocolConfig = internalProtocolConfig {
+                externalProtocolConfigId = "impression"
+                measurementType = InternalProtocolConfig.MeasurementType.IMPRESSION
+                protocols +=
+                  InternalProtocolConfigKt.protocol { direct = InternalProtocolConfigKt.direct {} }
+              }
             }
           results.clear()
         }
@@ -449,9 +454,14 @@ class MeasurementsServiceTest {
           details =
             details.copy {
               clearFailure()
-              clearProtocolConfig()
               clearDuchyProtocolConfig()
               measurementSpec = request.measurement.measurementSpec.data
+              protocolConfig = internalProtocolConfig {
+                externalProtocolConfigId = "duration"
+                measurementType = InternalProtocolConfig.MeasurementType.DURATION
+                protocols +=
+                  InternalProtocolConfigKt.protocol { direct = InternalProtocolConfigKt.direct {} }
+              }
             }
           results.clear()
         }

--- a/src/test/kotlin/org/wfanet/measurement/kingdom/service/api/v2alpha/MeasurementsServiceTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/kingdom/service/api/v2alpha/MeasurementsServiceTest.kt
@@ -57,6 +57,7 @@ import org.wfanet.measurement.api.v2alpha.MeasurementSpecKt.impression
 import org.wfanet.measurement.api.v2alpha.MeasurementSpecKt.reachAndFrequency
 import org.wfanet.measurement.api.v2alpha.MeasurementSpecKt.vidSamplingInterval
 import org.wfanet.measurement.api.v2alpha.ProtocolConfig
+import org.wfanet.measurement.api.v2alpha.ProtocolConfigKt
 import org.wfanet.measurement.api.v2alpha.ProtocolConfigKt.liquidLegionsV2
 import org.wfanet.measurement.api.v2alpha.cancelMeasurementRequest
 import org.wfanet.measurement.api.v2alpha.copy
@@ -249,8 +250,13 @@ class MeasurementsServiceTest {
           details =
             details.copy {
               clearFailure()
-              clearProtocolConfig()
-              clearDuchyProtocolConfig()
+              protocolConfig =
+                protocolConfig.copy {
+                  protocols +=
+                    InternalProtocolConfigKt.protocol {
+                      direct = InternalProtocolConfigKt.direct {}
+                    }
+                }
             }
           results.clear()
         }
@@ -1377,6 +1383,10 @@ class MeasurementsServiceTest {
             delta = 3.3
           }
         }
+      protocols +=
+        InternalProtocolConfigKt.protocol {
+          liquidLegionsV2 = this@internalProtocolConfig.liquidLegionsV2
+        }
     }
 
     private val PUBLIC_PROTOCOL_CONFIG = protocolConfig {
@@ -1393,6 +1403,8 @@ class MeasurementsServiceTest {
           delta = 3.3
         }
       }
+      protocols +=
+        ProtocolConfigKt.protocol { liquidLegionsV2 = this@protocolConfig.liquidLegionsV2 }
     }
 
     private val DUCHY_PROTOCOL_CONFIG = duchyProtocolConfig {

--- a/src/test/kotlin/org/wfanet/measurement/kingdom/service/api/v2alpha/MeasurementsServiceTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/kingdom/service/api/v2alpha/MeasurementsServiceTest.kt
@@ -14,17 +14,6 @@
 
 package org.wfanet.measurement.kingdom.service.api.v2alpha
 
-import org.wfanet.measurement.internal.kingdom.Measurement as InternalMeasurement
-import org.wfanet.measurement.internal.kingdom.Measurement.State as InternalState
-import org.wfanet.measurement.internal.kingdom.MeasurementKt as InternalMeasurementKt
-import org.wfanet.measurement.internal.kingdom.ProtocolConfig as InternalProtocolConfig
-import org.wfanet.measurement.internal.kingdom.ProtocolConfigKt as InternalProtocolConfigKt
-import org.wfanet.measurement.internal.kingdom.cancelMeasurementRequest as internalCancelMeasurementRequest
-import org.wfanet.measurement.internal.kingdom.differentialPrivacyParams as internalDifferentialPrivacyParams
-import org.wfanet.measurement.internal.kingdom.getMeasurementRequest as internalGetMeasurementRequest
-import org.wfanet.measurement.internal.kingdom.liquidLegionsSketchParams as internalLiquidLegionsSketchParams
-import org.wfanet.measurement.internal.kingdom.measurement as internalMeasurement
-import org.wfanet.measurement.internal.kingdom.protocolConfig as internalProtocolConfig
 import com.google.common.truth.Truth.assertThat
 import com.google.common.truth.extensions.proto.ProtoTruth.assertThat
 import com.google.protobuf.ByteString
@@ -95,12 +84,22 @@ import org.wfanet.measurement.common.testing.captureFirst
 import org.wfanet.measurement.common.testing.verifyProtoArgument
 import org.wfanet.measurement.common.toProtoTime
 import org.wfanet.measurement.internal.kingdom.DuchyProtocolConfig
+import org.wfanet.measurement.internal.kingdom.Measurement as InternalMeasurement
+import org.wfanet.measurement.internal.kingdom.Measurement.State as InternalState
+import org.wfanet.measurement.internal.kingdom.MeasurementKt as InternalMeasurementKt
 import org.wfanet.measurement.internal.kingdom.MeasurementKt.resultInfo
 import org.wfanet.measurement.internal.kingdom.MeasurementsGrpcKt
+import org.wfanet.measurement.internal.kingdom.ProtocolConfigKt as InternalProtocolConfigKt
 import org.wfanet.measurement.internal.kingdom.StreamMeasurementsRequest
 import org.wfanet.measurement.internal.kingdom.StreamMeasurementsRequestKt
+import org.wfanet.measurement.internal.kingdom.cancelMeasurementRequest as internalCancelMeasurementRequest
 import org.wfanet.measurement.internal.kingdom.copy
+import org.wfanet.measurement.internal.kingdom.differentialPrivacyParams as internalDifferentialPrivacyParams
 import org.wfanet.measurement.internal.kingdom.duchyProtocolConfig
+import org.wfanet.measurement.internal.kingdom.getMeasurementRequest as internalGetMeasurementRequest
+import org.wfanet.measurement.internal.kingdom.liquidLegionsSketchParams as internalLiquidLegionsSketchParams
+import org.wfanet.measurement.internal.kingdom.measurement as internalMeasurement
+import org.wfanet.measurement.internal.kingdom.protocolConfig as internalProtocolConfig
 import org.wfanet.measurement.internal.kingdom.streamMeasurementsRequest
 import org.wfanet.measurement.kingdom.deploy.common.Llv2ProtocolConfig
 
@@ -330,9 +329,9 @@ class MeasurementsServiceTest {
       }
 
     verifyProtoArgument(
-      internalMeasurementsMock,
-      MeasurementsGrpcKt.MeasurementsCoroutineImplBase::createMeasurement
-    )
+        internalMeasurementsMock,
+        MeasurementsGrpcKt.MeasurementsCoroutineImplBase::createMeasurement
+      )
       .isEqualTo(
         INTERNAL_MEASUREMENT.copy {
           clearUpdateTime()
@@ -363,15 +362,15 @@ class MeasurementsServiceTest {
                 clearProtocolConfig()
                 measurementSpec =
                   MEASUREMENT_SPEC.copy {
-                    clearReachAndFrequency()
-                    impression = impression {
-                      privacyParams = differentialPrivacyParams {
-                        epsilon = 1.0
-                        delta = 0.0
+                      clearReachAndFrequency()
+                      impression = impression {
+                        privacyParams = differentialPrivacyParams {
+                          epsilon = 1.0
+                          delta = 0.0
+                        }
+                        maximumFrequencyPerUser = 1
                       }
-                      maximumFrequencyPerUser = 1
                     }
-                  }
                     .toByteString()
               }
           }
@@ -409,15 +408,15 @@ class MeasurementsServiceTest {
         measurementSpec = signedData {
           data =
             MEASUREMENT_SPEC.copy {
-              clearReachAndFrequency()
-              impression = impression {
-                privacyParams = differentialPrivacyParams {
-                  epsilon = 1.0
-                  delta = 0.0
+                clearReachAndFrequency()
+                impression = impression {
+                  privacyParams = differentialPrivacyParams {
+                    epsilon = 1.0
+                    delta = 0.0
+                  }
+                  maximumFrequencyPerUser = 1
                 }
-                maximumFrequencyPerUser = 1
               }
-            }
               .toByteString()
           signature = UPDATE_TIME.toByteString()
         }
@@ -461,15 +460,15 @@ class MeasurementsServiceTest {
                 clearProtocolConfig()
                 measurementSpec =
                   MEASUREMENT_SPEC.copy {
-                    clearReachAndFrequency()
-                    duration = duration {
-                      privacyParams = differentialPrivacyParams {
-                        epsilon = 1.0
-                        delta = 0.0
+                      clearReachAndFrequency()
+                      duration = duration {
+                        privacyParams = differentialPrivacyParams {
+                          epsilon = 1.0
+                          delta = 0.0
+                        }
+                        maximumWatchDurationPerUser = 1
                       }
-                      maximumWatchDurationPerUser = 1
                     }
-                  }
                     .toByteString()
               }
           }
@@ -507,15 +506,15 @@ class MeasurementsServiceTest {
         measurementSpec = signedData {
           data =
             MEASUREMENT_SPEC.copy {
-              clearReachAndFrequency()
-              duration = duration {
-                privacyParams = differentialPrivacyParams {
-                  epsilon = 1.0
-                  delta = 0.0
+                clearReachAndFrequency()
+                duration = duration {
+                  privacyParams = differentialPrivacyParams {
+                    epsilon = 1.0
+                    delta = 0.0
+                  }
+                  maximumWatchDurationPerUser = 1
                 }
-                maximumWatchDurationPerUser = 1
               }
-            }
               .toByteString()
           signature = UPDATE_TIME.toByteString()
         }
@@ -1459,7 +1458,6 @@ class MeasurementsServiceTest {
 
     private val INTERNAL_PROTOCOL_CONFIG = internalProtocolConfig {
       externalProtocolConfigId = "llv2"
-      measurementType = InternalProtocolConfig.MeasurementType.REACH_AND_FREQUENCY
       liquidLegionsV2 =
         InternalProtocolConfigKt.liquidLegionsV2 {
           sketchParams = internalLiquidLegionsSketchParams {

--- a/src/test/kotlin/org/wfanet/measurement/kingdom/service/api/v2alpha/MeasurementsServiceTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/kingdom/service/api/v2alpha/MeasurementsServiceTest.kt
@@ -350,7 +350,21 @@ class MeasurementsServiceTest {
   fun `createMeasurement with impression type returns measurement with resource name set`() {
     runBlocking {
       whenever(internalMeasurementsMock.createMeasurement(any()))
-        .thenReturn(INTERNAL_MEASUREMENT.copy { details = details.copy { clearProtocolConfig() } })
+        .thenReturn(
+          INTERNAL_MEASUREMENT.copy {
+            details =
+              details.copy {
+                protocolConfig = internalProtocolConfig {
+                  externalProtocolConfigId = ProtocolConfig.Direct.getDescriptor().name
+                  measurementType = InternalProtocolConfig.MeasurementType.IMPRESSION
+                  protocols +=
+                    InternalProtocolConfigKt.protocol {
+                      direct = InternalProtocolConfigKt.direct {}
+                    }
+                }
+              }
+          }
+        )
     }
 
     val request = createMeasurementRequest {
@@ -379,7 +393,14 @@ class MeasurementsServiceTest {
         runBlocking { service.createMeasurement(request) }
       }
 
-    val expected = MEASUREMENT.copy { clearProtocolConfig() }
+    val expected =
+      MEASUREMENT.copy {
+        protocolConfig = protocolConfig {
+          name = "protocolConfigs/Direct"
+          measurementType = ProtocolConfig.MeasurementType.IMPRESSION
+          protocols += ProtocolConfigKt.protocol { direct = ProtocolConfigKt.direct {} }
+        }
+      }
 
     verifyProtoArgument(
         internalMeasurementsMock,
@@ -395,7 +416,7 @@ class MeasurementsServiceTest {
               clearDuchyProtocolConfig()
               measurementSpec = request.measurement.measurementSpec.data
               protocolConfig = internalProtocolConfig {
-                externalProtocolConfigId = "impression"
+                externalProtocolConfigId = ProtocolConfig.Direct.getDescriptor().name
                 measurementType = InternalProtocolConfig.MeasurementType.IMPRESSION
                 protocols +=
                   InternalProtocolConfigKt.protocol { direct = InternalProtocolConfigKt.direct {} }
@@ -412,7 +433,21 @@ class MeasurementsServiceTest {
   fun `createMeasurement with duration type returns measurement with resource name set`() {
     runBlocking {
       whenever(internalMeasurementsMock.createMeasurement(any()))
-        .thenReturn(INTERNAL_MEASUREMENT.copy { details = details.copy { clearProtocolConfig() } })
+        .thenReturn(
+          INTERNAL_MEASUREMENT.copy {
+            details =
+              details.copy {
+                protocolConfig = internalProtocolConfig {
+                  externalProtocolConfigId = ProtocolConfig.Direct.getDescriptor().name
+                  measurementType = InternalProtocolConfig.MeasurementType.DURATION
+                  protocols +=
+                    InternalProtocolConfigKt.protocol {
+                      direct = InternalProtocolConfigKt.direct {}
+                    }
+                }
+              }
+          }
+        )
     }
 
     val request = createMeasurementRequest {
@@ -441,7 +476,14 @@ class MeasurementsServiceTest {
         runBlocking { service.createMeasurement(request) }
       }
 
-    val expected = MEASUREMENT.copy { clearProtocolConfig() }
+    val expected =
+      MEASUREMENT.copy {
+        protocolConfig = protocolConfig {
+          name = "protocolConfigs/Direct"
+          measurementType = ProtocolConfig.MeasurementType.DURATION
+          protocols += ProtocolConfigKt.protocol { direct = ProtocolConfigKt.direct {} }
+        }
+      }
 
     verifyProtoArgument(
         internalMeasurementsMock,
@@ -456,8 +498,9 @@ class MeasurementsServiceTest {
               clearFailure()
               clearDuchyProtocolConfig()
               measurementSpec = request.measurement.measurementSpec.data
+
               protocolConfig = internalProtocolConfig {
-                externalProtocolConfigId = "duration"
+                externalProtocolConfigId = ProtocolConfig.Direct.getDescriptor().name
                 measurementType = InternalProtocolConfig.MeasurementType.DURATION
                 protocols +=
                   InternalProtocolConfigKt.protocol { direct = InternalProtocolConfigKt.direct {} }

--- a/src/test/kotlin/org/wfanet/measurement/kingdom/service/api/v2alpha/RequisitionsServiceTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/kingdom/service/api/v2alpha/RequisitionsServiceTest.kt
@@ -14,17 +14,6 @@
 
 package org.wfanet.measurement.kingdom.service.api.v2alpha
 
-import org.wfanet.measurement.internal.kingdom.Measurement as InternalMeasurement
-import org.wfanet.measurement.internal.kingdom.ProtocolConfig as InternalProtocolConfig
-import org.wfanet.measurement.internal.kingdom.Requisition as InternalRequisition
-import org.wfanet.measurement.internal.kingdom.Requisition.Refusal as InternalRefusal
-import org.wfanet.measurement.internal.kingdom.Requisition.State as InternalState
-import org.wfanet.measurement.internal.kingdom.RequisitionKt as InternalRequisitionKt
-import org.wfanet.measurement.internal.kingdom.certificate as internalCertificate
-import org.wfanet.measurement.internal.kingdom.fulfillRequisitionRequest as internalFulfillRequisitionRequest
-import org.wfanet.measurement.internal.kingdom.protocolConfig as internalProtocolConfig
-import org.wfanet.measurement.internal.kingdom.refuseRequisitionRequest as internalRefuseRequisitionRequest
-import org.wfanet.measurement.internal.kingdom.requisition as internalRequisition
 import com.google.common.truth.Truth.assertThat
 import com.google.common.truth.extensions.proto.ProtoTruth.assertThat
 import com.google.protobuf.ByteString
@@ -89,6 +78,12 @@ import org.wfanet.measurement.common.testing.verifyProtoArgument
 import org.wfanet.measurement.common.toProtoTime
 import org.wfanet.measurement.internal.kingdom.ComputationParticipantKt.liquidLegionsV2Details
 import org.wfanet.measurement.internal.kingdom.FulfillRequisitionRequestKt.directRequisitionParams
+import org.wfanet.measurement.internal.kingdom.Measurement as InternalMeasurement
+import org.wfanet.measurement.internal.kingdom.ProtocolConfig as InternalProtocolConfig
+import org.wfanet.measurement.internal.kingdom.Requisition as InternalRequisition
+import org.wfanet.measurement.internal.kingdom.Requisition.Refusal as InternalRefusal
+import org.wfanet.measurement.internal.kingdom.Requisition.State as InternalState
+import org.wfanet.measurement.internal.kingdom.RequisitionKt as InternalRequisitionKt
 import org.wfanet.measurement.internal.kingdom.RequisitionKt.details
 import org.wfanet.measurement.internal.kingdom.RequisitionKt.duchyValue
 import org.wfanet.measurement.internal.kingdom.RequisitionKt.parentMeasurement
@@ -96,7 +91,12 @@ import org.wfanet.measurement.internal.kingdom.RequisitionsGrpcKt.RequisitionsCo
 import org.wfanet.measurement.internal.kingdom.RequisitionsGrpcKt.RequisitionsCoroutineStub
 import org.wfanet.measurement.internal.kingdom.StreamRequisitionsRequest
 import org.wfanet.measurement.internal.kingdom.StreamRequisitionsRequestKt
+import org.wfanet.measurement.internal.kingdom.certificate as internalCertificate
 import org.wfanet.measurement.internal.kingdom.copy
+import org.wfanet.measurement.internal.kingdom.fulfillRequisitionRequest as internalFulfillRequisitionRequest
+import org.wfanet.measurement.internal.kingdom.protocolConfig as internalProtocolConfig
+import org.wfanet.measurement.internal.kingdom.refuseRequisitionRequest as internalRefuseRequisitionRequest
+import org.wfanet.measurement.internal.kingdom.requisition as internalRequisition
 import org.wfanet.measurement.internal.kingdom.streamRequisitionsRequest
 
 private val UPDATE_TIME: Timestamp = Instant.ofEpochSecond(123).toProtoTime()

--- a/src/test/kotlin/org/wfanet/measurement/loadtest/dataprovider/EdpSimulatorTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/loadtest/dataprovider/EdpSimulatorTest.kt
@@ -14,6 +14,10 @@
 
 package org.wfanet.measurement.loadtest.dataprovider
 
+import org.wfanet.measurement.api.v2alpha.event_templates.testing.TestPrivacyBudgetTemplate.AgeRange as PrivacyAgeRange
+import org.wfanet.measurement.api.v2alpha.event_templates.testing.TestPrivacyBudgetTemplateKt.ageRange as privacyAgeRange
+import org.wfanet.measurement.eventdataprovider.privacybudgetmanagement.AgeGroup as PrivacyLandscapeAge
+import org.wfanet.measurement.eventdataprovider.privacybudgetmanagement.Gender as PrivacyLandscapeGender
 import com.google.common.truth.Correspondence
 import com.google.common.truth.Truth.assertThat
 import java.nio.file.Path
@@ -73,8 +77,6 @@ import org.wfanet.measurement.api.v2alpha.event_templates.testing.TestBannerTemp
 import org.wfanet.measurement.api.v2alpha.event_templates.testing.TestBannerTemplateKt.gender
 import org.wfanet.measurement.api.v2alpha.event_templates.testing.TestEvent
 import org.wfanet.measurement.api.v2alpha.event_templates.testing.TestPrivacyBudgetTemplate
-import org.wfanet.measurement.api.v2alpha.event_templates.testing.TestPrivacyBudgetTemplate.AgeRange as PrivacyAgeRange
-import org.wfanet.measurement.api.v2alpha.event_templates.testing.TestPrivacyBudgetTemplateKt.ageRange as privacyAgeRange
 import org.wfanet.measurement.api.v2alpha.event_templates.testing.testBannerTemplate
 import org.wfanet.measurement.api.v2alpha.event_templates.testing.testEvent
 import org.wfanet.measurement.api.v2alpha.event_templates.testing.testPrivacyBudgetTemplate
@@ -107,9 +109,7 @@ import org.wfanet.measurement.consent.client.duchy.signElgamalPublicKey
 import org.wfanet.measurement.consent.client.measurementconsumer.encryptRequisitionSpec
 import org.wfanet.measurement.consent.client.measurementconsumer.signMeasurementSpec
 import org.wfanet.measurement.consent.client.measurementconsumer.signRequisitionSpec
-import org.wfanet.measurement.eventdataprovider.privacybudgetmanagement.AgeGroup as PrivacyLandscapeAge
 import org.wfanet.measurement.eventdataprovider.privacybudgetmanagement.Charge
-import org.wfanet.measurement.eventdataprovider.privacybudgetmanagement.Gender as PrivacyLandscapeGender
 import org.wfanet.measurement.eventdataprovider.privacybudgetmanagement.PrivacyBucketFilter
 import org.wfanet.measurement.eventdataprovider.privacybudgetmanagement.PrivacyBucketGroup
 import org.wfanet.measurement.eventdataprovider.privacybudgetmanagement.PrivacyBudgetBalanceEntry
@@ -692,18 +692,19 @@ class EdpSimulatorTest {
       measurementSpec = signMeasurementSpec(MEASUREMENT_SPEC, MC_SIGNING_KEY)
       encryptedRequisitionSpec = ENCRYPTED_REQUISITION_ONE_SPEC
       protocolConfig = protocolConfig {
-        liquidLegionsV2 =
-          ProtocolConfigKt.liquidLegionsV2 {
-            sketchParams = liquidLegionsSketchParams {
-              decayRate = LLV2_DECAY_RATE
-              maxSize = LLV2_MAX_SIZE
-              samplingIndicatorSize = 10_000_000
-            }
-            ellipticCurveId = 415
-            maximumFrequency = 12
-          }
         protocols +=
-          ProtocolConfigKt.protocol { liquidLegionsV2 = this@protocolConfig.liquidLegionsV2 }
+          ProtocolConfigKt.protocol {
+            liquidLegionsV2 =
+              ProtocolConfigKt.liquidLegionsV2 {
+                sketchParams = liquidLegionsSketchParams {
+                  decayRate = LLV2_DECAY_RATE
+                  maxSize = LLV2_MAX_SIZE
+                  samplingIndicatorSize = 10_000_000
+                }
+                ellipticCurveId = 415
+                maximumFrequency = 12
+              }
+          }
       }
       duchies += duchyEntry {
         key = DUCHIES_MAP_KEY

--- a/src/test/kotlin/org/wfanet/measurement/loadtest/dataprovider/EdpSimulatorTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/loadtest/dataprovider/EdpSimulatorTest.kt
@@ -702,6 +702,8 @@ class EdpSimulatorTest {
             ellipticCurveId = 415
             maximumFrequency = 12
           }
+        protocols +=
+          ProtocolConfigKt.protocol { liquidLegionsV2 = this@protocolConfig.liquidLegionsV2 }
       }
       duchies += duchyEntry {
         key = DUCHIES_MAP_KEY

--- a/src/test/kotlin/org/wfanet/measurement/loadtest/dataprovider/EdpSimulatorTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/loadtest/dataprovider/EdpSimulatorTest.kt
@@ -14,10 +14,6 @@
 
 package org.wfanet.measurement.loadtest.dataprovider
 
-import org.wfanet.measurement.api.v2alpha.event_templates.testing.TestPrivacyBudgetTemplate.AgeRange as PrivacyAgeRange
-import org.wfanet.measurement.api.v2alpha.event_templates.testing.TestPrivacyBudgetTemplateKt.ageRange as privacyAgeRange
-import org.wfanet.measurement.eventdataprovider.privacybudgetmanagement.AgeGroup as PrivacyLandscapeAge
-import org.wfanet.measurement.eventdataprovider.privacybudgetmanagement.Gender as PrivacyLandscapeGender
 import com.google.common.truth.Correspondence
 import com.google.common.truth.Truth.assertThat
 import java.nio.file.Path
@@ -77,6 +73,8 @@ import org.wfanet.measurement.api.v2alpha.event_templates.testing.TestBannerTemp
 import org.wfanet.measurement.api.v2alpha.event_templates.testing.TestBannerTemplateKt.gender
 import org.wfanet.measurement.api.v2alpha.event_templates.testing.TestEvent
 import org.wfanet.measurement.api.v2alpha.event_templates.testing.TestPrivacyBudgetTemplate
+import org.wfanet.measurement.api.v2alpha.event_templates.testing.TestPrivacyBudgetTemplate.AgeRange as PrivacyAgeRange
+import org.wfanet.measurement.api.v2alpha.event_templates.testing.TestPrivacyBudgetTemplateKt.ageRange as privacyAgeRange
 import org.wfanet.measurement.api.v2alpha.event_templates.testing.testBannerTemplate
 import org.wfanet.measurement.api.v2alpha.event_templates.testing.testEvent
 import org.wfanet.measurement.api.v2alpha.event_templates.testing.testPrivacyBudgetTemplate
@@ -109,7 +107,9 @@ import org.wfanet.measurement.consent.client.duchy.signElgamalPublicKey
 import org.wfanet.measurement.consent.client.measurementconsumer.encryptRequisitionSpec
 import org.wfanet.measurement.consent.client.measurementconsumer.signMeasurementSpec
 import org.wfanet.measurement.consent.client.measurementconsumer.signRequisitionSpec
+import org.wfanet.measurement.eventdataprovider.privacybudgetmanagement.AgeGroup as PrivacyLandscapeAge
 import org.wfanet.measurement.eventdataprovider.privacybudgetmanagement.Charge
+import org.wfanet.measurement.eventdataprovider.privacybudgetmanagement.Gender as PrivacyLandscapeGender
 import org.wfanet.measurement.eventdataprovider.privacybudgetmanagement.PrivacyBucketFilter
 import org.wfanet.measurement.eventdataprovider.privacybudgetmanagement.PrivacyBucketGroup
 import org.wfanet.measurement.eventdataprovider.privacybudgetmanagement.PrivacyBudgetBalanceEntry


### PR DESCRIPTION
- Kingdom supports repeated protocols in public protocol_config for requisition to specify if a measurement is direct reach and frequency measurement(single data provider). This way EDP can decide to do direct or MPC based reach and frequency computation for direct measurement. The internal protocol_config will remain unchanged
- Add Kingdom flag --allow-mpc-protocols-for-single-data-provider to control adding MPC protocol for single-edp reach and frequency measurement
- Update relevant unit tests and integrations tests

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/world-federation-of-advertisers/cross-media-measurement/728)
<!-- Reviewable:end -->
