### PR TITLE
Add a larger-scale SyntheticEventGroupSpec.

### DIFF
--- a/src/main/k8s/dev/duchy_gke.cue
+++ b/src/main/k8s/dev/duchy_gke.cue
@@ -37,7 +37,7 @@ _duchy_cert_name: "duchies/\(_duchy_name)/certificates/\(_certificateId)"
 }
 #MillResourceRequirements: ResourceRequirements=#ResourceRequirements & {
 	requests: {
-		cpu:    "800m"
+		cpu:    "3"
 		memory: "2Gi"
 	}
 	limits: {
@@ -74,6 +74,7 @@ duchy: #Duchy & {
 	_kingdom_system_api_target: #KingdomSystemApiTarget
 	_blob_storage_flags:        _cloudStorageConfig.flags
 	_verbose_grpc_logging:      "false"
+	_duchyMillParallelism:      4
 
 	deployments: {
 		"spanner-computations-server-deployment": {

--- a/src/main/k8s/dev/synthetic_generator_config_files_kustomization.yaml
+++ b/src/main/k8s/dev/synthetic_generator_config_files_kustomization.yaml
@@ -18,3 +18,4 @@ configMapGenerator:
   - synthetic_population_spec.textproto
   - synthetic_event_group_spec_1.textproto
   - synthetic_event_group_spec_2.textproto
+  - synthetic_event_group_spec_3.textproto

--- a/src/main/k8s/dev/synthetic_generator_edp_simulator_gke.cue
+++ b/src/main/k8s/dev/synthetic_generator_edp_simulator_gke.cue
@@ -16,8 +16,8 @@ package k8s
 
 _resourceRequirements: ResourceRequirements=#ResourceRequirements & {
 	requests: {
-		cpu:    "100m"
-		memory: "256Mi"
+		cpu:    "500m"
+		memory: "288Mi"
 	}
 	limits: {
 		memory: ResourceRequirements.requests.memory
@@ -28,6 +28,7 @@ _populationSpec: "/etc/\(#AppName)/config-files/synthetic_population_spec.textpr
 _eventGroupSpecs: [
 	"/etc/\(#AppName)/config-files/synthetic_event_group_spec_1.textproto",
 	"/etc/\(#AppName)/config-files/synthetic_event_group_spec_2.textproto",
+	"/etc/\(#AppName)/config-files/synthetic_event_group_spec_3.textproto",
 ]
 
 edp_simulators: {
@@ -43,6 +44,7 @@ edp_simulators: {
 			]
 			deployment: {
 				_container: {
+					_javaOptions: maxHeapSize: "96M"
 					resources: _resourceRequirements
 				}
 				spec: template: spec: {

--- a/src/main/k8s/testing/data/synthetic_event_group_spec_3.textproto
+++ b/src/main/k8s/testing/data/synthetic_event_group_spec_3.textproto
@@ -1,0 +1,139 @@
+# proto-file: wfa/measurement/api/v2alpha/event_group_metadata/testing/simulator_synthetic_data_spec.proto
+# proto-message: SyntheticEventGroupSpec
+
+# Spec for use with synthetic_population_spec.textproto.
+
+date_specs {
+  date_range {
+    start {
+      year: 2021
+      month: 3
+      day: 15
+    }
+    end_exclusive {
+      year: 2021
+      month: 3
+      day: 16
+    }
+  }
+  frequency_specs {
+    frequency: 1
+    vid_range_specs {
+      vid_range {
+        start: 1001
+        end_exclusive: 501001
+      }
+      non_population_field_values {
+        key: "video_ad.viewed_fraction"
+        value {
+          double_value: 0.25
+        }
+      }
+    }
+  }
+  frequency_specs {
+    frequency: 2
+    vid_range_specs {
+      vid_range {
+        start: 501001
+        end_exclusive: 600001
+      }
+      non_population_field_values {
+        key: "video_ad.viewed_fraction"
+        value {
+          double_value: 0.5
+        }
+      }
+    }
+  }
+  frequency_specs {
+    frequency: 1
+    vid_range_specs {
+      vid_range {
+        start: 5000001
+        end_exclusive: 5500001
+      }
+      non_population_field_values {
+        key: "video_ad.viewed_fraction"
+        value {
+          double_value: 0.75
+        }
+      }
+    }
+  }
+  frequency_specs {
+    frequency: 1
+    vid_range_specs {
+      vid_range {
+        start: 7000001
+        end_exclusive: 8000001
+      }
+      non_population_field_values {
+        key: "video_ad.viewed_fraction"
+        value {
+          double_value: 0.25
+        }
+      }
+    }
+  }
+  frequency_specs {
+    frequency: 1
+    vid_range_specs {
+      vid_range {
+        start: 11000001
+        end_exclusive: 1200001
+      }
+      non_population_field_values {
+        key: "video_ad.viewed_fraction"
+        value {
+          double_value: 0.5
+        }
+      }
+    }
+  }
+  frequency_specs {
+    frequency: 1
+    vid_range_specs {
+      vid_range {
+        start: 14000001
+        end_exclusive: 14100001
+      }
+      non_population_field_values {
+        key: "video_ad.viewed_fraction"
+        value {
+          double_value: 0.75
+        }
+      }
+    }
+  }
+  frequency_specs {
+    frequency: 1
+    vid_range_specs {
+      vid_range {
+        start: 18001001
+        end_exclusive: 18002001
+      }
+      non_population_field_values {
+        key: "video_ad.viewed_fraction"
+        value {
+          double_value: 0.25
+        }
+      }
+    }
+  }
+  frequency_specs {
+    frequency: 2
+    vid_range_specs {
+      vid_range {
+        start: 18002001
+        end_exclusive: 18003001
+      }
+      non_population_field_values {
+        key: "video_ad.viewed_fraction"
+        value {
+          double_value: 0.5
+        }
+      }
+    }
+  }
+}

--- a/src/main/terraform/gcloud/cmms/duchies.tf
+++ b/src/main/terraform/gcloud/cmms/duchies.tf
@@ -38,8 +38,8 @@ module "default_node_pools" {
   cluster         = each.value
   name            = "default"
   service_account = module.common.cluster_service_account
-  machine_type    = "e2-medium"
-  max_node_count  = 3
+  machine_type    = "e2-standard-2"
+  max_node_count  = 2
 }
 
 module "highmem_node_pools" {
@@ -49,7 +49,7 @@ module "highmem_node_pools" {
   cluster         = each.value
   name            = "highmem"
   service_account = module.common.cluster_service_account
-  machine_type    = "e2-standard-2"
+  machine_type    = "c3-highcpu-4"
   max_node_count  = 2
   spot            = true
 }

--- a/src/main/terraform/gcloud/cmms/simulators.tf
+++ b/src/main/terraform/gcloud/cmms/simulators.tf
@@ -34,7 +34,7 @@ module "simulators_default_node_pool" {
   name            = "default"
   cluster         = data.google_container_cluster.simulators
   service_account = module.common.cluster_service_account
-  machine_type    = "e2-medium"
+  machine_type    = "e2-standard-2"
   max_node_count  = 2
 }
 
@@ -44,7 +44,7 @@ module "simulators_spot_node_pool" {
   name            = "spot"
   cluster         = data.google_container_cluster.simulators
   service_account = module.common.cluster_service_account
-  machine_type    = "e2-custom-2-4096"
+  machine_type    = "c3-highcpu-4"
   max_node_count  = 3
   spot            = true
 }


### PR DESCRIPTION
This is used in the dev K8s configuration. It is not used in local tests due to CI memory constraints.