### PR TITLE
Add GcsCorrectnessTest.

### DIFF
--- a/build/variables.bzl
+++ b/build/variables.bzl
@@ -53,6 +53,11 @@ TEST_K8S_SETTINGS = struct(
     grafana_secret_name = "$(k8s_grafana_secret_name)",
 )
 
+GCLOUD_SETTINGS = struct(
+    project = "$(google_cloud_project)",
+    spanner_instance = "$(spanner_instance)",
+)
+
 # Settings for Kingdom Kubernetes deployments.
 KINGDOM_K8S_SETTINGS = struct(
     secret_name = "$(k8s_kingdom_secret_name)",

--- a/src/main/proto/wfa/measurement/integration/k8s/testing/BUILD.bazel
+++ b/src/main/proto/wfa/measurement/integration/k8s/testing/BUILD.bazel
@@ -45,3 +45,20 @@ kt_jvm_proto_library(
     srcs = [":forwarded_storage_config_proto"],
     deps = [":forwarded_storage_config_java_proto"],
 )
+
+proto_library(
+    name = "google_cloud_storage_config_proto",
+    srcs = ["google_cloud_storage_config.proto"],
+    strip_import_prefix = IMPORT_PREFIX,
+)
+
+java_proto_library(
+    name = "google_cloud_storage_config_java_proto",
+    deps = [":google_cloud_storage_config_proto"],
+)
+
+kt_jvm_proto_library(
+    name = "google_cloud_storage_config_kt_jvm_proto",
+    srcs = [":google_cloud_storage_config_proto"],
+    deps = [":google_cloud_storage_config_java_proto"],
+)

--- a/src/main/proto/wfa/measurement/integration/k8s/testing/google_cloud_storage_config.proto
+++ b/src/main/proto/wfa/measurement/integration/k8s/testing/google_cloud_storage_config.proto
@@ -1,0 +1,29 @@
+// Copyright 2023 The Cross-Media Measurement Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package wfa.measurement.integration.k8s.testing;
+
+option java_package = "org.measurement.integration.k8s.testing";
+option java_multiple_files = true;
+
+// Configuration for Google Cloud Storage (GCS).
+message GoogleCloudStorageConfig {
+  // Google Cloud project.
+  string project = 1;
+
+  // Google Cloud Storage bucket.
+  string bucket = 2;
+}

--- a/src/test/kotlin/org/wfanet/measurement/integration/k8s/BUILD.bazel
+++ b/src/test/kotlin/org/wfanet/measurement/integration/k8s/BUILD.bazel
@@ -1,7 +1,12 @@
 load("@io_bazel_rules_kotlin//kotlin:jvm.bzl", "kt_jvm_library")
 load("@rules_java//java:defs.bzl", "java_test")
 load("@wfa_common_jvm//build:defs.bzl", "expand_template")
-load("//build:variables.bzl", "TEST_K8S_SETTINGS")
+load(
+    "//build:variables.bzl",
+    "GCLOUD_SETTINGS",
+    "SIMULATOR_K8S_SETTINGS",
+    "TEST_K8S_SETTINGS",
+)
 
 package(default_testonly = True)
 
@@ -63,6 +68,22 @@ kt_jvm_library(
     ],
 )
 
+kt_jvm_library(
+    name = "gcs_correctness_test",
+    srcs = ["GcsCorrectnessTest.kt"],
+    deps = [
+        ":abstract_correctness_test",
+        "//src/main/kotlin/org/wfanet/measurement/loadtest/config:event_filters",
+        "//src/main/proto/wfa/measurement/integration/k8s/testing:correctness_test_config_kt_jvm_proto",
+        "//src/main/proto/wfa/measurement/integration/k8s/testing:google_cloud_storage_config_kt_jvm_proto",
+        "@wfa_common_jvm//imports/java/org/junit",
+        "@wfa_common_jvm//imports/kotlin/kotlinx/coroutines:core",
+        "@wfa_common_jvm//src/main/kotlin/org/wfanet/measurement/common/grpc",
+        "@wfa_common_jvm//src/main/kotlin/org/wfanet/measurement/common/testing",
+        "@wfa_common_jvm//src/main/kotlin/org/wfanet/measurement/gcloud/gcs",
+    ],
+)
+
 expand_template(
     name = "gen_correctness_test_config",
     out = "correctness_test_config.textproto",
@@ -85,6 +106,17 @@ expand_template(
     },
     tags = ["manual"],
     template = "forwarded_storage_config.tmpl.textproto",
+)
+
+expand_template(
+    name = "gen_gcs_config",
+    out = "gcs_config.textproto",
+    substitutions = {
+        "{project}": GCLOUD_SETTINGS.project,
+        "{bucket}": SIMULATOR_K8S_SETTINGS.storage_bucket,
+    },
+    tags = ["manual"],
+    template = "gcs_config.tmpl.textproto",
 )
 
 java_test(
@@ -118,4 +150,16 @@ java_test(
     tags = ["manual"],
     test_class = "org.wfanet.measurement.integration.k8s.ForwardedStorageCorrectnessTest",
     runtime_deps = [":forwarded_storage_correctness_test"],
+)
+
+java_test(
+    name = "GcsCorrectnessTest",
+    timeout = "long",
+    data = [
+        ":correctness_test_config.textproto",
+        ":gcs_config.textproto",
+    ],
+    tags = ["manual"],
+    test_class = "org.wfanet.measurement.integration.k8s.GcsCorrectnessTest",
+    runtime_deps = [":gcs_correctness_test"],
 )

--- a/src/test/kotlin/org/wfanet/measurement/integration/k8s/GcsCorrectnessTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/integration/k8s/GcsCorrectnessTest.kt
@@ -1,0 +1,144 @@
+/*
+ * Copyright 2023 The Cross-Media Measurement Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wfanet.measurement.integration.k8s
+
+import com.google.cloud.storage.StorageOptions
+import io.grpc.ManagedChannel
+import java.nio.file.Paths
+import java.time.Duration
+import java.util.UUID
+import org.junit.ClassRule
+import org.junit.rules.TemporaryFolder
+import org.junit.rules.TestRule
+import org.junit.runner.Description
+import org.junit.runners.model.Statement
+import org.measurement.integration.k8s.testing.CorrectnessTestConfig
+import org.measurement.integration.k8s.testing.GoogleCloudStorageConfig
+import org.wfanet.measurement.api.v2alpha.CertificatesGrpcKt
+import org.wfanet.measurement.api.v2alpha.DataProvidersGrpcKt
+import org.wfanet.measurement.api.v2alpha.EventGroupsGrpcKt
+import org.wfanet.measurement.api.v2alpha.MeasurementConsumersGrpcKt
+import org.wfanet.measurement.api.v2alpha.MeasurementsGrpcKt
+import org.wfanet.measurement.api.v2alpha.RequisitionsGrpcKt
+import org.wfanet.measurement.common.grpc.buildMutualTlsChannel
+import org.wfanet.measurement.common.grpc.withDefaultDeadline
+import org.wfanet.measurement.common.parseTextProto
+import org.wfanet.measurement.common.testing.chainRulesSequentially
+import org.wfanet.measurement.gcloud.gcs.GcsStorageClient
+import org.wfanet.measurement.loadtest.config.EventFilters
+import org.wfanet.measurement.loadtest.frontend.FrontendSimulator
+import org.wfanet.measurement.loadtest.frontend.MeasurementConsumerData
+import org.wfanet.measurement.loadtest.storage.SketchStore
+
+/**
+ * Test for correctness of an existing CMMS on Kubernetes where the EDP simulator sketches are
+ * accessible via a [GcsStorageClient].
+ *
+ * This currently assumes that the CMMS instance is using the certificates and keys from this Bazel
+ * workspace.
+ */
+class GcsCorrectnessTest : AbstractCorrectnessTest(measurementSystem) {
+  private class RunningMeasurementSystem : MeasurementSystem, TestRule {
+    override val runId: String by lazy { UUID.randomUUID().toString() }
+
+    private lateinit var _testHarness: FrontendSimulator
+    override val testHarness: FrontendSimulator
+      get() = _testHarness
+
+    private val channels = mutableListOf<ManagedChannel>()
+
+    override fun apply(base: Statement, description: Description): Statement {
+      return object : Statement() {
+        override fun evaluate() {
+          try {
+            _testHarness = createTestHarness()
+            base.evaluate()
+          } finally {
+            shutDownChannels()
+          }
+        }
+      }
+    }
+
+    private fun createTestHarness(): FrontendSimulator {
+      val measurementConsumerData =
+        MeasurementConsumerData(
+          TEST_CONFIG.measurementConsumer,
+          MC_SIGNING_KEY,
+          MC_ENCRYPTION_PRIVATE_KEY,
+          TEST_CONFIG.apiAuthenticationKey
+        )
+
+      val publicApiChannel =
+        buildMutualTlsChannel(
+            TEST_CONFIG.kingdomPublicApiTarget,
+            MEASUREMENT_CONSUMER_SIGNING_CERTS,
+            TEST_CONFIG.kingdomPublicApiCertHost.ifEmpty { null }
+          )
+          .also { channels.add(it) }
+          .withDefaultDeadline(RPC_DEADLINE_DURATION)
+
+      val gcs = StorageOptions.newBuilder().setProjectId(STORAGE_CONFIG.project).build().service
+      val storageClient = GcsStorageClient(gcs, STORAGE_CONFIG.bucket)
+
+      return FrontendSimulator(
+        measurementConsumerData,
+        OUTPUT_DP_PARAMS,
+        DataProvidersGrpcKt.DataProvidersCoroutineStub(publicApiChannel),
+        EventGroupsGrpcKt.EventGroupsCoroutineStub(publicApiChannel),
+        MeasurementsGrpcKt.MeasurementsCoroutineStub(publicApiChannel),
+        RequisitionsGrpcKt.RequisitionsCoroutineStub(publicApiChannel),
+        MeasurementConsumersGrpcKt.MeasurementConsumersCoroutineStub(publicApiChannel),
+        CertificatesGrpcKt.CertificatesCoroutineStub(publicApiChannel),
+        SketchStore(storageClient),
+        RESULT_POLLING_DELAY,
+        MEASUREMENT_CONSUMER_SIGNING_CERTS.trustedCertificates,
+        EventFilters.EVENT_TEMPLATES_TO_FILTERS_MAP
+      )
+    }
+
+    private fun shutDownChannels() {
+      for (channel in channels) {
+        channel.shutdown()
+      }
+    }
+  }
+
+  companion object {
+    private val RESULT_POLLING_DELAY = Duration.ofSeconds(10)
+    private val RPC_DEADLINE_DURATION = Duration.ofSeconds(30)
+    private val CONFIG_PATH =
+      Paths.get("src", "test", "kotlin", "org", "wfanet", "measurement", "integration", "k8s")
+    private const val TEST_CONFIG_NAME = "correctness_test_config.textproto"
+    private const val STORAGE_CONFIG_NAME = "gcs_config.textproto"
+
+    private val TEST_CONFIG: CorrectnessTestConfig by lazy {
+      val configFile = getRuntimePath(CONFIG_PATH.resolve(TEST_CONFIG_NAME)).toFile()
+      parseTextProto(configFile, CorrectnessTestConfig.getDefaultInstance())
+    }
+
+    private val STORAGE_CONFIG: GoogleCloudStorageConfig by lazy {
+      val configFile = getRuntimePath(CONFIG_PATH.resolve(STORAGE_CONFIG_NAME)).toFile()
+      parseTextProto(configFile, GoogleCloudStorageConfig.getDefaultInstance())
+    }
+
+    private val tempDir = TemporaryFolder()
+    private val measurementSystem = RunningMeasurementSystem()
+
+    @ClassRule @JvmField val chainedRule = chainRulesSequentially(tempDir, measurementSystem)
+  }
+}

--- a/src/test/kotlin/org/wfanet/measurement/integration/k8s/gcs_config.tmpl.textproto
+++ b/src/test/kotlin/org/wfanet/measurement/integration/k8s/gcs_config.tmpl.textproto
@@ -1,0 +1,4 @@
+# proto-file: src/main/proto/wfa/measurement/integration/k8s/testing/google_cloud_storage_config.proto
+# proto-message: GoogleCloudStorageConfig
+project: "{project}"
+bucket: "{bucket}"


### PR DESCRIPTION
This allows running the K8s correctness test against a running CMMS instance, with the following conditions:
* The instance uses the testing certificates/keys from the codebase.
* The EDP simulator sketches are accessible via a Google Cloud Storage bucket.

https://rally1.rallydev.com/#/?detail=/task/697342182701&fdp=true