### PR TITLE
Implement refactoring of custom direct methodology

### DIFF
--- a/build/repositories.bzl
+++ b/build/repositories.bzl
@@ -41,8 +41,8 @@ def wfa_measurement_system_repositories():
     wfa_repo_archive(
         name = "wfa_measurement_proto",
         repo = "cross-media-measurement-api",
-        sha256 = "f027ed6e6dfce0f1ce41be8d065e3f3227eb09e9d41fbc041650334301d72c42",
-        version = "0.45.0",
+        sha256 = "7fc35bd1b0504ae2168090d17da5480a86f0171c5e111549551e424dc1a89f6d",
+        version = "0.46.0",
     )
 
     wfa_repo_archive(

--- a/src/main/kotlin/org/wfanet/measurement/loadtest/dataprovider/EdpSimulator.kt
+++ b/src/main/kotlin/org/wfanet/measurement/loadtest/dataprovider/EdpSimulator.kt
@@ -1317,7 +1317,7 @@ class EdpSimulator(
             // TODO: Calculate impression from data.
             value = apiIdToExternalId(DataProviderKey.fromName(edpData.name)!!.dataProviderId)
             noiseMechanism = protocolConfigNoiseMechanism
-            customDirectMethodology = customDirectMethodology { variance = 0.0 }
+            customDirectMethodology = customDirectMethodology { scalar = 0.0 }
           }
         }
       }
@@ -1332,7 +1332,7 @@ class EdpSimulator(
               seconds = log2(externalDataProviderId.toDouble()).toLong()
             }
             noiseMechanism = protocolConfigNoiseMechanism
-            customDirectMethodology = customDirectMethodology { variance = 0.0 }
+            customDirectMethodology = customDirectMethodology { scalar = 0.0 }
           }
         }
       }

--- a/src/main/kotlin/org/wfanet/measurement/loadtest/measurementconsumer/MeasurementConsumerSimulator.kt
+++ b/src/main/kotlin/org/wfanet/measurement/loadtest/measurementconsumer/MeasurementConsumerSimulator.kt
@@ -321,7 +321,7 @@ class MeasurementConsumerSimulator(
           apiIdToExternalId(DataProviderCertificateKey.fromName(it.certificate)!!.dataProviderId)
         )
       assertThat(result.impression.customDirectMethodology)
-        .isEqualTo(customDirectMethodology { variance = 0.0 })
+        .isEqualTo(customDirectMethodology { scalar = 0.0 })
       assertThat(result.impression.noiseMechanism).isEqualTo(expectedDirectNoiseMechanism)
     }
     logger.info("Impression result is equal to the expected result")
@@ -350,7 +350,7 @@ class MeasurementConsumerSimulator(
         )
       // EdpSimulator hasn't had an implementation for watch duration.
       assertThat(result.watchDuration.customDirectMethodology)
-        .isEqualTo(customDirectMethodology { variance = 0.0 })
+        .isEqualTo(customDirectMethodology { scalar = 0.0 })
       assertThat(result.watchDuration.noiseMechanism).isEqualTo(expectedDirectNoiseMechanism)
     }
     logger.info("Duration result is equal to the expected result")

--- a/src/main/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/ProtoConversions.kt
+++ b/src/main/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/ProtoConversions.kt
@@ -33,6 +33,7 @@ import org.wfanet.measurement.api.v2alpha.ProtocolConfig
 import org.wfanet.measurement.api.v2alpha.differentialPrivacyParams
 import org.wfanet.measurement.config.reporting.MetricSpecConfig
 import org.wfanet.measurement.internal.reporting.v2.CustomDirectMethodology as InternalCustomDirectMethodology
+import org.wfanet.measurement.internal.reporting.v2.CustomDirectMethodologyKt
 import org.wfanet.measurement.internal.reporting.v2.DeterministicCount
 import org.wfanet.measurement.internal.reporting.v2.DeterministicCountDistinct
 import org.wfanet.measurement.internal.reporting.v2.DeterministicDistribution
@@ -813,7 +814,24 @@ fun ProtocolConfig.NoiseMechanism.toInternal(): NoiseMechanism {
 /** Converts a CMMS [CustomDirectMethodology] to an internal [InternalCustomDirectMethodology]. */
 fun CustomDirectMethodology.toInternal(): InternalCustomDirectMethodology {
   val source = this
-  return customDirectMethodology { variance = source.variance }
+  return customDirectMethodology {
+    @Suppress("WHEN_ENUM_CAN_BE_NULL_IN_JAVA")
+    when (source.varianceCase) {
+      CustomDirectMethodology.VarianceCase.SCALAR -> {
+        scalar = source.scalar
+      }
+      CustomDirectMethodology.VarianceCase.FREQUENCY -> {
+        frequency =
+          CustomDirectMethodologyKt.frequencyVariances {
+            variances.putAll(source.frequency.variancesMap)
+            kPlusVariances.putAll(source.frequency.kPlusVariancesMap)
+          }
+      }
+      CustomDirectMethodology.VarianceCase.VARIANCE_NOT_SET -> {
+        error("Variance in CustomDirectMethodology is not set.")
+      }
+    }
+  }
 }
 
 /**

--- a/src/main/proto/wfa/measurement/internal/reporting/v2/direct_computation.proto
+++ b/src/main/proto/wfa/measurement/internal/reporting/v2/direct_computation.proto
@@ -21,8 +21,23 @@ option java_multiple_files = true;
 
 // Information about the custom direct methodology.
 message CustomDirectMethodology {
-  // The variance of the result computed with the custom direct methodology.
-  double variance = 1;
+  // Different types of variances of a frequency distribution result.
+  message FrequencyVariances {
+    // The variances of a frequency distribution from frequency 1 to maximum
+    // frequency specified in the measurement spec.
+    map<int64, double> variances = 1;
+    // The variances of a k+ frequency distribution from frequency 1 to
+    // maximum frequency specified in the measurement spec.
+    map<int64, double> k_plus_variances = 2;
+  }
+
+  // The variance of the result computed from the custom direct methodology.
+  oneof variance {
+    // The variance when the result is a scalar type.
+    double scalar = 1;
+    // The variance when the result is a frequency type.
+    FrequencyVariances frequency = 2;
+  }
 }
 
 // Parameters used when applying the deterministic count distinct methodology.


### PR DESCRIPTION
## TL;DR
This pull request is the implementation of [this API change]([url](https://github.com/world-federation-of-advertisers/cross-media-measurement-api/pull/178)). 

## What changed
- Modification of the "customDirectMethodology" property in the "EdpSimulator" class, changing the "variance" property to "scalar" and setting its value to 0.0.
- Function to convert a CustomDirectMethodology object to an InternalCustomDirectMethodology object.
- Addition of a new message called "CustomDirectMethodology" in the internal "direct_computation.proto" file, including a "FrequencyVariances" message with two maps for storing variances of frequency distributions and a "variance" field to store the variance of the result computed from the custom direct methodology.
- Test cases in the "MetricsServiceTest.kt" file, checking the presence of a specific metric in a list and checking if an exception is thrown when the variance in a custom methodology is not set.