### PR TITLE
Remove non-template fields from our test templates.

### DIFF
--- a/src/main/kotlin/org/wfanet/measurement/loadtest/dataprovider/BUILD.bazel
+++ b/src/main/kotlin/org/wfanet/measurement/loadtest/dataprovider/BUILD.bazel
@@ -14,9 +14,16 @@ package(
 )
 
 kt_jvm_library(
+    name = "labeled_event",
+    srcs = ["LabeledEvent.kt"],
+    deps = ["@wfa_common_jvm//imports/java/com/google/protobuf"],
+)
+
+kt_jvm_library(
     name = "event_query",
     srcs = ["EventQuery.kt"],
     deps = [
+        ":labeled_event",
         "//imports/java/org/projectnessie/cel",
         "//src/main/kotlin/org/wfanet/measurement/eventdataprovider/eventfiltration:event_filters",
         "//src/main/proto/wfa/measurement/api/v2alpha:event_group_kt_jvm_proto",
@@ -30,6 +37,7 @@ kt_jvm_library(
     srcs = ["InMemoryEventQuery.kt"],
     deps = [
         ":event_query",
+        ":labeled_event",
         "//imports/java/org/projectnessie/cel",
         "//src/main/kotlin/org/wfanet/measurement/eventdataprovider/eventfiltration:event_filters",
         "//src/main/proto/wfa/measurement/api/v2alpha/event_templates/testing:test_event_kt_jvm_proto",
@@ -42,6 +50,7 @@ kt_jvm_library(
     srcs = ["CsvEventQuery.kt"],
     deps = [
         ":in_memory_event_query",
+        ":labeled_event",
         "//src/main/proto/wfa/measurement/api/v2alpha/event_templates/testing:test_event_kt_jvm_proto",
         "@wfa_common_jvm//imports/java/com/opencsv",
         "@wfa_common_jvm//src/main/kotlin/org/wfanet/measurement/common",
@@ -53,10 +62,12 @@ kt_jvm_library(
     srcs = ["BigQueryEventQuery.kt"],
     deps = [
         ":event_query",
+        ":labeled_event",
         "//src/main/kotlin/org/wfanet/measurement/eventdataprovider/eventfiltration:event_filters",
         "//src/main/proto/wfa/measurement/api/v2alpha/event_templates/testing:test_event_kt_jvm_proto",
         "@wfa_common_jvm//imports/java/com/google/cloud/bigquery",
         "@wfa_common_jvm//src/main/kotlin/org/wfanet/measurement/common",
+        "@wfa_common_jvm//src/main/kotlin/org/wfanet/measurement/gcloud/common",
     ],
 )
 
@@ -65,6 +76,7 @@ kt_jvm_library(
     srcs = ["SyntheticGeneratorEventQuery.kt"],
     deps = [
         ":event_query",
+        ":labeled_event",
         ":synthetic_data_generation",
         "//src/main/kotlin/org/wfanet/measurement/eventdataprovider/eventfiltration:event_filters",
         "//src/main/proto/wfa/measurement/api/v2alpha/event_group_metadata/testing:simulator_synthetic_data_spec_kt_jvm_proto",
@@ -79,6 +91,7 @@ kt_jvm_library(
         "SyntheticDataGeneration.kt",
     ],
     deps = [
+        ":labeled_event",
         "//src/main/proto/wfa/measurement/api/v2alpha/event_group_metadata/testing:simulator_synthetic_data_spec_kt_jvm_proto",
         "@wfa_common_jvm//src/main/kotlin/org/wfanet/measurement/common",
     ],

--- a/src/main/kotlin/org/wfanet/measurement/loadtest/dataprovider/EdpSimulator.kt
+++ b/src/main/kotlin/org/wfanet/measurement/loadtest/dataprovider/EdpSimulator.kt
@@ -145,7 +145,7 @@ class EdpSimulator(
   private val eventGroupMetadataDescriptorsStub: EventGroupMetadataDescriptorsCoroutineStub,
   private val requisitionsStub: RequisitionsCoroutineStub,
   private val requisitionFulfillmentStub: RequisitionFulfillmentCoroutineStub,
-  private val eventQuery: EventQuery,
+  private val eventQuery: EventQuery<Message>,
   private val throttler: Throttler,
   private val privacyBudgetManager: PrivacyBudgetManager,
   private val trustedCertificates: Map<ByteString, X509Certificate>,

--- a/src/main/kotlin/org/wfanet/measurement/loadtest/dataprovider/EdpSimulatorRunner.kt
+++ b/src/main/kotlin/org/wfanet/measurement/loadtest/dataprovider/EdpSimulatorRunner.kt
@@ -39,7 +39,7 @@ abstract class EdpSimulatorRunner() : Runnable {
   protected lateinit var flags: EdpSimulatorFlags
     private set
 
-  protected fun run(eventQuery: EventQuery, eventGroupMetadata: Message) {
+  protected fun run(eventQuery: EventQuery<Message>, eventGroupMetadata: Message) {
     val clientCerts =
       SigningCerts.fromPemFiles(
         certificateFile = flags.tlsFlags.certFile,

--- a/src/main/kotlin/org/wfanet/measurement/loadtest/dataprovider/LabeledEvent.kt
+++ b/src/main/kotlin/org/wfanet/measurement/loadtest/dataprovider/LabeledEvent.kt
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2023 The Cross-Media Measurement Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wfanet.measurement.loadtest.dataprovider
+
+import com.google.protobuf.Message
+import java.time.Instant
+
+/** An event [message] with [timestamp] and [vid] labels. */
+data class LabeledEvent<T : Message>(val timestamp: Instant, val vid: Long, val message: T)

--- a/src/main/kotlin/org/wfanet/measurement/loadtest/dataprovider/SketchGenerator.kt
+++ b/src/main/kotlin/org/wfanet/measurement/loadtest/dataprovider/SketchGenerator.kt
@@ -16,6 +16,7 @@
 
 package org.wfanet.measurement.loadtest.dataprovider
 
+import com.google.protobuf.Message
 import org.wfanet.anysketch.AnySketch
 import org.wfanet.anysketch.Sketch
 import org.wfanet.anysketch.SketchConfig
@@ -31,7 +32,7 @@ import org.wfanet.measurement.api.v2alpha.MeasurementSpec
 import org.wfanet.measurement.loadtest.config.VidSampling
 
 class SketchGenerator(
-  private val eventQuery: EventQuery,
+  private val eventQuery: EventQuery<Message>,
   private val sketchConfig: SketchConfig,
   private val vidSamplingInterval: MeasurementSpec.VidSamplingInterval
 ) {

--- a/src/main/kotlin/org/wfanet/measurement/loadtest/dataprovider/SyntheticDataGeneration.kt
+++ b/src/main/kotlin/org/wfanet/measurement/loadtest/dataprovider/SyntheticDataGeneration.kt
@@ -16,11 +16,8 @@
 
 package org.wfanet.measurement.loadtest.dataprovider
 
-import com.google.protobuf.Descriptors.Descriptor
 import com.google.protobuf.Descriptors.FieldDescriptor
-import com.google.protobuf.DynamicMessage
 import com.google.protobuf.Message
-import java.time.Instant
 import java.time.ZoneOffset
 import org.wfanet.measurement.api.v2alpha.event_group_metadata.testing.FieldValue
 import org.wfanet.measurement.api.v2alpha.event_group_metadata.testing.SimulatorSyntheticDataSpec
@@ -33,21 +30,22 @@ import org.wfanet.measurement.common.rangeTo
 import org.wfanet.measurement.common.toLocalDate
 
 object SyntheticDataGeneration {
-  data class LabeledEvent(val vid: Long, val timestamp: Instant, val event: Message)
-
   /**
-   * Generates a sequence of [LabeledEvent].
+   * Generates a sequence of [EventQuery.LabeledEvent].
    *
    * Consumption of [Sequence] throws
    * * [IllegalArgumentException] when [SimulatorSyntheticDataSpec] is invalid, or incompatible
-   * * with the [Descriptor].
+   * * with [T].
+   *
+   * @param messageInstance an instance of the event message type [T]
+   * @param populationSpec specification of the synthetic population
+   * @param syntheticEventGroupSpec specification of the synthetic event group
    */
-  @JvmStatic
-  fun generateEvents(
-    descriptor: Descriptor,
+  fun <T : Message> generateEvents(
+    messageInstance: T,
     populationSpec: SyntheticPopulationSpec,
     syntheticEventGroupSpec: SyntheticEventGroupSpec
-  ): Sequence<LabeledEvent> {
+  ): Sequence<LabeledEvent<T>> {
     val subPopulations = populationSpec.subPopulationsList
 
     return sequence {
@@ -60,7 +58,7 @@ object SyntheticDataGeneration {
               vidRangeSpec.vidRange.findSubPopulation(subPopulations)
                 ?: throw IllegalArgumentException()
 
-            val builder = DynamicMessage.newBuilder(descriptor)
+            val builder: Message.Builder = messageInstance.newBuilderForType()
 
             populationSpec.populationFieldsList.forEach {
               val subPopulationFieldValue: FieldValue =
@@ -76,11 +74,13 @@ object SyntheticDataGeneration {
               builder.setField(fieldPath, nonPopulationFieldValue)
             }
 
-            val event: DynamicMessage = builder.build()
+            @Suppress("UNCHECKED_CAST") // Safe per protobuf API.
+            val message = builder.build() as T
+
             for (vid in vidRangeSpec.vidRange.start until vidRangeSpec.vidRange.endExclusive) {
               for (date in dateProgression) {
                 for (i in 0 until frequencySpec.frequency) {
-                  yield(LabeledEvent(vid, date.atStartOfDay().toInstant(ZoneOffset.UTC), event))
+                  yield(LabeledEvent(date.atStartOfDay().toInstant(ZoneOffset.UTC), vid, message))
                 }
               }
             }
@@ -118,7 +118,7 @@ object SyntheticDataGeneration {
    */
   private fun Message.Builder.setField(fieldPath: Collection<String>, fieldValue: FieldValue) {
     val builder = this
-    val curFieldDescriptor: FieldDescriptor =
+    val field: FieldDescriptor =
       descriptorForType.findFieldByName(fieldPath.first()) ?: throw IllegalArgumentException()
 
     if (fieldPath.size == 1) {
@@ -127,8 +127,7 @@ object SyntheticDataGeneration {
         when (fieldValue.valueCase) {
           FieldValue.ValueCase.STRING_VALUE -> fieldValue.stringValue
           FieldValue.ValueCase.BOOL_VALUE -> fieldValue.boolValue
-          FieldValue.ValueCase.ENUM_VALUE ->
-            curFieldDescriptor.enumType.findValueByNumber(fieldValue.enumValue)
+          FieldValue.ValueCase.ENUM_VALUE -> field.enumType.findValueByNumber(fieldValue.enumValue)
           FieldValue.ValueCase.DOUBLE_VALUE -> fieldValue.doubleValue
           FieldValue.ValueCase.FLOAT_VALUE -> fieldValue.floatValue
           FieldValue.ValueCase.INT32_VALUE -> fieldValue.int32Value
@@ -138,12 +137,15 @@ object SyntheticDataGeneration {
           FieldValue.ValueCase.VALUE_NOT_SET -> throw IllegalArgumentException()
         }
 
-      builder.setField(curFieldDescriptor, value)
-
+      try {
+        builder.setField(field, value)
+      } catch (e: ClassCastException) {
+        throw IllegalArgumentException("Incorrect field value type for $fieldPath", e)
+      }
       return
     }
 
-    val nestedBuilder = builder.getFieldBuilder(curFieldDescriptor)
+    val nestedBuilder = builder.getFieldBuilder(field)
     val traversedFieldPath = fieldPath.drop(1)
     nestedBuilder.setField(traversedFieldPath, fieldValue)
   }

--- a/src/main/kotlin/org/wfanet/measurement/loadtest/measurementconsumer/MeasurementConsumerSimulator.kt
+++ b/src/main/kotlin/org/wfanet/measurement/loadtest/measurementconsumer/MeasurementConsumerSimulator.kt
@@ -16,6 +16,7 @@ package org.wfanet.measurement.loadtest.measurementconsumer
 
 import com.google.common.truth.Truth.assertThat
 import com.google.protobuf.ByteString
+import com.google.protobuf.Message
 import com.google.type.interval
 import io.grpc.StatusException
 import java.security.SignatureException
@@ -114,7 +115,7 @@ class MeasurementConsumerSimulator(
   private val certificatesClient: CertificatesCoroutineStub,
   private val resultPollingDelay: Duration,
   private val trustedCertificates: Map<ByteString, X509Certificate>,
-  private val eventQuery: EventQuery,
+  private val eventQuery: EventQuery<Message>,
 ) {
   /** Cache of resource name to [Certificate]. */
   private val certificateCache = mutableMapOf<String, Certificate>()

--- a/src/main/proto/wfa/measurement/api/v2alpha/event_templates/testing/BUILD.bazel
+++ b/src/main/proto/wfa/measurement/api/v2alpha/event_templates/testing/BUILD.bazel
@@ -39,7 +39,6 @@ proto_library(
         ":banner_proto",
         ":person_proto",
         ":video_proto",
-        "@com_google_protobuf//:timestamp_proto",
         "@uk_pilot_event_templates//src/main/proto/eventtemplates:event_templates_proto",
     ],
 )

--- a/src/main/proto/wfa/measurement/api/v2alpha/event_templates/testing/person.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/event_templates/testing/person.proto
@@ -32,14 +32,12 @@ message Person {
     description: "Common fields about a person"
   };
 
-  int64 vid = 1;
-
   enum Gender {
     GENDER_UNSPECIFIED = 0;
     MALE = 1;
     FEMALE = 2;
   }
-  Gender gender = 2 [
+  Gender gender = 1 [
     (.wfa.measurement.api.v2alpha.template_field) = { display_name: "Gender" }
   ];
 
@@ -49,7 +47,7 @@ message Person {
     YEARS_35_TO_54 = 2;
     YEARS_55_PLUS = 3;
   }
-  AgeGroup age_group = 3 [(.wfa.measurement.api.v2alpha.template_field) = {
+  AgeGroup age_group = 2 [(.wfa.measurement.api.v2alpha.template_field) = {
     display_name: "Age Group"
   }];
 
@@ -58,7 +56,7 @@ message Person {
     A_B_C1 = 1;
     C2_D_E = 2;
   }
-  SocialGradeGroup social_grade_group = 4
+  SocialGradeGroup social_grade_group = 3
       [(.wfa.measurement.api.v2alpha.template_field) = {
         display_name: "Social Grade"
       }];

--- a/src/main/proto/wfa/measurement/api/v2alpha/event_templates/testing/test_event.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/event_templates/testing/test_event.proto
@@ -18,7 +18,6 @@ package wfa.measurement.api.v2alpha.event_templates.testing;
 
 import "eventtemplates/common_template.proto";
 import "eventtemplates/video_event_template.proto";
-import "google/protobuf/timestamp.proto";
 import "wfa/measurement/api/v2alpha/event_templates/testing/banner_ad.proto";
 import "wfa/measurement/api/v2alpha/event_templates/testing/person.proto";
 import "wfa/measurement/api/v2alpha/event_templates/testing/video.proto";
@@ -27,12 +26,10 @@ option java_package = "org.wfanet.measurement.api.v2alpha.event_templates.testin
 option java_multiple_files = true;
 
 message TestEvent {
-  google.protobuf.Timestamp time = 1;
+  Person person = 1;
+  Video video_ad = 2;
+  Banner banner_ad = 3;
 
-  Person person = 2;
-  Video video_ad = 3;
-  Banner banner_ad = 4;
-
-  eventtemplates.CommonTemplate common_template = 5;
-  eventtemplates.VideoEventTemplate video_event_template = 6;
+  eventtemplates.CommonTemplate common_template = 4;
+  eventtemplates.VideoEventTemplate video_event_template = 5;
 }

--- a/src/test/kotlin/org/wfanet/measurement/loadtest/dataprovider/EdpSimulatorTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/loadtest/dataprovider/EdpSimulatorTest.kt
@@ -289,19 +289,15 @@ class EdpSimulatorTest {
     date: LocalDate,
     ageGroup: Person.AgeGroup,
     gender: Person.Gender
-  ): Map<Long, List<TestEvent>> {
-    return vidRange.associateWith { vid ->
-      listOf(
-        testEvent {
-          time = date.atStartOfDay().toInstant(ZoneOffset.UTC).toProtoTime()
-          person = person {
-            this.vid = vid
-            this.ageGroup = ageGroup
-            this.gender = gender
-          }
-        }
-      )
+  ): List<LabeledTestEvent> {
+    val timestamp = date.atStartOfDay().toInstant(ZoneOffset.UTC)
+    val message = testEvent {
+      person = person {
+        this.ageGroup = ageGroup
+        this.gender = gender
+      }
     }
+    return vidRange.map { vid -> LabeledTestEvent(timestamp, vid, message) }
   }
 
   @Test
@@ -727,7 +723,7 @@ class EdpSimulatorTest {
 
   @Test
   fun `refuses requisition when DuchyEntry verification fails`() {
-    val eventQueryMock = mock<EventQuery>()
+    val eventQueryMock = mock<EventQuery<TestEvent>>()
     val simulator =
       EdpSimulator(
         EDP_DATA,
@@ -786,7 +782,7 @@ class EdpSimulatorTest {
 
   @Test
   fun `refuses Requisition when EventGroup not found`() {
-    val eventQueryMock = mock<EventQuery>()
+    val eventQueryMock = mock<EventQuery<TestEvent>>()
     val simulator =
       EdpSimulator(
         EDP_DATA,

--- a/src/test/kotlin/org/wfanet/measurement/loadtest/dataprovider/SyntheticDataGenerationTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/loadtest/dataprovider/SyntheticDataGenerationTest.kt
@@ -185,18 +185,12 @@ class SyntheticDataGenerationTest {
         }
     }
 
-    val eventSequence =
-      SyntheticDataGeneration.generateEvents(TEST_EVENT_DESCRIPTOR, population, eventGroupSpec)
-
-    val parsedLabeledEvents =
-      eventSequence
-        .map {
-          SyntheticDataGeneration.LabeledEvent(
-            it.vid,
-            it.timestamp,
-            TestEvent.parseFrom(it.event.toByteString())
-          )
-        }
+    val labeledEvents: List<LabeledEvent<TestEvent>> =
+      SyntheticDataGeneration.generateEvents(
+          TestEvent.getDefaultInstance(),
+          population,
+          eventGroupSpec
+        )
         .toList()
 
     val subPopulationPerson = person {
@@ -236,31 +230,23 @@ class SyntheticDataGenerationTest {
     val timestamp = LocalDate.of(2023, 6, 27).atStartOfDay().toInstant(ZoneOffset.UTC)
     val timestamp2 = LocalDate.of(2023, 6, 28).atStartOfDay().toInstant(ZoneOffset.UTC)
 
-    val expectedTestEvents = mutableListOf<SyntheticDataGeneration.LabeledEvent>()
+    val expectedTestEvents = mutableListOf<LabeledEvent<TestEvent>>()
     repeat(2) {
       for (vid in 0L until 25L) {
-        expectedTestEvents.add(
-          SyntheticDataGeneration.LabeledEvent(vid, timestamp, expectedTestEvent)
-        )
+        expectedTestEvents.add(LabeledEvent(timestamp, vid, expectedTestEvent))
       }
       for (vid in 25L until 50L) {
-        expectedTestEvents.add(
-          SyntheticDataGeneration.LabeledEvent(vid, timestamp, expectedTestEvent2)
-        )
+        expectedTestEvents.add(LabeledEvent(timestamp, vid, expectedTestEvent2))
       }
     }
     for (vid in 50L until 75L) {
-      expectedTestEvents.add(
-        SyntheticDataGeneration.LabeledEvent(vid, timestamp, expectedTestEvent3)
-      )
+      expectedTestEvents.add(LabeledEvent(timestamp, vid, expectedTestEvent3))
     }
     for (vid in 75L until 100L) {
-      expectedTestEvents.add(
-        SyntheticDataGeneration.LabeledEvent(vid, timestamp2, expectedTestEvent4)
-      )
+      expectedTestEvents.add(LabeledEvent(timestamp2, vid, expectedTestEvent4))
     }
 
-    assertThat(parsedLabeledEvents).containsExactlyElementsIn(expectedTestEvents)
+    assertThat(labeledEvents).containsExactlyElementsIn(expectedTestEvents)
   }
 
   @Test
@@ -314,8 +300,12 @@ class SyntheticDataGenerationTest {
     }
 
     val testEvents: List<TestEvent> =
-      SyntheticDataGeneration.generateEvents(TEST_EVENT_DESCRIPTOR, populationSpec, eventGroupSpec)
-        .map { TestEvent.parseFrom(it.event.toByteString()) }
+      SyntheticDataGeneration.generateEvents(
+          TestEvent.getDefaultInstance(),
+          populationSpec,
+          eventGroupSpec
+        )
+        .map { TestEvent.parseFrom(it.message.toByteString()) }
         .toList()
 
     assertThat(testEvents).hasSize(10)
@@ -385,7 +375,11 @@ class SyntheticDataGenerationTest {
     }
 
     assertFailsWith<IllegalArgumentException> {
-      SyntheticDataGeneration.generateEvents(TEST_EVENT_DESCRIPTOR, population, eventGroupSpec)
+      SyntheticDataGeneration.generateEvents(
+          TestEvent.getDefaultInstance(),
+          population,
+          eventGroupSpec
+        )
         .toList()
     }
   }
@@ -451,7 +445,11 @@ class SyntheticDataGenerationTest {
     }
 
     assertFailsWith<IllegalArgumentException> {
-      SyntheticDataGeneration.generateEvents(TEST_EVENT_DESCRIPTOR, population, eventGroupSpec)
+      SyntheticDataGeneration.generateEvents(
+          TestEvent.getDefaultInstance(),
+          population,
+          eventGroupSpec
+        )
         .toList()
     }
   }
@@ -517,7 +515,11 @@ class SyntheticDataGenerationTest {
     }
 
     assertFailsWith<IllegalArgumentException> {
-      SyntheticDataGeneration.generateEvents(TEST_EVENT_DESCRIPTOR, population, eventGroupSpec)
+      SyntheticDataGeneration.generateEvents(
+          TestEvent.getDefaultInstance(),
+          population,
+          eventGroupSpec
+        )
         .toList()
     }
   }
@@ -583,12 +585,12 @@ class SyntheticDataGenerationTest {
     }
 
     assertFailsWith<IllegalArgumentException> {
-      SyntheticDataGeneration.generateEvents(TEST_EVENT_DESCRIPTOR, population, eventGroupSpec)
+      SyntheticDataGeneration.generateEvents(
+          TestEvent.getDefaultInstance(),
+          population,
+          eventGroupSpec
+        )
         .toList()
     }
-  }
-
-  companion object {
-    private val TEST_EVENT_DESCRIPTOR = TestEvent.getDescriptor()
   }
 }


### PR DESCRIPTION
Every field on an event message should use a message type that has an event_template annotation, and every field on a template message should have a template_field annotation.