### PR TITLE
Add db agnostic computations service API tests

### DIFF
--- a/src/main/kotlin/org/wfanet/measurement/duchy/service/internal/testing/BUILD.bazel
+++ b/src/main/kotlin/org/wfanet/measurement/duchy/service/internal/testing/BUILD.bazel
@@ -14,6 +14,8 @@ kt_jvm_library(
     name = "testing",
     srcs = glob(["*.kt"]),
     deps = [
+        "//src/main/kotlin/org/wfanet/measurement/duchy:computation_stage",
+        "//src/main/proto/wfa/measurement/internal/duchy:computations_service_kt_jvm_grpc_proto",
         "//src/main/proto/wfa/measurement/internal/duchy:continuation_tokens_service_kt_jvm_grpc_proto",
         "//src/main/proto/wfa/measurement/system/v1alpha:computations_service_kt_jvm_grpc_proto",
         "@wfa_common_jvm//imports/java/com/google/common/truth",

--- a/src/main/kotlin/org/wfanet/measurement/duchy/service/internal/testing/ComputationsServiceTest.kt
+++ b/src/main/kotlin/org/wfanet/measurement/duchy/service/internal/testing/ComputationsServiceTest.kt
@@ -1,0 +1,96 @@
+// Copyright 2022 The Cross-Media Measurement Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.wfanet.measurement.duchy.service.internal.testing
+
+import com.google.common.truth.Truth.assertThat
+import com.google.common.truth.extensions.proto.ProtoTruth.assertThat
+import io.grpc.Status
+import io.grpc.StatusRuntimeException
+import kotlin.test.assertFailsWith
+import kotlinx.coroutines.runBlocking
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+import org.wfanet.measurement.duchy.toProtocolStage
+import org.wfanet.measurement.internal.duchy.ComputationsGrpcKt.ComputationsCoroutineImplBase
+import org.wfanet.measurement.internal.duchy.*
+import org.wfanet.measurement.internal.duchy.config.LiquidLegionsV2SetupConfig
+import org.wfanet.measurement.internal.duchy.protocol.LiquidLegionsSketchAggregationV2
+
+
+@RunWith(JUnit4::class)
+abstract class ComputationsServiceTest<T : ComputationsCoroutineImplBase> {
+  /** Instance of the service under test. */
+  private lateinit var service: T
+
+  /** Constructs the service being tested. */
+  protected abstract fun newService(): T
+
+  @Before
+  fun initService() {
+    service = newService()
+  }
+
+  private val GLOBAL_COMPUTATION_ID = "1234"
+  private val AGGREGATOR_COMPUTATION_DETAILS =
+    ComputationDetails.newBuilder()
+      .apply { liquidLegionsV2Builder.apply { role = LiquidLegionsV2SetupConfig.RoleInComputation.AGGREGATOR } }
+      .build()
+  private val DEFAULT_CREATE_COMPUTATION_REQUEST = CreateComputationRequest.newBuilder()
+    .apply {
+      computationType = ComputationTypeEnum.ComputationType.LIQUID_LEGIONS_SKETCH_AGGREGATION_V2
+      globalComputationId = GLOBAL_COMPUTATION_ID
+      computationStage { LiquidLegionsSketchAggregationV2.Stage.EXECUTION_PHASE_ONE.toProtocolStage() }
+      computationDetails = AGGREGATOR_COMPUTATION_DETAILS
+    }
+    .build()
+  private val DEFAULT_CREATE_COMPUTATION_RESP_TOKEN = computationToken {
+    localComputationId = 1234
+    globalComputationId = GLOBAL_COMPUTATION_ID
+    computationStage = computationStage {
+      liquidLegionsSketchAggregationV2 =
+        LiquidLegionsSketchAggregationV2.Stage.INITIALIZATION_PHASE
+    }
+    computationDetails = AGGREGATOR_COMPUTATION_DETAILS
+    blobs.add(computationStageBlobMetadata{dependencyType = ComputationBlobDependency.OUTPUT})
+  }
+
+  @Test
+  fun `createComputation creates a new computation`() = runBlocking {
+    val createComputationResponse = service.createComputation(DEFAULT_CREATE_COMPUTATION_REQUEST)
+    assertThat(createComputationResponse)
+      .isEqualTo(createComputationResponse { token = DEFAULT_CREATE_COMPUTATION_RESP_TOKEN })
+
+    val getComputationTokenRequest = getComputationTokenRequest {
+      globalComputationId = GLOBAL_COMPUTATION_ID
+    }
+    val getComputationTokenResponse = service.getComputationToken(getComputationTokenRequest)
+    assertThat(getComputationTokenResponse)
+      .isEqualTo(getComputationTokenResponse{ token = DEFAULT_CREATE_COMPUTATION_RESP_TOKEN })
+  }
+
+  @Test
+  fun `createComputation throws ALREADY_EXISTS when called with existing id`() = runBlocking {
+    assertThat(service.createComputation(DEFAULT_CREATE_COMPUTATION_REQUEST))
+      .isEqualTo(createComputationResponse { token = DEFAULT_CREATE_COMPUTATION_RESP_TOKEN })
+
+    val exception =
+      assertFailsWith<StatusRuntimeException> {
+        service.createComputation(DEFAULT_CREATE_COMPUTATION_REQUEST)
+      }
+    assertThat(exception.status.code).isEqualTo(Status.Code.ALREADY_EXISTS)
+  }
+}

--- a/src/test/kotlin/org/wfanet/measurement/duchy/deploy/gcloud/spanner/computation/BUILD.bazel
+++ b/src/test/kotlin/org/wfanet/measurement/duchy/deploy/gcloud/spanner/computation/BUILD.bazel
@@ -78,3 +78,15 @@ spanner_emulator_test(
         "@wfa_common_jvm//src/main/kotlin/org/wfanet/measurement/gcloud/spanner/testing",
     ],
 )
+
+kt_jvm_test(
+    name = "SpannerComputationsServiceTest",
+    srcs = ["SpannerComputationsServiceTest.kt"],
+    test_class = "org.wfanet.measurement.duchy.deploy.gcloud.spanner.computation.SpannerComputationsServiceTest",
+    deps = [
+        "//src/main/kotlin/org/wfanet/measurement/duchy/db/computation/testing",
+        "//src/main/kotlin/org/wfanet/measurement/duchy/service/internal/computations",
+        "//src/main/kotlin/org/wfanet/measurement/duchy/service/internal/testing",
+        "@wfa_common_jvm//src/main/kotlin/org/wfanet/measurement/storage/filesystem:client",
+    ],
+)

--- a/src/test/kotlin/org/wfanet/measurement/duchy/deploy/gcloud/spanner/computation/SpannerComputationsServiceTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/duchy/deploy/gcloud/spanner/computation/SpannerComputationsServiceTest.kt
@@ -1,0 +1,72 @@
+// Copyright 2021 The Cross-Media Measurement Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.wfanet.measurement.duchy.deploy.gcloud.spanner.computation
+
+import java.time.Clock
+import org.junit.Rule
+import org.junit.rules.TemporaryFolder
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+import org.wfanet.measurement.common.grpc.testing.GrpcTestServerRule
+import org.wfanet.measurement.common.grpc.testing.mockService
+import org.wfanet.measurement.common.testing.chainRulesSequentially
+import org.wfanet.measurement.duchy.db.computation.*
+import org.wfanet.measurement.duchy.db.computation.testing.FakeComputationsDatabase
+import org.wfanet.measurement.duchy.service.internal.computations.ComputationsService
+import org.wfanet.measurement.duchy.service.internal.testing.ComputationsServiceTest
+import org.wfanet.measurement.duchy.storage.ComputationStore
+import org.wfanet.measurement.duchy.storage.RequisitionStore
+import org.wfanet.measurement.storage.filesystem.FileSystemStorageClient
+import org.wfanet.measurement.system.v1alpha.ComputationLogEntriesGrpcKt.ComputationLogEntriesCoroutineImplBase
+import org.wfanet.measurement.system.v1alpha.ComputationLogEntriesGrpcKt.ComputationLogEntriesCoroutineStub
+
+private const val ALSACE = "Alsace"
+
+@RunWith(JUnit4::class)
+class SpannerComputationsServiceTest : ComputationsServiceTest<ComputationsService>() {
+
+  private val mockComputationLogEntriesService: ComputationLogEntriesCoroutineImplBase =
+    mockService()
+  private val tempDirectory = TemporaryFolder()
+  private lateinit var storageClient: FileSystemStorageClient
+  private lateinit var computationStore: ComputationStore
+  private lateinit var requisitionStore: RequisitionStore
+
+  val grpcTestServerRule = GrpcTestServerRule {
+    storageClient = FileSystemStorageClient(tempDirectory.root)
+    computationStore = ComputationStore(storageClient)
+    requisitionStore = RequisitionStore(storageClient)
+    addService(mockComputationLogEntriesService)
+  }
+
+
+  @get:Rule val ruleChain = chainRulesSequentially(tempDirectory, grpcTestServerRule)
+
+  override fun newService(): ComputationsService {
+    val fakeDatabase = FakeComputationsDatabase()
+    val systemComputationLogEntriesClient =
+      ComputationLogEntriesCoroutineStub(grpcTestServerRule.channel)
+
+    return ComputationsService(
+      fakeDatabase,
+      systemComputationLogEntriesClient,
+      ComputationStore(storageClient),
+      RequisitionStore(storageClient),
+      ALSACE,
+      Clock.systemUTC()
+    )
+
+  }
+}


### PR DESCRIPTION
This PR adds a new abstract ComputationsServiceTest class which is supposed to define test cases for all Duchy Computations Service APIs. This PR only implements two test cases for createComputation rpc.

This PR also adds a Spanner implementation of this test which runs all API tests against the Duchy Computations Service with spanner database.