### PR TITLE
Reduce usages of correlated lists in ReportsServiceTest.

### DIFF
--- a/src/main/kotlin/org/wfanet/measurement/api/v2alpha/DataProviderCertificateKey.kt
+++ b/src/main/kotlin/org/wfanet/measurement/api/v2alpha/DataProviderCertificateKey.kt
@@ -42,7 +42,3 @@ data class DataProviderCertificateKey(
     }
   }
 }
-
-fun makeDataProviderCertificateName(dataProviderId: String, certificateId: String): String {
-  return DataProviderCertificateKey(dataProviderId, certificateId).toName()
-}

--- a/src/main/kotlin/org/wfanet/measurement/api/v2alpha/DuchyCertificateKey.kt
+++ b/src/main/kotlin/org/wfanet/measurement/api/v2alpha/DuchyCertificateKey.kt
@@ -37,7 +37,3 @@ data class DuchyCertificateKey(val duchyId: String, override val certificateId: 
     }
   }
 }
-
-fun makeDuchyCertificateName(duchyId: String, certificateId: String): String {
-  return DuchyCertificateKey(duchyId, certificateId).toName()
-}

--- a/src/main/kotlin/org/wfanet/measurement/api/v2alpha/MeasurementConsumerCertificateKey.kt
+++ b/src/main/kotlin/org/wfanet/measurement/api/v2alpha/MeasurementConsumerCertificateKey.kt
@@ -46,10 +46,3 @@ data class MeasurementConsumerCertificateKey(
     }
   }
 }
-
-fun makeMeasurementConsumerCertificateName(
-  measurementConsumerId: String,
-  certificateId: String
-): String {
-  return MeasurementConsumerCertificateKey(measurementConsumerId, certificateId).toName()
-}

--- a/src/main/kotlin/org/wfanet/measurement/api/v2alpha/ModelProviderCertificateKey.kt
+++ b/src/main/kotlin/org/wfanet/measurement/api/v2alpha/ModelProviderCertificateKey.kt
@@ -43,7 +43,3 @@ data class ModelProviderCertificateKey(
     }
   }
 }
-
-fun makeModelProviderCertificateName(modelProviderId: String, certificateId: String): String {
-  return ModelProviderCertificateKey(modelProviderId, certificateId).toName()
-}

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/service/api/v2alpha/CertificatesService.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/service/api/v2alpha/CertificatesService.kt
@@ -38,10 +38,6 @@ import org.wfanet.measurement.api.v2alpha.ModelProviderPrincipal
 import org.wfanet.measurement.api.v2alpha.ReleaseCertificateHoldRequest
 import org.wfanet.measurement.api.v2alpha.RevokeCertificateRequest
 import org.wfanet.measurement.api.v2alpha.certificate
-import org.wfanet.measurement.api.v2alpha.makeDataProviderCertificateName
-import org.wfanet.measurement.api.v2alpha.makeDuchyCertificateName
-import org.wfanet.measurement.api.v2alpha.makeMeasurementConsumerCertificateName
-import org.wfanet.measurement.api.v2alpha.makeModelProviderCertificateName
 import org.wfanet.measurement.api.v2alpha.principalFromCurrentContext
 import org.wfanet.measurement.common.api.ResourceKey
 import org.wfanet.measurement.common.grpc.failGrpc
@@ -468,19 +464,19 @@ private fun InternalCertificate.toCertificate(): Certificate {
     @Suppress("WHEN_ENUM_CAN_BE_NULL_IN_JAVA")
     when (parentCase) {
       InternalCertificate.ParentCase.EXTERNAL_MEASUREMENT_CONSUMER_ID ->
-        makeMeasurementConsumerCertificateName(
-          externalIdToApiId(externalMeasurementConsumerId),
-          certificateApiId
-        )
+        MeasurementConsumerCertificateKey(
+            externalIdToApiId(externalMeasurementConsumerId),
+            certificateApiId
+          )
+          .toName()
       InternalCertificate.ParentCase.EXTERNAL_DATA_PROVIDER_ID ->
-        makeDataProviderCertificateName(externalIdToApiId(externalDataProviderId), certificateApiId)
+        DataProviderCertificateKey(externalIdToApiId(externalDataProviderId), certificateApiId)
+          .toName()
       InternalCertificate.ParentCase.EXTERNAL_DUCHY_ID ->
-        makeDuchyCertificateName(externalDuchyId, certificateApiId)
+        DuchyCertificateKey(externalDuchyId, certificateApiId).toName()
       InternalCertificate.ParentCase.EXTERNAL_MODEL_PROVIDER_ID ->
-        makeModelProviderCertificateName(
-          externalIdToApiId(externalModelProviderId),
-          certificateApiId
-        )
+        ModelProviderCertificateKey(externalIdToApiId(externalModelProviderId), certificateApiId)
+          .toName()
       InternalCertificate.ParentCase.PARENT_NOT_SET ->
         failGrpc(Status.INTERNAL) { "Parent missing" }
     }

--- a/src/main/kotlin/org/wfanet/measurement/reporting/service/api/v1alpha/EncryptionKeyPairStore.kt
+++ b/src/main/kotlin/org/wfanet/measurement/reporting/service/api/v1alpha/EncryptionKeyPairStore.kt
@@ -22,6 +22,12 @@ import org.wfanet.measurement.common.crypto.PrivateKeyHandle
 private const val DEFAULT_HASH_MINIMUM_BITS = 128
 
 interface EncryptionKeyPairStore {
+  /**
+   * Retrieves the corresponding [PrivateKeyHandle] for a serialized public key.
+   *
+   * @param principal resource name the public key belongs to
+   * @param publicKey `data` field of an [EncryptionPublicKey]
+   */
   suspend fun getPrivateKeyHandle(principal: String, publicKey: ByteString): PrivateKeyHandle?
 }
 
@@ -37,12 +43,6 @@ class InMemoryEncryptionKeyPairStore(
       keyPairs.associate { (publicKey, privateKey) -> fingerprint(publicKey) to privateKey }
     }
 
-  /**
-   * Retrieves the corresponding [PrivateKeyHandle] for a serialized public key.
-   *
-   * @param principal resource name the public key belongs to
-   * @param publicKey `data` field of an [EncryptionPublicKey]
-   */
   override suspend fun getPrivateKeyHandle(
     principal: String,
     publicKey: ByteString

--- a/src/main/kotlin/org/wfanet/measurement/reporting/service/api/v1alpha/ReportsService.kt
+++ b/src/main/kotlin/org/wfanet/measurement/reporting/service/api/v1alpha/ReportsService.kt
@@ -550,8 +550,8 @@ class ReportsService(
     signingConfig: SigningConfig,
     internalReportingSetMap: Map<Long, InternalReportingSet>
   ): Measurement {
-    val dataProviderNameToInternalEventGroupEntriesList =
-      aggregateInternalEventGroupEntryByDataProviderName(
+    val eventGroupEntriesByDataProvider =
+      groupEventGroupEntriesByDataProvider(
         weightedMeasurementInfo.weightedMeasurement.reportingSets,
         weightedMeasurementInfo.timeInterval.toMeasurementTimeInterval(),
         reportInfo.eventGroupFilters,
@@ -561,7 +561,7 @@ class ReportsService(
     val createMeasurementRequest: CreateMeasurementRequest =
       buildCreateMeasurementRequest(
         measurementConsumer,
-        dataProviderNameToInternalEventGroupEntriesList,
+        eventGroupEntriesByDataProvider,
         internalMetricDetails,
         weightedMeasurementInfo.reportingMeasurementId,
         apiAuthenticationKey,
@@ -1063,7 +1063,7 @@ class ReportsService(
   /** Builds a [CreateMeasurementRequest]. */
   private suspend fun buildCreateMeasurementRequest(
     measurementConsumer: MeasurementConsumer,
-    dataProviderNameToInternalEventGroupEntriesList: Map<String, List<EventGroupEntry>>,
+    eventGroupEntriesByDataProvider: Map<DataProviderKey, List<EventGroupEntry>>,
     internalMetricDetails: InternalMetricDetails,
     measurementReferenceId: String,
     apiAuthenticationKey: String,
@@ -1089,7 +1089,7 @@ class ReportsService(
 
       dataProviders +=
         buildDataProviderEntries(
-          dataProviderNameToInternalEventGroupEntriesList,
+          eventGroupEntriesByDataProvider,
           measurementEncryptionPublicKey,
           measurementConsumerSigningKey,
           apiAuthenticationKey,
@@ -1111,77 +1111,64 @@ class ReportsService(
     return createMeasurementRequest { this.measurement = measurement }
   }
 
-  /** Builds a map of data provider resource name to a list of [EventGroupEntry]s. */
-  private fun aggregateInternalEventGroupEntryByDataProviderName(
+  /**
+   * Converts internal event group entries into [EventGroupEntry] messages, grouping them by
+   * DataProvider.
+   */
+  private fun groupEventGroupEntriesByDataProvider(
     reportingSetNames: List<String>,
     timeInterval: MeasurementTimeInterval,
     eventGroupFilters: Map<String, String>,
     internalReportingSetMap: Map<Long, InternalReportingSet>
-  ): Map<String, List<EventGroupEntry>> {
-    val internalReportingSetsList = mutableListOf<InternalReportingSet>()
-
-    for (reportingSetName in reportingSetNames) {
-      val reportingSetKey =
-        grpcRequireNotNull(ReportingSetKey.fromName(reportingSetName)) {
-          "Invalid reporting set name $reportingSetName."
-        }
-
-      internalReportingSetsList +=
-        internalReportingSetMap.getValue(apiIdToExternalId(reportingSetKey.reportingSetId))
-    }
-
-    val dataProviderNameToInternalEventGroupEntriesList =
-      mutableMapOf<String, MutableList<EventGroupEntry>>()
-
-    for (internalReportingSet in internalReportingSetsList) {
-      for (eventGroupKey in internalReportingSet.eventGroupKeysList) {
-        val dataProviderName = DataProviderKey(eventGroupKey.dataProviderReferenceId).toName()
-        val eventGroupName =
-          EventGroupKey(
-              eventGroupKey.measurementConsumerReferenceId,
-              eventGroupKey.dataProviderReferenceId,
-              eventGroupKey.eventGroupReferenceId
+  ): Map<DataProviderKey, List<EventGroupEntry>> {
+    return reportingSetNames
+      .flatMap {
+        val reportingSetKey =
+          grpcRequireNotNull(ReportingSetKey.fromName(it)) { "Invalid reporting set name $it" }
+        val internalReportingSet =
+          internalReportingSetMap.getValue(apiIdToExternalId(reportingSetKey.reportingSetId))
+        internalReportingSet.eventGroupKeysList.map { internalEventGroupKey ->
+          val eventGroupKey =
+            EventGroupKey(
+              internalEventGroupKey.measurementConsumerReferenceId,
+              internalEventGroupKey.dataProviderReferenceId,
+              internalEventGroupKey.eventGroupReferenceId
             )
-            .toName()
+          val eventGroupName = eventGroupKey.toName()
+          val filter =
+            combineEventGroupFilters(internalReportingSet.filter, eventGroupFilters[eventGroupName])
 
-        dataProviderNameToInternalEventGroupEntriesList.getOrPut(
-          dataProviderName,
-          ::mutableListOf
-        ) +=
-          RequisitionSpecKt.eventGroupEntry {
-            key = eventGroupName
-            value =
-              RequisitionSpecKt.EventGroupEntryKt.value {
-                collectionInterval = timeInterval
-
-                val filter =
-                  combineEventGroupFilters(
-                    internalReportingSet.filter,
-                    eventGroupFilters[eventGroupName]
-                  )
-                if (filter != null) {
-                  this.filter = RequisitionSpecKt.eventFilter { expression = filter }
+          eventGroupKey to
+            RequisitionSpecKt.eventGroupEntry {
+              key = eventGroupName
+              value =
+                RequisitionSpecKt.EventGroupEntryKt.value {
+                  collectionInterval = timeInterval
+                  if (filter != null) {
+                    this.filter = RequisitionSpecKt.eventFilter { expression = filter }
+                  }
                 }
-              }
-          }
+            }
+        }
       }
-    }
-
-    return dataProviderNameToInternalEventGroupEntriesList.mapValues { it.value.toList() }.toMap()
+      .groupBy(
+        { (eventGroupKey, _) -> DataProviderKey(eventGroupKey.dataProviderReferenceId) },
+        { (_, eventGroupEntry) -> eventGroupEntry }
+      )
   }
 
-  /** Builds a list of [DataProviderEntry]s from lists of [EventGroupEntry]s. */
+  /** Builds a [List] of [DataProviderEntry] messages from [eventGroupEntriesByDataProvider]. */
   private suspend fun buildDataProviderEntries(
-    dataProviderNameToInternalEventGroupEntriesList: Map<String, List<EventGroupEntry>>,
+    eventGroupEntriesByDataProvider: Map<DataProviderKey, List<EventGroupEntry>>,
     measurementEncryptionPublicKey: ByteString,
     measurementConsumerSigningKey: SigningKeyHandle,
     apiAuthenticationKey: String,
   ): List<DataProviderEntry> {
-    return dataProviderNameToInternalEventGroupEntriesList.map {
-      (dataProviderName, eventGroupEntriesList) ->
+    return eventGroupEntriesByDataProvider.map { (dataProviderKey, eventGroupEntries) ->
+      val dataProviderName: String = dataProviderKey.toName()
       dataProviderEntry {
         val requisitionSpec = requisitionSpec {
-          eventGroups += eventGroupEntriesList
+          eventGroups += eventGroupEntries
           this.measurementPublicKey = measurementEncryptionPublicKey
           nonce = secureRandom.nextLong()
         }
@@ -1192,7 +1179,7 @@ class ReportsService(
               .withAuthenticationKey(apiAuthenticationKey)
               .getDataProvider(getDataProviderRequest { name = dataProviderName })
           } catch (e: StatusException) {
-            throw Exception("Unable to retrieve the data provider [$dataProviderName].", e)
+            throw Exception("Unable to retrieve $dataProviderName", e)
           }
 
         key = dataProvider.name

--- a/src/test/kotlin/org/wfanet/measurement/reporting/service/api/v1alpha/ReportsServiceTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/reporting/service/api/v1alpha/ReportsServiceTest.kt
@@ -16,8 +16,8 @@ package org.wfanet.measurement.reporting.service.api.v1alpha
 
 import com.google.common.truth.Truth.assertThat
 import com.google.common.truth.extensions.proto.ProtoTruth.assertThat
-import com.google.protobuf.ByteString
 import com.google.protobuf.duration
+import com.google.protobuf.kotlin.toByteString
 import com.google.protobuf.kotlin.toByteStringUtf8
 import com.google.protobuf.timestamp
 import com.google.protobuf.util.Timestamps
@@ -26,6 +26,7 @@ import io.grpc.StatusRuntimeException
 import java.nio.file.Paths
 import java.security.SecureRandom
 import java.security.cert.X509Certificate
+import java.time.Duration
 import java.time.Instant
 import kotlin.test.assertFails
 import kotlin.test.assertFailsWith
@@ -52,6 +53,7 @@ import org.wfanet.measurement.api.v2.alpha.listReportsPageToken
 import org.wfanet.measurement.api.v2alpha.CertificatesGrpcKt.CertificatesCoroutineImplBase
 import org.wfanet.measurement.api.v2alpha.CertificatesGrpcKt.CertificatesCoroutineStub
 import org.wfanet.measurement.api.v2alpha.CreateMeasurementRequest
+import org.wfanet.measurement.api.v2alpha.DataProviderCertificateKey
 import org.wfanet.measurement.api.v2alpha.DataProviderKey
 import org.wfanet.measurement.api.v2alpha.DataProvidersGrpcKt.DataProvidersCoroutineImplBase
 import org.wfanet.measurement.api.v2alpha.DataProvidersGrpcKt.DataProvidersCoroutineStub
@@ -59,6 +61,7 @@ import org.wfanet.measurement.api.v2alpha.EncryptionPublicKey
 import org.wfanet.measurement.api.v2alpha.GetDataProviderRequest
 import org.wfanet.measurement.api.v2alpha.Measurement
 import org.wfanet.measurement.api.v2alpha.Measurement.DataProviderEntry.Value.ENCRYPTED_REQUISITION_SPEC_FIELD_NUMBER
+import org.wfanet.measurement.api.v2alpha.MeasurementConsumer
 import org.wfanet.measurement.api.v2alpha.MeasurementConsumerCertificateKey
 import org.wfanet.measurement.api.v2alpha.MeasurementConsumerKey
 import org.wfanet.measurement.api.v2alpha.MeasurementConsumersGrpcKt.MeasurementConsumersCoroutineImplBase
@@ -87,12 +90,10 @@ import org.wfanet.measurement.api.v2alpha.getCertificateRequest
 import org.wfanet.measurement.api.v2alpha.getDataProviderRequest
 import org.wfanet.measurement.api.v2alpha.getMeasurementConsumerRequest
 import org.wfanet.measurement.api.v2alpha.getMeasurementRequest
-import org.wfanet.measurement.api.v2alpha.makeDataProviderCertificateName
 import org.wfanet.measurement.api.v2alpha.measurement
 import org.wfanet.measurement.api.v2alpha.measurementConsumer
 import org.wfanet.measurement.api.v2alpha.measurementSpec
 import org.wfanet.measurement.api.v2alpha.requisitionSpec
-import org.wfanet.measurement.api.v2alpha.signedData
 import org.wfanet.measurement.api.v2alpha.timeInterval as measurementTimeInterval
 import org.wfanet.measurement.api.v2alpha.withDataProviderPrincipal
 import org.wfanet.measurement.common.base64UrlEncode
@@ -100,25 +101,27 @@ import org.wfanet.measurement.common.crypto.PrivateKeyHandle
 import org.wfanet.measurement.common.crypto.SigningKeyHandle
 import org.wfanet.measurement.common.crypto.hashSha256
 import org.wfanet.measurement.common.crypto.readCertificate
-import org.wfanet.measurement.common.crypto.readPrivateKey
 import org.wfanet.measurement.common.crypto.subjectKeyIdentifier
+import org.wfanet.measurement.common.crypto.testing.loadSigningKey
 import org.wfanet.measurement.common.crypto.tink.loadPrivateKey
-import org.wfanet.measurement.common.crypto.tink.loadPublicKey
 import org.wfanet.measurement.common.getRuntimePath
 import org.wfanet.measurement.common.grpc.testing.GrpcTestServerRule
 import org.wfanet.measurement.common.grpc.testing.mockService
+import org.wfanet.measurement.common.identity.ExternalId
 import org.wfanet.measurement.common.identity.externalIdToApiId
 import org.wfanet.measurement.common.readByteString
 import org.wfanet.measurement.common.testing.captureFirst
 import org.wfanet.measurement.common.testing.verifyProtoArgument
+import org.wfanet.measurement.common.toProtoDuration
+import org.wfanet.measurement.common.toProtoTime
 import org.wfanet.measurement.config.reporting.measurementConsumerConfig
-import org.wfanet.measurement.consent.client.common.toEncryptionPublicKey
 import org.wfanet.measurement.consent.client.dataprovider.decryptRequisitionSpec
 import org.wfanet.measurement.consent.client.dataprovider.verifyMeasurementSpec
 import org.wfanet.measurement.consent.client.dataprovider.verifyRequisitionSpec
 import org.wfanet.measurement.consent.client.duchy.encryptResult
 import org.wfanet.measurement.consent.client.duchy.signResult
 import org.wfanet.measurement.consent.client.measurementconsumer.encryptRequisitionSpec
+import org.wfanet.measurement.consent.client.measurementconsumer.signEncryptionPublicKey
 import org.wfanet.measurement.consent.client.measurementconsumer.signMeasurementSpec
 import org.wfanet.measurement.consent.client.measurementconsumer.signRequisitionSpec
 import org.wfanet.measurement.internal.reporting.CreateReportRequestKt as InternalCreateReportRequestKt
@@ -137,6 +140,7 @@ import org.wfanet.measurement.internal.reporting.Report as InternalReport
 import org.wfanet.measurement.internal.reporting.ReportKt as InternalReportKt
 import org.wfanet.measurement.internal.reporting.ReportKt.DetailsKt as InternalReportDetailsKt
 import org.wfanet.measurement.internal.reporting.ReportKt.DetailsKt.ResultKt as InternalReportResultKt
+import org.wfanet.measurement.internal.reporting.ReportingSet as InternalReportingSet
 import org.wfanet.measurement.internal.reporting.ReportingSetKt as InternalReportingSetKt
 import org.wfanet.measurement.internal.reporting.ReportingSetsGrpcKt.ReportingSetsCoroutineImplBase as InternalReportingSetsCoroutineImplBase
 import org.wfanet.measurement.internal.reporting.ReportingSetsGrpcKt.ReportingSetsCoroutineStub as InternalReportingSetsCoroutineStub
@@ -252,222 +256,178 @@ private val SECRETS_DIR =
 private const val API_AUTHENTICATION_KEY = "nR5QPN7ptx"
 
 // Aggregator certificate
-private val AGGREGATOR_CERTIFICATE_DER =
-  SECRETS_DIR.resolve("aggregator_cs_cert.der").readByteString()
-private val AGGREGATOR_PRIVATE_KEY_DER =
-  SECRETS_DIR.resolve("aggregator_cs_private.der").readByteString()
+
 private val AGGREGATOR_SIGNING_KEY: SigningKeyHandle by lazy {
-  val consentSignal509Cert = readCertificate(AGGREGATOR_CERTIFICATE_DER)
-  SigningKeyHandle(
-    consentSignal509Cert,
-    readPrivateKey(AGGREGATOR_PRIVATE_KEY_DER, consentSignal509Cert.publicKey.algorithm)
+  loadSigningKey(
+    SECRETS_DIR.resolve("aggregator_cs_cert.der"),
+    SECRETS_DIR.resolve("aggregator_cs_private.der")
   )
 }
-private val AGGREGATOR_CERTIFICATE = certificate { x509Der = AGGREGATOR_CERTIFICATE_DER }
+private val AGGREGATOR_CERTIFICATE = certificate {
+  name = "duchies/aggregator/certificates/abc123"
+  x509Der = AGGREGATOR_SIGNING_KEY.certificate.encoded.toByteString()
+}
 private val AGGREGATOR_ROOT_CERTIFICATE: X509Certificate =
   readCertificate(SECRETS_DIR.resolve("aggregator_root.pem"))
 
-// Public keys of measurement consumers
-private val MEASUREMENT_PUBLIC_KEY_DATA = SECRETS_DIR.resolve("mc_enc_public.tink").readByteString()
-private val MEASUREMENT_PUBLIC_KEY = encryptionPublicKey {
-  format = EncryptionPublicKey.Format.TINK_KEYSET
-  data = MEASUREMENT_PUBLIC_KEY_DATA
-}
 private val INVALID_MEASUREMENT_PUBLIC_KEY_DATA = "Invalid public key".toByteStringUtf8()
 
-// Private keys of measurement consumers
-private val MEASUREMENT_CONSUMER_CERTIFICATE_DER =
-  SECRETS_DIR.resolve("mc_cs_cert.der").readByteString()
-private val MEASUREMENT_CONSUMER_PRIVATE_KEY_DER =
-  SECRETS_DIR.resolve("mc_cs_private.der").readByteString()
-private val MEASUREMENT_CONSUMER_CERTIFICATE = readCertificate(MEASUREMENT_CONSUMER_CERTIFICATE_DER)
+// Measurement consumer crypto
+
 private val TRUSTED_MEASUREMENT_CONSUMER_ISSUER: X509Certificate =
   readCertificate(SECRETS_DIR.resolve("mc_root.pem"))
-private val MEASUREMENT_CONSUMER_SIGNING_PRIVATE_KEY =
-  readPrivateKey(
-    MEASUREMENT_CONSUMER_PRIVATE_KEY_DER,
-    MEASUREMENT_CONSUMER_CERTIFICATE.publicKey.algorithm
-  )
 private val MEASUREMENT_CONSUMER_SIGNING_KEY_HANDLE =
-  SigningKeyHandle(MEASUREMENT_CONSUMER_CERTIFICATE, MEASUREMENT_CONSUMER_SIGNING_PRIVATE_KEY)
-
-// Private key handles of measurement consumers
-private val MEASUREMENT_CONSUMER_PRIVATE_KEY_DATA = SECRETS_DIR.resolve("mc_enc_private.tink")
+  loadSigningKey(SECRETS_DIR.resolve("mc_cs_cert.der"), SECRETS_DIR.resolve("mc_cs_private.der"))
+private val MEASUREMENT_CONSUMER_CERTIFICATE = MEASUREMENT_CONSUMER_SIGNING_KEY_HANDLE.certificate
 private val MEASUREMENT_CONSUMER_PRIVATE_KEY_HANDLE: PrivateKeyHandle =
-  loadPrivateKey(MEASUREMENT_CONSUMER_PRIVATE_KEY_DATA)
+  loadPrivateKey(SECRETS_DIR.resolve("mc_enc_private.tink"))
+private val MEASUREMENT_CONSUMER_PUBLIC_KEY = encryptionPublicKey {
+  format = EncryptionPublicKey.Format.TINK_KEYSET
+  data = SECRETS_DIR.resolve("mc_enc_public.tink").readByteString()
+}
 
-// Measurement consumer IDs and names
-private val MEASUREMENT_CONSUMER_EXTERNAL_IDS = listOf(111L, 112L)
-private val MEASUREMENT_CONSUMER_REFERENCE_IDS =
-  MEASUREMENT_CONSUMER_EXTERNAL_IDS.map { externalIdToApiId(it) }
-private val MEASUREMENT_CONSUMER_NAMES =
-  MEASUREMENT_CONSUMER_REFERENCE_IDS.map { MeasurementConsumerKey(it).toName() }
+private val MEASUREMENT_CONSUMERS: Map<MeasurementConsumerKey, MeasurementConsumer> =
+  (1L..2L).associate {
+    val measurementConsumerKey = MeasurementConsumerKey(ExternalId(it + 110L).apiId.value)
+    val certificateKey =
+      MeasurementConsumerCertificateKey(
+        measurementConsumerKey.measurementConsumerId,
+        ExternalId(it + 120L).apiId.value
+      )
+    measurementConsumerKey to
+      measurementConsumer {
+        name = measurementConsumerKey.toName()
+        certificate = certificateKey.toName()
+        certificateDer = MEASUREMENT_CONSUMER_SIGNING_KEY_HANDLE.certificate.encoded.toByteString()
+        publicKey =
+          signEncryptionPublicKey(
+            MEASUREMENT_CONSUMER_PUBLIC_KEY,
+            MEASUREMENT_CONSUMER_SIGNING_KEY_HANDLE
+          )
+      }
+  }
+
+private val CONFIG = measurementConsumerConfig {
+  apiKey = API_AUTHENTICATION_KEY
+  signingCertificateName = MEASUREMENT_CONSUMERS.values.first().certificate
+  signingPrivateKeyPath = "mc_cs_private.der"
+}
 
 // InMemoryEncryptionKeyPairStore
 private val ENCRYPTION_KEY_PAIR_STORE =
   InMemoryEncryptionKeyPairStore(
-    mapOf(
-      MEASUREMENT_CONSUMER_NAMES[0] to
-        listOf(MEASUREMENT_PUBLIC_KEY_DATA to MEASUREMENT_CONSUMER_PRIVATE_KEY_HANDLE)
+    MEASUREMENT_CONSUMERS.values.associateBy(
+      { it.name },
+      {
+        listOf(
+          EncryptionPublicKey.parseFrom(it.publicKey.data).data to
+            MEASUREMENT_CONSUMER_PRIVATE_KEY_HANDLE
+        )
+      }
     )
   )
-
-// Measurement consumer certificate IDs
-private const val MEASUREMENT_CONSUMER_CERTIFICATE_EXTERNAL_ID = 121L
-private val MEASUREMENT_CONSUMER_CERTIFICATE_REFERENCE_ID =
-  externalIdToApiId(MEASUREMENT_CONSUMER_CERTIFICATE_EXTERNAL_ID)
-private val MEASUREMENT_CONSUMER_CERTIFICATE_NAME =
-  MeasurementConsumerCertificateKey(
-      MEASUREMENT_CONSUMER_REFERENCE_IDS[0],
-      MEASUREMENT_CONSUMER_CERTIFICATE_REFERENCE_ID
-    )
-    .toName()
-
-private val CONFIG = measurementConsumerConfig {
-  apiKey = API_AUTHENTICATION_KEY
-  signingCertificateName = MEASUREMENT_CONSUMER_CERTIFICATE_NAME
-  signingPrivateKeyPath = "mc_cs_private.der"
-}
-
-// Measurement consumers
-private val MEASUREMENT_CONSUMER = measurementConsumer {
-  name = MEASUREMENT_CONSUMER_NAMES[0]
-  certificateDer = MEASUREMENT_CONSUMER_CERTIFICATE_DER
-  certificate = MEASUREMENT_CONSUMER_CERTIFICATE_NAME
-  publicKey = signedData { data = MEASUREMENT_PUBLIC_KEY.toByteString() }
-}
-
-// Reporting set IDs and names
-private val REPORTING_SET_EXTERNAL_IDS = listOf(221L, 222L, 223L, 224L)
-private const val REPORTING_SET_EXTERNAL_ID_FOR_MC_2 = 241L
-
-private val REPORTING_SET_NAMES =
-  REPORTING_SET_EXTERNAL_IDS.map {
-    ReportingSetKey(MEASUREMENT_CONSUMER_REFERENCE_IDS[0], externalIdToApiId(it)).toName()
-  }
-private const val INVALID_REPORTING_SET_NAME = "INVALID_REPORTING_SET_NAME"
-private val REPORTING_SET_NAME_FOR_MC_2 =
-  ReportingSetKey(
-      MEASUREMENT_CONSUMER_REFERENCE_IDS[1],
-      externalIdToApiId(REPORTING_SET_EXTERNAL_ID_FOR_MC_2)
-    )
-    .toName()
 
 // Report IDs and names
 private val REPORT_EXTERNAL_IDS = listOf(331L, 332L, 333L, 334L)
 private val REPORT_NAMES =
   REPORT_EXTERNAL_IDS.map {
-    ReportKey(MEASUREMENT_CONSUMER_REFERENCE_IDS[0], externalIdToApiId(it)).toName()
-  }
-// Typo causes invalid name
-private const val INVALID_REPORT_NAME = "measurementConsumer/AAAAAAAAAG8/report/AAAAAAAAAU0"
-
-// Data provider IDs and names
-private val DATA_PROVIDER_EXTERNAL_IDS = listOf(551L, 552L, 553L)
-private val DATA_PROVIDER_REFERENCE_IDS = DATA_PROVIDER_EXTERNAL_IDS.map { externalIdToApiId(it) }
-
-private val DATA_PROVIDER_PUBLIC_KEY =
-  loadPublicKey(SECRETS_DIR.resolve("edp1_enc_public.tink")).toEncryptionPublicKey()
-private val DATA_PROVIDER_PRIVATE_KEY_HANDLE =
-  loadPrivateKey(SECRETS_DIR.resolve("edp1_enc_private.tink"))
-
-// Data provider certificates
-private val DATA_PROVIDER_CERTIFICATE_EXTERNAL_IDS = listOf(561L, 562L, 563L)
-private val DATA_PROVIDER_CERTIFICATE_REFERENCE_IDS =
-  DATA_PROVIDER_CERTIFICATE_EXTERNAL_IDS.map { externalIdToApiId(it) }
-private val DATA_PROVIDER_CERTIFICATE_NAMES =
-  DATA_PROVIDER_CERTIFICATE_REFERENCE_IDS.mapIndexed { index, referenceId ->
-    makeDataProviderCertificateName(DATA_PROVIDER_REFERENCE_IDS[index], referenceId)
-  }
-
-// Data providers
-private val DATA_PROVIDERS =
-  DATA_PROVIDER_REFERENCE_IDS.mapIndexed { index, dataProviderReferenceId ->
-    dataProvider {
-      name = DataProviderKey(dataProviderReferenceId).toName()
-      certificate = DATA_PROVIDER_CERTIFICATE_NAMES[index]
-      publicKey = signedData { data = DATA_PROVIDER_PUBLIC_KEY.toByteString() }
-    }
-  }
-
-// Event group IDs and names
-private const val NUMBER_COVERED_EVENT_GROUPS = 3
-private val EVENT_GROUP_EXTERNAL_IDS = listOf(661L, 662L, 663L, 664L)
-private val EVENT_GROUP_REFERENCE_IDS = EVENT_GROUP_EXTERNAL_IDS.map { externalIdToApiId(it) }
-
-private val COVERED_EVENT_GROUP_NAMES =
-  (0 until NUMBER_COVERED_EVENT_GROUPS).map { index ->
-    EventGroupKey(
-        MEASUREMENT_CONSUMER_REFERENCE_IDS[0],
-        DATA_PROVIDER_REFERENCE_IDS[index],
-        EVENT_GROUP_REFERENCE_IDS[index]
-      )
+    ReportKey(MEASUREMENT_CONSUMERS.keys.first().measurementConsumerId, externalIdToApiId(it))
       .toName()
   }
 
-private val UNCOVERED_EVENT_GROUP_NAME =
-  EventGroupKey(
-      MEASUREMENT_CONSUMER_REFERENCE_IDS[0],
-      DATA_PROVIDER_REFERENCE_IDS[2],
-      EVENT_GROUP_REFERENCE_IDS[3]
-    )
-    .toName()
+// Typo causes invalid name
+private const val INVALID_REPORT_NAME = "measurementConsumer/AAAAAAAAAG8/report/AAAAAAAAAU0"
+
+private val DATA_PROVIDER_PUBLIC_KEY = encryptionPublicKey {
+  format = EncryptionPublicKey.Format.TINK_KEYSET
+  data = SECRETS_DIR.resolve("edp1_enc_public.tink").readByteString()
+}
+private val DATA_PROVIDER_PRIVATE_KEY_HANDLE =
+  loadPrivateKey(SECRETS_DIR.resolve("edp1_enc_private.tink"))
+private val DATA_PROVIDER_SIGNING_KEY =
+  loadSigningKey(
+    SECRETS_DIR.resolve("edp1_cs_cert.der"),
+    SECRETS_DIR.resolve("edp1_cs_private.der")
+  )
+private val DATA_PROVIDER_ROOT_CERTIFICATE = readCertificate(SECRETS_DIR.resolve("edp1_root.pem"))
+
+// Data providers
+
+private val DATA_PROVIDERS =
+  (1L..3L).associate {
+    val dataProviderKey = DataProviderKey(ExternalId(it + 550L).apiId.value)
+    val certificateKey =
+      DataProviderCertificateKey(dataProviderKey.dataProviderId, ExternalId(it + 560L).apiId.value)
+    dataProviderKey to
+      dataProvider {
+        name = dataProviderKey.toName()
+        certificate = certificateKey.toName()
+        publicKey = signEncryptionPublicKey(DATA_PROVIDER_PUBLIC_KEY, DATA_PROVIDER_SIGNING_KEY)
+      }
+  }
+private val DATA_PROVIDERS_LIST = DATA_PROVIDERS.values.toList()
 
 // Event group keys
-private val COVERED_INTERNAL_EVENT_GROUP_KEYS =
-  (0 until NUMBER_COVERED_EVENT_GROUPS).map { index ->
-    InternalReportingSetKt.eventGroupKey {
-      measurementConsumerReferenceId = MEASUREMENT_CONSUMER_REFERENCE_IDS[0]
-      dataProviderReferenceId = DATA_PROVIDER_REFERENCE_IDS[index]
-      eventGroupReferenceId = EVENT_GROUP_REFERENCE_IDS[index]
-    }
+
+private val COVERED_EVENT_GROUP_KEYS =
+  DATA_PROVIDERS.keys.mapIndexed { index, dataProviderKey ->
+    val measurementConsumerKey = MEASUREMENT_CONSUMERS.keys.first()
+    EventGroupKey(
+      measurementConsumerKey.measurementConsumerId,
+      dataProviderKey.dataProviderId,
+      ExternalId(index + 660L).apiId.value
+    )
   }
-private val UNCOVERED_INTERNAL_EVENT_GROUP_KEY =
-  InternalReportingSetKt.eventGroupKey {
-    measurementConsumerReferenceId = MEASUREMENT_CONSUMER_REFERENCE_IDS[0]
-    dataProviderReferenceId = DATA_PROVIDER_REFERENCE_IDS[2]
-    eventGroupReferenceId = EVENT_GROUP_REFERENCE_IDS[3]
-  }
+private val UNCOVERED_EVENT_GROUP_KEY =
+  EventGroupKey(
+    MEASUREMENT_CONSUMERS.keys.first().measurementConsumerId,
+    DATA_PROVIDERS.keys.last().dataProviderId,
+    ExternalId(664L).apiId.value
+  )
+private val UNCOVERED_EVENT_GROUP_NAME = UNCOVERED_EVENT_GROUP_KEY.toName()
+private val UNCOVERED_INTERNAL_EVENT_GROUP_KEY = UNCOVERED_EVENT_GROUP_KEY.toInternal()
 
 // Reporting sets
 private const val REPORTING_SET_FILTER = "AGE>18"
 
-private val REPORTING_SET_DISPLAY_NAMES = REPORTING_SET_NAMES.map { it + REPORTING_SET_FILTER }
-
 private val INTERNAL_REPORTING_SETS =
-  (0 until NUMBER_COVERED_EVENT_GROUPS).map { index ->
+  COVERED_EVENT_GROUP_KEYS.mapIndexed { index, eventGroupKey ->
     internalReportingSet {
-      measurementConsumerReferenceId = MEASUREMENT_CONSUMER_REFERENCE_IDS[0]
-      externalReportingSetId = REPORTING_SET_EXTERNAL_IDS[index]
-      eventGroupKeys.add(COVERED_INTERNAL_EVENT_GROUP_KEYS[index])
+      measurementConsumerReferenceId = MEASUREMENT_CONSUMERS.keys.first().measurementConsumerId
+      externalReportingSetId = index + 220L
+      eventGroupKeys += eventGroupKey.toInternal()
       filter = REPORTING_SET_FILTER
-      displayName = REPORTING_SET_DISPLAY_NAMES[index]
+      displayName = "$measurementConsumerReferenceId-$externalReportingSetId-$filter"
     }
   }
 private val UNCOVERED_INTERNAL_REPORTING_SET = internalReportingSet {
-  measurementConsumerReferenceId = MEASUREMENT_CONSUMER_REFERENCE_IDS[0]
-  externalReportingSetId = REPORTING_SET_EXTERNAL_IDS[3]
-  eventGroupKeys.add(UNCOVERED_INTERNAL_EVENT_GROUP_KEY)
+  measurementConsumerReferenceId = MEASUREMENT_CONSUMERS.keys.first().measurementConsumerId
+  externalReportingSetId = INTERNAL_REPORTING_SETS.last().externalReportingSetId + 1
+  eventGroupKeys += UNCOVERED_INTERNAL_EVENT_GROUP_KEY
   filter = REPORTING_SET_FILTER
-  displayName = REPORTING_SET_DISPLAY_NAMES[3]
+  displayName = "$measurementConsumerReferenceId-$externalReportingSetId-$filter"
 }
+
+// Reporting set IDs and names
+
+private const val REPORTING_SET_EXTERNAL_ID_FOR_MC_2 = 241L
+
+private const val INVALID_REPORTING_SET_NAME = "INVALID_REPORTING_SET_NAME"
+private val REPORTING_SET_NAME_FOR_MC_2 =
+  ReportingSetKey(
+      MEASUREMENT_CONSUMERS.keys.last().measurementConsumerId,
+      externalIdToApiId(REPORTING_SET_EXTERNAL_ID_FOR_MC_2)
+    )
+    .toName()
 
 // Time intervals
 private val START_INSTANT = Instant.now()
-private const val DAY_SECONDS = 86400L
-private val END_INSTANT =
-  Instant.ofEpochSecond(START_INSTANT.epochSecond + DAY_SECONDS, START_INSTANT.nano.toLong())
+private val END_INSTANT = START_INSTANT.plus(Duration.ofDays(1))
 
-private val START_TIME = timestamp {
-  seconds = START_INSTANT.epochSecond
-  nanos = START_INSTANT.nano
-}
-private val TIME_INTERVAL_INCREMENT = duration { seconds = DAY_SECONDS }
+private val START_TIME = START_INSTANT.toProtoTime()
+private val TIME_INTERVAL_INCREMENT = Duration.ofDays(1).toProtoDuration()
 private const val INTERVAL_COUNT = 1
-private val END_TIME = timestamp {
-  seconds = END_INSTANT.epochSecond
-  nanos = END_INSTANT.nano
-}
+private val END_TIME = END_INSTANT.toProtoTime()
 private val MEASUREMENT_TIME_INTERVAL = measurementTimeInterval {
   startTime = START_TIME
   endTime = END_TIME
@@ -518,20 +478,34 @@ private val WATCH_DURATION_MEASUREMENT_REFERENCE_ID =
     "-$START_INSTANT-$END_INSTANT-measurement-0"
 
 private val REACH_MEASUREMENT_NAME =
-  MeasurementKey(MEASUREMENT_CONSUMER_REFERENCE_IDS[0], REACH_MEASUREMENT_REFERENCE_ID).toName()
+  MeasurementKey(
+      MEASUREMENT_CONSUMERS.keys.first().measurementConsumerId,
+      REACH_MEASUREMENT_REFERENCE_ID
+    )
+    .toName()
 private val REACH_MEASUREMENT_NAME_2 =
-  MeasurementKey(MEASUREMENT_CONSUMER_REFERENCE_IDS[0], REACH_MEASUREMENT_REFERENCE_ID_2).toName()
+  MeasurementKey(
+      MEASUREMENT_CONSUMERS.keys.first().measurementConsumerId,
+      REACH_MEASUREMENT_REFERENCE_ID_2
+    )
+    .toName()
 private val FREQUENCY_HISTOGRAM_MEASUREMENT_NAME =
   MeasurementKey(
-      MEASUREMENT_CONSUMER_REFERENCE_IDS[0],
+      MEASUREMENT_CONSUMERS.keys.first().measurementConsumerId,
       FREQUENCY_HISTOGRAM_MEASUREMENT_REFERENCE_ID
     )
     .toName()
 private val IMPRESSION_MEASUREMENT_NAME =
-  MeasurementKey(MEASUREMENT_CONSUMER_REFERENCE_IDS[0], IMPRESSION_MEASUREMENT_REFERENCE_ID)
+  MeasurementKey(
+      MEASUREMENT_CONSUMERS.keys.first().measurementConsumerId,
+      IMPRESSION_MEASUREMENT_REFERENCE_ID
+    )
     .toName()
 private val WATCH_DURATION_MEASUREMENT_NAME =
-  MeasurementKey(MEASUREMENT_CONSUMER_REFERENCE_IDS[0], WATCH_DURATION_MEASUREMENT_REFERENCE_ID)
+  MeasurementKey(
+      MEASUREMENT_CONSUMERS.keys.first().measurementConsumerId,
+      WATCH_DURATION_MEASUREMENT_REFERENCE_ID
+    )
     .toName()
 
 // Set operations
@@ -541,90 +515,94 @@ private val INTERNAL_SET_OPERATION =
     lhs =
       InternalMetricKt.SetOperationKt.operand {
         reportingSetId = reportingSetKey {
-          measurementConsumerReferenceId = MEASUREMENT_CONSUMER_REFERENCE_IDS[0]
-          externalReportingSetId = REPORTING_SET_EXTERNAL_IDS[0]
+          measurementConsumerReferenceId = MEASUREMENT_CONSUMERS.keys.first().measurementConsumerId
+          externalReportingSetId = INTERNAL_REPORTING_SETS[0].externalReportingSetId
         }
       }
     rhs =
       InternalMetricKt.SetOperationKt.operand {
         reportingSetId = reportingSetKey {
-          measurementConsumerReferenceId = MEASUREMENT_CONSUMER_REFERENCE_IDS[0]
-          externalReportingSetId = REPORTING_SET_EXTERNAL_IDS[1]
+          measurementConsumerReferenceId = MEASUREMENT_CONSUMERS.keys.first().measurementConsumerId
+          externalReportingSetId = INTERNAL_REPORTING_SETS[1].externalReportingSetId
         }
       }
   }
 
 private val SET_OPERATION = setOperation {
   type = SetOperation.Type.UNION
-  lhs = SetOperationKt.operand { reportingSet = REPORTING_SET_NAMES[0] }
-  rhs = SetOperationKt.operand { reportingSet = REPORTING_SET_NAMES[1] }
+  lhs = SetOperationKt.operand { reportingSet = INTERNAL_REPORTING_SETS[0].resourceName }
+  rhs = SetOperationKt.operand { reportingSet = INTERNAL_REPORTING_SETS[1].resourceName }
 }
-private val DATA_PROVIDER_INDICES_IN_SET_OPERATION = listOf(0, 1)
+private val DATA_PROVIDER_KEYS_IN_SET_OPERATION = DATA_PROVIDERS.keys.take(2)
 
 private val SET_OPERATION_WITH_INVALID_REPORTING_SET = setOperation {
   type = SetOperation.Type.UNION
   lhs = SetOperationKt.operand { reportingSet = INVALID_REPORTING_SET_NAME }
-  rhs = SetOperationKt.operand { reportingSet = REPORTING_SET_NAMES[1] }
+  rhs = SetOperationKt.operand { reportingSet = INTERNAL_REPORTING_SETS[1].resourceName }
 }
 
 private val SET_OPERATION_WITH_INACCESSIBLE_REPORTING_SET = setOperation {
   type = SetOperation.Type.UNION
   lhs = SetOperationKt.operand { reportingSet = REPORTING_SET_NAME_FOR_MC_2 }
-  rhs = SetOperationKt.operand { reportingSet = REPORTING_SET_NAMES[1] }
+  rhs = SetOperationKt.operand { reportingSet = INTERNAL_REPORTING_SETS[1].resourceName }
 }
 
 // Event group filters
 private const val EVENT_GROUP_FILTER = "AGE>20"
-private val EVENT_GROUP_FILTERS_MAP = COVERED_EVENT_GROUP_NAMES.associateWith { EVENT_GROUP_FILTER }
+private val EVENT_GROUP_FILTERS_MAP =
+  COVERED_EVENT_GROUP_KEYS.associateBy(EventGroupKey::toName) { EVENT_GROUP_FILTER }
 
 // Event group entries
 private val EVENT_GROUP_ENTRIES =
-  COVERED_EVENT_GROUP_NAMES.map {
-    eventGroupEntry {
-      key = it
-      value =
-        EventGroupEntryKt.value {
-          collectionInterval = MEASUREMENT_TIME_INTERVAL
-          filter = eventFilter { expression = "($REPORTING_SET_FILTER) AND ($EVENT_GROUP_FILTER)" }
-        }
+  COVERED_EVENT_GROUP_KEYS.groupBy(
+    { DataProviderKey(it.dataProviderReferenceId) },
+    {
+      eventGroupEntry {
+        key = it.toName()
+        value =
+          EventGroupEntryKt.value {
+            collectionInterval = MEASUREMENT_TIME_INTERVAL
+            filter = eventFilter {
+              expression = "($REPORTING_SET_FILTER) AND ($EVENT_GROUP_FILTER)"
+            }
+          }
+      }
     }
-  }
+  )
 
 // Requisition specs
-private val REQUISITION_SPECS =
-  EVENT_GROUP_ENTRIES.map {
+private val REQUISITION_SPECS: Map<DataProviderKey, RequisitionSpec> =
+  EVENT_GROUP_ENTRIES.mapValues {
     requisitionSpec {
-      eventGroups.add(it)
-      measurementPublicKey = MEASUREMENT_CONSUMER.publicKey.data
+      eventGroups += it.value
+      measurementPublicKey = MEASUREMENT_CONSUMERS.values.first().publicKey.data
       nonce = SECURE_RANDOM_OUTPUT_LONG
     }
   }
 
 // Data provider entries
 private val DATA_PROVIDER_ENTRIES =
-  (REQUISITION_SPECS.indices).map { index ->
+  REQUISITION_SPECS.mapValues { (dataProviderKey, requisitionSpec) ->
+    val dataProvider = DATA_PROVIDERS.getValue(dataProviderKey)
     dataProviderEntry {
-      key = DATA_PROVIDERS[index].name
+      key = dataProvider.name
       value =
         DataProviderEntryKt.value {
-          dataProviderCertificate = DATA_PROVIDERS[index].certificate
-          dataProviderPublicKey = DATA_PROVIDERS[index].publicKey
+          dataProviderCertificate = dataProvider.certificate
+          dataProviderPublicKey = dataProvider.publicKey
           encryptedRequisitionSpec =
             encryptRequisitionSpec(
-              signRequisitionSpec(
-                REQUISITION_SPECS[index],
-                MEASUREMENT_CONSUMER_SIGNING_KEY_HANDLE
-              ),
-              EncryptionPublicKey.parseFrom(DATA_PROVIDERS[index].publicKey.data)
+              signRequisitionSpec(requisitionSpec, MEASUREMENT_CONSUMER_SIGNING_KEY_HANDLE),
+              EncryptionPublicKey.parseFrom(dataProvider.publicKey.data)
             )
-          nonceHash = hashSha256(REQUISITION_SPECS[index].nonce)
+          nonceHash = hashSha256(requisitionSpec.nonce)
         }
     }
   }
 
 // Measurements
 private val BASE_MEASUREMENT = measurement {
-  measurementConsumerCertificate = MEASUREMENT_CONSUMER_CERTIFICATE_NAME
+  measurementConsumerCertificate = MEASUREMENT_CONSUMERS.values.first().certificate
 }
 
 // Measurement values
@@ -652,7 +630,7 @@ private val PENDING_REACH_MEASUREMENT =
   BASE_REACH_MEASUREMENT.copy { state = Measurement.State.COMPUTING }
 
 private val REACH_ONLY_MEASUREMENT_SPEC = measurementSpec {
-  measurementPublicKey = MEASUREMENT_PUBLIC_KEY.toByteString()
+  measurementPublicKey = MEASUREMENT_CONSUMER_PUBLIC_KEY.toByteString()
 
   nonceHashes.addAll(
     listOf(hashSha256(SECURE_RANDOM_OUTPUT_LONG), hashSha256(SECURE_RANDOM_OUTPUT_LONG))
@@ -678,8 +656,7 @@ private val REACH_ONLY_MEASUREMENT_SPEC = measurementSpec {
 
 private val SUCCEEDED_REACH_MEASUREMENT =
   BASE_REACH_MEASUREMENT.copy {
-    dataProviders +=
-      DATA_PROVIDER_INDICES_IN_SET_OPERATION.map { index -> DATA_PROVIDER_ENTRIES[index] }
+    dataProviders += DATA_PROVIDER_KEYS_IN_SET_OPERATION.map { DATA_PROVIDER_ENTRIES.getValue(it) }
 
     measurementSpec =
       signMeasurementSpec(REACH_ONLY_MEASUREMENT_SPEC, MEASUREMENT_CONSUMER_SIGNING_KEY_HANDLE)
@@ -695,13 +672,14 @@ private val SUCCEEDED_REACH_MEASUREMENT =
               relativeFrequencyDistribution.putAll(FREQUENCY_DISTRIBUTION)
             }
         }
-      encryptedResult = getEncryptedResult(result)
-      certificate = DATA_PROVIDER_CERTIFICATE_NAMES[0]
+      encryptedResult =
+        encryptResult(signResult(result, AGGREGATOR_SIGNING_KEY), MEASUREMENT_CONSUMER_PUBLIC_KEY)
+      certificate = AGGREGATOR_CERTIFICATE.name
     }
   }
 
 private val INTERNAL_PENDING_REACH_MEASUREMENT = internalMeasurement {
-  measurementConsumerReferenceId = MEASUREMENT_CONSUMER_REFERENCE_IDS[0]
+  measurementConsumerReferenceId = MEASUREMENT_CONSUMERS.keys.first().measurementConsumerId
   measurementReferenceId = REACH_MEASUREMENT_REFERENCE_ID
   state = InternalMeasurement.State.PENDING
 }
@@ -726,7 +704,7 @@ private val BASE_REACH_FREQUENCY_HISTOGRAM_MEASUREMENT =
   }
 
 private val REACH_FREQUENCY_MEASUREMENT_SPEC = measurementSpec {
-  measurementPublicKey = MEASUREMENT_PUBLIC_KEY.toByteString()
+  measurementPublicKey = MEASUREMENT_CONSUMER_PUBLIC_KEY.toByteString()
 
   nonceHashes.addAll(
     listOf(hashSha256(SECURE_RANDOM_OUTPUT_LONG), hashSha256(SECURE_RANDOM_OUTPUT_LONG))
@@ -752,8 +730,7 @@ private val REACH_FREQUENCY_MEASUREMENT_SPEC = measurementSpec {
 
 private val SUCCEEDED_FREQUENCY_HISTOGRAM_MEASUREMENT =
   BASE_REACH_FREQUENCY_HISTOGRAM_MEASUREMENT.copy {
-    dataProviders +=
-      DATA_PROVIDER_INDICES_IN_SET_OPERATION.map { index -> DATA_PROVIDER_ENTRIES[index] }
+    dataProviders += DATA_PROVIDER_KEYS_IN_SET_OPERATION.map { DATA_PROVIDER_ENTRIES.getValue(it) }
 
     measurementSpec =
       signMeasurementSpec(REACH_FREQUENCY_MEASUREMENT_SPEC, MEASUREMENT_CONSUMER_SIGNING_KEY_HANDLE)
@@ -768,13 +745,14 @@ private val SUCCEEDED_FREQUENCY_HISTOGRAM_MEASUREMENT =
               relativeFrequencyDistribution.putAll(FREQUENCY_DISTRIBUTION)
             }
         }
-      encryptedResult = getEncryptedResult(result)
-      certificate = DATA_PROVIDER_CERTIFICATE_NAMES[0]
+      encryptedResult =
+        encryptResult(signResult(result, AGGREGATOR_SIGNING_KEY), MEASUREMENT_CONSUMER_PUBLIC_KEY)
+      certificate = AGGREGATOR_CERTIFICATE.name
     }
   }
 
 private val INTERNAL_PENDING_FREQUENCY_HISTOGRAM_MEASUREMENT = internalMeasurement {
-  measurementConsumerReferenceId = MEASUREMENT_CONSUMER_REFERENCE_IDS[0]
+  measurementConsumerReferenceId = MEASUREMENT_CONSUMERS.keys.first().measurementConsumerId
   measurementReferenceId = FREQUENCY_HISTOGRAM_MEASUREMENT_REFERENCE_ID
   state = InternalMeasurement.State.PENDING
 }
@@ -800,7 +778,7 @@ private val BASE_IMPRESSION_MEASUREMENT =
   }
 
 private val IMPRESSION_MEASUREMENT_SPEC = measurementSpec {
-  measurementPublicKey = MEASUREMENT_PUBLIC_KEY.toByteString()
+  measurementPublicKey = MEASUREMENT_CONSUMER_PUBLIC_KEY.toByteString()
 
   nonceHashes.addAll(
     listOf(hashSha256(SECURE_RANDOM_OUTPUT_LONG), hashSha256(SECURE_RANDOM_OUTPUT_LONG))
@@ -822,34 +800,34 @@ private val IMPRESSION_MEASUREMENT_SPEC = measurementSpec {
 
 private val SUCCEEDED_IMPRESSION_MEASUREMENT =
   BASE_IMPRESSION_MEASUREMENT.copy {
-    dataProviders +=
-      DATA_PROVIDER_INDICES_IN_SET_OPERATION.map { index -> DATA_PROVIDER_ENTRIES[index] }
+    dataProviders += DATA_PROVIDER_KEYS_IN_SET_OPERATION.map { DATA_PROVIDER_ENTRIES.getValue(it) }
 
     measurementSpec =
       signMeasurementSpec(IMPRESSION_MEASUREMENT_SPEC, MEASUREMENT_CONSUMER_SIGNING_KEY_HANDLE)
 
     state = Measurement.State.SUCCEEDED
 
-    results += resultPair {
-      val result =
-        MeasurementKt.result {
-          impression = MeasurementKt.ResultKt.impression { value = IMPRESSION_VALUES[0] }
+    results +=
+      DATA_PROVIDER_KEYS_IN_SET_OPERATION.zip(IMPRESSION_VALUES).map {
+        (dataProviderKey, numImpressions) ->
+        val dataProvider = DATA_PROVIDERS.getValue(dataProviderKey)
+        resultPair {
+          val result =
+            MeasurementKt.result {
+              impression = MeasurementKt.ResultKt.impression { value = numImpressions }
+            }
+          encryptedResult =
+            encryptResult(
+              signResult(result, DATA_PROVIDER_SIGNING_KEY),
+              MEASUREMENT_CONSUMER_PUBLIC_KEY
+            )
+          certificate = dataProvider.certificate
         }
-      encryptedResult = getEncryptedResult(result)
-      certificate = DATA_PROVIDER_CERTIFICATE_NAMES[0]
-    }
-    results += resultPair {
-      val result =
-        MeasurementKt.result {
-          impression = MeasurementKt.ResultKt.impression { value = IMPRESSION_VALUES[1] }
-        }
-      encryptedResult = getEncryptedResult(result)
-      certificate = DATA_PROVIDER_CERTIFICATE_NAMES[1]
-    }
+      }
   }
 
 private val INTERNAL_PENDING_IMPRESSION_MEASUREMENT = internalMeasurement {
-  measurementConsumerReferenceId = MEASUREMENT_CONSUMER_REFERENCE_IDS[0]
+  measurementConsumerReferenceId = MEASUREMENT_CONSUMERS.keys.first().measurementConsumerId
   measurementReferenceId = IMPRESSION_MEASUREMENT_REFERENCE_ID
   state = InternalMeasurement.State.PENDING
 }
@@ -874,7 +852,7 @@ private val PENDING_WATCH_DURATION_MEASUREMENT =
   BASE_WATCH_DURATION_MEASUREMENT.copy { state = Measurement.State.COMPUTING }
 
 private val WATCH_DURATION_MEASUREMENT_SPEC = measurementSpec {
-  measurementPublicKey = MEASUREMENT_PUBLIC_KEY.toByteString()
+  measurementPublicKey = MEASUREMENT_CONSUMER_PUBLIC_KEY.toByteString()
 
   nonceHashes.addAll(
     listOf(hashSha256(SECURE_RANDOM_OUTPUT_LONG), hashSha256(SECURE_RANDOM_OUTPUT_LONG))
@@ -897,34 +875,34 @@ private val WATCH_DURATION_MEASUREMENT_SPEC = measurementSpec {
 
 private val SUCCEEDED_WATCH_DURATION_MEASUREMENT =
   BASE_WATCH_DURATION_MEASUREMENT.copy {
-    dataProviders +=
-      DATA_PROVIDER_INDICES_IN_SET_OPERATION.map { index -> DATA_PROVIDER_ENTRIES[index] }
+    dataProviders += DATA_PROVIDER_KEYS_IN_SET_OPERATION.map { DATA_PROVIDER_ENTRIES.getValue(it) }
 
     measurementSpec =
       signMeasurementSpec(WATCH_DURATION_MEASUREMENT_SPEC, MEASUREMENT_CONSUMER_SIGNING_KEY_HANDLE)
 
     state = Measurement.State.SUCCEEDED
 
-    results += resultPair {
-      val result =
-        MeasurementKt.result {
-          watchDuration = MeasurementKt.ResultKt.watchDuration { value = WATCH_DURATION_LIST[0] }
+    results +=
+      DATA_PROVIDER_KEYS_IN_SET_OPERATION.zip(WATCH_DURATION_LIST).map {
+        (dataProviderKey, watchDuration) ->
+        val dataProvider = DATA_PROVIDERS.getValue(dataProviderKey)
+        resultPair {
+          val result =
+            MeasurementKt.result {
+              this.watchDuration = MeasurementKt.ResultKt.watchDuration { value = watchDuration }
+            }
+          encryptedResult =
+            encryptResult(
+              signResult(result, DATA_PROVIDER_SIGNING_KEY),
+              MEASUREMENT_CONSUMER_PUBLIC_KEY
+            )
+          certificate = dataProvider.certificate
         }
-      encryptedResult = getEncryptedResult(result)
-      certificate = DATA_PROVIDER_CERTIFICATE_NAMES[0]
-    }
-    results += resultPair {
-      val result =
-        MeasurementKt.result {
-          watchDuration = MeasurementKt.ResultKt.watchDuration { value = WATCH_DURATION_LIST[1] }
-        }
-      encryptedResult = getEncryptedResult(result)
-      certificate = DATA_PROVIDER_CERTIFICATE_NAMES[1]
-    }
+      }
   }
 
 private val INTERNAL_PENDING_WATCH_DURATION_MEASUREMENT = internalMeasurement {
-  measurementConsumerReferenceId = MEASUREMENT_CONSUMER_REFERENCE_IDS[0]
+  measurementConsumerReferenceId = MEASUREMENT_CONSUMERS.keys.first().measurementConsumerId
   measurementReferenceId = WATCH_DURATION_MEASUREMENT_REFERENCE_ID
   state = InternalMeasurement.State.PENDING
 }
@@ -936,14 +914,6 @@ private val INTERNAL_SUCCEEDED_WATCH_DURATION_MEASUREMENT =
         watchDuration = InternalMeasurementResultKt.watchDuration { value = TOTAL_WATCH_DURATION }
       }
   }
-
-/** Verify and decrypt a measurement result. */
-private fun getEncryptedResult(
-  result: Measurement.Result,
-): ByteString {
-  val signedResult = signResult(result, AGGREGATOR_SIGNING_KEY)
-  return encryptResult(signedResult, MEASUREMENT_PUBLIC_KEY)
-}
 
 // Weighted measurements
 private val WEIGHTED_REACH_MEASUREMENT = weightedMeasurement {
@@ -999,6 +969,7 @@ private val NAMED_REACH_SET_OPERATION = namedSetOperation {
   uniqueName = REACH_SET_OPERATION_UNIQUE_NAME
   setOperation = SET_OPERATION
 }
+
 // Frequency histogram set operation
 private val INTERNAL_NAMED_FREQUENCY_HISTOGRAM_SET_OPERATION =
   InternalMetricKt.namedSetOperation {
@@ -1010,6 +981,7 @@ private val NAMED_FREQUENCY_HISTOGRAM_SET_OPERATION = namedSetOperation {
   uniqueName = FREQUENCY_HISTOGRAM_SET_OPERATION_UNIQUE_NAME
   setOperation = SET_OPERATION
 }
+
 // Impression set operation
 private val INTERNAL_NAMED_IMPRESSION_SET_OPERATION =
   InternalMetricKt.namedSetOperation {
@@ -1021,6 +993,7 @@ private val NAMED_IMPRESSION_SET_OPERATION = namedSetOperation {
   uniqueName = IMPRESSION_SET_OPERATION_UNIQUE_NAME
   setOperation = SET_OPERATION
 }
+
 // Watch duration set operation
 private val INTERNAL_NAMED_WATCH_DURATION_SET_OPERATION =
   InternalMetricKt.namedSetOperation {
@@ -1051,6 +1024,7 @@ private val INTERNAL_REACH_METRIC = internalMetric {
     }
   namedSetOperations.add(INTERNAL_NAMED_REACH_SET_OPERATION)
 }
+
 // Frequency histogram metric
 private val FREQUENCY_HISTOGRAM_METRIC = metric {
   frequencyHistogram = frequencyHistogramParams {
@@ -1070,6 +1044,7 @@ private val INTERNAL_FREQUENCY_HISTOGRAM_METRIC = internalMetric {
     }
   namedSetOperations.add(INTERNAL_NAMED_FREQUENCY_HISTOGRAM_SET_OPERATION)
 }
+
 // Impression metric
 private val IMPRESSION_METRIC = metric {
   impressionCount = impressionCountParams { maximumFrequencyPerUser = MAXIMUM_FREQUENCY_PER_USER }
@@ -1087,6 +1062,7 @@ private val INTERNAL_IMPRESSION_METRIC = internalMetric {
     }
   namedSetOperations.add(INTERNAL_NAMED_IMPRESSION_SET_OPERATION)
 }
+
 // Watch duration metric
 private val WATCH_DURATION_METRIC = metric {
   watchDuration = watchDurationParams {
@@ -1112,7 +1088,7 @@ private val INTERNAL_WATCH_DURATION_METRIC = internalMetric {
 // Internal reports with running states
 // Internal reports of reach
 private val INTERNAL_PENDING_REACH_REPORT = internalReport {
-  measurementConsumerReferenceId = MEASUREMENT_CONSUMER_REFERENCE_IDS[0]
+  measurementConsumerReferenceId = MEASUREMENT_CONSUMERS.keys.first().measurementConsumerId
   externalReportId = REPORT_EXTERNAL_IDS[0]
   periodicTimeInterval = INTERNAL_PERIODIC_TIME_INTERVAL
   metrics.add(INTERNAL_REACH_METRIC)
@@ -1127,9 +1103,10 @@ private val INTERNAL_SUCCEEDED_REACH_REPORT =
     state = InternalReport.State.SUCCEEDED
     measurements.put(REACH_MEASUREMENT_REFERENCE_ID, INTERNAL_SUCCEEDED_REACH_MEASUREMENT)
   }
+
 // Internal reports of impression
 private val INTERNAL_PENDING_IMPRESSION_REPORT = internalReport {
-  measurementConsumerReferenceId = MEASUREMENT_CONSUMER_REFERENCE_IDS[0]
+  measurementConsumerReferenceId = MEASUREMENT_CONSUMERS.keys.first().measurementConsumerId
   externalReportId = REPORT_EXTERNAL_IDS[1]
   periodicTimeInterval = INTERNAL_PERIODIC_TIME_INTERVAL
   metrics.add(INTERNAL_IMPRESSION_METRIC)
@@ -1144,9 +1121,10 @@ private val INTERNAL_SUCCEEDED_IMPRESSION_REPORT =
     state = InternalReport.State.SUCCEEDED
     measurements.put(IMPRESSION_MEASUREMENT_REFERENCE_ID, INTERNAL_SUCCEEDED_IMPRESSION_MEASUREMENT)
   }
+
 // Internal reports of watch duration
 private val INTERNAL_PENDING_WATCH_DURATION_REPORT = internalReport {
-  measurementConsumerReferenceId = MEASUREMENT_CONSUMER_REFERENCE_IDS[0]
+  measurementConsumerReferenceId = MEASUREMENT_CONSUMERS.keys.first().measurementConsumerId
   externalReportId = REPORT_EXTERNAL_IDS[2]
   periodicTimeInterval = INTERNAL_PERIODIC_TIME_INTERVAL
   metrics.add(INTERNAL_WATCH_DURATION_METRIC)
@@ -1167,9 +1145,10 @@ private val INTERNAL_SUCCEEDED_WATCH_DURATION_REPORT =
       INTERNAL_SUCCEEDED_WATCH_DURATION_MEASUREMENT
     )
   }
+
 // Internal reports of frequency histogram
 private val INTERNAL_PENDING_FREQUENCY_HISTOGRAM_REPORT = internalReport {
-  measurementConsumerReferenceId = MEASUREMENT_CONSUMER_REFERENCE_IDS[0]
+  measurementConsumerReferenceId = MEASUREMENT_CONSUMERS.keys.first().measurementConsumerId
   externalReportId = REPORT_EXTERNAL_IDS[3]
   periodicTimeInterval = INTERNAL_PERIODIC_TIME_INTERVAL
   metrics.add(INTERNAL_FREQUENCY_HISTOGRAM_METRIC)
@@ -1191,17 +1170,14 @@ private val INTERNAL_SUCCEEDED_FREQUENCY_HISTOGRAM_REPORT =
     )
   }
 
-// Event Group Universe
-private val EVENT_GROUP_UNIVERSE_ENTRIES =
-  COVERED_EVENT_GROUP_NAMES.map {
-    EventGroupUniverseKt.eventGroupEntry {
-      key = it
-      value = EVENT_GROUP_FILTER
-    }
-  }
-
 private val EVENT_GROUP_UNIVERSE = eventGroupUniverse {
-  eventGroupEntries += EVENT_GROUP_UNIVERSE_ENTRIES
+  eventGroupEntries +=
+    COVERED_EVENT_GROUP_KEYS.map {
+      EventGroupUniverseKt.eventGroupEntry {
+        key = it.toName()
+        value = EVENT_GROUP_FILTER
+      }
+    }
 }
 
 // Public reports with running states
@@ -1209,18 +1185,19 @@ private val EVENT_GROUP_UNIVERSE = eventGroupUniverse {
 private val PENDING_REACH_REPORT = report {
   name = REPORT_NAMES[0]
   reportIdempotencyKey = REACH_REPORT_IDEMPOTENCY_KEY
-  measurementConsumer = MEASUREMENT_CONSUMER_NAMES[0]
+  measurementConsumer = MEASUREMENT_CONSUMERS.values.first().name
   eventGroupUniverse = EVENT_GROUP_UNIVERSE
   periodicTimeInterval = PERIODIC_TIME_INTERVAL
   metrics.add(REACH_METRIC)
   state = Report.State.RUNNING
 }
 private val SUCCEEDED_REACH_REPORT = PENDING_REACH_REPORT.copy { state = Report.State.SUCCEEDED }
+
 // Reports of impression
 private val PENDING_IMPRESSION_REPORT = report {
   name = REPORT_NAMES[1]
   reportIdempotencyKey = IMPRESSION_REPORT_IDEMPOTENCY_KEY
-  measurementConsumer = MEASUREMENT_CONSUMER_NAMES[0]
+  measurementConsumer = MEASUREMENT_CONSUMERS.values.first().name
   eventGroupUniverse = EVENT_GROUP_UNIVERSE
   periodicTimeInterval = PERIODIC_TIME_INTERVAL
   metrics.add(IMPRESSION_METRIC)
@@ -1228,11 +1205,12 @@ private val PENDING_IMPRESSION_REPORT = report {
 }
 private val SUCCEEDED_IMPRESSION_REPORT =
   PENDING_IMPRESSION_REPORT.copy { state = Report.State.SUCCEEDED }
+
 // Reports of watch duration
 private val PENDING_WATCH_DURATION_REPORT = report {
   name = REPORT_NAMES[2]
   reportIdempotencyKey = WATCH_DURATION_REPORT_IDEMPOTENCY_KEY
-  measurementConsumer = MEASUREMENT_CONSUMER_NAMES[0]
+  measurementConsumer = MEASUREMENT_CONSUMERS.values.first().name
   eventGroupUniverse = EVENT_GROUP_UNIVERSE
   periodicTimeInterval = PERIODIC_TIME_INTERVAL
   metrics.add(WATCH_DURATION_METRIC)
@@ -1240,11 +1218,12 @@ private val PENDING_WATCH_DURATION_REPORT = report {
 }
 private val SUCCEEDED_WATCH_DURATION_REPORT =
   PENDING_WATCH_DURATION_REPORT.copy { state = Report.State.SUCCEEDED }
+
 // Reports of frequency histogram
 private val PENDING_FREQUENCY_HISTOGRAM_REPORT = report {
   name = REPORT_NAMES[3]
   reportIdempotencyKey = FREQUENCY_HISTOGRAM_REPORT_IDEMPOTENCY_KEY
-  measurementConsumer = MEASUREMENT_CONSUMER_NAMES[0]
+  measurementConsumer = MEASUREMENT_CONSUMERS.values.first().name
   eventGroupUniverse = EVENT_GROUP_UNIVERSE
   periodicTimeInterval = PERIODIC_TIME_INTERVAL
   metrics.add(FREQUENCY_HISTOGRAM_METRIC)
@@ -1313,31 +1292,39 @@ class ReportsServiceTest {
   }
 
   private val measurementConsumersMock: MeasurementConsumersCoroutineImplBase = mockService {
-    onBlocking { getMeasurementConsumer(any()) }.thenReturn(MEASUREMENT_CONSUMER)
+    onBlocking { getMeasurementConsumer(any()) }.thenReturn(MEASUREMENT_CONSUMERS.values.first())
   }
 
   private val dataProvidersMock: DataProvidersCoroutineImplBase = mockService {
-    onBlocking { getDataProvider(any()) }.thenReturn(DATA_PROVIDERS[0], DATA_PROVIDERS[1])
+    var stubbing = onBlocking { getDataProvider(any()) }
+    for (dataProvider in DATA_PROVIDERS.values) {
+      stubbing = stubbing.thenReturn(dataProvider)
+    }
   }
 
   private val certificateMock: CertificatesCoroutineImplBase = mockService {
-    onBlocking {
-        getCertificate(eq(getCertificateRequest { name = DATA_PROVIDER_CERTIFICATE_NAMES[0] }))
-      }
-      .thenReturn(AGGREGATOR_CERTIFICATE.copy { name = DATA_PROVIDER_CERTIFICATE_NAMES[0] })
-    onBlocking {
-        getCertificate(eq(getCertificateRequest { name = DATA_PROVIDER_CERTIFICATE_NAMES[1] }))
-      }
-      .thenReturn(AGGREGATOR_CERTIFICATE.copy { name = DATA_PROVIDER_CERTIFICATE_NAMES[1] })
-    onBlocking {
-        getCertificate(eq(getCertificateRequest { name = MEASUREMENT_CONSUMER_CERTIFICATE_NAME }))
-      }
-      .thenReturn(
-        certificate {
-          name = MEASUREMENT_CONSUMER_CERTIFICATE_NAME
-          x509Der = MEASUREMENT_CONSUMER_CERTIFICATE_DER
+    onBlocking { getCertificate(eq(getCertificateRequest { name = AGGREGATOR_CERTIFICATE.name })) }
+      .thenReturn(AGGREGATOR_CERTIFICATE)
+    for (dataProvider in DATA_PROVIDERS.values) {
+      onBlocking { getCertificate(eq(getCertificateRequest { name = dataProvider.certificate })) }
+        .thenReturn(
+          certificate {
+            name = dataProvider.certificate
+            x509Der = DATA_PROVIDER_SIGNING_KEY.certificate.encoded.toByteString()
+          }
+        )
+    }
+    for (measurementConsumer in MEASUREMENT_CONSUMERS.values) {
+      onBlocking {
+          getCertificate(eq(getCertificateRequest { name = measurementConsumer.certificate }))
         }
-      )
+        .thenReturn(
+          certificate {
+            name = measurementConsumer.certificate
+            x509Der = measurementConsumer.certificateDer
+          }
+        )
+    }
   }
 
   private val secureRandomMock: SecureRandom = mock()
@@ -1374,19 +1361,21 @@ class ReportsServiceTest {
         ENCRYPTION_KEY_PAIR_STORE,
         secureRandomMock,
         SECRETS_DIR,
-        mapOf(AGGREGATOR_ROOT_CERTIFICATE.subjectKeyIdentifier!! to AGGREGATOR_ROOT_CERTIFICATE)
+        listOf(AGGREGATOR_ROOT_CERTIFICATE, DATA_PROVIDER_ROOT_CERTIFICATE).associateBy {
+          it.subjectKeyIdentifier!!
+        }
       )
   }
 
   @Test
   fun `createReport returns a report of reach with RUNNING state`() {
     val request = createReportRequest {
-      parent = MEASUREMENT_CONSUMER_NAMES[0]
+      parent = MEASUREMENT_CONSUMERS.values.first().name
       report = PENDING_REACH_REPORT.copy { clearState() }
     }
 
     val result =
-      withMeasurementConsumerPrincipal(MEASUREMENT_CONSUMER_NAMES[0], CONFIG) {
+      withMeasurementConsumerPrincipal(MEASUREMENT_CONSUMERS.values.first().name, CONFIG) {
         runBlocking { service.createReport(request) }
       }
 
@@ -1396,7 +1385,7 @@ class ReportsServiceTest {
     verifyProtoArgument(internalReportsMock, ReportsCoroutineImplBase::getReportByIdempotencyKey)
       .isEqualTo(
         getReportByIdempotencyKeyRequest {
-          measurementConsumerReferenceId = MEASUREMENT_CONSUMER_REFERENCE_IDS[0]
+          measurementConsumerReferenceId = MEASUREMENT_CONSUMERS.keys.first().measurementConsumerId
           reportIdempotencyKey = REACH_REPORT_IDEMPOTENCY_KEY
         }
       )
@@ -1408,9 +1397,9 @@ class ReportsServiceTest {
       )
       .isEqualTo(
         batchGetReportingSetRequest {
-          measurementConsumerReferenceId = MEASUREMENT_CONSUMER_REFERENCE_IDS[0]
-          externalReportingSetIds += REPORTING_SET_EXTERNAL_IDS[0]
-          externalReportingSetIds += REPORTING_SET_EXTERNAL_IDS[1]
+          measurementConsumerReferenceId = MEASUREMENT_CONSUMERS.keys.first().measurementConsumerId
+          externalReportingSetIds += INTERNAL_REPORTING_SETS[0].externalReportingSetId
+          externalReportingSetIds += INTERNAL_REPORTING_SETS[1].externalReportingSetId
         }
       )
 
@@ -1419,7 +1408,7 @@ class ReportsServiceTest {
         measurementConsumersMock,
         MeasurementConsumersCoroutineImplBase::getMeasurementConsumer
       )
-      .isEqualTo(getMeasurementConsumerRequest { name = MEASUREMENT_CONSUMER_NAMES[0] })
+      .isEqualTo(getMeasurementConsumerRequest { name = MEASUREMENT_CONSUMERS.values.first().name })
 
     // Verify proto argument of DataProvidersCoroutineImplBase::getDataProvider
     val dataProvidersCaptor: KArgumentCaptor<GetDataProviderRequest> = argumentCaptor()
@@ -1427,8 +1416,8 @@ class ReportsServiceTest {
     val capturedDataProviderRequests = dataProvidersCaptor.allValues
     assertThat(capturedDataProviderRequests)
       .containsExactly(
-        getDataProviderRequest { name = DATA_PROVIDERS[0].name },
-        getDataProviderRequest { name = DATA_PROVIDERS[1].name }
+        getDataProviderRequest { name = DATA_PROVIDERS_LIST[0].name },
+        getDataProviderRequest { name = DATA_PROVIDERS_LIST[1].name }
       )
 
     // Verify proto argument of MeasurementsCoroutineImplBase::createMeasurement
@@ -1440,7 +1429,7 @@ class ReportsServiceTest {
     val expectedMeasurement =
       BASE_REACH_MEASUREMENT.copy {
         dataProviders +=
-          DATA_PROVIDER_INDICES_IN_SET_OPERATION.map { index -> DATA_PROVIDER_ENTRIES[index] }
+          DATA_PROVIDER_KEYS_IN_SET_OPERATION.map { DATA_PROVIDER_ENTRIES.getValue(it) }
         measurementSpec =
           signMeasurementSpec(REACH_ONLY_MEASUREMENT_SPEC, MEASUREMENT_CONSUMER_SIGNING_KEY_HANDLE)
       }
@@ -1487,7 +1476,7 @@ class ReportsServiceTest {
       )
       .isEqualTo(
         internalMeasurement {
-          measurementConsumerReferenceId = MEASUREMENT_CONSUMER_REFERENCE_IDS[0]
+          measurementConsumerReferenceId = MEASUREMENT_CONSUMERS.keys.first().measurementConsumerId
           measurementReferenceId = REACH_MEASUREMENT_REFERENCE_ID
           state = InternalMeasurement.State.PENDING
         }
@@ -1507,7 +1496,8 @@ class ReportsServiceTest {
             }
           measurements +=
             InternalCreateReportRequestKt.measurementKey {
-              measurementConsumerReferenceId = MEASUREMENT_CONSUMER_REFERENCE_IDS[0]
+              measurementConsumerReferenceId =
+                MEASUREMENT_CONSUMERS.keys.first().measurementConsumerId
               measurementReferenceId = REACH_MEASUREMENT_REFERENCE_ID
             }
         }
@@ -1531,7 +1521,7 @@ class ReportsServiceTest {
     runBlocking { whenever(internalReportsMock.createReport(any())).thenReturn(internalReport) }
 
     val request = createReportRequest {
-      parent = MEASUREMENT_CONSUMER_NAMES[0]
+      parent = MEASUREMENT_CONSUMERS.values.first().name
       report =
         PENDING_REACH_REPORT.copy {
           clearState()
@@ -1546,7 +1536,7 @@ class ReportsServiceTest {
     }
 
     val result =
-      withMeasurementConsumerPrincipal(MEASUREMENT_CONSUMER_NAMES[0], CONFIG) {
+      withMeasurementConsumerPrincipal(MEASUREMENT_CONSUMERS.values.first().name, CONFIG) {
         runBlocking { service.createReport(request) }
       }
 
@@ -1565,7 +1555,7 @@ class ReportsServiceTest {
     verifyProtoArgument(internalReportsMock, ReportsCoroutineImplBase::getReportByIdempotencyKey)
       .isEqualTo(
         getReportByIdempotencyKeyRequest {
-          measurementConsumerReferenceId = MEASUREMENT_CONSUMER_REFERENCE_IDS[0]
+          measurementConsumerReferenceId = MEASUREMENT_CONSUMERS.keys.first().measurementConsumerId
           reportIdempotencyKey = REACH_REPORT_IDEMPOTENCY_KEY
         }
       )
@@ -1577,9 +1567,9 @@ class ReportsServiceTest {
       )
       .isEqualTo(
         batchGetReportingSetRequest {
-          measurementConsumerReferenceId = MEASUREMENT_CONSUMER_REFERENCE_IDS[0]
-          externalReportingSetIds += REPORTING_SET_EXTERNAL_IDS[0]
-          externalReportingSetIds += REPORTING_SET_EXTERNAL_IDS[1]
+          measurementConsumerReferenceId = MEASUREMENT_CONSUMERS.keys.first().measurementConsumerId
+          externalReportingSetIds += INTERNAL_REPORTING_SETS[0].externalReportingSetId
+          externalReportingSetIds += INTERNAL_REPORTING_SETS[1].externalReportingSetId
         }
       )
 
@@ -1588,7 +1578,7 @@ class ReportsServiceTest {
         measurementConsumersMock,
         MeasurementConsumersCoroutineImplBase::getMeasurementConsumer
       )
-      .isEqualTo(getMeasurementConsumerRequest { name = MEASUREMENT_CONSUMER_NAMES[0] })
+      .isEqualTo(getMeasurementConsumerRequest { name = MEASUREMENT_CONSUMERS.values.first().name })
 
     // Verify proto argument of DataProvidersCoroutineImplBase::getDataProvider
     val dataProvidersCaptor: KArgumentCaptor<GetDataProviderRequest> = argumentCaptor()
@@ -1596,8 +1586,8 @@ class ReportsServiceTest {
     val capturedDataProviderRequests = dataProvidersCaptor.allValues
     assertThat(capturedDataProviderRequests)
       .containsExactly(
-        getDataProviderRequest { name = DATA_PROVIDERS[0].name },
-        getDataProviderRequest { name = DATA_PROVIDERS[1].name }
+        getDataProviderRequest { name = DATA_PROVIDERS_LIST[0].name },
+        getDataProviderRequest { name = DATA_PROVIDERS_LIST[1].name }
       )
 
     // Verify proto argument of MeasurementsCoroutineImplBase::createMeasurement
@@ -1609,7 +1599,7 @@ class ReportsServiceTest {
     val expectedMeasurement =
       BASE_REACH_MEASUREMENT.copy {
         dataProviders +=
-          DATA_PROVIDER_INDICES_IN_SET_OPERATION.map { index -> DATA_PROVIDER_ENTRIES[index] }
+          DATA_PROVIDER_KEYS_IN_SET_OPERATION.map { DATA_PROVIDER_ENTRIES.getValue(it) }
         measurementSpec =
           signMeasurementSpec(REACH_ONLY_MEASUREMENT_SPEC, MEASUREMENT_CONSUMER_SIGNING_KEY_HANDLE)
       }
@@ -1656,7 +1646,7 @@ class ReportsServiceTest {
       )
       .isEqualTo(
         internalMeasurement {
-          measurementConsumerReferenceId = MEASUREMENT_CONSUMER_REFERENCE_IDS[0]
+          measurementConsumerReferenceId = MEASUREMENT_CONSUMERS.keys.first().measurementConsumerId
           measurementReferenceId = REACH_MEASUREMENT_REFERENCE_ID
           state = InternalMeasurement.State.PENDING
         }
@@ -1676,7 +1666,8 @@ class ReportsServiceTest {
             }
           measurements +=
             InternalCreateReportRequestKt.measurementKey {
-              measurementConsumerReferenceId = MEASUREMENT_CONSUMER_REFERENCE_IDS[0]
+              measurementConsumerReferenceId =
+                MEASUREMENT_CONSUMERS.keys.first().measurementConsumerId
               measurementReferenceId = REACH_MEASUREMENT_REFERENCE_ID
             }
         }
@@ -1707,12 +1698,12 @@ class ReportsServiceTest {
       }
 
     val request = createReportRequest {
-      parent = MEASUREMENT_CONSUMER_NAMES[0]
+      parent = MEASUREMENT_CONSUMERS.values.first().name
       report = cumulativeReport.copy { clearState() }
     }
 
     val result =
-      withMeasurementConsumerPrincipal(MEASUREMENT_CONSUMER_NAMES[0], CONFIG) {
+      withMeasurementConsumerPrincipal(MEASUREMENT_CONSUMERS.values.first().name, CONFIG) {
         runBlocking { service.createReport(request) }
       }
 
@@ -1720,7 +1711,7 @@ class ReportsServiceTest {
     verifyProtoArgument(internalReportsMock, ReportsCoroutineImplBase::getReportByIdempotencyKey)
       .isEqualTo(
         getReportByIdempotencyKeyRequest {
-          measurementConsumerReferenceId = MEASUREMENT_CONSUMER_REFERENCE_IDS[0]
+          measurementConsumerReferenceId = MEASUREMENT_CONSUMERS.keys.first().measurementConsumerId
           reportIdempotencyKey = REACH_REPORT_IDEMPOTENCY_KEY
         }
       )
@@ -1732,9 +1723,9 @@ class ReportsServiceTest {
       )
       .isEqualTo(
         batchGetReportingSetRequest {
-          measurementConsumerReferenceId = MEASUREMENT_CONSUMER_REFERENCE_IDS[0]
-          externalReportingSetIds += REPORTING_SET_EXTERNAL_IDS[0]
-          externalReportingSetIds += REPORTING_SET_EXTERNAL_IDS[1]
+          measurementConsumerReferenceId = MEASUREMENT_CONSUMERS.keys.first().measurementConsumerId
+          externalReportingSetIds += INTERNAL_REPORTING_SETS[0].externalReportingSetId
+          externalReportingSetIds += INTERNAL_REPORTING_SETS[1].externalReportingSetId
         }
       )
 
@@ -1743,7 +1734,7 @@ class ReportsServiceTest {
         measurementConsumersMock,
         MeasurementConsumersCoroutineImplBase::getMeasurementConsumer
       )
-      .isEqualTo(getMeasurementConsumerRequest { name = MEASUREMENT_CONSUMER_NAMES[0] })
+      .isEqualTo(getMeasurementConsumerRequest { name = MEASUREMENT_CONSUMERS.values.first().name })
 
     // Verify proto argument of DataProvidersCoroutineImplBase::getDataProvider
     val dataProvidersCaptor: KArgumentCaptor<GetDataProviderRequest> = argumentCaptor()
@@ -1751,8 +1742,8 @@ class ReportsServiceTest {
     val capturedDataProviderRequests = dataProvidersCaptor.allValues
     assertThat(capturedDataProviderRequests)
       .containsExactly(
-        getDataProviderRequest { name = DATA_PROVIDERS[0].name },
-        getDataProviderRequest { name = DATA_PROVIDERS[1].name }
+        getDataProviderRequest { name = DATA_PROVIDERS_LIST[0].name },
+        getDataProviderRequest { name = DATA_PROVIDERS_LIST[1].name }
       )
 
     // Verify proto argument of MeasurementsCoroutineImplBase::createMeasurement
@@ -1764,7 +1755,7 @@ class ReportsServiceTest {
     val expectedMeasurement =
       BASE_REACH_MEASUREMENT.copy {
         dataProviders +=
-          DATA_PROVIDER_INDICES_IN_SET_OPERATION.map { index -> DATA_PROVIDER_ENTRIES[index] }
+          DATA_PROVIDER_KEYS_IN_SET_OPERATION.map { DATA_PROVIDER_ENTRIES.getValue(it) }
         measurementSpec =
           signMeasurementSpec(REACH_ONLY_MEASUREMENT_SPEC, MEASUREMENT_CONSUMER_SIGNING_KEY_HANDLE)
       }
@@ -1811,7 +1802,7 @@ class ReportsServiceTest {
       )
       .isEqualTo(
         internalMeasurement {
-          measurementConsumerReferenceId = MEASUREMENT_CONSUMER_REFERENCE_IDS[0]
+          measurementConsumerReferenceId = MEASUREMENT_CONSUMERS.keys.first().measurementConsumerId
           measurementReferenceId = REACH_MEASUREMENT_REFERENCE_ID
           state = InternalMeasurement.State.PENDING
         }
@@ -1831,7 +1822,8 @@ class ReportsServiceTest {
             }
           measurements +=
             InternalCreateReportRequestKt.measurementKey {
-              measurementConsumerReferenceId = MEASUREMENT_CONSUMER_REFERENCE_IDS[0]
+              measurementConsumerReferenceId =
+                MEASUREMENT_CONSUMERS.keys.first().measurementConsumerId
               measurementReferenceId = REACH_MEASUREMENT_REFERENCE_ID
             }
         }
@@ -1889,20 +1881,22 @@ class ReportsServiceTest {
             uniqueName = REACH_SET_OPERATION_UNIQUE_NAME
             setOperation = setOperation {
               type = SetOperation.Type.DIFFERENCE
-              lhs = SetOperationKt.operand { reportingSet = REPORTING_SET_NAMES[0] }
-              rhs = SetOperationKt.operand { reportingSet = REPORTING_SET_NAMES[1] }
+              lhs =
+                SetOperationKt.operand { reportingSet = INTERNAL_REPORTING_SETS[0].resourceName }
+              rhs =
+                SetOperationKt.operand { reportingSet = INTERNAL_REPORTING_SETS[1].resourceName }
             }
           }
         }
       }
 
     val request = createReportRequest {
-      parent = MEASUREMENT_CONSUMER_NAMES[0]
+      parent = MEASUREMENT_CONSUMERS.values.first().name
       report = pendingReachReportWithSetDifference
     }
 
     val result =
-      withMeasurementConsumerPrincipal(MEASUREMENT_CONSUMER_NAMES[0], CONFIG) {
+      withMeasurementConsumerPrincipal(MEASUREMENT_CONSUMERS.values.first().name, CONFIG) {
         runBlocking { service.createReport(request) }
       }
 
@@ -1910,7 +1904,7 @@ class ReportsServiceTest {
     verifyProtoArgument(internalReportsMock, ReportsCoroutineImplBase::getReportByIdempotencyKey)
       .isEqualTo(
         getReportByIdempotencyKeyRequest {
-          measurementConsumerReferenceId = MEASUREMENT_CONSUMER_REFERENCE_IDS[0]
+          measurementConsumerReferenceId = MEASUREMENT_CONSUMERS.keys.first().measurementConsumerId
           reportIdempotencyKey = REACH_REPORT_IDEMPOTENCY_KEY
         }
       )
@@ -1923,9 +1917,9 @@ class ReportsServiceTest {
       .ignoringRepeatedFieldOrder()
       .isEqualTo(
         batchGetReportingSetRequest {
-          measurementConsumerReferenceId = MEASUREMENT_CONSUMER_REFERENCE_IDS[0]
-          externalReportingSetIds += REPORTING_SET_EXTERNAL_IDS[0]
-          externalReportingSetIds += REPORTING_SET_EXTERNAL_IDS[1]
+          measurementConsumerReferenceId = MEASUREMENT_CONSUMERS.keys.first().measurementConsumerId
+          externalReportingSetIds += INTERNAL_REPORTING_SETS[0].externalReportingSetId
+          externalReportingSetIds += INTERNAL_REPORTING_SETS[1].externalReportingSetId
         }
       )
 
@@ -1934,7 +1928,7 @@ class ReportsServiceTest {
         measurementConsumersMock,
         MeasurementConsumersCoroutineImplBase::getMeasurementConsumer
       )
-      .isEqualTo(getMeasurementConsumerRequest { name = MEASUREMENT_CONSUMER_NAMES[0] })
+      .isEqualTo(getMeasurementConsumerRequest { name = MEASUREMENT_CONSUMERS.values.first().name })
 
     // Verify proto argument of DataProvidersCoroutineImplBase::getDataProvider
     val dataProvidersCaptor: KArgumentCaptor<GetDataProviderRequest> = argumentCaptor()
@@ -1942,9 +1936,9 @@ class ReportsServiceTest {
     val capturedDataProviderRequests = dataProvidersCaptor.allValues
     assertThat(capturedDataProviderRequests)
       .containsExactly(
-        getDataProviderRequest { name = DATA_PROVIDERS[1].name },
-        getDataProviderRequest { name = DATA_PROVIDERS[0].name },
-        getDataProviderRequest { name = DATA_PROVIDERS[1].name }
+        getDataProviderRequest { name = DATA_PROVIDERS_LIST[1].name },
+        getDataProviderRequest { name = DATA_PROVIDERS_LIST[0].name },
+        getDataProviderRequest { name = DATA_PROVIDERS_LIST[1].name }
       )
 
     // Verify proto argument of MeasurementsCoroutineImplBase::createMeasurement
@@ -1970,12 +1964,14 @@ class ReportsServiceTest {
             }
           measurements +=
             InternalCreateReportRequestKt.measurementKey {
-              measurementConsumerReferenceId = MEASUREMENT_CONSUMER_REFERENCE_IDS[0]
+              measurementConsumerReferenceId =
+                MEASUREMENT_CONSUMERS.keys.first().measurementConsumerId
               measurementReferenceId = REACH_MEASUREMENT_REFERENCE_ID
             }
           measurements +=
             InternalCreateReportRequestKt.measurementKey {
-              measurementConsumerReferenceId = MEASUREMENT_CONSUMER_REFERENCE_IDS[0]
+              measurementConsumerReferenceId =
+                MEASUREMENT_CONSUMERS.keys.first().measurementConsumerId
               measurementReferenceId = REACH_MEASUREMENT_REFERENCE_ID_2
             }
         }
@@ -1991,12 +1987,12 @@ class ReportsServiceTest {
         .thenThrow(StatusRuntimeException(Status.ALREADY_EXISTS))
 
       val request = createReportRequest {
-        parent = MEASUREMENT_CONSUMER_NAMES[0]
+        parent = MEASUREMENT_CONSUMERS.values.first().name
         report = PENDING_REACH_REPORT.copy { clearState() }
       }
 
       val report =
-        withMeasurementConsumerPrincipal(MEASUREMENT_CONSUMER_NAMES[0], CONFIG) {
+        withMeasurementConsumerPrincipal(MEASUREMENT_CONSUMERS.values.first().name, CONFIG) {
           runBlocking { service.createReport(request) }
         }
       assertThat(report.state).isEqualTo(Report.State.RUNNING)
@@ -2005,7 +2001,7 @@ class ReportsServiceTest {
   @Test
   fun `createReport throws UNAUTHENTICATED when no principal is found`() {
     val request = createReportRequest {
-      parent = MEASUREMENT_CONSUMER_NAMES[0]
+      parent = MEASUREMENT_CONSUMERS.values.first().name
       report = PENDING_REACH_REPORT.copy { clearState() }
     }
     val exception =
@@ -2016,12 +2012,12 @@ class ReportsServiceTest {
   @Test
   fun `createReport throws PERMISSION_DENIED when MeasurementConsumer caller doesn't match`() {
     val request = createReportRequest {
-      parent = MEASUREMENT_CONSUMER_NAMES[0]
+      parent = MEASUREMENT_CONSUMERS.values.first().name
       report = PENDING_REACH_REPORT.copy { clearState() }
     }
     val exception =
       assertFailsWith<StatusRuntimeException> {
-        withMeasurementConsumerPrincipal(MEASUREMENT_CONSUMER_NAMES[1], CONFIG) {
+        withMeasurementConsumerPrincipal(MEASUREMENT_CONSUMERS.values.last().name, CONFIG) {
           runBlocking { service.createReport(request) }
         }
       }
@@ -2033,12 +2029,12 @@ class ReportsServiceTest {
   @Test
   fun `createReport throws PERMISSION_DENIED when report doesn't belong to caller`() {
     val request = createReportRequest {
-      parent = MEASUREMENT_CONSUMER_NAMES[1]
+      parent = MEASUREMENT_CONSUMERS.values.last().name
       report = PENDING_REACH_REPORT.copy { clearState() }
     }
     val exception =
       assertFailsWith<StatusRuntimeException> {
-        withMeasurementConsumerPrincipal(MEASUREMENT_CONSUMER_NAMES[0], CONFIG) {
+        withMeasurementConsumerPrincipal(MEASUREMENT_CONSUMERS.values.first().name, CONFIG) {
           runBlocking { service.createReport(request) }
         }
       }
@@ -2050,12 +2046,12 @@ class ReportsServiceTest {
   @Test
   fun `createReport throws UNAUTHENTICATED when the caller is not MeasurementConsumer`() {
     val request = createReportRequest {
-      parent = MEASUREMENT_CONSUMER_NAMES[0]
+      parent = MEASUREMENT_CONSUMERS.values.first().name
       report = PENDING_REACH_REPORT.copy { clearState() }
     }
     val exception =
       assertFailsWith<StatusRuntimeException> {
-        withDataProviderPrincipal(DATA_PROVIDERS[0].name) {
+        withDataProviderPrincipal(DATA_PROVIDERS_LIST[0].name) {
           runBlocking { service.createReport(request) }
         }
       }
@@ -2069,7 +2065,7 @@ class ReportsServiceTest {
 
     val exception =
       assertFailsWith<StatusRuntimeException> {
-        withMeasurementConsumerPrincipal(MEASUREMENT_CONSUMER_NAMES[0], CONFIG) {
+        withMeasurementConsumerPrincipal(MEASUREMENT_CONSUMERS.values.first().name, CONFIG) {
           runBlocking { service.createReport(request) }
         }
       }
@@ -2079,11 +2075,11 @@ class ReportsServiceTest {
 
   @Test
   fun `createReport throws INVALID_ARGUMENT when report is unspecified`() {
-    val request = createReportRequest { parent = MEASUREMENT_CONSUMER_NAMES[0] }
+    val request = createReportRequest { parent = MEASUREMENT_CONSUMERS.values.first().name }
 
     val exception =
       assertFailsWith<StatusRuntimeException> {
-        withMeasurementConsumerPrincipal(MEASUREMENT_CONSUMER_NAMES[0], CONFIG) {
+        withMeasurementConsumerPrincipal(MEASUREMENT_CONSUMERS.values.first().name, CONFIG) {
           runBlocking { service.createReport(request) }
         }
       }
@@ -2094,7 +2090,7 @@ class ReportsServiceTest {
   @Test
   fun `createReport throws INVALID_ARGUMENT when reportIdempotencyKey is unspecified`() {
     val request = createReportRequest {
-      parent = MEASUREMENT_CONSUMER_NAMES[0]
+      parent = MEASUREMENT_CONSUMERS.values.first().name
       report =
         PENDING_REACH_REPORT.copy {
           clearState()
@@ -2104,7 +2100,7 @@ class ReportsServiceTest {
 
     val exception =
       assertFailsWith<StatusRuntimeException> {
-        withMeasurementConsumerPrincipal(MEASUREMENT_CONSUMER_NAMES[0], CONFIG) {
+        withMeasurementConsumerPrincipal(MEASUREMENT_CONSUMERS.values.first().name, CONFIG) {
           runBlocking { service.createReport(request) }
         }
       }
@@ -2115,7 +2111,7 @@ class ReportsServiceTest {
   @Test
   fun `createReport throws INVALID_ARGUMENT when eventGroupUniverse in Report is unspecified`() {
     val request = createReportRequest {
-      parent = MEASUREMENT_CONSUMER_NAMES[0]
+      parent = MEASUREMENT_CONSUMERS.values.first().name
       report =
         PENDING_REACH_REPORT.copy {
           clearState()
@@ -2125,7 +2121,7 @@ class ReportsServiceTest {
 
     val exception =
       assertFailsWith<StatusRuntimeException> {
-        withMeasurementConsumerPrincipal(MEASUREMENT_CONSUMER_NAMES[0], CONFIG) {
+        withMeasurementConsumerPrincipal(MEASUREMENT_CONSUMERS.values.first().name, CONFIG) {
           runBlocking { service.createReport(request) }
         }
       }
@@ -2136,7 +2132,7 @@ class ReportsServiceTest {
   @Test
   fun `createReport throws INVALID_ARGUMENT when eventGroupUniverse entries list is empty`() {
     val request = createReportRequest {
-      parent = MEASUREMENT_CONSUMER_NAMES[0]
+      parent = MEASUREMENT_CONSUMERS.values.first().name
       report =
         PENDING_REACH_REPORT.copy {
           clearState()
@@ -2146,7 +2142,7 @@ class ReportsServiceTest {
 
     val exception =
       assertFailsWith<StatusRuntimeException> {
-        withMeasurementConsumerPrincipal(MEASUREMENT_CONSUMER_NAMES[0], CONFIG) {
+        withMeasurementConsumerPrincipal(MEASUREMENT_CONSUMERS.values.first().name, CONFIG) {
           runBlocking { service.createReport(request) }
         }
       }
@@ -2156,7 +2152,7 @@ class ReportsServiceTest {
   @Test
   fun `createReport throws INVALID_ARGUMENT when eventGroupUniverse entry is missing key`() {
     val request = createReportRequest {
-      parent = MEASUREMENT_CONSUMER_NAMES[0]
+      parent = MEASUREMENT_CONSUMERS.values.first().name
       report =
         PENDING_REACH_REPORT.copy {
           clearState()
@@ -2168,7 +2164,7 @@ class ReportsServiceTest {
 
     val exception =
       assertFailsWith<StatusRuntimeException> {
-        withMeasurementConsumerPrincipal(MEASUREMENT_CONSUMER_NAMES[0], CONFIG) {
+        withMeasurementConsumerPrincipal(MEASUREMENT_CONSUMERS.values.first().name, CONFIG) {
           runBlocking { service.createReport(request) }
         }
       }
@@ -2178,7 +2174,7 @@ class ReportsServiceTest {
   @Test
   fun `createReport throws INVALID_ARGUMENT when setOperationName duplicate for same metricType`() {
     val request = createReportRequest {
-      parent = MEASUREMENT_CONSUMER_NAMES[0]
+      parent = MEASUREMENT_CONSUMERS.values.first().name
       report =
         PENDING_REACH_REPORT.copy {
           clearState()
@@ -2188,7 +2184,7 @@ class ReportsServiceTest {
 
     val exception =
       assertFailsWith<StatusRuntimeException> {
-        withMeasurementConsumerPrincipal(MEASUREMENT_CONSUMER_NAMES[0], CONFIG) {
+        withMeasurementConsumerPrincipal(MEASUREMENT_CONSUMERS.values.first().name, CONFIG) {
           runBlocking { service.createReport(request) }
         }
       }
@@ -2200,7 +2196,7 @@ class ReportsServiceTest {
   @Test
   fun `createReport throws INVALID_ARGUMENT when time in Report is unspecified`() {
     val request = createReportRequest {
-      parent = MEASUREMENT_CONSUMER_NAMES[0]
+      parent = MEASUREMENT_CONSUMERS.values.first().name
       report =
         PENDING_REACH_REPORT.copy {
           clearState()
@@ -2210,7 +2206,7 @@ class ReportsServiceTest {
 
     val exception =
       assertFailsWith<StatusRuntimeException> {
-        withMeasurementConsumerPrincipal(MEASUREMENT_CONSUMER_NAMES[0], CONFIG) {
+        withMeasurementConsumerPrincipal(MEASUREMENT_CONSUMERS.values.first().name, CONFIG) {
           runBlocking { service.createReport(request) }
         }
       }
@@ -2221,7 +2217,7 @@ class ReportsServiceTest {
   @Test
   fun `createReport throws INVALID_ARGUMENT when TimeIntervals is set and cumulative is true`() {
     val request = createReportRequest {
-      parent = MEASUREMENT_CONSUMER_NAMES[0]
+      parent = MEASUREMENT_CONSUMERS.values.first().name
       report =
         PENDING_REACH_REPORT.copy {
           clearState()
@@ -2239,7 +2235,7 @@ class ReportsServiceTest {
 
     val exception =
       assertFailsWith<StatusRuntimeException> {
-        withMeasurementConsumerPrincipal(MEASUREMENT_CONSUMER_NAMES[0], CONFIG) {
+        withMeasurementConsumerPrincipal(MEASUREMENT_CONSUMERS.values.first().name, CONFIG) {
           runBlocking { service.createReport(request) }
         }
       }
@@ -2249,7 +2245,7 @@ class ReportsServiceTest {
   @Test
   fun `createReport throws INVALID_ARGUMENT when TimeIntervals timeIntervalsList is empty`() {
     val request = createReportRequest {
-      parent = MEASUREMENT_CONSUMER_NAMES[0]
+      parent = MEASUREMENT_CONSUMERS.values.first().name
       report =
         PENDING_REACH_REPORT.copy {
           clearState()
@@ -2260,7 +2256,7 @@ class ReportsServiceTest {
 
     val exception =
       assertFailsWith<StatusRuntimeException> {
-        withMeasurementConsumerPrincipal(MEASUREMENT_CONSUMER_NAMES[0], CONFIG) {
+        withMeasurementConsumerPrincipal(MEASUREMENT_CONSUMERS.values.first().name, CONFIG) {
           runBlocking { service.createReport(request) }
         }
       }
@@ -2270,7 +2266,7 @@ class ReportsServiceTest {
   @Test
   fun `createReport throws INVALID_ARGUMENT when TimeInterval startTime is unspecified`() {
     val request = createReportRequest {
-      parent = MEASUREMENT_CONSUMER_NAMES[0]
+      parent = MEASUREMENT_CONSUMERS.values.first().name
       report =
         PENDING_REACH_REPORT.copy {
           clearState()
@@ -2283,7 +2279,7 @@ class ReportsServiceTest {
 
     val exception =
       assertFailsWith<StatusRuntimeException> {
-        withMeasurementConsumerPrincipal(MEASUREMENT_CONSUMER_NAMES[0], CONFIG) {
+        withMeasurementConsumerPrincipal(MEASUREMENT_CONSUMERS.values.first().name, CONFIG) {
           runBlocking { service.createReport(request) }
         }
       }
@@ -2293,7 +2289,7 @@ class ReportsServiceTest {
   @Test
   fun `createReport throws INVALID_ARGUMENT when TimeInterval endTime is unspecified`() {
     val request = createReportRequest {
-      parent = MEASUREMENT_CONSUMER_NAMES[0]
+      parent = MEASUREMENT_CONSUMERS.values.first().name
       report =
         PENDING_REACH_REPORT.copy {
           clearState()
@@ -2306,7 +2302,7 @@ class ReportsServiceTest {
 
     val exception =
       assertFailsWith<StatusRuntimeException> {
-        withMeasurementConsumerPrincipal(MEASUREMENT_CONSUMER_NAMES[0], CONFIG) {
+        withMeasurementConsumerPrincipal(MEASUREMENT_CONSUMERS.values.first().name, CONFIG) {
           runBlocking { service.createReport(request) }
         }
       }
@@ -2316,7 +2312,7 @@ class ReportsServiceTest {
   @Test
   fun `createReport throws INVALID_ARGUMENT when TimeInterval endTime is before startTime`() {
     val request = createReportRequest {
-      parent = MEASUREMENT_CONSUMER_NAMES[0]
+      parent = MEASUREMENT_CONSUMERS.values.first().name
       report =
         PENDING_REACH_REPORT.copy {
           clearState()
@@ -2338,7 +2334,7 @@ class ReportsServiceTest {
 
     val exception =
       assertFailsWith<StatusRuntimeException> {
-        withMeasurementConsumerPrincipal(MEASUREMENT_CONSUMER_NAMES[0], CONFIG) {
+        withMeasurementConsumerPrincipal(MEASUREMENT_CONSUMERS.values.first().name, CONFIG) {
           runBlocking { service.createReport(request) }
         }
       }
@@ -2348,7 +2344,7 @@ class ReportsServiceTest {
   @Test
   fun `createReport throws INVALID_ARGUMENT when PeriodicTimeInterval startTime is unspecified`() {
     val request = createReportRequest {
-      parent = MEASUREMENT_CONSUMER_NAMES[0]
+      parent = MEASUREMENT_CONSUMERS.values.first().name
       report =
         PENDING_REACH_REPORT.copy {
           clearState()
@@ -2362,7 +2358,7 @@ class ReportsServiceTest {
 
     val exception =
       assertFailsWith<StatusRuntimeException> {
-        withMeasurementConsumerPrincipal(MEASUREMENT_CONSUMER_NAMES[0], CONFIG) {
+        withMeasurementConsumerPrincipal(MEASUREMENT_CONSUMERS.values.first().name, CONFIG) {
           runBlocking { service.createReport(request) }
         }
       }
@@ -2372,7 +2368,7 @@ class ReportsServiceTest {
   @Test
   fun `createReport throws INVALID_ARGUMENT when PeriodicTimeInterval increment is unspecified`() {
     val request = createReportRequest {
-      parent = MEASUREMENT_CONSUMER_NAMES[0]
+      parent = MEASUREMENT_CONSUMERS.values.first().name
       report =
         PENDING_REACH_REPORT.copy {
           clearState()
@@ -2389,7 +2385,7 @@ class ReportsServiceTest {
 
     val exception =
       assertFailsWith<StatusRuntimeException> {
-        withMeasurementConsumerPrincipal(MEASUREMENT_CONSUMER_NAMES[0], CONFIG) {
+        withMeasurementConsumerPrincipal(MEASUREMENT_CONSUMERS.values.first().name, CONFIG) {
           runBlocking { service.createReport(request) }
         }
       }
@@ -2399,7 +2395,7 @@ class ReportsServiceTest {
   @Test
   fun `createReport throws INVALID_ARGUMENT when PeriodicTimeInterval intervalCount is 0`() {
     val request = createReportRequest {
-      parent = MEASUREMENT_CONSUMER_NAMES[0]
+      parent = MEASUREMENT_CONSUMERS.values.first().name
       report =
         PENDING_REACH_REPORT.copy {
           clearState()
@@ -2416,7 +2412,7 @@ class ReportsServiceTest {
 
     val exception =
       assertFailsWith<StatusRuntimeException> {
-        withMeasurementConsumerPrincipal(MEASUREMENT_CONSUMER_NAMES[0], CONFIG) {
+        withMeasurementConsumerPrincipal(MEASUREMENT_CONSUMERS.values.first().name, CONFIG) {
           runBlocking { service.createReport(request) }
         }
       }
@@ -2426,7 +2422,7 @@ class ReportsServiceTest {
   @Test
   fun `createReport throws INVALID_ARGUMENT when any metric type in Report is unspecified`() {
     val request = createReportRequest {
-      parent = MEASUREMENT_CONSUMER_NAMES[0]
+      parent = MEASUREMENT_CONSUMERS.values.first().name
       report =
         PENDING_REACH_REPORT.copy {
           clearState()
@@ -2437,7 +2433,7 @@ class ReportsServiceTest {
 
     val exception =
       assertFailsWith<StatusRuntimeException> {
-        withMeasurementConsumerPrincipal(MEASUREMENT_CONSUMER_NAMES[0], CONFIG) {
+        withMeasurementConsumerPrincipal(MEASUREMENT_CONSUMERS.values.first().name, CONFIG) {
           runBlocking { service.createReport(request) }
         }
       }
@@ -2449,7 +2445,7 @@ class ReportsServiceTest {
   @Test
   fun `createReport throws INVALID_ARGUMENT when metrics list is empty`() {
     val request = createReportRequest {
-      parent = MEASUREMENT_CONSUMER_NAMES[0]
+      parent = MEASUREMENT_CONSUMERS.values.first().name
       report =
         PENDING_REACH_REPORT.copy {
           clearState()
@@ -2459,7 +2455,7 @@ class ReportsServiceTest {
 
     val exception =
       assertFailsWith<StatusRuntimeException> {
-        withMeasurementConsumerPrincipal(MEASUREMENT_CONSUMER_NAMES[0], CONFIG) {
+        withMeasurementConsumerPrincipal(MEASUREMENT_CONSUMERS.values.first().name, CONFIG) {
           runBlocking { service.createReport(request) }
         }
       }
@@ -2469,7 +2465,7 @@ class ReportsServiceTest {
   @Test
   fun `createReport throws INVALID_ARGUMENT when namedSetOperation uniqueName is unspecified`() {
     val request = createReportRequest {
-      parent = MEASUREMENT_CONSUMER_NAMES[0]
+      parent = MEASUREMENT_CONSUMERS.values.first().name
       report =
         PENDING_REACH_REPORT.copy {
           clearState()
@@ -2479,7 +2475,8 @@ class ReportsServiceTest {
             setOperations += namedSetOperation {
               setOperation = setOperation {
                 type = SetOperation.Type.UNION
-                lhs = SetOperationKt.operand { reportingSet = REPORTING_SET_NAMES[0] }
+                lhs =
+                  SetOperationKt.operand { reportingSet = INTERNAL_REPORTING_SETS[0].resourceName }
               }
             }
           }
@@ -2488,7 +2485,7 @@ class ReportsServiceTest {
 
     val exception =
       assertFailsWith<StatusRuntimeException> {
-        withMeasurementConsumerPrincipal(MEASUREMENT_CONSUMER_NAMES[0], CONFIG) {
+        withMeasurementConsumerPrincipal(MEASUREMENT_CONSUMERS.values.first().name, CONFIG) {
           runBlocking { service.createReport(request) }
         }
       }
@@ -2498,7 +2495,7 @@ class ReportsServiceTest {
   @Test
   fun `createReport throws INVALID_ARGUMENT when setOperation type is unspecified`() {
     val request = createReportRequest {
-      parent = MEASUREMENT_CONSUMER_NAMES[0]
+      parent = MEASUREMENT_CONSUMERS.values.first().name
       report =
         PENDING_REACH_REPORT.copy {
           clearState()
@@ -2508,7 +2505,8 @@ class ReportsServiceTest {
             setOperations += namedSetOperation {
               uniqueName = "name"
               setOperation = setOperation {
-                lhs = SetOperationKt.operand { reportingSet = REPORTING_SET_NAMES[0] }
+                lhs =
+                  SetOperationKt.operand { reportingSet = INTERNAL_REPORTING_SETS[0].resourceName }
               }
             }
           }
@@ -2517,7 +2515,7 @@ class ReportsServiceTest {
 
     val exception =
       assertFailsWith<StatusRuntimeException> {
-        withMeasurementConsumerPrincipal(MEASUREMENT_CONSUMER_NAMES[0], CONFIG) {
+        withMeasurementConsumerPrincipal(MEASUREMENT_CONSUMERS.values.first().name, CONFIG) {
           runBlocking { service.createReport(request) }
         }
       }
@@ -2527,7 +2525,7 @@ class ReportsServiceTest {
   @Test
   fun `createReport throws INVALID_ARGUMENT when setOperation lhs is unspecified`() {
     val request = createReportRequest {
-      parent = MEASUREMENT_CONSUMER_NAMES[0]
+      parent = MEASUREMENT_CONSUMERS.values.first().name
       report =
         PENDING_REACH_REPORT.copy {
           clearState()
@@ -2544,7 +2542,7 @@ class ReportsServiceTest {
 
     val exception =
       assertFailsWith<StatusRuntimeException> {
-        withMeasurementConsumerPrincipal(MEASUREMENT_CONSUMER_NAMES[0], CONFIG) {
+        withMeasurementConsumerPrincipal(MEASUREMENT_CONSUMERS.values.first().name, CONFIG) {
           runBlocking { service.createReport(request) }
         }
       }
@@ -2562,7 +2560,7 @@ class ReportsServiceTest {
     }
 
     val request = createReportRequest {
-      parent = MEASUREMENT_CONSUMER_NAMES[0]
+      parent = MEASUREMENT_CONSUMERS.values.first().name
       report =
         PENDING_REACH_REPORT.copy {
           clearState()
@@ -2573,7 +2571,7 @@ class ReportsServiceTest {
 
     val exception =
       assertFailsWith<StatusRuntimeException> {
-        withMeasurementConsumerPrincipal(MEASUREMENT_CONSUMER_NAMES[0], CONFIG) {
+        withMeasurementConsumerPrincipal(MEASUREMENT_CONSUMERS.values.first().name, CONFIG) {
           runBlocking { service.createReport(request) }
         }
       }
@@ -2595,7 +2593,7 @@ class ReportsServiceTest {
     }
 
     val request = createReportRequest {
-      parent = MEASUREMENT_CONSUMER_NAMES[0]
+      parent = MEASUREMENT_CONSUMERS.values.first().name
       report =
         PENDING_REACH_REPORT.copy {
           clearState()
@@ -2606,7 +2604,7 @@ class ReportsServiceTest {
 
     val exception =
       assertFailsWith<StatusRuntimeException> {
-        withMeasurementConsumerPrincipal(MEASUREMENT_CONSUMER_NAMES[0], CONFIG) {
+        withMeasurementConsumerPrincipal(MEASUREMENT_CONSUMERS.values.first().name, CONFIG) {
           runBlocking { service.createReport(request) }
         }
       }
@@ -2621,13 +2619,13 @@ class ReportsServiceTest {
       whenever(internalReportingSetsMock.batchGetReportingSet(any()))
         .thenReturn(flowOf(INTERNAL_REPORTING_SETS[0], UNCOVERED_INTERNAL_REPORTING_SET))
       val request = createReportRequest {
-        parent = MEASUREMENT_CONSUMER_NAMES[0]
+        parent = MEASUREMENT_CONSUMERS.values.first().name
         report = PENDING_REACH_REPORT.copy { clearState() }
       }
 
       val exception =
         assertFailsWith<StatusRuntimeException> {
-          withMeasurementConsumerPrincipal(MEASUREMENT_CONSUMER_NAMES[0], CONFIG) {
+          withMeasurementConsumerPrincipal(MEASUREMENT_CONSUMERS.values.first().name, CONFIG) {
             runBlocking { service.createReport(request) }
           }
         }
@@ -2644,13 +2642,13 @@ class ReportsServiceTest {
     whenever(internalReportingSetsMock.batchGetReportingSet(any()))
       .thenReturn(flowOf(INTERNAL_REPORTING_SETS[0]))
     val request = createReportRequest {
-      parent = MEASUREMENT_CONSUMER_NAMES[0]
+      parent = MEASUREMENT_CONSUMERS.values.first().name
       report = PENDING_REACH_REPORT.copy { clearState() }
     }
 
     val exception =
       assertFailsWith<StatusRuntimeException> {
-        withMeasurementConsumerPrincipal(MEASUREMENT_CONSUMER_NAMES[0], CONFIG) {
+        withMeasurementConsumerPrincipal(MEASUREMENT_CONSUMERS.values.first().name, CONFIG) {
           runBlocking { service.createReport(request) }
         }
       }
@@ -2664,13 +2662,13 @@ class ReportsServiceTest {
         .thenThrow(StatusRuntimeException(Status.INVALID_ARGUMENT))
 
       val request = createReportRequest {
-        parent = MEASUREMENT_CONSUMER_NAMES[0]
+        parent = MEASUREMENT_CONSUMERS.values.first().name
         report = PENDING_REACH_REPORT.copy { clearState() }
       }
 
       val exception =
         assertFailsWith(Exception::class) {
-          withMeasurementConsumerPrincipal(MEASUREMENT_CONSUMER_NAMES[0], CONFIG) {
+          withMeasurementConsumerPrincipal(MEASUREMENT_CONSUMERS.values.first().name, CONFIG) {
             runBlocking { service.createReport(request) }
           }
         }
@@ -2686,13 +2684,13 @@ class ReportsServiceTest {
       .thenThrow(StatusRuntimeException(Status.INVALID_ARGUMENT))
 
     val request = createReportRequest {
-      parent = MEASUREMENT_CONSUMER_NAMES[0]
+      parent = MEASUREMENT_CONSUMERS.values.first().name
       report = PENDING_REACH_REPORT.copy { clearState() }
     }
 
     val exception =
       assertFailsWith(Exception::class) {
-        withMeasurementConsumerPrincipal(MEASUREMENT_CONSUMER_NAMES[0], CONFIG) {
+        withMeasurementConsumerPrincipal(MEASUREMENT_CONSUMERS.values.first().name, CONFIG) {
           runBlocking { service.createReport(request) }
         }
       }
@@ -2707,13 +2705,13 @@ class ReportsServiceTest {
         .thenThrow(StatusRuntimeException(Status.INVALID_ARGUMENT))
 
       val request = createReportRequest {
-        parent = MEASUREMENT_CONSUMER_NAMES[0]
+        parent = MEASUREMENT_CONSUMERS.values.first().name
         report = PENDING_REACH_REPORT.copy { clearState() }
       }
 
       val exception =
         assertFailsWith(Exception::class) {
-          withMeasurementConsumerPrincipal(MEASUREMENT_CONSUMER_NAMES[0], CONFIG) {
+          withMeasurementConsumerPrincipal(MEASUREMENT_CONSUMERS.values.first().name, CONFIG) {
             runBlocking { service.createReport(request) }
           }
         }
@@ -2729,13 +2727,13 @@ class ReportsServiceTest {
         .thenThrow(StatusRuntimeException(Status.INVALID_ARGUMENT))
 
       val request = createReportRequest {
-        parent = MEASUREMENT_CONSUMER_NAMES[0]
+        parent = MEASUREMENT_CONSUMERS.values.first().name
         report = PENDING_REACH_REPORT.copy { clearState() }
       }
 
       val exception =
         assertFailsWith(Exception::class) {
-          withMeasurementConsumerPrincipal(MEASUREMENT_CONSUMER_NAMES[0], CONFIG) {
+          withMeasurementConsumerPrincipal(MEASUREMENT_CONSUMERS.values.first().name, CONFIG) {
             runBlocking { service.createReport(request) }
           }
         }
@@ -2750,18 +2748,18 @@ class ReportsServiceTest {
       .thenThrow(StatusRuntimeException(Status.INVALID_ARGUMENT))
 
     val request = createReportRequest {
-      parent = MEASUREMENT_CONSUMER_NAMES[0]
+      parent = MEASUREMENT_CONSUMERS.values.first().name
       report = PENDING_REACH_REPORT.copy { clearState() }
     }
 
     val exception =
       assertFailsWith(Exception::class) {
-        withMeasurementConsumerPrincipal(MEASUREMENT_CONSUMER_NAMES[0], CONFIG) {
+        withMeasurementConsumerPrincipal(MEASUREMENT_CONSUMERS.values.first().name, CONFIG) {
           runBlocking { service.createReport(request) }
         }
       }
     val expectedExceptionDescription =
-      "Unable to retrieve the measurement consumer [${MEASUREMENT_CONSUMER_NAMES[0]}]."
+      "Unable to retrieve the measurement consumer [${MEASUREMENT_CONSUMERS.values.first().name}]."
     assertThat(exception.message).isEqualTo(expectedExceptionDescription)
   }
 
@@ -2772,12 +2770,12 @@ class ReportsServiceTest {
       .thenThrow(StatusRuntimeException(Status.UNKNOWN))
 
     val request = createReportRequest {
-      parent = MEASUREMENT_CONSUMER_NAMES[0]
+      parent = MEASUREMENT_CONSUMERS.values.first().name
       report = PENDING_REACH_REPORT.copy { clearState() }
     }
 
     assertFails {
-      withMeasurementConsumerPrincipal(MEASUREMENT_CONSUMER_NAMES[0], CONFIG) {
+      withMeasurementConsumerPrincipal(MEASUREMENT_CONSUMERS.values.first().name, CONFIG) {
         runBlocking { service.createReport(request) }
       }
     }
@@ -2789,26 +2787,25 @@ class ReportsServiceTest {
       .thenThrow(StatusRuntimeException(Status.INVALID_ARGUMENT))
 
     val request = createReportRequest {
-      parent = MEASUREMENT_CONSUMER_NAMES[0]
+      parent = MEASUREMENT_CONSUMERS.values.first().name
       report = PENDING_REACH_REPORT.copy { clearState() }
     }
 
     val exception =
       assertFailsWith(Exception::class) {
-        withMeasurementConsumerPrincipal(MEASUREMENT_CONSUMER_NAMES[0], CONFIG) {
+        withMeasurementConsumerPrincipal(MEASUREMENT_CONSUMERS.values.first().name, CONFIG) {
           runBlocking { service.createReport(request) }
         }
       }
-    val expectedExceptionDescription = "Unable to retrieve the data provider"
-    assertThat(exception.message).contains(expectedExceptionDescription)
+    assertThat(exception).hasMessageThat().contains("dataProviders/")
   }
 
   @Test
   fun `listReports returns without a next page token when there is no previous page token`() {
-    val request = listReportsRequest { parent = MEASUREMENT_CONSUMER_NAMES[0] }
+    val request = listReportsRequest { parent = MEASUREMENT_CONSUMERS.values.first().name }
 
     val result =
-      withMeasurementConsumerPrincipal(MEASUREMENT_CONSUMER_NAMES[0], CONFIG) {
+      withMeasurementConsumerPrincipal(MEASUREMENT_CONSUMERS.values.first().name, CONFIG) {
         runBlocking { service.listReports(request) }
       }
 
@@ -2824,7 +2821,8 @@ class ReportsServiceTest {
         streamReportsRequest {
           limit = DEFAULT_PAGE_SIZE + 1
           this.filter = filter {
-            measurementConsumerReferenceId = MEASUREMENT_CONSUMER_REFERENCE_IDS[0]
+            measurementConsumerReferenceId =
+              MEASUREMENT_CONSUMERS.keys.first().measurementConsumerId
           }
         }
       )
@@ -2835,12 +2833,12 @@ class ReportsServiceTest {
   @Test
   fun `listReports returns with a next page token when there is no previous page token`() {
     val request = listReportsRequest {
-      parent = MEASUREMENT_CONSUMER_NAMES[0]
+      parent = MEASUREMENT_CONSUMERS.values.first().name
       pageSize = PAGE_SIZE
     }
 
     val result =
-      withMeasurementConsumerPrincipal(MEASUREMENT_CONSUMER_NAMES[0], CONFIG) {
+      withMeasurementConsumerPrincipal(MEASUREMENT_CONSUMERS.values.first().name, CONFIG) {
         runBlocking { service.listReports(request) }
       }
 
@@ -2852,9 +2850,11 @@ class ReportsServiceTest {
       nextPageToken =
         listReportsPageToken {
             pageSize = PAGE_SIZE
-            measurementConsumerReferenceId = MEASUREMENT_CONSUMER_REFERENCE_IDS[0]
+            measurementConsumerReferenceId =
+              MEASUREMENT_CONSUMERS.keys.first().measurementConsumerId
             lastReport = previousPageEnd {
-              measurementConsumerReferenceId = MEASUREMENT_CONSUMER_REFERENCE_IDS[0]
+              measurementConsumerReferenceId =
+                MEASUREMENT_CONSUMERS.keys.first().measurementConsumerId
               externalReportId = REPORT_EXTERNAL_IDS[2]
             }
           }
@@ -2867,7 +2867,8 @@ class ReportsServiceTest {
         streamReportsRequest {
           limit = PAGE_SIZE + 1
           this.filter = filter {
-            measurementConsumerReferenceId = MEASUREMENT_CONSUMER_REFERENCE_IDS[0]
+            measurementConsumerReferenceId =
+              MEASUREMENT_CONSUMERS.keys.first().measurementConsumerId
           }
         }
       )
@@ -2878,14 +2879,16 @@ class ReportsServiceTest {
   @Test
   fun `listReports returns with a next page token when there is a previous page token`() {
     val request = listReportsRequest {
-      parent = MEASUREMENT_CONSUMER_NAMES[0]
+      parent = MEASUREMENT_CONSUMERS.values.first().name
       pageSize = PAGE_SIZE
       pageToken =
         listReportsPageToken {
             pageSize = PAGE_SIZE
-            measurementConsumerReferenceId = MEASUREMENT_CONSUMER_REFERENCE_IDS[0]
+            measurementConsumerReferenceId =
+              MEASUREMENT_CONSUMERS.keys.first().measurementConsumerId
             lastReport = previousPageEnd {
-              measurementConsumerReferenceId = MEASUREMENT_CONSUMER_REFERENCE_IDS[0]
+              measurementConsumerReferenceId =
+                MEASUREMENT_CONSUMERS.keys.first().measurementConsumerId
               externalReportId = REPORT_EXTERNAL_IDS[0]
             }
           }
@@ -2894,7 +2897,7 @@ class ReportsServiceTest {
     }
 
     val result =
-      withMeasurementConsumerPrincipal(MEASUREMENT_CONSUMER_NAMES[0], CONFIG) {
+      withMeasurementConsumerPrincipal(MEASUREMENT_CONSUMERS.values.first().name, CONFIG) {
         runBlocking { service.listReports(request) }
       }
 
@@ -2906,9 +2909,11 @@ class ReportsServiceTest {
       nextPageToken =
         listReportsPageToken {
             pageSize = PAGE_SIZE
-            measurementConsumerReferenceId = MEASUREMENT_CONSUMER_REFERENCE_IDS[0]
+            measurementConsumerReferenceId =
+              MEASUREMENT_CONSUMERS.keys.first().measurementConsumerId
             lastReport = previousPageEnd {
-              measurementConsumerReferenceId = MEASUREMENT_CONSUMER_REFERENCE_IDS[0]
+              measurementConsumerReferenceId =
+                MEASUREMENT_CONSUMERS.keys.first().measurementConsumerId
               externalReportId = REPORT_EXTERNAL_IDS[2]
             }
           }
@@ -2921,7 +2926,8 @@ class ReportsServiceTest {
         streamReportsRequest {
           limit = PAGE_SIZE + 1
           this.filter = filter {
-            measurementConsumerReferenceId = MEASUREMENT_CONSUMER_REFERENCE_IDS[0]
+            measurementConsumerReferenceId =
+              MEASUREMENT_CONSUMERS.keys.first().measurementConsumerId
             externalReportIdAfter = REPORT_EXTERNAL_IDS[0]
           }
         }
@@ -2934,12 +2940,12 @@ class ReportsServiceTest {
   fun `listReports with page size replaced with a valid value and no previous page token`() {
     val invalidPageSize = MAX_PAGE_SIZE * 2
     val request = listReportsRequest {
-      parent = MEASUREMENT_CONSUMER_NAMES[0]
+      parent = MEASUREMENT_CONSUMERS.values.first().name
       pageSize = invalidPageSize
     }
 
     val result =
-      withMeasurementConsumerPrincipal(MEASUREMENT_CONSUMER_NAMES[0], CONFIG) {
+      withMeasurementConsumerPrincipal(MEASUREMENT_CONSUMERS.values.first().name, CONFIG) {
         runBlocking { service.listReports(request) }
       }
 
@@ -2955,7 +2961,8 @@ class ReportsServiceTest {
         streamReportsRequest {
           limit = MAX_PAGE_SIZE + 1
           this.filter = filter {
-            measurementConsumerReferenceId = MEASUREMENT_CONSUMER_REFERENCE_IDS[0]
+            measurementConsumerReferenceId =
+              MEASUREMENT_CONSUMERS.keys.first().measurementConsumerId
           }
         }
       )
@@ -2968,14 +2975,16 @@ class ReportsServiceTest {
     val invalidPageSize = MAX_PAGE_SIZE * 2
     val previousPageSize = PAGE_SIZE
     val request = listReportsRequest {
-      parent = MEASUREMENT_CONSUMER_NAMES[0]
+      parent = MEASUREMENT_CONSUMERS.values.first().name
       pageSize = invalidPageSize
       pageToken =
         listReportsPageToken {
             pageSize = previousPageSize
-            measurementConsumerReferenceId = MEASUREMENT_CONSUMER_REFERENCE_IDS[0]
+            measurementConsumerReferenceId =
+              MEASUREMENT_CONSUMERS.keys.first().measurementConsumerId
             lastReport = previousPageEnd {
-              measurementConsumerReferenceId = MEASUREMENT_CONSUMER_REFERENCE_IDS[0]
+              measurementConsumerReferenceId =
+                MEASUREMENT_CONSUMERS.keys.first().measurementConsumerId
               externalReportId = REPORT_EXTERNAL_IDS[0]
             }
           }
@@ -2984,7 +2993,7 @@ class ReportsServiceTest {
     }
 
     val result =
-      withMeasurementConsumerPrincipal(MEASUREMENT_CONSUMER_NAMES[0], CONFIG) {
+      withMeasurementConsumerPrincipal(MEASUREMENT_CONSUMERS.values.first().name, CONFIG) {
         runBlocking { service.listReports(request) }
       }
 
@@ -2996,9 +3005,11 @@ class ReportsServiceTest {
       nextPageToken =
         listReportsPageToken {
             pageSize = previousPageSize
-            measurementConsumerReferenceId = MEASUREMENT_CONSUMER_REFERENCE_IDS[0]
+            measurementConsumerReferenceId =
+              MEASUREMENT_CONSUMERS.keys.first().measurementConsumerId
             lastReport = previousPageEnd {
-              measurementConsumerReferenceId = MEASUREMENT_CONSUMER_REFERENCE_IDS[0]
+              measurementConsumerReferenceId =
+                MEASUREMENT_CONSUMERS.keys.first().measurementConsumerId
               externalReportId = REPORT_EXTERNAL_IDS[2]
             }
           }
@@ -3011,7 +3022,8 @@ class ReportsServiceTest {
         streamReportsRequest {
           limit = previousPageSize + 1
           this.filter = filter {
-            measurementConsumerReferenceId = MEASUREMENT_CONSUMER_REFERENCE_IDS[0]
+            measurementConsumerReferenceId =
+              MEASUREMENT_CONSUMERS.keys.first().measurementConsumerId
             externalReportIdAfter = REPORT_EXTERNAL_IDS[0]
           }
         }
@@ -3025,14 +3037,16 @@ class ReportsServiceTest {
     val newPageSize = PAGE_SIZE
     val previousPageSize = 1
     val request = listReportsRequest {
-      parent = MEASUREMENT_CONSUMER_NAMES[0]
+      parent = MEASUREMENT_CONSUMERS.values.first().name
       pageSize = newPageSize
       pageToken =
         listReportsPageToken {
             pageSize = previousPageSize
-            measurementConsumerReferenceId = MEASUREMENT_CONSUMER_REFERENCE_IDS[0]
+            measurementConsumerReferenceId =
+              MEASUREMENT_CONSUMERS.keys.first().measurementConsumerId
             lastReport = previousPageEnd {
-              measurementConsumerReferenceId = MEASUREMENT_CONSUMER_REFERENCE_IDS[0]
+              measurementConsumerReferenceId =
+                MEASUREMENT_CONSUMERS.keys.first().measurementConsumerId
               externalReportId = REPORT_EXTERNAL_IDS[0]
             }
           }
@@ -3041,7 +3055,7 @@ class ReportsServiceTest {
     }
 
     val result =
-      withMeasurementConsumerPrincipal(MEASUREMENT_CONSUMER_NAMES[0], CONFIG) {
+      withMeasurementConsumerPrincipal(MEASUREMENT_CONSUMERS.values.first().name, CONFIG) {
         runBlocking { service.listReports(request) }
       }
 
@@ -3053,9 +3067,11 @@ class ReportsServiceTest {
       nextPageToken =
         listReportsPageToken {
             pageSize = newPageSize
-            measurementConsumerReferenceId = MEASUREMENT_CONSUMER_REFERENCE_IDS[0]
+            measurementConsumerReferenceId =
+              MEASUREMENT_CONSUMERS.keys.first().measurementConsumerId
             lastReport = previousPageEnd {
-              measurementConsumerReferenceId = MEASUREMENT_CONSUMER_REFERENCE_IDS[0]
+              measurementConsumerReferenceId =
+                MEASUREMENT_CONSUMERS.keys.first().measurementConsumerId
               externalReportId = REPORT_EXTERNAL_IDS[2]
             }
           }
@@ -3068,7 +3084,8 @@ class ReportsServiceTest {
         streamReportsRequest {
           limit = newPageSize + 1
           this.filter = filter {
-            measurementConsumerReferenceId = MEASUREMENT_CONSUMER_REFERENCE_IDS[0]
+            measurementConsumerReferenceId =
+              MEASUREMENT_CONSUMERS.keys.first().measurementConsumerId
             externalReportIdAfter = REPORT_EXTERNAL_IDS[0]
           }
         }
@@ -3079,7 +3096,7 @@ class ReportsServiceTest {
 
   @Test
   fun `listReports throws UNAUTHENTICATED when no principal is found`() {
-    val request = listReportsRequest { parent = MEASUREMENT_CONSUMER_NAMES[0] }
+    val request = listReportsRequest { parent = MEASUREMENT_CONSUMERS.values.first().name }
     val exception =
       assertFailsWith<StatusRuntimeException> { runBlocking { service.listReports(request) } }
     assertThat(exception.status.code).isEqualTo(Status.Code.UNAUTHENTICATED)
@@ -3087,10 +3104,10 @@ class ReportsServiceTest {
 
   @Test
   fun `listReports throws PERMISSION_DENIED when MeasurementConsumer caller doesn't match`() {
-    val request = listReportsRequest { parent = MEASUREMENT_CONSUMER_NAMES[0] }
+    val request = listReportsRequest { parent = MEASUREMENT_CONSUMERS.values.first().name }
     val exception =
       assertFailsWith<StatusRuntimeException> {
-        withMeasurementConsumerPrincipal(MEASUREMENT_CONSUMER_NAMES[1], CONFIG) {
+        withMeasurementConsumerPrincipal(MEASUREMENT_CONSUMERS.values.last().name, CONFIG) {
           runBlocking { service.listReports(request) }
         }
       }
@@ -3101,10 +3118,10 @@ class ReportsServiceTest {
 
   @Test
   fun `listReports throws UNAUTHENTICATED when the caller is not MeasurementConsumer`() {
-    val request = listReportsRequest { parent = MEASUREMENT_CONSUMER_NAMES[0] }
+    val request = listReportsRequest { parent = MEASUREMENT_CONSUMERS.values.first().name }
     val exception =
       assertFailsWith<StatusRuntimeException> {
-        withDataProviderPrincipal(DATA_PROVIDERS[0].name) {
+        withDataProviderPrincipal(DATA_PROVIDERS.values.first().name) {
           runBlocking { service.listReports(request) }
         }
       }
@@ -3115,12 +3132,12 @@ class ReportsServiceTest {
   @Test
   fun `listReports throws INVALID_ARGUMENT when page size is less than 0`() {
     val request = listReportsRequest {
-      parent = MEASUREMENT_CONSUMER_NAMES[0]
+      parent = MEASUREMENT_CONSUMERS.values.first().name
       pageSize = -1
     }
     val exception =
       assertFailsWith<StatusRuntimeException> {
-        withMeasurementConsumerPrincipal(MEASUREMENT_CONSUMER_NAMES[0], CONFIG) {
+        withMeasurementConsumerPrincipal(MEASUREMENT_CONSUMERS.values.first().name, CONFIG) {
           runBlocking { service.listReports(request) }
         }
       }
@@ -3132,7 +3149,7 @@ class ReportsServiceTest {
   fun `listReports throws INVALID_ARGUMENT when parent is unspecified`() {
     val exception =
       assertFailsWith<StatusRuntimeException> {
-        withMeasurementConsumerPrincipal(MEASUREMENT_CONSUMER_NAMES[0], CONFIG) {
+        withMeasurementConsumerPrincipal(MEASUREMENT_CONSUMERS.values.first().name, CONFIG) {
           runBlocking { service.listReports(ListReportsRequest.getDefaultInstance()) }
         }
       }
@@ -3141,13 +3158,14 @@ class ReportsServiceTest {
 
   @Test
   fun `listReports throws INVALID_ARGUMENT when mc id doesn't match one in page token`() {
+    val measurementConsumerReferenceId = MEASUREMENT_CONSUMERS.keys.last().measurementConsumerId
     val request = listReportsRequest {
-      parent = MEASUREMENT_CONSUMER_NAMES[0]
+      parent = MEASUREMENT_CONSUMERS.values.first().name
       pageToken =
         listReportsPageToken {
-            measurementConsumerReferenceId = MEASUREMENT_CONSUMER_REFERENCE_IDS[1]
+            this.measurementConsumerReferenceId = measurementConsumerReferenceId
             lastReport = previousPageEnd {
-              measurementConsumerReferenceId = MEASUREMENT_CONSUMER_REFERENCE_IDS[1]
+              this.measurementConsumerReferenceId = measurementConsumerReferenceId
               externalReportId = REPORT_EXTERNAL_IDS[0]
             }
           }
@@ -3157,7 +3175,7 @@ class ReportsServiceTest {
 
     val exception =
       assertFailsWith<StatusRuntimeException> {
-        withMeasurementConsumerPrincipal(MEASUREMENT_CONSUMER_NAMES[0], CONFIG) {
+        withMeasurementConsumerPrincipal(MEASUREMENT_CONSUMERS.values.first().name, CONFIG) {
           runBlocking { service.listReports(request) }
         }
       }
@@ -3170,11 +3188,11 @@ class ReportsServiceTest {
       whenever(internalReportsMock.streamReports(any()))
         .thenThrow(StatusRuntimeException(Status.INVALID_ARGUMENT))
 
-      val request = listReportsRequest { parent = MEASUREMENT_CONSUMER_NAMES[0] }
+      val request = listReportsRequest { parent = MEASUREMENT_CONSUMERS.values.first().name }
 
       val exception =
         assertFailsWith(Exception::class) {
-          withMeasurementConsumerPrincipal(MEASUREMENT_CONSUMER_NAMES[0], CONFIG) {
+          withMeasurementConsumerPrincipal(MEASUREMENT_CONSUMERS.values.first().name, CONFIG) {
             runBlocking { service.listReports(request) }
           }
         }
@@ -3187,11 +3205,11 @@ class ReportsServiceTest {
     whenever(internalReportsMock.getReport(any()))
       .thenThrow(StatusRuntimeException(Status.INVALID_ARGUMENT))
 
-    val request = listReportsRequest { parent = MEASUREMENT_CONSUMER_NAMES[0] }
+    val request = listReportsRequest { parent = MEASUREMENT_CONSUMERS.values.first().name }
 
     val exception =
       assertFailsWith(Exception::class) {
-        withMeasurementConsumerPrincipal(MEASUREMENT_CONSUMER_NAMES[0], CONFIG) {
+        withMeasurementConsumerPrincipal(MEASUREMENT_CONSUMERS.values.first().name, CONFIG) {
           runBlocking { service.listReports(request) }
         }
       }
@@ -3205,11 +3223,11 @@ class ReportsServiceTest {
     whenever(measurementsMock.getMeasurement(any()))
       .thenThrow(StatusRuntimeException(Status.INVALID_ARGUMENT))
 
-    val request = listReportsRequest { parent = MEASUREMENT_CONSUMER_NAMES[0] }
+    val request = listReportsRequest { parent = MEASUREMENT_CONSUMERS.values.first().name }
 
     val exception =
       assertFailsWith(Exception::class) {
-        withMeasurementConsumerPrincipal(MEASUREMENT_CONSUMER_NAMES[0], CONFIG) {
+        withMeasurementConsumerPrincipal(MEASUREMENT_CONSUMERS.values.first().name, CONFIG) {
           runBlocking { service.listReports(request) }
         }
       }
@@ -3224,11 +3242,11 @@ class ReportsServiceTest {
       whenever(internalMeasurementsMock.setMeasurementResult(any()))
         .thenThrow(StatusRuntimeException(Status.INVALID_ARGUMENT))
 
-      val request = listReportsRequest { parent = MEASUREMENT_CONSUMER_NAMES[0] }
+      val request = listReportsRequest { parent = MEASUREMENT_CONSUMERS.values.first().name }
 
       val exception =
         assertFailsWith(Exception::class) {
-          withMeasurementConsumerPrincipal(MEASUREMENT_CONSUMER_NAMES[0], CONFIG) {
+          withMeasurementConsumerPrincipal(MEASUREMENT_CONSUMERS.values.first().name, CONFIG) {
             runBlocking { service.listReports(request) }
           }
         }
@@ -3260,11 +3278,11 @@ class ReportsServiceTest {
           INTERNAL_PENDING_REACH_REPORT.copy { state = InternalReport.State.FAILED },
         )
 
-      val request = listReportsRequest { parent = MEASUREMENT_CONSUMER_NAMES[0] }
+      val request = listReportsRequest { parent = MEASUREMENT_CONSUMERS.values.first().name }
 
       val exception =
         assertFailsWith(Exception::class) {
-          withMeasurementConsumerPrincipal(MEASUREMENT_CONSUMER_NAMES[0], CONFIG) {
+          withMeasurementConsumerPrincipal(MEASUREMENT_CONSUMERS.values.first().name, CONFIG) {
             runBlocking { service.listReports(request) }
           }
         }
@@ -3278,17 +3296,16 @@ class ReportsServiceTest {
     whenever(certificateMock.getCertificate(any()))
       .thenThrow(StatusRuntimeException(Status.INVALID_ARGUMENT))
 
-    val request = listReportsRequest { parent = MEASUREMENT_CONSUMER_NAMES[0] }
+    val request = listReportsRequest { parent = MEASUREMENT_CONSUMERS.values.first().name }
 
     val exception =
       assertFailsWith(Exception::class) {
-        withMeasurementConsumerPrincipal(MEASUREMENT_CONSUMER_NAMES[0], CONFIG) {
+        withMeasurementConsumerPrincipal(MEASUREMENT_CONSUMERS.values.first().name, CONFIG) {
           runBlocking { service.listReports(request) }
         }
       }
-    val expectedExceptionDescription =
-      "Unable to retrieve the certificate [${DATA_PROVIDER_CERTIFICATE_NAMES[0]}]."
-    assertThat(exception.message).isEqualTo(expectedExceptionDescription)
+
+    assertThat(exception).hasMessageThat().contains(AGGREGATOR_CERTIFICATE.name)
   }
 
   @Test
@@ -3303,10 +3320,10 @@ class ReportsServiceTest {
         )
       )
 
-    val request = listReportsRequest { parent = MEASUREMENT_CONSUMER_NAMES[0] }
+    val request = listReportsRequest { parent = MEASUREMENT_CONSUMERS.values.first().name }
 
     val result =
-      withMeasurementConsumerPrincipal(MEASUREMENT_CONSUMER_NAMES[0], CONFIG) {
+      withMeasurementConsumerPrincipal(MEASUREMENT_CONSUMERS.values.first().name, CONFIG) {
         runBlocking { service.listReports(request) }
       }
 
@@ -3322,7 +3339,8 @@ class ReportsServiceTest {
         streamReportsRequest {
           limit = DEFAULT_PAGE_SIZE + 1
           this.filter = filter {
-            measurementConsumerReferenceId = MEASUREMENT_CONSUMER_REFERENCE_IDS[0]
+            measurementConsumerReferenceId =
+              MEASUREMENT_CONSUMERS.keys.first().measurementConsumerId
           }
         }
       )
@@ -3342,10 +3360,10 @@ class ReportsServiceTest {
         )
       )
 
-    val request = listReportsRequest { parent = MEASUREMENT_CONSUMER_NAMES[0] }
+    val request = listReportsRequest { parent = MEASUREMENT_CONSUMERS.values.first().name }
 
     val result =
-      withMeasurementConsumerPrincipal(MEASUREMENT_CONSUMER_NAMES[0], CONFIG) {
+      withMeasurementConsumerPrincipal(MEASUREMENT_CONSUMERS.values.first().name, CONFIG) {
         runBlocking { service.listReports(request) }
       }
 
@@ -3361,7 +3379,8 @@ class ReportsServiceTest {
         streamReportsRequest {
           limit = DEFAULT_PAGE_SIZE + 1
           this.filter = filter {
-            measurementConsumerReferenceId = MEASUREMENT_CONSUMER_REFERENCE_IDS[0]
+            measurementConsumerReferenceId =
+              MEASUREMENT_CONSUMERS.keys.first().measurementConsumerId
           }
         }
       )
@@ -3383,10 +3402,10 @@ class ReportsServiceTest {
         )
       whenever(internalReportsMock.getReport(any())).thenReturn(INTERNAL_PENDING_REACH_REPORT)
 
-      val request = listReportsRequest { parent = MEASUREMENT_CONSUMER_NAMES[0] }
+      val request = listReportsRequest { parent = MEASUREMENT_CONSUMERS.values.first().name }
 
       val result =
-        withMeasurementConsumerPrincipal(MEASUREMENT_CONSUMER_NAMES[0], CONFIG) {
+        withMeasurementConsumerPrincipal(MEASUREMENT_CONSUMERS.values.first().name, CONFIG) {
           runBlocking { service.listReports(request) }
         }
 
@@ -3397,7 +3416,8 @@ class ReportsServiceTest {
           streamReportsRequest {
             limit = DEFAULT_PAGE_SIZE + 1
             this.filter = filter {
-              measurementConsumerReferenceId = MEASUREMENT_CONSUMER_REFERENCE_IDS[0]
+              measurementConsumerReferenceId =
+                MEASUREMENT_CONSUMERS.keys.first().measurementConsumerId
             }
           }
         )
@@ -3406,7 +3426,8 @@ class ReportsServiceTest {
       verifyProtoArgument(internalReportsMock, ReportsCoroutineImplBase::getReport)
         .isEqualTo(
           getInternalReportRequest {
-            measurementConsumerReferenceId = MEASUREMENT_CONSUMER_REFERENCE_IDS[0]
+            measurementConsumerReferenceId =
+              MEASUREMENT_CONSUMERS.keys.first().measurementConsumerId
             externalReportId = REPORT_EXTERNAL_IDS[0]
           }
         )
@@ -3434,10 +3455,10 @@ class ReportsServiceTest {
           INTERNAL_PENDING_REACH_REPORT.copy { state = InternalReport.State.FAILED },
         )
 
-      val request = listReportsRequest { parent = MEASUREMENT_CONSUMER_NAMES[0] }
+      val request = listReportsRequest { parent = MEASUREMENT_CONSUMERS.values.first().name }
 
       val result =
-        withMeasurementConsumerPrincipal(MEASUREMENT_CONSUMER_NAMES[0], CONFIG) {
+        withMeasurementConsumerPrincipal(MEASUREMENT_CONSUMERS.values.first().name, CONFIG) {
           runBlocking { service.listReports(request) }
         }
 
@@ -3450,7 +3471,8 @@ class ReportsServiceTest {
           streamReportsRequest {
             limit = DEFAULT_PAGE_SIZE + 1
             this.filter = filter {
-              measurementConsumerReferenceId = MEASUREMENT_CONSUMER_REFERENCE_IDS[0]
+              measurementConsumerReferenceId =
+                MEASUREMENT_CONSUMERS.keys.first().measurementConsumerId
             }
           }
         )
@@ -3462,7 +3484,8 @@ class ReportsServiceTest {
         )
         .isEqualTo(
           setMeasurementFailureRequest {
-            measurementConsumerReferenceId = MEASUREMENT_CONSUMER_REFERENCE_IDS[0]
+            measurementConsumerReferenceId =
+              MEASUREMENT_CONSUMERS.keys.first().measurementConsumerId
             measurementReferenceId = REACH_MEASUREMENT_REFERENCE_ID
             failure =
               InternalMeasurementKt.failure {
@@ -3474,7 +3497,8 @@ class ReportsServiceTest {
       verifyProtoArgument(internalReportsMock, ReportsCoroutineImplBase::getReport)
         .isEqualTo(
           getInternalReportRequest {
-            measurementConsumerReferenceId = MEASUREMENT_CONSUMER_REFERENCE_IDS[0]
+            measurementConsumerReferenceId =
+              MEASUREMENT_CONSUMERS.keys.first().measurementConsumerId
             externalReportId = REPORT_EXTERNAL_IDS[0]
           }
         )
@@ -3490,10 +3514,10 @@ class ReportsServiceTest {
       whenever(measurementsMock.getMeasurement(any())).thenReturn(SUCCEEDED_REACH_MEASUREMENT)
       whenever(internalReportsMock.getReport(any())).thenReturn(INTERNAL_SUCCEEDED_REACH_REPORT)
 
-      val request = listReportsRequest { parent = MEASUREMENT_CONSUMER_NAMES[0] }
+      val request = listReportsRequest { parent = MEASUREMENT_CONSUMERS.values.first().name }
 
       val result =
-        withMeasurementConsumerPrincipal(MEASUREMENT_CONSUMER_NAMES[0], CONFIG) {
+        withMeasurementConsumerPrincipal(MEASUREMENT_CONSUMERS.values.first().name, CONFIG) {
           runBlocking { service.listReports(request) }
         }
 
@@ -3504,7 +3528,8 @@ class ReportsServiceTest {
           streamReportsRequest {
             limit = DEFAULT_PAGE_SIZE + 1
             this.filter = filter {
-              measurementConsumerReferenceId = MEASUREMENT_CONSUMER_REFERENCE_IDS[0]
+              measurementConsumerReferenceId =
+                MEASUREMENT_CONSUMERS.keys.first().measurementConsumerId
             }
           }
         )
@@ -3517,7 +3542,8 @@ class ReportsServiceTest {
         .usingDoubleTolerance(1e-12)
         .isEqualTo(
           setMeasurementResultRequest {
-            measurementConsumerReferenceId = MEASUREMENT_CONSUMER_REFERENCE_IDS[0]
+            measurementConsumerReferenceId =
+              MEASUREMENT_CONSUMERS.keys.first().measurementConsumerId
             measurementReferenceId = REACH_MEASUREMENT_REFERENCE_ID
             this.result =
               InternalMeasurementKt.result {
@@ -3532,7 +3558,8 @@ class ReportsServiceTest {
       verifyProtoArgument(internalReportsMock, ReportsCoroutineImplBase::getReport)
         .isEqualTo(
           getInternalReportRequest {
-            measurementConsumerReferenceId = MEASUREMENT_CONSUMER_REFERENCE_IDS[0]
+            measurementConsumerReferenceId =
+              MEASUREMENT_CONSUMERS.keys.first().measurementConsumerId
             externalReportId = REPORT_EXTERNAL_IDS[0]
           }
         )
@@ -3547,10 +3574,10 @@ class ReportsServiceTest {
     whenever(measurementsMock.getMeasurement(any())).thenReturn(SUCCEEDED_IMPRESSION_MEASUREMENT)
     whenever(internalReportsMock.getReport(any())).thenReturn(INTERNAL_SUCCEEDED_IMPRESSION_REPORT)
 
-    val request = listReportsRequest { parent = MEASUREMENT_CONSUMER_NAMES[0] }
+    val request = listReportsRequest { parent = MEASUREMENT_CONSUMERS.values.first().name }
 
     val result =
-      withMeasurementConsumerPrincipal(MEASUREMENT_CONSUMER_NAMES[0], CONFIG) {
+      withMeasurementConsumerPrincipal(MEASUREMENT_CONSUMERS.values.first().name, CONFIG) {
         runBlocking { service.listReports(request) }
       }
 
@@ -3561,7 +3588,8 @@ class ReportsServiceTest {
         streamReportsRequest {
           limit = DEFAULT_PAGE_SIZE + 1
           this.filter = filter {
-            measurementConsumerReferenceId = MEASUREMENT_CONSUMER_REFERENCE_IDS[0]
+            measurementConsumerReferenceId =
+              MEASUREMENT_CONSUMERS.keys.first().measurementConsumerId
           }
         }
       )
@@ -3573,7 +3601,7 @@ class ReportsServiceTest {
       )
       .isEqualTo(
         setMeasurementResultRequest {
-          measurementConsumerReferenceId = MEASUREMENT_CONSUMER_REFERENCE_IDS[0]
+          measurementConsumerReferenceId = MEASUREMENT_CONSUMERS.keys.first().measurementConsumerId
           measurementReferenceId = IMPRESSION_MEASUREMENT_REFERENCE_ID
           this.result =
             InternalMeasurementKt.result {
@@ -3584,7 +3612,7 @@ class ReportsServiceTest {
     verifyProtoArgument(internalReportsMock, ReportsCoroutineImplBase::getReport)
       .isEqualTo(
         getInternalReportRequest {
-          measurementConsumerReferenceId = MEASUREMENT_CONSUMER_REFERENCE_IDS[0]
+          measurementConsumerReferenceId = MEASUREMENT_CONSUMERS.keys.first().measurementConsumerId
           externalReportId = REPORT_EXTERNAL_IDS[1]
         }
       )
@@ -3601,10 +3629,10 @@ class ReportsServiceTest {
     whenever(internalReportsMock.getReport(any()))
       .thenReturn(INTERNAL_SUCCEEDED_WATCH_DURATION_REPORT)
 
-    val request = listReportsRequest { parent = MEASUREMENT_CONSUMER_NAMES[0] }
+    val request = listReportsRequest { parent = MEASUREMENT_CONSUMERS.values.first().name }
 
     val result =
-      withMeasurementConsumerPrincipal(MEASUREMENT_CONSUMER_NAMES[0], CONFIG) {
+      withMeasurementConsumerPrincipal(MEASUREMENT_CONSUMERS.values.first().name, CONFIG) {
         runBlocking { service.listReports(request) }
       }
 
@@ -3615,7 +3643,8 @@ class ReportsServiceTest {
         streamReportsRequest {
           limit = DEFAULT_PAGE_SIZE + 1
           this.filter = filter {
-            measurementConsumerReferenceId = MEASUREMENT_CONSUMER_REFERENCE_IDS[0]
+            measurementConsumerReferenceId =
+              MEASUREMENT_CONSUMERS.keys.first().measurementConsumerId
           }
         }
       )
@@ -3627,7 +3656,7 @@ class ReportsServiceTest {
       )
       .isEqualTo(
         setMeasurementResultRequest {
-          measurementConsumerReferenceId = MEASUREMENT_CONSUMER_REFERENCE_IDS[0]
+          measurementConsumerReferenceId = MEASUREMENT_CONSUMERS.keys.first().measurementConsumerId
           measurementReferenceId = WATCH_DURATION_MEASUREMENT_REFERENCE_ID
           this.result =
             InternalMeasurementKt.result {
@@ -3639,7 +3668,7 @@ class ReportsServiceTest {
     verifyProtoArgument(internalReportsMock, ReportsCoroutineImplBase::getReport)
       .isEqualTo(
         getInternalReportRequest {
-          measurementConsumerReferenceId = MEASUREMENT_CONSUMER_REFERENCE_IDS[0]
+          measurementConsumerReferenceId = MEASUREMENT_CONSUMERS.keys.first().measurementConsumerId
           externalReportId = REPORT_EXTERNAL_IDS[2]
         }
       )
@@ -3656,7 +3685,7 @@ class ReportsServiceTest {
       val request = getReportRequest { name = REPORT_NAMES[2] }
 
       val report =
-        withMeasurementConsumerPrincipal(MEASUREMENT_CONSUMER_NAMES[0], CONFIG) {
+        withMeasurementConsumerPrincipal(MEASUREMENT_CONSUMERS.values.first().name, CONFIG) {
           runBlocking { service.getReport(request) }
         }
 
@@ -3665,7 +3694,8 @@ class ReportsServiceTest {
       verifyProtoArgument(internalReportsMock, ReportsCoroutineImplBase::getReport)
         .isEqualTo(
           getInternalReportRequest {
-            measurementConsumerReferenceId = MEASUREMENT_CONSUMER_REFERENCE_IDS[0]
+            measurementConsumerReferenceId =
+              MEASUREMENT_CONSUMERS.keys.first().measurementConsumerId
             externalReportId = REPORT_EXTERNAL_IDS[2]
           }
         )
@@ -3681,7 +3711,7 @@ class ReportsServiceTest {
     val request = getReportRequest { name = REPORT_NAMES[2] }
 
     val report =
-      withMeasurementConsumerPrincipal(MEASUREMENT_CONSUMER_NAMES[0], CONFIG) {
+      withMeasurementConsumerPrincipal(MEASUREMENT_CONSUMERS.values.first().name, CONFIG) {
         runBlocking { service.getReport(request) }
       }
 
@@ -3690,7 +3720,7 @@ class ReportsServiceTest {
     verifyProtoArgument(internalReportsMock, ReportsCoroutineImplBase::getReport)
       .isEqualTo(
         getInternalReportRequest {
-          measurementConsumerReferenceId = MEASUREMENT_CONSUMER_REFERENCE_IDS[0]
+          measurementConsumerReferenceId = MEASUREMENT_CONSUMERS.keys.first().measurementConsumerId
           externalReportId = REPORT_EXTERNAL_IDS[2]
         }
       )
@@ -3707,7 +3737,7 @@ class ReportsServiceTest {
       val request = getReportRequest { name = REPORT_NAMES[2] }
 
       val report =
-        withMeasurementConsumerPrincipal(MEASUREMENT_CONSUMER_NAMES[0], CONFIG) {
+        withMeasurementConsumerPrincipal(MEASUREMENT_CONSUMERS.values.first().name, CONFIG) {
           runBlocking { service.getReport(request) }
         }
 
@@ -3722,11 +3752,13 @@ class ReportsServiceTest {
       assertThat(internalReportCaptor.allValues)
         .containsExactly(
           getInternalReportRequest {
-            measurementConsumerReferenceId = MEASUREMENT_CONSUMER_REFERENCE_IDS[0]
+            measurementConsumerReferenceId =
+              MEASUREMENT_CONSUMERS.keys.first().measurementConsumerId
             externalReportId = REPORT_EXTERNAL_IDS[2]
           },
           getInternalReportRequest {
-            measurementConsumerReferenceId = MEASUREMENT_CONSUMER_REFERENCE_IDS[0]
+            measurementConsumerReferenceId =
+              MEASUREMENT_CONSUMERS.keys.first().measurementConsumerId
             externalReportId = REPORT_EXTERNAL_IDS[2]
           }
         )
@@ -3742,7 +3774,7 @@ class ReportsServiceTest {
       val request = getReportRequest { name = REPORT_NAMES[1] }
 
       val report =
-        withMeasurementConsumerPrincipal(MEASUREMENT_CONSUMER_NAMES[0], CONFIG) {
+        withMeasurementConsumerPrincipal(MEASUREMENT_CONSUMERS.values.first().name, CONFIG) {
           runBlocking { service.getReport(request) }
         }
 
@@ -3756,7 +3788,8 @@ class ReportsServiceTest {
         )
         .isEqualTo(
           setMeasurementResultRequest {
-            measurementConsumerReferenceId = MEASUREMENT_CONSUMER_REFERENCE_IDS[0]
+            measurementConsumerReferenceId =
+              MEASUREMENT_CONSUMERS.keys.first().measurementConsumerId
             measurementReferenceId = IMPRESSION_MEASUREMENT_REFERENCE_ID
             this.result =
               InternalMeasurementKt.result {
@@ -3771,11 +3804,13 @@ class ReportsServiceTest {
       assertThat(internalReportCaptor.allValues)
         .containsExactly(
           getInternalReportRequest {
-            measurementConsumerReferenceId = MEASUREMENT_CONSUMER_REFERENCE_IDS[0]
+            measurementConsumerReferenceId =
+              MEASUREMENT_CONSUMERS.keys.first().measurementConsumerId
             externalReportId = REPORT_EXTERNAL_IDS[1]
           },
           getInternalReportRequest {
-            measurementConsumerReferenceId = MEASUREMENT_CONSUMER_REFERENCE_IDS[0]
+            measurementConsumerReferenceId =
+              MEASUREMENT_CONSUMERS.keys.first().measurementConsumerId
             externalReportId = REPORT_EXTERNAL_IDS[1]
           }
         )
@@ -3803,7 +3838,7 @@ class ReportsServiceTest {
       val request = getReportRequest { name = REPORT_NAMES[1] }
 
       val report =
-        withMeasurementConsumerPrincipal(MEASUREMENT_CONSUMER_NAMES[0], CONFIG) {
+        withMeasurementConsumerPrincipal(MEASUREMENT_CONSUMERS.values.first().name, CONFIG) {
           runBlocking { service.getReport(request) }
         }
 
@@ -3817,7 +3852,8 @@ class ReportsServiceTest {
         )
         .isEqualTo(
           setMeasurementFailureRequest {
-            measurementConsumerReferenceId = MEASUREMENT_CONSUMER_REFERENCE_IDS[0]
+            measurementConsumerReferenceId =
+              MEASUREMENT_CONSUMERS.keys.first().measurementConsumerId
             measurementReferenceId = IMPRESSION_MEASUREMENT_REFERENCE_ID
             failure =
               InternalMeasurementKt.failure {
@@ -3832,11 +3868,13 @@ class ReportsServiceTest {
       assertThat(internalReportCaptor.allValues)
         .containsExactly(
           getInternalReportRequest {
-            measurementConsumerReferenceId = MEASUREMENT_CONSUMER_REFERENCE_IDS[0]
+            measurementConsumerReferenceId =
+              MEASUREMENT_CONSUMERS.keys.first().measurementConsumerId
             externalReportId = REPORT_EXTERNAL_IDS[1]
           },
           getInternalReportRequest {
-            measurementConsumerReferenceId = MEASUREMENT_CONSUMER_REFERENCE_IDS[0]
+            measurementConsumerReferenceId =
+              MEASUREMENT_CONSUMERS.keys.first().measurementConsumerId
             externalReportId = REPORT_EXTERNAL_IDS[1]
           }
         )
@@ -3848,7 +3886,7 @@ class ReportsServiceTest {
 
     val exception =
       assertFailsWith<StatusRuntimeException> {
-        withMeasurementConsumerPrincipal(MEASUREMENT_CONSUMER_NAMES[0], CONFIG) {
+        withMeasurementConsumerPrincipal(MEASUREMENT_CONSUMERS.values.first().name, CONFIG) {
           runBlocking { service.getReport(request) }
         }
       }
@@ -3862,7 +3900,7 @@ class ReportsServiceTest {
 
     val exception =
       assertFailsWith<StatusRuntimeException> {
-        withMeasurementConsumerPrincipal(MEASUREMENT_CONSUMER_NAMES[1], CONFIG) {
+        withMeasurementConsumerPrincipal(MEASUREMENT_CONSUMERS.values.last().name, CONFIG) {
           runBlocking { service.getReport(request) }
         }
       }
@@ -3876,7 +3914,7 @@ class ReportsServiceTest {
 
     val exception =
       assertFailsWith<StatusRuntimeException> {
-        withDataProviderPrincipal(DATA_PROVIDERS[0].name) {
+        withDataProviderPrincipal(DATA_PROVIDERS.values.first().name) {
           runBlocking { service.getReport(request) }
         }
       }
@@ -3894,7 +3932,7 @@ class ReportsServiceTest {
         SUCCEEDED_WATCH_DURATION_MEASUREMENT.copy {
           val measurementSpec = measurementSpec {
             measurementPublicKey =
-              MEASUREMENT_PUBLIC_KEY.copy { data = INVALID_MEASUREMENT_PUBLIC_KEY_DATA }
+              MEASUREMENT_CONSUMER_PUBLIC_KEY.copy { data = INVALID_MEASUREMENT_PUBLIC_KEY_DATA }
                 .toByteString()
           }
           this.measurementSpec =
@@ -3906,7 +3944,7 @@ class ReportsServiceTest {
 
     val exception =
       assertFailsWith<StatusRuntimeException> {
-        withMeasurementConsumerPrincipal(MEASUREMENT_CONSUMER_NAMES[0], CONFIG) {
+        withMeasurementConsumerPrincipal(MEASUREMENT_CONSUMERS.values.first().name, CONFIG) {
           runBlocking { service.getReport(request) }
         }
       }
@@ -3924,7 +3962,7 @@ class ReportsServiceTest {
 
     val exception =
       assertFailsWith(Exception::class) {
-        withMeasurementConsumerPrincipal(MEASUREMENT_CONSUMER_NAMES[0], CONFIG) {
+        withMeasurementConsumerPrincipal(MEASUREMENT_CONSUMERS.values.first().name, CONFIG) {
           runBlocking { service.getReport(request) }
         }
       }
@@ -3980,7 +4018,7 @@ class ReportsServiceTest {
     val request = getReportRequest { name = REPORT_NAMES[2] }
 
     val report =
-      withMeasurementConsumerPrincipal(MEASUREMENT_CONSUMER_NAMES[0], CONFIG) {
+      withMeasurementConsumerPrincipal(MEASUREMENT_CONSUMERS.values.first().name, CONFIG) {
         runBlocking { service.getReport(request) }
       }
 
@@ -4016,3 +4054,18 @@ class ReportsServiceTest {
       )
   }
 }
+
+private fun EventGroupKey.toInternal(): InternalReportingSet.EventGroupKey {
+  val source = this
+  return InternalReportingSetKt.eventGroupKey {
+    measurementConsumerReferenceId = source.measurementConsumerReferenceId
+    dataProviderReferenceId = source.dataProviderReferenceId
+    eventGroupReferenceId = source.eventGroupReferenceId
+  }
+}
+
+private val InternalReportingSet.resourceKey: ReportingSetKey
+  get() =
+    ReportingSetKey(measurementConsumerReferenceId, ExternalId(externalReportingSetId).apiId.value)
+private val InternalReportingSet.resourceName: String
+  get() = resourceKey.toName()


### PR DESCRIPTION
Correlated lists are fragile and generally should not be used. This replaces some of the usage with maps. It also uses actual certificates/signatures to make the test more accurate.

This is pre-factoring for DataProvider public key signature verification.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/world-federation-of-advertisers/cross-media-measurement/824)
<!-- Reviewable:end -->
