### PR TITLE
Stop defaulting imagePullPolicy on K8s Jobs to `always`.

### DIFF
--- a/src/main/k8s/base.cue
+++ b/src/main/k8s/base.cue
@@ -512,9 +512,7 @@ objects: [ for objectSet in objectSets for object in objectSet {object}]
 #Job: {
 	_name:        string
 	_secretName?: string
-	_container:   #Container & {
-		imagePullPolicy: imagePullPolicy | *"Always"
-	}
+	_container:   #Container
 
 	apiVersion: "batch/v1"
 	kind:       "Job"
@@ -547,9 +545,7 @@ objects: [ for objectSet in objectSets for object in objectSet {object}]
 #CronJob: {
 	_name:        string
 	_secretName?: string
-	_container:   #Container & {
-		imagePullPolicy: imagePullPolicy | *"Always"
-	}
+	_container:   #Container
 
 	apiVersion: "batch/v1"
 	kind:       "CronJob"


### PR DESCRIPTION
This should prevent some unnecessary pulls when the image is unchanged.