### PR TITLE
Enable Gaussian noise and ACDP composition

### DIFF
--- a/src/main/k8s/testing/secretfiles/llv2_protocol_config_config.textproto
+++ b/src/main/k8s/testing/secretfiles/llv2_protocol_config_config.textproto
@@ -11,7 +11,7 @@ protocol_config {
     delta: 1.0
   }
   elliptic_curve_id: 415
-  noise_mechanism: GEOMETRIC
+  noise_mechanism: DISCRETE_GAUSSIAN
 }
 duchy_protocol_config {
   mpc_noise {

--- a/src/main/k8s/testing/secretfiles/ro_llv2_protocol_config_config.textproto
+++ b/src/main/k8s/testing/secretfiles/ro_llv2_protocol_config_config.textproto
@@ -12,7 +12,7 @@ protocol_config {
     delta: 1.0
   }
   elliptic_curve_id: 415
-  noise_mechanism: GEOMETRIC
+  noise_mechanism: DISCRETE_GAUSSIAN
 }
 duchy_protocol_config {
   mpc_noise {

--- a/src/main/kotlin/org/wfanet/measurement/integration/common/InProcessEdpSimulator.kt
+++ b/src/main/kotlin/org/wfanet/measurement/integration/common/InProcessEdpSimulator.kt
@@ -131,6 +131,6 @@ class InProcessEdpSimulator(
     private val logger: Logger = Logger.getLogger(this::class.java.name)
     private const val RANDOM_SEED: Long = 1
     private val random = Random(RANDOM_SEED)
-    private val COMPOSITION_MECHANISM = CompositionMechanism.DP_ADVANCED
+    private val COMPOSITION_MECHANISM = CompositionMechanism.ACDP
   }
 }

--- a/src/main/kotlin/org/wfanet/measurement/loadtest/dataprovider/EdpSimulator.kt
+++ b/src/main/kotlin/org/wfanet/measurement/loadtest/dataprovider/EdpSimulator.kt
@@ -1243,7 +1243,6 @@ class EdpSimulator(
   /**
    * Build [Measurement.Result] of the measurement type specified in [MeasurementSpec].
    *
-   * @param requisition Requisition.
    * @param measurementSpec Measurement spec.
    * @param samples sampled events.
    * @return [Measurement.Result].
@@ -1386,10 +1385,10 @@ class EdpSimulator(
     val preferences =
       when (compositionMechanism) {
         CompositionMechanism.DP_ADVANCED -> {
-          DIRECT_REACH_AND_FREQUENCY_NOISE_MECHANISM_PREFERENCES
+          DIRECT_MEASUREMENT_DP_NOISE_MECHANISM_PREFERENCES
         }
         CompositionMechanism.ACDP -> {
-          DIRECT_REACH_AND_FREQUENCY_ACDP_NOISE_MECHANISM_PREFERENCES
+          DIRECT_MEASUREMENT_ACDP_NOISE_MECHANISM_PREFERENCES
         }
       }
 
@@ -1407,7 +1406,15 @@ class EdpSimulator(
   private fun selectImpressionNoiseMechanism(
     options: Set<DirectNoiseMechanism>
   ): DirectNoiseMechanism {
-    val preferences = listOf(DirectNoiseMechanism.NONE)
+    val preferences =
+      when (compositionMechanism) {
+        CompositionMechanism.DP_ADVANCED -> {
+          DIRECT_MEASUREMENT_DP_NOISE_MECHANISM_PREFERENCES
+        }
+        CompositionMechanism.ACDP -> {
+          DIRECT_MEASUREMENT_ACDP_NOISE_MECHANISM_PREFERENCES
+        }
+      }
 
     return preferences.firstOrNull { preference -> options.contains(preference) }
       ?: throw RequisitionRefusalException(
@@ -1424,7 +1431,15 @@ class EdpSimulator(
   private fun selectWatchDurationNoiseMechanism(
     options: Set<DirectNoiseMechanism>
   ): DirectNoiseMechanism {
-    val preferences = listOf(DirectNoiseMechanism.NONE)
+    val preferences =
+      when (compositionMechanism) {
+        CompositionMechanism.DP_ADVANCED -> {
+          DIRECT_MEASUREMENT_DP_NOISE_MECHANISM_PREFERENCES
+        }
+        CompositionMechanism.ACDP -> {
+          DIRECT_MEASUREMENT_ACDP_NOISE_MECHANISM_PREFERENCES
+        }
+      }
 
     return preferences.firstOrNull { preference -> options.contains(preference) }
       ?: throw RequisitionRefusalException(
@@ -1516,16 +1531,17 @@ class EdpSimulator(
 
     private val logger: Logger = Logger.getLogger(this::class.java.name)
 
-    // The noise mechanisms for reach and frequency are in order of preference.
-    private val DIRECT_REACH_AND_FREQUENCY_NOISE_MECHANISM_PREFERENCES =
+    // The direct noise mechanisms for DP_ADVANCED composition in PBM for direct measurements in
+    // order of preference.
+    private val DIRECT_MEASUREMENT_DP_NOISE_MECHANISM_PREFERENCES =
       listOf(
         DirectNoiseMechanism.CONTINUOUS_LAPLACE,
         DirectNoiseMechanism.CONTINUOUS_GAUSSIAN,
       )
-    // The direct noise mechanisms for ACDP composition in PBM for reach and frequency in order
+    // The direct noise mechanisms for ACDP composition in PBM for direct measurements in order
     // of preference. Currently, ACDP composition only supports CONTINUOUS_GAUSSIAN noise for direct
-    // measurements
-    private val DIRECT_REACH_AND_FREQUENCY_ACDP_NOISE_MECHANISM_PREFERENCES =
+    // measurements.
+    private val DIRECT_MEASUREMENT_ACDP_NOISE_MECHANISM_PREFERENCES =
       listOf(
         DirectNoiseMechanism.CONTINUOUS_GAUSSIAN,
       )

--- a/src/main/kotlin/org/wfanet/measurement/loadtest/dataprovider/EdpSimulatorFlags.kt
+++ b/src/main/kotlin/org/wfanet/measurement/loadtest/dataprovider/EdpSimulatorFlags.kt
@@ -104,7 +104,7 @@ class EdpSimulatorFlags {
   @CommandLine.Option(
     names = ["--composition-mechanism"],
     description = ["Composition mechanism in Privacy Budget Manager"],
-    defaultValue = "DP_ADVANCED",
+    defaultValue = "ACDP",
   )
   lateinit var compositionMechanism: CompositionMechanism
     private set

--- a/src/test/kotlin/org/wfanet/measurement/eventdataprovider/privacybudgetmanagement/PrivacyBudgetLedgerTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/eventdataprovider/privacybudgetmanagement/PrivacyBudgetLedgerTest.kt
@@ -280,7 +280,7 @@ class PrivacyBudgetLedgerTest {
 
       // chargeInAcdp is no op when privacyBucketGroups is empty
       ledger.chargeInAcdp(createReference(0), setOf(), setOf(acdpCharge))
-      // The acdp charges succeed and fills the Privacy Budget.
+      // The acdpCharges succeed and fills the Privacy Budget.
       ledger.chargeInAcdp(createReference(1), setOf(bucket), setOf(acdpCharge))
 
       // The next acdpCharge should exceed the budget.
@@ -306,9 +306,9 @@ class PrivacyBudgetLedgerTest {
         )
       val acdpCharge = AcdpCharge(0.04, 5.0E-6)
 
-      // The acdp charges succeed and doesn't charge anything.
+      // The acdpCharges succeed and doesn't charge anything.
       ledger.chargeInAcdp(createReference(0), setOf(bucket), setOf())
-      // The acdp charges succeed and fills the Privacy Budget.
+      // The acdpCharges succeed and fills the Privacy Budget.
       ledger.chargeInAcdp(createReference(1), setOf(bucket), setOf(acdpCharge))
 
       // Next acdpCharge should exceed the budget.
@@ -339,7 +339,7 @@ class PrivacyBudgetLedgerTest {
       }
 
       assertFailsWith<PrivacyBudgetManagerException> {
-        ledger.chargeInAcdp(createReference(30), setOf(bucket), setOf(acdpCharge))
+        ledger.chargeInAcdp(createReference(10), setOf(bucket), setOf(acdpCharge))
       }
     }
 
@@ -358,7 +358,7 @@ class PrivacyBudgetLedgerTest {
         0.1f
       )
     val acdpCharge = AcdpCharge(0.04, 5.0E-6)
-    // Only the first acdp charge would fill the budget, rest are not processed by the ledger
+    // Only the first acdpCharge would fill the budget, rest are not processed by the ledger
     for (i in 1..100) {
       ledger.chargeInAcdp(createReference(0), setOf(bucket), setOf(acdpCharge))
     }
@@ -381,7 +381,7 @@ class PrivacyBudgetLedgerTest {
         )
       val acdpCharge = AcdpCharge(0.04, 5.0E-6)
 
-      // The acdp charge succeed and fills the Privacy Budget.
+      // The acdpCharge succeed and fills the Privacy Budget.
       ledger.chargeInAcdp(createReference(0), setOf(bucket), setOf(acdpCharge))
 
       assertFailsWith<PrivacyBudgetManagerException> {
@@ -390,10 +390,10 @@ class PrivacyBudgetLedgerTest {
 
       // The refund opens up Privacy Budget.
       ledger.chargeInAcdp(createReference(2, true), setOf(bucket), setOf(acdpCharge))
-      // Thus, this charge succeeds and fills the budget.
+      // Thus, this acdpCharge succeeds and fills the budget.
       ledger.chargeInAcdp(createReference(3), setOf(bucket), setOf(acdpCharge))
 
-      // Then this charge fails.
+      // Then this acdpCharge fails.
       assertFailsWith<PrivacyBudgetManagerException> {
         ledger.chargeInAcdp(createReference(4), setOf(bucket), setOf(acdpCharge))
       }
@@ -415,7 +415,7 @@ class PrivacyBudgetLedgerTest {
           0.1f
         )
 
-      // The charges succeed and fills the privacy budget.
+      // The acdpCharges succeed and fills the privacy budget.
       ledger.chargeInAcdp(createReference(0), setOf(bucket), setOf(AcdpCharge(0.04, 5.0E-6)))
       ledger.chargeInAcdp(createReference(1), setOf(bucket), setOf(AcdpCharge(0.05, 5.0E-6)))
       ledger.chargeInAcdp(createReference(2), setOf(bucket), setOf(AcdpCharge(0.06, 5.0E-6)))
@@ -455,18 +455,18 @@ class PrivacyBudgetLedgerTest {
         )
 
       val acdpCharge = AcdpCharge(0.04, 5.0E-6)
-      // The charges succeed and fills the Privacy Budget.
+      // The acdpCharges succeed and fills the Privacy Budget.
       ledger.chargeInAcdp(createReference(0), setOf(bucket1), setOf(acdpCharge))
       ledger.chargeInAcdp(createReference(1), setOf(bucket2), setOf(acdpCharge))
       ledger.chargeInAcdp(createReference(2), setOf(bucket1), setOf(acdpCharge))
       ledger.chargeInAcdp(createReference(3), setOf(bucket2), setOf(acdpCharge))
 
-      // DpCharge should exceed the budget.
+      // acdpCharge should exceed the budget.
       assertFailsWith<PrivacyBudgetManagerException> {
         ledger.chargeInAcdp(createReference(4), setOf(bucket1), setOf(acdpCharge))
       }
 
-      // DpCharge should exceed the budget.
+      // acdpCharge should exceed the budget.
       assertFailsWith<PrivacyBudgetManagerException> {
         ledger.chargeInAcdp(createReference(5), setOf(bucket2), setOf(acdpCharge))
       }

--- a/src/test/kotlin/org/wfanet/measurement/loadtest/dataprovider/EdpSimulatorTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/loadtest/dataprovider/EdpSimulatorTest.kt
@@ -175,7 +175,7 @@ private const val EDP_NAME = "dataProviders/$EDP_ID"
 
 private const val LLV2_DECAY_RATE = 12.0
 private const val LLV2_MAX_SIZE = 100_000L
-private val NOISE_MECHANISM = ProtocolConfig.NoiseMechanism.GEOMETRIC
+private val NOISE_MECHANISM = ProtocolConfig.NoiseMechanism.DISCRETE_GAUSSIAN
 
 private val MEASUREMENT_CONSUMER_CERTIFICATE_DER =
   SECRET_FILES_PATH.resolve("mc_cs_cert.der").toFile().readByteString()
@@ -200,7 +200,7 @@ private val TIME_RANGE = OpenEndTimeRange.fromClosedDateRange(FIRST_EVENT_DATE..
 
 private const val DUCHY_ID = "worker1"
 private const val RANDOM_SEED: Long = 0
-private val COMPOSITION_MECHANISM = CompositionMechanism.DP_ADVANCED
+private val COMPOSITION_MECHANISM = CompositionMechanism.ACDP
 
 // Resource ID for EventGroup that fails Requisitions with CONSENT_SIGNAL_INVALID if used.
 private const val CONSENT_SIGNAL_INVALID_EVENT_GROUP_ID = "consent-signal-invalid"
@@ -522,7 +522,7 @@ class EdpSimulatorTest {
   }
 
   @Test
-  fun `charges privacy budget with Geometric(Laplace) noise and DP_ADVANCED composition mechanism for mpc reach and frequency Requisition`() {
+  fun `charges privacy budget with Geometric noise and DP_ADVANCED composition mechanism for mpc reach and frequency Requisition`() {
     val measurementSpec =
       MEASUREMENT_SPEC.copy {
         vidSamplingInterval =
@@ -531,14 +531,34 @@ class EdpSimulatorTest {
             width = PRIVACY_BUCKET_VID_SAMPLE_WIDTH
           }
       }
-    val requisition =
+    val requisitionGeometric =
       REQUISITION.copy {
         this.measurementSpec = signMeasurementSpec(measurementSpec, MC_SIGNING_KEY)
+        protocolConfig =
+          protocolConfig.copy {
+            protocols.clear()
+            protocols +=
+              ProtocolConfigKt.protocol {
+                liquidLegionsV2 =
+                  ProtocolConfigKt.liquidLegionsV2 {
+                    noiseMechanism = ProtocolConfig.NoiseMechanism.GEOMETRIC
+                    sketchParams = liquidLegionsSketchParams {
+                      decayRate = LLV2_DECAY_RATE
+                      maxSize = LLV2_MAX_SIZE
+                      samplingIndicatorSize = 10_000_000
+                    }
+                    ellipticCurveId = 415
+                    maximumFrequency = 12
+                  }
+              }
+          }
       }
+
     requisitionsServiceMock.stub {
       onBlocking { listRequisitions(any()) }
-        .thenReturn(listRequisitionsResponse { requisitions += requisition })
+        .thenReturn(listRequisitionsResponse { requisitions += requisitionGeometric })
     }
+
     val matchingEvents =
       generateEvents(
         1L..10L,
@@ -588,7 +608,7 @@ class EdpSimulatorTest {
         dummyThrottler,
         privacyBudgetManager,
         TRUSTED_CERTIFICATES,
-        compositionMechanism = COMPOSITION_MECHANISM
+        compositionMechanism = CompositionMechanism.DP_ADVANCED
       )
     runBlocking {
       edpSimulator.ensureEventGroup(TEST_METADATA)
@@ -659,31 +679,13 @@ class EdpSimulatorTest {
               width = PRIVACY_BUCKET_VID_SAMPLE_WIDTH
             }
         }
-      val requisitionDiscreteGaussian =
+      val requisition =
         REQUISITION.copy {
           this.measurementSpec = signMeasurementSpec(measurementSpec, MC_SIGNING_KEY)
-          protocolConfig =
-            protocolConfig.copy {
-              protocols.clear()
-              protocols +=
-                ProtocolConfigKt.protocol {
-                  liquidLegionsV2 =
-                    ProtocolConfigKt.liquidLegionsV2 {
-                      noiseMechanism = ProtocolConfig.NoiseMechanism.DISCRETE_GAUSSIAN
-                      sketchParams = liquidLegionsSketchParams {
-                        decayRate = LLV2_DECAY_RATE
-                        maxSize = LLV2_MAX_SIZE
-                        samplingIndicatorSize = 10_000_000
-                      }
-                      ellipticCurveId = 415
-                    }
-                }
-            }
         }
-
       requisitionsServiceMock.stub {
         onBlocking { listRequisitions(any()) }
-          .thenReturn(listRequisitionsResponse { requisitions += requisitionDiscreteGaussian })
+          .thenReturn(listRequisitionsResponse { requisitions += requisition })
       }
 
       val matchingEvents =
@@ -1590,7 +1592,7 @@ class EdpSimulatorTest {
 
   @Test
   fun `fulfills direct reach and frequency Requisition`() {
-    val noiseMechanismOption = ProtocolConfig.NoiseMechanism.CONTINUOUS_LAPLACE
+    val noiseMechanismOption = ProtocolConfig.NoiseMechanism.CONTINUOUS_GAUSSIAN
     val requisition =
       REQUISITION.copy {
         protocolConfig =
@@ -1644,15 +1646,18 @@ class EdpSimulatorTest {
     assertThat(result.reach.hasDeterministicCountDistinct())
     assertThat(result.frequency.noiseMechanism == noiseMechanismOption)
     assertThat(result.frequency.hasDeterministicDistribution())
-    assertThat(result).reachValue().isEqualTo(2000L)
-    assertThat(result).frequencyDistribution().isWithin(0.001).of(mapOf(2L to 0.5, 4L to 0.5))
+    assertThat(result).reachValue().isEqualTo(2001L)
+    assertThat(result)
+      .frequencyDistribution()
+      .isWithin(0.001)
+      .of(mapOf(2L to 0.5011303262418495, 4L to 0.5062662903291533))
   }
 
   @Test
   fun `fulfills direct reach and frequency Requisition with sampling rate less than 1`() {
     val measurementSpec =
       MEASUREMENT_SPEC.copy { vidSamplingInterval = vidSamplingInterval.copy { width = 0.1f } }
-    val noiseMechanismOption = ProtocolConfig.NoiseMechanism.CONTINUOUS_LAPLACE
+    val noiseMechanismOption = ProtocolConfig.NoiseMechanism.CONTINUOUS_GAUSSIAN
     val requisition =
       REQUISITION.copy {
         this.measurementSpec = signMeasurementSpec(measurementSpec, MC_SIGNING_KEY)
@@ -1708,11 +1713,11 @@ class EdpSimulatorTest {
     assertThat(result.reach.hasDeterministicCountDistinct())
     assertThat(result.frequency.noiseMechanism == noiseMechanismOption)
     assertThat(result.frequency.hasDeterministicDistribution())
-    assertThat(result).reachValue().isEqualTo(1920)
+    assertThat(result).reachValue().isEqualTo(1930)
     assertThat(result)
       .frequencyDistribution()
       .isWithin(0.00001)
-      .of(mapOf(2L to 0.5010227687681921, 4L to 0.5072032690534161))
+      .of(mapOf(2L to 0.5065658983525991, 4L to 0.5704821909286802))
   }
 
   @Test
@@ -1781,7 +1786,7 @@ class EdpSimulatorTest {
 
   @Test
   fun `fails to fulfill direct reach and frequency Requisition when no direct methodology is picked by EDP`() {
-    val noiseMechanismOption = ProtocolConfig.NoiseMechanism.CONTINUOUS_LAPLACE
+    val noiseMechanismOption = ProtocolConfig.NoiseMechanism.CONTINUOUS_GAUSSIAN
     val requisition =
       REQUISITION.copy {
         protocolConfig =
@@ -1839,7 +1844,7 @@ class EdpSimulatorTest {
   @Test
   fun `fulfills direct reach-only Requisition`() {
     val measurementSpec = REACH_ONLY_MEASUREMENT_SPEC
-    val noiseMechanismOption = ProtocolConfig.NoiseMechanism.CONTINUOUS_LAPLACE
+    val noiseMechanismOption = ProtocolConfig.NoiseMechanism.CONTINUOUS_GAUSSIAN
     val requisition =
       REQUISITION.copy {
         this.measurementSpec = signMeasurementSpec(measurementSpec, MC_SIGNING_KEY)
@@ -1891,7 +1896,7 @@ class EdpSimulatorTest {
 
     assertThat(result.reach.noiseMechanism == noiseMechanismOption)
     assertThat(result.reach.hasDeterministicCountDistinct())
-    assertThat(result).reachValue().isEqualTo(2000L)
+    assertThat(result).reachValue().isEqualTo(2001L)
     assertThat(result.hasFrequency()).isFalse()
   }
 
@@ -1901,7 +1906,7 @@ class EdpSimulatorTest {
       REACH_ONLY_MEASUREMENT_SPEC.copy {
         vidSamplingInterval = vidSamplingInterval.copy { width = 0.1f }
       }
-    val noiseMechanismOption = ProtocolConfig.NoiseMechanism.CONTINUOUS_LAPLACE
+    val noiseMechanismOption = ProtocolConfig.NoiseMechanism.CONTINUOUS_GAUSSIAN
     val requisition =
       REQUISITION.copy {
         this.measurementSpec = signMeasurementSpec(measurementSpec, MC_SIGNING_KEY)
@@ -1953,7 +1958,7 @@ class EdpSimulatorTest {
 
     assertThat(result.reach.noiseMechanism == noiseMechanismOption)
     assertThat(result.reach.hasDeterministicCountDistinct())
-    assertThat(result).reachValue().isEqualTo(1920)
+    assertThat(result).reachValue().isEqualTo(1930)
     assertThat(result.hasFrequency()).isFalse()
   }
 
@@ -2030,7 +2035,7 @@ class EdpSimulatorTest {
       REACH_ONLY_MEASUREMENT_SPEC.copy {
         vidSamplingInterval = vidSamplingInterval.copy { width = 0.1f }
       }
-    val noiseMechanismOption = ProtocolConfig.NoiseMechanism.CONTINUOUS_LAPLACE
+    val noiseMechanismOption = ProtocolConfig.NoiseMechanism.CONTINUOUS_GAUSSIAN
     val requisition =
       REQUISITION.copy {
         this.measurementSpec = signMeasurementSpec(measurementSpec, MC_SIGNING_KEY)


### PR DESCRIPTION
Roll out Gaussian noise and ACDP composition by changing the default values of `noise_mechanism` to `DISCRETE_GAUSSIAN` in testing configs for the LLV2 protocols, and `compositionMechanism` to `ACDP` in EDP simulator. By changing `noise_mechanism` to `DISCRETE_GAUSSIAN`, Duchy will add discrete Gaussian noise distributedly to MPC measurements. And by changing compositionMechanism to ACDP, PBM in EDP simulator will use ACDP composition for privacy accounting, and EDP simulator will add continuous Gaussian noise to direct measurements.

The changes will be effective in the Halo QA environment as well as in InProcessLifeOfAMeasurementIntegrationTest and EmptyClusterCorrectnessTest.

Rally task link: https://rally1.rallydev.com/#/?detail=/task/720480912395&fdp=true