### PR TITLE
Wait for build to complete on main branch before running on PR.

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -27,9 +27,22 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  wait-for-main:
+    name: Wait for main branch build
+    runs-on: ubuntu-latest
+    steps:
+      # This is run in a separate job to avoid invalidating the build cache.
+      - uses: lewagon/wait-on-check-action@v1.3.1
+        if: github.event_name == 'pull_request'
+        with:
+          ref: main
+          check-name: Build and test
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          wait-interval: 90
   build-test:
     name: Build and test
     runs-on: ubuntu-20.04
+    needs: wait-for-main
     env:
       CLUSTER_LOGS_PATH: cluster-logs
     steps:


### PR DESCRIPTION
This ensures that the build for the pull request can use the latest build cache.