### PR TITLE
Validate certificate path when validating signatures.

### DIFF
--- a/build/repositories.bzl
+++ b/build/repositories.bzl
@@ -24,8 +24,8 @@ def wfa_measurement_system_repositories():
     wfa_repo_archive(
         name = "wfa_common_jvm",
         repo = "common-jvm",
-        sha256 = "9b7aa407b2f7a2f6aec6649bff2272d92f83022fcb5e6be183fa4b2aa31b976c",
-        version = "0.48.0",
+        sha256 = "4a66b0371fd54dc21d210f65c53881dcb1cfc981ec31f398878364dab8b7a1d0",
+        version = "0.49.1",
     )
 
     wfa_repo_archive(
@@ -66,8 +66,8 @@ def wfa_measurement_system_repositories():
     wfa_repo_archive(
         name = "wfa_consent_signaling_client",
         repo = "consent-signaling-client",
-        sha256 = "ad92284f50b685b2044756693271501feeff6054f09e2d1daaf33ffa54f48cd8",
-        version = "0.14.1",
+        sha256 = "99fde5608b79ff12a2a466cdd213e1535c62f80a96035006433ae9ba5a4a4d21",
+        version = "0.15.0",
     )
 
     wfa_repo_archive(

--- a/docs/gke/reporting-server-deployment.md
+++ b/docs/gke/reporting-server-deployment.md
@@ -200,11 +200,13 @@ First, prepare all the files we want to include in the Kubernetes secret. The
 
 1.  `all_root_certs.pem`
 
-    This makes up the TLS trusted root CA store. It's the concatenation of the
-    root CA certificates for all the entities that the Reporting server
-    interacts with, including:
+    This makes up the trusted root CA store. It's the concatenation of the root
+    CA certificates for all the entities that the Reporting server interacts
+    with, including:
 
     *   All Measurement Consumers
+    *   Any entity which produces Measurement results (e.g. the Aggregator Duchy
+        and Data Providers)
     *   The Kingdom
     *   The Reporting server itself (for internal traffic)
 

--- a/src/main/k8s/testing/secretfiles/BUILD.bazel
+++ b/src/main/k8s/testing/secretfiles/BUILD.bazel
@@ -34,6 +34,25 @@ filegroup(
 )
 
 filegroup(
+    name = "mc_trusted_certs",
+    srcs = [
+        "kingdom_root.pem",
+        "aggregator_root.pem",
+    ] + glob(["edp*_root.pem"]),
+)
+
+filegroup(
+    name = "edp_trusted_certs",
+    srcs = [
+        "aggregator_root.pem",
+        "kingdom_root.pem",
+        "mc_root.pem",
+        "worker1_root.pem",
+        "worker2_root.pem",
+    ],
+)
+
+filegroup(
     name = "encryption_public_keys",
     srcs = [
         ":mc_enc_public.pb",
@@ -45,6 +64,20 @@ genrule(
     name = "gen_trusted_certs",
     srcs = [":root_certs"],
     outs = ["all_root_certs.pem"],
+    cmd = "cat $(SRCS) > $@",
+)
+
+genrule(
+    name = "gen_mc_trusted_certs",
+    srcs = [":mc_trusted_certs"],
+    outs = ["mc_trusted_certs.pem"],
+    cmd = "cat $(SRCS) > $@",
+)
+
+genrule(
+    name = "gen_edp_trusted_certs",
+    srcs = [":edp_trusted_certs"],
+    outs = ["edp_trusted_certs.pem"],
     cmd = "cat $(SRCS) > $@",
 )
 

--- a/src/main/kotlin/org/wfanet/measurement/common/identity/DuchyInfo.kt
+++ b/src/main/kotlin/org/wfanet/measurement/common/identity/DuchyInfo.kt
@@ -29,9 +29,14 @@ object DuchyInfo {
     require(!DuchyInfo::entries.isInitialized)
     val configMessage =
       flags.config.reader().use { parseTextProto(it, DuchyCertConfig.getDefaultInstance()) }
-    require(configMessage.duchiesCount > 0) { "Duchy info config has no entries" }
+    initializeFromConfig(configMessage)
+  }
+
+  fun initializeFromConfig(certConfig: DuchyCertConfig) {
+    require(!DuchyInfo::entries.isInitialized)
+    require(certConfig.duchiesCount > 0) { "Duchy info config has no entries" }
     entries =
-      configMessage.duchiesList.associateBy(DuchyCertConfig.Duchy::getDuchyId) {
+      certConfig.duchiesList.associateBy(DuchyCertConfig.Duchy::getDuchyId) {
         it.toDuchyInfoEntry()
       }
   }

--- a/src/main/kotlin/org/wfanet/measurement/duchy/daemon/mill/liquidlegionsv2/BUILD.bazel
+++ b/src/main/kotlin/org/wfanet/measurement/duchy/daemon/mill/liquidlegionsv2/BUILD.bazel
@@ -22,6 +22,7 @@ kt_jvm_library(
     deps = [
         "//imports/java/io/opentelemetry/api",
         "//src/main/kotlin/org/wfanet/measurement/api:public_api_version",
+        "//src/main/kotlin/org/wfanet/measurement/common/identity",
         "//src/main/kotlin/org/wfanet/measurement/duchy/daemon/mill:mill_base",
         "//src/main/kotlin/org/wfanet/measurement/duchy/daemon/mill/liquidlegionsv2/crypto:liquidlegionsv2encryption",
         "//src/main/kotlin/org/wfanet/measurement/duchy/daemon/utils:computation_conversions",

--- a/src/main/kotlin/org/wfanet/measurement/duchy/deploy/common/daemon/mill/liquidlegionsv2/LiquidLegionsV2MillDaemon.kt
+++ b/src/main/kotlin/org/wfanet/measurement/duchy/deploy/common/daemon/mill/liquidlegionsv2/LiquidLegionsV2MillDaemon.kt
@@ -183,16 +183,17 @@ abstract class LiquidLegionsV2MillDaemon : Runnable {
         duchyId = flags.duchy.duchyName,
         signingKey = csSigningKey,
         consentSignalCert = csCertificate,
+        trustedCertificates = flags.tlsFlags.signingCerts.trustedCertificates,
         dataClients = dataClients,
         systemComputationParticipantsClient = systemComputationParticipantsClient,
         systemComputationsClient = systemComputationsClient,
         systemComputationLogEntriesClient = systemComputationLogEntriesClient,
         computationStatsClient = computationStatsClient,
+        throttler = MinimumIntervalThrottler(Clock.systemUTC(), flags.pollingInterval),
         workerStubs = computationControlClientMap,
         cryptoWorker = JniLiquidLegionsV2Encryption(),
-        throttler = MinimumIntervalThrottler(Clock.systemUTC(), flags.pollingInterval),
-        requestChunkSizeBytes = flags.requestChunkSizeBytes,
-        openTelemetry = openTelemetry
+        openTelemetry = openTelemetry,
+        requestChunkSizeBytes = flags.requestChunkSizeBytes
       )
 
     runBlocking { mill.continuallyProcessComputationQueue() }

--- a/src/main/kotlin/org/wfanet/measurement/integration/common/BUILD.bazel
+++ b/src/main/kotlin/org/wfanet/measurement/integration/common/BUILD.bazel
@@ -95,6 +95,7 @@ kt_jvm_library(
     data = [
         "//src/main/k8s/testing/secretfiles:all_configs",
         "//src/main/k8s/testing/secretfiles:all_der_files",
+        "//src/main/k8s/testing/secretfiles:all_root_certs.pem",
         "//src/main/k8s/testing/secretfiles:all_tink_keysets",
     ],
     deps = [

--- a/src/main/kotlin/org/wfanet/measurement/integration/common/Configs.kt
+++ b/src/main/kotlin/org/wfanet/measurement/integration/common/Configs.kt
@@ -18,8 +18,10 @@ import com.google.protobuf.ByteString
 import com.google.protobuf.Message
 import java.nio.file.Path
 import java.nio.file.Paths
+import java.security.cert.X509Certificate
 import org.jetbrains.annotations.Blocking
 import org.wfanet.measurement.common.crypto.SigningKeyHandle
+import org.wfanet.measurement.common.crypto.readCertificateCollection
 import org.wfanet.measurement.common.crypto.testing.loadSigningKey
 import org.wfanet.measurement.common.crypto.tink.TinkPrivateKeyHandle
 import org.wfanet.measurement.common.crypto.tink.TinkPublicKeyHandle
@@ -88,6 +90,10 @@ fun <T : Message> loadTextProto(fileName: String, default: T): T {
 fun loadTestCertDerFile(fileName: String): ByteString {
   return SECRET_FILES_PATH.resolve(fileName).toFile().readByteString()
 }
+
+@Blocking
+fun loadTestCertCollection(fileName: String): Collection<X509Certificate> =
+  readCertificateCollection(SECRET_FILES_PATH.resolve(fileName).toFile())
 
 @Blocking
 fun loadSigningKey(certDerFileName: String, privateKeyDerFileName: String): SigningKeyHandle {

--- a/src/main/kotlin/org/wfanet/measurement/integration/common/InProcessDuchy.kt
+++ b/src/main/kotlin/org/wfanet/measurement/integration/common/InProcessDuchy.kt
@@ -14,10 +14,12 @@
 
 package org.wfanet.measurement.integration.common
 
+import com.google.protobuf.ByteString
 import io.grpc.Channel
 import io.grpc.inprocess.InProcessChannelBuilder
 import io.grpc.testing.GrpcCleanupRule
 import io.opentelemetry.api.GlobalOpenTelemetry
+import java.security.cert.X509Certificate
 import java.time.Clock
 import java.time.Duration
 import java.util.logging.Level
@@ -79,6 +81,7 @@ class InProcessDuchy(
   val externalDuchyId: String,
   val kingdomSystemApiChannel: Channel,
   duchyDependenciesProvider: () -> DuchyDependencies,
+  private val trustedCertificates: Map<ByteString, X509Certificate>,
   val verboseGrpcLogging: Boolean = true,
   daemonContext: CoroutineContext = Dispatchers.Default,
 ) : TestRule {
@@ -199,23 +202,20 @@ class InProcessDuchy(
   }
 
   fun startLiquidLegionsV2mill(duchyCertMap: Map<String, String>) {
+    val consentSignal509Cert =
+      readCertificate(loadTestCertDerFile("${externalDuchyId}_cs_cert.der"))
+    val signingPrivateKey =
+      readPrivateKey(
+        loadTestCertDerFile("${externalDuchyId}_cs_private.der"),
+        consentSignal509Cert.publicKey.algorithm
+      )
     llv2MillJob =
       daemonScope.launch(CoroutineName("$externalDuchyId LLv2 Mill")) {
-        val consentSignal509Cert =
-          readCertificate(loadTestCertDerFile("${externalDuchyId}_cs_cert.der"))
-        val signingKey =
-          SigningKeyHandle(
-            consentSignal509Cert,
-            readPrivateKey(
-              loadTestCertDerFile("${externalDuchyId}_cs_private.der"),
-              consentSignal509Cert.publicKey.algorithm
-            )
-          )
+        val signingKey = SigningKeyHandle(consentSignal509Cert, signingPrivateKey)
         val workerStubs =
           ALL_DUCHY_NAMES.minus(externalDuchyId).associateWith {
             val channel = computationControlChannel(it)
-            val stub = SystemComputationControlCoroutineStub(channel).withDuchyId(externalDuchyId)
-            stub
+            SystemComputationControlCoroutineStub(channel).withDuchyId(externalDuchyId)
           }
         val liquidLegionsV2mill =
           LiquidLegionsV2Mill(
@@ -223,6 +223,7 @@ class InProcessDuchy(
             duchyId = externalDuchyId,
             signingKey = signingKey,
             consentSignalCert = Certificate(duchyCertMap[externalDuchyId]!!, consentSignal509Cert),
+            trustedCertificates = trustedCertificates,
             dataClients = computationDataClients,
             systemComputationParticipantsClient = systemComputationParticipantsClient,
             systemComputationsClient = systemComputationsClient,

--- a/src/main/kotlin/org/wfanet/measurement/integration/common/InProcessEdpSimulator.kt
+++ b/src/main/kotlin/org/wfanet/measurement/integration/common/InProcessEdpSimulator.kt
@@ -14,7 +14,9 @@
 
 package org.wfanet.measurement.integration.common
 
+import com.google.protobuf.ByteString
 import io.grpc.Channel
+import java.security.cert.X509Certificate
 import java.time.Clock
 import java.time.Duration
 import java.util.logging.Level
@@ -53,6 +55,7 @@ class InProcessEdpSimulator(
   kingdomPublicApiChannel: Channel,
   duchyPublicApiChannel: Channel,
   eventTemplateNames: List<String>,
+  trustedCertificates: Map<ByteString, X509Certificate>,
   coroutineContext: CoroutineContext = Dispatchers.Default,
 ) {
   private val loggingName = "${javaClass.simpleName} $displayName"
@@ -86,7 +89,8 @@ class InProcessEdpSimulator(
         InMemoryBackingStore(),
         100.0f,
         100.0f
-      )
+      ),
+      trustedCertificates
     )
 
   private lateinit var edpJob: Job

--- a/src/main/kotlin/org/wfanet/measurement/integration/common/reporting/InProcessReportingServer.kt
+++ b/src/main/kotlin/org/wfanet/measurement/integration/common/reporting/InProcessReportingServer.kt
@@ -14,9 +14,11 @@
 
 package org.wfanet.measurement.integration.common.reporting
 
+import com.google.protobuf.ByteString
 import io.grpc.Channel
 import java.io.File
 import java.security.SecureRandom
+import java.security.cert.X509Certificate
 import java.util.logging.Logger
 import org.junit.rules.TestRule
 import org.junit.runner.Description
@@ -52,6 +54,7 @@ class InProcessReportingServer(
   private val encryptionKeyPairConfig: EncryptionKeyPairConfig,
   private val signingPrivateKeyDir: File,
   private val measurementConsumerConfig: MeasurementConsumerConfig,
+  trustedCertificates: Map<ByteString, X509Certificate>,
   private val verboseGrpcLogging: Boolean = true,
 ) : TestRule {
   private val publicKingdomMeasurementConsumersClient by lazy {
@@ -128,7 +131,8 @@ class InProcessReportingServer(
               publicKingdomCertificatesClient,
               encryptionKeyPairStore,
               SecureRandom(),
-              signingPrivateKeyDir
+              signingPrivateKeyDir,
+              trustedCertificates
             )
             .withMetadataPrincipalIdentities(measurementConsumerConfig)
         )

--- a/src/main/kotlin/org/wfanet/measurement/loadtest/dataprovider/BUILD.bazel
+++ b/src/main/kotlin/org/wfanet/measurement/loadtest/dataprovider/BUILD.bazel
@@ -67,6 +67,7 @@ kt_jvm_library(
         "@wfa_common_jvm//src/main/kotlin/org/wfanet/measurement/common/identity",
         "@wfa_common_jvm//src/main/kotlin/org/wfanet/measurement/common/throttler",
         "@wfa_common_jvm//src/main/kotlin/org/wfanet/measurement/storage:client",
+        "@wfa_consent_signaling_client//src/main/kotlin/org/wfanet/measurement/consent/client/common:verification_exception",
         "@wfa_consent_signaling_client//src/main/kotlin/org/wfanet/measurement/consent/client/dataprovider",
         "@wfa_consent_signaling_client//src/main/kotlin/org/wfanet/measurement/consent/client/duchy",
         "@wfa_consent_signaling_client//src/main/kotlin/org/wfanet/measurement/consent/client/measurementconsumer",

--- a/src/main/kotlin/org/wfanet/measurement/loadtest/dataprovider/EdpSimulatorRunner.kt
+++ b/src/main/kotlin/org/wfanet/measurement/loadtest/dataprovider/EdpSimulatorRunner.kt
@@ -84,7 +84,8 @@ abstract class EdpSimulatorRunner : Runnable {
         eventQuery,
         MinimumIntervalThrottler(Clock.systemUTC(), flags.throttlerMinimumInterval),
         eventTemplateNames = EVENT_TEMPLATES_TO_FILTERS_MAP.keys.toList(),
-        createNoOpPrivacyBudgetManager()
+        createNoOpPrivacyBudgetManager(),
+        clientCerts.trustedCertificates
       )
     runBlocking {
       edpSimulator.createEventGroup()

--- a/src/main/kotlin/org/wfanet/measurement/loadtest/frontend/FrontendSimulatorRunner.kt
+++ b/src/main/kotlin/org/wfanet/measurement/loadtest/frontend/FrontendSimulatorRunner.kt
@@ -88,6 +88,7 @@ abstract class FrontendSimulatorRunner : Runnable {
         certificatesStub,
         SketchStore(storageClient),
         flags.resultPollingDelay,
+        flags.tlsFlags.signingCerts.trustedCertificates,
         EVENT_TEMPLATES_TO_FILTERS_MAP,
       )
 

--- a/src/main/kotlin/org/wfanet/measurement/reporting/deploy/common/server/V1AlphaPublicApiServer.kt
+++ b/src/main/kotlin/org/wfanet/measurement/reporting/deploy/common/server/V1AlphaPublicApiServer.kt
@@ -106,7 +106,8 @@ private fun run(
           KingdomCertificatesCoroutineStub(kingdomChannel),
           InMemoryEncryptionKeyPairStore(encryptionKeyPairMap.keyPairs),
           SecureRandom(),
-          v1AlphaFlags.signingPrivateKeyStoreDir
+          v1AlphaFlags.signingPrivateKeyStoreDir,
+          commonServerFlags.tlsFlags.signingCerts.trustedCertificates
         )
         .withPrincipalsFromX509AuthorityKeyIdentifiers(principalLookup)
     )

--- a/src/main/kotlin/org/wfanet/measurement/reporting/service/api/v1alpha/ReportsService.kt
+++ b/src/main/kotlin/org/wfanet/measurement/reporting/service/api/v1alpha/ReportsService.kt
@@ -24,6 +24,9 @@ import io.grpc.StatusException
 import java.io.File
 import java.security.PrivateKey
 import java.security.SecureRandom
+import java.security.SignatureException
+import java.security.cert.CertPathValidatorException
+import java.security.cert.X509Certificate
 import java.time.Instant
 import kotlin.math.min
 import kotlinx.coroutines.coroutineScope
@@ -68,6 +71,7 @@ import org.wfanet.measurement.common.base64UrlDecode
 import org.wfanet.measurement.common.base64UrlEncode
 import org.wfanet.measurement.common.crypto.PrivateKeyHandle
 import org.wfanet.measurement.common.crypto.SigningKeyHandle
+import org.wfanet.measurement.common.crypto.authorityKeyIdentifier
 import org.wfanet.measurement.common.crypto.hashSha256
 import org.wfanet.measurement.common.crypto.readCertificate
 import org.wfanet.measurement.common.crypto.readPrivateKey
@@ -236,6 +240,7 @@ class ReportsService(
   private val encryptionKeyPairStore: EncryptionKeyPairStore,
   private val secureRandom: SecureRandom,
   private val signingPrivateKeyDir: File,
+  private val trustedCertificates: Map<ByteString, X509Certificate>
 ) : ReportsCoroutineImplBase() {
   private val setOperationCompiler = SetOperationCompiler()
 
@@ -939,8 +944,19 @@ class ReportsService(
 
     val signedResult =
       decryptResult(measurementResultPair.encryptedResult, encryptionPrivateKeyHandle)
-    if (!verifyResult(signedResult, readCertificate(certificate.x509Der))) {
-      error("Signature of the result is invalid.")
+
+    val x509Certificate: X509Certificate = readCertificate(certificate.x509Der)
+    val trustedIssuer: X509Certificate =
+      checkNotNull(trustedCertificates[checkNotNull(x509Certificate.authorityKeyIdentifier)]) {
+        "${certificate.name} not issued by trusted CA"
+      }
+    // TODO: Record verification failure in internal Measurement rather than having the RPC fail.
+    try {
+      verifyResult(signedResult, x509Certificate, trustedIssuer)
+    } catch (e: CertPathValidatorException) {
+      throw Exception("Certificate path for ${certificate.name} is invalid", e)
+    } catch (e: SignatureException) {
+      throw Exception("Measurement result signature is invalid", e)
     }
     return Measurement.Result.parseFrom(signedResult.data)
   }

--- a/src/test/kotlin/org/wfanet/measurement/api/v2alpha/tools/BUILD.bazel
+++ b/src/test/kotlin/org/wfanet/measurement/api/v2alpha/tools/BUILD.bazel
@@ -6,6 +6,7 @@ kt_jvm_test(
     data = [
         "//src/main/k8s/testing/secretfiles:all_tink_keysets",
         "//src/main/k8s/testing/secretfiles:encryption_public_keys",
+        "//src/main/k8s/testing/secretfiles:mc_trusted_certs.pem",
         "//src/main/k8s/testing/secretfiles:root_certs",
         "//src/main/k8s/testing/secretfiles:secret_files",
     ],

--- a/src/test/kotlin/org/wfanet/measurement/api/v2alpha/tools/BenchmarkTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/api/v2alpha/tools/BenchmarkTest.kt
@@ -31,7 +31,6 @@ import java.nio.file.Paths
 import java.time.Clock
 import java.time.Instant
 import java.time.ZoneId
-import java.util.concurrent.TimeUnit.SECONDS
 import kotlinx.coroutines.runBlocking
 import org.junit.After
 import org.junit.Before
@@ -259,8 +258,8 @@ class BenchmarkTest {
 
   @After
   fun shutdownServer() {
-    server.server.shutdown()
-    server.server.awaitTermination(1, SECONDS)
+    server.shutdown()
+    server.blockUntilShutdown()
   }
 
   @Test

--- a/src/test/kotlin/org/wfanet/measurement/duchy/daemon/mill/liquidlegionsv2/LiquidLegionsV2MillTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/duchy/daemon/mill/liquidlegionsv2/LiquidLegionsV2MillTest.kt
@@ -31,6 +31,7 @@ import com.google.protobuf.ByteString
 import com.google.protobuf.kotlin.toByteString
 import io.grpc.Status
 import io.opentelemetry.api.GlobalOpenTelemetry
+import java.security.cert.X509Certificate
 import java.time.Clock
 import java.time.Duration
 import java.util.Base64
@@ -56,12 +57,12 @@ import org.wfanet.measurement.api.v2alpha.measurementSpec
 import org.wfanet.measurement.common.crypto.SigningKeyHandle
 import org.wfanet.measurement.common.crypto.readCertificate
 import org.wfanet.measurement.common.crypto.readPrivateKey
-import org.wfanet.measurement.common.crypto.testing.FIXED_SERVER_CERT_DER_FILE
-import org.wfanet.measurement.common.crypto.testing.FIXED_SERVER_KEY_DER_FILE
+import org.wfanet.measurement.common.crypto.testing.TestData
 import org.wfanet.measurement.common.crypto.tink.TinkPrivateKeyHandle
 import org.wfanet.measurement.common.flatten
 import org.wfanet.measurement.common.grpc.testing.GrpcTestServerRule
 import org.wfanet.measurement.common.grpc.testing.mockService
+import org.wfanet.measurement.common.identity.DuchyInfo
 import org.wfanet.measurement.common.testing.chainRulesSequentially
 import org.wfanet.measurement.common.testing.verifyProtoArgument
 import org.wfanet.measurement.common.throttler.MinimumIntervalThrottler
@@ -247,8 +248,12 @@ private val LLV2_PARAMETERS =
 
 // In the test, use the same set of cert and encryption key for all parties.
 private const val CONSENT_SIGNALING_CERT_NAME = "Just a name"
-private val CONSENT_SIGNALING_CERT_DER = FIXED_SERVER_CERT_DER_FILE.readBytes().toByteString()
-private val CONSENT_SIGNALING_PRIVATE_KEY_DER = FIXED_SERVER_KEY_DER_FILE.readBytes().toByteString()
+private val CONSENT_SIGNALING_CERT_DER =
+  TestData.FIXED_SERVER_CERT_DER_FILE.readBytes().toByteString()
+private val CONSENT_SIGNALING_PRIVATE_KEY_DER =
+  TestData.FIXED_SERVER_KEY_DER_FILE.readBytes().toByteString()
+private val CONSENT_SIGNALING_ROOT_CERT: X509Certificate =
+  readCertificate(TestData.FIXED_CA_CERT_PEM_FILE)
 private val ENCRYPTION_PRIVATE_KEY = TinkPrivateKeyHandle.generateEcies()
 private val ENCRYPTION_PUBLIC_KEY: org.wfanet.measurement.api.v2alpha.EncryptionPublicKey =
   ENCRYPTION_PRIVATE_KEY.publicKey.toEncryptionPublicKey()
@@ -562,6 +567,7 @@ class LiquidLegionsV2MillTest {
   @Before
   fun initializeMill() = runBlocking {
     val throttler = MinimumIntervalThrottler(Clock.systemUTC(), Duration.ofSeconds(60))
+    DuchyInfo.setForTest(setOf(DUCHY_ONE_NAME, DUCHY_TWO_NAME, DUCHY_THREE_NAME))
     val csX509Certificate = readCertificate(CONSENT_SIGNALING_CERT_DER)
     val csSigningKey =
       SigningKeyHandle(
@@ -569,6 +575,11 @@ class LiquidLegionsV2MillTest {
         readPrivateKey(CONSENT_SIGNALING_PRIVATE_KEY_DER, csX509Certificate.publicKey.algorithm)
       )
     val csCertificate = Certificate(CONSENT_SIGNALING_CERT_NAME, csX509Certificate)
+    val trustedCertificates =
+      DuchyInfo.entries.values.associateBy(
+        { it.rootCertificateSkid },
+        { CONSENT_SIGNALING_ROOT_CERT }
+      )
 
     aggregatorMill =
       LiquidLegionsV2Mill(
@@ -576,17 +587,18 @@ class LiquidLegionsV2MillTest {
         duchyId = DUCHY_ONE_NAME,
         signingKey = csSigningKey,
         consentSignalCert = csCertificate,
+        trustedCertificates = trustedCertificates,
         dataClients = computationDataClients,
         systemComputationParticipantsClient = systemComputationParticipantsStub,
         systemComputationsClient = systemComputationStub,
         systemComputationLogEntriesClient = systemComputationLogEntriesStub,
         computationStatsClient = computationStatsStub,
+        throttler = throttler,
         workerStubs = workerStubs,
         cryptoWorker = mockCryptoWorker,
-        throttler = throttler,
+        openTelemetry = GlobalOpenTelemetry.get(),
         requestChunkSizeBytes = 20,
         maximumAttempts = 2,
-        openTelemetry = GlobalOpenTelemetry.get(),
       )
     nonAggregatorMill =
       LiquidLegionsV2Mill(
@@ -594,17 +606,18 @@ class LiquidLegionsV2MillTest {
         duchyId = DUCHY_ONE_NAME,
         signingKey = csSigningKey,
         consentSignalCert = csCertificate,
+        trustedCertificates = trustedCertificates,
         dataClients = computationDataClients,
         systemComputationParticipantsClient = systemComputationParticipantsStub,
         systemComputationsClient = systemComputationStub,
         systemComputationLogEntriesClient = systemComputationLogEntriesStub,
         computationStatsClient = computationStatsStub,
+        throttler = throttler,
         workerStubs = workerStubs,
         cryptoWorker = mockCryptoWorker,
-        throttler = throttler,
+        openTelemetry = GlobalOpenTelemetry.get(),
         requestChunkSizeBytes = 20,
         maximumAttempts = 2,
-        openTelemetry = GlobalOpenTelemetry.get(),
       )
   }
 
@@ -1067,7 +1080,7 @@ class LiquidLegionsV2MillTest {
               errorMessage =
                 "java.lang.Exception: @Mill a nice mill, Computation 1234 failed due to:\n" +
                   "Cannot verify participation of all DataProviders.\n" +
-                  "ElGamalPublicKey signature of DUCHY_TWO is invalid."
+                  "Invalid ElGamal public key signature for Duchy $DUCHY_TWO_NAME"
               stageAttemptBuilder.apply {
                 stage = CONFIRMATION_PHASE.number
                 stageName = CONFIRMATION_PHASE.name

--- a/src/test/kotlin/org/wfanet/measurement/integration/k8s/BUILD.bazel
+++ b/src/test/kotlin/org/wfanet/measurement/integration/k8s/BUILD.bazel
@@ -10,6 +10,7 @@ kt_jvm_library(
         "//src/main/k8s/local/testing:duchies_and_edps_config",
         "//src/main/k8s/local/testing:emulators_config",
         "//src/main/k8s/local/testing:kingdom_config",
+        "//src/main/k8s/testing/secretfiles:mc_trusted_certs.pem",
         "//src/main/k8s/testing/secretfiles:secret_files",
     ],
     deps = [

--- a/src/test/kotlin/org/wfanet/measurement/integration/k8s/CorrectnessTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/integration/k8s/CorrectnessTest.kt
@@ -287,7 +287,7 @@ class CorrectnessTest {
 
     private val measurementConsumerSigningCerts: SigningCerts by lazy {
       val secretFiles = checkNotNull(getRuntimePath(SECRET_FILES_PATH))
-      val trustedCerts = secretFiles.resolve("kingdom_root.pem").toFile()
+      val trustedCerts = secretFiles.resolve("mc_trusted_certs.pem").toFile()
       val cert = secretFiles.resolve("mc_tls.pem").toFile()
       val key = secretFiles.resolve("mc_tls.key").toFile()
       SigningCerts.fromPemFiles(cert, key, trustedCerts)
@@ -434,6 +434,7 @@ class CorrectnessTest {
           CertificatesCoroutineStub(publicApiChannel),
           SketchStore(storageClient),
           Duration.ofSeconds(10L),
+          measurementConsumerSigningCerts.trustedCertificates,
           EventFilters.EVENT_TEMPLATES_TO_FILTERS_MAP
         )
         .also {

--- a/src/test/kotlin/org/wfanet/measurement/kingdom/service/api/v2alpha/CertificatesServiceTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/kingdom/service/api/v2alpha/CertificatesServiceTest.kt
@@ -58,7 +58,7 @@ import org.wfanet.measurement.api.v2alpha.withModelProviderPrincipal
 import org.wfanet.measurement.api.v2alpha.withPrincipal
 import org.wfanet.measurement.common.crypto.readCertificate
 import org.wfanet.measurement.common.crypto.subjectKeyIdentifier
-import org.wfanet.measurement.common.crypto.testing.FIXED_SERVER_CERT_PEM_FILE
+import org.wfanet.measurement.common.crypto.testing.TestData
 import org.wfanet.measurement.common.grpc.testing.GrpcTestServerRule
 import org.wfanet.measurement.common.grpc.testing.mockService
 import org.wfanet.measurement.common.identity.apiIdToExternalId
@@ -1096,7 +1096,8 @@ class CertificatesServiceTest {
   }
 }
 
-private val SERVER_CERTIFICATE: X509Certificate = readCertificate(FIXED_SERVER_CERT_PEM_FILE)
+private val SERVER_CERTIFICATE: X509Certificate =
+  readCertificate(TestData.FIXED_SERVER_CERT_PEM_FILE)
 private val SERVER_CERTIFICATE_DER = ByteString.copyFrom(SERVER_CERTIFICATE.encoded)
 
 private val CERTIFICATE: Certificate = certificate {

--- a/src/test/kotlin/org/wfanet/measurement/kingdom/service/api/v2alpha/DataProvidersServiceTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/kingdom/service/api/v2alpha/DataProvidersServiceTest.kt
@@ -39,8 +39,7 @@ import org.wfanet.measurement.api.v2alpha.withMeasurementConsumerPrincipal
 import org.wfanet.measurement.api.v2alpha.withModelProviderPrincipal
 import org.wfanet.measurement.common.crypto.readCertificate
 import org.wfanet.measurement.common.crypto.subjectKeyIdentifier
-import org.wfanet.measurement.common.crypto.testing.FIXED_ENCRYPTION_PUBLIC_KEYSET
-import org.wfanet.measurement.common.crypto.testing.FIXED_SERVER_CERT_PEM_FILE
+import org.wfanet.measurement.common.crypto.testing.TestData
 import org.wfanet.measurement.common.crypto.tink.loadPublicKey
 import org.wfanet.measurement.common.grpc.testing.GrpcTestServerRule
 import org.wfanet.measurement.common.grpc.testing.mockService
@@ -180,11 +179,12 @@ class DataProvidersServiceTest {
   }
 
   companion object {
-    private val serverCertificate: X509Certificate = readCertificate(FIXED_SERVER_CERT_PEM_FILE)
+    private val serverCertificate: X509Certificate =
+      readCertificate(TestData.FIXED_SERVER_CERT_PEM_FILE)
     private val SERVER_CERTIFICATE_DER = serverCertificate.encoded.toByteString()
 
     private val ENCRYPTION_PUBLIC_KEY =
-      loadPublicKey(FIXED_ENCRYPTION_PUBLIC_KEYSET).toEncryptionPublicKey()
+      loadPublicKey(TestData.FIXED_ENCRYPTION_PUBLIC_KEYSET).toEncryptionPublicKey()
     private val SIGNED_PUBLIC_KEY = signedData {
       data = ENCRYPTION_PUBLIC_KEY.toByteString()
       signature = ByteString.copyFromUtf8("Fake signature of public key")

--- a/src/test/kotlin/org/wfanet/measurement/kingdom/service/api/v2alpha/MeasurementConsumersServiceTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/kingdom/service/api/v2alpha/MeasurementConsumersServiceTest.kt
@@ -47,8 +47,7 @@ import org.wfanet.measurement.api.v2alpha.withModelProviderPrincipal
 import org.wfanet.measurement.common.crypto.hashSha256
 import org.wfanet.measurement.common.crypto.readCertificate
 import org.wfanet.measurement.common.crypto.subjectKeyIdentifier
-import org.wfanet.measurement.common.crypto.testing.FIXED_ENCRYPTION_PUBLIC_KEYSET
-import org.wfanet.measurement.common.crypto.testing.FIXED_SERVER_CERT_PEM_FILE
+import org.wfanet.measurement.common.crypto.testing.TestData
 import org.wfanet.measurement.common.crypto.tink.loadPublicKey
 import org.wfanet.measurement.common.grpc.testing.GrpcTestServerRule
 import org.wfanet.measurement.common.grpc.testing.mockService
@@ -527,11 +526,12 @@ class MeasurementConsumersServiceTest {
   }
 
   companion object {
-    private val serverCertificate: X509Certificate = readCertificate(FIXED_SERVER_CERT_PEM_FILE)
+    private val serverCertificate: X509Certificate =
+      readCertificate(TestData.FIXED_SERVER_CERT_PEM_FILE)
     private val SERVER_CERTIFICATE_DER = serverCertificate.encoded.toByteString()
 
     private val ENCRYPTION_PUBLIC_KEY =
-      loadPublicKey(FIXED_ENCRYPTION_PUBLIC_KEYSET).toEncryptionPublicKey()
+      loadPublicKey(TestData.FIXED_ENCRYPTION_PUBLIC_KEYSET).toEncryptionPublicKey()
     private val SIGNED_PUBLIC_KEY = signedData {
       data = ENCRYPTION_PUBLIC_KEY.toByteString()
       signature = ByteString.copyFromUtf8("Fake signature of public key")

--- a/src/test/kotlin/org/wfanet/measurement/loadtest/dataprovider/BUILD.bazel
+++ b/src/test/kotlin/org/wfanet/measurement/loadtest/dataprovider/BUILD.bazel
@@ -7,6 +7,7 @@ kt_jvm_test(
         "//src/main/k8s/testing/secretfiles:all_configs",
         "//src/main/k8s/testing/secretfiles:all_der_files",
         "//src/main/k8s/testing/secretfiles:all_tink_keysets",
+        "//src/main/k8s/testing/secretfiles:edp_trusted_certs.pem",
     ],
     test_class = "org.wfanet.measurement.loadtest.dataprovider.EdpSimulatorTest",
     deps = [

--- a/src/test/kotlin/org/wfanet/measurement/loadtest/dataprovider/EdpSimulatorTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/loadtest/dataprovider/EdpSimulatorTest.kt
@@ -16,8 +16,14 @@ package org.wfanet.measurement.loadtest.dataprovider
 
 import com.google.common.truth.Correspondence
 import com.google.common.truth.Truth.assertThat
+import com.google.common.truth.extensions.proto.FieldScopes
+import com.google.common.truth.extensions.proto.ProtoTruth.assertThat
+import com.google.protobuf.ByteString
+import com.google.protobuf.kotlin.toByteString
+import com.google.protobuf.kotlin.toByteStringUtf8
 import java.nio.file.Path
 import java.nio.file.Paths
+import java.security.cert.X509Certificate
 import java.time.Clock
 import java.time.Duration
 import java.time.LocalDate
@@ -33,6 +39,11 @@ import org.junit.rules.TemporaryFolder
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.stub
+import org.mockito.kotlin.verifyBlocking
 import org.wfanet.anysketch.AnySketch
 import org.wfanet.anysketch.AnySketch.Register
 import org.wfanet.anysketch.Sketch
@@ -48,25 +59,29 @@ import org.wfanet.anysketch.uniformDistribution
 import org.wfanet.estimation.VidSampler
 import org.wfanet.measurement.api.v2alpha.CertificatesGrpcKt.CertificatesCoroutineImplBase
 import org.wfanet.measurement.api.v2alpha.CertificatesGrpcKt.CertificatesCoroutineStub
+import org.wfanet.measurement.api.v2alpha.DuchyCertificateKey
+import org.wfanet.measurement.api.v2alpha.DuchyKey
 import org.wfanet.measurement.api.v2alpha.EventGroupsGrpcKt.EventGroupsCoroutineImplBase
 import org.wfanet.measurement.api.v2alpha.EventGroupsGrpcKt.EventGroupsCoroutineStub
-import org.wfanet.measurement.api.v2alpha.MeasurementConsumerCertificateKey
-import org.wfanet.measurement.api.v2alpha.MeasurementConsumerKey
 import org.wfanet.measurement.api.v2alpha.MeasurementSpecKt.reachAndFrequency
 import org.wfanet.measurement.api.v2alpha.MeasurementSpecKt.vidSamplingInterval
 import org.wfanet.measurement.api.v2alpha.ProtocolConfigKt
+import org.wfanet.measurement.api.v2alpha.RefuseRequisitionRequest
 import org.wfanet.measurement.api.v2alpha.Requisition
+import org.wfanet.measurement.api.v2alpha.Requisition.Refusal
 import org.wfanet.measurement.api.v2alpha.RequisitionFulfillmentGrpcKt.RequisitionFulfillmentCoroutineImplBase
 import org.wfanet.measurement.api.v2alpha.RequisitionFulfillmentGrpcKt.RequisitionFulfillmentCoroutineStub
 import org.wfanet.measurement.api.v2alpha.RequisitionKt.DuchyEntryKt.liquidLegionsV2
 import org.wfanet.measurement.api.v2alpha.RequisitionKt.DuchyEntryKt.value
 import org.wfanet.measurement.api.v2alpha.RequisitionKt.duchyEntry
+import org.wfanet.measurement.api.v2alpha.RequisitionKt.refusal
 import org.wfanet.measurement.api.v2alpha.RequisitionSpecKt
 import org.wfanet.measurement.api.v2alpha.RequisitionSpecKt.eventFilter
 import org.wfanet.measurement.api.v2alpha.RequisitionSpecKt.eventGroupEntry
 import org.wfanet.measurement.api.v2alpha.RequisitionsGrpcKt.RequisitionsCoroutineImplBase
 import org.wfanet.measurement.api.v2alpha.RequisitionsGrpcKt.RequisitionsCoroutineStub
 import org.wfanet.measurement.api.v2alpha.certificate
+import org.wfanet.measurement.api.v2alpha.copy
 import org.wfanet.measurement.api.v2alpha.elGamalPublicKey
 import org.wfanet.measurement.api.v2alpha.event_templates.testing.TestBannerTemplate
 import org.wfanet.measurement.api.v2alpha.event_templates.testing.TestBannerTemplate.Gender
@@ -74,33 +89,37 @@ import org.wfanet.measurement.api.v2alpha.event_templates.testing.TestBannerTemp
 import org.wfanet.measurement.api.v2alpha.event_templates.testing.TestEvent
 import org.wfanet.measurement.api.v2alpha.event_templates.testing.TestPrivacyBudgetTemplate
 import org.wfanet.measurement.api.v2alpha.event_templates.testing.TestPrivacyBudgetTemplate.AgeRange as PrivacyAgeRange
-import org.wfanet.measurement.api.v2alpha.event_templates.testing.TestPrivacyBudgetTemplateKt.ageRange as privacyAgeRange
+import org.wfanet.measurement.api.v2alpha.event_templates.testing.TestPrivacyBudgetTemplateKt as TestPrivacyBudgetTemplates
 import org.wfanet.measurement.api.v2alpha.event_templates.testing.testBannerTemplate
 import org.wfanet.measurement.api.v2alpha.event_templates.testing.testEvent
 import org.wfanet.measurement.api.v2alpha.event_templates.testing.testPrivacyBudgetTemplate
+import org.wfanet.measurement.api.v2alpha.getCertificateRequest
 import org.wfanet.measurement.api.v2alpha.liquidLegionsSketchParams
 import org.wfanet.measurement.api.v2alpha.listRequisitionsResponse
 import org.wfanet.measurement.api.v2alpha.measurementSpec
 import org.wfanet.measurement.api.v2alpha.protocolConfig
+import org.wfanet.measurement.api.v2alpha.refuseRequisitionRequest
 import org.wfanet.measurement.api.v2alpha.requisition
 import org.wfanet.measurement.api.v2alpha.requisitionSpec
 import org.wfanet.measurement.api.v2alpha.timeInterval
 import org.wfanet.measurement.common.HexString
 import org.wfanet.measurement.common.crypto.SigningKeyHandle
+import org.wfanet.measurement.common.crypto.authorityKeyIdentifier
 import org.wfanet.measurement.common.crypto.hashSha256
+import org.wfanet.measurement.common.crypto.readCertificateCollection
 import org.wfanet.measurement.common.crypto.testing.loadSigningKey
 import org.wfanet.measurement.common.crypto.tink.TinkPrivateKeyHandle
-import org.wfanet.measurement.common.crypto.tink.TinkPublicKeyHandle
 import org.wfanet.measurement.common.crypto.tink.loadPrivateKey
 import org.wfanet.measurement.common.crypto.tink.loadPublicKey
 import org.wfanet.measurement.common.flatten
 import org.wfanet.measurement.common.getRuntimePath
 import org.wfanet.measurement.common.grpc.testing.GrpcTestServerRule
 import org.wfanet.measurement.common.grpc.testing.mockService
-import org.wfanet.measurement.common.identity.apiIdToExternalId
 import org.wfanet.measurement.common.identity.externalIdToApiId
 import org.wfanet.measurement.common.readByteString
+import org.wfanet.measurement.common.testing.verifyAndCapture
 import org.wfanet.measurement.common.throttler.MinimumIntervalThrottler
+import org.wfanet.measurement.common.throttler.Throttler
 import org.wfanet.measurement.common.toProtoTime
 import org.wfanet.measurement.consent.client.common.toEncryptionPublicKey
 import org.wfanet.measurement.consent.client.duchy.signElgamalPublicKey
@@ -140,7 +159,6 @@ private const val EDP_NAME = "dataProviders/someDataProvider"
 
 private const val LLV2_DECAY_RATE = 12.0
 private const val LLV2_MAX_SIZE = 100_000L
-private const val MAX_FREQUENCY = 10
 
 private val SKETCH_CONFIG = sketchConfig {
   indexes += indexSpec {
@@ -170,10 +188,6 @@ private val SKETCH_CONFIG = sketchConfig {
 private val MEASUREMENT_CONSUMER_CERTIFICATE_DER =
   SECRET_FILES_PATH.resolve("mc_cs_cert.der").toFile().readByteString()
 private const val MEASUREMENT_CONSUMER_NAME = "measurementConsumers/AAAAAAAAAHs"
-private val EXTERNAL_MEASUREMENT_CONSUMER_ID =
-  apiIdToExternalId(
-    MeasurementConsumerKey.fromName(MEASUREMENT_CONSUMER_NAME)!!.measurementConsumerId
-  )
 private const val MEASUREMENT_CONSUMER_CERTIFICATE_NAME =
   "$MEASUREMENT_CONSUMER_NAME/certificates/AAAAAAAAAcg"
 private val MEASUREMENT_CONSUMER_CERTIFICATE = certificate {
@@ -206,13 +220,18 @@ private val REQUISITION_ONE_SPEC = requisitionSpec {
   measurementPublicKey = MEASUREMENT_PUBLIC_KEY
   nonce = Random.Default.nextLong()
 }
-private const val DUCHIES_MAP_KEY = "1"
-private const val DUCHY_NAME = "worker1"
+private const val DUCHY_ID = "worker1"
 
 @RunWith(JUnit4::class)
 class EdpSimulatorTest {
+
   private val certificatesServiceMock: CertificatesCoroutineImplBase = mockService {
-    onBlocking { getCertificate(any()) }.thenReturn(MEASUREMENT_CONSUMER_CERTIFICATE)
+    onBlocking {
+        getCertificate(eq(getCertificateRequest { name = MEASUREMENT_CONSUMER_CERTIFICATE.name }))
+      }
+      .thenReturn(MEASUREMENT_CONSUMER_CERTIFICATE)
+    onBlocking { getCertificate(eq(getCertificateRequest { name = DUCHY_CERTIFICATE.name })) }
+      .thenReturn(DUCHY_CERTIFICATE)
   }
   private val eventGroupsServiceMock: EventGroupsCoroutineImplBase = mockService()
   private val requisitionsServiceMock: RequisitionsCoroutineImplBase = mockService {
@@ -247,6 +266,10 @@ class EdpSimulatorTest {
     RequisitionFulfillmentCoroutineStub(grpcTestServerRule.channel)
   }
 
+  private val backingStore = TestInMemoryBackingStore()
+  private val privacyBudgetManager =
+    PrivacyBudgetManager(PrivacyBucketFilter(TestPrivacyBucketMapper()), backingStore, 10.0f, 0.02f)
+
   private fun getExpectedResult(
     matchingVids: List<Int>,
     vidSamplingIntervalStart: Float,
@@ -274,17 +297,14 @@ class EdpSimulatorTest {
     privacyBudget: TestPrivacyBudgetTemplate,
     vidRange: IntRange,
   ): Map<Int, List<TestEvent>> {
-    return vidRange
-      .map {
-        it to
-          listOf(
-            testEvent {
-              this.bannerAd = bannerAd
-              this.privacyBudget = privacyBudget
-            }
-          )
-      }
-      .toMap()
+    return vidRange.associateWith {
+      listOf(
+        testEvent {
+          this.bannerAd = bannerAd
+          this.privacyBudget = privacyBudget
+        }
+      )
+    }
   }
 
   @Test
@@ -296,14 +316,14 @@ class EdpSimulatorTest {
       val matchingVids = videoTemplateMatchingVids + bannerTemplateMatchingVids
 
       val matchingTestPrivacyTemplate = testPrivacyBudgetTemplate {
-        age = privacyAgeRange { value = PrivacyAgeRange.Value.AGE_35_TO_54 }
+        age = TestPrivacyBudgetTemplates.ageRange { value = PrivacyAgeRange.Value.AGE_35_TO_54 }
       }
       val matchingTestBannerTemplate = testBannerTemplate {
         gender = gender { value = Gender.Value.GENDER_FEMALE }
       }
 
       val nonMatchingTestPrivacyTemplate = testPrivacyBudgetTemplate {
-        age = privacyAgeRange { value = PrivacyAgeRange.Value.AGE_18_TO_34 }
+        age = TestPrivacyBudgetTemplates.ageRange { value = PrivacyAgeRange.Value.AGE_18_TO_34 }
       }
       val nonMatchingTestBannerTemplate = testBannerTemplate {
         gender = gender { value = Gender.Value.GENDER_MALE }
@@ -329,23 +349,9 @@ class EdpSimulatorTest {
       val matchingEvents = privacyTemplateMatchingEvents + bannerTemplateMatchingEvents
       val allEvents = matchingEvents + nonMatchingEvents
 
-      val backingStore = TestInMemoryBackingStore()
-      val privacyBudgetManager =
-        PrivacyBudgetManager(
-          PrivacyBucketFilter(TestPrivacyBucketMapper()),
-          backingStore,
-          10.0f,
-          0.02f
-        )
-
       val edpSimulator =
         EdpSimulator(
-          EdpData(
-            EDP_NAME,
-            EDP_DISPLAY_NAME,
-            loadEncryptionPrivateKey("${EDP_DISPLAY_NAME}_enc_private.tink"),
-            loadSigningKey("${EDP_DISPLAY_NAME}_cs_cert.der", "${EDP_DISPLAY_NAME}_cs_private.der")
-          ),
+          EDP_DATA,
           MC_NAME,
           certificatesStub,
           eventGroupsStub,
@@ -355,7 +361,8 @@ class EdpSimulatorTest {
           FilterEventQuery(allEvents),
           MinimumIntervalThrottler(Clock.systemUTC(), Duration.ofMillis(1000)),
           EVENT_TEMPLATES,
-          privacyBudgetManager
+          privacyBudgetManager,
+          TRUSTED_CERTIFICATES
         )
       edpSimulator.createEventGroup()
       edpSimulator.executeRequisitionFulfillingWorkflow()
@@ -657,14 +664,79 @@ class EdpSimulatorTest {
     }
   }
 
+  @Test
+  fun `refuses requisition when DuchyEntry verification fails`() {
+    val throttlerMock = mock<Throttler>()
+    val eventQueryMock = mock<EventQuery>()
+    val simulator =
+      EdpSimulator(
+        EDP_DATA,
+        MC_NAME,
+        certificatesStub,
+        eventGroupsStub,
+        requisitionsStub,
+        requisitionFulfillmentStub,
+        sketchStore,
+        eventQueryMock,
+        throttlerMock,
+        listOf(),
+        privacyBudgetManager,
+        TRUSTED_CERTIFICATES
+      )
+    val requisition =
+      REQUISITION_ONE.copy {
+        duchies[0] =
+          duchies[0].copy {
+            value =
+              value.copy {
+                liquidLegionsV2 =
+                  liquidLegionsV2.copy {
+                    elGamalPublicKey =
+                      elGamalPublicKey.copy { signature = "garbage".toByteStringUtf8() }
+                  }
+              }
+          }
+      }
+    requisitionsServiceMock.stub {
+      onBlocking { requisitionsServiceMock.listRequisitions(any()) }
+        .thenReturn(listRequisitionsResponse { requisitions += requisition })
+    }
+
+    runBlocking { simulator.executeRequisitionFulfillingWorkflow() }
+
+    val refuseRequest: RefuseRequisitionRequest =
+      verifyAndCapture(requisitionsServiceMock, RequisitionsCoroutineImplBase::refuseRequisition)
+    assertThat(refuseRequest)
+      .ignoringFieldScope(
+        FieldScopes.allowingFieldDescriptors(
+          Refusal.getDescriptor().findFieldByNumber(Refusal.MESSAGE_FIELD_NUMBER)
+        )
+      )
+      .isEqualTo(
+        refuseRequisitionRequest {
+          name = requisition.name
+          refusal = refusal { justification = Refusal.Justification.CONSENT_SIGNAL_INVALID }
+        }
+      )
+    assertThat(refuseRequest.refusal.message).contains(DUCHY_NAME)
+    verifyBlocking(requisitionFulfillmentServiceMock, never()) { fulfillRequisition(any()) }
+    verifyBlocking(requisitionsServiceMock, never()) { fulfillDirectRequisition(any()) }
+  }
+
   companion object {
     private val MC_SIGNING_KEY =
       loadSigningKey("${MC_NAME}_cs_cert.der", "${MC_NAME}_cs_private.der")
     private val DUCHY_SIGNING_KEY =
-      loadSigningKey("${DUCHY_NAME}_cs_cert.der", "${DUCHY_NAME}_cs_private.der")
+      loadSigningKey("${DUCHY_ID}_cs_cert.der", "${DUCHY_ID}_cs_private.der")
+
+    private val DUCHY_NAME = DuchyKey(DUCHY_ID).toName()
+    private val DUCHY_CERTIFICATE = certificate {
+      name = DuchyCertificateKey(DUCHY_ID, externalIdToApiId(6L)).toName()
+      x509Der = DUCHY_SIGNING_KEY.certificate.encoded.toByteString()
+    }
 
     private val MEASUREMENT_SPEC = measurementSpec {
-      measurementPublicKey = MEASUREMENT_PUBLIC_KEY
+      measurementPublicKey = org.wfanet.measurement.loadtest.dataprovider.MEASUREMENT_PUBLIC_KEY
       reachAndFrequency = reachAndFrequency {}
       vidSamplingInterval = vidSamplingInterval {
         start = 0.0f
@@ -673,22 +745,27 @@ class EdpSimulatorTest {
       nonceHashes += hashSha256(REQUISITION_ONE_SPEC.nonce)
     }
 
+    private val MEASUREMENT_PUBLIC_KEY =
+      loadPublicKey(SECRET_FILES_PATH.resolve("${EDP_DISPLAY_NAME}_enc_public.tink").toFile())
+        .toEncryptionPublicKey()
     private val ENCRYPTED_REQUISITION_ONE_SPEC =
       encryptRequisitionSpec(
-        signedRequisitionSpec = signRequisitionSpec(REQUISITION_ONE_SPEC, MC_SIGNING_KEY),
-        measurementPublicKey =
-          loadEncryptionPublicKey("${EDP_DISPLAY_NAME}_enc_public.tink").toEncryptionPublicKey()
+        signRequisitionSpec(REQUISITION_ONE_SPEC, MC_SIGNING_KEY),
+        MEASUREMENT_PUBLIC_KEY
+      )
+
+    private val EDP_DATA =
+      EdpData(
+        EDP_NAME,
+        EDP_DISPLAY_NAME,
+        loadEncryptionPrivateKey("${EDP_DISPLAY_NAME}_enc_private.tink"),
+        loadSigningKey("${EDP_DISPLAY_NAME}_cs_cert.der", "${EDP_DISPLAY_NAME}_cs_private.der")
       )
 
     private val REQUISITION_ONE = requisition {
       name = "requisition_one"
       state = Requisition.State.UNFULFILLED
-      measurementConsumerCertificate =
-        MeasurementConsumerCertificateKey(
-            externalIdToApiId(EXTERNAL_MEASUREMENT_CONSUMER_ID),
-            externalIdToApiId(8L)
-          )
-          .toName()
+      measurementConsumerCertificate = MEASUREMENT_CONSUMER_CERTIFICATE_NAME
       measurementSpec = signMeasurementSpec(MEASUREMENT_SPEC, MC_SIGNING_KEY)
       encryptedRequisitionSpec = ENCRYPTED_REQUISITION_ONE_SPEC
       protocolConfig = protocolConfig {
@@ -707,9 +784,9 @@ class EdpSimulatorTest {
           }
       }
       duchies += duchyEntry {
-        key = DUCHIES_MAP_KEY
+        key = DUCHY_NAME
         value = value {
-          duchyCertificate = externalIdToApiId(6L)
+          duchyCertificate = DUCHY_CERTIFICATE.name
           liquidLegionsV2 = liquidLegionsV2 {
             elGamalPublicKey =
               signElgamalPublicKey(CONSENT_SIGNALING_ELGAMAL_PUBLIC_KEY, DUCHY_SIGNING_KEY)
@@ -718,44 +795,48 @@ class EdpSimulatorTest {
       }
     }
 
+    private val TRUSTED_CERTIFICATES: Map<ByteString, X509Certificate> =
+      readCertificateCollection(SECRET_FILES_PATH.resolve("edp_trusted_certs.pem").toFile())
+        .associateBy { requireNotNull(it.authorityKeyIdentifier) }
+
     @JvmField @ClassRule val temporaryFolder: TemporaryFolder = TemporaryFolder()
-    fun loadSigningKey(certDerFileName: String, privateKeyDerFileName: String): SigningKeyHandle {
+
+    private fun loadSigningKey(
+      certDerFileName: String,
+      privateKeyDerFileName: String
+    ): SigningKeyHandle {
       return loadSigningKey(
         SECRET_FILES_PATH.resolve(certDerFileName).toFile(),
         SECRET_FILES_PATH.resolve(privateKeyDerFileName).toFile()
       )
     }
 
-    fun loadEncryptionPrivateKey(fileName: String): TinkPrivateKeyHandle {
+    private fun loadEncryptionPrivateKey(fileName: String): TinkPrivateKeyHandle {
       return loadPrivateKey(SECRET_FILES_PATH.resolve(fileName).toFile())
-    }
-
-    fun loadEncryptionPublicKey(fileName: String): TinkPublicKeyHandle {
-      return loadPublicKey(SECRET_FILES_PATH.resolve(fileName).toFile())
     }
 
     private val EQUIVALENCE: Correspondence<Register?, Register?> =
       Correspondence.from(EdpSimulatorTest::registersEquivalent, "is equivalent to")
 
-    fun registersEquivalent(result: Register?, expected: Register?): Boolean {
+    private fun registersEquivalent(result: Register?, expected: Register?): Boolean {
       if (result == null || expected == null) {
         return result == expected
       }
-      return result.getIndex() == expected.getIndex() &&
-        result.getValues().containsAll(expected.getValues()) &&
-        expected.getValues().containsAll(result.getValues())
+      return result.index == expected.index &&
+        result.values.containsAll(expected.values) &&
+        expected.values.containsAll(result.values)
     }
 
     private fun assertAnySketchEquals(sketch: AnySketch, other: AnySketch) {
       assertThat(sketch).comparingElementsUsing(EQUIVALENCE).containsExactlyElementsIn(other)
     }
 
-    lateinit var sketchStore: SketchStore
-      private set
+    private lateinit var sketchStore: SketchStore
 
     @JvmStatic
     @BeforeClass
-    fun initSketchStore() =
-      runBlocking<Unit> { sketchStore = SketchStore(FileSystemStorageClient(temporaryFolder.root)) }
+    fun initSketchStore() {
+      sketchStore = SketchStore(FileSystemStorageClient(temporaryFolder.root))
+    }
   }
 }

--- a/src/test/kotlin/org/wfanet/measurement/reporting/service/api/v1alpha/ReportsServiceTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/reporting/service/api/v1alpha/ReportsServiceTest.kt
@@ -24,6 +24,7 @@ import io.grpc.Status
 import io.grpc.StatusRuntimeException
 import java.nio.file.Paths
 import java.security.SecureRandom
+import java.security.cert.X509Certificate
 import java.time.Instant
 import kotlin.test.assertFails
 import kotlin.test.assertFailsWith
@@ -99,6 +100,7 @@ import org.wfanet.measurement.common.crypto.SigningKeyHandle
 import org.wfanet.measurement.common.crypto.hashSha256
 import org.wfanet.measurement.common.crypto.readCertificate
 import org.wfanet.measurement.common.crypto.readPrivateKey
+import org.wfanet.measurement.common.crypto.subjectKeyIdentifier
 import org.wfanet.measurement.common.crypto.tink.loadPrivateKey
 import org.wfanet.measurement.common.crypto.tink.loadPublicKey
 import org.wfanet.measurement.common.getRuntimePath
@@ -259,6 +261,8 @@ private val AGGREGATOR_SIGNING_KEY: SigningKeyHandle by lazy {
   )
 }
 private val AGGREGATOR_CERTIFICATE = certificate { x509Der = AGGREGATOR_CERTIFICATE_DER }
+private val AGGREGATOR_ROOT_CERTIFICATE: X509Certificate =
+  readCertificate(SECRETS_DIR.resolve("aggregator_root.pem"))
 
 // Public keys of measurement consumers
 private val MEASUREMENT_PUBLIC_KEY_DATA = SECRETS_DIR.resolve("mc_enc_public.tink").readByteString()
@@ -274,6 +278,8 @@ private val MEASUREMENT_CONSUMER_CERTIFICATE_DER =
 private val MEASUREMENT_CONSUMER_PRIVATE_KEY_DER =
   SECRETS_DIR.resolve("mc_cs_private.der").readByteString()
 private val MEASUREMENT_CONSUMER_CERTIFICATE = readCertificate(MEASUREMENT_CONSUMER_CERTIFICATE_DER)
+private val TRUSTED_MEASUREMENT_CONSUMER_ISSUER: X509Certificate =
+  readCertificate(SECRETS_DIR.resolve("mc_root.pem"))
 private val MEASUREMENT_CONSUMER_SIGNING_PRIVATE_KEY =
   readPrivateKey(
     MEASUREMENT_CONSUMER_PRIVATE_KEY_DER,
@@ -1303,15 +1309,20 @@ class ReportsServiceTest {
     onBlocking {
         getCertificate(eq(getCertificateRequest { name = DATA_PROVIDER_CERTIFICATE_NAMES[0] }))
       }
-      .thenReturn(AGGREGATOR_CERTIFICATE)
+      .thenReturn(AGGREGATOR_CERTIFICATE.copy { name = DATA_PROVIDER_CERTIFICATE_NAMES[0] })
     onBlocking {
         getCertificate(eq(getCertificateRequest { name = DATA_PROVIDER_CERTIFICATE_NAMES[1] }))
       }
-      .thenReturn(AGGREGATOR_CERTIFICATE)
+      .thenReturn(AGGREGATOR_CERTIFICATE.copy { name = DATA_PROVIDER_CERTIFICATE_NAMES[1] })
     onBlocking {
         getCertificate(eq(getCertificateRequest { name = MEASUREMENT_CONSUMER_CERTIFICATE_NAME }))
       }
-      .thenReturn(certificate { x509Der = MEASUREMENT_CONSUMER_CERTIFICATE_DER })
+      .thenReturn(
+        certificate {
+          name = MEASUREMENT_CONSUMER_CERTIFICATE_NAME
+          x509Der = MEASUREMENT_CONSUMER_CERTIFICATE_DER
+        }
+      )
   }
 
   private val secureRandomMock: SecureRandom = mock()
@@ -1347,7 +1358,8 @@ class ReportsServiceTest {
         CertificatesCoroutineStub(grpcTestServerRule.channel),
         ENCRYPTION_KEY_PAIR_STORE,
         secureRandomMock,
-        SECRETS_DIR
+        SECRETS_DIR,
+        mapOf(AGGREGATOR_ROOT_CERTIFICATE.subjectKeyIdentifier!! to AGGREGATOR_ROOT_CERTIFICATE)
       )
   }
 
@@ -1439,10 +1451,11 @@ class ReportsServiceTest {
       )
       .isEqualTo(expectedMeasurement)
 
-    assertThat(
-        verifyMeasurementSpec(capturedMeasurement.measurementSpec, MEASUREMENT_CONSUMER_CERTIFICATE)
-      )
-      .isTrue()
+    verifyMeasurementSpec(
+      capturedMeasurement.measurementSpec,
+      MEASUREMENT_CONSUMER_CERTIFICATE,
+      TRUSTED_MEASUREMENT_CONSUMER_ISSUER
+    )
     val measurementSpec = MeasurementSpec.parseFrom(capturedMeasurement.measurementSpec.data)
     assertThat(measurementSpec).isEqualTo(REACH_ONLY_MEASUREMENT_SPEC)
 
@@ -1455,15 +1468,13 @@ class ReportsServiceTest {
           DATA_PROVIDER_PRIVATE_KEY_HANDLE
         )
       val requisitionSpec = RequisitionSpec.parseFrom(signedRequisitionSpec.data)
-      assertThat(
-          verifyRequisitionSpec(
-            signedRequisitionSpec,
-            requisitionSpec,
-            measurementSpec,
-            MEASUREMENT_CONSUMER_CERTIFICATE
-          )
-        )
-        .isTrue()
+      verifyRequisitionSpec(
+        signedRequisitionSpec,
+        requisitionSpec,
+        measurementSpec,
+        MEASUREMENT_CONSUMER_CERTIFICATE,
+        TRUSTED_MEASUREMENT_CONSUMER_ISSUER
+      )
     }
 
     // Verify proto argument of InternalMeasurementsCoroutineImplBase::createMeasurement


### PR DESCRIPTION
This also updates EdpSimulator to verify the signed ElGamal public keys from Duchy participants when using the Liquid Legions v2 protocol.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/world-federation-of-advertisers/cross-media-measurement/773)
<!-- Reviewable:end -->

https://rally1.rallydev.com/#/?detail=/task/672131374749&fdp=true