### PR TITLE
EDP simulator supports ACDP composition

### DIFF
--- a/src/main/kotlin/org/wfanet/measurement/eventdataprovider/privacybudgetmanagement/PrivacyBudgetManagerException.kt
+++ b/src/main/kotlin/org/wfanet/measurement/eventdataprovider/privacybudgetmanagement/PrivacyBudgetManagerException.kt
@@ -20,6 +20,9 @@ enum class PrivacyBudgetManagerExceptionType(val errorMessage: String) {
   UPDATE_AFTER_COMMIT("Cannot update a transaction context after a commit"),
   NESTED_TRANSACTION("Backing Store doesn't support nested transactions"),
   BACKING_STORE_CLOSED("Cannot start a transaction after closing the backing store"),
+  INCORRECT_NOISE_MECHANISM(
+    "Noise mechanism should be DISCRETE_GAUSSIAN or GAUSSIAN for ACDP composition"
+  ),
 }
 
 /** An exception thrown by the privacy budget manager. */

--- a/src/main/kotlin/org/wfanet/measurement/eventdataprovider/privacybudgetmanagement/PrivacyQuery.kt
+++ b/src/main/kotlin/org/wfanet/measurement/eventdataprovider/privacybudgetmanagement/PrivacyQuery.kt
@@ -67,3 +67,13 @@ data class AcdpQuery(
   val landscapeMask: LandscapeMask,
   val acdpCharge: AcdpCharge,
 )
+
+/** Supported Composition mechanisms in Privacy Budget Manager. */
+enum class CompositionMechanism {
+  // DP_ADVANCED is Advanced Composition under Differential Privacy which should be used with
+  // Laplace noise.
+  DP_ADVANCED,
+  // ACDP is Almost Concentrated Differential Privacy Composition which should be used with
+  // Gaussian noise.
+  ACDP,
+}

--- a/src/main/kotlin/org/wfanet/measurement/eventdataprovider/privacybudgetmanagement/PrivacyQuery.kt
+++ b/src/main/kotlin/org/wfanet/measurement/eventdataprovider/privacybudgetmanagement/PrivacyQuery.kt
@@ -70,10 +70,11 @@ data class AcdpQuery(
 
 /** Supported Composition mechanisms in Privacy Budget Manager. */
 enum class CompositionMechanism {
-  // Advanced Composition under Differential Privacy which should be used with
-  // Laplace noise.
+  /** Advanced Composition under Differential Privacy which should be used with Laplace noise. */
   DP_ADVANCED,
-  // Almost Concentrated Differential Privacy Composition which should be used with
-  // Gaussian noise.
+
+  /**
+   * Almost Concentrated Differential Privacy Composition which should be used with Gaussian noise.
+   */
   ACDP,
 }

--- a/src/main/kotlin/org/wfanet/measurement/eventdataprovider/privacybudgetmanagement/PrivacyQuery.kt
+++ b/src/main/kotlin/org/wfanet/measurement/eventdataprovider/privacybudgetmanagement/PrivacyQuery.kt
@@ -70,10 +70,10 @@ data class AcdpQuery(
 
 /** Supported Composition mechanisms in Privacy Budget Manager. */
 enum class CompositionMechanism {
-  // DP_ADVANCED is Advanced Composition under Differential Privacy which should be used with
+  // Advanced Composition under Differential Privacy which should be used with
   // Laplace noise.
   DP_ADVANCED,
-  // ACDP is Almost Concentrated Differential Privacy Composition which should be used with
+  // Almost Concentrated Differential Privacy Composition which should be used with
   // Gaussian noise.
   ACDP,
 }

--- a/src/main/kotlin/org/wfanet/measurement/eventdataprovider/privacybudgetmanagement/api/v2alpha/PrivacyQueryMapper.kt
+++ b/src/main/kotlin/org/wfanet/measurement/eventdataprovider/privacybudgetmanagement/api/v2alpha/PrivacyQueryMapper.kt
@@ -94,7 +94,7 @@ object PrivacyQueryMapper {
     val acdpCharge =
       when (measurementSpec.measurementTypeCase) {
         MeasurementTypeCase.REACH -> {
-          AcdpParamsConverter.getMpcAcdpCharge(
+          AcdpParamsConverter.getLlv2AcdpCharge(
             DpParams(
               measurementSpec.reach.privacyParams.epsilon,
               measurementSpec.reach.privacyParams.delta
@@ -111,7 +111,7 @@ object PrivacyQueryMapper {
                 measurementSpec.reachAndFrequency.frequencyPrivacyParams.delta
             )
 
-          AcdpParamsConverter.getMpcAcdpCharge(
+          AcdpParamsConverter.getLlv2AcdpCharge(
             dpParams,
             contributorCount,
           )

--- a/src/main/kotlin/org/wfanet/measurement/eventdataprovider/privacybudgetmanagement/api/v2alpha/PrivacyQueryMapper.kt
+++ b/src/main/kotlin/org/wfanet/measurement/eventdataprovider/privacybudgetmanagement/api/v2alpha/PrivacyQueryMapper.kt
@@ -85,7 +85,21 @@ object PrivacyQueryMapper {
     )
   }
 
-  fun getMpcAcdpQuery(
+  /**
+   * Constructs a pbm specific [AcdpQuery] from given proto messages for LiquidLegionsV2 protocol.
+   *
+   * @param reference representing the reference key and if the charge is a refund.
+   * @param measurementSpec The measurementSpec protobuf that is associated with the query. The VID
+   *   sampling interval is obtained from this.
+   * @param eventSpecs event specs from the Requisition. The date range and demo groups are obtained
+   *   from this.
+   * @param contributorCount number of Duchies
+   * @throws
+   *   org.wfanet.measurement.eventdataprovider.privacybudgetmanagement.PrivacyBudgetManagerException
+   *   if an error occurs in handling this request. Possible exceptions could include running out of
+   *   privacy budget or a failure to commit the transaction to the database.
+   */
+  fun getLiquidLegionsV2AcdpQuery(
     reference: Reference,
     measurementSpec: MeasurementSpec,
     eventSpecs: Iterable<RequisitionSpec.EventGroupEntry.Value>,
@@ -133,6 +147,19 @@ object PrivacyQueryMapper {
     )
   }
 
+  /**
+   * Constructs a pbm specific [AcdpQuery] from given proto messages for direct measurements.
+   *
+   * @param reference representing the reference key and if the charge is a refund.
+   * @param measurementSpec The measurementSpec protobuf that is associated with the query. The VID
+   *   sampling interval is obtained from this.
+   * @param eventSpecs event specs from the Requisition. The date range and demo groups are obtained
+   *   from this.
+   * @throws
+   *   org.wfanet.measurement.eventdataprovider.privacybudgetmanagement.PrivacyBudgetManagerException
+   *   if an error occurs in handling this request. Possible exceptions could include running out of
+   *   privacy budget or a failure to commit the transaction to the database.
+   */
   fun getDirectAcdpQuery(
     reference: Reference,
     measurementSpec: MeasurementSpec,

--- a/src/main/kotlin/org/wfanet/measurement/integration/common/InProcessEdpSimulator.kt
+++ b/src/main/kotlin/org/wfanet/measurement/integration/common/InProcessEdpSimulator.kt
@@ -42,6 +42,7 @@ import org.wfanet.measurement.api.v2alpha.event_group_metadata.testing.Synthetic
 import org.wfanet.measurement.common.identity.withPrincipalName
 import org.wfanet.measurement.common.throttler.MinimumIntervalThrottler
 import org.wfanet.measurement.eventdataprovider.noiser.DirectNoiseMechanism
+import org.wfanet.measurement.eventdataprovider.privacybudgetmanagement.CompositionMechanism
 import org.wfanet.measurement.eventdataprovider.privacybudgetmanagement.InMemoryBackingStore
 import org.wfanet.measurement.eventdataprovider.privacybudgetmanagement.PrivacyBucketFilter
 import org.wfanet.measurement.eventdataprovider.privacybudgetmanagement.PrivacyBudgetManager
@@ -102,7 +103,8 @@ class InProcessEdpSimulator(
         ),
       trustedCertificates = trustedCertificates,
       DIRECT_NOISE_MECHANISM,
-      random = random
+      random = random,
+      compositionMechanism = COMPOSITION_MECHANISM,
     )
 
   private lateinit var edpJob: Job
@@ -132,5 +134,6 @@ class InProcessEdpSimulator(
     private const val RANDOM_SEED: Long = 1
     private val random = Random(RANDOM_SEED)
     private val DIRECT_NOISE_MECHANISM = DirectNoiseMechanism.LAPLACE
+    private val COMPOSITION_MECHANISM = CompositionMechanism.DP_ADVANCED
   }
 }

--- a/src/main/kotlin/org/wfanet/measurement/loadtest/dataprovider/BUILD.bazel
+++ b/src/main/kotlin/org/wfanet/measurement/loadtest/dataprovider/BUILD.bazel
@@ -179,6 +179,7 @@ kt_jvm_library(
     srcs = ["EdpSimulatorFlags.kt"],
     deps = [
         "//src/main/kotlin/org/wfanet/measurement/eventdataprovider/noiser",
+        "//src/main/kotlin/org/wfanet/measurement/eventdataprovider/privacybudgetmanagement:privacy_budget_manager",
         "//src/main/kotlin/org/wfanet/measurement/loadtest:service_flags",
         "@wfa_common_jvm//imports/java/picocli",
         "@wfa_common_jvm//src/main/kotlin/org/wfanet/measurement/common/grpc",

--- a/src/main/kotlin/org/wfanet/measurement/loadtest/dataprovider/EdpSimulator.kt
+++ b/src/main/kotlin/org/wfanet/measurement/loadtest/dataprovider/EdpSimulator.kt
@@ -125,7 +125,7 @@ import org.wfanet.measurement.eventdataprovider.privacybudgetmanagement.PrivacyB
 import org.wfanet.measurement.eventdataprovider.privacybudgetmanagement.Reference
 import org.wfanet.measurement.eventdataprovider.privacybudgetmanagement.api.v2alpha.PrivacyQueryMapper.getDirectAcdpQuery
 import org.wfanet.measurement.eventdataprovider.privacybudgetmanagement.api.v2alpha.PrivacyQueryMapper.getDpQuery
-import org.wfanet.measurement.eventdataprovider.privacybudgetmanagement.api.v2alpha.PrivacyQueryMapper.getMpcAcdpQuery
+import org.wfanet.measurement.eventdataprovider.privacybudgetmanagement.api.v2alpha.PrivacyQueryMapper.getLiquidLegionsV2AcdpQuery
 import org.wfanet.measurement.loadtest.config.TestIdentifiers.SIMULATOR_EVENT_GROUP_REFERENCE_ID_PREFIX
 import org.wfanet.measurement.loadtest.config.VidSampling
 
@@ -682,7 +682,7 @@ class EdpSimulator(
     }
   }
 
-  private suspend fun chargeMpcPrivacyBudget(
+  private suspend fun chargeLiquidLegionsV2PrivacyBudget(
     requisitionName: String,
     measurementSpec: MeasurementSpec,
     eventSpecs: Iterable<RequisitionSpec.EventGroupEntry.Value>,
@@ -690,7 +690,7 @@ class EdpSimulator(
     contributorCount: Int
   ) {
     logger.info(
-      "chargeMpcPrivacyBudget with $compositionMechanism composition mechanism for requisition with $noiseMechanism noise mechanism...",
+      "chargeLiquidLegionsV2PrivacyBudget with $compositionMechanism composition mechanism for requisition with $noiseMechanism noise mechanism...",
     )
 
     try {
@@ -711,7 +711,7 @@ class EdpSimulator(
           }
 
           privacyBudgetManager.chargePrivacyBudgetInAcdp(
-            getMpcAcdpQuery(
+            getLiquidLegionsV2AcdpQuery(
               Reference(measurementConsumerName, requisitionName, false),
               measurementSpec,
               eventSpecs,
@@ -721,7 +721,11 @@ class EdpSimulator(
         }
       }
     } catch (e: PrivacyBudgetManagerException) {
-      logger.log(Level.WARNING, "chargeMpcPrivacyBudget failed due to ${e.errorType}", e)
+      logger.log(
+        Level.WARNING,
+        "chargeLiquidLegionsV2PrivacyBudget failed due to ${e.errorType}",
+        e
+      )
       when (e.errorType) {
         PrivacyBudgetManagerExceptionType.PRIVACY_BUDGET_EXCEEDED -> {
           throw RequisitionRefusalException(
@@ -870,7 +874,7 @@ class EdpSimulator(
     val liquidLegionsV2: ProtocolConfig.LiquidLegionsV2 = llv2Protocol.liquidLegionsV2
     val combinedPublicKey = requisition.getCombinedPublicKey(liquidLegionsV2.ellipticCurveId)
 
-    chargeMpcPrivacyBudget(
+    chargeLiquidLegionsV2PrivacyBudget(
       requisition.name,
       measurementSpec,
       eventGroupSpecs.map { it.spec },
@@ -925,7 +929,7 @@ class EdpSimulator(
     val combinedPublicKey =
       requisition.getCombinedPublicKey(reachOnlyLiquidLegionsV2.ellipticCurveId)
 
-    chargeMpcPrivacyBudget(
+    chargeLiquidLegionsV2PrivacyBudget(
       requisition.name,
       measurementSpec,
       eventGroupSpecs.map { it.spec },

--- a/src/main/kotlin/org/wfanet/measurement/loadtest/dataprovider/EdpSimulator.kt
+++ b/src/main/kotlin/org/wfanet/measurement/loadtest/dataprovider/EdpSimulator.kt
@@ -69,6 +69,7 @@ import org.wfanet.measurement.api.v2alpha.MeasurementKt.ResultKt.reach
 import org.wfanet.measurement.api.v2alpha.MeasurementKt.ResultKt.watchDuration
 import org.wfanet.measurement.api.v2alpha.MeasurementSpec
 import org.wfanet.measurement.api.v2alpha.ProtocolConfig
+import org.wfanet.measurement.api.v2alpha.ProtocolConfig.NoiseMechanism
 import org.wfanet.measurement.api.v2alpha.Requisition
 import org.wfanet.measurement.api.v2alpha.Requisition.DuchyEntry
 import org.wfanet.measurement.api.v2alpha.RequisitionFulfillmentGrpcKt.RequisitionFulfillmentCoroutineStub
@@ -117,11 +118,14 @@ import org.wfanet.measurement.eventdataprovider.noiser.DirectNoiseMechanism
 import org.wfanet.measurement.eventdataprovider.noiser.DpParams
 import org.wfanet.measurement.eventdataprovider.noiser.GaussianNoiser
 import org.wfanet.measurement.eventdataprovider.noiser.LaplaceNoiser
+import org.wfanet.measurement.eventdataprovider.privacybudgetmanagement.CompositionMechanism
 import org.wfanet.measurement.eventdataprovider.privacybudgetmanagement.PrivacyBudgetManager
 import org.wfanet.measurement.eventdataprovider.privacybudgetmanagement.PrivacyBudgetManagerException
 import org.wfanet.measurement.eventdataprovider.privacybudgetmanagement.PrivacyBudgetManagerExceptionType
 import org.wfanet.measurement.eventdataprovider.privacybudgetmanagement.Reference
+import org.wfanet.measurement.eventdataprovider.privacybudgetmanagement.api.v2alpha.PrivacyQueryMapper.getDirectAcdpQuery
 import org.wfanet.measurement.eventdataprovider.privacybudgetmanagement.api.v2alpha.PrivacyQueryMapper.getDpQuery
+import org.wfanet.measurement.eventdataprovider.privacybudgetmanagement.api.v2alpha.PrivacyQueryMapper.getMpcAcdpQuery
 import org.wfanet.measurement.loadtest.config.TestIdentifiers.SIMULATOR_EVENT_GROUP_REFERENCE_ID_PREFIX
 import org.wfanet.measurement.loadtest.config.VidSampling
 
@@ -153,6 +157,7 @@ class EdpSimulator(
   private val directNoiseMechanism: DirectNoiseMechanism,
   private val sketchEncrypter: SketchEncrypter = SketchEncrypter.Default,
   private val random: Random = Random,
+  private val compositionMechanism: CompositionMechanism,
 ) {
   /** A sequence of operations done in the simulator. */
   suspend fun run() {
@@ -543,9 +548,19 @@ class EdpSimulator(
               eventGroupSpecs
             )
           } else if (measurementSpec.hasDuration()) {
-            fulfillDurationMeasurement(requisition, requisitionSpec, measurementSpec)
+            fulfillDurationMeasurement(
+              requisition,
+              requisitionSpec,
+              measurementSpec,
+              eventGroupSpecs
+            )
           } else if (measurementSpec.hasImpression()) {
-            fulfillImpressionMeasurement(requisition, requisitionSpec, measurementSpec)
+            fulfillImpressionMeasurement(
+              requisition,
+              requisitionSpec,
+              measurementSpec,
+              eventGroupSpecs
+            )
           } else {
             logger.log(
               Level.WARNING,
@@ -667,21 +682,46 @@ class EdpSimulator(
     }
   }
 
-  private suspend fun chargePrivacyBudget(
+  private suspend fun chargeMpcPrivacyBudget(
     requisitionName: String,
     measurementSpec: MeasurementSpec,
-    eventSpecs: Iterable<RequisitionSpec.EventGroupEntry.Value>
+    eventSpecs: Iterable<RequisitionSpec.EventGroupEntry.Value>,
+    noiseMechanism: NoiseMechanism,
+    contributorCount: Int
   ) {
+    logger.info(
+      "chargeMpcPrivacyBudget with $compositionMechanism composition mechanism for requisition with $noiseMechanism noise mechanism...",
+    )
+
     try {
-      privacyBudgetManager.chargePrivacyBudget(
-        getDpQuery(
-          Reference(measurementConsumerName, requisitionName, false),
-          measurementSpec,
-          eventSpecs
-        )
-      )
+      when (compositionMechanism) {
+        CompositionMechanism.DP_ADVANCED ->
+          privacyBudgetManager.chargePrivacyBudget(
+            getDpQuery(
+              Reference(measurementConsumerName, requisitionName, false),
+              measurementSpec,
+              eventSpecs,
+            )
+          )
+        CompositionMechanism.ACDP -> {
+          if (noiseMechanism != NoiseMechanism.DISCRETE_GAUSSIAN) {
+            throw PrivacyBudgetManagerException(
+              PrivacyBudgetManagerExceptionType.INCORRECT_NOISE_MECHANISM
+            )
+          }
+
+          privacyBudgetManager.chargePrivacyBudgetInAcdp(
+            getMpcAcdpQuery(
+              Reference(measurementConsumerName, requisitionName, false),
+              measurementSpec,
+              eventSpecs,
+              contributorCount,
+            )
+          )
+        }
+      }
     } catch (e: PrivacyBudgetManagerException) {
-      logger.log(Level.WARNING, "chargePrivacyBudget failed due to ${e.errorType}", e)
+      logger.log(Level.WARNING, "chargeMpcPrivacyBudget failed due to ${e.errorType}", e)
       when (e.errorType) {
         PrivacyBudgetManagerExceptionType.PRIVACY_BUDGET_EXCEEDED -> {
           throw RequisitionRefusalException(
@@ -693,6 +733,78 @@ class EdpSimulator(
           throw RequisitionRefusalException(
             Requisition.Refusal.Justification.SPEC_INVALID,
             "Invalid event filter"
+          )
+        }
+        PrivacyBudgetManagerExceptionType.INCORRECT_NOISE_MECHANISM -> {
+          throw RequisitionRefusalException(
+            Requisition.Refusal.Justification.SPEC_INVALID,
+            "Incorrect noise mechanism. Should be DISCRETE_GAUSSIAN for ACDP composition but is $noiseMechanism"
+          )
+        }
+        PrivacyBudgetManagerExceptionType.DATABASE_UPDATE_ERROR,
+        PrivacyBudgetManagerExceptionType.UPDATE_AFTER_COMMIT,
+        PrivacyBudgetManagerExceptionType.NESTED_TRANSACTION,
+        PrivacyBudgetManagerExceptionType.BACKING_STORE_CLOSED -> {
+          throw Exception("Unexpected PBM error", e)
+        }
+      }
+    }
+  }
+
+  private suspend fun chargeDirectPrivacyBudget(
+    requisitionName: String,
+    measurementSpec: MeasurementSpec,
+    eventSpecs: Iterable<RequisitionSpec.EventGroupEntry.Value>,
+  ) {
+    logger.info(
+      "chargeDirectPrivacyBudget with $compositionMechanism composition mechanism...",
+    )
+
+    try {
+      when (compositionMechanism) {
+        CompositionMechanism.DP_ADVANCED ->
+          privacyBudgetManager.chargePrivacyBudget(
+            getDpQuery(
+              Reference(measurementConsumerName, requisitionName, false),
+              measurementSpec,
+              eventSpecs,
+            )
+          )
+        CompositionMechanism.ACDP -> {
+          if (directNoiseMechanism != DirectNoiseMechanism.GAUSSIAN) {
+            throw PrivacyBudgetManagerException(
+              PrivacyBudgetManagerExceptionType.INCORRECT_NOISE_MECHANISM
+            )
+          }
+
+          privacyBudgetManager.chargePrivacyBudgetInAcdp(
+            getDirectAcdpQuery(
+              Reference(measurementConsumerName, requisitionName, false),
+              measurementSpec,
+              eventSpecs,
+            )
+          )
+        }
+      }
+    } catch (e: PrivacyBudgetManagerException) {
+      logger.log(Level.WARNING, "chargeDirectPrivacyBudget failed due to ${e.errorType}", e)
+      when (e.errorType) {
+        PrivacyBudgetManagerExceptionType.PRIVACY_BUDGET_EXCEEDED -> {
+          throw RequisitionRefusalException(
+            Requisition.Refusal.Justification.INSUFFICIENT_PRIVACY_BUDGET,
+            "Privacy budget exceeded"
+          )
+        }
+        PrivacyBudgetManagerExceptionType.INVALID_PRIVACY_BUCKET_FILTER -> {
+          throw RequisitionRefusalException(
+            Requisition.Refusal.Justification.SPEC_INVALID,
+            "Invalid event filter"
+          )
+        }
+        PrivacyBudgetManagerExceptionType.INCORRECT_NOISE_MECHANISM -> {
+          throw RequisitionRefusalException(
+            Requisition.Refusal.Justification.SPEC_INVALID,
+            "Incorrect noise mechanism. Should be GAUSSIAN for ACDP composition but is $directNoiseMechanism"
           )
         }
         PrivacyBudgetManagerExceptionType.DATABASE_UPDATE_ERROR,
@@ -710,8 +822,16 @@ class EdpSimulator(
     sketchConfig: SketchConfig,
     measurementSpec: MeasurementSpec,
     eventGroupSpecs: Iterable<EventQuery.EventGroupSpec>,
+    noiseMechanism: NoiseMechanism,
+    contributorCount: Int
   ): Sketch {
-    chargePrivacyBudget(requisitionName, measurementSpec, eventGroupSpecs.map { it.spec })
+    chargeMpcPrivacyBudget(
+      requisitionName,
+      measurementSpec,
+      eventGroupSpecs.map { it.spec },
+      noiseMechanism,
+      contributorCount
+    )
 
     logger.info("Generating Sketch...")
     return SketchGenerator(eventQuery, sketchConfig, measurementSpec.vidSamplingInterval)
@@ -767,7 +887,9 @@ class EdpSimulator(
           requisition.name,
           liquidLegionsV2.sketchParams.toSketchConfig(),
           measurementSpec,
-          eventGroupSpecs
+          eventGroupSpecs,
+          liquidLegionsV2.noiseMechanism,
+          requisition.duchiesCount
         )
       } catch (e: EventFilterValidationException) {
         logger.log(
@@ -815,7 +937,9 @@ class EdpSimulator(
           requisition.name,
           reachOnlyLiquidLegionsV2.sketchParams.toSketchConfig(),
           measurementSpec,
-          eventGroupSpecs
+          eventGroupSpecs,
+          reachOnlyLiquidLegionsV2.noiseMechanism,
+          requisition.duchiesCount
         )
       } catch (e: EventFilterValidationException) {
         logger.log(
@@ -902,6 +1026,12 @@ class EdpSimulator(
     nonce: Long,
     eventGroupSpecs: Iterable<EventQuery.EventGroupSpec>
   ) {
+    chargeDirectPrivacyBudget(
+      requisition.name,
+      measurementSpec,
+      eventGroupSpecs.map { it.spec },
+    )
+
     logger.info("Calculating direct reach and frequency...")
     val vidSamplingInterval = measurementSpec.vidSamplingInterval
     val vidSamplingIntervalStart = vidSamplingInterval.start
@@ -1066,8 +1196,15 @@ class EdpSimulator(
   private suspend fun fulfillImpressionMeasurement(
     requisition: Requisition,
     requisitionSpec: RequisitionSpec,
-    measurementSpec: MeasurementSpec
+    measurementSpec: MeasurementSpec,
+    eventGroupSpecs: Iterable<EventQuery.EventGroupSpec>
   ) {
+    chargeDirectPrivacyBudget(
+      requisition.name,
+      measurementSpec,
+      eventGroupSpecs.map { it.spec },
+    )
+
     val measurementResult =
       MeasurementKt.result {
         impression = impression {
@@ -1083,8 +1220,15 @@ class EdpSimulator(
   private suspend fun fulfillDurationMeasurement(
     requisition: Requisition,
     requisitionSpec: RequisitionSpec,
-    measurementSpec: MeasurementSpec
+    measurementSpec: MeasurementSpec,
+    eventGroupSpecs: Iterable<EventQuery.EventGroupSpec>
   ) {
+    chargeDirectPrivacyBudget(
+      requisition.name,
+      measurementSpec,
+      eventGroupSpecs.map { it.spec },
+    )
+
     val externalDataProviderId =
       apiIdToExternalId(DataProviderKey.fromName(edpData.name)!!.dataProviderId)
     val measurementResult =

--- a/src/main/kotlin/org/wfanet/measurement/loadtest/dataprovider/EdpSimulator.kt
+++ b/src/main/kotlin/org/wfanet/measurement/loadtest/dataprovider/EdpSimulator.kt
@@ -817,22 +817,11 @@ class EdpSimulator(
     }
   }
 
-  private suspend fun generateSketch(
-    requisitionName: String,
+  private fun generateSketch(
     sketchConfig: SketchConfig,
     measurementSpec: MeasurementSpec,
     eventGroupSpecs: Iterable<EventQuery.EventGroupSpec>,
-    noiseMechanism: NoiseMechanism,
-    contributorCount: Int
   ): Sketch {
-    chargeMpcPrivacyBudget(
-      requisitionName,
-      measurementSpec,
-      eventGroupSpecs.map { it.spec },
-      noiseMechanism,
-      contributorCount
-    )
-
     logger.info("Generating Sketch...")
     return SketchGenerator(eventQuery, sketchConfig, measurementSpec.vidSamplingInterval)
       .generate(eventGroupSpecs)
@@ -881,15 +870,20 @@ class EdpSimulator(
     val liquidLegionsV2: ProtocolConfig.LiquidLegionsV2 = llv2Protocol.liquidLegionsV2
     val combinedPublicKey = requisition.getCombinedPublicKey(liquidLegionsV2.ellipticCurveId)
 
+    chargeMpcPrivacyBudget(
+      requisition.name,
+      measurementSpec,
+      eventGroupSpecs.map { it.spec },
+      liquidLegionsV2.noiseMechanism,
+      requisition.duchiesCount
+    )
+
     val sketch =
       try {
         generateSketch(
-          requisition.name,
           liquidLegionsV2.sketchParams.toSketchConfig(),
           measurementSpec,
           eventGroupSpecs,
-          liquidLegionsV2.noiseMechanism,
-          requisition.duchiesCount
         )
       } catch (e: EventFilterValidationException) {
         logger.log(
@@ -931,15 +925,20 @@ class EdpSimulator(
     val combinedPublicKey =
       requisition.getCombinedPublicKey(reachOnlyLiquidLegionsV2.ellipticCurveId)
 
+    chargeMpcPrivacyBudget(
+      requisition.name,
+      measurementSpec,
+      eventGroupSpecs.map { it.spec },
+      reachOnlyLiquidLegionsV2.noiseMechanism,
+      requisition.duchiesCount
+    )
+
     val sketch =
       try {
         generateSketch(
-          requisition.name,
           reachOnlyLiquidLegionsV2.sketchParams.toSketchConfig(),
           measurementSpec,
           eventGroupSpecs,
-          reachOnlyLiquidLegionsV2.noiseMechanism,
-          requisition.duchiesCount
         )
       } catch (e: EventFilterValidationException) {
         logger.log(

--- a/src/main/kotlin/org/wfanet/measurement/loadtest/dataprovider/EdpSimulatorFlags.kt
+++ b/src/main/kotlin/org/wfanet/measurement/loadtest/dataprovider/EdpSimulatorFlags.kt
@@ -18,6 +18,7 @@ import java.io.File
 import java.time.Duration
 import org.wfanet.measurement.common.grpc.TlsFlags
 import org.wfanet.measurement.eventdataprovider.noiser.DirectNoiseMechanism
+import org.wfanet.measurement.eventdataprovider.privacybudgetmanagement.CompositionMechanism
 import org.wfanet.measurement.loadtest.KingdomPublicApiFlags
 import org.wfanet.measurement.loadtest.RequisitionFulfillmentServiceFlags
 import picocli.CommandLine
@@ -107,5 +108,13 @@ class EdpSimulatorFlags {
     defaultValue = "LAPLACE",
   )
   lateinit var directNoiseMechanism: DirectNoiseMechanism
+    private set
+
+  @CommandLine.Option(
+    names = ["--composition-mechanism"],
+    description = ["Composition mechanism in Privacy Budget Manager"],
+    defaultValue = "DP_ADVANCED",
+  )
+  lateinit var compositionMechanism: CompositionMechanism
     private set
 }

--- a/src/main/kotlin/org/wfanet/measurement/loadtest/dataprovider/EdpSimulatorRunner.kt
+++ b/src/main/kotlin/org/wfanet/measurement/loadtest/dataprovider/EdpSimulatorRunner.kt
@@ -34,7 +34,7 @@ import org.wfanet.measurement.loadtest.config.PrivacyBudgets.createNoOpPrivacyBu
 import picocli.CommandLine
 
 /** The base class of the EdpSimulator runner. */
-abstract class EdpSimulatorRunner() : Runnable {
+abstract class EdpSimulatorRunner : Runnable {
   @CommandLine.Mixin
   protected lateinit var flags: EdpSimulatorFlags
     private set
@@ -100,7 +100,8 @@ abstract class EdpSimulatorRunner() : Runnable {
         createNoOpPrivacyBudgetManager(),
         clientCerts.trustedCertificates,
         flags.directNoiseMechanism,
-        random = random
+        random = random,
+        compositionMechanism = flags.compositionMechanism,
       )
     runBlocking {
       edpSimulator.ensureEventGroup(eventGroupMetadata)

--- a/src/test/kotlin/org/wfanet/measurement/eventdataprovider/privacybudgetmanagement/AcdpParamsConverterTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/eventdataprovider/privacybudgetmanagement/AcdpParamsConverterTest.kt
@@ -25,9 +25,9 @@ import org.wfanet.measurement.eventdataprovider.noiser.DpParams
 class AcdpParamsConverterTest {
 
   @Test
-  fun `getMpcAcdpCharge throws exception with invalid epsilon`() {
+  fun `getLlv2AcdpCharge throws exception with invalid epsilon`() {
     assertFails {
-      AcdpParamsConverter.getMpcAcdpCharge(
+      AcdpParamsConverter.getLlv2AcdpCharge(
         DpParams(-0.1, 0.1),
         CONTRIBUTOR_COUNT,
       )
@@ -35,9 +35,9 @@ class AcdpParamsConverterTest {
   }
 
   @Test
-  fun `getMpcAcdpCharge throws exception with invalid delta`() {
+  fun `getLlv2AcdpCharge throws exception with invalid delta`() {
     assertFails {
-      AcdpParamsConverter.getMpcAcdpCharge(
+      AcdpParamsConverter.getLlv2AcdpCharge(
         DpParams(0.1, -0.1),
         CONTRIBUTOR_COUNT,
       )
@@ -45,9 +45,9 @@ class AcdpParamsConverterTest {
   }
 
   @Test
-  fun `getMpcAcdpCharge throws exception with invalid contributorCount`() {
+  fun `getLlv2AcdpCharge throws exception with invalid contributorCount`() {
     assertFails {
-      AcdpParamsConverter.getMpcAcdpCharge(
+      AcdpParamsConverter.getLlv2AcdpCharge(
         DP_PARAMS,
         -1,
       )
@@ -75,10 +75,10 @@ class AcdpParamsConverterTest {
   }
 
   @Test
-  fun `mpc rho and theta should be correct with given dpParams and one contributor`() {
+  fun `llv2 rho and theta should be correct with given dpParams and one contributor`() {
     // mu and sigmaDistributed with given DP params: mu = 261.0, sigma = 48.23177914088707
     val acdpCharge =
-      AcdpParamsConverter.getMpcAcdpCharge(
+      AcdpParamsConverter.getLlv2AcdpCharge(
         DP_PARAMS,
         CONTRIBUTOR_COUNT,
       )
@@ -89,9 +89,9 @@ class AcdpParamsConverterTest {
   }
 
   @Test
-  fun `mpc rho and theta should be correct with given dpParams and three contributors`() {
+  fun `llv2 rho and theta should be correct with given dpParams and three contributors`() {
     val acdpCharge =
-      AcdpParamsConverter.getMpcAcdpCharge(
+      AcdpParamsConverter.getLlv2AcdpCharge(
         DP_PARAMS,
         3,
       )
@@ -102,10 +102,10 @@ class AcdpParamsConverterTest {
   }
 
   @Test
-  fun `mpc rho and theta should be correct with large dpParams and three contributors`() {
+  fun `llv2 rho and theta should be correct with large dpParams and three contributors`() {
     // sigmaDistributed and lambda with this set of params: sigmaDistributed = 1.1509301704045332,
     // lambda = 2.12667410579919E-6
-    val acdpCharge = AcdpParamsConverter.getMpcAcdpCharge(DpParams(0.9, 0.5), 3)
+    val acdpCharge = AcdpParamsConverter.getLlv2AcdpCharge(DpParams(0.9, 0.5), 3)
     val expectedAcdpCharge = AcdpCharge(0.12582564093358586, 0.007149139528009278)
 
     assertThat(acdpCharge.rho).isWithin(TOLERANCE).of(expectedAcdpCharge.rho)

--- a/src/test/kotlin/org/wfanet/measurement/eventdataprovider/privacybudgetmanagement/api/v2alpha/PrivacyQueryMapperTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/eventdataprovider/privacybudgetmanagement/api/v2alpha/PrivacyQueryMapperTest.kt
@@ -40,7 +40,7 @@ import org.wfanet.measurement.eventdataprovider.privacybudgetmanagement.Landscap
 import org.wfanet.measurement.eventdataprovider.privacybudgetmanagement.Reference
 import org.wfanet.measurement.eventdataprovider.privacybudgetmanagement.api.v2alpha.PrivacyQueryMapper.getDirectAcdpQuery
 import org.wfanet.measurement.eventdataprovider.privacybudgetmanagement.api.v2alpha.PrivacyQueryMapper.getDpQuery
-import org.wfanet.measurement.eventdataprovider.privacybudgetmanagement.api.v2alpha.PrivacyQueryMapper.getMpcAcdpQuery
+import org.wfanet.measurement.eventdataprovider.privacybudgetmanagement.api.v2alpha.PrivacyQueryMapper.getLiquidLegionsV2AcdpQuery
 
 private const val MEASUREMENT_CONSUMER_ID = "ACME"
 
@@ -218,7 +218,7 @@ class PrivacyQueryMapperTest {
     val expectedAcdpCharge = AcdpParamsConverter.getLlv2AcdpCharge(dpParams, CONTRIBUTOR_COUNT)
 
     assertThat(
-        getMpcAcdpQuery(
+        getLiquidLegionsV2AcdpQuery(
           Reference(MEASUREMENT_CONSUMER_ID, referenceId, false),
           REACH_AND_FREQ_MEASUREMENT_SPEC,
           REQUISITION_SPEC.events.eventGroupsList.map { it.value },
@@ -276,7 +276,7 @@ class PrivacyQueryMapperTest {
       )
 
     assertThat(
-        getMpcAcdpQuery(
+        getLiquidLegionsV2AcdpQuery(
           Reference(MEASUREMENT_CONSUMER_ID, referenceId, false),
           REACH_MEASUREMENT_SPEC,
           REQUISITION_SPEC.events.eventGroupsList.map { it.value },

--- a/src/test/kotlin/org/wfanet/measurement/eventdataprovider/privacybudgetmanagement/api/v2alpha/PrivacyQueryMapperTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/eventdataprovider/privacybudgetmanagement/api/v2alpha/PrivacyQueryMapperTest.kt
@@ -206,7 +206,7 @@ class PrivacyQueryMapperTest {
   }
 
   @Test
-  fun `converts mpc reach and frequency measurement to AcdpQuery`() {
+  fun `converts llv2 reach and frequency measurement to AcdpQuery`() {
     val referenceId = "RequisitionId1"
     val dpParams =
       DpParams(
@@ -215,7 +215,7 @@ class PrivacyQueryMapperTest {
         REACH_AND_FREQ_MEASUREMENT_SPEC.reachAndFrequency.reachPrivacyParams.delta +
           REACH_AND_FREQ_MEASUREMENT_SPEC.reachAndFrequency.frequencyPrivacyParams.delta
       )
-    val expectedAcdpCharge = AcdpParamsConverter.getMpcAcdpCharge(dpParams, CONTRIBUTOR_COUNT)
+    val expectedAcdpCharge = AcdpParamsConverter.getLlv2AcdpCharge(dpParams, CONTRIBUTOR_COUNT)
 
     assertThat(
         getMpcAcdpQuery(
@@ -263,11 +263,11 @@ class PrivacyQueryMapperTest {
   }
 
   @Test
-  fun `converts mpc reach measurement to AcdpQuery`() {
+  fun `converts llv2 reach measurement to AcdpQuery`() {
     val referenceId = "RequisitionId1"
 
     val expectedAcdpCharge =
-      AcdpParamsConverter.getMpcAcdpCharge(
+      AcdpParamsConverter.getLlv2AcdpCharge(
         DpParams(
           REACH_MEASUREMENT_SPEC.reach.privacyParams.epsilon,
           REACH_MEASUREMENT_SPEC.reach.privacyParams.delta

--- a/src/test/kotlin/org/wfanet/measurement/loadtest/dataprovider/EdpSimulatorTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/loadtest/dataprovider/EdpSimulatorTest.kt
@@ -69,6 +69,7 @@ import org.wfanet.measurement.api.v2alpha.MeasurementSpecKt.reach
 import org.wfanet.measurement.api.v2alpha.MeasurementSpecKt.reachAndFrequency
 import org.wfanet.measurement.api.v2alpha.MeasurementSpecKt.vidSamplingInterval
 import org.wfanet.measurement.api.v2alpha.ProtocolConfig
+import org.wfanet.measurement.api.v2alpha.ProtocolConfig.NoiseMechanism
 import org.wfanet.measurement.api.v2alpha.ProtocolConfigKt
 import org.wfanet.measurement.api.v2alpha.RefuseRequisitionRequest
 import org.wfanet.measurement.api.v2alpha.Requisition
@@ -145,7 +146,9 @@ import org.wfanet.measurement.consent.client.measurementconsumer.signEncryptionP
 import org.wfanet.measurement.consent.client.measurementconsumer.signMeasurementSpec
 import org.wfanet.measurement.consent.client.measurementconsumer.signRequisitionSpec
 import org.wfanet.measurement.eventdataprovider.noiser.DirectNoiseMechanism
+import org.wfanet.measurement.eventdataprovider.privacybudgetmanagement.AcdpCharge
 import org.wfanet.measurement.eventdataprovider.privacybudgetmanagement.AgeGroup as PrivacyLandscapeAge
+import org.wfanet.measurement.eventdataprovider.privacybudgetmanagement.CompositionMechanism
 import org.wfanet.measurement.eventdataprovider.privacybudgetmanagement.DpCharge
 import org.wfanet.measurement.eventdataprovider.privacybudgetmanagement.Gender as PrivacyLandscapeGender
 import org.wfanet.measurement.eventdataprovider.privacybudgetmanagement.PrivacyBucketFilter
@@ -172,6 +175,7 @@ private const val EDP_NAME = "dataProviders/someDataProvider"
 
 private const val LLV2_DECAY_RATE = 12.0
 private const val LLV2_MAX_SIZE = 100_000L
+private val NOISE_MECHANISM = NoiseMechanism.GEOMETRIC
 
 private val MEASUREMENT_CONSUMER_CERTIFICATE_DER =
   SECRET_FILES_PATH.resolve("mc_cs_cert.der").toFile().readByteString()
@@ -197,6 +201,7 @@ private val TIME_RANGE = OpenEndTimeRange.fromClosedDateRange(FIRST_EVENT_DATE..
 private const val DUCHY_ID = "worker1"
 private const val RANDOM_SEED: Long = 0
 private val DIRECT_NOISE_MECHANISM = DirectNoiseMechanism.LAPLACE
+private val COMPOSITION_MECHANISM = CompositionMechanism.DP_ADVANCED
 
 @RunWith(JUnit4::class)
 class EdpSimulatorTest {
@@ -317,6 +322,7 @@ class EdpSimulatorTest {
         privacyBudgetManager,
         TRUSTED_CERTIFICATES,
         DIRECT_NOISE_MECHANISM,
+        compositionMechanism = COMPOSITION_MECHANISM
       )
 
     runBlocking { edpSimulator.ensureEventGroup(SYNTHETIC_DATA_SPEC) }
@@ -383,6 +389,7 @@ class EdpSimulatorTest {
         privacyBudgetManager,
         TRUSTED_CERTIFICATES,
         DIRECT_NOISE_MECHANISM,
+        compositionMechanism = COMPOSITION_MECHANISM
       )
 
     runBlocking { edpSimulator.ensureEventGroup(SYNTHETIC_DATA_SPEC) }
@@ -433,6 +440,7 @@ class EdpSimulatorTest {
         privacyBudgetManager,
         TRUSTED_CERTIFICATES,
         DIRECT_NOISE_MECHANISM,
+        compositionMechanism = COMPOSITION_MECHANISM
       )
 
     runBlocking { edpSimulator.ensureEventGroup(SYNTHETIC_DATA_SPEC) }
@@ -495,6 +503,7 @@ class EdpSimulatorTest {
         privacyBudgetManager,
         TRUSTED_CERTIFICATES,
         DIRECT_NOISE_MECHANISM,
+        compositionMechanism = COMPOSITION_MECHANISM
       )
 
     runBlocking {
@@ -507,7 +516,7 @@ class EdpSimulatorTest {
   }
 
   @Test
-  fun `charges privacy budget`() {
+  fun `charges privacy budget with Geometric(Laplace) noise and DP_ADVANCED composition mechanism for mpc reach and frequency Requisition`() {
     val measurementSpec =
       MEASUREMENT_SPEC.copy {
         vidSamplingInterval =
@@ -574,6 +583,7 @@ class EdpSimulatorTest {
         privacyBudgetManager,
         TRUSTED_CERTIFICATES,
         DIRECT_NOISE_MECHANISM,
+        compositionMechanism = COMPOSITION_MECHANISM
       )
     runBlocking {
       edpSimulator.ensureEventGroup(TEST_METADATA)
@@ -634,6 +644,283 @@ class EdpSimulatorTest {
   }
 
   @Test
+  fun `charges privacy budget with discrete Gaussian noise and ACDP composition mechanism for mpc reach and frequency Requisition`() {
+    runBlocking {
+      val measurementSpec =
+        MEASUREMENT_SPEC.copy {
+          vidSamplingInterval =
+            vidSamplingInterval.copy {
+              start = 0.0f
+              width = PRIVACY_BUCKET_VID_SAMPLE_WIDTH
+            }
+        }
+      val requisitionDiscreteGaussian =
+        REQUISITION.copy {
+          this.measurementSpec = signMeasurementSpec(measurementSpec, MC_SIGNING_KEY)
+          protocolConfig =
+            protocolConfig.copy {
+              protocols.clear()
+              protocols +=
+                ProtocolConfigKt.protocol {
+                  liquidLegionsV2 =
+                    ProtocolConfigKt.liquidLegionsV2 {
+                      noiseMechanism = NoiseMechanism.DISCRETE_GAUSSIAN
+                      sketchParams = liquidLegionsSketchParams {
+                        decayRate = LLV2_DECAY_RATE
+                        maxSize = LLV2_MAX_SIZE
+                        samplingIndicatorSize = 10_000_000
+                      }
+                      ellipticCurveId = 415
+                      maximumFrequency = 12
+                    }
+                }
+            }
+        }
+
+      requisitionsServiceMock.stub {
+        onBlocking { listRequisitions(any()) }
+          .thenReturn(listRequisitionsResponse { requisitions += requisitionDiscreteGaussian })
+      }
+
+      val matchingEvents =
+        generateEvents(
+          1L..10L,
+          FIRST_EVENT_DATE,
+          Person.AgeGroup.YEARS_18_TO_34,
+          Person.Gender.FEMALE
+        )
+      val nonMatchingEvents =
+        generateEvents(
+          11L..15L,
+          FIRST_EVENT_DATE,
+          Person.AgeGroup.YEARS_35_TO_54,
+          Person.Gender.FEMALE
+        ) +
+          generateEvents(
+            16L..20L,
+            FIRST_EVENT_DATE,
+            Person.AgeGroup.YEARS_55_PLUS,
+            Person.Gender.FEMALE
+          ) +
+          generateEvents(
+            21L..25L,
+            FIRST_EVENT_DATE,
+            Person.AgeGroup.YEARS_18_TO_34,
+            Person.Gender.MALE
+          ) +
+          generateEvents(
+            26L..30L,
+            FIRST_EVENT_DATE,
+            Person.AgeGroup.YEARS_35_TO_54,
+            Person.Gender.MALE
+          )
+
+      val allEvents = matchingEvents + nonMatchingEvents
+
+      val edpSimulator =
+        EdpSimulator(
+          EDP_DATA,
+          MC_NAME,
+          measurementConsumersStub,
+          certificatesStub,
+          eventGroupsStub,
+          eventGroupMetadataDescriptorsStub,
+          requisitionsStub,
+          requisitionFulfillmentStub,
+          InMemoryEventQuery(allEvents),
+          dummyThrottler,
+          privacyBudgetManager,
+          TRUSTED_CERTIFICATES,
+          DIRECT_NOISE_MECHANISM,
+          compositionMechanism = CompositionMechanism.ACDP
+        )
+      runBlocking {
+        edpSimulator.ensureEventGroup(TEST_METADATA)
+        edpSimulator.executeRequisitionFulfillingWorkflow()
+      }
+
+      val acdpBalancesMap: Map<PrivacyBucketGroup, AcdpCharge> = backingStore.getAcdpBalancesMap()
+
+      // reach and frequency delta, epsilon, contributorCount: epsilon = 2.0, delta = 2E-12,
+      // contributorCount = 1
+      for (acdpCharge in acdpBalancesMap.values) {
+        assertThat(acdpCharge.rho).isEqualTo(0.035901274080426)
+        assertThat(acdpCharge.theta).isEqualTo(7.715411332048879E-14)
+      }
+
+      // The list of all the charged privacy bucket groups should be correct based on the filter.
+      assertThat(acdpBalancesMap.keys)
+        .containsExactly(
+          PrivacyBucketGroup(
+            MC_NAME,
+            FIRST_EVENT_DATE,
+            FIRST_EVENT_DATE,
+            PrivacyLandscapeAge.RANGE_18_34,
+            PrivacyLandscapeGender.FEMALE,
+            0.0f,
+            PRIVACY_BUCKET_VID_SAMPLE_WIDTH
+          ),
+          PrivacyBucketGroup(
+            MC_NAME,
+            LAST_EVENT_DATE,
+            LAST_EVENT_DATE,
+            PrivacyLandscapeAge.RANGE_18_34,
+            PrivacyLandscapeGender.FEMALE,
+            0.0f,
+            PRIVACY_BUCKET_VID_SAMPLE_WIDTH
+          ),
+          PrivacyBucketGroup(
+            MC_NAME,
+            FIRST_EVENT_DATE,
+            FIRST_EVENT_DATE,
+            PrivacyLandscapeAge.RANGE_18_34,
+            PrivacyLandscapeGender.FEMALE,
+            PRIVACY_BUCKET_VID_SAMPLE_WIDTH,
+            PRIVACY_BUCKET_VID_SAMPLE_WIDTH
+          ),
+          PrivacyBucketGroup(
+            MC_NAME,
+            LAST_EVENT_DATE,
+            LAST_EVENT_DATE,
+            PrivacyLandscapeAge.RANGE_18_34,
+            PrivacyLandscapeGender.FEMALE,
+            PRIVACY_BUCKET_VID_SAMPLE_WIDTH,
+            PRIVACY_BUCKET_VID_SAMPLE_WIDTH
+          ),
+        )
+    }
+  }
+
+  @Test
+  fun `charges privacy budget with Gaussian noise and ACDP composition mechanism for direct reach and frequency Requisition`() {
+    runBlocking {
+      val measurementSpec =
+        MEASUREMENT_SPEC.copy {
+          vidSamplingInterval =
+            vidSamplingInterval.copy {
+              start = 0.0f
+              width = PRIVACY_BUCKET_VID_SAMPLE_WIDTH
+            }
+        }
+      val requisition =
+        DIRECT_REQUISITION.copy {
+          this.measurementSpec = signMeasurementSpec(measurementSpec, MC_SIGNING_KEY)
+        }
+
+      requisitionsServiceMock.stub {
+        onBlocking { listRequisitions(any()) }
+          .thenReturn(listRequisitionsResponse { requisitions += requisition })
+      }
+
+      val matchingEvents =
+        generateEvents(
+          1L..10L,
+          FIRST_EVENT_DATE,
+          Person.AgeGroup.YEARS_18_TO_34,
+          Person.Gender.FEMALE
+        )
+      val nonMatchingEvents =
+        generateEvents(
+          11L..15L,
+          FIRST_EVENT_DATE,
+          Person.AgeGroup.YEARS_35_TO_54,
+          Person.Gender.FEMALE
+        ) +
+          generateEvents(
+            16L..20L,
+            FIRST_EVENT_DATE,
+            Person.AgeGroup.YEARS_55_PLUS,
+            Person.Gender.FEMALE
+          ) +
+          generateEvents(
+            21L..25L,
+            FIRST_EVENT_DATE,
+            Person.AgeGroup.YEARS_18_TO_34,
+            Person.Gender.MALE
+          ) +
+          generateEvents(
+            26L..30L,
+            FIRST_EVENT_DATE,
+            Person.AgeGroup.YEARS_35_TO_54,
+            Person.Gender.MALE
+          )
+
+      val allEvents = matchingEvents + nonMatchingEvents
+
+      val edpSimulator =
+        EdpSimulator(
+          EDP_DATA,
+          MC_NAME,
+          measurementConsumersStub,
+          certificatesStub,
+          eventGroupsStub,
+          eventGroupMetadataDescriptorsStub,
+          requisitionsStub,
+          requisitionFulfillmentStub,
+          InMemoryEventQuery(allEvents),
+          dummyThrottler,
+          privacyBudgetManager,
+          TRUSTED_CERTIFICATES,
+          DirectNoiseMechanism.GAUSSIAN,
+          compositionMechanism = CompositionMechanism.ACDP
+        )
+      runBlocking {
+        edpSimulator.ensureEventGroup(TEST_METADATA)
+        edpSimulator.executeRequisitionFulfillingWorkflow()
+      }
+
+      val acdpBalancesMap: Map<PrivacyBucketGroup, AcdpCharge> = backingStore.getAcdpBalancesMap()
+
+      // reach and frequency delta, epsilon: epsilon = 2.0, delta = 2E-12,
+      for (acdpCharge in acdpBalancesMap.values) {
+        assertThat(acdpCharge.rho).isEqualTo(0.04552935394838453)
+        assertThat(acdpCharge.theta).isEqualTo(0.0)
+      }
+
+      // The list of all the charged privacy bucket groups should be correct based on the filter.
+      assertThat(acdpBalancesMap.keys)
+        .containsExactly(
+          PrivacyBucketGroup(
+            MC_NAME,
+            FIRST_EVENT_DATE,
+            FIRST_EVENT_DATE,
+            PrivacyLandscapeAge.RANGE_18_34,
+            PrivacyLandscapeGender.FEMALE,
+            0.0f,
+            PRIVACY_BUCKET_VID_SAMPLE_WIDTH
+          ),
+          PrivacyBucketGroup(
+            MC_NAME,
+            LAST_EVENT_DATE,
+            LAST_EVENT_DATE,
+            PrivacyLandscapeAge.RANGE_18_34,
+            PrivacyLandscapeGender.FEMALE,
+            0.0f,
+            PRIVACY_BUCKET_VID_SAMPLE_WIDTH
+          ),
+          PrivacyBucketGroup(
+            MC_NAME,
+            FIRST_EVENT_DATE,
+            FIRST_EVENT_DATE,
+            PrivacyLandscapeAge.RANGE_18_34,
+            PrivacyLandscapeGender.FEMALE,
+            PRIVACY_BUCKET_VID_SAMPLE_WIDTH,
+            PRIVACY_BUCKET_VID_SAMPLE_WIDTH
+          ),
+          PrivacyBucketGroup(
+            MC_NAME,
+            LAST_EVENT_DATE,
+            LAST_EVENT_DATE,
+            PrivacyLandscapeAge.RANGE_18_34,
+            PrivacyLandscapeGender.FEMALE,
+            PRIVACY_BUCKET_VID_SAMPLE_WIDTH,
+            PRIVACY_BUCKET_VID_SAMPLE_WIDTH
+          ),
+        )
+    }
+  }
+
+  @Test
   fun `fulfills reach and frequency Requisition`() {
     val events =
       generateEvents(
@@ -683,6 +970,7 @@ class EdpSimulatorTest {
         TRUSTED_CERTIFICATES,
         DIRECT_NOISE_MECHANISM,
         sketchEncrypter = fakeSketchEncrypter,
+        compositionMechanism = COMPOSITION_MECHANISM
       )
 
     runBlocking { edpSimulator.executeRequisitionFulfillingWorkflow() }
@@ -739,6 +1027,7 @@ class EdpSimulatorTest {
         privacyBudgetManager,
         TRUSTED_CERTIFICATES,
         DIRECT_NOISE_MECHANISM,
+        compositionMechanism = COMPOSITION_MECHANISM
       )
     val requisition =
       REQUISITION.copy {
@@ -798,6 +1087,7 @@ class EdpSimulatorTest {
         privacyBudgetManager,
         TRUSTED_CERTIFICATES,
         DIRECT_NOISE_MECHANISM,
+        compositionMechanism = COMPOSITION_MECHANISM
       )
     eventGroupsServiceMock.stub {
       onBlocking { getEventGroup(any()) }.thenThrow(Status.NOT_FOUND.asRuntimeException())
@@ -826,6 +1116,122 @@ class EdpSimulatorTest {
   }
 
   @Test
+  fun `refuses Requisition when noiseMechanism is GEOMETRIC and compositionMechanism is ACDP`() {
+    val requisitionGeometric =
+      REQUISITION.copy {
+        protocolConfig =
+          protocolConfig.copy {
+            protocols.clear()
+            protocols +=
+              ProtocolConfigKt.protocol {
+                liquidLegionsV2 =
+                  ProtocolConfigKt.liquidLegionsV2 {
+                    noiseMechanism = NoiseMechanism.GEOMETRIC
+                    sketchParams = liquidLegionsSketchParams {
+                      decayRate = LLV2_DECAY_RATE
+                      maxSize = LLV2_MAX_SIZE
+                      samplingIndicatorSize = 10_000_000
+                    }
+                    ellipticCurveId = 415
+                    maximumFrequency = 12
+                  }
+              }
+          }
+      }
+
+    requisitionsServiceMock.stub {
+      onBlocking { listRequisitions(any()) }
+        .thenReturn(listRequisitionsResponse { requisitions += requisitionGeometric })
+    }
+    val eventQueryMock = mock<EventQuery<TestEvent>>()
+    val simulator =
+      EdpSimulator(
+        EDP_DATA,
+        MC_NAME,
+        measurementConsumersStub,
+        certificatesStub,
+        eventGroupsStub,
+        eventGroupMetadataDescriptorsStub,
+        requisitionsStub,
+        requisitionFulfillmentStub,
+        eventQueryMock,
+        dummyThrottler,
+        privacyBudgetManager,
+        TRUSTED_CERTIFICATES,
+        DIRECT_NOISE_MECHANISM,
+        compositionMechanism = CompositionMechanism.ACDP
+      )
+
+    runBlocking { simulator.executeRequisitionFulfillingWorkflow() }
+
+    val refuseRequest: RefuseRequisitionRequest =
+      verifyAndCapture(requisitionsServiceMock, RequisitionsCoroutineImplBase::refuseRequisition)
+    assertThat(refuseRequest)
+      .ignoringFieldScope(
+        FieldScopes.allowingFieldDescriptors(
+          Refusal.getDescriptor().findFieldByNumber(Refusal.MESSAGE_FIELD_NUMBER)
+        )
+      )
+      .isEqualTo(
+        refuseRequisitionRequest {
+          name = REQUISITION.name
+          refusal = refusal { justification = Refusal.Justification.SPEC_INVALID }
+        }
+      )
+    assertThat(refuseRequest.refusal.message).contains(NoiseMechanism.GEOMETRIC.toString())
+    assertThat(fakeRequisitionFulfillmentService.fullfillRequisitionInvocations).isEmpty()
+    verifyBlocking(requisitionsServiceMock, never()) { fulfillDirectRequisition(any()) }
+  }
+
+  @Test
+  fun `refuses Requisition when directNoiseMechanism is LAPLACE and compositionMechanism is ACDP`() {
+    val requisition = DIRECT_REQUISITION
+
+    requisitionsServiceMock.stub {
+      onBlocking { listRequisitions(any()) }
+        .thenReturn(listRequisitionsResponse { requisitions += requisition })
+    }
+    val eventQueryMock = mock<EventQuery<TestEvent>>()
+    val simulator =
+      EdpSimulator(
+        EDP_DATA,
+        MC_NAME,
+        measurementConsumersStub,
+        certificatesStub,
+        eventGroupsStub,
+        eventGroupMetadataDescriptorsStub,
+        requisitionsStub,
+        requisitionFulfillmentStub,
+        eventQueryMock,
+        dummyThrottler,
+        privacyBudgetManager,
+        TRUSTED_CERTIFICATES,
+        DirectNoiseMechanism.LAPLACE,
+        compositionMechanism = CompositionMechanism.ACDP
+      )
+
+    runBlocking { simulator.executeRequisitionFulfillingWorkflow() }
+
+    val refuseRequest: RefuseRequisitionRequest =
+      verifyAndCapture(requisitionsServiceMock, RequisitionsCoroutineImplBase::refuseRequisition)
+    assertThat(refuseRequest)
+      .ignoringFieldScope(
+        FieldScopes.allowingFieldDescriptors(
+          Refusal.getDescriptor().findFieldByNumber(Refusal.MESSAGE_FIELD_NUMBER)
+        )
+      )
+      .isEqualTo(
+        refuseRequisitionRequest {
+          name = REQUISITION.name
+          refusal = refusal { justification = Refusal.Justification.SPEC_INVALID }
+        }
+      )
+    assertThat(refuseRequest.refusal.message).contains(DirectNoiseMechanism.LAPLACE.toString())
+    assertThat(fakeRequisitionFulfillmentService.fullfillRequisitionInvocations).isEmpty()
+    verifyBlocking(requisitionsServiceMock, never()) { fulfillDirectRequisition(any()) }
+  }
+
+  @Test
   fun `fulfills direct reach and frequency Requisition`() {
     val requisition = DIRECT_REQUISITION
     requisitionsServiceMock.stub {
@@ -847,7 +1253,8 @@ class EdpSimulatorTest {
         privacyBudgetManager,
         TRUSTED_CERTIFICATES,
         DIRECT_NOISE_MECHANISM,
-        random = Random(RANDOM_SEED)
+        random = Random(RANDOM_SEED),
+        compositionMechanism = COMPOSITION_MECHANISM
       )
 
     runBlocking { simulator.executeRequisitionFulfillingWorkflow() }
@@ -890,7 +1297,8 @@ class EdpSimulatorTest {
         privacyBudgetManager,
         TRUSTED_CERTIFICATES,
         DIRECT_NOISE_MECHANISM,
-        random = Random(RANDOM_SEED)
+        random = Random(RANDOM_SEED),
+        compositionMechanism = COMPOSITION_MECHANISM
       )
 
     runBlocking { simulator.executeRequisitionFulfillingWorkflow() }
@@ -935,7 +1343,8 @@ class EdpSimulatorTest {
         privacyBudgetManager,
         TRUSTED_CERTIFICATES,
         DIRECT_NOISE_MECHANISM,
-        random = Random(RANDOM_SEED)
+        random = Random(RANDOM_SEED),
+        compositionMechanism = COMPOSITION_MECHANISM
       )
 
     runBlocking { simulator.executeRequisitionFulfillingWorkflow() }
@@ -980,7 +1389,8 @@ class EdpSimulatorTest {
         privacyBudgetManager,
         TRUSTED_CERTIFICATES,
         DIRECT_NOISE_MECHANISM,
-        random = Random(RANDOM_SEED)
+        random = Random(RANDOM_SEED),
+        compositionMechanism = COMPOSITION_MECHANISM
       )
 
     runBlocking { simulator.executeRequisitionFulfillingWorkflow() }
@@ -1064,7 +1474,10 @@ class EdpSimulatorTest {
         DATA_PROVIDER_PUBLIC_KEY
       )
 
-    private val OUTPUT_DP_PARAMS = differentialPrivacyParams { epsilon = 1.0 }
+    private val OUTPUT_DP_PARAMS = differentialPrivacyParams {
+      epsilon = 1.0
+      delta = 1E-12
+    }
     private val MEASUREMENT_SPEC = measurementSpec {
       measurementPublicKey = MC_PUBLIC_KEY.toByteString()
       reachAndFrequency = reachAndFrequency {
@@ -1109,6 +1522,7 @@ class EdpSimulatorTest {
           ProtocolConfigKt.protocol {
             liquidLegionsV2 =
               ProtocolConfigKt.liquidLegionsV2 {
+                noiseMechanism = NOISE_MECHANISM
                 sketchParams = LIQUID_LEGIONS_SKETCH_PARAMS
                 ellipticCurveId = 415
                 maximumFrequency = 12


### PR DESCRIPTION
Update EDP simulator to support ACDP composition. Currently keep using the old DP_ADVANCED composition with MPC Geometric(Laplace) noise and direct Laplace noise for backward compatibility. Once MPC DP noise is switched to Discrete Gaussian noise in Kingdom, and direct DP noise is switched to Gaussian in EDP simulator, change compositionMechasnim to ACDP and start using ACDP composition in PBM. 

ACDP composition can only be used with MPC discrete Gaussian or direct Gaussian noise. Otherwise, the requisition will be refused. The old DP_ADVANCED PBM ledger and composition methods, old PrivacyBucketCharges BackingStore table should be deprecated/deleted after migration to ACDP is completed/stabilized.

Major changes in this PR:
* Create a new CompositionMechasnim flag(DP_ADVANCED, ACDP) in EdpSimulatorFlags
* EDP simulator supports charging privacy budget in ACDP composition
* Charge privacy budget for direct measurements
* Add EDP simulator unit tests for the new ACDP methods

Rally task link: https://rally1.rallydev.com/#/?detail=/task/704556858935&fdp=true
