### PR TITLE
Use participant count instead of gRPC stubs count in LLv2 mills.

### DIFF
--- a/src/main/kotlin/org/wfanet/measurement/duchy/daemon/mill/liquidlegionsv2/LiquidLegionsV2Mill.kt
+++ b/src/main/kotlin/org/wfanet/measurement/duchy/daemon/mill/liquidlegionsv2/LiquidLegionsV2Mill.kt
@@ -473,16 +473,18 @@ class LiquidLegionsV2Mill(
   private suspend fun completeSetupPhaseAtAggregator(token: ComputationToken): ComputationToken {
     val llv2Details = token.computationDetails.liquidLegionsV2
     require(AGGREGATOR == llv2Details.role) { "invalid role for this function." }
-    // TODO(world-federation-of-advertisers/cross-media-measurement#1194): Fix this to
-    // handle the case where the set of computation participants is a subset of all Duchies.
-    val inputBlobCount = workerStubs.size
+    val inputBlobCount = token.participantCount - 1
     val (bytes, nextToken) =
       existingOutputOr(token) {
         val request =
           dataClients
             .readAllRequisitionBlobs(token, duchyId)
             .concat(readAndCombineAllInputBlobs(token, inputBlobCount))
-            .toCompleteSetupPhaseRequest(llv2Details, token.requisitionsCount)
+            .toCompleteSetupPhaseRequest(
+              llv2Details,
+              token.requisitionsCount,
+              token.participantCount
+            )
         val cryptoResult: CompleteSetupPhaseResponse = cryptoWorker.completeSetupPhase(request)
         logStageDurationMetric(
           token,
@@ -518,7 +520,11 @@ class LiquidLegionsV2Mill(
         val request =
           dataClients
             .readAllRequisitionBlobs(token, duchyId)
-            .toCompleteSetupPhaseRequest(llv2Details, token.requisitionsCount)
+            .toCompleteSetupPhaseRequest(
+              llv2Details,
+              token.requisitionsCount,
+              token.participantCount
+            )
         val cryptoResult: CompleteSetupPhaseResponse = cryptoWorker.completeSetupPhase(request)
         logStageDurationMetric(
           token,
@@ -564,7 +570,7 @@ class LiquidLegionsV2Mill(
           totalSketchesCount = token.requisitionsCount
           noiseMechanism = llv2Details.parameters.noise.noiseMechanism
           if (llv2Parameters.noise.hasFrequencyNoiseConfig() && maximumRequestedFrequency > 1) {
-            noiseParameters = getFrequencyNoiseParams(llv2Parameters)
+            noiseParameters = getFrequencyNoiseParams(llv2Parameters, token.participantCount)
           }
         }
         val cryptoResult: CompleteExecutionPhaseOneAtAggregatorResponse =
@@ -674,17 +680,13 @@ class LiquidLegionsV2Mill(
           vidSamplingIntervalWidth = measurementSpec.vidSamplingInterval.width
           if (llv2Parameters.noise.hasReachNoiseConfig()) {
             reachDpNoiseBaseline = globalReachDpNoiseBaseline {
-              // TODO(world-federation-of-advertisers/cross-media-measurement#1194): Fix this to
-              // handle the case where the computation participants is a subset of all Duchies.
-              contributorsCount = workerStubs.size + 1
+              contributorsCount = token.participantCount
               globalReachDpNoise = llv2Parameters.noise.reachNoiseConfig.globalReachDpNoise
             }
           }
           if (llv2Parameters.noise.hasFrequencyNoiseConfig() && (maximumRequestedFrequency > 1)) {
             frequencyNoiseParameters = flagCountTupleNoiseGenerationParameters {
-              // TODO(world-federation-of-advertisers/cross-media-measurement#1194): Fix this to
-              // handle the case where the computation participants is a subset of all Duchies.
-              contributorsCount = workerStubs.size + 1
+              contributorsCount = token.participantCount
               maximumFrequency = maximumRequestedFrequency
               dpParams = llv2Parameters.noise.frequencyNoiseConfig
             }
@@ -768,7 +770,7 @@ class LiquidLegionsV2Mill(
           if (llv2Parameters.noise.hasFrequencyNoiseConfig()) {
             partialCompositeElGamalPublicKey = llv2Details.partiallyCombinedPublicKey
             if (maximumRequestedFrequency > 1) {
-              noiseParameters = getFrequencyNoiseParams(llv2Parameters)
+              noiseParameters = getFrequencyNoiseParams(llv2Parameters, token.participantCount)
             }
           }
           noiseMechanism = llv2Details.parameters.noise.noiseMechanism
@@ -824,9 +826,7 @@ class LiquidLegionsV2Mill(
           maximumFrequency = llv2Parameters.maximumFrequency.coerceAtLeast(1)
           if (llv2Parameters.noise.hasFrequencyNoiseConfig()) {
             globalFrequencyDpNoisePerBucket = perBucketFrequencyDpNoiseBaseline {
-              // TODO(world-federation-of-advertisers/cross-media-measurement#1194): Fix this to
-              // handle the case where the computation participants is a subset of all Duchies.
-              contributorsCount = workerStubs.size + 1
+              contributorsCount = token.participantCount
               dpParams = llv2Parameters.noise.frequencyNoiseConfig
             }
           }
@@ -945,7 +945,8 @@ class LiquidLegionsV2Mill(
 
   private fun ByteString.toCompleteSetupPhaseRequest(
     llv2Details: LiquidLegionsSketchAggregationV2.ComputationDetails,
-    totalRequisitionsCount: Int
+    totalRequisitionsCount: Int,
+    participantCount: Int,
   ): CompleteSetupPhaseRequest {
     val noiseConfig = llv2Details.parameters.noise
     return completeSetupPhaseRequest {
@@ -955,9 +956,7 @@ class LiquidLegionsV2Mill(
         noiseParameters = registerNoiseGenerationParameters {
           compositeElGamalPublicKey = llv2Details.combinedPublicKey
           curveId = llv2Details.parameters.ellipticCurveId.toLong()
-          // TODO(world-federation-of-advertisers/cross-media-measurement#1194): Fix this to handle
-          // the case where the computation participants is a subset of all Duchies.
-          contributorsCount = workerStubs.size + 1
+          contributorsCount = participantCount
           totalSketchesCount = totalRequisitionsCount
           dpParams = reachNoiseDifferentialPrivacyParams {
             blindHistogram = noiseConfig.reachNoiseConfig.blindHistogramNoise
@@ -972,16 +971,24 @@ class LiquidLegionsV2Mill(
   }
 
   private fun getFrequencyNoiseParams(
-    llv2Parameters: Parameters
+    llv2Parameters: Parameters,
+    participantCount: Int,
   ): FlagCountTupleNoiseGenerationParameters {
     return flagCountTupleNoiseGenerationParameters {
       maximumFrequency = llv2Parameters.maximumFrequency
-      // TODO(world-federation-of-advertisers/cross-media-measurement#1194): Fix this to handle the
-      // case where the computation participants is a subset of all Duchies.
-      contributorsCount = workerStubs.size + 1
+      contributorsCount = participantCount
       dpParams = llv2Parameters.noise.frequencyNoiseConfig
     }
   }
+
+  private val ComputationToken.participantCount: Int
+    get() =
+      if (computationDetails.kingdomComputation.participantCount != 0) {
+        computationDetails.kingdomComputation.participantCount
+      } else {
+        // For legacy Computations. See world-federation-of-advertisers/cross-media-measurement#1194
+        workerStubs.size + 1
+      }
 
   companion object {
     init {

--- a/src/main/kotlin/org/wfanet/measurement/duchy/daemon/utils/ComputationConversions.kt
+++ b/src/main/kotlin/org/wfanet/measurement/duchy/daemon/utils/ComputationConversions.kt
@@ -87,6 +87,7 @@ fun SystemComputation.toKingdomComputationDetails(): KingdomComputationDetails {
   return kingdomComputationDetails {
     publicApiVersion = source.publicApiVersion
     measurementSpec = source.measurementSpec
+    participantCount = source.computationParticipantsCount
     when (Version.fromString(source.publicApiVersion)) {
       Version.V2_ALPHA -> {
         val measurementSpec = MeasurementSpec.parseFrom(source.measurementSpec)

--- a/src/main/proto/wfa/measurement/internal/duchy/computation_details.proto
+++ b/src/main/proto/wfa/measurement/internal/duchy/computation_details.proto
@@ -55,6 +55,11 @@ message ComputationDetails {
     // Public key for asymmetric encryption. Used when encrypting the final
     // result.
     EncryptionPublicKey measurement_public_key = 4;
+
+    // Count of Duchy participants in this Computation.
+    //
+    // This may not be set for legacy Computations.
+    int32 participant_count = 5;
   }
   KingdomComputationDetails kingdom_computation = 3;
 

--- a/src/test/kotlin/org/wfanet/measurement/duchy/daemon/herald/HeraldTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/duchy/daemon/herald/HeraldTest.kt
@@ -413,7 +413,7 @@ class HeraldTest {
       buildComputationAtKingdom(
         "2",
         Computation.State.PENDING_REQUISITION_PARAMS,
-        listOf(systemApiRequisitions1, systemApiRequisitions2)
+        systemApiRequisitions = listOf(systemApiRequisitions1, systemApiRequisitions2)
       )
     mockStreamActiveComputationsToReturn(confirmingKnown, confirmingUnknown)
 
@@ -458,6 +458,7 @@ class HeraldTest {
             publicApiVersion = PUBLIC_API_VERSION
             measurementSpec = SERIALIZED_MEASUREMENT_SPEC
             measurementPublicKey = PUBLIC_API_ENCRYPTION_PUBLIC_KEY.toDuchyEncryptionPublicKey()
+            participantCount = 3
           }
           liquidLegionsV2 =
             LiquidLegionsSketchAggregationV2Kt.computationDetails {
@@ -560,6 +561,7 @@ class HeraldTest {
             publicApiVersion = PUBLIC_API_VERSION
             measurementSpec = SERIALIZED_REACH_ONLY_MEASUREMENT_SPEC
             measurementPublicKey = PUBLIC_API_ENCRYPTION_PUBLIC_KEY.toDuchyEncryptionPublicKey()
+            participantCount = 3
           }
           liquidLegionsV2 =
             LiquidLegionsSketchAggregationV2Kt.computationDetails {
@@ -660,6 +662,7 @@ class HeraldTest {
             publicApiVersion = PUBLIC_API_VERSION
             measurementSpec = SERIALIZED_REACH_ONLY_MEASUREMENT_SPEC
             measurementPublicKey = PUBLIC_API_ENCRYPTION_PUBLIC_KEY.toDuchyEncryptionPublicKey()
+            participantCount = 3
           }
           reachOnlyLiquidLegionsV2 =
             ReachOnlyLiquidLegionsSketchAggregationV2Kt.computationDetails {
@@ -1332,29 +1335,44 @@ class HeraldTest {
         )
     }
 
-  /**
-   * Builds a kingdom system Api Computation using default values for fields not included in the
-   * parameters.
-   */
-  private fun buildComputationAtKingdom(
-    globalId: String,
-    stateAtKingdom: Computation.State,
-    systemApiRequisitions: List<Requisition> = listOf(),
-    systemComputationParticipant: List<SystemComputationParticipant> = listOf(),
-    serializedMeasurementSpec: ByteString = SERIALIZED_MEASUREMENT_SPEC,
-    mpcProtocolConfig: MpcProtocolConfig = LLV2_MPC_PROTOCOL_CONFIG
-  ): Computation {
-    return computation {
-      name = ComputationKey(globalId).toName()
-      publicApiVersion = PUBLIC_API_VERSION
-      measurementSpec = serializedMeasurementSpec
-      state = stateAtKingdom
-      requisitions += systemApiRequisitions
-      computationParticipants += systemComputationParticipant
-      this.mpcProtocolConfig = mpcProtocolConfig
+  private fun Computation.continuationToken(): String = key.computationId
+
+  companion object {
+    private val ALL_COMPUTATION_PARTICIPANTS =
+      listOf(
+        computationParticipant {
+          name = ComputationParticipantKey(COMPUTATION_GLOBAL_ID, DUCHY_ONE).toName()
+        },
+        computationParticipant {
+          name = ComputationParticipantKey(COMPUTATION_GLOBAL_ID, DUCHY_TWO).toName()
+        },
+        computationParticipant {
+          name = ComputationParticipantKey(COMPUTATION_GLOBAL_ID, DUCHY_THREE).toName()
+        },
+      )
+
+    /**
+     * Builds a kingdom system Api Computation using default values for fields not included in the
+     * parameters.
+     */
+    private fun buildComputationAtKingdom(
+      globalId: String,
+      stateAtKingdom: Computation.State,
+      systemApiRequisitions: List<Requisition> = listOf(),
+      systemComputationParticipant: List<SystemComputationParticipant> =
+        ALL_COMPUTATION_PARTICIPANTS,
+      serializedMeasurementSpec: ByteString = SERIALIZED_MEASUREMENT_SPEC,
+      mpcProtocolConfig: MpcProtocolConfig = LLV2_MPC_PROTOCOL_CONFIG
+    ): Computation {
+      return computation {
+        name = ComputationKey(globalId).toName()
+        publicApiVersion = PUBLIC_API_VERSION
+        measurementSpec = serializedMeasurementSpec
+        state = stateAtKingdom
+        requisitions += systemApiRequisitions
+        computationParticipants += systemComputationParticipant
+        this.mpcProtocolConfig = mpcProtocolConfig
+      }
     }
   }
-
-  private var continuationTokenTimeSeq = 0L
-  private fun Computation.continuationToken(): String = key.computationId.toString()
 }

--- a/src/test/kotlin/org/wfanet/measurement/duchy/daemon/mill/liquidlegionsv2/LiquidLegionsV2MillTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/duchy/daemon/mill/liquidlegionsv2/LiquidLegionsV2MillTest.kt
@@ -360,6 +360,7 @@ private val AGGREGATOR_COMPUTATION_DETAILS = computationDetails {
     publicApiVersion = PUBLIC_API_VERSION
     measurementPublicKey = ENCRYPTION_PUBLIC_KEY.toDuchyEncryptionPublicKey()
     measurementSpec = SERIALIZED_MEASUREMENT_SPEC
+    participantCount = 3
   }
   liquidLegionsV2 =
     LiquidLegionsSketchAggregationV2Kt.computationDetails {
@@ -1284,6 +1285,111 @@ class LiquidLegionsV2MillTest {
             compositeElGamalPublicKey = COMBINED_PUBLIC_KEY
             curveId = CURVE_ID
             contributorsCount = WORKER_COUNT
+            totalSketchesCount = REQUISITIONS.size
+            dpParams = reachNoiseDifferentialPrivacyParams {
+              blindHistogram = TEST_NOISE_CONFIG.reachNoiseConfig.blindHistogramNoise
+              noiseForPublisherNoise = TEST_NOISE_CONFIG.reachNoiseConfig.noiseForPublisherNoise
+              globalReachDpNoise = TEST_NOISE_CONFIG.reachNoiseConfig.globalReachDpNoise
+            }
+          }
+          maximumFrequency = MAX_FREQUENCY
+          parallelism = PARALLELISM
+        }
+      )
+  }
+
+  @Test
+  fun `setup phase at aggregator using calculated result with fewer participants`() = runBlocking {
+    // Stage 0. preparing the storage and set up mock
+    val computationDetails =
+      AGGREGATOR_COMPUTATION_DETAILS.copy {
+        kingdomComputation =
+          kingdomComputation.copy {
+            // Indicates that the Kingdom selected only 2 of the 3 Duchies.
+            participantCount = 2
+          }
+      }
+    val partialToken =
+      FakeComputationsDatabase.newPartialToken(
+          localId = LOCAL_ID,
+          stage = SETUP_PHASE.toProtocolStage()
+        )
+        .build()
+    val requisitionBlobContext =
+      RequisitionBlobContext(GLOBAL_ID, REQUISITION_1.externalKey.externalRequisitionId)
+    requisitionStore.writeString(requisitionBlobContext, "local_requisition")
+    val inputBlob0Context = ComputationBlobContext(GLOBAL_ID, SETUP_PHASE.toProtocolStage(), 0L)
+    computationStore.writeString(inputBlob0Context, "-duchy_two_sketch")
+    fakeComputationDb.addComputation(
+      partialToken.localComputationId,
+      partialToken.computationStage,
+      computationDetails = computationDetails,
+      blobs =
+        listOf(newInputBlobMetadata(0L, inputBlob0Context.blobKey), newEmptyOutputBlobMetadata(3L)),
+      requisitions = listOf(REQUISITION_1, REQUISITION_2, REQUISITION_3)
+    )
+
+    var cryptoRequest = CompleteSetupPhaseRequest.getDefaultInstance()
+    whenever(mockCryptoWorker.completeSetupPhase(any())).thenAnswer {
+      cryptoRequest = it.getArgument(0)
+      val postFix = ByteString.copyFromUtf8("-completeSetupPhase_done")
+      CompleteSetupPhaseResponse.newBuilder()
+        .apply { combinedRegisterVector = cryptoRequest.combinedRegisterVector.concat(postFix) }
+        .build()
+    }
+
+    // Stage 1. Process the above computation
+    aggregatorMill.pollAndProcessNextComputation()
+
+    // Stage 2. Check the status of the computation
+    val blobKey = ComputationBlobContext(GLOBAL_ID, SETUP_PHASE.toProtocolStage(), 3L).blobKey
+    assertThat(fakeComputationDb[LOCAL_ID])
+      .isEqualTo(
+        ComputationToken.newBuilder()
+          .apply {
+            globalComputationId = GLOBAL_ID
+            localComputationId = LOCAL_ID
+            attempt = 1
+            computationStage = WAIT_EXECUTION_PHASE_ONE_INPUTS.toProtocolStage()
+            addBlobsBuilder().apply {
+              dependencyType = ComputationBlobDependency.INPUT
+              blobId = 0
+              path = blobKey
+            }
+            addBlobsBuilder().apply {
+              dependencyType = ComputationBlobDependency.OUTPUT
+              blobId = 1
+            }
+            version = 3 // claimTask + writeOutputBlob + transitionStage
+            this.computationDetails = computationDetails
+            addAllRequisitions(listOf(REQUISITION_1, REQUISITION_2, REQUISITION_3))
+          }
+          .build()
+      )
+
+    assertThat(computationStore.get(blobKey)?.readToString())
+      .isEqualTo("local_requisition-duchy_two_sketch-completeSetupPhase_done")
+
+    assertThat(computationControlRequests)
+      .containsExactlyElementsIn(
+        buildAdvanceComputationRequests(
+          GLOBAL_ID,
+          EXECUTION_PHASE_ONE_INPUT,
+          "local_requisition-du",
+          "chy_two_sketch-compl",
+          "eteSetupPhase_done",
+        )
+      )
+      .inOrder()
+
+    assertThat(cryptoRequest)
+      .isEqualTo(
+        completeSetupPhaseRequest {
+          combinedRegisterVector = ByteString.copyFromUtf8("local_requisition-duchy_two_sketch")
+          noiseParameters = registerNoiseGenerationParameters {
+            compositeElGamalPublicKey = COMBINED_PUBLIC_KEY
+            curveId = CURVE_ID
+            contributorsCount = 2
             totalSketchesCount = REQUISITIONS.size
             dpParams = reachNoiseDifferentialPrivacyParams {
               blindHistogram = TEST_NOISE_CONFIG.reachNoiseConfig.blindHistogramNoise

--- a/src/test/kotlin/org/wfanet/measurement/duchy/daemon/mill/liquidlegionsv2/ReachOnlyLiquidLegionsV2MillTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/duchy/daemon/mill/liquidlegionsv2/ReachOnlyLiquidLegionsV2MillTest.kt
@@ -320,6 +320,7 @@ private val AGGREGATOR_COMPUTATION_DETAILS = computationDetails {
     publicApiVersion = PUBLIC_API_VERSION
     measurementPublicKey = ENCRYPTION_PUBLIC_KEY.toDuchyEncryptionPublicKey()
     measurementSpec = SERIALIZED_MEASUREMENT_SPEC
+    participantCount = 3
   }
   reachOnlyLiquidLegionsV2 =
     ReachOnlyLiquidLegionsSketchAggregationV2Kt.computationDetails {
@@ -339,6 +340,7 @@ private val NON_AGGREGATOR_COMPUTATION_DETAILS = computationDetails {
     publicApiVersion = PUBLIC_API_VERSION
     measurementPublicKey = ENCRYPTION_PUBLIC_KEY.toDuchyEncryptionPublicKey()
     measurementSpec = SERIALIZED_MEASUREMENT_SPEC
+    participantCount = 3
   }
   reachOnlyLiquidLegionsV2 =
     ReachOnlyLiquidLegionsSketchAggregationV2Kt.computationDetails {
@@ -1405,6 +1407,117 @@ class ReachOnlyLiquidLegionsV2MillTest {
           compositeElGamalPublicKey = COMBINED_PUBLIC_KEY
           serializedExcessiveNoiseCiphertext =
             SERIALIZED_NOISE_CIPHERTEXT.concat(SERIALIZED_NOISE_CIPHERTEXT)
+          parallelism = PARALLELISM
+        }
+      )
+  }
+
+  @Test
+  fun `setup phase at aggregator using calculated result with fewer participants`() = runBlocking {
+    // Stage 0. preparing the storage and set up mock
+    val computationDetails =
+      AGGREGATOR_COMPUTATION_DETAILS.copy {
+        kingdomComputation =
+          kingdomComputation.copy {
+            // Indicates that the Kingdom selected only 2 of the 3 Duchies.
+            participantCount = 2
+          }
+      }
+    val partialToken =
+      FakeComputationsDatabase.newPartialToken(
+          localId = LOCAL_ID,
+          stage = SETUP_PHASE.toProtocolStage()
+        )
+        .build()
+    val requisitionBlobContext =
+      RequisitionBlobContext(GLOBAL_ID, REQUISITION_1.externalKey.externalRequisitionId)
+    requisitionStore.writeString(requisitionBlobContext, "local_requisition")
+    val inputBlob0Context = ComputationBlobContext(GLOBAL_ID, SETUP_PHASE.toProtocolStage(), 0L)
+    computationStore.writeString(inputBlob0Context, "-duchy_2_sketch$NOISE_CIPHERTEXT")
+    fakeComputationDb.addComputation(
+      partialToken.localComputationId,
+      partialToken.computationStage,
+      computationDetails = computationDetails,
+      blobs =
+        listOf(newInputBlobMetadata(0L, inputBlob0Context.blobKey), newEmptyOutputBlobMetadata(3L)),
+      requisitions = listOf(REQUISITION_1, REQUISITION_2, REQUISITION_3)
+    )
+
+    var cryptoRequest = CompleteReachOnlySetupPhaseRequest.getDefaultInstance()
+    whenever(mockCryptoWorker.completeReachOnlySetupPhaseAtAggregator(any())).thenAnswer {
+      cryptoRequest = it.getArgument(0)
+      val postFix = ByteString.copyFromUtf8("-completeReachOnlySetupPhase")
+      completeReachOnlySetupPhaseResponse {
+        combinedRegisterVector = cryptoRequest.combinedRegisterVector.concat(postFix)
+        serializedExcessiveNoiseCiphertext = ByteString.copyFromUtf8("-encryptedNoise")
+      }
+    }
+
+    // Stage 1. Process the above computation
+    aggregatorMill.pollAndProcessNextComputation()
+
+    // Stage 2. Check the status of the computation
+    val blobKey = ComputationBlobContext(GLOBAL_ID, SETUP_PHASE.toProtocolStage(), 3L).blobKey
+    assertThat(fakeComputationDb[LOCAL_ID])
+      .isEqualTo(
+        computationToken {
+          globalComputationId = GLOBAL_ID
+          localComputationId = LOCAL_ID
+          attempt = 1
+          computationStage = WAIT_EXECUTION_PHASE_INPUTS.toProtocolStage()
+          blobs.addAll(
+            listOf(
+              computationStageBlobMetadata {
+                dependencyType = ComputationBlobDependency.INPUT
+                blobId = 0
+                path = blobKey
+              },
+              computationStageBlobMetadata {
+                dependencyType = ComputationBlobDependency.OUTPUT
+                blobId = 1
+              }
+            )
+          )
+          version = 3 // claimTask + writeOutputBlob + transitionStage
+          this.computationDetails = computationDetails
+          requisitions.addAll(listOf(REQUISITION_1, REQUISITION_2, REQUISITION_3))
+        }
+      )
+
+    assertThat(computationStore.get(blobKey)?.readToString())
+      .isEqualTo("local_requisition-duchy_2_sketch-completeReachOnlySetupPhase-encryptedNoise")
+
+    assertThat(computationControlRequests)
+      .containsExactlyElementsIn(
+        buildAdvanceComputationRequests(
+          GLOBAL_ID,
+          EXECUTION_PHASE_INPUT,
+          "local_requisition-du",
+          "chy_2_sketch-complet",
+          "eReachOnlySetupPhase",
+          "-encryptedNoise",
+        )
+      )
+      .inOrder()
+
+    assertThat(cryptoRequest)
+      .isEqualTo(
+        completeReachOnlySetupPhaseRequest {
+          combinedRegisterVector = ByteString.copyFromUtf8("local_requisition-duchy_2_sketch")
+          curveId = CURVE_ID
+          noiseParameters = registerNoiseGenerationParameters {
+            compositeElGamalPublicKey = COMBINED_PUBLIC_KEY
+            curveId = CURVE_ID
+            contributorsCount = 2
+            totalSketchesCount = REQUISITIONS.size
+            dpParams = reachNoiseDifferentialPrivacyParams {
+              blindHistogram = TEST_NOISE_CONFIG.reachNoiseConfig.blindHistogramNoise
+              noiseForPublisherNoise = TEST_NOISE_CONFIG.reachNoiseConfig.noiseForPublisherNoise
+              globalReachDpNoise = TEST_NOISE_CONFIG.reachNoiseConfig.globalReachDpNoise
+            }
+          }
+          compositeElGamalPublicKey = COMBINED_PUBLIC_KEY
+          serializedExcessiveNoiseCiphertext = SERIALIZED_NOISE_CIPHERTEXT
           parallelism = PARALLELISM
         }
       )


### PR DESCRIPTION
Fixes #1194 