### PR TITLE
Enable reach-only LLv2 protocol in local and dev configurations.

### DIFF
--- a/src/main/k8s/kingdom.cue
+++ b/src/main/k8s/kingdom.cue
@@ -169,6 +169,7 @@ import ("strings")
 					_debug_verbose_grpc_server_logging_flag,
 					_llv2_protocol_config_config,
 					_ro_llv2_protocol_config_config,
+					_ro_llv2_enable_flag,
 					_kingdom_tls_cert_file_flag,
 					_kingdom_tls_key_file_flag,
 					_kingdom_cert_collection_file_flag,

--- a/src/main/kotlin/org/wfanet/measurement/integration/common/InProcessCmmsComponents.kt
+++ b/src/main/kotlin/org/wfanet/measurement/integration/common/InProcessCmmsComponents.kt
@@ -205,7 +205,6 @@ class InProcessCmmsComponents(
         RO_LLV2_PROTOCOL_CONFIG_CONFIG.duchyProtocolConfig,
         setOf("aggregator"),
         2,
-        false
       )
       DuchyInfo.initializeFromConfig(
         loadTextProto("duchy_cert_config.textproto", DuchyCertConfig.getDefaultInstance())

--- a/src/main/kotlin/org/wfanet/measurement/integration/common/InProcessKingdom.kt
+++ b/src/main/kotlin/org/wfanet/measurement/integration/common/InProcessKingdom.kt
@@ -151,7 +151,11 @@ class InProcessKingdom(
           EventGroupMetadataDescriptorsService(internalEventGroupMetadataDescriptorsClient)
             .withMetadataPrincipalIdentities()
             .withApiKeyAuthenticationServerInterceptor(internalApiKeysClient),
-          MeasurementsService(internalMeasurementsClient, MEASUREMENT_NOISE_MECHANISMS)
+          MeasurementsService(
+              internalMeasurementsClient,
+              MEASUREMENT_NOISE_MECHANISMS,
+              reachOnlyLlV2Enabled = true
+            )
             .withMetadataPrincipalIdentities()
             .withApiKeyAuthenticationServerInterceptor(internalApiKeysClient),
           PublicKeysService(internalPublicKeysClient)

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/common/RoLlv2ProtocolConfig.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/common/RoLlv2ProtocolConfig.kt
@@ -23,9 +23,6 @@ import org.wfanet.measurement.internal.kingdom.ProtocolConfig
 import picocli.CommandLine
 
 object RoLlv2ProtocolConfig {
-  var enabled: Boolean by Delegates.notNull()
-    private set
-
   const val name = "rollv2"
   lateinit var protocolConfig: ProtocolConfig.LiquidLegionsV2
     private set
@@ -49,7 +46,6 @@ object RoLlv2ProtocolConfig {
     duchyProtocolConfig = configMessage.duchyProtocolConfig
     requiredExternalDuchyIds = configMessage.requiredExternalDuchyIdsList.toSet()
     minimumNumberOfRequiredDuchies = configMessage.minimumDuchyParticipantCount
-    enabled = flags.enableRoLlv2Protocol
   }
 
   fun setForTest(
@@ -57,10 +53,7 @@ object RoLlv2ProtocolConfig {
     duchyProtocolConfig: DuchyProtocolConfig.LiquidLegionsV2,
     requiredExternalDuchyIds: Set<String>,
     minimumNumberOfRequiredDuchies: Int,
-    enabled: Boolean,
   ) {
-    RoLlv2ProtocolConfig.enabled = enabled
-
     require(!RoLlv2ProtocolConfig::protocolConfig.isInitialized)
     require(!RoLlv2ProtocolConfig::duchyProtocolConfig.isInitialized)
     require(!RoLlv2ProtocolConfig::requiredExternalDuchyIds.isInitialized)
@@ -78,13 +71,5 @@ class RoLlv2ProtocolConfigFlags {
     required = true
   )
   lateinit var config: File
-    private set
-
-  @CommandLine.Option(
-    names = ["--enable-ro-llv2-protocol"],
-    description = ["Determine whether enable reach-only liquid legions v2 protocol."],
-    required = false
-  )
-  var enableRoLlv2Protocol: Boolean = false
     private set
 }

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/common/server/V2alphaPublicApiServer.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/common/server/V2alphaPublicApiServer.kt
@@ -16,6 +16,7 @@ package org.wfanet.measurement.kingdom.deploy.common.server
 
 import io.grpc.ServerServiceDefinition
 import java.io.File
+import kotlin.properties.Delegates
 import org.wfanet.measurement.api.v2alpha.AkidPrincipalLookup
 import org.wfanet.measurement.api.v2alpha.ProtocolConfig.NoiseMechanism
 import org.wfanet.measurement.api.v2alpha.withPrincipalsFromX509AuthorityKeyIdentifiers
@@ -144,7 +145,8 @@ private fun run(
         .withApiKeyAuthenticationServerInterceptor(internalApiKeysCoroutineStub),
       MeasurementsService(
           InternalMeasurementsCoroutineStub(channel),
-          v2alphaFlags.directNoiseMechanisms
+          v2alphaFlags.directNoiseMechanisms,
+          v2alphaFlags.reachOnlyLlV2Enabled
         )
         .withPrincipalsFromX509AuthorityKeyIdentifiers(principalLookup)
         .withApiKeyAuthenticationServerInterceptor(internalApiKeysCoroutineStub),
@@ -216,6 +218,16 @@ private class V2alphaFlags {
 
   @CommandLine.Spec
   lateinit var spec: CommandLine.Model.CommandSpec // injected by picocli
+    private set
+
+  @set:CommandLine.Option(
+    names = ["--enable-ro-llv2-protocol"],
+    description = ["Whether to enable the Reach-Only Liquid Legions v2 protocol"],
+    negatable = true,
+    required = false,
+    defaultValue = "false",
+  )
+  var reachOnlyLlV2Enabled by Delegates.notNull<Boolean>()
     private set
 
   @CommandLine.Option(

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/service/api/v2alpha/MeasurementsService.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/service/api/v2alpha/MeasurementsService.kt
@@ -73,7 +73,8 @@ private const val MISSING_RESOURCE_NAME_ERROR = "Resource name is either unspeci
 
 class MeasurementsService(
   private val internalMeasurementsStub: MeasurementsCoroutineStub,
-  private val noiseMechanisms: List<NoiseMechanism>
+  private val noiseMechanisms: List<NoiseMechanism>,
+  private val reachOnlyLlV2Enabled: Boolean,
 ) : MeasurementsCoroutineImplBase() {
 
   override suspend fun getMeasurement(request: GetMeasurementRequest): Measurement {
@@ -167,7 +168,8 @@ class MeasurementsService(
           measurementConsumerCertificateKey,
           dataProvidersMap,
           parsedMeasurementSpec,
-          noiseMechanisms.map { it.toInternal() }
+          noiseMechanisms.map { it.toInternal() },
+          reachOnlyLlV2Enabled
         )
       requestId = request.requestId
     }

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/service/api/v2alpha/ProtoConversions.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/service/api/v2alpha/ProtoConversions.kt
@@ -907,7 +907,8 @@ fun Measurement.toInternal(
   measurementConsumerCertificateKey: MeasurementConsumerCertificateKey,
   dataProvidersMap: Map<Long, DataProviderValue>,
   measurementSpecProto: MeasurementSpec,
-  internalNoiseMechanisms: List<InternalProtocolConfig.NoiseMechanism>
+  internalNoiseMechanisms: List<InternalProtocolConfig.NoiseMechanism>,
+  reachOnlyLlV2Enabled: Boolean,
 ): InternalMeasurement {
   val publicMeasurement = this
 
@@ -927,7 +928,7 @@ fun Measurement.toInternal(
       when (measurementSpecProto.measurementTypeCase) {
         MeasurementSpec.MeasurementTypeCase.REACH -> {
           if (dataProvidersCount > 1) {
-            if (RoLlv2ProtocolConfig.enabled) {
+            if (reachOnlyLlV2Enabled) {
               protocolConfig = internalProtocolConfig {
                 externalProtocolConfigId = RoLlv2ProtocolConfig.name
                 reachOnlyLiquidLegionsV2 = RoLlv2ProtocolConfig.protocolConfig

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/service/internal/testing/MeasurementsServiceTest.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/service/internal/testing/MeasurementsServiceTest.kt
@@ -2227,8 +2227,7 @@ abstract class MeasurementsServiceTest<T : MeasurementsCoroutineImplBase> {
           Population.AGGREGATOR_DUCHY.externalDuchyId,
           Population.WORKER1_DUCHY.externalDuchyId
         ),
-        2,
-        true
+        2
       )
     }
   }

--- a/src/test/kotlin/org/wfanet/measurement/kingdom/service/api/v2alpha/MeasurementsServiceTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/kingdom/service/api/v2alpha/MeasurementsServiceTest.kt
@@ -174,7 +174,8 @@ class MeasurementsServiceTest {
     service =
       MeasurementsService(
         MeasurementsGrpcKt.MeasurementsCoroutineStub(grpcTestServerRule.channel),
-        NOISE_MECHANISMS
+        NOISE_MECHANISMS,
+        reachOnlyLlV2Enabled = true
       )
   }
 
@@ -1765,8 +1766,7 @@ class MeasurementsServiceTest {
         RO_LLV2_INTERNAL_PROTOCOL_CONFIG.reachOnlyLiquidLegionsV2,
         RO_LLV2_DUCHY_PROTOCOL_CONFIG.reachOnlyLiquidLegionsV2,
         setOf("aggregator"),
-        2,
-        true
+        2
       )
     }
 


### PR DESCRIPTION
This also removes the flag from the Kingdom internal API server since it is not read there.