### PR TITLE
Fix incorrect Duchy certificate name in Requisition.

### DIFF
--- a/src/main/kotlin/org/wfanet/measurement/kingdom/service/api/v2alpha/RequisitionsService.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/service/api/v2alpha/RequisitionsService.kt
@@ -26,6 +26,7 @@ import org.wfanet.measurement.api.v2.alpha.listRequisitionsPageToken
 import org.wfanet.measurement.api.v2alpha.DataProviderCertificateKey
 import org.wfanet.measurement.api.v2alpha.DataProviderKey
 import org.wfanet.measurement.api.v2alpha.DataProviderPrincipal
+import org.wfanet.measurement.api.v2alpha.DuchyCertificateKey
 import org.wfanet.measurement.api.v2alpha.FulfillDirectRequisitionRequest
 import org.wfanet.measurement.api.v2alpha.FulfillDirectRequisitionResponse
 import org.wfanet.measurement.api.v2alpha.ListRequisitionsRequest
@@ -405,10 +406,11 @@ private fun State.toInternal(): InternalState =
   }
 
 /** Converts an internal [DuchyValue] to a public [DuchyEntry.Value]. */
-private fun DuchyValue.toDuchyEntryValue(): DuchyEntry.Value {
+private fun DuchyValue.toDuchyEntryValue(externalDuchyId: String): DuchyEntry.Value {
   val value = this
   return value {
-    duchyCertificate = externalIdToApiId(externalDuchyCertificateId)
+    duchyCertificate =
+      DuchyCertificateKey(externalDuchyId, externalIdToApiId(externalDuchyCertificateId)).toName()
     @Suppress("WHEN_ENUM_CAN_BE_NULL_IN_JAVA")
     when (value.protocolCase) {
       DuchyValue.ProtocolCase.LIQUID_LEGIONS_V2 -> liquidLegionsV2 = liquidLegionsV2 {
@@ -427,7 +429,7 @@ private fun Map.Entry<String, DuchyValue>.toDuchyEntry(): DuchyEntry {
   val mapEntry = this
   return duchyEntry {
     key = mapEntry.key
-    value = mapEntry.value.toDuchyEntryValue()
+    value = mapEntry.value.toDuchyEntryValue(mapEntry.key)
   }
 }
 

--- a/src/test/kotlin/org/wfanet/measurement/kingdom/service/api/v2alpha/RequisitionsServiceTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/kingdom/service/api/v2alpha/RequisitionsServiceTest.kt
@@ -105,7 +105,8 @@ private const val DEFAULT_LIMIT = 50
 
 private const val WILDCARD_NAME = "dataProviders/-"
 
-private const val DUCHIES_MAP_KEY = "1"
+private const val DUCHY_ID = "worker1"
+private const val DUCHY_CERTIFICATE_NAME = "duchies/$DUCHY_ID/certificates/AAAAAAAAAAY"
 private const val MEASUREMENT_CONSUMER_NAME = "measurementConsumers/AAAAAAAAAHs"
 private const val MEASUREMENT_CONSUMER_NAME_2 = "measurementConsumers/BBBBBBBBBHs"
 private const val MEASUREMENT_NAME = "$MEASUREMENT_CONSUMER_NAME/measurements/AAAAAAAAAHs"
@@ -979,7 +980,7 @@ class RequisitionsServiceTest {
       updateTime = UPDATE_TIME
       state = InternalState.FULFILLED
       externalFulfillingDuchyId = "9"
-      duchies[DUCHIES_MAP_KEY] = duchyValue {
+      duchies[DUCHY_ID] = duchyValue {
         externalDuchyCertificateId = 6L
         liquidLegionsV2 = liquidLegionsV2Details {
           elGamalPublicKey = UPDATE_TIME.toByteString()
@@ -1049,16 +1050,16 @@ class RequisitionsServiceTest {
         signature = INTERNAL_REQUISITION.details.dataProviderPublicKeySignature
       }
 
-      val entry = INTERNAL_REQUISITION.duchiesMap[DUCHIES_MAP_KEY]!!
-
+      val internalDuchyValue: InternalRequisition.DuchyValue =
+        INTERNAL_REQUISITION.duchiesMap.getValue(DUCHY_ID)
       duchies += duchyEntry {
-        key = DUCHIES_MAP_KEY
+        key = DUCHY_ID
         value = value {
-          duchyCertificate = externalIdToApiId(entry.externalDuchyCertificateId)
+          duchyCertificate = DUCHY_CERTIFICATE_NAME
           liquidLegionsV2 = liquidLegionsV2 {
             elGamalPublicKey = signedData {
-              data = entry.liquidLegionsV2.elGamalPublicKey
-              signature = entry.liquidLegionsV2.elGamalPublicKeySignature
+              data = internalDuchyValue.liquidLegionsV2.elGamalPublicKey
+              signature = internalDuchyValue.liquidLegionsV2.elGamalPublicKeySignature
             }
           }
         }


### PR DESCRIPTION
The DuchyEntry.Value.duchy_certificate field was incorrectly being populated with the Certificate ID rather than the Certificate resource name.
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/world-federation-of-advertisers/cross-media-measurement/775)
<!-- Reviewable:end -->
