### PR TITLE
Attempt to address flakiness in integration tests.

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -11,7 +11,7 @@ build --java_runtime_version=remotejdk_11
 build --java_language_version=8
 
 # Pass environment variables.
-test --test_env=TESTCONTAINERS_RYUK_DISABLED
+test --test_env TESTCONTAINERS_RYUK_DISABLED=true
 
 # Disable rules_docker transitions, as it breaks our usage of glibc target
 # constraints for on images based on Distroless Java.

--- a/src/test/kotlin/org/wfanet/measurement/integration/deploy/gcloud/BUILD.bazel
+++ b/src/test/kotlin/org/wfanet/measurement/integration/deploy/gcloud/BUILD.bazel
@@ -23,7 +23,6 @@ spanner_emulator_test(
         "//src/main/kotlin/org/wfanet/measurement/integration/common:in_process_life_of_a_measurement_integration_test",
         "//src/main/kotlin/org/wfanet/measurement/integration/deploy/gcloud:spanner_duchy_dependency_provider_rule",
         "//src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/testing",
-        "@wfa_common_jvm//imports/kotlin/kotlinx/coroutines/debug",
     ],
 )
 
@@ -38,7 +37,6 @@ spanner_emulator_test(
         "//src/main/kotlin/org/wfanet/measurement/integration/common:in_process_life_of_a_measurement_integration_test",
         "//src/main/kotlin/org/wfanet/measurement/integration/deploy/common/postgres:postgres_duchy_dependency_provider_rule",
         "//src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/testing",
-        "@wfa_common_jvm//imports/kotlin/kotlinx/coroutines/debug",
     ],
 )
 

--- a/src/test/kotlin/org/wfanet/measurement/integration/deploy/gcloud/GCloudPostgresInProcessLifeOfAMeasurementIntegrationTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/integration/deploy/gcloud/GCloudPostgresInProcessLifeOfAMeasurementIntegrationTest.kt
@@ -16,9 +16,9 @@
 
 package org.wfanet.measurement.integration.deploy.gcloud
 
-import kotlinx.coroutines.debug.junit4.CoroutinesTimeout
 import org.junit.ClassRule
 import org.junit.Rule
+import org.junit.rules.Timeout
 import org.wfanet.measurement.common.db.r2dbc.postgres.testing.PostgresDatabaseProviderRule
 import org.wfanet.measurement.duchy.deploy.common.postgres.testing.Schemata
 import org.wfanet.measurement.integration.common.ALL_DUCHY_NAMES
@@ -36,7 +36,12 @@ class GCloudPostgresInProcessLifeOfAMeasurementIntegrationTest :
     PostgresDuchyDependencyProviderRule(databaseProvider, ALL_DUCHY_NAMES)
   ) {
 
-  @get:Rule val timeout = CoroutinesTimeout.seconds(90)
+  /**
+   * Rule to enforce test method timeout.
+   *
+   * TODO(Kotlin/kotlinx.coroutines#3865): Switch back to CoroutinesTimeout when fixed.
+   */
+  @get:Rule val timeout: Timeout = Timeout.seconds(90)
 
   companion object {
     @JvmStatic

--- a/src/test/kotlin/org/wfanet/measurement/integration/deploy/gcloud/GCloudSpannerInProcessLifeOfAMeasurementIntegrationTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/integration/deploy/gcloud/GCloudSpannerInProcessLifeOfAMeasurementIntegrationTest.kt
@@ -14,8 +14,8 @@
 
 package org.wfanet.measurement.integration.deploy.gcloud
 
-import kotlinx.coroutines.debug.junit4.CoroutinesTimeout
 import org.junit.Rule
+import org.junit.rules.Timeout
 import org.wfanet.measurement.integration.common.ALL_DUCHY_NAMES
 import org.wfanet.measurement.integration.common.InProcessLifeOfAMeasurementIntegrationTest
 import org.wfanet.measurement.kingdom.deploy.gcloud.spanner.testing.KingdomDataServicesProviderRule
@@ -30,5 +30,10 @@ class GCloudSpannerInProcessLifeOfAMeasurementIntegrationTest :
     SpannerDuchyDependencyProviderRule(ALL_DUCHY_NAMES)
   ) {
 
-  @get:Rule val timeout = CoroutinesTimeout.seconds(90)
+  /**
+   * Rule to enforce test method timeout.
+   *
+   * TODO(Kotlin/kotlinx.coroutines#3865): Switch back to CoroutinesTimeout when fixed.
+   */
+  @get:Rule val timeout: Timeout = Timeout.seconds(90)
 }

--- a/tools/bazel-container
+++ b/tools/bazel-container
@@ -144,8 +144,6 @@ main() {
       "HOME=${CONTAINER_HOME}"
     '--env'
       "BAZELISK_HOME=${BAZELISK_HOME}"
-    '--env'
-      'TESTCONTAINERS_RYUK_DISABLED=true'
     '--mount'
       "type=bind,source=${PWD},target=${PWD},readonly"
     '--mount'


### PR DESCRIPTION
* Ensure TestContainers Ryuk is always disabled.
* Stop using CoroutinesTimeout in order to avoid Kotlin/kotlinx.coroutines#3865.