### PR TITLE
Adds key-value pair tags to Report and ReportingSet.

### DIFF
--- a/src/main/proto/wfa/measurement/reporting/v2alpha/report.proto
+++ b/src/main/proto/wfa/measurement/reporting/v2alpha/report.proto
@@ -43,6 +43,10 @@ message Report {
   // Resource name.
   string name = 1;
 
+  // A map of arbitrary key-value pairs to support tagging of Reports
+  // for upstream use by UIs and other rich clients.
+  map<string, string> tags = 9 [(google.api.field_behavior) = IMMUTABLE];
+
   // Contain the grouping predicates.
   message Grouping {
     // The CEL expressions that are applied to the corresponding event message

--- a/src/main/proto/wfa/measurement/reporting/v2alpha/reporting_set.proto
+++ b/src/main/proto/wfa/measurement/reporting/v2alpha/reporting_set.proto
@@ -36,6 +36,10 @@ message ReportingSet {
   // Human-readable name for display purposes.
   string display_name = 2;
 
+  // A map of arbitrary key-value pairs to support tagging of ReportingSets
+  // for upstream use by UIs and other rich clients.
+  map<string, string> tags = 8 [(google.api.field_behavior) = IMMUTABLE];
+
   // CEL filter predicate that applies to this reporting set.
   // If unspecified, evaluates to `true`.
   string filter = 3 [(google.api.field_behavior) = IMMUTABLE];


### PR DESCRIPTION
Tags are a map of key-value pairs of strings intended to help UIs and other rich clients make connections between display artifacts and reporting artifacts without having to write code to interpret the structure of reports or reporting sets.