### PR TITLE
Remove unused dependencies from //src/main/kotlin/org/wfanet/panelmatch/common.

### DIFF
--- a/src/main/kotlin/org/wfanet/panelmatch/client/tools/BUILD.bazel
+++ b/src/main/kotlin/org/wfanet/panelmatch/client/tools/BUILD.bazel
@@ -109,6 +109,7 @@ kt_jvm_library(
         "//src/main/proto/wfa/panelmatch/common/compression:compression_kt_jvm_proto",
         "@wfa_common_jvm//imports/java/com/google/protobuf",
         "@wfa_common_jvm//imports/java/picocli",
+        "@wfa_common_jvm//src/main/kotlin/org/wfanet/measurement/common",
         "@wfa_virtual_people_common//src/main/proto/wfa/virtual_people/common:event_kt_jvm_proto",
     ],
 )

--- a/src/main/kotlin/org/wfanet/panelmatch/common/BUILD.bazel
+++ b/src/main/kotlin/org/wfanet/panelmatch/common/BUILD.bazel
@@ -9,16 +9,8 @@ kt_jvm_library(
     name = "common",
     srcs = glob(["*.kt"]),
     deps = [
-        "//imports/java/org/apache/beam:core",
-        "//src/main/proto/wfa/measurement/api/v2alpha:certificate_kt_jvm_proto",
-        "//src/main/proto/wfa/measurement/api/v2alpha:exchange_workflow_kt_jvm_proto",
         "@wfa_common_jvm//imports/java/com/google/common:guava",
         "@wfa_common_jvm//imports/java/com/google/protobuf",
         "@wfa_common_jvm//imports/kotlin/kotlinx/coroutines:core",
-        "@wfa_common_jvm//src/main/kotlin/org/wfanet/measurement/common",
-        "@wfa_common_jvm//src/main/kotlin/org/wfanet/measurement/common/crypto:signing_certs",
-        "@wfa_measurement_system//src/main/kotlin/org/wfanet/measurement/common/api:resource_key",
-        "@wfa_measurement_system//src/main/proto/wfa/measurement/api/v2alpha:certificates_service_kt_jvm_grpc",
-        "@wfa_measurement_system//src/main/proto/wfa/measurement/api/v2alpha:certificates_service_kt_jvm_proto",
     ],
 )

--- a/src/main/kotlin/org/wfanet/panelmatch/common/certificates/BUILD.bazel
+++ b/src/main/kotlin/org/wfanet/panelmatch/common/certificates/BUILD.bazel
@@ -17,8 +17,7 @@ kt_jvm_library(
         "//src/main/proto/wfa/panelmatch/common/certificates:signing_keys_kt_jvm_proto",
         "@wfa_common_jvm//imports/java/com/google/protobuf",
         "@wfa_common_jvm//imports/kotlin/com/google/protobuf/kotlin",
-        "@wfa_common_jvm//src/main/kotlin/org/wfanet/measurement/common",
+        "@wfa_common_jvm//src/main/kotlin/org/wfanet/measurement/common/crypto:pem_io",
         "@wfa_common_jvm//src/main/kotlin/org/wfanet/measurement/common/crypto:security_provider",
-        "@wfa_common_jvm//src/main/kotlin/org/wfanet/measurement/storage:client",
     ],
 )

--- a/src/main/kotlin/org/wfanet/panelmatch/common/crypto/testing/BUILD.bazel
+++ b/src/main/kotlin/org/wfanet/panelmatch/common/crypto/testing/BUILD.bazel
@@ -8,6 +8,9 @@ package(
 kt_jvm_library(
     name = "testing",
     srcs = glob(["*.kt"]),
+    runtime_deps = [
+        "@wfa_common_jvm//imports/kotlin/kotlin:stdlib_jdk7",
+    ],
     deps = [
         "//src/main/kotlin/org/wfanet/panelmatch/common",
         "//src/main/kotlin/org/wfanet/panelmatch/common/crypto",

--- a/src/main/kotlin/org/wfanet/panelmatch/common/storage/BUILD.bazel
+++ b/src/main/kotlin/org/wfanet/panelmatch/common/storage/BUILD.bazel
@@ -9,6 +9,7 @@ kt_jvm_library(
     name = "storage",
     srcs = glob(["*.kt"]),
     deps = [
+        "//imports/java/org/apache/beam:core",
         "//src/main/kotlin/org/wfanet/panelmatch/common",
         "@wfa_common_jvm//imports/kotlin/kotlinx/coroutines:core",
         "@wfa_common_jvm//src/main/kotlin/org/wfanet/measurement/storage:client",


### PR DESCRIPTION
In general Bazel targets should follow "strict deps", meaning each target includes all dependencies that are used without relying on transitive dependencies. This prevents errors when transitive dependencies change. Eventually this will be enforced by Kotlin rules.

Furthermore, Bazel targets should not include unused deps. This prevents unnecessary rebuilding of targets.