### PR TITLE
Implement logic to update Data Provider duchy list

### DIFF
--- a/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/SpannerDataProvidersService.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/SpannerDataProvidersService.kt
@@ -50,6 +50,7 @@ class SpannerDataProvidersService(
       ?.dataProvider
       ?: failGrpc(Status.NOT_FOUND) { "DataProvider not found" }
   }
+
   override suspend fun replaceDataProviderRequiredDuchies(
     request: ReplaceDataProviderRequiredDuchiesRequest
   ): DataProvider {

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/SpannerDataProvidersService.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/SpannerDataProvidersService.kt
@@ -24,6 +24,7 @@ import org.wfanet.measurement.internal.kingdom.DataProvider
 import org.wfanet.measurement.internal.kingdom.DataProvidersGrpcKt.DataProvidersCoroutineImplBase
 import org.wfanet.measurement.internal.kingdom.GetDataProviderRequest
 import org.wfanet.measurement.internal.kingdom.ReplaceDataProviderRequiredDuchiesRequest
+import org.wfanet.measurement.kingdom.deploy.gcloud.spanner.common.DataProviderNotFoundException
 import org.wfanet.measurement.kingdom.deploy.gcloud.spanner.readers.DataProviderReader
 import org.wfanet.measurement.kingdom.deploy.gcloud.spanner.writers.CreateDataProvider
 import org.wfanet.measurement.kingdom.deploy.gcloud.spanner.writers.ReplaceDataProviderRequiredDuchies
@@ -55,6 +56,10 @@ class SpannerDataProvidersService(
     grpcRequire(request.externalDataProviderId != null) {
       "externalDataProviderId field is missing."
     }
-    return ReplaceDataProviderRequiredDuchies(request).execute(client, idGenerator)
+    try {
+      return ReplaceDataProviderRequiredDuchies(request).execute(client, idGenerator)
+    } catch (e: DataProviderNotFoundException) {
+      e.throwStatusRuntimeException(Status.NOT_FOUND) { "DataProvider not found." }
+    }
   }
 }

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/SpannerDataProvidersService.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/SpannerDataProvidersService.kt
@@ -23,8 +23,10 @@ import org.wfanet.measurement.gcloud.spanner.AsyncDatabaseClient
 import org.wfanet.measurement.internal.kingdom.DataProvider
 import org.wfanet.measurement.internal.kingdom.DataProvidersGrpcKt.DataProvidersCoroutineImplBase
 import org.wfanet.measurement.internal.kingdom.GetDataProviderRequest
+import org.wfanet.measurement.internal.kingdom.ReplaceDataProviderRequiredDuchiesRequest
 import org.wfanet.measurement.kingdom.deploy.gcloud.spanner.readers.DataProviderReader
 import org.wfanet.measurement.kingdom.deploy.gcloud.spanner.writers.CreateDataProvider
+import org.wfanet.measurement.kingdom.deploy.gcloud.spanner.writers.ReplaceDataProviderRequiredDuchies
 
 // TODO(@marcopremier): Add method to update data provider required duchies list.
 class SpannerDataProvidersService(
@@ -46,5 +48,13 @@ class SpannerDataProvidersService(
       .readByExternalDataProviderId(client.singleUse(), ExternalId(request.externalDataProviderId))
       ?.dataProvider
       ?: failGrpc(Status.NOT_FOUND) { "DataProvider not found" }
+  }
+  override suspend fun replaceDataProviderRequiredDuchies(
+    request: ReplaceDataProviderRequiredDuchiesRequest
+  ): DataProvider {
+    grpcRequire(request.externalDataProviderId != null) {
+      "externalDataProviderId field is missing."
+    }
+    return ReplaceDataProviderRequiredDuchies(request).execute(client, idGenerator)
   }
 }

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/writers/ReplaceDataProviderRequiredDuchies.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/writers/ReplaceDataProviderRequiredDuchies.kt
@@ -55,10 +55,7 @@ class ReplaceDataProviderRequiredDuchies(
             ?: throw DuchyNotFoundException(externalDuchyId.toString())
         )
       transactionContext.buffer(
-        Mutation.delete(
-          "DataProviderRequiredDuchies",
-          KeySet.singleKey(Key.of(dataProviderId, duchyId.value))
-        )
+        Mutation.delete("DataProviderRequiredDuchies", KeySet.prefixRange(Key.of(dataProviderId)))
       )
     }
 

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/writers/ReplaceDataProviderRequiredDuchies.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/writers/ReplaceDataProviderRequiredDuchies.kt
@@ -43,21 +43,13 @@ class ReplaceDataProviderRequiredDuchies(
 
     val dataProvider = dataProviderResult.dataProvider
     val dataProviderId = dataProviderResult.dataProviderId
-    val currentRequiredDuchyList = dataProvider.requiredExternalDuchyIdsList
     val desiredRequiredDuchyList =
       replaceDataProviderRequiredDuchiesRequest.requiredExternalDuchyIdsList
 
     // Delete old duchy list.
-    for (externalDuchyId in currentRequiredDuchyList) {
-      val duchyId =
-        InternalId(
-          DuchyIds.getInternalId(externalDuchyId.toString())
-            ?: throw DuchyNotFoundException(externalDuchyId.toString())
-        )
-      transactionContext.buffer(
-        Mutation.delete("DataProviderRequiredDuchies", KeySet.prefixRange(Key.of(dataProviderId)))
-      )
-    }
+    transactionContext.buffer(
+      Mutation.delete("DataProviderRequiredDuchies", KeySet.prefixRange(Key.of(dataProviderId)))
+    )
 
     // Write new duchy list.
     for (externalDuchyId in desiredRequiredDuchyList) {

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/writers/ReplaceDataProviderRequiredDuchies.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/writers/ReplaceDataProviderRequiredDuchies.kt
@@ -1,0 +1,88 @@
+// Copyright 2020 The Cross-Media Measurement Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package org.wfanet.measurement.kingdom.deploy.gcloud.spanner.writers
+
+import com.google.cloud.spanner.Key
+import com.google.cloud.spanner.KeySet
+import com.google.cloud.spanner.Mutation
+import org.wfanet.measurement.common.identity.ExternalId
+import org.wfanet.measurement.common.identity.InternalId
+import org.wfanet.measurement.gcloud.spanner.bufferInsertMutation
+import org.wfanet.measurement.gcloud.spanner.set
+import org.wfanet.measurement.internal.kingdom.DataProvider
+import org.wfanet.measurement.internal.kingdom.ReplaceDataProviderRequiredDuchiesRequest
+import org.wfanet.measurement.kingdom.deploy.common.DuchyIds
+import org.wfanet.measurement.kingdom.deploy.gcloud.spanner.common.DuchyNotFoundException
+import org.wfanet.measurement.kingdom.deploy.gcloud.spanner.readers.DataProviderReader
+
+class ReplaceDataProviderRequiredDuchies(
+  private val replaceDataProviderRequiredDuchiesRequest: ReplaceDataProviderRequiredDuchiesRequest
+) : SpannerWriter<DataProvider, DataProvider>() {
+  override suspend fun TransactionScope.runTransaction(): DataProvider {
+    val dataProviderResult =
+      DataProviderReader()
+        .readByExternalDataProviderId(
+          transactionContext,
+          ExternalId(replaceDataProviderRequiredDuchiesRequest.externalDataProviderId)
+        )
+    require(dataProviderResult != null)
+    val dataProvider = dataProviderResult.dataProvider
+    val dataProviderId = dataProviderResult.dataProviderId
+    val currentRequiredDuchyList = dataProvider.requiredExternalDuchyIdsList
+    val desiredRequiredDuchyList =
+      replaceDataProviderRequiredDuchiesRequest.requiredExternalDuchyIdsList
+
+    require(
+      !(currentRequiredDuchyList.size == desiredRequiredDuchyList.size &&
+        currentRequiredDuchyList.toSet() == desiredRequiredDuchyList.toSet())
+    )
+
+    // delete old duchy list
+    for (externalDuchyId in currentRequiredDuchyList) {
+      val duchyId =
+        InternalId(
+          DuchyIds.getInternalId(externalDuchyId.toString())
+            ?: throw DuchyNotFoundException(externalDuchyId.toString())
+        )
+      transactionContext.buffer(
+        Mutation.delete(
+          "DataProviderRequiredDuchies",
+          KeySet.singleKey(Key.of(dataProviderId, duchyId.value))
+        )
+      )
+    }
+
+    // write new duchy list
+    for (externalDuchyId in desiredRequiredDuchyList) {
+      val duchyId =
+        InternalId(
+          DuchyIds.getInternalId(externalDuchyId.toString())
+            ?: throw DuchyNotFoundException(externalDuchyId.toString())
+        )
+      transactionContext.bufferInsertMutation("DataProviderRequiredDuchies") {
+        set("DataProviderId" to dataProviderId)
+        set("DuchyId" to duchyId)
+      }
+    }
+
+    return dataProvider
+      .toBuilder()
+      .clearRequiredExternalDuchyIds()
+      .addAllRequiredExternalDuchyIds(desiredRequiredDuchyList)
+      .build()
+  }
+  override fun ResultScope<DataProvider>.buildResult(): DataProvider {
+    return checkNotNull(transactionResult)
+  }
+}

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/writers/ReplaceDataProviderRequiredDuchies.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/writers/ReplaceDataProviderRequiredDuchies.kt
@@ -33,19 +33,12 @@ class ReplaceDataProviderRequiredDuchies(
   override suspend fun TransactionScope.runTransaction(): DataProvider {
     val externalDataProviderId = ExternalId(request.externalDataProviderId)
     val dataProviderResult =
-      DataProviderReader()
-        .readByExternalDataProviderId(
-          transactionContext,
-          externalDataProviderId
-        )
-        ?: throw DataProviderNotFoundException(
-          externalDataProviderId
-        )
+      DataProviderReader().readByExternalDataProviderId(transactionContext, externalDataProviderId)
+        ?: throw DataProviderNotFoundException(externalDataProviderId)
 
     val dataProvider = dataProviderResult.dataProvider
     val dataProviderId = dataProviderResult.dataProviderId
-    val desiredRequiredDuchyList =
-      request.requiredExternalDuchyIdsList
+    val desiredRequiredDuchyList = request.requiredExternalDuchyIdsList
 
     // Delete old duchy list.
     transactionContext.buffer(

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/writers/ReplaceDataProviderRequiredDuchies.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/writers/ReplaceDataProviderRequiredDuchies.kt
@@ -28,23 +28,24 @@ import org.wfanet.measurement.kingdom.deploy.gcloud.spanner.common.DuchyNotFound
 import org.wfanet.measurement.kingdom.deploy.gcloud.spanner.readers.DataProviderReader
 
 class ReplaceDataProviderRequiredDuchies(
-  private val replaceDataProviderRequiredDuchiesRequest: ReplaceDataProviderRequiredDuchiesRequest
+  private val request: ReplaceDataProviderRequiredDuchiesRequest
 ) : SpannerWriter<DataProvider, DataProvider>() {
   override suspend fun TransactionScope.runTransaction(): DataProvider {
+    val externalDataProviderId = ExternalId(request.externalDataProviderId)
     val dataProviderResult =
       DataProviderReader()
         .readByExternalDataProviderId(
           transactionContext,
-          ExternalId(replaceDataProviderRequiredDuchiesRequest.externalDataProviderId)
+          externalDataProviderId
         )
         ?: throw DataProviderNotFoundException(
-          ExternalId(replaceDataProviderRequiredDuchiesRequest.externalDataProviderId)
+          externalDataProviderId
         )
 
     val dataProvider = dataProviderResult.dataProvider
     val dataProviderId = dataProviderResult.dataProviderId
     val desiredRequiredDuchyList =
-      replaceDataProviderRequiredDuchiesRequest.requiredExternalDuchyIdsList
+      request.requiredExternalDuchyIdsList
 
     // Delete old duchy list.
     transactionContext.buffer(

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/service/internal/testing/DataProvidersServiceTest.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/service/internal/testing/DataProvidersServiceTest.kt
@@ -36,9 +36,10 @@ import org.wfanet.measurement.internal.kingdom.DataProvider
 import org.wfanet.measurement.internal.kingdom.DataProviderKt
 import org.wfanet.measurement.internal.kingdom.DataProvidersGrpcKt.DataProvidersCoroutineImplBase
 import org.wfanet.measurement.internal.kingdom.GetDataProviderRequest
-import org.wfanet.measurement.internal.kingdom.ReplaceDataProviderRequiredDuchiesRequest
 import org.wfanet.measurement.internal.kingdom.certificate
 import org.wfanet.measurement.internal.kingdom.dataProvider
+import org.wfanet.measurement.internal.kingdom.getDataProviderRequest
+import org.wfanet.measurement.internal.kingdom.replaceDataProviderRequiredDuchiesRequest
 import org.wfanet.measurement.kingdom.deploy.common.testing.DuchyIdSetter
 import org.wfanet.measurement.kingdom.service.internal.testing.Population.Companion.DUCHIES
 
@@ -231,10 +232,10 @@ abstract class DataProvidersServiceTest<T : DataProvidersCoroutineImplBase> {
     val desiredDuchyList = listOf(Population.AGGREGATOR_DUCHY.externalDuchyId)
     val updatedDataProvider =
       dataProvidersService.replaceDataProviderRequiredDuchies(
-        ReplaceDataProviderRequiredDuchiesRequest.newBuilder()
-          .setExternalDataProviderId(createdDataProvider.externalDataProviderId)
-          .addAllRequiredExternalDuchyIds(desiredDuchyList)
-          .build()
+        replaceDataProviderRequiredDuchiesRequest {
+          externalDataProviderId = createdDataProvider.externalDataProviderId
+          requiredExternalDuchyIds += desiredDuchyList
+        }
       )
 
     // Ensure DataProvider with updated duchy list is returned from function
@@ -242,9 +243,9 @@ abstract class DataProvidersServiceTest<T : DataProvidersCoroutineImplBase> {
 
     val dataProviderRead =
       dataProvidersService.getDataProvider(
-        GetDataProviderRequest.newBuilder()
-          .setExternalDataProviderId(createdDataProvider.externalDataProviderId)
-          .build()
+        getDataProviderRequest {
+          externalDataProviderId = createdDataProvider.externalDataProviderId
+        }
       )
 
     // Ensure changes were written to DataProviderRequiredDuchies table

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/service/internal/testing/DataProvidersServiceTest.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/service/internal/testing/DataProvidersServiceTest.kt
@@ -232,7 +232,6 @@ abstract class DataProvidersServiceTest<T : DataProvidersCoroutineImplBase> {
           .addAllRequiredExternalDuchyIds(desiredDuchyList)
           .build()
       )
-    // read from database to make sure elements were written to table
     // Ensure DataProvider with updated duchy list is returned from function
     assertThat(updatedDataProvider.requiredExternalDuchyIdsList).isEqualTo(desiredDuchyList)
 
@@ -242,6 +241,7 @@ abstract class DataProvidersServiceTest<T : DataProvidersCoroutineImplBase> {
           .setExternalDataProviderId(createdDataProvider.externalDataProviderId)
           .build()
       )
+    // Ensure changes were written to DataProviderRequiredDuchies table
     assertThat(dataProviderRead.requiredExternalDuchyIdsList).isEqualTo(desiredDuchyList)
   }
 }


### PR DESCRIPTION
Create ReplaceDataProviderRequiredDuchies class to update duchy list in DataProviderRequiredDuchies table. The return value of the TransactionScope.runTransaction method in this class is the DataProvider object with the updated duchy list

Implement replaceDataProviderRequiredDuchies in SpannerDataProvidersService to call the new ReplaceDataProviderRequiredDuchies class with the ReplaceDataProviderRequiredDuchiesRequest. This method will throw an error if the externalDataProviderId is not present in the request.

Create test that checks:
1. the returned DataProvider has the updated duchy list
2. the DataProviderRequiredDuchies table is updated

https://rally1.rallydev.com/#/604612930531d/iterationstatus?detail=%2Ftask%2F697342533129