### PR TITLE
Handle wildcard DataProvider in BatchGetEventGroupMetadataDescriptors.

### DIFF
--- a/src/main/kotlin/org/wfanet/measurement/common/api/ResourceKey.kt
+++ b/src/main/kotlin/org/wfanet/measurement/common/api/ResourceKey.kt
@@ -27,4 +27,8 @@ interface ResourceKey {
      */
     fun fromName(resourceName: String): T?
   }
+
+  companion object {
+    const val WILDCARD_ID = "-"
+  }
 }

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/service/api/v2alpha/EventGroupMetadataDescriptorsService.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/service/api/v2alpha/EventGroupMetadataDescriptorsService.kt
@@ -33,6 +33,7 @@ import org.wfanet.measurement.api.v2alpha.UpdateEventGroupMetadataDescriptorRequ
 import org.wfanet.measurement.api.v2alpha.batchGetEventGroupMetadataDescriptorsResponse
 import org.wfanet.measurement.api.v2alpha.eventGroupMetadataDescriptor
 import org.wfanet.measurement.api.v2alpha.principalFromCurrentContext
+import org.wfanet.measurement.common.api.ResourceKey
 import org.wfanet.measurement.common.grpc.failGrpc
 import org.wfanet.measurement.common.grpc.grpcRequireNotNull
 import org.wfanet.measurement.common.identity.apiIdToExternalId
@@ -222,7 +223,9 @@ class EventGroupMetadataDescriptorsService(
 
     val streamRequest = streamEventGroupMetadataDescriptorsRequest {
       filter = filter {
-        externalDataProviderId = apiIdToExternalId(parentKey.dataProviderId)
+        if (parentKey.dataProviderId != ResourceKey.WILDCARD_ID) {
+          externalDataProviderId = apiIdToExternalId(parentKey.dataProviderId)
+        }
         externalEventGroupMetadataDescriptorIds += descriptorIds
       }
     }

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/service/api/v2alpha/EventGroupsService.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/service/api/v2alpha/EventGroupsService.kt
@@ -43,6 +43,7 @@ import org.wfanet.measurement.api.v2alpha.eventGroup
 import org.wfanet.measurement.api.v2alpha.listEventGroupsResponse
 import org.wfanet.measurement.api.v2alpha.principalFromCurrentContext
 import org.wfanet.measurement.api.v2alpha.signedData
+import org.wfanet.measurement.common.api.ResourceKey
 import org.wfanet.measurement.common.base64UrlDecode
 import org.wfanet.measurement.common.base64UrlEncode
 import org.wfanet.measurement.common.grpc.failGrpc
@@ -65,7 +66,7 @@ import org.wfanet.measurement.internal.kingdom.updateEventGroupRequest
 private const val MIN_PAGE_SIZE = 1
 private const val DEFAULT_PAGE_SIZE = 50
 private const val MAX_PAGE_SIZE = 100
-private const val WILDCARD = "-"
+private const val WILDCARD = ResourceKey.WILDCARD_ID
 private val API_VERSION = Version.V2_ALPHA
 
 class EventGroupsService(private val internalEventGroupsStub: EventGroupsCoroutineStub) :

--- a/src/main/kotlin/org/wfanet/measurement/reporting/service/api/v1alpha/EventGroupsService.kt
+++ b/src/main/kotlin/org/wfanet/measurement/reporting/service/api/v1alpha/EventGroupsService.kt
@@ -253,6 +253,7 @@ class EventGroupsService(
           Status.Code.CANCELLED -> Status.CANCELLED
           else -> Status.UNKNOWN
         }
+        .withDescription("Error retrieving EventGroupMetadataDescriptors")
         .withCause(e)
         .asRuntimeException()
     }
@@ -277,6 +278,11 @@ class EventGroupsService(
     cmmsEventGroup: CmmsEventGroup,
     principalName: String,
   ): CmmsEventGroup.Metadata {
+    if (!cmmsEventGroup.hasMeasurementConsumerPublicKey()) {
+      failGrpc(Status.FAILED_PRECONDITION) {
+        "EventGroup ${cmmsEventGroup.name} has encrypted metadata but no encryption public key"
+      }
+    }
     val encryptionKey =
       EncryptionPublicKey.parseFrom(cmmsEventGroup.measurementConsumerPublicKey.data)
     val decryptionKeyHandle: PrivateKeyHandle =

--- a/src/test/kotlin/org/wfanet/measurement/kingdom/service/api/v2alpha/BUILD.bazel
+++ b/src/test/kotlin/org/wfanet/measurement/kingdom/service/api/v2alpha/BUILD.bazel
@@ -111,7 +111,6 @@ kt_jvm_test(
     ],
     test_class = "org.wfanet.measurement.kingdom.service.api.v2alpha.EventGroupMetadataDescriptorsServiceTest",
     deps = [
-        "//src/main/kotlin/org/wfanet/measurement/api/v2alpha/testing",
         "@wfa_common_jvm//imports/java/com/google/common/truth",
         "@wfa_common_jvm//imports/java/com/google/common/truth/extensions/proto",
         "@wfa_common_jvm//imports/java/com/google/protobuf",


### PR DESCRIPTION
This avoids setting external_data_provider_id in the internal filter when the parent field in the request uses the wildcard character for the DataProvider ID. This also improves error messaging in upstream Reporting ListEventGroups calls.

Fixes #891