### PR TITLE
Force MeasurementsByContinuationToken index for COMPUTATION view.

### DIFF
--- a/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/readers/MeasurementReader.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/readers/MeasurementReader.kt
@@ -241,7 +241,7 @@ class MeasurementReader(private val view: Measurement.View) :
           AND Measurements.MeasurementId = DuchyMeasurementResults.MeasurementId
       ) AS DuchyResults
     FROM
-      Measurements
+      Measurements@{FORCE_INDEX=MeasurementsByContinuationToken}
       JOIN MeasurementConsumers USING (MeasurementConsumerId)
       JOIN MeasurementConsumerCertificates USING(MeasurementConsumerId, CertificateId)
     """


### PR DESCRIPTION
From observations on QA, Spanner does not pick up this index automatically. Use of this index drops rows scanned for a StreamActiveComputations call from 1,919 to 217.