### PR TITLE
s3fromBeam should be false by default

### DIFF
--- a/src/main/kotlin/org/wfanet/panelmatch/client/deploy/example/aws/AwsExampleDaemon.kt
+++ b/src/main/kotlin/org/wfanet/panelmatch/client/deploy/example/aws/AwsExampleDaemon.kt
@@ -77,7 +77,7 @@ private class AwsExampleDaemon : ExampleDaemon() {
   @set:Option(
     names = ["--s3-from-beam"],
     description = ["Whether to configure s3 access from Apache Beam."],
-    defaultValue = "true"
+    defaultValue = "false"
   )
   private var s3FromBeam by Delegates.notNull<Boolean>()
 

--- a/src/main/kotlin/org/wfanet/panelmatch/client/storage/aws/s3/S3StorageFactory.kt
+++ b/src/main/kotlin/org/wfanet/panelmatch/client/storage/aws/s3/S3StorageFactory.kt
@@ -41,11 +41,17 @@ class S3StorageFactory(
       return build()
     }
     val beamOptions = options.`as`(BeamOptions::class.java)
-    @Suppress("USELESS_ELVIS", ) // Beam returns String?
+    @Suppress(
+      "USELESS_ELVIS",
+    ) // Beam returns String?
     val accessKey = beamOptions.awsAccessKey ?: ""
-    @Suppress("USELESS_ELVIS", ) // Beam returns String?
+    @Suppress(
+      "USELESS_ELVIS",
+    ) // Beam returns String?
     val secretAccessKey = beamOptions.awsSecretAccessKey ?: ""
-    @Suppress("USELESS_ELVIS", ) // Beam returns String?
+    @Suppress(
+      "USELESS_ELVIS",
+    ) // Beam returns String?
     val sessionToken = beamOptions.awsSessionToken ?: ""
     if (accessKey.isEmpty() || secretAccessKey.isEmpty() || sessionToken.isEmpty()) {
       return build()

--- a/src/main/kotlin/org/wfanet/panelmatch/client/storage/aws/s3/S3StorageFactory.kt
+++ b/src/main/kotlin/org/wfanet/panelmatch/client/storage/aws/s3/S3StorageFactory.kt
@@ -41,9 +41,12 @@ class S3StorageFactory(
       return build()
     }
     val beamOptions = options.`as`(BeamOptions::class.java)
-    val accessKey = beamOptions.awsAccessKey
-    val secretAccessKey = beamOptions.awsSecretAccessKey
-    val sessionToken = beamOptions.awsSessionToken
+    @Suppress("USELESS_ELVIS", ) // Beam returns String?
+    val accessKey = beamOptions.awsAccessKey ?: ""
+    @Suppress("USELESS_ELVIS", ) // Beam returns String?
+    val secretAccessKey = beamOptions.awsSecretAccessKey ?: ""
+    @Suppress("USELESS_ELVIS", ) // Beam returns String?
+    val sessionToken = beamOptions.awsSessionToken ?: ""
     if (accessKey.isEmpty() || secretAccessKey.isEmpty() || sessionToken.isEmpty()) {
       return build()
     }


### PR DESCRIPTION
s3FromBeam can have unintended consequences and today doesn't play nice with other code that assumes roles. This will need further fixing in the future once we move to executing beam jobs in a distributed environement.

This also fixes an issue where we assume beam options always returns a non-nullable String. However, sometimes, it is null.