### PR TITLE
Add MetricSpecBuilder.

### DIFF
--- a/src/main/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/BUILD.bazel
+++ b/src/main/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/BUILD.bazel
@@ -61,9 +61,23 @@ kt_jvm_library(
 )
 
 kt_jvm_library(
+    name = "metric_spec_defaults",
+    srcs = ["MetricSpecDefaults.kt"],
+    deps = [
+        "//src/main/kotlin/org/wfanet/measurement/api:api_key_constants",
+        "//src/main/kotlin/org/wfanet/measurement/api:public_api_version",
+        "//src/main/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha:resource_key",
+        "//src/main/proto/wfa/measurement/config/reporting:metric_spec_config_kt_jvm_proto",
+        "//src/main/proto/wfa/measurement/reporting/v2alpha:metrics_service_kt_jvm_grpc_proto",
+        "@wfa_common_jvm//imports/java/com/google/protobuf/util",
+    ],
+)
+
+kt_jvm_library(
     name = "proto_conversions",
     srcs = ["ProtoConversions.kt"],
     deps = [
+        "//src/main/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha:metric_spec_defaults",
         "//src/main/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha:resource_key",
         "//src/main/proto/wfa/measurement/api/v2alpha:measurement_consumers_service_kt_jvm_grpc_proto",
         "//src/main/proto/wfa/measurement/api/v2alpha:measurement_kt_jvm_proto",
@@ -89,6 +103,7 @@ kt_jvm_library(
         "//src/main/kotlin/org/wfanet/measurement/api:api_key_constants",
         "//src/main/kotlin/org/wfanet/measurement/api:public_api_version",
         "//src/main/kotlin/org/wfanet/measurement/reporting/service/api:encryption_key_pair_store",
+        "//src/main/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha:metric_spec_defaults",
         "//src/main/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha:principal_server_interceptor",
         "//src/main/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha:proto_conversions",
         "//src/main/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha:reporting_principal",

--- a/src/main/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/MetricSpecDefaults.kt
+++ b/src/main/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/MetricSpecDefaults.kt
@@ -1,0 +1,233 @@
+/*
+ * Copyright 2023 The Cross-Media Measurement Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wfanet.measurement.reporting.service.api.v2alpha
+
+import org.wfanet.measurement.config.reporting.MetricSpecConfig
+import org.wfanet.measurement.reporting.v2alpha.MetricSpec
+import org.wfanet.measurement.reporting.v2alpha.MetricSpecKt
+import org.wfanet.measurement.reporting.v2alpha.copy
+
+class MetricSpecDefaultsException(message: String? = null, cause: Throwable? = null) :
+  Exception(message, cause)
+
+/**
+ * Specifies default values using [MetricSpecConfig] when optional fields in the [MetricSpec] are
+ * not set.
+ */
+fun MetricSpec.withDefaults(metricSpecConfig: MetricSpecConfig): MetricSpec {
+  return copy {
+    val defaultVidSamplingInterval: MetricSpecConfig.VidSamplingInterval =
+      when (typeCase) {
+        MetricSpec.TypeCase.REACH -> {
+          reach = reach.withDefaults(metricSpecConfig)
+          metricSpecConfig.reachVidSamplingInterval
+        }
+        MetricSpec.TypeCase.FREQUENCY_HISTOGRAM -> {
+          frequencyHistogram = frequencyHistogram.withDefaults(metricSpecConfig)
+          metricSpecConfig.frequencyHistogramVidSamplingInterval
+        }
+        MetricSpec.TypeCase.IMPRESSION_COUNT -> {
+          impressionCount = impressionCount.withDefaults(metricSpecConfig)
+          metricSpecConfig.impressionCountVidSamplingInterval
+        }
+        MetricSpec.TypeCase.WATCH_DURATION -> {
+          watchDuration = watchDuration.withDefaults(metricSpecConfig)
+          metricSpecConfig.watchDurationVidSamplingInterval
+        }
+        MetricSpec.TypeCase.TYPE_NOT_SET ->
+          throw MetricSpecDefaultsException(
+            "Invalid metric spec type",
+            IllegalArgumentException("The metric type in Metric is not specified.")
+          )
+      }
+
+    vidSamplingInterval =
+      if (hasVidSamplingInterval()) {
+        vidSamplingInterval
+      } else defaultVidSamplingInterval.toVidSamplingInterval()
+
+    if (vidSamplingInterval.start < 0) {
+      throw MetricSpecDefaultsException(
+        "Invalid vidSamplingInterval",
+        IllegalArgumentException("vidSamplingInterval.start cannot be negative.")
+      )
+    }
+    if (vidSamplingInterval.start >= 1) {
+      throw MetricSpecDefaultsException(
+        "Invalid vidSamplingInterval",
+        IllegalArgumentException("vidSamplingInterval.start must be smaller than 1.")
+      )
+    }
+    if (vidSamplingInterval.width <= 0) {
+      throw MetricSpecDefaultsException(
+        "Invalid vidSamplingInterval",
+        IllegalArgumentException("vidSamplingInterval.width must be greater than 0.")
+      )
+    }
+    if (vidSamplingInterval.start + vidSamplingInterval.width > 1) {
+      throw MetricSpecDefaultsException(
+        "Invalid vidSamplingInterval",
+        IllegalArgumentException("vidSamplingInterval start + width cannot be greater than 1.")
+      )
+    }
+  }
+}
+
+/**
+ * Specifies default values using [MetricSpecConfig] when optional fields in the
+ * [MetricSpec.ReachParams] are not set.
+ */
+private fun MetricSpec.ReachParams.withDefaults(
+  metricSpecConfig: MetricSpecConfig
+): MetricSpec.ReachParams {
+  if (!hasPrivacyParams()) {
+    throw MetricSpecDefaultsException(
+      "Invalid privacy params",
+      IllegalArgumentException("privacyParams in reach is not set.")
+    )
+  }
+
+  return copy {
+    privacyParams =
+      privacyParams.withDefaults(
+        metricSpecConfig.reachParams.privacyParams.epsilon,
+        metricSpecConfig.reachParams.privacyParams.delta
+      )
+  }
+}
+
+/**
+ * Specifies default values using [MetricSpecConfig] when optional fields in the
+ * [MetricSpec.FrequencyHistogramParams] are not set.
+ */
+private fun MetricSpec.FrequencyHistogramParams.withDefaults(
+  metricSpecConfig: MetricSpecConfig
+): MetricSpec.FrequencyHistogramParams {
+  if (!hasReachPrivacyParams()) {
+    throw MetricSpecDefaultsException(
+      "Invalid privacy params",
+      IllegalArgumentException("reachPrivacyParams in frequency histogram is not set.")
+    )
+  }
+  if (!hasFrequencyPrivacyParams()) {
+    throw MetricSpecDefaultsException(
+      "Invalid privacy params",
+      IllegalArgumentException("frequencyPrivacyParams in frequency histogram is not set.")
+    )
+  }
+
+  return copy {
+    reachPrivacyParams =
+      reachPrivacyParams.withDefaults(
+        metricSpecConfig.frequencyHistogramParams.reachPrivacyParams.epsilon,
+        metricSpecConfig.frequencyHistogramParams.reachPrivacyParams.delta
+      )
+    frequencyPrivacyParams =
+      frequencyPrivacyParams.withDefaults(
+        metricSpecConfig.frequencyHistogramParams.frequencyPrivacyParams.epsilon,
+        metricSpecConfig.frequencyHistogramParams.frequencyPrivacyParams.delta
+      )
+    maximumFrequencyPerUser =
+      if (hasMaximumFrequencyPerUser()) {
+        maximumFrequencyPerUser
+      } else {
+        metricSpecConfig.frequencyHistogramParams.maximumFrequencyPerUser
+      }
+  }
+}
+
+/**
+ * Specifies default values using [MetricSpecConfig] when optional fields in the
+ * [MetricSpec.WatchDurationParams] are not set.
+ */
+private fun MetricSpec.WatchDurationParams.withDefaults(
+  metricSpecConfig: MetricSpecConfig
+): MetricSpec.WatchDurationParams {
+  if (!hasPrivacyParams()) {
+    throw MetricSpecDefaultsException(
+      "Invalid privacy params",
+      IllegalArgumentException("privacyParams in watch duration is not set.")
+    )
+  }
+
+  return copy {
+    privacyParams =
+      privacyParams.withDefaults(
+        metricSpecConfig.watchDurationParams.privacyParams.epsilon,
+        metricSpecConfig.watchDurationParams.privacyParams.delta
+      )
+    maximumWatchDurationPerUser =
+      if (hasMaximumWatchDurationPerUser()) {
+        maximumWatchDurationPerUser
+      } else {
+        metricSpecConfig.watchDurationParams.maximumWatchDurationPerUser
+      }
+  }
+}
+
+/**
+ * Specifies default values using [MetricSpecConfig] when optional fields in the
+ * [MetricSpec.ImpressionCountParams] are not set.
+ */
+private fun MetricSpec.ImpressionCountParams.withDefaults(
+  metricSpecConfig: MetricSpecConfig
+): MetricSpec.ImpressionCountParams {
+  if (!hasPrivacyParams()) {
+    throw MetricSpecDefaultsException(
+      "Invalid privacy params",
+      IllegalArgumentException("privacyParams in impression count is not set.")
+    )
+  }
+
+  return copy {
+    privacyParams =
+      privacyParams.withDefaults(
+        metricSpecConfig.impressionCountParams.privacyParams.epsilon,
+        metricSpecConfig.impressionCountParams.privacyParams.delta
+      )
+    maximumFrequencyPerUser =
+      if (hasMaximumFrequencyPerUser()) {
+        maximumFrequencyPerUser
+      } else {
+        metricSpecConfig.impressionCountParams.maximumFrequencyPerUser
+      }
+  }
+}
+
+/**
+ * Specifies the values in the optional fields of [MetricSpec.DifferentialPrivacyParams] when they
+ * are not set.
+ */
+private fun MetricSpec.DifferentialPrivacyParams.withDefaults(
+  defaultEpsilon: Double,
+  defaultDelta: Double
+): MetricSpec.DifferentialPrivacyParams {
+  return copy {
+    epsilon = if (hasEpsilon()) epsilon else defaultEpsilon
+    delta = if (hasDelta()) delta else defaultDelta
+  }
+}
+
+/** Converts an [MetricSpecConfig.VidSamplingInterval] to an [MetricSpec.VidSamplingInterval]. */
+private fun MetricSpecConfig.VidSamplingInterval.toVidSamplingInterval():
+  MetricSpec.VidSamplingInterval {
+  val source = this
+  return MetricSpecKt.vidSamplingInterval {
+    start = source.start
+    width = source.width
+  }
+}

--- a/src/main/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/MetricsService.kt
+++ b/src/main/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/MetricsService.kt
@@ -100,7 +100,6 @@ import org.wfanet.measurement.internal.reporting.v2.Metric.WeightedMeasurement
 import org.wfanet.measurement.internal.reporting.v2.MetricKt as InternalMetricKt
 import org.wfanet.measurement.internal.reporting.v2.MetricKt.weightedMeasurement
 import org.wfanet.measurement.internal.reporting.v2.MetricSpec as InternalMetricSpec
-import org.wfanet.measurement.internal.reporting.v2.MetricSpecKt as InternalMetricSpecKt
 import org.wfanet.measurement.internal.reporting.v2.MetricsGrpcKt.MetricsCoroutineStub as InternalMetricsCoroutineStub
 import org.wfanet.measurement.internal.reporting.v2.ReportingSet as InternalReportingSet
 import org.wfanet.measurement.internal.reporting.v2.ReportingSetsGrpcKt.ReportingSetsCoroutineStub as InternalReportingSetsCoroutineStub
@@ -115,7 +114,6 @@ import org.wfanet.measurement.internal.reporting.v2.copy
 import org.wfanet.measurement.internal.reporting.v2.createMetricRequest as internalCreateMetricRequest
 import org.wfanet.measurement.internal.reporting.v2.measurement as internalMeasurement
 import org.wfanet.measurement.internal.reporting.v2.metric as internalMetric
-import org.wfanet.measurement.internal.reporting.v2.metricSpec as internalMetricSpec
 import org.wfanet.measurement.reporting.service.api.EncryptionKeyPairStore
 import org.wfanet.measurement.reporting.v2alpha.BatchCreateMetricsRequest
 import org.wfanet.measurement.reporting.v2alpha.BatchCreateMetricsResponse
@@ -135,7 +133,6 @@ import org.wfanet.measurement.reporting.v2alpha.MetricResultKt.histogramResult
 import org.wfanet.measurement.reporting.v2alpha.MetricResultKt.impressionCountResult
 import org.wfanet.measurement.reporting.v2alpha.MetricResultKt.reachResult
 import org.wfanet.measurement.reporting.v2alpha.MetricResultKt.watchDurationResult
-import org.wfanet.measurement.reporting.v2alpha.MetricSpec
 import org.wfanet.measurement.reporting.v2alpha.MetricsGrpcKt.MetricsCoroutineImplBase
 import org.wfanet.measurement.reporting.v2alpha.batchCreateMetricsResponse
 import org.wfanet.measurement.reporting.v2alpha.batchGetMetricsResponse
@@ -1298,7 +1295,17 @@ class MetricsService(
         this.cmmsMeasurementConsumerId = cmmsMeasurementConsumerId
         externalReportingSetId = internalReportingSet.externalReportingSetId
         timeInterval = request.metric.timeInterval.toInternal()
-        metricSpec = buildInternalMetricSpec(request.metric.metricSpec)
+        metricSpec =
+          try {
+            request.metric.metricSpec.withDefaults(metricSpecConfig).toInternal()
+          } catch (e: MetricSpecDefaultsException) {
+            failGrpc(Status.INVALID_ARGUMENT) {
+              listOfNotNull("Invalid metric spec.", e.message, e.cause?.message)
+                .joinToString(separator = "\n")
+            }
+          } catch (e: Exception) {
+            failGrpc(Status.UNKNOWN) { "Failed to read the metric spec." }
+          }
         weightedMeasurements +=
           buildInitialInternalMeasurements(
             cmmsMeasurementConsumerId,
@@ -1307,160 +1314,6 @@ class MetricsService(
           )
         details = InternalMetricKt.details { filters += request.metric.filtersList }
       }
-    }
-  }
-
-  /** Builds an [InternalMetricSpec] given a [MetricSpec]. */
-  private fun buildInternalMetricSpec(
-    metricSpec: MetricSpec,
-  ): InternalMetricSpec {
-    return internalMetricSpec {
-      val defaultVidSamplingInterval: MetricSpecConfig.VidSamplingInterval =
-        @Suppress("WHEN_ENUM_CAN_BE_NULL_IN_JAVA") // Proto enum fields are never null.
-        when (metricSpec.typeCase) {
-          MetricSpec.TypeCase.REACH -> {
-            reach = buildInternalReachParams(metricSpec.reach)
-            metricSpecConfig.reachVidSamplingInterval
-          }
-          MetricSpec.TypeCase.FREQUENCY_HISTOGRAM -> {
-            frequencyHistogram =
-              buildInternalFrequencyHistogramParams(metricSpec.frequencyHistogram)
-            metricSpecConfig.frequencyHistogramVidSamplingInterval
-          }
-          MetricSpec.TypeCase.IMPRESSION_COUNT -> {
-            impressionCount = buildInternalImpressionCountParams(metricSpec.impressionCount)
-            metricSpecConfig.impressionCountVidSamplingInterval
-          }
-          MetricSpec.TypeCase.WATCH_DURATION -> {
-            watchDuration = buildInternalWatchDurationParams(metricSpec.watchDuration)
-            metricSpecConfig.watchDurationVidSamplingInterval
-          }
-          MetricSpec.TypeCase.TYPE_NOT_SET ->
-            failGrpc(Status.INVALID_ARGUMENT) { "The metric type in Metric is not specified." }
-        }
-
-      vidSamplingInterval =
-        if (metricSpec.hasVidSamplingInterval()) {
-          metricSpec.vidSamplingInterval.toInternal()
-        } else defaultVidSamplingInterval.toInternal()
-
-      grpcRequire(vidSamplingInterval.start >= 0) {
-        "vidSamplingInterval.start cannot be negative."
-      }
-      grpcRequire(vidSamplingInterval.start < 1) {
-        "vidSamplingInterval.start must be smaller than 1."
-      }
-      grpcRequire(vidSamplingInterval.width > 0) {
-        "vidSamplingInterval.width must be greater than 0."
-      }
-      grpcRequire(vidSamplingInterval.start + vidSamplingInterval.width <= 1) {
-        "vidSamplingInterval start + width cannot be greater than 1."
-      }
-    }
-  }
-
-  /** Builds an [InternalMetricSpec.ReachParams] given a [MetricSpec.ReachParams]. */
-  private fun buildInternalReachParams(
-    reachParams: MetricSpec.ReachParams,
-  ): InternalMetricSpec.ReachParams {
-    grpcRequire(reachParams.hasPrivacyParams()) { "privacyParams in reach is not set." }
-
-    return InternalMetricSpecKt.reachParams {
-      privacyParams =
-        buildInternalDifferentialPrivacyParams(
-          reachParams.privacyParams,
-          metricSpecConfig.reachParams.privacyParams.epsilon,
-          metricSpecConfig.reachParams.privacyParams.delta
-        )
-    }
-  }
-
-  /**
-   * Builds an [InternalMetricSpec.FrequencyHistogramParams] given a
-   * [MetricSpec.FrequencyHistogramParams].
-   */
-  private fun buildInternalFrequencyHistogramParams(
-    frequencyHistogramParams: MetricSpec.FrequencyHistogramParams
-  ): InternalMetricSpec.FrequencyHistogramParams {
-    grpcRequire(frequencyHistogramParams.hasReachPrivacyParams()) {
-      "reachPrivacyParams in frequency histogram is not set."
-    }
-    grpcRequire(frequencyHistogramParams.hasFrequencyPrivacyParams()) {
-      "frequencyPrivacyParams in frequency histogram is not set."
-    }
-
-    return InternalMetricSpecKt.frequencyHistogramParams {
-      reachPrivacyParams =
-        buildInternalDifferentialPrivacyParams(
-          frequencyHistogramParams.reachPrivacyParams,
-          metricSpecConfig.frequencyHistogramParams.reachPrivacyParams.epsilon,
-          metricSpecConfig.frequencyHistogramParams.reachPrivacyParams.delta
-        )
-      frequencyPrivacyParams =
-        buildInternalDifferentialPrivacyParams(
-          frequencyHistogramParams.frequencyPrivacyParams,
-          metricSpecConfig.frequencyHistogramParams.frequencyPrivacyParams.epsilon,
-          metricSpecConfig.frequencyHistogramParams.frequencyPrivacyParams.delta
-        )
-      maximumFrequencyPerUser =
-        if (frequencyHistogramParams.hasMaximumFrequencyPerUser()) {
-          frequencyHistogramParams.maximumFrequencyPerUser
-        } else {
-          metricSpecConfig.frequencyHistogramParams.maximumFrequencyPerUser
-        }
-    }
-  }
-
-  /**
-   * Builds an [InternalMetricSpec.WatchDurationParams] given a [MetricSpec.WatchDurationParams].
-   */
-  private fun buildInternalWatchDurationParams(
-    watchDurationParams: MetricSpec.WatchDurationParams
-  ): InternalMetricSpec.WatchDurationParams {
-    grpcRequire(watchDurationParams.hasPrivacyParams()) {
-      "privacyParams in watch duration is not set."
-    }
-
-    return InternalMetricSpecKt.watchDurationParams {
-      privacyParams =
-        buildInternalDifferentialPrivacyParams(
-          watchDurationParams.privacyParams,
-          metricSpecConfig.watchDurationParams.privacyParams.epsilon,
-          metricSpecConfig.watchDurationParams.privacyParams.delta
-        )
-      maximumWatchDurationPerUser =
-        if (watchDurationParams.hasMaximumWatchDurationPerUser()) {
-          watchDurationParams.maximumWatchDurationPerUser
-        } else {
-          metricSpecConfig.watchDurationParams.maximumWatchDurationPerUser
-        }
-    }
-  }
-
-  /**
-   * Builds an [InternalMetricSpec.ImpressionCountParams] given a
-   * [MetricSpec.ImpressionCountParams].
-   */
-  private fun buildInternalImpressionCountParams(
-    impressionCountParams: MetricSpec.ImpressionCountParams
-  ): InternalMetricSpec.ImpressionCountParams {
-    grpcRequire(impressionCountParams.hasPrivacyParams()) {
-      "privacyParams in impression count is not set."
-    }
-
-    return InternalMetricSpecKt.impressionCountParams {
-      privacyParams =
-        buildInternalDifferentialPrivacyParams(
-          impressionCountParams.privacyParams,
-          metricSpecConfig.impressionCountParams.privacyParams.epsilon,
-          metricSpecConfig.impressionCountParams.privacyParams.delta
-        )
-      maximumFrequencyPerUser =
-        if (impressionCountParams.hasMaximumFrequencyPerUser()) {
-          impressionCountParams.maximumFrequencyPerUser
-        } else {
-          metricSpecConfig.impressionCountParams.maximumFrequencyPerUser
-        }
     }
   }
 
@@ -1516,22 +1369,6 @@ class MetricsService(
         e
       )
     }
-  }
-}
-
-/**
- * Build an [InternalMetricSpec.DifferentialPrivacyParams] given
- * [MetricSpec.DifferentialPrivacyParams]. If any field in the given
- * [MetricSpec.DifferentialPrivacyParams] is unspecified, it will use the provided default value.
- */
-private fun buildInternalDifferentialPrivacyParams(
-  dpParams: MetricSpec.DifferentialPrivacyParams,
-  defaultEpsilon: Double,
-  defaultDelta: Double
-): InternalMetricSpec.DifferentialPrivacyParams {
-  return InternalMetricSpecKt.differentialPrivacyParams {
-    epsilon = if (dpParams.hasEpsilon()) dpParams.epsilon else defaultEpsilon
-    delta = if (dpParams.hasDelta()) dpParams.delta else defaultDelta
   }
 }
 

--- a/src/main/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/ProtoConversions.kt
+++ b/src/main/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/ProtoConversions.kt
@@ -36,6 +36,7 @@ import org.wfanet.measurement.internal.reporting.v2.StreamMetricsRequestKt
 import org.wfanet.measurement.internal.reporting.v2.StreamReportingSetsRequest
 import org.wfanet.measurement.internal.reporting.v2.StreamReportingSetsRequestKt
 import org.wfanet.measurement.internal.reporting.v2.TimeInterval as InternalTimeInterval
+import org.wfanet.measurement.internal.reporting.v2.metricSpec as internalMetricSpec
 import org.wfanet.measurement.internal.reporting.v2.streamMetricsRequest
 import org.wfanet.measurement.internal.reporting.v2.streamReportingSetsRequest
 import org.wfanet.measurement.internal.reporting.v2.timeInterval as internalTimeInterval
@@ -107,6 +108,130 @@ fun TimeInterval.toInternal(): InternalTimeInterval {
   }
 }
 
+/** Converts a [MetricSpec] to an [InternalMetricSpec]. */
+fun MetricSpec.toInternal(): InternalMetricSpec {
+  val source = this
+
+  return internalMetricSpec {
+    @Suppress("WHEN_ENUM_CAN_BE_NULL_IN_JAVA")
+    when (source.typeCase) {
+      MetricSpec.TypeCase.REACH -> {
+        reach = source.reach.toInternal()
+      }
+      MetricSpec.TypeCase.FREQUENCY_HISTOGRAM -> {
+        frequencyHistogram = source.frequencyHistogram.toInternal()
+      }
+      MetricSpec.TypeCase.IMPRESSION_COUNT -> {
+        impressionCount = source.impressionCount.toInternal()
+      }
+      MetricSpec.TypeCase.WATCH_DURATION -> {
+        watchDuration = source.watchDuration.toInternal()
+      }
+      MetricSpec.TypeCase.TYPE_NOT_SET ->
+        throw MetricSpecDefaultsException(
+          "Invalid metric spec type",
+          IllegalArgumentException("The metric type in Metric is not specified.")
+        )
+    }
+
+    if (source.hasVidSamplingInterval()) {
+      vidSamplingInterval = source.vidSamplingInterval.toInternal()
+    }
+  }
+}
+
+/** Converts a [MetricSpec.WatchDurationParams] to an [InternalMetricSpec.WatchDurationParams]. */
+fun MetricSpec.WatchDurationParams.toInternal(): InternalMetricSpec.WatchDurationParams {
+  val source = this
+  if (!source.hasPrivacyParams()) {
+    throw MetricSpecDefaultsException(
+      "Invalid privacy params",
+      IllegalArgumentException("privacyParams in watch duration is not set.")
+    )
+  }
+  return InternalMetricSpecKt.watchDurationParams {
+    privacyParams = source.privacyParams.toInternal()
+    if (source.hasMaximumWatchDurationPerUser()) {
+      maximumWatchDurationPerUser = source.maximumWatchDurationPerUser
+    }
+  }
+}
+
+/**
+ * Converts a [MetricSpec.ImpressionCountParams] to an [InternalMetricSpec.ImpressionCountParams].
+ */
+fun MetricSpec.ImpressionCountParams.toInternal(): InternalMetricSpec.ImpressionCountParams {
+  val source = this
+  if (!source.hasPrivacyParams()) {
+    throw MetricSpecDefaultsException(
+      "Invalid privacy params",
+      IllegalArgumentException("privacyParams in impression count is not set.")
+    )
+  }
+  return InternalMetricSpecKt.impressionCountParams {
+    privacyParams = source.privacyParams.toInternal()
+    if (source.hasMaximumFrequencyPerUser()) {
+      maximumFrequencyPerUser = source.maximumFrequencyPerUser
+    }
+  }
+}
+
+/**
+ * Converts a [MetricSpec.FrequencyHistogramParams] to an
+ * [InternalMetricSpec.FrequencyHistogramParams].
+ */
+fun MetricSpec.FrequencyHistogramParams.toInternal(): InternalMetricSpec.FrequencyHistogramParams {
+  val source = this
+  if (!source.hasReachPrivacyParams()) {
+    throw MetricSpecDefaultsException(
+      "Invalid privacy params",
+      IllegalArgumentException("reachPrivacyParams in frequency histogram is not set.")
+    )
+  }
+  if (!source.hasFrequencyPrivacyParams()) {
+    throw MetricSpecDefaultsException(
+      "Invalid privacy params",
+      IllegalArgumentException("frequencyPrivacyParams in frequency histogram is not set.")
+    )
+  }
+  return InternalMetricSpecKt.frequencyHistogramParams {
+    reachPrivacyParams = source.reachPrivacyParams.toInternal()
+    frequencyPrivacyParams = source.frequencyPrivacyParams.toInternal()
+    if (source.hasMaximumFrequencyPerUser()) {
+      maximumFrequencyPerUser = source.maximumFrequencyPerUser
+    }
+  }
+}
+
+/** Converts a [MetricSpec.ReachParams] to an [InternalMetricSpec.ReachParams]. */
+fun MetricSpec.ReachParams.toInternal(): InternalMetricSpec.ReachParams {
+  val source = this
+  if (!source.hasPrivacyParams()) {
+    throw MetricSpecDefaultsException(
+      "Invalid privacy params",
+      IllegalArgumentException("privacyParams in reach is not set.")
+    )
+  }
+  return InternalMetricSpecKt.reachParams { privacyParams = source.privacyParams.toInternal() }
+}
+
+/**
+ * Converts a [MetricSpec.DifferentialPrivacyParams] to an
+ * [InternalMetricSpec.DifferentialPrivacyParams].
+ */
+fun MetricSpec.DifferentialPrivacyParams.toInternal():
+  InternalMetricSpec.DifferentialPrivacyParams {
+  val source = this
+  return InternalMetricSpecKt.differentialPrivacyParams {
+    if (source.hasEpsilon()) {
+      this.epsilon = source.epsilon
+    }
+    if (source.hasDelta()) {
+      this.delta = source.delta
+    }
+  }
+}
+
 /** Converts an [InternalMetricSpec] to a public [MetricSpec]. */
 fun InternalMetricSpec.toMetricSpec(): MetricSpec {
   val source = this
@@ -121,6 +246,8 @@ fun InternalMetricSpec.toMetricSpec(): MetricSpec {
           MetricSpecKt.frequencyHistogramParams {
             maximumFrequencyPerUser = source.frequencyHistogram.maximumFrequencyPerUser
             reachPrivacyParams = source.frequencyHistogram.reachPrivacyParams.toPrivacyParams()
+            frequencyPrivacyParams =
+              source.frequencyHistogram.frequencyPrivacyParams.toPrivacyParams()
           }
       InternalMetricSpec.TypeCase.IMPRESSION_COUNT ->
         impressionCount =

--- a/src/test/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/BUILD.bazel
+++ b/src/test/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/BUILD.bazel
@@ -1,6 +1,21 @@
 load("@io_bazel_rules_kotlin//kotlin:jvm.bzl", "kt_jvm_test")
 
 kt_jvm_test(
+    name = "MetricSpecDefaultsTest",
+    srcs = ["MetricSpecDefaultsTest.kt"],
+    associates = [
+        "//src/main/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha:metric_spec_defaults",
+    ],
+    test_class = "org.wfanet.measurement.reporting.service.api.v2alpha.MetricSpecDefaultsTest",
+    deps = [
+        "@wfa_common_jvm//imports/java/com/google/common/truth",
+        "@wfa_common_jvm//imports/java/com/google/common/truth/extensions/proto",
+        "@wfa_common_jvm//imports/kotlin/kotlin/test",
+        "@wfa_common_jvm//src/main/kotlin/org/wfanet/measurement/common/testing",
+    ],
+)
+
+kt_jvm_test(
     name = "MetricsServiceTest",
     srcs = ["MetricsServiceTest.kt"],
     associates = [

--- a/src/test/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/MetricSpecDefaultsTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/MetricSpecDefaultsTest.kt
@@ -1,0 +1,486 @@
+/*
+ * Copyright 2023 The Cross-Media Measurement Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wfanet.measurement.reporting.service.api.v2alpha
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Assert.assertThrows
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+import org.wfanet.measurement.config.reporting.MetricSpecConfigKt
+import org.wfanet.measurement.config.reporting.metricSpecConfig
+import org.wfanet.measurement.reporting.v2alpha.MetricSpec
+import org.wfanet.measurement.reporting.v2alpha.MetricSpecKt
+import org.wfanet.measurement.reporting.v2alpha.MetricSpecKt.frequencyHistogramParams
+import org.wfanet.measurement.reporting.v2alpha.MetricSpecKt.impressionCountParams
+import org.wfanet.measurement.reporting.v2alpha.MetricSpecKt.reachParams
+import org.wfanet.measurement.reporting.v2alpha.MetricSpecKt.watchDurationParams
+import org.wfanet.measurement.reporting.v2alpha.copy
+import org.wfanet.measurement.reporting.v2alpha.metricSpec
+
+private const val NUMBER_VID_BUCKETS = 300
+private const val REACH_ONLY_VID_SAMPLING_WIDTH = 3.0f / NUMBER_VID_BUCKETS
+private const val REACH_ONLY_VID_SAMPLING_START = 0.0f
+private const val REACH_ONLY_REACH_EPSILON = 0.0041
+
+private const val REACH_FREQUENCY_VID_SAMPLING_WIDTH = 5.0f / NUMBER_VID_BUCKETS
+private const val REACH_FREQUENCY_VID_SAMPLING_START = 48.0f / NUMBER_VID_BUCKETS
+private const val REACH_FREQUENCY_REACH_EPSILON = 0.0033
+private const val REACH_FREQUENCY_FREQUENCY_EPSILON = 0.115
+private const val REACH_FREQUENCY_MAXIMUM_FREQUENCY_PER_USER = 10
+
+private const val IMPRESSION_VID_SAMPLING_WIDTH = 62.0f / NUMBER_VID_BUCKETS
+private const val IMPRESSION_VID_SAMPLING_START = 143.0f / NUMBER_VID_BUCKETS
+private const val IMPRESSION_EPSILON = 0.0011
+private const val IMPRESSION_MAXIMUM_FREQUENCY_PER_USER = 60
+
+private const val WATCH_DURATION_VID_SAMPLING_WIDTH = 95.0f / NUMBER_VID_BUCKETS
+private const val WATCH_DURATION_VID_SAMPLING_START = 205.0f / NUMBER_VID_BUCKETS
+private const val WATCH_DURATION_EPSILON = 0.001
+private const val MAXIMUM_WATCH_DURATION_PER_USER = 4000
+
+private const val DIFFERENTIAL_PRIVACY_DELTA = 1e-12
+
+@RunWith(JUnit4::class)
+class MetricSpecDefaultsTest {
+
+  @Test
+  fun `buildMetricSpec builds a reach metric spec when no field is filled`() {
+    val result = REACH_METRIC_SPEC.withDefaults(METRIC_SPEC_CONFIG)
+    val expect = metricSpec {
+      reach = reachParams {
+        privacyParams =
+          MetricSpecKt.differentialPrivacyParams {
+            epsilon = METRIC_SPEC_CONFIG.reachParams.privacyParams.epsilon
+            delta = METRIC_SPEC_CONFIG.reachParams.privacyParams.delta
+          }
+      }
+      vidSamplingInterval =
+        MetricSpecKt.vidSamplingInterval {
+          start = METRIC_SPEC_CONFIG.reachVidSamplingInterval.start
+          width = METRIC_SPEC_CONFIG.reachVidSamplingInterval.width
+        }
+    }
+    assertThat(result).isEqualTo(expect)
+  }
+
+  @Test
+  fun `buildMetricSpec builds a reach metric spec when all fields are filled`() {
+    val expect = metricSpec {
+      reach = reachParams {
+        privacyParams =
+          MetricSpecKt.differentialPrivacyParams {
+            epsilon = METRIC_SPEC_CONFIG.reachParams.privacyParams.epsilon * 2
+            delta = METRIC_SPEC_CONFIG.reachParams.privacyParams.delta * 2
+          }
+      }
+      vidSamplingInterval =
+        MetricSpecKt.vidSamplingInterval {
+          start = METRIC_SPEC_CONFIG.reachVidSamplingInterval.start + 0.001f
+          width = METRIC_SPEC_CONFIG.reachVidSamplingInterval.width / 2
+        }
+    }
+
+    val result = expect.withDefaults(METRIC_SPEC_CONFIG)
+
+    assertThat(result).isEqualTo(expect)
+  }
+
+  @Test
+  fun `buildMetricSpec builds a frequency histogram metric spec when no field is filled`() {
+    val result = FREQUENCY_HISTOGRAM_METRIC_SPEC.withDefaults(METRIC_SPEC_CONFIG)
+    val expect = metricSpec {
+      frequencyHistogram = frequencyHistogramParams {
+        reachPrivacyParams =
+          MetricSpecKt.differentialPrivacyParams {
+            epsilon = METRIC_SPEC_CONFIG.frequencyHistogramParams.reachPrivacyParams.epsilon
+            delta = METRIC_SPEC_CONFIG.frequencyHistogramParams.reachPrivacyParams.delta
+          }
+        frequencyPrivacyParams =
+          MetricSpecKt.differentialPrivacyParams {
+            epsilon = METRIC_SPEC_CONFIG.frequencyHistogramParams.frequencyPrivacyParams.epsilon
+            delta = METRIC_SPEC_CONFIG.frequencyHistogramParams.frequencyPrivacyParams.delta
+          }
+        maximumFrequencyPerUser =
+          METRIC_SPEC_CONFIG.frequencyHistogramParams.maximumFrequencyPerUser
+      }
+      vidSamplingInterval =
+        MetricSpecKt.vidSamplingInterval {
+          start = METRIC_SPEC_CONFIG.frequencyHistogramVidSamplingInterval.start
+          width = METRIC_SPEC_CONFIG.frequencyHistogramVidSamplingInterval.width
+        }
+    }
+    assertThat(result).isEqualTo(expect)
+  }
+
+  @Test
+  fun `buildMetricSpec builds a frequency histogram metric spec when all fields are filled`() {
+    val expect = metricSpec {
+      frequencyHistogram = frequencyHistogramParams {
+        reachPrivacyParams =
+          MetricSpecKt.differentialPrivacyParams {
+            epsilon = METRIC_SPEC_CONFIG.frequencyHistogramParams.reachPrivacyParams.epsilon * 2
+            delta = METRIC_SPEC_CONFIG.frequencyHistogramParams.reachPrivacyParams.delta * 2
+          }
+        frequencyPrivacyParams =
+          MetricSpecKt.differentialPrivacyParams {
+            epsilon = METRIC_SPEC_CONFIG.frequencyHistogramParams.frequencyPrivacyParams.epsilon * 2
+            delta = METRIC_SPEC_CONFIG.frequencyHistogramParams.frequencyPrivacyParams.delta * 2
+          }
+        maximumFrequencyPerUser =
+          METRIC_SPEC_CONFIG.frequencyHistogramParams.maximumFrequencyPerUser * 2
+      }
+      vidSamplingInterval =
+        MetricSpecKt.vidSamplingInterval {
+          start = METRIC_SPEC_CONFIG.frequencyHistogramVidSamplingInterval.start + 0.001f
+          width = METRIC_SPEC_CONFIG.frequencyHistogramVidSamplingInterval.width / 2
+        }
+    }
+    val result = expect.withDefaults(METRIC_SPEC_CONFIG)
+    assertThat(result).isEqualTo(expect)
+  }
+
+  @Test
+  fun `buildMetricSpec builds an impression count metric spec when no field is filled`() {
+    val result = IMPRESSION_COUNT_METRIC_SPEC.withDefaults(METRIC_SPEC_CONFIG)
+    val expect = metricSpec {
+      impressionCount = impressionCountParams {
+        privacyParams =
+          MetricSpecKt.differentialPrivacyParams {
+            epsilon = METRIC_SPEC_CONFIG.impressionCountParams.privacyParams.epsilon
+            delta = METRIC_SPEC_CONFIG.impressionCountParams.privacyParams.delta
+          }
+        maximumFrequencyPerUser = METRIC_SPEC_CONFIG.impressionCountParams.maximumFrequencyPerUser
+      }
+      vidSamplingInterval =
+        MetricSpecKt.vidSamplingInterval {
+          start = METRIC_SPEC_CONFIG.impressionCountVidSamplingInterval.start
+          width = METRIC_SPEC_CONFIG.impressionCountVidSamplingInterval.width
+        }
+    }
+    assertThat(result).isEqualTo(expect)
+  }
+
+  @Test
+  fun `buildMetricSpec builds an impression count metric spec when all fields are filled`() {
+    val expect = metricSpec {
+      impressionCount = impressionCountParams {
+        privacyParams =
+          MetricSpecKt.differentialPrivacyParams {
+            epsilon = METRIC_SPEC_CONFIG.impressionCountParams.privacyParams.epsilon * 2
+            delta = METRIC_SPEC_CONFIG.impressionCountParams.privacyParams.delta * 2
+          }
+        maximumFrequencyPerUser =
+          METRIC_SPEC_CONFIG.impressionCountParams.maximumFrequencyPerUser * 2
+      }
+      vidSamplingInterval =
+        MetricSpecKt.vidSamplingInterval {
+          start = METRIC_SPEC_CONFIG.impressionCountVidSamplingInterval.start + 0.001f
+          width = METRIC_SPEC_CONFIG.impressionCountVidSamplingInterval.width / 2
+        }
+    }
+    val result = expect.withDefaults(METRIC_SPEC_CONFIG)
+    assertThat(result).isEqualTo(expect)
+  }
+
+  @Test
+  fun `buildMetricSpec builds a watch duration metric spec when no field is filled`() {
+    val result = WATCH_DURATION_METRIC_SPEC.withDefaults(METRIC_SPEC_CONFIG)
+    val expect = metricSpec {
+      watchDuration = watchDurationParams {
+        privacyParams =
+          MetricSpecKt.differentialPrivacyParams {
+            epsilon = METRIC_SPEC_CONFIG.watchDurationParams.privacyParams.epsilon
+            delta = METRIC_SPEC_CONFIG.watchDurationParams.privacyParams.delta
+          }
+        maximumWatchDurationPerUser =
+          METRIC_SPEC_CONFIG.watchDurationParams.maximumWatchDurationPerUser
+      }
+      vidSamplingInterval =
+        MetricSpecKt.vidSamplingInterval {
+          start = METRIC_SPEC_CONFIG.watchDurationVidSamplingInterval.start
+          width = METRIC_SPEC_CONFIG.watchDurationVidSamplingInterval.width
+        }
+    }
+    assertThat(result).isEqualTo(expect)
+  }
+
+  @Test
+  fun `buildMetricSpec builds a watch duration metric spec when all fields are filled`() {
+    val expect = metricSpec {
+      watchDuration = watchDurationParams {
+        privacyParams =
+          MetricSpecKt.differentialPrivacyParams {
+            epsilon = METRIC_SPEC_CONFIG.watchDurationParams.privacyParams.epsilon * 2
+            delta = METRIC_SPEC_CONFIG.watchDurationParams.privacyParams.delta * 2
+          }
+        maximumWatchDurationPerUser =
+          METRIC_SPEC_CONFIG.watchDurationParams.maximumWatchDurationPerUser * 2
+      }
+      vidSamplingInterval =
+        MetricSpecKt.vidSamplingInterval {
+          start = METRIC_SPEC_CONFIG.watchDurationVidSamplingInterval.start + 0.001f
+          width = METRIC_SPEC_CONFIG.watchDurationVidSamplingInterval.width / 2
+        }
+    }
+    val result = expect.withDefaults(METRIC_SPEC_CONFIG)
+    assertThat(result).isEqualTo(expect)
+  }
+
+  @Test
+  fun `buildMetricSpec throw MetricSpecBuildingException when no metric type specified`() {
+    val metricSpecWithoutType = metricSpec {}
+
+    val exception =
+      assertThrows(MetricSpecDefaultsException::class.java) {
+        metricSpecWithoutType.withDefaults(METRIC_SPEC_CONFIG)
+      }
+    assertThat(exception).hasCauseThat().isInstanceOf(IllegalArgumentException::class.java)
+    assertThat(exception).hasMessageThat().contains("metric spec type")
+  }
+
+  @Test
+  fun `buildMetricSpec throw MetricSpecBuildingException when reach privacy params is not set`() {
+    val metricSpecWithoutPrivacyParams = metricSpec { reach = reachParams {} }
+
+    val exception =
+      assertThrows(MetricSpecDefaultsException::class.java) {
+        metricSpecWithoutPrivacyParams.withDefaults(METRIC_SPEC_CONFIG)
+      }
+    assertThat(exception).hasMessageThat().contains("privacy params")
+    assertThat(exception).hasCauseThat().isInstanceOf(IllegalArgumentException::class.java)
+    assertThat(exception.cause).hasMessageThat().contains("reach")
+  }
+
+  @Test
+  fun `buildMetricSpec throw MetricSpecBuildingException when reach privacy params in frequency histogram is not set`() {
+    val metricSpecWithoutPrivacyParams =
+      FREQUENCY_HISTOGRAM_METRIC_SPEC.copy {
+        frequencyHistogram = frequencyHistogram.copy { clearReachPrivacyParams() }
+      }
+
+    val exception =
+      assertThrows(MetricSpecDefaultsException::class.java) {
+        metricSpecWithoutPrivacyParams.withDefaults(METRIC_SPEC_CONFIG)
+      }
+    assertThat(exception).hasMessageThat().contains("privacy params")
+    assertThat(exception).hasCauseThat().isInstanceOf(IllegalArgumentException::class.java)
+    assertThat(exception.cause).hasMessageThat().contains("reachPrivacyParams")
+  }
+
+  @Test
+  fun `buildMetricSpec throw MetricSpecBuildingException when frequency histogram privacy params is not set`() {
+    val metricSpecWithoutPrivacyParams =
+      FREQUENCY_HISTOGRAM_METRIC_SPEC.copy {
+        frequencyHistogram = frequencyHistogram.copy { clearFrequencyPrivacyParams() }
+      }
+
+    val exception =
+      assertThrows(MetricSpecDefaultsException::class.java) {
+        metricSpecWithoutPrivacyParams.withDefaults(METRIC_SPEC_CONFIG)
+      }
+    assertThat(exception).hasMessageThat().contains("privacy params")
+    assertThat(exception).hasCauseThat().isInstanceOf(IllegalArgumentException::class.java)
+    assertThat(exception.cause).hasMessageThat().contains("frequencyPrivacyParams")
+  }
+
+  @Test
+  fun `buildMetricSpec throw MetricSpecBuildingException when impression privacy params is not set`() {
+    val metricSpecWithoutPrivacyParams = metricSpec { impressionCount = impressionCountParams {} }
+
+    val exception =
+      assertThrows(MetricSpecDefaultsException::class.java) {
+        metricSpecWithoutPrivacyParams.withDefaults(METRIC_SPEC_CONFIG)
+      }
+    assertThat(exception).hasMessageThat().contains("privacy params")
+    assertThat(exception).hasCauseThat().isInstanceOf(IllegalArgumentException::class.java)
+    assertThat(exception.cause).hasMessageThat().contains("impression count")
+  }
+
+  @Test
+  fun `buildMetricSpec throw MetricSpecBuildingException when watch duration privacy params is not set`() {
+    val metricSpecWithoutPrivacyParams = metricSpec { watchDuration = watchDurationParams {} }
+
+    val exception =
+      assertThrows(MetricSpecDefaultsException::class.java) {
+        metricSpecWithoutPrivacyParams.withDefaults(METRIC_SPEC_CONFIG)
+      }
+    assertThat(exception).hasMessageThat().contains("privacy params")
+    assertThat(exception).hasCauseThat().isInstanceOf(IllegalArgumentException::class.java)
+    assertThat(exception.cause).hasMessageThat().contains("watch duration")
+  }
+
+  @Test
+  fun `buildMetricSpec throw MetricSpecBuildingException when vidSamplingInterval start is less than 0`() {
+    val metricSpec =
+      REACH_METRIC_SPEC.copy {
+        vidSamplingInterval = MetricSpecKt.vidSamplingInterval { start = -1.0f }
+      }
+
+    val exception =
+      assertThrows(MetricSpecDefaultsException::class.java) {
+        metricSpec.withDefaults(METRIC_SPEC_CONFIG)
+      }
+    assertThat(exception).hasMessageThat().contains("vidSamplingInterval")
+    assertThat(exception).hasCauseThat().isInstanceOf(IllegalArgumentException::class.java)
+    assertThat(exception.cause).hasMessageThat().contains("start")
+  }
+
+  @Test
+  fun `buildMetricSpec throw MetricSpecBuildingException when vidSamplingInterval start is not less than 1`() {
+    val metricSpec =
+      REACH_METRIC_SPEC.copy {
+        vidSamplingInterval = MetricSpecKt.vidSamplingInterval { start = 1.0f }
+      }
+
+    val exception =
+      assertThrows(MetricSpecDefaultsException::class.java) {
+        metricSpec.withDefaults(METRIC_SPEC_CONFIG)
+      }
+    assertThat(exception).hasMessageThat().contains("vidSamplingInterval")
+    assertThat(exception).hasCauseThat().isInstanceOf(IllegalArgumentException::class.java)
+    assertThat(exception.cause).hasMessageThat().contains("start")
+  }
+
+  @Test
+  fun `buildMetricSpec throw MetricSpecBuildingException when vidSamplingInterval width is not larger than 0`() {
+    val metricSpec =
+      REACH_METRIC_SPEC.copy {
+        vidSamplingInterval = MetricSpecKt.vidSamplingInterval { width = 0f }
+      }
+
+    val exception =
+      assertThrows(MetricSpecDefaultsException::class.java) {
+        metricSpec.withDefaults(METRIC_SPEC_CONFIG)
+      }
+    assertThat(exception).hasMessageThat().contains("vidSamplingInterval")
+    assertThat(exception).hasCauseThat().isInstanceOf(IllegalArgumentException::class.java)
+    assertThat(exception.cause).hasMessageThat().contains("width")
+  }
+
+  @Test
+  fun `buildMetricSpec throw MetricSpecBuildingException when vidSamplingInterval is too long`() {
+    val metricSpec =
+      REACH_METRIC_SPEC.copy {
+        vidSamplingInterval =
+          MetricSpecKt.vidSamplingInterval {
+            start = 0.5f
+            width = 1.0f
+          }
+      }
+
+    val exception =
+      assertThrows(MetricSpecDefaultsException::class.java) {
+        metricSpec.withDefaults(METRIC_SPEC_CONFIG)
+      }
+    assertThat(exception).hasMessageThat().contains("vidSamplingInterval")
+    assertThat(exception).hasCauseThat().isInstanceOf(IllegalArgumentException::class.java)
+    assertThat(exception.cause).hasMessageThat().contains("start + width")
+  }
+
+  companion object {
+    private val METRIC_SPEC_CONFIG = metricSpecConfig {
+      reachParams =
+        MetricSpecConfigKt.reachParams {
+          privacyParams =
+            MetricSpecConfigKt.differentialPrivacyParams {
+              epsilon = REACH_ONLY_REACH_EPSILON
+              delta = DIFFERENTIAL_PRIVACY_DELTA
+            }
+        }
+      reachVidSamplingInterval =
+        MetricSpecConfigKt.vidSamplingInterval {
+          start = REACH_ONLY_VID_SAMPLING_START
+          width = REACH_ONLY_VID_SAMPLING_WIDTH
+        }
+
+      frequencyHistogramParams =
+        MetricSpecConfigKt.frequencyHistogramParams {
+          reachPrivacyParams =
+            MetricSpecConfigKt.differentialPrivacyParams {
+              epsilon = REACH_FREQUENCY_REACH_EPSILON
+              delta = DIFFERENTIAL_PRIVACY_DELTA
+            }
+          frequencyPrivacyParams =
+            MetricSpecConfigKt.differentialPrivacyParams {
+              epsilon = REACH_FREQUENCY_FREQUENCY_EPSILON
+              delta = DIFFERENTIAL_PRIVACY_DELTA
+            }
+          maximumFrequencyPerUser = REACH_FREQUENCY_MAXIMUM_FREQUENCY_PER_USER
+        }
+      frequencyHistogramVidSamplingInterval =
+        MetricSpecConfigKt.vidSamplingInterval {
+          start = REACH_FREQUENCY_VID_SAMPLING_START
+          width = REACH_FREQUENCY_VID_SAMPLING_WIDTH
+        }
+
+      impressionCountParams =
+        MetricSpecConfigKt.impressionCountParams {
+          privacyParams =
+            MetricSpecConfigKt.differentialPrivacyParams {
+              epsilon = IMPRESSION_EPSILON
+              delta = DIFFERENTIAL_PRIVACY_DELTA
+            }
+          maximumFrequencyPerUser = IMPRESSION_MAXIMUM_FREQUENCY_PER_USER
+        }
+      impressionCountVidSamplingInterval =
+        MetricSpecConfigKt.vidSamplingInterval {
+          start = IMPRESSION_VID_SAMPLING_START
+          width = IMPRESSION_VID_SAMPLING_WIDTH
+        }
+
+      watchDurationParams =
+        MetricSpecConfigKt.watchDurationParams {
+          privacyParams =
+            MetricSpecConfigKt.differentialPrivacyParams {
+              epsilon = WATCH_DURATION_EPSILON
+              delta = DIFFERENTIAL_PRIVACY_DELTA
+            }
+          maximumWatchDurationPerUser = MAXIMUM_WATCH_DURATION_PER_USER
+        }
+      watchDurationVidSamplingInterval =
+        MetricSpecConfigKt.vidSamplingInterval {
+          start = WATCH_DURATION_VID_SAMPLING_START
+          width = WATCH_DURATION_VID_SAMPLING_WIDTH
+        }
+    }
+
+    // Metric Specs
+
+    private val REACH_METRIC_SPEC: MetricSpec = metricSpec {
+      reach = reachParams {
+        privacyParams = MetricSpec.DifferentialPrivacyParams.getDefaultInstance()
+      }
+    }
+    private val FREQUENCY_HISTOGRAM_METRIC_SPEC: MetricSpec = metricSpec {
+      frequencyHistogram = frequencyHistogramParams {
+        reachPrivacyParams = MetricSpec.DifferentialPrivacyParams.getDefaultInstance()
+        frequencyPrivacyParams = MetricSpec.DifferentialPrivacyParams.getDefaultInstance()
+      }
+    }
+    private val IMPRESSION_COUNT_METRIC_SPEC: MetricSpec = metricSpec {
+      impressionCount = impressionCountParams {
+        privacyParams = MetricSpec.DifferentialPrivacyParams.getDefaultInstance()
+      }
+    }
+    private val WATCH_DURATION_METRIC_SPEC: MetricSpec = metricSpec {
+      watchDuration = watchDurationParams {
+        privacyParams = MetricSpec.DifferentialPrivacyParams.getDefaultInstance()
+      }
+    }
+  }
+}

--- a/src/test/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/MetricsServiceTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/MetricsServiceTest.kt
@@ -2340,7 +2340,6 @@ class MetricsServiceTest {
         }
       }
     assertThat(exception.status.code).isEqualTo(Status.Code.INVALID_ARGUMENT)
-    assertThat(exception.status.description).isEqualTo("privacyParams in reach is not set.")
   }
 
   @Test
@@ -2361,8 +2360,6 @@ class MetricsServiceTest {
         }
       }
     assertThat(exception.status.code).isEqualTo(Status.Code.INVALID_ARGUMENT)
-    assertThat(exception.status.description)
-      .isEqualTo("vidSamplingInterval.start cannot be negative.")
   }
 
   @Test
@@ -2383,8 +2380,6 @@ class MetricsServiceTest {
         }
       }
     assertThat(exception.status.code).isEqualTo(Status.Code.INVALID_ARGUMENT)
-    assertThat(exception.status.description)
-      .isEqualTo("vidSamplingInterval.start must be smaller than 1.")
   }
 
   @Test
@@ -2405,8 +2400,6 @@ class MetricsServiceTest {
         }
       }
     assertThat(exception.status.code).isEqualTo(Status.Code.INVALID_ARGUMENT)
-    assertThat(exception.status.description)
-      .isEqualTo("vidSamplingInterval.width must be greater than 0.")
   }
 
   @Test
@@ -2433,8 +2426,6 @@ class MetricsServiceTest {
         }
       }
     assertThat(exception.status.code).isEqualTo(Status.Code.INVALID_ARGUMENT)
-    assertThat(exception.status.description)
-      .isEqualTo("vidSamplingInterval start + width cannot be greater than 1.")
   }
 
   @Test


### PR DESCRIPTION
Refactor the code that processes user-defined metric spec. The extension method of `MetricSpec` takes as input the metric spec config and fills all optional fields underneath if they are unset.