### PR TITLE
Add MeasurementResultSubject Truth extension.

### DIFF
--- a/src/main/kotlin/org/wfanet/measurement/api/v2alpha/testing/BUILD.bazel
+++ b/src/main/kotlin/org/wfanet/measurement/api/v2alpha/testing/BUILD.bazel
@@ -2,11 +2,7 @@ load("@io_bazel_rules_kotlin//kotlin:jvm.bzl", "kt_jvm_library")
 
 package(
     default_testonly = True,
-    default_visibility = [
-        "//src/main/kotlin/org/wfanet/measurement/integration/common:__pkg__",
-        "//src/test/kotlin/org/wfanet/measurement/kingdom/service/api/v2alpha:__pkg__",
-        "//src/test/kotlin/org/wfanet/measurement/reporting/service/api/v1alpha:__pkg__",
-    ],
+    default_visibility = ["//visibility:public"],
 )
 
 kt_jvm_library(
@@ -16,6 +12,9 @@ kt_jvm_library(
         "//src/main/kotlin/org/wfanet/measurement/api/v2alpha:principal_server_interceptor",
         "//src/main/kotlin/org/wfanet/measurement/common/identity",
         "//src/main/kotlin/org/wfanet/measurement/common/identity:principal_identity",
+        "//src/main/proto/wfa/measurement/api/v2alpha:measurement_kt_jvm_proto",
+        "@wfa_common_jvm//imports/java/com/google/common/truth",
+        "@wfa_common_jvm//imports/java/com/google/common/truth/extensions/proto",
         "@wfa_common_jvm//imports/java/org/junit",
         "@wfa_common_jvm//imports/kotlin/kotlinx/coroutines:core",
         "@wfa_common_jvm//src/main/kotlin/org/wfanet/measurement/common/identity",

--- a/src/main/kotlin/org/wfanet/measurement/api/v2alpha/testing/FrequencyDistributionSubject.kt
+++ b/src/main/kotlin/org/wfanet/measurement/api/v2alpha/testing/FrequencyDistributionSubject.kt
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2023 The Cross-Media Measurement Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wfanet.measurement.api.v2alpha.testing
+
+import com.google.common.truth.FailureMetadata
+import com.google.common.truth.MapSubject
+import com.google.common.truth.Truth.assertAbout
+
+typealias RelativeFrequencyDistribution = Map<Long, Double>
+
+class FrequencyDistributionSubject
+private constructor(failureMetadata: FailureMetadata, subject: RelativeFrequencyDistribution) :
+  MapSubject(failureMetadata, subject) {
+
+  private val actual: RelativeFrequencyDistribution = subject
+
+  fun isWithin(tolerance: Double): DistributionComparison {
+    return object : DistributionComparison() {
+      override fun of(expected: RelativeFrequencyDistribution, maxFrequency: Long) {
+        for (bucket in 1L..maxFrequency) {
+          val actualValue = actual.getOrDefault(bucket, 0.0)
+          val expectedValue = expected.getOrDefault(bucket, 0.0)
+          check("getValue($bucket)").that(actualValue).isWithin(tolerance).of(expectedValue)
+        }
+      }
+    }
+  }
+
+  abstract class DistributionComparison internal constructor() {
+    abstract fun of(expected: RelativeFrequencyDistribution, maxFrequency: Long)
+  }
+
+  companion object {
+    fun frequencyDistributions():
+      (
+        failureMetadata: FailureMetadata, subject: RelativeFrequencyDistribution
+      ) -> FrequencyDistributionSubject = ::FrequencyDistributionSubject
+
+    fun assertThat(subject: RelativeFrequencyDistribution): FrequencyDistributionSubject =
+      assertAbout(frequencyDistributions()).that(subject)
+  }
+}

--- a/src/main/kotlin/org/wfanet/measurement/api/v2alpha/testing/FuzzyLongSubject.kt
+++ b/src/main/kotlin/org/wfanet/measurement/api/v2alpha/testing/FuzzyLongSubject.kt
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2023 The Cross-Media Measurement Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wfanet.measurement.api.v2alpha.testing
+
+import com.google.common.truth.Fact
+import com.google.common.truth.FailureMetadata
+import com.google.common.truth.LongSubject
+import kotlin.math.abs
+
+/**
+ * [LongSubject] that allows fuzzy comparisons.
+ *
+ * TODO(@SanjayVas): Move this to common-jvm.
+ */
+class FuzzyLongSubject private constructor(failureMetadata: FailureMetadata, subject: Long) :
+  LongSubject(failureMetadata, subject) {
+
+  private val actual: Long = subject
+
+  fun isWithinPercent(percent: Double): LongRatioComparison {
+    return object : LongRatioComparison() {
+      override fun of(expected: Long) {
+        val actualRatio: Double = abs(expected - actual) / expected.toDouble()
+        val expectedRatio: Double = percent / 100.0
+        if (actualRatio > expectedRatio) {
+          failWithActual(Fact.fact("expected to be within", "$percent%"), Fact.fact("of", expected))
+        }
+      }
+    }
+  }
+
+  abstract class LongRatioComparison internal constructor() {
+    abstract fun of(expected: Long)
+  }
+
+  companion object {
+    fun fuzzyLongs(): (failureMetadata: FailureMetadata, subject: Long) -> FuzzyLongSubject =
+      ::FuzzyLongSubject
+  }
+}

--- a/src/main/kotlin/org/wfanet/measurement/api/v2alpha/testing/MeasurementResultSubject.kt
+++ b/src/main/kotlin/org/wfanet/measurement/api/v2alpha/testing/MeasurementResultSubject.kt
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2023 The Cross-Media Measurement Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wfanet.measurement.api.v2alpha.testing
+
+import com.google.common.truth.FailureMetadata
+import com.google.common.truth.Truth.assertAbout
+import com.google.common.truth.extensions.proto.ProtoSubject
+import org.wfanet.measurement.api.v2alpha.Measurement
+
+class MeasurementResultSubject
+private constructor(failureMetadata: FailureMetadata, subject: Measurement.Result) :
+  ProtoSubject(failureMetadata, subject) {
+
+  private val actual: Measurement.Result = subject
+
+  fun reachValue(): FuzzyLongSubject {
+    return check("reach.value").about(FuzzyLongSubject.fuzzyLongs()).that(actual.reach.value)
+  }
+
+  fun frequencyDistribution(): FrequencyDistributionSubject {
+    return check("frequency.relativeFrequencyDistribution")
+      .about(FrequencyDistributionSubject.frequencyDistributions())
+      .that(actual.frequency.relativeFrequencyDistributionMap)
+  }
+
+  companion object {
+    fun measurementResults():
+      (failureMetadata: FailureMetadata, subject: Measurement.Result) -> MeasurementResultSubject =
+      ::MeasurementResultSubject
+
+    fun assertThat(subject: Measurement.Result): MeasurementResultSubject =
+      assertAbout(measurementResults()).that(subject)
+  }
+}

--- a/src/main/kotlin/org/wfanet/measurement/loadtest/frontend/BUILD.bazel
+++ b/src/main/kotlin/org/wfanet/measurement/loadtest/frontend/BUILD.bazel
@@ -18,6 +18,7 @@ kt_jvm_library(
     deps = [
         "//src/main/kotlin/org/wfanet/measurement/api:api_key_constants",
         "//src/main/kotlin/org/wfanet/measurement/api/v2alpha:resource_key",
+        "//src/main/kotlin/org/wfanet/measurement/api/v2alpha/testing",
         "//src/main/kotlin/org/wfanet/measurement/common/identity",
         "//src/main/kotlin/org/wfanet/measurement/kingdom/service/api/v2alpha:api_key_authentication_server_interceptor",
         "//src/main/kotlin/org/wfanet/measurement/loadtest/config:test_identifiers",

--- a/src/main/kotlin/org/wfanet/measurement/loadtest/frontend/FrontendSimulator.kt
+++ b/src/main/kotlin/org/wfanet/measurement/loadtest/frontend/FrontendSimulator.kt
@@ -81,6 +81,7 @@ import org.wfanet.measurement.api.v2alpha.listRequisitionsRequest
 import org.wfanet.measurement.api.v2alpha.measurement
 import org.wfanet.measurement.api.v2alpha.measurementSpec
 import org.wfanet.measurement.api.v2alpha.requisitionSpec
+import org.wfanet.measurement.api.v2alpha.testing.MeasurementResultSubject.Companion.assertThat
 import org.wfanet.measurement.api.v2alpha.timeInterval
 import org.wfanet.measurement.api.withAuthenticationKey
 import org.wfanet.measurement.common.OpenEndTimeRange
@@ -216,11 +217,10 @@ class FrontendSimulator(
         4L to 0.003942332254929154
       )
 
-    assertThat(reachAndFrequencyResult.reach.value).isEqualTo(expectedReachValue)
-    reachAndFrequencyResult.frequency.relativeFrequencyDistributionMap.forEach {
-      (frequency, percentage) ->
-      assertThat(percentage).isEqualTo(expectedFrequencyMap[frequency])
-    }
+    assertThat(reachAndFrequencyResult).reachValue().isEqualTo(expectedReachValue)
+    assertThat(reachAndFrequencyResult)
+      .frequencyDistribution()
+      .containsExactlyEntriesIn(expectedFrequencyMap)
 
     logger.info("Direct reach and frequency result is equal to the expected result")
   }
@@ -313,13 +313,12 @@ class FrontendSimulator(
     actualResult: Result,
     maximumFrequency: Long
   ) {
-    val reachRatio = expectedResult.reach.value.toDouble() / actualResult.reach.value.toDouble()
-    assertThat(reachRatio).isWithin(0.10).of(1.0)
-    (1L..maximumFrequency).forEach {
-      val expected = expectedResult.frequency.relativeFrequencyDistributionMap.getOrDefault(it, 0.0)
-      val actual = actualResult.frequency.relativeFrequencyDistributionMap.getOrDefault(it, 0.0)
-      assertThat(actual).isWithin(0.05).of(expected)
-    }
+    // TODO(@riemanli): Use margin of error rather than fixed tolerance values.
+    assertThat(actualResult).reachValue().isWithinPercent(10.0).of(expectedResult.reach.value)
+    assertThat(actualResult)
+      .frequencyDistribution()
+      .isWithin(0.05)
+      .of(expectedResult.frequency.relativeFrequencyDistributionMap, maximumFrequency)
   }
 
   /** Creates a Measurement on behalf of the [MeasurementConsumer]. */

--- a/src/test/kotlin/org/wfanet/measurement/api/v2alpha/testing/BUILD.bazel
+++ b/src/test/kotlin/org/wfanet/measurement/api/v2alpha/testing/BUILD.bazel
@@ -1,0 +1,12 @@
+load("@io_bazel_rules_kotlin//kotlin:jvm.bzl", "kt_jvm_test")
+
+kt_jvm_test(
+    name = "MeasurementResultSubjectTest",
+    srcs = ["MeasurementResultSubjectTest.kt"],
+    deps = [
+        "//src/main/kotlin/org/wfanet/measurement/api/v2alpha/testing",
+        "//src/main/proto/wfa/measurement/api/v2alpha:measurement_kt_jvm_proto",
+        "@wfa_common_jvm//imports/java/com/google/common/truth",
+        "@wfa_common_jvm//imports/java/org/junit",
+    ],
+)

--- a/src/test/kotlin/org/wfanet/measurement/api/v2alpha/testing/MeasurementResultSubjectTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/api/v2alpha/testing/MeasurementResultSubjectTest.kt
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2023 The Cross-Media Measurement Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wfanet.measurement.api.v2alpha.testing
+
+import com.google.common.truth.ExpectFailure.assertThat
+import com.google.common.truth.ExpectFailure.expectFailureAbout
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+import org.wfanet.measurement.api.v2alpha.Measurement
+import org.wfanet.measurement.api.v2alpha.MeasurementKt.ResultKt.frequency
+import org.wfanet.measurement.api.v2alpha.MeasurementKt.ResultKt.reach
+import org.wfanet.measurement.api.v2alpha.MeasurementKt.result
+import org.wfanet.measurement.api.v2alpha.copy
+import org.wfanet.measurement.api.v2alpha.testing.MeasurementResultSubject.Companion.assertThat
+import org.wfanet.measurement.api.v2alpha.testing.MeasurementResultSubject.Companion.measurementResults
+
+@RunWith(JUnit4::class)
+class MeasurementResultSubjectTest {
+  @Test
+  fun `reach comparison passes`() {
+    assertThat(PASSING_ACTUAL_RESULT)
+      .reachValue()
+      .isWithinPercent(COMPARISON_PERCENT)
+      .of(EXPECTED_RESULT.reach.value)
+  }
+
+  @Test
+  fun `reach comparison fails`() {
+    val failure =
+      expectFailureAbout(measurementResults()) { whenTesting ->
+        whenTesting
+          .that(PASSING_ACTUAL_RESULT.copy { reach = reach.copy { value = 1500 } })
+          .reachValue()
+          .isWithinPercent(COMPARISON_PERCENT)
+          .of(EXPECTED_RESULT.reach.value)
+      }
+    assertThat(failure).factValue("expected to be within").isEqualTo("$COMPARISON_PERCENT%")
+  }
+
+  @Test
+  fun `frequencyHistogram comparison passes`() {
+    assertThat(PASSING_ACTUAL_RESULT)
+      .frequencyDistribution()
+      .isWithin(COMPARISON_TOLERANCE)
+      .of(EXPECTED_RESULT.frequency.relativeFrequencyDistributionMap, MAX_FREQUENCY)
+  }
+
+  @Test
+  fun `frequencyHistogram comparison fails`() {
+    val failure =
+      expectFailureAbout(measurementResults()) { whenTesting ->
+        whenTesting
+          .that(
+            PASSING_ACTUAL_RESULT.copy {
+              frequency = frequency.copy { relativeFrequencyDistribution[2] = 0.1234 }
+            }
+          )
+          .frequencyDistribution()
+          .isWithin(COMPARISON_TOLERANCE)
+          .of(EXPECTED_RESULT.frequency.relativeFrequencyDistributionMap, MAX_FREQUENCY)
+      }
+    assertThat(failure).factValue("outside tolerance").isEqualTo("$COMPARISON_TOLERANCE")
+  }
+
+  companion object {
+    private const val MAX_FREQUENCY = 10L
+    private const val COMPARISON_PERCENT = 10.0
+    private const val COMPARISON_TOLERANCE = 0.05
+
+    private val EXPECTED_RESULT: Measurement.Result = result {
+      reach = reach { value = 1296 }
+      frequency = frequency {
+        relativeFrequencyDistribution[1] = 0.3078817733990148
+        relativeFrequencyDistribution[2] = 0.6042692939244664
+        relativeFrequencyDistribution[3] = 0.031198686371100164
+        relativeFrequencyDistribution[4] = 0.05008210180623974
+        relativeFrequencyDistribution[5] = 0.004105090311986864
+        relativeFrequencyDistribution[6] = 0.0024630541871921183
+      }
+    }
+
+    private val PASSING_ACTUAL_RESULT: Measurement.Result = result {
+      reach = reach { value = 1308 }
+      frequency = frequency {
+        relativeFrequencyDistribution[1] = 0.3058446757405925
+        relativeFrequencyDistribution[2] = 0.6132906325060048
+        relativeFrequencyDistribution[3] = 0.01120896717373899
+        relativeFrequencyDistribution[4] = 0.036028823058446756
+        relativeFrequencyDistribution[5] = 0.0040032025620496394
+        relativeFrequencyDistribution[9] = 0.029623698959167333
+      }
+    }
+  }
+}


### PR DESCRIPTION
This makes correctness test failure messages more clear.