### PR TITLE
Handle Duchy gRPC errors appropriately w.r.t. retryability.

### DIFF
--- a/src/main/kotlin/org/wfanet/measurement/common/BUILD.bazel
+++ b/src/main/kotlin/org/wfanet/measurement/common/BUILD.bazel
@@ -1,0 +1,8 @@
+load("@io_bazel_rules_kotlin//kotlin:jvm.bzl", "kt_jvm_library")
+
+package(default_visibility = ["//visibility:public"])
+
+kt_jvm_library(
+    name = "exponential_backoff",
+    srcs = ["ExponentialBackoff.kt"],
+)

--- a/src/main/kotlin/org/wfanet/measurement/common/ExponentialBackoff.kt
+++ b/src/main/kotlin/org/wfanet/measurement/common/ExponentialBackoff.kt
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2023 The Cross-Media Measurement Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wfanet.measurement.common
+
+import java.time.Duration
+import kotlin.math.pow
+import kotlin.random.Random
+
+/**
+ * Exponential backoff durations at millisecond resolution.
+ *
+ * TODO(@SanjayVas): Move this to common-jvm.
+ */
+data class ExponentialBackoff(
+  val initialDelay: Duration = Duration.ofMillis(500),
+  val multiplier: Double = 1.5,
+  val randomnessFactor: Double = 0.5,
+  val random: Random = Random,
+) {
+  init {
+    require(initialDelay >= MIN_INITIAL_DELAY) {
+      "Initial delay must be at least $MIN_INITIAL_DELAY"
+    }
+    require(randomnessFactor >= 0.0) { "Randomness factor may not be negative" }
+  }
+
+  /** Returns the [Duration] for the specified [attemptNumber], starting at `1`. */
+  fun durationForAttempt(attemptNumber: Int): Duration {
+    return random.randomizedDuration(
+      exponentialDuration(
+        initialDelay = initialDelay,
+        multiplier = multiplier,
+        attemptNumber = attemptNumber,
+      ),
+      randomnessFactor = randomnessFactor,
+    )
+  }
+
+  companion object {
+    /** Minimum initial delay. */
+    val MIN_INITIAL_DELAY: Duration = Duration.ofMillis(1)
+
+    private fun exponentialDuration(
+      initialDelay: Duration,
+      multiplier: Double,
+      attemptNumber: Int
+    ): Duration {
+      require(attemptNumber > 0) { "Attempts start at 1" }
+      if (attemptNumber == 1) {
+        // Minor optimization to avoid unnecessary floating point math.
+        return initialDelay
+      }
+      return Duration.ofMillis(
+        (initialDelay.toMillis() * (multiplier.pow(attemptNumber - 1))).toLong()
+      )
+    }
+
+    private fun Random.randomizedDuration(
+      delay: Duration,
+      randomnessFactor: Double,
+    ): Duration {
+      if (randomnessFactor == 0.0) {
+        return delay
+      }
+      val maxOffset = randomnessFactor * delay.toMillis()
+      return delay.plusMillis(nextDouble(-maxOffset, maxOffset).toLong())
+    }
+  }
+}

--- a/src/main/kotlin/org/wfanet/measurement/duchy/daemon/herald/BUILD.bazel
+++ b/src/main/kotlin/org/wfanet/measurement/duchy/daemon/herald/BUILD.bazel
@@ -30,6 +30,7 @@ kt_jvm_library(
     deps = [
         "continuation_token_manager",
         "//src/main/kotlin/org/wfanet/measurement/api:public_api_version",
+        "//src/main/kotlin/org/wfanet/measurement/common:exponential_backoff",
         "//src/main/kotlin/org/wfanet/measurement/duchy:computation_stage",
         "//src/main/kotlin/org/wfanet/measurement/duchy/daemon/utils:computation_conversions",
         "//src/main/kotlin/org/wfanet/measurement/duchy/daemon/utils:duchy_order",

--- a/src/main/kotlin/org/wfanet/measurement/duchy/daemon/mill/MillBase.kt
+++ b/src/main/kotlin/org/wfanet/measurement/duchy/daemon/mill/MillBase.kt
@@ -54,10 +54,14 @@ import org.wfanet.measurement.internal.duchy.ComputationStatsGrpcKt.ComputationS
 import org.wfanet.measurement.internal.duchy.ComputationToken
 import org.wfanet.measurement.internal.duchy.ComputationTypeEnum.ComputationType
 import org.wfanet.measurement.internal.duchy.CreateComputationStatRequest
-import org.wfanet.measurement.internal.duchy.EnqueueComputationRequest
-import org.wfanet.measurement.internal.duchy.FinishComputationRequest
-import org.wfanet.measurement.internal.duchy.GetComputationTokenRequest
+import org.wfanet.measurement.internal.duchy.FinishComputationResponse
+import org.wfanet.measurement.internal.duchy.GetComputationTokenResponse
+import org.wfanet.measurement.internal.duchy.UpdateComputationDetailsRequest
+import org.wfanet.measurement.internal.duchy.UpdateComputationDetailsResponse
 import org.wfanet.measurement.internal.duchy.claimWorkRequest
+import org.wfanet.measurement.internal.duchy.enqueueComputationRequest
+import org.wfanet.measurement.internal.duchy.finishComputationRequest
+import org.wfanet.measurement.internal.duchy.getComputationTokenRequest
 import org.wfanet.measurement.system.v1alpha.AdvanceComputationRequest
 import org.wfanet.measurement.system.v1alpha.ComputationControlGrpcKt.ComputationControlCoroutineStub
 import org.wfanet.measurement.system.v1alpha.ComputationKey
@@ -139,12 +143,12 @@ abstract class MillBase(
     val claimWorkResponse =
       try {
         dataClients.computationsClient.claimWork(claimWorkRequest)
-      } catch (ex: StatusException) {
-        if (!computationsServerReady && ex.status.code == Status.Code.UNAVAILABLE) {
+      } catch (e: StatusException) {
+        if (!computationsServerReady && e.status.code == Status.Code.UNAVAILABLE) {
           logger.info("ComputationServer not ready")
           return
         }
-        throw Exception("Error claiming work", ex)
+        throw Exception("Error claiming work", e)
       }
     computationsServerReady = true
 
@@ -189,10 +193,14 @@ abstract class MillBase(
     try {
       processComputationImpl(token)
     } catch (e: Exception) {
-      // The token version may have already changed. We need the latest token in order to complete
-      // or enqueue the computation.
-      val latestToken = getLatestComputationToken(globalId)
-      handleExceptions(latestToken, e)
+      try {
+        // The token version may have already changed. We need the latest token in order to complete
+        // or enqueue the computation.
+        val latestToken = getLatestComputationToken(globalId)
+        handleExceptions(latestToken, e)
+      } catch (e: Exception) {
+        handleExceptions(token, e)
+      }
     }
     logger.info("$globalId@$millId: Processed computation ")
   }
@@ -200,23 +208,26 @@ abstract class MillBase(
   private suspend fun handleExceptions(token: ComputationToken, e: Exception) {
     val globalId = token.globalComputationId
     when (e) {
-      is IllegalStateException,
-      is IllegalArgumentException,
-      is PermanentComputationError -> {
-        failComputation(token, "PERMANENT error: ${e.localizedMessage}")
-      }
-      else -> {
+      is ComputationDataClients.TransientErrorException -> {
         if (token.attempt > maximumAttempts) {
-          failComputation(token, "Failing computation due to too many failed attempts.")
+          failComputation(
+            token,
+            message = "Failing computation due to too many failed attempts.",
+            cause = e
+          )
         } else {
-          // Treat all other errors as transient.
-          logger.log(Level.WARNING, "$globalId@$millId: TRANSIENT error", e)
+          logger.log(Level.WARNING, e) { "$globalId@$millId: TRANSIENT error" }
           sendStatusUpdateToKingdom(
             newErrorUpdateRequest(token, e.localizedMessage, Type.TRANSIENT)
           )
           // Enqueue the computation again for future retry
           enqueueComputation(token)
         }
+      }
+      is StatusException -> throw IllegalStateException("Programming bug: uncaught gRPC error", e)
+      else -> {
+        // Treat any other exception type as a permanent computation error.
+        failComputation(token, cause = e)
       }
     }
   }
@@ -246,8 +257,24 @@ abstract class MillBase(
     systemComputationParticipantsClient.failComputationParticipant(request)
   }
 
-  private suspend fun failComputation(token: ComputationToken, errorMessage: String) {
-    logger.log(Level.SEVERE, "${token.globalComputationId}@$millId: $errorMessage")
+  private suspend fun failComputation(token: ComputationToken, cause: Exception) {
+    logger.log(Level.SEVERE, cause) { "${token.globalComputationId}@$millId: ${cause.message}" }
+    failComputationAtKingdom(token, cause.message.orEmpty())
+    completeComputation(token, CompletedReason.FAILED)
+  }
+
+  private suspend fun failComputation(
+    token: ComputationToken,
+    message: String? = null,
+    cause: Throwable? = null
+  ) {
+    val errorMessage: String = message ?: cause?.message.orEmpty()
+    val logMessageSupplier = { "${token.globalComputationId}@$millId: $errorMessage" }
+    if (cause == null) {
+      logger.log(Level.SEVERE, logMessageSupplier)
+    } else {
+      logger.log(Level.SEVERE, cause, logMessageSupplier)
+    }
     failComputationAtKingdom(token, errorMessage)
     completeComputation(token, CompletedReason.FAILED)
   }
@@ -381,7 +408,16 @@ abstract class MillBase(
           AdvanceComputationRequest.newBuilder().apply { bodyChunkBuilder.partialData = it }.build()
         }
         .onStart { emit(AdvanceComputationRequest.newBuilder().setHeader(header).build()) }
-    stub.advanceComputation(requestFlow)
+    try {
+      stub.advanceComputation(requestFlow)
+    } catch (e: StatusException) {
+      val message = "Error advancing computation at other Duchy"
+      throw when (e.status.code) {
+        Status.Code.UNAVAILABLE,
+        Status.Code.ABORTED -> ComputationDataClients.TransientErrorException(message, e)
+        else -> ComputationDataClients.PermanentErrorException(message, e)
+      }
+    }
   }
 
   /**
@@ -398,23 +434,16 @@ abstract class MillBase(
         token
       )
     }
-    val newResult: ByteString =
-      try {
-        val wallDurationLogger = wallDurationLogger()
-        val result = block()
-        wallDurationLogger.logStageDurationMetric(
-          token,
-          JNI_WALL_CLOCK_DURATION,
-          jniWallClockDurationHistogram
-        )
-        result
-      } catch (error: Throwable) {
-        // All errors from block() are permanent and would cause the computation to FAIL
-        throw PermanentComputationError(error)
-      }
+    val wallDurationLogger = wallDurationLogger()
+    val result = block()
+    wallDurationLogger.logStageDurationMetric(
+      token,
+      JNI_WALL_CLOCK_DURATION,
+      jniWallClockDurationHistogram
+    )
     return EncryptedComputationResult(
-      flowOf(newResult),
-      dataClients.writeSingleOutputBlob(token, newResult)
+      flowOf(result),
+      dataClients.writeSingleOutputBlob(token, result)
     )
   }
 
@@ -425,8 +454,8 @@ abstract class MillBase(
   ): ByteString {
     val blobMap: Map<BlobRef, ByteString> = dataClients.readInputBlobs(token)
     if (blobMap.size != count) {
-      throw PermanentComputationError(
-        Exception("Unexpected number of input blobs. expected $count, actual ${blobMap.size}.")
+      throw ComputationDataClients.PermanentErrorException(
+        "Unexpected number of input blobs. expected $count, actual ${blobMap.size}."
       )
     }
     return blobMap.values.flatten()
@@ -437,26 +466,43 @@ abstract class MillBase(
     token: ComputationToken,
     reason: CompletedReason
   ): ComputationToken {
-    val response =
-      dataClients.computationsClient.finishComputation(
-        FinishComputationRequest.newBuilder()
-          .also {
-            it.token = token
-            it.endingComputationStage = endingStage
-            it.reason = reason
+    val response: FinishComputationResponse =
+      try {
+        dataClients.computationsClient.finishComputation(
+          finishComputationRequest {
+            this.token = token
+            endingComputationStage = endingStage
+            this.reason = reason
           }
-          .build()
-      )
+        )
+      } catch (e: StatusException) {
+        val message = "Error finishing computation"
+        throw when (e.status.code) {
+          Status.Code.UNAVAILABLE,
+          Status.Code.ABORTED -> ComputationDataClients.TransientErrorException(message, e)
+          else -> ComputationDataClients.PermanentErrorException(message, e)
+        }
+      }
     return response.token
   }
 
   /** Gets the latest [ComputationToken] for computation with [globalId]. */
   private suspend fun getLatestComputationToken(globalId: String): ComputationToken {
-    return dataClients.computationsClient
-      .getComputationToken(
-        GetComputationTokenRequest.newBuilder().apply { globalComputationId = globalId }.build()
-      )
-      .token
+    val response: GetComputationTokenResponse =
+      try {
+        dataClients.computationsClient.getComputationToken(
+          getComputationTokenRequest { globalComputationId = globalId }
+        )
+      } catch (e: StatusException) {
+        val message = "Error retrieving computation token"
+        throw when (e.status.code) {
+          Status.Code.UNAVAILABLE,
+          Status.Code.ABORTED -> ComputationDataClients.TransientErrorException(message, e)
+          else -> ComputationDataClients.PermanentErrorException(message, e)
+        }
+      }
+
+    return response.token
   }
 
   /** Enqueue a computation with a delay. */
@@ -465,14 +511,45 @@ abstract class MillBase(
     val baseDelay = minOf(600.0, (2.0.pow(token.attempt))).toInt()
     // A random delay in the range of [baseDelay, 2*baseDelay]
     val delaySecond = baseDelay + Random.nextInt(baseDelay + 1)
-    dataClients.computationsClient.enqueueComputation(
-      EnqueueComputationRequest.newBuilder().setToken(token).setDelaySecond(delaySecond).build()
-    )
+
+    try {
+      dataClients.computationsClient.enqueueComputation(
+        enqueueComputationRequest {
+          this.token = token
+          this.delaySecond = delaySecond
+        }
+      )
+    } catch (e: StatusException) {
+      val message = "Error enqueuing computation"
+      throw when (e.status.code) {
+        Status.Code.UNAVAILABLE,
+        Status.Code.ABORTED -> ComputationDataClients.TransientErrorException(message, e)
+        else -> ComputationDataClients.PermanentErrorException(message, e)
+      }
+    }
   }
 
   private fun getCpuTimeMillis(): Long {
     val cpuTime = Duration.ofNanos(threadBean.allThreadIds.sumOf(threadBean::getThreadCpuTime))
     return cpuTime.toMillis()
+  }
+
+  protected suspend fun updateComputationDetails(
+    request: UpdateComputationDetailsRequest
+  ): ComputationToken {
+    val response: UpdateComputationDetailsResponse =
+      try {
+        dataClients.computationsClient.updateComputationDetails(request)
+      } catch (e: StatusException) {
+        val message = "Error updating computation details"
+        throw when (e.status.code) {
+          Status.Code.UNAVAILABLE,
+          Status.Code.ABORTED -> ComputationDataClients.TransientErrorException(message, e)
+          else -> ComputationDataClients.PermanentErrorException(message, e)
+        }
+      }
+
+    return response.token
   }
 
   private inner class CpuDurationLogger(private val getTimeMillis: () -> Long) {
@@ -525,8 +602,6 @@ data class Certificate(
   // The value of the certificate.
   val value: X509Certificate
 )
-
-class PermanentComputationError(cause: Throwable) : Exception(cause)
 
 /** Converts a milliseconds to a human friendly string. */
 fun Long.toHumanFriendlyDuration(): String {

--- a/src/main/kotlin/org/wfanet/measurement/duchy/daemon/mill/liquidlegionsv2/LiquidLegionsV2Mill.kt
+++ b/src/main/kotlin/org/wfanet/measurement/duchy/daemon/mill/liquidlegionsv2/LiquidLegionsV2Mill.kt
@@ -15,6 +15,8 @@
 package org.wfanet.measurement.duchy.daemon.mill.liquidlegionsv2
 
 import com.google.protobuf.ByteString
+import io.grpc.Status
+import io.grpc.StatusException
 import io.opentelemetry.api.OpenTelemetry
 import io.opentelemetry.api.metrics.LongHistogram
 import io.opentelemetry.api.metrics.Meter
@@ -41,7 +43,6 @@ import org.wfanet.measurement.consent.client.duchy.verifyElGamalPublicKey
 import org.wfanet.measurement.duchy.daemon.mill.CRYPTO_LIB_CPU_DURATION
 import org.wfanet.measurement.duchy.daemon.mill.Certificate
 import org.wfanet.measurement.duchy.daemon.mill.MillBase
-import org.wfanet.measurement.duchy.daemon.mill.PermanentComputationError
 import org.wfanet.measurement.duchy.daemon.mill.liquidlegionsv2.crypto.LiquidLegionsV2Encryption
 import org.wfanet.measurement.duchy.daemon.utils.ComputationResult
 import org.wfanet.measurement.duchy.daemon.utils.ReachAndFrequencyResult
@@ -247,7 +248,16 @@ class LiquidLegionsV2Mill(
           }
         }
         .build()
-    systemComputationParticipantsClient.setParticipantRequisitionParams(request)
+    try {
+      systemComputationParticipantsClient.setParticipantRequisitionParams(request)
+    } catch (e: StatusException) {
+      val message = "Error setting participant requisition params"
+      throw when (e.status.code) {
+        Status.Code.UNAVAILABLE,
+        Status.Code.ABORTED -> ComputationDataClients.TransientErrorException(message, e)
+        else -> ComputationDataClients.PermanentErrorException(message, e)
+      }
+    }
   }
 
   /** Processes computation in the initialization phase */
@@ -275,20 +285,18 @@ class LiquidLegionsV2Mill(
         )
 
         // Updates the newly generated localElgamalKey to the ComputationDetails.
-        dataClients.computationsClient
-          .updateComputationDetails(
-            UpdateComputationDetailsRequest.newBuilder()
-              .also {
-                it.token = token
-                it.details =
-                  token.computationDetails
-                    .toBuilder()
-                    .apply { liquidLegionsV2Builder.localElgamalKey = cryptoResult.elGamalKeyPair }
-                    .build()
-              }
-              .build()
-          )
-          .token
+        updateComputationDetails(
+          UpdateComputationDetailsRequest.newBuilder()
+            .also {
+              it.token = token
+              it.details =
+                token.computationDetails
+                  .toBuilder()
+                  .apply { liquidLegionsV2Builder.localElgamalKey = cryptoResult.elGamalKeyPair }
+                  .build()
+            }
+            .build()
+        )
       }
 
     sendRequisitionParamsToKingdom(nextToken)
@@ -369,7 +377,7 @@ class LiquidLegionsV2Mill(
     val errorMessage =
       "@Mill $millId, Computation ${token.globalComputationId} failed due to:\n" +
         errorList.joinToString(separator = "\n")
-    throw PermanentComputationError(Exception(errorMessage))
+    throw ComputationDataClients.PermanentErrorException(errorMessage)
   }
 
   private fun List<ElGamalPublicKey>.toCombinedPublicKey(curveId: Int): ElGamalPublicKey {
@@ -412,34 +420,41 @@ class LiquidLegionsV2Mill(
         UNRECOGNIZED -> error("Invalid role ${llv2Details.role}")
       }
 
-    return dataClients.computationsClient
-      .updateComputationDetails(
-        UpdateComputationDetailsRequest.newBuilder()
-          .apply {
-            this.token = token
-            details =
-              token.computationDetails
-                .toBuilder()
-                .apply {
-                  liquidLegionsV2Builder.also {
-                    it.combinedPublicKey = combinedPublicKey
-                    it.partiallyCombinedPublicKey = partiallyCombinedPublicKey
-                  }
+    return updateComputationDetails(
+      UpdateComputationDetailsRequest.newBuilder()
+        .apply {
+          this.token = token
+          details =
+            token.computationDetails
+              .toBuilder()
+              .apply {
+                liquidLegionsV2Builder.also {
+                  it.combinedPublicKey = combinedPublicKey
+                  it.partiallyCombinedPublicKey = partiallyCombinedPublicKey
                 }
-                .build()
-          }
-          .build()
-      )
-      .token
+              }
+              .build()
+        }
+        .build()
+    )
   }
 
   /** Sends confirmation to the kingdom and transits the local computation to the next stage. */
   private suspend fun passConfirmationPhase(token: ComputationToken): ComputationToken {
-    systemComputationParticipantsClient.confirmComputationParticipant(
-      ConfirmComputationParticipantRequest.newBuilder()
-        .apply { name = ComputationParticipantKey(token.globalComputationId, duchyId).toName() }
-        .build()
-    )
+    try {
+      systemComputationParticipantsClient.confirmComputationParticipant(
+        ConfirmComputationParticipantRequest.newBuilder()
+          .apply { name = ComputationParticipantKey(token.globalComputationId, duchyId).toName() }
+          .build()
+      )
+    } catch (e: StatusException) {
+      val message = "Error confirming computation participant"
+      throw when (e.status.code) {
+        Status.Code.UNAVAILABLE,
+        Status.Code.ABORTED -> ComputationDataClients.TransientErrorException(message, e)
+        else -> ComputationDataClients.PermanentErrorException(message, e)
+      }
+    }
     val latestToken = updatePublicElgamalKey(token)
     return dataClients.transitionComputationToStage(
       latestToken,
@@ -712,20 +727,18 @@ class LiquidLegionsV2Mill(
         tempToken
       } else {
         // Update the newly calculated reach to the ComputationDetails.
-        dataClients.computationsClient
-          .updateComputationDetails(
-            UpdateComputationDetailsRequest.newBuilder()
-              .also {
-                it.token = tempToken
-                it.details =
-                  token.computationDetails
-                    .toBuilder()
-                    .apply { liquidLegionsV2Builder.reachEstimateBuilder.reach = reach }
-                    .build()
-              }
-              .build()
-          )
-          .token
+        updateComputationDetails(
+          UpdateComputationDetailsRequest.newBuilder()
+            .also {
+              it.token = tempToken
+              it.details =
+                token.computationDetails
+                  .toBuilder()
+                  .apply { liquidLegionsV2Builder.reachEstimateBuilder.reach = reach }
+                  .build()
+            }
+            .build()
+        )
       }
 
     // If this is a reach-only computation, then our job is done.
@@ -929,17 +942,15 @@ class LiquidLegionsV2Mill(
     val index = duchyList.indexOfFirst { it.duchyId == duchyId }
     val nextDuchy = duchyList[(index + 1) % duchyList.size].duchyId
     return workerStubs[nextDuchy]
-      ?: throw PermanentComputationError(
-        IllegalArgumentException("No ComputationControlService stub for next duchy '$nextDuchy'")
+      ?: throw ComputationDataClients.PermanentErrorException(
+        "No ComputationControlService stub for next duchy '$nextDuchy'"
       )
   }
 
   private fun aggregatorDuchyStub(aggregatorId: String): ComputationControlCoroutineStub {
     return workerStubs[aggregatorId]
-      ?: throw PermanentComputationError(
-        IllegalArgumentException(
-          "No ComputationControlService stub for the Aggregator duchy '$aggregatorId'"
-        )
+      ?: throw ComputationDataClients.PermanentErrorException(
+        "No ComputationControlService stub for the Aggregator duchy '$aggregatorId'"
       )
   }
 

--- a/src/main/kotlin/org/wfanet/measurement/duchy/db/computation/ComputationsDatabase.kt
+++ b/src/main/kotlin/org/wfanet/measurement/duchy/db/computation/ComputationsDatabase.kt
@@ -104,6 +104,11 @@ interface ComputationsDatabaseTransactor<ProtocolT, StageT, StageDetailsT, Compu
    * Adds a computation to the work queue, saying it can be worked on by a worker job.
    *
    * This will release any ownership and locks associated with the computation after delaySecond.
+   *
+   * @throws org.wfanet.measurement.duchy.service.internal.ComputationNotFoundException if the
+   *   Computation is not found
+   * @throws org.wfanet.measurement.duchy.service.internal.ComputationTokenVersionMismatchException
+   *   if the [token] version does not match
    */
   suspend fun enqueue(token: ComputationEditToken<ProtocolT, StageT>, delaySecond: Int)
 
@@ -129,6 +134,10 @@ interface ComputationsDatabaseTransactor<ProtocolT, StageT, StageDetailsT, Compu
    *   computation so they do not have a reference to the real storage location.
    * @param afterTransition The work to be do with the computation after a successful transition.
    * @param nextStageDetails Details specific to the next stage.
+   * @throws org.wfanet.measurement.duchy.service.internal.ComputationNotFoundException if the
+   *   Computation is not found
+   * @throws org.wfanet.measurement.duchy.service.internal.ComputationTokenVersionMismatchException
+   *   if the [token] version does not match
    */
   suspend fun updateComputationStage(
     token: ComputationEditToken<ProtocolT, StageT>,
@@ -141,7 +150,14 @@ interface ComputationsDatabaseTransactor<ProtocolT, StageT, StageDetailsT, Compu
     lockExtension: Duration?
   )
 
-  /** Moves a computation to a terminal state and records the reason why it ended. */
+  /**
+   * Moves a computation to a terminal state and records the reason why it ended.
+   *
+   * @throws org.wfanet.measurement.duchy.service.internal.ComputationNotFoundException if the
+   *   Computation is not found
+   * @throws org.wfanet.measurement.duchy.service.internal.ComputationTokenVersionMismatchException
+   *   if the [token] version does not match
+   */
   suspend fun endComputation(
     token: ComputationEditToken<ProtocolT, StageT>,
     endingStage: StageT,
@@ -149,14 +165,28 @@ interface ComputationsDatabaseTransactor<ProtocolT, StageT, StageDetailsT, Compu
     computationDetails: ComputationDetailsT
   )
 
-  /** Overrides the computationDetails of the computation using the given value. */
+  /**
+   * Overrides the computationDetails of the computation using the given value.
+   *
+   * @throws org.wfanet.measurement.duchy.service.internal.ComputationNotFoundException if the
+   *   Computation is not found
+   * @throws org.wfanet.measurement.duchy.service.internal.ComputationTokenVersionMismatchException
+   *   if the [token] version does not match
+   */
   suspend fun updateComputationDetails(
     token: ComputationEditToken<ProtocolT, StageT>,
     computationDetails: ComputationDetailsT,
     requisitions: List<RequisitionEntry> = listOf()
   )
 
-  /** Writes the reference to a blob needed for an output blob from a stage. */
+  /**
+   * Writes the reference to a blob needed for an output blob from a stage.
+   *
+   * @throws org.wfanet.measurement.duchy.service.internal.ComputationNotFoundException if the
+   *   Computation is not found
+   * @throws org.wfanet.measurement.duchy.service.internal.ComputationTokenVersionMismatchException
+   *   if the [token] version does not match
+   */
   suspend fun writeOutputBlobReference(
     token: ComputationEditToken<ProtocolT, StageT>,
     blobRef: BlobRef

--- a/src/main/kotlin/org/wfanet/measurement/duchy/db/computation/testing/BUILD.bazel
+++ b/src/main/kotlin/org/wfanet/measurement/duchy/db/computation/testing/BUILD.bazel
@@ -11,6 +11,7 @@ kt_jvm_library(
     srcs = glob(["*.kt"]),
     deps = [
         "//src/main/kotlin/org/wfanet/measurement/duchy/db/computation",
+        "//src/main/kotlin/org/wfanet/measurement/duchy/service/internal:internal_exception",
         "@wfa_common_jvm//imports/java/com/google/common/truth",
         "@wfa_common_jvm//imports/java/com/google/common/truth/extensions/proto",
         "@wfa_common_jvm//src/main/kotlin/org/wfanet/measurement/common",

--- a/src/main/kotlin/org/wfanet/measurement/duchy/db/computation/testing/FakeComputationsDatabase.kt
+++ b/src/main/kotlin/org/wfanet/measurement/duchy/db/computation/testing/FakeComputationsDatabase.kt
@@ -28,6 +28,7 @@ import org.wfanet.measurement.duchy.db.computation.ComputationStatMetric
 import org.wfanet.measurement.duchy.db.computation.ComputationsDatabase
 import org.wfanet.measurement.duchy.db.computation.EndComputationReason
 import org.wfanet.measurement.duchy.db.computation.toCompletedReason
+import org.wfanet.measurement.duchy.service.internal.ComputationTokenVersionMismatchException
 import org.wfanet.measurement.duchy.service.internal.computations.newEmptyOutputBlobMetadata
 import org.wfanet.measurement.duchy.service.internal.computations.newInputBlobMetadata
 import org.wfanet.measurement.duchy.service.internal.computations.newPassThroughBlobMetadata
@@ -181,8 +182,13 @@ private constructor(
     val current = getNonNull(token.localId)
     // Just the last update time is checked because it mimics the way in which a relational database
     // will check the version of the update.
-    require(current.version == token.editVersion) {
-      "Token provided $token != current token $current"
+    if (current.version != token.editVersion) {
+      throw ComputationTokenVersionMismatchException(
+        computationId = token.localId,
+        version = current.version,
+        tokenVersion = token.editVersion,
+        message = "Token provided $token != current token $current"
+      )
     }
     return current
   }

--- a/src/main/kotlin/org/wfanet/measurement/duchy/deploy/common/ServiceFlags.kt
+++ b/src/main/kotlin/org/wfanet/measurement/duchy/deploy/common/ServiceFlags.kt
@@ -37,7 +37,7 @@ class ComputationsServiceFlags {
 
   @CommandLine.Option(
     names = ["--computations-default-deadline"],
-    description = ["Default deadline duration for RPCs to Duchy internal Computations API"],
+    description = ["Default deadline duration for RPCs to the Duchy internal Computations service"],
     defaultValue = "30s"
   )
   lateinit var defaultDeadlineDuration: Duration
@@ -59,6 +59,14 @@ class AsyncComputationControlServiceFlags {
     required = true,
   )
   lateinit var certHost: String
+    private set
+
+  @CommandLine.Option(
+    names = ["--async-computation-control-default-deadline"],
+    description = ["Default deadline duration for RPCs to the AsyncComputationControl service"],
+    defaultValue = "30s"
+  )
+  lateinit var defaultDeadlineDuration: Duration
     private set
 }
 

--- a/src/main/kotlin/org/wfanet/measurement/duchy/deploy/common/postgres/PostgresComputationsService.kt
+++ b/src/main/kotlin/org/wfanet/measurement/duchy/deploy/common/postgres/PostgresComputationsService.kt
@@ -53,6 +53,7 @@ import org.wfanet.measurement.duchy.service.internal.ComputationAlreadyExistsExc
 import org.wfanet.measurement.duchy.service.internal.ComputationDetailsNotFoundException
 import org.wfanet.measurement.duchy.service.internal.ComputationInitialStageInvalidException
 import org.wfanet.measurement.duchy.service.internal.ComputationNotFoundException
+import org.wfanet.measurement.duchy.service.internal.ComputationTokenVersionMismatchException
 import org.wfanet.measurement.duchy.service.internal.computations.toAdvanceComputationStageResponse
 import org.wfanet.measurement.duchy.service.internal.computations.toClaimWorkResponse
 import org.wfanet.measurement.duchy.service.internal.computations.toCreateComputationResponse
@@ -70,6 +71,7 @@ import org.wfanet.measurement.internal.duchy.ClaimWorkResponse
 import org.wfanet.measurement.internal.duchy.ComputationDetails
 import org.wfanet.measurement.internal.duchy.ComputationStage
 import org.wfanet.measurement.internal.duchy.ComputationStageDetails
+import org.wfanet.measurement.internal.duchy.ComputationToken
 import org.wfanet.measurement.internal.duchy.ComputationTypeEnum.ComputationType
 import org.wfanet.measurement.internal.duchy.ComputationsGrpcKt.ComputationsCoroutineImplBase
 import org.wfanet.measurement.internal.duchy.CreateComputationRequest
@@ -264,24 +266,31 @@ class PostgresComputationsService(
   override suspend fun finishComputation(
     request: FinishComputationRequest,
   ): FinishComputationResponse {
-    val token =
+    val writer =
       FinishComputation(
-          request.token.toDatabaseEditToken(),
-          endingStage = request.endingComputationStage,
-          endComputationReason =
-            when (request.reason) {
-              ComputationDetails.CompletedReason.SUCCEEDED -> EndComputationReason.SUCCEEDED
-              ComputationDetails.CompletedReason.FAILED -> EndComputationReason.FAILED
-              ComputationDetails.CompletedReason.CANCELED -> EndComputationReason.CANCELED
-              else -> error("Unknown CompletedReason ${request.reason}")
-            },
-          computationDetails = request.token.computationDetails,
-          clock = clock,
-          protocolStagesEnumHelper = protocolStagesEnumHelper,
-          protocolStageDetailsHelper = computationProtocolStageDetailsHelper,
-          computationReader = computationReader,
-        )
-        .execute(client, idGenerator)
+        request.token.toDatabaseEditToken(),
+        endingStage = request.endingComputationStage,
+        endComputationReason =
+          when (request.reason) {
+            ComputationDetails.CompletedReason.SUCCEEDED -> EndComputationReason.SUCCEEDED
+            ComputationDetails.CompletedReason.FAILED -> EndComputationReason.FAILED
+            ComputationDetails.CompletedReason.CANCELED -> EndComputationReason.CANCELED
+            else -> error("Unknown CompletedReason ${request.reason}")
+          },
+        computationDetails = request.token.computationDetails,
+        clock = clock,
+        protocolStagesEnumHelper = protocolStagesEnumHelper,
+        protocolStageDetailsHelper = computationProtocolStageDetailsHelper,
+        computationReader = computationReader,
+      )
+    val token: ComputationToken =
+      try {
+        writer.execute(client, idGenerator)
+      } catch (e: ComputationNotFoundException) {
+        throw e.asStatusRuntimeException(Status.Code.NOT_FOUND)
+      } catch (e: ComputationTokenVersionMismatchException) {
+        throw e.asStatusRuntimeException(Status.Code.ABORTED)
+      }
 
     sendStatusUpdateToKingdom(
       newCreateComputationLogEntryRequest(
@@ -300,15 +309,22 @@ class PostgresComputationsService(
       "The protocol type cannot change."
     }
 
-    val token =
+    val writer =
       UpdateComputationDetails(
-          token = request.token.toDatabaseEditToken(),
-          clock = clock,
-          computationDetails = request.details,
-          requisitionEntries = request.requisitionsList,
-          computationReader = computationReader,
-        )
-        .execute(client, idGenerator)
+        token = request.token.toDatabaseEditToken(),
+        clock = clock,
+        computationDetails = request.details,
+        requisitionEntries = request.requisitionsList,
+        computationReader = computationReader,
+      )
+    val token: ComputationToken =
+      try {
+        writer.execute(client, idGenerator)
+      } catch (e: ComputationNotFoundException) {
+        throw e.asStatusRuntimeException(Status.Code.NOT_FOUND)
+      } catch (e: ComputationTokenVersionMismatchException) {
+        throw e.asStatusRuntimeException(Status.Code.ABORTED)
+      }
 
     return token.toUpdateComputationDetailsResponse()
   }
@@ -316,15 +332,22 @@ class PostgresComputationsService(
   override suspend fun recordOutputBlobPath(
     request: RecordOutputBlobPathRequest,
   ): RecordOutputBlobPathResponse {
-    val token =
+    val writer =
       RecordOutputBlobPath(
-          token = request.token.toDatabaseEditToken(),
-          clock = clock,
-          blobRef = BlobRef(request.outputBlobId, request.blobPath),
-          protocolStagesEnumHelper = protocolStagesEnumHelper,
-          computationReader = computationReader,
-        )
-        .execute(client, idGenerator)
+        token = request.token.toDatabaseEditToken(),
+        clock = clock,
+        blobRef = BlobRef(request.outputBlobId, request.blobPath),
+        protocolStagesEnumHelper = protocolStagesEnumHelper,
+        computationReader = computationReader,
+      )
+    val token: ComputationToken =
+      try {
+        writer.execute(client, idGenerator)
+      } catch (e: ComputationNotFoundException) {
+        throw e.asStatusRuntimeException(Status.Code.NOT_FOUND)
+      } catch (e: ComputationTokenVersionMismatchException) {
+        throw e.asStatusRuntimeException(Status.Code.ABORTED)
+      }
 
     return token.toRecordOutputBlobPathResponse()
   }
@@ -348,21 +371,28 @@ class PostgresComputationsService(
           )
       }
 
-    val token =
+    val writer =
       AdvanceComputationStage(
-          request.token.toDatabaseEditToken(),
-          nextStage = request.nextComputationStage,
-          nextStageDetails = request.stageDetails,
-          inputBlobPaths = request.inputBlobsList,
-          passThroughBlobPaths = request.passThroughBlobsList,
-          outputBlobs = request.outputBlobs,
-          afterTransition = afterTransition,
-          lockExtension = lockExtension,
-          clock = clock,
-          protocolStagesEnumHelper = protocolStagesEnumHelper,
-          computationReader = computationReader,
-        )
-        .execute(client, idGenerator)
+        request.token.toDatabaseEditToken(),
+        nextStage = request.nextComputationStage,
+        nextStageDetails = request.stageDetails,
+        inputBlobPaths = request.inputBlobsList,
+        passThroughBlobPaths = request.passThroughBlobsList,
+        outputBlobs = request.outputBlobs,
+        afterTransition = afterTransition,
+        lockExtension = lockExtension,
+        clock = clock,
+        protocolStagesEnumHelper = protocolStagesEnumHelper,
+        computationReader = computationReader,
+      )
+    val token: ComputationToken =
+      try {
+        writer.execute(client, idGenerator)
+      } catch (e: ComputationNotFoundException) {
+        throw e.asStatusRuntimeException(Status.Code.NOT_FOUND)
+      } catch (e: ComputationTokenVersionMismatchException) {
+        throw e.asStatusRuntimeException(Status.Code.ABORTED)
+      }
 
     sendStatusUpdateToKingdom(
       newCreateComputationLogEntryRequest(
@@ -387,13 +417,21 @@ class PostgresComputationsService(
     grpcRequire(request.delaySecond >= 0) {
       "DelaySecond ${request.delaySecond} should be non-negative."
     }
-    EnqueueComputation(
+    val writer =
+      EnqueueComputation(
         request.token.localComputationId,
         request.token.version,
         request.delaySecond.toLong(),
         clock,
       )
-      .execute(client, idGenerator)
+    try {
+      writer.execute(client, idGenerator)
+    } catch (e: ComputationNotFoundException) {
+      throw e.asStatusRuntimeException(Status.Code.NOT_FOUND)
+    } catch (e: ComputationTokenVersionMismatchException) {
+      throw e.asStatusRuntimeException(Status.Code.ABORTED)
+    }
+
     return EnqueueComputationResponse.getDefaultInstance()
   }
 

--- a/src/main/kotlin/org/wfanet/measurement/duchy/deploy/common/postgres/writers/ComputationMutations.kt
+++ b/src/main/kotlin/org/wfanet/measurement/duchy/deploy/common/postgres/writers/ComputationMutations.kt
@@ -25,6 +25,7 @@ import org.wfanet.measurement.common.db.r2dbc.postgres.PostgresWriter
 import org.wfanet.measurement.common.toJson
 import org.wfanet.measurement.duchy.service.internal.ComputationAlreadyExistsException
 import org.wfanet.measurement.duchy.service.internal.ComputationNotFoundException
+import org.wfanet.measurement.duchy.service.internal.ComputationTokenVersionMismatchException
 
 /** Insert a new row into the Postgres Computations table. */
 suspend fun PostgresWriter.TransactionScope.insertComputation(
@@ -203,7 +204,10 @@ private suspend fun setLock(
 /**
  * Checks if the version of local computation matches with the version in database.
  *
- * @throws [IllegalStateException] if versions mismatched.
+ * The token edit version is used similarly to an `etag`. See https://google.aip.dev/154
+ *
+ * @throws ComputationNotFoundException if the Computation with [localId] is not found
+ * @throws ComputationTokenVersionMismatchException if [editVersion] does not match
  */
 suspend fun PostgresWriter.TransactionScope.checkComputationUnmodified(
   localId: Long,
@@ -229,14 +233,19 @@ suspend fun PostgresWriter.TransactionScope.checkComputationUnmodified(
   val updateTimeMillis = updateTime.toEpochMilli()
   if (editVersion != updateTimeMillis) {
     val editVersionTime = Instant.ofEpochMilli(editVersion)
-    error(
+    val message =
       """
-          Failed to update because of editVersion mismatch.
-            Local computation's version: $editVersion ($editVersionTime)
-            Computations table's version: $updateTimeMillis ($updateTime)
-            Difference: ${Duration.between(editVersionTime, updateTime)}
-          """
+      Failed to update because of editVersion mismatch.
+        Local computation's version: $editVersion ($editVersionTime)
+        Computations table's version: $updateTimeMillis ($updateTime)
+        Difference: ${Duration.between(editVersionTime, updateTime)}
+      """
         .trimIndent()
+    throw ComputationTokenVersionMismatchException(
+      computationId = localId,
+      version = updateTimeMillis,
+      tokenVersion = editVersion,
+      message = message
     )
   }
 }

--- a/src/main/kotlin/org/wfanet/measurement/duchy/deploy/common/postgres/writers/RecordOutputBlobPath.kt
+++ b/src/main/kotlin/org/wfanet/measurement/duchy/deploy/common/postgres/writers/RecordOutputBlobPath.kt
@@ -61,7 +61,7 @@ class RecordOutputBlobPath<ProtocolT, StageT>(
           "No ComputationBlobReferences row for " +
             "($localId, $stage, ${blobRef.idInRelationalDatabase})",
         )
-    require(type == ComputationBlobDependency.OUTPUT) { "Cannot write to $type blob" }
+    check(type == ComputationBlobDependency.OUTPUT) { "Cannot write to $type blob" }
 
     updateComputation(localId = localId, updateTime = clock.instant())
 

--- a/src/main/kotlin/org/wfanet/measurement/duchy/deploy/common/server/AsyncComputationControlServer.kt
+++ b/src/main/kotlin/org/wfanet/measurement/duchy/deploy/common/server/AsyncComputationControlServer.kt
@@ -47,6 +47,18 @@ class AsyncComputationControlServiceFlags {
   @CommandLine.Mixin
   lateinit var computationsServiceFlags: ComputationsServiceFlags
     private set
+
+  @CommandLine.Option(
+    names = ["--max-advance-attempts"],
+    description =
+      [
+        "Maximum number of attempts for the Advance operation.",
+        "The default is effectively unlimited.",
+      ],
+    required = false,
+  )
+  var maxAdvanceAttempts = Int.MAX_VALUE
+    private set
 }
 
 @CommandLine.Command(
@@ -76,7 +88,7 @@ private fun run(@CommandLine.Mixin flags: AsyncComputationControlServiceFlags) {
   CommonServer.fromFlags(
       flags.server,
       SERVER_NAME,
-      AsyncComputationControlService(ComputationsCoroutineStub(channel))
+      AsyncComputationControlService(ComputationsCoroutineStub(channel), flags.maxAdvanceAttempts)
     )
     .start()
     .blockUntilShutdown()

--- a/src/main/kotlin/org/wfanet/measurement/duchy/deploy/common/server/ComputationControlServer.kt
+++ b/src/main/kotlin/org/wfanet/measurement/duchy/deploy/common/server/ComputationControlServer.kt
@@ -14,10 +14,11 @@
 
 package org.wfanet.measurement.duchy.deploy.common.server
 
-import io.grpc.ManagedChannel
+import io.grpc.Channel
 import org.wfanet.measurement.common.crypto.SigningCerts
 import org.wfanet.measurement.common.grpc.CommonServer
 import org.wfanet.measurement.common.grpc.buildMutualTlsChannel
+import org.wfanet.measurement.common.grpc.withDefaultDeadline
 import org.wfanet.measurement.common.identity.DuchyInfo
 import org.wfanet.measurement.common.identity.DuchyInfoFlags
 import org.wfanet.measurement.common.identity.withDuchyIdentities
@@ -47,12 +48,13 @@ abstract class ComputationControlServer : Runnable {
         trustedCertCollectionFile = flags.server.tlsFlags.certCollectionFile
       )
 
-    val channel: ManagedChannel =
+    val channel: Channel =
       buildMutualTlsChannel(
-        flags.asyncComputationControlServiceFlags.target,
-        clientCerts,
-        flags.asyncComputationControlServiceFlags.certHost
-      )
+          flags.asyncComputationControlServiceFlags.target,
+          clientCerts,
+          flags.asyncComputationControlServiceFlags.certHost
+        )
+        .withDefaultDeadline(flags.asyncComputationControlServiceFlags.defaultDeadlineDuration)
 
     CommonServer.fromFlags(
         flags.server,

--- a/src/main/kotlin/org/wfanet/measurement/duchy/deploy/gcloud/spanner/computation/BUILD.bazel
+++ b/src/main/kotlin/org/wfanet/measurement/duchy/deploy/gcloud/spanner/computation/BUILD.bazel
@@ -11,6 +11,7 @@ kt_jvm_library(
     deps = [
         "//src/main/kotlin/org/wfanet/measurement/duchy/db/computation",
         "//src/main/kotlin/org/wfanet/measurement/duchy/deploy/gcloud/spanner/common",
+        "//src/main/kotlin/org/wfanet/measurement/duchy/service/internal:internal_exception",
         "//src/main/proto/wfa/measurement/internal/duchy:computation_blob_dependency_kt_jvm_proto",
         "//src/main/proto/wfa/measurement/internal/duchy:computation_details_kt_jvm_proto",
         "//src/main/proto/wfa/measurement/internal/duchy:computation_token_kt_jvm_proto",

--- a/src/main/kotlin/org/wfanet/measurement/duchy/service/internal/BUILD.bazel
+++ b/src/main/kotlin/org/wfanet/measurement/duchy/service/internal/BUILD.bazel
@@ -1,7 +1,9 @@
 load("@io_bazel_rules_kotlin//kotlin:jvm.bzl", "kt_jvm_library")
 
 package(default_visibility = [
+    "//src/main/kotlin/org/wfanet/measurement/duchy/db:__subpackages__",
     "//src/main/kotlin/org/wfanet/measurement/duchy/deploy:__subpackages__",
+    "//src/main/kotlin/org/wfanet/measurement/duchy/service/internal:__subpackages__",
 ])
 
 kt_jvm_library(

--- a/src/main/kotlin/org/wfanet/measurement/duchy/service/internal/DuchyInternalException.kt
+++ b/src/main/kotlin/org/wfanet/measurement/duchy/service/internal/DuchyInternalException.kt
@@ -22,8 +22,14 @@ import io.grpc.StatusRuntimeException
 import io.grpc.protobuf.StatusProto
 import org.wfanet.measurement.internal.duchy.ErrorCode
 
-sealed class DuchyInternalException(val code: ErrorCode, override val message: String) :
-  Exception() {
+sealed class DuchyInternalException(
+  val code: ErrorCode,
+  message: String,
+  cause: Throwable? = null,
+) : Exception(message, cause) {
+  override val message: String
+    get() = super.message!!
+
   protected abstract val context: Map<String, String>
 
   fun asStatusRuntimeException(
@@ -100,4 +106,19 @@ class ComputationAlreadyExistsException(
 ) : DuchyInternalException(ErrorCode.COMPUTATION_ALREADY_EXISTS, message) {
   override val context
     get() = mapOf("global_computation_id" to globalComputationId)
+}
+
+class ComputationTokenVersionMismatchException(
+  val computationId: Long,
+  val version: Long,
+  val tokenVersion: Long,
+  message: String = "ComputationToken version mismatch",
+) : DuchyInternalException(ErrorCode.COMPUTATION_TOKEN_VERSION_MISMATCH, message) {
+  override val context
+    get() =
+      mapOf(
+        "computation_id" to computationId.toString(),
+        "version" to version.toString(),
+        "token_version" to tokenVersion.toString()
+      )
 }

--- a/src/main/kotlin/org/wfanet/measurement/duchy/service/internal/computationcontrol/BUILD.bazel
+++ b/src/main/kotlin/org/wfanet/measurement/duchy/service/internal/computationcontrol/BUILD.bazel
@@ -17,6 +17,7 @@ kt_jvm_library(
     ],
     deps = [
         ":protocol_stages",
+        "//src/main/kotlin/org/wfanet/measurement/common:exponential_backoff",
         "//src/main/kotlin/org/wfanet/measurement/duchy/db/computation",
         "//src/main/proto/wfa/measurement/internal/duchy:async_computation_control_service_kt_jvm_grpc_proto",
         "@wfa_common_jvm//imports/java/com/google/protobuf",

--- a/src/main/kotlin/org/wfanet/measurement/duchy/service/internal/computations/BUILD.bazel
+++ b/src/main/kotlin/org/wfanet/measurement/duchy/service/internal/computations/BUILD.bazel
@@ -33,6 +33,7 @@ kt_jvm_library(
         ":protos",
         "//src/main/kotlin/org/wfanet/measurement/common/identity",
         "//src/main/kotlin/org/wfanet/measurement/duchy/db/computation",
+        "//src/main/kotlin/org/wfanet/measurement/duchy/service/internal:internal_exception",
         "//src/main/kotlin/org/wfanet/measurement/system/v1alpha:resource_key",
         "//src/main/proto/wfa/measurement/system/v1alpha:computation_log_entries_service_kt_jvm_grpc_proto",
         "//src/main/proto/wfa/measurement/system/v1alpha:stage_attempt_kt_jvm_proto",

--- a/src/main/kotlin/org/wfanet/measurement/duchy/service/internal/computations/ComputationsService.kt
+++ b/src/main/kotlin/org/wfanet/measurement/duchy/service/internal/computations/ComputationsService.kt
@@ -31,6 +31,8 @@ import org.wfanet.measurement.duchy.db.computation.EndComputationReason
 import org.wfanet.measurement.duchy.db.computation.toDatabaseEditToken
 import org.wfanet.measurement.duchy.name
 import org.wfanet.measurement.duchy.number
+import org.wfanet.measurement.duchy.service.internal.ComputationNotFoundException
+import org.wfanet.measurement.duchy.service.internal.ComputationTokenVersionMismatchException
 import org.wfanet.measurement.duchy.storage.ComputationStore
 import org.wfanet.measurement.duchy.storage.RequisitionStore
 import org.wfanet.measurement.internal.duchy.AdvanceComputationStageRequest
@@ -181,17 +183,23 @@ class ComputationsService(
   override suspend fun finishComputation(
     request: FinishComputationRequest
   ): FinishComputationResponse {
-    computationsDatabase.endComputation(
-      request.token.toDatabaseEditToken(),
-      request.endingComputationStage,
-      when (val it = request.reason) {
-        ComputationDetails.CompletedReason.SUCCEEDED -> EndComputationReason.SUCCEEDED
-        ComputationDetails.CompletedReason.FAILED -> EndComputationReason.FAILED
-        ComputationDetails.CompletedReason.CANCELED -> EndComputationReason.CANCELED
-        else -> error("Unknown CompletedReason $it")
-      },
-      request.token.computationDetails
-    )
+    try {
+      computationsDatabase.endComputation(
+        request.token.toDatabaseEditToken(),
+        request.endingComputationStage,
+        when (val it = request.reason) {
+          ComputationDetails.CompletedReason.SUCCEEDED -> EndComputationReason.SUCCEEDED
+          ComputationDetails.CompletedReason.FAILED -> EndComputationReason.FAILED
+          ComputationDetails.CompletedReason.CANCELED -> EndComputationReason.CANCELED
+          else -> error("Unknown CompletedReason $it")
+        },
+        request.token.computationDetails
+      )
+    } catch (e: ComputationNotFoundException) {
+      throw e.asStatusRuntimeException(Status.Code.NOT_FOUND)
+    } catch (e: ComputationTokenVersionMismatchException) {
+      throw e.asStatusRuntimeException(Status.Code.ABORTED)
+    }
 
     sendStatusUpdateToKingdom(
       newCreateComputationLogEntryRequest(
@@ -228,11 +236,17 @@ class ComputationsService(
     require(request.token.computationDetails.protocolCase == request.details.protocolCase) {
       "The protocol type cannot change."
     }
-    computationsDatabase.updateComputationDetails(
-      request.token.toDatabaseEditToken(),
-      request.details,
-      request.requisitionsList
-    )
+    try {
+      computationsDatabase.updateComputationDetails(
+        request.token.toDatabaseEditToken(),
+        request.details,
+        request.requisitionsList
+      )
+    } catch (e: ComputationNotFoundException) {
+      throw e.asStatusRuntimeException(Status.Code.NOT_FOUND)
+    } catch (e: ComputationTokenVersionMismatchException) {
+      throw e.asStatusRuntimeException(Status.Code.ABORTED)
+    }
     return computationsDatabase
       .readComputationToken(request.token.globalComputationId)!!
       .toUpdateComputationDetailsResponse()
@@ -241,10 +255,16 @@ class ComputationsService(
   override suspend fun recordOutputBlobPath(
     request: RecordOutputBlobPathRequest
   ): RecordOutputBlobPathResponse {
-    computationsDatabase.writeOutputBlobReference(
-      request.token.toDatabaseEditToken(),
-      BlobRef(request.outputBlobId, request.blobPath)
-    )
+    try {
+      computationsDatabase.writeOutputBlobReference(
+        request.token.toDatabaseEditToken(),
+        BlobRef(request.outputBlobId, request.blobPath)
+      )
+    } catch (e: ComputationNotFoundException) {
+      throw e.asStatusRuntimeException(Status.Code.NOT_FOUND)
+    } catch (e: ComputationTokenVersionMismatchException) {
+      throw e.asStatusRuntimeException(Status.Code.ABORTED)
+    }
     return computationsDatabase
       .readComputationToken(request.token.globalComputationId)!!
       .toRecordOutputBlobPathResponse()
@@ -255,24 +275,30 @@ class ComputationsService(
   ): AdvanceComputationStageResponse {
     val lockExtension: Duration =
       if (request.hasLockExtension()) request.lockExtension.toDuration() else defaultLockDuration
-    computationsDatabase.updateComputationStage(
-      request.token.toDatabaseEditToken(),
-      request.nextComputationStage,
-      request.inputBlobsList,
-      request.passThroughBlobsList,
-      request.outputBlobs,
-      when (val it = request.afterTransition) {
-        AdvanceComputationStageRequest.AfterTransition.ADD_UNCLAIMED_TO_QUEUE ->
-          AfterTransition.ADD_UNCLAIMED_TO_QUEUE
-        AdvanceComputationStageRequest.AfterTransition.DO_NOT_ADD_TO_QUEUE ->
-          AfterTransition.DO_NOT_ADD_TO_QUEUE
-        AdvanceComputationStageRequest.AfterTransition.RETAIN_AND_EXTEND_LOCK ->
-          AfterTransition.CONTINUE_WORKING
-        else -> error("Unsupported AdvanceComputationStageRequest.AfterTransition '$it'. ")
-      },
-      request.stageDetails,
-      lockExtension
-    )
+    try {
+      computationsDatabase.updateComputationStage(
+        request.token.toDatabaseEditToken(),
+        request.nextComputationStage,
+        request.inputBlobsList,
+        request.passThroughBlobsList,
+        request.outputBlobs,
+        when (val it = request.afterTransition) {
+          AdvanceComputationStageRequest.AfterTransition.ADD_UNCLAIMED_TO_QUEUE ->
+            AfterTransition.ADD_UNCLAIMED_TO_QUEUE
+          AdvanceComputationStageRequest.AfterTransition.DO_NOT_ADD_TO_QUEUE ->
+            AfterTransition.DO_NOT_ADD_TO_QUEUE
+          AdvanceComputationStageRequest.AfterTransition.RETAIN_AND_EXTEND_LOCK ->
+            AfterTransition.CONTINUE_WORKING
+          else -> error("Unsupported AdvanceComputationStageRequest.AfterTransition '$it'. ")
+        },
+        request.stageDetails,
+        lockExtension
+      )
+    } catch (e: ComputationNotFoundException) {
+      throw e.asStatusRuntimeException(Status.Code.NOT_FOUND)
+    } catch (e: ComputationTokenVersionMismatchException) {
+      throw e.asStatusRuntimeException(Status.Code.ABORTED)
+    }
 
     sendStatusUpdateToKingdom(
       newCreateComputationLogEntryRequest(
@@ -298,7 +324,13 @@ class ComputationsService(
     grpcRequire(request.delaySecond >= 0) {
       "DelaySecond ${request.delaySecond} should be non-negative."
     }
-    computationsDatabase.enqueue(request.token.toDatabaseEditToken(), request.delaySecond)
+    try {
+      computationsDatabase.enqueue(request.token.toDatabaseEditToken(), request.delaySecond)
+    } catch (e: ComputationNotFoundException) {
+      throw e.asStatusRuntimeException(Status.Code.NOT_FOUND)
+    } catch (e: ComputationTokenVersionMismatchException) {
+      throw e.asStatusRuntimeException(Status.Code.ABORTED)
+    }
     return EnqueueComputationResponse.getDefaultInstance()
   }
 

--- a/src/main/kotlin/org/wfanet/measurement/integration/common/InProcessDuchy.kt
+++ b/src/main/kotlin/org/wfanet/measurement/integration/common/InProcessDuchy.kt
@@ -43,7 +43,6 @@ import org.wfanet.measurement.common.grpc.testing.GrpcTestServerRule
 import org.wfanet.measurement.common.grpc.withVerboseLogging
 import org.wfanet.measurement.common.identity.testing.withMetadataDuchyIdentities
 import org.wfanet.measurement.common.identity.withDuchyId
-import org.wfanet.measurement.common.logAndSuppressExceptionSuspend
 import org.wfanet.measurement.common.testing.ProviderRule
 import org.wfanet.measurement.common.testing.chainRulesSequentially
 import org.wfanet.measurement.common.throttler.MinimumIntervalThrottler
@@ -143,7 +142,9 @@ class InProcessDuchy(
     }
   private val asyncComputationControlServer =
     GrpcTestServerRule(logAllRequests = verboseGrpcLogging) {
-      addService(AsyncComputationControlService(computationsClient))
+      addService(
+        AsyncComputationControlService(computationsClient, maxAdvanceAttempts = Int.MAX_VALUE)
+      )
     }
   private val computationControlServer =
     GrpcTestServerRule(
@@ -254,10 +255,8 @@ class InProcessDuchy(
 
         val throttler = MinimumIntervalThrottler(Clock.systemUTC(), Duration.ofSeconds(1))
         throttler.loopOnReady {
-          logAndSuppressExceptionSuspend { liquidLegionsV2Mill.pollAndProcessNextComputation() }
-          logAndSuppressExceptionSuspend {
-            reachOnlyLiquidLegionsV2Mill.pollAndProcessNextComputation()
-          }
+          liquidLegionsV2Mill.pollAndProcessNextComputation()
+          reachOnlyLiquidLegionsV2Mill.pollAndProcessNextComputation()
         }
       }
   }

--- a/src/main/proto/wfa/measurement/internal/duchy/error_code.proto
+++ b/src/main/proto/wfa/measurement/internal/duchy/error_code.proto
@@ -39,4 +39,8 @@ enum ErrorCode {
 
   /** Computation with the same global ID already exists. */
   COMPUTATION_ALREADY_EXISTS = 6;
+
+  /** The version from the request ComputationToken does not match the persisted
+   * value. */
+  COMPUTATION_TOKEN_VERSION_MISMATCH = 7;
 }

--- a/src/test/kotlin/org/wfanet/measurement/common/BUILD.bazel
+++ b/src/test/kotlin/org/wfanet/measurement/common/BUILD.bazel
@@ -1,0 +1,15 @@
+load("@io_bazel_rules_kotlin//kotlin:jvm.bzl", "kt_jvm_test")
+
+package(default_testonly = True)
+
+kt_jvm_test(
+    name = "ExponentialBackoffTest",
+    srcs = ["ExponentialBackoffTest.kt"],
+    test_class = "org.wfanet.measurement.common.ExponentialBackoffTest",
+    deps = [
+        "//src/main/kotlin/org/wfanet/measurement/common:exponential_backoff",
+        "@wfa_common_jvm//imports/java/com/google/common/truth",
+        "@wfa_common_jvm//imports/java/org/junit",
+        "@wfa_common_jvm//imports/kotlin/kotlin/test",
+    ],
+)

--- a/src/test/kotlin/org/wfanet/measurement/common/ExponentialBackoffTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/common/ExponentialBackoffTest.kt
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2023 The Cross-Media Measurement Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wfanet.measurement.common
+
+import com.google.common.truth.Truth.assertThat
+import java.time.Duration
+import kotlin.random.Random
+import kotlin.test.assertFailsWith
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+
+/** Test for [ExponentialBackoff]. */
+@RunWith(JUnit4::class)
+class ExponentialBackoffTest {
+  @Test
+  fun `durationForAttempt returns initial delay for attempt 1`() {
+    val backoff =
+      ExponentialBackoff(
+        initialDelay = Duration.ofMillis(250),
+        randomnessFactor = 0.0,
+      )
+
+    val duration: Duration = backoff.durationForAttempt(1)
+
+    assertThat(duration).isEqualTo(backoff.initialDelay)
+  }
+
+  @Test
+  fun `durationForAttempt returns multiplied value with no randomness factor`() {
+    val backoff =
+      ExponentialBackoff(
+        initialDelay = Duration.ofMillis(500),
+        multiplier = 2.0,
+        randomnessFactor = 0.0,
+      )
+
+    val duration: Duration = backoff.durationForAttempt(4)
+
+    assertThat(duration).isEqualTo(Duration.ofMillis(4000))
+  }
+
+  @Test
+  fun `durationForAttempt returns multiplied value with randomness factor`() {
+    val backoff =
+      ExponentialBackoff(
+        initialDelay = Duration.ofMillis(500),
+        multiplier = 2.0,
+        randomnessFactor = 0.5,
+        random = Random(RANDOM_SEED)
+      )
+
+    val duration: Duration = backoff.durationForAttempt(4)
+
+    assertThat(duration).isEqualTo(Duration.ofMillis(2559))
+  }
+
+  @Test
+  fun `durationForAttempt throws IllegalArgumentException for invalid attempt number`() {
+    val backoff = ExponentialBackoff()
+
+    val exception = assertFailsWith<IllegalArgumentException> { backoff.durationForAttempt(0) }
+
+    assertThat(exception).hasMessageThat().ignoringCase().contains("attempt")
+  }
+
+  @Test
+  fun `init throws IllegalArgumentException for invalid randomness factor`() {
+    val exception =
+      assertFailsWith<IllegalArgumentException> { ExponentialBackoff(randomnessFactor = -0.5) }
+
+    assertThat(exception).hasMessageThat().ignoringCase().contains("randomness")
+  }
+
+  @Test
+  fun `init throws IllegalArgumentException for invalid initial delay`() {
+    val exception =
+      assertFailsWith<IllegalArgumentException> {
+        ExponentialBackoff(initialDelay = Duration.ofNanos(1))
+      }
+
+    assertThat(exception).hasMessageThat().ignoringCase().contains("delay")
+  }
+
+  companion object {
+    private const val RANDOM_SEED = 1L
+  }
+}

--- a/src/test/kotlin/org/wfanet/measurement/duchy/daemon/mill/liquidlegionsv2/LiquidLegionsV2MillTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/duchy/daemon/mill/liquidlegionsv2/LiquidLegionsV2MillTest.kt
@@ -641,7 +641,7 @@ class LiquidLegionsV2MillTest {
 
     // This will result in TRANSIENT gRPC failure.
     whenever(mockComputationParticipants.setParticipantRequisitionParams(any()))
-      .thenThrow(Status.UNKNOWN.asRuntimeException())
+      .thenThrow(Status.ABORTED.asRuntimeException())
 
     // First attempt fails, which doesn't change the computation stage.
     nonAggregatorMill.pollAndProcessNextComputation()
@@ -892,10 +892,12 @@ class LiquidLegionsV2MillTest {
             failureBuilder.apply {
               participantChildReferenceId = MILL_ID
               errorMessage =
-                "PERMANENT error: java.lang.Exception: @Mill a nice mill, Computation 1234 " +
-                  "failed due to:\n" +
-                  "Cannot verify participation of all DataProviders.\n" +
-                  "Missing expected data for requisition 222."
+                """
+                @Mill a nice mill, Computation 1234 failed due to:
+                Cannot verify participation of all DataProviders.
+                Missing expected data for requisition 222.
+                """
+                  .trimIndent()
               stageAttemptBuilder.apply {
                 stage = CONFIRMATION_PHASE.number
                 stageName = CONFIRMATION_PHASE.name
@@ -1083,10 +1085,12 @@ class LiquidLegionsV2MillTest {
             failureBuilder.apply {
               participantChildReferenceId = MILL_ID
               errorMessage =
-                "PERMANENT error: java.lang.Exception: @Mill a nice mill, Computation 1234 " +
-                  "failed due to:\n" +
-                  "Cannot verify participation of all DataProviders.\n" +
-                  "Invalid ElGamal public key signature for Duchy $DUCHY_TWO_NAME"
+                """
+                @Mill a nice mill, Computation 1234 failed due to:
+                Cannot verify participation of all DataProviders.
+                Invalid ElGamal public key signature for Duchy $DUCHY_TWO_NAME
+                """
+                  .trimIndent()
               stageAttemptBuilder.apply {
                 stage = CONFIRMATION_PHASE.number
                 stageName = CONFIRMATION_PHASE.name

--- a/src/test/kotlin/org/wfanet/measurement/duchy/daemon/mill/liquidlegionsv2/ReachOnlyLiquidLegionsV2MillTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/duchy/daemon/mill/liquidlegionsv2/ReachOnlyLiquidLegionsV2MillTest.kt
@@ -584,7 +584,7 @@ class ReachOnlyLiquidLegionsV2MillTest {
 
     // This will result in TRANSIENT gRPC failure.
     whenever(mockComputationParticipants.setParticipantRequisitionParams(any()))
-      .thenThrow(Status.UNKNOWN.asRuntimeException())
+      .thenThrow(Status.ABORTED.asRuntimeException())
 
     // First attempt fails, which doesn't change the computation stage.
     nonAggregatorMill.pollAndProcessNextComputation()
@@ -859,10 +859,12 @@ class ReachOnlyLiquidLegionsV2MillTest {
             ComputationParticipantKt.failure {
               participantChildReferenceId = MILL_ID
               errorMessage =
-                "PERMANENT error: java.lang.Exception: @Mill a nice mill, Computation 1234 " +
-                  "failed due to:\n" +
-                  "Cannot verify participation of all DataProviders.\n" +
-                  "Missing expected data for requisition 222."
+                """
+                @Mill a nice mill, Computation 1234 failed due to:
+                Cannot verify participation of all DataProviders.
+                Missing expected data for requisition 222.
+                """
+                  .trimIndent()
               this.stageAttempt = stageAttempt {
                 stage = CONFIRMATION_PHASE.number
                 stageName = CONFIRMATION_PHASE.name
@@ -1067,10 +1069,12 @@ class ReachOnlyLiquidLegionsV2MillTest {
             ComputationParticipantKt.failure {
               participantChildReferenceId = MILL_ID
               errorMessage =
-                "PERMANENT error: java.lang.Exception: @Mill a nice mill, Computation 1234 " +
-                  "failed due to:\n" +
-                  "Cannot verify participation of all DataProviders.\n" +
-                  "Invalid ElGamal public key signature for Duchy $DUCHY_TWO_NAME"
+                """
+                @Mill a nice mill, Computation 1234 failed due to:
+                Cannot verify participation of all DataProviders.
+                Invalid ElGamal public key signature for Duchy $DUCHY_TWO_NAME
+                """
+                  .trimIndent()
               this.stageAttempt = stageAttempt {
                 stage = CONFIRMATION_PHASE.number
                 stageName = CONFIRMATION_PHASE.name
@@ -1585,8 +1589,8 @@ class ReachOnlyLiquidLegionsV2MillTest {
             ComputationParticipantKt.failure {
               participantChildReferenceId = MILL_ID
               errorMessage =
-                "PERMANENT error: java.lang.IllegalArgumentException: Invalid input blob size. Input" +
-                  " blob duchy_2_sketch_ has size 15 which is less than (66)."
+                "Invalid input blob size. Input blob duchy_2_sketch_ has size 15 which is less " +
+                  "than (66)."
               this.stageAttempt = stageAttempt {
                 stage = SETUP_PHASE.number
                 stageName = SETUP_PHASE.name
@@ -1779,7 +1783,7 @@ class ReachOnlyLiquidLegionsV2MillTest {
             ComputationParticipantKt.failure {
               participantChildReferenceId = MILL_ID
               errorMessage =
-                "PERMANENT error: Invalid input blob size. Input blob data has size 4 which is less than (66)."
+                "Invalid input blob size. Input blob data has size 4 which is less than (66)."
               this.stageAttempt = stageAttempt {
                 stage = EXECUTION_PHASE.number
                 stageName = EXECUTION_PHASE.name
@@ -2007,7 +2011,7 @@ class ReachOnlyLiquidLegionsV2MillTest {
             ComputationParticipantKt.failure {
               participantChildReferenceId = MILL_ID
               errorMessage =
-                "PERMANENT error: Invalid input blob size. Input blob data has size 4 which is less than (66)."
+                "Invalid input blob size. Input blob data has size 4 which is less than (66)."
               this.stageAttempt = stageAttempt {
                 stage = EXECUTION_PHASE.number
                 stageName = EXECUTION_PHASE.name


### PR DESCRIPTION
* Handle gRPC errors at call sites.
* Follow gRPC guidelines for retryability based on status code.
* Mitigate write contention in `AsyncComputationControl.AdvanceComputation` method by retrying the read-modify-write operation on `ABORTED` errors.

This is intended to address failures due to editVersionMismatch errors. In tests, this would sometimes surface as R/F Measurements resulting in a reach value of 1.

Fixes #680
Fixes #984