### PR TITLE
Add metric variance calculations

### DIFF
--- a/src/main/kotlin/org/wfanet/measurement/measurementconsumer/stats/BUILD.bazel
+++ b/src/main/kotlin/org/wfanet/measurement/measurementconsumer/stats/BUILD.bazel
@@ -22,11 +22,19 @@ kt_jvm_library(
 )
 
 kt_jvm_library(
+    name = "stats_exceptions",
+    srcs = ["StatsExceptions.kt"],
+)
+
+kt_jvm_library(
     name = "variances",
     srcs = ["Variances.kt"],
     deps = [
+        ":covariances",
         ":liquid_legions",
         ":measurement_statistics",
+        ":metric_statistics",
+        ":stats_exceptions",
         "//src/main/kotlin/org/wfanet/measurement/eventdataprovider/noiser",
         "@wfa_common_jvm//imports/java/org/apache/commons:math3",
     ],
@@ -38,7 +46,17 @@ kt_jvm_library(
     deps = [
         ":liquid_legions",
         ":measurement_statistics",
+        ":metric_statistics",
+        ":stats_exceptions",
         "//src/main/kotlin/org/wfanet/measurement/eventdataprovider/noiser",
         "@wfa_common_jvm//imports/java/org/apache/commons:math3",
+    ],
+)
+
+kt_jvm_library(
+    name = "metric_statistics",
+    srcs = ["MetricStatistics.kt"],
+    deps = [
+        ":measurement_statistics",
     ],
 )

--- a/src/main/kotlin/org/wfanet/measurement/measurementconsumer/stats/Covariances.kt
+++ b/src/main/kotlin/org/wfanet/measurement/measurementconsumer/stats/Covariances.kt
@@ -16,6 +16,9 @@
 
 package org.wfanet.measurement.measurementconsumer.stats
 
+import kotlin.math.max
+import kotlin.math.min
+
 /** Functions to compute different covariances. */
 object Covariances {
   /**
@@ -67,5 +70,138 @@ object Covariances {
           reachMeasurementCovarianceParams.unionSamplingWidth,
       inflation = 0.0
     )
+  }
+
+  /** Computes the covariance of two reach measurements based on their methodologies. */
+  fun computeMeasurementCovariance(
+    weightedMeasurementVarianceParams: WeightedReachMeasurementVarianceParams,
+    otherWeightedMeasurementVarianceParams: WeightedReachMeasurementVarianceParams,
+    unionWeightedMeasurementVarianceParams: WeightedReachMeasurementVarianceParams,
+  ): Double {
+    val unionSamplingWidth =
+      computeUnionSamplingWidth(
+        weightedMeasurementVarianceParams.measurementVarianceParams.measurementParams
+          .vidSamplingInterval,
+        otherWeightedMeasurementVarianceParams.measurementVarianceParams.measurementParams
+          .vidSamplingInterval
+      )
+
+    val liquidLegionsSketchParams =
+      when (val methodology = weightedMeasurementVarianceParams.methodology) {
+        is CustomDirectScalarMethodology,
+        is CustomDirectFrequencyMethodology -> {
+          // Custom direct methodology must guarantee independence.
+          return 0.0
+        }
+        is DeterministicMethodology -> {
+          return computeDeterministicCovariance(
+            ReachMeasurementCovarianceParams(
+              reach = weightedMeasurementVarianceParams.measurementVarianceParams.reach,
+              otherReach = otherWeightedMeasurementVarianceParams.measurementVarianceParams.reach,
+              unionReach = unionWeightedMeasurementVarianceParams.measurementVarianceParams.reach,
+              samplingWidth =
+                weightedMeasurementVarianceParams.measurementVarianceParams.measurementParams
+                  .vidSamplingInterval
+                  .width,
+              otherSamplingWidth =
+                otherWeightedMeasurementVarianceParams.measurementVarianceParams.measurementParams
+                  .vidSamplingInterval
+                  .width,
+              unionSamplingWidth = unionSamplingWidth
+            )
+          )
+        }
+        is LiquidLegionsSketchMethodology -> {
+          LiquidLegionsSketchParams(methodology.decayRate, methodology.sketchSize)
+        }
+        is LiquidLegionsV2Methodology -> {
+          LiquidLegionsSketchParams(methodology.decayRate, methodology.sketchSize)
+        }
+      }
+
+    when (val otherMethodology = otherWeightedMeasurementVarianceParams.methodology) {
+      is CustomDirectScalarMethodology,
+      is CustomDirectFrequencyMethodology -> {
+        // Custom direct methodology must guarantee independence.
+        return 0.0
+      }
+      is DeterministicMethodology -> {
+        return computeDeterministicCovariance(
+          ReachMeasurementCovarianceParams(
+            reach = weightedMeasurementVarianceParams.measurementVarianceParams.reach,
+            otherReach = otherWeightedMeasurementVarianceParams.measurementVarianceParams.reach,
+            unionReach = unionWeightedMeasurementVarianceParams.measurementVarianceParams.reach,
+            samplingWidth =
+              weightedMeasurementVarianceParams.measurementVarianceParams.measurementParams
+                .vidSamplingInterval
+                .width,
+            otherSamplingWidth =
+              otherWeightedMeasurementVarianceParams.measurementVarianceParams.measurementParams
+                .vidSamplingInterval
+                .width,
+            unionSamplingWidth = unionSamplingWidth
+          )
+        )
+      }
+      is LiquidLegionsSketchMethodology -> {
+        if (
+          liquidLegionsSketchParams.decayRate != otherMethodology.decayRate ||
+            liquidLegionsSketchParams.sketchSize != otherMethodology.sketchSize
+        ) {
+          throw IllegalArgumentException(
+            "Covariance calculation for Liquid Legions based measurements requires two " +
+              "measurements using the same decay rate and sketch size."
+          )
+        }
+      }
+      is LiquidLegionsV2Methodology -> {
+        if (
+          liquidLegionsSketchParams.decayRate != otherMethodology.decayRate ||
+            liquidLegionsSketchParams.sketchSize != otherMethodology.sketchSize
+        ) {
+          throw IllegalArgumentException(
+            "Covariance calculation for Liquid Legions based measurements requires two " +
+              "measurements using the same decay rate and sketch size."
+          )
+        }
+      }
+    }
+    return computeLiquidLegionsCovariance(
+      sketchParams = liquidLegionsSketchParams,
+      ReachMeasurementCovarianceParams(
+        reach = weightedMeasurementVarianceParams.measurementVarianceParams.reach,
+        otherReach = otherWeightedMeasurementVarianceParams.measurementVarianceParams.reach,
+        unionReach = unionWeightedMeasurementVarianceParams.measurementVarianceParams.reach,
+        samplingWidth =
+          weightedMeasurementVarianceParams.measurementVarianceParams.measurementParams
+            .vidSamplingInterval
+            .width,
+        otherSamplingWidth =
+          otherWeightedMeasurementVarianceParams.measurementVarianceParams.measurementParams
+            .vidSamplingInterval
+            .width,
+        unionSamplingWidth = unionSamplingWidth
+      )
+    )
+  }
+
+  /** Computes the width of the union of two sampling intervals. */
+  private fun computeUnionSamplingWidth(
+    vidSamplingInterval: VidSamplingInterval,
+    otherVidSamplingInterval: VidSamplingInterval,
+  ): Double {
+    return max(
+      vidSamplingInterval.start + vidSamplingInterval.width,
+      otherVidSamplingInterval.start + otherVidSamplingInterval.width
+    ) -
+      min(vidSamplingInterval.start, otherVidSamplingInterval.start) -
+      max(
+        0.0,
+        otherVidSamplingInterval.start - vidSamplingInterval.start - vidSamplingInterval.width
+      ) -
+      max(
+        0.0,
+        vidSamplingInterval.start - otherVidSamplingInterval.start - otherVidSamplingInterval.width
+      )
   }
 }

--- a/src/main/kotlin/org/wfanet/measurement/measurementconsumer/stats/LiquidLegions.kt
+++ b/src/main/kotlin/org/wfanet/measurement/measurementconsumer/stats/LiquidLegions.kt
@@ -30,7 +30,7 @@ private const val DECAY_RATE_THRESHOLD = 0.01
 private const val MIN_SUM_OF_REGISTER_PROBABILITY_POWERS = 1e-16
 
 /** The parameters that are used to compute Liquid Legions sketch. */
-data class LiquidLegionsSketchParams(val decayRate: Double, val sketchSize: Double) {
+data class LiquidLegionsSketchParams(val decayRate: Double, val sketchSize: Long) {
   val constValue =
     if (decayRate < DECAY_RATE_THRESHOLD) {
       1.0 / sketchSize
@@ -103,7 +103,7 @@ object LiquidLegions {
 
     val prob =
       if (decayRate < DECAY_RATE_THRESHOLD) {
-        sketchSize.pow(1.0 - k) * exp(-y / sketchSize)
+        sketchSize.toDouble().pow(1.0 - k) * exp(-y / sketchSize)
       } else if (k == 0.0) {
         sketchSize / decayRate *
           (expIntForNegativeInput(-constValue * y) -
@@ -294,24 +294,6 @@ object LiquidLegions {
           (registerNumVariancePerFrequency + multiplier * frequencyNoiseVariance) -
         2.0 * reachRatio / expectedRegisterNum.pow(2.0) * covariance
 
-    return max(0.0, variance)
-  }
-
-  /**
-   * Outputs the variance of the given reach count at a certain frequency from the Liquid Legions
-   * based distribution methodology.
-   *
-   * Reach count = [totalReach] * [reachRatio]
-   */
-  fun liquidLegionsFrequencyCountVariance(
-    totalReach: Long,
-    totalReachVariance: Double,
-    reachRatio: Double,
-    reachRatioVariance: Double,
-  ): Double {
-    val variance =
-      (reachRatioVariance + reachRatio.pow(2.0)) *
-        (totalReachVariance + totalReach.toDouble().pow(2.0)) - (reachRatio * totalReach).pow(2.0)
     return max(0.0, variance)
   }
 }

--- a/src/main/kotlin/org/wfanet/measurement/measurementconsumer/stats/MetricStatistics.kt
+++ b/src/main/kotlin/org/wfanet/measurement/measurementconsumer/stats/MetricStatistics.kt
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2023 The Cross-Media Measurement Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wfanet.measurement.measurementconsumer.stats
+
+sealed interface Methodology
+
+data class CustomDirectScalarMethodology(val variance: Double) : Methodology
+
+data class CustomDirectFrequencyMethodology(
+  val relativeVariances: FrequencyVariance,
+  val kPlusRelativeVariances: FrequencyVariance
+) : Methodology
+
+object DeterministicMethodology : Methodology
+
+data class LiquidLegionsSketchMethodology(val decayRate: Double, val sketchSize: Long) :
+  Methodology
+
+data class LiquidLegionsV2Methodology(
+  val decayRate: Double,
+  val sketchSize: Long,
+  val samplingIndicatorSize: Long
+) : Methodology
+
+data class WeightedReachMeasurementVarianceParams(
+  val binaryRepresentation: Int,
+  val weight: Int,
+  val measurementVarianceParams: ReachMeasurementVarianceParams,
+  val methodology: Methodology
+)
+
+data class WeightedFrequencyMeasurementVarianceParams(
+  val binaryRepresentation: Int,
+  val weight: Int,
+  val measurementVarianceParams: FrequencyMeasurementVarianceParams,
+  val methodology: Methodology
+)
+
+data class WeightedImpressionMeasurementVarianceParams(
+  val binaryRepresentation: Int,
+  val weight: Int,
+  val measurementVarianceParams: ImpressionMeasurementVarianceParams,
+  val methodology: Methodology
+)
+
+data class WeightedWatchDurationMeasurementVarianceParams(
+  val binaryRepresentation: Int,
+  val weight: Int,
+  val measurementVarianceParams: WatchDurationMeasurementVarianceParams,
+  val methodology: Methodology
+)
+
+/** The parameters used to compute the variance of a reach metric. */
+data class ReachMetricVarianceParams(
+  val weightedMeasurementVarianceParamsList: List<WeightedReachMeasurementVarianceParams>
+)
+
+/** The parameters used to compute the variance of a reach-and-frequency metric. */
+data class FrequencyMetricVarianceParams(
+  val weightedMeasurementVarianceParamsList: List<WeightedFrequencyMeasurementVarianceParams>
+)
+
+/** The parameters used to compute the variance of an impression metric. */
+data class ImpressionMetricVarianceParams(
+  val weightedMeasurementVarianceParamsList: List<WeightedImpressionMeasurementVarianceParams>
+)
+
+/** The parameters used to compute the variance of a watch duration metric. */
+data class WatchDurationMetricVarianceParams(
+  val weightedMeasurementVarianceParamsList: List<WeightedWatchDurationMeasurementVarianceParams>
+)

--- a/src/main/kotlin/org/wfanet/measurement/measurementconsumer/stats/StatsExceptions.kt
+++ b/src/main/kotlin/org/wfanet/measurement/measurementconsumer/stats/StatsExceptions.kt
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2023 The Cross-Media Measurement Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wfanet.measurement.measurementconsumer.stats
+
+/** [Exception] indicates a unsupported usage of a methodology. */
+class UnsupportedMethodologyUsageException(message: String? = null, cause: Throwable? = null) :
+  Exception(message, cause)

--- a/src/main/kotlin/org/wfanet/measurement/measurementconsumer/stats/Variances.kt
+++ b/src/main/kotlin/org/wfanet/measurement/measurementconsumer/stats/Variances.kt
@@ -79,7 +79,7 @@ object Variances {
     return frequencyVariance(
       params,
       ::deterministicFrequencyRelativeVariance,
-      ::deterministicFrequencyCountVariance
+      ::frequencyCountVariance
     )
   }
 
@@ -108,12 +108,11 @@ object Variances {
   }
 
   /**
-   * Outputs the variance of the given reach count at a certain frequency and the reach ratio
-   * computed using the deterministic distribution methodology.
+   * Outputs the variance of the reach count and the reach ratio at a certain frequency.
    *
    * Reach count = [totalReach] * [reachRatio]
    */
-  private fun deterministicFrequencyCountVariance(
+  private fun frequencyCountVariance(
     totalReach: Long,
     totalReachVariance: Double,
     reachRatio: Double,
@@ -136,9 +135,7 @@ object Variances {
     maximumFrequencyPerUser: Double,
     noiseMechanism: NoiseMechanism,
   ): Double {
-    if (measurementValue < 0.0) {
-      throw IllegalArgumentException("The scalar measurement value cannot be negative.")
-    }
+    require(measurementValue >= 0.0) { "The scalar measurement value cannot be negative." }
     val noiseVariance: Double = computeNoiseVariance(dpParams, noiseMechanism)
     val variance =
       (maximumFrequencyPerUser *
@@ -192,7 +189,7 @@ object Variances {
     return frequencyVariance(
       params,
       constructLiquidLegionsSketchFrequencyRelativeVariance(sketchParams, params.measurementParams),
-      LiquidLegions::liquidLegionsFrequencyCountVariance
+      ::frequencyCountVariance
     )
   }
 
@@ -261,7 +258,7 @@ object Variances {
     return frequencyVariance(
       params,
       constructLiquidLegionsV2FrequencyRelativeVariance(sketchParams, params.measurementParams),
-      LiquidLegions::liquidLegionsFrequencyCountVariance
+      ::frequencyCountVariance
     )
   }
 
@@ -350,11 +347,9 @@ object Variances {
         reachRatioVariance: Double,
       ) -> Double
   ): FrequencyVariances {
-    if (params.totalReach < 0.0) {
-      throw IllegalArgumentException("The total reach value cannot be negative.")
-    }
-    if (params.reachMeasurementVariance < 0.0) {
-      throw IllegalArgumentException("The reach variance value cannot be negative.")
+    require(params.totalReach >= 0.0) { "The total reach value cannot be negative." }
+    require(params.reachMeasurementVariance >= 0.0) {
+      "The reach variance value cannot be negative."
     }
 
     val maximumFrequency = params.measurementParams.maximumFrequency
@@ -414,4 +409,350 @@ object Variances {
       kPlusCountVariances
     )
   }
+  /**
+   * Common function that computes [FrequencyVariances] with known [relativeVariances] and
+   * [kPlusRelativeVariances].
+   */
+  private fun frequencyVariance(
+    params: FrequencyMeasurementVarianceParams,
+    relativeVariances: Map<Int, Double>,
+    kPlusRelativeVariances: Map<Int, Double>,
+    frequencyCountVarianceFun:
+      (
+        totalReach: Long,
+        totalReachVariance: Double,
+        reachRatio: Double,
+        reachRatioVariance: Double,
+      ) -> Double
+  ): FrequencyVariances {
+    require(params.totalReach >= 0.0) { "The total reach value cannot be negative." }
+    require(params.reachMeasurementVariance >= 0.0) {
+      "The reach variance value cannot be negative."
+    }
+
+    val maximumFrequency = params.measurementParams.maximumFrequency
+
+    var suffixSum = 0.0
+    // There is no estimate of zero-frequency reach
+    val kPlusRelativeFrequencyDistribution: Map<Int, Double> =
+      (maximumFrequency downTo 1).associateWith { frequency ->
+        suffixSum += params.relativeFrequencyDistribution.getOrDefault(frequency, 0.0)
+        suffixSum
+      }
+
+    val countVariances: Map<Int, Double> =
+      (1..maximumFrequency).associateWith { frequency ->
+        frequencyCountVarianceFun(
+          params.totalReach,
+          params.reachMeasurementVariance,
+          params.relativeFrequencyDistribution.getOrDefault(frequency, 0.0),
+          relativeVariances.getValue(frequency)
+        )
+      }
+
+    val kPlusCountVariances: Map<Int, Double> =
+      (1..maximumFrequency).associateWith { frequency ->
+        frequencyCountVarianceFun(
+          params.totalReach,
+          params.reachMeasurementVariance,
+          kPlusRelativeFrequencyDistribution.getValue(frequency),
+          kPlusRelativeVariances.getValue(frequency)
+        )
+      }
+
+    return FrequencyVariances(
+      relativeVariances,
+      kPlusRelativeVariances,
+      countVariances,
+      kPlusCountVariances
+    )
+  }
+
+  /** Computes variance of a reach metric. */
+  fun computeMetricVariance(params: ReachMetricVarianceParams): Double {
+    require(params.weightedMeasurementVarianceParamsList.isNotEmpty()) {
+      "Invalid params: number of measurements must be greater than 0."
+    }
+
+    // Sum of weighted measurement variances = Sum_i a_i^2 * msmt_var_i
+    var metricVariance: Double =
+      params.weightedMeasurementVarianceParamsList.sumOf { weightedMeasurementVarianceParams ->
+        weightedMeasurementVarianceParams.weight.square() *
+          computeMeasurementVariance(
+            weightedMeasurementVarianceParams.methodology,
+            weightedMeasurementVarianceParams.measurementVarianceParams
+          )
+      }
+
+    val weightedMeasurementVarianceParamsMap =
+      params.weightedMeasurementVarianceParamsList.associateBy { weightedMeasurementVarianceParams
+        ->
+        weightedMeasurementVarianceParams.binaryRepresentation
+      }
+    val numberMeasurements = params.weightedMeasurementVarianceParamsList.size
+
+    // For every two distinct measurements in the list
+    for (index in 0 until numberMeasurements) {
+      for (otherIndex in index + 1 until numberMeasurements) {
+        val weightedMeasurementVarianceParams = params.weightedMeasurementVarianceParamsList[index]
+        val otherWeightedMeasurementVarianceParams =
+          params.weightedMeasurementVarianceParamsList[otherIndex]
+        val unionWeightedMeasurementVarianceParams =
+          weightedMeasurementVarianceParamsMap.getValue(
+            weightedMeasurementVarianceParams.binaryRepresentation or
+              otherWeightedMeasurementVarianceParams.binaryRepresentation
+          )
+
+        // Add weighted measurement covariance = 2 * a_i * a_j * cov(msmt_i, msmt_j)
+        metricVariance +=
+          2 *
+            weightedMeasurementVarianceParams.weight *
+            otherWeightedMeasurementVarianceParams.weight *
+            Covariances.computeMeasurementCovariance(
+              weightedMeasurementVarianceParams,
+              otherWeightedMeasurementVarianceParams,
+              unionWeightedMeasurementVarianceParams
+            )
+      }
+    }
+
+    return max(0.0, metricVariance)
+  }
+
+  /** Computes variance of a reach measurement based on the methodology. */
+  fun computeMeasurementVariance(
+    methodology: Methodology,
+    measurementVarianceParams: ReachMeasurementVarianceParams
+  ): Double {
+    return when (methodology) {
+      is CustomDirectScalarMethodology -> {
+        methodology.variance
+      }
+      is CustomDirectFrequencyMethodology -> {
+        throw UnsupportedMethodologyUsageException(
+          "Custom direct methodology for frequency cannot be used for reach."
+        )
+      }
+      is DeterministicMethodology -> {
+        computeDeterministicVariance(measurementVarianceParams)
+      }
+      is LiquidLegionsSketchMethodology -> {
+        computeLiquidLegionsSketchVariance(
+          LiquidLegionsSketchParams(methodology.decayRate, methodology.sketchSize),
+          measurementVarianceParams
+        )
+      }
+      is LiquidLegionsV2Methodology -> {
+        computeLiquidLegionsV2Variance(
+          LiquidLegionsSketchParams(methodology.decayRate, methodology.sketchSize),
+          measurementVarianceParams
+        )
+      }
+    }
+  }
+
+  /**
+   * Computes variance of a frequency metric.
+   *
+   * Currently, only support variance of frequency metrics that are computed on union-only set
+   * expression. That is, metrics that are composed of single source measurement.
+   */
+  fun computeMetricVariance(params: FrequencyMetricVarianceParams): FrequencyVariances {
+    require(params.weightedMeasurementVarianceParamsList.isNotEmpty()) {
+      "Invalid params: number of measurements must be greater than 0."
+    }
+
+    require(params.weightedMeasurementVarianceParamsList.size == 1) {
+      "Only support variance calculation of frequency metrics computed on union-only set " +
+        "expressions."
+    }
+
+    val weightedMeasurementVarianceParams = params.weightedMeasurementVarianceParamsList.first()
+
+    val coefficient = weightedMeasurementVarianceParams.weight.square()
+
+    val frequencyVariances: FrequencyVariances =
+      computeMeasurementVariance(
+        weightedMeasurementVarianceParams.methodology,
+        weightedMeasurementVarianceParams.measurementVarianceParams
+      )
+
+    return FrequencyVariances(
+      relativeVariances = frequencyVariances.relativeVariances.mapValues { coefficient * it.value },
+      kPlusRelativeVariances =
+        frequencyVariances.relativeVariances.mapValues { coefficient * it.value },
+      countVariances = frequencyVariances.countVariances.mapValues { coefficient * it.value },
+      kPlusCountVariances =
+        frequencyVariances.kPlusCountVariances.mapValues { coefficient * it.value },
+    )
+  }
+
+  /** Computes variance of a frequency measurement based on the methodology. */
+  fun computeMeasurementVariance(
+    methodology: Methodology,
+    measurementVarianceParams: FrequencyMeasurementVarianceParams
+  ): FrequencyVariances {
+    return when (methodology) {
+      is CustomDirectScalarMethodology -> {
+        throw UnsupportedMethodologyUsageException(
+          "Custom direct methodology for scalar cannot be used for frequency."
+        )
+      }
+      is CustomDirectFrequencyMethodology -> {
+        computeCustomDirectMethodologyVariance(methodology, measurementVarianceParams)
+      }
+      is DeterministicMethodology -> {
+        computeDeterministicVariance(measurementVarianceParams)
+      }
+      is LiquidLegionsSketchMethodology -> {
+        computeLiquidLegionsSketchVariance(
+          LiquidLegionsSketchParams(methodology.decayRate, methodology.sketchSize),
+          measurementVarianceParams
+        )
+      }
+      is LiquidLegionsV2Methodology -> {
+        computeLiquidLegionsV2Variance(
+          LiquidLegionsSketchParams(methodology.decayRate, methodology.sketchSize),
+          measurementVarianceParams
+        )
+      }
+    }
+  }
+
+  /**
+   * Computes [FrequencyVariances] of a reach-and-frequency measurement where the frequency
+   * distribution result is computed using a custom direct frequency methodology.
+   *
+   * Note that the reach can be computed using any methodology.
+   */
+  private fun computeCustomDirectMethodologyVariance(
+    methodology: CustomDirectFrequencyMethodology,
+    params: FrequencyMeasurementVarianceParams,
+  ): FrequencyVariances {
+    return frequencyVariance(
+      params,
+      methodology.relativeVariances,
+      methodology.kPlusRelativeVariances,
+      ::frequencyCountVariance
+    )
+  }
+
+  /**
+   * Computes variance of an impression metric.
+   *
+   * Currently, only support variance of impression metrics that are computed on union-only set
+   * expression. That is, metrics that are composed of single source measurement.
+   */
+  fun computeMetricVariance(params: ImpressionMetricVarianceParams): Double {
+    require(params.weightedMeasurementVarianceParamsList.isNotEmpty()) {
+      "Invalid params: number of measurements must be greater than 0."
+    }
+
+    require(params.weightedMeasurementVarianceParamsList.size == 1) {
+      "Only support variance calculation of impression metrics computed on union-only set " +
+        "expressions."
+    }
+
+    val weightedMeasurementVarianceParams = params.weightedMeasurementVarianceParamsList.first()
+
+    return weightedMeasurementVarianceParams.weight.square() *
+      computeMeasurementVariance(
+        weightedMeasurementVarianceParams.methodology,
+        weightedMeasurementVarianceParams.measurementVarianceParams
+      )
+  }
+
+  /** Computes variance of an impression measurement based on the methodology. */
+  private fun computeMeasurementVariance(
+    methodology: Methodology,
+    measurementVarianceParams: ImpressionMeasurementVarianceParams,
+  ): Double {
+    return when (methodology) {
+      is CustomDirectScalarMethodology -> {
+        methodology.variance
+      }
+      is CustomDirectFrequencyMethodology -> {
+        throw UnsupportedMethodologyUsageException(
+          "Custom direct methodology for frequency cannot be used for impression."
+        )
+      }
+      is DeterministicMethodology -> {
+        computeDeterministicVariance(measurementVarianceParams)
+      }
+      is LiquidLegionsSketchMethodology -> {
+        throw UnsupportedMethodologyUsageException(
+          "Methodology LIQUID_LEGIONS_SKETCH is not supported for impression.",
+          IllegalArgumentException("Invalid methodology")
+        )
+      }
+      is LiquidLegionsV2Methodology -> {
+        throw UnsupportedMethodologyUsageException(
+          "Methodology LIQUID_LEGIONS_V2 is not supported for impression.",
+          IllegalArgumentException("Invalid methodology")
+        )
+      }
+    }
+  }
+
+  /**
+   * Computes variance of a watch duration metric.
+   *
+   * Currently, only support variance of watch duration metrics that are computed on union-only set
+   * expression. That is, metrics that are composed of single source measurement.
+   */
+  fun computeMetricVariance(params: WatchDurationMetricVarianceParams): Double {
+    require(params.weightedMeasurementVarianceParamsList.isNotEmpty()) {
+      "Invalid params: number of measurements must be greater than 0."
+    }
+
+    require(params.weightedMeasurementVarianceParamsList.size == 1) {
+      "Only support variance calculation of watch duration metrics computed on union-only set " +
+        "expressions."
+    }
+
+    val weightedMeasurementVarianceParams = params.weightedMeasurementVarianceParamsList.first()
+
+    return weightedMeasurementVarianceParams.weight.square() *
+      computeMeasurementVariance(
+        weightedMeasurementVarianceParams.methodology,
+        weightedMeasurementVarianceParams.measurementVarianceParams
+      )
+  }
+
+  /** Computes variance of a watch duration measurement based on the methodology. */
+  private fun computeMeasurementVariance(
+    methodology: Methodology,
+    measurementVarianceParams: WatchDurationMeasurementVarianceParams,
+  ): Double {
+    return when (methodology) {
+      is CustomDirectScalarMethodology -> {
+        methodology.variance
+      }
+      is CustomDirectFrequencyMethodology -> {
+        throw UnsupportedMethodologyUsageException(
+          "Custom direct methodology for frequency cannot be used for watch duration."
+        )
+      }
+      is DeterministicMethodology -> {
+        computeDeterministicVariance(measurementVarianceParams)
+      }
+      is LiquidLegionsSketchMethodology -> {
+        throw UnsupportedMethodologyUsageException(
+          "Methodology LIQUID_LEGIONS_SKETCH is not supported for watch duration.",
+          IllegalArgumentException("Invalid methodology")
+        )
+      }
+      is LiquidLegionsV2Methodology -> {
+        throw UnsupportedMethodologyUsageException(
+          "Methodology LIQUID_LEGIONS_V2 is not supported for watch duration.",
+          IllegalArgumentException("Invalid methodology")
+        )
+      }
+    }
+  }
+}
+
+/** Outputs the square of an [Int] value. */
+private fun Int.square(): Int {
+  return this * this
 }

--- a/src/test/kotlin/org/wfanet/measurement/measurementconsumer/stats/CovariancesTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/measurementconsumer/stats/CovariancesTest.kt
@@ -18,9 +18,11 @@ package org.wfanet.measurement.measurementconsumer.stats
 
 import com.google.common.truth.Truth.assertThat
 import kotlin.math.abs
+import kotlin.test.assertFailsWith
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
+import org.wfanet.measurement.eventdataprovider.noiser.DpParams
 
 @RunWith(JUnit4::class)
 class CovariancesTest {
@@ -29,18 +31,18 @@ class CovariancesTest {
     val reachMeasurementCovarianceParams =
       ReachMeasurementCovarianceParams(1, 2, 2, 2e-4, 3e-4, 4e-4)
     val covariance = Covariances.computeDeterministicCovariance(reachMeasurementCovarianceParams)
-    val expect = 1665.6666666666665
-    val percentageError = percentageError(covariance, expect)
-    assertThat(percentageError).isLessThan(ERROR_TOLERANCE)
+    val expected = 1665.6666666666665
+    val tolerance = computeErrorTolerance(covariance, expected)
+    assertThat(covariance).isWithin(tolerance).of(expected)
   }
 
   @Test
   fun `computeDeterministicCovariance returns a value for reach when small reaches not overlap and large sampling widths not overlap `() {
     val reachMeasurementCovarianceParams = ReachMeasurementCovarianceParams(1, 2, 3, 0.5, 0.5, 1.0)
     val covariance = Covariances.computeDeterministicCovariance(reachMeasurementCovarianceParams)
-    val expect = 0.0
-    val percentageError = percentageError(covariance, expect)
-    assertThat(percentageError).isLessThan(ERROR_TOLERANCE)
+    val expected = 0.0
+    val tolerance = computeErrorTolerance(covariance, expected)
+    assertThat(covariance).isWithin(tolerance).of(expected)
   }
 
   @Test
@@ -49,9 +51,9 @@ class CovariancesTest {
       ReachMeasurementCovarianceParams(3e8.toLong(), 3e8.toLong(), 4e8.toLong(), 1e-4, 1e-4, 2e-4)
     val covariance = Covariances.computeDeterministicCovariance(reachMeasurementCovarianceParams)
 
-    val expect = -2e+8
-    val percentageError = percentageError(covariance, expect)
-    assertThat(percentageError).isLessThan(ERROR_TOLERANCE)
+    val expected = -2e+8
+    val tolerance = computeErrorTolerance(covariance, expected)
+    assertThat(covariance).isWithin(tolerance).of(expected)
   }
 
   @Test
@@ -59,9 +61,9 @@ class CovariancesTest {
     val reachMeasurementCovarianceParams =
       ReachMeasurementCovarianceParams(1, 3e6.toLong(), 3e6.toLong(), 0.5, 0.4, 0.7)
     val covariance = Covariances.computeDeterministicCovariance(reachMeasurementCovarianceParams)
-    val expect = 2.220446049250313e-16
-    val percentageError = percentageError(covariance, expect)
-    assertThat(percentageError).isLessThan(ERROR_TOLERANCE)
+    val expected = 2.220446049250313e-16
+    val tolerance = computeErrorTolerance(covariance, expected)
+    assertThat(covariance).isWithin(tolerance).of(expected)
   }
 
   @Test
@@ -76,110 +78,440 @@ class CovariancesTest {
         0.7,
       )
     val covariance = Covariances.computeDeterministicCovariance(reachMeasurementCovarianceParams)
-    val expect = 0.0
-    assertThat(covariance).isEqualTo(expect)
+    val expected = 0.0
+    assertThat(covariance).isEqualTo(expected)
   }
 
   @Test
   fun `computeLiquidLegionsCovariance returns a value for reach when small reaches overlap and small sampling widths not overlap`() {
     val decayRate = 1e-3
-    val sketchSize = 1e5
+    val sketchSize = 100000L
     val sketchParams = LiquidLegionsSketchParams(decayRate, sketchSize)
     val reachMeasurementCovarianceParams =
       ReachMeasurementCovarianceParams(5, 5, 5, 0.01, 0.01, 0.02)
     val covariance =
       Covariances.computeLiquidLegionsCovariance(sketchParams, reachMeasurementCovarianceParams)
 
-    val expect = -4.849999813860015
-    val percentageError = percentageError(covariance, expect)
-    assertThat(percentageError).isLessThan(ERROR_TOLERANCE)
+    val expected = -4.849999813860015
+    val tolerance = computeErrorTolerance(covariance, expected)
+    assertThat(covariance).isWithin(tolerance).of(expected)
   }
 
   @Test
   fun `computeLiquidLegionsCovariance returns a value for reach when small reaches not overlap and large sampling widths overlap `() {
     val decayRate = 15.0
-    val sketchSize = 1e5
+    val sketchSize = 100000L
     val sketchParams = LiquidLegionsSketchParams(decayRate, sketchSize)
     val reachMeasurementCovarianceParams = ReachMeasurementCovarianceParams(1, 1, 2, 0.5, 0.4, 0.5)
     val covariance =
       Covariances.computeLiquidLegionsCovariance(sketchParams, reachMeasurementCovarianceParams)
 
-    val expect = 0.000562525536043962
-    val percentageError = percentageError(covariance, expect)
-    assertThat(percentageError).isLessThan(ERROR_TOLERANCE)
+    val expected = 0.000562525536043962
+    val tolerance = computeErrorTolerance(covariance, expected)
+    assertThat(covariance).isWithin(tolerance).of(expected)
   }
 
   @Test
   fun `computeLiquidLegionsCovariance returns a value for reach when large reaches overlap and small sampling widths overlap`() {
     val decayRate = 15.0
-    val sketchSize = 1e5
+    val sketchSize = 100000L
     val sketchParams = LiquidLegionsSketchParams(decayRate, sketchSize)
     val reachMeasurementCovarianceParams =
       ReachMeasurementCovarianceParams(1e6.toLong(), 3e8.toLong(), 3e8.toLong(), 0.02, 0.01, 0.02)
     val covariance =
       Covariances.computeLiquidLegionsCovariance(sketchParams, reachMeasurementCovarianceParams)
 
-    val expect = 156079036.5929788
-    val percentageError = percentageError(covariance, expect)
-    assertThat(percentageError).isLessThan(ERROR_TOLERANCE)
+    val expected = 156079036.5929788
+    val tolerance = computeErrorTolerance(covariance, expected)
+    assertThat(covariance).isWithin(tolerance).of(expected)
   }
 
   @Test
   fun `computeLiquidLegionsCovariance returns a value for reach when large reaches not overlap and large sampling widths not overlap`() {
     val decayRate = 100.0
-    val sketchSize = 1e5
+    val sketchSize = 100000L
     val sketchParams = LiquidLegionsSketchParams(decayRate, sketchSize)
     val reachMeasurementCovarianceParams =
       ReachMeasurementCovarianceParams(3e8.toLong(), 3e8.toLong(), 6e8.toLong(), 0.3, 0.4, 0.7)
     val covariance =
       Covariances.computeLiquidLegionsCovariance(sketchParams, reachMeasurementCovarianceParams)
 
-    val expect = 428562.31521871715
-    val percentageError = percentageError(covariance, expect)
-    assertThat(percentageError).isLessThan(ERROR_TOLERANCE)
+    val expected = 428562.31521871715
+    val tolerance = computeErrorTolerance(covariance, expected)
+    assertThat(covariance).isWithin(tolerance).of(expected)
   }
 
   @Test
   fun `computeLiquidLegionsCovariance returns a value for reach when one reach is small`() {
     val decayRate = 1.0
-    val sketchSize = 1e5
+    val sketchSize = 100000L
     val sketchParams = LiquidLegionsSketchParams(decayRate, sketchSize)
     val reachMeasurementCovarianceParams =
       ReachMeasurementCovarianceParams(1, 3e6.toLong(), 3e6.toLong(), 0.5, 0.4, 0.7)
     val covariance =
       Covariances.computeLiquidLegionsCovariance(sketchParams, reachMeasurementCovarianceParams)
 
-    val expect = 0.0002056053253447586
-    val percentageError = percentageError(covariance, expect)
-    assertThat(percentageError).isLessThan(ERROR_TOLERANCE)
+    val expected = 0.0002056053253447586
+    val tolerance = computeErrorTolerance(covariance, expected)
+    assertThat(covariance).isWithin(tolerance).of(expected)
   }
 
   @Test
   fun `computeLiquidLegionsCovariance returns a value for reach when large reaches not overlap and large sampling widths overlap`() {
     val decayRate = 100.0
-    val sketchSize = 1e5
+    val sketchSize = 100000L
     val sketchParams = LiquidLegionsSketchParams(decayRate, sketchSize)
     val reachMeasurementCovarianceParams =
       ReachMeasurementCovarianceParams(3e8.toLong(), 3e8.toLong(), 6e8.toLong(), 0.7, 0.7, 0.7)
     val covariance =
       Covariances.computeLiquidLegionsCovariance(sketchParams, reachMeasurementCovarianceParams)
 
-    val expect = 214283.93565983986
-    val percentageError = percentageError(covariance, expect)
-    assertThat(percentageError).isLessThan(ERROR_TOLERANCE)
+    val expected = 214283.93565983986
+    val tolerance = computeErrorTolerance(covariance, expected)
+    assertThat(covariance).isWithin(tolerance).of(expected)
+  }
+
+  @Test
+  fun `computeMeasurementCovariance returns zero for reach when one is from custom direct methodology`() {
+    val weightedReachMeasurementVarianceParams =
+      WeightedReachMeasurementVarianceParams(
+        binaryRepresentation = 1,
+        weight = 1,
+        measurementVarianceParams =
+          ReachMeasurementVarianceParams(
+            reach = 1,
+            measurementParams =
+              ReachMeasurementParams(
+                vidSamplingInterval = VidSamplingInterval(0.0, 2e-4),
+                dpParams = DpParams(1.0, 1e-5),
+                noiseMechanism = NoiseMechanism.LAPLACE
+              )
+          ),
+        methodology = CustomDirectScalarMethodology(0.0)
+      )
+
+    val otherWeightedReachMeasurementVarianceParams =
+      WeightedReachMeasurementVarianceParams(
+        binaryRepresentation = 2,
+        weight = 1,
+        measurementVarianceParams =
+          ReachMeasurementVarianceParams(
+            reach = 2,
+            measurementParams =
+              ReachMeasurementParams(
+                vidSamplingInterval = VidSamplingInterval(1e-4, 3e-4),
+                dpParams = DpParams(1.0, 1e-5),
+                noiseMechanism = NoiseMechanism.LAPLACE
+              )
+          ),
+        methodology = DeterministicMethodology
+      )
+
+    val unionWeightedReachMeasurementVarianceParams =
+      WeightedReachMeasurementVarianceParams(
+        binaryRepresentation = 3,
+        weight = -1,
+        measurementVarianceParams =
+          ReachMeasurementVarianceParams(
+            reach = 2,
+            measurementParams =
+              ReachMeasurementParams(
+                vidSamplingInterval = VidSamplingInterval(0.0, 4e-4),
+                dpParams = DpParams(1.0, 1e-5),
+                noiseMechanism = NoiseMechanism.LAPLACE
+              )
+          ),
+        methodology = DeterministicMethodology
+      )
+
+    val covariance =
+      Covariances.computeMeasurementCovariance(
+        weightedReachMeasurementVarianceParams,
+        otherWeightedReachMeasurementVarianceParams,
+        unionWeightedReachMeasurementVarianceParams
+      )
+
+    val expected = 0.0
+
+    val tolerance = computeErrorTolerance(covariance, expected)
+    assertThat(covariance).isWithin(tolerance).of(expected)
+  }
+
+  @Test
+  fun `computeMeasurementCovariance returns a value for reach when two reach measurements are deterministic`() {
+    val weightedReachMeasurementVarianceParams =
+      WeightedReachMeasurementVarianceParams(
+        binaryRepresentation = 1,
+        weight = 1,
+        measurementVarianceParams =
+          ReachMeasurementVarianceParams(
+            reach = 1,
+            measurementParams =
+              ReachMeasurementParams(
+                vidSamplingInterval = VidSamplingInterval(0.0, 2e-4),
+                dpParams = DpParams(1.0, 1e-5),
+                noiseMechanism = NoiseMechanism.LAPLACE
+              )
+          ),
+        methodology = DeterministicMethodology
+      )
+
+    val otherWeightedReachMeasurementVarianceParams =
+      WeightedReachMeasurementVarianceParams(
+        binaryRepresentation = 2,
+        weight = 1,
+        measurementVarianceParams =
+          ReachMeasurementVarianceParams(
+            reach = 2,
+            measurementParams =
+              ReachMeasurementParams(
+                vidSamplingInterval = VidSamplingInterval(1e-4, 3e-4),
+                dpParams = DpParams(1.0, 1e-5),
+                noiseMechanism = NoiseMechanism.LAPLACE
+              )
+          ),
+        methodology = DeterministicMethodology
+      )
+
+    val unionWeightedReachMeasurementVarianceParams =
+      WeightedReachMeasurementVarianceParams(
+        binaryRepresentation = 3,
+        weight = -1,
+        measurementVarianceParams =
+          ReachMeasurementVarianceParams(
+            reach = 2,
+            measurementParams =
+              ReachMeasurementParams(
+                vidSamplingInterval = VidSamplingInterval(0.0, 4e-4),
+                dpParams = DpParams(1.0, 1e-5),
+                noiseMechanism = NoiseMechanism.LAPLACE
+              )
+          ),
+        methodology = DeterministicMethodology
+      )
+
+    val covariance =
+      Covariances.computeMeasurementCovariance(
+        weightedReachMeasurementVarianceParams,
+        otherWeightedReachMeasurementVarianceParams,
+        unionWeightedReachMeasurementVarianceParams
+      )
+
+    val expected = 1665.6666666666665
+
+    val tolerance = computeErrorTolerance(covariance, expected)
+    assertThat(covariance).isWithin(tolerance).of(expected)
+  }
+
+  @Test
+  fun `computeMeasurementCovariance returns a value for reach when one is LiquidLegionsSketch and one is deterministic`() {
+    val weightedReachMeasurementVarianceParams =
+      WeightedReachMeasurementVarianceParams(
+        binaryRepresentation = 1,
+        weight = 1,
+        measurementVarianceParams =
+          ReachMeasurementVarianceParams(
+            reach = 1,
+            measurementParams =
+              ReachMeasurementParams(
+                vidSamplingInterval = VidSamplingInterval(0.0, 2e-4),
+                dpParams = DpParams(1.0, 1e-5),
+                noiseMechanism = NoiseMechanism.LAPLACE
+              )
+          ),
+        methodology = LiquidLegionsSketchMethodology(100.0, 100000L)
+      )
+
+    val otherWeightedReachMeasurementVarianceParams =
+      WeightedReachMeasurementVarianceParams(
+        binaryRepresentation = 2,
+        weight = 1,
+        measurementVarianceParams =
+          ReachMeasurementVarianceParams(
+            reach = 2,
+            measurementParams =
+              ReachMeasurementParams(
+                vidSamplingInterval = VidSamplingInterval(1e-4, 3e-4),
+                dpParams = DpParams(1.0, 1e-5),
+                noiseMechanism = NoiseMechanism.LAPLACE
+              )
+          ),
+        methodology = DeterministicMethodology
+      )
+
+    val unionWeightedReachMeasurementVarianceParams =
+      WeightedReachMeasurementVarianceParams(
+        binaryRepresentation = 3,
+        weight = -1,
+        measurementVarianceParams =
+          ReachMeasurementVarianceParams(
+            reach = 2,
+            measurementParams =
+              ReachMeasurementParams(
+                vidSamplingInterval = VidSamplingInterval(0.0, 4e-4),
+                dpParams = DpParams(1.0, 1e-5),
+                noiseMechanism = NoiseMechanism.LAPLACE
+              )
+          ),
+        methodology = DeterministicMethodology
+      )
+
+    val covariance =
+      Covariances.computeMeasurementCovariance(
+        weightedReachMeasurementVarianceParams,
+        otherWeightedReachMeasurementVarianceParams,
+        unionWeightedReachMeasurementVarianceParams
+      )
+
+    val expected = 1665.6666666666665
+
+    val tolerance = computeErrorTolerance(covariance, expected)
+    assertThat(covariance).isWithin(tolerance).of(expected)
+  }
+
+  @Test
+  fun `computeMeasurementCovariance returns a value for reach when two reach measurements are LiquidLegionsSketch`() {
+    val decayRate = 100.0
+    val sketchSize = 100000L
+
+    val weightedReachMeasurementVarianceParams =
+      WeightedReachMeasurementVarianceParams(
+        binaryRepresentation = 1,
+        weight = 1,
+        measurementVarianceParams =
+          ReachMeasurementVarianceParams(
+            reach = 3e8.toLong(),
+            measurementParams =
+              ReachMeasurementParams(
+                vidSamplingInterval = VidSamplingInterval(0.0, 0.7),
+                dpParams = DpParams(1.0, 1e-5),
+                noiseMechanism = NoiseMechanism.LAPLACE
+              )
+          ),
+        methodology = LiquidLegionsSketchMethodology(decayRate, sketchSize)
+      )
+
+    val otherWeightedReachMeasurementVarianceParams =
+      WeightedReachMeasurementVarianceParams(
+        binaryRepresentation = 2,
+        weight = 1,
+        measurementVarianceParams =
+          ReachMeasurementVarianceParams(
+            reach = 3e8.toLong(),
+            measurementParams =
+              ReachMeasurementParams(
+                vidSamplingInterval = VidSamplingInterval(0.0, 0.7),
+                dpParams = DpParams(1.0, 1e-5),
+                noiseMechanism = NoiseMechanism.LAPLACE
+              )
+          ),
+        methodology = LiquidLegionsSketchMethodology(decayRate, sketchSize)
+      )
+
+    val unionWeightedReachMeasurementVarianceParams =
+      WeightedReachMeasurementVarianceParams(
+        binaryRepresentation = 3,
+        weight = -1,
+        measurementVarianceParams =
+          ReachMeasurementVarianceParams(
+            reach = 6e8.toLong(),
+            measurementParams =
+              ReachMeasurementParams(
+                vidSamplingInterval = VidSamplingInterval(0.0, 0.7),
+                dpParams = DpParams(1.0, 1e-5),
+                noiseMechanism = NoiseMechanism.LAPLACE
+              )
+          ),
+        methodology = LiquidLegionsSketchMethodology(decayRate, sketchSize)
+      )
+
+    val covariance =
+      Covariances.computeMeasurementCovariance(
+        weightedReachMeasurementVarianceParams,
+        otherWeightedReachMeasurementVarianceParams,
+        unionWeightedReachMeasurementVarianceParams
+      )
+
+    val expected = 214283.93565983986
+
+    val tolerance = computeErrorTolerance(covariance, expected)
+    assertThat(covariance).isWithin(tolerance).of(expected)
+  }
+
+  @Test
+  fun `computeMeasurementCovariance throws IllegalArgumentException for reach when sketch params are not matched`() {
+    val decayRate = 100.0
+    val sketchSize = 100000L
+
+    val weightedReachMeasurementVarianceParams =
+      WeightedReachMeasurementVarianceParams(
+        binaryRepresentation = 1,
+        weight = 1,
+        measurementVarianceParams =
+          ReachMeasurementVarianceParams(
+            reach = 3e8.toLong(),
+            measurementParams =
+              ReachMeasurementParams(
+                vidSamplingInterval = VidSamplingInterval(0.0, 0.7),
+                dpParams = DpParams(1.0, 1e-5),
+                noiseMechanism = NoiseMechanism.LAPLACE
+              )
+          ),
+        methodology = LiquidLegionsSketchMethodology(decayRate, sketchSize)
+      )
+
+    val otherWeightedReachMeasurementVarianceParams =
+      WeightedReachMeasurementVarianceParams(
+        binaryRepresentation = 2,
+        weight = 1,
+        measurementVarianceParams =
+          ReachMeasurementVarianceParams(
+            reach = 3e8.toLong(),
+            measurementParams =
+              ReachMeasurementParams(
+                vidSamplingInterval = VidSamplingInterval(0.0, 0.7),
+                dpParams = DpParams(1.0, 1e-5),
+                noiseMechanism = NoiseMechanism.LAPLACE
+              )
+          ),
+        methodology = LiquidLegionsSketchMethodology(decayRate + 1, sketchSize)
+      )
+
+    val unionWeightedReachMeasurementVarianceParams =
+      WeightedReachMeasurementVarianceParams(
+        binaryRepresentation = 3,
+        weight = -1,
+        measurementVarianceParams =
+          ReachMeasurementVarianceParams(
+            reach = 6e8.toLong(),
+            measurementParams =
+              ReachMeasurementParams(
+                vidSamplingInterval = VidSamplingInterval(0.0, 0.7),
+                dpParams = DpParams(1.0, 1e-5),
+                noiseMechanism = NoiseMechanism.LAPLACE
+              )
+          ),
+        methodology = LiquidLegionsV2Methodology(decayRate + 2, sketchSize, 100000L)
+      )
+
+    assertFailsWith<IllegalArgumentException> {
+      Covariances.computeMeasurementCovariance(
+        weightedReachMeasurementVarianceParams,
+        otherWeightedReachMeasurementVarianceParams,
+        unionWeightedReachMeasurementVarianceParams
+      )
+    }
   }
 
   companion object {
-    fun percentageError(estimate: Double, truth: Double): Double {
-      return if (truth == 0.0) {
-        estimate
-      } else if (estimate == 0.0) {
-        truth
+    fun computeErrorTolerance(actual: Double, expected: Double): Double {
+      return if (expected == 0.0 || actual == 0.0) {
+        ERROR_TOLERANCE_PERCENTAGE
       } else {
-        abs(1.0 - (estimate / truth))
+        abs(expected * ERROR_TOLERANCE_PERCENTAGE)
       }
     }
 
-    const val ERROR_TOLERANCE = 5e-3
+    private const val ERROR_TOLERANCE_PERCENTAGE = 5e-3
   }
 }

--- a/src/test/kotlin/org/wfanet/measurement/measurementconsumer/stats/VariancesTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/measurementconsumer/stats/VariancesTest.kt
@@ -18,7 +18,7 @@ package org.wfanet.measurement.measurementconsumer.stats
 
 import com.google.common.truth.Truth.assertThat
 import kotlin.math.abs
-import org.junit.Assert.assertThrows
+import kotlin.test.assertFailsWith
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
@@ -41,9 +41,9 @@ class VariancesTest {
       ReachMeasurementVarianceParams(reach, reachMeasurementParams)
 
     val variance = Variances.computeDeterministicVariance(reachMeasurementVarianceParams)
-    val expect = 2.5e-7
-    val percentageError = percentageError(variance, expect)
-    assertThat(percentageError).isLessThan(ERROR_TOLERANCE)
+    val expected = 2.5e-7
+    val tolerance = computeErrorTolerance(variance, expected)
+    assertThat(variance).isWithin(tolerance).of(expected)
   }
 
   @Test
@@ -61,9 +61,9 @@ class VariancesTest {
       ReachMeasurementVarianceParams(reach, reachMeasurementParams)
 
     val variance = Variances.computeDeterministicVariance(reachMeasurementVarianceParams)
-    val expect = 1701291910758399.5
-    val percentageError = percentageError(variance, expect)
-    assertThat(percentageError).isLessThan(ERROR_TOLERANCE)
+    val expected = 1701291910758399.5
+    val tolerance = computeErrorTolerance(variance, expected)
+    assertThat(variance).isWithin(tolerance).of(expected)
   }
 
   @Test
@@ -81,9 +81,9 @@ class VariancesTest {
       ReachMeasurementVarianceParams(reach, reachMeasurementParams)
 
     val variance = Variances.computeDeterministicVariance(reachMeasurementVarianceParams)
-    val expect = 33906671.712079
-    val percentageError = percentageError(variance, expect)
-    assertThat(percentageError).isLessThan(ERROR_TOLERANCE)
+    val expected = 33906671.712079
+    val tolerance = computeErrorTolerance(variance, expected)
+    assertThat(variance).isWithin(tolerance).of(expected)
   }
 
   @Test
@@ -101,9 +101,9 @@ class VariancesTest {
       ReachMeasurementVarianceParams(reach, reachMeasurementParams)
 
     val variance = Variances.computeDeterministicVariance(reachMeasurementVarianceParams)
-    val expect = 49440108678400.01
-    val percentageError = percentageError(variance, expect)
-    assertThat(percentageError).isLessThan(ERROR_TOLERANCE)
+    val expected = 49440108678400.01
+    val tolerance = computeErrorTolerance(variance, expected)
+    assertThat(variance).isWithin(tolerance).of(expected)
   }
 
   @Test
@@ -120,7 +120,7 @@ class VariancesTest {
     val reachMeasurementVarianceParams =
       ReachMeasurementVarianceParams(reach, reachMeasurementParams)
 
-    assertThrows(IllegalArgumentException::class.java) {
+    assertFailsWith<IllegalArgumentException> {
       Variances.computeDeterministicVariance(reachMeasurementVarianceParams)
     }
   }
@@ -142,9 +142,9 @@ class VariancesTest {
       ImpressionMeasurementVarianceParams(impressions, impressionMeasurementParams)
 
     val variance = Variances.computeDeterministicVariance(impressionMeasurementVariancesParams)
-    val expect = 2.5e-7
-    val percentageError = percentageError(variance, expect)
-    assertThat(percentageError).isLessThan(ERROR_TOLERANCE)
+    val expected = 2.5e-7
+    val tolerance = computeErrorTolerance(variance, expected)
+    assertThat(variance).isWithin(tolerance).of(expected)
   }
 
   @Test
@@ -164,9 +164,9 @@ class VariancesTest {
       ImpressionMeasurementVarianceParams(impressions, impressionMeasurementParams)
 
     val variance = Variances.computeDeterministicVariance(impressionMeasurementVariancesParams)
-    val expect = 2102185919.1600006
-    val percentageError = percentageError(variance, expect)
-    assertThat(percentageError).isLessThan(ERROR_TOLERANCE)
+    val expected = 2102185919.1600006
+    val tolerance = computeErrorTolerance(variance, expected)
+    assertThat(variance).isWithin(tolerance).of(expected)
   }
 
   @Test
@@ -186,9 +186,9 @@ class VariancesTest {
       ImpressionMeasurementVarianceParams(impressions, impressionMeasurementParams)
 
     val variance = Variances.computeDeterministicVariance(impressionMeasurementVariancesParams)
-    val expect = 210218.58201600003
-    val percentageError = percentageError(variance, expect)
-    assertThat(percentageError).isLessThan(ERROR_TOLERANCE)
+    val expected = 210218.58201600003
+    val tolerance = computeErrorTolerance(variance, expected)
+    assertThat(variance).isWithin(tolerance).of(expected)
   }
 
   @Test
@@ -208,9 +208,9 @@ class VariancesTest {
       ImpressionMeasurementVarianceParams(impressions, impressionMeasurementParams)
 
     val variance = Variances.computeDeterministicVariance(impressionMeasurementVariancesParams)
-    val expect = 90027432806400.0
-    val percentageError = percentageError(variance, expect)
-    assertThat(percentageError).isLessThan(ERROR_TOLERANCE)
+    val expected = 90027432806400.0
+    val tolerance = computeErrorTolerance(variance, expected)
+    assertThat(variance).isWithin(tolerance).of(expected)
   }
 
   @Test
@@ -230,9 +230,9 @@ class VariancesTest {
       ImpressionMeasurementVarianceParams(impressions, impressionMeasurementParams)
 
     val variance = Variances.computeDeterministicVariance(impressionMeasurementVariancesParams)
-    val expect = 8408743280.640002
-    val percentageError = percentageError(variance, expect)
-    assertThat(percentageError).isLessThan(ERROR_TOLERANCE)
+    val expected = 8408743280.640002
+    val tolerance = computeErrorTolerance(variance, expected)
+    assertThat(variance).isWithin(tolerance).of(expected)
   }
 
   @Test
@@ -250,7 +250,7 @@ class VariancesTest {
     val impressionMeasurementVariancesParams =
       ImpressionMeasurementVarianceParams(impressions, impressionMeasurementParams)
 
-    assertThrows(IllegalArgumentException::class.java) {
+    assertFailsWith<IllegalArgumentException> {
       Variances.computeDeterministicVariance(impressionMeasurementVariancesParams)
     }
   }
@@ -272,9 +272,9 @@ class VariancesTest {
       WatchDurationMeasurementVarianceParams(watchDuration, watchDurationMeasurementParams)
 
     val variance = Variances.computeDeterministicVariance(watchDurationMeasurementVarianceParams)
-    val expect = 2.5e-7
-    val percentageError = percentageError(variance, expect)
-    assertThat(percentageError).isLessThan(ERROR_TOLERANCE)
+    val expected = 2.5e-7
+    val tolerance = computeErrorTolerance(variance, expected)
+    assertThat(variance).isWithin(tolerance).of(expected)
   }
 
   @Test
@@ -294,9 +294,9 @@ class VariancesTest {
       WatchDurationMeasurementVarianceParams(watchDuration, watchDurationMeasurementParams)
 
     val variance = Variances.computeDeterministicVariance(watchDurationMeasurementVarianceParams)
-    val expect = 2102185919.1600006
-    val percentageError = percentageError(variance, expect)
-    assertThat(percentageError).isLessThan(ERROR_TOLERANCE)
+    val expected = 2102185919.1600006
+    val tolerance = computeErrorTolerance(variance, expected)
+    assertThat(variance).isWithin(tolerance).of(expected)
   }
 
   @Test
@@ -316,9 +316,9 @@ class VariancesTest {
       WatchDurationMeasurementVarianceParams(watchDuration, watchDurationMeasurementParams)
 
     val variance = Variances.computeDeterministicVariance(watchDurationMeasurementVarianceParams)
-    val expect = 210218.58201600003
-    val percentageError = percentageError(variance, expect)
-    assertThat(percentageError).isLessThan(ERROR_TOLERANCE)
+    val expected = 210218.58201600003
+    val tolerance = computeErrorTolerance(variance, expected)
+    assertThat(variance).isWithin(tolerance).of(expected)
   }
 
   @Test
@@ -338,9 +338,9 @@ class VariancesTest {
       WatchDurationMeasurementVarianceParams(watchDuration, watchDurationMeasurementParams)
 
     val variance = Variances.computeDeterministicVariance(watchDurationMeasurementVarianceParams)
-    val expect = 90027432806400.0
-    val percentageError = percentageError(variance, expect)
-    assertThat(percentageError).isLessThan(ERROR_TOLERANCE)
+    val expected = 90027432806400.0
+    val tolerance = computeErrorTolerance(variance, expected)
+    assertThat(variance).isWithin(tolerance).of(expected)
   }
 
   @Test
@@ -360,9 +360,9 @@ class VariancesTest {
       WatchDurationMeasurementVarianceParams(watchDuration, watchDurationMeasurementParams)
 
     val variance = Variances.computeDeterministicVariance(watchDurationMeasurementVarianceParams)
-    val expect = 8408743280.640002
-    val percentageError = percentageError(variance, expect)
-    assertThat(percentageError).isLessThan(ERROR_TOLERANCE)
+    val expected = 8408743280.640002
+    val tolerance = computeErrorTolerance(variance, expected)
+    assertThat(variance).isWithin(tolerance).of(expected)
   }
 
   @Test
@@ -380,7 +380,7 @@ class VariancesTest {
     val watchDurationMeasurementVarianceParams =
       WatchDurationMeasurementVarianceParams(watchDuration, watchDurationMeasurementParams)
 
-    assertThrows(IllegalArgumentException::class.java) {
+    assertFailsWith<IllegalArgumentException> {
       Variances.computeDeterministicVariance(watchDurationMeasurementVarianceParams)
     }
   }
@@ -445,20 +445,27 @@ class VariancesTest {
       )
 
     for (frequency in 1..maximumFrequency) {
-      assertThat(percentageError(rKVars.getValue(frequency), expectedRK[frequency - 1]))
-        .isLessThan(ERROR_TOLERANCE)
+      assertThat(rKVars.getValue(frequency))
+        .isWithin(computeErrorTolerance(rKVars.getValue(frequency), expectedRK[frequency - 1]))
     }
     for (frequency in 1..maximumFrequency) {
-      assertThat(percentageError(rKPlusVars.getValue(frequency), expectedRKPlus[frequency - 1]))
-        .isLessThan(ERROR_TOLERANCE)
+      assertThat(rKPlusVars.getValue(frequency))
+        .isWithin(
+          computeErrorTolerance(rKPlusVars.getValue(frequency), expectedRKPlus[frequency - 1])
+        )
+        .of(expectedRKPlus[frequency - 1])
     }
     for (frequency in 1..maximumFrequency) {
-      assertThat(percentageError(nKVars.getValue(frequency), expectedNK[frequency - 1]))
-        .isLessThan(ERROR_TOLERANCE)
+      assertThat(nKVars.getValue(frequency))
+        .isWithin(computeErrorTolerance(nKVars.getValue(frequency), expectedNK[frequency - 1]))
+        .of(expectedNK[frequency - 1])
     }
     for (frequency in 1..maximumFrequency) {
-      assertThat(percentageError(nKPlusVars.getValue(frequency), expectedNKPlus[frequency - 1]))
-        .isLessThan(ERROR_TOLERANCE)
+      assertThat(nKPlusVars.getValue(frequency))
+        .isWithin(
+          computeErrorTolerance(nKPlusVars.getValue(frequency), expectedNKPlus[frequency - 1])
+        )
+        .of(expectedNKPlus[frequency - 1])
     }
   }
 
@@ -528,20 +535,28 @@ class VariancesTest {
       )
 
     for (frequency in 1..maximumFrequency) {
-      assertThat(percentageError(rKVars.getValue(frequency), expectedRK[frequency - 1]))
-        .isLessThan(ERROR_TOLERANCE)
+      assertThat(rKVars.getValue(frequency))
+        .isWithin(computeErrorTolerance(rKVars.getValue(frequency), expectedRK[frequency - 1]))
+        .of(expectedRK[frequency - 1])
     }
     for (frequency in 1..maximumFrequency) {
-      assertThat(percentageError(rKPlusVars.getValue(frequency), expectedRKPlus[frequency - 1]))
-        .isLessThan(ERROR_TOLERANCE)
+      assertThat(rKPlusVars.getValue(frequency))
+        .isWithin(
+          computeErrorTolerance(rKPlusVars.getValue(frequency), expectedRKPlus[frequency - 1])
+        )
+        .of(expectedRKPlus[frequency - 1])
     }
     for (frequency in 1..maximumFrequency) {
-      assertThat(percentageError(nKVars.getValue(frequency), expectedNK[frequency - 1]))
-        .isLessThan(ERROR_TOLERANCE)
+      assertThat(nKVars.getValue(frequency))
+        .isWithin(computeErrorTolerance(nKVars.getValue(frequency), expectedNK[frequency - 1]))
+        .of(expectedNK[frequency - 1])
     }
     for (frequency in 1..maximumFrequency) {
-      assertThat(percentageError(nKPlusVars.getValue(frequency), expectedNKPlus[frequency - 1]))
-        .isLessThan(ERROR_TOLERANCE)
+      assertThat(nKPlusVars.getValue(frequency))
+        .isWithin(
+          computeErrorTolerance(nKPlusVars.getValue(frequency), expectedNKPlus[frequency - 1])
+        )
+        .of(expectedNKPlus[frequency - 1])
     }
   }
 
@@ -617,20 +632,28 @@ class VariancesTest {
       )
 
     for (frequency in 1..maximumFrequency) {
-      assertThat(percentageError(rKVars.getValue(frequency), expectedRK[frequency - 1]))
-        .isLessThan(ERROR_TOLERANCE)
+      assertThat(rKVars.getValue(frequency))
+        .isWithin(computeErrorTolerance(rKVars.getValue(frequency), expectedRK[frequency - 1]))
+        .of(expectedRK[frequency - 1])
     }
     for (frequency in 1..maximumFrequency) {
-      assertThat(percentageError(rKPlusVars.getValue(frequency), expectedRKPlus[frequency - 1]))
-        .isLessThan(ERROR_TOLERANCE)
+      assertThat(rKPlusVars.getValue(frequency))
+        .isWithin(
+          computeErrorTolerance(rKPlusVars.getValue(frequency), expectedRKPlus[frequency - 1])
+        )
+        .of(expectedRKPlus[frequency - 1])
     }
     for (frequency in 1..maximumFrequency) {
-      assertThat(percentageError(nKVars.getValue(frequency), expectedNK[frequency - 1]))
-        .isLessThan(ERROR_TOLERANCE)
+      assertThat(nKVars.getValue(frequency))
+        .isWithin(computeErrorTolerance(nKVars.getValue(frequency), expectedNK[frequency - 1]))
+        .of(expectedNK[frequency - 1])
     }
     for (frequency in 1..maximumFrequency) {
-      assertThat(percentageError(nKPlusVars.getValue(frequency), expectedNKPlus[frequency - 1]))
-        .isLessThan(ERROR_TOLERANCE)
+      assertThat(nKPlusVars.getValue(frequency))
+        .isWithin(
+          computeErrorTolerance(nKPlusVars.getValue(frequency), expectedNKPlus[frequency - 1])
+        )
+        .of(expectedNKPlus[frequency - 1])
     }
   }
 
@@ -706,20 +729,28 @@ class VariancesTest {
       )
 
     for (frequency in 1..maximumFrequency) {
-      assertThat(percentageError(rKVars.getValue(frequency), expectedRK[frequency - 1]))
-        .isLessThan(ERROR_TOLERANCE)
+      assertThat(rKVars.getValue(frequency))
+        .isWithin(computeErrorTolerance(rKVars.getValue(frequency), expectedRK[frequency - 1]))
+        .of(expectedRK[frequency - 1])
     }
     for (frequency in 1..maximumFrequency) {
-      assertThat(percentageError(rKPlusVars.getValue(frequency), expectedRKPlus[frequency - 1]))
-        .isLessThan(ERROR_TOLERANCE)
+      assertThat(rKPlusVars.getValue(frequency))
+        .isWithin(
+          computeErrorTolerance(rKPlusVars.getValue(frequency), expectedRKPlus[frequency - 1])
+        )
+        .of(expectedRKPlus[frequency - 1])
     }
     for (frequency in 1..maximumFrequency) {
-      assertThat(percentageError(nKVars.getValue(frequency), expectedNK[frequency - 1]))
-        .isLessThan(ERROR_TOLERANCE)
+      assertThat(nKVars.getValue(frequency))
+        .isWithin(computeErrorTolerance(nKVars.getValue(frequency), expectedNK[frequency - 1]))
+        .of(expectedNK[frequency - 1])
     }
     for (frequency in 1..maximumFrequency) {
-      assertThat(percentageError(nKPlusVars.getValue(frequency), expectedNKPlus[frequency - 1]))
-        .isLessThan(ERROR_TOLERANCE)
+      assertThat(nKPlusVars.getValue(frequency))
+        .isWithin(
+          computeErrorTolerance(nKPlusVars.getValue(frequency), expectedNKPlus[frequency - 1])
+        )
+        .of(expectedNKPlus[frequency - 1])
     }
   }
 
@@ -765,10 +796,18 @@ class VariancesTest {
     val expectedNK = 19788711484.000004
     val expectedNKPlus = 19788711484.000004
 
-    assertThat(percentageError(rKVars.getValue(1), expectedRK)).isLessThan(ERROR_TOLERANCE)
-    assertThat(percentageError(rKPlusVars.getValue(1), expectedRKPlus)).isLessThan(ERROR_TOLERANCE)
-    assertThat(percentageError(nKVars.getValue(1), expectedNK)).isLessThan(ERROR_TOLERANCE)
-    assertThat(percentageError(nKPlusVars.getValue(1), expectedNKPlus)).isLessThan(ERROR_TOLERANCE)
+    assertThat(rKVars.getValue(1))
+      .isWithin(computeErrorTolerance(rKVars.getValue(1), expectedRK))
+      .of(expectedRK)
+    assertThat(rKPlusVars.getValue(1))
+      .isWithin(computeErrorTolerance(rKPlusVars.getValue(1), expectedRKPlus))
+      .of(expectedRKPlus)
+    assertThat(nKVars.getValue(1))
+      .isWithin(computeErrorTolerance(nKVars.getValue(1), expectedNK))
+      .of(expectedNK)
+    assertThat(nKPlusVars.getValue(1))
+      .isWithin(computeErrorTolerance(nKPlusVars.getValue(1), expectedNKPlus))
+      .of(expectedNKPlus)
   }
 
   @Test
@@ -796,7 +835,7 @@ class VariancesTest {
         frequencyMeasurementParams
       )
 
-    assertThrows(IllegalArgumentException::class.java) {
+    assertFailsWith<IllegalArgumentException> {
       Variances.computeDeterministicVariance(frequencyMeasurementVarianceParams)
     }
   }
@@ -826,7 +865,7 @@ class VariancesTest {
         frequencyMeasurementParams
       )
 
-    assertThrows(IllegalArgumentException::class.java) {
+    assertFailsWith<IllegalArgumentException> {
       Variances.computeDeterministicVariance(frequencyMeasurementVarianceParams)
     }
   }
@@ -834,7 +873,7 @@ class VariancesTest {
   @Test
   fun `computeLiquidLegionsSketchVariance returns a value for reach when reach is small, sampling width is small, and small decay rate`() {
     val decayRate = 1e-3
-    val sketchSize = 1e5
+    val sketchSize = 100000L
     val liquidLegionsSketchParams = LiquidLegionsSketchParams(decayRate, sketchSize)
     val reach = 2L
     val vidSamplingIntervalWidth = 0.1
@@ -853,15 +892,15 @@ class VariancesTest {
         liquidLegionsSketchParams,
         reachMeasurementVarianceParams
       )
-    val expect = 252107.369636947
-    val percentageError = percentageError(variance, expect)
-    assertThat(percentageError).isLessThan(ERROR_TOLERANCE)
+    val expected = 252107.369636947
+    val tolerance = computeErrorTolerance(variance, expected)
+    assertThat(variance).isWithin(tolerance).of(expected)
   }
 
   @Test
   fun `computeLiquidLegionsSketchVariance returns a value for reach when reach is small, sampling width is small, and large decay rate`() {
     val decayRate = 1e2
-    val sketchSize = 1e5
+    val sketchSize = 100000L
     val liquidLegionsSketchParams = LiquidLegionsSketchParams(decayRate, sketchSize)
     val reach = 2L
     val vidSamplingIntervalWidth = 0.1
@@ -880,15 +919,15 @@ class VariancesTest {
         liquidLegionsSketchParams,
         reachMeasurementVarianceParams
       )
-    val expect = 252354.6749380062
-    val percentageError = percentageError(variance, expect)
-    assertThat(percentageError).isLessThan(ERROR_TOLERANCE)
+    val expected = 252354.6749380062
+    val tolerance = computeErrorTolerance(variance, expected)
+    assertThat(variance).isWithin(tolerance).of(expected)
   }
 
   @Test
   fun `computeLiquidLegionsSketchVariance returns a value for reach when reach is small, sampling width is large, and small decay rate`() {
     val decayRate = 1e-3
-    val sketchSize = 1e5
+    val sketchSize = 100000L
     val liquidLegionsSketchParams = LiquidLegionsSketchParams(decayRate, sketchSize)
     val reach = 2L
     val vidSamplingIntervalWidth = 1.0
@@ -908,15 +947,15 @@ class VariancesTest {
         reachMeasurementVarianceParams
       )
 
-    val expect = 2520.9441397473865
-    val percentageError = percentageError(variance, expect)
-    assertThat(percentageError).isLessThan(ERROR_TOLERANCE)
+    val expected = 2520.9441397473865
+    val tolerance = computeErrorTolerance(variance, expected)
+    assertThat(variance).isWithin(tolerance).of(expected)
   }
 
   @Test
   fun `computeLiquidLegionsSketchVariance returns a value for reach when reach is small, sampling width is large, and large decay rate`() {
     val decayRate = 1e2
-    val sketchSize = 1e5
+    val sketchSize = 100000L
     val liquidLegionsSketchParams = LiquidLegionsSketchParams(decayRate, sketchSize)
     val reach = 2L
     val vidSamplingIntervalWidth = 1.0
@@ -936,15 +975,15 @@ class VariancesTest {
         reachMeasurementVarianceParams
       )
 
-    val expect = 2525.8928386525
-    val percentageError = percentageError(variance, expect)
-    assertThat(percentageError).isLessThan(ERROR_TOLERANCE)
+    val expected = 2525.8928386525
+    val tolerance = computeErrorTolerance(variance, expected)
+    assertThat(variance).isWithin(tolerance).of(expected)
   }
 
   @Test
   fun `computeLiquidLegionsSketchVariance returns a value for reach when reach is large, sampling width is small, and small decay rate`() {
     val decayRate = 1e-3
-    val sketchSize = 1e5
+    val sketchSize = 100000L
     val liquidLegionsSketchParams = LiquidLegionsSketchParams(decayRate, sketchSize)
     val reach = 3e6.toLong()
     val vidSamplingIntervalWidth = 0.1
@@ -964,15 +1003,15 @@ class VariancesTest {
         reachMeasurementVarianceParams
       )
 
-    val expect = 289553744.8898575
-    val percentageError = percentageError(variance, expect)
-    assertThat(percentageError).isLessThan(ERROR_TOLERANCE)
+    val expected = 289553744.8898575
+    val tolerance = computeErrorTolerance(variance, expected)
+    assertThat(variance).isWithin(tolerance).of(expected)
   }
 
   @Test
   fun `computeLiquidLegionsSketchVariance returns a value for reach when reach is large, sampling width is small, and large decay rate`() {
     val decayRate = 1e2
-    val sketchSize = 1e5
+    val sketchSize = 100000L
     val liquidLegionsSketchParams = LiquidLegionsSketchParams(decayRate, sketchSize)
     val reach = 3e6.toLong()
     val vidSamplingIntervalWidth = 0.1
@@ -992,15 +1031,15 @@ class VariancesTest {
         reachMeasurementVarianceParams
       )
 
-    val expect = 28923114340.800056
-    val percentageError = percentageError(variance, expect)
-    assertThat(percentageError).isLessThan(ERROR_TOLERANCE)
+    val expected = 28923114340.800056
+    val tolerance = computeErrorTolerance(variance, expected)
+    assertThat(variance).isWithin(tolerance).of(expected)
   }
 
   @Test
   fun `computeLiquidLegionsSketchVariance returns a value for reach when reach is large, sampling width is large, and small decay rate`() {
     val decayRate = 1e-3
-    val sketchSize = 1e5
+    val sketchSize = 100000L
     val liquidLegionsSketchParams = LiquidLegionsSketchParams(decayRate, sketchSize)
     val reach = 3e6.toLong()
     val vidSamplingIntervalWidth = 1.0
@@ -1020,15 +1059,15 @@ class VariancesTest {
         reachMeasurementVarianceParams
       )
 
-    val expect = 2.8788216360657764e+29
-    val percentageError = percentageError(variance, expect)
-    assertThat(percentageError).isLessThan(ERROR_TOLERANCE)
+    val expected = 2.8788216360657764e+29
+    val tolerance = computeErrorTolerance(variance, expected)
+    assertThat(variance).isWithin(tolerance).of(expected)
   }
 
   @Test
   fun `computeLiquidLegionsSketchVariance returns a value for reach when reach is large, sampling width is large, and large decay rate`() {
     val decayRate = 1e2
-    val sketchSize = 1e5
+    val sketchSize = 100000L
     val liquidLegionsSketchParams = LiquidLegionsSketchParams(decayRate, sketchSize)
     val reach = 3e6.toLong()
     val vidSamplingIntervalWidth = 1.0
@@ -1048,15 +1087,15 @@ class VariancesTest {
         reachMeasurementVarianceParams
       )
 
-    val expect = 28922934034.98562
-    val percentageError = percentageError(variance, expect)
-    assertThat(percentageError).isLessThan(ERROR_TOLERANCE)
+    val expected = 28922934034.98562
+    val tolerance = computeErrorTolerance(variance, expected)
+    assertThat(variance).isWithin(tolerance).of(expected)
   }
 
   @Test
   fun `computeLiquidLegionsV2Variance returns a value for reach when reach is small, sampling width is small, and small decay rate`() {
     val decayRate = 1e-3
-    val sketchSize = 1e5
+    val sketchSize = 100000L
     val liquidLegionsSketchParams = LiquidLegionsSketchParams(decayRate, sketchSize)
     val reach = 2L
     val vidSamplingIntervalWidth = 0.1
@@ -1075,15 +1114,15 @@ class VariancesTest {
         liquidLegionsSketchParams,
         reachMeasurementVarianceParams
       )
-    val expect = 432817.78878559935
-    val percentageError = percentageError(variance, expect)
-    assertThat(percentageError).isLessThan(ERROR_TOLERANCE)
+    val expected = 432817.78878559935
+    val tolerance = computeErrorTolerance(variance, expected)
+    assertThat(variance).isWithin(tolerance).of(expected)
   }
 
   @Test
   fun `computeLiquidLegionsV2Variance returns a value for reach when reach is small, sampling width is small, and large decay rate`() {
     val decayRate = 1e2
-    val sketchSize = 1e5
+    val sketchSize = 100000L
     val liquidLegionsSketchParams = LiquidLegionsSketchParams(decayRate, sketchSize)
     val reach = 2L
     val vidSamplingIntervalWidth = 0.1
@@ -1102,15 +1141,15 @@ class VariancesTest {
         liquidLegionsSketchParams,
         reachMeasurementVarianceParams
       )
-    val expect = 433242.3223399124
-    val percentageError = percentageError(variance, expect)
-    assertThat(percentageError).isLessThan(ERROR_TOLERANCE)
+    val expected = 433242.3223399124
+    val tolerance = computeErrorTolerance(variance, expected)
+    assertThat(variance).isWithin(tolerance).of(expected)
   }
 
   @Test
   fun `computeLiquidLegionsV2Variance returns a value for reach when reach is small, sampling width is large, and small decay rate`() {
     val decayRate = 1e-3
-    val sketchSize = 1e5
+    val sketchSize = 100000L
     val liquidLegionsSketchParams = LiquidLegionsSketchParams(decayRate, sketchSize)
     val reach = 2L
     val vidSamplingIntervalWidth = 1.0
@@ -1130,15 +1169,15 @@ class VariancesTest {
         reachMeasurementVarianceParams
       )
 
-    val expect = 4328.084473679164
-    val percentageError = percentageError(variance, expect)
-    assertThat(percentageError).isLessThan(ERROR_TOLERANCE)
+    val expected = 4328.084473679164
+    val tolerance = computeErrorTolerance(variance, expected)
+    assertThat(variance).isWithin(tolerance).of(expected)
   }
 
   @Test
   fun `computeLiquidLegionsV2Variance returns a value for reach when reach is small, sampling width is large, and large decay rate`() {
     val decayRate = 1e2
-    val sketchSize = 1e5
+    val sketchSize = 100000L
     val liquidLegionsSketchParams = LiquidLegionsSketchParams(decayRate, sketchSize)
     val reach = 2L
     val vidSamplingIntervalWidth = 1.0
@@ -1158,15 +1197,15 @@ class VariancesTest {
         reachMeasurementVarianceParams
       )
 
-    val expect = 4336.579244624804
-    val percentageError = percentageError(variance, expect)
-    assertThat(percentageError).isLessThan(ERROR_TOLERANCE)
+    val expected = 4336.579244624804
+    val tolerance = computeErrorTolerance(variance, expected)
+    assertThat(variance).isWithin(tolerance).of(expected)
   }
 
   @Test
   fun `computeLiquidLegionsV2Variance returns a value for reach when reach is large, sampling width is small, and small decay rate`() {
     val decayRate = 1e-3
-    val sketchSize = 1e5
+    val sketchSize = 100000L
     val liquidLegionsSketchParams = LiquidLegionsSketchParams(decayRate, sketchSize)
     val reach = 3e6.toLong()
     val vidSamplingIntervalWidth = 0.1
@@ -1186,15 +1225,15 @@ class VariancesTest {
         reachMeasurementVarianceParams
       )
 
-    val expect = 362456073.197418
-    val percentageError = percentageError(variance, expect)
-    assertThat(percentageError).isLessThan(ERROR_TOLERANCE)
+    val expected = 362456073.197418
+    val tolerance = computeErrorTolerance(variance, expected)
+    assertThat(variance).isWithin(tolerance).of(expected)
   }
 
   @Test
   fun `computeLiquidLegionsV2Variance returns a value for reach when reach is large, sampling width is small, and large decay rate`() {
     val decayRate = 1e2
-    val sketchSize = 1e5
+    val sketchSize = 100000L
     val liquidLegionsSketchParams = LiquidLegionsSketchParams(decayRate, sketchSize)
     val reach = 3e6.toLong()
     val vidSamplingIntervalWidth = 0.1
@@ -1214,15 +1253,15 @@ class VariancesTest {
         reachMeasurementVarianceParams
       )
 
-    val expect = 45186835212.94076
-    val percentageError = percentageError(variance, expect)
-    assertThat(percentageError).isLessThan(ERROR_TOLERANCE)
+    val expected = 45186835212.94076
+    val tolerance = computeErrorTolerance(variance, expected)
+    assertThat(variance).isWithin(tolerance).of(expected)
   }
 
   @Test
   fun `computeLiquidLegionsV2Variance returns a value for reach when reach is large, sampling width is large, and small decay rate`() {
     val decayRate = 1e-3
-    val sketchSize = 1e5
+    val sketchSize = 100000L
     val liquidLegionsSketchParams = LiquidLegionsSketchParams(decayRate, sketchSize)
     val reach = 3e6.toLong()
     val vidSamplingIntervalWidth = 1.0
@@ -1242,15 +1281,15 @@ class VariancesTest {
         reachMeasurementVarianceParams
       )
 
-    val expect = 4.94250670279621e+29
-    val percentageError = percentageError(variance, expect)
-    assertThat(percentageError).isLessThan(ERROR_TOLERANCE)
+    val expected = 4.94250670279621e+29
+    val tolerance = computeErrorTolerance(variance, expected)
+    assertThat(variance).isWithin(tolerance).of(expected)
   }
 
   @Test
   fun `computeLiquidLegionsV2Variance returns a value for reach when reach is large, sampling width is large, and large decay rate`() {
     val decayRate = 1e2
-    val sketchSize = 1e5
+    val sketchSize = 100000L
     val liquidLegionsSketchParams = LiquidLegionsSketchParams(decayRate, sketchSize)
     val reach = 3e6.toLong()
     val vidSamplingIntervalWidth = 1.0
@@ -1270,15 +1309,15 @@ class VariancesTest {
         reachMeasurementVarianceParams
       )
 
-    val expect = 45186557325.27274
-    val percentageError = percentageError(variance, expect)
-    assertThat(percentageError).isLessThan(ERROR_TOLERANCE)
+    val expected = 45186557325.27274
+    val tolerance = computeErrorTolerance(variance, expected)
+    assertThat(variance).isWithin(tolerance).of(expected)
   }
 
   @Test
   fun `computeLiquidLegionsSketchVariance returns for reach-frequency when small total reach, small sampling width, and small decay rate`() {
     val decayRate = 1e-3
-    val sketchSize = 1e5
+    val sketchSize = 100000L
     val liquidLegionsSketchParams = LiquidLegionsSketchParams(decayRate, sketchSize)
 
     val vidSamplingIntervalWidth = 1e-2
@@ -1331,27 +1370,35 @@ class VariancesTest {
       listOf(25209926.963694707, 9075573.706930095, 2268893.426732524, 252099.26963694714, 0.0)
 
     for (frequency in 1..maximumFrequency) {
-      assertThat(percentageError(rKVars.getValue(frequency), expectedRK[frequency - 1]))
-        .isLessThan(ERROR_TOLERANCE)
+      assertThat(rKVars.getValue(frequency))
+        .isWithin(computeErrorTolerance(rKVars.getValue(frequency), expectedRK[frequency - 1]))
+        .of(expectedRK[frequency - 1])
     }
     for (frequency in 1..maximumFrequency) {
-      assertThat(percentageError(rKPlusVars.getValue(frequency), expectedRKPlus[frequency - 1]))
-        .isLessThan(ERROR_TOLERANCE)
+      assertThat(rKPlusVars.getValue(frequency))
+        .isWithin(
+          computeErrorTolerance(rKPlusVars.getValue(frequency), expectedRKPlus[frequency - 1])
+        )
+        .of(expectedRKPlus[frequency - 1])
     }
     for (frequency in 1..maximumFrequency) {
-      assertThat(percentageError(nKVars.getValue(frequency), expectedNK[frequency - 1]))
-        .isLessThan(ERROR_TOLERANCE)
+      assertThat(nKVars.getValue(frequency))
+        .isWithin(computeErrorTolerance(nKVars.getValue(frequency), expectedNK[frequency - 1]))
+        .of(expectedNK[frequency - 1])
     }
     for (frequency in 1..maximumFrequency) {
-      assertThat(percentageError(nKPlusVars.getValue(frequency), expectedNKPlus[frequency - 1]))
-        .isLessThan(ERROR_TOLERANCE)
+      assertThat(nKPlusVars.getValue(frequency))
+        .isWithin(
+          computeErrorTolerance(nKPlusVars.getValue(frequency), expectedNKPlus[frequency - 1])
+        )
+        .of(expectedNKPlus[frequency - 1])
     }
   }
 
   @Test
   fun `computeLiquidLegionsSketchVariance returns for reach-frequency when small total reach, small sampling width, and large decay rate`() {
     val decayRate = 100.0
-    val sketchSize = 1e5
+    val sketchSize = 100000L
     val liquidLegionsSketchParams = LiquidLegionsSketchParams(decayRate, sketchSize)
 
     val vidSamplingIntervalWidth = 1e-2
@@ -1404,27 +1451,35 @@ class VariancesTest {
       listOf(25234657.493800625, 9084476.697768226, 2271119.1744420566, 252346.5749380063, 0.0)
 
     for (frequency in 1..maximumFrequency) {
-      assertThat(percentageError(rKVars.getValue(frequency), expectedRK[frequency - 1]))
-        .isLessThan(ERROR_TOLERANCE)
+      assertThat(rKVars.getValue(frequency))
+        .isWithin(computeErrorTolerance(rKVars.getValue(frequency), expectedRK[frequency - 1]))
+        .of(expectedRK[frequency - 1])
     }
     for (frequency in 1..maximumFrequency) {
-      assertThat(percentageError(rKPlusVars.getValue(frequency), expectedRKPlus[frequency - 1]))
-        .isLessThan(ERROR_TOLERANCE)
+      assertThat(rKPlusVars.getValue(frequency))
+        .isWithin(
+          computeErrorTolerance(rKPlusVars.getValue(frequency), expectedRKPlus[frequency - 1])
+        )
+        .of(expectedRKPlus[frequency - 1])
     }
     for (frequency in 1..maximumFrequency) {
-      assertThat(percentageError(nKVars.getValue(frequency), expectedNK[frequency - 1]))
-        .isLessThan(ERROR_TOLERANCE)
+      assertThat(nKVars.getValue(frequency))
+        .isWithin(computeErrorTolerance(nKVars.getValue(frequency), expectedNK[frequency - 1]))
+        .of(expectedNK[frequency - 1])
     }
     for (frequency in 1..maximumFrequency) {
-      assertThat(percentageError(nKPlusVars.getValue(frequency), expectedNKPlus[frequency - 1]))
-        .isLessThan(ERROR_TOLERANCE)
+      assertThat(nKPlusVars.getValue(frequency))
+        .isWithin(
+          computeErrorTolerance(nKPlusVars.getValue(frequency), expectedNKPlus[frequency - 1])
+        )
+        .of(expectedNKPlus[frequency - 1])
     }
   }
 
   @Test
   fun `computeLiquidLegionsSketchVariance returns for reach-frequency when small total reach, large sampling width, and small decay rate`() {
     val decayRate = 1e-3
-    val sketchSize = 1e5
+    val sketchSize = 100000L
     val liquidLegionsSketchParams = LiquidLegionsSketchParams(decayRate, sketchSize)
 
     val vidSamplingIntervalWidth = 1.0
@@ -1497,27 +1552,35 @@ class VariancesTest {
       )
 
     for (frequency in 1..maximumFrequency) {
-      assertThat(percentageError(rKVars.getValue(frequency), expectedRK[frequency - 1]))
-        .isLessThan(ERROR_TOLERANCE)
+      assertThat(rKVars.getValue(frequency))
+        .isWithin(computeErrorTolerance(rKVars.getValue(frequency), expectedRK[frequency - 1]))
+        .of(expectedRK[frequency - 1])
     }
     for (frequency in 1..maximumFrequency) {
-      assertThat(percentageError(rKPlusVars.getValue(frequency), expectedRKPlus[frequency - 1]))
-        .isLessThan(ERROR_TOLERANCE)
+      assertThat(rKPlusVars.getValue(frequency))
+        .isWithin(
+          computeErrorTolerance(rKPlusVars.getValue(frequency), expectedRKPlus[frequency - 1])
+        )
+        .of(expectedRKPlus[frequency - 1])
     }
     for (frequency in 1..maximumFrequency) {
-      assertThat(percentageError(nKVars.getValue(frequency), expectedNK[frequency - 1]))
-        .isLessThan(ERROR_TOLERANCE)
+      assertThat(nKVars.getValue(frequency))
+        .isWithin(computeErrorTolerance(nKVars.getValue(frequency), expectedNK[frequency - 1]))
+        .of(expectedNK[frequency - 1])
     }
     for (frequency in 1..maximumFrequency) {
-      assertThat(percentageError(nKPlusVars.getValue(frequency), expectedNKPlus[frequency - 1]))
-        .isLessThan(ERROR_TOLERANCE)
+      assertThat(nKPlusVars.getValue(frequency))
+        .isWithin(
+          computeErrorTolerance(nKPlusVars.getValue(frequency), expectedNKPlus[frequency - 1])
+        )
+        .of(expectedNKPlus[frequency - 1])
     }
   }
 
   @Test
   fun `computeLiquidLegionsSketchVariance returns for reach-frequency when small total reach, large sampling width, and large decay rate`() {
     val decayRate = 100.0
-    val sketchSize = 1e5
+    val sketchSize = 100000L
     val liquidLegionsSketchParams = LiquidLegionsSketchParams(decayRate, sketchSize)
 
     val vidSamplingIntervalWidth = 1.0
@@ -1590,27 +1653,35 @@ class VariancesTest {
       )
 
     for (frequency in 1..maximumFrequency) {
-      assertThat(percentageError(rKVars.getValue(frequency), expectedRK[frequency - 1]))
-        .isLessThan(ERROR_TOLERANCE)
+      assertThat(rKVars.getValue(frequency))
+        .isWithin(computeErrorTolerance(rKVars.getValue(frequency), expectedRK[frequency - 1]))
+        .of(expectedRK[frequency - 1])
     }
     for (frequency in 1..maximumFrequency) {
-      assertThat(percentageError(rKPlusVars.getValue(frequency), expectedRKPlus[frequency - 1]))
-        .isLessThan(ERROR_TOLERANCE)
+      assertThat(rKPlusVars.getValue(frequency))
+        .isWithin(
+          computeErrorTolerance(rKPlusVars.getValue(frequency), expectedRKPlus[frequency - 1])
+        )
+        .of(expectedRKPlus[frequency - 1])
     }
     for (frequency in 1..maximumFrequency) {
-      assertThat(percentageError(nKVars.getValue(frequency), expectedNK[frequency - 1]))
-        .isLessThan(ERROR_TOLERANCE)
+      assertThat(nKVars.getValue(frequency))
+        .isWithin(computeErrorTolerance(nKVars.getValue(frequency), expectedNK[frequency - 1]))
+        .of(expectedNK[frequency - 1])
     }
     for (frequency in 1..maximumFrequency) {
-      assertThat(percentageError(nKPlusVars.getValue(frequency), expectedNKPlus[frequency - 1]))
-        .isLessThan(ERROR_TOLERANCE)
+      assertThat(nKPlusVars.getValue(frequency))
+        .isWithin(
+          computeErrorTolerance(nKPlusVars.getValue(frequency), expectedNKPlus[frequency - 1])
+        )
+        .of(expectedNKPlus[frequency - 1])
     }
   }
 
   @Test
   fun `computeLiquidLegionsSketchVariance returns for reach-frequency when large total reach, small sampling width, and small decay rate`() {
     val decayRate = 1e-3
-    val sketchSize = 1e5
+    val sketchSize = 100000L
     val liquidLegionsSketchParams = LiquidLegionsSketchParams(decayRate, sketchSize)
 
     val vidSamplingIntervalWidth = 0.01
@@ -1689,27 +1760,35 @@ class VariancesTest {
       )
 
     for (frequency in 1..maximumFrequency) {
-      assertThat(percentageError(rKVars.getValue(frequency), expectedRK[frequency - 1]))
-        .isLessThan(ERROR_TOLERANCE)
+      assertThat(rKVars.getValue(frequency))
+        .isWithin(computeErrorTolerance(rKVars.getValue(frequency), expectedRK[frequency - 1]))
+        .of(expectedRK[frequency - 1])
     }
     for (frequency in 1..maximumFrequency) {
-      assertThat(percentageError(rKPlusVars.getValue(frequency), expectedRKPlus[frequency - 1]))
-        .isLessThan(ERROR_TOLERANCE)
+      assertThat(rKPlusVars.getValue(frequency))
+        .isWithin(
+          computeErrorTolerance(rKPlusVars.getValue(frequency), expectedRKPlus[frequency - 1])
+        )
+        .of(expectedRKPlus[frequency - 1])
     }
     for (frequency in 1..maximumFrequency) {
-      assertThat(percentageError(nKVars.getValue(frequency), expectedNK[frequency - 1]))
-        .isLessThan(ERROR_TOLERANCE)
+      assertThat(nKVars.getValue(frequency))
+        .isWithin(computeErrorTolerance(nKVars.getValue(frequency), expectedNK[frequency - 1]))
+        .of(expectedNK[frequency - 1])
     }
     for (frequency in 1..maximumFrequency) {
-      assertThat(percentageError(nKPlusVars.getValue(frequency), expectedNKPlus[frequency - 1]))
-        .isLessThan(ERROR_TOLERANCE)
+      assertThat(nKPlusVars.getValue(frequency))
+        .isWithin(
+          computeErrorTolerance(nKPlusVars.getValue(frequency), expectedNKPlus[frequency - 1])
+        )
+        .of(expectedNKPlus[frequency - 1])
     }
   }
 
   @Test
   fun `computeLiquidLegionsSketchVariance returns for reach-frequency when large total reach, small sampling width, and large decay rate`() {
     val decayRate = 100.0
-    val sketchSize = 1e5
+    val sketchSize = 100000L
     val liquidLegionsSketchParams = LiquidLegionsSketchParams(decayRate, sketchSize)
 
     val vidSamplingIntervalWidth = 0.01
@@ -1788,27 +1867,35 @@ class VariancesTest {
       )
 
     for (frequency in 1..maximumFrequency) {
-      assertThat(percentageError(rKVars.getValue(frequency), expectedRK[frequency - 1]))
-        .isLessThan(ERROR_TOLERANCE)
+      assertThat(rKVars.getValue(frequency))
+        .isWithin(computeErrorTolerance(rKVars.getValue(frequency), expectedRK[frequency - 1]))
+        .of(expectedRK[frequency - 1])
     }
     for (frequency in 1..maximumFrequency) {
-      assertThat(percentageError(rKPlusVars.getValue(frequency), expectedRKPlus[frequency - 1]))
-        .isLessThan(ERROR_TOLERANCE)
+      assertThat(rKPlusVars.getValue(frequency))
+        .isWithin(
+          computeErrorTolerance(rKPlusVars.getValue(frequency), expectedRKPlus[frequency - 1])
+        )
+        .of(expectedRKPlus[frequency - 1])
     }
     for (frequency in 1..maximumFrequency) {
-      assertThat(percentageError(nKVars.getValue(frequency), expectedNK[frequency - 1]))
-        .isLessThan(ERROR_TOLERANCE)
+      assertThat(nKVars.getValue(frequency))
+        .isWithin(computeErrorTolerance(nKVars.getValue(frequency), expectedNK[frequency - 1]))
+        .of(expectedNK[frequency - 1])
     }
     for (frequency in 1..maximumFrequency) {
-      assertThat(percentageError(nKPlusVars.getValue(frequency), expectedNKPlus[frequency - 1]))
-        .isLessThan(ERROR_TOLERANCE)
+      assertThat(nKPlusVars.getValue(frequency))
+        .isWithin(
+          computeErrorTolerance(nKPlusVars.getValue(frequency), expectedNKPlus[frequency - 1])
+        )
+        .of(expectedNKPlus[frequency - 1])
     }
   }
 
   @Test
   fun `computeLiquidLegionsSketchVariance returns for reach-frequency when large total reach, large sampling width, and large decay rate`() {
     val decayRate = 100.0
-    val sketchSize = 1e5
+    val sketchSize = 100000L
     val liquidLegionsSketchParams = LiquidLegionsSketchParams(decayRate, sketchSize)
 
     val vidSamplingIntervalWidth = 0.99
@@ -1887,27 +1974,35 @@ class VariancesTest {
       )
 
     for (frequency in 1..maximumFrequency) {
-      assertThat(percentageError(rKVars.getValue(frequency), expectedRK[frequency - 1]))
-        .isLessThan(ERROR_TOLERANCE)
+      assertThat(rKVars.getValue(frequency))
+        .isWithin(computeErrorTolerance(rKVars.getValue(frequency), expectedRK[frequency - 1]))
+        .of(expectedRK[frequency - 1])
     }
     for (frequency in 1..maximumFrequency) {
-      assertThat(percentageError(rKPlusVars.getValue(frequency), expectedRKPlus[frequency - 1]))
-        .isLessThan(ERROR_TOLERANCE)
+      assertThat(rKPlusVars.getValue(frequency))
+        .isWithin(
+          computeErrorTolerance(rKPlusVars.getValue(frequency), expectedRKPlus[frequency - 1])
+        )
+        .of(expectedRKPlus[frequency - 1])
     }
     for (frequency in 1..maximumFrequency) {
-      assertThat(percentageError(nKVars.getValue(frequency), expectedNK[frequency - 1]))
-        .isLessThan(ERROR_TOLERANCE)
+      assertThat(nKVars.getValue(frequency))
+        .isWithin(computeErrorTolerance(nKVars.getValue(frequency), expectedNK[frequency - 1]))
+        .of(expectedNK[frequency - 1])
     }
     for (frequency in 1..maximumFrequency) {
-      assertThat(percentageError(nKPlusVars.getValue(frequency), expectedNKPlus[frequency - 1]))
-        .isLessThan(ERROR_TOLERANCE)
+      assertThat(nKPlusVars.getValue(frequency))
+        .isWithin(
+          computeErrorTolerance(nKPlusVars.getValue(frequency), expectedNKPlus[frequency - 1])
+        )
+        .of(expectedNKPlus[frequency - 1])
     }
   }
 
   @Test
   fun `computeLiquidLegionsSketchVariance returns for reach-frequency when maximum frequency is 1`() {
     val decayRate = 1e-3
-    val sketchSize = 1e5
+    val sketchSize = 100000L
     val liquidLegionsSketchParams = LiquidLegionsSketchParams(decayRate, sketchSize)
 
     val vidSamplingIntervalWidth = 0.1
@@ -1956,16 +2051,24 @@ class VariancesTest {
     val expectedNK = 253034.8083089697
     val expectedNKPlus = 253034.8083089697
 
-    assertThat(percentageError(rKVars.getValue(1), expectedRK)).isLessThan(ERROR_TOLERANCE)
-    assertThat(percentageError(rKPlusVars.getValue(1), expectedRKPlus)).isLessThan(ERROR_TOLERANCE)
-    assertThat(percentageError(nKVars.getValue(1), expectedNK)).isLessThan(ERROR_TOLERANCE)
-    assertThat(percentageError(nKPlusVars.getValue(1), expectedNKPlus)).isLessThan(ERROR_TOLERANCE)
+    assertThat(rKVars.getValue(1))
+      .isWithin(computeErrorTolerance(rKVars.getValue(1), expectedRK))
+      .of(expectedRK)
+    assertThat(rKPlusVars.getValue(1))
+      .isWithin(computeErrorTolerance(rKPlusVars.getValue(1), expectedRKPlus))
+      .of(expectedRKPlus)
+    assertThat(nKVars.getValue(1))
+      .isWithin(computeErrorTolerance(nKVars.getValue(1), expectedNK))
+      .of(expectedNK)
+    assertThat(nKPlusVars.getValue(1))
+      .isWithin(computeErrorTolerance(nKPlusVars.getValue(1), expectedNKPlus))
+      .of(expectedNKPlus)
   }
 
   @Test
   fun `computeLiquidLegionsSketchVariance returns for reach-frequency when reach is less than 3`() {
     val decayRate = 100.0
-    val sketchSize = 1e5
+    val sketchSize = 100000L
     val liquidLegionsSketchParams = LiquidLegionsSketchParams(decayRate, sketchSize)
 
     val vidSamplingIntervalWidth = 1e-3
@@ -2018,27 +2121,35 @@ class VariancesTest {
       listOf(2523367748.380063, 908412389.416823, 227103097.35420576, 25233677.483800635, 0.0)
 
     for (frequency in 1..maximumFrequency) {
-      assertThat(percentageError(rKVars.getValue(frequency), expectedRK[frequency - 1]))
-        .isLessThan(ERROR_TOLERANCE)
+      assertThat(rKVars.getValue(frequency))
+        .isWithin(computeErrorTolerance(rKVars.getValue(frequency), expectedRK[frequency - 1]))
+        .of(expectedRK[frequency - 1])
     }
     for (frequency in 1..maximumFrequency) {
-      assertThat(percentageError(rKPlusVars.getValue(frequency), expectedRKPlus[frequency - 1]))
-        .isLessThan(ERROR_TOLERANCE)
+      assertThat(rKPlusVars.getValue(frequency))
+        .isWithin(
+          computeErrorTolerance(rKPlusVars.getValue(frequency), expectedRKPlus[frequency - 1])
+        )
+        .of(expectedRKPlus[frequency - 1])
     }
     for (frequency in 1..maximumFrequency) {
-      assertThat(percentageError(nKVars.getValue(frequency), expectedNK[frequency - 1]))
-        .isLessThan(ERROR_TOLERANCE)
+      assertThat(nKVars.getValue(frequency))
+        .isWithin(computeErrorTolerance(nKVars.getValue(frequency), expectedNK[frequency - 1]))
+        .of(expectedNK[frequency - 1])
     }
     for (frequency in 1..maximumFrequency) {
-      assertThat(percentageError(nKPlusVars.getValue(frequency), expectedNKPlus[frequency - 1]))
-        .isLessThan(ERROR_TOLERANCE)
+      assertThat(nKPlusVars.getValue(frequency))
+        .isWithin(
+          computeErrorTolerance(nKPlusVars.getValue(frequency), expectedNKPlus[frequency - 1])
+        )
+        .of(expectedNKPlus[frequency - 1])
     }
   }
 
   @Test
   fun `computeLiquidLegionsV2Variance returns for reach-frequency when small total reach, small sampling width, and small decay rate`() {
     val decayRate = 1e-3
-    val sketchSize = 1e5
+    val sketchSize = 100000L
     val liquidLegionsSketchParams = LiquidLegionsSketchParams(decayRate, sketchSize)
 
     val vidSamplingIntervalWidth = 1e-2
@@ -2091,27 +2202,35 @@ class VariancesTest {
       listOf(43280968.87855994, 15581148.79628158, 3895287.199070395, 432809.6887855995, 0.0)
 
     for (frequency in 1..maximumFrequency) {
-      assertThat(percentageError(rKVars.getValue(frequency), expectedRK[frequency - 1]))
-        .isLessThan(ERROR_TOLERANCE)
+      assertThat(rKVars.getValue(frequency))
+        .isWithin(computeErrorTolerance(rKVars.getValue(frequency), expectedRK[frequency - 1]))
+        .of(expectedRK[frequency - 1])
     }
     for (frequency in 1..maximumFrequency) {
-      assertThat(percentageError(rKPlusVars.getValue(frequency), expectedRKPlus[frequency - 1]))
-        .isLessThan(ERROR_TOLERANCE)
+      assertThat(rKPlusVars.getValue(frequency))
+        .isWithin(
+          computeErrorTolerance(rKPlusVars.getValue(frequency), expectedRKPlus[frequency - 1])
+        )
+        .of(expectedRKPlus[frequency - 1])
     }
     for (frequency in 1..maximumFrequency) {
-      assertThat(percentageError(nKVars.getValue(frequency), expectedNK[frequency - 1]))
-        .isLessThan(ERROR_TOLERANCE)
+      assertThat(nKVars.getValue(frequency))
+        .isWithin(computeErrorTolerance(nKVars.getValue(frequency), expectedNK[frequency - 1]))
+        .of(expectedNK[frequency - 1])
     }
     for (frequency in 1..maximumFrequency) {
-      assertThat(percentageError(nKPlusVars.getValue(frequency), expectedNKPlus[frequency - 1]))
-        .isLessThan(ERROR_TOLERANCE)
+      assertThat(nKPlusVars.getValue(frequency))
+        .isWithin(
+          computeErrorTolerance(nKPlusVars.getValue(frequency), expectedNKPlus[frequency - 1])
+        )
+        .of(expectedNKPlus[frequency - 1])
     }
   }
 
   @Test
   fun `computeLiquidLegionsV2Variance returns for reach-frequency when small total reach, small sampling width, and large decay rate`() {
     val decayRate = 100.0
-    val sketchSize = 1e5
+    val sketchSize = 100000L
     val liquidLegionsSketchParams = LiquidLegionsSketchParams(decayRate, sketchSize)
 
     val vidSamplingIntervalWidth = 1e-2
@@ -2164,27 +2283,35 @@ class VariancesTest {
       listOf(43323422.233991235, 15596432.004236847, 3899108.001059212, 433234.2223399125, 0.0)
 
     for (frequency in 1..maximumFrequency) {
-      assertThat(percentageError(rKVars.getValue(frequency), expectedRK[frequency - 1]))
-        .isLessThan(ERROR_TOLERANCE)
+      assertThat(rKVars.getValue(frequency))
+        .isWithin(computeErrorTolerance(rKVars.getValue(frequency), expectedRK[frequency - 1]))
+        .of(expectedRK[frequency - 1])
     }
     for (frequency in 1..maximumFrequency) {
-      assertThat(percentageError(rKPlusVars.getValue(frequency), expectedRKPlus[frequency - 1]))
-        .isLessThan(ERROR_TOLERANCE)
+      assertThat(rKPlusVars.getValue(frequency))
+        .isWithin(
+          computeErrorTolerance(rKPlusVars.getValue(frequency), expectedRKPlus[frequency - 1])
+        )
+        .of(expectedRKPlus[frequency - 1])
     }
     for (frequency in 1..maximumFrequency) {
-      assertThat(percentageError(nKVars.getValue(frequency), expectedNK[frequency - 1]))
-        .isLessThan(ERROR_TOLERANCE)
+      assertThat(nKVars.getValue(frequency))
+        .isWithin(computeErrorTolerance(nKVars.getValue(frequency), expectedNK[frequency - 1]))
+        .of(expectedNK[frequency - 1])
     }
     for (frequency in 1..maximumFrequency) {
-      assertThat(percentageError(nKPlusVars.getValue(frequency), expectedNKPlus[frequency - 1]))
-        .isLessThan(ERROR_TOLERANCE)
+      assertThat(nKPlusVars.getValue(frequency))
+        .isWithin(
+          computeErrorTolerance(nKPlusVars.getValue(frequency), expectedNKPlus[frequency - 1])
+        )
+        .of(expectedNKPlus[frequency - 1])
     }
   }
 
   @Test
   fun `computeLiquidLegionsV2Variance returns for reach-frequency when small total reach, large sampling width, and small decay rate`() {
     val decayRate = 1e-3
-    val sketchSize = 1e5
+    val sketchSize = 100000L
     val liquidLegionsSketchParams = LiquidLegionsSketchParams(decayRate, sketchSize)
 
     val vidSamplingIntervalWidth = 1.0
@@ -2257,27 +2384,35 @@ class VariancesTest {
       )
 
     for (frequency in 1..maximumFrequency) {
-      assertThat(percentageError(rKVars.getValue(frequency), expectedRK[frequency - 1]))
-        .isLessThan(ERROR_TOLERANCE)
+      assertThat(rKVars.getValue(frequency))
+        .isWithin(computeErrorTolerance(rKVars.getValue(frequency), expectedRK[frequency - 1]))
+        .of(expectedRK[frequency - 1])
     }
     for (frequency in 1..maximumFrequency) {
-      assertThat(percentageError(rKPlusVars.getValue(frequency), expectedRKPlus[frequency - 1]))
-        .isLessThan(ERROR_TOLERANCE)
+      assertThat(rKPlusVars.getValue(frequency))
+        .isWithin(
+          computeErrorTolerance(rKPlusVars.getValue(frequency), expectedRKPlus[frequency - 1])
+        )
+        .of(expectedRKPlus[frequency - 1])
     }
     for (frequency in 1..maximumFrequency) {
-      assertThat(percentageError(nKVars.getValue(frequency), expectedNK[frequency - 1]))
-        .isLessThan(ERROR_TOLERANCE)
+      assertThat(nKVars.getValue(frequency))
+        .isWithin(computeErrorTolerance(nKVars.getValue(frequency), expectedNK[frequency - 1]))
+        .of(expectedNK[frequency - 1])
     }
     for (frequency in 1..maximumFrequency) {
-      assertThat(percentageError(nKPlusVars.getValue(frequency), expectedNKPlus[frequency - 1]))
-        .isLessThan(ERROR_TOLERANCE)
+      assertThat(nKPlusVars.getValue(frequency))
+        .isWithin(
+          computeErrorTolerance(nKPlusVars.getValue(frequency), expectedNKPlus[frequency - 1])
+        )
+        .of(expectedNKPlus[frequency - 1])
     }
   }
 
   @Test
   fun `computeLiquidLegionsV2Variance returns for reach-frequency when small total reach, large sampling width, and large decay rate`() {
     val decayRate = 100.0
-    val sketchSize = 1e5
+    val sketchSize = 100000L
     val liquidLegionsSketchParams = LiquidLegionsSketchParams(decayRate, sketchSize)
 
     val vidSamplingIntervalWidth = 1.0
@@ -2350,27 +2485,35 @@ class VariancesTest {
       )
 
     for (frequency in 1..maximumFrequency) {
-      assertThat(percentageError(rKVars.getValue(frequency), expectedRK[frequency - 1]))
-        .isLessThan(ERROR_TOLERANCE)
+      assertThat(rKVars.getValue(frequency))
+        .isWithin(computeErrorTolerance(rKVars.getValue(frequency), expectedRK[frequency - 1]))
+        .of(expectedRK[frequency - 1])
     }
     for (frequency in 1..maximumFrequency) {
-      assertThat(percentageError(rKPlusVars.getValue(frequency), expectedRKPlus[frequency - 1]))
-        .isLessThan(ERROR_TOLERANCE)
+      assertThat(rKPlusVars.getValue(frequency))
+        .isWithin(
+          computeErrorTolerance(rKPlusVars.getValue(frequency), expectedRKPlus[frequency - 1])
+        )
+        .of(expectedRKPlus[frequency - 1])
     }
     for (frequency in 1..maximumFrequency) {
-      assertThat(percentageError(nKVars.getValue(frequency), expectedNK[frequency - 1]))
-        .isLessThan(ERROR_TOLERANCE)
+      assertThat(nKVars.getValue(frequency))
+        .isWithin(computeErrorTolerance(nKVars.getValue(frequency), expectedNK[frequency - 1]))
+        .of(expectedNK[frequency - 1])
     }
     for (frequency in 1..maximumFrequency) {
-      assertThat(percentageError(nKPlusVars.getValue(frequency), expectedNKPlus[frequency - 1]))
-        .isLessThan(ERROR_TOLERANCE)
+      assertThat(nKPlusVars.getValue(frequency))
+        .isWithin(
+          computeErrorTolerance(nKPlusVars.getValue(frequency), expectedNKPlus[frequency - 1])
+        )
+        .of(expectedNKPlus[frequency - 1])
     }
   }
 
   @Test
   fun `computeLiquidLegionsV2Variance returns for reach-frequency when large total reach, small sampling width, and small decay rate`() {
     val decayRate = 1e-3
-    val sketchSize = 1e5
+    val sketchSize = 100000L
     val liquidLegionsSketchParams = LiquidLegionsSketchParams(decayRate, sketchSize)
 
     val vidSamplingIntervalWidth = 0.01
@@ -2435,27 +2578,35 @@ class VariancesTest {
       )
 
     for (frequency in 1..maximumFrequency) {
-      assertThat(percentageError(rKVars.getValue(frequency), expectedRK[frequency - 1]))
-        .isLessThan(ERROR_TOLERANCE)
+      assertThat(rKVars.getValue(frequency))
+        .isWithin(computeErrorTolerance(rKVars.getValue(frequency), expectedRK[frequency - 1]))
+        .of(expectedRK[frequency - 1])
     }
     for (frequency in 1..maximumFrequency) {
-      assertThat(percentageError(rKPlusVars.getValue(frequency), expectedRKPlus[frequency - 1]))
-        .isLessThan(ERROR_TOLERANCE)
+      assertThat(rKPlusVars.getValue(frequency))
+        .isWithin(
+          computeErrorTolerance(rKPlusVars.getValue(frequency), expectedRKPlus[frequency - 1])
+        )
+        .of(expectedRKPlus[frequency - 1])
     }
     for (frequency in 1..maximumFrequency) {
-      assertThat(percentageError(nKVars.getValue(frequency), expectedNK[frequency - 1]))
-        .isLessThan(ERROR_TOLERANCE)
+      assertThat(nKVars.getValue(frequency))
+        .isWithin(computeErrorTolerance(nKVars.getValue(frequency), expectedNK[frequency - 1]))
+        .of(expectedNK[frequency - 1])
     }
     for (frequency in 1..maximumFrequency) {
-      assertThat(percentageError(nKPlusVars.getValue(frequency), expectedNKPlus[frequency - 1]))
-        .isLessThan(ERROR_TOLERANCE)
+      assertThat(nKPlusVars.getValue(frequency))
+        .isWithin(
+          computeErrorTolerance(nKPlusVars.getValue(frequency), expectedNKPlus[frequency - 1])
+        )
+        .of(expectedNKPlus[frequency - 1])
     }
   }
 
   @Test
   fun `computeLiquidLegionsV2Variance returns for reach-frequency when large total reach, small sampling width, and large decay rate`() {
     val decayRate = 100.0
-    val sketchSize = 1e5
+    val sketchSize = 100000L
     val liquidLegionsSketchParams = LiquidLegionsSketchParams(decayRate, sketchSize)
 
     val vidSamplingIntervalWidth = 0.01
@@ -2534,27 +2685,35 @@ class VariancesTest {
       )
 
     for (frequency in 1..maximumFrequency) {
-      assertThat(percentageError(rKVars.getValue(frequency), expectedRK[frequency - 1]))
-        .isLessThan(ERROR_TOLERANCE)
+      assertThat(rKVars.getValue(frequency))
+        .isWithin(computeErrorTolerance(rKVars.getValue(frequency), expectedRK[frequency - 1]))
+        .of(expectedRK[frequency - 1])
     }
     for (frequency in 1..maximumFrequency) {
-      assertThat(percentageError(rKPlusVars.getValue(frequency), expectedRKPlus[frequency - 1]))
-        .isLessThan(ERROR_TOLERANCE)
+      assertThat(rKPlusVars.getValue(frequency))
+        .isWithin(
+          computeErrorTolerance(rKPlusVars.getValue(frequency), expectedRKPlus[frequency - 1])
+        )
+        .of(expectedRKPlus[frequency - 1])
     }
     for (frequency in 1..maximumFrequency) {
-      assertThat(percentageError(nKVars.getValue(frequency), expectedNK[frequency - 1]))
-        .isLessThan(ERROR_TOLERANCE)
+      assertThat(nKVars.getValue(frequency))
+        .isWithin(computeErrorTolerance(nKVars.getValue(frequency), expectedNK[frequency - 1]))
+        .of(expectedNK[frequency - 1])
     }
     for (frequency in 1..maximumFrequency) {
-      assertThat(percentageError(nKPlusVars.getValue(frequency), expectedNKPlus[frequency - 1]))
-        .isLessThan(ERROR_TOLERANCE)
+      assertThat(nKPlusVars.getValue(frequency))
+        .isWithin(
+          computeErrorTolerance(nKPlusVars.getValue(frequency), expectedNKPlus[frequency - 1])
+        )
+        .of(expectedNKPlus[frequency - 1])
     }
   }
 
   @Test
   fun `computeLiquidLegionsV2Variance returns for reach-frequency when large total reach, large sampling width, and large decay rate`() {
     val decayRate = 100.0
-    val sketchSize = 1e5
+    val sketchSize = 100000L
     val liquidLegionsSketchParams = LiquidLegionsSketchParams(decayRate, sketchSize)
 
     val vidSamplingIntervalWidth = 0.99
@@ -2633,27 +2792,35 @@ class VariancesTest {
       )
 
     for (frequency in 1..maximumFrequency) {
-      assertThat(percentageError(rKVars.getValue(frequency), expectedRK[frequency - 1]))
-        .isLessThan(ERROR_TOLERANCE)
+      assertThat(rKVars.getValue(frequency))
+        .isWithin(computeErrorTolerance(rKVars.getValue(frequency), expectedRK[frequency - 1]))
+        .of(expectedRK[frequency - 1])
     }
     for (frequency in 1..maximumFrequency) {
-      assertThat(percentageError(rKPlusVars.getValue(frequency), expectedRKPlus[frequency - 1]))
-        .isLessThan(ERROR_TOLERANCE)
+      assertThat(rKPlusVars.getValue(frequency))
+        .isWithin(
+          computeErrorTolerance(rKPlusVars.getValue(frequency), expectedRKPlus[frequency - 1])
+        )
+        .of(expectedRKPlus[frequency - 1])
     }
     for (frequency in 1..maximumFrequency) {
-      assertThat(percentageError(nKVars.getValue(frequency), expectedNK[frequency - 1]))
-        .isLessThan(ERROR_TOLERANCE)
+      assertThat(nKVars.getValue(frequency))
+        .isWithin(computeErrorTolerance(nKVars.getValue(frequency), expectedNK[frequency - 1]))
+        .of(expectedNK[frequency - 1])
     }
     for (frequency in 1..maximumFrequency) {
-      assertThat(percentageError(nKPlusVars.getValue(frequency), expectedNKPlus[frequency - 1]))
-        .isLessThan(ERROR_TOLERANCE)
+      assertThat(nKPlusVars.getValue(frequency))
+        .isWithin(
+          computeErrorTolerance(nKPlusVars.getValue(frequency), expectedNKPlus[frequency - 1])
+        )
+        .of(expectedNKPlus[frequency - 1])
     }
   }
 
   @Test
   fun `computeLiquidLegionsV2Variance returns for reach-frequency when maximum frequency is 1`() {
     val decayRate = 1e-3
-    val sketchSize = 1e5
+    val sketchSize = 100000L
     val liquidLegionsSketchParams = LiquidLegionsSketchParams(decayRate, sketchSize)
 
     val vidSamplingIntervalWidth = 0.1
@@ -2702,16 +2869,24 @@ class VariancesTest {
     val expectedNK = 433777.75826075335
     val expectedNKPlus = 433777.75826075335
 
-    assertThat(percentageError(rKVars.getValue(1), expectedRK)).isLessThan(ERROR_TOLERANCE)
-    assertThat(percentageError(rKPlusVars.getValue(1), expectedRKPlus)).isLessThan(ERROR_TOLERANCE)
-    assertThat(percentageError(nKVars.getValue(1), expectedNK)).isLessThan(ERROR_TOLERANCE)
-    assertThat(percentageError(nKPlusVars.getValue(1), expectedNKPlus)).isLessThan(ERROR_TOLERANCE)
+    assertThat(rKVars.getValue(1))
+      .isWithin(computeErrorTolerance(rKVars.getValue(1), expectedRK))
+      .of(expectedRK)
+    assertThat(rKPlusVars.getValue(1))
+      .isWithin(computeErrorTolerance(rKPlusVars.getValue(1), expectedRKPlus))
+      .of(expectedRKPlus)
+    assertThat(nKVars.getValue(1))
+      .isWithin(computeErrorTolerance(nKVars.getValue(1), expectedNK))
+      .of(expectedNK)
+    assertThat(nKPlusVars.getValue(1))
+      .isWithin(computeErrorTolerance(nKPlusVars.getValue(1), expectedNKPlus))
+      .of(expectedNKPlus)
   }
 
   @Test
   fun `computeLiquidLegionsV2Variance returns for reach-frequency when reach is less than 3`() {
     val decayRate = 100.0
-    val sketchSize = 1e5
+    val sketchSize = 100000L
     val liquidLegionsSketchParams = LiquidLegionsSketchParams(decayRate, sketchSize)
 
     val vidSamplingIntervalWidth = 1e-3
@@ -2764,34 +2939,651 @@ class VariancesTest {
       listOf(4327998886.855994, 1558079599.2681584, 389519899.8170396, 43279988.86855995, 0.0)
 
     for (frequency in 1..maximumFrequency) {
-      assertThat(percentageError(rKVars.getValue(frequency), expectedRK[frequency - 1]))
-        .isLessThan(ERROR_TOLERANCE)
+      assertThat(rKVars.getValue(frequency))
+        .isWithin(computeErrorTolerance(rKVars.getValue(frequency), expectedRK[frequency - 1]))
+        .of(expectedRK[frequency - 1])
     }
     for (frequency in 1..maximumFrequency) {
-      assertThat(percentageError(rKPlusVars.getValue(frequency), expectedRKPlus[frequency - 1]))
-        .isLessThan(ERROR_TOLERANCE)
+      assertThat(rKPlusVars.getValue(frequency))
+        .isWithin(
+          computeErrorTolerance(rKPlusVars.getValue(frequency), expectedRKPlus[frequency - 1])
+        )
+        .of(expectedRKPlus[frequency - 1])
     }
     for (frequency in 1..maximumFrequency) {
-      assertThat(percentageError(nKVars.getValue(frequency), expectedNK[frequency - 1]))
-        .isLessThan(ERROR_TOLERANCE)
+      assertThat(nKVars.getValue(frequency))
+        .isWithin(computeErrorTolerance(nKVars.getValue(frequency), expectedNK[frequency - 1]))
+        .of(expectedNK[frequency - 1])
     }
     for (frequency in 1..maximumFrequency) {
-      assertThat(percentageError(nKPlusVars.getValue(frequency), expectedNKPlus[frequency - 1]))
-        .isLessThan(ERROR_TOLERANCE)
+      assertThat(nKPlusVars.getValue(frequency))
+        .isWithin(
+          computeErrorTolerance(nKPlusVars.getValue(frequency), expectedNKPlus[frequency - 1])
+        )
+        .of(expectedNKPlus[frequency - 1])
+    }
+  }
+
+  @Test
+  fun `computeMetricVariance returns a value for reach when sampling intervals are fully overlapped`() {
+    val weightedReachMeasurementVarianceParams =
+      WeightedReachMeasurementVarianceParams(
+        binaryRepresentation = 3,
+        weight = 1,
+        measurementVarianceParams =
+          ReachMeasurementVarianceParams(
+            reach = 2L,
+            measurementParams =
+              ReachMeasurementParams(
+                vidSamplingInterval = VidSamplingInterval(0.0, 0.5),
+                dpParams = DpParams(0.1, 1e-9),
+                noiseMechanism = NoiseMechanism.GAUSSIAN
+              )
+          ),
+        methodology = LiquidLegionsV2Methodology(0.0, 1e6.toLong(), 1e8.toLong())
+      )
+
+    val otherWeightedReachMeasurementVarianceParams =
+      WeightedReachMeasurementVarianceParams(
+        binaryRepresentation = 2,
+        weight = -1,
+        measurementVarianceParams =
+          ReachMeasurementVarianceParams(
+            reach = 1L,
+            measurementParams =
+              ReachMeasurementParams(
+                vidSamplingInterval = VidSamplingInterval(0.0, 0.5),
+                dpParams = DpParams(0.1, 1e-9),
+                noiseMechanism = NoiseMechanism.GAUSSIAN
+              )
+          ),
+        methodology = DeterministicMethodology
+      )
+
+    val params =
+      ReachMetricVarianceParams(
+        listOf(weightedReachMeasurementVarianceParams, otherWeightedReachMeasurementVarianceParams)
+      )
+
+    val variance = Variances.computeMetricVariance(params)
+
+    val expected = 27396.052940381534
+    val tolerance = computeErrorTolerance(variance, expected)
+    assertThat(variance).isWithin(tolerance).of(expected)
+  }
+
+  @Test
+  fun `computeMetricVariance returns a value for reach when sampling intervals are partially overlapped`() {
+    val weightedReachMeasurementVarianceParams =
+      WeightedReachMeasurementVarianceParams(
+        binaryRepresentation = 3,
+        weight = 1,
+        measurementVarianceParams =
+          ReachMeasurementVarianceParams(
+            reach = 2L,
+            measurementParams =
+              ReachMeasurementParams(
+                vidSamplingInterval = VidSamplingInterval(0.0, 0.5),
+                dpParams = DpParams(0.1, 1e-9),
+                noiseMechanism = NoiseMechanism.GAUSSIAN
+              )
+          ),
+        methodology = LiquidLegionsV2Methodology(0.0, 1e6.toLong(), 1e8.toLong())
+      )
+
+    val otherWeightedReachMeasurementVarianceParams =
+      WeightedReachMeasurementVarianceParams(
+        binaryRepresentation = 1,
+        weight = -1,
+        measurementVarianceParams =
+          ReachMeasurementVarianceParams(
+            reach = 1L,
+            measurementParams =
+              ReachMeasurementParams(
+                vidSamplingInterval = VidSamplingInterval(0.3, 0.8),
+                dpParams = DpParams(0.1, 1e-9),
+                noiseMechanism = NoiseMechanism.GAUSSIAN
+              )
+          ),
+        methodology = DeterministicMethodology
+      )
+
+    val params =
+      ReachMetricVarianceParams(
+        listOf(weightedReachMeasurementVarianceParams, otherWeightedReachMeasurementVarianceParams)
+      )
+
+    val variance = Variances.computeMetricVariance(params)
+
+    val expected = 21253.74748438153
+    val tolerance = computeErrorTolerance(variance, expected)
+    assertThat(variance).isWithin(tolerance).of(expected)
+  }
+
+  @Test
+  fun `computeMetricVariance returns a value for reach when sampling intervals are not overlapped`() {
+    val weightedReachMeasurementVarianceParams =
+      WeightedReachMeasurementVarianceParams(
+        binaryRepresentation = 3,
+        weight = 1,
+        measurementVarianceParams =
+          ReachMeasurementVarianceParams(
+            reach = 2L,
+            measurementParams =
+              ReachMeasurementParams(
+                vidSamplingInterval = VidSamplingInterval(0.0, 0.5),
+                dpParams = DpParams(0.1, 1e-9),
+                noiseMechanism = NoiseMechanism.GAUSSIAN
+              )
+          ),
+        methodology = LiquidLegionsV2Methodology(0.0, 1e6.toLong(), 1e8.toLong())
+      )
+
+    val otherWeightedReachMeasurementVarianceParams =
+      WeightedReachMeasurementVarianceParams(
+        binaryRepresentation = 1,
+        weight = -1,
+        measurementVarianceParams =
+          ReachMeasurementVarianceParams(
+            reach = 1L,
+            measurementParams =
+              ReachMeasurementParams(
+                vidSamplingInterval = VidSamplingInterval(0.5, 1.0),
+                dpParams = DpParams(0.1, 1e-9),
+                noiseMechanism = NoiseMechanism.GAUSSIAN
+              )
+          ),
+        methodology = DeterministicMethodology
+      )
+
+    val params =
+      ReachMetricVarianceParams(
+        listOf(weightedReachMeasurementVarianceParams, otherWeightedReachMeasurementVarianceParams)
+      )
+
+    val variance = Variances.computeMetricVariance(params)
+
+    val expected = 19836.523148381533
+    val tolerance = computeErrorTolerance(variance, expected)
+    assertThat(variance).isWithin(tolerance).of(expected)
+  }
+
+  @Test
+  fun `computeMetricVariance returns a value for reach when one is from custom direct methodology`() {
+    val weightedReachMeasurementVarianceParams =
+      WeightedReachMeasurementVarianceParams(
+        binaryRepresentation = 3,
+        weight = 1,
+        measurementVarianceParams =
+          ReachMeasurementVarianceParams(
+            reach = 2L,
+            measurementParams =
+              ReachMeasurementParams(
+                vidSamplingInterval = VidSamplingInterval(0.0, 0.5),
+                dpParams = DpParams(0.1, 1e-9),
+                noiseMechanism = NoiseMechanism.GAUSSIAN
+              )
+          ),
+        methodology = LiquidLegionsV2Methodology(0.0, 1e6.toLong(), 1e8.toLong())
+      )
+
+    val varianceSingleMeasurement =
+      Variances.computeMetricVariance(
+        ReachMetricVarianceParams(listOf(weightedReachMeasurementVarianceParams))
+      )
+
+    val varianceOtherSingleMeasurement = 1e4
+
+    val otherWeightedReachMeasurementVarianceParams =
+      WeightedReachMeasurementVarianceParams(
+        binaryRepresentation = 1,
+        weight = -1,
+        measurementVarianceParams =
+          ReachMeasurementVarianceParams(
+            reach = 1L,
+            measurementParams =
+              ReachMeasurementParams(
+                vidSamplingInterval = VidSamplingInterval(0.5, 1.0),
+                dpParams = DpParams(0.1, 1e-9),
+                noiseMechanism = NoiseMechanism.GAUSSIAN
+              )
+          ),
+        methodology = CustomDirectScalarMethodology(varianceOtherSingleMeasurement)
+      )
+
+    val params =
+      ReachMetricVarianceParams(
+        listOf(weightedReachMeasurementVarianceParams, otherWeightedReachMeasurementVarianceParams)
+      )
+
+    val variance = Variances.computeMetricVariance(params)
+
+    val expected = varianceSingleMeasurement + varianceOtherSingleMeasurement
+    val tolerance = computeErrorTolerance(variance, expected)
+    assertThat(variance).isWithin(tolerance).of(expected)
+  }
+
+  @Test
+  fun `computeMetricVariance returns a value for reach intersection`() {
+    val unionWeightedReachMeasurementVarianceParams =
+      WeightedReachMeasurementVarianceParams(
+        binaryRepresentation = 3,
+        weight = -1,
+        measurementVarianceParams =
+          ReachMeasurementVarianceParams(
+            reach = 4L,
+            measurementParams =
+              ReachMeasurementParams(
+                vidSamplingInterval = VidSamplingInterval(0.1, 1.0),
+                dpParams = DpParams(0.1, 1e-9),
+                noiseMechanism = NoiseMechanism.GAUSSIAN
+              )
+          ),
+        methodology = LiquidLegionsV2Methodology(0.0, 1e6.toLong(), 1e8.toLong())
+      )
+
+    val weightedReachMeasurementVarianceParams =
+      WeightedReachMeasurementVarianceParams(
+        binaryRepresentation = 1,
+        weight = 1,
+        measurementVarianceParams =
+          ReachMeasurementVarianceParams(
+            reach = 2L,
+            measurementParams =
+              ReachMeasurementParams(
+                vidSamplingInterval = VidSamplingInterval(0.0, 0.9),
+                dpParams = DpParams(0.1, 1e-9),
+                noiseMechanism = NoiseMechanism.GAUSSIAN
+              )
+          ),
+        methodology = DeterministicMethodology
+      )
+
+    val otherWeightedReachMeasurementVarianceParams =
+      WeightedReachMeasurementVarianceParams(
+        binaryRepresentation = 2,
+        weight = 1,
+        measurementVarianceParams =
+          ReachMeasurementVarianceParams(
+            reach = 1L,
+            measurementParams =
+              ReachMeasurementParams(
+                vidSamplingInterval = VidSamplingInterval(0.0, 0.9),
+                dpParams = DpParams(0.1, 1e-9),
+                noiseMechanism = NoiseMechanism.GAUSSIAN
+              )
+          ),
+        methodology = DeterministicMethodology
+      )
+
+    val params =
+      ReachMetricVarianceParams(
+        listOf(
+          unionWeightedReachMeasurementVarianceParams,
+          weightedReachMeasurementVarianceParams,
+          otherWeightedReachMeasurementVarianceParams
+        )
+      )
+
+    val variance = Variances.computeMetricVariance(params)
+
+    val expected = 10554.13919363766
+    val tolerance = computeErrorTolerance(variance, expected)
+    assertThat(variance).isWithin(tolerance).of(expected)
+  }
+
+  @Test
+  fun `computeMetricVariance for reach throws IllegalArgumentException when no measurement params`() {
+    assertFailsWith<IllegalArgumentException> {
+      Variances.computeMetricVariance(ReachMetricVarianceParams(listOf()))
+    }
+  }
+
+  @Test
+  fun `computeMetricVariance for reach throws UnsupportedMethodologyException when using CustomDirectFrequencyMethodology`() {
+    val weightedReachMeasurementVarianceParams =
+      WeightedReachMeasurementVarianceParams(
+        binaryRepresentation = 3,
+        weight = 1,
+        measurementVarianceParams =
+          ReachMeasurementVarianceParams(
+            reach = 2L,
+            measurementParams =
+              ReachMeasurementParams(
+                vidSamplingInterval = VidSamplingInterval(0.0, 0.5),
+                dpParams = DpParams(0.1, 1e-9),
+                noiseMechanism = NoiseMechanism.GAUSSIAN
+              )
+          ),
+        methodology = CustomDirectFrequencyMethodology(mapOf(), mapOf())
+      )
+
+    assertFailsWith<UnsupportedMethodologyUsageException> {
+      Variances.computeMetricVariance(
+        ReachMetricVarianceParams(listOf(weightedReachMeasurementVarianceParams))
+      )
+    }
+  }
+
+  @Test
+  fun `computeMetricVariance for reach-frequency throws IllegalArgumentException when no measurement params`() {
+    assertFailsWith<IllegalArgumentException> {
+      Variances.computeMetricVariance(FrequencyMetricVarianceParams(listOf()))
+    }
+  }
+
+  @Test
+  fun `computeMetricVariance for reach-frequency throws IllegalArgumentException when there are two measurements`() {
+    val weightedFrequencyMeasurementVarianceParams =
+      WeightedFrequencyMeasurementVarianceParams(
+        binaryRepresentation = 1,
+        weight = 1,
+        measurementVarianceParams =
+          FrequencyMeasurementVarianceParams(
+            totalReach = 2L,
+            reachMeasurementVariance = 100.0,
+            relativeFrequencyDistribution = mapOf(1 to 1.0),
+            measurementParams =
+              FrequencyMeasurementParams(
+                vidSamplingInterval = VidSamplingInterval(0.0, 0.9),
+                dpParams = DpParams(0.1, 1e-9),
+                noiseMechanism = NoiseMechanism.GAUSSIAN,
+                maximumFrequency = 10
+              )
+          ),
+        methodology = DeterministicMethodology
+      )
+
+    assertFailsWith<IllegalArgumentException> {
+      Variances.computeMetricVariance(
+        FrequencyMetricVarianceParams(
+          listOf(
+            weightedFrequencyMeasurementVarianceParams,
+            weightedFrequencyMeasurementVarianceParams
+          )
+        )
+      )
+    }
+  }
+
+  @Test
+  fun `computeMetricVariance for reach-frequency throws UnsupportedMethodologyException when CustomDirectScalarMethodology is used`() {
+    val weightedFrequencyMeasurementVarianceParams =
+      WeightedFrequencyMeasurementVarianceParams(
+        binaryRepresentation = 1,
+        weight = 1,
+        measurementVarianceParams =
+          FrequencyMeasurementVarianceParams(
+            totalReach = 2L,
+            reachMeasurementVariance = 100.0,
+            relativeFrequencyDistribution = mapOf(1 to 1.0),
+            measurementParams =
+              FrequencyMeasurementParams(
+                vidSamplingInterval = VidSamplingInterval(0.0, 0.9),
+                dpParams = DpParams(0.1, 1e-9),
+                noiseMechanism = NoiseMechanism.GAUSSIAN,
+                maximumFrequency = 10
+              )
+          ),
+        methodology = CustomDirectScalarMethodology(0.0)
+      )
+
+    assertFailsWith<UnsupportedMethodologyUsageException> {
+      Variances.computeMetricVariance(
+        FrequencyMetricVarianceParams(listOf(weightedFrequencyMeasurementVarianceParams))
+      )
+    }
+  }
+
+  @Test
+  fun `computeMetricVariance for impression throws IllegalArgumentException when no measurement params`() {
+    assertFailsWith<IllegalArgumentException> {
+      Variances.computeMetricVariance(ImpressionMetricVarianceParams(listOf()))
+    }
+  }
+
+  @Test
+  fun `computeMetricVariance for impression throws IllegalArgumentException when there are two measurements`() {
+    val weightedImpressionMeasurementVarianceParams =
+      WeightedImpressionMeasurementVarianceParams(
+        binaryRepresentation = 1,
+        weight = 1,
+        measurementVarianceParams =
+          ImpressionMeasurementVarianceParams(
+            impression = 2L,
+            measurementParams =
+              ImpressionMeasurementParams(
+                vidSamplingInterval = VidSamplingInterval(0.0, 0.9),
+                dpParams = DpParams(0.1, 1e-9),
+                noiseMechanism = NoiseMechanism.GAUSSIAN,
+                maximumFrequencyPerUser = 10
+              )
+          ),
+        methodology = DeterministicMethodology
+      )
+
+    assertFailsWith<IllegalArgumentException> {
+      Variances.computeMetricVariance(
+        ImpressionMetricVarianceParams(
+          listOf(
+            weightedImpressionMeasurementVarianceParams,
+            weightedImpressionMeasurementVarianceParams
+          )
+        )
+      )
+    }
+  }
+
+  @Test
+  fun `computeMetricVariance for impression throws UnsupportedMethodologyException when using CustomDirectFrequencyMethodology`() {
+    val weightedImpressionMeasurementVarianceParams =
+      WeightedImpressionMeasurementVarianceParams(
+        binaryRepresentation = 1,
+        weight = 1,
+        measurementVarianceParams =
+          ImpressionMeasurementVarianceParams(
+            impression = 2L,
+            measurementParams =
+              ImpressionMeasurementParams(
+                vidSamplingInterval = VidSamplingInterval(0.0, 0.9),
+                dpParams = DpParams(0.1, 1e-9),
+                noiseMechanism = NoiseMechanism.GAUSSIAN,
+                maximumFrequencyPerUser = 10
+              )
+          ),
+        methodology = CustomDirectFrequencyMethodology(mapOf(), mapOf())
+      )
+
+    assertFailsWith<UnsupportedMethodologyUsageException> {
+      Variances.computeMetricVariance(
+        ImpressionMetricVarianceParams(listOf(weightedImpressionMeasurementVarianceParams))
+      )
+    }
+  }
+
+  @Test
+  fun `computeMetricVariance for impression throws UnsupportedMethodologyException when using Liquid Legions Sketch methodology`() {
+    val weightedImpressionMeasurementVarianceParams =
+      WeightedImpressionMeasurementVarianceParams(
+        binaryRepresentation = 1,
+        weight = 1,
+        measurementVarianceParams =
+          ImpressionMeasurementVarianceParams(
+            impression = 2L,
+            measurementParams =
+              ImpressionMeasurementParams(
+                vidSamplingInterval = VidSamplingInterval(0.0, 0.9),
+                dpParams = DpParams(0.1, 1e-9),
+                noiseMechanism = NoiseMechanism.GAUSSIAN,
+                maximumFrequencyPerUser = 10
+              )
+          ),
+        methodology = LiquidLegionsSketchMethodology(1.0, 1L)
+      )
+
+    assertFailsWith<UnsupportedMethodologyUsageException> {
+      Variances.computeMetricVariance(
+        ImpressionMetricVarianceParams(listOf(weightedImpressionMeasurementVarianceParams))
+      )
+    }
+  }
+
+  @Test
+  fun `computeMetricVariance for impression throws UnsupportedMethodologyException when using Liquid Legions V2 methodology`() {
+    val weightedImpressionMeasurementVarianceParams =
+      WeightedImpressionMeasurementVarianceParams(
+        binaryRepresentation = 1,
+        weight = 1,
+        measurementVarianceParams =
+          ImpressionMeasurementVarianceParams(
+            impression = 2L,
+            measurementParams =
+              ImpressionMeasurementParams(
+                vidSamplingInterval = VidSamplingInterval(0.0, 0.9),
+                dpParams = DpParams(0.1, 1e-9),
+                noiseMechanism = NoiseMechanism.GAUSSIAN,
+                maximumFrequencyPerUser = 10
+              )
+          ),
+        methodology = LiquidLegionsV2Methodology(1.0, 1L, 1L)
+      )
+
+    assertFailsWith<UnsupportedMethodologyUsageException> {
+      Variances.computeMetricVariance(
+        ImpressionMetricVarianceParams(listOf(weightedImpressionMeasurementVarianceParams))
+      )
+    }
+  }
+
+  @Test
+  fun `computeMetricVariance for watch duration throws IllegalArgumentException when no measurement params`() {
+    assertFailsWith<IllegalArgumentException> {
+      Variances.computeMetricVariance(WatchDurationMetricVarianceParams(listOf()))
+    }
+  }
+
+  @Test
+  fun `computeMetricVariance for watch duration throws IllegalArgumentException when there are two measurements`() {
+    val weightedWatchDurationMeasurementVarianceParams =
+      WeightedWatchDurationMeasurementVarianceParams(
+        binaryRepresentation = 1,
+        weight = 1,
+        measurementVarianceParams =
+          WatchDurationMeasurementVarianceParams(
+            duration = 1.0,
+            measurementParams =
+              WatchDurationMeasurementParams(
+                vidSamplingInterval = VidSamplingInterval(0.0, 0.9),
+                dpParams = DpParams(0.1, 1e-9),
+                noiseMechanism = NoiseMechanism.GAUSSIAN,
+                maximumDurationPerUser = 10.0
+              )
+          ),
+        methodology = DeterministicMethodology
+      )
+
+    assertFailsWith<IllegalArgumentException> {
+      Variances.computeMetricVariance(
+        WatchDurationMetricVarianceParams(
+          listOf(
+            weightedWatchDurationMeasurementVarianceParams,
+            weightedWatchDurationMeasurementVarianceParams
+          )
+        )
+      )
+    }
+  }
+
+  @Test
+  fun `computeMetricVariance for watch duration throws UnsupportedMethodologyException when using CustomDirectFrequencyMethodology`() {
+    val weightedWatchDurationMeasurementVarianceParams =
+      WeightedWatchDurationMeasurementVarianceParams(
+        binaryRepresentation = 1,
+        weight = 1,
+        measurementVarianceParams =
+          WatchDurationMeasurementVarianceParams(
+            duration = 1.0,
+            measurementParams =
+              WatchDurationMeasurementParams(
+                vidSamplingInterval = VidSamplingInterval(0.0, 0.9),
+                dpParams = DpParams(0.1, 1e-9),
+                noiseMechanism = NoiseMechanism.GAUSSIAN,
+                maximumDurationPerUser = 10.0
+              )
+          ),
+        methodology = CustomDirectFrequencyMethodology(mapOf(), mapOf())
+      )
+
+    assertFailsWith<UnsupportedMethodologyUsageException> {
+      Variances.computeMetricVariance(
+        WatchDurationMetricVarianceParams(listOf(weightedWatchDurationMeasurementVarianceParams))
+      )
+    }
+  }
+
+  @Test
+  fun `computeMetricVariance for watch duration throws UnsupportedMethodologyException when using Liquid Legions sketch methodology`() {
+    val weightedWatchDurationMeasurementVarianceParams =
+      WeightedWatchDurationMeasurementVarianceParams(
+        binaryRepresentation = 1,
+        weight = 1,
+        measurementVarianceParams =
+          WatchDurationMeasurementVarianceParams(
+            duration = 1.0,
+            measurementParams =
+              WatchDurationMeasurementParams(
+                vidSamplingInterval = VidSamplingInterval(0.0, 0.9),
+                dpParams = DpParams(0.1, 1e-9),
+                noiseMechanism = NoiseMechanism.GAUSSIAN,
+                maximumDurationPerUser = 10.0
+              )
+          ),
+        methodology = LiquidLegionsSketchMethodology(1.0, 1L)
+      )
+
+    assertFailsWith<UnsupportedMethodologyUsageException> {
+      Variances.computeMetricVariance(
+        WatchDurationMetricVarianceParams(listOf(weightedWatchDurationMeasurementVarianceParams))
+      )
+    }
+  }
+
+  @Test
+  fun `computeMetricVariance for watch duration throws UnsupportedMethodologyException when using Liquid Legions V2 methodology`() {
+    val weightedWatchDurationMeasurementVarianceParams =
+      WeightedWatchDurationMeasurementVarianceParams(
+        binaryRepresentation = 1,
+        weight = 1,
+        measurementVarianceParams =
+          WatchDurationMeasurementVarianceParams(
+            duration = 1.0,
+            measurementParams =
+              WatchDurationMeasurementParams(
+                vidSamplingInterval = VidSamplingInterval(0.0, 0.9),
+                dpParams = DpParams(0.1, 1e-9),
+                noiseMechanism = NoiseMechanism.GAUSSIAN,
+                maximumDurationPerUser = 10.0
+              )
+          ),
+        methodology = LiquidLegionsV2Methodology(1.0, 1L, 1L)
+      )
+
+    assertFailsWith<UnsupportedMethodologyUsageException> {
+      Variances.computeMetricVariance(
+        WatchDurationMetricVarianceParams(listOf(weightedWatchDurationMeasurementVarianceParams))
+      )
     }
   }
 
   companion object {
-    fun percentageError(estimate: Double, truth: Double): Double {
-      return if (truth == 0.0) {
-        estimate
-      } else if (estimate == 0.0) {
-        truth
+    fun computeErrorTolerance(actual: Double, expected: Double): Double {
+      return if (expected == 0.0 || actual == 0.0) {
+        ERROR_TOLERANCE_PERCENTAGE
       } else {
-        abs(1.0 - (estimate / truth))
+        abs(expected * ERROR_TOLERANCE_PERCENTAGE)
       }
     }
 
-    const val ERROR_TOLERANCE = 5e-3
+    private const val ERROR_TOLERANCE_PERCENTAGE = 5e-3
   }
 }


### PR DESCRIPTION
Implementing metric variances for different metric types. This includes:
* A function to compute the covariance of two reach measurements based on their methodologies.
* Unifying functions to compute variances of frequency count to one function.
* Functions to compute measurement variances based on the methodologies.
* Functions to compute metric variances based on the composition of their weighted measurements.
* Changing the type of `SketchSize` and `SamplingIndicatorSize` from `Double` to `Long`.