### PR TITLE
Fix path to base cue in panel match

### DIFF
--- a/src/main/k8s/panelmatch/BUILD.bazel
+++ b/src/main/k8s/panelmatch/BUILD.bazel
@@ -4,5 +4,5 @@ package(default_visibility = ["//src/main/k8s/panelmatch:__subpackages__"])
 
 cue_library(
     name = "base",
-    srcs = ["panelmatch/base.cue"],
+    srcs = ["base.cue"],
 )


### PR DESCRIPTION
Small fix during other development, file was pointing to a nonexistent location