### PR TITLE
Store set operation compilation IDs

### DIFF
--- a/src/main/kotlin/org/wfanet/measurement/reporting/deploy/v2/postgres/readers/MetricReader.kt
+++ b/src/main/kotlin/org/wfanet/measurement/reporting/deploy/v2/postgres/readers/MetricReader.kt
@@ -72,6 +72,7 @@ class MetricReader(private val readContext: ReadContext) {
 
   private data class WeightedMeasurementInfo(
     val weight: Int,
+    val binaryRepresentation: Int,
     val measurementInfo: MeasurementInfo,
   )
 
@@ -113,6 +114,7 @@ class MetricReader(private val readContext: ReadContext) {
       Metrics.CreateTime,
       Metrics.MetricDetails,
       MetricMeasurements.Coefficient,
+      MetricMeasurements.BinaryRepresentation,
       Measurements.MeasurementId,
       Measurements.CmmsCreateMeasurementRequestId,
       Measurements.CmmsMeasurementId,
@@ -321,6 +323,7 @@ class MetricReader(private val readContext: ReadContext) {
         weightedMeasurements +=
           MetricKt.weightedMeasurement {
             weight = it.weight
+            binaryRepresentation = it.binaryRepresentation
             measurement = measurement {
               cmmsMeasurementConsumerId = metricInfo.cmmsMeasurementConsumerId
               if (it.measurementInfo.cmmsMeasurementId != null) {
@@ -375,6 +378,7 @@ class MetricReader(private val readContext: ReadContext) {
       val metricDetails: Metric.Details =
         row.getProtoMessage("MetricDetails", Metric.Details.parser())
       val weight: Int = row["Coefficient"]
+      val binaryRepresentation: Int = row["BinaryRepresentation"]
       val measurementId: InternalId = row["MeasurementId"]
       val cmmsCreateMeasurementRequestId: UUID = row["CmmsCreateMeasurementRequestId"]
       val cmmsMeasurementId: String? = row["CmmsMeasurementId"]
@@ -510,6 +514,7 @@ class MetricReader(private val readContext: ReadContext) {
 
           WeightedMeasurementInfo(
             weight = weight,
+            binaryRepresentation = binaryRepresentation,
             measurementInfo = measurementInfo,
           )
         }

--- a/src/main/kotlin/org/wfanet/measurement/reporting/deploy/v2/postgres/readers/ReportingSetReader.kt
+++ b/src/main/kotlin/org/wfanet/measurement/reporting/deploy/v2/postgres/readers/ReportingSetReader.kt
@@ -71,6 +71,7 @@ class ReportingSetReader(private val readContext: ReadContext) {
 
   private data class WeightedSubsetUnionInfo(
     val weight: Int,
+    val binaryRepresentation: Int,
     // Key is primitiveReportingSetBasisId.
     val primitiveReportingSetBasisInfoMap: MutableMap<InternalId, PrimitiveReportingSetBasisInfo>,
   )
@@ -97,6 +98,7 @@ class ReportingSetReader(private val readContext: ReadContext) {
       ReportingSets.Filter AS ReportingSetFilter,
       WeightedSubsetUnionId,
       WeightedSubsetUnions.Weight,
+      WeightedSubsetUnions.BinaryRepresentation,
       PrimitiveReportingSetBasisId,
       PrimitiveReportingSets.ExternalReportingSetId AS PrimitiveExternalReportingSetId,
       PrimitiveReportingSetBasisFilters.Filter AS PrimitiveReportingSetBasisFilter,
@@ -262,6 +264,7 @@ class ReportingSetReader(private val readContext: ReadContext) {
         weightedSubsetUnions +=
           ReportingSetKt.weightedSubsetUnion {
             weight = 1
+            binaryRepresentation = 1
             primitiveReportingSetBases +=
               ReportingSetKt.primitiveReportingSetBasis {
                 this.externalReportingSetId = reportingSetInfo.externalReportingSetId
@@ -281,6 +284,7 @@ class ReportingSetReader(private val readContext: ReadContext) {
           weightedSubsetUnions +=
             ReportingSetKt.weightedSubsetUnion {
               weight = it.weight
+              binaryRepresentation = it.binaryRepresentation
               it.primitiveReportingSetBasisInfoMap.values.forEach {
                 primitiveReportingSetBases +=
                   ReportingSetKt.primitiveReportingSetBasis {
@@ -309,6 +313,7 @@ class ReportingSetReader(private val readContext: ReadContext) {
       val reportingSetFilter: String? = row["ReportingSetFilter"]
       val weightedSubsetUnionId: InternalId? = row["WeightedSubsetUnionId"]
       val weight: Int? = row["Weight"]
+      val binaryRepresentation: Int? = row["BinaryRepresentation"]
       val primitiveReportingSetBasisId: InternalId? = row["PrimitiveReportingSetBasisId"]
       val primitiveExternalReportingSetId: String? = row["PrimitiveExternalReportingSetId"]
       val primitiveReportingSetBasisFilter: String? = row["PrimitiveReportingSetBasisFilter"]
@@ -361,6 +366,7 @@ class ReportingSetReader(private val readContext: ReadContext) {
       if (
         weightedSubsetUnionId != null &&
           weight != null &&
+          binaryRepresentation != null &&
           primitiveReportingSetBasisId != null &&
           primitiveExternalReportingSetId != null
       ) {
@@ -368,6 +374,7 @@ class ReportingSetReader(private val readContext: ReadContext) {
           reportingSetInfo.weightedSubsetUnionInfoMap.computeIfAbsent(weightedSubsetUnionId) {
             WeightedSubsetUnionInfo(
               weight = weight,
+              binaryRepresentation = binaryRepresentation,
               primitiveReportingSetBasisInfoMap = mutableMapOf(),
             )
           }

--- a/src/main/kotlin/org/wfanet/measurement/reporting/deploy/v2/postgres/writers/CreateMetrics.kt
+++ b/src/main/kotlin/org/wfanet/measurement/reporting/deploy/v2/postgres/writers/CreateMetrics.kt
@@ -337,9 +337,10 @@ class CreateMetrics(private val requests: List<CreateMetricRequest>) :
           MeasurementConsumerId,
           MetricId,
           MeasurementId,
-          Coefficient
+          Coefficient,
+          BinaryRepresentation
         )
-        VALUES ($1, $2, $3, $4)
+        VALUES ($1, $2, $3, $4, $5)
       """
       ) {
         metricMeasurementsBinders.forEach { addBinding(it) }
@@ -449,6 +450,7 @@ class CreateMetrics(private val requests: List<CreateMetricRequest>) :
         bind("$2", metricId)
         bind("$3", measurementId)
         bind("$4", it.weight)
+        bind("$5", it.binaryRepresentation)
       }
 
       val primitiveReportingSetBasesBindings =

--- a/src/main/kotlin/org/wfanet/measurement/reporting/deploy/v2/postgres/writers/CreateReportingSet.kt
+++ b/src/main/kotlin/org/wfanet/measurement/reporting/deploy/v2/postgres/writers/CreateReportingSet.kt
@@ -161,6 +161,7 @@ class CreateReportingSet(private val request: CreateReportingSetRequest) :
         weightedSubsetUnions +=
           ReportingSetKt.weightedSubsetUnion {
             weight = 1
+            binaryRepresentation = 1
             primitiveReportingSetBases +=
               ReportingSetKt.primitiveReportingSetBasis {
                 this.externalReportingSetId = externalReportingSetId
@@ -392,6 +393,7 @@ class CreateReportingSet(private val request: CreateReportingSetRequest) :
         bind("$2", reportingSetId)
         bind("$3", weightedSubsetUnionId)
         bind("$4", weightedSubsetUnion.weight)
+        bind("$5", weightedSubsetUnion.binaryRepresentation)
       }
 
       weightedSubsetUnion.primitiveReportingSetBasesList.forEach {
@@ -416,8 +418,8 @@ class CreateReportingSet(private val request: CreateReportingSetRequest) :
     val weightedSubsetUnionsStatement =
       boundStatement(
         """
-        INSERT INTO WeightedSubsetUnions (MeasurementConsumerId, ReportingSetId, WeightedSubsetUnionId, Weight)
-        VALUES ($1, $2, $3, $4)
+        INSERT INTO WeightedSubsetUnions (MeasurementConsumerId, ReportingSetId, WeightedSubsetUnionId, Weight, BinaryRepresentation)
+        VALUES ($1, $2, $3, $4, $5)
         """
       ) {
         weightedSubsetUnionsBinders.forEach { addBinding(it) }

--- a/src/main/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/MetricsService.kt
+++ b/src/main/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/MetricsService.kt
@@ -1391,6 +1391,7 @@ class MetricsService(
     return internalReportingSet.weightedSubsetUnionsList.map { weightedSubsetUnion ->
       weightedMeasurement {
         weight = weightedSubsetUnion.weight
+        binaryRepresentation = weightedSubsetUnion.binaryRepresentation
         measurement = internalMeasurement {
           this.cmmsMeasurementConsumerId = cmmsMeasurementConsumerId
           timeInterval = metric.timeInterval

--- a/src/main/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/ReportingSetsService.kt
+++ b/src/main/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/ReportingSetsService.kt
@@ -151,7 +151,6 @@ class ReportingSetsService(private val internalReportingSetsStub: ReportingSetsC
     idToPrimitiveReportingSetBasis: Map<Int, PrimitiveReportingSetBasis>,
   ): InternalReportingSet.WeightedSubsetUnion {
     return InternalReportingSetKt.weightedSubsetUnion {
-      weight = weightedSubsetUnion.coefficient
       primitiveReportingSetBases +=
         weightedSubsetUnion.reportingSetIds.map { reportingSetId ->
           InternalReportingSetKt.primitiveReportingSetBasis {
@@ -160,6 +159,8 @@ class ReportingSetsService(private val internalReportingSetsStub: ReportingSetsC
             filters += primitiveReportingSetBasis.filters.toList()
           }
         }
+      weight = weightedSubsetUnion.coefficient
+      binaryRepresentation = weightedSubsetUnion.reportingSetIds.sumOf { 1 shl it }
     }
   }
 

--- a/src/main/kotlin/org/wfanet/measurement/reporting/service/internal/testing/v2/MetricsServiceTest.kt
+++ b/src/main/kotlin/org/wfanet/measurement/reporting/service/internal/testing/v2/MetricsServiceTest.kt
@@ -114,6 +114,7 @@ abstract class MetricsServiceTest<T : MetricsCoroutineImplBase> {
       weightedMeasurements +=
         MetricKt.weightedMeasurement {
           weight = 2
+          binaryRepresentation = 1
           measurement = measurement {
             cmmsMeasurementConsumerId = CMMS_MEASUREMENT_CONSUMER_ID
             timeInterval = interval {
@@ -137,6 +138,7 @@ abstract class MetricsServiceTest<T : MetricsCoroutineImplBase> {
       weightedMeasurements +=
         MetricKt.weightedMeasurement {
           weight = 3
+          binaryRepresentation = 2
           measurement = measurement {
             cmmsMeasurementConsumerId = CMMS_MEASUREMENT_CONSUMER_ID
             timeInterval = interval {
@@ -215,6 +217,7 @@ abstract class MetricsServiceTest<T : MetricsCoroutineImplBase> {
       weightedMeasurements +=
         MetricKt.weightedMeasurement {
           weight = 2
+          binaryRepresentation = 1
           measurement = measurement {
             cmmsMeasurementConsumerId = CMMS_MEASUREMENT_CONSUMER_ID
             timeInterval = interval {
@@ -238,6 +241,7 @@ abstract class MetricsServiceTest<T : MetricsCoroutineImplBase> {
       weightedMeasurements +=
         MetricKt.weightedMeasurement {
           weight = 3
+          binaryRepresentation = 2
           measurement = measurement {
             cmmsMeasurementConsumerId = CMMS_MEASUREMENT_CONSUMER_ID
             timeInterval = interval {
@@ -311,6 +315,7 @@ abstract class MetricsServiceTest<T : MetricsCoroutineImplBase> {
       weightedMeasurements +=
         MetricKt.weightedMeasurement {
           weight = 2
+          binaryRepresentation = 1
           measurement = measurement {
             cmmsMeasurementConsumerId = CMMS_MEASUREMENT_CONSUMER_ID
             timeInterval = interval {
@@ -334,6 +339,7 @@ abstract class MetricsServiceTest<T : MetricsCoroutineImplBase> {
       weightedMeasurements +=
         MetricKt.weightedMeasurement {
           weight = 3
+          binaryRepresentation = 2
           measurement = measurement {
             cmmsMeasurementConsumerId = CMMS_MEASUREMENT_CONSUMER_ID
             timeInterval = interval {
@@ -407,6 +413,7 @@ abstract class MetricsServiceTest<T : MetricsCoroutineImplBase> {
       weightedMeasurements +=
         MetricKt.weightedMeasurement {
           weight = 2
+          binaryRepresentation = 1
           measurement = measurement {
             cmmsMeasurementConsumerId = CMMS_MEASUREMENT_CONSUMER_ID
             timeInterval = interval {
@@ -430,6 +437,7 @@ abstract class MetricsServiceTest<T : MetricsCoroutineImplBase> {
       weightedMeasurements +=
         MetricKt.weightedMeasurement {
           weight = 3
+          binaryRepresentation = 2
           measurement = measurement {
             cmmsMeasurementConsumerId = CMMS_MEASUREMENT_CONSUMER_ID
             timeInterval = interval {
@@ -503,6 +511,7 @@ abstract class MetricsServiceTest<T : MetricsCoroutineImplBase> {
       weightedMeasurements +=
         MetricKt.weightedMeasurement {
           weight = 2
+          binaryRepresentation = 1
           measurement = measurement {
             cmmsMeasurementConsumerId = CMMS_MEASUREMENT_CONSUMER_ID
             timeInterval = interval {
@@ -573,6 +582,7 @@ abstract class MetricsServiceTest<T : MetricsCoroutineImplBase> {
       weightedMeasurements +=
         MetricKt.weightedMeasurement {
           weight = 2
+          binaryRepresentation = 1
           measurement = measurement {
             cmmsMeasurementConsumerId = CMMS_MEASUREMENT_CONSUMER_ID
             timeInterval = interval {
@@ -596,6 +606,7 @@ abstract class MetricsServiceTest<T : MetricsCoroutineImplBase> {
       weightedMeasurements +=
         MetricKt.weightedMeasurement {
           weight = 3
+          binaryRepresentation = 2
           measurement = measurement {
             cmmsMeasurementConsumerId = CMMS_MEASUREMENT_CONSUMER_ID
             timeInterval = interval {
@@ -684,6 +695,7 @@ abstract class MetricsServiceTest<T : MetricsCoroutineImplBase> {
         weightedMeasurements +=
           MetricKt.weightedMeasurement {
             weight = 2
+            binaryRepresentation = 1
             measurement = measurement {
               cmmsMeasurementConsumerId = CMMS_MEASUREMENT_CONSUMER_ID
               timeInterval = interval {
@@ -707,6 +719,7 @@ abstract class MetricsServiceTest<T : MetricsCoroutineImplBase> {
         weightedMeasurements +=
           MetricKt.weightedMeasurement {
             weight = 3
+            binaryRepresentation = 2
             measurement = measurement {
               cmmsMeasurementConsumerId = CMMS_MEASUREMENT_CONSUMER_ID
               timeInterval = interval {
@@ -794,6 +807,7 @@ abstract class MetricsServiceTest<T : MetricsCoroutineImplBase> {
       weightedMeasurements +=
         MetricKt.weightedMeasurement {
           weight = 2
+          binaryRepresentation = 1
           measurement = measurement {
             cmmsMeasurementConsumerId = CMMS_MEASUREMENT_CONSUMER_ID
             timeInterval = interval {
@@ -865,6 +879,7 @@ abstract class MetricsServiceTest<T : MetricsCoroutineImplBase> {
       weightedMeasurements +=
         MetricKt.weightedMeasurement {
           weight = 2
+          binaryRepresentation = 1
           measurement = measurement {
             cmmsMeasurementConsumerId = CMMS_MEASUREMENT_CONSUMER_ID
             timeInterval = interval {
@@ -939,6 +954,7 @@ abstract class MetricsServiceTest<T : MetricsCoroutineImplBase> {
       weightedMeasurements +=
         MetricKt.weightedMeasurement {
           weight = 2
+          binaryRepresentation = 1
           measurement = measurement {
             cmmsMeasurementConsumerId = CMMS_MEASUREMENT_CONSUMER_ID
             timeInterval = interval {
@@ -996,6 +1012,7 @@ abstract class MetricsServiceTest<T : MetricsCoroutineImplBase> {
       weightedMeasurements +=
         MetricKt.weightedMeasurement {
           weight = 2
+          binaryRepresentation = 1
           measurement = measurement {
             cmmsMeasurementConsumerId = CMMS_MEASUREMENT_CONSUMER_ID
             timeInterval = interval {
@@ -1058,6 +1075,7 @@ abstract class MetricsServiceTest<T : MetricsCoroutineImplBase> {
         weightedMeasurements +=
           MetricKt.weightedMeasurement {
             weight = 2
+            binaryRepresentation = 1
             measurement = measurement {
               cmmsMeasurementConsumerId = CMMS_MEASUREMENT_CONSUMER_ID
               timeInterval = interval {
@@ -1179,6 +1197,7 @@ abstract class MetricsServiceTest<T : MetricsCoroutineImplBase> {
       weightedMeasurements +=
         MetricKt.weightedMeasurement {
           weight = 2
+          binaryRepresentation = 1
           measurement = measurement {
             cmmsMeasurementConsumerId = CMMS_MEASUREMENT_CONSUMER_ID
             timeInterval = interval {
@@ -1250,6 +1269,7 @@ abstract class MetricsServiceTest<T : MetricsCoroutineImplBase> {
       weightedMeasurements +=
         MetricKt.weightedMeasurement {
           weight = 2
+          binaryRepresentation = 1
           measurement = measurement {
             cmmsMeasurementConsumerId = CMMS_MEASUREMENT_CONSUMER_ID
             timeInterval = interval {
@@ -1327,6 +1347,7 @@ abstract class MetricsServiceTest<T : MetricsCoroutineImplBase> {
       weightedMeasurements +=
         MetricKt.weightedMeasurement {
           weight = 2
+          binaryRepresentation = 1
           measurement = measurement {
             cmmsMeasurementConsumerId = CMMS_MEASUREMENT_CONSUMER_ID
             timeInterval = interval {
@@ -1415,6 +1436,7 @@ abstract class MetricsServiceTest<T : MetricsCoroutineImplBase> {
         weightedMeasurements +=
           MetricKt.weightedMeasurement {
             weight = 2
+            binaryRepresentation = 1
             measurement = measurement {
               cmmsMeasurementConsumerId = CMMS_MEASUREMENT_CONSUMER_ID
               timeInterval = interval {
@@ -1512,6 +1534,7 @@ abstract class MetricsServiceTest<T : MetricsCoroutineImplBase> {
         weightedMeasurements +=
           MetricKt.weightedMeasurement {
             weight = 2
+            binaryRepresentation = 1
             measurement = measurement {
               cmmsMeasurementConsumerId = CMMS_MEASUREMENT_CONSUMER_ID
               timeInterval = interval {
@@ -1602,6 +1625,7 @@ abstract class MetricsServiceTest<T : MetricsCoroutineImplBase> {
         weightedMeasurements +=
           MetricKt.weightedMeasurement {
             weight = 2
+            binaryRepresentation = 1
             measurement = measurement {
               cmmsMeasurementConsumerId = CMMS_MEASUREMENT_CONSUMER_ID
               timeInterval = interval {
@@ -1681,6 +1705,7 @@ abstract class MetricsServiceTest<T : MetricsCoroutineImplBase> {
         weightedMeasurements +=
           MetricKt.weightedMeasurement {
             weight = 2
+            binaryRepresentation = 1
             measurement = measurement {
               cmmsMeasurementConsumerId = CMMS_MEASUREMENT_CONSUMER_ID
               timeInterval = interval {
@@ -1759,6 +1784,7 @@ abstract class MetricsServiceTest<T : MetricsCoroutineImplBase> {
       weightedMeasurements +=
         MetricKt.weightedMeasurement {
           weight = 2
+          binaryRepresentation = 1
           measurement = measurement {
             cmmsMeasurementConsumerId = CMMS_MEASUREMENT_CONSUMER_ID
             timeInterval = interval {
@@ -1839,6 +1865,7 @@ abstract class MetricsServiceTest<T : MetricsCoroutineImplBase> {
         weightedMeasurements +=
           MetricKt.weightedMeasurement {
             weight = 2
+            binaryRepresentation = 1
             measurement = measurement {
               cmmsMeasurementConsumerId = CMMS_MEASUREMENT_CONSUMER_ID
               timeInterval = interval {
@@ -1920,6 +1947,7 @@ abstract class MetricsServiceTest<T : MetricsCoroutineImplBase> {
         weightedMeasurements +=
           MetricKt.weightedMeasurement {
             weight = 2
+            binaryRepresentation = 1
             measurement = measurement {
               cmmsMeasurementConsumerId = CMMS_MEASUREMENT_CONSUMER_ID
               timeInterval = interval {
@@ -2000,6 +2028,7 @@ abstract class MetricsServiceTest<T : MetricsCoroutineImplBase> {
         weightedMeasurements +=
           MetricKt.weightedMeasurement {
             weight = 2
+            binaryRepresentation = 1
             measurement = measurement {
               cmmsMeasurementConsumerId = CMMS_MEASUREMENT_CONSUMER_ID
               timeInterval = interval {
@@ -2079,6 +2108,7 @@ abstract class MetricsServiceTest<T : MetricsCoroutineImplBase> {
       weightedMeasurements +=
         MetricKt.weightedMeasurement {
           weight = 2
+          binaryRepresentation = 1
           measurement = measurement {
             cmmsMeasurementConsumerId = CMMS_MEASUREMENT_CONSUMER_ID
             timeInterval = interval {
@@ -2340,6 +2370,7 @@ abstract class MetricsServiceTest<T : MetricsCoroutineImplBase> {
             weightedMeasurements +=
               MetricKt.weightedMeasurement {
                 weight = 2
+                binaryRepresentation = 1
                 measurement = measurement {
                   cmmsMeasurementConsumerId = CMMS_MEASUREMENT_CONSUMER_ID
                   timeInterval = interval {
@@ -2654,6 +2685,7 @@ abstract class MetricsServiceTest<T : MetricsCoroutineImplBase> {
         weightedMeasurements +=
           MetricKt.weightedMeasurement {
             weight = 2
+            binaryRepresentation = 1
             measurement = measurement {
               this.cmmsMeasurementConsumerId = cmmsMeasurementConsumerId
               timeInterval = interval {
@@ -2677,6 +2709,7 @@ abstract class MetricsServiceTest<T : MetricsCoroutineImplBase> {
         weightedMeasurements +=
           MetricKt.weightedMeasurement {
             weight = 3
+            binaryRepresentation = 2
             measurement = measurement {
               this.cmmsMeasurementConsumerId = cmmsMeasurementConsumerId
               timeInterval = interval {

--- a/src/main/kotlin/org/wfanet/measurement/reporting/service/internal/testing/v2/ReportingSetsServiceTest.kt
+++ b/src/main/kotlin/org/wfanet/measurement/reporting/service/internal/testing/v2/ReportingSetsServiceTest.kt
@@ -108,6 +108,7 @@ abstract class ReportingSetsServiceTest<T : ReportingSetsCoroutineImplBase> {
       .containsExactly(
         ReportingSetKt.weightedSubsetUnion {
           weight = 1
+          binaryRepresentation = 1
           primitiveReportingSetBases +=
             ReportingSetKt.primitiveReportingSetBasis {
               this.externalReportingSetId = createdReportingSet.externalReportingSetId
@@ -163,6 +164,7 @@ abstract class ReportingSetsServiceTest<T : ReportingSetsCoroutineImplBase> {
       .containsExactly(
         ReportingSetKt.weightedSubsetUnion {
           weight = 1
+          binaryRepresentation = 1
           primitiveReportingSetBases +=
             ReportingSetKt.primitiveReportingSetBasis {
               this.externalReportingSetId = createdReportingSet.externalReportingSetId
@@ -302,6 +304,7 @@ abstract class ReportingSetsServiceTest<T : ReportingSetsCoroutineImplBase> {
               filters += "filter1"
               filters += "filter2"
             }
+          binaryRepresentation = 1
           weight = 5
         }
 
@@ -319,6 +322,7 @@ abstract class ReportingSetsServiceTest<T : ReportingSetsCoroutineImplBase> {
               filters += "filter1"
               filters += "filter2"
             }
+          binaryRepresentation = 1
           weight = 6
         }
     }
@@ -538,6 +542,7 @@ abstract class ReportingSetsServiceTest<T : ReportingSetsCoroutineImplBase> {
       .containsExactly(
         ReportingSetKt.weightedSubsetUnion {
           weight = 1
+          binaryRepresentation = 1
           primitiveReportingSetBases +=
             ReportingSetKt.primitiveReportingSetBasis {
               this.externalReportingSetId = createdReportingSet.externalReportingSetId
@@ -1049,6 +1054,7 @@ abstract class ReportingSetsServiceTest<T : ReportingSetsCoroutineImplBase> {
           weightedSubsetUnions +=
             ReportingSetKt.weightedSubsetUnion {
               weight = 1
+              binaryRepresentation = 1
               primitiveReportingSetBases +=
                 ReportingSetKt.primitiveReportingSetBasis {
                   this.externalReportingSetId = createdReportingSet.externalReportingSetId
@@ -1311,6 +1317,7 @@ abstract class ReportingSetsServiceTest<T : ReportingSetsCoroutineImplBase> {
             weightedSubsetUnions +=
               ReportingSetKt.weightedSubsetUnion {
                 weight = 1
+                binaryRepresentation = 1
                 primitiveReportingSetBases +=
                   ReportingSetKt.primitiveReportingSetBasis {
                     this.externalReportingSetId =
@@ -1596,6 +1603,7 @@ abstract class ReportingSetsServiceTest<T : ReportingSetsCoroutineImplBase> {
           weightedSubsetUnions +=
             ReportingSetKt.weightedSubsetUnion {
               weight = 1
+              binaryRepresentation = 1
               primitiveReportingSetBases +=
                 ReportingSetKt.primitiveReportingSetBasis {
                   this.externalReportingSetId = createdReportingSet.externalReportingSetId

--- a/src/main/proto/wfa/measurement/internal/reporting/v2/metric.proto
+++ b/src/main/proto/wfa/measurement/internal/reporting/v2/metric.proto
@@ -78,7 +78,8 @@ message Metric {
 
   message WeightedMeasurement {
     int32 weight = 1;
-    Measurement measurement = 2;
+    int32 binary_representation = 2;
+    Measurement measurement = 3;
   }
   repeated WeightedMeasurement weighted_measurements = 7;
 

--- a/src/main/proto/wfa/measurement/internal/reporting/v2/reporting_set.proto
+++ b/src/main/proto/wfa/measurement/internal/reporting/v2/reporting_set.proto
@@ -71,6 +71,7 @@ message ReportingSet {
   message WeightedSubsetUnion {
     repeated PrimitiveReportingSetBasis primitive_reporting_set_bases = 1;
     int32 weight = 2;
+    int32 binary_representation = 3;
   }
   repeated WeightedSubsetUnion weighted_subset_unions = 7;
 }

--- a/src/main/resources/reporting/postgres/add-binary-representation-column-to-weighted-subset-unions-and-metric-measurements.sql
+++ b/src/main/resources/reporting/postgres/add-binary-representation-column-to-weighted-subset-unions-and-metric-measurements.sql
@@ -1,0 +1,46 @@
+-- liquibase formatted sql
+
+-- Copyright 2023 The Cross-Media Measurement Authors
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--      http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+-- Postgres database schema for the Reporting server.
+--
+-- Table hierarchy:
+--   Root
+--   └── MeasurementConsumers
+--       ├── EventGroups
+--       ├── ReportingSets
+--       │   ├── ReportingSetEventGroups
+--       │   ├── PrimitiveReportingSetBases
+--       │   │   └── PrimitiveReportingSetBasisFilters
+--       │   ├── SetExpressions
+--       │   └── WeightedSubsetUnions
+--       │       └── WeightedSubsetUnionPrimitiveReportingSetBases
+--       ├── Metrics
+--       │   └── MetricMeasurements
+--       ├── Measurements
+--       │   └── MeasurementPrimitiveReportingSetBases
+--       └── Reports
+--           ├── ReportTimeIntervals
+--           └── MetricCalculationSpecs
+--               └── MetricCalculationSpecMetrics
+
+-- changeset riemanli:alter-weighted-subset-unions-table dbms:postgresql
+ALTER TABLE WeightedSubsetUnions
+  ADD BinaryRepresentation integer NOT NULL;
+
+-- changeset riemanli:alter-metric-measurements-table dbms:postgresql
+ALTER TABLE MetricMeasurements
+  ADD BinaryRepresentation integer NOT NULL;
+

--- a/src/main/resources/reporting/postgres/changelog-v2.yaml
+++ b/src/main/resources/reporting/postgres/changelog-v2.yaml
@@ -22,3 +22,6 @@ databaseChangeLog:
 - include:
     file: create-v2-reporting-schema.sql
     relativeToChangeLogFile: true
+- include:
+      file: add-binary-representation-column-to-weighted-subset-unions-and-metric-measurements.sql
+      relativeToChangeLogFile: true

--- a/src/test/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/MetricsServiceTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/MetricsServiceTest.kt
@@ -439,6 +439,7 @@ private val INTERNAL_UNION_ALL_REPORTING_SET = internalReportingSet {
       filters += this@internalReportingSet.filter
     }
     weight = 1
+    binaryRepresentation = 1
   }
 }
 private val INTERNAL_UNION_ALL_BUT_LAST_PUBLISHER_REPORTING_SET = internalReportingSet {
@@ -458,6 +459,7 @@ private val INTERNAL_UNION_ALL_BUT_LAST_PUBLISHER_REPORTING_SET = internalReport
       filters += this@internalReportingSet.filter
     }
     weight = 1
+    binaryRepresentation = 1
   }
 }
 private val INTERNAL_SINGLE_PUBLISHER_REPORTING_SET = internalReportingSet {
@@ -484,6 +486,7 @@ private val INTERNAL_SINGLE_PUBLISHER_REPORTING_SET = internalReportingSet {
       filters += this@internalReportingSet.filter
     }
     weight = 1
+    binaryRepresentation = 1
   }
 }
 
@@ -512,6 +515,7 @@ private val INTERNAL_INCREMENTAL_REPORTING_SET = internalReportingSet {
       filters += INTERNAL_UNION_ALL_REPORTING_SET.filter
     }
     weight = 1
+    binaryRepresentation = 1
   }
   weightedSubsetUnions += weightedSubsetUnion {
     primitiveReportingSetBases += primitiveReportingSetBasis {
@@ -521,6 +525,7 @@ private val INTERNAL_INCREMENTAL_REPORTING_SET = internalReportingSet {
       filters += INTERNAL_UNION_ALL_BUT_LAST_PUBLISHER_REPORTING_SET.filter
     }
     weight = -1
+    binaryRepresentation = 2
   }
 }
 
@@ -934,6 +939,7 @@ private val INTERNAL_REQUESTING_INCREMENTAL_REACH_METRIC = internalMetric {
   }
   weightedMeasurements += weightedMeasurement {
     weight = 1
+    binaryRepresentation = 1
     measurement =
       INTERNAL_PENDING_UNION_ALL_REACH_MEASUREMENT.copy {
         clearCmmsCreateMeasurementRequestId()
@@ -943,6 +949,7 @@ private val INTERNAL_REQUESTING_INCREMENTAL_REACH_METRIC = internalMetric {
   }
   weightedMeasurements += weightedMeasurement {
     weight = -1
+    binaryRepresentation = 2
     measurement =
       INTERNAL_PENDING_UNION_ALL_BUT_LAST_PUBLISHER_REACH_MEASUREMENT.copy {
         clearCmmsCreateMeasurementRequestId()
@@ -960,10 +967,12 @@ private val INTERNAL_PENDING_INITIAL_INCREMENTAL_REACH_METRIC =
     weightedMeasurements.clear()
     weightedMeasurements += weightedMeasurement {
       weight = 1
+      binaryRepresentation = 1
       measurement = INTERNAL_PENDING_UNION_ALL_REACH_MEASUREMENT.copy { clearCmmsMeasurementId() }
     }
     weightedMeasurements += weightedMeasurement {
       weight = -1
+      binaryRepresentation = 2
       measurement =
         INTERNAL_PENDING_UNION_ALL_BUT_LAST_PUBLISHER_REACH_MEASUREMENT.copy {
           clearCmmsMeasurementId()
@@ -976,10 +985,12 @@ private val INTERNAL_PENDING_INCREMENTAL_REACH_METRIC =
     weightedMeasurements.clear()
     weightedMeasurements += weightedMeasurement {
       weight = 1
+      binaryRepresentation = 1
       measurement = INTERNAL_PENDING_UNION_ALL_REACH_MEASUREMENT
     }
     weightedMeasurements += weightedMeasurement {
       weight = -1
+      binaryRepresentation = 2
       measurement = INTERNAL_PENDING_UNION_ALL_BUT_LAST_PUBLISHER_REACH_MEASUREMENT
     }
   }
@@ -989,10 +1000,12 @@ private val INTERNAL_SUCCEEDED_INCREMENTAL_REACH_METRIC =
     weightedMeasurements.clear()
     weightedMeasurements += weightedMeasurement {
       weight = 1
+      binaryRepresentation = 1
       measurement = INTERNAL_SUCCEEDED_UNION_ALL_REACH_MEASUREMENT
     }
     weightedMeasurements += weightedMeasurement {
       weight = -1
+      binaryRepresentation = 2
       measurement =
         INTERNAL_PENDING_UNION_ALL_BUT_LAST_PUBLISHER_REACH_MEASUREMENT.copy {
           state = InternalMeasurement.State.SUCCEEDED
@@ -1033,6 +1046,7 @@ private val INTERNAL_REQUESTING_SINGLE_PUBLISHER_IMPRESSION_METRIC = internalMet
   }
   weightedMeasurements += weightedMeasurement {
     weight = 1
+    binaryRepresentation = 1
     measurement =
       INTERNAL_PENDING_SINGLE_PUBLISHER_IMPRESSION_MEASUREMENT.copy {
         clearCmmsCreateMeasurementRequestId()
@@ -1050,6 +1064,7 @@ private val INTERNAL_PENDING_INITIAL_SINGLE_PUBLISHER_IMPRESSION_METRIC =
     weightedMeasurements.clear()
     weightedMeasurements += weightedMeasurement {
       weight = 1
+      binaryRepresentation = 1
       measurement =
         INTERNAL_PENDING_SINGLE_PUBLISHER_IMPRESSION_MEASUREMENT.copy { clearCmmsMeasurementId() }
     }
@@ -1060,6 +1075,7 @@ private val INTERNAL_PENDING_SINGLE_PUBLISHER_IMPRESSION_METRIC =
     weightedMeasurements.clear()
     weightedMeasurements += weightedMeasurement {
       weight = 1
+      binaryRepresentation = 1
       measurement = INTERNAL_PENDING_SINGLE_PUBLISHER_IMPRESSION_MEASUREMENT
     }
   }
@@ -1069,6 +1085,7 @@ private val INTERNAL_FAILED_SINGLE_PUBLISHER_IMPRESSION_METRIC =
     weightedMeasurements.clear()
     weightedMeasurements += weightedMeasurement {
       weight = 1
+      binaryRepresentation = 1
       measurement = INTERNAL_FAILED_SINGLE_PUBLISHER_IMPRESSION_MEASUREMENT
     }
   }
@@ -1995,6 +2012,7 @@ class MetricsServiceTest {
             externalReportingSetId = this@copy.externalReportingSetId
           }
           weight = 1
+          binaryRepresentation = 1
         }
       }
     val internalCreateMetricRequest = internalCreateMetricRequest {
@@ -2003,6 +2021,7 @@ class MetricsServiceTest {
           weightedMeasurements.clear()
           weightedMeasurements += weightedMeasurement {
             weight = 1
+            binaryRepresentation = 1
             measurement = internalMeasurement {
               cmmsMeasurementConsumerId = MEASUREMENT_CONSUMERS.keys.first().measurementConsumerId
               timeInterval = TIME_INTERVAL
@@ -2021,6 +2040,7 @@ class MetricsServiceTest {
         weightedMeasurements.clear()
         weightedMeasurements += weightedMeasurement {
           weight = 1
+          binaryRepresentation = 1
           measurement =
             INTERNAL_PENDING_SINGLE_PUBLISHER_IMPRESSION_MEASUREMENT.copy {
               clearCmmsMeasurementId()
@@ -2103,6 +2123,7 @@ class MetricsServiceTest {
           weightedMeasurements.clear()
           weightedMeasurements += weightedMeasurement {
             weight = 1
+            binaryRepresentation = 1
             measurement =
               INTERNAL_PENDING_UNION_ALL_REACH_MEASUREMENT.copy {
                 clearCmmsMeasurementId()
@@ -2153,6 +2174,7 @@ class MetricsServiceTest {
       (0..BATCH_SET_CMMS_MEASUREMENT_IDS_LIMIT).map { id ->
         weightedMeasurement {
           weight = 1
+          binaryRepresentation = 1
           measurement =
             INTERNAL_PENDING_UNION_ALL_REACH_MEASUREMENT.copy {
               cmmsCreateMeasurementRequestId = "$id"
@@ -3628,10 +3650,12 @@ class MetricsServiceTest {
               weightedMeasurements.clear()
               weightedMeasurements += weightedMeasurement {
                 weight = 1
+                binaryRepresentation = 1
                 measurement = INTERNAL_SUCCEEDED_UNION_ALL_REACH_MEASUREMENT
               }
               weightedMeasurements += weightedMeasurement {
                 weight = -1
+                binaryRepresentation = 2
                 measurement = internalSucceededUnionAllButLastPublisherReachMeasurement
               }
             }
@@ -3801,6 +3825,7 @@ class MetricsServiceTest {
               weightedMeasurements.clear()
               weightedMeasurements += weightedMeasurement {
                 weight = 1
+                binaryRepresentation = 1
                 measurement = INTERNAL_FAILED_SINGLE_PUBLISHER_IMPRESSION_MEASUREMENT
               }
             }
@@ -4156,6 +4181,7 @@ class MetricsServiceTest {
         (0..BATCH_SET_MEASUREMENT_RESULTS_LIMIT).map { id ->
           weightedMeasurement {
             weight = 1
+            binaryRepresentation = 1
             measurement =
               INTERNAL_PENDING_UNION_ALL_REACH_MEASUREMENT.copy {
                 cmmsCreateMeasurementRequestId = "UNION_ALL_REACH_MEASUREMENT$id"
@@ -4211,6 +4237,7 @@ class MetricsServiceTest {
         (0..BATCH_SET_MEASUREMENT_FAILURES_LIMIT).map { id ->
           weightedMeasurement {
             weight = 1
+            binaryRepresentation = 1
             measurement =
               INTERNAL_PENDING_UNION_ALL_REACH_MEASUREMENT.copy {
                 cmmsCreateMeasurementRequestId = "UNION_ALL_REACH_MEASUREMENT$id"

--- a/src/test/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/ReportingSetsServiceTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/ReportingSetsServiceTest.kt
@@ -67,200 +67,6 @@ private const val MAX_PAGE_SIZE = 1000
 private const val PAGE_SIZE = 2
 
 private const val API_AUTHENTICATION_KEY = "nR5QPN7ptx"
-private val CONFIG = measurementConsumerConfig { apiKey = API_AUTHENTICATION_KEY }
-
-// Measurement consumers
-private val MEASUREMENT_CONSUMER_KEYS: List<MeasurementConsumerKey> =
-  (1L..2L).map { MeasurementConsumerKey(ExternalId(it + 110L).apiId.value) }
-
-// Data providers
-private val DATA_PROVIDER_KEYS: List<DataProviderKey> =
-  (1L..3L).map { DataProviderKey(ExternalId(it + 220L).apiId.value) }
-
-// Event group IDs and names
-private val CMMS_EVENT_GROUP_KEYS =
-  DATA_PROVIDER_KEYS.mapIndexed { index, dataProviderKey ->
-    CmmsEventGroupKey(dataProviderKey.dataProviderId, ExternalId(index + 330L).apiId.value)
-  }
-
-// Internal reporting sets
-private val INTERNAL_PRIMITIVE_REPORTING_SETS: List<InternalReportingSet> =
-  (0L..2L).map {
-    internalReportingSet {
-      cmmsMeasurementConsumerId = MEASUREMENT_CONSUMER_KEYS.first().measurementConsumerId
-      externalReportingSetId = (it + 440L).toString()
-      filter = "AGE>18"
-      displayName = "primitive_reporting_set_display_name$it"
-      primitive =
-        InternalReportingSetKt.primitive {
-          eventGroupKeys += CMMS_EVENT_GROUP_KEYS[it.toInt()].toInternal()
-        }
-      weightedSubsetUnions +=
-        InternalReportingSetKt.weightedSubsetUnion {
-          primitiveReportingSetBases +=
-            InternalReportingSetKt.primitiveReportingSetBasis {
-              externalReportingSetId = this@internalReportingSet.externalReportingSetId
-              filters += this@internalReportingSet.filter
-            }
-          weight = 1
-        }
-    }
-  }
-
-private val INTERNAL_COMPOSITE_REPORTING_SET: InternalReportingSet = internalReportingSet {
-  cmmsMeasurementConsumerId = MEASUREMENT_CONSUMER_KEYS.first().measurementConsumerId
-  externalReportingSetId = "450"
-  filter = "GENDER==MALE"
-  displayName = "composite_reporting_set_display_name"
-  composite =
-    InternalReportingSetKt.setExpression {
-      operation = InternalReportingSet.SetExpression.Operation.UNION
-      lhs =
-        InternalReportingSetKt.SetExpressionKt.operand {
-          externalReportingSetId = INTERNAL_PRIMITIVE_REPORTING_SETS[0].externalReportingSetId
-        }
-      rhs =
-        InternalReportingSetKt.SetExpressionKt.operand {
-          externalReportingSetId = INTERNAL_PRIMITIVE_REPORTING_SETS[1].externalReportingSetId
-        }
-    }
-  weightedSubsetUnions +=
-    InternalReportingSetKt.weightedSubsetUnion {
-      primitiveReportingSetBases +=
-        InternalReportingSetKt.primitiveReportingSetBasis {
-          externalReportingSetId = INTERNAL_PRIMITIVE_REPORTING_SETS[0].externalReportingSetId
-          filters += INTERNAL_PRIMITIVE_REPORTING_SETS[0].filter
-        }
-      primitiveReportingSetBases +=
-        InternalReportingSetKt.primitiveReportingSetBasis {
-          externalReportingSetId = INTERNAL_PRIMITIVE_REPORTING_SETS[1].externalReportingSetId
-          filters += INTERNAL_PRIMITIVE_REPORTING_SETS[1].filter
-        }
-      weight = 1
-    }
-}
-
-private val INTERNAL_COMPOSITE_REPORTING_SET2: InternalReportingSet =
-  INTERNAL_COMPOSITE_REPORTING_SET.copy {
-    externalReportingSetId += "2"
-    displayName = "composite_reporting_set_display_name2"
-  }
-
-private val INTERNAL_ROOT_COMPOSITE_REPORTING_SET: InternalReportingSet = internalReportingSet {
-  cmmsMeasurementConsumerId = MEASUREMENT_CONSUMER_KEYS.first().measurementConsumerId
-  externalReportingSetId = "451"
-  displayName = "root_composite_reporting_set_display_name"
-  composite =
-    InternalReportingSetKt.setExpression {
-      operation = InternalReportingSet.SetExpression.Operation.DIFFERENCE
-      lhs =
-        InternalReportingSetKt.SetExpressionKt.operand {
-          expression =
-            InternalReportingSetKt.setExpression {
-              operation = InternalReportingSet.SetExpression.Operation.UNION
-              lhs =
-                InternalReportingSetKt.SetExpressionKt.operand {
-                  externalReportingSetId =
-                    INTERNAL_PRIMITIVE_REPORTING_SETS[2].externalReportingSetId
-                }
-              rhs =
-                InternalReportingSetKt.SetExpressionKt.operand {
-                  externalReportingSetId = INTERNAL_COMPOSITE_REPORTING_SET2.externalReportingSetId
-                }
-            }
-        }
-      rhs =
-        InternalReportingSetKt.SetExpressionKt.operand {
-          externalReportingSetId = INTERNAL_COMPOSITE_REPORTING_SET.externalReportingSetId
-        }
-    }
-  weightedSubsetUnions +=
-    InternalReportingSetKt.weightedSubsetUnion {
-      primitiveReportingSetBases +=
-        InternalReportingSetKt.primitiveReportingSetBasis {
-          externalReportingSetId = INTERNAL_PRIMITIVE_REPORTING_SETS[0].externalReportingSetId
-          filters += INTERNAL_COMPOSITE_REPORTING_SET2.filter
-          filters += INTERNAL_PRIMITIVE_REPORTING_SETS[0].filter
-        }
-      primitiveReportingSetBases +=
-        InternalReportingSetKt.primitiveReportingSetBasis {
-          externalReportingSetId = INTERNAL_PRIMITIVE_REPORTING_SETS[1].externalReportingSetId
-          filters += INTERNAL_COMPOSITE_REPORTING_SET2.filter
-          filters += INTERNAL_PRIMITIVE_REPORTING_SETS[1].filter
-        }
-      primitiveReportingSetBases +=
-        InternalReportingSetKt.primitiveReportingSetBasis {
-          externalReportingSetId = INTERNAL_PRIMITIVE_REPORTING_SETS[2].externalReportingSetId
-          filters += INTERNAL_PRIMITIVE_REPORTING_SETS[2].filter
-        }
-      weight = 1
-    }
-  weightedSubsetUnions +=
-    InternalReportingSetKt.weightedSubsetUnion {
-      primitiveReportingSetBases +=
-        InternalReportingSetKt.primitiveReportingSetBasis {
-          externalReportingSetId = INTERNAL_PRIMITIVE_REPORTING_SETS[0].externalReportingSetId
-          filters += INTERNAL_COMPOSITE_REPORTING_SET.filter
-          filters += INTERNAL_PRIMITIVE_REPORTING_SETS[0].filter
-        }
-      primitiveReportingSetBases +=
-        InternalReportingSetKt.primitiveReportingSetBasis {
-          externalReportingSetId = INTERNAL_PRIMITIVE_REPORTING_SETS[1].externalReportingSetId
-          filters += INTERNAL_COMPOSITE_REPORTING_SET.filter
-          filters += INTERNAL_PRIMITIVE_REPORTING_SETS[1].filter
-        }
-      weight = -1
-    }
-}
-
-// Reporting sets
-private val PRIMITIVE_REPORTING_SETS: List<ReportingSet> =
-  INTERNAL_PRIMITIVE_REPORTING_SETS.map { internalReportingSet ->
-    reportingSet {
-      name = internalReportingSet.resourceName
-      filter = internalReportingSet.filter
-      displayName = internalReportingSet.displayName
-      primitive =
-        ReportingSetKt.primitive {
-          cmmsEventGroups +=
-            internalReportingSet.primitive.eventGroupKeysList.map {
-              CmmsEventGroupKey(it.cmmsDataProviderId, it.cmmsEventGroupId).toName()
-            }
-        }
-    }
-  }
-
-private val ROOT_COMPOSITE_REPORTING_SET: ReportingSet = reportingSet {
-  name = INTERNAL_ROOT_COMPOSITE_REPORTING_SET.resourceName
-  filter = INTERNAL_ROOT_COMPOSITE_REPORTING_SET.filter
-  displayName = INTERNAL_ROOT_COMPOSITE_REPORTING_SET.displayName
-  composite =
-    ReportingSetKt.composite {
-      expression =
-        ReportingSetKt.setExpression {
-          operation = ReportingSet.SetExpression.Operation.DIFFERENCE
-          lhs =
-            ReportingSetKt.SetExpressionKt.operand {
-              expression =
-                ReportingSetKt.setExpression {
-                  operation = ReportingSet.SetExpression.Operation.UNION
-                  lhs =
-                    ReportingSetKt.SetExpressionKt.operand {
-                      reportingSet = INTERNAL_PRIMITIVE_REPORTING_SETS[2].resourceName
-                    }
-                  rhs =
-                    ReportingSetKt.SetExpressionKt.operand {
-                      reportingSet = INTERNAL_COMPOSITE_REPORTING_SET2.resourceName
-                    }
-                }
-            }
-          rhs =
-            ReportingSetKt.SetExpressionKt.operand {
-              reportingSet = INTERNAL_COMPOSITE_REPORTING_SET.resourceName
-            }
-        }
-    }
-}
 
 @RunWith(JUnit4::class)
 class ReportingSetsServiceTest {
@@ -431,6 +237,7 @@ class ReportingSetsServiceTest {
                   filters += INTERNAL_PRIMITIVE_REPORTING_SETS[2].filter
                 }
               weight = 1
+              binaryRepresentation = (1 shl 5) - 1
             }
           weightedSubsetUnions +=
             InternalReportingSetKt.weightedSubsetUnion {
@@ -449,6 +256,7 @@ class ReportingSetsServiceTest {
                   filters += INTERNAL_PRIMITIVE_REPORTING_SETS[1].filter
                 }
               weight = -1
+              binaryRepresentation = (1 shl 3) + (1 shl 4)
             }
         }
 
@@ -1193,6 +1001,208 @@ class ReportingSetsServiceTest {
         }
       }
     assertThat(exception.status.code).isEqualTo(Status.Code.INVALID_ARGUMENT)
+  }
+
+  companion object {
+    private val CONFIG = measurementConsumerConfig { apiKey = API_AUTHENTICATION_KEY }
+
+    // Measurement consumers
+    private val MEASUREMENT_CONSUMER_KEYS: List<MeasurementConsumerKey> =
+      (1L..2L).map { MeasurementConsumerKey(ExternalId(it + 110L).apiId.value) }
+
+    // Data providers
+    private val DATA_PROVIDER_KEYS: List<DataProviderKey> =
+      (1L..3L).map { DataProviderKey(ExternalId(it + 220L).apiId.value) }
+
+    // Event group IDs and names
+    private val CMMS_EVENT_GROUP_KEYS =
+      DATA_PROVIDER_KEYS.mapIndexed { index, dataProviderKey ->
+        CmmsEventGroupKey(dataProviderKey.dataProviderId, ExternalId(index + 330L).apiId.value)
+      }
+
+    // Internal reporting sets
+    private val INTERNAL_PRIMITIVE_REPORTING_SETS: List<InternalReportingSet> =
+      (0L..2L).map {
+        internalReportingSet {
+          cmmsMeasurementConsumerId = MEASUREMENT_CONSUMER_KEYS.first().measurementConsumerId
+          externalReportingSetId = (it + 440L).toString()
+          filter = "AGE>18"
+          displayName = "primitive_reporting_set_display_name$it"
+          primitive =
+            InternalReportingSetKt.primitive {
+              eventGroupKeys += CMMS_EVENT_GROUP_KEYS[it.toInt()].toInternal()
+            }
+          weightedSubsetUnions +=
+            InternalReportingSetKt.weightedSubsetUnion {
+              primitiveReportingSetBases +=
+                InternalReportingSetKt.primitiveReportingSetBasis {
+                  externalReportingSetId = this@internalReportingSet.externalReportingSetId
+                  filters += this@internalReportingSet.filter
+                }
+              weight = 1
+              binaryRepresentation = 1
+            }
+        }
+      }
+
+    private val INTERNAL_COMPOSITE_REPORTING_SET: InternalReportingSet = internalReportingSet {
+      cmmsMeasurementConsumerId = MEASUREMENT_CONSUMER_KEYS.first().measurementConsumerId
+      externalReportingSetId = "450"
+      filter = "GENDER==MALE"
+      displayName = "composite_reporting_set_display_name"
+      composite =
+        InternalReportingSetKt.setExpression {
+          operation = InternalReportingSet.SetExpression.Operation.UNION
+          lhs =
+            InternalReportingSetKt.SetExpressionKt.operand {
+              externalReportingSetId = INTERNAL_PRIMITIVE_REPORTING_SETS[0].externalReportingSetId
+            }
+          rhs =
+            InternalReportingSetKt.SetExpressionKt.operand {
+              externalReportingSetId = INTERNAL_PRIMITIVE_REPORTING_SETS[1].externalReportingSetId
+            }
+        }
+      weightedSubsetUnions +=
+        InternalReportingSetKt.weightedSubsetUnion {
+          primitiveReportingSetBases +=
+            InternalReportingSetKt.primitiveReportingSetBasis {
+              externalReportingSetId = INTERNAL_PRIMITIVE_REPORTING_SETS[0].externalReportingSetId
+              filters += INTERNAL_PRIMITIVE_REPORTING_SETS[0].filter
+            }
+          primitiveReportingSetBases +=
+            InternalReportingSetKt.primitiveReportingSetBasis {
+              externalReportingSetId = INTERNAL_PRIMITIVE_REPORTING_SETS[1].externalReportingSetId
+              filters += INTERNAL_PRIMITIVE_REPORTING_SETS[1].filter
+            }
+          weight = 1
+          binaryRepresentation = 3
+        }
+    }
+
+    private val INTERNAL_COMPOSITE_REPORTING_SET2: InternalReportingSet =
+      INTERNAL_COMPOSITE_REPORTING_SET.copy {
+        externalReportingSetId += "2"
+        displayName = "composite_reporting_set_display_name2"
+      }
+
+    private val INTERNAL_ROOT_COMPOSITE_REPORTING_SET: InternalReportingSet = internalReportingSet {
+      cmmsMeasurementConsumerId = MEASUREMENT_CONSUMER_KEYS.first().measurementConsumerId
+      externalReportingSetId = "451"
+      displayName = "root_composite_reporting_set_display_name"
+      composite =
+        InternalReportingSetKt.setExpression {
+          operation = InternalReportingSet.SetExpression.Operation.DIFFERENCE
+          lhs =
+            InternalReportingSetKt.SetExpressionKt.operand {
+              expression =
+                InternalReportingSetKt.setExpression {
+                  operation = InternalReportingSet.SetExpression.Operation.UNION
+                  lhs =
+                    InternalReportingSetKt.SetExpressionKt.operand {
+                      externalReportingSetId =
+                        INTERNAL_PRIMITIVE_REPORTING_SETS[2].externalReportingSetId
+                    }
+                  rhs =
+                    InternalReportingSetKt.SetExpressionKt.operand {
+                      externalReportingSetId =
+                        INTERNAL_COMPOSITE_REPORTING_SET2.externalReportingSetId
+                    }
+                }
+            }
+          rhs =
+            InternalReportingSetKt.SetExpressionKt.operand {
+              externalReportingSetId = INTERNAL_COMPOSITE_REPORTING_SET.externalReportingSetId
+            }
+        }
+      weightedSubsetUnions +=
+        InternalReportingSetKt.weightedSubsetUnion {
+          primitiveReportingSetBases +=
+            InternalReportingSetKt.primitiveReportingSetBasis {
+              externalReportingSetId = INTERNAL_PRIMITIVE_REPORTING_SETS[0].externalReportingSetId
+              filters += INTERNAL_COMPOSITE_REPORTING_SET2.filter
+              filters += INTERNAL_PRIMITIVE_REPORTING_SETS[0].filter
+            }
+          primitiveReportingSetBases +=
+            InternalReportingSetKt.primitiveReportingSetBasis {
+              externalReportingSetId = INTERNAL_PRIMITIVE_REPORTING_SETS[1].externalReportingSetId
+              filters += INTERNAL_COMPOSITE_REPORTING_SET2.filter
+              filters += INTERNAL_PRIMITIVE_REPORTING_SETS[1].filter
+            }
+          primitiveReportingSetBases +=
+            InternalReportingSetKt.primitiveReportingSetBasis {
+              externalReportingSetId = INTERNAL_PRIMITIVE_REPORTING_SETS[2].externalReportingSetId
+              filters += INTERNAL_PRIMITIVE_REPORTING_SETS[2].filter
+            }
+          weight = 1
+          binaryRepresentation = 7
+        }
+      weightedSubsetUnions +=
+        InternalReportingSetKt.weightedSubsetUnion {
+          primitiveReportingSetBases +=
+            InternalReportingSetKt.primitiveReportingSetBasis {
+              externalReportingSetId = INTERNAL_PRIMITIVE_REPORTING_SETS[0].externalReportingSetId
+              filters += INTERNAL_COMPOSITE_REPORTING_SET.filter
+              filters += INTERNAL_PRIMITIVE_REPORTING_SETS[0].filter
+            }
+          primitiveReportingSetBases +=
+            InternalReportingSetKt.primitiveReportingSetBasis {
+              externalReportingSetId = INTERNAL_PRIMITIVE_REPORTING_SETS[1].externalReportingSetId
+              filters += INTERNAL_COMPOSITE_REPORTING_SET.filter
+              filters += INTERNAL_PRIMITIVE_REPORTING_SETS[1].filter
+            }
+          weight = -1
+          binaryRepresentation = 6
+        }
+    }
+
+    // Reporting sets
+    private val PRIMITIVE_REPORTING_SETS: List<ReportingSet> =
+      INTERNAL_PRIMITIVE_REPORTING_SETS.map { internalReportingSet ->
+        reportingSet {
+          name = internalReportingSet.resourceName
+          filter = internalReportingSet.filter
+          displayName = internalReportingSet.displayName
+          primitive =
+            ReportingSetKt.primitive {
+              cmmsEventGroups +=
+                internalReportingSet.primitive.eventGroupKeysList.map {
+                  CmmsEventGroupKey(it.cmmsDataProviderId, it.cmmsEventGroupId).toName()
+                }
+            }
+        }
+      }
+
+    private val ROOT_COMPOSITE_REPORTING_SET: ReportingSet = reportingSet {
+      name = INTERNAL_ROOT_COMPOSITE_REPORTING_SET.resourceName
+      filter = INTERNAL_ROOT_COMPOSITE_REPORTING_SET.filter
+      displayName = INTERNAL_ROOT_COMPOSITE_REPORTING_SET.displayName
+      composite =
+        ReportingSetKt.composite {
+          expression =
+            ReportingSetKt.setExpression {
+              operation = ReportingSet.SetExpression.Operation.DIFFERENCE
+              lhs =
+                ReportingSetKt.SetExpressionKt.operand {
+                  expression =
+                    ReportingSetKt.setExpression {
+                      operation = ReportingSet.SetExpression.Operation.UNION
+                      lhs =
+                        ReportingSetKt.SetExpressionKt.operand {
+                          reportingSet = INTERNAL_PRIMITIVE_REPORTING_SETS[2].resourceName
+                        }
+                      rhs =
+                        ReportingSetKt.SetExpressionKt.operand {
+                          reportingSet = INTERNAL_COMPOSITE_REPORTING_SET2.resourceName
+                        }
+                    }
+                }
+              rhs =
+                ReportingSetKt.SetExpressionKt.operand {
+                  reportingSet = INTERNAL_COMPOSITE_REPORTING_SET.resourceName
+                }
+            }
+        }
+    }
   }
 }
 


### PR DESCRIPTION
Part of the changes for implementing error bars in reporting server. To easily find the union of any two weighted measurements in a metric, we store the binary representation of each measurement from the binary representation of the weighed subset union created during set expression compilation of a reporting set.