### PR TITLE
Derive metric states

### DIFF
--- a/src/main/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/MetricsService.kt
+++ b/src/main/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/MetricsService.kt
@@ -900,7 +900,7 @@ class MetricsService(
     // Only syncs pending measurements which can only be in metrics that are still running.
     val toBeSyncedInternalMeasurements: List<InternalMeasurement> =
       subResults
-        .filter { internalMetric -> determineMetricState(internalMetric) == Metric.State.RUNNING }
+        .filter { internalMetric -> internalMetric.state == Metric.State.RUNNING }
         .flatMap { internalMetric -> internalMetric.weightedMeasurementsList }
         .map { weightedMeasurement -> weightedMeasurement.measurement }
         .filter { internalMeasurement ->
@@ -979,7 +979,7 @@ class MetricsService(
         throw Exception("Unable to create the metric in the reporting database.", e)
       }
 
-    if (determineMetricState(internalMetric) == Metric.State.RUNNING) {
+    if (internalMetric.state == Metric.State.RUNNING) {
       measurementSupplier.createCmmsMeasurements(listOf(internalMetric), principal)
     }
 
@@ -1029,7 +1029,7 @@ class MetricsService(
             }
           )
           .metricsList
-          .filter { internalMetric -> determineMetricState(internalMetric) == Metric.State.RUNNING }
+          .filter { internalMetric -> internalMetric.state == Metric.State.RUNNING }
       } catch (e: StatusException) {
         throw Exception("Unable to create the metric in the reporting database.", e)
       }
@@ -1373,23 +1373,11 @@ private fun InternalMetric.toMetric(): Metric {
     timeInterval = source.timeInterval.toTimeInterval()
     metricSpec = source.metricSpec.toMetricSpec()
     filters += source.details.filtersList
-    state = determineMetricState(source)
+    state = source.state
     createTime = source.createTime
     if (state == Metric.State.SUCCEEDED) {
       result = buildMetricResult(source)
     }
-  }
-}
-
-/** Determines the [Metric.State] based on the given [InternalMetric]. */
-private fun determineMetricState(metric: InternalMetric): Metric.State {
-  val measurementStates = metric.weightedMeasurementsList.map { it.measurement.state }
-  return if (measurementStates.all { it == InternalMeasurement.State.SUCCEEDED }) {
-    Metric.State.SUCCEEDED
-  } else if (measurementStates.any { it == InternalMeasurement.State.FAILED }) {
-    Metric.State.FAILED
-  } else {
-    Metric.State.RUNNING
   }
 }
 
@@ -1528,3 +1516,15 @@ private operator fun Duration.times(weight: Int): Duration {
 private operator fun Duration.plus(other: Duration): Duration {
   return Durations.add(this, other)
 }
+
+private val InternalMetric.state: Metric.State
+  get() {
+    val measurementStates = weightedMeasurementsList.map { it.measurement.state }
+    return if (measurementStates.all { it == InternalMeasurement.State.SUCCEEDED }) {
+      Metric.State.SUCCEEDED
+    } else if (measurementStates.any { it == InternalMeasurement.State.FAILED }) {
+      Metric.State.FAILED
+    } else {
+      Metric.State.RUNNING
+    }
+  }

--- a/src/main/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/ProtoConversions.kt
+++ b/src/main/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/ProtoConversions.kt
@@ -25,12 +25,9 @@ import org.wfanet.measurement.api.v2alpha.MeasurementSpecKt
 import org.wfanet.measurement.api.v2alpha.TimeInterval as CmmsTimeInterval
 import org.wfanet.measurement.api.v2alpha.differentialPrivacyParams
 import org.wfanet.measurement.api.v2alpha.timeInterval as cmmsTimeInterval
-import org.wfanet.measurement.common.identity.externalIdToApiId
 import org.wfanet.measurement.config.reporting.MetricSpecConfig
 import org.wfanet.measurement.internal.reporting.v2.Measurement as InternalMeasurement
 import org.wfanet.measurement.internal.reporting.v2.MeasurementKt as InternalMeasurementKt
-import org.wfanet.measurement.internal.reporting.v2.Metric as InternalMetric
-import org.wfanet.measurement.internal.reporting.v2.MetricResult as InternalMetricResult
 import org.wfanet.measurement.internal.reporting.v2.MetricSpec as InternalMetricSpec
 import org.wfanet.measurement.internal.reporting.v2.MetricSpecKt as InternalMetricSpecKt
 import org.wfanet.measurement.internal.reporting.v2.StreamMetricsRequest
@@ -38,19 +35,9 @@ import org.wfanet.measurement.internal.reporting.v2.StreamMetricsRequestKt
 import org.wfanet.measurement.internal.reporting.v2.TimeInterval as InternalTimeInterval
 import org.wfanet.measurement.internal.reporting.v2.streamMetricsRequest
 import org.wfanet.measurement.internal.reporting.v2.timeInterval as internalTimeInterval
-import org.wfanet.measurement.reporting.v2alpha.Metric
-import org.wfanet.measurement.reporting.v2alpha.MetricResult
-import org.wfanet.measurement.reporting.v2alpha.MetricResultKt.HistogramResultKt.bin
-import org.wfanet.measurement.reporting.v2alpha.MetricResultKt.HistogramResultKt.binResult
-import org.wfanet.measurement.reporting.v2alpha.MetricResultKt.histogramResult
-import org.wfanet.measurement.reporting.v2alpha.MetricResultKt.impressionCountResult
-import org.wfanet.measurement.reporting.v2alpha.MetricResultKt.reachResult
-import org.wfanet.measurement.reporting.v2alpha.MetricResultKt.watchDurationResult
 import org.wfanet.measurement.reporting.v2alpha.MetricSpec
 import org.wfanet.measurement.reporting.v2alpha.MetricSpecKt
 import org.wfanet.measurement.reporting.v2alpha.TimeInterval
-import org.wfanet.measurement.reporting.v2alpha.metric
-import org.wfanet.measurement.reporting.v2alpha.metricResult
 import org.wfanet.measurement.reporting.v2alpha.metricSpec
 import org.wfanet.measurement.reporting.v2alpha.timeInterval
 
@@ -108,112 +95,6 @@ fun TimeInterval.toInternal(): InternalTimeInterval {
   return internalTimeInterval {
     startTime = source.startTime
     endTime = source.endTime
-  }
-}
-
-/** Converts an [InternalMetric] to a public [Metric]. */
-fun InternalMetric.toMetric(): Metric {
-  val source = this
-  return metric {
-    name =
-      MetricKey(
-          cmmsMeasurementConsumerId = source.cmmsMeasurementConsumerId,
-          metricId = externalIdToApiId(source.externalMetricId)
-        )
-        .toName()
-    reportingSet =
-      ReportingSetKey(
-          source.cmmsMeasurementConsumerId,
-          externalIdToApiId(source.externalReportingSetId)
-        )
-        .toName()
-    timeInterval = source.timeInterval.toTimeInterval()
-    metricSpec = source.metricSpec.toMetricSpec()
-    filters += source.details.filtersList
-    state = source.state.toState()
-    createTime = source.createTime
-    if (source.details.hasResult()) {
-      result = source.details.result.toResult()
-    }
-  }
-}
-
-/** Converts an [InternalMetricResult] to a public [MetricResult]. */
-fun InternalMetricResult.toResult(): MetricResult {
-  val source = this
-
-  return metricResult {
-    @Suppress("WHEN_ENUM_CAN_BE_NULL_IN_JAVA") // Proto enum fields are never null.
-    when (source.resultCase) {
-      InternalMetricResult.ResultCase.REACH -> {
-        reach = source.reach.toReachResult()
-      }
-      InternalMetricResult.ResultCase.FREQUENCY_HISTOGRAM -> {
-        frequencyHistogram = source.frequencyHistogram.toHistogramResult()
-      }
-      InternalMetricResult.ResultCase.IMPRESSION_COUNT -> {
-        impressionCount = source.impressionCount.toImpressionCountResult()
-      }
-      InternalMetricResult.ResultCase.WATCH_DURATION -> {
-        watchDuration = source.watchDuration.toWatchDurationResult()
-      }
-      InternalMetricResult.ResultCase
-        .RESULT_NOT_SET -> {} // No action if the result hasn't been set yet.
-    }
-  }
-}
-
-/**
- * Converts an [InternalMetricResult.WatchDurationResult] to a public
- * [MetricResult.WatchDurationResult].
- */
-fun InternalMetricResult.WatchDurationResult.toWatchDurationResult():
-  MetricResult.WatchDurationResult {
-  val source = this
-  return watchDurationResult { value = source.value }
-}
-
-/**
- * Converts an [InternalMetricResult.ImpressionCountResult] to a public
- * [MetricResult.ImpressionCountResult].
- */
-fun InternalMetricResult.ImpressionCountResult.toImpressionCountResult():
-  MetricResult.ImpressionCountResult {
-  val source = this
-  return impressionCountResult { value = source.value }
-}
-
-/** Converts an [InternalMetricResult.ReachResult] to a public [MetricResult.ReachResult]. */
-fun InternalMetricResult.ReachResult.toReachResult(): MetricResult.ReachResult {
-  val source = this
-  return reachResult { value = source.value }
-}
-
-/**
- * Converts an [InternalMetricResult.HistogramResult] to a public [MetricResult.HistogramResult].
- */
-fun InternalMetricResult.HistogramResult.toHistogramResult(): MetricResult.HistogramResult {
-  val source = this
-  return histogramResult {
-    bins +=
-      source.binsList.map { internalBin ->
-        bin {
-          label = internalBin.label
-          binResult = binResult { value = internalBin.binResult.value }
-        }
-      }
-  }
-}
-
-/** Converts an [InternalMetric.State] to a public [Metric.State]. */
-fun InternalMetric.State.toState(): Metric.State {
-  @Suppress("WHEN_ENUM_CAN_BE_NULL_IN_JAVA") // Proto enum fields are never null.
-  return when (this) {
-    InternalMetric.State.RUNNING -> Metric.State.RUNNING
-    InternalMetric.State.SUCCEEDED -> Metric.State.SUCCEEDED
-    InternalMetric.State.FAILED -> Metric.State.FAILED
-    InternalMetric.State.STATE_UNSPECIFIED -> error("Metric state should've been set.")
-    InternalMetric.State.UNRECOGNIZED -> error("Unrecognized metric state.")
   }
 }
 

--- a/src/main/proto/wfa/measurement/internal/reporting/v2/metric.proto
+++ b/src/main/proto/wfa/measurement/internal/reporting/v2/metric.proto
@@ -110,17 +110,6 @@ message Metric {
 
   MetricSpec metric_spec = 6;
 
-  enum State {
-    // Default value. This value is unused.
-    STATE_UNSPECIFIED = 0;
-    // Computation is running.
-    RUNNING = 1;
-    // Completed successfully. Terminal state.
-    SUCCEEDED = 2;
-    // Completed with failure. Terminal state.
-    FAILED = 3;
-  }
-
   message WeightedMeasurement {
     int32 weight = 1;
     Measurement measurement = 2;

--- a/src/main/proto/wfa/measurement/internal/reporting/v2/metric.proto
+++ b/src/main/proto/wfa/measurement/internal/reporting/v2/metric.proto
@@ -1,16 +1,18 @@
-// Copyright 2023 The Cross-Media Measurement Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//      http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+/*
+ * Copyright 2023 The Cross-Media Measurement Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 syntax = "proto3";
 
@@ -119,17 +121,14 @@ message Metric {
     FAILED = 3;
   }
 
-  State state = 7;
-
   message WeightedMeasurement {
     int32 weight = 1;
     Measurement measurement = 2;
   }
-  repeated WeightedMeasurement weighted_measurements = 8;
+  repeated WeightedMeasurement weighted_measurements = 7;
 
   message Details {
     repeated string filters = 1;
-    MetricResult result = 2;
   }
-  Details details = 9;
+  Details details = 8;
 }

--- a/src/main/proto/wfa/measurement/internal/reporting/v2/metrics_service.proto
+++ b/src/main/proto/wfa/measurement/internal/reporting/v2/metrics_service.proto
@@ -1,16 +1,18 @@
-// Copyright 2023 The Cross-Media Measurement Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//      http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+/*
+ * Copyright 2023 The Cross-Media Measurement Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 syntax = "proto3";
 
@@ -32,12 +34,6 @@ service Metrics {
 
   // Ordered by (cmms_measurement_consumer_id, external_metric_id).
   rpc StreamMetrics(StreamMetricsRequest) returns (stream Metric);
-
-  rpc BatchSetMetricSucceed(BatchSetMetricSucceedRequest)
-      returns (BatchSetMetricSucceedResponse);
-
-  rpc BatchSetMetricFail(BatchSetMetricFailRequest)
-      returns (BatchSetMetricFailResponse);
 }
 
 message CreateMetricRequest {
@@ -79,33 +75,4 @@ message StreamMetricsRequest {
   Filter filter = 1;
 
   int32 limit = 2;
-}
-
-message SetMetricSucceedRequest {
-  fixed64 external_metric_id = 1;
-  MetricResult result = 2;
-}
-
-message BatchSetMetricSucceedRequest {
-  // `MeasurementConsumer` ID from the CMMS public API.
-  string cmms_measurement_consumer_id = 1;
-
-  // Maximum is 1000.
-  repeated SetMetricSucceedRequest requests = 2;
-}
-
-message BatchSetMetricSucceedResponse {
-  repeated Metric metrics = 1;
-}
-
-message BatchSetMetricFailRequest {
-  // `MeasurementConsumer` ID from the CMMS public API.
-  string cmms_measurement_consumer_id = 1;
-
-  // Maximum is 1000.
-  repeated fixed64 external_metric_ids = 2;
-}
-
-message BatchSetMetricFailResponse {
-  repeated Metric metrics = 1;
 }

--- a/src/main/resources/reporting/postgres/create-v2-reporting-schema.sql
+++ b/src/main/resources/reporting/postgres/create-v2-reporting-schema.sql
@@ -242,10 +242,6 @@ CREATE TABLE Metrics (
   VidSamplingIntervalStart DOUBLE PRECISION NOT NULL,
   VidSamplingIntervalEnd DOUBLE PRECISION NOT NULL,
 
-  -- org.wfanet.measurement.internal.reporting.Metric.State
-  -- protobuf enum encoded as an integer.
-  State integer NOT NULL,
-
   CreateTime TIMESTAMP WITH TIME ZONE NOT NULL,
 
   -- Serialized byte string of a proto3 protobuf with details about the


### PR DESCRIPTION
Motivation:

* In the current design, the metric state is updated using a on-demand strategy -- only updated when the public `get` or `list` is called. This causes the internal metric state is not consistent with what the states of the associated measurements indicate. For example, a metric might have all measurements with SUCCEEDED states, but itself is PENDING. 



Design change:

* The metric state is essentially a derivative from the states of the associated measurements. Therefore, we could instead determine the metric state in the public server call and remove the state column in the internal metrics DB.

* Similarly, the metric result can be calculated easily on the public side, so we don't need to store metric result in the database.