### PR TITLE
Use fixed sizes for JVM memory in dev environment.

### DIFF
--- a/docs/gke/duchy-deployment.md
+++ b/docs/gke/duchy-deployment.md
@@ -328,8 +328,9 @@ _computation_control_targets: {
 }
 ```
 
-You can also modify things such as the memory and CPU request/limit of each pod,
-as well as the number of replicas per deployment.
+You can also modify things such as the number of replicas per deployment, the
+memory and CPU requirements of each container, and the JVM options of each
+container.
 
 To generate the YAML manifest from the CUE files, run the following
 (substituting your own values for the `--define` options):

--- a/docs/gke/kingdom-deployment.md
+++ b/docs/gke/kingdom-deployment.md
@@ -350,8 +350,9 @@ For example,
 # SpannerInstance:   "halo-kingdom-demo-instance"
 ```
 
-You can also modify things such as the memory and CPU request/limit of each pod,
-as well as the number of replicas per deployment.
+You can also modify things such as the number of replicas per deployment, the
+memory and CPU requirements of each container, and the JVM options of each
+container.
 
 To generate the YAML manifest from the CUE files, run the following
 (substituting your own secret name and image tag):

--- a/src/main/k8s/base.cue
+++ b/src/main/k8s/base.cue
@@ -78,19 +78,19 @@ objects: [ for objectSet in objectSets for object in objectSet {object}]
 }
 
 #JavaOptions: {
-	maxRamPercentage?:      float
-	initialRamPercentage?:  float
-	maxHeapSize?:           string
-	initialHeapSize?:       string
-	reservedCodeCacheSize?: string
-	maxMetaspaceSize?:      string
-	maxDirectMemorySize?:   string
-	maxCachedBufferSize:    uint | *262144 // 256KiB
-	nettyMaxDirectMemory?:  int
-	loggingConfigFile?:     string
-	heapDumpOnOutOfMemory:  bool | *false
-	heapDumpPath?:          string
-	exitOnOutOfMemory:      bool | *heapDumpOnOutOfMemory
+	maxRamPercentage?:        float
+	initialRamPercentage?:    float
+	maxHeapSize?:             string
+	initialHeapSize?:         string
+	profiledCodeHeapSize?:    string
+	nonProfiledCodeHeapSize?: string
+	maxDirectMemorySize?:     string
+	maxCachedBufferSize:      uint | *262144 // 256KiB
+	nettyMaxDirectMemory?:    int
+	loggingConfigFile?:       string
+	heapDumpOnOutOfMemory:    bool | *false
+	heapDumpPath?:            string
+	exitOnOutOfMemory:        bool | *heapDumpOnOutOfMemory
 
 	_maxRamPercentageOpts: [...string]
 	if maxRamPercentage != _|_ {
@@ -112,11 +112,11 @@ objects: [ for objectSet in objectSets for object in objectSet {object}]
 		if initialHeapSize != _|_ {
 			"-Xms\(initialHeapSize)"
 		},
-		if reservedCodeCacheSize != _|_ {
-			"-XX:ReservedCodeCacheSize=\(reservedCodeCacheSize)"
+		if profiledCodeHeapSize != _|_ {
+			"-XX:ProfiledCodeHeapSize=\(profiledCodeHeapSize)"
 		},
-		if maxMetaspaceSize != _|_ {
-			"-XX:MaxMetaspaceSize=\(maxMetaspaceSize)"
+		if nonProfiledCodeHeapSize != _|_ {
+			"-XX:NonProfiledCodeHeapSize=\(nonProfiledCodeHeapSize)"
 		},
 		if maxDirectMemorySize != _|_ {
 			"-XX:MaxDirectMemorySize=\(maxDirectMemorySize)"

--- a/src/main/k8s/dev/base_gke.cue
+++ b/src/main/k8s/dev/base_gke.cue
@@ -57,3 +57,8 @@ package k8s
 		effect:   "NoSchedule"
 	}
 }
+
+#JavaOptions: {
+	initialHeapSize: _ | *"32M"
+	maxHeapSize:     _ | *"96M"
+}

--- a/src/main/k8s/dev/duchy_gke.cue
+++ b/src/main/k8s/dev/duchy_gke.cue
@@ -22,17 +22,22 @@ _certificateId:                string @tag("certificate_id")
 
 _duchy_cert_name: "duchies/\(_duchy_name)/certificates/\(_certificateId)"
 
-#KingdomSystemApiTarget:       "system.kingdom.dev.halo-cmm.org:8443"
-#InternalServerServiceAccount: "internal-server"
-#StorageServiceAccount:        "storage"
-#MillResourceRequirements:     #ResourceRequirements & {
-	requests: cpu:  "800m"
-	limits: memory: "2Gi"
+#KingdomSystemApiTarget:             "system.kingdom.dev.halo-cmm.org:8443"
+#InternalServerServiceAccount:       "internal-server"
+#StorageServiceAccount:              "storage"
+#InternalServerResourceRequirements: #ResourceRequirements & {
+	requests: {
+		memory: "256Mi"
+	}
 }
-#SpannerComputationsResourceRequirements: #ResourceRequirements & {
-	limits: memory: "384Mi"
+#MillResourceRequirements: #ResourceRequirements & {
+	requests: {
+		cpu:    "800m"
+		memory: "2Gi"
+	}
 }
-#MillReplicas: 1
+#MillMaxHeapSize: "1G"
+#MillReplicas:    1
 
 objectSets: [
 	default_deny_ingress_and_egress,
@@ -86,7 +91,9 @@ duchy: #Duchy & {
 
 	deployments: {
 		"spanner-computations-server-deployment": {
-			_container: resources: #SpannerComputationsResourceRequirements
+			_container: {
+				resources: #InternalServerResourceRequirements
+			}
 			spec: template: spec: #ServiceAccountPodSpec & {
 				serviceAccountName: #InternalServerServiceAccount
 			}
@@ -96,7 +103,7 @@ duchy: #Duchy & {
 		}
 		"liquid-legions-v2-mill-daemon-deployment": {
 			_container: {
-				_javaOptions: maxRamPercentage: 50.0
+				_javaOptions: maxHeapSize: #MillMaxHeapSize
 				resources: #MillResourceRequirements
 			}
 			spec: {

--- a/src/main/k8s/dev/kingdom_gke.cue
+++ b/src/main/k8s/dev/kingdom_gke.cue
@@ -29,8 +29,20 @@ _secret_name: string @tag("secret_name")
 #SystemServerGrpcThreads: 5
 
 #InternalServerResourceRequirements: #ResourceRequirements & {
-	requests: cpu:  "500m"
-	limits: memory: "512Mi"
+	requests: {
+		cpu:    "500m"
+		memory: "352Mi"
+	}
+}
+#PublicServerResourceRequirements: #ResourceRequirements & {
+	requests: {
+		memory: "256Mi"
+	}
+}
+#SystemServerResourceRequirements: #ResourceRequirements & {
+	requests: {
+		memory: "256Mi"
+	}
 }
 
 objectSets: [
@@ -70,7 +82,6 @@ kingdom: #Kingdom & {
 	deployments: {
 		"gcp-kingdom-data-server": {
 			_container: {
-				_javaOptions: maxRamPercentage: 40.0
 				_grpcThreadPoolSize: #InternalServerGrpcThreads
 				resources:           #InternalServerResourceRequirements
 			}
@@ -81,6 +92,12 @@ kingdom: #Kingdom & {
 		"system-api-server": {
 			_container: {
 				_grpcThreadPoolSize: #SystemServerGrpcThreads
+				resources:           #SystemServerResourceRequirements
+			}
+		}
+		"v2alpha-public-api-server": {
+			_container: {
+				resources: #PublicServerResourceRequirements
 			}
 		}
 	}

--- a/src/main/k8s/dev/reporting_gke.cue
+++ b/src/main/k8s/dev/reporting_gke.cue
@@ -25,6 +25,12 @@ _reportingMcConfigSecretName: string @tag("mc_config_secret_name")
 // Name of K8s service account for the internal API server.
 #InternalServerServiceAccount: "internal-reporting-server"
 
+#InternalServerResourceRequirements: #ResourceRequirements & {
+	requests: {
+		memory: "256Mi"
+	}
+}
+
 objectSets: [
 	default_deny_ingress_and_egress,
 	reporting.deployments,
@@ -67,6 +73,7 @@ reporting: #Reporting & {
 
 	deployments: {
 		"postgres-reporting-data-server": {
+			_container: resources: #InternalServerResourceRequirements
 			spec: template: spec: #ServiceAccountPodSpec & {
 				serviceAccountName: #InternalServerServiceAccount
 			}

--- a/src/main/k8s/dev/resource_requirements.yaml
+++ b/src/main/k8s/dev/resource_requirements.yaml
@@ -19,5 +19,5 @@ metadata:
 spec:
   limits:
   - type: Container
-    default:
-      memory: 256Mi
+    defaultRequest:
+      memory: 192Mi

--- a/src/main/k8s/local/config.cue
+++ b/src/main/k8s/local/config.cue
@@ -24,8 +24,6 @@ package k8s
 }
 
 #JavaOptions: {
-	initialHeapSize:       _ | *"32M"
-	maxHeapSize:           _ | *"96M"
-	reservedCodeCacheSize: _ | *"64M"
-	maxDirectMemorySize:   _ | *"32M"
+	initialHeapSize: _ | *"32M"
+	maxHeapSize:     _ | *"96M"
 }


### PR DESCRIPTION
Percentage sizes do not allow for scaling heap memory independently of non-heap memory.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/world-federation-of-advertisers/cross-media-measurement/745)
<!-- Reviewable:end -->
