### PR TITLE
Correct noised reach calculation in fulfillDirectReachAndFrequencyMeasurement in EDP simulator

### DIFF
--- a/src/main/kotlin/org/wfanet/measurement/loadtest/dataprovider/EdpSimulator.kt
+++ b/src/main/kotlin/org/wfanet/measurement/loadtest/dataprovider/EdpSimulator.kt
@@ -799,13 +799,19 @@ class EdpSimulator(
     /**
      * Calculate direct reach and frequency from VIDs in
      * fulfillDirectReachAndFrequencyMeasurement().
-     * @param vidList List of VIDs
-     * @return Pair of reach value and frequency map
+     * @param vidList List of VIDs.
+     * @return Pair of reach value and frequency map.
      */
-    fun calculateDirectReachAndFrequency(
+    private fun calculateDirectReachAndFrequency(
       vidList: List<Long>,
     ): Pair<Long, Map<Long, Double>> {
-
+      // Example: vidList: [1L, 1L, 1L, 2L, 2L, 3L, 4L, 5L]
+      // 5 unique people(1, 2, 3, 4, 5) being reached
+      // reach = 5
+      // 1 reach -> 0.6(3/5)(VID 3L, 4L, 5L)
+      // 2 reach -> 0.2(1/5)(VID 2L)
+      // 3 reach -> 0.2(1/5)(VID 1L)
+      // frequencyMap = {1L: 0.6, 2L to 0.2, 3L: 0.2}
       val reachValue = vidList.toSet().size.toLong()
       val frequencyMap = mutableMapOf<Long, Double>().withDefault { 0.0 }
 
@@ -823,16 +829,17 @@ class EdpSimulator(
       return Pair(reachValue, frequencyMap)
     }
 
+    // TODO(alberthsuu): Create a class for this function when we need to add Gaussian noise
     /**
      * Add Laplace publisher noise to calculated direct reach and frequency. Noised reach needs to
-     * scale by sampling rate
-     * @param reachValue Direct reach value
-     * @param frequencyMap Direct frequency
-     * @param samplingRate Probability of sampling which is vidSamplingIntervalWidth
-     * @param reachAndFrequency ReachAndFrequency from MeasurementSpec
-     * @return Pair of noised reach value and frequency map
+     * scale by sampling rate.
+     * @param reachValue Direct reach value.
+     * @param frequencyMap Direct frequency.
+     * @param samplingRate Probability of sampling which is vidSamplingIntervalWidth.
+     * @param reachAndFrequency ReachAndFrequency from MeasurementSpec.
+     * @return Pair of noised reach value and frequency map.
      */
-    fun addPublisherNoise(
+    private fun addPublisherNoise(
       reachValue: Long,
       frequencyMap: Map<Long, Double>,
       samplingRate: Float,

--- a/src/main/kotlin/org/wfanet/measurement/loadtest/frontend/FrontendSimulator.kt
+++ b/src/main/kotlin/org/wfanet/measurement/loadtest/frontend/FrontendSimulator.kt
@@ -209,7 +209,7 @@ class FrontendSimulator(
     logger.info("Got direct reach and frequency result from Kingdom: $reachAndFrequencyResult")
 
     // For InProcessLifeOfAMeasurementIntegrationTest, EdpSimulator sets to those values with seeded
-    // random VIDs and Laplace noise.
+    // random VIDs and Laplace publisher noise.
     val expectedReachValue = 948L
     val expectedFrequencyMap =
       mapOf(

--- a/src/test/kotlin/org/wfanet/measurement/loadtest/dataprovider/EdpSimulatorTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/loadtest/dataprovider/EdpSimulatorTest.kt
@@ -29,7 +29,6 @@ import java.time.Duration
 import java.time.LocalDate
 import java.time.ZoneOffset
 import kotlin.random.Random
-import kotlin.test.assertFails
 import kotlinx.coroutines.runBlocking
 import org.junit.BeforeClass
 import org.junit.ClassRule
@@ -43,6 +42,7 @@ import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
 import org.mockito.kotlin.stub
+import org.mockito.kotlin.times
 import org.mockito.kotlin.verifyBlocking
 import org.wfanet.anysketch.AnySketch
 import org.wfanet.anysketch.AnySketch.Register
@@ -61,10 +61,13 @@ import org.wfanet.measurement.api.v2alpha.CertificatesGrpcKt.CertificatesCorouti
 import org.wfanet.measurement.api.v2alpha.CertificatesGrpcKt.CertificatesCoroutineStub
 import org.wfanet.measurement.api.v2alpha.DuchyCertificateKey
 import org.wfanet.measurement.api.v2alpha.DuchyKey
+import org.wfanet.measurement.api.v2alpha.EncryptionPublicKey
 import org.wfanet.measurement.api.v2alpha.EventGroupMetadataDescriptorsGrpcKt
 import org.wfanet.measurement.api.v2alpha.EventGroupMetadataDescriptorsGrpcKt.EventGroupMetadataDescriptorsCoroutineStub
 import org.wfanet.measurement.api.v2alpha.EventGroupsGrpcKt.EventGroupsCoroutineImplBase
 import org.wfanet.measurement.api.v2alpha.EventGroupsGrpcKt.EventGroupsCoroutineStub
+import org.wfanet.measurement.api.v2alpha.FulfillDirectRequisitionRequest
+import org.wfanet.measurement.api.v2alpha.Measurement
 import org.wfanet.measurement.api.v2alpha.MeasurementConsumersGrpcKt
 import org.wfanet.measurement.api.v2alpha.MeasurementConsumersGrpcKt.MeasurementConsumersCoroutineStub
 import org.wfanet.measurement.api.v2alpha.MeasurementSpecKt.reachAndFrequency
@@ -88,6 +91,7 @@ import org.wfanet.measurement.api.v2alpha.certificate
 import org.wfanet.measurement.api.v2alpha.copy
 import org.wfanet.measurement.api.v2alpha.differentialPrivacyParams
 import org.wfanet.measurement.api.v2alpha.elGamalPublicKey
+import org.wfanet.measurement.api.v2alpha.encryptionPublicKey
 import org.wfanet.measurement.api.v2alpha.eventGroupMetadataDescriptor
 import org.wfanet.measurement.api.v2alpha.event_templates.testing.TestBannerTemplate
 import org.wfanet.measurement.api.v2alpha.event_templates.testing.TestBannerTemplate.Gender
@@ -99,6 +103,7 @@ import org.wfanet.measurement.api.v2alpha.event_templates.testing.TestPrivacyBud
 import org.wfanet.measurement.api.v2alpha.event_templates.testing.testBannerTemplate
 import org.wfanet.measurement.api.v2alpha.event_templates.testing.testEvent
 import org.wfanet.measurement.api.v2alpha.event_templates.testing.testPrivacyBudgetTemplate
+import org.wfanet.measurement.api.v2alpha.fulfillDirectRequisitionResponse
 import org.wfanet.measurement.api.v2alpha.getCertificateRequest
 import org.wfanet.measurement.api.v2alpha.liquidLegionsSketchParams
 import org.wfanet.measurement.api.v2alpha.listRequisitionsResponse
@@ -130,6 +135,7 @@ import org.wfanet.measurement.common.throttler.Throttler
 import org.wfanet.measurement.common.toProtoTime
 import org.wfanet.measurement.consent.client.common.toEncryptionPublicKey
 import org.wfanet.measurement.consent.client.duchy.signElgamalPublicKey
+import org.wfanet.measurement.consent.client.measurementconsumer.decryptResult
 import org.wfanet.measurement.consent.client.measurementconsumer.encryptRequisitionSpec
 import org.wfanet.measurement.consent.client.measurementconsumer.signEncryptionPublicKey
 import org.wfanet.measurement.consent.client.measurementconsumer.signMeasurementSpec
@@ -203,7 +209,12 @@ private val MEASUREMENT_CONSUMER_CERTIFICATE = certificate {
   x509Der = MEASUREMENT_CONSUMER_CERTIFICATE_DER
 }
 private val MEASUREMENT_PUBLIC_KEY =
-  SECRET_FILES_PATH.resolve("${MC_NAME}_enc_public.tink").toFile().readByteString()
+  encryptionPublicKey {
+      format = EncryptionPublicKey.Format.TINK_KEYSET
+      data = SECRET_FILES_PATH.resolve("${MC_NAME}_enc_public.tink").toFile().readByteString()
+    }
+    .toByteString()
+
 private val CONSENT_SIGNALING_ELGAMAL_PUBLIC_KEY = elGamalPublicKey {
   ellipticCurveId = 415
   generator = HexString("036B17D1F2E12C4247F8BCE6E563A440F277037D812DEB33A0F4A13945D898C296").bytes
@@ -265,7 +276,7 @@ class EdpSimulatorTest {
   private val requisitionsServiceMock: RequisitionsCoroutineImplBase = mockService {
     onBlocking { listRequisitions(any()) }
       .thenReturn(listRequisitionsResponse { requisitions += REQUISITION_ONE })
-      .thenReturn(listRequisitionsResponse {})
+    onBlocking { fulfillDirectRequisition(any()) }.thenReturn(fulfillDirectRequisitionResponse {})
   }
   private val requisitionFulfillmentServiceMock: RequisitionFulfillmentCoroutineImplBase =
     mockService()
@@ -651,112 +662,6 @@ class EdpSimulatorTest {
   }
 
   @Test
-  fun `calculate direct reach and frequency correctly`() {
-    runBlocking {
-      val vidList = listOf(1L, 1L, 1L, 2L, 2L, 3L, 4L, 5L)
-      val (reachValue, frequencyMap) = EdpSimulator.calculateDirectReachAndFrequency(vidList)
-
-      // 5 unique people(1, 2, 3, 4, 5) being reached
-      val expectedReachValue = 5
-      // 1 reach -> 0.6(3/5)(VID 3L, 4L, 5L)
-      // 2 reach -> 0.2(1/5)(VID 2L)
-      // 3 reach -> 0.2(1/5)(VID 1L)
-      val expectedFrequencyMap = mapOf(1L to 0.6, 2L to 0.2, 3L to 0.2)
-
-      assertThat(reachValue).isEqualTo(expectedReachValue)
-      frequencyMap.forEach { (frequency, percentage) ->
-        assertThat(percentage).isEqualTo(expectedFrequencyMap[frequency])
-      }
-    }
-  }
-
-  @Test
-  fun `addPublisherNoise fails with sampling rate 0`() {
-    runBlocking {
-      val reachValue = 5L
-      val frequencyMap = mapOf(1L to 0.6, 2L to 0.2, 3L to 0.2)
-
-      assertFails {
-        EdpSimulator.addPublisherNoise(
-          reachValue,
-          frequencyMap,
-          0.0f,
-          MEASUREMENT_SPEC.reachAndFrequency
-        )
-      }
-    }
-  }
-
-  @Test
-  fun `addPublisherNoise fails with sampling rate bigger than 1`() {
-    runBlocking {
-      val reachValue = 5L
-      val frequencyMap = mapOf(1L to 0.6, 2L to 0.2, 3L to 0.2)
-
-      assertFails {
-        EdpSimulator.addPublisherNoise(
-          reachValue,
-          frequencyMap,
-          1.1f,
-          MEASUREMENT_SPEC.reachAndFrequency
-        )
-      }
-    }
-  }
-
-  @Test
-  fun `calculate noised direct reach and frequency correctly with sampling rate equal to 1`() {
-    runBlocking {
-      val reachValue = 500L
-      val frequencyMap = mapOf(1L to 0.6, 2L to 0.2, 3L to 0.2)
-      val samplingRate = 1f
-
-      val (noisedReachValue, noisedFrequencyMap) =
-        EdpSimulator.addPublisherNoise(
-          reachValue,
-          frequencyMap,
-          samplingRate,
-          MEASUREMENT_SPEC.reachAndFrequency
-        )
-
-      val expectedNoisedReachValue = 499
-      val expectedNoisedFrequencyMap =
-        mapOf(1L to 0.5961455846667975, 2L to 0.19919901208134336, 3L to 0.20523867948429547)
-
-      assertThat(noisedReachValue).isEqualTo(expectedNoisedReachValue)
-      noisedFrequencyMap.forEach { (frequency, percentage) ->
-        assertThat(percentage).isEqualTo(expectedNoisedFrequencyMap[frequency])
-      }
-    }
-  }
-
-  @Test
-  fun `calculate noised direct reach and frequency correctly with sampling rate smaller than 1`() {
-    runBlocking {
-      val reachValue = 500L
-      val frequencyMap = mapOf(1L to 0.6, 2L to 0.2, 3L to 0.2)
-      val samplingRate = 0.1f
-
-      val (noisedReachValue, noisedFrequencyMap) =
-        EdpSimulator.addPublisherNoise(
-          reachValue,
-          frequencyMap,
-          samplingRate,
-          MEASUREMENT_SPEC.reachAndFrequency
-        )
-
-      val expectedNoisedReachValue = 4990
-      val expectedNoisedFrequencyMap =
-        mapOf(1L to 0.5961455846667975, 2L to 0.19919901208134336, 3L to 0.20523867948429547)
-
-      assertThat(noisedReachValue).isEqualTo(expectedNoisedReachValue)
-      noisedFrequencyMap.forEach { (frequency, percentage) ->
-        assertThat(percentage).isEqualTo(expectedNoisedFrequencyMap[frequency])
-      }
-    }
-  }
-
-  @Test
   fun `refuses requisition when DuchyEntry verification fails`() {
     val throttlerMock = mock<Throttler>()
     val eventQueryMock = mock<EventQuery>()
@@ -817,6 +722,150 @@ class EdpSimulatorTest {
     verifyBlocking(requisitionsServiceMock, never()) { fulfillDirectRequisition(any()) }
   }
 
+  @Test
+  fun `fulfill direct reach and frequency requisition correctly with sampling rate equal to 1`() {
+    val throttlerMock = mock<Throttler>()
+    val eventQuery = RandomEventQuery(SketchGenerationParams(reach = 1000, universeSize = 10000))
+    val simulator =
+      EdpSimulator(
+        EDP_DATA,
+        MC_NAME,
+        measurementConsumersStub,
+        certificatesStub,
+        eventGroupsStub,
+        eventGroupMetadataDescriptorsStub,
+        requisitionsStub,
+        requisitionFulfillmentStub,
+        sketchStore,
+        eventQuery,
+        throttlerMock,
+        listOf(),
+        privacyBudgetManager,
+        TRUSTED_CERTIFICATES
+      )
+
+    val vidSamplingIntervalWidth = 1f
+    val newMeasurementSpec =
+      MEASUREMENT_SPEC.copy {
+        vidSamplingInterval = vidSamplingInterval.copy { width = vidSamplingIntervalWidth }
+      }
+    val requisition =
+      REQUISITION_ONE.copy {
+        name = "requisition_direct"
+        protocolConfig =
+          protocolConfig.copy {
+            protocols += ProtocolConfigKt.protocol { direct = ProtocolConfigKt.direct {} }
+          }
+        measurementSpec = signMeasurementSpec(newMeasurementSpec, MC_SIGNING_KEY)
+      }
+
+    requisitionsServiceMock.stub {
+      onBlocking { requisitionsServiceMock.listRequisitions(any()) }
+        .thenReturn(listRequisitionsResponse { requisitions += requisition })
+    }
+
+    runBlocking { simulator.executeRequisitionFulfillingWorkflow() }
+
+    val fulfillDirectRequisitionRequest: FulfillDirectRequisitionRequest =
+      verifyAndCapture(
+        requisitionsServiceMock,
+        RequisitionsCoroutineImplBase::fulfillDirectRequisition
+      )
+
+    val signedResult = decryptResult(fulfillDirectRequisitionRequest.encryptedData, MC_PRIVATE_KEY)
+    val reachAndFrequencyResult = Measurement.Result.parseFrom(signedResult.data)
+
+    val expectedReachValue = 948L
+    val expectedFrequencyMap =
+      mapOf(
+        1L to 0.947389665261748,
+        2L to 0.04805005905234108,
+        3L to 0.0038138458821366963,
+        4L to 9.558853281715655E-5
+      )
+
+    assertThat(reachAndFrequencyResult.reach.value).isEqualTo(expectedReachValue)
+    reachAndFrequencyResult.frequency.relativeFrequencyDistributionMap.forEach {
+      (frequency, percentage) ->
+      assertThat(percentage).isEqualTo(expectedFrequencyMap[frequency])
+    }
+
+    verifyBlocking(requisitionFulfillmentServiceMock, never()) { fulfillRequisition(any()) }
+    verifyBlocking(requisitionsServiceMock, times(1)) { fulfillDirectRequisition(any()) }
+  }
+
+  @Test
+  fun `fulfill direct reach and frequency requisition correctly with sampling rate smaller than 1`() {
+    val throttlerMock = mock<Throttler>()
+    val eventQuery = RandomEventQuery(SketchGenerationParams(reach = 1000, universeSize = 10000))
+    val simulator =
+      EdpSimulator(
+        EDP_DATA,
+        MC_NAME,
+        measurementConsumersStub,
+        certificatesStub,
+        eventGroupsStub,
+        eventGroupMetadataDescriptorsStub,
+        requisitionsStub,
+        requisitionFulfillmentStub,
+        sketchStore,
+        eventQuery,
+        throttlerMock,
+        listOf(),
+        privacyBudgetManager,
+        TRUSTED_CERTIFICATES
+      )
+
+    val vidSamplingIntervalWidth = 0.1f
+    val newMeasurementSpec =
+      MEASUREMENT_SPEC.copy {
+        vidSamplingInterval = vidSamplingInterval.copy { width = vidSamplingIntervalWidth }
+      }
+    val requisition =
+      REQUISITION_ONE.copy {
+        name = "requisition_direct"
+        protocolConfig =
+          protocolConfig.copy {
+            protocols += ProtocolConfigKt.protocol { direct = ProtocolConfigKt.direct {} }
+          }
+        measurementSpec = signMeasurementSpec(newMeasurementSpec, MC_SIGNING_KEY)
+      }
+
+    requisitionsServiceMock.stub {
+      onBlocking { requisitionsServiceMock.listRequisitions(any()) }
+        .thenReturn(listRequisitionsResponse { requisitions += requisition })
+    }
+
+    runBlocking { simulator.executeRequisitionFulfillingWorkflow() }
+
+    val fulfillDirectRequisitionRequest: FulfillDirectRequisitionRequest =
+      verifyAndCapture(
+        requisitionsServiceMock,
+        RequisitionsCoroutineImplBase::fulfillDirectRequisition
+      )
+
+    val signedResult = decryptResult(fulfillDirectRequisitionRequest.encryptedData, MC_PRIVATE_KEY)
+    val reachAndFrequencyResult = Measurement.Result.parseFrom(signedResult.data)
+
+    // vidList is first filtered by vidSampler and noised reach is scaled by sampling rate which is
+    // vidSamplingInterval.
+    val expectedReachValue = 1010L
+    val expectedFrequencyMap =
+      mapOf(
+        1L to 0.9614979640529286,
+        2L to 0.01568143177129103,
+      )
+
+    assertThat(reachAndFrequencyResult.reach.value).isEqualTo(expectedReachValue)
+    reachAndFrequencyResult.frequency.relativeFrequencyDistributionMap.forEach {
+      (frequency, percentage) ->
+      assertThat(percentage).isEqualTo(expectedFrequencyMap[frequency])
+    }
+
+    verifyBlocking(requisitionFulfillmentServiceMock, never()) { fulfillRequisition(any()) }
+    verifyBlocking(requisitionsServiceMock, times(1)) { fulfillDirectRequisition(any()) }
+  }
+
   companion object {
     private val MC_SIGNING_KEY =
       loadSigningKey("${MC_NAME}_cs_cert.der", "${MC_NAME}_cs_private.der")
@@ -845,6 +894,8 @@ class EdpSimulatorTest {
     private val MC_PUBLIC_KEY =
       loadPublicKey(SECRET_FILES_PATH.resolve("mc_enc_public.tink").toFile())
         .toEncryptionPublicKey()
+    private val MC_PRIVATE_KEY =
+      loadPrivateKey(SECRET_FILES_PATH.resolve("mc_enc_private.tink").toFile())
     private val MEASUREMENT_PUBLIC_KEY =
       loadPublicKey(SECRET_FILES_PATH.resolve("${EDP_DISPLAY_NAME}_enc_public.tink").toFile())
         .toEncryptionPublicKey()


### PR DESCRIPTION
This PR should fix https://github.com/world-federation-of-advertisers/cross-media-measurement/issues/808

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/world-federation-of-advertisers/cross-media-measurement/814)
<!-- Reviewable:end -->
