### PR TITLE
Add internal DP params proto

### DIFF
--- a/src/main/kotlin/org/wfanet/measurement/reporting/deploy/v2/postgres/readers/MetricReader.kt
+++ b/src/main/kotlin/org/wfanet/measurement/reporting/deploy/v2/postgres/readers/MetricReader.kt
@@ -38,6 +38,7 @@ import org.wfanet.measurement.internal.reporting.v2.MetricSpec
 import org.wfanet.measurement.internal.reporting.v2.MetricSpecKt
 import org.wfanet.measurement.internal.reporting.v2.ReportingSetKt
 import org.wfanet.measurement.internal.reporting.v2.StreamMetricsRequest
+import org.wfanet.measurement.internal.reporting.v2.differentialPrivacyParams
 import org.wfanet.measurement.internal.reporting.v2.measurement
 import org.wfanet.measurement.internal.reporting.v2.metric
 import org.wfanet.measurement.internal.reporting.v2.metricSpec
@@ -409,11 +410,10 @@ class MetricReader(private val readContext: ReadContext) {
               MetricSpec.TypeCase.REACH ->
                 reach =
                   MetricSpecKt.reachParams {
-                    privacyParams =
-                      MetricSpecKt.differentialPrivacyParams {
-                        epsilon = differentialPrivacyEpsilon
-                        delta = differentialPrivacyDelta
-                      }
+                    privacyParams = differentialPrivacyParams {
+                      epsilon = differentialPrivacyEpsilon
+                      delta = differentialPrivacyDelta
+                    }
                   }
               MetricSpec.TypeCase.FREQUENCY_HISTOGRAM -> {
                 if (
@@ -426,16 +426,14 @@ class MetricReader(private val readContext: ReadContext) {
 
                 frequencyHistogram =
                   MetricSpecKt.frequencyHistogramParams {
-                    reachPrivacyParams =
-                      MetricSpecKt.differentialPrivacyParams {
-                        epsilon = differentialPrivacyEpsilon
-                        delta = differentialPrivacyDelta
-                      }
-                    frequencyPrivacyParams =
-                      MetricSpecKt.differentialPrivacyParams {
-                        epsilon = frequencyDifferentialPrivacyEpsilon
-                        delta = frequencyDifferentialPrivacyDelta
-                      }
+                    reachPrivacyParams = differentialPrivacyParams {
+                      epsilon = differentialPrivacyEpsilon
+                      delta = differentialPrivacyDelta
+                    }
+                    frequencyPrivacyParams = differentialPrivacyParams {
+                      epsilon = frequencyDifferentialPrivacyEpsilon
+                      delta = frequencyDifferentialPrivacyDelta
+                    }
                     this.maximumFrequencyPerUser = maximumFrequencyPerUser
                   }
               }
@@ -446,11 +444,10 @@ class MetricReader(private val readContext: ReadContext) {
 
                 impressionCount =
                   MetricSpecKt.impressionCountParams {
-                    privacyParams =
-                      MetricSpecKt.differentialPrivacyParams {
-                        epsilon = differentialPrivacyEpsilon
-                        delta = differentialPrivacyDelta
-                      }
+                    privacyParams = differentialPrivacyParams {
+                      epsilon = differentialPrivacyEpsilon
+                      delta = differentialPrivacyDelta
+                    }
                     this.maximumFrequencyPerUser = maximumFrequencyPerUser
                   }
               }
@@ -461,11 +458,10 @@ class MetricReader(private val readContext: ReadContext) {
 
                 watchDuration =
                   MetricSpecKt.watchDurationParams {
-                    privacyParams =
-                      MetricSpecKt.differentialPrivacyParams {
-                        epsilon = differentialPrivacyEpsilon
-                        delta = differentialPrivacyDelta
-                      }
+                    privacyParams = differentialPrivacyParams {
+                      epsilon = differentialPrivacyEpsilon
+                      delta = differentialPrivacyDelta
+                    }
                     this.maximumWatchDurationPerUser = maximumWatchDurationPerUser
                   }
               }

--- a/src/main/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/ProtoConversions.kt
+++ b/src/main/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/ProtoConversions.kt
@@ -28,6 +28,7 @@ import org.wfanet.measurement.api.v2alpha.MeasurementSpec.VidSamplingInterval
 import org.wfanet.measurement.api.v2alpha.MeasurementSpecKt
 import org.wfanet.measurement.api.v2alpha.differentialPrivacyParams
 import org.wfanet.measurement.config.reporting.MetricSpecConfig
+import org.wfanet.measurement.internal.reporting.v2.DifferentialPrivacyParams as InternalDifferentialPrivacyParams
 import org.wfanet.measurement.internal.reporting.v2.Measurement as InternalMeasurement
 import org.wfanet.measurement.internal.reporting.v2.MeasurementKt as InternalMeasurementKt
 import org.wfanet.measurement.internal.reporting.v2.MetricSpec as InternalMetricSpec
@@ -42,6 +43,7 @@ import org.wfanet.measurement.internal.reporting.v2.StreamReportingSetsRequestKt
 import org.wfanet.measurement.internal.reporting.v2.StreamReportsRequest
 import org.wfanet.measurement.internal.reporting.v2.StreamReportsRequestKt
 import org.wfanet.measurement.internal.reporting.v2.TimeIntervals as InternalTimeIntervals
+import org.wfanet.measurement.internal.reporting.v2.differentialPrivacyParams as internalDifferentialPrivacyParams
 import org.wfanet.measurement.internal.reporting.v2.metricSpec as internalMetricSpec
 import org.wfanet.measurement.internal.reporting.v2.periodicTimeInterval as internalPeriodicTimeInterval
 import org.wfanet.measurement.internal.reporting.v2.streamMetricsRequest
@@ -217,10 +219,9 @@ fun MetricSpec.ReachParams.toInternal(): InternalMetricSpec.ReachParams {
  * Converts a [MetricSpec.DifferentialPrivacyParams] to an
  * [InternalMetricSpec.DifferentialPrivacyParams].
  */
-fun MetricSpec.DifferentialPrivacyParams.toInternal():
-  InternalMetricSpec.DifferentialPrivacyParams {
+fun MetricSpec.DifferentialPrivacyParams.toInternal(): InternalDifferentialPrivacyParams {
   val source = this
-  return InternalMetricSpecKt.differentialPrivacyParams {
+  return internalDifferentialPrivacyParams {
     if (source.hasEpsilon()) {
       this.epsilon = source.epsilon
     }
@@ -282,11 +283,10 @@ fun InternalMetricSpec.toMetricSpec(): MetricSpec {
 }
 
 /**
- * Converts an [InternalMetricSpec.DifferentialPrivacyParams] to a public
+ * Converts an [InternalDifferentialPrivacyParams] to a public
  * [MetricSpec.DifferentialPrivacyParams].
  */
-fun InternalMetricSpec.DifferentialPrivacyParams.toPrivacyParams():
-  MetricSpec.DifferentialPrivacyParams {
+fun InternalDifferentialPrivacyParams.toPrivacyParams(): MetricSpec.DifferentialPrivacyParams {
   val source = this
   return MetricSpecKt.differentialPrivacyParams {
     epsilon = source.epsilon
@@ -294,8 +294,8 @@ fun InternalMetricSpec.DifferentialPrivacyParams.toPrivacyParams():
   }
 }
 
-/** Converts an [InternalMetricSpec.DifferentialPrivacyParams] to [DifferentialPrivacyParams]. */
-fun InternalMetricSpec.DifferentialPrivacyParams.toCmmsPrivacyParams(): DifferentialPrivacyParams {
+/** Converts an [InternalDifferentialPrivacyParams] to [DifferentialPrivacyParams]. */
+fun InternalDifferentialPrivacyParams.toCmmsPrivacyParams(): DifferentialPrivacyParams {
   val source = this
   return differentialPrivacyParams {
     epsilon = source.epsilon

--- a/src/main/kotlin/org/wfanet/measurement/reporting/service/internal/testing/v2/MeasurementsServiceTest.kt
+++ b/src/main/kotlin/org/wfanet/measurement/reporting/service/internal/testing/v2/MeasurementsServiceTest.kt
@@ -53,6 +53,7 @@ import org.wfanet.measurement.internal.reporting.v2.batchSetMeasurementResultsRe
 import org.wfanet.measurement.internal.reporting.v2.copy
 import org.wfanet.measurement.internal.reporting.v2.createMetricRequest
 import org.wfanet.measurement.internal.reporting.v2.createReportingSetRequest
+import org.wfanet.measurement.internal.reporting.v2.differentialPrivacyParams
 import org.wfanet.measurement.internal.reporting.v2.measurement
 import org.wfanet.measurement.internal.reporting.v2.measurementConsumer
 import org.wfanet.measurement.internal.reporting.v2.metric
@@ -1263,11 +1264,10 @@ abstract class MeasurementsServiceTest<T : MeasurementsGrpcKt.MeasurementsCorout
         metricSpec = metricSpec {
           reach =
             MetricSpecKt.reachParams {
-              privacyParams =
-                MetricSpecKt.differentialPrivacyParams {
-                  epsilon = 1.0
-                  delta = 2.0
-                }
+              privacyParams = differentialPrivacyParams {
+                epsilon = 1.0
+                delta = 2.0
+              }
             }
           vidSamplingInterval =
             MetricSpecKt.vidSamplingInterval {

--- a/src/main/kotlin/org/wfanet/measurement/reporting/service/internal/testing/v2/MetricsServiceTest.kt
+++ b/src/main/kotlin/org/wfanet/measurement/reporting/service/internal/testing/v2/MetricsServiceTest.kt
@@ -47,6 +47,7 @@ import org.wfanet.measurement.internal.reporting.v2.batchGetMetricsRequest
 import org.wfanet.measurement.internal.reporting.v2.copy
 import org.wfanet.measurement.internal.reporting.v2.createMetricRequest
 import org.wfanet.measurement.internal.reporting.v2.createReportingSetRequest
+import org.wfanet.measurement.internal.reporting.v2.differentialPrivacyParams
 import org.wfanet.measurement.internal.reporting.v2.measurement
 import org.wfanet.measurement.internal.reporting.v2.measurementConsumer
 import org.wfanet.measurement.internal.reporting.v2.metric
@@ -99,11 +100,10 @@ abstract class MetricsServiceTest<T : MetricsCoroutineImplBase> {
       metricSpec = metricSpec {
         reach =
           MetricSpecKt.reachParams {
-            privacyParams =
-              MetricSpecKt.differentialPrivacyParams {
-                epsilon = 1.0
-                delta = 2.0
-              }
+            privacyParams = differentialPrivacyParams {
+              epsilon = 1.0
+              delta = 2.0
+            }
           }
         vidSamplingInterval =
           MetricSpecKt.vidSamplingInterval {
@@ -196,16 +196,14 @@ abstract class MetricsServiceTest<T : MetricsCoroutineImplBase> {
       metricSpec = metricSpec {
         frequencyHistogram =
           MetricSpecKt.frequencyHistogramParams {
-            reachPrivacyParams =
-              MetricSpecKt.differentialPrivacyParams {
-                epsilon = 1.0
-                delta = 2.0
-              }
-            frequencyPrivacyParams =
-              MetricSpecKt.differentialPrivacyParams {
-                epsilon = 1.0
-                delta = 2.0
-              }
+            reachPrivacyParams = differentialPrivacyParams {
+              epsilon = 1.0
+              delta = 2.0
+            }
+            frequencyPrivacyParams = differentialPrivacyParams {
+              epsilon = 1.0
+              delta = 2.0
+            }
             maximumFrequencyPerUser = 5
           }
         vidSamplingInterval =
@@ -299,11 +297,10 @@ abstract class MetricsServiceTest<T : MetricsCoroutineImplBase> {
       metricSpec = metricSpec {
         impressionCount =
           MetricSpecKt.impressionCountParams {
-            privacyParams =
-              MetricSpecKt.differentialPrivacyParams {
-                epsilon = 1.0
-                delta = 2.0
-              }
+            privacyParams = differentialPrivacyParams {
+              epsilon = 1.0
+              delta = 2.0
+            }
             maximumFrequencyPerUser = 5
           }
         vidSamplingInterval =
@@ -397,11 +394,10 @@ abstract class MetricsServiceTest<T : MetricsCoroutineImplBase> {
       metricSpec = metricSpec {
         watchDuration =
           MetricSpecKt.watchDurationParams {
-            privacyParams =
-              MetricSpecKt.differentialPrivacyParams {
-                epsilon = 1.0
-                delta = 2.0
-              }
+            privacyParams = differentialPrivacyParams {
+              epsilon = 1.0
+              delta = 2.0
+            }
             maximumWatchDurationPerUser = 100
           }
         vidSamplingInterval =
@@ -495,11 +491,10 @@ abstract class MetricsServiceTest<T : MetricsCoroutineImplBase> {
       metricSpec = metricSpec {
         watchDuration =
           MetricSpecKt.watchDurationParams {
-            privacyParams =
-              MetricSpecKt.differentialPrivacyParams {
-                epsilon = 1.0
-                delta = 2.0
-              }
+            privacyParams = differentialPrivacyParams {
+              epsilon = 1.0
+              delta = 2.0
+            }
             maximumWatchDurationPerUser = 100
           }
         vidSamplingInterval =
@@ -561,16 +556,14 @@ abstract class MetricsServiceTest<T : MetricsCoroutineImplBase> {
       metricSpec = metricSpec {
         frequencyHistogram =
           MetricSpecKt.frequencyHistogramParams {
-            reachPrivacyParams =
-              MetricSpecKt.differentialPrivacyParams {
-                epsilon = 1.0
-                delta = 2.0
-              }
-            frequencyPrivacyParams =
-              MetricSpecKt.differentialPrivacyParams {
-                epsilon = 1.0
-                delta = 2.0
-              }
+            reachPrivacyParams = differentialPrivacyParams {
+              epsilon = 1.0
+              delta = 2.0
+            }
+            frequencyPrivacyParams = differentialPrivacyParams {
+              epsilon = 1.0
+              delta = 2.0
+            }
             maximumFrequencyPerUser = 5
           }
         vidSamplingInterval =
@@ -674,16 +667,14 @@ abstract class MetricsServiceTest<T : MetricsCoroutineImplBase> {
         metricSpec = metricSpec {
           frequencyHistogram =
             MetricSpecKt.frequencyHistogramParams {
-              reachPrivacyParams =
-                MetricSpecKt.differentialPrivacyParams {
-                  epsilon = 1.0
-                  delta = 2.0
-                }
-              frequencyPrivacyParams =
-                MetricSpecKt.differentialPrivacyParams {
-                  epsilon = 1.0
-                  delta = 2.0
-                }
+              reachPrivacyParams = differentialPrivacyParams {
+                epsilon = 1.0
+                delta = 2.0
+              }
+              frequencyPrivacyParams = differentialPrivacyParams {
+                epsilon = 1.0
+                delta = 2.0
+              }
               maximumFrequencyPerUser = 5
             }
           vidSamplingInterval =
@@ -786,16 +777,14 @@ abstract class MetricsServiceTest<T : MetricsCoroutineImplBase> {
       metricSpec = metricSpec {
         frequencyHistogram =
           MetricSpecKt.frequencyHistogramParams {
-            reachPrivacyParams =
-              MetricSpecKt.differentialPrivacyParams {
-                epsilon = 1.0
-                delta = 2.0
-              }
-            frequencyPrivacyParams =
-              MetricSpecKt.differentialPrivacyParams {
-                epsilon = 3.0
-                delta = 4.0
-              }
+            reachPrivacyParams = differentialPrivacyParams {
+              epsilon = 1.0
+              delta = 2.0
+            }
+            frequencyPrivacyParams = differentialPrivacyParams {
+              epsilon = 3.0
+              delta = 4.0
+            }
             maximumFrequencyPerUser = 5
           }
         vidSamplingInterval =
@@ -858,16 +847,14 @@ abstract class MetricsServiceTest<T : MetricsCoroutineImplBase> {
       metricSpec = metricSpec {
         frequencyHistogram =
           MetricSpecKt.frequencyHistogramParams {
-            reachPrivacyParams =
-              MetricSpecKt.differentialPrivacyParams {
-                epsilon = 1.0
-                delta = 2.0
-              }
-            frequencyPrivacyParams =
-              MetricSpecKt.differentialPrivacyParams {
-                epsilon = 1.0
-                delta = 2.0
-              }
+            reachPrivacyParams = differentialPrivacyParams {
+              epsilon = 1.0
+              delta = 2.0
+            }
+            frequencyPrivacyParams = differentialPrivacyParams {
+              epsilon = 1.0
+              delta = 2.0
+            }
             maximumFrequencyPerUser = 5
           }
         vidSamplingInterval =
@@ -939,11 +926,10 @@ abstract class MetricsServiceTest<T : MetricsCoroutineImplBase> {
       metricSpec = metricSpec {
         reach =
           MetricSpecKt.reachParams {
-            privacyParams =
-              MetricSpecKt.differentialPrivacyParams {
-                epsilon = 1.0
-                delta = 2.0
-              }
+            privacyParams = differentialPrivacyParams {
+              epsilon = 1.0
+              delta = 2.0
+            }
           }
         vidSamplingInterval =
           MetricSpecKt.vidSamplingInterval {
@@ -1065,11 +1051,10 @@ abstract class MetricsServiceTest<T : MetricsCoroutineImplBase> {
         metricSpec = metricSpec {
           reach =
             MetricSpecKt.reachParams {
-              privacyParams =
-                MetricSpecKt.differentialPrivacyParams {
-                  epsilon = 1.0
-                  delta = 2.0
-                }
+              privacyParams = differentialPrivacyParams {
+                epsilon = 1.0
+                delta = 2.0
+              }
             }
         }
         weightedMeasurements +=
@@ -1128,11 +1113,10 @@ abstract class MetricsServiceTest<T : MetricsCoroutineImplBase> {
         metricSpec = metricSpec {
           reach =
             MetricSpecKt.reachParams {
-              privacyParams =
-                MetricSpecKt.differentialPrivacyParams {
-                  epsilon = 1.0
-                  delta = 2.0
-                }
+              privacyParams = differentialPrivacyParams {
+                epsilon = 1.0
+                delta = 2.0
+              }
             }
           vidSamplingInterval =
             MetricSpecKt.vidSamplingInterval {
@@ -1176,16 +1160,14 @@ abstract class MetricsServiceTest<T : MetricsCoroutineImplBase> {
       metricSpec = metricSpec {
         frequencyHistogram =
           MetricSpecKt.frequencyHistogramParams {
-            reachPrivacyParams =
-              MetricSpecKt.differentialPrivacyParams {
-                epsilon = 1.0
-                delta = 2.0
-              }
-            frequencyPrivacyParams =
-              MetricSpecKt.differentialPrivacyParams {
-                epsilon = 1.0
-                delta = 2.0
-              }
+            reachPrivacyParams = differentialPrivacyParams {
+              epsilon = 1.0
+              delta = 2.0
+            }
+            frequencyPrivacyParams = differentialPrivacyParams {
+              epsilon = 1.0
+              delta = 2.0
+            }
             maximumFrequencyPerUser = 5
           }
         vidSamplingInterval =
@@ -1248,16 +1230,14 @@ abstract class MetricsServiceTest<T : MetricsCoroutineImplBase> {
       metricSpec = metricSpec {
         frequencyHistogram =
           MetricSpecKt.frequencyHistogramParams {
-            reachPrivacyParams =
-              MetricSpecKt.differentialPrivacyParams {
-                epsilon = 1.0
-                delta = 2.0
-              }
-            frequencyPrivacyParams =
-              MetricSpecKt.differentialPrivacyParams {
-                epsilon = 1.0
-                delta = 2.0
-              }
+            reachPrivacyParams = differentialPrivacyParams {
+              epsilon = 1.0
+              delta = 2.0
+            }
+            frequencyPrivacyParams = differentialPrivacyParams {
+              epsilon = 1.0
+              delta = 2.0
+            }
             maximumFrequencyPerUser = 5
           }
         vidSamplingInterval =
@@ -1326,16 +1306,14 @@ abstract class MetricsServiceTest<T : MetricsCoroutineImplBase> {
       metricSpec = metricSpec {
         frequencyHistogram =
           MetricSpecKt.frequencyHistogramParams {
-            reachPrivacyParams =
-              MetricSpecKt.differentialPrivacyParams {
-                epsilon = 1.0
-                delta = 2.0
-              }
-            frequencyPrivacyParams =
-              MetricSpecKt.differentialPrivacyParams {
-                epsilon = 1.0
-                delta = 2.0
-              }
+            reachPrivacyParams = differentialPrivacyParams {
+              epsilon = 1.0
+              delta = 2.0
+            }
+            frequencyPrivacyParams = differentialPrivacyParams {
+              epsilon = 1.0
+              delta = 2.0
+            }
             maximumFrequencyPerUser = 5
           }
         vidSamplingInterval =
@@ -1415,16 +1393,14 @@ abstract class MetricsServiceTest<T : MetricsCoroutineImplBase> {
         metricSpec = metricSpec {
           frequencyHistogram =
             MetricSpecKt.frequencyHistogramParams {
-              reachPrivacyParams =
-                MetricSpecKt.differentialPrivacyParams {
-                  epsilon = 1.0
-                  delta = 2.0
-                }
-              frequencyPrivacyParams =
-                MetricSpecKt.differentialPrivacyParams {
-                  epsilon = 1.0
-                  delta = 2.0
-                }
+              reachPrivacyParams = differentialPrivacyParams {
+                epsilon = 1.0
+                delta = 2.0
+              }
+              frequencyPrivacyParams = differentialPrivacyParams {
+                epsilon = 1.0
+                delta = 2.0
+              }
               maximumFrequencyPerUser = 5
             }
           vidSamplingInterval =
@@ -1513,16 +1489,14 @@ abstract class MetricsServiceTest<T : MetricsCoroutineImplBase> {
         metricSpec = metricSpec {
           frequencyHistogram =
             MetricSpecKt.frequencyHistogramParams {
-              reachPrivacyParams =
-                MetricSpecKt.differentialPrivacyParams {
-                  epsilon = 1.0
-                  delta = 2.0
-                }
-              frequencyPrivacyParams =
-                MetricSpecKt.differentialPrivacyParams {
-                  epsilon = 1.0
-                  delta = 2.0
-                }
+              reachPrivacyParams = differentialPrivacyParams {
+                epsilon = 1.0
+                delta = 2.0
+              }
+              frequencyPrivacyParams = differentialPrivacyParams {
+                epsilon = 1.0
+                delta = 2.0
+              }
               maximumFrequencyPerUser = 5
             }
           vidSamplingInterval =
@@ -1604,16 +1578,14 @@ abstract class MetricsServiceTest<T : MetricsCoroutineImplBase> {
         metricSpec = metricSpec {
           frequencyHistogram =
             MetricSpecKt.frequencyHistogramParams {
-              reachPrivacyParams =
-                MetricSpecKt.differentialPrivacyParams {
-                  epsilon = 1.0
-                  delta = 2.0
-                }
-              frequencyPrivacyParams =
-                MetricSpecKt.differentialPrivacyParams {
-                  epsilon = 1.0
-                  delta = 2.0
-                }
+              reachPrivacyParams = differentialPrivacyParams {
+                epsilon = 1.0
+                delta = 2.0
+              }
+              frequencyPrivacyParams = differentialPrivacyParams {
+                epsilon = 1.0
+                delta = 2.0
+              }
               maximumFrequencyPerUser = 5
             }
           vidSamplingInterval =
@@ -1684,16 +1656,14 @@ abstract class MetricsServiceTest<T : MetricsCoroutineImplBase> {
         metricSpec = metricSpec {
           frequencyHistogram =
             MetricSpecKt.frequencyHistogramParams {
-              reachPrivacyParams =
-                MetricSpecKt.differentialPrivacyParams {
-                  epsilon = 1.0
-                  delta = 2.0
-                }
-              frequencyPrivacyParams =
-                MetricSpecKt.differentialPrivacyParams {
-                  epsilon = 1.0
-                  delta = 2.0
-                }
+              reachPrivacyParams = differentialPrivacyParams {
+                epsilon = 1.0
+                delta = 2.0
+              }
+              frequencyPrivacyParams = differentialPrivacyParams {
+                epsilon = 1.0
+                delta = 2.0
+              }
               maximumFrequencyPerUser = 5
             }
           vidSamplingInterval =
@@ -1763,16 +1733,14 @@ abstract class MetricsServiceTest<T : MetricsCoroutineImplBase> {
       metricSpec = metricSpec {
         frequencyHistogram =
           MetricSpecKt.frequencyHistogramParams {
-            reachPrivacyParams =
-              MetricSpecKt.differentialPrivacyParams {
-                epsilon = 1.0
-                delta = 2.0
-              }
-            frequencyPrivacyParams =
-              MetricSpecKt.differentialPrivacyParams {
-                epsilon = 1.0
-                delta = 2.0
-              }
+            reachPrivacyParams = differentialPrivacyParams {
+              epsilon = 1.0
+              delta = 2.0
+            }
+            frequencyPrivacyParams = differentialPrivacyParams {
+              epsilon = 1.0
+              delta = 2.0
+            }
             maximumFrequencyPerUser = 5
           }
         vidSamplingInterval =
@@ -1844,16 +1812,14 @@ abstract class MetricsServiceTest<T : MetricsCoroutineImplBase> {
         metricSpec = metricSpec {
           frequencyHistogram =
             MetricSpecKt.frequencyHistogramParams {
-              reachPrivacyParams =
-                MetricSpecKt.differentialPrivacyParams {
-                  epsilon = 1.0
-                  delta = 2.0
-                }
-              frequencyPrivacyParams =
-                MetricSpecKt.differentialPrivacyParams {
-                  epsilon = 1.0
-                  delta = 2.0
-                }
+              reachPrivacyParams = differentialPrivacyParams {
+                epsilon = 1.0
+                delta = 2.0
+              }
+              frequencyPrivacyParams = differentialPrivacyParams {
+                epsilon = 1.0
+                delta = 2.0
+              }
               maximumFrequencyPerUser = 5
             }
           vidSamplingInterval =
@@ -1926,16 +1892,14 @@ abstract class MetricsServiceTest<T : MetricsCoroutineImplBase> {
         metricSpec = metricSpec {
           frequencyHistogram =
             MetricSpecKt.frequencyHistogramParams {
-              reachPrivacyParams =
-                MetricSpecKt.differentialPrivacyParams {
-                  epsilon = 1.0
-                  delta = 2.0
-                }
-              frequencyPrivacyParams =
-                MetricSpecKt.differentialPrivacyParams {
-                  epsilon = 1.0
-                  delta = 2.0
-                }
+              reachPrivacyParams = differentialPrivacyParams {
+                epsilon = 1.0
+                delta = 2.0
+              }
+              frequencyPrivacyParams = differentialPrivacyParams {
+                epsilon = 1.0
+                delta = 2.0
+              }
               maximumFrequencyPerUser = 5
             }
           vidSamplingInterval =
@@ -2007,16 +1971,14 @@ abstract class MetricsServiceTest<T : MetricsCoroutineImplBase> {
         metricSpec = metricSpec {
           frequencyHistogram =
             MetricSpecKt.frequencyHistogramParams {
-              reachPrivacyParams =
-                MetricSpecKt.differentialPrivacyParams {
-                  epsilon = 1.0
-                  delta = 2.0
-                }
-              frequencyPrivacyParams =
-                MetricSpecKt.differentialPrivacyParams {
-                  epsilon = 1.0
-                  delta = 2.0
-                }
+              reachPrivacyParams = differentialPrivacyParams {
+                epsilon = 1.0
+                delta = 2.0
+              }
+              frequencyPrivacyParams = differentialPrivacyParams {
+                epsilon = 1.0
+                delta = 2.0
+              }
               maximumFrequencyPerUser = 5
             }
           vidSamplingInterval =
@@ -2087,16 +2049,14 @@ abstract class MetricsServiceTest<T : MetricsCoroutineImplBase> {
       metricSpec = metricSpec {
         frequencyHistogram =
           MetricSpecKt.frequencyHistogramParams {
-            reachPrivacyParams =
-              MetricSpecKt.differentialPrivacyParams {
-                epsilon = 1.0
-                delta = 2.0
-              }
-            frequencyPrivacyParams =
-              MetricSpecKt.differentialPrivacyParams {
-                epsilon = 1.0
-                delta = 2.0
-              }
+            reachPrivacyParams = differentialPrivacyParams {
+              epsilon = 1.0
+              delta = 2.0
+            }
+            frequencyPrivacyParams = differentialPrivacyParams {
+              epsilon = 1.0
+              delta = 2.0
+            }
             maximumFrequencyPerUser = 5
           }
         vidSamplingInterval =
@@ -2160,11 +2120,10 @@ abstract class MetricsServiceTest<T : MetricsCoroutineImplBase> {
             metricSpec = metricSpec {
               reach =
                 MetricSpecKt.reachParams {
-                  privacyParams =
-                    MetricSpecKt.differentialPrivacyParams {
-                      epsilon = 1.0
-                      delta = 2.0
-                    }
+                  privacyParams = differentialPrivacyParams {
+                    epsilon = 1.0
+                    delta = 2.0
+                  }
                 }
               vidSamplingInterval =
                 MetricSpecKt.vidSamplingInterval {
@@ -2200,16 +2159,14 @@ abstract class MetricsServiceTest<T : MetricsCoroutineImplBase> {
             metricSpec = metricSpec {
               frequencyHistogram =
                 MetricSpecKt.frequencyHistogramParams {
-                  reachPrivacyParams =
-                    MetricSpecKt.differentialPrivacyParams {
-                      epsilon = 1.0
-                      delta = 2.0
-                    }
-                  frequencyPrivacyParams =
-                    MetricSpecKt.differentialPrivacyParams {
-                      epsilon = 1.0
-                      delta = 2.0
-                    }
+                  reachPrivacyParams = differentialPrivacyParams {
+                    epsilon = 1.0
+                    delta = 2.0
+                  }
+                  frequencyPrivacyParams = differentialPrivacyParams {
+                    epsilon = 1.0
+                    delta = 2.0
+                  }
                   maximumFrequencyPerUser = 5
                 }
               vidSamplingInterval =
@@ -2246,11 +2203,10 @@ abstract class MetricsServiceTest<T : MetricsCoroutineImplBase> {
             metricSpec = metricSpec {
               impressionCount =
                 MetricSpecKt.impressionCountParams {
-                  privacyParams =
-                    MetricSpecKt.differentialPrivacyParams {
-                      epsilon = 1.0
-                      delta = 2.0
-                    }
+                  privacyParams = differentialPrivacyParams {
+                    epsilon = 1.0
+                    delta = 2.0
+                  }
                   maximumFrequencyPerUser = 5
                 }
               vidSamplingInterval =
@@ -2287,11 +2243,10 @@ abstract class MetricsServiceTest<T : MetricsCoroutineImplBase> {
             metricSpec = metricSpec {
               watchDuration =
                 MetricSpecKt.watchDurationParams {
-                  privacyParams =
-                    MetricSpecKt.differentialPrivacyParams {
-                      epsilon = 1.0
-                      delta = 2.0
-                    }
+                  privacyParams = differentialPrivacyParams {
+                    epsilon = 1.0
+                    delta = 2.0
+                  }
                   maximumWatchDurationPerUser = 100
                 }
               vidSamplingInterval =
@@ -2670,11 +2625,10 @@ abstract class MetricsServiceTest<T : MetricsCoroutineImplBase> {
         metricSpec = metricSpec {
           reach =
             MetricSpecKt.reachParams {
-              privacyParams =
-                MetricSpecKt.differentialPrivacyParams {
-                  epsilon = 1.0
-                  delta = 2.0
-                }
+              privacyParams = differentialPrivacyParams {
+                epsilon = 1.0
+                delta = 2.0
+              }
             }
           vidSamplingInterval =
             MetricSpecKt.vidSamplingInterval {

--- a/src/main/kotlin/org/wfanet/measurement/reporting/service/internal/testing/v2/ReportsServiceTest.kt
+++ b/src/main/kotlin/org/wfanet/measurement/reporting/service/internal/testing/v2/ReportsServiceTest.kt
@@ -49,6 +49,7 @@ import org.wfanet.measurement.internal.reporting.v2.copy
 import org.wfanet.measurement.internal.reporting.v2.createMetricRequest
 import org.wfanet.measurement.internal.reporting.v2.createReportRequest
 import org.wfanet.measurement.internal.reporting.v2.createReportingSetRequest
+import org.wfanet.measurement.internal.reporting.v2.differentialPrivacyParams
 import org.wfanet.measurement.internal.reporting.v2.getReportRequest
 import org.wfanet.measurement.internal.reporting.v2.measurement
 import org.wfanet.measurement.internal.reporting.v2.measurementConsumer
@@ -191,11 +192,10 @@ abstract class ReportsServiceTest<T : ReportsGrpcKt.ReportsCoroutineImplBase> {
                     metricSpec = metricSpec {
                       reach =
                         MetricSpecKt.reachParams {
-                          privacyParams =
-                            MetricSpecKt.differentialPrivacyParams {
-                              epsilon = 1.0
-                              delta = 2.0
-                            }
+                          privacyParams = differentialPrivacyParams {
+                            epsilon = 1.0
+                            delta = 2.0
+                          }
                         }
                       vidSamplingInterval =
                         MetricSpecKt.vidSamplingInterval {
@@ -215,11 +215,10 @@ abstract class ReportsServiceTest<T : ReportsGrpcKt.ReportsCoroutineImplBase> {
                 metricSpecs += metricSpec {
                   reach =
                     MetricSpecKt.reachParams {
-                      privacyParams =
-                        MetricSpecKt.differentialPrivacyParams {
-                          epsilon = 1.0
-                          delta = 2.0
-                        }
+                      privacyParams = differentialPrivacyParams {
+                        epsilon = 1.0
+                        delta = 2.0
+                      }
                     }
                   vidSamplingInterval =
                     MetricSpecKt.vidSamplingInterval {
@@ -245,11 +244,10 @@ abstract class ReportsServiceTest<T : ReportsGrpcKt.ReportsCoroutineImplBase> {
                     metricSpec = metricSpec {
                       reach =
                         MetricSpecKt.reachParams {
-                          privacyParams =
-                            MetricSpecKt.differentialPrivacyParams {
-                              epsilon = 1.0
-                              delta = 2.0
-                            }
+                          privacyParams = differentialPrivacyParams {
+                            epsilon = 1.0
+                            delta = 2.0
+                          }
                         }
                       vidSamplingInterval =
                         MetricSpecKt.vidSamplingInterval {
@@ -269,11 +267,10 @@ abstract class ReportsServiceTest<T : ReportsGrpcKt.ReportsCoroutineImplBase> {
                 metricSpecs += metricSpec {
                   reach =
                     MetricSpecKt.reachParams {
-                      privacyParams =
-                        MetricSpecKt.differentialPrivacyParams {
-                          epsilon = 1.0
-                          delta = 2.0
-                        }
+                      privacyParams = differentialPrivacyParams {
+                        epsilon = 1.0
+                        delta = 2.0
+                      }
                     }
                   vidSamplingInterval =
                     MetricSpecKt.vidSamplingInterval {
@@ -346,11 +343,10 @@ abstract class ReportsServiceTest<T : ReportsGrpcKt.ReportsCoroutineImplBase> {
                     metricSpec = metricSpec {
                       reach =
                         MetricSpecKt.reachParams {
-                          privacyParams =
-                            MetricSpecKt.differentialPrivacyParams {
-                              epsilon = 1.0
-                              delta = 2.0
-                            }
+                          privacyParams = differentialPrivacyParams {
+                            epsilon = 1.0
+                            delta = 2.0
+                          }
                         }
                       vidSamplingInterval =
                         MetricSpecKt.vidSamplingInterval {
@@ -372,11 +368,10 @@ abstract class ReportsServiceTest<T : ReportsGrpcKt.ReportsCoroutineImplBase> {
                     metricSpec = metricSpec {
                       reach =
                         MetricSpecKt.reachParams {
-                          privacyParams =
-                            MetricSpecKt.differentialPrivacyParams {
-                              epsilon = 1.0
-                              delta = 2.0
-                            }
+                          privacyParams = differentialPrivacyParams {
+                            epsilon = 1.0
+                            delta = 2.0
+                          }
                         }
                       vidSamplingInterval =
                         MetricSpecKt.vidSamplingInterval {
@@ -396,11 +391,10 @@ abstract class ReportsServiceTest<T : ReportsGrpcKt.ReportsCoroutineImplBase> {
                 metricSpecs += metricSpec {
                   reach =
                     MetricSpecKt.reachParams {
-                      privacyParams =
-                        MetricSpecKt.differentialPrivacyParams {
-                          epsilon = 1.0
-                          delta = 2.0
-                        }
+                      privacyParams = differentialPrivacyParams {
+                        epsilon = 1.0
+                        delta = 2.0
+                      }
                     }
                   vidSamplingInterval =
                     MetricSpecKt.vidSamplingInterval {
@@ -506,11 +500,10 @@ abstract class ReportsServiceTest<T : ReportsGrpcKt.ReportsCoroutineImplBase> {
                       metricSpec = metricSpec {
                         reach =
                           MetricSpecKt.reachParams {
-                            privacyParams =
-                              MetricSpecKt.differentialPrivacyParams {
-                                epsilon = 1.0
-                                delta = 2.0
-                              }
+                            privacyParams = differentialPrivacyParams {
+                              epsilon = 1.0
+                              delta = 2.0
+                            }
                           }
                         vidSamplingInterval =
                           MetricSpecKt.vidSamplingInterval {
@@ -530,11 +523,10 @@ abstract class ReportsServiceTest<T : ReportsGrpcKt.ReportsCoroutineImplBase> {
                   metricSpecs += metricSpec {
                     reach =
                       MetricSpecKt.reachParams {
-                        privacyParams =
-                          MetricSpecKt.differentialPrivacyParams {
-                            epsilon = 1.0
-                            delta = 2.0
-                          }
+                        privacyParams = differentialPrivacyParams {
+                          epsilon = 1.0
+                          delta = 2.0
+                        }
                       }
                     vidSamplingInterval =
                       MetricSpecKt.vidSamplingInterval {
@@ -586,11 +578,10 @@ abstract class ReportsServiceTest<T : ReportsGrpcKt.ReportsCoroutineImplBase> {
                     metricSpec = metricSpec {
                       reach =
                         MetricSpecKt.reachParams {
-                          privacyParams =
-                            MetricSpecKt.differentialPrivacyParams {
-                              epsilon = 1.0
-                              delta = 2.0
-                            }
+                          privacyParams = differentialPrivacyParams {
+                            epsilon = 1.0
+                            delta = 2.0
+                          }
                         }
                       vidSamplingInterval =
                         MetricSpecKt.vidSamplingInterval {
@@ -610,11 +601,10 @@ abstract class ReportsServiceTest<T : ReportsGrpcKt.ReportsCoroutineImplBase> {
                 metricSpecs += metricSpec {
                   reach =
                     MetricSpecKt.reachParams {
-                      privacyParams =
-                        MetricSpecKt.differentialPrivacyParams {
-                          epsilon = 1.0
-                          delta = 2.0
-                        }
+                      privacyParams = differentialPrivacyParams {
+                        epsilon = 1.0
+                        delta = 2.0
+                      }
                     }
                   vidSamplingInterval =
                     MetricSpecKt.vidSamplingInterval {
@@ -640,11 +630,10 @@ abstract class ReportsServiceTest<T : ReportsGrpcKt.ReportsCoroutineImplBase> {
                     metricSpec = metricSpec {
                       reach =
                         MetricSpecKt.reachParams {
-                          privacyParams =
-                            MetricSpecKt.differentialPrivacyParams {
-                              epsilon = 1.0
-                              delta = 2.0
-                            }
+                          privacyParams = differentialPrivacyParams {
+                            epsilon = 1.0
+                            delta = 2.0
+                          }
                         }
                       vidSamplingInterval =
                         MetricSpecKt.vidSamplingInterval {
@@ -664,11 +653,10 @@ abstract class ReportsServiceTest<T : ReportsGrpcKt.ReportsCoroutineImplBase> {
                 metricSpecs += metricSpec {
                   reach =
                     MetricSpecKt.reachParams {
-                      privacyParams =
-                        MetricSpecKt.differentialPrivacyParams {
-                          epsilon = 1.0
-                          delta = 2.0
-                        }
+                      privacyParams = differentialPrivacyParams {
+                        epsilon = 1.0
+                        delta = 2.0
+                      }
                     }
                   vidSamplingInterval =
                     MetricSpecKt.vidSamplingInterval {
@@ -724,11 +712,10 @@ abstract class ReportsServiceTest<T : ReportsGrpcKt.ReportsCoroutineImplBase> {
                     metricSpec = metricSpec {
                       reach =
                         MetricSpecKt.reachParams {
-                          privacyParams =
-                            MetricSpecKt.differentialPrivacyParams {
-                              epsilon = 1.0
-                              delta = 2.0
-                            }
+                          privacyParams = differentialPrivacyParams {
+                            epsilon = 1.0
+                            delta = 2.0
+                          }
                         }
                       vidSamplingInterval =
                         MetricSpecKt.vidSamplingInterval {
@@ -748,11 +735,10 @@ abstract class ReportsServiceTest<T : ReportsGrpcKt.ReportsCoroutineImplBase> {
                 metricSpecs += metricSpec {
                   reach =
                     MetricSpecKt.reachParams {
-                      privacyParams =
-                        MetricSpecKt.differentialPrivacyParams {
-                          epsilon = 1.0
-                          delta = 2.0
-                        }
+                      privacyParams = differentialPrivacyParams {
+                        epsilon = 1.0
+                        delta = 2.0
+                      }
                     }
                   vidSamplingInterval =
                     MetricSpecKt.vidSamplingInterval {
@@ -934,11 +920,10 @@ abstract class ReportsServiceTest<T : ReportsGrpcKt.ReportsCoroutineImplBase> {
                       metricSpec = metricSpec {
                         reach =
                           MetricSpecKt.reachParams {
-                            privacyParams =
-                              MetricSpecKt.differentialPrivacyParams {
-                                epsilon = 1.0
-                                delta = 2.0
-                              }
+                            privacyParams = differentialPrivacyParams {
+                              epsilon = 1.0
+                              delta = 2.0
+                            }
                           }
                         vidSamplingInterval =
                           MetricSpecKt.vidSamplingInterval {
@@ -958,11 +943,10 @@ abstract class ReportsServiceTest<T : ReportsGrpcKt.ReportsCoroutineImplBase> {
                   metricSpecs += metricSpec {
                     reach =
                       MetricSpecKt.reachParams {
-                        privacyParams =
-                          MetricSpecKt.differentialPrivacyParams {
-                            epsilon = 1.0
-                            delta = 2.0
-                          }
+                        privacyParams = differentialPrivacyParams {
+                          epsilon = 1.0
+                          delta = 2.0
+                        }
                       }
                     vidSamplingInterval =
                       MetricSpecKt.vidSamplingInterval {
@@ -989,11 +973,10 @@ abstract class ReportsServiceTest<T : ReportsGrpcKt.ReportsCoroutineImplBase> {
                       metricSpec = metricSpec {
                         reach =
                           MetricSpecKt.reachParams {
-                            privacyParams =
-                              MetricSpecKt.differentialPrivacyParams {
-                                epsilon = 1.0
-                                delta = 2.0
-                              }
+                            privacyParams = differentialPrivacyParams {
+                              epsilon = 1.0
+                              delta = 2.0
+                            }
                           }
                         vidSamplingInterval =
                           MetricSpecKt.vidSamplingInterval {
@@ -1013,11 +996,10 @@ abstract class ReportsServiceTest<T : ReportsGrpcKt.ReportsCoroutineImplBase> {
                   metricSpecs += metricSpec {
                     reach =
                       MetricSpecKt.reachParams {
-                        privacyParams =
-                          MetricSpecKt.differentialPrivacyParams {
-                            epsilon = 1.0
-                            delta = 2.0
-                          }
+                        privacyParams = differentialPrivacyParams {
+                          epsilon = 1.0
+                          delta = 2.0
+                        }
                       }
                     vidSamplingInterval =
                       MetricSpecKt.vidSamplingInterval {
@@ -1311,11 +1293,10 @@ abstract class ReportsServiceTest<T : ReportsGrpcKt.ReportsCoroutineImplBase> {
                         metricSpec = metricSpec {
                           reach =
                             MetricSpecKt.reachParams {
-                              privacyParams =
-                                MetricSpecKt.differentialPrivacyParams {
-                                  epsilon = 1.0
-                                  delta = 2.0
-                                }
+                              privacyParams = differentialPrivacyParams {
+                                epsilon = 1.0
+                                delta = 2.0
+                              }
                             }
                           vidSamplingInterval =
                             MetricSpecKt.vidSamplingInterval {
@@ -1335,11 +1316,10 @@ abstract class ReportsServiceTest<T : ReportsGrpcKt.ReportsCoroutineImplBase> {
                     metricSpecs += metricSpec {
                       reach =
                         MetricSpecKt.reachParams {
-                          privacyParams =
-                            MetricSpecKt.differentialPrivacyParams {
-                              epsilon = 1.0
-                              delta = 2.0
-                            }
+                          privacyParams = differentialPrivacyParams {
+                            epsilon = 1.0
+                            delta = 2.0
+                          }
                         }
                       vidSamplingInterval =
                         MetricSpecKt.vidSamplingInterval {
@@ -1392,11 +1372,10 @@ abstract class ReportsServiceTest<T : ReportsGrpcKt.ReportsCoroutineImplBase> {
                       metricSpec = metricSpec {
                         reach =
                           MetricSpecKt.reachParams {
-                            privacyParams =
-                              MetricSpecKt.differentialPrivacyParams {
-                                epsilon = 1.0
-                                delta = 2.0
-                              }
+                            privacyParams = differentialPrivacyParams {
+                              epsilon = 1.0
+                              delta = 2.0
+                            }
                           }
                         vidSamplingInterval =
                           MetricSpecKt.vidSamplingInterval {
@@ -1416,11 +1395,10 @@ abstract class ReportsServiceTest<T : ReportsGrpcKt.ReportsCoroutineImplBase> {
                   metricSpecs += metricSpec {
                     reach =
                       MetricSpecKt.reachParams {
-                        privacyParams =
-                          MetricSpecKt.differentialPrivacyParams {
-                            epsilon = 1.0
-                            delta = 2.0
-                          }
+                        privacyParams = differentialPrivacyParams {
+                          epsilon = 1.0
+                          delta = 2.0
+                        }
                       }
                     vidSamplingInterval =
                       MetricSpecKt.vidSamplingInterval {

--- a/src/main/proto/wfa/measurement/internal/reporting/v2/BUILD.bazel
+++ b/src/main/proto/wfa/measurement/internal/reporting/v2/BUILD.bazel
@@ -36,6 +36,10 @@ proto_and_java_proto_library(
 )
 
 proto_and_java_proto_library(
+    name = "differential_privacy",
+)
+
+proto_and_java_proto_library(
     name = "measurement",
     deps = [
         ":reporting_set_proto",
@@ -75,6 +79,7 @@ kt_jvm_grpc_proto_library(
 proto_and_java_proto_library(
     name = "metric",
     deps = [
+        ":differential_privacy_proto",
         ":measurement_proto",
         "@com_google_googleapis//google/type:interval_proto",
         "@com_google_protobuf//:timestamp_proto",

--- a/src/main/proto/wfa/measurement/internal/reporting/v2/differential_privacy.proto
+++ b/src/main/proto/wfa/measurement/internal/reporting/v2/differential_privacy.proto
@@ -1,0 +1,30 @@
+// Copyright 2023 The Cross-Media Measurement Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package wfa.measurement.internal.reporting.v2;
+
+option java_package = "org.wfanet.measurement.internal.reporting.v2";
+option java_multiple_files = true;
+
+// Parameters for differential privacy (DP).
+//
+// For detail, refer to "Dwork, C. and Roth, A., 2014. The algorithmic
+// foundations of differential privacy. Foundations and Trends in Theoretical
+// Computer Science, 9(3-4), pp.211-407."
+message DifferentialPrivacyParams {
+  double epsilon = 1;
+  double delta = 2;
+}

--- a/src/main/proto/wfa/measurement/internal/reporting/v2/metric.proto
+++ b/src/main/proto/wfa/measurement/internal/reporting/v2/metric.proto
@@ -19,16 +19,12 @@ package wfa.measurement.internal.reporting.v2;
 import "google/protobuf/timestamp.proto";
 import "google/type/interval.proto";
 import "wfa/measurement/internal/reporting/v2/measurement.proto";
+import "wfa/measurement/internal/reporting/v2/differential_privacy.proto";
 
 option java_package = "org.wfanet.measurement.internal.reporting.v2";
 option java_multiple_files = true;
 
 message MetricSpec {
-  message DifferentialPrivacyParams {
-    double epsilon = 1;
-    double delta = 2;
-  }
-
   message ReachParams {
     DifferentialPrivacyParams privacy_params = 1;
   }

--- a/src/test/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/MetricsServiceTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/MetricsServiceTest.kt
@@ -163,6 +163,7 @@ import org.wfanet.measurement.internal.reporting.v2.batchSetMeasurementFailuresR
 import org.wfanet.measurement.internal.reporting.v2.batchSetMeasurementResultsRequest
 import org.wfanet.measurement.internal.reporting.v2.copy
 import org.wfanet.measurement.internal.reporting.v2.createMetricRequest as internalCreateMetricRequest
+import org.wfanet.measurement.internal.reporting.v2.differentialPrivacyParams as internalDifferentialPrivacyParams
 import org.wfanet.measurement.internal.reporting.v2.measurement as internalMeasurement
 import org.wfanet.measurement.internal.reporting.v2.metric as internalMetric
 import org.wfanet.measurement.internal.reporting.v2.metricSpec as internalMetricSpec
@@ -925,11 +926,10 @@ private val INTERNAL_REQUESTING_INCREMENTAL_REACH_METRIC = internalMetric {
   metricSpec = internalMetricSpec {
     reach =
       InternalMetricSpecKt.reachParams {
-        privacyParams =
-          InternalMetricSpecKt.differentialPrivacyParams {
-            epsilon = REACH_ONLY_REACH_EPSILON
-            delta = DIFFERENTIAL_PRIVACY_DELTA
-          }
+        privacyParams = internalDifferentialPrivacyParams {
+          epsilon = REACH_ONLY_REACH_EPSILON
+          delta = DIFFERENTIAL_PRIVACY_DELTA
+        }
       }
     vidSamplingInterval =
       InternalMetricSpecKt.vidSamplingInterval {
@@ -1031,11 +1031,10 @@ private val INTERNAL_REQUESTING_SINGLE_PUBLISHER_IMPRESSION_METRIC = internalMet
   metricSpec = internalMetricSpec {
     impressionCount =
       InternalMetricSpecKt.impressionCountParams {
-        privacyParams =
-          InternalMetricSpecKt.differentialPrivacyParams {
-            epsilon = IMPRESSION_EPSILON
-            delta = DIFFERENTIAL_PRIVACY_DELTA
-          }
+        privacyParams = internalDifferentialPrivacyParams {
+          epsilon = IMPRESSION_EPSILON
+          delta = DIFFERENTIAL_PRIVACY_DELTA
+        }
         maximumFrequencyPerUser = IMPRESSION_MAXIMUM_FREQUENCY_PER_USER
       }
     vidSamplingInterval =
@@ -1098,11 +1097,10 @@ private val INTERNAL_REQUESTING_CROSS_PUBLISHER_WATCH_DURATION_METRIC = internal
   metricSpec = internalMetricSpec {
     watchDuration =
       InternalMetricSpecKt.watchDurationParams {
-        privacyParams =
-          InternalMetricSpecKt.differentialPrivacyParams {
-            epsilon = WATCH_DURATION_EPSILON
-            delta = DIFFERENTIAL_PRIVACY_DELTA
-          }
+        privacyParams = internalDifferentialPrivacyParams {
+          epsilon = WATCH_DURATION_EPSILON
+          delta = DIFFERENTIAL_PRIVACY_DELTA
+        }
         maximumWatchDurationPerUser = MAXIMUM_WATCH_DURATION_PER_USER
       }
     vidSamplingInterval =
@@ -1699,11 +1697,10 @@ class MetricsServiceTest {
     val internalMetricSpec = internalMetricSpec {
       impressionCount =
         InternalMetricSpecKt.impressionCountParams {
-          privacyParams =
-            InternalMetricSpecKt.differentialPrivacyParams {
-              this.epsilon = epsilon
-              this.delta = delta
-            }
+          privacyParams = internalDifferentialPrivacyParams {
+            this.epsilon = epsilon
+            this.delta = delta
+          }
           this.maximumFrequencyPerUser = maximumFrequencyPerUser
         }
       vidSamplingInterval =

--- a/src/test/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/ReportsServiceTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/ReportsServiceTest.kt
@@ -62,6 +62,7 @@ import org.wfanet.measurement.internal.reporting.v2.ReportsGrpcKt.ReportsCorouti
 import org.wfanet.measurement.internal.reporting.v2.StreamReportsRequestKt
 import org.wfanet.measurement.internal.reporting.v2.copy
 import org.wfanet.measurement.internal.reporting.v2.createReportRequest as internalCreateReportRequest
+import org.wfanet.measurement.internal.reporting.v2.differentialPrivacyParams
 import org.wfanet.measurement.internal.reporting.v2.getReportRequest as internalGetReportRequest
 import org.wfanet.measurement.internal.reporting.v2.metricSpec as internalMetricSpec
 import org.wfanet.measurement.internal.reporting.v2.periodicTimeInterval as internalPeriodicTimeInterval
@@ -3221,11 +3222,10 @@ class ReportsServiceTest {
     private val INTERNAL_REACH_METRIC_SPEC: InternalMetricSpec = internalMetricSpec {
       reach =
         InternalMetricSpecKt.reachParams {
-          privacyParams =
-            InternalMetricSpecKt.differentialPrivacyParams {
-              epsilon = REACH_ONLY_REACH_EPSILON
-              delta = DIFFERENTIAL_PRIVACY_DELTA
-            }
+          privacyParams = differentialPrivacyParams {
+            epsilon = REACH_ONLY_REACH_EPSILON
+            delta = DIFFERENTIAL_PRIVACY_DELTA
+          }
         }
       vidSamplingInterval =
         InternalMetricSpecKt.vidSamplingInterval {
@@ -3257,16 +3257,14 @@ class ReportsServiceTest {
     private val INTERNAL_FREQUENCY_HISTOGRAM_METRIC_SPEC: InternalMetricSpec = internalMetricSpec {
       frequencyHistogram =
         InternalMetricSpecKt.frequencyHistogramParams {
-          reachPrivacyParams =
-            InternalMetricSpecKt.differentialPrivacyParams {
-              epsilon = REACH_FREQUENCY_REACH_EPSILON
-              delta = DIFFERENTIAL_PRIVACY_DELTA
-            }
-          frequencyPrivacyParams =
-            InternalMetricSpecKt.differentialPrivacyParams {
-              epsilon = REACH_FREQUENCY_FREQUENCY_EPSILON
-              delta = DIFFERENTIAL_PRIVACY_DELTA
-            }
+          reachPrivacyParams = differentialPrivacyParams {
+            epsilon = REACH_FREQUENCY_REACH_EPSILON
+            delta = DIFFERENTIAL_PRIVACY_DELTA
+          }
+          frequencyPrivacyParams = differentialPrivacyParams {
+            epsilon = REACH_FREQUENCY_FREQUENCY_EPSILON
+            delta = DIFFERENTIAL_PRIVACY_DELTA
+          }
           maximumFrequencyPerUser = REACH_FREQUENCY_MAXIMUM_FREQUENCY_PER_USER
         }
       vidSamplingInterval =
@@ -3295,11 +3293,10 @@ class ReportsServiceTest {
     private val INTERNAL_WATCH_DURATION_METRIC_SPEC: InternalMetricSpec = internalMetricSpec {
       watchDuration =
         InternalMetricSpecKt.watchDurationParams {
-          privacyParams =
-            InternalMetricSpecKt.differentialPrivacyParams {
-              epsilon = WATCH_DURATION_EPSILON
-              delta = DIFFERENTIAL_PRIVACY_DELTA
-            }
+          privacyParams = differentialPrivacyParams {
+            epsilon = WATCH_DURATION_EPSILON
+            delta = DIFFERENTIAL_PRIVACY_DELTA
+          }
           maximumWatchDurationPerUser = MAXIMUM_WATCH_DURATION_PER_USER
         }
       vidSamplingInterval =


### PR DESCRIPTION
Part of the changes for implementing error bars in reporting server. Before adding an internal protocol config of measurements to the internal reporting server, we pulled the DP params message out of the internal metric message as later the internal protocol config needs it.