### PR TITLE
Refuse requisition from EDP simulator when filter is invalid.

### DIFF
--- a/src/main/kotlin/org/wfanet/measurement/eventdataprovider/eventfiltration/validation/EventFilterValidationException.kt
+++ b/src/main/kotlin/org/wfanet/measurement/eventdataprovider/eventfiltration/validation/EventFilterValidationException.kt
@@ -16,23 +16,16 @@ package org.wfanet.measurement.eventdataprovider.eventfiltration.validation
 
 class EventFilterValidationException(val code: Code, message: String) : Exception(message) {
 
-  enum class Code {
-    /** An expression that cannot be interpreted as a valid CEL due to syntax or typing. */
-    INVALID_CEL_EXPRESSION,
-
-    /** Expression uses a CEL operation that currently is not supported for Halo. */
-    UNSUPPORTED_OPERATION,
-
-    /** A CEL value has a type that is invalid for Halo. */
-    INVALID_VALUE_TYPE,
-
-    /** Field comparison is not done within a leaf node. */
-    FIELD_COMPARISON_OUTSIDE_LEAF,
-
-    /** The expression is a single value, not a condition. */
-    EXPRESSION_IS_NOT_CONDITIONAL,
-
-    /** Leaf-only operator used outside leaf. */
-    INVALID_OPERATION_OUTSIDE_LEAF,
+  enum class Code(val description: String) {
+    INVALID_CEL_EXPRESSION(
+      "An expression that cannot be interpreted as a valid CEL due to syntax or typing."
+    ),
+    UNSUPPORTED_OPERATION(
+      "Expression uses a CEL operation that currently is not supported for Halo."
+    ),
+    INVALID_VALUE_TYPE("A CEL value has a type that is invalid for Halo."),
+    FIELD_COMPARISON_OUTSIDE_LEAF("Field comparison is not done within a leaf node."),
+    EXPRESSION_IS_NOT_CONDITIONAL("The expression is a single value, not a condition."),
+    INVALID_OPERATION_OUTSIDE_LEAF("Leaf-only operator used outside leaf."),
   }
 }

--- a/src/main/kotlin/org/wfanet/measurement/loadtest/dataprovider/EdpSimulator.kt
+++ b/src/main/kotlin/org/wfanet/measurement/loadtest/dataprovider/EdpSimulator.kt
@@ -599,9 +599,14 @@ class EdpSimulator(
       try {
         generateSketch(requisition.name, sketchConfig, measurementSpec, requisitionSpec)
       } catch (e: EventFilterValidationException) {
+        refuseRequisition(
+          requisition.name,
+          Requisition.Refusal.Justification.SPECIFICATION_INVALID,
+          "Invalid event filter (${e.code}): ${e.code.description}"
+        )
         logger.log(
           Level.WARNING,
-          "RequisitionFulfillmentWorkflow failed due to: invalid EventFilter",
+          "RequisitionFulfillmentWorkflow failed due to invalid event filter",
           e
         )
         return


### PR DESCRIPTION
The requisition was being logged as refused, but not actually refused.