### PR TITLE
Fix deployment docs.

### DIFF
--- a/docs/gke/kingdom-deployment.md
+++ b/docs/gke/kingdom-deployment.md
@@ -166,13 +166,19 @@ gcloud container clusters create halo-cmm-kingdom-demo-cluster \
   --service-account='gke-cluster@halo-kingdom-demo.iam.gserviceaccount.com' \
   --database-encryption-key=projects/halo-cmm-dev/locations/us-central1/keyRings/test-key-ring/cryptoKeys/k8s-secret \
   --num-nodes=3 --enable-autoscaling --min-nodes=3 --max-nodes=6 \
-  --machine-type=e2-highcpu-2 --cluster-version='1.24.2-gke.1900'
+  --machine-type=e2-highcpu-2 --release-channel=regular \
+  --cluster-version='1.24.5-gke.600'
 ```
 
 Adjust the number of nodes and machine type according to your expected usage.
 
-The GKE version should be no older than `1.24.0` in order to support built-in
-gRPC health probe.
+The cluster version should be no older than `1.24.0` in order to support
+built-in gRPC health probe. You can use the following command to determine what
+versions are supported for each release channel:
+
+```shell
+gcloud container get-server-config
+```
 
 After creating the cluster, we can configure `kubectl` to be able to access it
 

--- a/docs/gke/reporting-server-deployment.md
+++ b/docs/gke/reporting-server-deployment.md
@@ -143,10 +143,19 @@ gcloud container clusters create reporting \
   --service-account="gke-cluster@halo-cmm-dev.iam.gserviceaccount.com" \
   --database-encryption-key=projects/halo-cmm-dev/locations/us-central1/keyRings/test-key-ring/cryptoKeys/k8s-secret \
   --num-nodes=3 --enable-autoscaling --min-nodes=2 --max-nodes=4 \
-  --machine-type=e2-small
+  --machine-type=e2-small --release-channel=regular \
+  --cluster-version='1.24.5-gke.600'
 ```
 
 Adjust the number of nodes and machine type according to your expected usage.
+
+The cluster version should be no older than `1.24.0` in order to support
+built-in gRPC health probe. You can use the following command to determine what
+versions are supported for each release channel:
+
+```shell
+gcloud container get-server-config
+```
 
 ## Create the K8s ServiceAccount
 

--- a/src/main/k8s/local/README.md
+++ b/src/main/k8s/local/README.md
@@ -249,25 +249,21 @@ The ConfigMap also needs an additional file named
 # proto-file: wfa/measurement/config/reporting/encryption_key_pair_config.proto
 # proto-message: EncryptionKeyPairConfig
 principal_key_pairs {
-  principal: "measurement_consumer1"
+  principal: "measurementConsumers/G7laM7LMIAA"
   key_pairs {
     public_key_file: "mc_enc_public.tink"
     private_key_file: "mc_enc_private.tink"
   }
   key_pairs {
-    public_key_file: "edp1_enc_public.tink"
-    private_key_file: "edp1_enc_private.tink"
+    public_key_file: "mc_enc_public_2.tink"
+    private_key_file: "mc_enc_private_2.tink"
   }
 }
 principal_key_pairs {
-  principal: "measurement_consumer2"
+  principal: "measurementConsumers/FS1n8aTrck0"
   key_pairs {
-    public_key_file: "edp2_enc_public.tink"
-    private_key_file: "edp2_enc_private.tink"
-  }
-  key_pairs {
-    public_key_file: "edp3_enc_public.tink"
-    private_key_file: "edp3_enc_private.tink"
+    public_key_file: "mc2_enc_public.tink"
+    private_key_file: "mc2_enc_private.tink"
   }
 }
 ```


### PR DESCRIPTION
* Add missing duchy_cert_config.textproto entry in Duchy deployment doc.
* Fix misleading EncryptionKeyPairConfig sample in local reporting server deployment doc.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/world-federation-of-advertisers/cross-media-measurement/735)
<!-- Reviewable:end -->
