### PR TITLE
Create MeasurementsByContinuationToken database index.

### DIFF
--- a/src/main/resources/kingdom/spanner/changelog.yaml
+++ b/src/main/resources/kingdom/spanner/changelog.yaml
@@ -27,3 +27,6 @@ databaseChangeLog:
 - include:
     file: add-event-group-state.sql
     relativeToChangeLogFile: true
+- include:
+    file: create-measurements-by-token-index.sql
+    relativeToChangeLogFile: true

--- a/src/main/resources/kingdom/spanner/create-measurements-by-token-index.sql
+++ b/src/main/resources/kingdom/spanner/create-measurements-by-token-index.sql
@@ -1,0 +1,24 @@
+-- liquibase formatted sql
+
+-- Copyright 2023 The Cross-Media Measurement Authors
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--      http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+-- changeset sanjayvas:5 dbms:cloudspanner
+DROP INDEX MeasurementsByState;
+
+-- For querying "active" measurements after a given
+-- StreamActiveComputationsContinuationToken.
+-- changeset sanjayvas:6 dbms:cloudspanner
+CREATE INDEX MeasurementsByContinuationToken
+ON Measurements(State, UpdateTime ASC, ExternalComputationId ASC);


### PR DESCRIPTION
This replaces the unused MeasurementsByState index in order to avoid a full table scan for the StreamActiveComputations system API method.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/world-federation-of-advertisers/cross-media-measurement/844)
<!-- Reviewable:end -->

Depends on #843.
For #840.
