### PR TITLE
Refactor Int type to Long type in MC stats library

### DIFF
--- a/src/main/kotlin/org/wfanet/measurement/measurementconsumer/stats/LiquidLegions.kt
+++ b/src/main/kotlin/org/wfanet/measurement/measurementconsumer/stats/LiquidLegions.kt
@@ -120,9 +120,9 @@ object LiquidLegions {
   /** The covariance between two LiquidLegions-based reach measurements with an inflation term. */
   fun inflatedReachCovariance(
     sketchParams: LiquidLegionsSketchParams,
-    reach: Int,
-    otherReach: Int,
-    overlapReach: Int,
+    reach: Long,
+    otherReach: Long,
+    overlapReach: Long,
     samplingWidth: Double,
     otherSamplingWidth: Double,
     overlapSamplingWidth: Double,
@@ -157,7 +157,7 @@ object LiquidLegions {
   private fun expectedNumberOfNonDestroyedRegisters(
     sketchParams: LiquidLegionsSketchParams,
     collisionResolution: Boolean,
-    totalReach: Int,
+    totalReach: Long,
     vidSamplingIntervalWidth: Double,
   ): Double {
     // Expected sampled reach
@@ -176,7 +176,7 @@ object LiquidLegions {
   private fun varianceOfNumberOfNonDestroyedRegisters(
     sketchParams: LiquidLegionsSketchParams,
     collisionResolution: Boolean,
-    totalReach: Int,
+    totalReach: Long,
     vidSamplingIntervalWidth: Double,
   ): Double {
     // Expected sampled reach
@@ -222,7 +222,7 @@ object LiquidLegions {
   private fun varianceOfNumberOfNonDestroyedRegistersPerFrequency(
     sketchParams: LiquidLegionsSketchParams,
     collisionResolution: Boolean,
-    totalReach: Int,
+    totalReach: Long,
     reachRatio: Double,
     vidSamplingIntervalWidth: Double,
   ): Double {
@@ -253,7 +253,7 @@ object LiquidLegions {
     sketchParams: LiquidLegionsSketchParams,
     collisionResolution: Boolean,
     frequencyNoiseVariance: Double,
-    totalReach: Int,
+    totalReach: Long,
     reachRatio: Double,
     frequencyMeasurementParams: FrequencyMeasurementParams,
     multiplier: Int,
@@ -304,7 +304,7 @@ object LiquidLegions {
    * Reach count = [totalReach] * [reachRatio]
    */
   fun liquidLegionsFrequencyCountVariance(
-    totalReach: Int,
+    totalReach: Long,
     totalReachVariance: Double,
     reachRatio: Double,
     reachRatioVariance: Double,

--- a/src/main/kotlin/org/wfanet/measurement/measurementconsumer/stats/MeasurementStatistics.kt
+++ b/src/main/kotlin/org/wfanet/measurement/measurementconsumer/stats/MeasurementStatistics.kt
@@ -60,13 +60,13 @@ data class WatchDurationMeasurementParams(
 
 /** The parameters used to compute the variance of a reach measurement. */
 data class ReachMeasurementVarianceParams(
-  val reach: Int,
+  val reach: Long,
   val measurementParams: ReachMeasurementParams
 )
 
 /** The parameters used to compute the variance of a reach-and-frequency measurement. */
 data class FrequencyMeasurementVarianceParams(
-  val totalReach: Int,
+  val totalReach: Long,
   val reachMeasurementVariance: Double,
   val relativeFrequencyDistribution: Map<Int, Double>,
   val measurementParams: FrequencyMeasurementParams
@@ -74,7 +74,7 @@ data class FrequencyMeasurementVarianceParams(
 
 /** The parameters used to compute the variance of an impression measurement. */
 data class ImpressionMeasurementVarianceParams(
-  val impression: Int,
+  val impression: Long,
   val measurementParams: ImpressionMeasurementParams
 )
 
@@ -96,9 +96,9 @@ data class FrequencyVariances(
 
 /** The parameters used to compute the covariance of two reach measurements. */
 data class ReachMeasurementCovarianceParams(
-  val reach: Int,
-  val otherReach: Int,
-  val unionReach: Int,
+  val reach: Long,
+  val otherReach: Long,
+  val unionReach: Long,
   val samplingWidth: Double,
   val otherSamplingWidth: Double,
   val unionSamplingWidth: Double

--- a/src/main/kotlin/org/wfanet/measurement/measurementconsumer/stats/Variances.kt
+++ b/src/main/kotlin/org/wfanet/measurement/measurementconsumer/stats/Variances.kt
@@ -90,7 +90,7 @@ object Variances {
    * Different types of frequency histograms have different values of [multiplier].
    */
   private fun deterministicFrequencyRelativeVariance(
-    totalReach: Int,
+    totalReach: Long,
     reachRatio: Double,
     measurementParams: FrequencyMeasurementParams,
     multiplier: Int
@@ -114,7 +114,7 @@ object Variances {
    * Reach count = [totalReach] * [reachRatio]
    */
   private fun deterministicFrequencyCountVariance(
-    totalReach: Int,
+    totalReach: Long,
     totalReachVariance: Double,
     reachRatio: Double,
     reachRatioVariance: Double,
@@ -204,7 +204,7 @@ object Variances {
     sketchParams: LiquidLegionsSketchParams,
     measurementParams: FrequencyMeasurementParams,
   ): (
-    totalReach: Int,
+    totalReach: Long,
     reachRatio: Double,
     measurementParams: FrequencyMeasurementParams,
     multiplier: Int
@@ -273,7 +273,7 @@ object Variances {
     sketchParams: LiquidLegionsSketchParams,
     measurementParams: FrequencyMeasurementParams,
   ): (
-    totalReach: Int,
+    totalReach: Long,
     reachRatio: Double,
     measurementParams: FrequencyMeasurementParams,
     multiplier: Int
@@ -337,14 +337,14 @@ object Variances {
     params: FrequencyMeasurementVarianceParams,
     frequencyRelativeVarianceFun:
       (
-        totalReach: Int,
+        totalReach: Long,
         reachRatio: Double,
         measurementParams: FrequencyMeasurementParams,
         multiplier: Int
       ) -> Double,
     frequencyCountVarianceFun:
       (
-        totalReach: Int,
+        totalReach: Long,
         totalReachVariance: Double,
         reachRatio: Double,
         reachRatioVariance: Double,

--- a/src/test/kotlin/org/wfanet/measurement/measurementconsumer/stats/CovariancesTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/measurementconsumer/stats/CovariancesTest.kt
@@ -46,7 +46,7 @@ class CovariancesTest {
   @Test
   fun `computeDeterministicCovariance returns a value for reach when large reaches overlap and small sampling widths not overlap`() {
     val reachMeasurementCovarianceParams =
-      ReachMeasurementCovarianceParams(3e8.toInt(), 3e8.toInt(), 4e8.toInt(), 1e-4, 1e-4, 2e-4)
+      ReachMeasurementCovarianceParams(3e8.toLong(), 3e8.toLong(), 4e8.toLong(), 1e-4, 1e-4, 2e-4)
     val covariance = Covariances.computeDeterministicCovariance(reachMeasurementCovarianceParams)
 
     val expect = -2e+8
@@ -57,7 +57,7 @@ class CovariancesTest {
   @Test
   fun `computeDeterministicCovariance returns a value for reach when one reach is small`() {
     val reachMeasurementCovarianceParams =
-      ReachMeasurementCovarianceParams(1, 3e6.toInt(), 3e6.toInt(), 0.5, 0.4, 0.7)
+      ReachMeasurementCovarianceParams(1, 3e6.toLong(), 3e6.toLong(), 0.5, 0.4, 0.7)
     val covariance = Covariances.computeDeterministicCovariance(reachMeasurementCovarianceParams)
     val expect = 2.220446049250313e-16
     val percentageError = percentageError(covariance, expect)
@@ -68,9 +68,9 @@ class CovariancesTest {
   fun `computeDeterministicCovariance returns a value for reach when large reaches not overlap and large sampling widths overlap`() {
     val reachMeasurementCovarianceParams =
       ReachMeasurementCovarianceParams(
-        3e8.toInt(),
-        3e8.toInt(),
-        6e8.toInt(),
+        3e8.toLong(),
+        3e8.toLong(),
+        6e8.toLong(),
         0.7,
         0.7,
         0.7,
@@ -115,7 +115,7 @@ class CovariancesTest {
     val sketchSize = 1e5
     val sketchParams = LiquidLegionsSketchParams(decayRate, sketchSize)
     val reachMeasurementCovarianceParams =
-      ReachMeasurementCovarianceParams(1e6.toInt(), 3e8.toInt(), 3e8.toInt(), 0.02, 0.01, 0.02)
+      ReachMeasurementCovarianceParams(1e6.toLong(), 3e8.toLong(), 3e8.toLong(), 0.02, 0.01, 0.02)
     val covariance =
       Covariances.computeLiquidLegionsCovariance(sketchParams, reachMeasurementCovarianceParams)
 
@@ -130,7 +130,7 @@ class CovariancesTest {
     val sketchSize = 1e5
     val sketchParams = LiquidLegionsSketchParams(decayRate, sketchSize)
     val reachMeasurementCovarianceParams =
-      ReachMeasurementCovarianceParams(3e8.toInt(), 3e8.toInt(), 6e8.toInt(), 0.3, 0.4, 0.7)
+      ReachMeasurementCovarianceParams(3e8.toLong(), 3e8.toLong(), 6e8.toLong(), 0.3, 0.4, 0.7)
     val covariance =
       Covariances.computeLiquidLegionsCovariance(sketchParams, reachMeasurementCovarianceParams)
 
@@ -145,7 +145,7 @@ class CovariancesTest {
     val sketchSize = 1e5
     val sketchParams = LiquidLegionsSketchParams(decayRate, sketchSize)
     val reachMeasurementCovarianceParams =
-      ReachMeasurementCovarianceParams(1, 3e6.toInt(), 3e6.toInt(), 0.5, 0.4, 0.7)
+      ReachMeasurementCovarianceParams(1, 3e6.toLong(), 3e6.toLong(), 0.5, 0.4, 0.7)
     val covariance =
       Covariances.computeLiquidLegionsCovariance(sketchParams, reachMeasurementCovarianceParams)
 
@@ -160,7 +160,7 @@ class CovariancesTest {
     val sketchSize = 1e5
     val sketchParams = LiquidLegionsSketchParams(decayRate, sketchSize)
     val reachMeasurementCovarianceParams =
-      ReachMeasurementCovarianceParams(3e8.toInt(), 3e8.toInt(), 6e8.toInt(), 0.7, 0.7, 0.7)
+      ReachMeasurementCovarianceParams(3e8.toLong(), 3e8.toLong(), 6e8.toLong(), 0.7, 0.7, 0.7)
     val covariance =
       Covariances.computeLiquidLegionsCovariance(sketchParams, reachMeasurementCovarianceParams)
 

--- a/src/test/kotlin/org/wfanet/measurement/measurementconsumer/stats/VariancesTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/measurementconsumer/stats/VariancesTest.kt
@@ -28,7 +28,7 @@ import org.wfanet.measurement.eventdataprovider.noiser.DpParams
 class VariancesTest {
   @Test
   fun `computeDeterministicVariance returns a value for reach when reach is small and vid sampling interval width is large`() {
-    val reach = 0
+    val reach = 0L
     val vidSamplingIntervalWidth = 1.0
     val dpParams = DpParams(1.0, 1.0)
     val reachMeasurementParams =
@@ -48,7 +48,7 @@ class VariancesTest {
 
   @Test
   fun `computeDeterministicVariance returns a value for reach when reach is small and vid sampling interval width is small`() {
-    val reach = 0
+    val reach = 0L
     val vidSamplingIntervalWidth = 1e-4
     val dpParams = DpParams(1e-3, 1e-9)
     val reachMeasurementParams =
@@ -68,7 +68,7 @@ class VariancesTest {
 
   @Test
   fun `computeDeterministicVariance returns a value for reach when reach is large and vid sampling interval width is large`() {
-    val reach = 3e8.toInt()
+    val reach = 3e8.toLong()
     val vidSamplingIntervalWidth = 0.9
     val dpParams = DpParams(1e-2, 1e-15)
     val reachMeasurementParams =
@@ -88,7 +88,7 @@ class VariancesTest {
 
   @Test
   fun `computeDeterministicVariance returns a value for reach when reach is large and vid sampling interval width is small`() {
-    val reach = 3e8.toInt()
+    val reach = 3e8.toLong()
     val vidSamplingIntervalWidth = 1e-4
     val dpParams = DpParams(1e-2, 1e-15)
     val reachMeasurementParams =
@@ -108,7 +108,7 @@ class VariancesTest {
 
   @Test
   fun `computeDeterministicVariance for reach throws IllegalArgumentException when reach is negative`() {
-    val reach = -1
+    val reach = -1L
     val vidSamplingIntervalWidth = 1.0
     val dpParams = DpParams(1.0, 1.0)
     val reachMeasurementParams =
@@ -127,7 +127,7 @@ class VariancesTest {
 
   @Test
   fun `computeDeterministicVariance returns a value for impression when impressions is 0`() {
-    val impressions = 0
+    val impressions = 0L
     val vidSamplingIntervalWidth = 1.0
     val dpParams = DpParams(1.0, 1.0)
     val maximumFrequencyPerUser = 1
@@ -149,7 +149,7 @@ class VariancesTest {
 
   @Test
   fun `computeDeterministicVariance returns a value for impression when impressions is small and sampling width is small`() {
-    val impressions = 1
+    val impressions = 1L
     val vidSamplingIntervalWidth = 1e-2
     val dpParams = DpParams(1e-2, 1e-9)
     val maximumFrequencyPerUser = 1
@@ -171,7 +171,7 @@ class VariancesTest {
 
   @Test
   fun `computeDeterministicVariance returns a value for impression when impressions is small and sampling width is large`() {
-    val impressions = 1
+    val impressions = 1L
     val vidSamplingIntervalWidth = 1.0
     val dpParams = DpParams(1e-2, 1e-9)
     val maximumFrequencyPerUser = 1
@@ -193,7 +193,7 @@ class VariancesTest {
 
   @Test
   fun `computeDeterministicVariance returns a value for impression when impressions is large and sampling width is small`() {
-    val impressions = 3e8.toInt()
+    val impressions = 3e8.toLong()
     val vidSamplingIntervalWidth = 1e-2
     val dpParams = DpParams(1e-2, 1e-9)
     val maximumFrequencyPerUser = 200
@@ -215,7 +215,7 @@ class VariancesTest {
 
   @Test
   fun `computeDeterministicVariance returns a value for impression when impressions is large and sampling width is large`() {
-    val impressions = 3e8.toInt()
+    val impressions = 3e8.toLong()
     val vidSamplingIntervalWidth = 1.0
     val dpParams = DpParams(1e-2, 1e-9)
     val maximumFrequencyPerUser = 200
@@ -237,7 +237,7 @@ class VariancesTest {
 
   @Test
   fun `computeDeterministicVariance for impression throws IllegalArgumentException when impressions is negative`() {
-    val impressions = -1
+    val impressions = -1L
     val vidSamplingIntervalWidth = 1.0
     val dpParams = DpParams(1.0, 1.0)
     val impressionMeasurementParams =
@@ -388,7 +388,7 @@ class VariancesTest {
   @Test
   fun `computeDeterministicVariance returns for reach-frequency when total reach is small and sampling width is small`() {
     val vidSamplingIntervalWidth = 1e-4
-    val totalReach = 1
+    val totalReach = 1L
     val reachDpParams = DpParams(0.05, 1e-15)
     val reachMeasurementParams =
       ReachMeasurementParams(
@@ -465,7 +465,7 @@ class VariancesTest {
   @Test
   fun `computeDeterministicVariance returns for reach-frequency when total reach is small and sampling width is large`() {
     val vidSamplingIntervalWidth = 0.9
-    val totalReach = 10
+    val totalReach = 10L
     val reachDpParams = DpParams(0.05, 1e-15)
     val reachMeasurementParams =
       ReachMeasurementParams(
@@ -548,7 +548,7 @@ class VariancesTest {
   @Test
   fun `computeDeterministicVariance returns for reach-frequency when total reach is large and sampling width is small`() {
     val vidSamplingIntervalWidth = 0.1
-    val totalReach = 3e8.toInt()
+    val totalReach = 3e8.toLong()
     val reachDpParams = DpParams(0.05, 1e-15)
     val reachMeasurementParams =
       ReachMeasurementParams(
@@ -637,7 +637,7 @@ class VariancesTest {
   @Test
   fun `computeDeterministicVariance returns for reach-frequency when total reach is large and sampling width is large`() {
     val vidSamplingIntervalWidth = 0.9
-    val totalReach = 3e8.toInt()
+    val totalReach = 3e8.toLong()
     val reachDpParams = DpParams(0.05, 1e-15)
     val reachMeasurementParams =
       ReachMeasurementParams(
@@ -726,7 +726,7 @@ class VariancesTest {
   @Test
   fun `computeDeterministicVariance returns for reach-frequency when maximum frequency is 1`() {
     val vidSamplingIntervalWidth = 1e-3
-    val totalReach = 100
+    val totalReach = 100L
     val reachDpParams = DpParams(0.05, 1e-15)
     val reachMeasurementParams =
       ReachMeasurementParams(
@@ -774,7 +774,7 @@ class VariancesTest {
   @Test
   fun `computeDeterministicVariance for reach-frequency throws IllegalArgumentException when reach is negative`() {
     val vidSamplingIntervalWidth = 1e-3
-    val totalReach = -1
+    val totalReach = -1L
     val reachMeasurementVariance = 0.1
 
     val maximumFrequency = 5
@@ -804,7 +804,7 @@ class VariancesTest {
   @Test
   fun `computeDeterministicVariance for reach-frequency throws IllegalArgumentException when reach variance is negative`() {
     val vidSamplingIntervalWidth = 1e-3
-    val totalReach = 10
+    val totalReach = 10L
     val reachMeasurementVariance = -0.1
 
     val maximumFrequency = 5
@@ -836,7 +836,7 @@ class VariancesTest {
     val decayRate = 1e-3
     val sketchSize = 1e5
     val liquidLegionsSketchParams = LiquidLegionsSketchParams(decayRate, sketchSize)
-    val reach = 2
+    val reach = 2L
     val vidSamplingIntervalWidth = 0.1
     val dpParams = DpParams(0.1, 1e-9)
     val reachMeasurementParams =
@@ -863,7 +863,7 @@ class VariancesTest {
     val decayRate = 1e2
     val sketchSize = 1e5
     val liquidLegionsSketchParams = LiquidLegionsSketchParams(decayRate, sketchSize)
-    val reach = 2
+    val reach = 2L
     val vidSamplingIntervalWidth = 0.1
     val dpParams = DpParams(0.1, 1e-9)
     val reachMeasurementParams =
@@ -890,7 +890,7 @@ class VariancesTest {
     val decayRate = 1e-3
     val sketchSize = 1e5
     val liquidLegionsSketchParams = LiquidLegionsSketchParams(decayRate, sketchSize)
-    val reach = 2
+    val reach = 2L
     val vidSamplingIntervalWidth = 1.0
     val dpParams = DpParams(0.1, 1e-9)
     val reachMeasurementParams =
@@ -918,7 +918,7 @@ class VariancesTest {
     val decayRate = 1e2
     val sketchSize = 1e5
     val liquidLegionsSketchParams = LiquidLegionsSketchParams(decayRate, sketchSize)
-    val reach = 2
+    val reach = 2L
     val vidSamplingIntervalWidth = 1.0
     val dpParams = DpParams(0.1, 1e-9)
     val reachMeasurementParams =
@@ -946,7 +946,7 @@ class VariancesTest {
     val decayRate = 1e-3
     val sketchSize = 1e5
     val liquidLegionsSketchParams = LiquidLegionsSketchParams(decayRate, sketchSize)
-    val reach = 3e6.toInt()
+    val reach = 3e6.toLong()
     val vidSamplingIntervalWidth = 0.1
     val dpParams = DpParams(0.1, 1e-9)
     val reachMeasurementParams =
@@ -974,7 +974,7 @@ class VariancesTest {
     val decayRate = 1e2
     val sketchSize = 1e5
     val liquidLegionsSketchParams = LiquidLegionsSketchParams(decayRate, sketchSize)
-    val reach = 3e6.toInt()
+    val reach = 3e6.toLong()
     val vidSamplingIntervalWidth = 0.1
     val dpParams = DpParams(0.1, 1e-9)
     val reachMeasurementParams =
@@ -1002,7 +1002,7 @@ class VariancesTest {
     val decayRate = 1e-3
     val sketchSize = 1e5
     val liquidLegionsSketchParams = LiquidLegionsSketchParams(decayRate, sketchSize)
-    val reach = 3e6.toInt()
+    val reach = 3e6.toLong()
     val vidSamplingIntervalWidth = 1.0
     val dpParams = DpParams(0.1, 1e-9)
     val reachMeasurementParams =
@@ -1030,7 +1030,7 @@ class VariancesTest {
     val decayRate = 1e2
     val sketchSize = 1e5
     val liquidLegionsSketchParams = LiquidLegionsSketchParams(decayRate, sketchSize)
-    val reach = 3e6.toInt()
+    val reach = 3e6.toLong()
     val vidSamplingIntervalWidth = 1.0
     val dpParams = DpParams(0.1, 1e-9)
     val reachMeasurementParams =
@@ -1058,7 +1058,7 @@ class VariancesTest {
     val decayRate = 1e-3
     val sketchSize = 1e5
     val liquidLegionsSketchParams = LiquidLegionsSketchParams(decayRate, sketchSize)
-    val reach = 2
+    val reach = 2L
     val vidSamplingIntervalWidth = 0.1
     val dpParams = DpParams(0.1, 1e-9)
     val reachMeasurementParams =
@@ -1085,7 +1085,7 @@ class VariancesTest {
     val decayRate = 1e2
     val sketchSize = 1e5
     val liquidLegionsSketchParams = LiquidLegionsSketchParams(decayRate, sketchSize)
-    val reach = 2
+    val reach = 2L
     val vidSamplingIntervalWidth = 0.1
     val dpParams = DpParams(0.1, 1e-9)
     val reachMeasurementParams =
@@ -1112,7 +1112,7 @@ class VariancesTest {
     val decayRate = 1e-3
     val sketchSize = 1e5
     val liquidLegionsSketchParams = LiquidLegionsSketchParams(decayRate, sketchSize)
-    val reach = 2
+    val reach = 2L
     val vidSamplingIntervalWidth = 1.0
     val dpParams = DpParams(0.1, 1e-9)
     val reachMeasurementParams =
@@ -1140,7 +1140,7 @@ class VariancesTest {
     val decayRate = 1e2
     val sketchSize = 1e5
     val liquidLegionsSketchParams = LiquidLegionsSketchParams(decayRate, sketchSize)
-    val reach = 2
+    val reach = 2L
     val vidSamplingIntervalWidth = 1.0
     val dpParams = DpParams(0.1, 1e-9)
     val reachMeasurementParams =
@@ -1168,7 +1168,7 @@ class VariancesTest {
     val decayRate = 1e-3
     val sketchSize = 1e5
     val liquidLegionsSketchParams = LiquidLegionsSketchParams(decayRate, sketchSize)
-    val reach = 3e6.toInt()
+    val reach = 3e6.toLong()
     val vidSamplingIntervalWidth = 0.1
     val dpParams = DpParams(0.1, 1e-9)
     val reachMeasurementParams =
@@ -1196,7 +1196,7 @@ class VariancesTest {
     val decayRate = 1e2
     val sketchSize = 1e5
     val liquidLegionsSketchParams = LiquidLegionsSketchParams(decayRate, sketchSize)
-    val reach = 3e6.toInt()
+    val reach = 3e6.toLong()
     val vidSamplingIntervalWidth = 0.1
     val dpParams = DpParams(0.1, 1e-9)
     val reachMeasurementParams =
@@ -1224,7 +1224,7 @@ class VariancesTest {
     val decayRate = 1e-3
     val sketchSize = 1e5
     val liquidLegionsSketchParams = LiquidLegionsSketchParams(decayRate, sketchSize)
-    val reach = 3e6.toInt()
+    val reach = 3e6.toLong()
     val vidSamplingIntervalWidth = 1.0
     val dpParams = DpParams(0.1, 1e-9)
     val reachMeasurementParams =
@@ -1252,7 +1252,7 @@ class VariancesTest {
     val decayRate = 1e2
     val sketchSize = 1e5
     val liquidLegionsSketchParams = LiquidLegionsSketchParams(decayRate, sketchSize)
-    val reach = 3e6.toInt()
+    val reach = 3e6.toLong()
     val vidSamplingIntervalWidth = 1.0
     val dpParams = DpParams(0.1, 1e-9)
     val reachMeasurementParams =
@@ -1282,7 +1282,7 @@ class VariancesTest {
     val liquidLegionsSketchParams = LiquidLegionsSketchParams(decayRate, sketchSize)
 
     val vidSamplingIntervalWidth = 1e-2
-    val totalReach = 10
+    val totalReach = 10L
     val reachDpParams = DpParams(0.1, 1e-9)
     val reachMeasurementParams =
       ReachMeasurementParams(
@@ -1355,7 +1355,7 @@ class VariancesTest {
     val liquidLegionsSketchParams = LiquidLegionsSketchParams(decayRate, sketchSize)
 
     val vidSamplingIntervalWidth = 1e-2
-    val totalReach = 10
+    val totalReach = 10L
     val reachDpParams = DpParams(0.1, 1e-9)
     val reachMeasurementParams =
       ReachMeasurementParams(
@@ -1428,7 +1428,7 @@ class VariancesTest {
     val liquidLegionsSketchParams = LiquidLegionsSketchParams(decayRate, sketchSize)
 
     val vidSamplingIntervalWidth = 1.0
-    val totalReach = 10
+    val totalReach = 10L
     val reachDpParams = DpParams(0.1, 1e-9)
     val reachMeasurementParams =
       ReachMeasurementParams(
@@ -1521,7 +1521,7 @@ class VariancesTest {
     val liquidLegionsSketchParams = LiquidLegionsSketchParams(decayRate, sketchSize)
 
     val vidSamplingIntervalWidth = 1.0
-    val totalReach = 10
+    val totalReach = 10L
     val reachDpParams = DpParams(0.1, 1e-9)
     val reachMeasurementParams =
       ReachMeasurementParams(
@@ -1614,7 +1614,7 @@ class VariancesTest {
     val liquidLegionsSketchParams = LiquidLegionsSketchParams(decayRate, sketchSize)
 
     val vidSamplingIntervalWidth = 0.01
-    val totalReach = 3e8.toInt()
+    val totalReach = 3e8.toLong()
     val reachDpParams = DpParams(0.1, 1e-9)
     val reachMeasurementParams =
       ReachMeasurementParams(
@@ -1713,7 +1713,7 @@ class VariancesTest {
     val liquidLegionsSketchParams = LiquidLegionsSketchParams(decayRate, sketchSize)
 
     val vidSamplingIntervalWidth = 0.01
-    val totalReach = 3e8.toInt()
+    val totalReach = 3e8.toLong()
     val reachDpParams = DpParams(0.1, 1e-9)
     val reachMeasurementParams =
       ReachMeasurementParams(
@@ -1812,7 +1812,7 @@ class VariancesTest {
     val liquidLegionsSketchParams = LiquidLegionsSketchParams(decayRate, sketchSize)
 
     val vidSamplingIntervalWidth = 0.99
-    val totalReach = 3e8.toInt()
+    val totalReach = 3e8.toLong()
     val reachDpParams = DpParams(0.1, 1e-9)
     val reachMeasurementParams =
       ReachMeasurementParams(
@@ -1911,7 +1911,7 @@ class VariancesTest {
     val liquidLegionsSketchParams = LiquidLegionsSketchParams(decayRate, sketchSize)
 
     val vidSamplingIntervalWidth = 0.1
-    val totalReach = 100
+    val totalReach = 100L
     val reachDpParams = DpParams(0.1, 1e-9)
     val reachMeasurementParams =
       ReachMeasurementParams(
@@ -1969,7 +1969,7 @@ class VariancesTest {
     val liquidLegionsSketchParams = LiquidLegionsSketchParams(decayRate, sketchSize)
 
     val vidSamplingIntervalWidth = 1e-3
-    val totalReach = 1
+    val totalReach = 1L
     val reachDpParams = DpParams(0.1, 1e-9)
     val reachMeasurementParams =
       ReachMeasurementParams(
@@ -2042,7 +2042,7 @@ class VariancesTest {
     val liquidLegionsSketchParams = LiquidLegionsSketchParams(decayRate, sketchSize)
 
     val vidSamplingIntervalWidth = 1e-2
-    val totalReach = 10
+    val totalReach = 10L
     val reachDpParams = DpParams(0.1, 1e-9)
     val reachMeasurementParams =
       ReachMeasurementParams(
@@ -2115,7 +2115,7 @@ class VariancesTest {
     val liquidLegionsSketchParams = LiquidLegionsSketchParams(decayRate, sketchSize)
 
     val vidSamplingIntervalWidth = 1e-2
-    val totalReach = 10
+    val totalReach = 10L
     val reachDpParams = DpParams(0.1, 1e-9)
     val reachMeasurementParams =
       ReachMeasurementParams(
@@ -2188,7 +2188,7 @@ class VariancesTest {
     val liquidLegionsSketchParams = LiquidLegionsSketchParams(decayRate, sketchSize)
 
     val vidSamplingIntervalWidth = 1.0
-    val totalReach = 10
+    val totalReach = 10L
     val reachDpParams = DpParams(0.1, 1e-9)
     val reachMeasurementParams =
       ReachMeasurementParams(
@@ -2281,7 +2281,7 @@ class VariancesTest {
     val liquidLegionsSketchParams = LiquidLegionsSketchParams(decayRate, sketchSize)
 
     val vidSamplingIntervalWidth = 1.0
-    val totalReach = 10
+    val totalReach = 10L
     val reachDpParams = DpParams(0.1, 1e-9)
     val reachMeasurementParams =
       ReachMeasurementParams(
@@ -2374,7 +2374,7 @@ class VariancesTest {
     val liquidLegionsSketchParams = LiquidLegionsSketchParams(decayRate, sketchSize)
 
     val vidSamplingIntervalWidth = 0.01
-    val totalReach = 3e8.toInt()
+    val totalReach = 3e8.toLong()
     val reachDpParams = DpParams(0.1, 1e-9)
     val reachMeasurementParams =
       ReachMeasurementParams(
@@ -2459,7 +2459,7 @@ class VariancesTest {
     val liquidLegionsSketchParams = LiquidLegionsSketchParams(decayRate, sketchSize)
 
     val vidSamplingIntervalWidth = 0.01
-    val totalReach = 3e8.toInt()
+    val totalReach = 3e8.toLong()
     val reachDpParams = DpParams(0.1, 1e-9)
     val reachMeasurementParams =
       ReachMeasurementParams(
@@ -2558,7 +2558,7 @@ class VariancesTest {
     val liquidLegionsSketchParams = LiquidLegionsSketchParams(decayRate, sketchSize)
 
     val vidSamplingIntervalWidth = 0.99
-    val totalReach = 3e8.toInt()
+    val totalReach = 3e8.toLong()
     val reachDpParams = DpParams(0.1, 1e-9)
     val reachMeasurementParams =
       ReachMeasurementParams(
@@ -2657,7 +2657,7 @@ class VariancesTest {
     val liquidLegionsSketchParams = LiquidLegionsSketchParams(decayRate, sketchSize)
 
     val vidSamplingIntervalWidth = 0.1
-    val totalReach = 100
+    val totalReach = 100L
     val reachDpParams = DpParams(0.1, 1e-9)
     val reachMeasurementParams =
       ReachMeasurementParams(
@@ -2715,7 +2715,7 @@ class VariancesTest {
     val liquidLegionsSketchParams = LiquidLegionsSketchParams(decayRate, sketchSize)
 
     val vidSamplingIntervalWidth = 1e-3
-    val totalReach = 1
+    val totalReach = 1L
     val reachDpParams = DpParams(0.1, 1e-9)
     val reachMeasurementParams =
       ReachMeasurementParams(


### PR DESCRIPTION
## TL;DR
This pull request changes the data type of `Reach` and `Impression` variables from Int to Long in multiple functions and test cases within the code. 

## Why make this change
- The change to the data type of the "totalReach" variable from Int to Long allows for larger values to be used in the computation of variances.
- Updating the data classes to use Long data types instead of Int for certain variables ensures consistency and accuracy in the computation of variances.
- The change improves the precision and accuracy of the computations, especially when dealing with large reach values.