### PR TITLE
Update common-jvm to 0.65.0.

### DIFF
--- a/build/repositories.bzl
+++ b/build/repositories.bzl
@@ -27,8 +27,8 @@ def wfa_measurement_system_repositories():
     wfa_repo_archive(
         name = "wfa_common_jvm",
         repo = "common-jvm",
-        sha256 = "c376dded419cdce9d804fa491a76146a2c6318adc60c90eba83927a4858f92c8",
-        version = "0.64.1",
+        sha256 = "c0e39569064363ed61b9b780bf2aa37b99d0c81933a7a434b6b320c2e81063b4",
+        version = "0.65.0",
     )
 
     wfa_repo_archive(


### PR DESCRIPTION
This picks up an update to Java base images.