### PR TITLE
Updated measurement retention job to have a flag to control maximum number of measurement to delete

### DIFF
--- a/src/main/k8s/kingdom.cue
+++ b/src/main/k8s/kingdom.cue
@@ -24,12 +24,13 @@ import ("strings")
 
 	_kingdom_secret_name: string
 
-	_completedMeasurementsTimeToLive: string | *"180d"
-	_completedMeasurementsDryRun:     bool | *false
-	_pendingMeasurementsTimeToLive:   string | *"15d"
-	_pendingMeasurementsDryRun:       bool | *false
-	_exchangesDaysToLive:             int | *"100"
-	_exchangesDryRun:                 bool | *false
+	_completedMeasurementsTimeToLive:        string | *"180d"
+	_completedMeasurementsMaxToDeletePerRpc: int | *25
+	_completedMeasurementsDryRun:            bool | *false
+	_pendingMeasurementsTimeToLive:          string | *"15d"
+	_pendingMeasurementsDryRun:              bool | *false
+	_exchangesDaysToLive:                    int | *"100"
+	_exchangesDryRun:                        bool | *false
 
 	_imageSuffixes: [string]: string
 	_imageSuffixes: {
@@ -79,6 +80,7 @@ import ("strings")
 	]
 
 	_kingdomCompletedMeasurementsTimeToLiveFlag:            "--time-to-live=\(_completedMeasurementsTimeToLive)"
+	_kingdomCompletedMeasurementsMaxToDeletePerRpcFlag:     "--max-to-delete-per-rpc=\(_completedMeasurementsMaxToDeletePerRpc)"
 	_kingdomCompletedMeasurementsDryRunRetentionPolicyFlag: "--dry-run=\(_completedMeasurementsDryRun)"
 	_kingdomPendingMeasurementsTimeToLiveFlag:              "--time-to-live=\(_pendingMeasurementsTimeToLive)"
 	_kingdomPendingMeasurementsDryRunRetentionPolicyFlag:   "--dry-run=\(_pendingMeasurementsDryRun)"
@@ -202,6 +204,7 @@ import ("strings")
 				_kingdom_tls_key_file_flag,
 				_kingdom_cert_collection_file_flag,
 				_kingdomCompletedMeasurementsTimeToLiveFlag,
+				_kingdomCompletedMeasurementsMaxToDeletePerRpcFlag,
 				_kingdomCompletedMeasurementsDryRunRetentionPolicyFlag,
 				_debug_verbose_grpc_client_logging_flag,
 				_otlpEndpoint,

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/common/job/CompletedMeasurementsDeletionJob.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/common/job/CompletedMeasurementsDeletionJob.kt
@@ -48,6 +48,18 @@ private class Flags {
     private set
 
   @CommandLine.Option(
+    names = ["--max-to-delete-per-rpc"],
+    defaultValue = "25",
+    description =
+      [
+        "The maximum number of measurements to delete in a single call to the API. " +
+          "This flag can be adjusted to ensure the RPC does not timeout."
+      ],
+  )
+  lateinit var maxToDeletePerRpc: Integer
+    private set
+
+  @CommandLine.Option(
     names = ["--time-to-live"],
     defaultValue = "100d",
     description =
@@ -137,6 +149,7 @@ private fun run(@CommandLine.Mixin flags: Flags) {
   val completedMeasurementsDeletion =
     CompletedMeasurementsDeletion(
       internalMeasurementsClient,
+      flags.maxToDeletePerRpc.toInt(),
       flags.measurementsTimeToLive,
       flags.dryRun,
       Clock.systemUTC(),


### PR DESCRIPTION
Added a flag to control the number of measurements to delete in each delete RPC.

https://github.com/world-federation-of-advertisers/cross-media-measurement/issues/1199
https://rally1.rallydev.com/#/?detail=/defect/721441730037&fdp=true