### PR TITLE
Support request_id field in CreateEventGroupMetadataDescriptorRequest.

### DIFF
--- a/build/repositories.bzl
+++ b/build/repositories.bzl
@@ -38,8 +38,8 @@ def wfa_measurement_system_repositories():
     wfa_repo_archive(
         name = "wfa_measurement_proto",
         repo = "cross-media-measurement-api",
-        sha256 = "8412e478f15119b624e6696b578ca308b55f61a240e83ea2f72444692118d1ff",
-        version = "0.24.0",
+        sha256 = "4fb33696b16dfcd2baeb3808f53b56b49e4c18884c0e0cbd9dbcb1700fe55934",
+        version = "0.25.0",
     )
 
     wfa_repo_archive(

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/readers/EventGroupMetadataDescriptorReader.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/readers/EventGroupMetadataDescriptorReader.kt
@@ -23,19 +23,7 @@ import org.wfanet.measurement.gcloud.spanner.appendClause
 import org.wfanet.measurement.gcloud.spanner.bind
 import org.wfanet.measurement.gcloud.spanner.getProtoMessage
 import org.wfanet.measurement.internal.kingdom.EventGroupMetadataDescriptor
-
-private val BASE_SQL =
-  """
-    SELECT
-      EventGroupMetadataDescriptors.DataProviderId,
-      EventGroupMetadataDescriptors.EventGroupMetadataDescriptorId,
-      EventGroupMetadataDescriptors.ExternalEventGroupMetadataDescriptorId,
-      EventGroupMetadataDescriptors.DescriptorDetails,
-      DataProviders.ExternalDataProviderId
-    FROM EventGroupMetadataDescriptors
-    JOIN DataProviders USING (DataProviderId)
-    """
-    .trimIndent()
+import org.wfanet.measurement.internal.kingdom.eventGroupMetadataDescriptor
 
 class EventGroupMetadataDescriptorReader :
   BaseSpannerReader<EventGroupMetadataDescriptorReader.Result>() {
@@ -74,47 +62,88 @@ class EventGroupMetadataDescriptorReader :
     readContext: AsyncDatabaseClient.ReadContext,
     externalDataProviderId: Long,
     externalDescriptorId: Long,
-  ): EventGroupMetadataDescriptorReader.Result? {
-    val externalDataProviderIdParam = "externalDataProviderId"
-    val externalDescriptorIdParam = "externalEventGroupMetadataDescriptorId"
-
+  ): Result? {
     return fillStatementBuilder {
         appendClause(
           """
           WHERE
-            ExternalDataProviderId = @$externalDataProviderIdParam
-            AND ExternalEventGroupMetadataDescriptorId = @$externalDescriptorIdParam
+            ExternalDataProviderId = @$EXTERNAL_DATA_PROVIDER_ID_PARAM
+            AND ExternalEventGroupMetadataDescriptorId = @$EXTERNAL_EVENT_GROUP_METADATA_DESCRIPTOR_ID_PARAM
           """
             .trimIndent()
         )
-        bind(externalDataProviderIdParam to externalDataProviderId)
-        bind(externalDescriptorIdParam to externalDescriptorId)
+        bind(EXTERNAL_DATA_PROVIDER_ID_PARAM to externalDataProviderId)
+        bind(EXTERNAL_EVENT_GROUP_METADATA_DESCRIPTOR_ID_PARAM to externalDescriptorId)
         appendClause("LIMIT 1")
       }
       .execute(readContext)
       .singleOrNull()
   }
 
-  override suspend fun translate(struct: Struct): EventGroupMetadataDescriptorReader.Result =
-    EventGroupMetadataDescriptorReader.Result(
+  suspend fun readByIdempotencyKey(
+    readContext: AsyncDatabaseClient.ReadContext,
+    dataProviderId: InternalId,
+    idempotencyKey: String
+  ): Result? {
+    return fillStatementBuilder {
+        appendClause(
+          """
+          WHERE
+            DataProviderId = @$DATA_PROVIDER_ID_PARAM
+            AND IdempotencyKey = @$IDEMPOTENCY_KEY_PARAM
+          """
+            .trimIndent()
+        )
+        bind(DATA_PROVIDER_ID_PARAM to dataProviderId)
+        bind(IDEMPOTENCY_KEY_PARAM to idempotencyKey)
+
+        appendClause("LIMIT 1")
+      }
+      .execute(readContext)
+      .singleOrNull()
+  }
+
+  override suspend fun translate(struct: Struct): Result =
+    Result(
       buildEventGroupMetadataDescriptor(struct),
       InternalId(struct.getLong("EventGroupMetadataDescriptorId")),
       InternalId(struct.getLong("DataProviderId"))
     )
 
-  private fun buildEventGroupMetadataDescriptor(struct: Struct): EventGroupMetadataDescriptor =
-    EventGroupMetadataDescriptor.newBuilder()
-      .apply {
-        externalDataProviderId = struct.getLong("ExternalDataProviderId")
-        externalEventGroupMetadataDescriptorId =
-          struct.getLong("ExternalEventGroupMetadataDescriptorId")
-        if (!struct.isNull("DescriptorDetails")) {
-          details =
-            struct.getProtoMessage(
-              "DescriptorDetails",
-              EventGroupMetadataDescriptor.Details.parser()
-            )
-        }
+  private fun buildEventGroupMetadataDescriptor(struct: Struct): EventGroupMetadataDescriptor {
+    return eventGroupMetadataDescriptor {
+      externalDataProviderId = struct.getLong("ExternalDataProviderId")
+      externalEventGroupMetadataDescriptorId =
+        struct.getLong("ExternalEventGroupMetadataDescriptorId")
+      if (!struct.isNull("IdempotencyKey")) {
+        idempotencyKey = struct.getString("IdempotencyKey")
       }
-      .build()
+      if (!struct.isNull("DescriptorDetails")) {
+        details =
+          struct.getProtoMessage("DescriptorDetails", EventGroupMetadataDescriptor.Details.parser())
+      }
+    }
+  }
+
+  companion object {
+    private const val IDEMPOTENCY_KEY_PARAM = "idempotencyKey"
+    private const val DATA_PROVIDER_ID_PARAM = "dataProviderId"
+    private const val EXTERNAL_DATA_PROVIDER_ID_PARAM = "externalDataProviderId"
+    private const val EXTERNAL_EVENT_GROUP_METADATA_DESCRIPTOR_ID_PARAM =
+      "externalEventGroupMetadataDescriptorId"
+
+    private val BASE_SQL =
+      """
+      SELECT
+        EventGroupMetadataDescriptors.DataProviderId,
+        EventGroupMetadataDescriptors.EventGroupMetadataDescriptorId,
+        EventGroupMetadataDescriptors.ExternalEventGroupMetadataDescriptorId,
+        EventGroupMetadataDescriptors.IdempotencyKey,
+        EventGroupMetadataDescriptors.DescriptorDetails,
+        DataProviders.ExternalDataProviderId
+      FROM EventGroupMetadataDescriptors
+      JOIN DataProviders USING (DataProviderId)
+      """
+        .trimIndent()
+  }
 }

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/service/api/v2alpha/EventGroupMetadataDescriptorsService.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/service/api/v2alpha/EventGroupMetadataDescriptorsService.kt
@@ -117,7 +117,11 @@ class EventGroupMetadataDescriptorsService(
       }
     }
 
-    val createRequest = request.eventGroupMetadataDescriptor.toInternal(parentKey.dataProviderId)
+    val createRequest =
+      request.eventGroupMetadataDescriptor.toInternal(
+        parentKey.dataProviderId,
+        idempotencyKey = request.requestId
+      )
     val internalEventGroupMetadataDescriptor =
       try {
         internalEventGroupMetadataDescriptorsStub.createEventGroupMetadataDescriptor(createRequest)
@@ -270,12 +274,17 @@ private fun InternalEventGroupMetadataDescriptor.toEventGroupMetadataDescriptor(
  */
 private fun EventGroupMetadataDescriptor.toInternal(
   dataProviderId: String,
-  eventGroupMetadataDescriptorId: String = ""
+  eventGroupMetadataDescriptorId: String = "",
+  idempotencyKey: String = ""
 ): InternalEventGroupMetadataDescriptor {
   return internalEventGroupMetadataDescriptor {
     externalDataProviderId = apiIdToExternalId(dataProviderId)
-    if (eventGroupMetadataDescriptorId != "")
+    if (eventGroupMetadataDescriptorId.isNotEmpty()) {
       externalEventGroupMetadataDescriptorId = apiIdToExternalId(eventGroupMetadataDescriptorId)
+    }
+    if (idempotencyKey.isNotEmpty()) {
+      this.idempotencyKey = idempotencyKey
+    }
 
     details = details {
       apiVersion = API_VERSION.string

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/service/internal/testing/EventGroupMetadataDescriptorsServiceTest.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/service/internal/testing/EventGroupMetadataDescriptorsServiceTest.kt
@@ -158,30 +158,23 @@ abstract class EventGroupMetadataDescriptorsServiceTest<
   }
 
   @Test
-  fun `createEventGroupMetadataDescriptor returns created Descriptor for existing external ID`() =
+  fun `createEventGroupMetadataDescriptor returns existing Descriptor by idempotency key`() =
     runBlocking {
       val externalDataProviderId =
         population.createDataProvider(dataProvidersService).externalDataProviderId
+      val idempotencyKey = "type.googleapis.com/example.TestMetadataMessage"
+      val request = eventGroupMetadataDescriptor {
+        this.externalDataProviderId = externalDataProviderId
+        this.idempotencyKey = idempotencyKey
+        this.details = DETAILS
+      }
+      val existingDescriptor: EventGroupMetadataDescriptor =
+        eventGroupMetadataDescriptorService.createEventGroupMetadataDescriptor(request)
 
-      val createdEventGroupMetadataDescriptor =
-        eventGroupMetadataDescriptorService.createEventGroupMetadataDescriptor(
-          eventGroupMetadataDescriptor {
-            this.externalDataProviderId = externalDataProviderId
-            details = DETAILS
-          }
-        )
-      val secondCreatedEventGroupMetadataDescriptorAttempt =
-        eventGroupMetadataDescriptorService.createEventGroupMetadataDescriptor(
-          eventGroupMetadataDescriptor {
-            this.externalDataProviderId = externalDataProviderId
-            externalEventGroupMetadataDescriptorId =
-              createdEventGroupMetadataDescriptor.externalEventGroupMetadataDescriptorId
-            details = DETAILS
-          }
-        )
+      val createdDescriptor =
+        eventGroupMetadataDescriptorService.createEventGroupMetadataDescriptor(request)
 
-      assertThat(secondCreatedEventGroupMetadataDescriptorAttempt)
-        .isEqualTo(createdEventGroupMetadataDescriptor)
+      assertThat(createdDescriptor).isEqualTo(existingDescriptor)
     }
 
   @Test

--- a/src/main/proto/wfa/measurement/internal/kingdom/event_group_metadata_descriptor.proto
+++ b/src/main/proto/wfa/measurement/internal/kingdom/event_group_metadata_descriptor.proto
@@ -25,6 +25,8 @@ message EventGroupMetadataDescriptor {
   fixed64 external_data_provider_id = 1;
   fixed64 external_event_group_metadata_descriptor_id = 2;
 
+  string idempotency_key = 4;
+
   message Details {
     // Version of the public API for serialized message definitions.
     string api_version = 1;

--- a/src/main/resources/kingdom/spanner/add-event-group-metadata-idempotency-key.sql
+++ b/src/main/resources/kingdom/spanner/add-event-group-metadata-idempotency-key.sql
@@ -1,0 +1,26 @@
+-- liquibase formatted sql
+
+-- Copyright 2022 The Cross-Media Measurement Authors
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--      http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+-- changeset sanjayvas:3 dbms:cloudspanner
+START BATCH DDL;
+
+ALTER TABLE EventGroupMetadataDescriptors
+  ADD COLUMN IdempotencyKey STRING(MAX);
+
+CREATE UNIQUE NULL_FILTERED INDEX EventGroupMetadataDescriptorsByRequestId
+  ON EventGroupMetadataDescriptors(DataProviderId, IdempotencyKey);
+
+RUN BATCH;

--- a/src/main/resources/kingdom/spanner/changelog.yaml
+++ b/src/main/resources/kingdom/spanner/changelog.yaml
@@ -21,3 +21,6 @@ databaseChangeLog:
 - include:
     file: create-exchange-schema.sql
     relativeToChangeLogFile: true
+- include:
+    file: add-event-group-metadata-idempotency-key.sql
+    relativeToChangeLogFile: true

--- a/src/test/kotlin/org/wfanet/measurement/kingdom/service/api/v2alpha/EventGroupMetadataDescriptorsServiceTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/kingdom/service/api/v2alpha/EventGroupMetadataDescriptorsServiceTest.kt
@@ -220,6 +220,7 @@ class EventGroupMetadataDescriptorsServiceTest {
     val request = createEventGroupMetadataDescriptorRequest {
       parent = DATA_PROVIDER_NAME
       eventGroupMetadataDescriptor = EVENT_GROUP_METADATA_DESCRIPTOR
+      requestId = "type.googleapis.com/example.MetadataMessage"
     }
 
     val result =
@@ -236,6 +237,7 @@ class EventGroupMetadataDescriptorsServiceTest {
       .isEqualTo(
         INTERNAL_EVENT_GROUP_METADATA_DESCRIPTOR.copy {
           clearExternalEventGroupMetadataDescriptorId()
+          idempotencyKey = request.requestId
         }
       )
 


### PR DESCRIPTION
This allows for idempotent create operations.

This is for #768 and depends on https://github.com/world-federation-of-advertisers/cross-media-measurement-api/pull/115

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/world-federation-of-advertisers/cross-media-measurement/785)
<!-- Reviewable:end -->
