### PR TITLE
Fix Bazel build output not being saved to Actions cache.

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -34,7 +34,6 @@ jobs:
         uses: world-federation-of-advertisers/actions/bazel-build-test@v1
         with:
           cache-version: 1
-          cache-save-events:
           workspace-path: .
           target-patterns: |
             //...


### PR DESCRIPTION
There was a previous misconfiguration in an attempt to get the cache to save only if the correctness test passes, but the action is configured to only save when the all targets wildcard is used (`//...`).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/world-federation-of-advertisers/cross-media-measurement/826)
<!-- Reviewable:end -->
