### PR TITLE
Specify signature algorithm in CMMS API.

### DIFF
--- a/build/repositories.bzl
+++ b/build/repositories.bzl
@@ -27,8 +27,8 @@ def wfa_measurement_system_repositories():
     wfa_repo_archive(
         name = "wfa_common_jvm",
         repo = "common-jvm",
-        sha256 = "2719f6147eccd2a493e573720c64fa3a13f344840f8416060753d97fe13ab942",
-        version = "0.66.0",
+        sha256 = "d461f4109ef26c28dccfb8077e4c2c43d789344f660eb61ebf15886002220bb0",
+        version = "0.67.0",
     )
 
     wfa_repo_archive(
@@ -41,8 +41,8 @@ def wfa_measurement_system_repositories():
     wfa_repo_archive(
         name = "wfa_measurement_proto",
         repo = "cross-media-measurement-api",
-        sha256 = "2106c2fd73775f5b0ad8d02c0ac01761b497920b363e1c90f12663d5321f5873",
-        version = "0.43.0",
+        sha256 = "f027ed6e6dfce0f1ce41be8d065e3f3227eb09e9d41fbc041650334301d72c42",
+        version = "0.45.0",
     )
 
     wfa_repo_archive(
@@ -76,8 +76,8 @@ def wfa_measurement_system_repositories():
     wfa_repo_archive(
         name = "wfa_consent_signaling_client",
         repo = "consent-signaling-client",
-        sha256 = "bf9c4665f3e97f970465cfcc0e671d98d8c0521c96d2938b3b04a9ec9ee5e681",
-        version = "0.17.0",
+        sha256 = "15ac09575ca232e83d81cc2b1013c3429fadc3fe717c6f24fa23b75cf14b2c3f",
+        version = "0.18.0",
     )
 
     wfa_repo_archive(

--- a/src/main/kotlin/org/wfanet/measurement/api/v2alpha/tools/EncryptionPublicKeys.kt
+++ b/src/main/kotlin/org/wfanet/measurement/api/v2alpha/tools/EncryptionPublicKeys.kt
@@ -16,10 +16,14 @@
 
 package org.wfanet.measurement.api.v2alpha.tools
 
+import com.google.protobuf.ByteString
 import java.io.File
+import java.security.PrivateKey
+import java.security.cert.X509Certificate
 import org.wfanet.measurement.api.v2alpha.EncryptionPublicKey
 import org.wfanet.measurement.api.v2alpha.encryptionPublicKey
 import org.wfanet.measurement.common.commandLineMain
+import org.wfanet.measurement.common.crypto.SignatureAlgorithm
 import org.wfanet.measurement.common.crypto.SigningKeyHandle
 import org.wfanet.measurement.common.crypto.readCertificate
 import org.wfanet.measurement.common.crypto.readPrivateKey
@@ -93,7 +97,10 @@ private class Deserialize : Runnable {
   }
 }
 
-@CommandLine.Command(name = "sign")
+@CommandLine.Command(
+  name = "sign",
+  description = ["Signs the input message, outputting a digital signature"]
+)
 private class Sign : Runnable {
   @CommandLine.Option(
     names = ["--certificate"],
@@ -108,6 +115,13 @@ private class Sign : Runnable {
     required = true
   )
   private lateinit var signingKeyFile: File
+
+  @CommandLine.Option(
+    names = ["--signature-algorithm"],
+    description = ["Signature algorithm. One will be chosen if not specified."],
+    required = false
+  )
+  private var algorithm: SignatureAlgorithm? = null
 
   @CommandLine.Option(
     names = ["--in", "-i"],
@@ -125,10 +139,14 @@ private class Sign : Runnable {
     // Validate that input is an EncryptionPublicKey message.
     EncryptionPublicKey.parseFrom(serialized)
 
-    val certificate = certificateFile.inputStream().use { readCertificate(it) }
-    val privateKey =
+    val certificate: X509Certificate = certificateFile.inputStream().use { readCertificate(it) }
+    val privateKey: PrivateKey =
       readPrivateKey(signingKeyFile.readByteString(), certificate.publicKey.algorithm)
-    val signature = SigningKeyHandle(certificate, privateKey).sign(serialized)
+    val keyHandle = SigningKeyHandle(certificate, privateKey)
+    val algorithm = algorithm ?: keyHandle.defaultAlgorithm
+    val signature: ByteString = keyHandle.sign(algorithm, serialized)
+
+    println("Signature algorithm: $algorithm (${algorithm.oid})")
 
     outFile.outputStream().use { signature.writeTo(it) }
   }

--- a/src/main/kotlin/org/wfanet/measurement/api/v2alpha/tools/README.md
+++ b/src/main/kotlin/org/wfanet/measurement/api/v2alpha/tools/README.md
@@ -19,7 +19,7 @@ for usage information.
     ```shell
     EncryptionPublicKeys serialize \
       --data=src/main/k8s/testing/secretfiles/mp1_enc_public.tink \
-      --out=/tmp/mp1_enc_public.pb
+      --out=/tmp/mp1_enc_public.binpb
     ```
 
 *   Signing above serialized `EncryptionPublicKey`
@@ -28,7 +28,7 @@ for usage information.
     EncryptionPublicKeys sign \
       --certificate src/main/k8s/testing/secretfiles/mp1_cs_cert.der \
       --signing-key src/main/k8s/testing/secretfiles/mp1_cs_private.der \
-      --in /tmp/mp1_enc_public.pb --out /tmp/mp1_enc_public_sig.sha256
+      --in /tmp/mp1_enc_public.binpb --out /tmp/mp1_enc_public.sig
     ```
 
 ## `MeasurementSystem`
@@ -143,8 +143,9 @@ using the `--api-key` option.
     `dataProviders/1/eventGroups/2` while `dataProviders/2` contains
     `dataProviders/2/eventGroups/1`. The order of options within a group does
     not matter.
-    
+
     `Measurement` type of `ReachAndFrequency`:
+
     ```shell
     MeasurementSystem \
     --tls-cert-file=secretfiles/mc_tls.pem --tls-key-file=secretfiles/mc_tls.key \
@@ -178,8 +179,9 @@ using the `--api-key` option.
     --event-start-time=2022-04-22T01:19:42.336Z \
     --event-end-time=2022-05-22T01:56:12.257Z
     ```
-    
+
     `Measurement` type of `Reach`:
+
     ```shell
     MeasurementSystem \
     --tls-cert-file=secretfiles/mc_tls.pem --tls-key-file=secretfiles/mc_tls.key \

--- a/src/main/kotlin/org/wfanet/measurement/duchy/daemon/herald/LiquidLegionsV2Starter.kt
+++ b/src/main/kotlin/org/wfanet/measurement/duchy/daemon/herald/LiquidLegionsV2Starter.kt
@@ -37,6 +37,7 @@ import org.wfanet.measurement.internal.duchy.protocol.LiquidLegionsSketchAggrega
 import org.wfanet.measurement.internal.duchy.protocol.LiquidLegionsSketchAggregationV2.ComputationDetails.Parameters
 import org.wfanet.measurement.internal.duchy.protocol.LiquidLegionsSketchAggregationV2.Stage
 import org.wfanet.measurement.internal.duchy.protocol.LiquidLegionsSketchAggregationV2Kt.ComputationDetailsKt.ParametersKt
+import org.wfanet.measurement.internal.duchy.protocol.LiquidLegionsSketchAggregationV2Kt.ComputationDetailsKt.computationParticipant
 import org.wfanet.measurement.internal.duchy.protocol.LiquidLegionsSketchAggregationV2Kt.ComputationDetailsKt.parameters
 import org.wfanet.measurement.internal.duchy.protocol.LiquidLegionsV2NoiseConfig.NoiseMechanism
 import org.wfanet.measurement.internal.duchy.protocol.LiquidLegionsV2NoiseConfigKt.reachNoiseConfig
@@ -268,18 +269,18 @@ object LiquidLegionsV2Starter {
     require(requisitionParams.hasLiquidLegionsV2()) {
       "Missing liquid legions v2 requisition params."
     }
-    return ComputationParticipant.newBuilder()
-      .also {
-        it.duchyId = key.duchyId
-        it.publicKey =
-          requisitionParams.liquidLegionsV2.elGamalPublicKey.toDuchyElGamalPublicKey(
-            Version.fromString(publicApiVersion)
-          )
-        it.elGamalPublicKey = requisitionParams.liquidLegionsV2.elGamalPublicKey
-        it.elGamalPublicKeySignature = requisitionParams.liquidLegionsV2.elGamalPublicKeySignature
-        it.duchyCertificateDer = requisitionParams.duchyCertificateDer
-      }
-      .build()
+    return computationParticipant {
+      duchyId = key.duchyId
+      publicKey =
+        requisitionParams.liquidLegionsV2.elGamalPublicKey.toDuchyElGamalPublicKey(
+          Version.fromString(publicApiVersion)
+        )
+      elGamalPublicKey = requisitionParams.liquidLegionsV2.elGamalPublicKey
+      elGamalPublicKeySignature = requisitionParams.liquidLegionsV2.elGamalPublicKeySignature
+      elGamalPublicKeySignatureAlgorithmOid =
+        requisitionParams.liquidLegionsV2.elGamalPublicKeySignatureAlgorithmOid
+      duchyCertificateDer = requisitionParams.duchyCertificateDer
+    }
   }
 
   private fun SystemNoiseMechanism.toInternalNoiseMechanism(): NoiseMechanism {

--- a/src/main/kotlin/org/wfanet/measurement/duchy/daemon/herald/ReachOnlyLiquidLegionsV2Starter.kt
+++ b/src/main/kotlin/org/wfanet/measurement/duchy/daemon/herald/ReachOnlyLiquidLegionsV2Starter.kt
@@ -266,6 +266,8 @@ object ReachOnlyLiquidLegionsV2Starter {
       elGamalPublicKey = requisitionParams.reachOnlyLiquidLegionsV2.elGamalPublicKey
       elGamalPublicKeySignature =
         requisitionParams.reachOnlyLiquidLegionsV2.elGamalPublicKeySignature
+      elGamalPublicKeySignatureAlgorithmOid =
+        requisitionParams.reachOnlyLiquidLegionsV2.elGamalPublicKeySignatureAlgorithmOid
       duchyCertificateDer = requisitionParams.duchyCertificateDer
     }
   }

--- a/src/main/kotlin/org/wfanet/measurement/duchy/daemon/mill/liquidlegionsv2/LiquidLegionsV2Mill.kt
+++ b/src/main/kotlin/org/wfanet/measurement/duchy/daemon/mill/liquidlegionsv2/LiquidLegionsV2Mill.kt
@@ -30,6 +30,7 @@ import java.util.logging.Logger
 import org.wfanet.anysketch.crypto.CombineElGamalPublicKeysRequest
 import org.wfanet.measurement.api.Version
 import org.wfanet.measurement.api.v2alpha.MeasurementSpec
+import org.wfanet.measurement.common.crypto.SignatureAlgorithm
 import org.wfanet.measurement.common.crypto.SigningKeyHandle
 import org.wfanet.measurement.common.crypto.readCertificate
 import org.wfanet.measurement.common.flatten
@@ -244,6 +245,7 @@ class LiquidLegionsV2Mill(
             liquidLegionsV2Builder.apply {
               elGamalPublicKey = signedElgamalPublicKey.data
               elGamalPublicKeySignature = signedElgamalPublicKey.signature
+              elGamalPublicKeySignatureAlgorithmOid = signedElgamalPublicKey.signatureAlgorithmOid
             }
           }
         }
@@ -349,13 +351,21 @@ class LiquidLegionsV2Mill(
       requireNotNull(DuchyInfo.getByDuchyId(duchy.duchyId)) {
         "DuchyInfo not found for ${duchy.duchyId}"
       }
+    val duchyCertificate: X509Certificate = readCertificate(duchy.duchyCertificateDer)
+    val signatureAlgorithmOid =
+      duchy.elGamalPublicKeySignatureAlgorithmOid.ifEmpty { duchyCertificate.sigAlgOID }
+    val signatureAlgorithm =
+      requireNotNull(SignatureAlgorithm.fromOid(signatureAlgorithmOid)) {
+        "Unsupported signature algorithm OID $signatureAlgorithmOid"
+      }
     when (publicApiVersion) {
       Version.V2_ALPHA -> {
         try {
           verifyElGamalPublicKey(
             duchy.elGamalPublicKey,
             duchy.elGamalPublicKeySignature,
-            readCertificate(duchy.duchyCertificateDer),
+            signatureAlgorithm,
+            duchyCertificate,
             trustedCertificates.getValue(duchyInfo.rootCertificateSkid)
           )
         } catch (e: CertPathValidatorException) {

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/readers/MeasurementReader.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/readers/MeasurementReader.kt
@@ -395,6 +395,8 @@ private fun MeasurementKt.Dsl.fillDefaultView(struct: Struct) {
       this.externalDataProviderCertificateId = externalDataProviderCertificateId
       dataProviderPublicKey = requisitionDetails.dataProviderPublicKey
       dataProviderPublicKeySignature = requisitionDetails.dataProviderPublicKeySignature
+      dataProviderPublicKeySignatureAlgorithmOid =
+        requisitionDetails.dataProviderPublicKeySignatureAlgorithmOid
       encryptedRequisitionSpec = requisitionDetails.encryptedRequisitionSpec
     }
 

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/readers/RequisitionReader.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/readers/RequisitionReader.kt
@@ -246,6 +246,7 @@ class RequisitionReader : BaseSpannerReader<RequisitionReader.Result>() {
         struct.getLong("ExternalMeasurementConsumerCertificateId")
       measurementSpec = measurementDetails.measurementSpec
       measurementSpecSignature = measurementDetails.measurementSpecSignature
+      measurementSpecSignatureAlgorithmOid = measurementDetails.measurementSpecSignatureAlgorithmOid
       protocolConfig = measurementDetails.protocolConfig
       state = struct.getProtoEnum("MeasurementState", Measurement.State::forNumber)
       dataProvidersCount = dataProviderCount

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/writers/CreateMeasurement.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/writers/CreateMeasurement.kt
@@ -310,6 +310,8 @@ class CreateMeasurement(private val request: CreateMeasurementRequest) :
       RequisitionKt.details {
         dataProviderPublicKey = dataProviderValue.dataProviderPublicKey
         dataProviderPublicKeySignature = dataProviderValue.dataProviderPublicKeySignature
+        dataProviderPublicKeySignatureAlgorithmOid =
+          dataProviderValue.dataProviderPublicKeySignatureAlgorithmOid
         encryptedRequisitionSpec = dataProviderValue.encryptedRequisitionSpec
         nonceHash = dataProviderValue.nonceHash
       }

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/writers/UpdatePublicKey.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/writers/UpdatePublicKey.kt
@@ -73,6 +73,7 @@ class UpdatePublicKey(private val request: UpdatePublicKeyRequest) : SimpleSpann
           apiVersion = request.apiVersion
           publicKey = request.publicKey
           publicKeySignature = request.publicKeySignature
+          publicKeySignatureAlgorithmOid = request.publicKeySignatureAlgorithmOid
         }
 
       transactionContext.bufferUpdateMutation("MeasurementConsumers") {
@@ -106,6 +107,7 @@ class UpdatePublicKey(private val request: UpdatePublicKeyRequest) : SimpleSpann
           apiVersion = request.apiVersion
           publicKey = request.publicKey
           publicKeySignature = request.publicKeySignature
+          publicKeySignatureAlgorithmOid = request.publicKeySignatureAlgorithmOid
         }
 
       transactionContext.bufferUpdateMutation("DataProviders") {

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/tools/CreateResource.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/tools/CreateResource.kt
@@ -30,6 +30,7 @@ import org.wfanet.measurement.api.v2alpha.ExchangeWorkflow
 import org.wfanet.measurement.api.v2alpha.ModelProviderKey
 import org.wfanet.measurement.api.v2alpha.RecurringExchangeKey
 import org.wfanet.measurement.common.commandLineMain
+import org.wfanet.measurement.common.crypto.SignatureAlgorithm
 import org.wfanet.measurement.common.crypto.SigningCerts
 import org.wfanet.measurement.common.crypto.readCertificate
 import org.wfanet.measurement.common.grpc.TlsFlags
@@ -68,45 +69,6 @@ import picocli.CommandLine.ParentCommand
 private const val API_VERSION = "v2alpha"
 private const val RECURRING_EXCHANGE_CRON_SCHEDULE = "@daily"
 
-private abstract class CreatePrincipalCommand : Runnable {
-  @ParentCommand
-  protected lateinit var parent: CreateResource
-    private set
-
-  @Option(
-    names = ["--certificate-der-file"],
-    description = ["Certificate for the principal"],
-    required = true
-  )
-  private lateinit var certificateDerFile: File
-
-  protected val certificate: Certificate by lazy {
-    certificate { fillCertificateFromDer(certificateDerFile.readBytes().toByteString()) }
-  }
-
-  @Option(
-    names = ["--encryption-public-key-file"],
-    description = ["Principal's serialized EncryptionPublicKey"],
-    required = true
-  )
-  private lateinit var encryptionPublicKeyFile: File
-
-  protected val serializedEncryptionPublicKey: ByteString by lazy {
-    encryptionPublicKeyFile.readBytes().toByteString()
-  }
-
-  @Option(
-    names = ["--encryption-public-key-signature-file"],
-    description = ["Principal's signature of serialized EncryptionPublicKey"],
-    required = true
-  )
-  private lateinit var encryptionPublicKeySignatureFile: File
-
-  protected val encryptionPublicKeySignature: ByteString by lazy {
-    encryptionPublicKeySignatureFile.readBytes().toByteString()
-  }
-}
-
 @Command(name = "account", description = ["Creates an Account"])
 private class CreateAccountCommand : Runnable {
   @ParentCommand private lateinit var parent: CreateResource
@@ -139,7 +101,48 @@ private class CreateMcCreationTokenCommand : Runnable {
 }
 
 @Command(name = "data-provider", description = ["Creates a DataProvider"])
-private class CreateDataProviderCommand : CreatePrincipalCommand() {
+private class CreateDataProviderCommand : Runnable {
+  @ParentCommand private lateinit var parent: CreateResource
+
+  @Option(
+    names = ["--certificate-der-file"],
+    description = ["Certificate for the principal"],
+    required = true
+  )
+  private lateinit var certificateDerFile: File
+
+  private val certificate: Certificate by lazy {
+    certificate { fillCertificateFromDer(certificateDerFile.readBytes().toByteString()) }
+  }
+
+  @Option(
+    names = ["--encryption-public-key-file"],
+    description = ["Principal's serialized EncryptionPublicKey"],
+    required = true
+  )
+  private lateinit var encryptionPublicKeyFile: File
+
+  private val serializedEncryptionPublicKey: ByteString by lazy {
+    encryptionPublicKeyFile.readBytes().toByteString()
+  }
+
+  @Option(
+    names = ["--encryption-public-key-signature-file"],
+    description = ["Principal's signature of serialized EncryptionPublicKey"],
+    required = true
+  )
+  private lateinit var encryptionPublicKeySignatureFile: File
+
+  private val encryptionPublicKeySignature: ByteString by lazy {
+    encryptionPublicKeySignatureFile.readBytes().toByteString()
+  }
+
+  @Option(
+    names = ["--encryption-public-key-signature-algorithm"],
+    description = ["Algorithm for EncryptionPublicKey signature"],
+    required = true,
+  )
+  private lateinit var signatureAlgorithm: SignatureAlgorithm
 
   @Option(
     names = ["--required-duchies"],
@@ -159,7 +162,8 @@ private class CreateDataProviderCommand : CreatePrincipalCommand() {
         DataProviderKt.details {
           apiVersion = API_VERSION
           publicKey = serializedEncryptionPublicKey
-          publicKeySignature = this@CreateDataProviderCommand.encryptionPublicKeySignature
+          publicKeySignature = encryptionPublicKeySignature
+          publicKeySignatureAlgorithmOid = signatureAlgorithm.oid
         }
 
       requiredExternalDuchyIds += requiredDuchies

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/tools/README.md
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/tools/README.md
@@ -52,9 +52,9 @@ to the executable.
 
     Assuming you have a serialized `EncryptionPublicKey` message containing
     [`edp1_enc_public.tink`](../../../../../../../k8s/testing/secretfiles/edp1_enc_public.tink)
-    at `/tmp/edp1_enc_public.pb`, and a signature of that using
+    at `/tmp/edp1_enc_public.binpb`, and a signature of that using
     [`edp1_cs_private.der`](../../../../../../../k8s/testing/secretfiles/edp1_cs_private.der)
-    at `/tmp/edp1_enc_public_sig.sha256`.
+    at `/tmp/edp1_enc_public.sig`.
 
     ```shell
     CreateResource \
@@ -64,8 +64,9 @@ to the executable.
       --internal-api-target=localhost:8443 --internal-api-cert-host=localhost \
       data-provider \
       --certificate-der-file=src/main/k8s/testing/secretfiles/edp1_cs_cert.der \
-      --encryption-public-key-file=/tmp/edp1_enc_public.pb \
-      --encryption-public-key-signature-file=/tmp/edp1_enc_public_sig.sha256
+      --encryption-public-key-file=/tmp/edp1_enc_public.binpb \
+      --encryption-public-key-signature-file=/tmp/edp1_enc_public.sig \
+      --encryption-public-key-signature-algorithm=ECDSA_WITH_SHA256
     ```
 
 *   Creating a `ModelProvider` in the `dev` environment

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/service/api/v2alpha/DataProvidersService.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/service/api/v2alpha/DataProvidersService.kt
@@ -140,6 +140,7 @@ private fun InternalDataProvider.toDataProvider(): DataProvider {
     publicKey = signedData {
       data = internalDataProvider.details.publicKey
       signature = internalDataProvider.details.publicKeySignature
+      signatureAlgorithmOid = internalDataProvider.details.publicKeySignatureAlgorithmOid
     }
     requiredDuchies +=
       internalDataProvider.requiredExternalDuchyIdsList.map { DuchyKey(it).toName() }

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/service/api/v2alpha/EventGroupsService.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/service/api/v2alpha/EventGroupsService.kt
@@ -473,6 +473,7 @@ private fun InternalEventGroup.toEventGroup(): EventGroup {
       measurementConsumerPublicKey = signedData {
         data = details.measurementConsumerPublicKey
         signature = details.measurementConsumerPublicKeySignature
+        signatureAlgorithmOid = details.measurementConsumerPublicKeySignatureAlgorithmOid
       }
     }
     vidModelLines += details.vidModelLinesList
@@ -490,12 +491,13 @@ private fun EventGroup.toInternal(
   eventGroupId: String = ""
 ): InternalEventGroup {
   val measurementConsumerKey =
-    grpcRequireNotNull(MeasurementConsumerKey.fromName(this.measurementConsumer)) {
+    grpcRequireNotNull(MeasurementConsumerKey.fromName(measurementConsumer)) {
       "Measurement consumer is either unspecified or invalid"
     }
   val measurementConsumerCertificateKey =
-    MeasurementConsumerCertificateKey.fromName(this.measurementConsumerCertificate)
+    MeasurementConsumerCertificateKey.fromName(measurementConsumerCertificate)
 
+  val source = this
   return internalEventGroup {
     externalDataProviderId = apiIdToExternalId(dataProviderId)
     if (eventGroupId.isNotEmpty()) {
@@ -507,18 +509,20 @@ private fun EventGroup.toInternal(
         apiIdToExternalId(measurementConsumerCertificateKey.certificateId)
     }
 
-    providedEventGroupId = eventGroupReferenceId
+    providedEventGroupId = source.eventGroupReferenceId
     details = details {
       apiVersion = Version.V2_ALPHA.string
-      measurementConsumerPublicKey = this@toInternal.measurementConsumerPublicKey.data
-      measurementConsumerPublicKeySignature = this@toInternal.measurementConsumerPublicKey.signature
-      vidModelLines += this@toInternal.vidModelLinesList
+      measurementConsumerPublicKey = source.measurementConsumerPublicKey.data
+      measurementConsumerPublicKeySignature = source.measurementConsumerPublicKey.signature
+      measurementConsumerPublicKeySignatureAlgorithmOid =
+        source.measurementConsumerPublicKey.signatureAlgorithmOid
+      vidModelLines += source.vidModelLinesList
       eventTemplates.addAll(
-        this@toInternal.eventTemplatesList.map { event ->
+        source.eventTemplatesList.map { event ->
           internalEventTemplate { fullyQualifiedType = event.type }
         }
       )
-      encryptedMetadata = this@toInternal.encryptedMetadata
+      encryptedMetadata = source.encryptedMetadata
     }
   }
 }

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/service/api/v2alpha/MeasurementConsumersService.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/service/api/v2alpha/MeasurementConsumersService.kt
@@ -76,6 +76,7 @@ class MeasurementConsumersService(
           apiVersion = API_VERSION.string
           publicKey = measurementConsumer.publicKey.data
           publicKeySignature = measurementConsumer.publicKey.signature
+          publicKeySignatureAlgorithmOid = measurementConsumer.publicKey.signatureAlgorithmOid
         }
       }
       externalAccountId = account.externalAccountId
@@ -246,6 +247,7 @@ private fun InternalMeasurementConsumer.toMeasurementConsumer(): MeasurementCons
     publicKey = signedData {
       data = internalMeasurementConsumer.details.publicKey
       signature = internalMeasurementConsumer.details.publicKeySignature
+      signatureAlgorithmOid = internalMeasurementConsumer.details.publicKeySignatureAlgorithmOid
     }
   }
 }

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/service/api/v2alpha/MeasurementsService.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/service/api/v2alpha/MeasurementsService.kt
@@ -356,6 +356,7 @@ private fun DataProviderEntry.validateAndMap(): Map.Entry<Long, DataProviderValu
     externalDataProviderCertificateId = apiIdToExternalId(dataProviderCertificateKey.certificateId)
     dataProviderPublicKey = publicKey.data
     dataProviderPublicKeySignature = publicKey.signature
+    dataProviderPublicKeySignatureAlgorithmOid = publicKey.signatureAlgorithmOid
     encryptedRequisitionSpec = value.encryptedRequisitionSpec
     nonceHash = value.nonceHash
   }

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/service/api/v2alpha/ProtoConversions.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/service/api/v2alpha/ProtoConversions.kt
@@ -827,6 +827,7 @@ fun InternalMeasurement.toMeasurement(): Measurement {
     measurementSpec = signedData {
       data = source.details.measurementSpec
       signature = source.details.measurementSpecSignature
+      signatureAlgorithmOid = source.details.measurementSpecSignatureAlgorithmOid
     }
     dataProviders +=
       source.dataProvidersMap.entries.map(Map.Entry<Long, DataProviderValue>::toDataProviderEntry)
@@ -882,6 +883,7 @@ fun DataProviderValue.toDataProviderEntryValue(dataProviderId: String): DataProv
     dataProviderPublicKey = signedData {
       data = dataProviderValue.dataProviderPublicKey
       signature = dataProviderPublicKeySignature
+      signatureAlgorithmOid = dataProviderPublicKeySignatureAlgorithmOid
     }
     encryptedRequisitionSpec = dataProviderValue.encryptedRequisitionSpec
     nonceHash = dataProviderValue.nonceHash
@@ -922,6 +924,7 @@ fun Measurement.toInternal(
       apiVersion = Version.V2_ALPHA.string
       measurementSpec = publicMeasurement.measurementSpec.data
       measurementSpecSignature = publicMeasurement.measurementSpec.signature
+      measurementSpecSignatureAlgorithmOid = publicMeasurement.measurementSpec.signatureAlgorithmOid
 
       @Suppress("WHEN_ENUM_CAN_BE_NULL_IN_JAVA") // Proto enum fields are never null.
       when (measurementSpecProto.measurementTypeCase) {

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/service/api/v2alpha/PublicKeysService.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/service/api/v2alpha/PublicKeysService.kt
@@ -125,6 +125,7 @@ class PublicKeysService(private val internalPublicKeysStub: PublicKeysCoroutineS
       apiVersion = Version.V2_ALPHA.toString()
       publicKey = request.publicKey.publicKey.data
       publicKeySignature = request.publicKey.publicKey.signature
+      publicKeySignatureAlgorithmOid = request.publicKey.publicKey.signatureAlgorithmOid
     }
     try {
       internalPublicKeysStub.updatePublicKey(updateRequest)

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/service/api/v2alpha/RequisitionsService.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/service/api/v2alpha/RequisitionsService.kt
@@ -287,6 +287,7 @@ private fun InternalRequisition.toRequisition(): Requisition {
     measurementSpec = signedData {
       data = parentMeasurement.measurementSpec
       signature = parentMeasurement.measurementSpecSignature
+      signatureAlgorithmOid = parentMeasurement.measurementSpecSignatureAlgorithmOid
     }
 
     val measurementTypeCase =
@@ -312,6 +313,7 @@ private fun InternalRequisition.toRequisition(): Requisition {
     dataProviderPublicKey = signedData {
       data = details.dataProviderPublicKey
       signature = details.dataProviderPublicKeySignature
+      signatureAlgorithmOid = details.dataProviderPublicKeySignatureAlgorithmOid
     }
     nonce = details.nonce
 
@@ -389,6 +391,7 @@ private fun DuchyValue.toDuchyEntryValue(externalDuchyId: String): DuchyEntry.Va
           elGamalPublicKey = signedData {
             data = value.liquidLegionsV2.elGamalPublicKey
             signature = value.liquidLegionsV2.elGamalPublicKeySignature
+            signatureAlgorithmOid = value.liquidLegionsV2.elGamalPublicKeySignatureAlgorithmOid
           }
         }
       DuchyValue.ProtocolCase.REACH_ONLY_LIQUID_LEGIONS_V2 -> reachOnlyLiquidLegionsV2 =
@@ -396,6 +399,8 @@ private fun DuchyValue.toDuchyEntryValue(externalDuchyId: String): DuchyEntry.Va
             elGamalPublicKey = signedData {
               data = value.reachOnlyLiquidLegionsV2.elGamalPublicKey
               signature = value.reachOnlyLiquidLegionsV2.elGamalPublicKeySignature
+              signatureAlgorithmOid =
+                value.reachOnlyLiquidLegionsV2.elGamalPublicKeySignatureAlgorithmOid
             }
           }
       DuchyValue.ProtocolCase.PROTOCOL_NOT_SET -> {}

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/service/internal/testing/ExchangeStepAttemptsServiceTest.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/service/internal/testing/ExchangeStepAttemptsServiceTest.kt
@@ -124,6 +124,7 @@ private val DATA_PROVIDER = dataProvider {
     apiVersion = "2"
     publicKey = ByteString.copyFromUtf8("This is a  public key.")
     publicKeySignature = ByteString.copyFromUtf8("This is a  public key signature.")
+    publicKeySignatureAlgorithmOid = "2.9999"
   }
   requiredExternalDuchyIds += DUCHIES.map { it.externalDuchyId }
 }

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/service/internal/testing/ExchangeStepsServiceTest.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/service/internal/testing/ExchangeStepsServiceTest.kt
@@ -139,6 +139,7 @@ private val DATA_PROVIDER = dataProvider {
     apiVersion = "2"
     publicKey = ByteString.copyFromUtf8("This is a  public key.")
     publicKeySignature = ByteString.copyFromUtf8("This is a  public key signature.")
+    publicKeySignatureAlgorithmOid = "2.9999"
   }
   requiredExternalDuchyIds += DUCHIES.map { it.externalDuchyId }
 }

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/service/internal/testing/MeasurementConsumersServiceTest.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/service/internal/testing/MeasurementConsumersServiceTest.kt
@@ -53,6 +53,7 @@ private const val FIXED_GENERATED_INTERNAL_ID = 2345L
 private const val FIXED_GENERATED_EXTERNAL_ID = 6789L
 private val PUBLIC_KEY = ByteString.copyFromUtf8("This is a  public key.")
 private val PUBLIC_KEY_SIGNATURE = ByteString.copyFromUtf8("This is a  public key signature.")
+private const val PUBLIC_KEY_SIGNATURE_ALGORITHM_OID = "2.9999"
 private val CERTIFICATE_DER = ByteString.copyFromUtf8("This is a certificate der.")
 
 private val MEASUREMENT_CONSUMER = measurementConsumer {
@@ -65,6 +66,7 @@ private val MEASUREMENT_CONSUMER = measurementConsumer {
     apiVersion = "v2alpha"
     publicKey = PUBLIC_KEY
     publicKeySignature = PUBLIC_KEY_SIGNATURE
+    publicKeySignatureAlgorithmOid = PUBLIC_KEY_SIGNATURE_ALGORITHM_OID
   }
 }
 

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/service/internal/testing/MeasurementsServiceTest.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/service/internal/testing/MeasurementsServiceTest.kt
@@ -93,6 +93,7 @@ private val MEASUREMENT = measurement {
       apiVersion = API_VERSION
       measurementSpec = ByteString.copyFromUtf8("MeasurementSpec")
       measurementSpecSignature = ByteString.copyFromUtf8("MeasurementSpec signature")
+      measurementSpecSignatureAlgorithmOid = "2.9999"
       duchyProtocolConfig = duchyProtocolConfig {
         liquidLegionsV2 = DuchyProtocolConfig.LiquidLegionsV2.getDefaultInstance()
       }
@@ -102,21 +103,18 @@ private val MEASUREMENT = measurement {
     }
 }
 
-private val REACH_ONLY_MEASUREMENT = measurement {
-  providedMeasurementId = PROVIDED_MEASUREMENT_ID
-  details =
-    MeasurementKt.details {
-      apiVersion = API_VERSION
-      measurementSpec = ByteString.copyFromUtf8("MeasurementSpec")
-      measurementSpecSignature = ByteString.copyFromUtf8("MeasurementSpec signature")
-      duchyProtocolConfig = duchyProtocolConfig {
-        reachOnlyLiquidLegionsV2 = DuchyProtocolConfig.LiquidLegionsV2.getDefaultInstance()
+private val REACH_ONLY_MEASUREMENT =
+  MEASUREMENT.copy {
+    details =
+      details.copy {
+        duchyProtocolConfig = duchyProtocolConfig {
+          reachOnlyLiquidLegionsV2 = DuchyProtocolConfig.LiquidLegionsV2.getDefaultInstance()
+        }
+        protocolConfig = protocolConfig {
+          reachOnlyLiquidLegionsV2 = ProtocolConfig.LiquidLegionsV2.getDefaultInstance()
+        }
       }
-      protocolConfig = protocolConfig {
-        reachOnlyLiquidLegionsV2 = ProtocolConfig.LiquidLegionsV2.getDefaultInstance()
-      }
-    }
-}
+  }
 
 private val INVALID_WORKER_DUCHY =
   DuchyIds.Entry(4, "worker3", Instant.now().minusSeconds(100L)..Instant.now().minusSeconds(50L))
@@ -883,6 +881,8 @@ abstract class MeasurementsServiceTest<T : MeasurementsCoroutineImplBase> {
               state = createdMeasurement.state
               measurementSpec = createdMeasurement.details.measurementSpec
               measurementSpecSignature = createdMeasurement.details.measurementSpecSignature
+              measurementSpecSignatureAlgorithmOid =
+                createdMeasurement.details.measurementSpecSignatureAlgorithmOid
               protocolConfig = protocolConfig {
                 liquidLegionsV2 = ProtocolConfig.LiquidLegionsV2.getDefaultInstance()
               }
@@ -891,6 +891,8 @@ abstract class MeasurementsServiceTest<T : MeasurementsCoroutineImplBase> {
             details = details {
               dataProviderPublicKey = dataProviderValue.dataProviderPublicKey
               dataProviderPublicKeySignature = dataProviderValue.dataProviderPublicKeySignature
+              dataProviderPublicKeySignatureAlgorithmOid =
+                dataProviderValue.dataProviderPublicKeySignatureAlgorithmOid
               encryptedRequisitionSpec = dataProviderValue.encryptedRequisitionSpec
               nonceHash = dataProviderValue.nonceHash
             }

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/service/internal/testing/Population.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/service/internal/testing/Population.kt
@@ -134,6 +134,7 @@ class Population(val clock: Clock, val idGenerator: IdGenerator) {
               apiVersion = API_VERSION
               publicKey = "MC public key".toByteStringUtf8()
               publicKeySignature = "MC public key signature".toByteStringUtf8()
+              publicKeySignatureAlgorithmOid = "2.9999"
             }
         }
         externalAccountId = account.externalAccountId
@@ -162,6 +163,7 @@ class Population(val clock: Clock, val idGenerator: IdGenerator) {
             apiVersion = API_VERSION
             publicKey = "EDP public key".toByteStringUtf8()
             publicKeySignature = "EDP public key signature".toByteStringUtf8()
+            publicKeySignatureAlgorithmOid = "2.9999"
           }
         requiredExternalDuchyIds += WORKER1_DUCHY.externalDuchyId
         requiredExternalDuchyIds += WORKER2_DUCHY.externalDuchyId
@@ -275,6 +277,7 @@ class Population(val clock: Clock, val idGenerator: IdGenerator) {
         apiVersion = API_VERSION
         measurementSpec = "MeasurementSpec".toByteStringUtf8()
         measurementSpecSignature = "MeasurementSpec signature".toByteStringUtf8()
+        measurementSpecSignatureAlgorithmOid = "2.9999"
         duchyProtocolConfig = duchyProtocolConfig {
           liquidLegionsV2 = DuchyProtocolConfigKt.liquidLegionsV2 {}
         }
@@ -314,6 +317,7 @@ class Population(val clock: Clock, val idGenerator: IdGenerator) {
         apiVersion = API_VERSION
         measurementSpec = "MeasurementSpec".toByteStringUtf8()
         measurementSpecSignature = "MeasurementSpec signature".toByteStringUtf8()
+        measurementSpecSignatureAlgorithmOid = "2.9999"
         protocolConfig = protocolConfig { direct = ProtocolConfig.Direct.getDefaultInstance() }
       }
     return createMeasurement(
@@ -481,6 +485,7 @@ fun DataProvider.toDataProviderValue(nonce: Long = Random.Default.nextLong()) = 
   externalDataProviderCertificateId = certificate.externalCertificateId
   dataProviderPublicKey = details.publicKey
   dataProviderPublicKeySignature = details.publicKeySignature
+  dataProviderPublicKeySignatureAlgorithmOid = details.publicKeySignatureAlgorithmOid
   encryptedRequisitionSpec = "Encrypted RequisitionSpec $nonce".toByteStringUtf8()
   nonceHash = Hashing.hashSha256(nonce)
 }

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/service/internal/testing/RequisitionsServiceTest.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/service/internal/testing/RequisitionsServiceTest.kt
@@ -564,6 +564,8 @@ abstract class RequisitionsServiceTest<T : RequisitionsCoroutineService> {
         RequisitionKt.details {
           dataProviderPublicKey = dataProviderValue.dataProviderPublicKey
           dataProviderPublicKeySignature = dataProviderValue.dataProviderPublicKeySignature
+          dataProviderPublicKeySignatureAlgorithmOid =
+            dataProviderValue.dataProviderPublicKeySignatureAlgorithmOid
           encryptedRequisitionSpec = dataProviderValue.encryptedRequisitionSpec
           nonceHash = dataProviderValue.nonceHash
         }
@@ -574,6 +576,8 @@ abstract class RequisitionsServiceTest<T : RequisitionsCoroutineService> {
           measurement.externalMeasurementConsumerCertificateId
         measurementSpec = measurement.details.measurementSpec
         measurementSpecSignature = measurement.details.measurementSpecSignature
+        measurementSpecSignatureAlgorithmOid =
+          measurement.details.measurementSpecSignatureAlgorithmOid
         state = Measurement.State.PENDING_REQUISITION_PARAMS
         protocolConfig = protocolConfig {
           liquidLegionsV2 = ProtocolConfig.LiquidLegionsV2.getDefaultInstance()
@@ -641,6 +645,8 @@ abstract class RequisitionsServiceTest<T : RequisitionsCoroutineService> {
         RequisitionKt.details {
           dataProviderPublicKey = dataProviderValue.dataProviderPublicKey
           dataProviderPublicKeySignature = dataProviderValue.dataProviderPublicKeySignature
+          dataProviderPublicKeySignatureAlgorithmOid =
+            dataProviderValue.dataProviderPublicKeySignatureAlgorithmOid
           encryptedRequisitionSpec = dataProviderValue.encryptedRequisitionSpec
           nonceHash = dataProviderValue.nonceHash
         }
@@ -651,6 +657,8 @@ abstract class RequisitionsServiceTest<T : RequisitionsCoroutineService> {
           measurement.externalMeasurementConsumerCertificateId
         measurementSpec = measurement.details.measurementSpec
         measurementSpecSignature = measurement.details.measurementSpecSignature
+        measurementSpecSignatureAlgorithmOid =
+          measurement.details.measurementSpecSignatureAlgorithmOid
         state = Measurement.State.PENDING_REQUISITION_FULFILLMENT
         protocolConfig = protocolConfig { direct = ProtocolConfig.Direct.getDefaultInstance() }
         dataProvidersCount = 1

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/service/system/v1alpha/ComputationParticipantsService.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/service/system/v1alpha/ComputationParticipantsService.kt
@@ -85,6 +85,8 @@ class ComputationParticipantsService(
           liquidLegionsV2 = liquidLegionsV2Details {
             elGamalPublicKey = requisitionParams.liquidLegionsV2.elGamalPublicKey
             elGamalPublicKeySignature = requisitionParams.liquidLegionsV2.elGamalPublicKeySignature
+            elGamalPublicKeySignatureAlgorithmOid =
+              requisitionParams.liquidLegionsV2.elGamalPublicKeySignatureAlgorithmOid
           }
         }
         ProtocolCase.REACH_ONLY_LIQUID_LEGIONS_V2 -> {

--- a/src/main/kotlin/org/wfanet/measurement/loadtest/dataprovider/BUILD.bazel
+++ b/src/main/kotlin/org/wfanet/measurement/loadtest/dataprovider/BUILD.bazel
@@ -170,7 +170,6 @@ kt_jvm_library(
         "@wfa_common_jvm//src/main/kotlin/org/wfanet/measurement/common/throttler",
         "@wfa_consent_signaling_client//src/main/kotlin/org/wfanet/measurement/consent/client/common:verification_exception",
         "@wfa_consent_signaling_client//src/main/kotlin/org/wfanet/measurement/consent/client/dataprovider",
-        "@wfa_consent_signaling_client//src/main/kotlin/org/wfanet/measurement/consent/client/duchy",
         "@wfa_consent_signaling_client//src/main/kotlin/org/wfanet/measurement/consent/client/measurementconsumer",
     ],
 )

--- a/src/main/kotlin/org/wfanet/measurement/loadtest/panelmatchresourcesetup/PanelMatchResourceSetup.kt
+++ b/src/main/kotlin/org/wfanet/measurement/loadtest/panelmatchresourcesetup/PanelMatchResourceSetup.kt
@@ -159,6 +159,7 @@ class PanelMatchResourceSetup(
               apiVersion = API_VERSION.string
               publicKey = signedPublicKey.data
               publicKeySignature = signedPublicKey.signature
+              publicKeySignatureAlgorithmOid = signedPublicKey.signatureAlgorithmOid
             }
         }
       )

--- a/src/main/kotlin/org/wfanet/measurement/loadtest/resourcesetup/ResourceSetup.kt
+++ b/src/main/kotlin/org/wfanet/measurement/loadtest/resourcesetup/ResourceSetup.kt
@@ -249,6 +249,7 @@ class ResourceSetup(
                 apiVersion = API_VERSION.string
                 publicKey = signedPublicKey.data
                 publicKeySignature = signedPublicKey.signature
+                publicKeySignatureAlgorithmOid = signedPublicKey.signatureAlgorithmOid
               }
             requiredExternalDuchyIds += requiredDuchies
           }

--- a/src/main/kotlin/org/wfanet/measurement/reporting/service/api/v1alpha/ReportsService.kt
+++ b/src/main/kotlin/org/wfanet/measurement/reporting/service/api/v1alpha/ReportsService.kt
@@ -18,7 +18,6 @@ package org.wfanet.measurement.reporting.service.api.v1alpha
 
 import com.google.protobuf.ByteString
 import com.google.protobuf.Duration as ProtoDuration
-import com.google.protobuf.duration
 import com.google.protobuf.util.Durations
 import com.google.protobuf.util.Timestamps
 import com.google.type.Interval
@@ -204,7 +203,7 @@ class ReportsService(
   private val secureRandom: SecureRandom,
   private val signingPrivateKeyDir: File,
   private val trustedCertificates: Map<ByteString, X509Certificate>,
-  private val measurementSpecConfig: MeasurementSpecConfig,
+  measurementSpecConfig: MeasurementSpecConfig,
 ) : ReportsCoroutineImplBase() {
   private val setOperationCompiler = SetOperationCompiler()
   private val measurementSpecComponentFactory =

--- a/src/main/kotlin/org/wfanet/panelmatch/client/storage/VerifyingStorageClient.kt
+++ b/src/main/kotlin/org/wfanet/panelmatch/client/storage/VerifyingStorageClient.kt
@@ -20,6 +20,7 @@ import java.security.cert.X509Certificate
 import kotlinx.coroutines.flow.Flow
 import org.apache.beam.sdk.options.PipelineOptions
 import org.wfanet.measurement.common.crypto.SignedBlob
+import org.wfanet.measurement.common.crypto.signatureAlgorithm
 import org.wfanet.measurement.common.flatten
 import org.wfanet.measurement.storage.StorageClient
 import org.wfanet.measurement.storage.StorageClient.Blob
@@ -49,7 +50,16 @@ class VerifyingStorageClient(
     val sharedStorage: StorageClient = sharedStorageFactory.build(pipelineOptions)
     val sourceBlob: Blob = sharedStorage.getBlob(blobKey) ?: throw BlobNotFoundException(blobKey)
     val namedSignature: NamedSignature = sharedStorage.getBlobSignature(blobKey)
-    return VerifiedBlob(SignedBlob(sourceBlob, namedSignature.signature), x509)
+
+    // We assume that the signature algorithm is the one from the certificate, since that is the
+    // behavior SigningStorageClient has been using.
+    // TODO(@stevenwarejones): Figure out how to pass signature algorithm going forward.
+    val algorithm =
+      checkNotNull(x509.signatureAlgorithm) {
+        "Unsupported signature algorithm: ${x509.sigAlgName} ${x509.sigAlgOID}"
+      }
+
+    return VerifiedBlob(SignedBlob(sourceBlob, namedSignature.signature, algorithm), x509)
   }
 
   /** [Blob] wrapper that ensures the blob's signature is verified when read. */

--- a/src/main/proto/wfa/measurement/internal/duchy/protocol/liquid_legions_sketch_aggregation_v2.proto
+++ b/src/main/proto/wfa/measurement/internal/duchy/protocol/liquid_legions_sketch_aggregation_v2.proto
@@ -139,6 +139,11 @@ message LiquidLegionsSketchAggregationV2 {
       // Cryptographic digital signature of `el_gamal_public_key`.
       // For consent signaling verification only.
       bytes el_gamal_public_key_signature = 4;
+      // Object identifier (OID) of the signature algorithm in dot notation.
+      //
+      // If not specified, this is assumed to be the signature algorithm of the
+      // accompanying certificate.
+      string el_gamal_public_key_signature_algorithm_oid = 6;
       // The duchy's X.509 certificate in DER format which can used to verify
       // the above el_gamal_public_key_signature
       bytes duchy_certificate_der = 5;

--- a/src/main/proto/wfa/measurement/internal/duchy/protocol/reach_only_liquid_legions_sketch_aggregation_v2.proto
+++ b/src/main/proto/wfa/measurement/internal/duchy/protocol/reach_only_liquid_legions_sketch_aggregation_v2.proto
@@ -121,6 +121,11 @@ message ReachOnlyLiquidLegionsSketchAggregationV2 {
       // Cryptographic digital signature of `el_gamal_public_key`.
       // For consent signaling verification only.
       bytes el_gamal_public_key_signature = 4;
+      // Object identifier (OID) of the signature algorithm in dot notation.
+      //
+      // If not specified, this is assumed to be the signature algorithm of the
+      // accompanying certificate.
+      string el_gamal_public_key_signature_algorithm_oid = 6;
       // The duchy's X.509 certificate in DER format which can used to verify
       // the above el_gamal_public_key_signature
       bytes duchy_certificate_der = 5;

--- a/src/main/proto/wfa/measurement/internal/kingdom/computation_participant.proto
+++ b/src/main/proto/wfa/measurement/internal/kingdom/computation_participant.proto
@@ -58,6 +58,7 @@ message ComputationParticipant {
     // Serialized `ElGamalPublicKey` message from public API.
     bytes el_gamal_public_key = 1;
     bytes el_gamal_public_key_signature = 2;
+    string el_gamal_public_key_signature_algorithm_oid = 3;
   }
 
   message Details {

--- a/src/main/proto/wfa/measurement/internal/kingdom/data_provider.proto
+++ b/src/main/proto/wfa/measurement/internal/kingdom/data_provider.proto
@@ -36,6 +36,7 @@ message DataProvider {
     // Serialized `EncryptionPublicKey` from public API.
     bytes public_key = 2;
     bytes public_key_signature = 3;
+    string public_key_signature_algorithm_oid = 4;
   }
   Details details = 3;
 

--- a/src/main/proto/wfa/measurement/internal/kingdom/event_group.proto
+++ b/src/main/proto/wfa/measurement/internal/kingdom/event_group.proto
@@ -42,6 +42,7 @@ message EventGroup {
     // Serialized `EncryptionPublicKey` message from the public API.
     bytes measurement_consumer_public_key = 2;
     bytes measurement_consumer_public_key_signature = 3;
+    string measurement_consumer_public_key_signature_algorithm_oid = 7;
 
     // The set of VID model lines used to label events in this Event Group.
     repeated string vid_model_lines = 4;

--- a/src/main/proto/wfa/measurement/internal/kingdom/measurement.proto
+++ b/src/main/proto/wfa/measurement/internal/kingdom/measurement.proto
@@ -105,6 +105,7 @@ message Measurement {
     // Serialized `EncryptionPublicKey` message from the public API.
     bytes data_provider_public_key = 2;
     bytes data_provider_public_key_signature = 3;
+    string data_provider_public_key_signature_algorithm_oid = 6;
 
     bytes encrypted_requisition_spec = 4;
     bytes nonce_hash = 5;
@@ -121,6 +122,7 @@ message Measurement {
     // Serialized `MeasurementSpec` from public API.
     bytes measurement_spec = 2;
     bytes measurement_spec_signature = 3;
+    string measurement_spec_signature_algorithm_oid = 9;
 
     // The protocol config used in this measurement.
     ProtocolConfig protocol_config = 6;
@@ -249,6 +251,7 @@ message Requisition {
     // Serialized `EncryptionPublicKey` message from the public API.
     bytes data_provider_public_key = 1;
     bytes data_provider_public_key_signature = 2;
+    string data_provider_public_key_signature_algorithm_oid = 8;
 
     bytes encrypted_requisition_spec = 3;
     bytes nonce_hash = 4;
@@ -279,6 +282,7 @@ message Requisition {
     // Serialized `MeasurementSpec` from public API.
     bytes measurement_spec = 3;
     bytes measurement_spec_signature = 4;
+    string measurement_spec_signature_algorithm_oid = 8;
 
     // The protocol config used in this measurement.
     ProtocolConfig protocol_config = 5;

--- a/src/main/proto/wfa/measurement/internal/kingdom/measurement_consumer.proto
+++ b/src/main/proto/wfa/measurement/internal/kingdom/measurement_consumer.proto
@@ -36,6 +36,7 @@ message MeasurementConsumer {
     // Serialized `EncryptionPublicKey` from public API.
     bytes public_key = 2;
     bytes public_key_signature = 3;
+    string public_key_signature_algorithm_oid = 4;
   }
   Details details = 3;
 }

--- a/src/main/proto/wfa/measurement/internal/kingdom/public_keys_service.proto
+++ b/src/main/proto/wfa/measurement/internal/kingdom/public_keys_service.proto
@@ -38,6 +38,7 @@ message UpdatePublicKeyRequest {
   // Serialized `EncryptionPublicKey` from public API.
   bytes public_key = 5;
   bytes public_key_signature = 6;
+  string public_key_signature_algorithm_oid = 7;
 }
 
 message UpdatePublicKeyResponse {}

--- a/src/main/proto/wfa/measurement/system/v1alpha/computation_participant.proto
+++ b/src/main/proto/wfa/measurement/system/v1alpha/computation_participant.proto
@@ -90,6 +90,11 @@ message ComputationParticipant {
       // `duchy_certificate`.
       bytes el_gamal_public_key_signature = 2
           [(google.api.field_behavior) = REQUIRED];
+      // Object identifier (OID) of the signature algorithm in dot notation.
+      //
+      // If not specified, this is assumed to be the signature algorithm of the
+      // accompanying certificate.
+      string el_gamal_public_key_signature_algorithm_oid = 3;
     }
 
     // Protocol. Required.

--- a/src/test/kotlin/org/wfanet/measurement/kingdom/service/api/v2alpha/DataProvidersServiceTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/kingdom/service/api/v2alpha/DataProvidersServiceTest.kt
@@ -362,6 +362,7 @@ class DataProvidersServiceTest {
     private val SIGNED_PUBLIC_KEY = signedData {
       data = ENCRYPTION_PUBLIC_KEY.toByteString()
       signature = ByteString.copyFromUtf8("Fake signature of public key")
+      signatureAlgorithmOid = "2.9999"
     }
 
     private val INTERNAL_DATA_PROVIDER: InternalDataProvider = internalDataProvider {
@@ -370,6 +371,7 @@ class DataProvidersServiceTest {
         apiVersion = Version.V2_ALPHA.string
         publicKey = SIGNED_PUBLIC_KEY.data
         publicKeySignature = SIGNED_PUBLIC_KEY.signature
+        publicKeySignatureAlgorithmOid = SIGNED_PUBLIC_KEY.signatureAlgorithmOid
       }
       certificate = internalCertificate {
         externalDataProviderId = DATA_PROVIDER_ID

--- a/src/test/kotlin/org/wfanet/measurement/kingdom/service/api/v2alpha/EventGroupsServiceTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/kingdom/service/api/v2alpha/EventGroupsServiceTest.kt
@@ -117,6 +117,7 @@ private val MEASUREMENT_CONSUMER_EXTERNAL_ID =
 
 private val MEASUREMENT_CONSUMER_PUBLIC_KEY_DATA = ByteString.copyFromUtf8("foodata")
 private val MEASUREMENT_CONSUMER_PUBLIC_KEY_SIGNATURE = ByteString.copyFromUtf8("foosig")
+private const val MEASUREMENT_CONSUMER_PUBLIC_KEY_SIGNATURE_ALGORITHM_OID = "2.9999"
 private val VID_MODEL_LINES = listOf("model1", "model2")
 private val EVENT_TEMPLATE_TYPES = listOf("type1", "type2")
 private val EVENT_TEMPLATES =
@@ -132,6 +133,7 @@ private val EVENT_GROUP: EventGroup = eventGroup {
   measurementConsumerPublicKey = signedData {
     data = MEASUREMENT_CONSUMER_PUBLIC_KEY_DATA
     signature = MEASUREMENT_CONSUMER_PUBLIC_KEY_SIGNATURE
+    signatureAlgorithmOid = MEASUREMENT_CONSUMER_PUBLIC_KEY_SIGNATURE_ALGORITHM_OID
   }
   vidModelLines.addAll(VID_MODEL_LINES)
   eventTemplates.addAll(EVENT_TEMPLATES)
@@ -161,6 +163,8 @@ private val INTERNAL_EVENT_GROUP: InternalEventGroup = internalEventGroup {
     apiVersion = API_VERSION.string
     measurementConsumerPublicKey = MEASUREMENT_CONSUMER_PUBLIC_KEY_DATA
     measurementConsumerPublicKeySignature = MEASUREMENT_CONSUMER_PUBLIC_KEY_SIGNATURE
+    measurementConsumerPublicKeySignatureAlgorithmOid =
+      MEASUREMENT_CONSUMER_PUBLIC_KEY_SIGNATURE_ALGORITHM_OID
     vidModelLines.addAll(VID_MODEL_LINES)
     eventTemplates.addAll(INTERNAL_EVENT_TEMPLATES)
     encryptedMetadata = ENCRYPTED_METADATA

--- a/src/test/kotlin/org/wfanet/measurement/kingdom/service/api/v2alpha/MeasurementConsumersServiceTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/kingdom/service/api/v2alpha/MeasurementConsumersServiceTest.kt
@@ -535,6 +535,7 @@ class MeasurementConsumersServiceTest {
     private val SIGNED_PUBLIC_KEY = signedData {
       data = ENCRYPTION_PUBLIC_KEY.toByteString()
       signature = ByteString.copyFromUtf8("Fake signature of public key")
+      signatureAlgorithmOid = "2.9999"
     }
 
     private val INTERNAL_MEASUREMENT_CONSUMER: InternalMeasurementConsumer =
@@ -544,6 +545,7 @@ class MeasurementConsumersServiceTest {
           apiVersion = Version.V2_ALPHA.string
           publicKey = SIGNED_PUBLIC_KEY.data
           publicKeySignature = SIGNED_PUBLIC_KEY.signature
+          publicKeySignatureAlgorithmOid = SIGNED_PUBLIC_KEY.signatureAlgorithmOid
         }
         certificate = certificate {
           externalMeasurementConsumerId = MEASUREMENT_CONSUMER_ID
@@ -565,6 +567,7 @@ class MeasurementConsumersServiceTest {
       publicKey = signedData {
         data = INTERNAL_MEASUREMENT_CONSUMER.details.publicKey
         signature = INTERNAL_MEASUREMENT_CONSUMER.details.publicKeySignature
+        signatureAlgorithmOid = INTERNAL_MEASUREMENT_CONSUMER.details.publicKeySignatureAlgorithmOid
       }
     }
 

--- a/src/test/kotlin/org/wfanet/measurement/kingdom/service/api/v2alpha/MeasurementsServiceTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/kingdom/service/api/v2alpha/MeasurementsServiceTest.kt
@@ -712,15 +712,16 @@ class MeasurementsServiceTest {
               createMeasurementRequest {
                 measurement =
                   MEASUREMENT.copy {
-                    measurementSpec = signedData {
-                      data =
-                        MEASUREMENT_SPEC.copy {
-                            clearReachAndFrequency()
-                            population = population {}
-                          }
-                          .toByteString()
-                      signature = UPDATE_TIME.toByteString()
-                    }
+                    measurementSpec =
+                      measurementSpec.copy {
+                        data =
+                          MEASUREMENT_SPEC.copy {
+                              clearReachAndFrequency()
+                              population = population {}
+                            }
+                            .toByteString()
+                        signature = UPDATE_TIME.toByteString()
+                      }
                   }
               }
             )
@@ -857,9 +858,10 @@ class MeasurementsServiceTest {
       parent = MEASUREMENT_CONSUMER_NAME
       measurement =
         MEASUREMENT.copy {
-          measurementSpec = signedData {
-            data = MEASUREMENT_SPEC.copy { clearMeasurementPublicKey() }.toByteString()
-          }
+          measurementSpec =
+            measurementSpec.copy {
+              data = MEASUREMENT_SPEC.copy { clearMeasurementPublicKey() }.toByteString()
+            }
         }
     }
 
@@ -880,13 +882,14 @@ class MeasurementsServiceTest {
       parent = MEASUREMENT_CONSUMER_NAME
       measurement =
         MEASUREMENT.copy {
-          measurementSpec = signedData {
-            data =
-              MEASUREMENT_SPEC.copy {
-                  reachAndFrequency = reachAndFrequency.copy { clearReachPrivacyParams() }
-                }
-                .toByteString()
-          }
+          measurementSpec =
+            measurementSpec.copy {
+              data =
+                MEASUREMENT_SPEC.copy {
+                    reachAndFrequency = reachAndFrequency.copy { clearReachPrivacyParams() }
+                  }
+                  .toByteString()
+            }
         }
     }
 
@@ -907,13 +910,14 @@ class MeasurementsServiceTest {
       parent = MEASUREMENT_CONSUMER_NAME
       measurement =
         MEASUREMENT.copy {
-          measurementSpec = signedData {
-            data =
-              MEASUREMENT_SPEC.copy {
-                  reachAndFrequency = reachAndFrequency.copy { clearFrequencyPrivacyParams() }
-                }
-                .toByteString()
-          }
+          measurementSpec =
+            measurementSpec.copy {
+              data =
+                MEASUREMENT_SPEC.copy {
+                    reachAndFrequency = reachAndFrequency.copy { clearFrequencyPrivacyParams() }
+                  }
+                  .toByteString()
+            }
         }
     }
 
@@ -934,9 +938,10 @@ class MeasurementsServiceTest {
       parent = MEASUREMENT_CONSUMER_NAME
       measurement =
         MEASUREMENT.copy {
-          measurementSpec = signedData {
-            data = MEASUREMENT_SPEC.copy { clearVidSamplingInterval() }.toByteString()
-          }
+          measurementSpec =
+            measurementSpec.copy {
+              data = MEASUREMENT_SPEC.copy { clearVidSamplingInterval() }.toByteString()
+            }
         }
     }
 
@@ -957,16 +962,17 @@ class MeasurementsServiceTest {
       parent = MEASUREMENT_CONSUMER_NAME
       measurement =
         MEASUREMENT.copy {
-          measurementSpec = signedData {
-            data =
-              MEASUREMENT_SPEC.copy {
-                  reachAndFrequency =
-                    reachAndFrequency.copy {
-                      reachPrivacyParams = reachPrivacyParams.copy { clearEpsilon() }
-                    }
-                }
-                .toByteString()
-          }
+          measurementSpec =
+            measurementSpec.copy {
+              data =
+                MEASUREMENT_SPEC.copy {
+                    reachAndFrequency =
+                      reachAndFrequency.copy {
+                        reachPrivacyParams = reachPrivacyParams.copy { clearEpsilon() }
+                      }
+                  }
+                  .toByteString()
+            }
         }
     }
 
@@ -987,13 +993,14 @@ class MeasurementsServiceTest {
       parent = MEASUREMENT_CONSUMER_NAME
       measurement =
         MEASUREMENT.copy {
-          measurementSpec = signedData {
-            data =
-              MEASUREMENT_SPEC.copy {
-                  reachAndFrequency = reachAndFrequency.copy { clearMaximumFrequency() }
-                }
-                .toByteString()
-          }
+          measurementSpec =
+            measurementSpec.copy {
+              data =
+                MEASUREMENT_SPEC.copy {
+                    reachAndFrequency = reachAndFrequency.copy { clearMaximumFrequency() }
+                  }
+                  .toByteString()
+            }
         }
     }
 
@@ -1014,11 +1021,12 @@ class MeasurementsServiceTest {
       parent = MEASUREMENT_CONSUMER_NAME
       measurement =
         REACH_ONLY_MEASUREMENT.copy {
-          measurementSpec = signedData {
-            data =
-              REACH_ONLY_MEASUREMENT_SPEC.copy { reach = reach.copy { clearPrivacyParams() } }
-                .toByteString()
-          }
+          measurementSpec =
+            measurementSpec.copy {
+              data =
+                REACH_ONLY_MEASUREMENT_SPEC.copy { reach = reach.copy { clearPrivacyParams() } }
+                  .toByteString()
+            }
         }
     }
 
@@ -1039,9 +1047,10 @@ class MeasurementsServiceTest {
       parent = MEASUREMENT_CONSUMER_NAME
       measurement =
         REACH_ONLY_MEASUREMENT.copy {
-          measurementSpec = signedData {
-            data = REACH_ONLY_MEASUREMENT_SPEC.copy { clearVidSamplingInterval() }.toByteString()
-          }
+          measurementSpec =
+            measurementSpec.copy {
+              data = REACH_ONLY_MEASUREMENT_SPEC.copy { clearVidSamplingInterval() }.toByteString()
+            }
         }
     }
 
@@ -1062,13 +1071,14 @@ class MeasurementsServiceTest {
       parent = MEASUREMENT_CONSUMER_NAME
       measurement =
         REACH_ONLY_MEASUREMENT.copy {
-          measurementSpec = signedData {
-            data =
-              REACH_ONLY_MEASUREMENT_SPEC.copy {
-                  reach = reach.copy { privacyParams = privacyParams.copy { clearEpsilon() } }
-                }
-                .toByteString()
-          }
+          measurementSpec =
+            measurementSpec.copy {
+              data =
+                REACH_ONLY_MEASUREMENT_SPEC.copy {
+                    reach = reach.copy { privacyParams = privacyParams.copy { clearEpsilon() } }
+                  }
+                  .toByteString()
+            }
         }
     }
 
@@ -1915,6 +1925,7 @@ class MeasurementsServiceTest {
       measurementSpec = signedData {
         data = MEASUREMENT_SPEC.toByteString()
         signature = UPDATE_TIME.toByteString()
+        signatureAlgorithmOid = "2.9999"
       }
       dataProviders +=
         EXTERNAL_DATA_PROVIDER_IDS.map {
@@ -1928,6 +1939,7 @@ class MeasurementsServiceTest {
               dataProviderPublicKey = signedData {
                 data = UPDATE_TIME.toByteString()
                 signature = UPDATE_TIME.toByteString()
+                signatureAlgorithmOid = "2.9999"
               }
               encryptedRequisitionSpec = UPDATE_TIME.toByteString()
               nonceHash = DATA_PROVIDER_NONCE_HASH
@@ -1972,6 +1984,8 @@ class MeasurementsServiceTest {
                 )
               dataProviderPublicKey = it.value.dataProviderPublicKey.data
               dataProviderPublicKeySignature = it.value.dataProviderPublicKey.signature
+              dataProviderPublicKeySignatureAlgorithmOid =
+                it.value.dataProviderPublicKey.signatureAlgorithmOid
               encryptedRequisitionSpec = it.value.encryptedRequisitionSpec
               nonceHash = it.value.nonceHash
             }
@@ -1983,6 +1997,7 @@ class MeasurementsServiceTest {
           apiVersion = Version.V2_ALPHA.string
           measurementSpec = MEASUREMENT.measurementSpec.data
           measurementSpecSignature = MEASUREMENT.measurementSpec.signature
+          measurementSpecSignatureAlgorithmOid = MEASUREMENT.measurementSpec.signatureAlgorithmOid
           protocolConfig = LLV2_INTERNAL_PROTOCOL_CONFIG
           duchyProtocolConfig = LLV2_DUCHY_PROTOCOL_CONFIG
           failure =
@@ -2021,6 +2036,7 @@ class MeasurementsServiceTest {
         measurementSpec = signedData {
           data = REACH_ONLY_MEASUREMENT_SPEC.toByteString()
           signature = UPDATE_TIME.toByteString()
+          signatureAlgorithmOid = "2.9999"
         }
         protocolConfig = RO_LLV2_PUBLIC_PROTOCOL_CONFIG
       }
@@ -2032,6 +2048,8 @@ class MeasurementsServiceTest {
             apiVersion = Version.V2_ALPHA.string
             measurementSpec = REACH_ONLY_MEASUREMENT.measurementSpec.data
             measurementSpecSignature = REACH_ONLY_MEASUREMENT.measurementSpec.signature
+            measurementSpecSignatureAlgorithmOid =
+              REACH_ONLY_MEASUREMENT.measurementSpec.signatureAlgorithmOid
             protocolConfig = RO_LLV2_INTERNAL_PROTOCOL_CONFIG
             duchyProtocolConfig = RO_LLV2_DUCHY_PROTOCOL_CONFIG
             failure =

--- a/src/test/kotlin/org/wfanet/measurement/kingdom/service/api/v2alpha/PublicKeysServiceTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/kingdom/service/api/v2alpha/PublicKeysServiceTest.kt
@@ -99,6 +99,7 @@ class PublicKeysServiceTest {
           apiVersion = Version.V2_ALPHA.toString()
           publicKey = PUBLIC_KEY.publicKey.data
           publicKeySignature = PUBLIC_KEY.publicKey.signature
+          publicKeySignatureAlgorithmOid = PUBLIC_KEY.publicKey.signatureAlgorithmOid
         }
       )
 
@@ -139,6 +140,7 @@ class PublicKeysServiceTest {
           apiVersion = Version.V2_ALPHA.toString()
           publicKey = PUBLIC_KEY.publicKey.data
           publicKeySignature = PUBLIC_KEY.publicKey.signature
+          publicKeySignatureAlgorithmOid = PUBLIC_KEY.publicKey.signatureAlgorithmOid
         }
       )
 
@@ -313,6 +315,7 @@ private val PUBLIC_KEY: PublicKey = publicKey {
   publicKey = signedData {
     data = ByteString.copyFromUtf8("1")
     signature = ByteString.copyFromUtf8("1")
+    signatureAlgorithmOid = "2.9999"
   }
   certificate = DATA_PROVIDERS_CERTIFICATE_NAME
 }

--- a/src/test/kotlin/org/wfanet/measurement/kingdom/service/api/v2alpha/RequisitionsServiceTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/kingdom/service/api/v2alpha/RequisitionsServiceTest.kt
@@ -913,6 +913,7 @@ class RequisitionsServiceTest {
         liquidLegionsV2 = liquidLegionsV2Details {
           elGamalPublicKey = UPDATE_TIME.toByteString()
           elGamalPublicKeySignature = UPDATE_TIME.toByteString()
+          elGamalPublicKeySignatureAlgorithmOid = "2.9999"
         }
       }
       dataProviderCertificate = internalCertificate {
@@ -957,6 +958,8 @@ class RequisitionsServiceTest {
       measurementSpec = signedData {
         data = INTERNAL_REQUISITION.parentMeasurement.measurementSpec
         signature = INTERNAL_REQUISITION.parentMeasurement.measurementSpecSignature
+        signatureAlgorithmOid =
+          INTERNAL_REQUISITION.parentMeasurement.measurementSpecSignatureAlgorithmOid
       }
       protocolConfig = protocolConfig {
         measurementType = ProtocolConfig.MeasurementType.REACH_AND_FREQUENCY
@@ -972,6 +975,8 @@ class RequisitionsServiceTest {
       dataProviderPublicKey = signedData {
         data = INTERNAL_REQUISITION.details.dataProviderPublicKey
         signature = INTERNAL_REQUISITION.details.dataProviderPublicKeySignature
+        signatureAlgorithmOid =
+          INTERNAL_REQUISITION.details.dataProviderPublicKeySignatureAlgorithmOid
       }
 
       val internalDuchyValue: InternalRequisition.DuchyValue =
@@ -984,6 +989,8 @@ class RequisitionsServiceTest {
             elGamalPublicKey = signedData {
               data = internalDuchyValue.liquidLegionsV2.elGamalPublicKey
               signature = internalDuchyValue.liquidLegionsV2.elGamalPublicKeySignature
+              signatureAlgorithmOid =
+                internalDuchyValue.liquidLegionsV2.elGamalPublicKeySignatureAlgorithmOid
             }
           }
         }

--- a/src/test/kotlin/org/wfanet/measurement/loadtest/dataprovider/EdpSimulatorTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/loadtest/dataprovider/EdpSimulatorTest.kt
@@ -548,7 +548,6 @@ class EdpSimulatorTest {
                       samplingIndicatorSize = 10_000_000
                     }
                     ellipticCurveId = 415
-                    maximumFrequency = 12
                   }
               }
           }

--- a/src/test/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/DataProvidersServiceTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/DataProvidersServiceTest.kt
@@ -174,6 +174,7 @@ class DataProvidersServiceTest {
     private val SIGNED_PUBLIC_KEY = signedData {
       data = ENCRYPTION_PUBLIC_KEY.toByteString()
       signature = ByteString.copyFromUtf8("Fake signature of public key")
+      signatureAlgorithmOid = "2.9999"
     }
 
     private val DATA_PROVIDER = dataProvider {


### PR DESCRIPTION
Updates common-jvm to 0.67.0, cross-media-measurement-api to 0.45.0, and consent-signaling-client to 0.18.0.

Closes world-federation-of-advertisers/cross-media-measurement-api#176