### PR TITLE
Store measurement computation details in reporting for error bars

### DIFF
--- a/src/main/kotlin/org/wfanet/measurement/reporting/deploy/v2/postgres/writers/SetMeasurementResults.kt
+++ b/src/main/kotlin/org/wfanet/measurement/reporting/deploy/v2/postgres/writers/SetMeasurementResults.kt
@@ -52,7 +52,7 @@ class SetMeasurementResults(private val request: BatchSetMeasurementResultsReque
       ) {
         val state = Measurement.State.SUCCEEDED
         request.measurementResultsList.forEach {
-          val details = MeasurementKt.details { result = it.result }
+          val details = MeasurementKt.details { results += it.resultsList }
           addBinding {
             bind("$1", details)
             bind("$2", details.toJson())

--- a/src/main/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/MetricsService.kt
+++ b/src/main/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/MetricsService.kt
@@ -96,6 +96,7 @@ import org.wfanet.measurement.internal.reporting.v2.BatchSetCmmsMeasurementIdsRe
 import org.wfanet.measurement.internal.reporting.v2.BatchSetCmmsMeasurementIdsResponse
 import org.wfanet.measurement.internal.reporting.v2.BatchSetCmmsMeasurementResultsResponse
 import org.wfanet.measurement.internal.reporting.v2.BatchSetMeasurementFailuresRequestKt.measurementFailure
+import org.wfanet.measurement.internal.reporting.v2.BatchSetMeasurementResultsRequest
 import org.wfanet.measurement.internal.reporting.v2.BatchSetMeasurementResultsRequestKt.measurementResult
 import org.wfanet.measurement.internal.reporting.v2.CreateMetricRequest as InternalCreateMetricRequest
 import org.wfanet.measurement.internal.reporting.v2.Measurement as InternalMeasurement
@@ -770,15 +771,11 @@ class MetricsService(
         cmmsMeasurementConsumerId = principal.resourceKey.measurementConsumerId
         measurementResults +=
           succeededMeasurementsList.map { measurement ->
-            measurementResult {
-              cmmsMeasurementId = MeasurementKey.fromName(measurement.name)!!.measurementId
-              result =
-                buildInternalMeasurementResult(
-                  measurement,
-                  apiAuthenticationKey,
-                  principal.resourceKey.toName()
-                )
-            }
+            buildInternalMeasurementResult(
+              measurement,
+              apiAuthenticationKey,
+              principal.resourceKey.toName()
+            )
           }
       }
 
@@ -839,7 +836,7 @@ class MetricsService(
       measurement: Measurement,
       apiAuthenticationKey: String,
       principalName: String,
-    ): InternalMeasurement.Result {
+    ): BatchSetMeasurementResultsRequest.MeasurementResult {
       val measurementSpec = MeasurementSpec.parseFrom(measurement.measurementSpec.data)
       val encryptionPrivateKeyHandle =
         encryptionKeyPairStore.getPrivateKeyHandle(
@@ -850,13 +847,22 @@ class MetricsService(
             "Encryption private key not found for the measurement ${measurement.name}."
           }
 
-      return aggregateResults(
-        measurement.resultsList
-          .map {
-            decryptMeasurementResultPair(it, encryptionPrivateKeyHandle, apiAuthenticationKey)
+      val decryptedMeasurementResults: List<Measurement.Result> =
+        measurement.resultsList.map {
+          decryptMeasurementResultPair(it, encryptionPrivateKeyHandle, apiAuthenticationKey)
+        }
+
+      return measurementResult {
+        cmmsMeasurementId = MeasurementKey.fromName(measurement.name)!!.measurementId
+        results +=
+          decryptedMeasurementResults.map {
+            try {
+              it.toInternal(measurement.protocolConfig)
+            } catch (e: Throwable) {
+              failGrpc(Status.UNKNOWN) { e.message ?: "Unable to read measurement result." }
+            }
           }
-          .map(Measurement.Result::toInternal)
-      )
+      }
     }
 
     /** Decrypts a [Measurement.ResultPair] to [Measurement.Result] */
@@ -903,66 +909,6 @@ class MetricsService(
         throw Exception("Measurement result signature is invalid", e)
       }
       return Measurement.Result.parseFrom(signedResult.data)
-    }
-
-    /** Aggregates a list of [InternalMeasurement.Result]s to a [InternalMeasurement.Result] */
-    private fun aggregateResults(
-      internalMeasurementResults: List<InternalMeasurement.Result>
-    ): InternalMeasurement.Result {
-      if (internalMeasurementResults.isEmpty()) {
-        error("No measurement result.")
-      }
-      var reachValue = 0L
-      var impressionValue = 0L
-      val frequencyDistribution = mutableMapOf<Long, Double>()
-      var watchDurationValue = duration {
-        seconds = 0
-        nanos = 0
-      }
-
-      // Aggregation
-      for (result in internalMeasurementResults) {
-        if (result.hasFrequency()) {
-          if (!result.hasReach()) {
-            error("Missing reach measurement in the Reach-Frequency measurement.")
-          }
-          for ((frequency, percentage) in result.frequency.relativeFrequencyDistributionMap) {
-            val previousTotalReachCount =
-              frequencyDistribution.getOrDefault(frequency, 0.0) * reachValue
-            val currentReachCount = percentage * result.reach.value
-            frequencyDistribution[frequency] =
-              (previousTotalReachCount + currentReachCount) / (reachValue + result.reach.value)
-          }
-        }
-        if (result.hasReach()) {
-          reachValue += result.reach.value
-        }
-        if (result.hasImpression()) {
-          impressionValue += result.impression.value
-        }
-        if (result.hasWatchDuration()) {
-          watchDurationValue += result.watchDuration.value
-        }
-      }
-
-      return InternalMeasurementKt.result {
-        if (internalMeasurementResults.first().hasReach()) {
-          this.reach = InternalMeasurementKt.ResultKt.reach { value = reachValue }
-        }
-        if (internalMeasurementResults.first().hasFrequency()) {
-          this.frequency =
-            InternalMeasurementKt.ResultKt.frequency {
-              relativeFrequencyDistribution.putAll(frequencyDistribution)
-            }
-        }
-        if (internalMeasurementResults.first().hasImpression()) {
-          this.impression = InternalMeasurementKt.ResultKt.impression { value = impressionValue }
-        }
-        if (internalMeasurementResults.first().hasWatchDuration()) {
-          this.watchDuration =
-            InternalMeasurementKt.ResultKt.watchDuration { value = watchDurationValue }
-        }
-      }
     }
   }
 
@@ -1080,6 +1026,7 @@ class MetricsService(
         }
     }
   }
+
   override suspend fun listMetrics(request: ListMetricsRequest): ListMetricsResponse {
     val parentKey =
       grpcRequireNotNull(MeasurementConsumerKey.fromName(request.parent)) {
@@ -1527,6 +1474,66 @@ private fun buildMetricResult(metric: InternalMetric): MetricResult {
   }
 }
 
+/** Aggregates a list of [InternalMeasurement.Result]s to a [InternalMeasurement.Result] */
+private fun aggregateResults(
+  internalMeasurementResults: List<InternalMeasurement.Result>
+): InternalMeasurement.Result {
+  if (internalMeasurementResults.isEmpty()) {
+    error("No measurement result.")
+  }
+  var reachValue = 0L
+  var impressionValue = 0L
+  val frequencyDistribution = mutableMapOf<Long, Double>()
+  var watchDurationValue = duration {
+    seconds = 0
+    nanos = 0
+  }
+
+  // Aggregation
+  for (result in internalMeasurementResults) {
+    if (result.hasFrequency()) {
+      if (!result.hasReach()) {
+        error("Missing reach measurement in the Reach-Frequency measurement.")
+      }
+      for ((frequency, percentage) in result.frequency.relativeFrequencyDistributionMap) {
+        val previousTotalReachCount =
+          frequencyDistribution.getOrDefault(frequency, 0.0) * reachValue
+        val currentReachCount = percentage * result.reach.value
+        frequencyDistribution[frequency] =
+          (previousTotalReachCount + currentReachCount) / (reachValue + result.reach.value)
+      }
+    }
+    if (result.hasReach()) {
+      reachValue += result.reach.value
+    }
+    if (result.hasImpression()) {
+      impressionValue += result.impression.value
+    }
+    if (result.hasWatchDuration()) {
+      watchDurationValue += result.watchDuration.value
+    }
+  }
+
+  return InternalMeasurementKt.result {
+    if (internalMeasurementResults.first().hasReach()) {
+      this.reach = InternalMeasurementKt.ResultKt.reach { value = reachValue }
+    }
+    if (internalMeasurementResults.first().hasFrequency()) {
+      this.frequency =
+        InternalMeasurementKt.ResultKt.frequency {
+          relativeFrequencyDistribution.putAll(frequencyDistribution)
+        }
+    }
+    if (internalMeasurementResults.first().hasImpression()) {
+      this.impression = InternalMeasurementKt.ResultKt.impression { value = impressionValue }
+    }
+    if (internalMeasurementResults.first().hasWatchDuration()) {
+      this.watchDuration =
+        InternalMeasurementKt.ResultKt.watchDuration { value = watchDurationValue }
+    }
+  }
+}
+
 /** Calculates the watch duration result by summing up [WeightedMeasurement]s. */
 private fun calculateWatchDurationResults(
   weightedMeasurements: List<WeightedMeasurement>
@@ -1535,11 +1542,12 @@ private fun calculateWatchDurationResults(
     val watchDuration: Duration =
       weightedMeasurements
         .map { weightedMeasurement ->
-          if (!weightedMeasurement.measurement.details.result.hasWatchDuration()) {
+          if (weightedMeasurement.measurement.details.resultsList.any { !it.hasWatchDuration() }) {
             error("Watch duration measurement is missing.")
           }
-          weightedMeasurement.measurement.details.result.watchDuration.value *
-            weightedMeasurement.weight
+          aggregateResults(weightedMeasurement.measurement.details.resultsList)
+            .watchDuration
+            .value * weightedMeasurement.weight
         }
         .reduce { sum, element -> sum + element }
     value = watchDuration.seconds + (watchDuration.nanos.toDouble() / NANOS_PER_SECOND)
@@ -1553,10 +1561,11 @@ private fun calculateImpressionResults(
   return impressionCountResult {
     value =
       weightedMeasurements.sumOf { weightedMeasurement ->
-        if (!weightedMeasurement.measurement.details.result.hasImpression()) {
+        if (weightedMeasurement.measurement.details.resultsList.any { !it.hasImpression() }) {
           error("Impression measurement is missing.")
         }
-        weightedMeasurement.measurement.details.result.impression.value * weightedMeasurement.weight
+        aggregateResults(weightedMeasurement.measurement.details.resultsList).impression.value *
+          weightedMeasurement.weight
       }
   }
 }
@@ -1569,10 +1578,14 @@ private fun calculateFrequencyHistogramResults(
   val aggregatedFrequencyHistogramMap: MutableMap<Long, Double> =
     weightedMeasurements
       .map { weightedMeasurement ->
-        val result = weightedMeasurement.measurement.details.result
-        if (!result.hasFrequency() || !result.hasReach()) {
+        if (
+          weightedMeasurement.measurement.details.resultsList.any {
+            !it.hasReach() || !it.hasFrequency()
+          }
+        ) {
           error("Reach-Frequency measurement is missing.")
         }
+        val result = aggregateResults(weightedMeasurement.measurement.details.resultsList)
         val reach = result.reach.value
         result.frequency.relativeFrequencyDistributionMap.mapValues { (_, rate) ->
           rate * weightedMeasurement.weight * reach
@@ -1613,10 +1626,11 @@ private fun calculateReachResults(
   return reachResult {
     value =
       weightedMeasurements.sumOf { weightedMeasurement ->
-        if (!weightedMeasurement.measurement.details.result.hasReach()) {
+        if (weightedMeasurement.measurement.details.resultsList.any { !it.hasReach() }) {
           error("Reach measurement is missing.")
         }
-        weightedMeasurement.measurement.details.result.reach.value * weightedMeasurement.weight
+        aggregateResults(weightedMeasurement.measurement.details.resultsList).reach.value *
+          weightedMeasurement.weight
       }
   }
 }

--- a/src/main/kotlin/org/wfanet/measurement/reporting/service/internal/testing/v2/MeasurementsServiceTest.kt
+++ b/src/main/kotlin/org/wfanet/measurement/reporting/service/internal/testing/v2/MeasurementsServiceTest.kt
@@ -35,6 +35,7 @@ import org.wfanet.measurement.common.identity.RandomIdGenerator
 import org.wfanet.measurement.internal.reporting.v2.BatchSetCmmsMeasurementIdsRequestKt
 import org.wfanet.measurement.internal.reporting.v2.BatchSetMeasurementFailuresRequestKt
 import org.wfanet.measurement.internal.reporting.v2.BatchSetMeasurementResultsRequestKt
+import org.wfanet.measurement.internal.reporting.v2.DeterministicCountDistinct
 import org.wfanet.measurement.internal.reporting.v2.Measurement
 import org.wfanet.measurement.internal.reporting.v2.MeasurementConsumersGrpcKt
 import org.wfanet.measurement.internal.reporting.v2.MeasurementKt
@@ -43,6 +44,7 @@ import org.wfanet.measurement.internal.reporting.v2.Metric
 import org.wfanet.measurement.internal.reporting.v2.MetricKt
 import org.wfanet.measurement.internal.reporting.v2.MetricSpecKt
 import org.wfanet.measurement.internal.reporting.v2.MetricsGrpcKt
+import org.wfanet.measurement.internal.reporting.v2.NoiseMechanism
 import org.wfanet.measurement.internal.reporting.v2.ReportingSet
 import org.wfanet.measurement.internal.reporting.v2.ReportingSetKt
 import org.wfanet.measurement.internal.reporting.v2.ReportingSetsGrpcKt
@@ -450,7 +452,15 @@ abstract class MeasurementsServiceTest<T : MeasurementsGrpcKt.MeasurementsCorout
         measurementResults +=
           BatchSetMeasurementResultsRequestKt.measurementResult {
             cmmsMeasurementId = "1234"
-            result = MeasurementKt.result { reach = MeasurementKt.ResultKt.reach { value = 1 } }
+            results +=
+              MeasurementKt.result {
+                reach =
+                  MeasurementKt.ResultKt.reach {
+                    value = 1
+                    noiseMechanism = NoiseMechanism.GEOMETRIC
+                    deterministicCountDistinct = DeterministicCountDistinct.getDefaultInstance()
+                  }
+              }
           }
       }
     )
@@ -472,8 +482,16 @@ abstract class MeasurementsServiceTest<T : MeasurementsGrpcKt.MeasurementsCorout
               cmmsMeasurementId = "1234"
               details =
                 MeasurementKt.details {
-                  result =
-                    MeasurementKt.result { reach = MeasurementKt.ResultKt.reach { value = 1 } }
+                  results +=
+                    MeasurementKt.result {
+                      reach =
+                        MeasurementKt.ResultKt.reach {
+                          value = 1
+                          noiseMechanism = NoiseMechanism.GEOMETRIC
+                          deterministicCountDistinct =
+                            DeterministicCountDistinct.getDefaultInstance()
+                        }
+                    }
                 }
               state = Measurement.State.SUCCEEDED
             }
@@ -515,12 +533,30 @@ abstract class MeasurementsServiceTest<T : MeasurementsGrpcKt.MeasurementsCorout
         measurementResults +=
           BatchSetMeasurementResultsRequestKt.measurementResult {
             cmmsMeasurementId = "1234"
-            result = MeasurementKt.result { reach = MeasurementKt.ResultKt.reach { value = 1 } }
+            results +=
+              MeasurementKt.result {
+                reach =
+                  MeasurementKt.ResultKt.reach {
+                    value = 1
+
+                    noiseMechanism = NoiseMechanism.GEOMETRIC
+                    deterministicCountDistinct = DeterministicCountDistinct.getDefaultInstance()
+                  }
+              }
           }
         measurementResults +=
           BatchSetMeasurementResultsRequestKt.measurementResult {
             cmmsMeasurementId = "1235"
-            result = MeasurementKt.result { reach = MeasurementKt.ResultKt.reach { value = 2 } }
+            results +=
+              MeasurementKt.result {
+                reach =
+                  MeasurementKt.ResultKt.reach {
+                    value = 2
+
+                    noiseMechanism = NoiseMechanism.GEOMETRIC
+                    deterministicCountDistinct = DeterministicCountDistinct.getDefaultInstance()
+                  }
+              }
           }
       }
     )
@@ -542,8 +578,16 @@ abstract class MeasurementsServiceTest<T : MeasurementsGrpcKt.MeasurementsCorout
               cmmsMeasurementId = "1234"
               details =
                 MeasurementKt.details {
-                  result =
-                    MeasurementKt.result { reach = MeasurementKt.ResultKt.reach { value = 1 } }
+                  results +=
+                    MeasurementKt.result {
+                      reach =
+                        MeasurementKt.ResultKt.reach {
+                          value = 1
+                          noiseMechanism = NoiseMechanism.GEOMETRIC
+                          deterministicCountDistinct =
+                            DeterministicCountDistinct.getDefaultInstance()
+                        }
+                    }
                 }
               state = Measurement.State.SUCCEEDED
             }
@@ -554,8 +598,16 @@ abstract class MeasurementsServiceTest<T : MeasurementsGrpcKt.MeasurementsCorout
               cmmsMeasurementId = "1235"
               details =
                 MeasurementKt.details {
-                  result =
-                    MeasurementKt.result { reach = MeasurementKt.ResultKt.reach { value = 2 } }
+                  results +=
+                    MeasurementKt.result {
+                      reach =
+                        MeasurementKt.ResultKt.reach {
+                          value = 2
+                          noiseMechanism = NoiseMechanism.GEOMETRIC
+                          deterministicCountDistinct =
+                            DeterministicCountDistinct.getDefaultInstance()
+                        }
+                    }
                 }
               state = Measurement.State.SUCCEEDED
             }
@@ -599,12 +651,28 @@ abstract class MeasurementsServiceTest<T : MeasurementsGrpcKt.MeasurementsCorout
           measurementResults +=
             BatchSetMeasurementResultsRequestKt.measurementResult {
               cmmsMeasurementId = "1234"
-              result = MeasurementKt.result { reach = MeasurementKt.ResultKt.reach { value = 1 } }
+              results +=
+                MeasurementKt.result {
+                  reach =
+                    MeasurementKt.ResultKt.reach {
+                      value = 1
+                      noiseMechanism = NoiseMechanism.GEOMETRIC
+                      deterministicCountDistinct = DeterministicCountDistinct.getDefaultInstance()
+                    }
+                }
             }
           measurementResults +=
             BatchSetMeasurementResultsRequestKt.measurementResult {
               cmmsMeasurementId = "1235"
-              result = MeasurementKt.result { reach = MeasurementKt.ResultKt.reach { value = 2 } }
+              results +=
+                MeasurementKt.result {
+                  reach =
+                    MeasurementKt.ResultKt.reach {
+                      value = 2
+                      noiseMechanism = NoiseMechanism.GEOMETRIC
+                      deterministicCountDistinct = DeterministicCountDistinct.getDefaultInstance()
+                    }
+                }
             }
         }
       )
@@ -626,8 +694,16 @@ abstract class MeasurementsServiceTest<T : MeasurementsGrpcKt.MeasurementsCorout
                 cmmsMeasurementId = "1234"
                 details =
                   MeasurementKt.details {
-                    result =
-                      MeasurementKt.result { reach = MeasurementKt.ResultKt.reach { value = 1 } }
+                    results +=
+                      MeasurementKt.result {
+                        reach =
+                          MeasurementKt.ResultKt.reach {
+                            value = 1
+                            noiseMechanism = NoiseMechanism.GEOMETRIC
+                            deterministicCountDistinct =
+                              DeterministicCountDistinct.getDefaultInstance()
+                          }
+                      }
                   }
                 state = Measurement.State.SUCCEEDED
               }
@@ -638,8 +714,17 @@ abstract class MeasurementsServiceTest<T : MeasurementsGrpcKt.MeasurementsCorout
                 cmmsMeasurementId = "1235"
                 details =
                   MeasurementKt.details {
-                    result =
-                      MeasurementKt.result { reach = MeasurementKt.ResultKt.reach { value = 2 } }
+                    results +=
+                      MeasurementKt.result {
+                        reach =
+                          MeasurementKt.ResultKt.reach {
+                            value = 2
+
+                            noiseMechanism = NoiseMechanism.GEOMETRIC
+                            deterministicCountDistinct =
+                              DeterministicCountDistinct.getDefaultInstance()
+                          }
+                      }
                   }
                 state = Measurement.State.SUCCEEDED
               }
@@ -675,7 +760,15 @@ abstract class MeasurementsServiceTest<T : MeasurementsGrpcKt.MeasurementsCorout
         measurementResults +=
           BatchSetMeasurementResultsRequestKt.measurementResult {
             cmmsMeasurementId = "1234"
-            result = MeasurementKt.result { reach = MeasurementKt.ResultKt.reach { value = 1 } }
+            results +=
+              MeasurementKt.result {
+                reach =
+                  MeasurementKt.ResultKt.reach {
+                    value = 1
+                    noiseMechanism = NoiseMechanism.GEOMETRIC
+                    deterministicCountDistinct = DeterministicCountDistinct.getDefaultInstance()
+                  }
+              }
           }
       }
 
@@ -699,8 +792,16 @@ abstract class MeasurementsServiceTest<T : MeasurementsGrpcKt.MeasurementsCorout
                 cmmsMeasurementId = "1234"
                 details =
                   MeasurementKt.details {
-                    result =
-                      MeasurementKt.result { reach = MeasurementKt.ResultKt.reach { value = 1 } }
+                    results +=
+                      MeasurementKt.result {
+                        reach =
+                          MeasurementKt.ResultKt.reach {
+                            value = 1
+                            noiseMechanism = NoiseMechanism.GEOMETRIC
+                            deterministicCountDistinct =
+                              DeterministicCountDistinct.getDefaultInstance()
+                          }
+                      }
                   }
                 state = Measurement.State.SUCCEEDED
               }
@@ -739,12 +840,12 @@ abstract class MeasurementsServiceTest<T : MeasurementsGrpcKt.MeasurementsCorout
               measurementResults +=
                 BatchSetMeasurementResultsRequestKt.measurementResult {
                   cmmsMeasurementId = "1234"
-                  result = Measurement.Result.getDefaultInstance()
+                  results += Measurement.Result.getDefaultInstance()
                 }
               measurementResults +=
                 BatchSetMeasurementResultsRequestKt.measurementResult {
                   cmmsMeasurementId = "1235"
-                  result = Measurement.Result.getDefaultInstance()
+                  results += Measurement.Result.getDefaultInstance()
                 }
             }
           )
@@ -767,7 +868,7 @@ abstract class MeasurementsServiceTest<T : MeasurementsGrpcKt.MeasurementsCorout
               measurementResults +=
                 BatchSetMeasurementResultsRequestKt.measurementResult {
                   cmmsMeasurementId = "1234"
-                  result = Measurement.Result.getDefaultInstance()
+                  results += Measurement.Result.getDefaultInstance()
                 }
             }
           )
@@ -788,7 +889,7 @@ abstract class MeasurementsServiceTest<T : MeasurementsGrpcKt.MeasurementsCorout
               measurementResults +=
                 BatchSetMeasurementResultsRequestKt.measurementResult {
                   cmmsMeasurementId = "1234"
-                  result = Measurement.Result.getDefaultInstance()
+                  results += Measurement.Result.getDefaultInstance()
                 }
             }
           )
@@ -808,7 +909,7 @@ abstract class MeasurementsServiceTest<T : MeasurementsGrpcKt.MeasurementsCorout
               measurementResults +=
                 BatchSetMeasurementResultsRequestKt.measurementResult {
                   cmmsMeasurementId = "1234"
-                  result = Measurement.Result.getDefaultInstance()
+                  results += Measurement.Result.getDefaultInstance()
                 }
             }
           )
@@ -829,7 +930,7 @@ abstract class MeasurementsServiceTest<T : MeasurementsGrpcKt.MeasurementsCorout
                 measurementResults +=
                   BatchSetMeasurementResultsRequestKt.measurementResult {
                     cmmsMeasurementId = "1234"
-                    result = Measurement.Result.getDefaultInstance()
+                    results += Measurement.Result.getDefaultInstance()
                   }
               }
             }

--- a/src/main/proto/wfa/measurement/internal/reporting/v2/BUILD.bazel
+++ b/src/main/proto/wfa/measurement/internal/reporting/v2/BUILD.bazel
@@ -36,8 +36,23 @@ proto_and_java_proto_library(
 )
 
 proto_and_java_proto_library(
+    name = "noise_mechanism",
+)
+
+proto_and_java_proto_library(
+    name = "direct_computation",
+)
+
+proto_and_java_proto_library(
+    name = "mpc_protocol",
+)
+
+proto_and_java_proto_library(
     name = "measurement",
     deps = [
+        ":direct_computation_proto",
+        ":mpc_protocol_proto",
+        ":noise_mechanism_proto",
         ":reporting_set_proto",
         "@com_google_googleapis//google/type:interval_proto",
         "@com_google_protobuf//:duration_proto",

--- a/src/main/proto/wfa/measurement/internal/reporting/v2/direct_computation.proto
+++ b/src/main/proto/wfa/measurement/internal/reporting/v2/direct_computation.proto
@@ -1,0 +1,90 @@
+// Copyright 2023 The Cross-Media Measurement Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package wfa.measurement.internal.reporting.v2;
+
+option java_package = "org.wfanet.measurement.internal.reporting.v2";
+option java_multiple_files = true;
+
+// Information about the custom direct methodology.
+message CustomDirectMethodology {
+  // The variance of the result computed with the custom direct methodology.
+  double variance = 1;
+}
+
+// Parameters used when applying the deterministic count distinct methodology.
+message DeterministicCountDistinct {}
+
+// Parameters used when applying the deterministic distribution methodology.
+message DeterministicDistribution {}
+
+// Parameters used when applying the deterministic count methodology.
+message DeterministicCount {}
+
+// Parameters used when applying the deterministic sum methodology.
+message DeterministicSum {}
+
+// Parameters used when applying the Liquid Legions count distinct methodology.
+//
+// May only be set when the measurement type is REACH.
+// To obtain differentially private result, one should add a DP noise to the
+// estimate number of sampled registers instead of the target estimate.
+message LiquidLegionsCountDistinct {
+  // The decay rate of the Liquid Legions sketch. REQUIRED.
+  double decay_rate = 1;
+
+  // The maximum size of the Liquid Legions sketch. REQUIRED.
+  int64 max_size = 2;
+}
+
+// Parameters used when applying the Liquid Legions distribution methodology.
+//
+// May only be set when the measurement type is REACH_AND_FREQUENCY.
+// `Requisition`s using this protocol can be fulfilled by calling
+// RequisitionFulfillment/FulfillRequisition with an encrypted sketch.
+message LiquidLegionsDistribution {
+  // The decay rate of the Liquid Legions sketch. REQUIRED.
+  double decay_rate = 1;
+
+  // The maximum size of the Liquid Legions sketch. REQUIRED.
+  int64 max_size = 2;
+}
+
+// Parameters used when applying the Liquid Legions count methodology
+//
+// May only be set when the measurement type is IMPRESSION.
+// To obtain differentially private result, one should add a DP noise scaled by
+// `maximum_frequency_per_user` to the sampled count before scaling up.
+message LiquidLegionsCount {
+  // The decay rate of the Liquid Legions sketch. REQUIRED.
+  double decay_rate = 1;
+
+  // The maximum size of the Liquid Legions sketch. REQUIRED.
+  int64 max_size = 2;
+}
+
+// Parameters used when applying the Liquid Legions sum methodology
+//
+// May only be set when the measurement type is WATCH_DURATION.
+// To obtain differentially private result, one should add a DP noise scaled by
+// `maximum_duration_per_user` to the sampled sum before scaling up.
+message LiquidLegionsSum {
+  // The decay rate of the Liquid Legions sketch. REQUIRED.
+  double decay_rate = 1;
+
+  // The maximum size of the Liquid Legions sketch. REQUIRED.
+  int64 max_size = 2;
+}

--- a/src/main/proto/wfa/measurement/internal/reporting/v2/measurement.proto
+++ b/src/main/proto/wfa/measurement/internal/reporting/v2/measurement.proto
@@ -19,6 +19,9 @@ package wfa.measurement.internal.reporting.v2;
 import "google/protobuf/duration.proto";
 import "google/type/interval.proto";
 import "wfa/measurement/internal/reporting/v2/reporting_set.proto";
+import "wfa/measurement/internal/reporting/v2/noise_mechanism.proto";
+import "wfa/measurement/internal/reporting/v2/mpc_protocol.proto";
+import "wfa/measurement/internal/reporting/v2/direct_computation.proto";
 
 option java_package = "org.wfanet.measurement.internal.reporting.v2";
 option java_multiple_files = true;
@@ -67,21 +70,50 @@ message Measurement {
   message Result {
     message Reach {
       int64 value = 1;
+      // The mechanism used to generate noise during computation.
+      NoiseMechanism noise_mechanism = 2;
+      oneof methodology {
+        CustomDirectMethodology custom_direct_methodology = 3;
+        DeterministicCountDistinct deterministic_count_distinct = 4;
+        LiquidLegionsCountDistinct liquid_legions_count_distinct = 5;
+        LiquidLegionsV2 liquid_legions_v2 = 6;
+        ReachOnlyLiquidLegionsV2 reach_only_liquid_legions_v2 = 7;
+      }
     }
     Reach reach = 1;
 
     message Frequency {
       map<int64, double> relative_frequency_distribution = 1;
+      // The mechanism used to generate noise during computation.
+      NoiseMechanism noise_mechanism = 2;
+      oneof methodology {
+        CustomDirectMethodology custom_direct_methodology = 3;
+        DeterministicDistribution deterministic_distribution = 4;
+        LiquidLegionsDistribution liquid_legions_distribution = 5;
+        LiquidLegionsV2 liquid_legions_v2 = 6;
+      }
     }
     Frequency frequency = 2;
 
     message Impression {
       int64 value = 1;
+      // The mechanism used to generate noise during computation.
+      NoiseMechanism noise_mechanism = 2;
+      oneof methodology {
+        CustomDirectMethodology custom_direct_methodology = 3;
+        DeterministicCount deterministic_count = 4;
+      }
     }
     Impression impression = 3;
 
     message WatchDuration {
       google.protobuf.Duration value = 1;
+      // The mechanism used to generate noise during computation.
+      NoiseMechanism noise_mechanism = 2;
+      oneof methodology {
+        CustomDirectMethodology custom_direct_methodology = 3;
+        DeterministicSum deterministic_sum = 4;
+      }
     }
     WatchDuration watchDuration = 4;
   }
@@ -90,8 +122,12 @@ message Measurement {
     // Failure reason of the `Measurement` derived from the CMMS public API.
     // Set when the state is set to FAILED.
     Failure failure = 1;
-    // The result of the `Measurement` derived from the CMMS public API.
-    Result result = 2;
+    // The results of the `Measurement` derived from the CMMS public API.
+    //
+    // For measurement computed using a Direct protocol, it provides one result
+    // per data provider. For LLV2 and reach-only LLV2, there is only one
+    // result.
+    repeated Result results = 2;
   }
   Details details = 7;
 }

--- a/src/main/proto/wfa/measurement/internal/reporting/v2/measurements_service.proto
+++ b/src/main/proto/wfa/measurement/internal/reporting/v2/measurements_service.proto
@@ -58,7 +58,7 @@ message BatchSetMeasurementResultsRequest {
   message MeasurementResult {
     // `Measurement` ID from the CMMS public API.
     string cmms_measurement_id = 1;
-    Measurement.Result result = 2;
+    repeated Measurement.Result results = 2;
   }
   // Maximum is 1000.
   repeated MeasurementResult measurement_results = 2;

--- a/src/main/proto/wfa/measurement/internal/reporting/v2/mpc_protocol.proto
+++ b/src/main/proto/wfa/measurement/internal/reporting/v2/mpc_protocol.proto
@@ -1,0 +1,56 @@
+// Copyright 2023 The Cross-Media Measurement Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package wfa.measurement.internal.reporting.v2;
+
+option java_package = "org.wfanet.measurement.internal.reporting.v2";
+option java_multiple_files = true;
+
+// Parameters for a Liquid Legions sketch.
+message LiquidLegionsSketchParams {
+  // The decay rate of the Liquid Legions sketch. Required.
+  double decay_rate = 1;
+
+  // The maximum size of the Liquid Legions sketch. Required.
+  int64 max_size = 2;
+
+  // The size of the distribution of the sampling indicator value, i.e.
+  // fingerprint size. Required.
+  int64 sampling_indicator_size = 3;
+}
+
+// Parameters for a Reach-Only Liquid Legions sketch.
+message ReachOnlyLiquidLegionsSketchParams {
+  // The decay rate of the Liquid Legions sketch. REQUIRED.
+  double decay_rate = 1;
+
+  // The maximum size of the Liquid Legions sketch. REQUIRED.
+  int64 max_size = 2;
+}
+
+message LiquidLegionsV2 {
+  // Parameters for sketch. REQUIRED.
+  LiquidLegionsSketchParams sketch_params = 1;
+
+  // The maximum frequency to reveal in the histogram.
+  int32 maximum_frequency = 4;
+}
+
+// Configuration for the Reach-Only Liquid Legions v2 protocol.
+message ReachOnlyLiquidLegionsV2 {
+  // Parameters for sketch. REQUIRED.
+  ReachOnlyLiquidLegionsSketchParams sketch_params = 1;
+}

--- a/src/main/proto/wfa/measurement/internal/reporting/v2/noise_mechanism.proto
+++ b/src/main/proto/wfa/measurement/internal/reporting/v2/noise_mechanism.proto
@@ -1,0 +1,36 @@
+// Copyright 2023 The Cross-Media Measurement Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package wfa.measurement.internal.reporting.v2;
+
+option java_package = "org.wfanet.measurement.internal.reporting.v2";
+option java_multiple_files = true;
+
+// The mechanism used to generate noise in computations.
+enum NoiseMechanism {
+  // Default value used if the mechanism is omitted.
+  NOISE_MECHANISM_UNSPECIFIED = 0;
+  // No noise is added.
+  NONE = 1;
+  // Geometric, i.e. discrete Laplace.
+  GEOMETRIC = 2;
+  // Discrete Gaussian.
+  DISCRETE_GAUSSIAN = 3;
+  // Continuous Laplace.
+  CONTINUOUS_LAPLACE = 4;
+  // Continuous Gaussian.
+  CONTINUOUS_GAUSSIAN = 5;
+}

--- a/src/test/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/MetricsServiceTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/MetricsServiceTest.kt
@@ -60,6 +60,8 @@ import org.wfanet.measurement.api.v2alpha.CreateMeasurementRequest
 import org.wfanet.measurement.api.v2alpha.DataProviderCertificateKey
 import org.wfanet.measurement.api.v2alpha.DataProviderKey
 import org.wfanet.measurement.api.v2alpha.DataProvidersGrpcKt
+import org.wfanet.measurement.api.v2alpha.DeterministicCountDistinct
+import org.wfanet.measurement.api.v2alpha.DeterministicSum
 import org.wfanet.measurement.api.v2alpha.EncryptionPublicKey
 import org.wfanet.measurement.api.v2alpha.EventGroupKey as CmmsEventGroupKey
 import org.wfanet.measurement.api.v2alpha.GetDataProviderRequest
@@ -78,6 +80,8 @@ import org.wfanet.measurement.api.v2alpha.MeasurementSpec
 import org.wfanet.measurement.api.v2alpha.MeasurementSpecKt
 import org.wfanet.measurement.api.v2alpha.MeasurementsGrpcKt
 import org.wfanet.measurement.api.v2alpha.MeasurementsGrpcKt.MeasurementsCoroutineImplBase
+import org.wfanet.measurement.api.v2alpha.ProtocolConfig
+import org.wfanet.measurement.api.v2alpha.ProtocolConfigKt
 import org.wfanet.measurement.api.v2alpha.RequisitionSpec
 import org.wfanet.measurement.api.v2alpha.RequisitionSpecKt
 import org.wfanet.measurement.api.v2alpha.certificate
@@ -90,9 +94,12 @@ import org.wfanet.measurement.api.v2alpha.getCertificateRequest
 import org.wfanet.measurement.api.v2alpha.getDataProviderRequest
 import org.wfanet.measurement.api.v2alpha.getMeasurementConsumerRequest
 import org.wfanet.measurement.api.v2alpha.getMeasurementRequest
+import org.wfanet.measurement.api.v2alpha.liquidLegionsDistribution
 import org.wfanet.measurement.api.v2alpha.measurement
 import org.wfanet.measurement.api.v2alpha.measurementConsumer
 import org.wfanet.measurement.api.v2alpha.measurementSpec
+import org.wfanet.measurement.api.v2alpha.protocolConfig
+import org.wfanet.measurement.api.v2alpha.reachOnlyLiquidLegionsSketchParams
 import org.wfanet.measurement.api.v2alpha.requisitionSpec
 import org.wfanet.measurement.api.v2alpha.withDataProviderPrincipal
 import org.wfanet.measurement.common.OpenEndTimeRange
@@ -134,6 +141,8 @@ import org.wfanet.measurement.internal.reporting.v2.BatchSetMeasurementFailuresR
 import org.wfanet.measurement.internal.reporting.v2.BatchSetMeasurementFailuresRequestKt.measurementFailure
 import org.wfanet.measurement.internal.reporting.v2.BatchSetMeasurementResultsRequest
 import org.wfanet.measurement.internal.reporting.v2.BatchSetMeasurementResultsRequestKt.measurementResult
+import org.wfanet.measurement.internal.reporting.v2.DeterministicCountDistinct as InternalDeterministicCountDistinct
+import org.wfanet.measurement.internal.reporting.v2.DeterministicSum as InternalDeterministicSum
 import org.wfanet.measurement.internal.reporting.v2.Measurement as InternalMeasurement
 import org.wfanet.measurement.internal.reporting.v2.MeasurementKt as InternalMeasurementKt
 import org.wfanet.measurement.internal.reporting.v2.MeasurementsGrpcKt as InternalMeasurementsGrpcKt
@@ -143,6 +152,7 @@ import org.wfanet.measurement.internal.reporting.v2.MetricKt.weightedMeasurement
 import org.wfanet.measurement.internal.reporting.v2.MetricSpecKt as InternalMetricSpecKt
 import org.wfanet.measurement.internal.reporting.v2.MetricsGrpcKt as InternalMetricsGrpcKt
 import org.wfanet.measurement.internal.reporting.v2.MetricsGrpcKt.MetricsCoroutineImplBase
+import org.wfanet.measurement.internal.reporting.v2.NoiseMechanism
 import org.wfanet.measurement.internal.reporting.v2.ReportingSet as InternalReportingSet
 import org.wfanet.measurement.internal.reporting.v2.ReportingSet.SetExpression as InternalSetExpression
 import org.wfanet.measurement.internal.reporting.v2.ReportingSetKt as InternalReportingSetKt
@@ -164,9 +174,12 @@ import org.wfanet.measurement.internal.reporting.v2.batchSetMeasurementFailuresR
 import org.wfanet.measurement.internal.reporting.v2.batchSetMeasurementResultsRequest
 import org.wfanet.measurement.internal.reporting.v2.copy
 import org.wfanet.measurement.internal.reporting.v2.createMetricRequest as internalCreateMetricRequest
+import org.wfanet.measurement.internal.reporting.v2.liquidLegionsDistribution as internalLiquidLegionsDistribution
 import org.wfanet.measurement.internal.reporting.v2.measurement as internalMeasurement
 import org.wfanet.measurement.internal.reporting.v2.metric as internalMetric
 import org.wfanet.measurement.internal.reporting.v2.metricSpec as internalMetricSpec
+import org.wfanet.measurement.internal.reporting.v2.reachOnlyLiquidLegionsSketchParams as internalReachOnlyLiquidLegionsSketchParams
+import org.wfanet.measurement.internal.reporting.v2.reachOnlyLiquidLegionsV2
 import org.wfanet.measurement.internal.reporting.v2.reportingSet as internalReportingSet
 import org.wfanet.measurement.internal.reporting.v2.streamMetricsRequest
 import org.wfanet.measurement.reporting.service.api.InMemoryEncryptionKeyPairStore
@@ -177,6 +190,7 @@ import org.wfanet.measurement.reporting.v2alpha.Metric
 import org.wfanet.measurement.reporting.v2alpha.MetricResultKt
 import org.wfanet.measurement.reporting.v2alpha.MetricSpec
 import org.wfanet.measurement.reporting.v2alpha.MetricSpecKt
+import org.wfanet.measurement.reporting.v2alpha.MetricSpecKt.frequencyHistogramParams
 import org.wfanet.measurement.reporting.v2alpha.MetricSpecKt.impressionCountParams
 import org.wfanet.measurement.reporting.v2alpha.MetricSpecKt.reachParams
 import org.wfanet.measurement.reporting.v2alpha.MetricSpecKt.watchDurationParams
@@ -211,7 +225,7 @@ private const val REACH_FREQUENCY_VID_SAMPLING_WIDTH = 5.0f / NUMBER_VID_BUCKETS
 private const val REACH_FREQUENCY_VID_SAMPLING_START = 48.0f / NUMBER_VID_BUCKETS
 private const val REACH_FREQUENCY_REACH_EPSILON = 0.0033
 private const val REACH_FREQUENCY_FREQUENCY_EPSILON = 0.115
-private const val REACH_FREQUENCY_MAXIMUM_FREQUENCY = 10
+private const val REACH_FREQUENCY_MAXIMUM_FREQUENCY = 5
 
 private const val IMPRESSION_VID_SAMPLING_WIDTH = 62.0f / NUMBER_VID_BUCKETS
 private const val IMPRESSION_VID_SAMPLING_START = 143.0f / NUMBER_VID_BUCKETS
@@ -589,11 +603,19 @@ private val BASE_MEASUREMENT = measurement {
   measurementConsumerCertificate = MEASUREMENT_CONSUMERS.values.first().certificate
 }
 
+private const val LL_DISTRIBUTION_DECAY_RATE = 2e-2
+private const val LL_DISTRIBUTION_SKETCH_SIZE = 20000L
+private const val REACH_ONLY_LLV2_DECAY_RATE = 1e-2
+private const val REACH_ONLY_LLV2_SKETCH_SIZE = 10000L
+
 // Measurement values
 private const val UNION_ALL_REACH_VALUE = 100_000L
 private const val UNION_ALL_BUT_LAST_PUBLISHER_REACH_VALUE = 70_000L
 private const val INCREMENTAL_REACH_VALUE =
   UNION_ALL_REACH_VALUE - UNION_ALL_BUT_LAST_PUBLISHER_REACH_VALUE
+private const val REACH_FREQUENCY_REACH_VALUE = 100_000L
+private val REACH_FREQUENCY_FREQUENCY_VALUE = mapOf(1L to 0.1, 2L to 0.2, 3L to 0.3, 4L to 0.4)
+
 private val WATCH_DURATION_SECOND_LIST = listOf(100L, 200L, 300L)
 private val WATCH_DURATION_LIST = WATCH_DURATION_SECOND_LIST.map { duration { seconds = it } }
 private val TOTAL_WATCH_DURATION = duration { seconds = WATCH_DURATION_SECOND_LIST.sum() }
@@ -630,9 +652,82 @@ private val INTERNAL_SUCCEEDED_UNION_ALL_REACH_MEASUREMENT =
     state = InternalMeasurement.State.SUCCEEDED
     details =
       InternalMeasurementKt.details {
-        result =
+        results +=
           InternalMeasurementKt.result {
-            reach = InternalMeasurementKt.ResultKt.reach { value = UNION_ALL_REACH_VALUE }
+            reach =
+              InternalMeasurementKt.ResultKt.reach {
+                value = UNION_ALL_REACH_VALUE
+                noiseMechanism = NoiseMechanism.GEOMETRIC
+                reachOnlyLiquidLegionsV2 = reachOnlyLiquidLegionsV2 {
+                  sketchParams = internalReachOnlyLiquidLegionsSketchParams {
+                    decayRate = REACH_ONLY_LLV2_DECAY_RATE
+                    maxSize = REACH_ONLY_LLV2_SKETCH_SIZE
+                  }
+                }
+              }
+          }
+      }
+  }
+
+private val INTERNAL_SUCCEEDED_UNION_ALL_BUT_LAST_PUBLISHER_REACH_MEASUREMENT =
+  INTERNAL_PENDING_UNION_ALL_BUT_LAST_PUBLISHER_REACH_MEASUREMENT.copy {
+    state = InternalMeasurement.State.SUCCEEDED
+    details =
+      InternalMeasurementKt.details {
+        results +=
+          InternalMeasurementKt.result {
+            reach =
+              InternalMeasurementKt.ResultKt.reach {
+                value = UNION_ALL_BUT_LAST_PUBLISHER_REACH_VALUE
+                noiseMechanism = NoiseMechanism.GEOMETRIC
+                reachOnlyLiquidLegionsV2 = reachOnlyLiquidLegionsV2 {
+                  sketchParams = internalReachOnlyLiquidLegionsSketchParams {
+                    decayRate = REACH_ONLY_LLV2_DECAY_RATE
+                    maxSize = REACH_ONLY_LLV2_SKETCH_SIZE
+                  }
+                }
+              }
+          }
+      }
+  }
+
+// Internal single publisher reach-frequency measurements
+
+private val INTERNAL_PENDING_SINGLE_PUBLISHER_REACH_FREQUENCY_MEASUREMENT = internalMeasurement {
+  cmmsMeasurementConsumerId = MEASUREMENT_CONSUMERS.keys.first().measurementConsumerId
+  cmmsCreateMeasurementRequestId = "SINGLE_PUBLISHER_REACH_FREQUENCY_MEASUREMENT"
+  cmmsMeasurementId = externalIdToApiId(443L)
+  timeInterval = TIME_INTERVAL
+  primitiveReportingSetBases += primitiveReportingSetBasis {
+    externalReportingSetId = INTERNAL_SINGLE_PUBLISHER_REPORTING_SET.externalReportingSetId
+    filters += METRIC_FILTER
+    filters += PRIMITIVE_REPORTING_SET_FILTER
+  }
+  state = InternalMeasurement.State.PENDING
+}
+
+private val INTERNAL_SUCCEEDED_SINGLE_PUBLISHER_REACH_FREQUENCY_MEASUREMENT =
+  INTERNAL_PENDING_SINGLE_PUBLISHER_REACH_FREQUENCY_MEASUREMENT.copy {
+    state = InternalMeasurement.State.SUCCEEDED
+    details =
+      InternalMeasurementKt.details {
+        results +=
+          InternalMeasurementKt.result {
+            reach =
+              InternalMeasurementKt.ResultKt.reach {
+                value = REACH_FREQUENCY_REACH_VALUE
+                noiseMechanism = NoiseMechanism.CONTINUOUS_LAPLACE
+                deterministicCountDistinct = InternalDeterministicCountDistinct.getDefaultInstance()
+              }
+            frequency =
+              InternalMeasurementKt.ResultKt.frequency {
+                relativeFrequencyDistribution.putAll(REACH_FREQUENCY_FREQUENCY_VALUE)
+                noiseMechanism = NoiseMechanism.CONTINUOUS_LAPLACE
+                liquidLegionsDistribution = internalLiquidLegionsDistribution {
+                  decayRate = LL_DISTRIBUTION_DECAY_RATE
+                  maxSize = LL_DISTRIBUTION_SKETCH_SIZE
+                }
+              }
           }
       }
   }
@@ -692,17 +787,23 @@ private val INTERNAL_SUCCEEDED_UNION_ALL_WATCH_DURATION_MEASUREMENT =
     state = InternalMeasurement.State.SUCCEEDED
     details =
       InternalMeasurementKt.details {
-        result =
-          InternalMeasurementKt.result {
-            watchDuration =
-              InternalMeasurementKt.ResultKt.watchDuration { value = TOTAL_WATCH_DURATION }
+        results +=
+          WATCH_DURATION_LIST.map { duration ->
+            InternalMeasurementKt.result {
+              watchDuration =
+                InternalMeasurementKt.ResultKt.watchDuration {
+                  value = duration
+                  noiseMechanism = NoiseMechanism.CONTINUOUS_LAPLACE
+                  deterministicSum = InternalDeterministicSum.getDefaultInstance()
+                }
+            }
           }
       }
   }
 
-// CMMs measurements
+// CMMS measurements
 
-// CMMs incremental reach measurements
+// CMMS incremental reach measurements
 private val UNION_ALL_BUT_LAST_PUBLISHER_REACH_MEASUREMENT_SPEC = measurementSpec {
   measurementPublicKey = MEASUREMENT_CONSUMER_PUBLIC_KEY.toByteString()
 
@@ -724,6 +825,21 @@ private val UNION_ALL_BUT_LAST_PUBLISHER_REACH_MEASUREMENT_SPEC = measurementSpe
     MeasurementSpecKt.vidSamplingInterval {
       start = REACH_ONLY_VID_SAMPLING_START
       width = REACH_ONLY_VID_SAMPLING_WIDTH
+    }
+}
+
+private val REACH_PROTOCOL_CONFIG: ProtocolConfig = protocolConfig {
+  measurementType = ProtocolConfig.MeasurementType.REACH
+  protocols +=
+    ProtocolConfigKt.protocol {
+      reachOnlyLiquidLegionsV2 =
+        ProtocolConfigKt.reachOnlyLiquidLegionsV2 {
+          sketchParams = reachOnlyLiquidLegionsSketchParams {
+            decayRate = REACH_ONLY_LLV2_DECAY_RATE
+            maxSize = REACH_ONLY_LLV2_SKETCH_SIZE
+          }
+          noiseMechanism = ProtocolConfig.NoiseMechanism.GEOMETRIC
+        }
     }
 }
 
@@ -758,6 +874,7 @@ private val PENDING_UNION_ALL_REACH_MEASUREMENT =
           INTERNAL_PENDING_UNION_ALL_REACH_MEASUREMENT.cmmsMeasurementId
         )
         .toName()
+    protocolConfig = REACH_PROTOCOL_CONFIG
     state = Measurement.State.COMPUTING
   }
 private val PENDING_UNION_ALL_BUT_LAST_PUBLISHER_REACH_MEASUREMENT =
@@ -768,6 +885,7 @@ private val PENDING_UNION_ALL_BUT_LAST_PUBLISHER_REACH_MEASUREMENT =
           INTERNAL_PENDING_UNION_ALL_BUT_LAST_PUBLISHER_REACH_MEASUREMENT.cmmsMeasurementId
         )
         .toName()
+    protocolConfig = REACH_PROTOCOL_CONFIG
     state = Measurement.State.COMPUTING
   }
 
@@ -800,7 +918,103 @@ private val SUCCEEDED_UNION_ALL_BUT_LAST_PUBLISHER_REACH_MEASUREMENT =
     }
   }
 
-// CMMs single publisher impression measurements
+// CMMS single publisher reach-frequency measurements
+private val SINGLE_PUBLISHER_REACH_FREQUENCY_MEASUREMENT_SPEC = measurementSpec {
+  measurementPublicKey = MEASUREMENT_CONSUMER_PUBLIC_KEY.toByteString()
+
+  nonceHashes.add(Hashing.hashSha256(SECURE_RANDOM_OUTPUT_LONG))
+
+  reachAndFrequency =
+    MeasurementSpecKt.reachAndFrequency {
+      reachPrivacyParams = differentialPrivacyParams {
+        epsilon = REACH_FREQUENCY_REACH_EPSILON
+        delta = DIFFERENTIAL_PRIVACY_DELTA
+      }
+      frequencyPrivacyParams = differentialPrivacyParams {
+        epsilon = REACH_FREQUENCY_FREQUENCY_EPSILON
+        delta = DIFFERENTIAL_PRIVACY_DELTA
+      }
+      maximumFrequency = REACH_FREQUENCY_MAXIMUM_FREQUENCY
+    }
+  vidSamplingInterval =
+    MeasurementSpecKt.vidSamplingInterval {
+      start = REACH_FREQUENCY_VID_SAMPLING_START
+      width = REACH_FREQUENCY_VID_SAMPLING_WIDTH
+    }
+}
+
+private val REACH_FREQUENCY_PROTOCOL_CONFIG: ProtocolConfig = protocolConfig {
+  measurementType = ProtocolConfig.MeasurementType.REACH_AND_FREQUENCY
+  protocols +=
+    ProtocolConfigKt.protocol {
+      direct =
+        ProtocolConfigKt.direct {
+          noiseMechanisms +=
+            listOf(
+              ProtocolConfig.NoiseMechanism.NONE,
+              ProtocolConfig.NoiseMechanism.CONTINUOUS_LAPLACE,
+              ProtocolConfig.NoiseMechanism.CONTINUOUS_GAUSSIAN
+            )
+          deterministicCount = ProtocolConfig.Direct.DeterministicCount.getDefaultInstance()
+          liquidLegionsDistribution =
+            ProtocolConfig.Direct.LiquidLegionsDistribution.getDefaultInstance()
+        }
+    }
+}
+
+private val REQUESTING_SINGLE_PUBLISHER_REACH_FREQUENCY_MEASUREMENT =
+  BASE_MEASUREMENT.copy {
+    dataProviders += DATA_PROVIDER_ENTRIES.getValue(DATA_PROVIDERS.keys.first())
+
+    measurementSpec =
+      signMeasurementSpec(
+        SINGLE_PUBLISHER_REACH_FREQUENCY_MEASUREMENT_SPEC,
+        MEASUREMENT_CONSUMER_SIGNING_KEY_HANDLE
+      )
+  }
+
+private val PENDING_SINGLE_PUBLISHER_REACH_FREQUENCY_MEASUREMENT =
+  REQUESTING_SINGLE_PUBLISHER_REACH_FREQUENCY_MEASUREMENT.copy {
+    name =
+      MeasurementKey(
+          MEASUREMENT_CONSUMERS.keys.first().measurementConsumerId,
+          INTERNAL_PENDING_SINGLE_PUBLISHER_REACH_FREQUENCY_MEASUREMENT.cmmsMeasurementId
+        )
+        .toName()
+    protocolConfig = REACH_FREQUENCY_PROTOCOL_CONFIG
+    state = Measurement.State.COMPUTING
+  }
+
+private val SUCCEEDED_SINGLE_PUBLISHER_REACH_FREQUENCY_MEASUREMENT =
+  PENDING_SINGLE_PUBLISHER_REACH_FREQUENCY_MEASUREMENT.copy {
+    state = Measurement.State.SUCCEEDED
+
+    results += resultPair {
+      val result =
+        MeasurementKt.result {
+          reach =
+            MeasurementKt.ResultKt.reach {
+              value = REACH_FREQUENCY_REACH_VALUE
+              noiseMechanism = ProtocolConfig.NoiseMechanism.CONTINUOUS_LAPLACE
+              deterministicCountDistinct = DeterministicCountDistinct.getDefaultInstance()
+            }
+          frequency =
+            MeasurementKt.ResultKt.frequency {
+              relativeFrequencyDistribution.putAll(REACH_FREQUENCY_FREQUENCY_VALUE)
+              noiseMechanism = ProtocolConfig.NoiseMechanism.CONTINUOUS_LAPLACE
+              liquidLegionsDistribution = liquidLegionsDistribution {
+                decayRate = LL_DISTRIBUTION_DECAY_RATE
+                maxSize = LL_DISTRIBUTION_SKETCH_SIZE
+              }
+            }
+        }
+      encryptedResult =
+        encryptResult(signResult(result, AGGREGATOR_SIGNING_KEY), MEASUREMENT_CONSUMER_PUBLIC_KEY)
+      certificate = AGGREGATOR_CERTIFICATE.name
+    }
+  }
+
+// CMMS single publisher impression measurements
 private val SINGLE_PUBLISHER_IMPRESSION_MEASUREMENT_SPEC = measurementSpec {
   measurementPublicKey = MEASUREMENT_CONSUMER_PUBLIC_KEY.toByteString()
 
@@ -818,6 +1032,23 @@ private val SINGLE_PUBLISHER_IMPRESSION_MEASUREMENT_SPEC = measurementSpec {
     MeasurementSpecKt.vidSamplingInterval {
       start = IMPRESSION_VID_SAMPLING_START
       width = IMPRESSION_VID_SAMPLING_WIDTH
+    }
+}
+
+private val IMPRESSION_PROTOCOL_CONFIG: ProtocolConfig = protocolConfig {
+  measurementType = ProtocolConfig.MeasurementType.IMPRESSION
+  protocols +=
+    ProtocolConfigKt.protocol {
+      direct =
+        ProtocolConfigKt.direct {
+          noiseMechanisms +=
+            listOf(
+              ProtocolConfig.NoiseMechanism.NONE,
+              ProtocolConfig.NoiseMechanism.CONTINUOUS_LAPLACE,
+              ProtocolConfig.NoiseMechanism.CONTINUOUS_GAUSSIAN
+            )
+          deterministicCount = ProtocolConfig.Direct.DeterministicCount.getDefaultInstance()
+        }
     }
 }
 
@@ -840,10 +1071,11 @@ private val PENDING_SINGLE_PUBLISHER_IMPRESSION_MEASUREMENT =
           INTERNAL_PENDING_SINGLE_PUBLISHER_IMPRESSION_MEASUREMENT.cmmsMeasurementId
         )
         .toName()
+    protocolConfig = IMPRESSION_PROTOCOL_CONFIG
     state = Measurement.State.COMPUTING
   }
 
-// CMMs cross publisher watch duration measurements
+// CMMS cross publisher watch duration measurements
 private val UNION_ALL_WATCH_DURATION_MEASUREMENT_SPEC = measurementSpec {
   measurementPublicKey = MEASUREMENT_CONSUMER_PUBLIC_KEY.toByteString()
 
@@ -873,6 +1105,23 @@ private val UNION_ALL_WATCH_DURATION_MEASUREMENT_SPEC = measurementSpec {
     }
 }
 
+private val WATCH_DURATION_PROTOCOL_CONFIG: ProtocolConfig = protocolConfig {
+  measurementType = ProtocolConfig.MeasurementType.DURATION
+  protocols +=
+    ProtocolConfigKt.protocol {
+      direct =
+        ProtocolConfigKt.direct {
+          noiseMechanisms +=
+            listOf(
+              ProtocolConfig.NoiseMechanism.NONE,
+              ProtocolConfig.NoiseMechanism.CONTINUOUS_LAPLACE,
+              ProtocolConfig.NoiseMechanism.CONTINUOUS_GAUSSIAN
+            )
+          deterministicSum = ProtocolConfig.Direct.DeterministicSum.getDefaultInstance()
+        }
+    }
+}
+
 private val REQUESTING_UNION_ALL_WATCH_DURATION_MEASUREMENT =
   BASE_MEASUREMENT.copy {
     dataProviders += DATA_PROVIDERS.keys.map { DATA_PROVIDER_ENTRIES.getValue(it) }
@@ -894,6 +1143,7 @@ private val PENDING_UNION_ALL_WATCH_DURATION_MEASUREMENT =
           INTERNAL_PENDING_UNION_ALL_WATCH_DURATION_MEASUREMENT.cmmsMeasurementId
         )
         .toName()
+    protocolConfig = WATCH_DURATION_PROTOCOL_CONFIG
     state = Measurement.State.COMPUTING
   }
 
@@ -901,6 +1151,12 @@ private val PENDING_UNION_ALL_WATCH_DURATION_MEASUREMENT =
 
 private val REACH_METRIC_SPEC: MetricSpec = metricSpec {
   reach = reachParams { privacyParams = MetricSpec.DifferentialPrivacyParams.getDefaultInstance() }
+}
+private val REACH_FREQUENCY_METRIC_SPEC: MetricSpec = metricSpec {
+  frequencyHistogram = frequencyHistogramParams {
+    reachPrivacyParams = MetricSpec.DifferentialPrivacyParams.getDefaultInstance()
+    frequencyPrivacyParams = MetricSpec.DifferentialPrivacyParams.getDefaultInstance()
+  }
 }
 private val IMPRESSION_COUNT_METRIC_SPEC: MetricSpec = metricSpec {
   impressionCount = impressionCountParams {
@@ -1007,24 +1263,85 @@ private val INTERNAL_SUCCEEDED_INCREMENTAL_REACH_METRIC =
     weightedMeasurements += weightedMeasurement {
       weight = -1
       binaryRepresentation = 2
+      measurement = INTERNAL_SUCCEEDED_UNION_ALL_BUT_LAST_PUBLISHER_REACH_MEASUREMENT
+    }
+  }
+
+// Internal Single publisher reach-frequency metrics
+private val INTERNAL_REQUESTING_SINGLE_PUBLISHER_REACH_FREQUENCY_METRIC = internalMetric {
+  cmmsMeasurementConsumerId = MEASUREMENT_CONSUMERS.keys.first().measurementConsumerId
+  externalReportingSetId = INTERNAL_SINGLE_PUBLISHER_REPORTING_SET.externalReportingSetId
+  timeInterval = TIME_INTERVAL
+  metricSpec = internalMetricSpec {
+    frequencyHistogram =
+      InternalMetricSpecKt.frequencyHistogramParams {
+        reachPrivacyParams =
+          InternalMetricSpecKt.differentialPrivacyParams {
+            epsilon = REACH_FREQUENCY_REACH_EPSILON
+            delta = DIFFERENTIAL_PRIVACY_DELTA
+          }
+        frequencyPrivacyParams =
+          InternalMetricSpecKt.differentialPrivacyParams {
+            epsilon = REACH_FREQUENCY_FREQUENCY_EPSILON
+            delta = DIFFERENTIAL_PRIVACY_DELTA
+          }
+        maximumFrequency = REACH_FREQUENCY_MAXIMUM_FREQUENCY
+      }
+    vidSamplingInterval =
+      InternalMetricSpecKt.vidSamplingInterval {
+        start = REACH_FREQUENCY_VID_SAMPLING_START
+        width = REACH_FREQUENCY_VID_SAMPLING_WIDTH
+      }
+  }
+  weightedMeasurements += weightedMeasurement {
+    weight = 1
+    binaryRepresentation = 1
+    measurement =
+      INTERNAL_PENDING_SINGLE_PUBLISHER_REACH_FREQUENCY_MEASUREMENT.copy {
+        clearCmmsCreateMeasurementRequestId()
+        clearCmmsMeasurementId()
+        clearState()
+      }
+  }
+  details = InternalMetricKt.details { filters += listOf(METRIC_FILTER) }
+}
+
+private val INTERNAL_PENDING_INITIAL_SINGLE_PUBLISHER_REACH_FREQUENCY_METRIC =
+  INTERNAL_REQUESTING_SINGLE_PUBLISHER_REACH_FREQUENCY_METRIC.copy {
+    externalMetricId = "332L"
+    createTime = Instant.now().toProtoTime()
+    weightedMeasurements.clear()
+    weightedMeasurements += weightedMeasurement {
+      weight = 1
+      binaryRepresentation = 1
       measurement =
-        INTERNAL_PENDING_UNION_ALL_BUT_LAST_PUBLISHER_REACH_MEASUREMENT.copy {
-          state = InternalMeasurement.State.SUCCEEDED
-          details =
-            InternalMeasurementKt.details {
-              result =
-                InternalMeasurementKt.result {
-                  reach =
-                    InternalMeasurementKt.ResultKt.reach {
-                      value = UNION_ALL_BUT_LAST_PUBLISHER_REACH_VALUE
-                    }
-                }
-            }
+        INTERNAL_PENDING_SINGLE_PUBLISHER_REACH_FREQUENCY_MEASUREMENT.copy {
+          clearCmmsMeasurementId()
         }
     }
   }
 
-// Internal Single publisher Metrics
+private val INTERNAL_PENDING_SINGLE_PUBLISHER_REACH_FREQUENCY_METRIC =
+  INTERNAL_PENDING_INITIAL_SINGLE_PUBLISHER_REACH_FREQUENCY_METRIC.copy {
+    weightedMeasurements.clear()
+    weightedMeasurements += weightedMeasurement {
+      weight = 1
+      binaryRepresentation = 1
+      measurement = INTERNAL_PENDING_SINGLE_PUBLISHER_REACH_FREQUENCY_MEASUREMENT
+    }
+  }
+
+private val INTERNAL_SUCCEEDED_SINGLE_PUBLISHER_REACH_FREQUENCY_METRIC =
+  INTERNAL_PENDING_SINGLE_PUBLISHER_REACH_FREQUENCY_METRIC.copy {
+    weightedMeasurements.clear()
+    weightedMeasurements += weightedMeasurement {
+      weight = 1
+      binaryRepresentation = 1
+      measurement = INTERNAL_SUCCEEDED_SINGLE_PUBLISHER_REACH_FREQUENCY_MEASUREMENT
+    }
+  }
+
+// Internal Single publisher impression metrics
 private val INTERNAL_REQUESTING_SINGLE_PUBLISHER_IMPRESSION_METRIC = internalMetric {
   cmmsMeasurementConsumerId = MEASUREMENT_CONSUMERS.keys.first().measurementConsumerId
   externalReportingSetId = INTERNAL_SINGLE_PUBLISHER_REPORTING_SET.externalReportingSetId
@@ -1188,6 +1505,68 @@ private val SUCCEEDED_INCREMENTAL_REACH_METRIC =
   PENDING_INCREMENTAL_REACH_METRIC.copy {
     state = Metric.State.SUCCEEDED
     result = metricResult { reach = MetricResultKt.reachResult { value = INCREMENTAL_REACH_VALUE } }
+  }
+
+// Single publisher reach-frequency metrics
+private val REQUESTING_SINGLE_PUBLISHER_REACH_FREQUENCY_METRIC = metric {
+  reportingSet = INTERNAL_SINGLE_PUBLISHER_REPORTING_SET.resourceName
+  timeInterval = TIME_INTERVAL
+  metricSpec = REACH_FREQUENCY_METRIC_SPEC
+  filters += INTERNAL_REQUESTING_SINGLE_PUBLISHER_REACH_FREQUENCY_METRIC.details.filtersList
+}
+
+private val PENDING_SINGLE_PUBLISHER_REACH_FREQUENCY_METRIC =
+  REQUESTING_SINGLE_PUBLISHER_REACH_FREQUENCY_METRIC.copy {
+    name =
+      MetricKey(
+          MEASUREMENT_CONSUMERS.keys.first().measurementConsumerId,
+          INTERNAL_PENDING_SINGLE_PUBLISHER_REACH_FREQUENCY_METRIC.externalMetricId
+        )
+        .toName()
+    metricSpec = metricSpec {
+      frequencyHistogram = frequencyHistogramParams {
+        reachPrivacyParams =
+          MetricSpecKt.differentialPrivacyParams {
+            epsilon = REACH_FREQUENCY_REACH_EPSILON
+            delta = DIFFERENTIAL_PRIVACY_DELTA
+          }
+        frequencyPrivacyParams =
+          MetricSpecKt.differentialPrivacyParams {
+            epsilon = REACH_FREQUENCY_FREQUENCY_EPSILON
+            delta = DIFFERENTIAL_PRIVACY_DELTA
+          }
+        maximumFrequency = REACH_FREQUENCY_MAXIMUM_FREQUENCY
+      }
+      vidSamplingInterval =
+        MetricSpecKt.vidSamplingInterval {
+          start = REACH_FREQUENCY_VID_SAMPLING_START
+          width = REACH_FREQUENCY_VID_SAMPLING_WIDTH
+        }
+    }
+    state = Metric.State.RUNNING
+    createTime = INTERNAL_PENDING_SINGLE_PUBLISHER_REACH_FREQUENCY_METRIC.createTime
+  }
+
+private val SUCCEEDED_SINGLE_PUBLISHER_REACH_FREQUENCY_METRIC =
+  PENDING_SINGLE_PUBLISHER_REACH_FREQUENCY_METRIC.copy {
+    state = Metric.State.SUCCEEDED
+    result = metricResult {
+      frequencyHistogram =
+        MetricResultKt.histogramResult {
+          bins +=
+            (1..REACH_FREQUENCY_MAXIMUM_FREQUENCY).map { frequency ->
+              MetricResultKt.HistogramResultKt.bin {
+                label = frequency.toString()
+                binResult =
+                  MetricResultKt.HistogramResultKt.binResult {
+                    value =
+                      REACH_FREQUENCY_REACH_VALUE *
+                        REACH_FREQUENCY_FREQUENCY_VALUE.getOrDefault(frequency.toLong(), 0.0)
+                  }
+              }
+            }
+        }
+    }
   }
 
 // Single publisher impression metrics
@@ -1586,6 +1965,110 @@ class MetricsServiceTest {
 
     assertThat(result).isEqualTo(expected)
   }
+
+  @Test
+  fun `createMetric creates CMMS measurements for single pub reach frequency metric`() =
+    runBlocking {
+      whenever(internalMetricsMock.createMetric(any()))
+        .thenReturn(INTERNAL_PENDING_INITIAL_SINGLE_PUBLISHER_REACH_FREQUENCY_METRIC)
+      whenever(measurementsMock.createMeasurement(any()))
+        .thenReturn(PENDING_SINGLE_PUBLISHER_REACH_FREQUENCY_MEASUREMENT)
+
+      val request = createMetricRequest {
+        parent = MEASUREMENT_CONSUMERS.values.first().name
+        metric = REQUESTING_SINGLE_PUBLISHER_REACH_FREQUENCY_METRIC
+        metricId = "metric-id"
+      }
+
+      val result =
+        withMeasurementConsumerPrincipal(MEASUREMENT_CONSUMERS.values.first().name, CONFIG) {
+          runBlocking { service.createMetric(request) }
+        }
+
+      val expected = PENDING_SINGLE_PUBLISHER_REACH_FREQUENCY_METRIC
+
+      // Verify proto argument of the internal MetricsCoroutineImplBase::createMetric
+      verifyProtoArgument(internalMetricsMock, MetricsCoroutineImplBase::createMetric)
+        .ignoringRepeatedFieldOrder()
+        .isEqualTo(
+          internalCreateMetricRequest {
+            metric = INTERNAL_REQUESTING_SINGLE_PUBLISHER_REACH_FREQUENCY_METRIC
+            externalMetricId = "metric-id"
+          }
+        )
+
+      // Verify proto argument of MeasurementsCoroutineImplBase::createMeasurement
+      val measurementsCaptor: KArgumentCaptor<CreateMeasurementRequest> = argumentCaptor()
+      verifyBlocking(measurementsMock, times(1)) { createMeasurement(measurementsCaptor.capture()) }
+      val capturedMeasurementRequests = measurementsCaptor.allValues
+      assertThat(capturedMeasurementRequests)
+        .ignoringRepeatedFieldOrder()
+        .ignoringFieldDescriptors(
+          MEASUREMENT_SPEC_FIELD,
+          ENCRYPTED_REQUISITION_SPEC_FIELD,
+        )
+        .containsExactly(
+          createMeasurementRequest {
+            parent = request.parent
+            measurement = REQUESTING_SINGLE_PUBLISHER_REACH_FREQUENCY_MEASUREMENT
+            requestId =
+              INTERNAL_PENDING_SINGLE_PUBLISHER_REACH_FREQUENCY_MEASUREMENT
+                .cmmsCreateMeasurementRequestId
+          },
+        )
+
+      capturedMeasurementRequests.forEach { capturedMeasurementRequest ->
+        verifyMeasurementSpec(
+          capturedMeasurementRequest.measurement.measurementSpec,
+          MEASUREMENT_CONSUMER_CERTIFICATE,
+          TRUSTED_MEASUREMENT_CONSUMER_ISSUER
+        )
+
+        val dataProvidersList =
+          capturedMeasurementRequest.measurement.dataProvidersList.sortedBy { it.key }
+
+        val measurementSpec =
+          MeasurementSpec.parseFrom(capturedMeasurementRequest.measurement.measurementSpec.data)
+        assertThat(measurementSpec).isEqualTo(SINGLE_PUBLISHER_REACH_FREQUENCY_MEASUREMENT_SPEC)
+
+        dataProvidersList.map { dataProviderEntry ->
+          val signedRequisitionSpec =
+            decryptRequisitionSpec(
+              dataProviderEntry.value.encryptedRequisitionSpec,
+              DATA_PROVIDER_PRIVATE_KEY_HANDLE
+            )
+          val requisitionSpec = RequisitionSpec.parseFrom(signedRequisitionSpec.data)
+          verifyRequisitionSpec(
+            signedRequisitionSpec,
+            requisitionSpec,
+            measurementSpec,
+            MEASUREMENT_CONSUMER_CERTIFICATE,
+            TRUSTED_MEASUREMENT_CONSUMER_ISSUER
+          )
+        }
+      }
+
+      // Verify proto argument of internal MeasurementsCoroutineImplBase::batchSetCmmsMeasurementIds
+      verifyProtoArgument(
+          internalMeasurementsMock,
+          InternalMeasurementsGrpcKt.MeasurementsCoroutineImplBase::batchSetCmmsMeasurementIds
+        )
+        .ignoringRepeatedFieldOrder()
+        .isEqualTo(
+          batchSetCmmsMeasurementIdsRequest {
+            cmmsMeasurementConsumerId = MEASUREMENT_CONSUMERS.keys.first().measurementConsumerId
+            this.measurementIds += measurementIds {
+              cmmsCreateMeasurementRequestId =
+                INTERNAL_PENDING_SINGLE_PUBLISHER_REACH_FREQUENCY_MEASUREMENT
+                  .cmmsCreateMeasurementRequestId
+              cmmsMeasurementId =
+                INTERNAL_PENDING_SINGLE_PUBLISHER_REACH_FREQUENCY_MEASUREMENT.cmmsMeasurementId
+            }
+          }
+        )
+
+      assertThat(result).isEqualTo(expected)
+    }
 
   @Test
   fun `createMetric creates CMMS measurements for single pub impression metric`() = runBlocking {
@@ -2911,7 +3394,7 @@ class MetricsServiceTest {
     }
 
   @Test
-  fun `createMetric throws exception when the CMMs createMeasurement throws INVALID_ARGUMENT`() =
+  fun `createMetric throws exception when the CMMS createMeasurement throws INVALID_ARGUMENT`() =
     runBlocking {
       whenever(measurementsMock.createMeasurement(any()))
         .thenThrow(StatusRuntimeException(Status.INVALID_ARGUMENT))
@@ -3453,6 +3936,7 @@ class MetricsServiceTest {
 
     assertThat(result).ignoringRepeatedFieldOrder().isEqualTo(expected)
   }
+
   @Test
   fun `listMetrics with invalid page size replaced with the one in previous page token`() =
     runBlocking {
@@ -3603,21 +4087,6 @@ class MetricsServiceTest {
 
   @Test
   fun `listMetrics returns succeeded metrics when the measurements are SUCCEEDED`() = runBlocking {
-    val internalSucceededUnionAllButLastPublisherReachMeasurement =
-      INTERNAL_PENDING_UNION_ALL_BUT_LAST_PUBLISHER_REACH_MEASUREMENT.copy {
-        state = InternalMeasurement.State.SUCCEEDED
-        details =
-          InternalMeasurementKt.details {
-            result =
-              InternalMeasurementKt.result {
-                reach =
-                  InternalMeasurementKt.ResultKt.reach {
-                    value = UNION_ALL_BUT_LAST_PUBLISHER_REACH_VALUE
-                  }
-              }
-          }
-      }
-
     val measurementsMap =
       mapOf(
         SUCCEEDED_UNION_ALL_REACH_MEASUREMENT.name to SUCCEEDED_UNION_ALL_REACH_MEASUREMENT,
@@ -3657,7 +4126,7 @@ class MetricsServiceTest {
               weightedMeasurements += weightedMeasurement {
                 weight = -1
                 binaryRepresentation = 2
-                measurement = internalSucceededUnionAllButLastPublisherReachMeasurement
+                measurement = INTERNAL_SUCCEEDED_UNION_ALL_BUT_LAST_PUBLISHER_REACH_MEASUREMENT
               }
             }
           metrics += INTERNAL_PENDING_SINGLE_PUBLISHER_IMPRESSION_METRIC
@@ -3701,12 +4170,13 @@ class MetricsServiceTest {
           cmmsMeasurementConsumerId = MEASUREMENT_CONSUMERS.keys.first().measurementConsumerId
           measurementResults += measurementResult {
             cmmsMeasurementId = INTERNAL_SUCCEEDED_UNION_ALL_REACH_MEASUREMENT.cmmsMeasurementId
-            this.result = INTERNAL_SUCCEEDED_UNION_ALL_REACH_MEASUREMENT.details.result
+            this.results += INTERNAL_SUCCEEDED_UNION_ALL_REACH_MEASUREMENT.details.resultsList
           }
           measurementResults += measurementResult {
             cmmsMeasurementId =
-              internalSucceededUnionAllButLastPublisherReachMeasurement.cmmsMeasurementId
-            this.result = internalSucceededUnionAllButLastPublisherReachMeasurement.details.result
+              INTERNAL_SUCCEEDED_UNION_ALL_BUT_LAST_PUBLISHER_REACH_MEASUREMENT.cmmsMeasurementId
+            this.results +=
+              INTERNAL_SUCCEEDED_UNION_ALL_BUT_LAST_PUBLISHER_REACH_MEASUREMENT.details.resultsList
           }
         }
       )
@@ -4395,7 +4865,87 @@ class MetricsServiceTest {
   }
 
   @Test
-  fun `getMetric returns the metric with SUCCEEDED when measurements are updated to SUCCEEDED`() =
+  fun `getMetric returns frequency histogram metric with SUCCEEDED when measurements are updated to SUCCEEDED`() =
+    runBlocking {
+      whenever(
+          internalMetricsMock.batchGetMetrics(
+            eq(
+              internalBatchGetMetricsRequest {
+                cmmsMeasurementConsumerId =
+                  INTERNAL_PENDING_SINGLE_PUBLISHER_REACH_FREQUENCY_METRIC.cmmsMeasurementConsumerId
+                externalMetricIds +=
+                  INTERNAL_PENDING_SINGLE_PUBLISHER_REACH_FREQUENCY_METRIC.externalMetricId
+              }
+            )
+          )
+        )
+        .thenReturn(
+          internalBatchGetMetricsResponse {
+            metrics += INTERNAL_PENDING_SINGLE_PUBLISHER_REACH_FREQUENCY_METRIC
+          },
+          internalBatchGetMetricsResponse {
+            metrics += INTERNAL_SUCCEEDED_SINGLE_PUBLISHER_REACH_FREQUENCY_METRIC
+          },
+        )
+
+      whenever(
+          measurementsMock.getMeasurement(
+            eq(
+              getMeasurementRequest {
+                name = PENDING_SINGLE_PUBLISHER_REACH_FREQUENCY_MEASUREMENT.name
+              }
+            )
+          )
+        )
+        .thenReturn(SUCCEEDED_SINGLE_PUBLISHER_REACH_FREQUENCY_MEASUREMENT)
+      whenever(internalMeasurementsMock.batchSetMeasurementResults(any()))
+        .thenReturn(
+          batchSetCmmsMeasurementResultsResponse {
+            measurements += INTERNAL_SUCCEEDED_SINGLE_PUBLISHER_REACH_FREQUENCY_MEASUREMENT
+          }
+        )
+
+      val request = getMetricRequest { name = PENDING_SINGLE_PUBLISHER_REACH_FREQUENCY_METRIC.name }
+
+      val result =
+        withMeasurementConsumerPrincipal(MEASUREMENT_CONSUMERS.values.first().name, CONFIG) {
+          runBlocking { service.getMetric(request) }
+        }
+
+      // Verify proto argument of internal MeasurementsCoroutineImplBase::batchSetMeasurementResults
+      val batchSetMeasurementResultsCaptor: KArgumentCaptor<BatchSetMeasurementResultsRequest> =
+        argumentCaptor()
+      verifyBlocking(internalMeasurementsMock, times(1)) {
+        batchSetMeasurementResults(batchSetMeasurementResultsCaptor.capture())
+      }
+      assertThat(batchSetMeasurementResultsCaptor.allValues)
+        .containsExactly(
+          batchSetMeasurementResultsRequest {
+            cmmsMeasurementConsumerId =
+              INTERNAL_SUCCEEDED_SINGLE_PUBLISHER_REACH_FREQUENCY_MEASUREMENT
+                .cmmsMeasurementConsumerId
+            measurementResults += measurementResult {
+              cmmsMeasurementId =
+                INTERNAL_SUCCEEDED_SINGLE_PUBLISHER_REACH_FREQUENCY_MEASUREMENT.cmmsMeasurementId
+              this.results +=
+                INTERNAL_SUCCEEDED_SINGLE_PUBLISHER_REACH_FREQUENCY_MEASUREMENT.details.resultsList
+            }
+          }
+        )
+
+      // Verify proto argument of internal
+      // MeasurementsCoroutineImplBase::batchSetMeasurementFailures
+      val batchSetMeasurementFailuresCaptor: KArgumentCaptor<BatchSetMeasurementFailuresRequest> =
+        argumentCaptor()
+      verifyBlocking(internalMeasurementsMock, never()) {
+        batchSetMeasurementFailures(batchSetMeasurementFailuresCaptor.capture())
+      }
+
+      assertThat(result).isEqualTo(SUCCEEDED_SINGLE_PUBLISHER_REACH_FREQUENCY_METRIC)
+    }
+
+  @Test
+  fun `getMetric returns duration metric with SUCCEEDED when measurements are updated to SUCCEEDED`() =
     runBlocking {
       whenever(
           internalMetricsMock.batchGetMetrics(
@@ -4429,7 +4979,11 @@ class MetricsServiceTest {
                 val result =
                   MeasurementKt.result {
                     this.watchDuration =
-                      MeasurementKt.ResultKt.watchDuration { value = watchDuration }
+                      MeasurementKt.ResultKt.watchDuration {
+                        value = watchDuration
+                        noiseMechanism = ProtocolConfig.NoiseMechanism.CONTINUOUS_LAPLACE
+                        deterministicSum = DeterministicSum.getDefaultInstance()
+                      }
                   }
                 encryptedResult =
                   encryptResult(
@@ -4474,7 +5028,8 @@ class MetricsServiceTest {
             measurementResults += measurementResult {
               cmmsMeasurementId =
                 INTERNAL_SUCCEEDED_UNION_ALL_WATCH_DURATION_MEASUREMENT.cmmsMeasurementId
-              this.result = INTERNAL_SUCCEEDED_UNION_ALL_WATCH_DURATION_MEASUREMENT.details.result
+              this.results +=
+                INTERNAL_SUCCEEDED_UNION_ALL_WATCH_DURATION_MEASUREMENT.details.resultsList
             }
           }
         )
@@ -4577,7 +5132,63 @@ class MetricsServiceTest {
     }
 
   @Test
-  fun `getMetric returns the metric with SUCCEEDED when measurements are already SUCCEEDED`() =
+  fun `getMetric returns reach frequency metric with SUCCEEDED when measurements are already SUCCEEDED`() =
+    runBlocking {
+      whenever(internalMetricsMock.batchGetMetrics(any()))
+        .thenReturn(
+          internalBatchGetMetricsResponse {
+            metrics += INTERNAL_SUCCEEDED_SINGLE_PUBLISHER_REACH_FREQUENCY_METRIC
+          },
+        )
+
+      val request = getMetricRequest { name = PENDING_SINGLE_PUBLISHER_REACH_FREQUENCY_METRIC.name }
+
+      val result =
+        withMeasurementConsumerPrincipal(MEASUREMENT_CONSUMERS.values.first().name, CONFIG) {
+          runBlocking { service.getMetric(request) }
+        }
+
+      // Verify proto argument of internal MetricsCoroutineImplBase::batchGetMetrics
+      val batchGetInternalMetricsCaptor: KArgumentCaptor<InternalBatchGetMetricsRequest> =
+        argumentCaptor()
+      verifyBlocking(internalMetricsMock, times(1)) {
+        batchGetMetrics(batchGetInternalMetricsCaptor.capture())
+      }
+      val capturedInternalGetMetricRequests = batchGetInternalMetricsCaptor.allValues
+      assertThat(capturedInternalGetMetricRequests)
+        .containsExactly(
+          internalBatchGetMetricsRequest {
+            cmmsMeasurementConsumerId =
+              INTERNAL_PENDING_SINGLE_PUBLISHER_REACH_FREQUENCY_METRIC.cmmsMeasurementConsumerId
+            externalMetricIds +=
+              INTERNAL_PENDING_SINGLE_PUBLISHER_REACH_FREQUENCY_METRIC.externalMetricId
+          },
+        )
+
+      // Verify proto argument of MeasurementsCoroutineImplBase::getMeasurement
+      val getMeasurementCaptor: KArgumentCaptor<GetMeasurementRequest> = argumentCaptor()
+      verifyBlocking(measurementsMock, never()) { getMeasurement(getMeasurementCaptor.capture()) }
+
+      // Verify proto argument of internal MeasurementsCoroutineImplBase::batchSetMeasurementResults
+      val batchSetMeasurementResultsCaptor: KArgumentCaptor<BatchSetMeasurementResultsRequest> =
+        argumentCaptor()
+      verifyBlocking(internalMeasurementsMock, never()) {
+        batchSetMeasurementResults(batchSetMeasurementResultsCaptor.capture())
+      }
+
+      // Verify proto argument of internal
+      // MeasurementsCoroutineImplBase::batchSetMeasurementFailures
+      val batchSetMeasurementFailuresCaptor: KArgumentCaptor<BatchSetMeasurementFailuresRequest> =
+        argumentCaptor()
+      verifyBlocking(internalMeasurementsMock, never()) {
+        batchSetMeasurementFailures(batchSetMeasurementFailuresCaptor.capture())
+      }
+
+      assertThat(result).isEqualTo(SUCCEEDED_SINGLE_PUBLISHER_REACH_FREQUENCY_METRIC)
+    }
+
+  @Test
+  fun `getMetric returns duration metric with SUCCEEDED when measurements are already SUCCEEDED`() =
     runBlocking {
       whenever(internalMetricsMock.batchGetMetrics(any()))
         .thenReturn(


### PR DESCRIPTION
In addition to storing results in the internal measurements, we also store the computation details about the measurement creation. The structure of the internal measurement result is now same as the one in Kingdom -- measurement results are in a list to represent results from different data providers; noise mechanisms and computation methodologies are added to `Result`. Note that unlike the Kingdom `Result` which stores only direct noise mechanisms and direct methodologies, here we store both direct and MPC noise mechanisms and methodologies.

The additional computation details can be used to compute measurement variances and potentially used to identify measurements. No DB change is needed as the changes happened in `Details`. 