### PR TITLE
Add egress to OpenTelemetry collector on GKE network policies.

### DIFF
--- a/src/main/k8s/base.cue
+++ b/src/main/k8s/base.cue
@@ -568,7 +568,7 @@ objects: [ for objectSet in objectSets for object in objectSet {object}]
 	}
 	_egresses: {
 		if len(_destinationMatchLabels) > 0 {
-			pods: {
+			grpc: {
 				to: [ for appLabel in _destinationMatchLabels {
 					podSelector: matchLabels: app: appLabel
 				}]

--- a/src/main/k8s/dev/base_gke.cue
+++ b/src/main/k8s/dev/base_gke.cue
@@ -23,6 +23,12 @@ package k8s
 				port:     988
 			}]
 		}
+		openTelemetryCollector: {
+			to: [{podSelector: matchLabels: app: "opentelemetry-collector-app"}]
+			ports: [{
+				port: #OpenTelemetryReceiverPort
+			}]
+		}
 	}
 
 	_ingresses: {

--- a/src/main/k8s/kingdom.cue
+++ b/src/main/k8s/kingdom.cue
@@ -166,10 +166,7 @@ package k8s
 		}
 		"system-api-server": {
 			_app_label: "system-api-server-app"
-			_destinationMatchLabels: [
-				"gcp-kingdom-data-server-app",
-				"opentelemetry-collector-app",
-			]
+			_destinationMatchLabels: ["gcp-kingdom-data-server-app"]
 			_ingresses: {
 				// External API server; allow ingress from anywhere to service port.
 				gRpc: {


### PR DESCRIPTION
This fixes metrics only being collected for pods with permissive egress rules.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/world-federation-of-advertisers/cross-media-measurement/849)
<!-- Reviewable:end -->
