### PR TITLE
Fix frontend simulator gke cue config

### DIFF
--- a/src/main/k8s/dev/frontend_simulator_gke.cue
+++ b/src/main/k8s/dev/frontend_simulator_gke.cue
@@ -32,7 +32,6 @@ frontend_simulator: #FrontendSimulator & {
 	_mc_api_authentication_key: _mc_api_key
 	_mc_secret_name:            _secret_name
 	_kingdom_public_api_target: #KingdomPublicApiTarget
-	_simulator_image:           _imageConfig.image
 	_blob_storage_flags:        _cloudStorageConfig.flags
 	job: spec: template: spec: #ServiceAccountPodSpec & {
 		serviceAccountName: #ServiceAccount


### PR DESCRIPTION
From #923 _simulator_image removed from frontend simulator definition and local deployment, but not for gke deployment.