### PR TITLE
Refactor MeasurementStatistics

### DIFF
--- a/src/main/kotlin/org/wfanet/measurement/measurementconsumer/stats/Covariances.kt
+++ b/src/main/kotlin/org/wfanet/measurement/measurementconsumer/stats/Covariances.kt
@@ -25,17 +25,20 @@ object Covariances {
    * Precisely, computes the covariance between any two reach measurements when at least one reach
    * is computed using deterministic count distinct methodology.
    */
-  fun computeDeterministicCovariance(reachCovarianceParams: ReachCovarianceParams): Double {
+  fun computeDeterministicCovariance(
+    reachMeasurementCovarianceParams: ReachMeasurementCovarianceParams
+  ): Double {
     val overlapReach =
-      reachCovarianceParams.reach + reachCovarianceParams.otherReach -
-        reachCovarianceParams.unionReach
+      reachMeasurementCovarianceParams.reach + reachMeasurementCovarianceParams.otherReach -
+        reachMeasurementCovarianceParams.unionReach
     val overlapSamplingWidth =
-      reachCovarianceParams.samplingWidth + reachCovarianceParams.otherSamplingWidth -
-        reachCovarianceParams.unionSamplingWidth
+      reachMeasurementCovarianceParams.samplingWidth +
+        reachMeasurementCovarianceParams.otherSamplingWidth -
+        reachMeasurementCovarianceParams.unionSamplingWidth
     return overlapReach *
       (overlapSamplingWidth /
-        reachCovarianceParams.samplingWidth /
-        reachCovarianceParams.otherSamplingWidth - 1.0)
+        reachMeasurementCovarianceParams.samplingWidth /
+        reachMeasurementCovarianceParams.otherSamplingWidth - 1.0)
   }
 
   /**
@@ -47,20 +50,21 @@ object Covariances {
    */
   fun computeLiquidLegionsCovariance(
     sketchParams: LiquidLegionsSketchParams,
-    reachCovarianceParams: ReachCovarianceParams,
+    reachMeasurementCovarianceParams: ReachMeasurementCovarianceParams,
   ): Double {
     return LiquidLegions.inflatedReachCovariance(
       sketchParams = sketchParams,
-      reach = reachCovarianceParams.reach,
-      otherReach = reachCovarianceParams.otherReach,
+      reach = reachMeasurementCovarianceParams.reach,
+      otherReach = reachMeasurementCovarianceParams.otherReach,
       overlapReach =
-        reachCovarianceParams.reach + reachCovarianceParams.otherReach -
-          reachCovarianceParams.unionReach,
-      samplingWidth = reachCovarianceParams.samplingWidth,
-      otherSamplingWidth = reachCovarianceParams.otherSamplingWidth,
+        reachMeasurementCovarianceParams.reach + reachMeasurementCovarianceParams.otherReach -
+          reachMeasurementCovarianceParams.unionReach,
+      samplingWidth = reachMeasurementCovarianceParams.samplingWidth,
+      otherSamplingWidth = reachMeasurementCovarianceParams.otherSamplingWidth,
       overlapSamplingWidth =
-        reachCovarianceParams.samplingWidth + reachCovarianceParams.otherSamplingWidth -
-          reachCovarianceParams.unionSamplingWidth,
+        reachMeasurementCovarianceParams.samplingWidth +
+          reachMeasurementCovarianceParams.otherSamplingWidth -
+          reachMeasurementCovarianceParams.unionSamplingWidth,
       inflation = 0.0
     )
   }

--- a/src/main/kotlin/org/wfanet/measurement/measurementconsumer/stats/LiquidLegions.kt
+++ b/src/main/kotlin/org/wfanet/measurement/measurementconsumer/stats/LiquidLegions.kt
@@ -263,7 +263,7 @@ object LiquidLegions {
         sketchParams,
         collisionResolution,
         totalReach,
-        frequencyMeasurementParams.vidSamplingIntervalWidth
+        frequencyMeasurementParams.vidSamplingInterval.width
       )
     if (expectedRegisterNum < 1.0) {
       return 0.0
@@ -274,7 +274,7 @@ object LiquidLegions {
         sketchParams,
         collisionResolution,
         totalReach,
-        frequencyMeasurementParams.vidSamplingIntervalWidth
+        frequencyMeasurementParams.vidSamplingInterval.width
       )
     val registerNumVariancePerFrequency =
       varianceOfNumberOfNonDestroyedRegistersPerFrequency(
@@ -282,7 +282,7 @@ object LiquidLegions {
         collisionResolution,
         totalReach,
         reachRatio,
-        frequencyMeasurementParams.vidSamplingIntervalWidth
+        frequencyMeasurementParams.vidSamplingInterval.width
       )
 
     val covariance = (reachRatio * registerNumVariance + multiplier * frequencyNoiseVariance)

--- a/src/main/kotlin/org/wfanet/measurement/measurementconsumer/stats/MeasurementStatistics.kt
+++ b/src/main/kotlin/org/wfanet/measurement/measurementconsumer/stats/MeasurementStatistics.kt
@@ -25,16 +25,18 @@ enum class NoiseMechanism {
   GAUSSIAN,
 }
 
+data class VidSamplingInterval(val start: Double, val width: Double)
+
 /** The parameters used to compute a reach measurement. */
 data class ReachMeasurementParams(
-  val vidSamplingIntervalWidth: Double,
+  val vidSamplingInterval: VidSamplingInterval,
   val dpParams: DpParams,
   val noiseMechanism: NoiseMechanism
 )
 
 /** The parameters used to compute a reach-and-frequency measurement. */
 data class FrequencyMeasurementParams(
-  val vidSamplingIntervalWidth: Double,
+  val vidSamplingInterval: VidSamplingInterval,
   val dpParams: DpParams,
   val noiseMechanism: NoiseMechanism,
   val maximumFrequency: Int,
@@ -42,7 +44,7 @@ data class FrequencyMeasurementParams(
 
 /** The parameters used to compute an impression measurement. */
 data class ImpressionMeasurementParams(
-  val vidSamplingIntervalWidth: Double,
+  val vidSamplingInterval: VidSamplingInterval,
   val dpParams: DpParams,
   val maximumFrequencyPerUser: Int,
   val noiseMechanism: NoiseMechanism
@@ -50,38 +52,41 @@ data class ImpressionMeasurementParams(
 
 /** The parameters used to compute a watch duration measurement. */
 data class WatchDurationMeasurementParams(
-  val vidSamplingIntervalWidth: Double,
+  val vidSamplingInterval: VidSamplingInterval,
   val dpParams: DpParams,
   val maximumDurationPerUser: Double,
   val noiseMechanism: NoiseMechanism
 )
 
 /** The parameters used to compute the variance of a reach measurement. */
-data class ReachVarianceParams(val reach: Int, val measurementParams: ReachMeasurementParams)
+data class ReachMeasurementVarianceParams(
+  val reach: Int,
+  val measurementParams: ReachMeasurementParams
+)
 
 /** The parameters used to compute the variance of a reach-and-frequency measurement. */
-data class FrequencyVarianceParams(
+data class FrequencyMeasurementVarianceParams(
   val totalReach: Int,
-  val reachVariance: Double,
+  val reachMeasurementVariance: Double,
   val relativeFrequencyDistribution: Map<Int, Double>,
   val measurementParams: FrequencyMeasurementParams
 )
 
 /** The parameters used to compute the variance of an impression measurement. */
-data class ImpressionVarianceParams(
+data class ImpressionMeasurementVarianceParams(
   val impression: Int,
   val measurementParams: ImpressionMeasurementParams
 )
 
 /** The parameters used to compute the variance of a watch duration measurement. */
-data class WatchDurationVarianceParams(
+data class WatchDurationMeasurementVarianceParams(
   val duration: Double,
   val measurementParams: WatchDurationMeasurementParams
 )
 
 typealias FrequencyVariance = Map<Int, Double>
 
-/** A data class that wraps different types of variances of a reach-and-frequency measurement. */
+/** A data class that wraps different types of variances of a reach-and-frequency result. */
 data class FrequencyVariances(
   val relativeVariances: FrequencyVariance,
   val kPlusRelativeVariances: FrequencyVariance,
@@ -90,7 +95,7 @@ data class FrequencyVariances(
 )
 
 /** The parameters used to compute the covariance of two reach measurements. */
-data class ReachCovarianceParams(
+data class ReachMeasurementCovarianceParams(
   val reach: Int,
   val otherReach: Int,
   val unionReach: Int,

--- a/src/main/kotlin/org/wfanet/measurement/measurementconsumer/stats/Variances.kt
+++ b/src/main/kotlin/org/wfanet/measurement/measurementconsumer/stats/Variances.kt
@@ -31,10 +31,10 @@ object Variances {
    * Computes the variance of a reach measurement that is computed using the deterministic count
    * distinct methodology.
    */
-  fun computeDeterministicVariance(params: ReachVarianceParams): Double {
+  fun computeDeterministicVariance(params: ReachMeasurementVarianceParams): Double {
     return computeDeterministicScalarMeasurementVariance(
       params.reach.toDouble(),
-      params.measurementParams.vidSamplingIntervalWidth,
+      params.measurementParams.vidSamplingInterval.width,
       params.measurementParams.dpParams,
       1.0,
       params.measurementParams.noiseMechanism
@@ -45,10 +45,10 @@ object Variances {
    * Computes the variance of an impression measurement that is computed using the deterministic
    * count methodology.
    */
-  fun computeDeterministicVariance(params: ImpressionVarianceParams): Double {
+  fun computeDeterministicVariance(params: ImpressionMeasurementVarianceParams): Double {
     return computeDeterministicScalarMeasurementVariance(
       params.impression.toDouble(),
-      params.measurementParams.vidSamplingIntervalWidth,
+      params.measurementParams.vidSamplingInterval.width,
       params.measurementParams.dpParams,
       params.measurementParams.maximumFrequencyPerUser.toDouble(),
       params.measurementParams.noiseMechanism
@@ -59,10 +59,10 @@ object Variances {
    * Computes the variance of a watch duration measurement that is computed using the deterministic
    * sum methodology.
    */
-  fun computeDeterministicVariance(params: WatchDurationVarianceParams): Double {
+  fun computeDeterministicVariance(params: WatchDurationMeasurementVarianceParams): Double {
     return computeDeterministicScalarMeasurementVariance(
       params.duration,
-      params.measurementParams.vidSamplingIntervalWidth,
+      params.measurementParams.vidSamplingInterval.width,
       params.measurementParams.dpParams,
       params.measurementParams.maximumDurationPerUser,
       params.measurementParams.noiseMechanism
@@ -75,7 +75,7 @@ object Variances {
    *
    * Note that the reach measurement can be computed using any methodology.
    */
-  fun computeDeterministicVariance(params: FrequencyVarianceParams): FrequencyVariances {
+  fun computeDeterministicVariance(params: FrequencyMeasurementVarianceParams): FrequencyVariances {
     return frequencyVariance(
       params,
       ::deterministicFrequencyRelativeVariance,
@@ -98,12 +98,12 @@ object Variances {
     val frequencyNoiseVariance: Double =
       computeNoiseVariance(measurementParams.dpParams, measurementParams.noiseMechanism)
     val varPart1 =
-      reachRatio * (1.0 - reachRatio) * (1.0 - measurementParams.vidSamplingIntervalWidth) /
-        (totalReach * measurementParams.vidSamplingIntervalWidth)
+      reachRatio * (1.0 - reachRatio) * (1.0 - measurementParams.vidSamplingInterval.width) /
+        (totalReach * measurementParams.vidSamplingInterval.width)
     var varPart2 = (1.0 - 2.0 * reachRatio) * multiplier
     varPart2 += reachRatio.pow(2) * measurementParams.maximumFrequency
     varPart2 *=
-      frequencyNoiseVariance / (totalReach * measurementParams.vidSamplingIntervalWidth).pow(2)
+      frequencyNoiseVariance / (totalReach * measurementParams.vidSamplingInterval.width).pow(2)
     return max(0.0, varPart1 + varPart2)
   }
 
@@ -156,7 +156,7 @@ object Variances {
    */
   fun computeLiquidLegionsSketchVariance(
     sketchParams: LiquidLegionsSketchParams,
-    varianceParams: ReachVarianceParams,
+    varianceParams: ReachMeasurementVarianceParams,
   ): Double {
     val noiseVariance: Double =
       computeNoiseVariance(
@@ -170,9 +170,9 @@ object Variances {
         reach = varianceParams.reach,
         otherReach = varianceParams.reach,
         overlapReach = varianceParams.reach,
-        samplingWidth = varianceParams.measurementParams.vidSamplingIntervalWidth,
-        otherSamplingWidth = varianceParams.measurementParams.vidSamplingIntervalWidth,
-        overlapSamplingWidth = varianceParams.measurementParams.vidSamplingIntervalWidth,
+        samplingWidth = varianceParams.measurementParams.vidSamplingInterval.width,
+        otherSamplingWidth = varianceParams.measurementParams.vidSamplingInterval.width,
+        overlapSamplingWidth = varianceParams.measurementParams.vidSamplingInterval.width,
         inflation = noiseVariance
       )
 
@@ -187,7 +187,7 @@ object Variances {
    */
   fun computeLiquidLegionsSketchVariance(
     sketchParams: LiquidLegionsSketchParams,
-    params: FrequencyVarianceParams
+    params: FrequencyMeasurementVarianceParams
   ): FrequencyVariances {
     return frequencyVariance(
       params,
@@ -227,7 +227,7 @@ object Variances {
   /** Computes the variance of a reach measurement which is computed using Liquid Legions V2. */
   fun computeLiquidLegionsV2Variance(
     sketchParams: LiquidLegionsSketchParams,
-    varianceParams: ReachVarianceParams,
+    varianceParams: ReachMeasurementVarianceParams,
   ): Double {
     val distributedGaussianNoiseVariance: Double =
       computeDistributedNoiseVariance(
@@ -241,9 +241,9 @@ object Variances {
         reach = varianceParams.reach,
         otherReach = varianceParams.reach,
         overlapReach = varianceParams.reach,
-        samplingWidth = varianceParams.measurementParams.vidSamplingIntervalWidth,
-        otherSamplingWidth = varianceParams.measurementParams.vidSamplingIntervalWidth,
-        overlapSamplingWidth = varianceParams.measurementParams.vidSamplingIntervalWidth,
+        samplingWidth = varianceParams.measurementParams.vidSamplingInterval.width,
+        otherSamplingWidth = varianceParams.measurementParams.vidSamplingInterval.width,
+        overlapSamplingWidth = varianceParams.measurementParams.vidSamplingInterval.width,
         inflation = distributedGaussianNoiseVariance
       )
 
@@ -256,7 +256,7 @@ object Variances {
    */
   fun computeLiquidLegionsV2Variance(
     sketchParams: LiquidLegionsSketchParams,
-    params: FrequencyVarianceParams
+    params: FrequencyMeasurementVarianceParams
   ): FrequencyVariances {
     return frequencyVariance(
       params,
@@ -334,7 +334,7 @@ object Variances {
 
   /** Common function that computes [FrequencyVariances]. */
   private fun frequencyVariance(
-    params: FrequencyVarianceParams,
+    params: FrequencyMeasurementVarianceParams,
     frequencyRelativeVarianceFun:
       (
         totalReach: Int,
@@ -353,7 +353,7 @@ object Variances {
     if (params.totalReach < 0.0) {
       throw IllegalArgumentException("The total reach value cannot be negative.")
     }
-    if (params.reachVariance < 0.0) {
+    if (params.reachMeasurementVariance < 0.0) {
       throw IllegalArgumentException("The reach variance value cannot be negative.")
     }
 
@@ -391,7 +391,7 @@ object Variances {
       (1..maximumFrequency).associateWith { frequency ->
         frequencyCountVarianceFun(
           params.totalReach,
-          params.reachVariance,
+          params.reachMeasurementVariance,
           params.relativeFrequencyDistribution.getOrDefault(frequency, 0.0),
           relativeVariances.getValue(frequency)
         )
@@ -401,7 +401,7 @@ object Variances {
       (1..maximumFrequency).associateWith { frequency ->
         frequencyCountVarianceFun(
           params.totalReach,
-          params.reachVariance,
+          params.reachMeasurementVariance,
           kPlusRelativeFrequencyDistribution.getValue(frequency),
           kPlusRelativeVariances.getValue(frequency)
         )

--- a/src/test/kotlin/org/wfanet/measurement/measurementconsumer/stats/CovariancesTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/measurementconsumer/stats/CovariancesTest.kt
@@ -26,8 +26,9 @@ import org.junit.runners.JUnit4
 class CovariancesTest {
   @Test
   fun `computeDeterministicCovariance returns a value for reach when small reaches overlap and small sampling widths overlap `() {
-    val reachCovarianceParams = ReachCovarianceParams(1, 2, 2, 2e-4, 3e-4, 4e-4)
-    val covariance = Covariances.computeDeterministicCovariance(reachCovarianceParams)
+    val reachMeasurementCovarianceParams =
+      ReachMeasurementCovarianceParams(1, 2, 2, 2e-4, 3e-4, 4e-4)
+    val covariance = Covariances.computeDeterministicCovariance(reachMeasurementCovarianceParams)
     val expect = 1665.6666666666665
     val percentageError = percentageError(covariance, expect)
     assertThat(percentageError).isLessThan(ERROR_TOLERANCE)
@@ -35,8 +36,8 @@ class CovariancesTest {
 
   @Test
   fun `computeDeterministicCovariance returns a value for reach when small reaches not overlap and large sampling widths not overlap `() {
-    val reachCovarianceParams = ReachCovarianceParams(1, 2, 3, 0.5, 0.5, 1.0)
-    val covariance = Covariances.computeDeterministicCovariance(reachCovarianceParams)
+    val reachMeasurementCovarianceParams = ReachMeasurementCovarianceParams(1, 2, 3, 0.5, 0.5, 1.0)
+    val covariance = Covariances.computeDeterministicCovariance(reachMeasurementCovarianceParams)
     val expect = 0.0
     val percentageError = percentageError(covariance, expect)
     assertThat(percentageError).isLessThan(ERROR_TOLERANCE)
@@ -44,9 +45,9 @@ class CovariancesTest {
 
   @Test
   fun `computeDeterministicCovariance returns a value for reach when large reaches overlap and small sampling widths not overlap`() {
-    val reachCovarianceParams =
-      ReachCovarianceParams(3e8.toInt(), 3e8.toInt(), 4e8.toInt(), 1e-4, 1e-4, 2e-4)
-    val covariance = Covariances.computeDeterministicCovariance(reachCovarianceParams)
+    val reachMeasurementCovarianceParams =
+      ReachMeasurementCovarianceParams(3e8.toInt(), 3e8.toInt(), 4e8.toInt(), 1e-4, 1e-4, 2e-4)
+    val covariance = Covariances.computeDeterministicCovariance(reachMeasurementCovarianceParams)
 
     val expect = -2e+8
     val percentageError = percentageError(covariance, expect)
@@ -55,8 +56,9 @@ class CovariancesTest {
 
   @Test
   fun `computeDeterministicCovariance returns a value for reach when one reach is small`() {
-    val reachCovarianceParams = ReachCovarianceParams(1, 3e6.toInt(), 3e6.toInt(), 0.5, 0.4, 0.7)
-    val covariance = Covariances.computeDeterministicCovariance(reachCovarianceParams)
+    val reachMeasurementCovarianceParams =
+      ReachMeasurementCovarianceParams(1, 3e6.toInt(), 3e6.toInt(), 0.5, 0.4, 0.7)
+    val covariance = Covariances.computeDeterministicCovariance(reachMeasurementCovarianceParams)
     val expect = 2.220446049250313e-16
     val percentageError = percentageError(covariance, expect)
     assertThat(percentageError).isLessThan(ERROR_TOLERANCE)
@@ -64,8 +66,8 @@ class CovariancesTest {
 
   @Test
   fun `computeDeterministicCovariance returns a value for reach when large reaches not overlap and large sampling widths overlap`() {
-    val reachCovarianceParams =
-      ReachCovarianceParams(
+    val reachMeasurementCovarianceParams =
+      ReachMeasurementCovarianceParams(
         3e8.toInt(),
         3e8.toInt(),
         6e8.toInt(),
@@ -73,7 +75,7 @@ class CovariancesTest {
         0.7,
         0.7,
       )
-    val covariance = Covariances.computeDeterministicCovariance(reachCovarianceParams)
+    val covariance = Covariances.computeDeterministicCovariance(reachMeasurementCovarianceParams)
     val expect = 0.0
     assertThat(covariance).isEqualTo(expect)
   }
@@ -83,8 +85,10 @@ class CovariancesTest {
     val decayRate = 1e-3
     val sketchSize = 1e5
     val sketchParams = LiquidLegionsSketchParams(decayRate, sketchSize)
-    val reachCovarianceParams = ReachCovarianceParams(5, 5, 5, 0.01, 0.01, 0.02)
-    val covariance = Covariances.computeLiquidLegionsCovariance(sketchParams, reachCovarianceParams)
+    val reachMeasurementCovarianceParams =
+      ReachMeasurementCovarianceParams(5, 5, 5, 0.01, 0.01, 0.02)
+    val covariance =
+      Covariances.computeLiquidLegionsCovariance(sketchParams, reachMeasurementCovarianceParams)
 
     val expect = -4.849999813860015
     val percentageError = percentageError(covariance, expect)
@@ -96,8 +100,9 @@ class CovariancesTest {
     val decayRate = 15.0
     val sketchSize = 1e5
     val sketchParams = LiquidLegionsSketchParams(decayRate, sketchSize)
-    val reachCovarianceParams = ReachCovarianceParams(1, 1, 2, 0.5, 0.4, 0.5)
-    val covariance = Covariances.computeLiquidLegionsCovariance(sketchParams, reachCovarianceParams)
+    val reachMeasurementCovarianceParams = ReachMeasurementCovarianceParams(1, 1, 2, 0.5, 0.4, 0.5)
+    val covariance =
+      Covariances.computeLiquidLegionsCovariance(sketchParams, reachMeasurementCovarianceParams)
 
     val expect = 0.000562525536043962
     val percentageError = percentageError(covariance, expect)
@@ -109,9 +114,10 @@ class CovariancesTest {
     val decayRate = 15.0
     val sketchSize = 1e5
     val sketchParams = LiquidLegionsSketchParams(decayRate, sketchSize)
-    val reachCovarianceParams =
-      ReachCovarianceParams(1e6.toInt(), 3e8.toInt(), 3e8.toInt(), 0.02, 0.01, 0.02)
-    val covariance = Covariances.computeLiquidLegionsCovariance(sketchParams, reachCovarianceParams)
+    val reachMeasurementCovarianceParams =
+      ReachMeasurementCovarianceParams(1e6.toInt(), 3e8.toInt(), 3e8.toInt(), 0.02, 0.01, 0.02)
+    val covariance =
+      Covariances.computeLiquidLegionsCovariance(sketchParams, reachMeasurementCovarianceParams)
 
     val expect = 156079036.5929788
     val percentageError = percentageError(covariance, expect)
@@ -123,9 +129,10 @@ class CovariancesTest {
     val decayRate = 100.0
     val sketchSize = 1e5
     val sketchParams = LiquidLegionsSketchParams(decayRate, sketchSize)
-    val reachCovarianceParams =
-      ReachCovarianceParams(3e8.toInt(), 3e8.toInt(), 6e8.toInt(), 0.3, 0.4, 0.7)
-    val covariance = Covariances.computeLiquidLegionsCovariance(sketchParams, reachCovarianceParams)
+    val reachMeasurementCovarianceParams =
+      ReachMeasurementCovarianceParams(3e8.toInt(), 3e8.toInt(), 6e8.toInt(), 0.3, 0.4, 0.7)
+    val covariance =
+      Covariances.computeLiquidLegionsCovariance(sketchParams, reachMeasurementCovarianceParams)
 
     val expect = 428562.31521871715
     val percentageError = percentageError(covariance, expect)
@@ -137,8 +144,10 @@ class CovariancesTest {
     val decayRate = 1.0
     val sketchSize = 1e5
     val sketchParams = LiquidLegionsSketchParams(decayRate, sketchSize)
-    val reachCovarianceParams = ReachCovarianceParams(1, 3e6.toInt(), 3e6.toInt(), 0.5, 0.4, 0.7)
-    val covariance = Covariances.computeLiquidLegionsCovariance(sketchParams, reachCovarianceParams)
+    val reachMeasurementCovarianceParams =
+      ReachMeasurementCovarianceParams(1, 3e6.toInt(), 3e6.toInt(), 0.5, 0.4, 0.7)
+    val covariance =
+      Covariances.computeLiquidLegionsCovariance(sketchParams, reachMeasurementCovarianceParams)
 
     val expect = 0.0002056053253447586
     val percentageError = percentageError(covariance, expect)
@@ -150,9 +159,10 @@ class CovariancesTest {
     val decayRate = 100.0
     val sketchSize = 1e5
     val sketchParams = LiquidLegionsSketchParams(decayRate, sketchSize)
-    val reachCovarianceParams =
-      ReachCovarianceParams(3e8.toInt(), 3e8.toInt(), 6e8.toInt(), 0.7, 0.7, 0.7)
-    val covariance = Covariances.computeLiquidLegionsCovariance(sketchParams, reachCovarianceParams)
+    val reachMeasurementCovarianceParams =
+      ReachMeasurementCovarianceParams(3e8.toInt(), 3e8.toInt(), 6e8.toInt(), 0.7, 0.7, 0.7)
+    val covariance =
+      Covariances.computeLiquidLegionsCovariance(sketchParams, reachMeasurementCovarianceParams)
 
     val expect = 214283.93565983986
     val percentageError = percentageError(covariance, expect)

--- a/src/test/kotlin/org/wfanet/measurement/measurementconsumer/stats/VariancesTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/measurementconsumer/stats/VariancesTest.kt
@@ -32,10 +32,15 @@ class VariancesTest {
     val vidSamplingIntervalWidth = 1.0
     val dpParams = DpParams(1.0, 1.0)
     val reachMeasurementParams =
-      ReachMeasurementParams(vidSamplingIntervalWidth, dpParams, NoiseMechanism.GAUSSIAN)
-    val reachVarianceParams = ReachVarianceParams(reach, reachMeasurementParams)
+      ReachMeasurementParams(
+        VidSamplingInterval(0.0, vidSamplingIntervalWidth),
+        dpParams,
+        NoiseMechanism.GAUSSIAN
+      )
+    val reachMeasurementVarianceParams =
+      ReachMeasurementVarianceParams(reach, reachMeasurementParams)
 
-    val variance = Variances.computeDeterministicVariance(reachVarianceParams)
+    val variance = Variances.computeDeterministicVariance(reachMeasurementVarianceParams)
     val expect = 2.5e-7
     val percentageError = percentageError(variance, expect)
     assertThat(percentageError).isLessThan(ERROR_TOLERANCE)
@@ -47,10 +52,15 @@ class VariancesTest {
     val vidSamplingIntervalWidth = 1e-4
     val dpParams = DpParams(1e-3, 1e-9)
     val reachMeasurementParams =
-      ReachMeasurementParams(vidSamplingIntervalWidth, dpParams, NoiseMechanism.GAUSSIAN)
-    val reachVarianceParams = ReachVarianceParams(reach, reachMeasurementParams)
+      ReachMeasurementParams(
+        VidSamplingInterval(0.0, vidSamplingIntervalWidth),
+        dpParams,
+        NoiseMechanism.GAUSSIAN
+      )
+    val reachMeasurementVarianceParams =
+      ReachMeasurementVarianceParams(reach, reachMeasurementParams)
 
-    val variance = Variances.computeDeterministicVariance(reachVarianceParams)
+    val variance = Variances.computeDeterministicVariance(reachMeasurementVarianceParams)
     val expect = 1701291910758399.5
     val percentageError = percentageError(variance, expect)
     assertThat(percentageError).isLessThan(ERROR_TOLERANCE)
@@ -62,10 +72,15 @@ class VariancesTest {
     val vidSamplingIntervalWidth = 0.9
     val dpParams = DpParams(1e-2, 1e-15)
     val reachMeasurementParams =
-      ReachMeasurementParams(vidSamplingIntervalWidth, dpParams, NoiseMechanism.GAUSSIAN)
-    val reachVarianceParams = ReachVarianceParams(reach, reachMeasurementParams)
+      ReachMeasurementParams(
+        VidSamplingInterval(0.0, vidSamplingIntervalWidth),
+        dpParams,
+        NoiseMechanism.GAUSSIAN
+      )
+    val reachMeasurementVarianceParams =
+      ReachMeasurementVarianceParams(reach, reachMeasurementParams)
 
-    val variance = Variances.computeDeterministicVariance(reachVarianceParams)
+    val variance = Variances.computeDeterministicVariance(reachMeasurementVarianceParams)
     val expect = 33906671.712079
     val percentageError = percentageError(variance, expect)
     assertThat(percentageError).isLessThan(ERROR_TOLERANCE)
@@ -77,10 +92,15 @@ class VariancesTest {
     val vidSamplingIntervalWidth = 1e-4
     val dpParams = DpParams(1e-2, 1e-15)
     val reachMeasurementParams =
-      ReachMeasurementParams(vidSamplingIntervalWidth, dpParams, NoiseMechanism.GAUSSIAN)
-    val reachVarianceParams = ReachVarianceParams(reach, reachMeasurementParams)
+      ReachMeasurementParams(
+        VidSamplingInterval(0.0, vidSamplingIntervalWidth),
+        dpParams,
+        NoiseMechanism.GAUSSIAN
+      )
+    val reachMeasurementVarianceParams =
+      ReachMeasurementVarianceParams(reach, reachMeasurementParams)
 
-    val variance = Variances.computeDeterministicVariance(reachVarianceParams)
+    val variance = Variances.computeDeterministicVariance(reachMeasurementVarianceParams)
     val expect = 49440108678400.01
     val percentageError = percentageError(variance, expect)
     assertThat(percentageError).isLessThan(ERROR_TOLERANCE)
@@ -92,11 +112,16 @@ class VariancesTest {
     val vidSamplingIntervalWidth = 1.0
     val dpParams = DpParams(1.0, 1.0)
     val reachMeasurementParams =
-      ReachMeasurementParams(vidSamplingIntervalWidth, dpParams, NoiseMechanism.GAUSSIAN)
-    val reachVarianceParams = ReachVarianceParams(reach, reachMeasurementParams)
+      ReachMeasurementParams(
+        VidSamplingInterval(0.0, vidSamplingIntervalWidth),
+        dpParams,
+        NoiseMechanism.GAUSSIAN
+      )
+    val reachMeasurementVarianceParams =
+      ReachMeasurementVarianceParams(reach, reachMeasurementParams)
 
     assertThrows(IllegalArgumentException::class.java) {
-      Variances.computeDeterministicVariance(reachVarianceParams)
+      Variances.computeDeterministicVariance(reachMeasurementVarianceParams)
     }
   }
 
@@ -108,15 +133,15 @@ class VariancesTest {
     val maximumFrequencyPerUser = 1
     val impressionMeasurementParams =
       ImpressionMeasurementParams(
-        vidSamplingIntervalWidth,
+        VidSamplingInterval(0.0, vidSamplingIntervalWidth),
         dpParams,
         maximumFrequencyPerUser,
         NoiseMechanism.GAUSSIAN
       )
-    val impressionVariancesParams =
-      ImpressionVarianceParams(impressions, impressionMeasurementParams)
+    val impressionMeasurementVariancesParams =
+      ImpressionMeasurementVarianceParams(impressions, impressionMeasurementParams)
 
-    val variance = Variances.computeDeterministicVariance(impressionVariancesParams)
+    val variance = Variances.computeDeterministicVariance(impressionMeasurementVariancesParams)
     val expect = 2.5e-7
     val percentageError = percentageError(variance, expect)
     assertThat(percentageError).isLessThan(ERROR_TOLERANCE)
@@ -130,15 +155,15 @@ class VariancesTest {
     val maximumFrequencyPerUser = 1
     val impressionMeasurementParams =
       ImpressionMeasurementParams(
-        vidSamplingIntervalWidth,
+        VidSamplingInterval(0.0, vidSamplingIntervalWidth),
         dpParams,
         maximumFrequencyPerUser,
         NoiseMechanism.GAUSSIAN
       )
-    val impressionVariancesParams =
-      ImpressionVarianceParams(impressions, impressionMeasurementParams)
+    val impressionMeasurementVariancesParams =
+      ImpressionMeasurementVarianceParams(impressions, impressionMeasurementParams)
 
-    val variance = Variances.computeDeterministicVariance(impressionVariancesParams)
+    val variance = Variances.computeDeterministicVariance(impressionMeasurementVariancesParams)
     val expect = 2102185919.1600006
     val percentageError = percentageError(variance, expect)
     assertThat(percentageError).isLessThan(ERROR_TOLERANCE)
@@ -152,15 +177,15 @@ class VariancesTest {
     val maximumFrequencyPerUser = 1
     val impressionMeasurementParams =
       ImpressionMeasurementParams(
-        vidSamplingIntervalWidth,
+        VidSamplingInterval(0.0, vidSamplingIntervalWidth),
         dpParams,
         maximumFrequencyPerUser,
         NoiseMechanism.GAUSSIAN
       )
-    val impressionVariancesParams =
-      ImpressionVarianceParams(impressions, impressionMeasurementParams)
+    val impressionMeasurementVariancesParams =
+      ImpressionMeasurementVarianceParams(impressions, impressionMeasurementParams)
 
-    val variance = Variances.computeDeterministicVariance(impressionVariancesParams)
+    val variance = Variances.computeDeterministicVariance(impressionMeasurementVariancesParams)
     val expect = 210218.58201600003
     val percentageError = percentageError(variance, expect)
     assertThat(percentageError).isLessThan(ERROR_TOLERANCE)
@@ -174,15 +199,15 @@ class VariancesTest {
     val maximumFrequencyPerUser = 200
     val impressionMeasurementParams =
       ImpressionMeasurementParams(
-        vidSamplingIntervalWidth,
+        VidSamplingInterval(0.0, vidSamplingIntervalWidth),
         dpParams,
         maximumFrequencyPerUser,
         NoiseMechanism.GAUSSIAN
       )
-    val impressionVariancesParams =
-      ImpressionVarianceParams(impressions, impressionMeasurementParams)
+    val impressionMeasurementVariancesParams =
+      ImpressionMeasurementVarianceParams(impressions, impressionMeasurementParams)
 
-    val variance = Variances.computeDeterministicVariance(impressionVariancesParams)
+    val variance = Variances.computeDeterministicVariance(impressionMeasurementVariancesParams)
     val expect = 90027432806400.0
     val percentageError = percentageError(variance, expect)
     assertThat(percentageError).isLessThan(ERROR_TOLERANCE)
@@ -196,15 +221,15 @@ class VariancesTest {
     val maximumFrequencyPerUser = 200
     val impressionMeasurementParams =
       ImpressionMeasurementParams(
-        vidSamplingIntervalWidth,
+        VidSamplingInterval(0.0, vidSamplingIntervalWidth),
         dpParams,
         maximumFrequencyPerUser,
         NoiseMechanism.GAUSSIAN
       )
-    val impressionVariancesParams =
-      ImpressionVarianceParams(impressions, impressionMeasurementParams)
+    val impressionMeasurementVariancesParams =
+      ImpressionMeasurementVarianceParams(impressions, impressionMeasurementParams)
 
-    val variance = Variances.computeDeterministicVariance(impressionVariancesParams)
+    val variance = Variances.computeDeterministicVariance(impressionMeasurementVariancesParams)
     val expect = 8408743280.640002
     val percentageError = percentageError(variance, expect)
     assertThat(percentageError).isLessThan(ERROR_TOLERANCE)
@@ -216,12 +241,17 @@ class VariancesTest {
     val vidSamplingIntervalWidth = 1.0
     val dpParams = DpParams(1.0, 1.0)
     val impressionMeasurementParams =
-      ImpressionMeasurementParams(vidSamplingIntervalWidth, dpParams, 1, NoiseMechanism.GAUSSIAN)
-    val impressionVariancesParams =
-      ImpressionVarianceParams(impressions, impressionMeasurementParams)
+      ImpressionMeasurementParams(
+        VidSamplingInterval(0.0, vidSamplingIntervalWidth),
+        dpParams,
+        1,
+        NoiseMechanism.GAUSSIAN
+      )
+    val impressionMeasurementVariancesParams =
+      ImpressionMeasurementVarianceParams(impressions, impressionMeasurementParams)
 
     assertThrows(IllegalArgumentException::class.java) {
-      Variances.computeDeterministicVariance(impressionVariancesParams)
+      Variances.computeDeterministicVariance(impressionMeasurementVariancesParams)
     }
   }
 
@@ -233,15 +263,15 @@ class VariancesTest {
     val maximumDurationPerUser = 1.0
     val watchDurationMeasurementParams =
       WatchDurationMeasurementParams(
-        vidSamplingIntervalWidth,
+        VidSamplingInterval(0.0, vidSamplingIntervalWidth),
         dpParams,
         maximumDurationPerUser,
         NoiseMechanism.GAUSSIAN
       )
-    val watchDurationVarianceParams =
-      WatchDurationVarianceParams(watchDuration, watchDurationMeasurementParams)
+    val watchDurationMeasurementVarianceParams =
+      WatchDurationMeasurementVarianceParams(watchDuration, watchDurationMeasurementParams)
 
-    val variance = Variances.computeDeterministicVariance(watchDurationVarianceParams)
+    val variance = Variances.computeDeterministicVariance(watchDurationMeasurementVarianceParams)
     val expect = 2.5e-7
     val percentageError = percentageError(variance, expect)
     assertThat(percentageError).isLessThan(ERROR_TOLERANCE)
@@ -255,15 +285,15 @@ class VariancesTest {
     val maximumDurationPerUser = 1.0
     val watchDurationMeasurementParams =
       WatchDurationMeasurementParams(
-        vidSamplingIntervalWidth,
+        VidSamplingInterval(0.0, vidSamplingIntervalWidth),
         dpParams,
         maximumDurationPerUser,
         NoiseMechanism.GAUSSIAN
       )
-    val watchDurationVarianceParams =
-      WatchDurationVarianceParams(watchDuration, watchDurationMeasurementParams)
+    val watchDurationMeasurementVarianceParams =
+      WatchDurationMeasurementVarianceParams(watchDuration, watchDurationMeasurementParams)
 
-    val variance = Variances.computeDeterministicVariance(watchDurationVarianceParams)
+    val variance = Variances.computeDeterministicVariance(watchDurationMeasurementVarianceParams)
     val expect = 2102185919.1600006
     val percentageError = percentageError(variance, expect)
     assertThat(percentageError).isLessThan(ERROR_TOLERANCE)
@@ -277,15 +307,15 @@ class VariancesTest {
     val maximumDurationPerUser = 1.0
     val watchDurationMeasurementParams =
       WatchDurationMeasurementParams(
-        vidSamplingIntervalWidth,
+        VidSamplingInterval(0.0, vidSamplingIntervalWidth),
         dpParams,
         maximumDurationPerUser,
         NoiseMechanism.GAUSSIAN
       )
-    val watchDurationVarianceParams =
-      WatchDurationVarianceParams(watchDuration, watchDurationMeasurementParams)
+    val watchDurationMeasurementVarianceParams =
+      WatchDurationMeasurementVarianceParams(watchDuration, watchDurationMeasurementParams)
 
-    val variance = Variances.computeDeterministicVariance(watchDurationVarianceParams)
+    val variance = Variances.computeDeterministicVariance(watchDurationMeasurementVarianceParams)
     val expect = 210218.58201600003
     val percentageError = percentageError(variance, expect)
     assertThat(percentageError).isLessThan(ERROR_TOLERANCE)
@@ -299,15 +329,15 @@ class VariancesTest {
     val maximumDurationPerUser = 200.0
     val watchDurationMeasurementParams =
       WatchDurationMeasurementParams(
-        vidSamplingIntervalWidth,
+        VidSamplingInterval(0.0, vidSamplingIntervalWidth),
         dpParams,
         maximumDurationPerUser,
         NoiseMechanism.GAUSSIAN
       )
-    val watchDurationVarianceParams =
-      WatchDurationVarianceParams(watchDuration, watchDurationMeasurementParams)
+    val watchDurationMeasurementVarianceParams =
+      WatchDurationMeasurementVarianceParams(watchDuration, watchDurationMeasurementParams)
 
-    val variance = Variances.computeDeterministicVariance(watchDurationVarianceParams)
+    val variance = Variances.computeDeterministicVariance(watchDurationMeasurementVarianceParams)
     val expect = 90027432806400.0
     val percentageError = percentageError(variance, expect)
     assertThat(percentageError).isLessThan(ERROR_TOLERANCE)
@@ -321,15 +351,15 @@ class VariancesTest {
     val maximumDurationPerUser = 200.0
     val watchDurationMeasurementParams =
       WatchDurationMeasurementParams(
-        vidSamplingIntervalWidth,
+        VidSamplingInterval(0.0, vidSamplingIntervalWidth),
         dpParams,
         maximumDurationPerUser,
         NoiseMechanism.GAUSSIAN
       )
-    val watchDurationVarianceParams =
-      WatchDurationVarianceParams(watchDuration, watchDurationMeasurementParams)
+    val watchDurationMeasurementVarianceParams =
+      WatchDurationMeasurementVarianceParams(watchDuration, watchDurationMeasurementParams)
 
-    val variance = Variances.computeDeterministicVariance(watchDurationVarianceParams)
+    val variance = Variances.computeDeterministicVariance(watchDurationMeasurementVarianceParams)
     val expect = 8408743280.640002
     val percentageError = percentageError(variance, expect)
     assertThat(percentageError).isLessThan(ERROR_TOLERANCE)
@@ -342,16 +372,16 @@ class VariancesTest {
     val dpParams = DpParams(1.0, 1.0)
     val watchDurationMeasurementParams =
       WatchDurationMeasurementParams(
-        vidSamplingIntervalWidth,
+        VidSamplingInterval(0.0, vidSamplingIntervalWidth),
         dpParams,
         1.0,
         NoiseMechanism.GAUSSIAN
       )
-    val watchDurationVarianceParams =
-      WatchDurationVarianceParams(watchDuration, watchDurationMeasurementParams)
+    val watchDurationMeasurementVarianceParams =
+      WatchDurationMeasurementVarianceParams(watchDuration, watchDurationMeasurementParams)
 
     assertThrows(IllegalArgumentException::class.java) {
-      Variances.computeDeterministicVariance(watchDurationVarianceParams)
+      Variances.computeDeterministicVariance(watchDurationMeasurementVarianceParams)
     }
   }
 
@@ -361,9 +391,15 @@ class VariancesTest {
     val totalReach = 1
     val reachDpParams = DpParams(0.05, 1e-15)
     val reachMeasurementParams =
-      ReachMeasurementParams(vidSamplingIntervalWidth, reachDpParams, NoiseMechanism.GAUSSIAN)
-    val reachVarianceParams = ReachVarianceParams(totalReach, reachMeasurementParams)
-    val reachVariance = Variances.computeDeterministicVariance(reachVarianceParams)
+      ReachMeasurementParams(
+        VidSamplingInterval(0.0, vidSamplingIntervalWidth),
+        reachDpParams,
+        NoiseMechanism.GAUSSIAN
+      )
+    val reachMeasurementVarianceParams =
+      ReachMeasurementVarianceParams(totalReach, reachMeasurementParams)
+    val reachMeasurementVariance =
+      Variances.computeDeterministicVariance(reachMeasurementVarianceParams)
 
     val maximumFrequency = 5
     val relativeFrequencyDistribution =
@@ -371,21 +407,21 @@ class VariancesTest {
     val frequencyDpParams = DpParams(0.2, 1e-15)
     val frequencyMeasurementParams =
       FrequencyMeasurementParams(
-        vidSamplingIntervalWidth,
+        VidSamplingInterval(0.0, vidSamplingIntervalWidth),
         frequencyDpParams,
         NoiseMechanism.GAUSSIAN,
         maximumFrequency,
       )
-    val frequencyVarianceParams =
-      FrequencyVarianceParams(
+    val frequencyMeasurementVarianceParams =
+      FrequencyMeasurementVarianceParams(
         totalReach,
-        reachVariance,
+        reachMeasurementVariance,
         relativeFrequencyDistribution,
         frequencyMeasurementParams
       )
 
     val (rKVars, rKPlusVars, nKVars, nKPlusVars) =
-      Variances.computeDeterministicVariance(frequencyVarianceParams)
+      Variances.computeDeterministicVariance(frequencyMeasurementVarianceParams)
 
     val expectedRK =
       listOf(130523240799.76, 110944754739.79, 104418592319.84, 110944753539.91, 130523238400.0)
@@ -432,9 +468,15 @@ class VariancesTest {
     val totalReach = 10
     val reachDpParams = DpParams(0.05, 1e-15)
     val reachMeasurementParams =
-      ReachMeasurementParams(vidSamplingIntervalWidth, reachDpParams, NoiseMechanism.GAUSSIAN)
-    val reachVarianceParams = ReachVarianceParams(totalReach, reachMeasurementParams)
-    val reachVariance = Variances.computeDeterministicVariance(reachVarianceParams)
+      ReachMeasurementParams(
+        VidSamplingInterval(0.0, vidSamplingIntervalWidth),
+        reachDpParams,
+        NoiseMechanism.GAUSSIAN
+      )
+    val reachMeasurementVarianceParams =
+      ReachMeasurementVarianceParams(totalReach, reachMeasurementParams)
+    val reachMeasurementVariance =
+      Variances.computeDeterministicVariance(reachMeasurementVarianceParams)
 
     val maximumFrequency = 5
     val relativeFrequencyDistribution =
@@ -442,21 +484,21 @@ class VariancesTest {
     val frequencyDpParams = DpParams(0.2, 1e-15)
     val frequencyMeasurementParams =
       FrequencyMeasurementParams(
-        vidSamplingIntervalWidth,
+        VidSamplingInterval(0.0, vidSamplingIntervalWidth),
         frequencyDpParams,
         NoiseMechanism.GAUSSIAN,
         maximumFrequency,
       )
-    val frequencyVarianceParams =
-      FrequencyVarianceParams(
+    val frequencyMeasurementVarianceParams =
+      FrequencyMeasurementVarianceParams(
         totalReach,
-        reachVariance,
+        reachMeasurementVariance,
         relativeFrequencyDistribution,
         frequencyMeasurementParams
       )
 
     val (rKVars, rKPlusVars, nKVars, nKPlusVars) =
-      Variances.computeDeterministicVariance(frequencyVarianceParams)
+      Variances.computeDeterministicVariance(frequencyMeasurementVarianceParams)
 
     val expectedRK =
       listOf(
@@ -509,9 +551,15 @@ class VariancesTest {
     val totalReach = 3e8.toInt()
     val reachDpParams = DpParams(0.05, 1e-15)
     val reachMeasurementParams =
-      ReachMeasurementParams(vidSamplingIntervalWidth, reachDpParams, NoiseMechanism.GAUSSIAN)
-    val reachVarianceParams = ReachVarianceParams(totalReach, reachMeasurementParams)
-    val reachVariance = Variances.computeDeterministicVariance(reachVarianceParams)
+      ReachMeasurementParams(
+        VidSamplingInterval(0.0, vidSamplingIntervalWidth),
+        reachDpParams,
+        NoiseMechanism.GAUSSIAN
+      )
+    val reachMeasurementVarianceParams =
+      ReachMeasurementVarianceParams(totalReach, reachMeasurementParams)
+    val reachMeasurementVariance =
+      Variances.computeDeterministicVariance(reachMeasurementVarianceParams)
 
     val maximumFrequency = 5
     val relativeFrequencyDistribution =
@@ -519,21 +567,21 @@ class VariancesTest {
     val frequencyDpParams = DpParams(0.2, 1e-15)
     val frequencyMeasurementParams =
       FrequencyMeasurementParams(
-        vidSamplingIntervalWidth,
+        VidSamplingInterval(0.0, vidSamplingIntervalWidth),
         frequencyDpParams,
         NoiseMechanism.GAUSSIAN,
         maximumFrequency,
       )
-    val frequencyVarianceParams =
-      FrequencyVarianceParams(
+    val frequencyMeasurementVarianceParams =
+      FrequencyMeasurementVarianceParams(
         totalReach,
-        reachVariance,
+        reachMeasurementVariance,
         relativeFrequencyDistribution,
         frequencyMeasurementParams
       )
 
     val (rKVars, rKPlusVars, nKVars, nKPlusVars) =
-      Variances.computeDeterministicVariance(frequencyVarianceParams)
+      Variances.computeDeterministicVariance(frequencyMeasurementVarianceParams)
 
     val expectedRK =
       listOf(
@@ -592,9 +640,15 @@ class VariancesTest {
     val totalReach = 3e8.toInt()
     val reachDpParams = DpParams(0.05, 1e-15)
     val reachMeasurementParams =
-      ReachMeasurementParams(vidSamplingIntervalWidth, reachDpParams, NoiseMechanism.GAUSSIAN)
-    val reachVarianceParams = ReachVarianceParams(totalReach, reachMeasurementParams)
-    val reachVariance = Variances.computeDeterministicVariance(reachVarianceParams)
+      ReachMeasurementParams(
+        VidSamplingInterval(0.0, vidSamplingIntervalWidth),
+        reachDpParams,
+        NoiseMechanism.GAUSSIAN
+      )
+    val reachMeasurementVarianceParams =
+      ReachMeasurementVarianceParams(totalReach, reachMeasurementParams)
+    val reachMeasurementVariance =
+      Variances.computeDeterministicVariance(reachMeasurementVarianceParams)
 
     val maximumFrequency = 5
     val relativeFrequencyDistribution =
@@ -602,21 +656,21 @@ class VariancesTest {
     val frequencyDpParams = DpParams(0.2, 1e-15)
     val frequencyMeasurementParams =
       FrequencyMeasurementParams(
-        vidSamplingIntervalWidth,
+        VidSamplingInterval(0.0, vidSamplingIntervalWidth),
         frequencyDpParams,
         NoiseMechanism.GAUSSIAN,
         maximumFrequency,
       )
-    val frequencyVarianceParams =
-      FrequencyVarianceParams(
+    val frequencyMeasurementVarianceParams =
+      FrequencyMeasurementVarianceParams(
         totalReach,
-        reachVariance,
+        reachMeasurementVariance,
         relativeFrequencyDistribution,
         frequencyMeasurementParams
       )
 
     val (rKVars, rKPlusVars, nKVars, nKPlusVars) =
-      Variances.computeDeterministicVariance(frequencyVarianceParams)
+      Variances.computeDeterministicVariance(frequencyMeasurementVarianceParams)
 
     val expectedRK =
       listOf(
@@ -675,30 +729,36 @@ class VariancesTest {
     val totalReach = 100
     val reachDpParams = DpParams(0.05, 1e-15)
     val reachMeasurementParams =
-      ReachMeasurementParams(vidSamplingIntervalWidth, reachDpParams, NoiseMechanism.GAUSSIAN)
-    val reachVarianceParams = ReachVarianceParams(totalReach, reachMeasurementParams)
-    val reachVariance = Variances.computeDeterministicVariance(reachVarianceParams)
+      ReachMeasurementParams(
+        VidSamplingInterval(0.0, vidSamplingIntervalWidth),
+        reachDpParams,
+        NoiseMechanism.GAUSSIAN
+      )
+    val reachMeasurementVarianceParams =
+      ReachMeasurementVarianceParams(totalReach, reachMeasurementParams)
+    val reachMeasurementVariance =
+      Variances.computeDeterministicVariance(reachMeasurementVarianceParams)
 
     val maximumFrequency = 1
     val relativeFrequencyDistribution = mapOf(1 to 1.0)
     val frequencyDpParams = DpParams(0.2, 1e-15)
     val frequencyMeasurementParams =
       FrequencyMeasurementParams(
-        vidSamplingIntervalWidth,
+        VidSamplingInterval(0.0, vidSamplingIntervalWidth),
         frequencyDpParams,
         NoiseMechanism.GAUSSIAN,
         maximumFrequency,
       )
-    val frequencyVarianceParams =
-      FrequencyVarianceParams(
+    val frequencyMeasurementVarianceParams =
+      FrequencyMeasurementVarianceParams(
         totalReach,
-        reachVariance,
+        reachMeasurementVariance,
         relativeFrequencyDistribution,
         frequencyMeasurementParams
       )
 
     val (rKVars, rKPlusVars, nKVars, nKPlusVars) =
-      Variances.computeDeterministicVariance(frequencyVarianceParams)
+      Variances.computeDeterministicVariance(frequencyMeasurementVarianceParams)
 
     val expectedRK = 0.0
     val expectedRKPlus = 0.0
@@ -715,7 +775,7 @@ class VariancesTest {
   fun `computeDeterministicVariance for reach-frequency throws IllegalArgumentException when reach is negative`() {
     val vidSamplingIntervalWidth = 1e-3
     val totalReach = -1
-    val reachVariance = 0.1
+    val reachMeasurementVariance = 0.1
 
     val maximumFrequency = 5
     val relativeFrequencyDistribution =
@@ -723,21 +783,21 @@ class VariancesTest {
     val frequencyDpParams = DpParams(0.2, 1e-15)
     val frequencyMeasurementParams =
       FrequencyMeasurementParams(
-        vidSamplingIntervalWidth,
+        VidSamplingInterval(0.0, vidSamplingIntervalWidth),
         frequencyDpParams,
         NoiseMechanism.GAUSSIAN,
         maximumFrequency,
       )
-    val frequencyVarianceParams =
-      FrequencyVarianceParams(
+    val frequencyMeasurementVarianceParams =
+      FrequencyMeasurementVarianceParams(
         totalReach,
-        reachVariance,
+        reachMeasurementVariance,
         relativeFrequencyDistribution,
         frequencyMeasurementParams
       )
 
     assertThrows(IllegalArgumentException::class.java) {
-      Variances.computeDeterministicVariance(frequencyVarianceParams)
+      Variances.computeDeterministicVariance(frequencyMeasurementVarianceParams)
     }
   }
 
@@ -745,7 +805,7 @@ class VariancesTest {
   fun `computeDeterministicVariance for reach-frequency throws IllegalArgumentException when reach variance is negative`() {
     val vidSamplingIntervalWidth = 1e-3
     val totalReach = 10
-    val reachVariance = -0.1
+    val reachMeasurementVariance = -0.1
 
     val maximumFrequency = 5
     val relativeFrequencyDistribution =
@@ -753,21 +813,21 @@ class VariancesTest {
     val frequencyDpParams = DpParams(0.2, 1e-15)
     val frequencyMeasurementParams =
       FrequencyMeasurementParams(
-        vidSamplingIntervalWidth,
+        VidSamplingInterval(0.0, vidSamplingIntervalWidth),
         frequencyDpParams,
         NoiseMechanism.GAUSSIAN,
         maximumFrequency,
       )
-    val frequencyVarianceParams =
-      FrequencyVarianceParams(
+    val frequencyMeasurementVarianceParams =
+      FrequencyMeasurementVarianceParams(
         totalReach,
-        reachVariance,
+        reachMeasurementVariance,
         relativeFrequencyDistribution,
         frequencyMeasurementParams
       )
 
     assertThrows(IllegalArgumentException::class.java) {
-      Variances.computeDeterministicVariance(frequencyVarianceParams)
+      Variances.computeDeterministicVariance(frequencyMeasurementVarianceParams)
     }
   }
 
@@ -780,11 +840,19 @@ class VariancesTest {
     val vidSamplingIntervalWidth = 0.1
     val dpParams = DpParams(0.1, 1e-9)
     val reachMeasurementParams =
-      ReachMeasurementParams(vidSamplingIntervalWidth, dpParams, NoiseMechanism.GAUSSIAN)
-    val reachVarianceParams = ReachVarianceParams(reach, reachMeasurementParams)
+      ReachMeasurementParams(
+        VidSamplingInterval(0.0, vidSamplingIntervalWidth),
+        dpParams,
+        NoiseMechanism.GAUSSIAN
+      )
+    val reachMeasurementVarianceParams =
+      ReachMeasurementVarianceParams(reach, reachMeasurementParams)
 
     val variance =
-      Variances.computeLiquidLegionsSketchVariance(liquidLegionsSketchParams, reachVarianceParams)
+      Variances.computeLiquidLegionsSketchVariance(
+        liquidLegionsSketchParams,
+        reachMeasurementVarianceParams
+      )
     val expect = 252107.369636947
     val percentageError = percentageError(variance, expect)
     assertThat(percentageError).isLessThan(ERROR_TOLERANCE)
@@ -799,11 +867,19 @@ class VariancesTest {
     val vidSamplingIntervalWidth = 0.1
     val dpParams = DpParams(0.1, 1e-9)
     val reachMeasurementParams =
-      ReachMeasurementParams(vidSamplingIntervalWidth, dpParams, NoiseMechanism.GAUSSIAN)
-    val reachVarianceParams = ReachVarianceParams(reach, reachMeasurementParams)
+      ReachMeasurementParams(
+        VidSamplingInterval(0.0, vidSamplingIntervalWidth),
+        dpParams,
+        NoiseMechanism.GAUSSIAN
+      )
+    val reachMeasurementVarianceParams =
+      ReachMeasurementVarianceParams(reach, reachMeasurementParams)
 
     val variance =
-      Variances.computeLiquidLegionsSketchVariance(liquidLegionsSketchParams, reachVarianceParams)
+      Variances.computeLiquidLegionsSketchVariance(
+        liquidLegionsSketchParams,
+        reachMeasurementVarianceParams
+      )
     val expect = 252354.6749380062
     val percentageError = percentageError(variance, expect)
     assertThat(percentageError).isLessThan(ERROR_TOLERANCE)
@@ -818,11 +894,19 @@ class VariancesTest {
     val vidSamplingIntervalWidth = 1.0
     val dpParams = DpParams(0.1, 1e-9)
     val reachMeasurementParams =
-      ReachMeasurementParams(vidSamplingIntervalWidth, dpParams, NoiseMechanism.GAUSSIAN)
-    val reachVarianceParams = ReachVarianceParams(reach, reachMeasurementParams)
+      ReachMeasurementParams(
+        VidSamplingInterval(0.0, vidSamplingIntervalWidth),
+        dpParams,
+        NoiseMechanism.GAUSSIAN
+      )
+    val reachMeasurementVarianceParams =
+      ReachMeasurementVarianceParams(reach, reachMeasurementParams)
 
     val variance =
-      Variances.computeLiquidLegionsSketchVariance(liquidLegionsSketchParams, reachVarianceParams)
+      Variances.computeLiquidLegionsSketchVariance(
+        liquidLegionsSketchParams,
+        reachMeasurementVarianceParams
+      )
 
     val expect = 2520.9441397473865
     val percentageError = percentageError(variance, expect)
@@ -838,11 +922,19 @@ class VariancesTest {
     val vidSamplingIntervalWidth = 1.0
     val dpParams = DpParams(0.1, 1e-9)
     val reachMeasurementParams =
-      ReachMeasurementParams(vidSamplingIntervalWidth, dpParams, NoiseMechanism.GAUSSIAN)
-    val reachVarianceParams = ReachVarianceParams(reach, reachMeasurementParams)
+      ReachMeasurementParams(
+        VidSamplingInterval(0.0, vidSamplingIntervalWidth),
+        dpParams,
+        NoiseMechanism.GAUSSIAN
+      )
+    val reachMeasurementVarianceParams =
+      ReachMeasurementVarianceParams(reach, reachMeasurementParams)
 
     val variance =
-      Variances.computeLiquidLegionsSketchVariance(liquidLegionsSketchParams, reachVarianceParams)
+      Variances.computeLiquidLegionsSketchVariance(
+        liquidLegionsSketchParams,
+        reachMeasurementVarianceParams
+      )
 
     val expect = 2525.8928386525
     val percentageError = percentageError(variance, expect)
@@ -858,11 +950,19 @@ class VariancesTest {
     val vidSamplingIntervalWidth = 0.1
     val dpParams = DpParams(0.1, 1e-9)
     val reachMeasurementParams =
-      ReachMeasurementParams(vidSamplingIntervalWidth, dpParams, NoiseMechanism.GAUSSIAN)
-    val reachVarianceParams = ReachVarianceParams(reach, reachMeasurementParams)
+      ReachMeasurementParams(
+        VidSamplingInterval(0.0, vidSamplingIntervalWidth),
+        dpParams,
+        NoiseMechanism.GAUSSIAN
+      )
+    val reachMeasurementVarianceParams =
+      ReachMeasurementVarianceParams(reach, reachMeasurementParams)
 
     val variance =
-      Variances.computeLiquidLegionsSketchVariance(liquidLegionsSketchParams, reachVarianceParams)
+      Variances.computeLiquidLegionsSketchVariance(
+        liquidLegionsSketchParams,
+        reachMeasurementVarianceParams
+      )
 
     val expect = 289553744.8898575
     val percentageError = percentageError(variance, expect)
@@ -878,11 +978,19 @@ class VariancesTest {
     val vidSamplingIntervalWidth = 0.1
     val dpParams = DpParams(0.1, 1e-9)
     val reachMeasurementParams =
-      ReachMeasurementParams(vidSamplingIntervalWidth, dpParams, NoiseMechanism.GAUSSIAN)
-    val reachVarianceParams = ReachVarianceParams(reach, reachMeasurementParams)
+      ReachMeasurementParams(
+        VidSamplingInterval(0.0, vidSamplingIntervalWidth),
+        dpParams,
+        NoiseMechanism.GAUSSIAN
+      )
+    val reachMeasurementVarianceParams =
+      ReachMeasurementVarianceParams(reach, reachMeasurementParams)
 
     val variance =
-      Variances.computeLiquidLegionsSketchVariance(liquidLegionsSketchParams, reachVarianceParams)
+      Variances.computeLiquidLegionsSketchVariance(
+        liquidLegionsSketchParams,
+        reachMeasurementVarianceParams
+      )
 
     val expect = 28923114340.800056
     val percentageError = percentageError(variance, expect)
@@ -898,11 +1006,19 @@ class VariancesTest {
     val vidSamplingIntervalWidth = 1.0
     val dpParams = DpParams(0.1, 1e-9)
     val reachMeasurementParams =
-      ReachMeasurementParams(vidSamplingIntervalWidth, dpParams, NoiseMechanism.GAUSSIAN)
-    val reachVarianceParams = ReachVarianceParams(reach, reachMeasurementParams)
+      ReachMeasurementParams(
+        VidSamplingInterval(0.0, vidSamplingIntervalWidth),
+        dpParams,
+        NoiseMechanism.GAUSSIAN
+      )
+    val reachMeasurementVarianceParams =
+      ReachMeasurementVarianceParams(reach, reachMeasurementParams)
 
     val variance =
-      Variances.computeLiquidLegionsSketchVariance(liquidLegionsSketchParams, reachVarianceParams)
+      Variances.computeLiquidLegionsSketchVariance(
+        liquidLegionsSketchParams,
+        reachMeasurementVarianceParams
+      )
 
     val expect = 2.8788216360657764e+29
     val percentageError = percentageError(variance, expect)
@@ -918,11 +1034,19 @@ class VariancesTest {
     val vidSamplingIntervalWidth = 1.0
     val dpParams = DpParams(0.1, 1e-9)
     val reachMeasurementParams =
-      ReachMeasurementParams(vidSamplingIntervalWidth, dpParams, NoiseMechanism.GAUSSIAN)
-    val reachVarianceParams = ReachVarianceParams(reach, reachMeasurementParams)
+      ReachMeasurementParams(
+        VidSamplingInterval(0.0, vidSamplingIntervalWidth),
+        dpParams,
+        NoiseMechanism.GAUSSIAN
+      )
+    val reachMeasurementVarianceParams =
+      ReachMeasurementVarianceParams(reach, reachMeasurementParams)
 
     val variance =
-      Variances.computeLiquidLegionsSketchVariance(liquidLegionsSketchParams, reachVarianceParams)
+      Variances.computeLiquidLegionsSketchVariance(
+        liquidLegionsSketchParams,
+        reachMeasurementVarianceParams
+      )
 
     val expect = 28922934034.98562
     val percentageError = percentageError(variance, expect)
@@ -938,11 +1062,19 @@ class VariancesTest {
     val vidSamplingIntervalWidth = 0.1
     val dpParams = DpParams(0.1, 1e-9)
     val reachMeasurementParams =
-      ReachMeasurementParams(vidSamplingIntervalWidth, dpParams, NoiseMechanism.GAUSSIAN)
-    val reachVarianceParams = ReachVarianceParams(reach, reachMeasurementParams)
+      ReachMeasurementParams(
+        VidSamplingInterval(0.0, vidSamplingIntervalWidth),
+        dpParams,
+        NoiseMechanism.GAUSSIAN
+      )
+    val reachMeasurementVarianceParams =
+      ReachMeasurementVarianceParams(reach, reachMeasurementParams)
 
     val variance =
-      Variances.computeLiquidLegionsV2Variance(liquidLegionsSketchParams, reachVarianceParams)
+      Variances.computeLiquidLegionsV2Variance(
+        liquidLegionsSketchParams,
+        reachMeasurementVarianceParams
+      )
     val expect = 432817.78878559935
     val percentageError = percentageError(variance, expect)
     assertThat(percentageError).isLessThan(ERROR_TOLERANCE)
@@ -957,11 +1089,19 @@ class VariancesTest {
     val vidSamplingIntervalWidth = 0.1
     val dpParams = DpParams(0.1, 1e-9)
     val reachMeasurementParams =
-      ReachMeasurementParams(vidSamplingIntervalWidth, dpParams, NoiseMechanism.GAUSSIAN)
-    val reachVarianceParams = ReachVarianceParams(reach, reachMeasurementParams)
+      ReachMeasurementParams(
+        VidSamplingInterval(0.0, vidSamplingIntervalWidth),
+        dpParams,
+        NoiseMechanism.GAUSSIAN
+      )
+    val reachMeasurementVarianceParams =
+      ReachMeasurementVarianceParams(reach, reachMeasurementParams)
 
     val variance =
-      Variances.computeLiquidLegionsV2Variance(liquidLegionsSketchParams, reachVarianceParams)
+      Variances.computeLiquidLegionsV2Variance(
+        liquidLegionsSketchParams,
+        reachMeasurementVarianceParams
+      )
     val expect = 433242.3223399124
     val percentageError = percentageError(variance, expect)
     assertThat(percentageError).isLessThan(ERROR_TOLERANCE)
@@ -976,11 +1116,19 @@ class VariancesTest {
     val vidSamplingIntervalWidth = 1.0
     val dpParams = DpParams(0.1, 1e-9)
     val reachMeasurementParams =
-      ReachMeasurementParams(vidSamplingIntervalWidth, dpParams, NoiseMechanism.GAUSSIAN)
-    val reachVarianceParams = ReachVarianceParams(reach, reachMeasurementParams)
+      ReachMeasurementParams(
+        VidSamplingInterval(0.0, vidSamplingIntervalWidth),
+        dpParams,
+        NoiseMechanism.GAUSSIAN
+      )
+    val reachMeasurementVarianceParams =
+      ReachMeasurementVarianceParams(reach, reachMeasurementParams)
 
     val variance =
-      Variances.computeLiquidLegionsV2Variance(liquidLegionsSketchParams, reachVarianceParams)
+      Variances.computeLiquidLegionsV2Variance(
+        liquidLegionsSketchParams,
+        reachMeasurementVarianceParams
+      )
 
     val expect = 4328.084473679164
     val percentageError = percentageError(variance, expect)
@@ -996,11 +1144,19 @@ class VariancesTest {
     val vidSamplingIntervalWidth = 1.0
     val dpParams = DpParams(0.1, 1e-9)
     val reachMeasurementParams =
-      ReachMeasurementParams(vidSamplingIntervalWidth, dpParams, NoiseMechanism.GAUSSIAN)
-    val reachVarianceParams = ReachVarianceParams(reach, reachMeasurementParams)
+      ReachMeasurementParams(
+        VidSamplingInterval(0.0, vidSamplingIntervalWidth),
+        dpParams,
+        NoiseMechanism.GAUSSIAN
+      )
+    val reachMeasurementVarianceParams =
+      ReachMeasurementVarianceParams(reach, reachMeasurementParams)
 
     val variance =
-      Variances.computeLiquidLegionsV2Variance(liquidLegionsSketchParams, reachVarianceParams)
+      Variances.computeLiquidLegionsV2Variance(
+        liquidLegionsSketchParams,
+        reachMeasurementVarianceParams
+      )
 
     val expect = 4336.579244624804
     val percentageError = percentageError(variance, expect)
@@ -1016,11 +1172,19 @@ class VariancesTest {
     val vidSamplingIntervalWidth = 0.1
     val dpParams = DpParams(0.1, 1e-9)
     val reachMeasurementParams =
-      ReachMeasurementParams(vidSamplingIntervalWidth, dpParams, NoiseMechanism.GAUSSIAN)
-    val reachVarianceParams = ReachVarianceParams(reach, reachMeasurementParams)
+      ReachMeasurementParams(
+        VidSamplingInterval(0.0, vidSamplingIntervalWidth),
+        dpParams,
+        NoiseMechanism.GAUSSIAN
+      )
+    val reachMeasurementVarianceParams =
+      ReachMeasurementVarianceParams(reach, reachMeasurementParams)
 
     val variance =
-      Variances.computeLiquidLegionsV2Variance(liquidLegionsSketchParams, reachVarianceParams)
+      Variances.computeLiquidLegionsV2Variance(
+        liquidLegionsSketchParams,
+        reachMeasurementVarianceParams
+      )
 
     val expect = 362456073.197418
     val percentageError = percentageError(variance, expect)
@@ -1036,11 +1200,19 @@ class VariancesTest {
     val vidSamplingIntervalWidth = 0.1
     val dpParams = DpParams(0.1, 1e-9)
     val reachMeasurementParams =
-      ReachMeasurementParams(vidSamplingIntervalWidth, dpParams, NoiseMechanism.GAUSSIAN)
-    val reachVarianceParams = ReachVarianceParams(reach, reachMeasurementParams)
+      ReachMeasurementParams(
+        VidSamplingInterval(0.0, vidSamplingIntervalWidth),
+        dpParams,
+        NoiseMechanism.GAUSSIAN
+      )
+    val reachMeasurementVarianceParams =
+      ReachMeasurementVarianceParams(reach, reachMeasurementParams)
 
     val variance =
-      Variances.computeLiquidLegionsV2Variance(liquidLegionsSketchParams, reachVarianceParams)
+      Variances.computeLiquidLegionsV2Variance(
+        liquidLegionsSketchParams,
+        reachMeasurementVarianceParams
+      )
 
     val expect = 45186835212.94076
     val percentageError = percentageError(variance, expect)
@@ -1056,11 +1228,19 @@ class VariancesTest {
     val vidSamplingIntervalWidth = 1.0
     val dpParams = DpParams(0.1, 1e-9)
     val reachMeasurementParams =
-      ReachMeasurementParams(vidSamplingIntervalWidth, dpParams, NoiseMechanism.GAUSSIAN)
-    val reachVarianceParams = ReachVarianceParams(reach, reachMeasurementParams)
+      ReachMeasurementParams(
+        VidSamplingInterval(0.0, vidSamplingIntervalWidth),
+        dpParams,
+        NoiseMechanism.GAUSSIAN
+      )
+    val reachMeasurementVarianceParams =
+      ReachMeasurementVarianceParams(reach, reachMeasurementParams)
 
     val variance =
-      Variances.computeLiquidLegionsV2Variance(liquidLegionsSketchParams, reachVarianceParams)
+      Variances.computeLiquidLegionsV2Variance(
+        liquidLegionsSketchParams,
+        reachMeasurementVarianceParams
+      )
 
     val expect = 4.94250670279621e+29
     val percentageError = percentageError(variance, expect)
@@ -1076,11 +1256,19 @@ class VariancesTest {
     val vidSamplingIntervalWidth = 1.0
     val dpParams = DpParams(0.1, 1e-9)
     val reachMeasurementParams =
-      ReachMeasurementParams(vidSamplingIntervalWidth, dpParams, NoiseMechanism.GAUSSIAN)
-    val reachVarianceParams = ReachVarianceParams(reach, reachMeasurementParams)
+      ReachMeasurementParams(
+        VidSamplingInterval(0.0, vidSamplingIntervalWidth),
+        dpParams,
+        NoiseMechanism.GAUSSIAN
+      )
+    val reachMeasurementVarianceParams =
+      ReachMeasurementVarianceParams(reach, reachMeasurementParams)
 
     val variance =
-      Variances.computeLiquidLegionsV2Variance(liquidLegionsSketchParams, reachVarianceParams)
+      Variances.computeLiquidLegionsV2Variance(
+        liquidLegionsSketchParams,
+        reachMeasurementVarianceParams
+      )
 
     val expect = 45186557325.27274
     val percentageError = percentageError(variance, expect)
@@ -1097,10 +1285,18 @@ class VariancesTest {
     val totalReach = 10
     val reachDpParams = DpParams(0.1, 1e-9)
     val reachMeasurementParams =
-      ReachMeasurementParams(vidSamplingIntervalWidth, reachDpParams, NoiseMechanism.GAUSSIAN)
-    val reachVarianceParams = ReachVarianceParams(totalReach, reachMeasurementParams)
-    val reachVariance =
-      Variances.computeLiquidLegionsSketchVariance(liquidLegionsSketchParams, reachVarianceParams)
+      ReachMeasurementParams(
+        VidSamplingInterval(0.0, vidSamplingIntervalWidth),
+        reachDpParams,
+        NoiseMechanism.GAUSSIAN
+      )
+    val reachMeasurementVarianceParams =
+      ReachMeasurementVarianceParams(totalReach, reachMeasurementParams)
+    val reachMeasurementVariance =
+      Variances.computeLiquidLegionsSketchVariance(
+        liquidLegionsSketchParams,
+        reachMeasurementVarianceParams
+      )
 
     val maximumFrequency = 5
     val relativeFrequencyDistribution =
@@ -1108,15 +1304,15 @@ class VariancesTest {
     val frequencyDpParams = DpParams(0.3, 1e-9)
     val frequencyMeasurementParams =
       FrequencyMeasurementParams(
-        vidSamplingIntervalWidth,
+        VidSamplingInterval(0.0, vidSamplingIntervalWidth),
         frequencyDpParams,
         NoiseMechanism.GAUSSIAN,
         maximumFrequency,
       )
-    val frequencyVarianceParams =
-      FrequencyVarianceParams(
+    val frequencyMeasurementVarianceParams =
+      FrequencyMeasurementVarianceParams(
         totalReach,
-        reachVariance,
+        reachMeasurementVariance,
         relativeFrequencyDistribution,
         frequencyMeasurementParams
       )
@@ -1124,7 +1320,7 @@ class VariancesTest {
     val (rKVars, rKPlusVars, nKVars, nKPlusVars) =
       Variances.computeLiquidLegionsSketchVariance(
         liquidLegionsSketchParams,
-        frequencyVarianceParams
+        frequencyMeasurementVarianceParams
       )
 
     val expectedRK = listOf(0.0, 0.0, 0.0, 0.0, 0.0)
@@ -1162,10 +1358,18 @@ class VariancesTest {
     val totalReach = 10
     val reachDpParams = DpParams(0.1, 1e-9)
     val reachMeasurementParams =
-      ReachMeasurementParams(vidSamplingIntervalWidth, reachDpParams, NoiseMechanism.GAUSSIAN)
-    val reachVarianceParams = ReachVarianceParams(totalReach, reachMeasurementParams)
-    val reachVariance =
-      Variances.computeLiquidLegionsSketchVariance(liquidLegionsSketchParams, reachVarianceParams)
+      ReachMeasurementParams(
+        VidSamplingInterval(0.0, vidSamplingIntervalWidth),
+        reachDpParams,
+        NoiseMechanism.GAUSSIAN
+      )
+    val reachMeasurementVarianceParams =
+      ReachMeasurementVarianceParams(totalReach, reachMeasurementParams)
+    val reachMeasurementVariance =
+      Variances.computeLiquidLegionsSketchVariance(
+        liquidLegionsSketchParams,
+        reachMeasurementVarianceParams
+      )
 
     val maximumFrequency = 5
     val relativeFrequencyDistribution =
@@ -1173,15 +1377,15 @@ class VariancesTest {
     val frequencyDpParams = DpParams(0.3, 1e-9)
     val frequencyMeasurementParams =
       FrequencyMeasurementParams(
-        vidSamplingIntervalWidth,
+        VidSamplingInterval(0.0, vidSamplingIntervalWidth),
         frequencyDpParams,
         NoiseMechanism.GAUSSIAN,
         maximumFrequency,
       )
-    val frequencyVarianceParams =
-      FrequencyVarianceParams(
+    val frequencyMeasurementVarianceParams =
+      FrequencyMeasurementVarianceParams(
         totalReach,
-        reachVariance,
+        reachMeasurementVariance,
         relativeFrequencyDistribution,
         frequencyMeasurementParams
       )
@@ -1189,7 +1393,7 @@ class VariancesTest {
     val (rKVars, rKPlusVars, nKVars, nKPlusVars) =
       Variances.computeLiquidLegionsSketchVariance(
         liquidLegionsSketchParams,
-        frequencyVarianceParams
+        frequencyMeasurementVarianceParams
       )
 
     val expectedRK = listOf(0.0, 0.0, 0.0, 0.0, 0.0)
@@ -1227,10 +1431,18 @@ class VariancesTest {
     val totalReach = 10
     val reachDpParams = DpParams(0.1, 1e-9)
     val reachMeasurementParams =
-      ReachMeasurementParams(vidSamplingIntervalWidth, reachDpParams, NoiseMechanism.GAUSSIAN)
-    val reachVarianceParams = ReachVarianceParams(totalReach, reachMeasurementParams)
-    val reachVariance =
-      Variances.computeLiquidLegionsSketchVariance(liquidLegionsSketchParams, reachVarianceParams)
+      ReachMeasurementParams(
+        VidSamplingInterval(0.0, vidSamplingIntervalWidth),
+        reachDpParams,
+        NoiseMechanism.GAUSSIAN
+      )
+    val reachMeasurementVarianceParams =
+      ReachMeasurementVarianceParams(totalReach, reachMeasurementParams)
+    val reachMeasurementVariance =
+      Variances.computeLiquidLegionsSketchVariance(
+        liquidLegionsSketchParams,
+        reachMeasurementVarianceParams
+      )
 
     val maximumFrequency = 5
     val relativeFrequencyDistribution =
@@ -1238,15 +1450,15 @@ class VariancesTest {
     val frequencyDpParams = DpParams(0.3, 1e-9)
     val frequencyMeasurementParams =
       FrequencyMeasurementParams(
-        vidSamplingIntervalWidth,
+        VidSamplingInterval(0.0, vidSamplingIntervalWidth),
         frequencyDpParams,
         NoiseMechanism.GAUSSIAN,
         maximumFrequency,
       )
-    val frequencyVarianceParams =
-      FrequencyVarianceParams(
+    val frequencyMeasurementVarianceParams =
+      FrequencyMeasurementVarianceParams(
         totalReach,
-        reachVariance,
+        reachMeasurementVariance,
         relativeFrequencyDistribution,
         frequencyMeasurementParams
       )
@@ -1254,7 +1466,7 @@ class VariancesTest {
     val (rKVars, rKPlusVars, nKVars, nKPlusVars) =
       Variances.computeLiquidLegionsSketchVariance(
         liquidLegionsSketchParams,
-        frequencyVarianceParams
+        frequencyMeasurementVarianceParams
       )
 
     val expectedRK =
@@ -1312,10 +1524,18 @@ class VariancesTest {
     val totalReach = 10
     val reachDpParams = DpParams(0.1, 1e-9)
     val reachMeasurementParams =
-      ReachMeasurementParams(vidSamplingIntervalWidth, reachDpParams, NoiseMechanism.GAUSSIAN)
-    val reachVarianceParams = ReachVarianceParams(totalReach, reachMeasurementParams)
-    val reachVariance =
-      Variances.computeLiquidLegionsSketchVariance(liquidLegionsSketchParams, reachVarianceParams)
+      ReachMeasurementParams(
+        VidSamplingInterval(0.0, vidSamplingIntervalWidth),
+        reachDpParams,
+        NoiseMechanism.GAUSSIAN
+      )
+    val reachMeasurementVarianceParams =
+      ReachMeasurementVarianceParams(totalReach, reachMeasurementParams)
+    val reachMeasurementVariance =
+      Variances.computeLiquidLegionsSketchVariance(
+        liquidLegionsSketchParams,
+        reachMeasurementVarianceParams
+      )
 
     val maximumFrequency = 5
     val relativeFrequencyDistribution =
@@ -1323,15 +1543,15 @@ class VariancesTest {
     val frequencyDpParams = DpParams(0.3, 1e-9)
     val frequencyMeasurementParams =
       FrequencyMeasurementParams(
-        vidSamplingIntervalWidth,
+        VidSamplingInterval(0.0, vidSamplingIntervalWidth),
         frequencyDpParams,
         NoiseMechanism.GAUSSIAN,
         maximumFrequency,
       )
-    val frequencyVarianceParams =
-      FrequencyVarianceParams(
+    val frequencyMeasurementVarianceParams =
+      FrequencyMeasurementVarianceParams(
         totalReach,
-        reachVariance,
+        reachMeasurementVariance,
         relativeFrequencyDistribution,
         frequencyMeasurementParams
       )
@@ -1339,7 +1559,7 @@ class VariancesTest {
     val (rKVars, rKPlusVars, nKVars, nKPlusVars) =
       Variances.computeLiquidLegionsSketchVariance(
         liquidLegionsSketchParams,
-        frequencyVarianceParams
+        frequencyMeasurementVarianceParams
       )
 
     val expectedRK =
@@ -1397,10 +1617,18 @@ class VariancesTest {
     val totalReach = 3e8.toInt()
     val reachDpParams = DpParams(0.1, 1e-9)
     val reachMeasurementParams =
-      ReachMeasurementParams(vidSamplingIntervalWidth, reachDpParams, NoiseMechanism.GAUSSIAN)
-    val reachVarianceParams = ReachVarianceParams(totalReach, reachMeasurementParams)
-    val reachVariance =
-      Variances.computeLiquidLegionsSketchVariance(liquidLegionsSketchParams, reachVarianceParams)
+      ReachMeasurementParams(
+        VidSamplingInterval(0.0, vidSamplingIntervalWidth),
+        reachDpParams,
+        NoiseMechanism.GAUSSIAN
+      )
+    val reachMeasurementVarianceParams =
+      ReachMeasurementVarianceParams(totalReach, reachMeasurementParams)
+    val reachMeasurementVariance =
+      Variances.computeLiquidLegionsSketchVariance(
+        liquidLegionsSketchParams,
+        reachMeasurementVarianceParams
+      )
 
     val maximumFrequency = 5
     val relativeFrequencyDistribution =
@@ -1408,15 +1636,15 @@ class VariancesTest {
     val frequencyDpParams = DpParams(0.3, 1e-9)
     val frequencyMeasurementParams =
       FrequencyMeasurementParams(
-        vidSamplingIntervalWidth,
+        VidSamplingInterval(0.0, vidSamplingIntervalWidth),
         frequencyDpParams,
         NoiseMechanism.GAUSSIAN,
         maximumFrequency,
       )
-    val frequencyVarianceParams =
-      FrequencyVarianceParams(
+    val frequencyMeasurementVarianceParams =
+      FrequencyMeasurementVarianceParams(
         totalReach,
-        reachVariance,
+        reachMeasurementVariance,
         relativeFrequencyDistribution,
         frequencyMeasurementParams
       )
@@ -1424,7 +1652,7 @@ class VariancesTest {
     val (rKVars, rKPlusVars, nKVars, nKPlusVars) =
       Variances.computeLiquidLegionsSketchVariance(
         liquidLegionsSketchParams,
-        frequencyVarianceParams
+        frequencyMeasurementVarianceParams
       )
 
     val expectedRK =
@@ -1488,10 +1716,18 @@ class VariancesTest {
     val totalReach = 3e8.toInt()
     val reachDpParams = DpParams(0.1, 1e-9)
     val reachMeasurementParams =
-      ReachMeasurementParams(vidSamplingIntervalWidth, reachDpParams, NoiseMechanism.GAUSSIAN)
-    val reachVarianceParams = ReachVarianceParams(totalReach, reachMeasurementParams)
-    val reachVariance =
-      Variances.computeLiquidLegionsSketchVariance(liquidLegionsSketchParams, reachVarianceParams)
+      ReachMeasurementParams(
+        VidSamplingInterval(0.0, vidSamplingIntervalWidth),
+        reachDpParams,
+        NoiseMechanism.GAUSSIAN
+      )
+    val reachMeasurementVarianceParams =
+      ReachMeasurementVarianceParams(totalReach, reachMeasurementParams)
+    val reachMeasurementVariance =
+      Variances.computeLiquidLegionsSketchVariance(
+        liquidLegionsSketchParams,
+        reachMeasurementVarianceParams
+      )
 
     val maximumFrequency = 5
     val relativeFrequencyDistribution =
@@ -1499,15 +1735,15 @@ class VariancesTest {
     val frequencyDpParams = DpParams(0.3, 1e-9)
     val frequencyMeasurementParams =
       FrequencyMeasurementParams(
-        vidSamplingIntervalWidth,
+        VidSamplingInterval(0.0, vidSamplingIntervalWidth),
         frequencyDpParams,
         NoiseMechanism.GAUSSIAN,
         maximumFrequency,
       )
-    val frequencyVarianceParams =
-      FrequencyVarianceParams(
+    val frequencyMeasurementVarianceParams =
+      FrequencyMeasurementVarianceParams(
         totalReach,
-        reachVariance,
+        reachMeasurementVariance,
         relativeFrequencyDistribution,
         frequencyMeasurementParams
       )
@@ -1515,7 +1751,7 @@ class VariancesTest {
     val (rKVars, rKPlusVars, nKVars, nKPlusVars) =
       Variances.computeLiquidLegionsSketchVariance(
         liquidLegionsSketchParams,
-        frequencyVarianceParams
+        frequencyMeasurementVarianceParams
       )
 
     val expectedRK =
@@ -1579,10 +1815,18 @@ class VariancesTest {
     val totalReach = 3e8.toInt()
     val reachDpParams = DpParams(0.1, 1e-9)
     val reachMeasurementParams =
-      ReachMeasurementParams(vidSamplingIntervalWidth, reachDpParams, NoiseMechanism.GAUSSIAN)
-    val reachVarianceParams = ReachVarianceParams(totalReach, reachMeasurementParams)
-    val reachVariance =
-      Variances.computeLiquidLegionsSketchVariance(liquidLegionsSketchParams, reachVarianceParams)
+      ReachMeasurementParams(
+        VidSamplingInterval(0.0, vidSamplingIntervalWidth),
+        reachDpParams,
+        NoiseMechanism.GAUSSIAN
+      )
+    val reachMeasurementVarianceParams =
+      ReachMeasurementVarianceParams(totalReach, reachMeasurementParams)
+    val reachMeasurementVariance =
+      Variances.computeLiquidLegionsSketchVariance(
+        liquidLegionsSketchParams,
+        reachMeasurementVarianceParams
+      )
 
     val maximumFrequency = 5
     val relativeFrequencyDistribution =
@@ -1590,15 +1834,15 @@ class VariancesTest {
     val frequencyDpParams = DpParams(0.3, 1e-9)
     val frequencyMeasurementParams =
       FrequencyMeasurementParams(
-        vidSamplingIntervalWidth,
+        VidSamplingInterval(0.0, vidSamplingIntervalWidth),
         frequencyDpParams,
         NoiseMechanism.GAUSSIAN,
         maximumFrequency,
       )
-    val frequencyVarianceParams =
-      FrequencyVarianceParams(
+    val frequencyMeasurementVarianceParams =
+      FrequencyMeasurementVarianceParams(
         totalReach,
-        reachVariance,
+        reachMeasurementVariance,
         relativeFrequencyDistribution,
         frequencyMeasurementParams
       )
@@ -1606,7 +1850,7 @@ class VariancesTest {
     val (rKVars, rKPlusVars, nKVars, nKPlusVars) =
       Variances.computeLiquidLegionsSketchVariance(
         liquidLegionsSketchParams,
-        frequencyVarianceParams
+        frequencyMeasurementVarianceParams
       )
 
     val expectedRK =
@@ -1670,25 +1914,33 @@ class VariancesTest {
     val totalReach = 100
     val reachDpParams = DpParams(0.1, 1e-9)
     val reachMeasurementParams =
-      ReachMeasurementParams(vidSamplingIntervalWidth, reachDpParams, NoiseMechanism.GAUSSIAN)
-    val reachVarianceParams = ReachVarianceParams(totalReach, reachMeasurementParams)
-    val reachVariance =
-      Variances.computeLiquidLegionsSketchVariance(liquidLegionsSketchParams, reachVarianceParams)
+      ReachMeasurementParams(
+        VidSamplingInterval(0.0, vidSamplingIntervalWidth),
+        reachDpParams,
+        NoiseMechanism.GAUSSIAN
+      )
+    val reachMeasurementVarianceParams =
+      ReachMeasurementVarianceParams(totalReach, reachMeasurementParams)
+    val reachMeasurementVariance =
+      Variances.computeLiquidLegionsSketchVariance(
+        liquidLegionsSketchParams,
+        reachMeasurementVarianceParams
+      )
 
     val maximumFrequency = 1
     val relativeFrequencyDistribution = mapOf(1 to 1.0)
     val frequencyDpParams = DpParams(0.3, 1e-9)
     val frequencyMeasurementParams =
       FrequencyMeasurementParams(
-        vidSamplingIntervalWidth,
+        VidSamplingInterval(0.0, vidSamplingIntervalWidth),
         frequencyDpParams,
         NoiseMechanism.GAUSSIAN,
         maximumFrequency,
       )
-    val frequencyVarianceParams =
-      FrequencyVarianceParams(
+    val frequencyMeasurementVarianceParams =
+      FrequencyMeasurementVarianceParams(
         totalReach,
-        reachVariance,
+        reachMeasurementVariance,
         relativeFrequencyDistribution,
         frequencyMeasurementParams
       )
@@ -1696,7 +1948,7 @@ class VariancesTest {
     val (rKVars, rKPlusVars, nKVars, nKPlusVars) =
       Variances.computeLiquidLegionsSketchVariance(
         liquidLegionsSketchParams,
-        frequencyVarianceParams
+        frequencyMeasurementVarianceParams
       )
 
     val expectedRK = 0.0
@@ -1720,10 +1972,18 @@ class VariancesTest {
     val totalReach = 1
     val reachDpParams = DpParams(0.1, 1e-9)
     val reachMeasurementParams =
-      ReachMeasurementParams(vidSamplingIntervalWidth, reachDpParams, NoiseMechanism.GAUSSIAN)
-    val reachVarianceParams = ReachVarianceParams(totalReach, reachMeasurementParams)
-    val reachVariance =
-      Variances.computeLiquidLegionsSketchVariance(liquidLegionsSketchParams, reachVarianceParams)
+      ReachMeasurementParams(
+        VidSamplingInterval(0.0, vidSamplingIntervalWidth),
+        reachDpParams,
+        NoiseMechanism.GAUSSIAN
+      )
+    val reachMeasurementVarianceParams =
+      ReachMeasurementVarianceParams(totalReach, reachMeasurementParams)
+    val reachMeasurementVariance =
+      Variances.computeLiquidLegionsSketchVariance(
+        liquidLegionsSketchParams,
+        reachMeasurementVarianceParams
+      )
 
     val maximumFrequency = 5
     val relativeFrequencyDistribution =
@@ -1731,15 +1991,15 @@ class VariancesTest {
     val frequencyDpParams = DpParams(0.3, 1e-9)
     val frequencyMeasurementParams =
       FrequencyMeasurementParams(
-        vidSamplingIntervalWidth,
+        VidSamplingInterval(0.0, vidSamplingIntervalWidth),
         frequencyDpParams,
         NoiseMechanism.GAUSSIAN,
         maximumFrequency,
       )
-    val frequencyVarianceParams =
-      FrequencyVarianceParams(
+    val frequencyMeasurementVarianceParams =
+      FrequencyMeasurementVarianceParams(
         totalReach,
-        reachVariance,
+        reachMeasurementVariance,
         relativeFrequencyDistribution,
         frequencyMeasurementParams
       )
@@ -1747,7 +2007,7 @@ class VariancesTest {
     val (rKVars, rKPlusVars, nKVars, nKPlusVars) =
       Variances.computeLiquidLegionsSketchVariance(
         liquidLegionsSketchParams,
-        frequencyVarianceParams
+        frequencyMeasurementVarianceParams
       )
 
     val expectedRK = listOf(0.0, 0.0, 0.0, 0.0, 0.0)
@@ -1785,10 +2045,18 @@ class VariancesTest {
     val totalReach = 10
     val reachDpParams = DpParams(0.1, 1e-9)
     val reachMeasurementParams =
-      ReachMeasurementParams(vidSamplingIntervalWidth, reachDpParams, NoiseMechanism.GAUSSIAN)
-    val reachVarianceParams = ReachVarianceParams(totalReach, reachMeasurementParams)
-    val reachVariance =
-      Variances.computeLiquidLegionsV2Variance(liquidLegionsSketchParams, reachVarianceParams)
+      ReachMeasurementParams(
+        VidSamplingInterval(0.0, vidSamplingIntervalWidth),
+        reachDpParams,
+        NoiseMechanism.GAUSSIAN
+      )
+    val reachMeasurementVarianceParams =
+      ReachMeasurementVarianceParams(totalReach, reachMeasurementParams)
+    val reachMeasurementVariance =
+      Variances.computeLiquidLegionsV2Variance(
+        liquidLegionsSketchParams,
+        reachMeasurementVarianceParams
+      )
 
     val maximumFrequency = 5
     val relativeFrequencyDistribution =
@@ -1796,21 +2064,24 @@ class VariancesTest {
     val frequencyDpParams = DpParams(0.3, 1e-9)
     val frequencyMeasurementParams =
       FrequencyMeasurementParams(
-        vidSamplingIntervalWidth,
+        VidSamplingInterval(0.0, vidSamplingIntervalWidth),
         frequencyDpParams,
         NoiseMechanism.GAUSSIAN,
         maximumFrequency,
       )
-    val frequencyVarianceParams =
-      FrequencyVarianceParams(
+    val frequencyMeasurementVarianceParams =
+      FrequencyMeasurementVarianceParams(
         totalReach,
-        reachVariance,
+        reachMeasurementVariance,
         relativeFrequencyDistribution,
         frequencyMeasurementParams
       )
 
     val (rKVars, rKPlusVars, nKVars, nKPlusVars) =
-      Variances.computeLiquidLegionsV2Variance(liquidLegionsSketchParams, frequencyVarianceParams)
+      Variances.computeLiquidLegionsV2Variance(
+        liquidLegionsSketchParams,
+        frequencyMeasurementVarianceParams
+      )
 
     val expectedRK = listOf(0.0, 0.0, 0.0, 0.0, 0.0)
     val expectedRKPlus = listOf(0.0, 0.0, 0.0, 0.0, 0.0)
@@ -1847,10 +2118,18 @@ class VariancesTest {
     val totalReach = 10
     val reachDpParams = DpParams(0.1, 1e-9)
     val reachMeasurementParams =
-      ReachMeasurementParams(vidSamplingIntervalWidth, reachDpParams, NoiseMechanism.GAUSSIAN)
-    val reachVarianceParams = ReachVarianceParams(totalReach, reachMeasurementParams)
-    val reachVariance =
-      Variances.computeLiquidLegionsV2Variance(liquidLegionsSketchParams, reachVarianceParams)
+      ReachMeasurementParams(
+        VidSamplingInterval(0.0, vidSamplingIntervalWidth),
+        reachDpParams,
+        NoiseMechanism.GAUSSIAN
+      )
+    val reachMeasurementVarianceParams =
+      ReachMeasurementVarianceParams(totalReach, reachMeasurementParams)
+    val reachMeasurementVariance =
+      Variances.computeLiquidLegionsV2Variance(
+        liquidLegionsSketchParams,
+        reachMeasurementVarianceParams
+      )
 
     val maximumFrequency = 5
     val relativeFrequencyDistribution =
@@ -1858,21 +2137,24 @@ class VariancesTest {
     val frequencyDpParams = DpParams(0.3, 1e-9)
     val frequencyMeasurementParams =
       FrequencyMeasurementParams(
-        vidSamplingIntervalWidth,
+        VidSamplingInterval(0.0, vidSamplingIntervalWidth),
         frequencyDpParams,
         NoiseMechanism.GAUSSIAN,
         maximumFrequency,
       )
-    val frequencyVarianceParams =
-      FrequencyVarianceParams(
+    val frequencyMeasurementVarianceParams =
+      FrequencyMeasurementVarianceParams(
         totalReach,
-        reachVariance,
+        reachMeasurementVariance,
         relativeFrequencyDistribution,
         frequencyMeasurementParams
       )
 
     val (rKVars, rKPlusVars, nKVars, nKPlusVars) =
-      Variances.computeLiquidLegionsV2Variance(liquidLegionsSketchParams, frequencyVarianceParams)
+      Variances.computeLiquidLegionsV2Variance(
+        liquidLegionsSketchParams,
+        frequencyMeasurementVarianceParams
+      )
 
     val expectedRK = listOf(0.0, 0.0, 0.0, 0.0, 0.0)
     val expectedRKPlus = listOf(0.0, 0.0, 0.0, 0.0, 0.0)
@@ -1909,10 +2191,18 @@ class VariancesTest {
     val totalReach = 10
     val reachDpParams = DpParams(0.1, 1e-9)
     val reachMeasurementParams =
-      ReachMeasurementParams(vidSamplingIntervalWidth, reachDpParams, NoiseMechanism.GAUSSIAN)
-    val reachVarianceParams = ReachVarianceParams(totalReach, reachMeasurementParams)
-    val reachVariance =
-      Variances.computeLiquidLegionsV2Variance(liquidLegionsSketchParams, reachVarianceParams)
+      ReachMeasurementParams(
+        VidSamplingInterval(0.0, vidSamplingIntervalWidth),
+        reachDpParams,
+        NoiseMechanism.GAUSSIAN
+      )
+    val reachMeasurementVarianceParams =
+      ReachMeasurementVarianceParams(totalReach, reachMeasurementParams)
+    val reachMeasurementVariance =
+      Variances.computeLiquidLegionsV2Variance(
+        liquidLegionsSketchParams,
+        reachMeasurementVarianceParams
+      )
 
     val maximumFrequency = 5
     val relativeFrequencyDistribution =
@@ -1920,21 +2210,24 @@ class VariancesTest {
     val frequencyDpParams = DpParams(0.3, 1e-9)
     val frequencyMeasurementParams =
       FrequencyMeasurementParams(
-        vidSamplingIntervalWidth,
+        VidSamplingInterval(0.0, vidSamplingIntervalWidth),
         frequencyDpParams,
         NoiseMechanism.GAUSSIAN,
         maximumFrequency,
       )
-    val frequencyVarianceParams =
-      FrequencyVarianceParams(
+    val frequencyMeasurementVarianceParams =
+      FrequencyMeasurementVarianceParams(
         totalReach,
-        reachVariance,
+        reachMeasurementVariance,
         relativeFrequencyDistribution,
         frequencyMeasurementParams
       )
 
     val (rKVars, rKPlusVars, nKVars, nKPlusVars) =
-      Variances.computeLiquidLegionsV2Variance(liquidLegionsSketchParams, frequencyVarianceParams)
+      Variances.computeLiquidLegionsV2Variance(
+        liquidLegionsSketchParams,
+        frequencyMeasurementVarianceParams
+      )
 
     val expectedRK =
       listOf(
@@ -1991,10 +2284,18 @@ class VariancesTest {
     val totalReach = 10
     val reachDpParams = DpParams(0.1, 1e-9)
     val reachMeasurementParams =
-      ReachMeasurementParams(vidSamplingIntervalWidth, reachDpParams, NoiseMechanism.GAUSSIAN)
-    val reachVarianceParams = ReachVarianceParams(totalReach, reachMeasurementParams)
-    val reachVariance =
-      Variances.computeLiquidLegionsV2Variance(liquidLegionsSketchParams, reachVarianceParams)
+      ReachMeasurementParams(
+        VidSamplingInterval(0.0, vidSamplingIntervalWidth),
+        reachDpParams,
+        NoiseMechanism.GAUSSIAN
+      )
+    val reachMeasurementVarianceParams =
+      ReachMeasurementVarianceParams(totalReach, reachMeasurementParams)
+    val reachMeasurementVariance =
+      Variances.computeLiquidLegionsV2Variance(
+        liquidLegionsSketchParams,
+        reachMeasurementVarianceParams
+      )
 
     val maximumFrequency = 5
     val relativeFrequencyDistribution =
@@ -2002,21 +2303,24 @@ class VariancesTest {
     val frequencyDpParams = DpParams(0.3, 1e-9)
     val frequencyMeasurementParams =
       FrequencyMeasurementParams(
-        vidSamplingIntervalWidth,
+        VidSamplingInterval(0.0, vidSamplingIntervalWidth),
         frequencyDpParams,
         NoiseMechanism.GAUSSIAN,
         maximumFrequency,
       )
-    val frequencyVarianceParams =
-      FrequencyVarianceParams(
+    val frequencyMeasurementVarianceParams =
+      FrequencyMeasurementVarianceParams(
         totalReach,
-        reachVariance,
+        reachMeasurementVariance,
         relativeFrequencyDistribution,
         frequencyMeasurementParams
       )
 
     val (rKVars, rKPlusVars, nKVars, nKPlusVars) =
-      Variances.computeLiquidLegionsV2Variance(liquidLegionsSketchParams, frequencyVarianceParams)
+      Variances.computeLiquidLegionsV2Variance(
+        liquidLegionsSketchParams,
+        frequencyMeasurementVarianceParams
+      )
 
     val expectedRK =
       listOf(
@@ -2073,10 +2377,18 @@ class VariancesTest {
     val totalReach = 3e8.toInt()
     val reachDpParams = DpParams(0.1, 1e-9)
     val reachMeasurementParams =
-      ReachMeasurementParams(vidSamplingIntervalWidth, reachDpParams, NoiseMechanism.GAUSSIAN)
-    val reachVarianceParams = ReachVarianceParams(totalReach, reachMeasurementParams)
-    val reachVariance =
-      Variances.computeLiquidLegionsV2Variance(liquidLegionsSketchParams, reachVarianceParams)
+      ReachMeasurementParams(
+        VidSamplingInterval(0.0, vidSamplingIntervalWidth),
+        reachDpParams,
+        NoiseMechanism.GAUSSIAN
+      )
+    val reachMeasurementVarianceParams =
+      ReachMeasurementVarianceParams(totalReach, reachMeasurementParams)
+    val reachMeasurementVariance =
+      Variances.computeLiquidLegionsV2Variance(
+        liquidLegionsSketchParams,
+        reachMeasurementVarianceParams
+      )
 
     val maximumFrequency = 5
     val relativeFrequencyDistribution =
@@ -2084,21 +2396,24 @@ class VariancesTest {
     val frequencyDpParams = DpParams(0.3, 1e-9)
     val frequencyMeasurementParams =
       FrequencyMeasurementParams(
-        vidSamplingIntervalWidth,
+        VidSamplingInterval(0.0, vidSamplingIntervalWidth),
         frequencyDpParams,
         NoiseMechanism.GAUSSIAN,
         maximumFrequency,
       )
-    val frequencyVarianceParams =
-      FrequencyVarianceParams(
+    val frequencyMeasurementVarianceParams =
+      FrequencyMeasurementVarianceParams(
         totalReach,
-        reachVariance,
+        reachMeasurementVariance,
         relativeFrequencyDistribution,
         frequencyMeasurementParams
       )
 
     val (rKVars, rKPlusVars, nKVars, nKPlusVars) =
-      Variances.computeLiquidLegionsV2Variance(liquidLegionsSketchParams, frequencyVarianceParams)
+      Variances.computeLiquidLegionsV2Variance(
+        liquidLegionsSketchParams,
+        frequencyMeasurementVarianceParams
+      )
 
     val expectedRK = listOf(0.0, 0.0, 0.0, 0.0, 0.0)
     val expectedRKPlus = listOf(0.0, 0.0, 0.0, 0.0, 0.0)
@@ -2147,10 +2462,18 @@ class VariancesTest {
     val totalReach = 3e8.toInt()
     val reachDpParams = DpParams(0.1, 1e-9)
     val reachMeasurementParams =
-      ReachMeasurementParams(vidSamplingIntervalWidth, reachDpParams, NoiseMechanism.GAUSSIAN)
-    val reachVarianceParams = ReachVarianceParams(totalReach, reachMeasurementParams)
-    val reachVariance =
-      Variances.computeLiquidLegionsV2Variance(liquidLegionsSketchParams, reachVarianceParams)
+      ReachMeasurementParams(
+        VidSamplingInterval(0.0, vidSamplingIntervalWidth),
+        reachDpParams,
+        NoiseMechanism.GAUSSIAN
+      )
+    val reachMeasurementVarianceParams =
+      ReachMeasurementVarianceParams(totalReach, reachMeasurementParams)
+    val reachMeasurementVariance =
+      Variances.computeLiquidLegionsV2Variance(
+        liquidLegionsSketchParams,
+        reachMeasurementVarianceParams
+      )
 
     val maximumFrequency = 5
     val relativeFrequencyDistribution =
@@ -2158,21 +2481,24 @@ class VariancesTest {
     val frequencyDpParams = DpParams(0.3, 1e-9)
     val frequencyMeasurementParams =
       FrequencyMeasurementParams(
-        vidSamplingIntervalWidth,
+        VidSamplingInterval(0.0, vidSamplingIntervalWidth),
         frequencyDpParams,
         NoiseMechanism.GAUSSIAN,
         maximumFrequency,
       )
-    val frequencyVarianceParams =
-      FrequencyVarianceParams(
+    val frequencyMeasurementVarianceParams =
+      FrequencyMeasurementVarianceParams(
         totalReach,
-        reachVariance,
+        reachMeasurementVariance,
         relativeFrequencyDistribution,
         frequencyMeasurementParams
       )
 
     val (rKVars, rKPlusVars, nKVars, nKPlusVars) =
-      Variances.computeLiquidLegionsV2Variance(liquidLegionsSketchParams, frequencyVarianceParams)
+      Variances.computeLiquidLegionsV2Variance(
+        liquidLegionsSketchParams,
+        frequencyMeasurementVarianceParams
+      )
 
     val expectedRK =
       listOf(
@@ -2235,10 +2561,18 @@ class VariancesTest {
     val totalReach = 3e8.toInt()
     val reachDpParams = DpParams(0.1, 1e-9)
     val reachMeasurementParams =
-      ReachMeasurementParams(vidSamplingIntervalWidth, reachDpParams, NoiseMechanism.GAUSSIAN)
-    val reachVarianceParams = ReachVarianceParams(totalReach, reachMeasurementParams)
-    val reachVariance =
-      Variances.computeLiquidLegionsV2Variance(liquidLegionsSketchParams, reachVarianceParams)
+      ReachMeasurementParams(
+        VidSamplingInterval(0.0, vidSamplingIntervalWidth),
+        reachDpParams,
+        NoiseMechanism.GAUSSIAN
+      )
+    val reachMeasurementVarianceParams =
+      ReachMeasurementVarianceParams(totalReach, reachMeasurementParams)
+    val reachMeasurementVariance =
+      Variances.computeLiquidLegionsV2Variance(
+        liquidLegionsSketchParams,
+        reachMeasurementVarianceParams
+      )
 
     val maximumFrequency = 5
     val relativeFrequencyDistribution =
@@ -2246,21 +2580,24 @@ class VariancesTest {
     val frequencyDpParams = DpParams(0.3, 1e-9)
     val frequencyMeasurementParams =
       FrequencyMeasurementParams(
-        vidSamplingIntervalWidth,
+        VidSamplingInterval(0.0, vidSamplingIntervalWidth),
         frequencyDpParams,
         NoiseMechanism.GAUSSIAN,
         maximumFrequency,
       )
-    val frequencyVarianceParams =
-      FrequencyVarianceParams(
+    val frequencyMeasurementVarianceParams =
+      FrequencyMeasurementVarianceParams(
         totalReach,
-        reachVariance,
+        reachMeasurementVariance,
         relativeFrequencyDistribution,
         frequencyMeasurementParams
       )
 
     val (rKVars, rKPlusVars, nKVars, nKPlusVars) =
-      Variances.computeLiquidLegionsV2Variance(liquidLegionsSketchParams, frequencyVarianceParams)
+      Variances.computeLiquidLegionsV2Variance(
+        liquidLegionsSketchParams,
+        frequencyMeasurementVarianceParams
+      )
 
     val expectedRK =
       listOf(
@@ -2323,31 +2660,42 @@ class VariancesTest {
     val totalReach = 100
     val reachDpParams = DpParams(0.1, 1e-9)
     val reachMeasurementParams =
-      ReachMeasurementParams(vidSamplingIntervalWidth, reachDpParams, NoiseMechanism.GAUSSIAN)
-    val reachVarianceParams = ReachVarianceParams(totalReach, reachMeasurementParams)
-    val reachVariance =
-      Variances.computeLiquidLegionsV2Variance(liquidLegionsSketchParams, reachVarianceParams)
+      ReachMeasurementParams(
+        VidSamplingInterval(0.0, vidSamplingIntervalWidth),
+        reachDpParams,
+        NoiseMechanism.GAUSSIAN
+      )
+    val reachMeasurementVarianceParams =
+      ReachMeasurementVarianceParams(totalReach, reachMeasurementParams)
+    val reachMeasurementVariance =
+      Variances.computeLiquidLegionsV2Variance(
+        liquidLegionsSketchParams,
+        reachMeasurementVarianceParams
+      )
 
     val maximumFrequency = 1
     val relativeFrequencyDistribution = mapOf(1 to 1.0)
     val frequencyDpParams = DpParams(0.3, 1e-9)
     val frequencyMeasurementParams =
       FrequencyMeasurementParams(
-        vidSamplingIntervalWidth,
+        VidSamplingInterval(0.0, vidSamplingIntervalWidth),
         frequencyDpParams,
         NoiseMechanism.GAUSSIAN,
         maximumFrequency,
       )
-    val frequencyVarianceParams =
-      FrequencyVarianceParams(
+    val frequencyMeasurementVarianceParams =
+      FrequencyMeasurementVarianceParams(
         totalReach,
-        reachVariance,
+        reachMeasurementVariance,
         relativeFrequencyDistribution,
         frequencyMeasurementParams
       )
 
     val (rKVars, rKPlusVars, nKVars, nKPlusVars) =
-      Variances.computeLiquidLegionsV2Variance(liquidLegionsSketchParams, frequencyVarianceParams)
+      Variances.computeLiquidLegionsV2Variance(
+        liquidLegionsSketchParams,
+        frequencyMeasurementVarianceParams
+      )
 
     val expectedRK = 0.0
     val expectedRKPlus = 0.0
@@ -2370,10 +2718,18 @@ class VariancesTest {
     val totalReach = 1
     val reachDpParams = DpParams(0.1, 1e-9)
     val reachMeasurementParams =
-      ReachMeasurementParams(vidSamplingIntervalWidth, reachDpParams, NoiseMechanism.GAUSSIAN)
-    val reachVarianceParams = ReachVarianceParams(totalReach, reachMeasurementParams)
-    val reachVariance =
-      Variances.computeLiquidLegionsV2Variance(liquidLegionsSketchParams, reachVarianceParams)
+      ReachMeasurementParams(
+        VidSamplingInterval(0.0, vidSamplingIntervalWidth),
+        reachDpParams,
+        NoiseMechanism.GAUSSIAN
+      )
+    val reachMeasurementVarianceParams =
+      ReachMeasurementVarianceParams(totalReach, reachMeasurementParams)
+    val reachMeasurementVariance =
+      Variances.computeLiquidLegionsV2Variance(
+        liquidLegionsSketchParams,
+        reachMeasurementVarianceParams
+      )
 
     val maximumFrequency = 5
     val relativeFrequencyDistribution =
@@ -2381,21 +2737,24 @@ class VariancesTest {
     val frequencyDpParams = DpParams(0.3, 1e-9)
     val frequencyMeasurementParams =
       FrequencyMeasurementParams(
-        vidSamplingIntervalWidth,
+        VidSamplingInterval(0.0, vidSamplingIntervalWidth),
         frequencyDpParams,
         NoiseMechanism.GAUSSIAN,
         maximumFrequency,
       )
-    val frequencyVarianceParams =
-      FrequencyVarianceParams(
+    val frequencyMeasurementVarianceParams =
+      FrequencyMeasurementVarianceParams(
         totalReach,
-        reachVariance,
+        reachMeasurementVariance,
         relativeFrequencyDistribution,
         frequencyMeasurementParams
       )
 
     val (rKVars, rKPlusVars, nKVars, nKPlusVars) =
-      Variances.computeLiquidLegionsV2Variance(liquidLegionsSketchParams, frequencyVarianceParams)
+      Variances.computeLiquidLegionsV2Variance(
+        liquidLegionsSketchParams,
+        frequencyMeasurementVarianceParams
+      )
 
     val expectedRK = listOf(0.0, 0.0, 0.0, 0.0, 0.0)
     val expectedRKPlus = listOf(0.0, 0.0, 0.0, 0.0, 0.0)


### PR DESCRIPTION
* Rename `*VarianceParams` to `*MeasurementVarianceParams` to better distinguish from `*MetricVarianceParams` later.
* Store `VidSamplingInterval` instead of just `vidSamplingIntervalWidth` in `*MeasurementParams` for later use in covariance calculations.