### PR TITLE
Re-enable K8s correctness test in Build and test workflow.

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -28,12 +28,13 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Check out revision
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Bazel build and test
         uses: world-federation-of-advertisers/actions/bazel-build-test@v1
         with:
           cache-version: 1
+          cache-save-events:
           workspace-path: .
           target-patterns: |
             //...
@@ -41,16 +42,19 @@ jobs:
             --compilation_mode=opt
             --host_platform=//build/platforms:ubuntu_20_04
 
-# TODO(world-federation-of-advertisers/cross-media-measurement#805): Re-enable once fixed.
-#      - name: Bazel build and test K8s Correctness Test
-#        uses: world-federation-of-advertisers/actions/bazel-build-test@v1
-#        with:
-#          cache-version: 1
-#          restore-cache: false
-#          workspace-path: .
-#          target-patterns: |
-#            //src/test/kotlin/org/wfanet/measurement/integration/k8s:CorrectnessTest
-#          build-options: |
-#            --compilation_mode=opt
-#            --host_platform=//build/platforms:ubuntu_20_04
-#          test-output: streamed
+      # Clear memory held from previous Bazel build to save on resources.
+      - name: Shut down Bazel server
+        run: bazel shutdown
+
+      - name: Bazel build and test K8s Correctness Test
+        uses: world-federation-of-advertisers/actions/bazel-build-test@v1
+        with:
+          cache-version: 1
+          restore-cache: false
+          workspace-path: .
+          target-patterns: |
+            //src/test/kotlin/org/wfanet/measurement/integration/k8s:CorrectnessTest
+          build-options: |
+            --compilation_mode=opt
+            --host_platform=//build/platforms:ubuntu_20_04
+          test-output: streamed

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,16 +14,17 @@ jobs:
         shell: bash
     steps:
     - name: Check out revision
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         fetch-depth: 0
 
     - name: Set up JDK 11
-      uses: actions/setup-java@v1
+      uses: actions/setup-java@v2
       with:
-        java-version: '11.0.10'
+        java-version: '11'
         java-package: jdk
         architecture: x64
+        distribution: 'zulu'
 
     - name: Set up linters
       uses: world-federation-of-advertisers/actions/setup-linters@v1

--- a/src/main/k8s/local/emulators.cue
+++ b/src/main/k8s/local/emulators.cue
@@ -73,7 +73,7 @@ deployments: {
 		_container: {
 			image: "bazel/src/main/kotlin/org/wfanet/measurement/storage/filesystem:server_image"
 			args: [
-				"--debug-verbose-grpc-server-logging=true",
+				"--debug-verbose-grpc-server-logging=false",
 				"--port=8443",
 				"--require-client-auth=false",
 				"--tls-cert-file=/var/run/secrets/files/kingdom_tls.pem",

--- a/src/test/kotlin/org/wfanet/measurement/integration/k8s/CorrectnessTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/integration/k8s/CorrectnessTest.kt
@@ -86,17 +86,17 @@ import org.wfanet.measurement.storage.forwarded.ForwardedStorageClient
 /** Test for correctness of the CMMS on [KinD](https://kind.sigs.k8s.io/). */
 @RunWith(JUnit4::class)
 class CorrectnessTest {
-  @Test(timeout = 2 * 60 * 1000)
+  @Test(timeout = 1 * 60 * 1000)
   fun `impression measurement completes with expected result`() = runBlocking {
     testHarness.executeImpression("$runId-impression")
   }
 
-  @Test(timeout = 2 * 60 * 1000)
+  @Test(timeout = 1 * 60 * 1000)
   fun `duration measurement completes with expected result`() = runBlocking {
     testHarness.executeDuration("$runId-duration")
   }
 
-  @Test(timeout = 10 * 60 * 1000)
+  @Test(timeout = 8 * 60 * 1000)
   fun `reach and frequency measurement completes with expected result`() = runBlocking {
     testHarness.executeReachAndFrequency("$runId-reach-and-freq")
   }


### PR DESCRIPTION
* Shut down Bazel server before correctness test run to save on RAM.
* Update to newer actions versions to avoid deprecation.
* Disable verbose gRPC logging on storage server to reduce log size to save.
* Tighten test method timeouts to decrease the likelihood of total test timeout.
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/world-federation-of-advertisers/cross-media-measurement/806)
<!-- Reviewable:end -->
https://rally1.rallydev.com/#/?detail=/defect/676017081901&fdp=true
