### PR TITLE
Use consistent time source for ExchangeStepAttempt ExpirationTime.

### DIFF
--- a/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/SpannerExchangeStepsService.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/SpannerExchangeStepsService.kt
@@ -97,7 +97,8 @@ class SpannerExchangeStepsService(
 
     ExchangeStepAttemptReader.forExpiredAttempts(
         externalModelProviderId = externalModelProviderId,
-        externalDataProviderId = externalDataProviderId
+        externalDataProviderId = externalDataProviderId,
+        clock
       )
       .execute(client.singleUse())
       .map { it.exchangeStepAttempt }


### PR DESCRIPTION
This addresses flakiness in SpannerExchangeStepsServiceTest.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/world-federation-of-advertisers/cross-media-measurement/830)
<!-- Reviewable:end -->
