### PR TITLE
Update EventGroup resource pattern in Reporting v2 API.

### DIFF
--- a/src/main/kotlin/org/wfanet/measurement/reporting/deploy/v2/postgres/readers/ReportingSetReader.kt
+++ b/src/main/kotlin/org/wfanet/measurement/reporting/deploy/v2/postgres/readers/ReportingSetReader.kt
@@ -258,7 +258,6 @@ class ReportingSetReader(private val readContext: ReadContext) {
             reportingSetInfo.cmmsEventGroupIdsSet.forEach {
               eventGroupKeys +=
                 ReportingSetKt.PrimitiveKt.eventGroupKey {
-                  cmmsMeasurementConsumerId = reportingSetInfo.cmmsMeasurementConsumerId
                   cmmsDataProviderId = it.cmmsDataProviderId
                   cmmsEventGroupId = it.cmmsEventGroupId
                 }

--- a/src/main/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/EventGroupKey.kt
+++ b/src/main/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/EventGroupKey.kt
@@ -19,39 +19,30 @@ package org.wfanet.measurement.reporting.service.api.v2alpha
 import org.wfanet.measurement.common.ResourceNameParser
 import org.wfanet.measurement.common.api.ResourceKey
 
-private val parser =
-  ResourceNameParser(
-    "measurementConsumers/{measurement_consumer}" +
-      "/dataProviders/{data_provider}/eventGroups/{event_group}"
-  )
-
 /** [ResourceKey] of an EventGroup. */
-class EventGroupKey(
-  val cmmsMeasurementConsumerId: String,
-  val cmmsDataProviderId: String,
-  val cmmsEventGroupId: String
-) : ResourceKey {
+class EventGroupKey(val cmmsMeasurementConsumerId: String, val cmmsEventGroupId: String) :
+  ResourceKey {
   override fun toName(): String {
     return parser.assembleName(
       mapOf(
         IdVariable.MEASUREMENT_CONSUMER to cmmsMeasurementConsumerId,
-        IdVariable.DATA_PROVIDER to cmmsDataProviderId,
         IdVariable.EVENT_GROUP to cmmsEventGroupId
       )
     )
   }
 
   companion object FACTORY : ResourceKey.Factory<EventGroupKey> {
-    val defaultValue = EventGroupKey("", "", "")
+    private val parser =
+      ResourceNameParser("measurementConsumers/{measurement_consumer}/eventGroups/{event_group}")
+
+    val defaultValue = EventGroupKey("", "")
 
     override fun fromName(resourceName: String): EventGroupKey? {
-      return parser.parseIdVars(resourceName)?.let {
-        EventGroupKey(
-          it.getValue(IdVariable.MEASUREMENT_CONSUMER),
-          it.getValue(IdVariable.DATA_PROVIDER),
-          it.getValue(IdVariable.EVENT_GROUP)
-        )
-      }
+      val idVars: Map<IdVariable, String> = parser.parseIdVars(resourceName) ?: return null
+      return EventGroupKey(
+        idVars.getValue(IdVariable.MEASUREMENT_CONSUMER),
+        idVars.getValue(IdVariable.EVENT_GROUP)
+      )
     }
   }
 }

--- a/src/main/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/MetricsService.kt
+++ b/src/main/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/MetricsService.kt
@@ -553,9 +553,8 @@ class MetricsService(
             )
 
           internalPrimitiveReportingSet.primitive.eventGroupKeysList.map { internalEventGroupKey ->
-            val eventGroupKey =
-              EventGroupKey(
-                internalEventGroupKey.cmmsMeasurementConsumerId,
+            val cmmsEventGroupKey =
+              CmmsEventGroupKey(
                 internalEventGroupKey.cmmsDataProviderId,
                 internalEventGroupKey.cmmsEventGroupId
               )
@@ -564,14 +563,9 @@ class MetricsService(
                 .filter { !it.isNullOrBlank() }
             val filter: String? = if (filtersList.isEmpty()) null else buildConjunction(filtersList)
 
-            eventGroupKey to
+            cmmsEventGroupKey to
               RequisitionSpecKt.eventGroupEntry {
-                key =
-                  CmmsEventGroupKey(
-                      internalEventGroupKey.cmmsDataProviderId,
-                      internalEventGroupKey.cmmsEventGroupId
-                    )
-                    .toName()
+                key = cmmsEventGroupKey.toName()
                 value =
                   RequisitionSpecKt.EventGroupEntryKt.value {
                     collectionInterval = measurement.timeInterval.toCmmsTimeInterval()
@@ -583,7 +577,7 @@ class MetricsService(
           }
         }
         .groupBy(
-          { (eventGroupKey, _) -> DataProviderKey(eventGroupKey.cmmsDataProviderId) },
+          { (cmmsEventGroupKey, _) -> DataProviderKey(cmmsEventGroupKey.dataProviderId) },
           { (_, eventGroupEntry) -> eventGroupEntry }
         )
     }

--- a/src/main/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/ProtoConversions.kt
+++ b/src/main/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/ProtoConversions.kt
@@ -18,6 +18,7 @@ package org.wfanet.measurement.reporting.service.api.v2alpha
 
 import com.google.protobuf.util.Timestamps
 import org.wfanet.measurement.api.v2alpha.DifferentialPrivacyParams
+import org.wfanet.measurement.api.v2alpha.EventGroupKey as CmmsEventGroupKey
 import org.wfanet.measurement.api.v2alpha.Measurement
 import org.wfanet.measurement.api.v2alpha.MeasurementConsumerKey
 import org.wfanet.measurement.api.v2alpha.MeasurementSpec
@@ -544,14 +545,9 @@ fun InternalReportingSet.SetExpression.Operand.toOperand(
 fun InternalReportingSet.Primitive.toPrimitive(): ReportingSet.Primitive {
   val source = this
   return ReportingSetKt.primitive {
-    eventGroups +=
+    cmmsEventGroups +=
       source.eventGroupKeysList.map { eventGroupKey ->
-        EventGroupKey(
-            eventGroupKey.cmmsMeasurementConsumerId,
-            eventGroupKey.cmmsDataProviderId,
-            eventGroupKey.cmmsEventGroupId
-          )
-          .toName()
+        CmmsEventGroupKey(eventGroupKey.cmmsDataProviderId, eventGroupKey.cmmsEventGroupId).toName()
       }
   }
 }

--- a/src/main/kotlin/org/wfanet/measurement/reporting/service/internal/testing/v2/MeasurementsServiceTest.kt
+++ b/src/main/kotlin/org/wfanet/measurement/reporting/service/internal/testing/v2/MeasurementsServiceTest.kt
@@ -1315,7 +1315,6 @@ abstract class MeasurementsServiceTest<T : MeasurementsGrpcKt.MeasurementsCorout
           ReportingSetKt.primitive {
             eventGroupKeys +=
               ReportingSetKt.PrimitiveKt.eventGroupKey {
-                this.cmmsMeasurementConsumerId = cmmsMeasurementConsumerId
                 cmmsDataProviderId = "1235"
                 cmmsEventGroupId = cmmsMeasurementConsumerId + "123"
               }

--- a/src/main/kotlin/org/wfanet/measurement/reporting/service/internal/testing/v2/MetricsServiceTest.kt
+++ b/src/main/kotlin/org/wfanet/measurement/reporting/service/internal/testing/v2/MetricsServiceTest.kt
@@ -2266,7 +2266,6 @@ abstract class MetricsServiceTest<T : MetricsCoroutineImplBase> {
           ReportingSetKt.primitive {
             eventGroupKeys +=
               ReportingSetKt.PrimitiveKt.eventGroupKey {
-                this.cmmsMeasurementConsumerId = cmmsMeasurementConsumerId
                 cmmsDataProviderId = "1235"
                 cmmsEventGroupId = cmmsMeasurementConsumerId + "123"
               }

--- a/src/main/kotlin/org/wfanet/measurement/reporting/service/internal/testing/v2/ReportingSetsServiceTest.kt
+++ b/src/main/kotlin/org/wfanet/measurement/reporting/service/internal/testing/v2/ReportingSetsServiceTest.kt
@@ -83,14 +83,12 @@ abstract class ReportingSetsServiceTest<T : ReportingSetsCoroutineImplBase> {
         ReportingSetKt.primitive {
           eventGroupKeys +=
             ReportingSetKt.PrimitiveKt.eventGroupKey {
-              cmmsMeasurementConsumerId = CMMS_MEASUREMENT_CONSUMER_ID
               cmmsDataProviderId = "1235"
               cmmsEventGroupId = "1236"
             }
 
           eventGroupKeys +=
             ReportingSetKt.PrimitiveKt.eventGroupKey {
-              cmmsMeasurementConsumerId = CMMS_MEASUREMENT_CONSUMER_ID
               cmmsDataProviderId = "2235"
               cmmsEventGroupId = "2236"
             }
@@ -128,21 +126,18 @@ abstract class ReportingSetsServiceTest<T : ReportingSetsCoroutineImplBase> {
         ReportingSetKt.primitive {
           eventGroupKeys +=
             ReportingSetKt.PrimitiveKt.eventGroupKey {
-              cmmsMeasurementConsumerId = CMMS_MEASUREMENT_CONSUMER_ID
               cmmsDataProviderId = "1235"
               cmmsEventGroupId = "1236"
             }
 
           eventGroupKeys +=
             ReportingSetKt.PrimitiveKt.eventGroupKey {
-              cmmsMeasurementConsumerId = CMMS_MEASUREMENT_CONSUMER_ID
               cmmsDataProviderId = "1235"
               cmmsEventGroupId = "1236"
             }
 
           eventGroupKeys +=
             ReportingSetKt.PrimitiveKt.eventGroupKey {
-              cmmsMeasurementConsumerId = CMMS_MEASUREMENT_CONSUMER_ID
               cmmsDataProviderId = "2235"
               cmmsEventGroupId = "2236"
             }
@@ -180,7 +175,6 @@ abstract class ReportingSetsServiceTest<T : ReportingSetsCoroutineImplBase> {
         ReportingSetKt.primitive {
           eventGroupKeys +=
             ReportingSetKt.PrimitiveKt.eventGroupKey {
-              cmmsMeasurementConsumerId = CMMS_MEASUREMENT_CONSUMER_ID
               cmmsDataProviderId = "1235"
               cmmsEventGroupId = "1236"
             }
@@ -196,7 +190,6 @@ abstract class ReportingSetsServiceTest<T : ReportingSetsCoroutineImplBase> {
         ReportingSetKt.primitive {
           eventGroupKeys +=
             ReportingSetKt.PrimitiveKt.eventGroupKey {
-              cmmsMeasurementConsumerId = CMMS_MEASUREMENT_CONSUMER_ID
               cmmsDataProviderId = "1235"
               cmmsEventGroupId = "1236"
             }
@@ -224,7 +217,6 @@ abstract class ReportingSetsServiceTest<T : ReportingSetsCoroutineImplBase> {
         ReportingSetKt.primitive {
           eventGroupKeys +=
             ReportingSetKt.PrimitiveKt.eventGroupKey {
-              cmmsMeasurementConsumerId = CMMS_MEASUREMENT_CONSUMER_ID
               cmmsDataProviderId = "1235"
               cmmsEventGroupId = "1236"
             }
@@ -321,7 +313,6 @@ abstract class ReportingSetsServiceTest<T : ReportingSetsCoroutineImplBase> {
         ReportingSetKt.primitive {
           eventGroupKeys +=
             ReportingSetKt.PrimitiveKt.eventGroupKey {
-              cmmsMeasurementConsumerId = CMMS_MEASUREMENT_CONSUMER_ID
               cmmsDataProviderId = "1235"
               cmmsEventGroupId = "1236"
             }
@@ -463,14 +454,12 @@ abstract class ReportingSetsServiceTest<T : ReportingSetsCoroutineImplBase> {
         ReportingSetKt.primitive {
           eventGroupKeys +=
             ReportingSetKt.PrimitiveKt.eventGroupKey {
-              cmmsMeasurementConsumerId = CMMS_MEASUREMENT_CONSUMER_ID
               cmmsDataProviderId = "1235"
               cmmsEventGroupId = "1236"
             }
 
           eventGroupKeys +=
             ReportingSetKt.PrimitiveKt.eventGroupKey {
-              cmmsMeasurementConsumerId = CMMS_MEASUREMENT_CONSUMER_ID
               cmmsDataProviderId = "2235"
               cmmsEventGroupId = "2236"
             }
@@ -507,7 +496,6 @@ abstract class ReportingSetsServiceTest<T : ReportingSetsCoroutineImplBase> {
         ReportingSetKt.primitive {
           eventGroupKeys +=
             ReportingSetKt.PrimitiveKt.eventGroupKey {
-              cmmsMeasurementConsumerId = CMMS_MEASUREMENT_CONSUMER_ID
               cmmsDataProviderId = "1235"
               cmmsEventGroupId = "1236"
             }
@@ -616,7 +604,6 @@ abstract class ReportingSetsServiceTest<T : ReportingSetsCoroutineImplBase> {
         ReportingSetKt.primitive {
           eventGroupKeys +=
             ReportingSetKt.PrimitiveKt.eventGroupKey {
-              cmmsMeasurementConsumerId = CMMS_MEASUREMENT_CONSUMER_ID
               cmmsDataProviderId = "1235"
               cmmsEventGroupId = "1236"
             }
@@ -678,7 +665,6 @@ abstract class ReportingSetsServiceTest<T : ReportingSetsCoroutineImplBase> {
         ReportingSetKt.primitive {
           eventGroupKeys +=
             ReportingSetKt.PrimitiveKt.eventGroupKey {
-              cmmsMeasurementConsumerId = CMMS_MEASUREMENT_CONSUMER_ID
               cmmsDataProviderId = "1235"
               cmmsEventGroupId = "1236"
             }
@@ -824,14 +810,12 @@ abstract class ReportingSetsServiceTest<T : ReportingSetsCoroutineImplBase> {
         ReportingSetKt.primitive {
           eventGroupKeys +=
             ReportingSetKt.PrimitiveKt.eventGroupKey {
-              cmmsMeasurementConsumerId = CMMS_MEASUREMENT_CONSUMER_ID
               cmmsDataProviderId = "1235"
               cmmsEventGroupId = "1236"
             }
 
           eventGroupKeys +=
             ReportingSetKt.PrimitiveKt.eventGroupKey {
-              cmmsMeasurementConsumerId = CMMS_MEASUREMENT_CONSUMER_ID
               cmmsDataProviderId = "2235"
               cmmsEventGroupId = "2236"
             }
@@ -883,7 +867,6 @@ abstract class ReportingSetsServiceTest<T : ReportingSetsCoroutineImplBase> {
         ReportingSetKt.primitive {
           eventGroupKeys +=
             ReportingSetKt.PrimitiveKt.eventGroupKey {
-              cmmsMeasurementConsumerId = CMMS_MEASUREMENT_CONSUMER_ID
               cmmsDataProviderId = "1235"
               cmmsEventGroupId = "1236"
             }
@@ -997,7 +980,6 @@ abstract class ReportingSetsServiceTest<T : ReportingSetsCoroutineImplBase> {
           ReportingSetKt.primitive {
             eventGroupKeys +=
               ReportingSetKt.PrimitiveKt.eventGroupKey {
-                cmmsMeasurementConsumerId = CMMS_MEASUREMENT_CONSUMER_ID
                 cmmsDataProviderId = "1235"
                 cmmsEventGroupId = "1236"
               }
@@ -1125,7 +1107,6 @@ abstract class ReportingSetsServiceTest<T : ReportingSetsCoroutineImplBase> {
         ReportingSetKt.primitive {
           eventGroupKeys +=
             ReportingSetKt.PrimitiveKt.eventGroupKey {
-              cmmsMeasurementConsumerId = CMMS_MEASUREMENT_CONSUMER_ID
               cmmsDataProviderId = "1235"
               cmmsEventGroupId = "1236"
             }
@@ -1201,7 +1182,6 @@ abstract class ReportingSetsServiceTest<T : ReportingSetsCoroutineImplBase> {
           ReportingSetKt.primitive {
             eventGroupKeys +=
               ReportingSetKt.PrimitiveKt.eventGroupKey {
-                cmmsMeasurementConsumerId = CMMS_MEASUREMENT_CONSUMER_ID
                 cmmsDataProviderId = "1235"
                 cmmsEventGroupId = "1236"
               }
@@ -1244,7 +1224,6 @@ abstract class ReportingSetsServiceTest<T : ReportingSetsCoroutineImplBase> {
         ReportingSetKt.primitive {
           eventGroupKeys +=
             ReportingSetKt.PrimitiveKt.eventGroupKey {
-              cmmsMeasurementConsumerId = CMMS_MEASUREMENT_CONSUMER_ID
               cmmsDataProviderId = "1235"
               cmmsEventGroupId = "1236"
             }
@@ -1307,7 +1286,6 @@ abstract class ReportingSetsServiceTest<T : ReportingSetsCoroutineImplBase> {
         ReportingSetKt.primitive {
           eventGroupKeys +=
             ReportingSetKt.PrimitiveKt.eventGroupKey {
-              cmmsMeasurementConsumerId = CMMS_MEASUREMENT_CONSUMER_ID
               cmmsDataProviderId = "1235"
               cmmsEventGroupId = "1236"
             }
@@ -1323,7 +1301,6 @@ abstract class ReportingSetsServiceTest<T : ReportingSetsCoroutineImplBase> {
         ReportingSetKt.primitive {
           eventGroupKeys +=
             ReportingSetKt.PrimitiveKt.eventGroupKey {
-              cmmsMeasurementConsumerId = CMMS_MEASUREMENT_CONSUMER_ID
               cmmsDataProviderId = "1235"
               cmmsEventGroupId = "1237"
             }
@@ -1378,14 +1355,12 @@ abstract class ReportingSetsServiceTest<T : ReportingSetsCoroutineImplBase> {
         ReportingSetKt.primitive {
           eventGroupKeys +=
             ReportingSetKt.PrimitiveKt.eventGroupKey {
-              cmmsMeasurementConsumerId = CMMS_MEASUREMENT_CONSUMER_ID
               cmmsDataProviderId = "1235"
               cmmsEventGroupId = "1236"
             }
 
           eventGroupKeys +=
             ReportingSetKt.PrimitiveKt.eventGroupKey {
-              cmmsMeasurementConsumerId = CMMS_MEASUREMENT_CONSUMER_ID
               cmmsDataProviderId = "2235"
               cmmsEventGroupId = "2236"
             }
@@ -1401,14 +1376,12 @@ abstract class ReportingSetsServiceTest<T : ReportingSetsCoroutineImplBase> {
         ReportingSetKt.primitive {
           eventGroupKeys +=
             ReportingSetKt.PrimitiveKt.eventGroupKey {
-              cmmsMeasurementConsumerId = CMMS_MEASUREMENT_CONSUMER_ID
               cmmsDataProviderId = "1235"
               cmmsEventGroupId = "1236"
             }
 
           eventGroupKeys +=
             ReportingSetKt.PrimitiveKt.eventGroupKey {
-              cmmsMeasurementConsumerId = CMMS_MEASUREMENT_CONSUMER_ID
               cmmsDataProviderId = "2235"
               cmmsEventGroupId = "2236"
             }
@@ -1486,14 +1459,12 @@ abstract class ReportingSetsServiceTest<T : ReportingSetsCoroutineImplBase> {
         ReportingSetKt.primitive {
           eventGroupKeys +=
             ReportingSetKt.PrimitiveKt.eventGroupKey {
-              cmmsMeasurementConsumerId = CMMS_MEASUREMENT_CONSUMER_ID
               cmmsDataProviderId = "1235"
               cmmsEventGroupId = "1236"
             }
 
           eventGroupKeys +=
             ReportingSetKt.PrimitiveKt.eventGroupKey {
-              cmmsMeasurementConsumerId = CMMS_MEASUREMENT_CONSUMER_ID
               cmmsDataProviderId = "2235"
               cmmsEventGroupId = "2236"
             }
@@ -1509,14 +1480,12 @@ abstract class ReportingSetsServiceTest<T : ReportingSetsCoroutineImplBase> {
         ReportingSetKt.primitive {
           eventGroupKeys +=
             ReportingSetKt.PrimitiveKt.eventGroupKey {
-              cmmsMeasurementConsumerId = CMMS_MEASUREMENT_CONSUMER_ID
               cmmsDataProviderId = "1235"
               cmmsEventGroupId = "1236"
             }
 
           eventGroupKeys +=
             ReportingSetKt.PrimitiveKt.eventGroupKey {
-              cmmsMeasurementConsumerId = CMMS_MEASUREMENT_CONSUMER_ID
               cmmsDataProviderId = "2235"
               cmmsEventGroupId = "2236"
             }

--- a/src/main/kotlin/org/wfanet/measurement/reporting/service/internal/testing/v2/ReportsServiceTest.kt
+++ b/src/main/kotlin/org/wfanet/measurement/reporting/service/internal/testing/v2/ReportsServiceTest.kt
@@ -1339,7 +1339,6 @@ abstract class ReportsServiceTest<T : ReportsGrpcKt.ReportsCoroutineImplBase> {
           ReportingSetKt.primitive {
             eventGroupKeys +=
               ReportingSetKt.PrimitiveKt.eventGroupKey {
-                this.cmmsMeasurementConsumerId = cmmsMeasurementConsumerId
                 cmmsDataProviderId = "1235"
                 cmmsEventGroupId = cmmsMeasurementConsumerId + "123"
               }

--- a/src/main/proto/wfa/measurement/internal/reporting/v2/reporting_set.proto
+++ b/src/main/proto/wfa/measurement/internal/reporting/v2/reporting_set.proto
@@ -30,12 +30,10 @@ message ReportingSet {
 
   message Primitive {
     message EventGroupKey {
-      // `MeasurementConsumer` ID from the CMMS public API.
-      string cmms_measurement_consumer_id = 1;
       // `DataProvider` ID from the CMMS public API.
-      string cmms_data_provider_id = 2;
+      string cmms_data_provider_id = 1;
       // `EventGroup` ID from the CMMS public API.
-      string cmms_event_group_id = 3;
+      string cmms_event_group_id = 2;
     }
     repeated EventGroupKey event_group_keys = 1;
   }

--- a/src/main/proto/wfa/measurement/reporting/v2alpha/event_group.proto
+++ b/src/main/proto/wfa/measurement/reporting/v2alpha/event_group.proto
@@ -29,25 +29,27 @@ option java_outer_classname = "EventGroupProto";
 message EventGroup {
   option (google.api.resource) = {
     type: "reporting.halo-cmm.org/EventGroup"
-    pattern: "measurementConsumers/{measurement_consumer}/dataProviders/{data_provider}/eventGroups/{event_group}"
+    pattern: "measurementConsumers/{measurement_consumer}/eventGroups/{event_group}"
   };
 
   // Resource name.
   string name = 1;
 
-  // Kingdom resource name of the `DataProvider` associated with this
-  // `EventGroup`.
-  string data_provider = 2 [
-    (google.api.field_behavior) = IMMUTABLE,
-    (google.api.resource_reference).type = "halo.wfanet.org/DataProvider"
+  // Resource name of the corresponding `EventGroup` in the CMMS API.
+  string cmms_event_group = 2 [
+    (google.api.resource_reference).type = "halo.wfanet.org/EventGroup",
+    (google.api.field_behavior) = OUTPUT_ONLY
+  ];
+
+  // Resource name of the parent `DataProvider` in the CMMS API.
+  string cmms_data_provider = 3 [
+    (google.api.resource_reference).type = "halo.wfanet.org/DataProvider",
+    (google.api.field_behavior) = OUTPUT_ONLY
   ];
 
   // ID referencing the `EventGroup` in an external system, provided by the
   // `DataProvider`.
-  //
-  // If set, this value must be unique among `EventGroup`s for the parent
-  // `DataProvider`.
-  string event_group_reference_id = 3;
+  string event_group_reference_id = 4;
 
   // The template that events associated with this `EventGroup` conform to.
   message EventTemplate {
@@ -59,7 +61,7 @@ message EventGroup {
   }
   // The `EventTemplate`s that events associated with this `EventGroup` conform
   // to.
-  repeated EventTemplate event_templates = 4;
+  repeated EventTemplate event_templates = 5;
 
   // Wrapper for per-EDP Event Group metadata.
   message Metadata {
@@ -73,5 +75,5 @@ message EventGroup {
   }
 
   // The metadata of the event group.
-  Metadata metadata = 5;
+  Metadata metadata = 6;
 }

--- a/src/main/proto/wfa/measurement/reporting/v2alpha/event_groups_service.proto
+++ b/src/main/proto/wfa/measurement/reporting/v2alpha/event_groups_service.proto
@@ -41,11 +41,7 @@ service EventGroups {
 
 // Request message for `ListEventGroups` method.
 message ListEventGroupsRequest {
-  // Resource name of the parent `DataProvider` under a given
-  // `MeasurementConsumer`, in the form
-  // `measurementConsumers/{measurement_consumer}/dataProviders/{data_provider}`.
-  // The wildcard ID (`-`) may be used in place of the `DataProvider` ID to list
-  // across `DataProvider`s, in which case a filter should be specified.
+  // Resource name of the parent `MeasurementConsumer`.
   string parent = 1 [
     (google.api.field_behavior) = REQUIRED,
     (google.api.resource_reference) = {

--- a/src/main/proto/wfa/measurement/reporting/v2alpha/reporting_set.proto
+++ b/src/main/proto/wfa/measurement/reporting/v2alpha/reporting_set.proto
@@ -44,10 +44,9 @@ message ReportingSet {
   //
   // It's the minimum building block of a set expression.
   message Primitive {
-    // Set of EventGroup resource names.
-    repeated string event_groups = 1 [
-      (google.api.resource_reference).type =
-          "reporting.halo-cmm.org/EventGroup",
+    // Set of EventGroup resource names from the CMMS API.
+    repeated string cmms_event_groups = 1 [
+      (google.api.resource_reference).type = "halo.wfanet.org/EventGroup",
       (google.api.field_behavior) = REQUIRED,
       (google.api.field_behavior) = IMMUTABLE
     ];

--- a/src/test/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/ReportsServiceTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/ReportsServiceTest.kt
@@ -2924,7 +2924,7 @@ class ReportsServiceTest {
               .toName()
           filter = "AGE>18"
           displayName = "reporting-set-$index-display-name"
-          primitive = ReportingSetKt.primitive { eventGroups += "event-group-$index" }
+          primitive = ReportingSetKt.primitive { cmmsEventGroups += "event-group-$index" }
         }
       }
 
@@ -3295,8 +3295,6 @@ private val Metric.resourceKey: MetricKey
   get() = MetricKey.fromName(name)!!
 private val Metric.apiId: String
   get() = resourceKey.metricId
-private val Metric.externalId: Long
-  get() = apiIdToExternalId(apiId)
 
 private val InternalReport.resourceKey: ReportKey
   get() = ReportKey(cmmsMeasurementConsumerId, ExternalId(externalReportId).apiId.value)


### PR DESCRIPTION
This takes advantage of the secondary resource pattern for EventGroups in the CMMS API.