### PR TITLE
Increase the time range for the correctness test.

### DIFF
--- a/src/main/kotlin/org/wfanet/measurement/loadtest/frontend/FrontendSimulator.kt
+++ b/src/main/kotlin/org/wfanet/measurement/loadtest/frontend/FrontendSimulator.kt
@@ -748,7 +748,7 @@ class FrontendSimulator(
      * TODO(@SanjayVas): Make this configurable.
      */
     private val EVENT_RANGE =
-      OpenEndTimeRange.fromClosedDateRange(LocalDate.of(2021, 3, 15)..LocalDate.of(2021, 3, 15))
+      OpenEndTimeRange.fromClosedDateRange(LocalDate.of(2021, 3, 15)..LocalDate.of(2021, 3, 17))
 
     private val logger: Logger = Logger.getLogger(this::class.java.name)
 


### PR DESCRIPTION
The current slice of the test data set is small enough that the noise sometimes puts the value outside of the expected range. Increasing the time range reduces the flakiness of the test.