### PR TITLE
Remove duplicate filter during event group entry creations

### DIFF
--- a/src/main/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/MetricsService.kt
+++ b/src/main/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/MetricsService.kt
@@ -555,9 +555,7 @@ class MetricsService(
                 internalEventGroupKey.cmmsDataProviderId,
                 internalEventGroupKey.cmmsEventGroupId
               )
-            val filtersList =
-              (primitiveReportingSetBasis.filtersList + internalPrimitiveReportingSet.filter)
-                .filter { !it.isNullOrBlank() }
+            val filtersList = primitiveReportingSetBasis.filtersList.filter { !it.isNullOrBlank() }
             val filter: String? = if (filtersList.isEmpty()) null else buildConjunction(filtersList)
 
             cmmsEventGroupKey to


### PR DESCRIPTION
## TL;DR
This pull request fixed the filter list creation in the MetricsService class.
> 
## What changed
Remove the filter of measurement's primitive reporting set basis from filter list creation.
>
## Why make this change
The filter list creation was previously done by concatenating the filter list from a measurement and the filter from the measurement's primitive reporting set basis. However, the filter from latter should already be included in the former.