### PR TITLE
Fix ResourceSetup to use Kingdom certs rather than MC certs.

### DIFF
--- a/src/main/k8s/resource_setup.cue
+++ b/src/main/k8s/resource_setup.cue
@@ -41,9 +41,9 @@ package k8s
 		"--mc-encryption-public-keyset=/var/run/secrets/files/mc_enc_public.tink",
 	]
 	_tls_cert_key_files_flags: [
-		"--tls-cert-file=/var/run/secrets/files/mc_tls.pem",
-		"--tls-key-file=/var/run/secrets/files/mc_tls.key",
-		"--cert-collection-file=/var/run/secrets/files/all_root_certs.pem",
+		"--tls-cert-file=/var/run/secrets/files/kingdom_tls.pem",
+		"--tls-key-file=/var/run/secrets/files/kingdom_tls.key",
+		"--cert-collection-file=/var/run/secrets/files/kingdom_root.pem",
 	]
 	_duchy_cs_cert_files_flags: [
 		for d in _duchy_ids {


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/world-federation-of-advertisers/cross-media-measurement/729)
<!-- Reviewable:end -->
