### PR TITLE
Only use testing EventGroups for CMMS correctness test.

### DIFF
--- a/src/main/kotlin/org/wfanet/measurement/loadtest/config/BUILD.bazel
+++ b/src/main/kotlin/org/wfanet/measurement/loadtest/config/BUILD.bazel
@@ -33,3 +33,8 @@ kt_jvm_library(
         "//src/main/proto/wfa/measurement/loadtest/config:loadtest_event_kt_jvm_proto",
     ],
 )
+
+kt_jvm_library(
+    name = "test_identifiers",
+    srcs = ["TestIdentifiers.kt"],
+)

--- a/src/main/kotlin/org/wfanet/measurement/loadtest/config/TestIdentifiers.kt
+++ b/src/main/kotlin/org/wfanet/measurement/loadtest/config/TestIdentifiers.kt
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2022 The Cross-Media Measurement Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wfanet.measurement.loadtest.config
+
+object TestIdentifiers {
+  const val EVENT_GROUP_REFERENCE_ID_PREFIX = "001"
+}

--- a/src/main/kotlin/org/wfanet/measurement/loadtest/dataprovider/BUILD.bazel
+++ b/src/main/kotlin/org/wfanet/measurement/loadtest/dataprovider/BUILD.bazel
@@ -38,6 +38,7 @@ kt_jvm_library(
         "//src/main/kotlin/org/wfanet/measurement/loadtest:service_flags",
         "//src/main/kotlin/org/wfanet/measurement/loadtest/config:event_filters",
         "//src/main/kotlin/org/wfanet/measurement/loadtest/config:privacy_budgets",
+        "//src/main/kotlin/org/wfanet/measurement/loadtest/config:test_identifiers",
         "//src/main/kotlin/org/wfanet/measurement/loadtest/storage",
         "//src/main/proto/wfa/any_sketch:sketch_kt_jvm_proto",
         "//src/main/proto/wfa/any_sketch/crypto:sketch_encryption_methods_kt_jvm_proto",

--- a/src/main/kotlin/org/wfanet/measurement/loadtest/dataprovider/EdpSimulator.kt
+++ b/src/main/kotlin/org/wfanet/measurement/loadtest/dataprovider/EdpSimulator.kt
@@ -96,6 +96,7 @@ import org.wfanet.measurement.eventdataprovider.privacybudgetmanagement.PrivacyB
 import org.wfanet.measurement.eventdataprovider.privacybudgetmanagement.Reference
 import org.wfanet.measurement.eventdataprovider.privacybudgetmanagement.api.v2alpha.PrivacyQueryMapper
 import org.wfanet.measurement.loadtest.config.EventFilters.VID_SAMPLER_HASH_FUNCTION
+import org.wfanet.measurement.loadtest.config.TestIdentifiers
 import org.wfanet.measurement.loadtest.storage.SketchStore
 
 data class EdpData(
@@ -135,7 +136,7 @@ class EdpSimulator(
       parent = edpData.name
       eventGroup = eventGroup {
         measurementConsumer = measurementConsumerName
-        eventGroupReferenceId = "001"
+        eventGroupReferenceId = TestIdentifiers.EVENT_GROUP_REFERENCE_ID_PREFIX
         eventTemplates += eventTemplateNames.map { eventTemplate { type = it } }
       }
     }

--- a/src/main/kotlin/org/wfanet/measurement/loadtest/frontend/BUILD.bazel
+++ b/src/main/kotlin/org/wfanet/measurement/loadtest/frontend/BUILD.bazel
@@ -25,6 +25,7 @@ kt_jvm_library(
         "//src/main/kotlin/org/wfanet/measurement/api/v2alpha:resource_key",
         "//src/main/kotlin/org/wfanet/measurement/common/identity",
         "//src/main/kotlin/org/wfanet/measurement/kingdom/service/api/v2alpha:api_key_authentication_server_interceptor",
+        "//src/main/kotlin/org/wfanet/measurement/loadtest/config:test_identifiers",
         "//src/main/kotlin/org/wfanet/measurement/loadtest/storage",
         "//src/main/proto/wfa/measurement/api/v2alpha:certificates_service_kt_jvm_grpc_proto",
         "//src/main/proto/wfa/measurement/api/v2alpha:crypto_kt_jvm_proto",


### PR DESCRIPTION
Testing EventGroups are identified by a reference ID prefix. The EventGroups created by EdpSimulator use this prefix. This helps prevent other EventGroups from interfering with the correctness test.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/world-federation-of-advertisers/cross-media-measurement/780)
<!-- Reviewable:end -->
