### PR TITLE
V2alpha DP params API

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -17,10 +17,6 @@ test --test_env=TESTCONTAINERS_RYUK_DISABLED
 build:debian-bullseye --platforms=//build/platforms:debian_bullseye
 build:ubuntu-bionic --platforms=//build/platforms:ubuntu_bionic
 
-# Enable explicit presence in proto3.
-# See https://github.com/protocolbuffers/protobuf/blob/main/docs/field_presence.md#how-to-enable-explicit-presence-in-proto3
-build --protocopt=--experimental_allow_proto3_optional
-
 import %workspace%/container.bazelrc
 import %workspace%/remote.bazelrc
 import %workspace%/results.bazelrc

--- a/.bazelrc
+++ b/.bazelrc
@@ -17,6 +17,10 @@ test --test_env=TESTCONTAINERS_RYUK_DISABLED
 build:debian-bullseye --platforms=//build/platforms:debian_bullseye
 build:ubuntu-bionic --platforms=//build/platforms:ubuntu_bionic
 
+# Enable explicit presence in proto3.
+# See https://github.com/protocolbuffers/protobuf/blob/main/docs/field_presence.md#how-to-enable-explicit-presence-in-proto3
+build --protocopt=--experimental_allow_proto3_optional
+
 import %workspace%/container.bazelrc
 import %workspace%/remote.bazelrc
 import %workspace%/results.bazelrc

--- a/src/main/proto/wfa/measurement/config/reporting/metric_spec_config.proto
+++ b/src/main/proto/wfa/measurement/config/reporting/metric_spec_config.proto
@@ -1,4 +1,4 @@
-// Copyright 2022 The Cross-Media Measurement Authors
+// Copyright 2023 The Cross-Media Measurement Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/main/proto/wfa/measurement/config/reporting/metric_spec_config.proto
+++ b/src/main/proto/wfa/measurement/config/reporting/metric_spec_config.proto
@@ -31,12 +31,24 @@ message MetricSpecConfig {
     double delta = 2;
   }
 
-  // Parameters that are used to generate `Reach` metric or
-  // `Frequency Histogram` metric.
-  message ReachFrequencyParams {
+  // Parameters that are used to generate `Reach` metric.
+  message ReachParams {
     // Differential privacy parameters for reach.
     DifferentialPrivacyParams reach_privacy_params = 1;
-
+    // Differential privacy parameters for frequency.
+    //
+    // Small default values are selected for the reach computation execution.
+    DifferentialPrivacyParams frequency_privacy_params = 2;
+    // Maximum frequency cut-off value in the frequency histogram.
+    //
+    // Counts with frequency higher than `max_frequency` will be aggregated
+    // together. For reach, this is equal to 1.
+    int32 maximum_frequency_per_user = 3;
+  }
+  // Parameters that are used to generate `Frequency Histogram` metric.
+  message FrequencyHistogramParams {
+    // Differential privacy parameters for reach.
+    DifferentialPrivacyParams reach_privacy_params = 1;
     // Differential privacy parameters for frequency.
     DifferentialPrivacyParams frequency_privacy_params = 2;
     // Maximum frequency cut-off value in the frequency histogram.
@@ -70,10 +82,10 @@ message MetricSpecConfig {
 
   // Parameters for generating the count of unique audiences reached given a set
   // of event groups.
-  ReachFrequencyParams reach_params = 1;
+  ReachParams reach_params = 1;
   // Parameters for generating the reach frequency histogram given a set of
   // event groups.
-  ReachFrequencyParams frequency_histogram_params = 2;
+  FrequencyHistogramParams frequency_histogram_params = 2;
   // Parameters for generating the impression count given a set of event groups.
   ImpressionCountParams impression_count_params = 3;
   // Parameters for generating the watch duration given a set of event groups.

--- a/src/main/proto/wfa/measurement/config/reporting/metric_spec_config.proto
+++ b/src/main/proto/wfa/measurement/config/reporting/metric_spec_config.proto
@@ -31,20 +31,19 @@ message MetricSpecConfig {
     double delta = 2;
   }
 
-  // Parameters that are used to generate `Reach` metric.
-  message ReachParams {
-    // Differential privacy parameters.
-    DifferentialPrivacyParams privacy_params = 1;
-  }
-  // Parameters that are used to generate `Frequency Histogram` metric.
-  message FrequencyHistogramParams {
-    // Differential privacy parameters.
-    DifferentialPrivacyParams privacy_params = 1;
+  // Parameters that are used to generate `Reach` metric or
+  // `Frequency Histogram` metric.
+  message ReachFrequencyParams {
+    // Differential privacy parameters for reach.
+    DifferentialPrivacyParams reach_privacy_params = 1;
+
+    // Differential privacy parameters for frequency.
+    DifferentialPrivacyParams frequency_privacy_params = 2;
     // Maximum frequency cut-off value in the frequency histogram.
     //
     // Counts with frequency higher than `max_frequency` will be aggregated
     // together.
-    int32 maximum_frequency_per_user = 2;
+    int32 maximum_frequency_per_user = 3;
   }
   // Parameters that are used to generate `Impression Count` metric.
   message ImpressionCountParams {

--- a/src/main/proto/wfa/measurement/config/reporting/metric_spec_config.proto
+++ b/src/main/proto/wfa/measurement/config/reporting/metric_spec_config.proto
@@ -1,0 +1,81 @@
+// Copyright 2022 The Cross-Media Measurement Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package wfa.measurement.config;
+
+option java_package = "org.wfanet.measurement.config.reporting";
+option java_multiple_files = true;
+
+// The configuration for metric spec in Metric in the reporting server
+message MetricSpecConfig {
+  // Parameters for differential privacy (DP).
+  //
+  // For detail, refer to "Dwork, C. and Roth, A., 2014. The algorithmic
+  // foundations of differential privacy. Foundations and Trends in Theoretical
+  // Computer Science, 9(3-4), pp.211-407."
+  message DifferentialPrivacyParams {
+    double epsilon = 1;
+    double delta = 2;
+  }
+
+  // Parameters that are used to generate `Reach` metric.
+  message ReachParams {
+    // Differential privacy parameters.
+    DifferentialPrivacyParams privacy_params = 1;
+  }
+  // Parameters that are used to generate `Frequency Histogram` metric.
+  message FrequencyHistogramParams {
+    // Differential privacy parameters.
+    DifferentialPrivacyParams privacy_params = 1;
+    // Maximum frequency cut-off value in the frequency histogram.
+    //
+    // Counts with frequency higher than `max_frequency` will be aggregated
+    // together.
+    int32 maximum_frequency_per_user = 2;
+  }
+  // Parameters that are used to generate `Impression Count` metric.
+  message ImpressionCountParams {
+    // Differential privacy parameters.
+    DifferentialPrivacyParams privacy_params = 1;
+    // Maximum frequency per user that will be included in this metric. Enforced
+    // on a per EDP basis.
+    //
+    // Setting the maximum frequency for each user is for noising the impression
+    // estimation with the noise proportional to maximum_frequency_per_user to
+    // guarantee epsilon-DP, i.e. the higher maximum_frequency_per_user, the
+    // larger the variance. On the other hand, if maximum_frequency_per_user is
+    // too small, there's a truncation bias.
+    int32 maximum_frequency_per_user = 2;
+  }
+  // Parameters that are used to generate `Watch Duration` metric.
+  message WatchDurationParams {
+    // Differential privacy parameters.
+    DifferentialPrivacyParams privacy_params = 1;
+    // Maximum watch duration per user in second that will be included in this
+    // metric. Enforced on a per EDP basis.
+    int32 maximum_watch_duration_per_user = 2;
+  }
+
+  // Specifies a range of VIDs to be sampled.
+  message VidSamplingInterval {
+    // The start of the sampling interval in [0, 1)
+    float start = 1;
+    // The width of the sampling interval.
+    float width = 2;
+  }
+  // Range of VIDs that will be included in this measurement
+  VidSamplingInterval vid_sampling_interval = 5;
+}

--- a/src/main/proto/wfa/measurement/config/reporting/metric_spec_config.proto
+++ b/src/main/proto/wfa/measurement/config/reporting/metric_spec_config.proto
@@ -34,16 +34,7 @@ message MetricSpecConfig {
   // Parameters that are used to generate `Reach` metric.
   message ReachParams {
     // Differential privacy parameters for reach.
-    DifferentialPrivacyParams reach_privacy_params = 1;
-    // Differential privacy parameters for frequency.
-    //
-    // Small default values are selected for the reach computation execution.
-    DifferentialPrivacyParams frequency_privacy_params = 2;
-    // Maximum frequency cut-off value in the frequency histogram.
-    //
-    // Counts with frequency higher than `max_frequency` will be aggregated
-    // together. For reach, this is equal to 1.
-    int32 maximum_frequency_per_user = 3;
+    DifferentialPrivacyParams privacy_params = 1;
   }
   // Parameters that are used to generate `Frequency Histogram` metric.
   message FrequencyHistogramParams {

--- a/src/main/proto/wfa/measurement/config/reporting/metric_spec_config.proto
+++ b/src/main/proto/wfa/measurement/config/reporting/metric_spec_config.proto
@@ -68,6 +68,17 @@ message MetricSpecConfig {
     int32 maximum_watch_duration_per_user = 2;
   }
 
+  // Parameters for generating the count of unique audiences reached given a set
+  // of event groups.
+  ReachFrequencyParams reach_params = 1;
+  // Parameters for generating the reach frequency histogram given a set of
+  // event groups.
+  ReachFrequencyParams frequency_histogram_params = 2;
+  // Parameters for generating the impression count given a set of event groups.
+  ImpressionCountParams impression_count_params = 3;
+  // Parameters for generating the watch duration given a set of event groups.
+  WatchDurationParams watch_duration_params = 4;
+
   // Specifies a range of VIDs to be sampled.
   message VidSamplingInterval {
     // The start of the sampling interval in [0, 1)

--- a/src/main/proto/wfa/measurement/internal/reporting/v2/metric.proto
+++ b/src/main/proto/wfa/measurement/internal/reporting/v2/metric.proto
@@ -33,8 +33,9 @@ message MetricSpec {
     DifferentialPrivacyParams privacy_params = 1;
   }
   message FrequencyHistogramParams {
-    DifferentialPrivacyParams privacy_params = 1;
-    int32 maximum_frequency_per_user = 2;
+    DifferentialPrivacyParams reach_privacy_params = 1;
+    DifferentialPrivacyParams frequency_privacy_params = 2;
+    int32 maximum_frequency_per_user = 3;
   }
   message ImpressionCountParams {
     DifferentialPrivacyParams privacy_params = 1;

--- a/src/main/proto/wfa/measurement/reporting/v2alpha/metric.proto
+++ b/src/main/proto/wfa/measurement/reporting/v2alpha/metric.proto
@@ -42,7 +42,7 @@ message MetricSpec {
     // Differential privacy parameters for reach.
     //
     // If this field is unspecified in a request message, the service
-    // implementation will choose a value.
+    // implementation will use the value specified in the system defaults.
     DifferentialPrivacyParams privacy_params = 1;
   }
   // Parameters that are used to generate `Frequency Histogram` metric.
@@ -50,12 +50,12 @@ message MetricSpec {
     // Differential privacy parameters for reach.
     //
     // If this field is unspecified in a request message, the service
-    // implementation will choose a value.
+    // implementation will use the value specified in the system defaults.
     DifferentialPrivacyParams reach_privacy_params = 1;
     // Differential privacy parameters for frequency distribution.
     //
     // If this field is unspecified in a request message, the service
-    // implementation will choose a value.
+    // implementation will use the value specified in the system defaults.
     DifferentialPrivacyParams frequency_privacy_params = 2;
     // Maximum frequency cut-off value in the frequency histogram.
     //
@@ -68,7 +68,7 @@ message MetricSpec {
     // Differential privacy parameters.
     //
     // If this field is unspecified in a request message, the service
-    // implementation will choose a value.
+    // implementation will use the value specified in the system defaults.
     DifferentialPrivacyParams privacy_params = 1;
     // Maximum frequency per user that will be included in this metric. Enforced
     // on a per EDP basis.
@@ -88,7 +88,7 @@ message MetricSpec {
     // Differential privacy parameters.
     //
     // If this field is unspecified in a request message, the service
-    // implementation will choose a value.
+    // implementation will use the value specified in the system defaults.
     DifferentialPrivacyParams privacy_params = 1;
     // Maximum watch duration per user in second that will be included in this
     // metric.
@@ -131,7 +131,7 @@ message MetricSpec {
   // Range of VIDs that will be included in this measurement
   //
   // If this field is unspecified in a request message, the service
-  // implementation will choose a value.
+  // implementation will use the value specified in the system defaults.
   VidSamplingInterval vid_sampling_interval = 5;
 }
 

--- a/src/main/proto/wfa/measurement/reporting/v2alpha/metric.proto
+++ b/src/main/proto/wfa/measurement/reporting/v2alpha/metric.proto
@@ -33,25 +33,29 @@ message MetricSpec {
   // foundations of differential privacy. Foundations and Trends in Theoretical
   // Computer Science, 9(3-4), pp.211-407."
   message DifferentialPrivacyParams {
-    double epsilon = 1;
-    double delta = 2;
+    double epsilon = 1 [(google.api.field_behavior) = REQUIRED];
+    double delta = 2 [(google.api.field_behavior) = REQUIRED];
   }
 
-  // Parameters that are used to generate `Reach` metric or
-  // `Frequency Histogram` metric.
-  message ReachFrequencyParams {
+  // Parameters that are used to generate `Reach` metric.
+  message ReachParams {
     // Differential privacy parameters for reach.
     //
-    // This field is either unset or fully set. The parameters in this field
-    // cannot be set partially. If this field is not set, the default values
-    // will be used and outputted here.
-    DifferentialPrivacyParams reach_privacy_params = 1;
-
-    // Differential privacy parameters for frequency.
+    // If this field is unspecified in a request message, the service
+    // implementation will choose a value.
+    DifferentialPrivacyParams privacy_params = 1;
+  }
+  // Parameters that are used to generate `Frequency Histogram` metric.
+  message FrequencyHistogramParams {
+    // Differential privacy parameters for reach.
     //
-    // This field is either unset or fully set. The parameters in this field
-    // cannot be set partially. If this field is not set, the default values
-    // will be used and outputted here.
+    // If this field is unspecified in a request message, the service
+    // implementation will choose a value.
+    DifferentialPrivacyParams reach_privacy_params = 1;
+    // Differential privacy parameters for frequency distribution.
+    //
+    // If this field is unspecified in a request message, the service
+    // implementation will choose a value.
     DifferentialPrivacyParams frequency_privacy_params = 2;
     // Maximum frequency cut-off value in the frequency histogram.
     //
@@ -63,9 +67,8 @@ message MetricSpec {
   message ImpressionCountParams {
     // Differential privacy parameters.
     //
-    // This field is either unset or fully set. The parameters in this field
-    // cannot be set partially. If this field is not set, the default values
-    // will be used and outputted here.
+    // If this field is unspecified in a request message, the service
+    // implementation will choose a value.
     DifferentialPrivacyParams privacy_params = 1;
     // Maximum frequency per user that will be included in this metric. Enforced
     // on a per EDP basis.
@@ -84,9 +87,8 @@ message MetricSpec {
   message WatchDurationParams {
     // Differential privacy parameters.
     //
-    // This field is either unset or fully set. The parameters in this field
-    // cannot be set partially. If this field is not set, the default values
-    // will be used and outputted here.
+    // If this field is unspecified in a request message, the service
+    // implementation will choose a value.
     DifferentialPrivacyParams privacy_params = 1;
     // Maximum watch duration per user in second that will be included in this
     // metric.
@@ -101,13 +103,13 @@ message MetricSpec {
   // Types of metric with parameters.
   oneof type {
     // The count of unique audiences reached given a set of event groups.
-    ReachFrequencyParams reach = 1 [(google.api.field_behavior) = IMMUTABLE];
+    ReachParams reach = 1 [(google.api.field_behavior) = IMMUTABLE];
     // The reach frequency histogram given a set of event groups.
     //
     // Currently, we only support union operations for frequency histograms. Any
     // other operations on frequency histograms won't guarantee the result is a
     // frequency histogram.
-    ReachFrequencyParams frequency_histogram = 2
+    FrequencyHistogramParams frequency_histogram = 2
         [(google.api.field_behavior) = IMMUTABLE];
     // The impression count given a set of event groups.
     ImpressionCountParams impression_count = 3
@@ -120,16 +122,16 @@ message MetricSpec {
   // Specifies a range of VIDs to be sampled.
   message VidSamplingInterval {
     // The start of the sampling interval in [0, 1)
-    float start = 1;
+    float start = 1 [(google.api.field_behavior) = REQUIRED];
     // The width of the sampling interval.
     //
     // start + width cannot be larger than 1
-    float width = 2;
+    float width = 2 [(google.api.field_behavior) = REQUIRED];
   }
   // Range of VIDs that will be included in this measurement
   //
-  // The parameters cannot be set partially. If no parameters are set, the
-  // default values will be used and outputted here.
+  // If this field is unspecified in a request message, the service
+  // implementation will choose a value.
   VidSamplingInterval vid_sampling_interval = 5;
 }
 

--- a/src/main/proto/wfa/measurement/reporting/v2alpha/metric.proto
+++ b/src/main/proto/wfa/measurement/reporting/v2alpha/metric.proto
@@ -40,20 +40,30 @@ message MetricSpec {
   // Parameters that are used to generate `Reach` metric.
   message ReachParams {
     // Differential privacy parameters.
+    //
+    // The parameters cannot be set partially. If no parameters are set, the
+    // default values will be used and outputted here.
     DifferentialPrivacyParams privacy_params = 1;
   }
   // Parameters that are used to generate `Frequency Histogram` metric.
   message FrequencyHistogramParams {
     // Differential privacy parameters.
+    //
+    // The parameters cannot be set partially. If no parameters are set, the
+    // default values will be used and outputted here.
     DifferentialPrivacyParams privacy_params = 1;
-    // Maximum frequency cut-off value in the frequency histogram. Counts with
-    // frequency higher than `max_frequency` will be aggregated together.
-    int32 maximum_frequency_per_user = 2
-        [(google.api.field_behavior) = REQUIRED];
+    // Maximum frequency cut-off value in the frequency histogram.
+    //
+    // Counts with frequency higher than `max_frequency` will be aggregated
+    // together. If not set, the default value will be used and outputted here.
+    int32 maximum_frequency_per_user = 2;
   }
   // Parameters that are used to generate `Impression Count` metric.
   message ImpressionCountParams {
     // Differential privacy parameters.
+    //
+    // The parameters cannot be set partially. If no parameters are set, the
+    // default values will be used and outputted here.
     DifferentialPrivacyParams privacy_params = 1;
     // Maximum frequency per user that will be included in this metric. Enforced
     // on a per EDP basis.
@@ -65,12 +75,15 @@ message MetricSpec {
     // too small, there's a truncation bias. Through optimization, the
     // recommended value for maximum_frequency_per_user = 60 for the case with
     // over 1M audience size.
-    int32 maximum_frequency_per_user = 2
-        [(google.api.field_behavior) = REQUIRED];
+    // If not set, the default value will be used and outputted here.
+    int32 maximum_frequency_per_user = 2;
   }
   // Parameters that are used to generate `Watch Duration` metric.
   message WatchDurationParams {
     // Differential privacy parameters.
+    //
+    // The parameters cannot be set partially. If no parameters are set, the
+    // default values will be used and outputted here.
     DifferentialPrivacyParams privacy_params = 1;
     // Maximum watch duration per user in second that will be included in this
     // metric.
@@ -78,8 +91,8 @@ message MetricSpec {
     // Recommended maximum_watch_duration_per_user = cap on the total watch
     // duration of all the impressions of a user = 4000 sec for the case with
     // over 1M audience size. Enforced on a per EDP basis.
-    int32 maximum_watch_duration_per_user = 2
-        [(google.api.field_behavior) = REQUIRED];
+    // If not set, the default value will be used and outputted here.
+    int32 maximum_watch_duration_per_user = 2;
   }
 
   // Types of metric with parameters.
@@ -111,6 +124,9 @@ message MetricSpec {
     float width = 2;
   }
   // Range of VIDs that will be included in this measurement
+  //
+  // The parameters cannot be set partially. If no parameters are set, the
+  // default values will be used and outputted here.
   VidSamplingInterval vid_sampling_interval = 5;
 }
 

--- a/src/main/proto/wfa/measurement/reporting/v2alpha/metric.proto
+++ b/src/main/proto/wfa/measurement/reporting/v2alpha/metric.proto
@@ -58,7 +58,7 @@ message MetricSpec {
     //
     // Counts with frequency higher than `max_frequency` will be aggregated
     // together. If not set, the default value will be used and outputted here.
-    int32 maximum_frequency_per_user = 3;
+    optional int32 maximum_frequency_per_user = 3;
   }
   // Parameters that are used to generate `Impression Count` metric.
   message ImpressionCountParams {
@@ -76,7 +76,7 @@ message MetricSpec {
     // recommended value for maximum_frequency_per_user = 60 for the case with
     // over 1M audience size.
     // If not set, the default value will be used and outputted here.
-    int32 maximum_frequency_per_user = 2;
+    optional int32 maximum_frequency_per_user = 2;
   }
   // Parameters that are used to generate `Watch Duration` metric.
   message WatchDurationParams {
@@ -90,7 +90,7 @@ message MetricSpec {
     // duration of all the impressions of a user = 4000 sec for the case with
     // over 1M audience size. Enforced on a per EDP basis.
     // If not set, the default value will be used and outputted here.
-    int32 maximum_watch_duration_per_user = 2;
+    optional int32 maximum_watch_duration_per_user = 2;
   }
 
   // Types of metric with parameters.

--- a/src/main/proto/wfa/measurement/reporting/v2alpha/metric.proto
+++ b/src/main/proto/wfa/measurement/reporting/v2alpha/metric.proto
@@ -37,33 +37,35 @@ message MetricSpec {
     double delta = 2;
   }
 
-  // Parameters that are used to generate `Reach` metric.
-  message ReachParams {
-    // Differential privacy parameters.
+  // Parameters that are used to generate `Reach` metric or
+  // `Frequency Histogram` metric.
+  message ReachFrequencyParams {
+    // Differential privacy parameters for reach.
     //
-    // The parameters cannot be set partially. If no parameters are set, the
-    // default values will be used and outputted here.
-    DifferentialPrivacyParams privacy_params = 1;
-  }
-  // Parameters that are used to generate `Frequency Histogram` metric.
-  message FrequencyHistogramParams {
-    // Differential privacy parameters.
+    // This field is either unset or fully set. The parameters in this field
+    // cannot be set partially. If this field is not set, the default values
+    // will be used and outputted here.
+    DifferentialPrivacyParams reach_privacy_params = 1;
+
+    // Differential privacy parameters for frequency.
     //
-    // The parameters cannot be set partially. If no parameters are set, the
-    // default values will be used and outputted here.
-    DifferentialPrivacyParams privacy_params = 1;
+    // This field is either unset or fully set. The parameters in this field
+    // cannot be set partially. If this field is not set, the default values
+    // will be used and outputted here.
+    DifferentialPrivacyParams frequency_privacy_params = 2;
     // Maximum frequency cut-off value in the frequency histogram.
     //
     // Counts with frequency higher than `max_frequency` will be aggregated
     // together. If not set, the default value will be used and outputted here.
-    int32 maximum_frequency_per_user = 2;
+    int32 maximum_frequency_per_user = 3;
   }
   // Parameters that are used to generate `Impression Count` metric.
   message ImpressionCountParams {
     // Differential privacy parameters.
     //
-    // The parameters cannot be set partially. If no parameters are set, the
-    // default values will be used and outputted here.
+    // This field is either unset or fully set. The parameters in this field
+    // cannot be set partially. If this field is not set, the default values
+    // will be used and outputted here.
     DifferentialPrivacyParams privacy_params = 1;
     // Maximum frequency per user that will be included in this metric. Enforced
     // on a per EDP basis.
@@ -82,8 +84,9 @@ message MetricSpec {
   message WatchDurationParams {
     // Differential privacy parameters.
     //
-    // The parameters cannot be set partially. If no parameters are set, the
-    // default values will be used and outputted here.
+    // This field is either unset or fully set. The parameters in this field
+    // cannot be set partially. If this field is not set, the default values
+    // will be used and outputted here.
     DifferentialPrivacyParams privacy_params = 1;
     // Maximum watch duration per user in second that will be included in this
     // metric.
@@ -98,13 +101,13 @@ message MetricSpec {
   // Types of metric with parameters.
   oneof type {
     // The count of unique audiences reached given a set of event groups.
-    ReachParams reach = 1 [(google.api.field_behavior) = IMMUTABLE];
+    ReachFrequencyParams reach = 1 [(google.api.field_behavior) = IMMUTABLE];
     // The reach frequency histogram given a set of event groups.
     //
     // Currently, we only support union operations for frequency histograms. Any
     // other operations on frequency histograms won't guarantee the result is a
     // frequency histogram.
-    FrequencyHistogramParams frequency_histogram = 2
+    ReachFrequencyParams frequency_histogram = 2
         [(google.api.field_behavior) = IMMUTABLE];
     // The impression count given a set of event groups.
     ImpressionCountParams impression_count = 3

--- a/src/main/proto/wfa/measurement/reporting/v2alpha/metric.proto
+++ b/src/main/proto/wfa/measurement/reporting/v2alpha/metric.proto
@@ -29,34 +29,31 @@ option java_outer_classname = "MetricProto";
 message MetricSpec {
   // Parameters for differential privacy (DP).
   //
+  // If any of the fields are not specified in a request message, the service
+  // implementation will choose values.
+  //
   // For detail, refer to "Dwork, C. and Roth, A., 2014. The algorithmic
   // foundations of differential privacy. Foundations and Trends in Theoretical
   // Computer Science, 9(3-4), pp.211-407."
   message DifferentialPrivacyParams {
-    double epsilon = 1 [(google.api.field_behavior) = REQUIRED];
-    double delta = 2 [(google.api.field_behavior) = REQUIRED];
+    optional double epsilon = 1;
+    optional double delta = 2;
   }
 
   // Parameters that are used to generate `Reach` metric.
   message ReachParams {
     // Differential privacy parameters for reach.
-    //
-    // If this field is unspecified in a request message, the service
-    // implementation will use the value specified in the system defaults.
-    DifferentialPrivacyParams privacy_params = 1;
+    DifferentialPrivacyParams privacy_params = 1
+        [(google.api.field_behavior) = REQUIRED];
   }
   // Parameters that are used to generate `Frequency Histogram` metric.
   message FrequencyHistogramParams {
     // Differential privacy parameters for reach.
-    //
-    // If this field is unspecified in a request message, the service
-    // implementation will use the value specified in the system defaults.
-    DifferentialPrivacyParams reach_privacy_params = 1;
+    DifferentialPrivacyParams reach_privacy_params = 1
+        [(google.api.field_behavior) = REQUIRED];
     // Differential privacy parameters for frequency distribution.
-    //
-    // If this field is unspecified in a request message, the service
-    // implementation will use the value specified in the system defaults.
-    DifferentialPrivacyParams frequency_privacy_params = 2;
+    DifferentialPrivacyParams frequency_privacy_params = 2
+        [(google.api.field_behavior) = REQUIRED];
     // Maximum frequency cut-off value in the frequency histogram.
     //
     // Counts with frequency higher than `max_frequency` will be aggregated
@@ -66,10 +63,8 @@ message MetricSpec {
   // Parameters that are used to generate `Impression Count` metric.
   message ImpressionCountParams {
     // Differential privacy parameters.
-    //
-    // If this field is unspecified in a request message, the service
-    // implementation will use the value specified in the system defaults.
-    DifferentialPrivacyParams privacy_params = 1;
+    DifferentialPrivacyParams privacy_params = 1
+        [(google.api.field_behavior) = REQUIRED];
     // Maximum frequency per user that will be included in this metric. Enforced
     // on a per EDP basis.
     //
@@ -86,10 +81,8 @@ message MetricSpec {
   // Parameters that are used to generate `Watch Duration` metric.
   message WatchDurationParams {
     // Differential privacy parameters.
-    //
-    // If this field is unspecified in a request message, the service
-    // implementation will use the value specified in the system defaults.
-    DifferentialPrivacyParams privacy_params = 1;
+    DifferentialPrivacyParams privacy_params = 1
+        [(google.api.field_behavior) = REQUIRED];
     // Maximum watch duration per user in second that will be included in this
     // metric.
     //


### PR DESCRIPTION
* Make all fields in metric spec not required. Document the usage.
* Incorporate the new kingdom measurement design.
* Add metric spec config for storing default values.