### PR TITLE
Define internal Measurements Service api retention methods

### DIFF
--- a/src/main/proto/wfa/measurement/internal/kingdom/measurements_service.proto
+++ b/src/main/proto/wfa/measurement/internal/kingdom/measurements_service.proto
@@ -49,7 +49,7 @@ service Measurements {
       returns (CancelPendingMeasurementsResponse);
 
   // Permanently deletes Measurements based on update_time for states:
-  // SUCCEEDED, FAILED, CANCELLED, and STATE_UNSPECIFIED.
+  // SUCCEEDED, FAILED, and CANCELLED.
   rpc DeleteCompletedMeasurements(DeleteCompletedMeasurementsRequest)
       returns (DeleteCompletedMeasurementsResponse);
 }
@@ -121,9 +121,9 @@ message DeleteCompletedMeasurementsRequest {
 }
 
 message CancelPendingMeasurementsResponse {
-  repeated Measurement measurements = 1;
+  repeated fixed64 external_measurement_ids = 1;
 }
 
 message DeleteCompletedMeasurementsResponse {
-  repeated Measurement measurements = 1;
+  repeated fixed64 external_measurement_ids = 1;
 }

--- a/src/main/proto/wfa/measurement/internal/kingdom/measurements_service.proto
+++ b/src/main/proto/wfa/measurement/internal/kingdom/measurements_service.proto
@@ -50,8 +50,8 @@ service Measurements {
 
   // Permanently deletes a limited amount of Measurements based on update_time
   // for states: SUCCEEDED, FAILED, and CANCELLED.
-  rpc DeleteCompletedMeasurements(DeleteCompletedMeasurementsRequest)
-      returns (DeleteCompletedMeasurementsResponse);
+  rpc PurgeCompletedMeasurements(PurgeCompletedMeasurementsRequest)
+      returns (PurgeCompletedMeasurementsResponse);
 }
 
 message GetMeasurementRequest {
@@ -112,12 +112,20 @@ message CancelMeasurementRequest {
 
 message CancelPendingMeasurementsRequest {
   google.protobuf.Timestamp created_before = 1;
-  bool dry_run = 2;
+
+  // Execute the state transitions to CANCELLED. If `force` is set to false,
+  // the method will return a sample of measurement keys that would be cancelled
+  // without transitioning their states.
+  bool force = 2;
 }
 
-message DeleteCompletedMeasurementsRequest {
+message PurgeCompletedMeasurementsRequest {
   google.protobuf.Timestamp updated_before = 1;
-  bool dry_run = 2;
+
+  // Execute the deletion. If `force` is set to false, the method will return
+  // a sample of measurement keys that would be deleted without executing
+  // deletions.
+  bool force = 2;
 }
 
 message CancelPendingMeasurementsResponse {
@@ -128,10 +136,14 @@ message CancelPendingMeasurementsResponse {
   repeated MeasurementKey measurement_keys = 1;
 }
 
-message DeleteCompletedMeasurementsResponse {
+message PurgeCompletedMeasurementsResponse {
+  int32 purge_count = 1;
+
   message MeasurementKey {
     fixed64 external_measurement_consumer_id = 1;
     fixed64 external_measurement_id = 2;
   }
-  repeated MeasurementKey measurement_keys = 1;
+  // A sample of measurement keys that would be deleted. The sample size is at
+  // maximum 100 measurement keys. Only populated if `force` is false.
+  repeated MeasurementKey purge_sample = 2;
 }

--- a/src/main/proto/wfa/measurement/internal/kingdom/measurements_service.proto
+++ b/src/main/proto/wfa/measurement/internal/kingdom/measurements_service.proto
@@ -128,21 +128,18 @@ message PurgeCompletedMeasurementsRequest {
   bool force = 2;
 }
 
+message MeasurementKey {
+  fixed64 external_measurement_consumer_id = 1;
+  fixed64 external_measurement_id = 2;
+}
+
 message CancelPendingMeasurementsResponse {
-  message MeasurementKey {
-    fixed64 external_measurement_consumer_id = 1;
-    fixed64 external_measurement_id = 2;
-  }
   repeated MeasurementKey measurement_keys = 1;
 }
 
 message PurgeCompletedMeasurementsResponse {
   int32 purge_count = 1;
 
-  message MeasurementKey {
-    fixed64 external_measurement_consumer_id = 1;
-    fixed64 external_measurement_id = 2;
-  }
   // A sample of measurement keys that would be deleted. The sample size is at
   // maximum 100 measurement keys. Only populated if `force` is false.
   repeated MeasurementKey purge_sample = 2;

--- a/src/main/proto/wfa/measurement/internal/kingdom/measurements_service.proto
+++ b/src/main/proto/wfa/measurement/internal/kingdom/measurements_service.proto
@@ -43,13 +43,13 @@ service Measurements {
   // Marks a Measurement as CANCELLED by transitioning its state.
   rpc CancelMeasurement(CancelMeasurementRequest) returns (Measurement);
 
-  // Marks Measurements as CANCELLED by transitioning their states based on
-  // create_time for states beginning with 'PENDING'.
+  // Marks a limited amount of Measurements as CANCELLED by transitioning their
+  // states based on create_time for states beginning with 'PENDING'.
   rpc CancelPendingMeasurements(CancelPendingMeasurementsRequest)
       returns (CancelPendingMeasurementsResponse);
 
-  // Permanently deletes Measurements based on update_time for states:
-  // SUCCEEDED, FAILED, and CANCELLED.
+  // Permanently deletes a limited amount of Measurements based on update_time
+  // for states: SUCCEEDED, FAILED, and CANCELLED.
   rpc DeleteCompletedMeasurements(DeleteCompletedMeasurementsRequest)
       returns (DeleteCompletedMeasurementsResponse);
 }
@@ -121,9 +121,17 @@ message DeleteCompletedMeasurementsRequest {
 }
 
 message CancelPendingMeasurementsResponse {
-  repeated fixed64 external_measurement_ids = 1;
+  message MeasurementKey {
+    fixed64 external_measurement_consumer_id = 1;
+    fixed64 external_measurement_id = 2;
+  }
+  repeated MeasurementKey measurement_keys = 1;
 }
 
 message DeleteCompletedMeasurementsResponse {
-  repeated fixed64 external_measurement_ids = 1;
+  message MeasurementKey {
+    fixed64 external_measurement_consumer_id = 1;
+    fixed64 external_measurement_id = 2;
+  }
+  repeated MeasurementKey measurement_keys = 1;
 }

--- a/src/main/proto/wfa/measurement/internal/kingdom/measurements_service.proto
+++ b/src/main/proto/wfa/measurement/internal/kingdom/measurements_service.proto
@@ -42,6 +42,16 @@ service Measurements {
 
   // Marks a Measurement as CANCELLED by transitioning its state.
   rpc CancelMeasurement(CancelMeasurementRequest) returns (Measurement);
+
+  // Marks Measurements as CANCELLED by transitioning their states based on
+  // create_time for states beginning with 'PENDING'.
+  rpc CancelPendingMeasurements(CancelPendingMeasurementsRequest)
+      returns (CancelPendingMeasurementsResponse);
+
+  // Permanently deletes Measurements based on update_time for states:
+  // SUCCEEDED, FAILED, CANCELLED, and STATE_UNSPECIFIED.
+  rpc DeleteCompletedMeasurements(DeleteCompletedMeasurementsRequest)
+      returns (DeleteCompletedMeasurementsResponse);
 }
 
 message GetMeasurementRequest {
@@ -98,4 +108,22 @@ message SetMeasurementResultRequest {
 message CancelMeasurementRequest {
   fixed64 external_measurement_consumer_id = 1;
   fixed64 external_measurement_id = 2;
+}
+
+message CancelPendingMeasurementsRequest {
+  google.protobuf.Timestamp created_before = 1;
+  bool dry_run = 2;
+}
+
+message DeleteCompletedMeasurementsRequest {
+  google.protobuf.Timestamp updated_before = 1;
+  bool dry_run = 2;
+}
+
+message CancelPendingMeasurementsResponse {
+  repeated Measurement measurements = 1;
+}
+
+message DeleteCompletedMeasurementsResponse {
+  repeated Measurement measurements = 1;
 }


### PR DESCRIPTION
deletion of completed measurements and cancellation of pending measurements