### PR TITLE
Revoke NONE type of noise mechanism in protocol config

### DIFF
--- a/build/repositories.bzl
+++ b/build/repositories.bzl
@@ -38,13 +38,13 @@ def wfa_measurement_system_repositories():
         version = "0.10.0",
     )
 
-    # DO_NOT_SUBMIT(world-federation-of-advertisers/cross-media-measurement-api/#172):
+    # DO_NOT_SUBMIT(world-federation-of-advertisers/cross-media-measurement-api/#173):
     # switch to a release version before submitting the PR.
     wfa_repo_archive(
         name = "wfa_measurement_proto",
         repo = "cross-media-measurement-api",
-        sha256 = "15c0dffe50c368caf96a7124812a1aa045daf8562a560857c8d28a1c5f5a62de",
-        commit = "ca9517d3cd50b4e01742e6d9eb2f6fc15033000f",
+        sha256 = "38546fd69dbfeb5de619f45a50f8fcef053f9834879802c77ff81f46c87729e5",
+        commit = "25cf35f8c6d48f22e218ea44be1ed57f12de00aa",
     )
 
     wfa_repo_archive(

--- a/src/main/k8s/kingdom.cue
+++ b/src/main/k8s/kingdom.cue
@@ -74,7 +74,6 @@ import ("strings")
 	_open_id_redirect_uri_flag: "--open-id-redirect-uri=https://localhost:2048"
 
 	_directNoiseMechanismFlags: [
-		"--direct-noise-mechanism=NONE",
 		"--direct-noise-mechanism=CONTINUOUS_LAPLACE",
 		"--direct-noise-mechanism=CONTINUOUS_GAUSSIAN",
 	]

--- a/src/main/kotlin/org/wfanet/measurement/eventdataprovider/noiser/Noiser.kt
+++ b/src/main/kotlin/org/wfanet/measurement/eventdataprovider/noiser/Noiser.kt
@@ -19,7 +19,7 @@ data class DpParams(val epsilon: Double, val delta: Double)
 
 /** Noise mechanism for generating publisher noise for direct measurements. */
 enum class DirectNoiseMechanism {
-  /** NONE mechanism is testing only. */
+  /** NONE mechanism is testing only and should not move to public API. */
   NONE,
   CONTINUOUS_LAPLACE,
   CONTINUOUS_GAUSSIAN,

--- a/src/main/kotlin/org/wfanet/measurement/integration/common/InProcessKingdom.kt
+++ b/src/main/kotlin/org/wfanet/measurement/integration/common/InProcessKingdom.kt
@@ -213,7 +213,6 @@ class InProcessKingdom(
     private const val DEFAULT_INTERNAL_DEADLINE_MILLIS = 30_000L
     private val MEASUREMENT_NOISE_MECHANISMS: List<ProtocolConfig.NoiseMechanism> =
       listOf(
-        ProtocolConfig.NoiseMechanism.NONE,
         ProtocolConfig.NoiseMechanism.CONTINUOUS_LAPLACE,
         ProtocolConfig.NoiseMechanism.CONTINUOUS_GAUSSIAN,
       )

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/common/server/V2alphaPublicApiServer.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/common/server/V2alphaPublicApiServer.kt
@@ -242,7 +242,6 @@ private class V2alphaFlags {
   fun setDirectNoiseMechanisms(noiseMechanisms: List<NoiseMechanism>) {
     for (noiseMechanism in noiseMechanisms) {
       when (noiseMechanism) {
-        NoiseMechanism.NONE,
         NoiseMechanism.CONTINUOUS_LAPLACE,
         NoiseMechanism.CONTINUOUS_GAUSSIAN -> {}
         NoiseMechanism.GEOMETRIC,

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/service/api/v2alpha/ProtoConversions.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/service/api/v2alpha/ProtoConversions.kt
@@ -123,7 +123,6 @@ import org.wfanet.measurement.kingdom.deploy.common.RoLlv2ProtocolConfig
 /** Default options of direct noise mechanisms to data providers. */
 val DEFAULT_DIRECT_NOISE_MECHANISMS: List<NoiseMechanism> =
   listOf(
-    NoiseMechanism.NONE,
     NoiseMechanism.GEOMETRIC,
     NoiseMechanism.DISCRETE_GAUSSIAN,
     NoiseMechanism.CONTINUOUS_LAPLACE,
@@ -251,7 +250,6 @@ fun InternalDifferentialPrivacyParams.toDifferentialPrivacyParams(): Differentia
 /** Converts an internal [InternalNoiseMechanism] to a public [NoiseMechanism]. */
 fun InternalNoiseMechanism.toNoiseMechanism(): NoiseMechanism {
   return when (this) {
-    InternalNoiseMechanism.NONE -> NoiseMechanism.NONE
     InternalNoiseMechanism.GEOMETRIC -> NoiseMechanism.GEOMETRIC
     InternalNoiseMechanism.DISCRETE_GAUSSIAN -> NoiseMechanism.DISCRETE_GAUSSIAN
     InternalNoiseMechanism.CONTINUOUS_LAPLACE -> NoiseMechanism.CONTINUOUS_LAPLACE
@@ -266,7 +264,6 @@ fun NoiseMechanism.toInternal(): InternalNoiseMechanism {
   return when (this) {
     NoiseMechanism.GEOMETRIC -> InternalNoiseMechanism.GEOMETRIC
     NoiseMechanism.DISCRETE_GAUSSIAN -> InternalNoiseMechanism.DISCRETE_GAUSSIAN
-    NoiseMechanism.NONE -> InternalNoiseMechanism.NONE
     NoiseMechanism.CONTINUOUS_LAPLACE -> InternalNoiseMechanism.CONTINUOUS_LAPLACE
     NoiseMechanism.CONTINUOUS_GAUSSIAN -> InternalNoiseMechanism.CONTINUOUS_GAUSSIAN
     NoiseMechanism.NOISE_MECHANISM_UNSPECIFIED,

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/service/system/v1alpha/ProtoConversions.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/service/system/v1alpha/ProtoConversions.kt
@@ -394,7 +394,6 @@ fun InternalNoiseMechanism.toSystemNoiseMechanism(): NoiseMechanism {
     InternalNoiseMechanism.CONTINUOUS_LAPLACE,
     InternalNoiseMechanism.CONTINUOUS_GAUSSIAN,
     InternalNoiseMechanism.NOISE_MECHANISM_UNSPECIFIED,
-    InternalNoiseMechanism.NONE,
     InternalNoiseMechanism.UNRECOGNIZED -> error("invalid internal noise mechanism.")
   }
 }

--- a/src/main/kotlin/org/wfanet/measurement/loadtest/dataprovider/EdpSimulator.kt
+++ b/src/main/kotlin/org/wfanet/measurement/loadtest/dataprovider/EdpSimulator.kt
@@ -1255,7 +1255,8 @@ class EdpSimulator(
   ): Measurement.Result {
     val directProtocolConfig = directProtocol.directProtocolConfig
     val directNoiseMechanism = directProtocol.selectedDirectNoiseMechanism
-    val protocolConfigNoiseMechanism = directNoiseMechanism.toProtocolConfigNoiseMechanism()
+    val protocolConfigNoiseMechanism =
+      directNoiseMechanism.toProtocolConfigNoiseMechanism() ?: error("Noise mechanism is NONE.")
 
     @Suppress("WHEN_ENUM_CAN_BE_NULL_IN_JAVA") // Protobuf enum fields cannot be null.
     return when (measurementSpec.measurementTypeCase) {
@@ -1558,9 +1559,14 @@ class EdpSimulator(
   }
 }
 
-private fun DirectNoiseMechanism.toProtocolConfigNoiseMechanism(): NoiseMechanism {
+/**
+ * Converts a [DirectNoiseMechanism] to a nullable [NoiseMechanism].
+ *
+ * @return [NoiseMechanism] when there is a matched, otherwise null.
+ */
+private fun DirectNoiseMechanism.toProtocolConfigNoiseMechanism(): NoiseMechanism? {
   return when (this) {
-    DirectNoiseMechanism.NONE -> NoiseMechanism.NONE
+    DirectNoiseMechanism.NONE -> null
     DirectNoiseMechanism.CONTINUOUS_LAPLACE -> NoiseMechanism.CONTINUOUS_LAPLACE
     DirectNoiseMechanism.CONTINUOUS_GAUSSIAN -> NoiseMechanism.CONTINUOUS_GAUSSIAN
   }
@@ -1573,7 +1579,6 @@ private fun DirectNoiseMechanism.toProtocolConfigNoiseMechanism(): NoiseMechanis
  */
 private fun NoiseMechanism.toDirectNoiseMechanism(): DirectNoiseMechanism? {
   return when (this) {
-    NoiseMechanism.NONE -> DirectNoiseMechanism.NONE
     NoiseMechanism.CONTINUOUS_LAPLACE -> DirectNoiseMechanism.CONTINUOUS_LAPLACE
     NoiseMechanism.CONTINUOUS_GAUSSIAN -> DirectNoiseMechanism.CONTINUOUS_GAUSSIAN
     NoiseMechanism.NOISE_MECHANISM_UNSPECIFIED,

--- a/src/main/proto/wfa/measurement/internal/kingdom/protocol_config.proto
+++ b/src/main/proto/wfa/measurement/internal/kingdom/protocol_config.proto
@@ -31,8 +31,9 @@ message ProtocolConfig {
 
   // The mechanism used to generate noise in computations.
   enum NoiseMechanism {
+    reserved 3;
+
     NOISE_MECHANISM_UNSPECIFIED = 0;
-    NONE = 3;
     GEOMETRIC = 1;
     DISCRETE_GAUSSIAN = 2;
     CONTINUOUS_LAPLACE = 4;

--- a/src/test/kotlin/org/wfanet/measurement/kingdom/service/api/v2alpha/MeasurementsServiceTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/kingdom/service/api/v2alpha/MeasurementsServiceTest.kt
@@ -1772,16 +1772,8 @@ class MeasurementsServiceTest {
 
     private val NOISE_MECHANISMS =
       listOf(
-        ProtocolConfig.NoiseMechanism.NONE,
         ProtocolConfig.NoiseMechanism.CONTINUOUS_LAPLACE,
         ProtocolConfig.NoiseMechanism.CONTINUOUS_GAUSSIAN,
-      )
-
-    private val INTERNAL_NOISE_MECHANISMS =
-      listOf(
-        InternalNoiseMechanism.NONE,
-        InternalNoiseMechanism.CONTINUOUS_LAPLACE,
-        InternalNoiseMechanism.CONTINUOUS_GAUSSIAN,
       )
 
     private val DIFFERENTIAL_PRIVACY_PARAMS = differentialPrivacyParams {
@@ -2043,7 +2035,6 @@ class MeasurementsServiceTest {
       }
     private val DEFAULT_INTERNAL_DIRECT_NOISE_MECHANISMS: List<InternalNoiseMechanism> =
       listOf(
-        InternalNoiseMechanism.NONE,
         InternalNoiseMechanism.CONTINUOUS_LAPLACE,
         InternalNoiseMechanism.CONTINUOUS_GAUSSIAN
       )

--- a/src/test/kotlin/org/wfanet/measurement/loadtest/dataprovider/EdpSimulatorTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/loadtest/dataprovider/EdpSimulatorTest.kt
@@ -1726,7 +1726,7 @@ class EdpSimulatorTest {
 
   @Test
   fun `fails to fulfill direct reach and frequency Requisition when no direct noise mechanism is picked by EDP`() {
-    val noiseMechanismOption = ProtocolConfig.NoiseMechanism.NONE
+    val noiseMechanismOption = ProtocolConfig.NoiseMechanism.DISCRETE_GAUSSIAN
     val requisition =
       REQUISITION.copy {
         protocolConfig =
@@ -1972,7 +1972,7 @@ class EdpSimulatorTest {
       REACH_ONLY_MEASUREMENT_SPEC.copy {
         vidSamplingInterval = vidSamplingInterval.copy { width = 0.1f }
       }
-    val noiseMechanismOption = ProtocolConfig.NoiseMechanism.NONE
+    val noiseMechanismOption = ProtocolConfig.NoiseMechanism.DISCRETE_GAUSSIAN
     val requisition =
       REQUISITION.copy {
         this.measurementSpec = signMeasurementSpec(measurementSpec, MC_SIGNING_KEY)


### PR DESCRIPTION
Implementation of the API change in https://github.com/world-federation-of-advertisers/cross-media-measurement-api/pull/173.