### PR TITLE
Revert changes to create-measurement-schema.sql from e4c1e242f94c961e3379f35b2cdca04ef2dee1d0

### DIFF
--- a/src/main/resources/kingdom/spanner/create-measurement-schema.sql
+++ b/src/main/resources/kingdom/spanner/create-measurement-schema.sql
@@ -36,7 +36,6 @@ START BATCH DDL;
 --   │   └── Measurements
 --   │       ├── ComputationParticipants
 --   │       ├── MeasurementLogEntries
---   │       │   └── DuchyMeasurementLogEntries
 --   │       ├── Requisitions
 --   │       └── DuchyMeasurementResults
 --   └── Accounts


### PR DESCRIPTION
Liquibase changesets must remain immutable to avoid failing validation. This includes comments.

Fixes #903.