### PR TITLE
Marcopremier add logic to include required duchies

### DIFF
--- a/src/main/k8s/testing/secretfiles/llv2_protocol_config_config.textproto
+++ b/src/main/k8s/testing/secretfiles/llv2_protocol_config_config.textproto
@@ -12,6 +12,7 @@ protocol_config {
   }
   elliptic_curve_id: 415
   maximum_frequency: 10
+  required_external_duchy_ids: "aggregator"
 }
 duchy_protocol_config {
   mpc_noise {

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/SpannerMeasurementsService.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/SpannerMeasurementsService.kt
@@ -34,6 +34,7 @@ import org.wfanet.measurement.kingdom.deploy.gcloud.spanner.common.CertificateNo
 import org.wfanet.measurement.kingdom.deploy.gcloud.spanner.common.DataProviderNotFoundException
 import org.wfanet.measurement.kingdom.deploy.gcloud.spanner.common.DuchyCertificateNotFoundException
 import org.wfanet.measurement.kingdom.deploy.gcloud.spanner.common.DuchyNotFoundException
+import org.wfanet.measurement.kingdom.deploy.gcloud.spanner.common.InsufficientNumberOfActiveDuchiesException
 import org.wfanet.measurement.kingdom.deploy.gcloud.spanner.common.KingdomInternalException
 import org.wfanet.measurement.kingdom.deploy.gcloud.spanner.common.MeasurementConsumerNotFoundException
 import org.wfanet.measurement.kingdom.deploy.gcloud.spanner.common.MeasurementNotFoundException
@@ -66,6 +67,8 @@ class SpannerMeasurementsService(
       e.throwStatusRuntimeException(Status.FAILED_PRECONDITION) { "Certificate not found." }
     } catch (e: RequiredDuchiesNotActiveException) {
       e.throwStatusRuntimeException(Status.FAILED_PRECONDITION) { "Inactive required duchy." }
+    } catch (e: InsufficientNumberOfActiveDuchiesException) {
+      e.throwStatusRuntimeException(Status.FAILED_PRECONDITION) { "Insufficient number of active duchies." }
     } catch (e: KingdomInternalException) {
       e.throwStatusRuntimeException(Status.INTERNAL) { "Unexpected internal error." }
     }

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/SpannerMeasurementsService.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/SpannerMeasurementsService.kt
@@ -64,6 +64,7 @@ class SpannerMeasurementsService(
     } catch (e: CertificateNotFoundException) {
       e.throwStatusRuntimeException(Status.FAILED_PRECONDITION) { "Certificate not found." }
     } catch (e: KingdomInternalException) {
+      println(e.message)
       e.throwStatusRuntimeException(Status.INTERNAL) { "Unexpected internal error." }
     }
   }

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/SpannerMeasurementsService.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/SpannerMeasurementsService.kt
@@ -38,6 +38,7 @@ import org.wfanet.measurement.kingdom.deploy.gcloud.spanner.common.KingdomIntern
 import org.wfanet.measurement.kingdom.deploy.gcloud.spanner.common.MeasurementConsumerNotFoundException
 import org.wfanet.measurement.kingdom.deploy.gcloud.spanner.common.MeasurementNotFoundException
 import org.wfanet.measurement.kingdom.deploy.gcloud.spanner.common.MeasurementStateIllegalException
+import org.wfanet.measurement.kingdom.deploy.gcloud.spanner.common.RequiredDuchiesNotActiveException
 import org.wfanet.measurement.kingdom.deploy.gcloud.spanner.queries.StreamMeasurements
 import org.wfanet.measurement.kingdom.deploy.gcloud.spanner.readers.MeasurementReader
 import org.wfanet.measurement.kingdom.deploy.gcloud.spanner.writers.CancelMeasurement
@@ -63,8 +64,9 @@ class SpannerMeasurementsService(
       e.throwStatusRuntimeException(Status.FAILED_PRECONDITION) { "Duchy not found." }
     } catch (e: CertificateNotFoundException) {
       e.throwStatusRuntimeException(Status.FAILED_PRECONDITION) { "Certificate not found." }
+    } catch (e: RequiredDuchiesNotActiveException) {
+      e.throwStatusRuntimeException(Status.FAILED_PRECONDITION) { "Inactive required duchy." }
     } catch (e: KingdomInternalException) {
-      println(e.message)
       e.throwStatusRuntimeException(Status.INTERNAL) { "Unexpected internal error." }
     }
   }

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/common/KingdomInternalException.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/common/KingdomInternalException.kt
@@ -102,6 +102,15 @@ class RequiredDuchiesNotActiveException(
     get() = emptyMap<String, String>()
 }
 
+class InsufficientNumberOfActiveDuchiesException(
+  provideDescription: () -> String = {
+    "There are not enough active duchies to create the measurement"
+  }
+) : KingdomInternalException(ErrorCode.INSUFFICIENT_ACTIVE_DUCHIES, provideDescription) {
+  override val context
+    get() = emptyMap<String, String>()
+}
+
 open class MeasurementNotFoundException(
   provideDescription: () -> String = { "Measurement not found" }
 ) : KingdomInternalException(ErrorCode.MEASUREMENT_NOT_FOUND, provideDescription) {

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/common/KingdomInternalException.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/common/KingdomInternalException.kt
@@ -93,6 +93,15 @@ class DuchyNotFoundException(
     get() = mapOf("external_duchy_id" to externalDuchyId)
 }
 
+class RequiredDuchiesNotActiveException(
+  provideDescription: () -> String = {
+    "One or more required duchies were inactive at measurement creation time"
+  }
+) : KingdomInternalException(ErrorCode.INACTIVE_REQUIRED_DUCHIES, provideDescription) {
+  override val context
+    get() = emptyMap<String, String>()
+}
+
 open class MeasurementNotFoundException(
   provideDescription: () -> String = { "Measurement not found" }
 ) : KingdomInternalException(ErrorCode.MEASUREMENT_NOT_FOUND, provideDescription) {

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/queries/StreamDataProviders.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/queries/StreamDataProviders.kt
@@ -1,0 +1,18 @@
+package org.wfanet.measurement.kingdom.deploy.gcloud.spanner.queries
+
+import org.wfanet.measurement.gcloud.spanner.appendClause
+import org.wfanet.measurement.kingdom.deploy.gcloud.spanner.readers.DataProviderReader
+
+class StreamDataProviders(externalDataProviderIds: List<Long>) :
+  SimpleSpannerQuery<DataProviderReader.Result>() {
+  override val reader =
+    DataProviderReader().fillStatementBuilder {
+      appendClause(
+        """
+        WHERE ExternalDataProviderId in UNNEST(@externalDataProviderIds)
+      """
+          .trimIndent()
+      )
+      bind("externalDataProviderIds").toInt64Array(externalDataProviderIds)
+    }
+}

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/writers/CreateMeasurement.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/writers/CreateMeasurement.kt
@@ -22,7 +22,6 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.singleOrNull
 import org.wfanet.measurement.common.identity.ExternalId
 import org.wfanet.measurement.common.identity.InternalId
-import org.wfanet.measurement.common.toProtoTime
 import org.wfanet.measurement.gcloud.spanner.appendClause
 import org.wfanet.measurement.gcloud.spanner.bind
 import org.wfanet.measurement.gcloud.spanner.bufferInsertMutation
@@ -39,6 +38,7 @@ import org.wfanet.measurement.kingdom.deploy.common.DuchyIds
 import org.wfanet.measurement.kingdom.deploy.gcloud.spanner.common.CertificateIsInvalidException
 import org.wfanet.measurement.kingdom.deploy.gcloud.spanner.common.DataProviderCertificateNotFoundException
 import org.wfanet.measurement.kingdom.deploy.gcloud.spanner.common.DataProviderNotFoundException
+import org.wfanet.measurement.kingdom.deploy.gcloud.spanner.common.InsufficientNumberOfActiveDuchiesException
 import org.wfanet.measurement.kingdom.deploy.gcloud.spanner.common.KingdomInternalException
 import org.wfanet.measurement.kingdom.deploy.gcloud.spanner.common.MeasurementConsumerCertificateNotFoundException
 import org.wfanet.measurement.kingdom.deploy.gcloud.spanner.common.MeasurementConsumerNotFoundException
@@ -93,28 +93,29 @@ class CreateMeasurement(private val measurement: Measurement) :
   ): Measurement {
     val initialMeasurementState = Measurement.State.PENDING_REQUISITION_PARAMS
 
-    val activeDuchies = getActiveDuchies()
-    if (activeDuchies.size < MINIMUM_NUMBER_OF_REQUIRED_DUCHIES) {
-      throw RequiredDuchiesNotActiveException()
+    val activeWorkers =
+      getActiveWorkers(
+        measurement.details.protocolConfig.liquidLegionsV2.requiredExternalDuchyIdsList
+      )
+    if (activeWorkers.size < MINIMUM_NUMBER_OF_REQUIRED_DUCHIES) {
+      throw InsufficientNumberOfActiveDuchiesException()
     }
 
     val requiredDuchyExternalIds =
       readDataProviderRequiredDuchies(measurement.dataProvidersMap.keys.toList())
 
-    if (!activeDuchies.containsAll(requiredDuchyExternalIds)) {
+    if (!activeWorkers.containsAll(requiredDuchyExternalIds)) {
       throw RequiredDuchiesNotActiveException()
     }
 
     if (requiredDuchyExternalIds.size < MINIMUM_NUMBER_OF_REQUIRED_DUCHIES) {
 
       val remainingDuchies =
-        DuchyIds.entries
-          .filter { !requiredDuchyExternalIds.contains(it.externalDuchyId) }
-          .filter { !measurement.details.protocolConfig.liquidLegionsV2.requiredExternalDuchyIdsList.contains(it.externalDuchyId) }
-          .toMutableList()
+        activeWorkers.filter { !requiredDuchyExternalIds.contains(it) }.toMutableList()
+
       while (requiredDuchyExternalIds.size < MINIMUM_NUMBER_OF_REQUIRED_DUCHIES) {
         requiredDuchyExternalIds.add(
-          remainingDuchies.removeAt(Random.nextInt(remainingDuchies.size)).externalDuchyId
+          remainingDuchies.removeAt(Random.nextInt(remainingDuchies.size))
         )
       }
     }
@@ -387,17 +388,16 @@ private fun validateCertificate(
   return certificateResult.certificateId
 }
 
-private fun getActiveDuchies(): List<String> {
-  val activeDuchies = mutableListOf<String>()
+private fun getActiveWorkers(protocolRequiredExternalDuchyIds: List<String>): List<String> {
+  val activeWorkers = mutableListOf<String>()
+  val now = Clock.systemUTC().instant()
   for (entry in DuchyIds.entries) {
-    if (isActiveDuchy(entry)) {
-      activeDuchies.add(entry.externalDuchyId)
+    if (
+      !protocolRequiredExternalDuchyIds.contains(entry.externalDuchyId) &&
+        entry.activeRange.contains(now)
+    ) {
+      activeWorkers.add(entry.externalDuchyId)
     }
   }
-  return activeDuchies
-}
-
-private fun isActiveDuchy(duchy: DuchyIds.Entry): Boolean {
-  val now = Clock.systemUTC().instant().toProtoTime()
-  return duchy.activeTimeBegin.seconds <= now.seconds && duchy.activeTimeEnd.seconds >= now.seconds
+  return activeWorkers
 }

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/service/internal/testing/CertificatesServiceTest.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/service/internal/testing/CertificatesServiceTest.kt
@@ -637,7 +637,6 @@ abstract class CertificatesServiceTest<T : CertificatesCoroutineImplBase> {
   fun `revokeCertificate for Duchy fails pending Measurements`(): Unit = runBlocking {
     val measurementConsumer =
       population.createMeasurementConsumer(measurementConsumersService, accountsService)
-
     val measurementOne =
       population.createComputedMeasurement(
         measurementsService,
@@ -656,9 +655,7 @@ abstract class CertificatesServiceTest<T : CertificatesCoroutineImplBase> {
         externalMeasurementId = measurementTwo.externalMeasurementId
       }
     )
-
     val externalDuchyId = DUCHIES[0].externalDuchyId
-
     val certificate =
       certificatesService.createCertificate(
         certificate {
@@ -668,7 +665,6 @@ abstract class CertificatesServiceTest<T : CertificatesCoroutineImplBase> {
           details = details { x509Der = X509_DER }
         }
       )
-
     computationParticipantsService.setParticipantRequisitionParams(
       setParticipantRequisitionParamsRequest {
         this.externalDuchyId = externalDuchyId
@@ -676,15 +672,12 @@ abstract class CertificatesServiceTest<T : CertificatesCoroutineImplBase> {
         externalComputationId = measurementOne.externalComputationId
       }
     )
-
     val request = revokeCertificateRequest {
       this.externalDuchyId = externalDuchyId
       externalCertificateId = certificate.externalCertificateId
       revocationState = Certificate.RevocationState.REVOKED
     }
-
     certificatesService.revokeCertificate(request)
-
     val measurements =
       measurementsService
         .streamMeasurements(
@@ -697,7 +690,6 @@ abstract class CertificatesServiceTest<T : CertificatesCoroutineImplBase> {
           }
         )
         .toList()
-
     assertThat(measurements)
       .comparingExpectedFieldsOnly()
       .containsExactly(

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/service/internal/testing/MeasurementsServiceTest.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/service/internal/testing/MeasurementsServiceTest.kt
@@ -45,6 +45,8 @@ import org.wfanet.measurement.internal.kingdom.MeasurementKt
 import org.wfanet.measurement.internal.kingdom.MeasurementKt.resultInfo
 import org.wfanet.measurement.internal.kingdom.MeasurementsGrpcKt.MeasurementsCoroutineImplBase
 import org.wfanet.measurement.internal.kingdom.ProtocolConfig
+import org.wfanet.measurement.internal.kingdom.ProtocolConfigKt
+import org.wfanet.measurement.internal.kingdom.ProtocolConfigKt.liquidLegionsV2
 import org.wfanet.measurement.internal.kingdom.Requisition
 import org.wfanet.measurement.internal.kingdom.RequisitionKt.details
 import org.wfanet.measurement.internal.kingdom.RequisitionKt.parentMeasurement
@@ -82,7 +84,9 @@ private val MEASUREMENT = measurement {
         liquidLegionsV2 = DuchyProtocolConfig.LiquidLegionsV2.getDefaultInstance()
       }
       protocolConfig = protocolConfig {
-        liquidLegionsV2 = ProtocolConfig.LiquidLegionsV2.getDefaultInstance()
+        liquidLegionsV2 = liquidLegionsV2 {
+          requiredExternalDuchyIds += Population.AGGREGATOR_DUCHY.externalDuchyId
+        }
       }
     }
 }
@@ -680,7 +684,7 @@ abstract class MeasurementsServiceTest<T : MeasurementsCoroutineImplBase> {
             dataProviders[dataProvider.externalDataProviderId] = dataProviderValue
           }
         )
-
+      println("-----------------------------> "+createdMeasurement.details.protocolConfig.liquidLegionsV2.requiredExternalDuchyIdsList)
       val measurement =
         measurementsService.getMeasurementByComputationId(
           getMeasurementByComputationIdRequest {
@@ -713,7 +717,9 @@ abstract class MeasurementsServiceTest<T : MeasurementsCoroutineImplBase> {
               measurementSpec = createdMeasurement.details.measurementSpec
               measurementSpecSignature = createdMeasurement.details.measurementSpecSignature
               protocolConfig = protocolConfig {
-                liquidLegionsV2 = ProtocolConfig.LiquidLegionsV2.getDefaultInstance()
+                liquidLegionsV2 = liquidLegionsV2 {
+                  requiredExternalDuchyIds += Population.AGGREGATOR_DUCHY.externalDuchyId
+                }
               }
               dataProvidersCount = 1
             }

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/service/internal/testing/Population.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/service/internal/testing/Population.kt
@@ -195,7 +195,11 @@ class Population(val clock: Clock, val idGenerator: IdGenerator) {
         duchyProtocolConfig = duchyProtocolConfig {
           liquidLegionsV2 = DuchyProtocolConfigKt.liquidLegionsV2 {}
         }
-        protocolConfig = protocolConfig { liquidLegionsV2 = ProtocolConfigKt.liquidLegionsV2 {} }
+        protocolConfig = protocolConfig {
+          liquidLegionsV2 = ProtocolConfigKt.liquidLegionsV2 {
+            requiredExternalDuchyIds += "aggregator"
+          }
+        }
       }
     return createMeasurement(
       measurementsService,

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/service/internal/testing/RequisitionsServiceTest.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/service/internal/testing/RequisitionsServiceTest.kt
@@ -23,6 +23,7 @@ import java.time.Clock
 import kotlin.random.Random
 import kotlin.test.assertFailsWith
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.runBlocking
 import org.junit.Before
 import org.junit.Rule
@@ -31,29 +32,26 @@ import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 import org.wfanet.measurement.common.identity.IdGenerator
 import org.wfanet.measurement.common.identity.RandomIdGenerator
+import org.wfanet.measurement.common.toInstant
 import org.wfanet.measurement.internal.kingdom.AccountsGrpcKt.AccountsCoroutineImplBase as AccountsCoroutineService
 import org.wfanet.measurement.internal.kingdom.Certificate
 import org.wfanet.measurement.internal.kingdom.CertificatesGrpcKt.CertificatesCoroutineImplBase as CertificatesCoroutineService
 import org.wfanet.measurement.internal.kingdom.ComputationParticipantsGrpcKt.ComputationParticipantsCoroutineImplBase as ComputationParticipantsCoroutineService
 import org.wfanet.measurement.internal.kingdom.DataProvidersGrpcKt.DataProvidersCoroutineImplBase as DataProvidersCoroutineService
-import org.wfanet.measurement.internal.kingdom.MeasurementConsumersGrpcKt.MeasurementConsumersCoroutineImplBase as MeasurementConsumersCoroutineService
-import org.wfanet.measurement.internal.kingdom.MeasurementsGrpcKt.MeasurementsCoroutineImplBase as MeasurementsCoroutineService
-import org.wfanet.measurement.internal.kingdom.Requisition
-import org.wfanet.measurement.internal.kingdom.RequisitionKt.refusal
-import org.wfanet.measurement.internal.kingdom.RequisitionsGrpcKt.RequisitionsCoroutineImplBase as RequisitionsCoroutineService
-import kotlinx.coroutines.flow.toList
-import org.wfanet.measurement.common.toInstant
 import org.wfanet.measurement.internal.kingdom.FulfillRequisitionRequestKt.computedRequisitionParams
 import org.wfanet.measurement.internal.kingdom.FulfillRequisitionRequestKt.directRequisitionParams
 import org.wfanet.measurement.internal.kingdom.Measurement
+import org.wfanet.measurement.internal.kingdom.MeasurementConsumersGrpcKt.MeasurementConsumersCoroutineImplBase as MeasurementConsumersCoroutineService
 import org.wfanet.measurement.internal.kingdom.MeasurementKt.resultInfo
-import org.wfanet.measurement.internal.kingdom.ProtocolConfig
+import org.wfanet.measurement.internal.kingdom.MeasurementsGrpcKt.MeasurementsCoroutineImplBase as MeasurementsCoroutineService
 import org.wfanet.measurement.internal.kingdom.ProtocolConfigKt.liquidLegionsV2
+import org.wfanet.measurement.internal.kingdom.Requisition
 import org.wfanet.measurement.internal.kingdom.RequisitionKt
 import org.wfanet.measurement.internal.kingdom.RequisitionKt.parentMeasurement
+import org.wfanet.measurement.internal.kingdom.RequisitionKt.refusal
+import org.wfanet.measurement.internal.kingdom.RequisitionsGrpcKt.RequisitionsCoroutineImplBase as RequisitionsCoroutineService
 import org.wfanet.measurement.internal.kingdom.StreamRequisitionsRequestKt.filter
 import org.wfanet.measurement.internal.kingdom.cancelMeasurementRequest
-import org.wfanet.measurement.internal.kingdom.copy
 import org.wfanet.measurement.internal.kingdom.fulfillRequisitionRequest
 import org.wfanet.measurement.internal.kingdom.getMeasurementRequest
 import org.wfanet.measurement.internal.kingdom.getRequisitionRequest
@@ -124,41 +122,132 @@ abstract class RequisitionsServiceTest<T : RequisitionsCoroutineService> {
     service = newService()
   }
 
-    @Test
-    fun `streamRequisitions returns all requisitions for MC`(): Unit = runBlocking {
+  @Test
+  fun `streamRequisitions returns all requisitions for MC`(): Unit = runBlocking {
+    val measurementConsumer =
+      population.createMeasurementConsumer(
+        dataServices.measurementConsumersService,
+        dataServices.accountsService
+      )
+    val dataProvider1 = population.createDataProvider(dataServices.dataProvidersService)
+    val dataProvider2 = population.createDataProvider(dataServices.dataProvidersService)
+    val measurement1 =
+      population.createComputedMeasurement(
+        dataServices.measurementsService,
+        measurementConsumer,
+        "measurement 1",
+        dataProvider1,
+        dataProvider2
+      )
+    val measurement2 =
+      population.createComputedMeasurement(
+        dataServices.measurementsService,
+        measurementConsumer,
+        "measurement 2",
+        dataProvider1
+      )
+    population.createComputedMeasurement(
+      dataServices.measurementsService,
+      population.createMeasurementConsumer(
+        dataServices.measurementConsumersService,
+        dataServices.accountsService
+      ),
+      "other MC measurement",
+      dataProvider1
+    )
+
+    val requisitions: List<Requisition> =
+      service
+        .streamRequisitions(
+          streamRequisitionsRequest {
+            filter = filter {
+              externalMeasurementConsumerId = measurementConsumer.externalMeasurementConsumerId
+            }
+          }
+        )
+        .toList()
+
+    assertThat(requisitions)
+      .comparingExpectedFieldsOnly()
+      .containsExactly(
+        requisition {
+          externalMeasurementConsumerId = measurementConsumer.externalMeasurementConsumerId
+          externalMeasurementId = measurement1.externalMeasurementId
+          externalDataProviderId = dataProvider1.externalDataProviderId
+        },
+        requisition {
+          externalMeasurementConsumerId = measurementConsumer.externalMeasurementConsumerId
+          externalMeasurementId = measurement1.externalMeasurementId
+          externalDataProviderId = dataProvider2.externalDataProviderId
+        },
+        requisition {
+          externalMeasurementConsumerId = measurementConsumer.externalMeasurementConsumerId
+          externalMeasurementId = measurement2.externalMeasurementId
+          externalDataProviderId = dataProvider1.externalDataProviderId
+        }
+      )
+  }
+
+  @Test
+  fun `streamRequisitions excludes requisitions with params set when filter excludes them`(): Unit =
+    runBlocking {
       val measurementConsumer =
         population.createMeasurementConsumer(
           dataServices.measurementConsumersService,
           dataServices.accountsService
         )
-      val dataProvider1 = population.createDataProvider(dataServices.dataProvidersService)
+      val dataProvider = population.createDataProvider(dataServices.dataProvidersService)
       val dataProvider2 = population.createDataProvider(dataServices.dataProvidersService)
-      val measurement1 =
+      val measurement =
         population.createComputedMeasurement(
           dataServices.measurementsService,
           measurementConsumer,
-          "measurement 1",
-          dataProvider1,
-          dataProvider2
+          "measurement",
+          dataProvider
         )
-      val measurement2 =
-        population.createComputedMeasurement(
-          dataServices.measurementsService,
-          measurementConsumer,
-          "measurement 2",
-          dataProvider1
-        )
+
       population.createComputedMeasurement(
         dataServices.measurementsService,
-        population.createMeasurementConsumer(
-          dataServices.measurementConsumersService,
-          dataServices.accountsService
-        ),
-        "other MC measurement",
-        dataProvider1
+        measurementConsumer,
+        "measurement2",
+        dataProvider2
       )
 
+      for (duchyCertificate in duchyCertificates.values) {
+        dataServices.computationParticipantsService.setParticipantRequisitionParams(
+          setParticipantRequisitionParamsRequest {
+            externalComputationId = measurement.externalComputationId
+            externalDuchyId = duchyCertificate.externalDuchyId
+            externalDuchyCertificateId = duchyCertificate.externalCertificateId
+          }
+        )
+      }
+
       val requisitions: List<Requisition> =
+        service
+          .streamRequisitions(
+            streamRequisitionsRequest {
+              filter = filter {
+                externalMeasurementConsumerId = measurementConsumer.externalMeasurementConsumerId
+                states += Requisition.State.UNFULFILLED
+                states += Requisition.State.FULFILLED
+                states += Requisition.State.REFUSED
+              }
+            }
+          )
+          .toList()
+
+      assertThat(requisitions)
+        .comparingExpectedFieldsOnly()
+        .containsExactly(
+          requisition {
+            externalMeasurementConsumerId = measurementConsumer.externalMeasurementConsumerId
+            externalMeasurementId = measurement.externalMeasurementId
+            externalDataProviderId = dataProvider.externalDataProviderId
+          }
+        )
+
+      val requisitions2: List<Requisition> =
         service
           .streamRequisitions(
             streamRequisitionsRequest {
@@ -169,207 +258,64 @@ abstract class RequisitionsServiceTest<T : RequisitionsCoroutineService> {
           )
           .toList()
 
-      assertThat(requisitions)
-        .comparingExpectedFieldsOnly()
-        .containsExactly(
-          requisition {
-            externalMeasurementConsumerId = measurementConsumer.externalMeasurementConsumerId
-            externalMeasurementId = measurement1.externalMeasurementId
-            externalDataProviderId = dataProvider1.externalDataProviderId
-          },
-          requisition {
-            externalMeasurementConsumerId = measurementConsumer.externalMeasurementConsumerId
-            externalMeasurementId = measurement1.externalMeasurementId
-            externalDataProviderId = dataProvider2.externalDataProviderId
-          },
-          requisition {
-            externalMeasurementConsumerId = measurementConsumer.externalMeasurementConsumerId
-            externalMeasurementId = measurement2.externalMeasurementId
-            externalDataProviderId = dataProvider1.externalDataProviderId
-          }
-        )
+      assertThat(requisitions.size).isLessThan(requisitions2.size)
     }
 
-    @Test
-    fun `streamRequisitions excludes requisitions with params set when filter excludes them`(): Unit =
-      runBlocking {
-        val measurementConsumer =
-          population.createMeasurementConsumer(
-            dataServices.measurementConsumersService,
-            dataServices.accountsService
-          )
-        val dataProvider = population.createDataProvider(dataServices.dataProvidersService)
-        val dataProvider2 = population.createDataProvider(dataServices.dataProvidersService)
-        val measurement =
-          population.createComputedMeasurement(
-            dataServices.measurementsService,
-            measurementConsumer,
-            "measurement",
-            dataProvider
-          )
-
-        population.createComputedMeasurement(
-          dataServices.measurementsService,
-          measurementConsumer,
-          "measurement2",
-          dataProvider2
-        )
-
-        for (duchyCertificate in duchyCertificates.values) {
-          dataServices.computationParticipantsService.setParticipantRequisitionParams(
-            setParticipantRequisitionParamsRequest {
-              externalComputationId = measurement.externalComputationId
-              externalDuchyId = duchyCertificate.externalDuchyId
-              externalDuchyCertificateId = duchyCertificate.externalCertificateId
-            }
-          )
-        }
-
-        val requisitions: List<Requisition> =
-          service
-            .streamRequisitions(
-              streamRequisitionsRequest {
-                filter = filter {
-                  externalMeasurementConsumerId = measurementConsumer.externalMeasurementConsumerId
-                  states += Requisition.State.UNFULFILLED
-                  states += Requisition.State.FULFILLED
-                  states += Requisition.State.REFUSED
-                }
-              }
-            )
-            .toList()
-
-        assertThat(requisitions)
-          .comparingExpectedFieldsOnly()
-          .containsExactly(
-            requisition {
-              externalMeasurementConsumerId = measurementConsumer.externalMeasurementConsumerId
-              externalMeasurementId = measurement.externalMeasurementId
-              externalDataProviderId = dataProvider.externalDataProviderId
-            }
-          )
-
-        val requisitions2: List<Requisition> =
-          service
-            .streamRequisitions(
-              streamRequisitionsRequest {
-                filter = filter {
-                  externalMeasurementConsumerId = measurementConsumer.externalMeasurementConsumerId
-                }
-              }
-            )
-            .toList()
-
-        assertThat(requisitions.size).isLessThan(requisitions2.size)
-      }
-
-    @Test
-    fun `streamRequisitions returns all requisitions for measurement`(): Unit = runBlocking {
-      val measurementConsumer =
-        population.createMeasurementConsumer(
-          dataServices.measurementConsumersService,
-          dataServices.accountsService
-        )
-      val dataProvider1 = population.createDataProvider(dataServices.dataProvidersService)
-      val dataProvider2 = population.createDataProvider(dataServices.dataProvidersService)
-      val measurement =
-        population.createComputedMeasurement(
-          dataServices.measurementsService,
-          measurementConsumer,
-          "measurement 1",
-          dataProvider1,
-          dataProvider2
-        )
+  @Test
+  fun `streamRequisitions returns all requisitions for measurement`(): Unit = runBlocking {
+    val measurementConsumer =
+      population.createMeasurementConsumer(
+        dataServices.measurementConsumersService,
+        dataServices.accountsService
+      )
+    val dataProvider1 = population.createDataProvider(dataServices.dataProvidersService)
+    val dataProvider2 = population.createDataProvider(dataServices.dataProvidersService)
+    val measurement =
       population.createComputedMeasurement(
         dataServices.measurementsService,
         measurementConsumer,
-        "measurement 2",
-        dataProvider1
+        "measurement 1",
+        dataProvider1,
+        dataProvider2
       )
+    population.createComputedMeasurement(
+      dataServices.measurementsService,
+      measurementConsumer,
+      "measurement 2",
+      dataProvider1
+    )
 
-      val requisitions: List<Requisition> =
-        service
-          .streamRequisitions(
-            streamRequisitionsRequest {
-              filter = filter {
-                externalMeasurementConsumerId = measurement.externalMeasurementConsumerId
-                externalMeasurementId = measurement.externalMeasurementId
-              }
+    val requisitions: List<Requisition> =
+      service
+        .streamRequisitions(
+          streamRequisitionsRequest {
+            filter = filter {
+              externalMeasurementConsumerId = measurement.externalMeasurementConsumerId
+              externalMeasurementId = measurement.externalMeasurementId
             }
-          )
-          .toList()
-
-      assertThat(requisitions)
-        .comparingExpectedFieldsOnly()
-        .containsExactly(
-          requisition {
-            externalMeasurementConsumerId = measurement.externalMeasurementConsumerId
-            externalMeasurementId = measurement.externalMeasurementId
-            externalDataProviderId = dataProvider1.externalDataProviderId
-          },
-          requisition {
-            externalMeasurementConsumerId = measurement.externalMeasurementConsumerId
-            externalMeasurementId = measurement.externalMeasurementId
-            externalDataProviderId = dataProvider2.externalDataProviderId
           }
         )
-    }
+        .toList()
 
-    @Test
-    fun `streamRequisitions only includes measurements with some states when filter set`(): Unit =
-      runBlocking {
-        val measurementConsumer =
-          population.createMeasurementConsumer(
-            dataServices.measurementConsumersService,
-            dataServices.accountsService
-          )
-        val dataProvider = population.createDataProvider(dataServices.dataProvidersService)
-        val measurement1 =
-          population.createComputedMeasurement(
-            dataServices.measurementsService,
-            measurementConsumer,
-            "measurement 1",
-            dataProvider
-          )
-        val measurement2 =
-          population.createComputedMeasurement(
-            dataServices.measurementsService,
-            measurementConsumer,
-            "measurement 2",
-            dataProvider
-          )
-        dataServices.measurementsService.cancelMeasurement(
-          cancelMeasurementRequest {
-            externalMeasurementConsumerId = measurementConsumer.externalMeasurementConsumerId
-            externalMeasurementId = measurement2.externalMeasurementId
-          }
-        )
+    assertThat(requisitions)
+      .comparingExpectedFieldsOnly()
+      .containsExactly(
+        requisition {
+          externalMeasurementConsumerId = measurement.externalMeasurementConsumerId
+          externalMeasurementId = measurement.externalMeasurementId
+          externalDataProviderId = dataProvider1.externalDataProviderId
+        },
+        requisition {
+          externalMeasurementConsumerId = measurement.externalMeasurementConsumerId
+          externalMeasurementId = measurement.externalMeasurementId
+          externalDataProviderId = dataProvider2.externalDataProviderId
+        }
+      )
+  }
 
-        val requisitions: List<Requisition> =
-          service
-            .streamRequisitions(
-              streamRequisitionsRequest {
-                filter = filter {
-                  externalMeasurementConsumerId = measurementConsumer.externalMeasurementConsumerId
-                  measurementStates += Measurement.State.PENDING_REQUISITION_PARAMS
-                }
-              }
-            )
-            .toList()
-
-        assertThat(requisitions)
-          .comparingExpectedFieldsOnly()
-          .containsExactly(
-            requisition {
-              externalMeasurementConsumerId = measurement1.externalMeasurementConsumerId
-              externalMeasurementId = measurement1.externalMeasurementId
-              externalDataProviderId = dataProvider.externalDataProviderId
-            }
-          )
-      }
-
-    @Test
-    fun `streamRequisitions respects updated_after`(): Unit = runBlocking {
+  @Test
+  fun `streamRequisitions only includes measurements with some states when filter set`(): Unit =
+    runBlocking {
       val measurementConsumer =
         population.createMeasurementConsumer(
           dataServices.measurementConsumersService,
@@ -390,11 +336,11 @@ abstract class RequisitionsServiceTest<T : RequisitionsCoroutineService> {
           "measurement 2",
           dataProvider
         )
-      population.createComputedMeasurement(
-        dataServices.measurementsService,
-        measurementConsumer,
-        "measurement 3",
-        population.createDataProvider(dataServices.dataProvidersService)
+      dataServices.measurementsService.cancelMeasurement(
+        cancelMeasurementRequest {
+          externalMeasurementConsumerId = measurementConsumer.externalMeasurementConsumerId
+          externalMeasurementId = measurement2.externalMeasurementId
+        }
       )
 
       val requisitions: List<Requisition> =
@@ -402,8 +348,8 @@ abstract class RequisitionsServiceTest<T : RequisitionsCoroutineService> {
           .streamRequisitions(
             streamRequisitionsRequest {
               filter = filter {
-                externalDataProviderId = dataProvider.externalDataProviderId
-                updatedAfter = measurement1.updateTime
+                externalMeasurementConsumerId = measurementConsumer.externalMeasurementConsumerId
+                measurementStates += Measurement.State.PENDING_REQUISITION_PARAMS
               }
             }
           )
@@ -413,126 +359,530 @@ abstract class RequisitionsServiceTest<T : RequisitionsCoroutineService> {
         .comparingExpectedFieldsOnly()
         .containsExactly(
           requisition {
+            externalMeasurementConsumerId = measurement1.externalMeasurementConsumerId
+            externalMeasurementId = measurement1.externalMeasurementId
             externalDataProviderId = dataProvider.externalDataProviderId
-            externalMeasurementId = measurement2.externalMeasurementId
           }
         )
     }
 
-    @Test
-    fun `streamRequisitions respects limit`(): Unit = runBlocking {
-      val measurementConsumer =
-        population.createMeasurementConsumer(
-          dataServices.measurementConsumersService,
-          dataServices.accountsService
-        )
-      val dataProvider = population.createDataProvider(dataServices.dataProvidersService)
+  @Test
+  fun `streamRequisitions respects updated_after`(): Unit = runBlocking {
+    val measurementConsumer =
+      population.createMeasurementConsumer(
+        dataServices.measurementConsumersService,
+        dataServices.accountsService
+      )
+    val dataProvider = population.createDataProvider(dataServices.dataProvidersService)
+    val measurement1 =
       population.createComputedMeasurement(
         dataServices.measurementsService,
         measurementConsumer,
         "measurement 1",
         dataProvider
       )
-
+    val measurement2 =
       population.createComputedMeasurement(
         dataServices.measurementsService,
         measurementConsumer,
         "measurement 2",
         dataProvider
       )
+    population.createComputedMeasurement(
+      dataServices.measurementsService,
+      measurementConsumer,
+      "measurement 3",
+      population.createDataProvider(dataServices.dataProvidersService)
+    )
 
-      val requisitions: List<Requisition> =
-        service
-          .streamRequisitions(
-            streamRequisitionsRequest {
-              filter = filter { externalDataProviderId = dataProvider.externalDataProviderId }
-              limit = 1
+    val requisitions: List<Requisition> =
+      service
+        .streamRequisitions(
+          streamRequisitionsRequest {
+            filter = filter {
+              externalDataProviderId = dataProvider.externalDataProviderId
+              updatedAfter = measurement1.updateTime
             }
-          )
-          .toList()
-
-      assertThat(requisitions)
-        .comparingExpectedFieldsOnly()
-        .containsExactly(requisition { externalDataProviderId = dataProvider.externalDataProviderId })
-    }
-
-    @Test
-    fun `streamRequisitions can get one page at a time`(): Unit = runBlocking {
-      val measurementConsumer =
-        population.createMeasurementConsumer(
-          dataServices.measurementConsumersService,
-          dataServices.accountsService
+          }
         )
-      val dataProvider = population.createDataProvider(dataServices.dataProvidersService)
+        .toList()
+
+    assertThat(requisitions)
+      .comparingExpectedFieldsOnly()
+      .containsExactly(
+        requisition {
+          externalDataProviderId = dataProvider.externalDataProviderId
+          externalMeasurementId = measurement2.externalMeasurementId
+        }
+      )
+  }
+
+  @Test
+  fun `streamRequisitions respects limit`(): Unit = runBlocking {
+    val measurementConsumer =
+      population.createMeasurementConsumer(
+        dataServices.measurementConsumersService,
+        dataServices.accountsService
+      )
+    val dataProvider = population.createDataProvider(dataServices.dataProvidersService)
+    population.createComputedMeasurement(
+      dataServices.measurementsService,
+      measurementConsumer,
+      "measurement 1",
+      dataProvider
+    )
+
+    population.createComputedMeasurement(
+      dataServices.measurementsService,
+      measurementConsumer,
+      "measurement 2",
+      dataProvider
+    )
+
+    val requisitions: List<Requisition> =
+      service
+        .streamRequisitions(
+          streamRequisitionsRequest {
+            filter = filter { externalDataProviderId = dataProvider.externalDataProviderId }
+            limit = 1
+          }
+        )
+        .toList()
+
+    assertThat(requisitions)
+      .comparingExpectedFieldsOnly()
+      .containsExactly(requisition { externalDataProviderId = dataProvider.externalDataProviderId })
+  }
+
+  @Test
+  fun `streamRequisitions can get one page at a time`(): Unit = runBlocking {
+    val measurementConsumer =
+      population.createMeasurementConsumer(
+        dataServices.measurementConsumersService,
+        dataServices.accountsService
+      )
+    val dataProvider = population.createDataProvider(dataServices.dataProvidersService)
+    population.createComputedMeasurement(
+      dataServices.measurementsService,
+      measurementConsumer,
+      "measurement 1",
+      dataProvider
+    )
+
+    population.createComputedMeasurement(
+      dataServices.measurementsService,
+      measurementConsumer,
+      "measurement 2",
+      dataProvider
+    )
+
+    val requisitions: List<Requisition> =
+      service
+        .streamRequisitions(
+          streamRequisitionsRequest {
+            filter = filter { externalDataProviderId = dataProvider.externalDataProviderId }
+            limit = 1
+          }
+        )
+        .toList()
+
+    assertThat(requisitions)
+      .comparingExpectedFieldsOnly()
+      .containsExactly(requisition { externalDataProviderId = dataProvider.externalDataProviderId })
+
+    val requisitions2: List<Requisition> =
+      service
+        .streamRequisitions(
+          streamRequisitionsRequest {
+            filter = filter {
+              externalDataProviderId = dataProvider.externalDataProviderId
+              externalRequisitionIdAfter = requisitions[0].externalRequisitionId
+              externalDataProviderIdAfter = requisitions[0].externalDataProviderId
+            }
+            limit = 1
+          }
+        )
+        .toList()
+
+    assertThat(requisitions2)
+      .comparingExpectedFieldsOnly()
+      .containsExactly(requisition { externalDataProviderId = dataProvider.externalDataProviderId })
+    assertThat(requisitions2[0].externalRequisitionId)
+      .isGreaterThan(requisitions[0].externalRequisitionId)
+  }
+
+  @Test
+  fun `getRequisition returns expected requisition`() = runBlocking {
+    val measurementConsumer =
+      population.createMeasurementConsumer(
+        dataServices.measurementConsumersService,
+        dataServices.accountsService
+      )
+    val dataProvider = population.createDataProvider(dataServices.dataProvidersService)
+    val dataProviderValue = dataProvider.toDataProviderValue()
+    val providedMeasurementId = "measurement"
+    val measurement =
       population.createComputedMeasurement(
         dataServices.measurementsService,
         measurementConsumer,
-        "measurement 1",
-        dataProvider
+        providedMeasurementId,
+        mapOf(dataProvider.externalDataProviderId to dataProviderValue)
       )
 
-      population.createComputedMeasurement(
-        dataServices.measurementsService,
-        measurementConsumer,
-        "measurement 2",
-        dataProvider
+    val externalDataProviderId = dataProvider.externalDataProviderId
+    val listedRequisition =
+      service
+        .streamRequisitions(
+          streamRequisitionsRequest {
+            filter = filter {
+              externalMeasurementConsumerId = measurement.externalMeasurementConsumerId
+              externalMeasurementId = measurement.externalMeasurementId
+            }
+          }
+        )
+        .first()
+    val externalRequisitionId = listedRequisition.externalRequisitionId
+
+    val requisition =
+      service.getRequisition(
+        getRequisitionRequest {
+          this.externalDataProviderId = externalDataProviderId
+          this.externalRequisitionId = externalRequisitionId
+        }
       )
 
-      val requisitions: List<Requisition> =
-        service
-          .streamRequisitions(
-            streamRequisitionsRequest {
-              filter = filter { externalDataProviderId = dataProvider.externalDataProviderId }
-              limit = 1
-            }
-          )
-          .toList()
-
-      assertThat(requisitions)
-        .comparingExpectedFieldsOnly()
-        .containsExactly(requisition { externalDataProviderId = dataProvider.externalDataProviderId })
-
-      val requisitions2: List<Requisition> =
-        service
-          .streamRequisitions(
-            streamRequisitionsRequest {
-              filter = filter {
-                externalDataProviderId = dataProvider.externalDataProviderId
-                externalRequisitionIdAfter = requisitions[0].externalRequisitionId
-                externalDataProviderIdAfter = requisitions[0].externalDataProviderId
-              }
-              limit = 1
-            }
-          )
-          .toList()
-
-      assertThat(requisitions2)
-        .comparingExpectedFieldsOnly()
-        .containsExactly(requisition { externalDataProviderId = dataProvider.externalDataProviderId })
-      assertThat(requisitions2[0].externalRequisitionId)
-        .isGreaterThan(requisitions[0].externalRequisitionId)
+    val expectedRequisition = requisition {
+      externalMeasurementConsumerId = measurement.externalMeasurementConsumerId
+      externalMeasurementId = measurement.externalMeasurementId
+      this.externalDataProviderId = externalDataProviderId
+      this.externalRequisitionId = externalRequisitionId
+      externalComputationId = measurement.externalComputationId
+      state = Requisition.State.PENDING_PARAMS
+      details =
+        RequisitionKt.details {
+          dataProviderPublicKey = dataProviderValue.dataProviderPublicKey
+          dataProviderPublicKeySignature = dataProviderValue.dataProviderPublicKeySignature
+          encryptedRequisitionSpec = dataProviderValue.encryptedRequisitionSpec
+          nonceHash = dataProviderValue.nonceHash
+        }
+      dataProviderCertificate = dataProvider.certificate
+      parentMeasurement = parentMeasurement {
+        apiVersion = measurement.details.apiVersion
+        externalMeasurementConsumerCertificateId =
+          measurement.externalMeasurementConsumerCertificateId
+        measurementSpec = measurement.details.measurementSpec
+        measurementSpecSignature = measurement.details.measurementSpecSignature
+        state = Measurement.State.PENDING_REQUISITION_PARAMS
+        protocolConfig = protocolConfig {
+          liquidLegionsV2 = liquidLegionsV2 {
+            requiredExternalDuchyIds += Population.AGGREGATOR_DUCHY.externalDuchyId
+          }
+        }
+        dataProvidersCount = 1
+      }
     }
+    assertThat(requisition)
+      .ignoringFields(Requisition.UPDATE_TIME_FIELD_NUMBER, Requisition.DUCHIES_FIELD_NUMBER)
+      .isEqualTo(expectedRequisition)
+    assertThat(requisition.duchiesMap)
+      .containsExactly(
+        Population.AGGREGATOR_DUCHY.externalDuchyId,
+        Requisition.DuchyValue.getDefaultInstance(),
+        Population.WORKER1_DUCHY.externalDuchyId,
+        Requisition.DuchyValue.getDefaultInstance(),
+        Population.WORKER2_DUCHY.externalDuchyId,
+        Requisition.DuchyValue.getDefaultInstance()
+      )
+    assertThat(requisition).isEqualTo(listedRequisition)
+  }
 
-    @Test
-    fun `getRequisition returns expected requisition`() = runBlocking {
-      val measurementConsumer =
+  @Test
+  fun `getRequisition returns expected direct requisition`() = runBlocking {
+    val dataProvider = population.createDataProvider(dataServices.dataProvidersService)
+    val dataProviderValue = dataProvider.toDataProviderValue()
+    val measurement =
+      population.createDirectMeasurement(
+        dataServices.measurementsService,
         population.createMeasurementConsumer(
           dataServices.measurementConsumersService,
           dataServices.accountsService
+        ),
+        "direct_measurement",
+        mapOf(dataProvider.externalDataProviderId to dataProviderValue)
+      )
+
+    val listedRequisition =
+      service
+        .streamRequisitions(
+          streamRequisitionsRequest {
+            filter = filter {
+              externalMeasurementConsumerId = measurement.externalMeasurementConsumerId
+              externalMeasurementId = measurement.externalMeasurementId
+            }
+          }
         )
-      val dataProvider = population.createDataProvider(dataServices.dataProvidersService)
-      val dataProviderValue = dataProvider.toDataProviderValue()
-      val providedMeasurementId = "measurement"
+        .first()
+
+    val requisition =
+      service.getRequisition(
+        getRequisitionRequest {
+          externalDataProviderId = listedRequisition.externalDataProviderId
+          externalRequisitionId = listedRequisition.externalRequisitionId
+        }
+      )
+
+    val expectedRequisition = requisition {
+      externalMeasurementConsumerId = measurement.externalMeasurementConsumerId
+      externalMeasurementId = measurement.externalMeasurementId
+      externalDataProviderId = dataProvider.externalDataProviderId
+      this.externalRequisitionId = listedRequisition.externalRequisitionId
+      state = Requisition.State.UNFULFILLED
+      details =
+        RequisitionKt.details {
+          dataProviderPublicKey = dataProviderValue.dataProviderPublicKey
+          dataProviderPublicKeySignature = dataProviderValue.dataProviderPublicKeySignature
+          encryptedRequisitionSpec = dataProviderValue.encryptedRequisitionSpec
+          nonceHash = dataProviderValue.nonceHash
+        }
+      dataProviderCertificate = dataProvider.certificate
+      parentMeasurement = parentMeasurement {
+        apiVersion = measurement.details.apiVersion
+        externalMeasurementConsumerCertificateId =
+          measurement.externalMeasurementConsumerCertificateId
+        measurementSpec = measurement.details.measurementSpec
+        measurementSpecSignature = measurement.details.measurementSpecSignature
+        state = Measurement.State.PENDING_REQUISITION_FULFILLMENT
+        protocolConfig = protocolConfig {}
+        dataProvidersCount = 1
+      }
+    }
+    assertThat(requisition)
+      .ignoringFields(Requisition.UPDATE_TIME_FIELD_NUMBER, Requisition.DUCHIES_FIELD_NUMBER)
+      .isEqualTo(expectedRequisition)
+    assertThat(requisition).isEqualTo(listedRequisition)
+  }
+
+  @Test
+  fun `fulfillRequisition transitions Requisition state`() = runBlocking {
+    val measurement =
+      population.createComputedMeasurement(
+        dataServices.measurementsService,
+        population.createMeasurementConsumer(
+          dataServices.measurementConsumersService,
+          dataServices.accountsService
+        ),
+        "measurement",
+        population.createDataProvider(dataServices.dataProvidersService),
+        population.createDataProvider(dataServices.dataProvidersService)
+      )
+    for (duchyCertificate in duchyCertificates.values) {
+      dataServices.computationParticipantsService.setParticipantRequisitionParams(
+        setParticipantRequisitionParamsRequest {
+          externalComputationId = measurement.externalComputationId
+          externalDuchyId = duchyCertificate.externalDuchyId
+          externalDuchyCertificateId = duchyCertificate.externalCertificateId
+        }
+      )
+    }
+    val requisition =
+      service
+        .streamRequisitions(
+          streamRequisitionsRequest {
+            filter = filter {
+              externalMeasurementConsumerId = measurement.externalMeasurementConsumerId
+              externalMeasurementId = measurement.externalMeasurementId
+            }
+          }
+        )
+        .first()
+
+    val response =
+      service.fulfillRequisition(
+        fulfillRequisitionRequest {
+          externalRequisitionId = requisition.externalRequisitionId
+          nonce = NONCE_1
+          computedParams = computedRequisitionParams {
+            externalComputationId = measurement.externalComputationId
+            externalFulfillingDuchyId = Population.WORKER1_DUCHY.externalDuchyId
+          }
+        }
+      )
+
+    assertThat(response.state).isEqualTo(Requisition.State.FULFILLED)
+    assertThat(response.externalFulfillingDuchyId)
+      .isEqualTo(Population.WORKER1_DUCHY.externalDuchyId)
+    assertThat(response.details.nonce).isEqualTo(NONCE_1)
+    assertThat(response.updateTime.toInstant()).isGreaterThan(requisition.updateTime.toInstant())
+    assertThat(response)
+      .isEqualTo(
+        service.getRequisition(
+          getRequisitionRequest {
+            externalDataProviderId = requisition.externalDataProviderId
+            externalRequisitionId = requisition.externalRequisitionId
+          }
+        )
+      )
+  }
+
+  @Test
+  fun `fulfillRequisition transitions Measurement state when all others fulfilled`() = runBlocking {
+    val measurement =
+      population.createComputedMeasurement(
+        dataServices.measurementsService,
+        population.createMeasurementConsumer(
+          dataServices.measurementConsumersService,
+          dataServices.accountsService
+        ),
+        "measurement",
+        population.createDataProvider(dataServices.dataProvidersService),
+        population.createDataProvider(dataServices.dataProvidersService)
+      )
+    for (duchyCertificate in duchyCertificates.values) {
+      dataServices.computationParticipantsService.setParticipantRequisitionParams(
+        setParticipantRequisitionParamsRequest {
+          externalComputationId = measurement.externalComputationId
+          externalDuchyId = duchyCertificate.externalDuchyId
+          externalDuchyCertificateId = duchyCertificate.externalCertificateId
+        }
+      )
+    }
+    val requisitions =
+      service
+        .streamRequisitions(
+          streamRequisitionsRequest {
+            filter = filter {
+              externalMeasurementConsumerId = measurement.externalMeasurementConsumerId
+              externalMeasurementId = measurement.externalMeasurementId
+            }
+          }
+        )
+        .toList()
+    service.fulfillRequisition(
+      fulfillRequisitionRequest {
+        externalRequisitionId = requisitions[0].externalRequisitionId
+        nonce = NONCE_1
+        computedParams = computedRequisitionParams {
+          externalComputationId = measurement.externalComputationId
+          externalFulfillingDuchyId = Population.WORKER1_DUCHY.externalDuchyId
+        }
+      }
+    )
+
+    val response =
+      service.fulfillRequisition(
+        fulfillRequisitionRequest {
+          externalRequisitionId = requisitions[1].externalRequisitionId
+          nonce = NONCE_2
+          computedParams = computedRequisitionParams {
+            externalComputationId = measurement.externalComputationId
+            externalFulfillingDuchyId = Population.WORKER1_DUCHY.externalDuchyId
+          }
+        }
+      )
+
+    assertThat(response.parentMeasurement.state)
+      .isEqualTo(Measurement.State.PENDING_PARTICIPANT_CONFIRMATION)
+    assertThat(response)
+      .isEqualTo(
+        service.getRequisition(
+          getRequisitionRequest {
+            externalDataProviderId = requisitions[1].externalDataProviderId
+            externalRequisitionId = requisitions[1].externalRequisitionId
+          }
+        )
+      )
+  }
+
+  @Test
+  fun `fulfillRequisition throws NOT_FOUND if Requisition not found`() = runBlocking {
+    val dataProvider = population.createDataProvider(dataServices.dataProvidersService)
+    val measurement =
+      population.createComputedMeasurement(
+        dataServices.measurementsService,
+        population.createMeasurementConsumer(
+          dataServices.measurementConsumersService,
+          dataServices.accountsService
+        ),
+        "measurement",
+        dataProvider
+      )
+
+    val nonExistentExternalRequisitionId = idGenerator.generateExternalId()
+    val exception =
+      assertFailsWith(StatusRuntimeException::class) {
+        service.fulfillRequisition(
+          fulfillRequisitionRequest {
+            externalRequisitionId = nonExistentExternalRequisitionId.value
+            nonce = NONCE_1
+            computedParams = computedRequisitionParams {
+              externalComputationId = measurement.externalComputationId
+              externalFulfillingDuchyId = Population.WORKER1_DUCHY.externalDuchyId
+            }
+          }
+        )
+      }
+
+    assertThat(exception.status.code).isEqualTo(Status.Code.NOT_FOUND)
+  }
+
+  @Test
+  fun `fulfillRequisition throws FAILED_PRECONDITION if Duchy not found`() = runBlocking {
+    val dataProvider = population.createDataProvider(dataServices.dataProvidersService)
+    val measurement =
+      population.createComputedMeasurement(
+        dataServices.measurementsService,
+        population.createMeasurementConsumer(
+          dataServices.measurementConsumersService,
+          dataServices.accountsService
+        ),
+        "measurement",
+        dataProvider
+      )
+    val requisition =
+      service
+        .streamRequisitions(
+          streamRequisitionsRequest {
+            filter = filter {
+              externalMeasurementConsumerId = measurement.externalMeasurementConsumerId
+              externalMeasurementId = measurement.externalMeasurementId
+            }
+          }
+        )
+        .first()
+
+    val nonExistentExternalDuchyId = "Chalced"
+    val exception =
+      assertFailsWith(StatusRuntimeException::class) {
+        service.fulfillRequisition(
+          fulfillRequisitionRequest {
+            externalRequisitionId = requisition.externalRequisitionId
+            nonce = NONCE_1
+            computedParams = computedRequisitionParams {
+              externalComputationId = measurement.externalComputationId
+              externalFulfillingDuchyId = nonExistentExternalDuchyId
+            }
+          }
+        )
+      }
+
+    assertThat(exception.status.code).isEqualTo(Status.Code.FAILED_PRECONDITION)
+  }
+
+  @Test
+  fun `fulfillRequisition throws FAILED_PRECONDITION if Measurement in illegal state`() =
+    runBlocking {
       val measurement =
         population.createComputedMeasurement(
           dataServices.measurementsService,
-          measurementConsumer,
-          providedMeasurementId,
-          mapOf(dataProvider.externalDataProviderId to dataProviderValue)
+          population.createMeasurementConsumer(
+            dataServices.measurementConsumersService,
+            dataServices.accountsService
+          ),
+          "measurement",
+          population.createDataProvider(dataServices.dataProvidersService),
+          population.createDataProvider(dataServices.dataProvidersService)
         )
-
-      val externalDataProviderId = dataProvider.externalDataProviderId
-      val listedRequisition =
+      val requisition =
         service
           .streamRequisitions(
             streamRequisitionsRequest {
@@ -543,65 +893,129 @@ abstract class RequisitionsServiceTest<T : RequisitionsCoroutineService> {
             }
           )
           .first()
-      val externalRequisitionId = listedRequisition.externalRequisitionId
 
-      val requisition =
-        service.getRequisition(
-          getRequisitionRequest {
-            this.externalDataProviderId = externalDataProviderId
-            this.externalRequisitionId = externalRequisitionId
-          }
-        )
-
-      val expectedRequisition = requisition {
-        externalMeasurementConsumerId = measurement.externalMeasurementConsumerId
-        externalMeasurementId = measurement.externalMeasurementId
-        this.externalDataProviderId = externalDataProviderId
-        this.externalRequisitionId = externalRequisitionId
-        externalComputationId = measurement.externalComputationId
-        state = Requisition.State.PENDING_PARAMS
-        details =
-          RequisitionKt.details {
-            dataProviderPublicKey = dataProviderValue.dataProviderPublicKey
-            dataProviderPublicKeySignature = dataProviderValue.dataProviderPublicKeySignature
-            encryptedRequisitionSpec = dataProviderValue.encryptedRequisitionSpec
-            nonceHash = dataProviderValue.nonceHash
-          }
-        dataProviderCertificate = dataProvider.certificate
-        parentMeasurement = parentMeasurement {
-          apiVersion = measurement.details.apiVersion
-          externalMeasurementConsumerCertificateId =
-            measurement.externalMeasurementConsumerCertificateId
-          measurementSpec = measurement.details.measurementSpec
-          measurementSpecSignature = measurement.details.measurementSpecSignature
-          state = Measurement.State.PENDING_REQUISITION_PARAMS
-          protocolConfig = protocolConfig {
-            liquidLegionsV2 = liquidLegionsV2{
-              requiredExternalDuchyIds += Population.AGGREGATOR_DUCHY.externalDuchyId
+      val exception =
+        assertFailsWith(StatusRuntimeException::class) {
+          service.fulfillRequisition(
+            fulfillRequisitionRequest {
+              externalRequisitionId = requisition.externalRequisitionId
+              nonce = NONCE_1
+              computedParams = computedRequisitionParams {
+                externalComputationId = measurement.externalComputationId
+                externalFulfillingDuchyId = Population.WORKER1_DUCHY.externalDuchyId
+              }
             }
-          }
-          dataProvidersCount = 1
+          )
         }
-      }
-      assertThat(requisition)
-        .ignoringFields(Requisition.UPDATE_TIME_FIELD_NUMBER, Requisition.DUCHIES_FIELD_NUMBER)
-        .isEqualTo(expectedRequisition)
-      assertThat(requisition.duchiesMap)
-        .containsExactly(
-          Population.AGGREGATOR_DUCHY.externalDuchyId,
-          Requisition.DuchyValue.getDefaultInstance(),
-          Population.WORKER1_DUCHY.externalDuchyId,
-          Requisition.DuchyValue.getDefaultInstance(),
-          Population.WORKER2_DUCHY.externalDuchyId,
-          Requisition.DuchyValue.getDefaultInstance()
-        )
-      assertThat(requisition).isEqualTo(listedRequisition)
+
+      assertThat(exception.status.code).isEqualTo(Status.Code.FAILED_PRECONDITION)
     }
 
-    @Test
-    fun `getRequisition returns expected direct requisition`() = runBlocking {
-      val dataProvider = population.createDataProvider(dataServices.dataProvidersService)
-      val dataProviderValue = dataProvider.toDataProviderValue()
+  @Test
+  fun `fulfillRequisition throws INVALID_ARGUMENT when signature not specified`() = runBlocking {
+    val measurement =
+      population.createComputedMeasurement(
+        dataServices.measurementsService,
+        population.createMeasurementConsumer(
+          dataServices.measurementConsumersService,
+          dataServices.accountsService
+        ),
+        "measurement",
+        population.createDataProvider(dataServices.dataProvidersService),
+        population.createDataProvider(dataServices.dataProvidersService)
+      )
+    for (duchyCertificate in duchyCertificates.values) {
+      dataServices.computationParticipantsService.setParticipantRequisitionParams(
+        setParticipantRequisitionParamsRequest {
+          externalComputationId = measurement.externalComputationId
+          externalDuchyId = duchyCertificate.externalDuchyId
+          externalDuchyCertificateId = duchyCertificate.externalCertificateId
+        }
+      )
+    }
+    val requisition =
+      service
+        .streamRequisitions(
+          streamRequisitionsRequest {
+            filter = filter {
+              externalMeasurementConsumerId = measurement.externalMeasurementConsumerId
+              externalMeasurementId = measurement.externalMeasurementId
+            }
+          }
+        )
+        .first()
+
+    val exception =
+      assertFailsWith(StatusRuntimeException::class) {
+        service.fulfillRequisition(
+          fulfillRequisitionRequest {
+            externalRequisitionId = requisition.externalRequisitionId
+            computedParams = computedRequisitionParams {
+              externalComputationId = measurement.externalComputationId
+              externalFulfillingDuchyId = Population.WORKER1_DUCHY.externalDuchyId
+            }
+          }
+        )
+      }
+
+    assertThat(exception.status.code).isEqualTo(Status.Code.INVALID_ARGUMENT)
+  }
+
+  @Test
+  fun `direct fulfillRequisition transitions Requisition state`() = runBlocking {
+    val measurement =
+      population.createDirectMeasurement(
+        dataServices.measurementsService,
+        population.createMeasurementConsumer(
+          dataServices.measurementConsumersService,
+          dataServices.accountsService
+        ),
+        "direct_measurement",
+        population.createDataProvider(dataServices.dataProvidersService),
+      )
+
+    val requisition =
+      service
+        .streamRequisitions(
+          streamRequisitionsRequest {
+            filter = filter {
+              externalMeasurementConsumerId = measurement.externalMeasurementConsumerId
+              externalMeasurementId = measurement.externalMeasurementId
+            }
+          }
+        )
+        .first()
+
+    val response =
+      service.fulfillRequisition(
+        fulfillRequisitionRequest {
+          externalRequisitionId = requisition.externalRequisitionId
+          nonce = NONCE_1
+          directParams = directRequisitionParams {
+            externalDataProviderId = requisition.externalDataProviderId
+            encryptedData = REQUISITION_ENCRYPTED_DATA
+          }
+        }
+      )
+
+    assertThat(response.state).isEqualTo(Requisition.State.FULFILLED)
+    assertThat(response.details.nonce).isEqualTo(NONCE_1)
+    assertThat(response.details.encryptedData).isEqualTo(REQUISITION_ENCRYPTED_DATA)
+    assertThat(response.updateTime.toInstant()).isGreaterThan(requisition.updateTime.toInstant())
+    assertThat(response)
+      .isEqualTo(
+        service.getRequisition(
+          getRequisitionRequest {
+            externalDataProviderId = requisition.externalDataProviderId
+            externalRequisitionId = requisition.externalRequisitionId
+          }
+        )
+      )
+  }
+
+  @Test
+  fun `direct fulfillRequisition transitions Measurement state when all others fulfilled`() =
+    runBlocking {
       val measurement =
         population.createDirectMeasurement(
           dataServices.measurementsService,
@@ -610,144 +1024,10 @@ abstract class RequisitionsServiceTest<T : RequisitionsCoroutineService> {
             dataServices.accountsService
           ),
           "direct_measurement",
-          mapOf(dataProvider.externalDataProviderId to dataProviderValue)
-        )
-
-      val listedRequisition =
-        service
-          .streamRequisitions(
-            streamRequisitionsRequest {
-              filter = filter {
-                externalMeasurementConsumerId = measurement.externalMeasurementConsumerId
-                externalMeasurementId = measurement.externalMeasurementId
-              }
-            }
-          )
-          .first()
-
-      val requisition =
-        service.getRequisition(
-          getRequisitionRequest {
-            externalDataProviderId = listedRequisition.externalDataProviderId
-            externalRequisitionId = listedRequisition.externalRequisitionId
-          }
-        )
-
-      val expectedRequisition = requisition {
-        externalMeasurementConsumerId = measurement.externalMeasurementConsumerId
-        externalMeasurementId = measurement.externalMeasurementId
-        externalDataProviderId = dataProvider.externalDataProviderId
-        this.externalRequisitionId = listedRequisition.externalRequisitionId
-        state = Requisition.State.UNFULFILLED
-        details =
-          RequisitionKt.details {
-            dataProviderPublicKey = dataProviderValue.dataProviderPublicKey
-            dataProviderPublicKeySignature = dataProviderValue.dataProviderPublicKeySignature
-            encryptedRequisitionSpec = dataProviderValue.encryptedRequisitionSpec
-            nonceHash = dataProviderValue.nonceHash
-          }
-        dataProviderCertificate = dataProvider.certificate
-        parentMeasurement = parentMeasurement {
-          apiVersion = measurement.details.apiVersion
-          externalMeasurementConsumerCertificateId =
-            measurement.externalMeasurementConsumerCertificateId
-          measurementSpec = measurement.details.measurementSpec
-          measurementSpecSignature = measurement.details.measurementSpecSignature
-          state = Measurement.State.PENDING_REQUISITION_FULFILLMENT
-          protocolConfig = protocolConfig {}
-          dataProvidersCount = 1
-        }
-      }
-      assertThat(requisition)
-        .ignoringFields(Requisition.UPDATE_TIME_FIELD_NUMBER, Requisition.DUCHIES_FIELD_NUMBER)
-        .isEqualTo(expectedRequisition)
-      assertThat(requisition).isEqualTo(listedRequisition)
-    }
-
-    @Test
-    fun `fulfillRequisition transitions Requisition state`() = runBlocking {
-      val measurement =
-        population.createComputedMeasurement(
-          dataServices.measurementsService,
-          population.createMeasurementConsumer(
-            dataServices.measurementConsumersService,
-            dataServices.accountsService
-          ),
-          "measurement",
           population.createDataProvider(dataServices.dataProvidersService),
-          population.createDataProvider(dataServices.dataProvidersService)
-        )
-      for (duchyCertificate in duchyCertificates.values) {
-        dataServices.computationParticipantsService.setParticipantRequisitionParams(
-          setParticipantRequisitionParamsRequest {
-            externalComputationId = measurement.externalComputationId
-            externalDuchyId = duchyCertificate.externalDuchyId
-            externalDuchyCertificateId = duchyCertificate.externalCertificateId
-          }
-        )
-      }
-      val requisition =
-        service
-          .streamRequisitions(
-            streamRequisitionsRequest {
-              filter = filter {
-                externalMeasurementConsumerId = measurement.externalMeasurementConsumerId
-                externalMeasurementId = measurement.externalMeasurementId
-              }
-            }
-          )
-          .first()
-
-      val response =
-        service.fulfillRequisition(
-          fulfillRequisitionRequest {
-            externalRequisitionId = requisition.externalRequisitionId
-            nonce = NONCE_1
-            computedParams = computedRequisitionParams {
-              externalComputationId = measurement.externalComputationId
-              externalFulfillingDuchyId = Population.WORKER1_DUCHY.externalDuchyId
-            }
-          }
-        )
-
-      assertThat(response.state).isEqualTo(Requisition.State.FULFILLED)
-      assertThat(response.externalFulfillingDuchyId)
-        .isEqualTo(Population.WORKER1_DUCHY.externalDuchyId)
-      assertThat(response.details.nonce).isEqualTo(NONCE_1)
-      assertThat(response.updateTime.toInstant()).isGreaterThan(requisition.updateTime.toInstant())
-      assertThat(response)
-        .isEqualTo(
-          service.getRequisition(
-            getRequisitionRequest {
-              externalDataProviderId = requisition.externalDataProviderId
-              externalRequisitionId = requisition.externalRequisitionId
-            }
-          )
-        )
-    }
-
-    @Test
-    fun `fulfillRequisition transitions Measurement state when all others fulfilled`() = runBlocking {
-      val measurement =
-        population.createComputedMeasurement(
-          dataServices.measurementsService,
-          population.createMeasurementConsumer(
-            dataServices.measurementConsumersService,
-            dataServices.accountsService
-          ),
-          "measurement",
           population.createDataProvider(dataServices.dataProvidersService),
-          population.createDataProvider(dataServices.dataProvidersService)
         )
-      for (duchyCertificate in duchyCertificates.values) {
-        dataServices.computationParticipantsService.setParticipantRequisitionParams(
-          setParticipantRequisitionParamsRequest {
-            externalComputationId = measurement.externalComputationId
-            externalDuchyId = duchyCertificate.externalDuchyId
-            externalDuchyCertificateId = duchyCertificate.externalCertificateId
-          }
-        )
-      }
+
       val requisitions =
         service
           .streamRequisitions(
@@ -759,31 +1039,30 @@ abstract class RequisitionsServiceTest<T : RequisitionsCoroutineService> {
             }
           )
           .toList()
+
       service.fulfillRequisition(
         fulfillRequisitionRequest {
           externalRequisitionId = requisitions[0].externalRequisitionId
           nonce = NONCE_1
-          computedParams = computedRequisitionParams {
-            externalComputationId = measurement.externalComputationId
-            externalFulfillingDuchyId = Population.WORKER1_DUCHY.externalDuchyId
+          directParams = directRequisitionParams {
+            externalDataProviderId = requisitions[0].externalDataProviderId
+            encryptedData = REQUISITION_ENCRYPTED_DATA
           }
         }
       )
-
       val response =
         service.fulfillRequisition(
           fulfillRequisitionRequest {
             externalRequisitionId = requisitions[1].externalRequisitionId
-            nonce = NONCE_2
-            computedParams = computedRequisitionParams {
-              externalComputationId = measurement.externalComputationId
-              externalFulfillingDuchyId = Population.WORKER1_DUCHY.externalDuchyId
+            nonce = NONCE_1
+            directParams = directRequisitionParams {
+              externalDataProviderId = requisitions[1].externalDataProviderId
+              encryptedData = REQUISITION_ENCRYPTED_DATA
             }
           }
         )
 
-      assertThat(response.parentMeasurement.state)
-        .isEqualTo(Measurement.State.PENDING_PARTICIPANT_CONFIRMATION)
+      assertThat(response.parentMeasurement.state).isEqualTo(Measurement.State.SUCCEEDED)
       assertThat(response)
         .isEqualTo(
           service.getRequisition(
@@ -795,176 +1074,9 @@ abstract class RequisitionsServiceTest<T : RequisitionsCoroutineService> {
         )
     }
 
-    @Test
-    fun `fulfillRequisition throws NOT_FOUND if Requisition not found`() = runBlocking {
-      val dataProvider = population.createDataProvider(dataServices.dataProvidersService)
-      val measurement =
-        population.createComputedMeasurement(
-          dataServices.measurementsService,
-          population.createMeasurementConsumer(
-            dataServices.measurementConsumersService,
-            dataServices.accountsService
-          ),
-          "measurement",
-          dataProvider
-        )
-
-      val nonExistentExternalRequisitionId = idGenerator.generateExternalId()
-      val exception =
-        assertFailsWith(StatusRuntimeException::class) {
-          service.fulfillRequisition(
-            fulfillRequisitionRequest {
-              externalRequisitionId = nonExistentExternalRequisitionId.value
-              nonce = NONCE_1
-              computedParams = computedRequisitionParams {
-                externalComputationId = measurement.externalComputationId
-                externalFulfillingDuchyId = Population.WORKER1_DUCHY.externalDuchyId
-              }
-            }
-          )
-        }
-
-      assertThat(exception.status.code).isEqualTo(Status.Code.NOT_FOUND)
-    }
-
-    @Test
-    fun `fulfillRequisition throws FAILED_PRECONDITION if Duchy not found`() = runBlocking {
-      val dataProvider = population.createDataProvider(dataServices.dataProvidersService)
-      val measurement =
-        population.createComputedMeasurement(
-          dataServices.measurementsService,
-          population.createMeasurementConsumer(
-            dataServices.measurementConsumersService,
-            dataServices.accountsService
-          ),
-          "measurement",
-          dataProvider
-        )
-      val requisition =
-        service
-          .streamRequisitions(
-            streamRequisitionsRequest {
-              filter = filter {
-                externalMeasurementConsumerId = measurement.externalMeasurementConsumerId
-                externalMeasurementId = measurement.externalMeasurementId
-              }
-            }
-          )
-          .first()
-
-      val nonExistentExternalDuchyId = "Chalced"
-      val exception =
-        assertFailsWith(StatusRuntimeException::class) {
-          service.fulfillRequisition(
-            fulfillRequisitionRequest {
-              externalRequisitionId = requisition.externalRequisitionId
-              nonce = NONCE_1
-              computedParams = computedRequisitionParams {
-                externalComputationId = measurement.externalComputationId
-                externalFulfillingDuchyId = nonExistentExternalDuchyId
-              }
-            }
-          )
-        }
-
-      assertThat(exception.status.code).isEqualTo(Status.Code.FAILED_PRECONDITION)
-    }
-
-    @Test
-    fun `fulfillRequisition throws FAILED_PRECONDITION if Measurement in illegal state`() =
-      runBlocking {
-        val measurement =
-          population.createComputedMeasurement(
-            dataServices.measurementsService,
-            population.createMeasurementConsumer(
-              dataServices.measurementConsumersService,
-              dataServices.accountsService
-            ),
-            "measurement",
-            population.createDataProvider(dataServices.dataProvidersService),
-            population.createDataProvider(dataServices.dataProvidersService)
-          )
-        val requisition =
-          service
-            .streamRequisitions(
-              streamRequisitionsRequest {
-                filter = filter {
-                  externalMeasurementConsumerId = measurement.externalMeasurementConsumerId
-                  externalMeasurementId = measurement.externalMeasurementId
-                }
-              }
-            )
-            .first()
-
-        val exception =
-          assertFailsWith(StatusRuntimeException::class) {
-            service.fulfillRequisition(
-              fulfillRequisitionRequest {
-                externalRequisitionId = requisition.externalRequisitionId
-                nonce = NONCE_1
-                computedParams = computedRequisitionParams {
-                  externalComputationId = measurement.externalComputationId
-                  externalFulfillingDuchyId = Population.WORKER1_DUCHY.externalDuchyId
-                }
-              }
-            )
-          }
-
-        assertThat(exception.status.code).isEqualTo(Status.Code.FAILED_PRECONDITION)
-      }
-
-    @Test
-    fun `fulfillRequisition throws INVALID_ARGUMENT when signature not specified`() = runBlocking {
-      val measurement =
-        population.createComputedMeasurement(
-          dataServices.measurementsService,
-          population.createMeasurementConsumer(
-            dataServices.measurementConsumersService,
-            dataServices.accountsService
-          ),
-          "measurement",
-          population.createDataProvider(dataServices.dataProvidersService),
-          population.createDataProvider(dataServices.dataProvidersService)
-        )
-      for (duchyCertificate in duchyCertificates.values) {
-        dataServices.computationParticipantsService.setParticipantRequisitionParams(
-          setParticipantRequisitionParamsRequest {
-            externalComputationId = measurement.externalComputationId
-            externalDuchyId = duchyCertificate.externalDuchyId
-            externalDuchyCertificateId = duchyCertificate.externalCertificateId
-          }
-        )
-      }
-      val requisition =
-        service
-          .streamRequisitions(
-            streamRequisitionsRequest {
-              filter = filter {
-                externalMeasurementConsumerId = measurement.externalMeasurementConsumerId
-                externalMeasurementId = measurement.externalMeasurementId
-              }
-            }
-          )
-          .first()
-
-      val exception =
-        assertFailsWith(StatusRuntimeException::class) {
-          service.fulfillRequisition(
-            fulfillRequisitionRequest {
-              externalRequisitionId = requisition.externalRequisitionId
-              computedParams = computedRequisitionParams {
-                externalComputationId = measurement.externalComputationId
-                externalFulfillingDuchyId = Population.WORKER1_DUCHY.externalDuchyId
-              }
-            }
-          )
-        }
-
-      assertThat(exception.status.code).isEqualTo(Status.Code.INVALID_ARGUMENT)
-    }
-
-    @Test
-    fun `direct fulfillRequisition transitions Requisition state`() = runBlocking {
+  @Test
+  fun `direct fulfillRequisition sets measurement result when all requisitions fulfilled`(): Unit =
+    runBlocking {
       val measurement =
         population.createDirectMeasurement(
           dataServices.measurementsService,
@@ -974,9 +1086,10 @@ abstract class RequisitionsServiceTest<T : RequisitionsCoroutineService> {
           ),
           "direct_measurement",
           population.createDataProvider(dataServices.dataProvidersService),
+          population.createDataProvider(dataServices.dataProvidersService),
         )
 
-      val requisition =
+      val requisitions =
         service
           .streamRequisitions(
             streamRequisitionsRequest {
@@ -986,203 +1099,157 @@ abstract class RequisitionsServiceTest<T : RequisitionsCoroutineService> {
               }
             }
           )
-          .first()
+          .toList()
 
-      val response =
-        service.fulfillRequisition(
-          fulfillRequisitionRequest {
-            externalRequisitionId = requisition.externalRequisitionId
-            nonce = NONCE_1
-            directParams = directRequisitionParams {
-              externalDataProviderId = requisition.externalDataProviderId
-              encryptedData = REQUISITION_ENCRYPTED_DATA
-            }
+      service.fulfillRequisition(
+        fulfillRequisitionRequest {
+          externalRequisitionId = requisitions[0].externalRequisitionId
+          nonce = NONCE_1
+          directParams = directRequisitionParams {
+            externalDataProviderId = requisitions[0].externalDataProviderId
+            encryptedData = REQUISITION_ENCRYPTED_DATA
+          }
+        }
+      )
+
+      service.fulfillRequisition(
+        fulfillRequisitionRequest {
+          externalRequisitionId = requisitions[1].externalRequisitionId
+          nonce = NONCE_1
+          directParams = directRequisitionParams {
+            externalDataProviderId = requisitions[1].externalDataProviderId
+            encryptedData = REQUISITION_ENCRYPTED_DATA
+          }
+        }
+      )
+
+      val succeededMeasurement =
+        dataServices.measurementsService.getMeasurement(
+          getMeasurementRequest {
+            externalMeasurementId = measurement.externalMeasurementId
+            externalMeasurementConsumerId = measurement.externalMeasurementConsumerId
           }
         )
 
-      assertThat(response.state).isEqualTo(Requisition.State.FULFILLED)
-      assertThat(response.details.nonce).isEqualTo(NONCE_1)
-      assertThat(response.details.encryptedData).isEqualTo(REQUISITION_ENCRYPTED_DATA)
-      assertThat(response.updateTime.toInstant()).isGreaterThan(requisition.updateTime.toInstant())
-      assertThat(response)
-        .isEqualTo(
-          service.getRequisition(
-            getRequisitionRequest {
-              externalDataProviderId = requisition.externalDataProviderId
-              externalRequisitionId = requisition.externalRequisitionId
-            }
-          )
+      assertThat(succeededMeasurement.resultsList.size).isEqualTo(2)
+      assertThat(succeededMeasurement.resultsList)
+        .ignoringRepeatedFieldOrder()
+        .containsAtLeast(
+          resultInfo {
+            externalDataProviderId = requisitions[0].externalDataProviderId
+            externalCertificateId = requisitions[0].dataProviderCertificate.externalCertificateId
+            encryptedResult = REQUISITION_ENCRYPTED_DATA
+          },
+          resultInfo {
+            externalDataProviderId = requisitions[1].externalDataProviderId
+            externalCertificateId = requisitions[1].dataProviderCertificate.externalCertificateId
+            encryptedResult = REQUISITION_ENCRYPTED_DATA
+          }
         )
     }
 
-    @Test
-    fun `direct fulfillRequisition transitions Measurement state when all others fulfilled`() =
-      runBlocking {
-        val measurement =
-          population.createDirectMeasurement(
-            dataServices.measurementsService,
-            population.createMeasurementConsumer(
-              dataServices.measurementConsumersService,
-              dataServices.accountsService
-            ),
-            "direct_measurement",
-            population.createDataProvider(dataServices.dataProvidersService),
-            population.createDataProvider(dataServices.dataProvidersService),
-          )
+  @Test
+  fun `direct fulfillRequisition throws NOT_FOUND if requisition not found`() = runBlocking {
+    val provider = population.createDataProvider(dataServices.dataProvidersService)
+    population.createDirectMeasurement(
+      dataServices.measurementsService,
+      population.createMeasurementConsumer(
+        dataServices.measurementConsumersService,
+        dataServices.accountsService
+      ),
+      "direct_measurement",
+      provider
+    )
 
-        val requisitions =
-          service
-            .streamRequisitions(
-              streamRequisitionsRequest {
-                filter = filter {
-                  externalMeasurementConsumerId = measurement.externalMeasurementConsumerId
-                  externalMeasurementId = measurement.externalMeasurementId
-                }
-              }
-            )
-            .toList()
-
+    val nonExistentExternalRequisitionId = idGenerator.generateExternalId()
+    val exception =
+      assertFailsWith(StatusRuntimeException::class) {
         service.fulfillRequisition(
           fulfillRequisitionRequest {
-            externalRequisitionId = requisitions[0].externalRequisitionId
+            externalRequisitionId = nonExistentExternalRequisitionId.value
             nonce = NONCE_1
             directParams = directRequisitionParams {
-              externalDataProviderId = requisitions[0].externalDataProviderId
+              externalDataProviderId = provider.externalDataProviderId
               encryptedData = REQUISITION_ENCRYPTED_DATA
             }
           }
         )
-        val response =
-          service.fulfillRequisition(
-            fulfillRequisitionRequest {
-              externalRequisitionId = requisitions[1].externalRequisitionId
-              nonce = NONCE_1
-              directParams = directRequisitionParams {
-                externalDataProviderId = requisitions[1].externalDataProviderId
-                encryptedData = REQUISITION_ENCRYPTED_DATA
-              }
-            }
-          )
-
-        assertThat(response.parentMeasurement.state).isEqualTo(Measurement.State.SUCCEEDED)
-        assertThat(response)
-          .isEqualTo(
-            service.getRequisition(
-              getRequisitionRequest {
-                externalDataProviderId = requisitions[1].externalDataProviderId
-                externalRequisitionId = requisitions[1].externalRequisitionId
-              }
-            )
-          )
       }
 
-    @Test
-    fun `direct fulfillRequisition sets measurement result when all requisitions fulfilled`(): Unit =
-      runBlocking {
-        val measurement =
-          population.createDirectMeasurement(
-            dataServices.measurementsService,
-            population.createMeasurementConsumer(
-              dataServices.measurementConsumersService,
-              dataServices.accountsService
-            ),
-            "direct_measurement",
-            population.createDataProvider(dataServices.dataProvidersService),
-            population.createDataProvider(dataServices.dataProvidersService),
-          )
+    assertThat(exception.status.code).isEqualTo(Status.Code.NOT_FOUND)
+  }
 
-        val requisitions =
-          service
-            .streamRequisitions(
-              streamRequisitionsRequest {
-                filter = filter {
-                  externalMeasurementConsumerId = measurement.externalMeasurementConsumerId
-                  externalMeasurementId = measurement.externalMeasurementId
-                }
-              }
-            )
-            .toList()
-
-        service.fulfillRequisition(
-          fulfillRequisitionRequest {
-            externalRequisitionId = requisitions[0].externalRequisitionId
-            nonce = NONCE_1
-            directParams = directRequisitionParams {
-              externalDataProviderId = requisitions[0].externalDataProviderId
-              encryptedData = REQUISITION_ENCRYPTED_DATA
-            }
-          }
-        )
-
-        service.fulfillRequisition(
-          fulfillRequisitionRequest {
-            externalRequisitionId = requisitions[1].externalRequisitionId
-            nonce = NONCE_1
-            directParams = directRequisitionParams {
-              externalDataProviderId = requisitions[1].externalDataProviderId
-              encryptedData = REQUISITION_ENCRYPTED_DATA
-            }
-          }
-        )
-
-        val succeededMeasurement =
-          dataServices.measurementsService.getMeasurement(
-            getMeasurementRequest {
-              externalMeasurementId = measurement.externalMeasurementId
-              externalMeasurementConsumerId = measurement.externalMeasurementConsumerId
-            }
-          )
-
-        assertThat(succeededMeasurement.resultsList.size).isEqualTo(2)
-        assertThat(succeededMeasurement.resultsList)
-          .ignoringRepeatedFieldOrder()
-          .containsAtLeast(
-            resultInfo {
-              externalDataProviderId = requisitions[0].externalDataProviderId
-              externalCertificateId = requisitions[0].dataProviderCertificate.externalCertificateId
-              encryptedResult = REQUISITION_ENCRYPTED_DATA
-            },
-            resultInfo {
-              externalDataProviderId = requisitions[1].externalDataProviderId
-              externalCertificateId = requisitions[1].dataProviderCertificate.externalCertificateId
-              encryptedResult = REQUISITION_ENCRYPTED_DATA
-            }
-          )
-      }
-
-    @Test
-    fun `direct fulfillRequisition throws NOT_FOUND if requisition not found`() = runBlocking {
-      val provider = population.createDataProvider(dataServices.dataProvidersService)
-      population.createDirectMeasurement(
+  @Test
+  fun `refuseRequisition transitions Requisition and Measurement states`() = runBlocking {
+    val measurement =
+      population.createComputedMeasurement(
         dataServices.measurementsService,
         population.createMeasurementConsumer(
           dataServices.measurementConsumersService,
           dataServices.accountsService
         ),
-        "direct_measurement",
-        provider
+        "measurement",
+        population.createDataProvider(dataServices.dataProvidersService),
+        population.createDataProvider(dataServices.dataProvidersService)
+      )
+    for (duchyCertificate in duchyCertificates.values) {
+      dataServices.computationParticipantsService.setParticipantRequisitionParams(
+        setParticipantRequisitionParamsRequest {
+          externalComputationId = measurement.externalComputationId
+          externalDuchyId = duchyCertificate.externalDuchyId
+          externalDuchyCertificateId = duchyCertificate.externalCertificateId
+        }
+      )
+    }
+    val requisition =
+      service
+        .streamRequisitions(
+          streamRequisitionsRequest {
+            filter = filter {
+              externalMeasurementConsumerId = measurement.externalMeasurementConsumerId
+              externalMeasurementId = measurement.externalMeasurementId
+            }
+          }
+        )
+        .first()
+
+    val response =
+      service.refuseRequisition(
+        refuseRequisitionRequest {
+          externalDataProviderId = requisition.externalDataProviderId
+          externalRequisitionId = requisition.externalRequisitionId
+          refusal = REFUSAL
+        }
       )
 
-      val nonExistentExternalRequisitionId = idGenerator.generateExternalId()
-      val exception =
-        assertFailsWith(StatusRuntimeException::class) {
-          service.fulfillRequisition(
-            fulfillRequisitionRequest {
-              externalRequisitionId = nonExistentExternalRequisitionId.value
-              nonce = NONCE_1
-              directParams = directRequisitionParams {
-                externalDataProviderId = provider.externalDataProviderId
-                encryptedData = REQUISITION_ENCRYPTED_DATA
-              }
-            }
-          )
+    assertThat(response.state).isEqualTo(Requisition.State.REFUSED)
+    assertThat(response.details.refusal).isEqualTo(REFUSAL)
+    assertThat(response.parentMeasurement.state).isEqualTo(Measurement.State.FAILED)
+    assertThat(response.updateTime.toInstant()).isGreaterThan(requisition.updateTime.toInstant())
+    assertThat(response)
+      .isEqualTo(
+        service.getRequisition(
+          getRequisitionRequest {
+            externalDataProviderId = requisition.externalDataProviderId
+            externalRequisitionId = requisition.externalRequisitionId
+          }
+        )
+      )
+    val updatedMeasurement =
+      dataServices.measurementsService.getMeasurement(
+        getMeasurementRequest {
+          externalMeasurementId = measurement.externalMeasurementId
+          externalMeasurementConsumerId = measurement.externalMeasurementConsumerId
         }
+      )
+    assertThat(updatedMeasurement.state).isEqualTo(Measurement.State.FAILED)
+    assertThat(updatedMeasurement.details.failure.reason)
+      .isEqualTo(Measurement.Failure.Reason.REQUISITION_REFUSED)
+  }
 
-      assertThat(exception.status.code).isEqualTo(Status.Code.NOT_FOUND)
-    }
-
-    @Test
-    fun `refuseRequisition transitions Requisition and Measurement states`() = runBlocking {
+  @Test
+  fun `refuseRequisition throws FAILED_PRECONDITION if Measurement in illegal state`() =
+    runBlocking {
       val measurement =
         population.createComputedMeasurement(
           dataServices.measurementsService,
@@ -1194,15 +1261,6 @@ abstract class RequisitionsServiceTest<T : RequisitionsCoroutineService> {
           population.createDataProvider(dataServices.dataProvidersService),
           population.createDataProvider(dataServices.dataProvidersService)
         )
-      for (duchyCertificate in duchyCertificates.values) {
-        dataServices.computationParticipantsService.setParticipantRequisitionParams(
-          setParticipantRequisitionParamsRequest {
-            externalComputationId = measurement.externalComputationId
-            externalDuchyId = duchyCertificate.externalDuchyId
-            externalDuchyCertificateId = duchyCertificate.externalCertificateId
-          }
-        )
-      }
       val requisition =
         service
           .streamRequisitions(
@@ -1215,107 +1273,47 @@ abstract class RequisitionsServiceTest<T : RequisitionsCoroutineService> {
           )
           .first()
 
-      val response =
-        service.refuseRequisition(
-          refuseRequisitionRequest {
-            externalDataProviderId = requisition.externalDataProviderId
-            externalRequisitionId = requisition.externalRequisitionId
-            refusal = REFUSAL
-          }
-        )
-
-      assertThat(response.state).isEqualTo(Requisition.State.REFUSED)
-      assertThat(response.details.refusal).isEqualTo(REFUSAL)
-      assertThat(response.parentMeasurement.state).isEqualTo(Measurement.State.FAILED)
-      assertThat(response.updateTime.toInstant()).isGreaterThan(requisition.updateTime.toInstant())
-      assertThat(response)
-        .isEqualTo(
-          service.getRequisition(
-            getRequisitionRequest {
-              externalDataProviderId = requisition.externalDataProviderId
-              externalRequisitionId = requisition.externalRequisitionId
-            }
-          )
-        )
-      val updatedMeasurement =
-        dataServices.measurementsService.getMeasurement(
-          getMeasurementRequest {
-            externalMeasurementId = measurement.externalMeasurementId
-            externalMeasurementConsumerId = measurement.externalMeasurementConsumerId
-          }
-        )
-      assertThat(updatedMeasurement.state).isEqualTo(Measurement.State.FAILED)
-      assertThat(updatedMeasurement.details.failure.reason)
-        .isEqualTo(Measurement.Failure.Reason.REQUISITION_REFUSED)
-    }
-
-    @Test
-    fun `refuseRequisition throws FAILED_PRECONDITION if Measurement in illegal state`() =
-      runBlocking {
-        val measurement =
-          population.createComputedMeasurement(
-            dataServices.measurementsService,
-            population.createMeasurementConsumer(
-              dataServices.measurementConsumersService,
-              dataServices.accountsService
-            ),
-            "measurement",
-            population.createDataProvider(dataServices.dataProvidersService),
-            population.createDataProvider(dataServices.dataProvidersService)
-          )
-        val requisition =
-          service
-            .streamRequisitions(
-              streamRequisitionsRequest {
-                filter = filter {
-                  externalMeasurementConsumerId = measurement.externalMeasurementConsumerId
-                  externalMeasurementId = measurement.externalMeasurementId
-                }
-              }
-            )
-            .first()
-
-        val exception =
-          assertFailsWith(StatusRuntimeException::class) {
-            service.refuseRequisition(
-              refuseRequisitionRequest {
-                externalDataProviderId = requisition.externalDataProviderId
-                externalRequisitionId = requisition.externalRequisitionId
-                refusal = REFUSAL
-              }
-            )
-          }
-
-        assertThat(exception.status.code).isEqualTo(Status.Code.FAILED_PRECONDITION)
-      }
-
-    @Test
-    fun `refuseRequisition throws NOT_FOUND if Requisition not found`() = runBlocking {
-      val dataProvider = population.createDataProvider(dataServices.dataProvidersService)
-      population.createComputedMeasurement(
-        dataServices.measurementsService,
-        population.createMeasurementConsumer(
-          dataServices.measurementConsumersService,
-          dataServices.accountsService
-        ),
-        "measurement",
-        dataProvider
-      )
-
-      val nonExistentExternalRequisitionId = idGenerator.generateExternalId()
       val exception =
         assertFailsWith(StatusRuntimeException::class) {
           service.refuseRequisition(
             refuseRequisitionRequest {
-              externalDataProviderId = dataProvider.externalDataProviderId
-              externalRequisitionId = nonExistentExternalRequisitionId.value
+              externalDataProviderId = requisition.externalDataProviderId
+              externalRequisitionId = requisition.externalRequisitionId
               refusal = REFUSAL
             }
           )
         }
 
-      assertThat(exception.status.code).isEqualTo(Status.Code.NOT_FOUND)
+      assertThat(exception.status.code).isEqualTo(Status.Code.FAILED_PRECONDITION)
     }
+
+  @Test
+  fun `refuseRequisition throws NOT_FOUND if Requisition not found`() = runBlocking {
+    val dataProvider = population.createDataProvider(dataServices.dataProvidersService)
+    population.createComputedMeasurement(
+      dataServices.measurementsService,
+      population.createMeasurementConsumer(
+        dataServices.measurementConsumersService,
+        dataServices.accountsService
+      ),
+      "measurement",
+      dataProvider
+    )
+
+    val nonExistentExternalRequisitionId = idGenerator.generateExternalId()
+    val exception =
+      assertFailsWith(StatusRuntimeException::class) {
+        service.refuseRequisition(
+          refuseRequisitionRequest {
+            externalDataProviderId = dataProvider.externalDataProviderId
+            externalRequisitionId = nonExistentExternalRequisitionId.value
+            refusal = REFUSAL
+          }
+        )
+      }
+
+    assertThat(exception.status.code).isEqualTo(Status.Code.NOT_FOUND)
+  }
 
   @Test
   fun `refuseRequisition throws INVALID_ARGUMENT when refusal justification not specified`() =
@@ -1331,7 +1329,6 @@ abstract class RequisitionsServiceTest<T : RequisitionsCoroutineService> {
           population.createDataProvider(dataServices.dataProvidersService),
           population.createDataProvider(dataServices.dataProvidersService)
         )
-
       for (duchyCertificate in duchyCertificates.values) {
         dataServices.computationParticipantsService.setParticipantRequisitionParams(
           setParticipantRequisitionParamsRequest {
@@ -1352,7 +1349,6 @@ abstract class RequisitionsServiceTest<T : RequisitionsCoroutineService> {
             }
           )
           .first()
-
       val exception =
         assertFailsWith(StatusRuntimeException::class) {
           service.refuseRequisition(

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/service/internal/testing/RequisitionsServiceTest.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/service/internal/testing/RequisitionsServiceTest.kt
@@ -23,7 +23,6 @@ import java.time.Clock
 import kotlin.random.Random
 import kotlin.test.assertFailsWith
 import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.runBlocking
 import org.junit.Before
 import org.junit.Rule
@@ -32,26 +31,29 @@ import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 import org.wfanet.measurement.common.identity.IdGenerator
 import org.wfanet.measurement.common.identity.RandomIdGenerator
-import org.wfanet.measurement.common.toInstant
 import org.wfanet.measurement.internal.kingdom.AccountsGrpcKt.AccountsCoroutineImplBase as AccountsCoroutineService
 import org.wfanet.measurement.internal.kingdom.Certificate
 import org.wfanet.measurement.internal.kingdom.CertificatesGrpcKt.CertificatesCoroutineImplBase as CertificatesCoroutineService
 import org.wfanet.measurement.internal.kingdom.ComputationParticipantsGrpcKt.ComputationParticipantsCoroutineImplBase as ComputationParticipantsCoroutineService
 import org.wfanet.measurement.internal.kingdom.DataProvidersGrpcKt.DataProvidersCoroutineImplBase as DataProvidersCoroutineService
+import org.wfanet.measurement.internal.kingdom.MeasurementConsumersGrpcKt.MeasurementConsumersCoroutineImplBase as MeasurementConsumersCoroutineService
+import org.wfanet.measurement.internal.kingdom.MeasurementsGrpcKt.MeasurementsCoroutineImplBase as MeasurementsCoroutineService
+import org.wfanet.measurement.internal.kingdom.Requisition
+import org.wfanet.measurement.internal.kingdom.RequisitionKt.refusal
+import org.wfanet.measurement.internal.kingdom.RequisitionsGrpcKt.RequisitionsCoroutineImplBase as RequisitionsCoroutineService
+import kotlinx.coroutines.flow.toList
+import org.wfanet.measurement.common.toInstant
 import org.wfanet.measurement.internal.kingdom.FulfillRequisitionRequestKt.computedRequisitionParams
 import org.wfanet.measurement.internal.kingdom.FulfillRequisitionRequestKt.directRequisitionParams
 import org.wfanet.measurement.internal.kingdom.Measurement
-import org.wfanet.measurement.internal.kingdom.MeasurementConsumersGrpcKt.MeasurementConsumersCoroutineImplBase as MeasurementConsumersCoroutineService
 import org.wfanet.measurement.internal.kingdom.MeasurementKt.resultInfo
-import org.wfanet.measurement.internal.kingdom.MeasurementsGrpcKt.MeasurementsCoroutineImplBase as MeasurementsCoroutineService
 import org.wfanet.measurement.internal.kingdom.ProtocolConfig
-import org.wfanet.measurement.internal.kingdom.Requisition
+import org.wfanet.measurement.internal.kingdom.ProtocolConfigKt.liquidLegionsV2
 import org.wfanet.measurement.internal.kingdom.RequisitionKt
 import org.wfanet.measurement.internal.kingdom.RequisitionKt.parentMeasurement
-import org.wfanet.measurement.internal.kingdom.RequisitionKt.refusal
-import org.wfanet.measurement.internal.kingdom.RequisitionsGrpcKt.RequisitionsCoroutineImplBase as RequisitionsCoroutineService
 import org.wfanet.measurement.internal.kingdom.StreamRequisitionsRequestKt.filter
 import org.wfanet.measurement.internal.kingdom.cancelMeasurementRequest
+import org.wfanet.measurement.internal.kingdom.copy
 import org.wfanet.measurement.internal.kingdom.fulfillRequisitionRequest
 import org.wfanet.measurement.internal.kingdom.getMeasurementRequest
 import org.wfanet.measurement.internal.kingdom.getRequisitionRequest
@@ -122,106 +124,39 @@ abstract class RequisitionsServiceTest<T : RequisitionsCoroutineService> {
     service = newService()
   }
 
-  @Test
-  fun `streamRequisitions returns all requisitions for MC`(): Unit = runBlocking {
-    val measurementConsumer =
-      population.createMeasurementConsumer(
-        dataServices.measurementConsumersService,
-        dataServices.accountsService
-      )
-    val dataProvider1 = population.createDataProvider(dataServices.dataProvidersService)
-    val dataProvider2 = population.createDataProvider(dataServices.dataProvidersService)
-    val measurement1 =
-      population.createComputedMeasurement(
-        dataServices.measurementsService,
-        measurementConsumer,
-        "measurement 1",
-        dataProvider1,
-        dataProvider2
-      )
-    val measurement2 =
-      population.createComputedMeasurement(
-        dataServices.measurementsService,
-        measurementConsumer,
-        "measurement 2",
-        dataProvider1
-      )
-    population.createComputedMeasurement(
-      dataServices.measurementsService,
-      population.createMeasurementConsumer(
-        dataServices.measurementConsumersService,
-        dataServices.accountsService
-      ),
-      "other MC measurement",
-      dataProvider1
-    )
-
-    val requisitions: List<Requisition> =
-      service
-        .streamRequisitions(
-          streamRequisitionsRequest {
-            filter = filter {
-              externalMeasurementConsumerId = measurementConsumer.externalMeasurementConsumerId
-            }
-          }
-        )
-        .toList()
-
-    assertThat(requisitions)
-      .comparingExpectedFieldsOnly()
-      .containsExactly(
-        requisition {
-          externalMeasurementConsumerId = measurementConsumer.externalMeasurementConsumerId
-          externalMeasurementId = measurement1.externalMeasurementId
-          externalDataProviderId = dataProvider1.externalDataProviderId
-        },
-        requisition {
-          externalMeasurementConsumerId = measurementConsumer.externalMeasurementConsumerId
-          externalMeasurementId = measurement1.externalMeasurementId
-          externalDataProviderId = dataProvider2.externalDataProviderId
-        },
-        requisition {
-          externalMeasurementConsumerId = measurementConsumer.externalMeasurementConsumerId
-          externalMeasurementId = measurement2.externalMeasurementId
-          externalDataProviderId = dataProvider1.externalDataProviderId
-        }
-      )
-  }
-
-  @Test
-  fun `streamRequisitions excludes requisitions with params set when filter excludes them`(): Unit =
-    runBlocking {
+    @Test
+    fun `streamRequisitions returns all requisitions for MC`(): Unit = runBlocking {
       val measurementConsumer =
         population.createMeasurementConsumer(
           dataServices.measurementConsumersService,
           dataServices.accountsService
         )
-      val dataProvider = population.createDataProvider(dataServices.dataProvidersService)
+      val dataProvider1 = population.createDataProvider(dataServices.dataProvidersService)
       val dataProvider2 = population.createDataProvider(dataServices.dataProvidersService)
-      val measurement =
+      val measurement1 =
         population.createComputedMeasurement(
           dataServices.measurementsService,
           measurementConsumer,
-          "measurement",
-          dataProvider
+          "measurement 1",
+          dataProvider1,
+          dataProvider2
         )
-
+      val measurement2 =
+        population.createComputedMeasurement(
+          dataServices.measurementsService,
+          measurementConsumer,
+          "measurement 2",
+          dataProvider1
+        )
       population.createComputedMeasurement(
         dataServices.measurementsService,
-        measurementConsumer,
-        "measurement2",
-        dataProvider2
+        population.createMeasurementConsumer(
+          dataServices.measurementConsumersService,
+          dataServices.accountsService
+        ),
+        "other MC measurement",
+        dataProvider1
       )
-
-      for (duchyCertificate in duchyCertificates.values) {
-        dataServices.computationParticipantsService.setParticipantRequisitionParams(
-          setParticipantRequisitionParamsRequest {
-            externalComputationId = measurement.externalComputationId
-            externalDuchyId = duchyCertificate.externalDuchyId
-            externalDuchyCertificateId = duchyCertificate.externalCertificateId
-          }
-        )
-      }
 
       val requisitions: List<Requisition> =
         service
@@ -229,9 +164,6 @@ abstract class RequisitionsServiceTest<T : RequisitionsCoroutineService> {
             streamRequisitionsRequest {
               filter = filter {
                 externalMeasurementConsumerId = measurementConsumer.externalMeasurementConsumerId
-                states += Requisition.State.UNFULFILLED
-                states += Requisition.State.FULFILLED
-                states += Requisition.State.REFUSED
               }
             }
           )
@@ -242,80 +174,202 @@ abstract class RequisitionsServiceTest<T : RequisitionsCoroutineService> {
         .containsExactly(
           requisition {
             externalMeasurementConsumerId = measurementConsumer.externalMeasurementConsumerId
-            externalMeasurementId = measurement.externalMeasurementId
-            externalDataProviderId = dataProvider.externalDataProviderId
+            externalMeasurementId = measurement1.externalMeasurementId
+            externalDataProviderId = dataProvider1.externalDataProviderId
+          },
+          requisition {
+            externalMeasurementConsumerId = measurementConsumer.externalMeasurementConsumerId
+            externalMeasurementId = measurement1.externalMeasurementId
+            externalDataProviderId = dataProvider2.externalDataProviderId
+          },
+          requisition {
+            externalMeasurementConsumerId = measurementConsumer.externalMeasurementConsumerId
+            externalMeasurementId = measurement2.externalMeasurementId
+            externalDataProviderId = dataProvider1.externalDataProviderId
           }
         )
+    }
 
-      val requisitions2: List<Requisition> =
+    @Test
+    fun `streamRequisitions excludes requisitions with params set when filter excludes them`(): Unit =
+      runBlocking {
+        val measurementConsumer =
+          population.createMeasurementConsumer(
+            dataServices.measurementConsumersService,
+            dataServices.accountsService
+          )
+        val dataProvider = population.createDataProvider(dataServices.dataProvidersService)
+        val dataProvider2 = population.createDataProvider(dataServices.dataProvidersService)
+        val measurement =
+          population.createComputedMeasurement(
+            dataServices.measurementsService,
+            measurementConsumer,
+            "measurement",
+            dataProvider
+          )
+
+        population.createComputedMeasurement(
+          dataServices.measurementsService,
+          measurementConsumer,
+          "measurement2",
+          dataProvider2
+        )
+
+        for (duchyCertificate in duchyCertificates.values) {
+          dataServices.computationParticipantsService.setParticipantRequisitionParams(
+            setParticipantRequisitionParamsRequest {
+              externalComputationId = measurement.externalComputationId
+              externalDuchyId = duchyCertificate.externalDuchyId
+              externalDuchyCertificateId = duchyCertificate.externalCertificateId
+            }
+          )
+        }
+
+        val requisitions: List<Requisition> =
+          service
+            .streamRequisitions(
+              streamRequisitionsRequest {
+                filter = filter {
+                  externalMeasurementConsumerId = measurementConsumer.externalMeasurementConsumerId
+                  states += Requisition.State.UNFULFILLED
+                  states += Requisition.State.FULFILLED
+                  states += Requisition.State.REFUSED
+                }
+              }
+            )
+            .toList()
+
+        assertThat(requisitions)
+          .comparingExpectedFieldsOnly()
+          .containsExactly(
+            requisition {
+              externalMeasurementConsumerId = measurementConsumer.externalMeasurementConsumerId
+              externalMeasurementId = measurement.externalMeasurementId
+              externalDataProviderId = dataProvider.externalDataProviderId
+            }
+          )
+
+        val requisitions2: List<Requisition> =
+          service
+            .streamRequisitions(
+              streamRequisitionsRequest {
+                filter = filter {
+                  externalMeasurementConsumerId = measurementConsumer.externalMeasurementConsumerId
+                }
+              }
+            )
+            .toList()
+
+        assertThat(requisitions.size).isLessThan(requisitions2.size)
+      }
+
+    @Test
+    fun `streamRequisitions returns all requisitions for measurement`(): Unit = runBlocking {
+      val measurementConsumer =
+        population.createMeasurementConsumer(
+          dataServices.measurementConsumersService,
+          dataServices.accountsService
+        )
+      val dataProvider1 = population.createDataProvider(dataServices.dataProvidersService)
+      val dataProvider2 = population.createDataProvider(dataServices.dataProvidersService)
+      val measurement =
+        population.createComputedMeasurement(
+          dataServices.measurementsService,
+          measurementConsumer,
+          "measurement 1",
+          dataProvider1,
+          dataProvider2
+        )
+      population.createComputedMeasurement(
+        dataServices.measurementsService,
+        measurementConsumer,
+        "measurement 2",
+        dataProvider1
+      )
+
+      val requisitions: List<Requisition> =
         service
           .streamRequisitions(
             streamRequisitionsRequest {
               filter = filter {
-                externalMeasurementConsumerId = measurementConsumer.externalMeasurementConsumerId
+                externalMeasurementConsumerId = measurement.externalMeasurementConsumerId
+                externalMeasurementId = measurement.externalMeasurementId
               }
             }
           )
           .toList()
 
-      assertThat(requisitions.size).isLessThan(requisitions2.size)
-    }
-
-  @Test
-  fun `streamRequisitions returns all requisitions for measurement`(): Unit = runBlocking {
-    val measurementConsumer =
-      population.createMeasurementConsumer(
-        dataServices.measurementConsumersService,
-        dataServices.accountsService
-      )
-    val dataProvider1 = population.createDataProvider(dataServices.dataProvidersService)
-    val dataProvider2 = population.createDataProvider(dataServices.dataProvidersService)
-    val measurement =
-      population.createComputedMeasurement(
-        dataServices.measurementsService,
-        measurementConsumer,
-        "measurement 1",
-        dataProvider1,
-        dataProvider2
-      )
-    population.createComputedMeasurement(
-      dataServices.measurementsService,
-      measurementConsumer,
-      "measurement 2",
-      dataProvider1
-    )
-
-    val requisitions: List<Requisition> =
-      service
-        .streamRequisitions(
-          streamRequisitionsRequest {
-            filter = filter {
-              externalMeasurementConsumerId = measurement.externalMeasurementConsumerId
-              externalMeasurementId = measurement.externalMeasurementId
-            }
+      assertThat(requisitions)
+        .comparingExpectedFieldsOnly()
+        .containsExactly(
+          requisition {
+            externalMeasurementConsumerId = measurement.externalMeasurementConsumerId
+            externalMeasurementId = measurement.externalMeasurementId
+            externalDataProviderId = dataProvider1.externalDataProviderId
+          },
+          requisition {
+            externalMeasurementConsumerId = measurement.externalMeasurementConsumerId
+            externalMeasurementId = measurement.externalMeasurementId
+            externalDataProviderId = dataProvider2.externalDataProviderId
           }
         )
-        .toList()
+    }
 
-    assertThat(requisitions)
-      .comparingExpectedFieldsOnly()
-      .containsExactly(
-        requisition {
-          externalMeasurementConsumerId = measurement.externalMeasurementConsumerId
-          externalMeasurementId = measurement.externalMeasurementId
-          externalDataProviderId = dataProvider1.externalDataProviderId
-        },
-        requisition {
-          externalMeasurementConsumerId = measurement.externalMeasurementConsumerId
-          externalMeasurementId = measurement.externalMeasurementId
-          externalDataProviderId = dataProvider2.externalDataProviderId
-        }
-      )
-  }
+    @Test
+    fun `streamRequisitions only includes measurements with some states when filter set`(): Unit =
+      runBlocking {
+        val measurementConsumer =
+          population.createMeasurementConsumer(
+            dataServices.measurementConsumersService,
+            dataServices.accountsService
+          )
+        val dataProvider = population.createDataProvider(dataServices.dataProvidersService)
+        val measurement1 =
+          population.createComputedMeasurement(
+            dataServices.measurementsService,
+            measurementConsumer,
+            "measurement 1",
+            dataProvider
+          )
+        val measurement2 =
+          population.createComputedMeasurement(
+            dataServices.measurementsService,
+            measurementConsumer,
+            "measurement 2",
+            dataProvider
+          )
+        dataServices.measurementsService.cancelMeasurement(
+          cancelMeasurementRequest {
+            externalMeasurementConsumerId = measurementConsumer.externalMeasurementConsumerId
+            externalMeasurementId = measurement2.externalMeasurementId
+          }
+        )
 
-  @Test
-  fun `streamRequisitions only includes measurements with some states when filter set`(): Unit =
-    runBlocking {
+        val requisitions: List<Requisition> =
+          service
+            .streamRequisitions(
+              streamRequisitionsRequest {
+                filter = filter {
+                  externalMeasurementConsumerId = measurementConsumer.externalMeasurementConsumerId
+                  measurementStates += Measurement.State.PENDING_REQUISITION_PARAMS
+                }
+              }
+            )
+            .toList()
+
+        assertThat(requisitions)
+          .comparingExpectedFieldsOnly()
+          .containsExactly(
+            requisition {
+              externalMeasurementConsumerId = measurement1.externalMeasurementConsumerId
+              externalMeasurementId = measurement1.externalMeasurementId
+              externalDataProviderId = dataProvider.externalDataProviderId
+            }
+          )
+      }
+
+    @Test
+    fun `streamRequisitions respects updated_after`(): Unit = runBlocking {
       val measurementConsumer =
         population.createMeasurementConsumer(
           dataServices.measurementConsumersService,
@@ -336,11 +390,11 @@ abstract class RequisitionsServiceTest<T : RequisitionsCoroutineService> {
           "measurement 2",
           dataProvider
         )
-      dataServices.measurementsService.cancelMeasurement(
-        cancelMeasurementRequest {
-          externalMeasurementConsumerId = measurementConsumer.externalMeasurementConsumerId
-          externalMeasurementId = measurement2.externalMeasurementId
-        }
+      population.createComputedMeasurement(
+        dataServices.measurementsService,
+        measurementConsumer,
+        "measurement 3",
+        population.createDataProvider(dataServices.dataProvidersService)
       )
 
       val requisitions: List<Requisition> =
@@ -348,8 +402,8 @@ abstract class RequisitionsServiceTest<T : RequisitionsCoroutineService> {
           .streamRequisitions(
             streamRequisitionsRequest {
               filter = filter {
-                externalMeasurementConsumerId = measurementConsumer.externalMeasurementConsumerId
-                measurementStates += Measurement.State.PENDING_REQUISITION_PARAMS
+                externalDataProviderId = dataProvider.externalDataProviderId
+                updatedAfter = measurement1.updateTime
               }
             }
           )
@@ -359,516 +413,259 @@ abstract class RequisitionsServiceTest<T : RequisitionsCoroutineService> {
         .comparingExpectedFieldsOnly()
         .containsExactly(
           requisition {
-            externalMeasurementConsumerId = measurement1.externalMeasurementConsumerId
-            externalMeasurementId = measurement1.externalMeasurementId
             externalDataProviderId = dataProvider.externalDataProviderId
+            externalMeasurementId = measurement2.externalMeasurementId
           }
         )
     }
 
-  @Test
-  fun `streamRequisitions respects updated_after`(): Unit = runBlocking {
-    val measurementConsumer =
-      population.createMeasurementConsumer(
-        dataServices.measurementConsumersService,
-        dataServices.accountsService
-      )
-    val dataProvider = population.createDataProvider(dataServices.dataProvidersService)
-    val measurement1 =
+    @Test
+    fun `streamRequisitions respects limit`(): Unit = runBlocking {
+      val measurementConsumer =
+        population.createMeasurementConsumer(
+          dataServices.measurementConsumersService,
+          dataServices.accountsService
+        )
+      val dataProvider = population.createDataProvider(dataServices.dataProvidersService)
       population.createComputedMeasurement(
         dataServices.measurementsService,
         measurementConsumer,
         "measurement 1",
         dataProvider
       )
-    val measurement2 =
+
       population.createComputedMeasurement(
         dataServices.measurementsService,
         measurementConsumer,
         "measurement 2",
         dataProvider
       )
-    population.createComputedMeasurement(
-      dataServices.measurementsService,
-      measurementConsumer,
-      "measurement 3",
-      population.createDataProvider(dataServices.dataProvidersService)
-    )
 
-    val requisitions: List<Requisition> =
-      service
-        .streamRequisitions(
-          streamRequisitionsRequest {
-            filter = filter {
-              externalDataProviderId = dataProvider.externalDataProviderId
-              updatedAfter = measurement1.updateTime
+      val requisitions: List<Requisition> =
+        service
+          .streamRequisitions(
+            streamRequisitionsRequest {
+              filter = filter { externalDataProviderId = dataProvider.externalDataProviderId }
+              limit = 1
             }
-          }
+          )
+          .toList()
+
+      assertThat(requisitions)
+        .comparingExpectedFieldsOnly()
+        .containsExactly(requisition { externalDataProviderId = dataProvider.externalDataProviderId })
+    }
+
+    @Test
+    fun `streamRequisitions can get one page at a time`(): Unit = runBlocking {
+      val measurementConsumer =
+        population.createMeasurementConsumer(
+          dataServices.measurementConsumersService,
+          dataServices.accountsService
         )
-        .toList()
-
-    assertThat(requisitions)
-      .comparingExpectedFieldsOnly()
-      .containsExactly(
-        requisition {
-          externalDataProviderId = dataProvider.externalDataProviderId
-          externalMeasurementId = measurement2.externalMeasurementId
-        }
-      )
-  }
-
-  @Test
-  fun `streamRequisitions respects limit`(): Unit = runBlocking {
-    val measurementConsumer =
-      population.createMeasurementConsumer(
-        dataServices.measurementConsumersService,
-        dataServices.accountsService
-      )
-    val dataProvider = population.createDataProvider(dataServices.dataProvidersService)
-    population.createComputedMeasurement(
-      dataServices.measurementsService,
-      measurementConsumer,
-      "measurement 1",
-      dataProvider
-    )
-
-    population.createComputedMeasurement(
-      dataServices.measurementsService,
-      measurementConsumer,
-      "measurement 2",
-      dataProvider
-    )
-
-    val requisitions: List<Requisition> =
-      service
-        .streamRequisitions(
-          streamRequisitionsRequest {
-            filter = filter { externalDataProviderId = dataProvider.externalDataProviderId }
-            limit = 1
-          }
-        )
-        .toList()
-
-    assertThat(requisitions)
-      .comparingExpectedFieldsOnly()
-      .containsExactly(requisition { externalDataProviderId = dataProvider.externalDataProviderId })
-  }
-
-  @Test
-  fun `streamRequisitions can get one page at a time`(): Unit = runBlocking {
-    val measurementConsumer =
-      population.createMeasurementConsumer(
-        dataServices.measurementConsumersService,
-        dataServices.accountsService
-      )
-    val dataProvider = population.createDataProvider(dataServices.dataProvidersService)
-    population.createComputedMeasurement(
-      dataServices.measurementsService,
-      measurementConsumer,
-      "measurement 1",
-      dataProvider
-    )
-
-    population.createComputedMeasurement(
-      dataServices.measurementsService,
-      measurementConsumer,
-      "measurement 2",
-      dataProvider
-    )
-
-    val requisitions: List<Requisition> =
-      service
-        .streamRequisitions(
-          streamRequisitionsRequest {
-            filter = filter { externalDataProviderId = dataProvider.externalDataProviderId }
-            limit = 1
-          }
-        )
-        .toList()
-
-    assertThat(requisitions)
-      .comparingExpectedFieldsOnly()
-      .containsExactly(requisition { externalDataProviderId = dataProvider.externalDataProviderId })
-
-    val requisitions2: List<Requisition> =
-      service
-        .streamRequisitions(
-          streamRequisitionsRequest {
-            filter = filter {
-              externalDataProviderId = dataProvider.externalDataProviderId
-              externalRequisitionIdAfter = requisitions[0].externalRequisitionId
-              externalDataProviderIdAfter = requisitions[0].externalDataProviderId
-            }
-            limit = 1
-          }
-        )
-        .toList()
-
-    assertThat(requisitions2)
-      .comparingExpectedFieldsOnly()
-      .containsExactly(requisition { externalDataProviderId = dataProvider.externalDataProviderId })
-    assertThat(requisitions2[0].externalRequisitionId)
-      .isGreaterThan(requisitions[0].externalRequisitionId)
-  }
-
-  @Test
-  fun `getRequisition returns expected requisition`() = runBlocking {
-    val measurementConsumer =
-      population.createMeasurementConsumer(
-        dataServices.measurementConsumersService,
-        dataServices.accountsService
-      )
-    val dataProvider = population.createDataProvider(dataServices.dataProvidersService)
-    val dataProviderValue = dataProvider.toDataProviderValue()
-    val providedMeasurementId = "measurement"
-    val measurement =
+      val dataProvider = population.createDataProvider(dataServices.dataProvidersService)
       population.createComputedMeasurement(
         dataServices.measurementsService,
         measurementConsumer,
-        providedMeasurementId,
-        mapOf(dataProvider.externalDataProviderId to dataProviderValue)
-      )
-
-    val externalDataProviderId = dataProvider.externalDataProviderId
-    val listedRequisition =
-      service
-        .streamRequisitions(
-          streamRequisitionsRequest {
-            filter = filter {
-              externalMeasurementConsumerId = measurement.externalMeasurementConsumerId
-              externalMeasurementId = measurement.externalMeasurementId
-            }
-          }
-        )
-        .first()
-    val externalRequisitionId = listedRequisition.externalRequisitionId
-
-    val requisition =
-      service.getRequisition(
-        getRequisitionRequest {
-          this.externalDataProviderId = externalDataProviderId
-          this.externalRequisitionId = externalRequisitionId
-        }
-      )
-
-    val expectedRequisition = requisition {
-      externalMeasurementConsumerId = measurement.externalMeasurementConsumerId
-      externalMeasurementId = measurement.externalMeasurementId
-      this.externalDataProviderId = externalDataProviderId
-      this.externalRequisitionId = externalRequisitionId
-      externalComputationId = measurement.externalComputationId
-      state = Requisition.State.PENDING_PARAMS
-      details =
-        RequisitionKt.details {
-          dataProviderPublicKey = dataProviderValue.dataProviderPublicKey
-          dataProviderPublicKeySignature = dataProviderValue.dataProviderPublicKeySignature
-          encryptedRequisitionSpec = dataProviderValue.encryptedRequisitionSpec
-          nonceHash = dataProviderValue.nonceHash
-        }
-      dataProviderCertificate = dataProvider.certificate
-      parentMeasurement = parentMeasurement {
-        apiVersion = measurement.details.apiVersion
-        externalMeasurementConsumerCertificateId =
-          measurement.externalMeasurementConsumerCertificateId
-        measurementSpec = measurement.details.measurementSpec
-        measurementSpecSignature = measurement.details.measurementSpecSignature
-        state = Measurement.State.PENDING_REQUISITION_PARAMS
-        protocolConfig = protocolConfig {
-          liquidLegionsV2 = ProtocolConfig.LiquidLegionsV2.getDefaultInstance()
-        }
-        dataProvidersCount = 1
-      }
-    }
-    assertThat(requisition)
-      .ignoringFields(Requisition.UPDATE_TIME_FIELD_NUMBER, Requisition.DUCHIES_FIELD_NUMBER)
-      .isEqualTo(expectedRequisition)
-    assertThat(requisition.duchiesMap)
-      .containsExactly(
-        Population.AGGREGATOR_DUCHY.externalDuchyId,
-        Requisition.DuchyValue.getDefaultInstance(),
-        Population.WORKER1_DUCHY.externalDuchyId,
-        Requisition.DuchyValue.getDefaultInstance(),
-        Population.WORKER2_DUCHY.externalDuchyId,
-        Requisition.DuchyValue.getDefaultInstance()
-      )
-    assertThat(requisition).isEqualTo(listedRequisition)
-  }
-
-  @Test
-  fun `getRequisition returns expected direct requisition`() = runBlocking {
-    val dataProvider = population.createDataProvider(dataServices.dataProvidersService)
-    val dataProviderValue = dataProvider.toDataProviderValue()
-    val measurement =
-      population.createDirectMeasurement(
-        dataServices.measurementsService,
-        population.createMeasurementConsumer(
-          dataServices.measurementConsumersService,
-          dataServices.accountsService
-        ),
-        "direct_measurement",
-        mapOf(dataProvider.externalDataProviderId to dataProviderValue)
-      )
-
-    val listedRequisition =
-      service
-        .streamRequisitions(
-          streamRequisitionsRequest {
-            filter = filter {
-              externalMeasurementConsumerId = measurement.externalMeasurementConsumerId
-              externalMeasurementId = measurement.externalMeasurementId
-            }
-          }
-        )
-        .first()
-
-    val requisition =
-      service.getRequisition(
-        getRequisitionRequest {
-          externalDataProviderId = listedRequisition.externalDataProviderId
-          externalRequisitionId = listedRequisition.externalRequisitionId
-        }
-      )
-
-    val expectedRequisition = requisition {
-      externalMeasurementConsumerId = measurement.externalMeasurementConsumerId
-      externalMeasurementId = measurement.externalMeasurementId
-      externalDataProviderId = dataProvider.externalDataProviderId
-      this.externalRequisitionId = listedRequisition.externalRequisitionId
-      state = Requisition.State.UNFULFILLED
-      details =
-        RequisitionKt.details {
-          dataProviderPublicKey = dataProviderValue.dataProviderPublicKey
-          dataProviderPublicKeySignature = dataProviderValue.dataProviderPublicKeySignature
-          encryptedRequisitionSpec = dataProviderValue.encryptedRequisitionSpec
-          nonceHash = dataProviderValue.nonceHash
-        }
-      dataProviderCertificate = dataProvider.certificate
-      parentMeasurement = parentMeasurement {
-        apiVersion = measurement.details.apiVersion
-        externalMeasurementConsumerCertificateId =
-          measurement.externalMeasurementConsumerCertificateId
-        measurementSpec = measurement.details.measurementSpec
-        measurementSpecSignature = measurement.details.measurementSpecSignature
-        state = Measurement.State.PENDING_REQUISITION_FULFILLMENT
-        protocolConfig = protocolConfig {}
-        dataProvidersCount = 1
-      }
-    }
-    assertThat(requisition)
-      .ignoringFields(Requisition.UPDATE_TIME_FIELD_NUMBER, Requisition.DUCHIES_FIELD_NUMBER)
-      .isEqualTo(expectedRequisition)
-    assertThat(requisition).isEqualTo(listedRequisition)
-  }
-
-  @Test
-  fun `fulfillRequisition transitions Requisition state`() = runBlocking {
-    val measurement =
-      population.createComputedMeasurement(
-        dataServices.measurementsService,
-        population.createMeasurementConsumer(
-          dataServices.measurementConsumersService,
-          dataServices.accountsService
-        ),
-        "measurement",
-        population.createDataProvider(dataServices.dataProvidersService),
-        population.createDataProvider(dataServices.dataProvidersService)
-      )
-    for (duchyCertificate in duchyCertificates.values) {
-      dataServices.computationParticipantsService.setParticipantRequisitionParams(
-        setParticipantRequisitionParamsRequest {
-          externalComputationId = measurement.externalComputationId
-          externalDuchyId = duchyCertificate.externalDuchyId
-          externalDuchyCertificateId = duchyCertificate.externalCertificateId
-        }
-      )
-    }
-    val requisition =
-      service
-        .streamRequisitions(
-          streamRequisitionsRequest {
-            filter = filter {
-              externalMeasurementConsumerId = measurement.externalMeasurementConsumerId
-              externalMeasurementId = measurement.externalMeasurementId
-            }
-          }
-        )
-        .first()
-
-    val response =
-      service.fulfillRequisition(
-        fulfillRequisitionRequest {
-          externalRequisitionId = requisition.externalRequisitionId
-          nonce = NONCE_1
-          computedParams = computedRequisitionParams {
-            externalComputationId = measurement.externalComputationId
-            externalFulfillingDuchyId = Population.WORKER1_DUCHY.externalDuchyId
-          }
-        }
-      )
-
-    assertThat(response.state).isEqualTo(Requisition.State.FULFILLED)
-    assertThat(response.externalFulfillingDuchyId)
-      .isEqualTo(Population.WORKER1_DUCHY.externalDuchyId)
-    assertThat(response.details.nonce).isEqualTo(NONCE_1)
-    assertThat(response.updateTime.toInstant()).isGreaterThan(requisition.updateTime.toInstant())
-    assertThat(response)
-      .isEqualTo(
-        service.getRequisition(
-          getRequisitionRequest {
-            externalDataProviderId = requisition.externalDataProviderId
-            externalRequisitionId = requisition.externalRequisitionId
-          }
-        )
-      )
-  }
-
-  @Test
-  fun `fulfillRequisition transitions Measurement state when all others fulfilled`() = runBlocking {
-    val measurement =
-      population.createComputedMeasurement(
-        dataServices.measurementsService,
-        population.createMeasurementConsumer(
-          dataServices.measurementConsumersService,
-          dataServices.accountsService
-        ),
-        "measurement",
-        population.createDataProvider(dataServices.dataProvidersService),
-        population.createDataProvider(dataServices.dataProvidersService)
-      )
-    for (duchyCertificate in duchyCertificates.values) {
-      dataServices.computationParticipantsService.setParticipantRequisitionParams(
-        setParticipantRequisitionParamsRequest {
-          externalComputationId = measurement.externalComputationId
-          externalDuchyId = duchyCertificate.externalDuchyId
-          externalDuchyCertificateId = duchyCertificate.externalCertificateId
-        }
-      )
-    }
-    val requisitions =
-      service
-        .streamRequisitions(
-          streamRequisitionsRequest {
-            filter = filter {
-              externalMeasurementConsumerId = measurement.externalMeasurementConsumerId
-              externalMeasurementId = measurement.externalMeasurementId
-            }
-          }
-        )
-        .toList()
-    service.fulfillRequisition(
-      fulfillRequisitionRequest {
-        externalRequisitionId = requisitions[0].externalRequisitionId
-        nonce = NONCE_1
-        computedParams = computedRequisitionParams {
-          externalComputationId = measurement.externalComputationId
-          externalFulfillingDuchyId = Population.WORKER1_DUCHY.externalDuchyId
-        }
-      }
-    )
-
-    val response =
-      service.fulfillRequisition(
-        fulfillRequisitionRequest {
-          externalRequisitionId = requisitions[1].externalRequisitionId
-          nonce = NONCE_2
-          computedParams = computedRequisitionParams {
-            externalComputationId = measurement.externalComputationId
-            externalFulfillingDuchyId = Population.WORKER1_DUCHY.externalDuchyId
-          }
-        }
-      )
-
-    assertThat(response.parentMeasurement.state)
-      .isEqualTo(Measurement.State.PENDING_PARTICIPANT_CONFIRMATION)
-    assertThat(response)
-      .isEqualTo(
-        service.getRequisition(
-          getRequisitionRequest {
-            externalDataProviderId = requisitions[1].externalDataProviderId
-            externalRequisitionId = requisitions[1].externalRequisitionId
-          }
-        )
-      )
-  }
-
-  @Test
-  fun `fulfillRequisition throws NOT_FOUND if Requisition not found`() = runBlocking {
-    val dataProvider = population.createDataProvider(dataServices.dataProvidersService)
-    val measurement =
-      population.createComputedMeasurement(
-        dataServices.measurementsService,
-        population.createMeasurementConsumer(
-          dataServices.measurementConsumersService,
-          dataServices.accountsService
-        ),
-        "measurement",
+        "measurement 1",
         dataProvider
       )
 
-    val nonExistentExternalRequisitionId = idGenerator.generateExternalId()
-    val exception =
-      assertFailsWith(StatusRuntimeException::class) {
-        service.fulfillRequisition(
-          fulfillRequisitionRequest {
-            externalRequisitionId = nonExistentExternalRequisitionId.value
-            nonce = NONCE_1
-            computedParams = computedRequisitionParams {
-              externalComputationId = measurement.externalComputationId
-              externalFulfillingDuchyId = Population.WORKER1_DUCHY.externalDuchyId
-            }
-          }
-        )
-      }
-
-    assertThat(exception.status.code).isEqualTo(Status.Code.NOT_FOUND)
-  }
-
-  @Test
-  fun `fulfillRequisition throws FAILED_PRECONDITION if Duchy not found`() = runBlocking {
-    val dataProvider = population.createDataProvider(dataServices.dataProvidersService)
-    val measurement =
       population.createComputedMeasurement(
         dataServices.measurementsService,
+        measurementConsumer,
+        "measurement 2",
+        dataProvider
+      )
+
+      val requisitions: List<Requisition> =
+        service
+          .streamRequisitions(
+            streamRequisitionsRequest {
+              filter = filter { externalDataProviderId = dataProvider.externalDataProviderId }
+              limit = 1
+            }
+          )
+          .toList()
+
+      assertThat(requisitions)
+        .comparingExpectedFieldsOnly()
+        .containsExactly(requisition { externalDataProviderId = dataProvider.externalDataProviderId })
+
+      val requisitions2: List<Requisition> =
+        service
+          .streamRequisitions(
+            streamRequisitionsRequest {
+              filter = filter {
+                externalDataProviderId = dataProvider.externalDataProviderId
+                externalRequisitionIdAfter = requisitions[0].externalRequisitionId
+                externalDataProviderIdAfter = requisitions[0].externalDataProviderId
+              }
+              limit = 1
+            }
+          )
+          .toList()
+
+      assertThat(requisitions2)
+        .comparingExpectedFieldsOnly()
+        .containsExactly(requisition { externalDataProviderId = dataProvider.externalDataProviderId })
+      assertThat(requisitions2[0].externalRequisitionId)
+        .isGreaterThan(requisitions[0].externalRequisitionId)
+    }
+
+    @Test
+    fun `getRequisition returns expected requisition`() = runBlocking {
+      val measurementConsumer =
         population.createMeasurementConsumer(
           dataServices.measurementConsumersService,
           dataServices.accountsService
-        ),
-        "measurement",
-        dataProvider
-      )
-    val requisition =
-      service
-        .streamRequisitions(
-          streamRequisitionsRequest {
-            filter = filter {
-              externalMeasurementConsumerId = measurement.externalMeasurementConsumerId
-              externalMeasurementId = measurement.externalMeasurementId
-            }
-          }
         )
-        .first()
+      val dataProvider = population.createDataProvider(dataServices.dataProvidersService)
+      val dataProviderValue = dataProvider.toDataProviderValue()
+      val providedMeasurementId = "measurement"
+      val measurement =
+        population.createComputedMeasurement(
+          dataServices.measurementsService,
+          measurementConsumer,
+          providedMeasurementId,
+          mapOf(dataProvider.externalDataProviderId to dataProviderValue)
+        )
 
-    val nonExistentExternalDuchyId = "Chalced"
-    val exception =
-      assertFailsWith(StatusRuntimeException::class) {
-        service.fulfillRequisition(
-          fulfillRequisitionRequest {
-            externalRequisitionId = requisition.externalRequisitionId
-            nonce = NONCE_1
-            computedParams = computedRequisitionParams {
-              externalComputationId = measurement.externalComputationId
-              externalFulfillingDuchyId = nonExistentExternalDuchyId
+      val externalDataProviderId = dataProvider.externalDataProviderId
+      val listedRequisition =
+        service
+          .streamRequisitions(
+            streamRequisitionsRequest {
+              filter = filter {
+                externalMeasurementConsumerId = measurement.externalMeasurementConsumerId
+                externalMeasurementId = measurement.externalMeasurementId
+              }
             }
+          )
+          .first()
+      val externalRequisitionId = listedRequisition.externalRequisitionId
+
+      val requisition =
+        service.getRequisition(
+          getRequisitionRequest {
+            this.externalDataProviderId = externalDataProviderId
+            this.externalRequisitionId = externalRequisitionId
           }
         )
+
+      val expectedRequisition = requisition {
+        externalMeasurementConsumerId = measurement.externalMeasurementConsumerId
+        externalMeasurementId = measurement.externalMeasurementId
+        this.externalDataProviderId = externalDataProviderId
+        this.externalRequisitionId = externalRequisitionId
+        externalComputationId = measurement.externalComputationId
+        state = Requisition.State.PENDING_PARAMS
+        details =
+          RequisitionKt.details {
+            dataProviderPublicKey = dataProviderValue.dataProviderPublicKey
+            dataProviderPublicKeySignature = dataProviderValue.dataProviderPublicKeySignature
+            encryptedRequisitionSpec = dataProviderValue.encryptedRequisitionSpec
+            nonceHash = dataProviderValue.nonceHash
+          }
+        dataProviderCertificate = dataProvider.certificate
+        parentMeasurement = parentMeasurement {
+          apiVersion = measurement.details.apiVersion
+          externalMeasurementConsumerCertificateId =
+            measurement.externalMeasurementConsumerCertificateId
+          measurementSpec = measurement.details.measurementSpec
+          measurementSpecSignature = measurement.details.measurementSpecSignature
+          state = Measurement.State.PENDING_REQUISITION_PARAMS
+          protocolConfig = protocolConfig {
+            liquidLegionsV2 = liquidLegionsV2{
+              requiredExternalDuchyIds += Population.AGGREGATOR_DUCHY.externalDuchyId
+            }
+          }
+          dataProvidersCount = 1
+        }
       }
+      assertThat(requisition)
+        .ignoringFields(Requisition.UPDATE_TIME_FIELD_NUMBER, Requisition.DUCHIES_FIELD_NUMBER)
+        .isEqualTo(expectedRequisition)
+      assertThat(requisition.duchiesMap)
+        .containsExactly(
+          Population.AGGREGATOR_DUCHY.externalDuchyId,
+          Requisition.DuchyValue.getDefaultInstance(),
+          Population.WORKER1_DUCHY.externalDuchyId,
+          Requisition.DuchyValue.getDefaultInstance(),
+          Population.WORKER2_DUCHY.externalDuchyId,
+          Requisition.DuchyValue.getDefaultInstance()
+        )
+      assertThat(requisition).isEqualTo(listedRequisition)
+    }
 
-    assertThat(exception.status.code).isEqualTo(Status.Code.FAILED_PRECONDITION)
-  }
+    @Test
+    fun `getRequisition returns expected direct requisition`() = runBlocking {
+      val dataProvider = population.createDataProvider(dataServices.dataProvidersService)
+      val dataProviderValue = dataProvider.toDataProviderValue()
+      val measurement =
+        population.createDirectMeasurement(
+          dataServices.measurementsService,
+          population.createMeasurementConsumer(
+            dataServices.measurementConsumersService,
+            dataServices.accountsService
+          ),
+          "direct_measurement",
+          mapOf(dataProvider.externalDataProviderId to dataProviderValue)
+        )
 
-  @Test
-  fun `fulfillRequisition throws FAILED_PRECONDITION if Measurement in illegal state`() =
-    runBlocking {
+      val listedRequisition =
+        service
+          .streamRequisitions(
+            streamRequisitionsRequest {
+              filter = filter {
+                externalMeasurementConsumerId = measurement.externalMeasurementConsumerId
+                externalMeasurementId = measurement.externalMeasurementId
+              }
+            }
+          )
+          .first()
+
+      val requisition =
+        service.getRequisition(
+          getRequisitionRequest {
+            externalDataProviderId = listedRequisition.externalDataProviderId
+            externalRequisitionId = listedRequisition.externalRequisitionId
+          }
+        )
+
+      val expectedRequisition = requisition {
+        externalMeasurementConsumerId = measurement.externalMeasurementConsumerId
+        externalMeasurementId = measurement.externalMeasurementId
+        externalDataProviderId = dataProvider.externalDataProviderId
+        this.externalRequisitionId = listedRequisition.externalRequisitionId
+        state = Requisition.State.UNFULFILLED
+        details =
+          RequisitionKt.details {
+            dataProviderPublicKey = dataProviderValue.dataProviderPublicKey
+            dataProviderPublicKeySignature = dataProviderValue.dataProviderPublicKeySignature
+            encryptedRequisitionSpec = dataProviderValue.encryptedRequisitionSpec
+            nonceHash = dataProviderValue.nonceHash
+          }
+        dataProviderCertificate = dataProvider.certificate
+        parentMeasurement = parentMeasurement {
+          apiVersion = measurement.details.apiVersion
+          externalMeasurementConsumerCertificateId =
+            measurement.externalMeasurementConsumerCertificateId
+          measurementSpec = measurement.details.measurementSpec
+          measurementSpecSignature = measurement.details.measurementSpecSignature
+          state = Measurement.State.PENDING_REQUISITION_FULFILLMENT
+          protocolConfig = protocolConfig {}
+          dataProvidersCount = 1
+        }
+      }
+      assertThat(requisition)
+        .ignoringFields(Requisition.UPDATE_TIME_FIELD_NUMBER, Requisition.DUCHIES_FIELD_NUMBER)
+        .isEqualTo(expectedRequisition)
+      assertThat(requisition).isEqualTo(listedRequisition)
+    }
+
+    @Test
+    fun `fulfillRequisition transitions Requisition state`() = runBlocking {
       val measurement =
         population.createComputedMeasurement(
           dataServices.measurementsService,
@@ -880,6 +677,264 @@ abstract class RequisitionsServiceTest<T : RequisitionsCoroutineService> {
           population.createDataProvider(dataServices.dataProvidersService),
           population.createDataProvider(dataServices.dataProvidersService)
         )
+      for (duchyCertificate in duchyCertificates.values) {
+        dataServices.computationParticipantsService.setParticipantRequisitionParams(
+          setParticipantRequisitionParamsRequest {
+            externalComputationId = measurement.externalComputationId
+            externalDuchyId = duchyCertificate.externalDuchyId
+            externalDuchyCertificateId = duchyCertificate.externalCertificateId
+          }
+        )
+      }
+      val requisition =
+        service
+          .streamRequisitions(
+            streamRequisitionsRequest {
+              filter = filter {
+                externalMeasurementConsumerId = measurement.externalMeasurementConsumerId
+                externalMeasurementId = measurement.externalMeasurementId
+              }
+            }
+          )
+          .first()
+
+      val response =
+        service.fulfillRequisition(
+          fulfillRequisitionRequest {
+            externalRequisitionId = requisition.externalRequisitionId
+            nonce = NONCE_1
+            computedParams = computedRequisitionParams {
+              externalComputationId = measurement.externalComputationId
+              externalFulfillingDuchyId = Population.WORKER1_DUCHY.externalDuchyId
+            }
+          }
+        )
+
+      assertThat(response.state).isEqualTo(Requisition.State.FULFILLED)
+      assertThat(response.externalFulfillingDuchyId)
+        .isEqualTo(Population.WORKER1_DUCHY.externalDuchyId)
+      assertThat(response.details.nonce).isEqualTo(NONCE_1)
+      assertThat(response.updateTime.toInstant()).isGreaterThan(requisition.updateTime.toInstant())
+      assertThat(response)
+        .isEqualTo(
+          service.getRequisition(
+            getRequisitionRequest {
+              externalDataProviderId = requisition.externalDataProviderId
+              externalRequisitionId = requisition.externalRequisitionId
+            }
+          )
+        )
+    }
+
+    @Test
+    fun `fulfillRequisition transitions Measurement state when all others fulfilled`() = runBlocking {
+      val measurement =
+        population.createComputedMeasurement(
+          dataServices.measurementsService,
+          population.createMeasurementConsumer(
+            dataServices.measurementConsumersService,
+            dataServices.accountsService
+          ),
+          "measurement",
+          population.createDataProvider(dataServices.dataProvidersService),
+          population.createDataProvider(dataServices.dataProvidersService)
+        )
+      for (duchyCertificate in duchyCertificates.values) {
+        dataServices.computationParticipantsService.setParticipantRequisitionParams(
+          setParticipantRequisitionParamsRequest {
+            externalComputationId = measurement.externalComputationId
+            externalDuchyId = duchyCertificate.externalDuchyId
+            externalDuchyCertificateId = duchyCertificate.externalCertificateId
+          }
+        )
+      }
+      val requisitions =
+        service
+          .streamRequisitions(
+            streamRequisitionsRequest {
+              filter = filter {
+                externalMeasurementConsumerId = measurement.externalMeasurementConsumerId
+                externalMeasurementId = measurement.externalMeasurementId
+              }
+            }
+          )
+          .toList()
+      service.fulfillRequisition(
+        fulfillRequisitionRequest {
+          externalRequisitionId = requisitions[0].externalRequisitionId
+          nonce = NONCE_1
+          computedParams = computedRequisitionParams {
+            externalComputationId = measurement.externalComputationId
+            externalFulfillingDuchyId = Population.WORKER1_DUCHY.externalDuchyId
+          }
+        }
+      )
+
+      val response =
+        service.fulfillRequisition(
+          fulfillRequisitionRequest {
+            externalRequisitionId = requisitions[1].externalRequisitionId
+            nonce = NONCE_2
+            computedParams = computedRequisitionParams {
+              externalComputationId = measurement.externalComputationId
+              externalFulfillingDuchyId = Population.WORKER1_DUCHY.externalDuchyId
+            }
+          }
+        )
+
+      assertThat(response.parentMeasurement.state)
+        .isEqualTo(Measurement.State.PENDING_PARTICIPANT_CONFIRMATION)
+      assertThat(response)
+        .isEqualTo(
+          service.getRequisition(
+            getRequisitionRequest {
+              externalDataProviderId = requisitions[1].externalDataProviderId
+              externalRequisitionId = requisitions[1].externalRequisitionId
+            }
+          )
+        )
+    }
+
+    @Test
+    fun `fulfillRequisition throws NOT_FOUND if Requisition not found`() = runBlocking {
+      val dataProvider = population.createDataProvider(dataServices.dataProvidersService)
+      val measurement =
+        population.createComputedMeasurement(
+          dataServices.measurementsService,
+          population.createMeasurementConsumer(
+            dataServices.measurementConsumersService,
+            dataServices.accountsService
+          ),
+          "measurement",
+          dataProvider
+        )
+
+      val nonExistentExternalRequisitionId = idGenerator.generateExternalId()
+      val exception =
+        assertFailsWith(StatusRuntimeException::class) {
+          service.fulfillRequisition(
+            fulfillRequisitionRequest {
+              externalRequisitionId = nonExistentExternalRequisitionId.value
+              nonce = NONCE_1
+              computedParams = computedRequisitionParams {
+                externalComputationId = measurement.externalComputationId
+                externalFulfillingDuchyId = Population.WORKER1_DUCHY.externalDuchyId
+              }
+            }
+          )
+        }
+
+      assertThat(exception.status.code).isEqualTo(Status.Code.NOT_FOUND)
+    }
+
+    @Test
+    fun `fulfillRequisition throws FAILED_PRECONDITION if Duchy not found`() = runBlocking {
+      val dataProvider = population.createDataProvider(dataServices.dataProvidersService)
+      val measurement =
+        population.createComputedMeasurement(
+          dataServices.measurementsService,
+          population.createMeasurementConsumer(
+            dataServices.measurementConsumersService,
+            dataServices.accountsService
+          ),
+          "measurement",
+          dataProvider
+        )
+      val requisition =
+        service
+          .streamRequisitions(
+            streamRequisitionsRequest {
+              filter = filter {
+                externalMeasurementConsumerId = measurement.externalMeasurementConsumerId
+                externalMeasurementId = measurement.externalMeasurementId
+              }
+            }
+          )
+          .first()
+
+      val nonExistentExternalDuchyId = "Chalced"
+      val exception =
+        assertFailsWith(StatusRuntimeException::class) {
+          service.fulfillRequisition(
+            fulfillRequisitionRequest {
+              externalRequisitionId = requisition.externalRequisitionId
+              nonce = NONCE_1
+              computedParams = computedRequisitionParams {
+                externalComputationId = measurement.externalComputationId
+                externalFulfillingDuchyId = nonExistentExternalDuchyId
+              }
+            }
+          )
+        }
+
+      assertThat(exception.status.code).isEqualTo(Status.Code.FAILED_PRECONDITION)
+    }
+
+    @Test
+    fun `fulfillRequisition throws FAILED_PRECONDITION if Measurement in illegal state`() =
+      runBlocking {
+        val measurement =
+          population.createComputedMeasurement(
+            dataServices.measurementsService,
+            population.createMeasurementConsumer(
+              dataServices.measurementConsumersService,
+              dataServices.accountsService
+            ),
+            "measurement",
+            population.createDataProvider(dataServices.dataProvidersService),
+            population.createDataProvider(dataServices.dataProvidersService)
+          )
+        val requisition =
+          service
+            .streamRequisitions(
+              streamRequisitionsRequest {
+                filter = filter {
+                  externalMeasurementConsumerId = measurement.externalMeasurementConsumerId
+                  externalMeasurementId = measurement.externalMeasurementId
+                }
+              }
+            )
+            .first()
+
+        val exception =
+          assertFailsWith(StatusRuntimeException::class) {
+            service.fulfillRequisition(
+              fulfillRequisitionRequest {
+                externalRequisitionId = requisition.externalRequisitionId
+                nonce = NONCE_1
+                computedParams = computedRequisitionParams {
+                  externalComputationId = measurement.externalComputationId
+                  externalFulfillingDuchyId = Population.WORKER1_DUCHY.externalDuchyId
+                }
+              }
+            )
+          }
+
+        assertThat(exception.status.code).isEqualTo(Status.Code.FAILED_PRECONDITION)
+      }
+
+    @Test
+    fun `fulfillRequisition throws INVALID_ARGUMENT when signature not specified`() = runBlocking {
+      val measurement =
+        population.createComputedMeasurement(
+          dataServices.measurementsService,
+          population.createMeasurementConsumer(
+            dataServices.measurementConsumersService,
+            dataServices.accountsService
+          ),
+          "measurement",
+          population.createDataProvider(dataServices.dataProvidersService),
+          population.createDataProvider(dataServices.dataProvidersService)
+        )
+      for (duchyCertificate in duchyCertificates.values) {
+        dataServices.computationParticipantsService.setParticipantRequisitionParams(
+          setParticipantRequisitionParamsRequest {
+            externalComputationId = measurement.externalComputationId
+            externalDuchyId = duchyCertificate.externalDuchyId
+            externalDuchyCertificateId = duchyCertificate.externalCertificateId
+          }
+        )
+      }
       val requisition =
         service
           .streamRequisitions(
@@ -897,7 +952,6 @@ abstract class RequisitionsServiceTest<T : RequisitionsCoroutineService> {
           service.fulfillRequisition(
             fulfillRequisitionRequest {
               externalRequisitionId = requisition.externalRequisitionId
-              nonce = NONCE_1
               computedParams = computedRequisitionParams {
                 externalComputationId = measurement.externalComputationId
                 externalFulfillingDuchyId = Population.WORKER1_DUCHY.externalDuchyId
@@ -906,114 +960,11 @@ abstract class RequisitionsServiceTest<T : RequisitionsCoroutineService> {
           )
         }
 
-      assertThat(exception.status.code).isEqualTo(Status.Code.FAILED_PRECONDITION)
+      assertThat(exception.status.code).isEqualTo(Status.Code.INVALID_ARGUMENT)
     }
 
-  @Test
-  fun `fulfillRequisition throws INVALID_ARGUMENT when signature not specified`() = runBlocking {
-    val measurement =
-      population.createComputedMeasurement(
-        dataServices.measurementsService,
-        population.createMeasurementConsumer(
-          dataServices.measurementConsumersService,
-          dataServices.accountsService
-        ),
-        "measurement",
-        population.createDataProvider(dataServices.dataProvidersService),
-        population.createDataProvider(dataServices.dataProvidersService)
-      )
-    for (duchyCertificate in duchyCertificates.values) {
-      dataServices.computationParticipantsService.setParticipantRequisitionParams(
-        setParticipantRequisitionParamsRequest {
-          externalComputationId = measurement.externalComputationId
-          externalDuchyId = duchyCertificate.externalDuchyId
-          externalDuchyCertificateId = duchyCertificate.externalCertificateId
-        }
-      )
-    }
-    val requisition =
-      service
-        .streamRequisitions(
-          streamRequisitionsRequest {
-            filter = filter {
-              externalMeasurementConsumerId = measurement.externalMeasurementConsumerId
-              externalMeasurementId = measurement.externalMeasurementId
-            }
-          }
-        )
-        .first()
-
-    val exception =
-      assertFailsWith(StatusRuntimeException::class) {
-        service.fulfillRequisition(
-          fulfillRequisitionRequest {
-            externalRequisitionId = requisition.externalRequisitionId
-            computedParams = computedRequisitionParams {
-              externalComputationId = measurement.externalComputationId
-              externalFulfillingDuchyId = Population.WORKER1_DUCHY.externalDuchyId
-            }
-          }
-        )
-      }
-
-    assertThat(exception.status.code).isEqualTo(Status.Code.INVALID_ARGUMENT)
-  }
-
-  @Test
-  fun `direct fulfillRequisition transitions Requisition state`() = runBlocking {
-    val measurement =
-      population.createDirectMeasurement(
-        dataServices.measurementsService,
-        population.createMeasurementConsumer(
-          dataServices.measurementConsumersService,
-          dataServices.accountsService
-        ),
-        "direct_measurement",
-        population.createDataProvider(dataServices.dataProvidersService),
-      )
-
-    val requisition =
-      service
-        .streamRequisitions(
-          streamRequisitionsRequest {
-            filter = filter {
-              externalMeasurementConsumerId = measurement.externalMeasurementConsumerId
-              externalMeasurementId = measurement.externalMeasurementId
-            }
-          }
-        )
-        .first()
-
-    val response =
-      service.fulfillRequisition(
-        fulfillRequisitionRequest {
-          externalRequisitionId = requisition.externalRequisitionId
-          nonce = NONCE_1
-          directParams = directRequisitionParams {
-            externalDataProviderId = requisition.externalDataProviderId
-            encryptedData = REQUISITION_ENCRYPTED_DATA
-          }
-        }
-      )
-
-    assertThat(response.state).isEqualTo(Requisition.State.FULFILLED)
-    assertThat(response.details.nonce).isEqualTo(NONCE_1)
-    assertThat(response.details.encryptedData).isEqualTo(REQUISITION_ENCRYPTED_DATA)
-    assertThat(response.updateTime.toInstant()).isGreaterThan(requisition.updateTime.toInstant())
-    assertThat(response)
-      .isEqualTo(
-        service.getRequisition(
-          getRequisitionRequest {
-            externalDataProviderId = requisition.externalDataProviderId
-            externalRequisitionId = requisition.externalRequisitionId
-          }
-        )
-      )
-  }
-
-  @Test
-  fun `direct fulfillRequisition transitions Measurement state when all others fulfilled`() =
-    runBlocking {
+    @Test
+    fun `direct fulfillRequisition transitions Requisition state`() = runBlocking {
       val measurement =
         population.createDirectMeasurement(
           dataServices.measurementsService,
@@ -1023,242 +974,8 @@ abstract class RequisitionsServiceTest<T : RequisitionsCoroutineService> {
           ),
           "direct_measurement",
           population.createDataProvider(dataServices.dataProvidersService),
-          population.createDataProvider(dataServices.dataProvidersService),
         )
 
-      val requisitions =
-        service
-          .streamRequisitions(
-            streamRequisitionsRequest {
-              filter = filter {
-                externalMeasurementConsumerId = measurement.externalMeasurementConsumerId
-                externalMeasurementId = measurement.externalMeasurementId
-              }
-            }
-          )
-          .toList()
-
-      service.fulfillRequisition(
-        fulfillRequisitionRequest {
-          externalRequisitionId = requisitions[0].externalRequisitionId
-          nonce = NONCE_1
-          directParams = directRequisitionParams {
-            externalDataProviderId = requisitions[0].externalDataProviderId
-            encryptedData = REQUISITION_ENCRYPTED_DATA
-          }
-        }
-      )
-      val response =
-        service.fulfillRequisition(
-          fulfillRequisitionRequest {
-            externalRequisitionId = requisitions[1].externalRequisitionId
-            nonce = NONCE_1
-            directParams = directRequisitionParams {
-              externalDataProviderId = requisitions[1].externalDataProviderId
-              encryptedData = REQUISITION_ENCRYPTED_DATA
-            }
-          }
-        )
-
-      assertThat(response.parentMeasurement.state).isEqualTo(Measurement.State.SUCCEEDED)
-      assertThat(response)
-        .isEqualTo(
-          service.getRequisition(
-            getRequisitionRequest {
-              externalDataProviderId = requisitions[1].externalDataProviderId
-              externalRequisitionId = requisitions[1].externalRequisitionId
-            }
-          )
-        )
-    }
-
-  @Test
-  fun `direct fulfillRequisition sets measurement result when all requisitions fulfilled`(): Unit =
-    runBlocking {
-      val measurement =
-        population.createDirectMeasurement(
-          dataServices.measurementsService,
-          population.createMeasurementConsumer(
-            dataServices.measurementConsumersService,
-            dataServices.accountsService
-          ),
-          "direct_measurement",
-          population.createDataProvider(dataServices.dataProvidersService),
-          population.createDataProvider(dataServices.dataProvidersService),
-        )
-
-      val requisitions =
-        service
-          .streamRequisitions(
-            streamRequisitionsRequest {
-              filter = filter {
-                externalMeasurementConsumerId = measurement.externalMeasurementConsumerId
-                externalMeasurementId = measurement.externalMeasurementId
-              }
-            }
-          )
-          .toList()
-
-      service.fulfillRequisition(
-        fulfillRequisitionRequest {
-          externalRequisitionId = requisitions[0].externalRequisitionId
-          nonce = NONCE_1
-          directParams = directRequisitionParams {
-            externalDataProviderId = requisitions[0].externalDataProviderId
-            encryptedData = REQUISITION_ENCRYPTED_DATA
-          }
-        }
-      )
-
-      service.fulfillRequisition(
-        fulfillRequisitionRequest {
-          externalRequisitionId = requisitions[1].externalRequisitionId
-          nonce = NONCE_1
-          directParams = directRequisitionParams {
-            externalDataProviderId = requisitions[1].externalDataProviderId
-            encryptedData = REQUISITION_ENCRYPTED_DATA
-          }
-        }
-      )
-
-      val succeededMeasurement =
-        dataServices.measurementsService.getMeasurement(
-          getMeasurementRequest {
-            externalMeasurementId = measurement.externalMeasurementId
-            externalMeasurementConsumerId = measurement.externalMeasurementConsumerId
-          }
-        )
-
-      assertThat(succeededMeasurement.resultsList.size).isEqualTo(2)
-      assertThat(succeededMeasurement.resultsList)
-        .ignoringRepeatedFieldOrder()
-        .containsAtLeast(
-          resultInfo {
-            externalDataProviderId = requisitions[0].externalDataProviderId
-            externalCertificateId = requisitions[0].dataProviderCertificate.externalCertificateId
-            encryptedResult = REQUISITION_ENCRYPTED_DATA
-          },
-          resultInfo {
-            externalDataProviderId = requisitions[1].externalDataProviderId
-            externalCertificateId = requisitions[1].dataProviderCertificate.externalCertificateId
-            encryptedResult = REQUISITION_ENCRYPTED_DATA
-          }
-        )
-    }
-
-  @Test
-  fun `direct fulfillRequisition throws NOT_FOUND if requisition not found`() = runBlocking {
-    val provider = population.createDataProvider(dataServices.dataProvidersService)
-    population.createDirectMeasurement(
-      dataServices.measurementsService,
-      population.createMeasurementConsumer(
-        dataServices.measurementConsumersService,
-        dataServices.accountsService
-      ),
-      "direct_measurement",
-      provider
-    )
-
-    val nonExistentExternalRequisitionId = idGenerator.generateExternalId()
-    val exception =
-      assertFailsWith(StatusRuntimeException::class) {
-        service.fulfillRequisition(
-          fulfillRequisitionRequest {
-            externalRequisitionId = nonExistentExternalRequisitionId.value
-            nonce = NONCE_1
-            directParams = directRequisitionParams {
-              externalDataProviderId = provider.externalDataProviderId
-              encryptedData = REQUISITION_ENCRYPTED_DATA
-            }
-          }
-        )
-      }
-
-    assertThat(exception.status.code).isEqualTo(Status.Code.NOT_FOUND)
-  }
-
-  @Test
-  fun `refuseRequisition transitions Requisition and Measurement states`() = runBlocking {
-    val measurement =
-      population.createComputedMeasurement(
-        dataServices.measurementsService,
-        population.createMeasurementConsumer(
-          dataServices.measurementConsumersService,
-          dataServices.accountsService
-        ),
-        "measurement",
-        population.createDataProvider(dataServices.dataProvidersService),
-        population.createDataProvider(dataServices.dataProvidersService)
-      )
-    for (duchyCertificate in duchyCertificates.values) {
-      dataServices.computationParticipantsService.setParticipantRequisitionParams(
-        setParticipantRequisitionParamsRequest {
-          externalComputationId = measurement.externalComputationId
-          externalDuchyId = duchyCertificate.externalDuchyId
-          externalDuchyCertificateId = duchyCertificate.externalCertificateId
-        }
-      )
-    }
-    val requisition =
-      service
-        .streamRequisitions(
-          streamRequisitionsRequest {
-            filter = filter {
-              externalMeasurementConsumerId = measurement.externalMeasurementConsumerId
-              externalMeasurementId = measurement.externalMeasurementId
-            }
-          }
-        )
-        .first()
-
-    val response =
-      service.refuseRequisition(
-        refuseRequisitionRequest {
-          externalDataProviderId = requisition.externalDataProviderId
-          externalRequisitionId = requisition.externalRequisitionId
-          refusal = REFUSAL
-        }
-      )
-
-    assertThat(response.state).isEqualTo(Requisition.State.REFUSED)
-    assertThat(response.details.refusal).isEqualTo(REFUSAL)
-    assertThat(response.parentMeasurement.state).isEqualTo(Measurement.State.FAILED)
-    assertThat(response.updateTime.toInstant()).isGreaterThan(requisition.updateTime.toInstant())
-    assertThat(response)
-      .isEqualTo(
-        service.getRequisition(
-          getRequisitionRequest {
-            externalDataProviderId = requisition.externalDataProviderId
-            externalRequisitionId = requisition.externalRequisitionId
-          }
-        )
-      )
-    val updatedMeasurement =
-      dataServices.measurementsService.getMeasurement(
-        getMeasurementRequest {
-          externalMeasurementId = measurement.externalMeasurementId
-          externalMeasurementConsumerId = measurement.externalMeasurementConsumerId
-        }
-      )
-    assertThat(updatedMeasurement.state).isEqualTo(Measurement.State.FAILED)
-    assertThat(updatedMeasurement.details.failure.reason)
-      .isEqualTo(Measurement.Failure.Reason.REQUISITION_REFUSED)
-  }
-
-  @Test
-  fun `refuseRequisition throws FAILED_PRECONDITION if Measurement in illegal state`() =
-    runBlocking {
-      val measurement =
-        population.createComputedMeasurement(
-          dataServices.measurementsService,
-          population.createMeasurementConsumer(
-            dataServices.measurementConsumersService,
-            dataServices.accountsService
-          ),
-          "measurement",
-          population.createDataProvider(dataServices.dataProvidersService),
-          population.createDataProvider(dataServices.dataProvidersService)
-        )
       val requisition =
         service
           .streamRequisitions(
@@ -1271,47 +988,334 @@ abstract class RequisitionsServiceTest<T : RequisitionsCoroutineService> {
           )
           .first()
 
+      val response =
+        service.fulfillRequisition(
+          fulfillRequisitionRequest {
+            externalRequisitionId = requisition.externalRequisitionId
+            nonce = NONCE_1
+            directParams = directRequisitionParams {
+              externalDataProviderId = requisition.externalDataProviderId
+              encryptedData = REQUISITION_ENCRYPTED_DATA
+            }
+          }
+        )
+
+      assertThat(response.state).isEqualTo(Requisition.State.FULFILLED)
+      assertThat(response.details.nonce).isEqualTo(NONCE_1)
+      assertThat(response.details.encryptedData).isEqualTo(REQUISITION_ENCRYPTED_DATA)
+      assertThat(response.updateTime.toInstant()).isGreaterThan(requisition.updateTime.toInstant())
+      assertThat(response)
+        .isEqualTo(
+          service.getRequisition(
+            getRequisitionRequest {
+              externalDataProviderId = requisition.externalDataProviderId
+              externalRequisitionId = requisition.externalRequisitionId
+            }
+          )
+        )
+    }
+
+    @Test
+    fun `direct fulfillRequisition transitions Measurement state when all others fulfilled`() =
+      runBlocking {
+        val measurement =
+          population.createDirectMeasurement(
+            dataServices.measurementsService,
+            population.createMeasurementConsumer(
+              dataServices.measurementConsumersService,
+              dataServices.accountsService
+            ),
+            "direct_measurement",
+            population.createDataProvider(dataServices.dataProvidersService),
+            population.createDataProvider(dataServices.dataProvidersService),
+          )
+
+        val requisitions =
+          service
+            .streamRequisitions(
+              streamRequisitionsRequest {
+                filter = filter {
+                  externalMeasurementConsumerId = measurement.externalMeasurementConsumerId
+                  externalMeasurementId = measurement.externalMeasurementId
+                }
+              }
+            )
+            .toList()
+
+        service.fulfillRequisition(
+          fulfillRequisitionRequest {
+            externalRequisitionId = requisitions[0].externalRequisitionId
+            nonce = NONCE_1
+            directParams = directRequisitionParams {
+              externalDataProviderId = requisitions[0].externalDataProviderId
+              encryptedData = REQUISITION_ENCRYPTED_DATA
+            }
+          }
+        )
+        val response =
+          service.fulfillRequisition(
+            fulfillRequisitionRequest {
+              externalRequisitionId = requisitions[1].externalRequisitionId
+              nonce = NONCE_1
+              directParams = directRequisitionParams {
+                externalDataProviderId = requisitions[1].externalDataProviderId
+                encryptedData = REQUISITION_ENCRYPTED_DATA
+              }
+            }
+          )
+
+        assertThat(response.parentMeasurement.state).isEqualTo(Measurement.State.SUCCEEDED)
+        assertThat(response)
+          .isEqualTo(
+            service.getRequisition(
+              getRequisitionRequest {
+                externalDataProviderId = requisitions[1].externalDataProviderId
+                externalRequisitionId = requisitions[1].externalRequisitionId
+              }
+            )
+          )
+      }
+
+    @Test
+    fun `direct fulfillRequisition sets measurement result when all requisitions fulfilled`(): Unit =
+      runBlocking {
+        val measurement =
+          population.createDirectMeasurement(
+            dataServices.measurementsService,
+            population.createMeasurementConsumer(
+              dataServices.measurementConsumersService,
+              dataServices.accountsService
+            ),
+            "direct_measurement",
+            population.createDataProvider(dataServices.dataProvidersService),
+            population.createDataProvider(dataServices.dataProvidersService),
+          )
+
+        val requisitions =
+          service
+            .streamRequisitions(
+              streamRequisitionsRequest {
+                filter = filter {
+                  externalMeasurementConsumerId = measurement.externalMeasurementConsumerId
+                  externalMeasurementId = measurement.externalMeasurementId
+                }
+              }
+            )
+            .toList()
+
+        service.fulfillRequisition(
+          fulfillRequisitionRequest {
+            externalRequisitionId = requisitions[0].externalRequisitionId
+            nonce = NONCE_1
+            directParams = directRequisitionParams {
+              externalDataProviderId = requisitions[0].externalDataProviderId
+              encryptedData = REQUISITION_ENCRYPTED_DATA
+            }
+          }
+        )
+
+        service.fulfillRequisition(
+          fulfillRequisitionRequest {
+            externalRequisitionId = requisitions[1].externalRequisitionId
+            nonce = NONCE_1
+            directParams = directRequisitionParams {
+              externalDataProviderId = requisitions[1].externalDataProviderId
+              encryptedData = REQUISITION_ENCRYPTED_DATA
+            }
+          }
+        )
+
+        val succeededMeasurement =
+          dataServices.measurementsService.getMeasurement(
+            getMeasurementRequest {
+              externalMeasurementId = measurement.externalMeasurementId
+              externalMeasurementConsumerId = measurement.externalMeasurementConsumerId
+            }
+          )
+
+        assertThat(succeededMeasurement.resultsList.size).isEqualTo(2)
+        assertThat(succeededMeasurement.resultsList)
+          .ignoringRepeatedFieldOrder()
+          .containsAtLeast(
+            resultInfo {
+              externalDataProviderId = requisitions[0].externalDataProviderId
+              externalCertificateId = requisitions[0].dataProviderCertificate.externalCertificateId
+              encryptedResult = REQUISITION_ENCRYPTED_DATA
+            },
+            resultInfo {
+              externalDataProviderId = requisitions[1].externalDataProviderId
+              externalCertificateId = requisitions[1].dataProviderCertificate.externalCertificateId
+              encryptedResult = REQUISITION_ENCRYPTED_DATA
+            }
+          )
+      }
+
+    @Test
+    fun `direct fulfillRequisition throws NOT_FOUND if requisition not found`() = runBlocking {
+      val provider = population.createDataProvider(dataServices.dataProvidersService)
+      population.createDirectMeasurement(
+        dataServices.measurementsService,
+        population.createMeasurementConsumer(
+          dataServices.measurementConsumersService,
+          dataServices.accountsService
+        ),
+        "direct_measurement",
+        provider
+      )
+
+      val nonExistentExternalRequisitionId = idGenerator.generateExternalId()
+      val exception =
+        assertFailsWith(StatusRuntimeException::class) {
+          service.fulfillRequisition(
+            fulfillRequisitionRequest {
+              externalRequisitionId = nonExistentExternalRequisitionId.value
+              nonce = NONCE_1
+              directParams = directRequisitionParams {
+                externalDataProviderId = provider.externalDataProviderId
+                encryptedData = REQUISITION_ENCRYPTED_DATA
+              }
+            }
+          )
+        }
+
+      assertThat(exception.status.code).isEqualTo(Status.Code.NOT_FOUND)
+    }
+
+    @Test
+    fun `refuseRequisition transitions Requisition and Measurement states`() = runBlocking {
+      val measurement =
+        population.createComputedMeasurement(
+          dataServices.measurementsService,
+          population.createMeasurementConsumer(
+            dataServices.measurementConsumersService,
+            dataServices.accountsService
+          ),
+          "measurement",
+          population.createDataProvider(dataServices.dataProvidersService),
+          population.createDataProvider(dataServices.dataProvidersService)
+        )
+      for (duchyCertificate in duchyCertificates.values) {
+        dataServices.computationParticipantsService.setParticipantRequisitionParams(
+          setParticipantRequisitionParamsRequest {
+            externalComputationId = measurement.externalComputationId
+            externalDuchyId = duchyCertificate.externalDuchyId
+            externalDuchyCertificateId = duchyCertificate.externalCertificateId
+          }
+        )
+      }
+      val requisition =
+        service
+          .streamRequisitions(
+            streamRequisitionsRequest {
+              filter = filter {
+                externalMeasurementConsumerId = measurement.externalMeasurementConsumerId
+                externalMeasurementId = measurement.externalMeasurementId
+              }
+            }
+          )
+          .first()
+
+      val response =
+        service.refuseRequisition(
+          refuseRequisitionRequest {
+            externalDataProviderId = requisition.externalDataProviderId
+            externalRequisitionId = requisition.externalRequisitionId
+            refusal = REFUSAL
+          }
+        )
+
+      assertThat(response.state).isEqualTo(Requisition.State.REFUSED)
+      assertThat(response.details.refusal).isEqualTo(REFUSAL)
+      assertThat(response.parentMeasurement.state).isEqualTo(Measurement.State.FAILED)
+      assertThat(response.updateTime.toInstant()).isGreaterThan(requisition.updateTime.toInstant())
+      assertThat(response)
+        .isEqualTo(
+          service.getRequisition(
+            getRequisitionRequest {
+              externalDataProviderId = requisition.externalDataProviderId
+              externalRequisitionId = requisition.externalRequisitionId
+            }
+          )
+        )
+      val updatedMeasurement =
+        dataServices.measurementsService.getMeasurement(
+          getMeasurementRequest {
+            externalMeasurementId = measurement.externalMeasurementId
+            externalMeasurementConsumerId = measurement.externalMeasurementConsumerId
+          }
+        )
+      assertThat(updatedMeasurement.state).isEqualTo(Measurement.State.FAILED)
+      assertThat(updatedMeasurement.details.failure.reason)
+        .isEqualTo(Measurement.Failure.Reason.REQUISITION_REFUSED)
+    }
+
+    @Test
+    fun `refuseRequisition throws FAILED_PRECONDITION if Measurement in illegal state`() =
+      runBlocking {
+        val measurement =
+          population.createComputedMeasurement(
+            dataServices.measurementsService,
+            population.createMeasurementConsumer(
+              dataServices.measurementConsumersService,
+              dataServices.accountsService
+            ),
+            "measurement",
+            population.createDataProvider(dataServices.dataProvidersService),
+            population.createDataProvider(dataServices.dataProvidersService)
+          )
+        val requisition =
+          service
+            .streamRequisitions(
+              streamRequisitionsRequest {
+                filter = filter {
+                  externalMeasurementConsumerId = measurement.externalMeasurementConsumerId
+                  externalMeasurementId = measurement.externalMeasurementId
+                }
+              }
+            )
+            .first()
+
+        val exception =
+          assertFailsWith(StatusRuntimeException::class) {
+            service.refuseRequisition(
+              refuseRequisitionRequest {
+                externalDataProviderId = requisition.externalDataProviderId
+                externalRequisitionId = requisition.externalRequisitionId
+                refusal = REFUSAL
+              }
+            )
+          }
+
+        assertThat(exception.status.code).isEqualTo(Status.Code.FAILED_PRECONDITION)
+      }
+
+    @Test
+    fun `refuseRequisition throws NOT_FOUND if Requisition not found`() = runBlocking {
+      val dataProvider = population.createDataProvider(dataServices.dataProvidersService)
+      population.createComputedMeasurement(
+        dataServices.measurementsService,
+        population.createMeasurementConsumer(
+          dataServices.measurementConsumersService,
+          dataServices.accountsService
+        ),
+        "measurement",
+        dataProvider
+      )
+
+      val nonExistentExternalRequisitionId = idGenerator.generateExternalId()
       val exception =
         assertFailsWith(StatusRuntimeException::class) {
           service.refuseRequisition(
             refuseRequisitionRequest {
-              externalDataProviderId = requisition.externalDataProviderId
-              externalRequisitionId = requisition.externalRequisitionId
+              externalDataProviderId = dataProvider.externalDataProviderId
+              externalRequisitionId = nonExistentExternalRequisitionId.value
               refusal = REFUSAL
             }
           )
         }
 
-      assertThat(exception.status.code).isEqualTo(Status.Code.FAILED_PRECONDITION)
+      assertThat(exception.status.code).isEqualTo(Status.Code.NOT_FOUND)
     }
-
-  @Test
-  fun `refuseRequisition throws NOT_FOUND if Requisition not found`() = runBlocking {
-    val dataProvider = population.createDataProvider(dataServices.dataProvidersService)
-    population.createComputedMeasurement(
-      dataServices.measurementsService,
-      population.createMeasurementConsumer(
-        dataServices.measurementConsumersService,
-        dataServices.accountsService
-      ),
-      "measurement",
-      dataProvider
-    )
-
-    val nonExistentExternalRequisitionId = idGenerator.generateExternalId()
-    val exception =
-      assertFailsWith(StatusRuntimeException::class) {
-        service.refuseRequisition(
-          refuseRequisitionRequest {
-            externalDataProviderId = dataProvider.externalDataProviderId
-            externalRequisitionId = nonExistentExternalRequisitionId.value
-            refusal = REFUSAL
-          }
-        )
-      }
-
-    assertThat(exception.status.code).isEqualTo(Status.Code.NOT_FOUND)
-  }
 
   @Test
   fun `refuseRequisition throws INVALID_ARGUMENT when refusal justification not specified`() =
@@ -1327,6 +1331,7 @@ abstract class RequisitionsServiceTest<T : RequisitionsCoroutineService> {
           population.createDataProvider(dataServices.dataProvidersService),
           population.createDataProvider(dataServices.dataProvidersService)
         )
+
       for (duchyCertificate in duchyCertificates.values) {
         dataServices.computationParticipantsService.setParticipantRequisitionParams(
           setParticipantRequisitionParamsRequest {

--- a/src/main/proto/wfa/measurement/internal/kingdom/error_code.proto
+++ b/src/main/proto/wfa/measurement/internal/kingdom/error_code.proto
@@ -76,4 +76,6 @@ enum ErrorCode {
   EXCHANGE_STEP_NOT_FOUND = 25;
   /** Required duchies are inactive */
   INACTIVE_REQUIRED_DUCHIES = 26;
+  /** Insufficient number of active duchies */
+  INSUFFICIENT_ACTIVE_DUCHIES = 27;
 }

--- a/src/main/proto/wfa/measurement/internal/kingdom/error_code.proto
+++ b/src/main/proto/wfa/measurement/internal/kingdom/error_code.proto
@@ -74,4 +74,6 @@ enum ErrorCode {
   EXCHANGE_STEP_ATTEMPT_NOT_FOUND = 24;
   /** ExchangeStep could not be found. */
   EXCHANGE_STEP_NOT_FOUND = 25;
+  /** Required duchies are inactive */
+  INACTIVE_REQUIRED_DUCHIES = 26;
 }

--- a/src/main/proto/wfa/measurement/internal/kingdom/protocol_config.proto
+++ b/src/main/proto/wfa/measurement/internal/kingdom/protocol_config.proto
@@ -46,6 +46,9 @@ message ProtocolConfig {
 
     // The maximum frequency to reveal in the histogram.
     int32 maximum_frequency = 4;
+
+    // List of required duchies for this protocol. E.g. aggregator.
+    repeated string required_external_duchy_ids = 5;
   }
 
   // Configuration for the specific protocol.

--- a/src/test/kotlin/org/wfanet/measurement/kingdom/service/api/v2alpha/MeasurementsServiceTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/kingdom/service/api/v2alpha/MeasurementsServiceTest.kt
@@ -1467,6 +1467,7 @@ class MeasurementsServiceTest {
             epsilon = 2.1
             delta = 3.3
           }
+          requiredExternalDuchyIds += "aggregator"
         }
     }
 


### PR DESCRIPTION
This PR contains:

- new field in ProtocolConfig to include required external duchy ids (aggregator in this case)
- update CreateMeasurement in order to only include required duchies plus eventually other duchies picked randomly till the number of required duchies for the measurement is reached
- update SetParticipantRequisitionParams since now participants can vary from measurement to measurement
- update tests 