### PR TITLE
Add Unique indexes on VID models tables

### DIFF
--- a/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/SpannerModelLinesService.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/SpannerModelLinesService.kt
@@ -101,6 +101,26 @@ class SpannerModelLinesService(
   override suspend fun setModelLineHoldbackModelLine(
     request: SetModelLineHoldbackModelLineRequest
   ): ModelLine {
+    grpcRequire(request.externalModelProviderId != 0L) {
+      "external_model_provider_id not specified"
+    }
+    grpcRequire(request.externalModelSuiteId != 0L) { "external_model_suite_id not specified" }
+    grpcRequire(request.externalModelLineId != 0L) { "external_model_line_id not specified" }
+    grpcRequire(request.externalHoldbackModelProviderId != 0L) {
+      "external_holdback_model_provider_id not specified"
+    }
+    grpcRequire(request.externalHoldbackModelSuiteId != 0L) {
+      "external_holdback_model_suite_id not specified"
+    }
+    grpcRequire(request.externalHoldbackModelLineId != 0L) {
+      "external_holdback_model_line_id not specified"
+    }
+    grpcRequire(
+      request.externalModelProviderId == request.externalHoldbackModelProviderId &&
+        request.externalModelSuiteId == request.externalHoldbackModelSuiteId
+    ) {
+      "HoldbackModelLine and ModelLine must be part of the same ModelSuite."
+    }
     try {
       return SetModelLineHoldbackModelLine(request).execute(client, idGenerator)
     } catch (e: ModelLineNotFoundException) {

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/readers/ModelLineReader.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/readers/ModelLineReader.kt
@@ -47,7 +47,6 @@ class ModelLineReader : SpannerReader<ModelLineReader.Result>() {
       ModelLines.ActiveStartTime,
       ModelLines.ActiveEndTime,
       ModelLines.Type,
-      ModelLines.HoldbackModelLine,
       ModelLines.CreateTime,
       ModelLines.UpdateTime,
       ModelSuites.ExternalModelSuiteId,
@@ -57,7 +56,11 @@ class ModelLineReader : SpannerReader<ModelLineReader.Result>() {
       JOIN ModelSuites USING (ModelSuiteId)
       JOIN ModelProviders ON (ModelSuites.ModelProviderId = ModelProviders.ModelProviderId)
       LEFT JOIN ModelLines as HoldbackModelLine
-      ON (ModelLines.HoldbackModelLine = HoldbackModelLine.ModelLineId)
+      ON (
+        ModelLines.ModelProviderId = HoldbackModelLine.ModelProviderId
+        AND ModelLines.ModelSuiteId = HoldbackModelLine.ModelSuiteId
+        AND ModelLines.HoldbackModelLineId = HoldbackModelLine.ModelLineId
+      )
     """
       .trimIndent()
 

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/readers/ModelRolloutReader.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/readers/ModelRolloutReader.kt
@@ -46,8 +46,6 @@ class ModelRolloutReader : SpannerReader<ModelRolloutReader.Result>() {
       ModelRollouts.RolloutPeriodStartTime,
       ModelRollouts.RolloutPeriodEndTime,
       ModelRollouts.RolloutFreezeTime,
-      ModelRollouts.PreviousModelRollout,
-      ModelRollouts.ModelRelease,
       ModelRollouts.CreateTime,
       ModelRollouts.UpdateTime,
       ModelLines.ExternalModelLineId,
@@ -59,8 +57,16 @@ class ModelRolloutReader : SpannerReader<ModelRolloutReader.Result>() {
       JOIN ModelLines USING (ModelProviderId, ModelSuiteId, ModelLineId)
       JOIN ModelSuites USING (ModelProviderId, ModelSuiteId)
       JOIN ModelProviders USING (ModelProviderId)
-      LEFT JOIN ModelRollouts as PreviousModelRollout ON (ModelRollouts.PreviousModelRollout = PreviousModelRollout.ModelRolloutId)
-      JOIN ModelReleases ON (ModelRollouts.ModelRelease = ModelReleases.ModelReleaseId)
+      LEFT JOIN ModelRollouts as PreviousModelRollout ON (
+        ModelRollouts.ModelProviderId = PreviousModelRollout.ModelProviderId
+        AND ModelRollouts.ModelSuiteId = PreviousModelRollout.ModelSuiteId
+        AND ModelRollouts.PreviousModelRolloutId = PreviousModelRollout.ModelRolloutId
+      )
+      JOIN ModelReleases ON (
+        ModelRollouts.ModelProviderId = ModelReleases.ModelProviderId
+        AND ModelRollouts.ModelSuiteId = ModelReleases.ModelSuiteId
+        AND ModelRollouts.ModelReleaseId = ModelReleases.ModelReleaseId
+      )
     """
       .trimIndent()
 

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/writers/CreateModelLine.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/writers/CreateModelLine.kt
@@ -131,8 +131,7 @@ class CreateModelLine(private val modelLine: ModelLine, private val clock: Clock
             "Only ModelLine with type == HOLDBACK can be set as Holdback ModelLine."
           }
         }
-
-        set("HoldbackModelLine" to holdbackModelLineResult.modelLineId)
+        set("HoldbackModelLineId" to holdbackModelLineResult.modelLineId)
       }
       set("CreateTime" to Value.COMMIT_TIMESTAMP)
       set("UpdateTime" to Value.COMMIT_TIMESTAMP)

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/writers/CreateModelRollout.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/writers/CreateModelRollout.kt
@@ -112,10 +112,10 @@ class CreateModelRollout(private val modelRollout: ModelRollout, private val clo
       set("RolloutPeriodEndTime" to modelRollout.rolloutPeriodEndTime.toGcloudTimestamp())
       if (previousModelRolloutData != null) {
         set(
-          "PreviousModelRollout" to InternalId(previousModelRolloutData.getLong("ModelRolloutId"))
+          "PreviousModelRolloutId" to InternalId(previousModelRolloutData.getLong("ModelRolloutId"))
         )
       }
-      set("ModelRelease" to modelReleaseResult.modelReleaseId)
+      set("ModelReleaseId" to modelReleaseResult.modelReleaseId)
       set("CreateTime" to Value.COMMIT_TIMESTAMP)
       set("UpdateTime" to Value.COMMIT_TIMESTAMP)
     }

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/writers/SetModelLineHoldbackModelLine.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/writers/SetModelLineHoldbackModelLine.kt
@@ -86,7 +86,7 @@ class SetModelLineHoldbackModelLine(private val request: SetModelLineHoldbackMod
       set("ModelSuiteId" to modelLineResult.modelSuiteId.value)
       set("ModelProviderId" to modelLineResult.modelProviderId.value)
       set("UpdateTime" to Value.COMMIT_TIMESTAMP)
-      set("HoldbackModelLine" to holdbackModelLineResult.modelLineId.value)
+      set("HoldbackModelLineId" to holdbackModelLineResult.modelLineId.value)
     }
 
     return modelLineResult.modelLine.copy {

--- a/src/main/resources/kingdom/spanner/changelog.yaml
+++ b/src/main/resources/kingdom/spanner/changelog.yaml
@@ -48,3 +48,6 @@ databaseChangeLog:
 - include:
     file: update-model-shards-foreign-key.sql
     relativeToChangeLogFile: true
+- include:
+    file: update-vid-model-foreign-keys-and-indexes.sql
+    relativeToChangeLogFile: true

--- a/src/main/resources/kingdom/spanner/update-vid-model-foreign-keys-and-indexes.sql
+++ b/src/main/resources/kingdom/spanner/update-vid-model-foreign-keys-and-indexes.sql
@@ -1,0 +1,96 @@
+-- liquibase formatted sql
+
+-- Copyright 2022 The Cross-Media Measurement Authors
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--      http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+-- changeset marcopremier:10 dbms:cloudspanner
+
+DROP TABLE ModelRollouts;
+DROP TABLE ModelOutages;
+DROP TABLE ModelLines;
+CREATE TABLE ModelLines (
+    ModelProviderId INT64 NOT NULL,
+    ModelSuiteId INT64 NOT NULL,
+    ModelLineId INT64 NOT NULL,
+    ExternalModelLineId INT64 NOT NULL,
+    DisplayName STRING(MAX),
+    Description STRING(MAX),
+    ActiveStartTime TIMESTAMP NOT NULL,
+    ActiveEndTime TIMESTAMP,
+
+    -- org.wfanet.measurement.internal.kingdom.ModelLine.Type
+    -- protobuf name encoded as an integer.
+    Type INT64 NOT NULL,
+
+    HoldbackModelLineId INT64,
+    CreateTime TIMESTAMP NOT NULL OPTIONS (allow_commit_timestamp = true),
+    UpdateTime TIMESTAMP OPTIONS (allow_commit_timestamp = true),
+
+    FOREIGN KEY (ModelProviderId, ModelSuiteId, HoldbackModelLineId)
+        REFERENCES ModelLines(ModelProviderId, ModelSuiteId, ModelLineId),
+) PRIMARY KEY (ModelProviderId, ModelSuiteId, ModelLineId),
+  INTERLEAVE IN PARENT ModelSuites ON DELETE CASCADE;
+
+CREATE TABLE ModelRollouts (
+    ModelProviderId INT64 NOT NULL,
+    ModelSuiteId INT64 NOT NULL,
+    ModelLineId INT64 NOT NULL,
+    ModelRolloutId INT64 NOT NULL,
+    ExternalModelRolloutId INT64 NOT NULL,
+    RolloutPeriodStartTime TIMESTAMP NOT NULL,
+    RolloutPeriodEndTime TIMESTAMP NOT NULL,
+    RolloutFreezeTime TIMESTAMP,
+    PreviousModelRolloutId INT64,
+    ModelReleaseId INT64 NOT NULL,
+    CreateTime TIMESTAMP NOT NULL OPTIONS (allow_commit_timestamp = true),
+    UpdateTime TIMESTAMP OPTIONS (allow_commit_timestamp = true),
+
+    FOREIGN KEY (ModelProviderId, ModelSuiteId, PreviousModelRolloutId)
+        REFERENCES ModelRollouts(ModelProviderId, ModelSuiteId, ModelRolloutId),
+    FOREIGN KEY (ModelProviderId, ModelSuiteId, ModelReleaseId)
+        REFERENCES ModelReleases(ModelProviderId, ModelSuiteId, ModelReleaseId),
+) PRIMARY KEY (ModelProviderId, ModelSuiteId, ModelLineId, ModelRolloutId),
+  INTERLEAVE IN PARENT ModelLines ON DELETE CASCADE;
+
+CREATE TABLE ModelOutages (
+    ModelProviderId INT64 NOT NULL,
+    ModelSuiteId INT64 NOT NULL,
+    ModelLineId INT64 NOT NULL,
+    ModelOutageId INT64 NOT NULL,
+    ExternalModelOutageId INT64 NOT NULL,
+    OutageStartTime TIMESTAMP NOT NULL,
+    OutageEndTime TIMESTAMP NOT NULL,
+
+    -- org.wfanet.measurement.internal.kingdom.ModelOutage.State
+    -- protobuf name encoded as an integer.
+    State INT64 NOT NULL,
+
+    CreateTime TIMESTAMP NOT NULL OPTIONS (allow_commit_timestamp = true),
+    DeleteTime TIMESTAMP OPTIONS (allow_commit_timestamp = true),
+) PRIMARY KEY (ModelProviderId, ModelSuiteId, ModelLineId, ModelOutageId),
+  INTERLEAVE IN PARENT ModelLines ON DELETE CASCADE;
+
+CREATE UNIQUE INDEX ModelSuitesByExternalId
+    ON ModelSuites(ModelProviderId, ExternalModelSuiteId);
+
+CREATE UNIQUE INDEX ModelLinesByExternalId
+    ON ModelLines(ModelProviderId, ModelSuiteId, ExternalModelLineId);
+
+CREATE UNIQUE INDEX ModelOutagesByExternalId
+    ON ModelOutages(ModelProviderId, ModelSuiteId, ModelLineId, ExternalModelOutageId);
+
+CREATE UNIQUE INDEX ModelRolloutsByExternalId
+    ON ModelRollouts(ModelProviderId, ModelSuiteId, ModelLineId, ExternalModelRolloutId);
+
+CREATE UNIQUE INDEX ModelShardsByExternalId
+    ON ModelShards(DataProviderId, ExternalModelShardId);


### PR DESCRIPTION
This PR introduces missing UNIQUE INDEXES for VID models related tables and also fix FOREIGN KEYS. They were not using the whole PRIMARY KEY.