### PR TITLE
Load DuchyCertConfig in public API server.

### DIFF
--- a/src/main/k8s/kingdom.cue
+++ b/src/main/k8s/kingdom.cue
@@ -126,6 +126,7 @@ package k8s
 					_internal_api_cert_host_flag,
 					_akid_to_principal_map_file_flag,
 					_open_id_redirect_uri_flag,
+					_duchy_info_config_flag,
 				] + Container._commonServerFlags
 			}
 			spec: template: spec: {

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/common/server/V2alphaPublicApiServer.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/common/server/V2alphaPublicApiServer.kt
@@ -25,6 +25,8 @@ import org.wfanet.measurement.common.grpc.CommonServer
 import org.wfanet.measurement.common.grpc.buildMutualTlsChannel
 import org.wfanet.measurement.common.grpc.withDefaultDeadline
 import org.wfanet.measurement.common.grpc.withVerboseLogging
+import org.wfanet.measurement.common.identity.DuchyInfo
+import org.wfanet.measurement.common.identity.DuchyInfoFlags
 import org.wfanet.measurement.internal.kingdom.AccountsGrpcKt.AccountsCoroutineStub as InternalAccountsCoroutineStub
 import org.wfanet.measurement.internal.kingdom.ApiKeysGrpcKt.ApiKeysCoroutineStub as InternalApiKeysCoroutineStub
 import org.wfanet.measurement.internal.kingdom.CertificatesGrpcKt.CertificatesCoroutineStub as InternalCertificatesCoroutineStub
@@ -67,9 +69,11 @@ private fun run(
   @CommandLine.Mixin kingdomApiServerFlags: KingdomApiServerFlags,
   @CommandLine.Mixin commonServerFlags: CommonServer.Flags,
   @CommandLine.Mixin llv2ProtocolConfigFlags: Llv2ProtocolConfigFlags,
-  @CommandLine.Mixin v2alphaFlags: V2alphaFlags
+  @CommandLine.Mixin v2alphaFlags: V2alphaFlags,
+  @CommandLine.Mixin duchyInfoFlags: DuchyInfoFlags,
 ) {
   Llv2ProtocolConfig.initializeFromFlags(llv2ProtocolConfigFlags)
+  DuchyInfo.initializeFromFlags(duchyInfoFlags)
 
   val clientCerts =
     SigningCerts.fromPemFiles(


### PR DESCRIPTION
The Certificates service needs to be callable using Duchy credentials. The auth checks are already in place, but the configuration file was not loaded.

Fixes #855