### PR TITLE
Adds an event filter to MetricCalculationSpec.

### DIFF
--- a/src/main/proto/wfa/measurement/reporting/v2alpha/report.proto
+++ b/src/main/proto/wfa/measurement/reporting/v2alpha/report.proto
@@ -64,6 +64,10 @@ message Report {
     // A collection of metrics.
     repeated MetricSpec metric_specs = 2
         [(google.api.field_behavior) = REQUIRED];
+    // An additional event filter that will be conjoined to any filters
+    // present on the ReportingSet provided as part of the
+    // ReportingMetricEntry below.
+    string filter = 5 [(google.api.field_behavior) = IMMUTABLE];
     // The final set of groups is the Cartesian product of `groupings` and will
     // fan out multiple metrics per metric spec and per time interval, i.e.
     // one metric per element of the Cartesian product of the groupings with a


### PR DESCRIPTION
Allow for an event filter on MetricCalculationSpec so that ReportingSets can be used without filters. This is in response to a request from @mariolamassaavedra.