### PR TITLE
Add metric variances to metric results in reporting v2

### DIFF
--- a/src/main/kotlin/org/wfanet/measurement/integration/common/reporting/v2/BUILD.bazel
+++ b/src/main/kotlin/org/wfanet/measurement/integration/common/reporting/v2/BUILD.bazel
@@ -46,6 +46,7 @@ kt_jvm_library(
         "//src/main/k8s/testing/secretfiles:secret_files",
     ],
     deps = [
+        "//src/main/kotlin/org/wfanet/measurement/measurementconsumer/stats:variances",
         "//src/main/kotlin/org/wfanet/measurement/reporting/deploy/v2/common/server:internal_reporting_server",
         "//src/main/kotlin/org/wfanet/measurement/reporting/service/api:cel_env_provider",
         "//src/main/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha:data_providers_service",

--- a/src/main/kotlin/org/wfanet/measurement/integration/common/reporting/v2/InProcessReportingServer.kt
+++ b/src/main/kotlin/org/wfanet/measurement/integration/common/reporting/v2/InProcessReportingServer.kt
@@ -57,6 +57,7 @@ import org.wfanet.measurement.internal.reporting.v2.MetricsGrpcKt.MetricsCorouti
 import org.wfanet.measurement.internal.reporting.v2.ReportingSetsGrpcKt.ReportingSetsCoroutineStub as InternalReportingSetsCoroutineStub
 import org.wfanet.measurement.internal.reporting.v2.ReportsGrpcKt.ReportsCoroutineStub as InternalReportsCoroutineStub
 import org.wfanet.measurement.internal.reporting.v2.measurementConsumer
+import org.wfanet.measurement.measurementconsumer.stats.VariancesImpl
 import org.wfanet.measurement.reporting.deploy.v2.common.server.InternalReportingServer
 import org.wfanet.measurement.reporting.deploy.v2.common.server.InternalReportingServer.Companion.toList
 import org.wfanet.measurement.reporting.service.api.CelEnvCacheProvider
@@ -199,6 +200,7 @@ class InProcessReportingServer(
                 METRIC_SPEC_CONFIG,
                 internalReportingSetsClient,
                 internalMetricsClient,
+                VariancesImpl,
                 internalMeasurementsClient,
                 publicKingdomDataProvidersClient,
                 publicKingdomMeasurementsClient,

--- a/src/main/kotlin/org/wfanet/measurement/reporting/deploy/v2/common/server/BUILD.bazel
+++ b/src/main/kotlin/org/wfanet/measurement/reporting/deploy/v2/common/server/BUILD.bazel
@@ -36,6 +36,7 @@ kt_jvm_library(
     deps = [
         ":reporting_api_server_flags",
         "//src/main/kotlin/org/wfanet/measurement/common/api:memoizing_principal_lookup",
+        "//src/main/kotlin/org/wfanet/measurement/measurementconsumer/stats:variances",
         "//src/main/kotlin/org/wfanet/measurement/reporting/deploy/common:encryption_key_pair_map",
         "//src/main/kotlin/org/wfanet/measurement/reporting/deploy/common:kingdom_flags",
         "//src/main/kotlin/org/wfanet/measurement/reporting/service/api:cel_env_provider",

--- a/src/main/kotlin/org/wfanet/measurement/reporting/deploy/v2/common/server/V2AlphaPublicApiServer.kt
+++ b/src/main/kotlin/org/wfanet/measurement/reporting/deploy/v2/common/server/V2AlphaPublicApiServer.kt
@@ -57,6 +57,7 @@ import org.wfanet.measurement.internal.reporting.v2.MetricsGrpcKt.MetricsCorouti
 import org.wfanet.measurement.internal.reporting.v2.ReportingSetsGrpcKt.ReportingSetsCoroutineStub as InternalReportingSetsCoroutineStub
 import org.wfanet.measurement.internal.reporting.v2.ReportsGrpcKt.ReportsCoroutineStub as InternalReportsCoroutineStub
 import org.wfanet.measurement.internal.reporting.v2.measurementConsumer
+import org.wfanet.measurement.measurementconsumer.stats.VariancesImpl
 import org.wfanet.measurement.reporting.deploy.common.EncryptionKeyPairMap
 import org.wfanet.measurement.reporting.deploy.common.KingdomApiFlags
 import org.wfanet.measurement.reporting.service.api.CelEnvCacheProvider
@@ -162,6 +163,7 @@ private fun run(
       metricSpecConfig,
       InternalReportingSetsCoroutineStub(channel),
       InternalMetricsCoroutineStub(channel),
+      VariancesImpl,
       InternalMeasurementsCoroutineStub(channel),
       KingdomDataProvidersCoroutineStub(kingdomChannel),
       KingdomMeasurementsCoroutineStub(kingdomChannel),

--- a/src/main/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/BUILD.bazel
+++ b/src/main/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/BUILD.bazel
@@ -74,9 +74,16 @@ kt_jvm_library(
 )
 
 kt_jvm_library(
+    name = "reporting_exceptions",
+    srcs = ["ReportingExceptions.kt"],
+)
+
+kt_jvm_library(
     name = "proto_conversions",
     srcs = ["ProtoConversions.kt"],
     deps = [
+        ":reporting_exceptions",
+        "//src/main/kotlin/org/wfanet/measurement/measurementconsumer/stats:measurement_statistics",
         "//src/main/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha:metric_spec_defaults",
         "//src/main/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha:reporting_principal",
         "//src/main/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha:resource_key",
@@ -164,8 +171,12 @@ kt_jvm_library(
     name = "metrics_service",
     srcs = ["MetricsService.kt"],
     deps = [
+        ":reporting_exceptions",
         "//src/main/kotlin/org/wfanet/measurement/api:api_key_constants",
         "//src/main/kotlin/org/wfanet/measurement/api:public_api_version",
+        "//src/main/kotlin/org/wfanet/measurement/measurementconsumer/stats:measurement_statistics",
+        "//src/main/kotlin/org/wfanet/measurement/measurementconsumer/stats:metric_statistics",
+        "//src/main/kotlin/org/wfanet/measurement/measurementconsumer/stats:variances",
         "//src/main/kotlin/org/wfanet/measurement/reporting/service/api:encryption_key_pair_store",
         "//src/main/kotlin/org/wfanet/measurement/reporting/service/api:submit_batch_requests",
         "//src/main/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha:metric_spec_defaults",

--- a/src/main/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/ProtoConversions.kt
+++ b/src/main/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/ProtoConversions.kt
@@ -32,6 +32,7 @@ import org.wfanet.measurement.api.v2alpha.MeasurementSpecKt
 import org.wfanet.measurement.api.v2alpha.ProtocolConfig
 import org.wfanet.measurement.api.v2alpha.differentialPrivacyParams
 import org.wfanet.measurement.config.reporting.MetricSpecConfig
+import org.wfanet.measurement.eventdataprovider.noiser.DpParams as NoiserDpParams
 import org.wfanet.measurement.internal.reporting.v2.CustomDirectMethodology as InternalCustomDirectMethodology
 import org.wfanet.measurement.internal.reporting.v2.CustomDirectMethodologyKt
 import org.wfanet.measurement.internal.reporting.v2.DeterministicCount
@@ -45,6 +46,7 @@ import org.wfanet.measurement.internal.reporting.v2.Measurement as InternalMeasu
 import org.wfanet.measurement.internal.reporting.v2.MeasurementKt as InternalMeasurementKt
 import org.wfanet.measurement.internal.reporting.v2.MetricSpec as InternalMetricSpec
 import org.wfanet.measurement.internal.reporting.v2.MetricSpecKt as InternalMetricSpecKt
+import org.wfanet.measurement.internal.reporting.v2.NoiseMechanism as InternalNoiseMechanism
 import org.wfanet.measurement.internal.reporting.v2.NoiseMechanism
 import org.wfanet.measurement.internal.reporting.v2.PeriodicTimeInterval as InternalPeriodicTimeInterval
 import org.wfanet.measurement.internal.reporting.v2.ReachOnlyLiquidLegionsV2
@@ -70,6 +72,8 @@ import org.wfanet.measurement.internal.reporting.v2.streamMetricsRequest
 import org.wfanet.measurement.internal.reporting.v2.streamReportingSetsRequest
 import org.wfanet.measurement.internal.reporting.v2.streamReportsRequest
 import org.wfanet.measurement.internal.reporting.v2.timeIntervals as internalTimeIntervals
+import org.wfanet.measurement.measurementconsumer.stats.NoiseMechanism as StatsNoiseMechanism
+import org.wfanet.measurement.measurementconsumer.stats.VidSamplingInterval as StatsVidSamplingInterval
 import org.wfanet.measurement.reporting.v2alpha.CreateMetricRequest
 import org.wfanet.measurement.reporting.v2alpha.ListMetricsPageToken
 import org.wfanet.measurement.reporting.v2alpha.ListReportingSetsPageToken
@@ -798,18 +802,18 @@ fun ListReportsPageToken.toStreamReportsRequest(): StreamReportsRequest {
   }
 }
 
-/** Converts a CMMS [ProtocolConfig.NoiseMechanism] to an internal [NoiseMechanism]. */
-fun ProtocolConfig.NoiseMechanism.toInternal(): NoiseMechanism {
+/** Converts a CMMS [ProtocolConfig.NoiseMechanism] to an internal [InternalNoiseMechanism]. */
+fun ProtocolConfig.NoiseMechanism.toInternal(): InternalNoiseMechanism {
   return when (this) {
-    ProtocolConfig.NoiseMechanism.NONE -> NoiseMechanism.NONE
-    ProtocolConfig.NoiseMechanism.GEOMETRIC -> NoiseMechanism.GEOMETRIC
-    ProtocolConfig.NoiseMechanism.DISCRETE_GAUSSIAN -> NoiseMechanism.DISCRETE_GAUSSIAN
+    ProtocolConfig.NoiseMechanism.NONE -> InternalNoiseMechanism.NONE
+    ProtocolConfig.NoiseMechanism.GEOMETRIC -> InternalNoiseMechanism.GEOMETRIC
+    ProtocolConfig.NoiseMechanism.DISCRETE_GAUSSIAN -> InternalNoiseMechanism.DISCRETE_GAUSSIAN
     ProtocolConfig.NoiseMechanism.NOISE_MECHANISM_UNSPECIFIED ->
-      NoiseMechanism.NOISE_MECHANISM_UNSPECIFIED
-    ProtocolConfig.NoiseMechanism.CONTINUOUS_LAPLACE -> NoiseMechanism.CONTINUOUS_LAPLACE
-    ProtocolConfig.NoiseMechanism.CONTINUOUS_GAUSSIAN -> NoiseMechanism.CONTINUOUS_GAUSSIAN
+      InternalNoiseMechanism.NOISE_MECHANISM_UNSPECIFIED
+    ProtocolConfig.NoiseMechanism.CONTINUOUS_LAPLACE -> InternalNoiseMechanism.CONTINUOUS_LAPLACE
+    ProtocolConfig.NoiseMechanism.CONTINUOUS_GAUSSIAN -> InternalNoiseMechanism.CONTINUOUS_GAUSSIAN
     ProtocolConfig.NoiseMechanism.UNRECOGNIZED -> {
-      error { "Noise mechanism $this is not recognized." }
+      throw NoiseMechanismUnrecognizedException("Noise mechanism $this is not recognized.")
     }
   }
 }
@@ -883,4 +887,33 @@ fun LiquidLegionsDistribution.toInternal(): InternalLiquidLegionsDistribution {
     decayRate = source.decayRate
     maxSize = source.maxSize
   }
+}
+
+/** Converts an internal [InternalNoiseMechanism] to a [StatsNoiseMechanism]. */
+fun InternalNoiseMechanism.toStatsNoiseMechanism(): StatsNoiseMechanism {
+  return when (this) {
+    NoiseMechanism.NONE -> StatsNoiseMechanism.NONE
+    NoiseMechanism.GEOMETRIC,
+    NoiseMechanism.CONTINUOUS_LAPLACE -> StatsNoiseMechanism.LAPLACE
+    NoiseMechanism.DISCRETE_GAUSSIAN,
+    NoiseMechanism.CONTINUOUS_GAUSSIAN -> StatsNoiseMechanism.GAUSSIAN
+    NoiseMechanism.NOISE_MECHANISM_UNSPECIFIED -> {
+      throw NoiseMechanismUnspecifiedException("Internal noise mechanism should've been specified.")
+    }
+    NoiseMechanism.UNRECOGNIZED -> {
+      throw NoiseMechanismUnrecognizedException("Internal noise mechanism $this is unrecognized.")
+    }
+  }
+}
+
+/** Converts an [InternalMetricSpec.VidSamplingInterval] to [StatsVidSamplingInterval]. */
+fun InternalMetricSpec.VidSamplingInterval.toStatsVidSamplingInterval(): StatsVidSamplingInterval {
+  val source = this
+  return StatsVidSamplingInterval(source.start.toDouble(), source.width.toDouble())
+}
+
+/** Converts an [InternalMetricSpec.DifferentialPrivacyParams] to [NoiserDpParams]. */
+fun InternalMetricSpec.DifferentialPrivacyParams.toNoiserDpParams(): NoiserDpParams {
+  val source = this
+  return NoiserDpParams(source.epsilon, source.delta)
 }

--- a/src/main/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/ReportingExceptions.kt
+++ b/src/main/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/ReportingExceptions.kt
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2023 The Cross-Media Measurement Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wfanet.measurement.reporting.service.api.v2alpha
+
+/** [Exception] which indicates an error that noise mechanism is not specified. */
+class NoiseMechanismUnspecifiedException(message: String? = null, cause: Throwable? = null) :
+  Exception(message, cause)
+
+/** [Exception] which indicates an error that noise mechanism is unrecognized. */
+class NoiseMechanismUnrecognizedException(message: String? = null, cause: Throwable? = null) :
+  Exception(message, cause)
+
+/** [Exception] which indicates an error that measurement methodology is not set. */
+class MethodologyNotSetException(message: String? = null, cause: Throwable? = null) :
+  Exception(message, cause)

--- a/src/main/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/ReportsService.kt
+++ b/src/main/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/ReportsService.kt
@@ -231,9 +231,11 @@ class ReportsService(
         )
     } catch (e: StatusException) {
       throw when (e.status.code) {
-          Status.Code.INVALID_ARGUMENT -> Status.INVALID_ARGUMENT.withDescription(e.message)
-          Status.Code.PERMISSION_DENIED -> Status.PERMISSION_DENIED.withDescription(e.message)
-          else -> Status.UNKNOWN.withDescription("Unable to get Metrics.")
+          Status.Code.INVALID_ARGUMENT ->
+            Status.INVALID_ARGUMENT.withDescription("Unable to get Metrics.\n${e.message}")
+          Status.Code.PERMISSION_DENIED ->
+            Status.PERMISSION_DENIED.withDescription("Unable to get Metrics.\n${e.message}")
+          else -> Status.UNKNOWN.withDescription("Unable to get Metrics.\n${e.message}")
         }
         .withCause(e)
         .asRuntimeException()

--- a/src/test/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/BUILD.bazel
+++ b/src/test/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/BUILD.bazel
@@ -126,6 +126,9 @@ kt_jvm_test(
     test_class = "org.wfanet.measurement.reporting.service.api.v2alpha.MetricsServiceTest",
     deps = [
         "//src/main/kotlin/org/wfanet/measurement/api/v2alpha:principal_server_interceptor",
+        "//src/main/kotlin/org/wfanet/measurement/measurementconsumer/stats:measurement_statistics",
+        "//src/main/kotlin/org/wfanet/measurement/measurementconsumer/stats:metric_statistics",
+        "//src/main/kotlin/org/wfanet/measurement/measurementconsumer/stats:variances",
         "//src/main/kotlin/org/wfanet/measurement/reporting/service/api:encryption_key_pair_store",
         "//src/main/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha:principal_server_interceptor",
         "//src/main/proto/wfa/measurement/api/v2alpha:certificate_kt_jvm_proto",

--- a/src/test/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/MetricsServiceTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/MetricsServiceTest.kt
@@ -32,6 +32,8 @@ import java.security.SecureRandom
 import java.security.cert.X509Certificate
 import java.time.Duration
 import java.time.Instant
+import kotlin.math.pow
+import kotlin.math.sqrt
 import kotlin.test.assertFails
 import kotlin.test.assertFailsWith
 import kotlinx.coroutines.flow.flowOf
@@ -61,6 +63,7 @@ import org.wfanet.measurement.api.v2alpha.CustomDirectMethodology
 import org.wfanet.measurement.api.v2alpha.DataProviderCertificateKey
 import org.wfanet.measurement.api.v2alpha.DataProviderKey
 import org.wfanet.measurement.api.v2alpha.DataProvidersGrpcKt
+import org.wfanet.measurement.api.v2alpha.DeterministicCount
 import org.wfanet.measurement.api.v2alpha.DeterministicCountDistinct
 import org.wfanet.measurement.api.v2alpha.DeterministicSum
 import org.wfanet.measurement.api.v2alpha.EncryptionPublicKey
@@ -142,6 +145,8 @@ import org.wfanet.measurement.internal.reporting.v2.BatchSetMeasurementFailuresR
 import org.wfanet.measurement.internal.reporting.v2.BatchSetMeasurementFailuresRequestKt.measurementFailure
 import org.wfanet.measurement.internal.reporting.v2.BatchSetMeasurementResultsRequest
 import org.wfanet.measurement.internal.reporting.v2.BatchSetMeasurementResultsRequestKt.measurementResult
+import org.wfanet.measurement.internal.reporting.v2.CustomDirectMethodology as InternalCustomDirectMethodology
+import org.wfanet.measurement.internal.reporting.v2.DeterministicCount as InternalDeterministicCount
 import org.wfanet.measurement.internal.reporting.v2.DeterministicCountDistinct as InternalDeterministicCountDistinct
 import org.wfanet.measurement.internal.reporting.v2.DeterministicSum as InternalDeterministicSum
 import org.wfanet.measurement.internal.reporting.v2.Measurement as InternalMeasurement
@@ -175,6 +180,7 @@ import org.wfanet.measurement.internal.reporting.v2.batchSetMeasurementFailuresR
 import org.wfanet.measurement.internal.reporting.v2.batchSetMeasurementResultsRequest
 import org.wfanet.measurement.internal.reporting.v2.copy
 import org.wfanet.measurement.internal.reporting.v2.createMetricRequest as internalCreateMetricRequest
+import org.wfanet.measurement.internal.reporting.v2.customDirectMethodology
 import org.wfanet.measurement.internal.reporting.v2.liquidLegionsDistribution as internalLiquidLegionsDistribution
 import org.wfanet.measurement.internal.reporting.v2.measurement as internalMeasurement
 import org.wfanet.measurement.internal.reporting.v2.metric as internalMetric
@@ -183,6 +189,17 @@ import org.wfanet.measurement.internal.reporting.v2.reachOnlyLiquidLegionsSketch
 import org.wfanet.measurement.internal.reporting.v2.reachOnlyLiquidLegionsV2
 import org.wfanet.measurement.internal.reporting.v2.reportingSet as internalReportingSet
 import org.wfanet.measurement.internal.reporting.v2.streamMetricsRequest
+import org.wfanet.measurement.measurementconsumer.stats.FrequencyMeasurementVarianceParams
+import org.wfanet.measurement.measurementconsumer.stats.FrequencyMetricVarianceParams
+import org.wfanet.measurement.measurementconsumer.stats.FrequencyVariances
+import org.wfanet.measurement.measurementconsumer.stats.ImpressionMeasurementVarianceParams
+import org.wfanet.measurement.measurementconsumer.stats.ImpressionMetricVarianceParams
+import org.wfanet.measurement.measurementconsumer.stats.Methodology
+import org.wfanet.measurement.measurementconsumer.stats.ReachMeasurementVarianceParams
+import org.wfanet.measurement.measurementconsumer.stats.ReachMetricVarianceParams
+import org.wfanet.measurement.measurementconsumer.stats.Variances
+import org.wfanet.measurement.measurementconsumer.stats.WatchDurationMeasurementVarianceParams
+import org.wfanet.measurement.measurementconsumer.stats.WatchDurationMetricVarianceParams
 import org.wfanet.measurement.reporting.service.api.InMemoryEncryptionKeyPairStore
 import org.wfanet.measurement.reporting.service.api.v2alpha.RequestIdMatcher.Companion.requestIdEq
 import org.wfanet.measurement.reporting.v2alpha.ListMetricsPageTokenKt.previousPageEnd
@@ -208,6 +225,7 @@ import org.wfanet.measurement.reporting.v2alpha.listMetricsResponse
 import org.wfanet.measurement.reporting.v2alpha.metric
 import org.wfanet.measurement.reporting.v2alpha.metricResult
 import org.wfanet.measurement.reporting.v2alpha.metricSpec
+import org.wfanet.measurement.reporting.v2alpha.univariateStatistics
 
 private const val MAX_BATCH_SIZE = 1000
 private const val DEFAULT_PAGE_SIZE = 50
@@ -530,8 +548,14 @@ private val INTERNAL_INCREMENTAL_REPORTING_SET = internalReportingSet {
       filters += INCREMENTAL_REPORTING_SET_FILTER
       filters += INTERNAL_UNION_ALL_REPORTING_SET.filter
     }
+    primitiveReportingSetBases += primitiveReportingSetBasis {
+      externalReportingSetId =
+        INTERNAL_UNION_ALL_BUT_LAST_PUBLISHER_REPORTING_SET.externalReportingSetId
+      filters += INCREMENTAL_REPORTING_SET_FILTER
+      filters += INTERNAL_UNION_ALL_BUT_LAST_PUBLISHER_REPORTING_SET.filter
+    }
     weight = 1
-    binaryRepresentation = 1
+    binaryRepresentation = 3
   }
   weightedSubsetUnions += weightedSubsetUnion {
     primitiveReportingSetBases += primitiveReportingSetBasis {
@@ -616,7 +640,7 @@ private const val INCREMENTAL_REACH_VALUE =
   UNION_ALL_REACH_VALUE - UNION_ALL_BUT_LAST_PUBLISHER_REACH_VALUE
 private const val REACH_FREQUENCY_REACH_VALUE = 100_000L
 private val REACH_FREQUENCY_FREQUENCY_VALUE = mapOf(1L to 0.1, 2L to 0.2, 3L to 0.3, 4L to 0.4)
-
+private const val IMPRESSION_VALUE = 1_000_000L
 private val WATCH_DURATION_SECOND_LIST = listOf(100L, 200L, 300L)
 private val WATCH_DURATION_LIST = WATCH_DURATION_SECOND_LIST.map { duration { seconds = it } }
 private val TOTAL_WATCH_DURATION = duration { seconds = WATCH_DURATION_SECOND_LIST.sum() }
@@ -630,6 +654,11 @@ private val INTERNAL_PENDING_UNION_ALL_REACH_MEASUREMENT = internalMeasurement {
   timeInterval = TIME_INTERVAL
   primitiveReportingSetBases += primitiveReportingSetBasis {
     externalReportingSetId = INTERNAL_UNION_ALL_REPORTING_SET.externalReportingSetId
+    filters += ALL_FILTERS
+  }
+  primitiveReportingSetBases += primitiveReportingSetBasis {
+    externalReportingSetId =
+      INTERNAL_UNION_ALL_BUT_LAST_PUBLISHER_REPORTING_SET.externalReportingSetId
     filters += ALL_FILTERS
   }
   state = InternalMeasurement.State.PENDING
@@ -658,7 +687,7 @@ private val INTERNAL_SUCCEEDED_UNION_ALL_REACH_MEASUREMENT =
             reach =
               InternalMeasurementKt.ResultKt.reach {
                 value = UNION_ALL_REACH_VALUE
-                noiseMechanism = NoiseMechanism.GEOMETRIC
+                noiseMechanism = NoiseMechanism.DISCRETE_GAUSSIAN
                 reachOnlyLiquidLegionsV2 = reachOnlyLiquidLegionsV2 {
                   sketchParams = internalReachOnlyLiquidLegionsSketchParams {
                     decayRate = REACH_ONLY_LLV2_DECAY_RATE
@@ -680,7 +709,7 @@ private val INTERNAL_SUCCEEDED_UNION_ALL_BUT_LAST_PUBLISHER_REACH_MEASUREMENT =
             reach =
               InternalMeasurementKt.ResultKt.reach {
                 value = UNION_ALL_BUT_LAST_PUBLISHER_REACH_VALUE
-                noiseMechanism = NoiseMechanism.GEOMETRIC
+                noiseMechanism = NoiseMechanism.DISCRETE_GAUSSIAN
                 reachOnlyLiquidLegionsV2 = reachOnlyLiquidLegionsV2 {
                   sketchParams = internalReachOnlyLiquidLegionsSketchParams {
                     decayRate = REACH_ONLY_LLV2_DECAY_RATE
@@ -757,6 +786,23 @@ private val INTERNAL_FAILED_SINGLE_PUBLISHER_IMPRESSION_MEASUREMENT =
           InternalMeasurementKt.failure {
             reason = InternalMeasurement.Failure.Reason.REQUISITION_REFUSED
             message = "Privacy budget exceeded."
+          }
+      }
+  }
+
+private val INTERNAL_SUCCEEDED_SINGLE_PUBLISHER_IMPRESSION_MEASUREMENT =
+  INTERNAL_PENDING_SINGLE_PUBLISHER_IMPRESSION_MEASUREMENT.copy {
+    state = InternalMeasurement.State.SUCCEEDED
+    details =
+      InternalMeasurementKt.details {
+        results +=
+          InternalMeasurementKt.result {
+            impression =
+              InternalMeasurementKt.ResultKt.impression {
+                value = IMPRESSION_VALUE
+                noiseMechanism = NoiseMechanism.CONTINUOUS_LAPLACE
+                deterministicCount = InternalDeterministicCount.getDefaultInstance()
+              }
           }
       }
   }
@@ -839,7 +885,7 @@ private val REACH_PROTOCOL_CONFIG: ProtocolConfig = protocolConfig {
             decayRate = REACH_ONLY_LLV2_DECAY_RATE
             maxSize = REACH_ONLY_LLV2_SKETCH_SIZE
           }
-          noiseMechanism = ProtocolConfig.NoiseMechanism.GEOMETRIC
+          noiseMechanism = ProtocolConfig.NoiseMechanism.DISCRETE_GAUSSIAN
         }
     }
 }
@@ -1076,6 +1122,25 @@ private val PENDING_SINGLE_PUBLISHER_IMPRESSION_MEASUREMENT =
     state = Measurement.State.COMPUTING
   }
 
+private val SUCCEEDED_SINGLE_PUBLISHER_IMPRESSION_MEASUREMENT =
+  PENDING_SINGLE_PUBLISHER_IMPRESSION_MEASUREMENT.copy {
+    state = Measurement.State.SUCCEEDED
+    results += resultPair {
+      val result =
+        MeasurementKt.result {
+          impression =
+            MeasurementKt.ResultKt.impression {
+              value = IMPRESSION_VALUE
+              noiseMechanism = ProtocolConfig.NoiseMechanism.CONTINUOUS_LAPLACE
+              deterministicCount = DeterministicCount.getDefaultInstance()
+            }
+        }
+      encryptedResult =
+        encryptResult(signResult(result, AGGREGATOR_SIGNING_KEY), MEASUREMENT_CONSUMER_PUBLIC_KEY)
+      certificate = AGGREGATOR_CERTIFICATE.name
+    }
+  }
+
 // CMMS cross publisher watch duration measurements
 private val UNION_ALL_WATCH_DURATION_MEASUREMENT_SPEC = measurementSpec {
   measurementPublicKey = MEASUREMENT_CONSUMER_PUBLIC_KEY.toByteString()
@@ -1148,6 +1213,33 @@ private val PENDING_UNION_ALL_WATCH_DURATION_MEASUREMENT =
     state = Measurement.State.COMPUTING
   }
 
+private val SUCCEEDED_UNION_ALL_WATCH_DURATION_MEASUREMENT =
+  PENDING_UNION_ALL_WATCH_DURATION_MEASUREMENT.copy {
+    state = Measurement.State.SUCCEEDED
+
+    results +=
+      DATA_PROVIDERS.keys.zip(WATCH_DURATION_LIST).map { (dataProviderKey, watchDuration) ->
+        val dataProvider = DATA_PROVIDERS.getValue(dataProviderKey)
+        resultPair {
+          val result =
+            MeasurementKt.result {
+              this.watchDuration =
+                MeasurementKt.ResultKt.watchDuration {
+                  value = watchDuration
+                  noiseMechanism = ProtocolConfig.NoiseMechanism.CONTINUOUS_LAPLACE
+                  deterministicSum = DeterministicSum.getDefaultInstance()
+                }
+            }
+          encryptedResult =
+            encryptResult(
+              signResult(result, DATA_PROVIDER_SIGNING_KEY),
+              MEASUREMENT_CONSUMER_PUBLIC_KEY
+            )
+          certificate = dataProvider.certificate
+        }
+      }
+  }
+
 // Metric Specs
 
 private val REACH_METRIC_SPEC: MetricSpec = metricSpec {
@@ -1197,7 +1289,7 @@ private val INTERNAL_REQUESTING_INCREMENTAL_REACH_METRIC = internalMetric {
   }
   weightedMeasurements += weightedMeasurement {
     weight = 1
-    binaryRepresentation = 1
+    binaryRepresentation = 3
     measurement =
       INTERNAL_PENDING_UNION_ALL_REACH_MEASUREMENT.copy {
         clearCmmsCreateMeasurementRequestId()
@@ -1225,7 +1317,7 @@ private val INTERNAL_PENDING_INITIAL_INCREMENTAL_REACH_METRIC =
     weightedMeasurements.clear()
     weightedMeasurements += weightedMeasurement {
       weight = 1
-      binaryRepresentation = 1
+      binaryRepresentation = 3
       measurement = INTERNAL_PENDING_UNION_ALL_REACH_MEASUREMENT.copy { clearCmmsMeasurementId() }
     }
     weightedMeasurements += weightedMeasurement {
@@ -1243,7 +1335,7 @@ private val INTERNAL_PENDING_INCREMENTAL_REACH_METRIC =
     weightedMeasurements.clear()
     weightedMeasurements += weightedMeasurement {
       weight = 1
-      binaryRepresentation = 1
+      binaryRepresentation = 3
       measurement = INTERNAL_PENDING_UNION_ALL_REACH_MEASUREMENT
     }
     weightedMeasurements += weightedMeasurement {
@@ -1258,7 +1350,7 @@ private val INTERNAL_SUCCEEDED_INCREMENTAL_REACH_METRIC =
     weightedMeasurements.clear()
     weightedMeasurements += weightedMeasurement {
       weight = 1
-      binaryRepresentation = 1
+      binaryRepresentation = 3
       measurement = INTERNAL_SUCCEEDED_UNION_ALL_REACH_MEASUREMENT
     }
     weightedMeasurements += weightedMeasurement {
@@ -1409,6 +1501,16 @@ private val INTERNAL_FAILED_SINGLE_PUBLISHER_IMPRESSION_METRIC =
     }
   }
 
+private val INTERNAL_SUCCEEDED_SINGLE_PUBLISHER_IMPRESSION_METRIC =
+  INTERNAL_PENDING_SINGLE_PUBLISHER_IMPRESSION_METRIC.copy {
+    weightedMeasurements.clear()
+    weightedMeasurements += weightedMeasurement {
+      weight = 1
+      binaryRepresentation = 1
+      measurement = INTERNAL_SUCCEEDED_SINGLE_PUBLISHER_IMPRESSION_MEASUREMENT
+    }
+  }
+
 // Internal Cross Publisher Watch Duration Metrics
 private val INTERNAL_REQUESTING_CROSS_PUBLISHER_WATCH_DURATION_METRIC = internalMetric {
   cmmsMeasurementConsumerId = MEASUREMENT_CONSUMERS.keys.first().measurementConsumerId
@@ -1432,6 +1534,7 @@ private val INTERNAL_REQUESTING_CROSS_PUBLISHER_WATCH_DURATION_METRIC = internal
   }
   weightedMeasurements += weightedMeasurement {
     weight = 1
+    binaryRepresentation = 1
     measurement = INTERNAL_REQUESTING_UNION_ALL_WATCH_DURATION_MEASUREMENT
   }
   details = InternalMetricKt.details { filters += listOf(METRIC_FILTER) }
@@ -1444,6 +1547,7 @@ private val INTERNAL_PENDING_INITIAL_CROSS_PUBLISHER_WATCH_DURATION_METRIC =
     weightedMeasurements.clear()
     weightedMeasurements += weightedMeasurement {
       weight = 1
+      binaryRepresentation = 1
       measurement = INTERNAL_PENDING_NOT_CREATED_UNION_ALL_WATCH_DURATION_MEASUREMENT
     }
   }
@@ -1453,6 +1557,7 @@ private val INTERNAL_PENDING_CROSS_PUBLISHER_WATCH_DURATION_METRIC =
     weightedMeasurements.clear()
     weightedMeasurements += weightedMeasurement {
       weight = 1
+      binaryRepresentation = 1
       measurement = INTERNAL_PENDING_UNION_ALL_WATCH_DURATION_MEASUREMENT
     }
   }
@@ -1462,6 +1567,7 @@ private val INTERNAL_SUCCEEDED_CROSS_PUBLISHER_WATCH_DURATION_METRIC =
     weightedMeasurements.clear()
     weightedMeasurements += weightedMeasurement {
       weight = 1
+      binaryRepresentation = 1
       measurement = INTERNAL_SUCCEEDED_UNION_ALL_WATCH_DURATION_MEASUREMENT
     }
   }
@@ -1502,10 +1608,24 @@ private val PENDING_INCREMENTAL_REACH_METRIC =
     createTime = INTERNAL_PENDING_INCREMENTAL_REACH_METRIC.createTime
   }
 
+private const val VARIANCE_VALUE = 4.0
+
+private val FREQUENCY_VARIANCE: Map<Int, Double> =
+  (1..REACH_FREQUENCY_MAXIMUM_FREQUENCY).associateWith { it.toDouble().pow(2.0) }
+private val FREQUENCY_VARIANCES =
+  FrequencyVariances(FREQUENCY_VARIANCE, FREQUENCY_VARIANCE, FREQUENCY_VARIANCE, FREQUENCY_VARIANCE)
+
 private val SUCCEEDED_INCREMENTAL_REACH_METRIC =
   PENDING_INCREMENTAL_REACH_METRIC.copy {
     state = Metric.State.SUCCEEDED
-    result = metricResult { reach = MetricResultKt.reachResult { value = INCREMENTAL_REACH_VALUE } }
+
+    result = metricResult {
+      reach =
+        MetricResultKt.reachResult {
+          value = INCREMENTAL_REACH_VALUE
+          univariateStatistics = univariateStatistics { standardDeviation = sqrt(VARIANCE_VALUE) }
+        }
+    }
   }
 
 // Single publisher reach-frequency metrics
@@ -1564,6 +1684,21 @@ private val SUCCEEDED_SINGLE_PUBLISHER_REACH_FREQUENCY_METRIC =
                       REACH_FREQUENCY_REACH_VALUE *
                         REACH_FREQUENCY_FREQUENCY_VALUE.getOrDefault(frequency.toLong(), 0.0)
                   }
+                resultUnivariateStatistics = univariateStatistics {
+                  standardDeviation = sqrt(FREQUENCY_VARIANCES.countVariances.getValue(frequency))
+                }
+                relativeUnivariateStatistics = univariateStatistics {
+                  standardDeviation =
+                    sqrt(FREQUENCY_VARIANCES.relativeVariances.getValue(frequency))
+                }
+                kPlusUnivariateStatistics = univariateStatistics {
+                  standardDeviation =
+                    sqrt(FREQUENCY_VARIANCES.kPlusCountVariances.getValue(frequency))
+                }
+                relativeKPlusUnivariateStatistics = univariateStatistics {
+                  standardDeviation =
+                    sqrt(FREQUENCY_VARIANCES.kPlusRelativeVariances.getValue(frequency))
+                }
               }
             }
         }
@@ -1608,6 +1743,18 @@ private val PENDING_SINGLE_PUBLISHER_IMPRESSION_METRIC =
 private val FAILED_SINGLE_PUBLISHER_IMPRESSION_METRIC =
   PENDING_SINGLE_PUBLISHER_IMPRESSION_METRIC.copy { state = Metric.State.FAILED }
 
+private val SUCCEEDED_SINGLE_PUBLISHER_IMPRESSION_METRIC =
+  PENDING_SINGLE_PUBLISHER_IMPRESSION_METRIC.copy {
+    state = Metric.State.SUCCEEDED
+    result = metricResult {
+      impressionCount =
+        MetricResultKt.impressionCountResult {
+          value = IMPRESSION_VALUE
+          univariateStatistics = univariateStatistics { standardDeviation = sqrt(VARIANCE_VALUE) }
+        }
+    }
+  }
+
 // Cross publisher watch duration metrics
 private val REQUESTING_CROSS_PUBLISHER_WATCH_DURATION_METRIC = metric {
   reportingSet = INTERNAL_UNION_ALL_REPORTING_SET.resourceName
@@ -1648,7 +1795,12 @@ private val SUCCEEDED_CROSS_PUBLISHER_WATCH_DURATION_METRIC =
     state = Metric.State.SUCCEEDED
     result = metricResult {
       watchDuration =
-        MetricResultKt.watchDurationResult { value = TOTAL_WATCH_DURATION.seconds.toDouble() }
+        MetricResultKt.watchDurationResult {
+          value = TOTAL_WATCH_DURATION.seconds.toDouble()
+          univariateStatistics = univariateStatistics {
+            standardDeviation = sqrt(WATCH_DURATION_LIST.sumOf { VARIANCE_VALUE })
+          }
+        }
     }
   }
 
@@ -1813,6 +1965,39 @@ class MetricsServiceTest {
 
   private val secureRandomMock: SecureRandom = mock()
 
+  private object VariancesMock : Variances {
+    override fun computeMetricVariance(params: ReachMetricVarianceParams): Double = VARIANCE_VALUE
+
+    override fun computeMeasurementVariance(
+      methodology: Methodology,
+      measurementVarianceParams: ReachMeasurementVarianceParams
+    ): Double = VARIANCE_VALUE
+
+    override fun computeMetricVariance(params: FrequencyMetricVarianceParams): FrequencyVariances =
+      FREQUENCY_VARIANCES
+
+    override fun computeMeasurementVariance(
+      methodology: Methodology,
+      measurementVarianceParams: FrequencyMeasurementVarianceParams
+    ): FrequencyVariances = FrequencyVariances(mapOf(), mapOf(), mapOf(), mapOf())
+
+    override fun computeMetricVariance(params: ImpressionMetricVarianceParams): Double =
+      VARIANCE_VALUE
+
+    override fun computeMeasurementVariance(
+      methodology: Methodology,
+      measurementVarianceParams: ImpressionMeasurementVarianceParams
+    ): Double = VARIANCE_VALUE
+
+    override fun computeMetricVariance(params: WatchDurationMetricVarianceParams): Double =
+      VARIANCE_VALUE
+
+    override fun computeMeasurementVariance(
+      methodology: Methodology,
+      measurementVarianceParams: WatchDurationMeasurementVarianceParams
+    ): Double = VARIANCE_VALUE
+  }
+
   @get:Rule
   val grpcTestServerRule = GrpcTestServerRule {
     addService(internalMetricsMock)
@@ -1838,6 +2023,7 @@ class MetricsServiceTest {
         METRIC_SPEC_CONFIG,
         InternalReportingSetsGrpcKt.ReportingSetsCoroutineStub(grpcTestServerRule.channel),
         InternalMetricsGrpcKt.MetricsCoroutineStub(grpcTestServerRule.channel),
+        VariancesMock,
         InternalMeasurementsGrpcKt.MeasurementsCoroutineStub(grpcTestServerRule.channel),
         DataProvidersGrpcKt.DataProvidersCoroutineStub(grpcTestServerRule.channel),
         MeasurementsGrpcKt.MeasurementsCoroutineStub(grpcTestServerRule.channel),
@@ -4141,7 +4327,7 @@ class MetricsServiceTest {
               weightedMeasurements.clear()
               weightedMeasurements += weightedMeasurement {
                 weight = 1
-                binaryRepresentation = 1
+                binaryRepresentation = 3
                 measurement = INTERNAL_SUCCEEDED_UNION_ALL_REACH_MEASUREMENT
               }
               weightedMeasurements += weightedMeasurement {
@@ -4667,6 +4853,308 @@ class MetricsServiceTest {
     }
 
   @Test
+  fun `getMetric returns reach metric with statistics not set when meeasurement has no noise mechanism`() =
+    runBlocking {
+      whenever(internalMetricsMock.batchGetMetrics(any()))
+        .thenReturn(
+          internalBatchGetMetricsResponse {
+            metrics +=
+              INTERNAL_SUCCEEDED_INCREMENTAL_REACH_METRIC.copy {
+                weightedMeasurements.clear()
+                weightedMeasurements += weightedMeasurement {
+                  weight = -1
+                  binaryRepresentation = 2
+                  measurement = INTERNAL_SUCCEEDED_UNION_ALL_BUT_LAST_PUBLISHER_REACH_MEASUREMENT
+                }
+                weightedMeasurements += weightedMeasurement {
+                  weight = 1
+                  binaryRepresentation = 3
+                  measurement =
+                    INTERNAL_SUCCEEDED_UNION_ALL_REACH_MEASUREMENT.copy {
+                      details =
+                        InternalMeasurementKt.details {
+                          results +=
+                            InternalMeasurementKt.result {
+                              reach =
+                                InternalMeasurementKt.ResultKt.reach {
+                                  value = UNION_ALL_REACH_VALUE
+                                  reachOnlyLiquidLegionsV2 = reachOnlyLiquidLegionsV2 {
+                                    sketchParams = internalReachOnlyLiquidLegionsSketchParams {
+                                      decayRate = REACH_ONLY_LLV2_DECAY_RATE
+                                      maxSize = REACH_ONLY_LLV2_SKETCH_SIZE
+                                    }
+                                  }
+                                }
+                            }
+                        }
+                    }
+                }
+              }
+          }
+        )
+
+      val request = getMetricRequest { name = SUCCEEDED_INCREMENTAL_REACH_METRIC.name }
+
+      val result =
+        withMeasurementConsumerPrincipal(MEASUREMENT_CONSUMERS.values.first().name, CONFIG) {
+          runBlocking { service.getMetric(request) }
+        }
+
+      // Verify proto argument of internal MetricsCoroutineImplBase::batchGetMetrics
+      val batchGetInternalMetricsCaptor: KArgumentCaptor<InternalBatchGetMetricsRequest> =
+        argumentCaptor()
+      verifyBlocking(internalMetricsMock, times(1)) {
+        batchGetMetrics(batchGetInternalMetricsCaptor.capture())
+      }
+      val capturedInternalGetMetricRequests = batchGetInternalMetricsCaptor.allValues
+      assertThat(capturedInternalGetMetricRequests)
+        .containsExactly(
+          internalBatchGetMetricsRequest {
+            cmmsMeasurementConsumerId =
+              INTERNAL_SUCCEEDED_INCREMENTAL_REACH_METRIC.cmmsMeasurementConsumerId
+            externalMetricIds += INTERNAL_SUCCEEDED_INCREMENTAL_REACH_METRIC.externalMetricId
+          }
+        )
+
+      // Verify proto argument of internal MeasurementsCoroutineImplBase::batchSetMeasurementResults
+      val batchSetMeasurementResultsCaptor: KArgumentCaptor<BatchSetMeasurementResultsRequest> =
+        argumentCaptor()
+      verifyBlocking(internalMeasurementsMock, never()) {
+        batchSetMeasurementResults(batchSetMeasurementResultsCaptor.capture())
+      }
+
+      // Verify proto argument of internal
+      // MeasurementsCoroutineImplBase::batchSetMeasurementFailures
+      val batchSetMeasurementFailuresCaptor: KArgumentCaptor<BatchSetMeasurementFailuresRequest> =
+        argumentCaptor()
+      verifyBlocking(internalMeasurementsMock, never()) {
+        batchSetMeasurementFailures(batchSetMeasurementFailuresCaptor.capture())
+      }
+
+      assertThat(result)
+        .isEqualTo(
+          SUCCEEDED_INCREMENTAL_REACH_METRIC.copy {
+            this.result = metricResult {
+              reach = MetricResultKt.reachResult { value = INCREMENTAL_REACH_VALUE }
+            }
+          }
+        )
+    }
+
+  @Test
+  fun `getMetric returns reach metric with statistics not set when meeasurement has no methodology`() =
+    runBlocking {
+      whenever(internalMetricsMock.batchGetMetrics(any()))
+        .thenReturn(
+          internalBatchGetMetricsResponse {
+            metrics +=
+              INTERNAL_SUCCEEDED_INCREMENTAL_REACH_METRIC.copy {
+                weightedMeasurements.clear()
+                weightedMeasurements += weightedMeasurement {
+                  weight = -1
+                  binaryRepresentation = 2
+                  measurement = INTERNAL_SUCCEEDED_UNION_ALL_BUT_LAST_PUBLISHER_REACH_MEASUREMENT
+                }
+                weightedMeasurements += weightedMeasurement {
+                  weight = 1
+                  binaryRepresentation = 3
+                  measurement =
+                    INTERNAL_SUCCEEDED_UNION_ALL_REACH_MEASUREMENT.copy {
+                      details =
+                        InternalMeasurementKt.details {
+                          results +=
+                            InternalMeasurementKt.result {
+                              reach =
+                                InternalMeasurementKt.ResultKt.reach {
+                                  value = UNION_ALL_REACH_VALUE
+                                  noiseMechanism = NoiseMechanism.DISCRETE_GAUSSIAN
+                                }
+                            }
+                        }
+                    }
+                }
+              }
+          }
+        )
+
+      val request = getMetricRequest { name = SUCCEEDED_INCREMENTAL_REACH_METRIC.name }
+
+      val result =
+        withMeasurementConsumerPrincipal(MEASUREMENT_CONSUMERS.values.first().name, CONFIG) {
+          runBlocking { service.getMetric(request) }
+        }
+
+      // Verify proto argument of internal MetricsCoroutineImplBase::batchGetMetrics
+      val batchGetInternalMetricsCaptor: KArgumentCaptor<InternalBatchGetMetricsRequest> =
+        argumentCaptor()
+      verifyBlocking(internalMetricsMock, times(1)) {
+        batchGetMetrics(batchGetInternalMetricsCaptor.capture())
+      }
+      val capturedInternalGetMetricRequests = batchGetInternalMetricsCaptor.allValues
+      assertThat(capturedInternalGetMetricRequests)
+        .containsExactly(
+          internalBatchGetMetricsRequest {
+            cmmsMeasurementConsumerId =
+              INTERNAL_SUCCEEDED_INCREMENTAL_REACH_METRIC.cmmsMeasurementConsumerId
+            externalMetricIds += INTERNAL_SUCCEEDED_INCREMENTAL_REACH_METRIC.externalMetricId
+          }
+        )
+
+      // Verify proto argument of internal MeasurementsCoroutineImplBase::batchSetMeasurementResults
+      val batchSetMeasurementResultsCaptor: KArgumentCaptor<BatchSetMeasurementResultsRequest> =
+        argumentCaptor()
+      verifyBlocking(internalMeasurementsMock, never()) {
+        batchSetMeasurementResults(batchSetMeasurementResultsCaptor.capture())
+      }
+
+      // Verify proto argument of internal
+      // MeasurementsCoroutineImplBase::batchSetMeasurementFailures
+      val batchSetMeasurementFailuresCaptor: KArgumentCaptor<BatchSetMeasurementFailuresRequest> =
+        argumentCaptor()
+      verifyBlocking(internalMeasurementsMock, never()) {
+        batchSetMeasurementFailures(batchSetMeasurementFailuresCaptor.capture())
+      }
+
+      assertThat(result)
+        .isEqualTo(
+          SUCCEEDED_INCREMENTAL_REACH_METRIC.copy {
+            this.result = metricResult {
+              reach = MetricResultKt.reachResult { value = INCREMENTAL_REACH_VALUE }
+            }
+          }
+        )
+    }
+
+  @Test
+  fun `getMetric throws StatusRuntimeException for reach when the succeeded metric contains measurement with two results`():
+    Unit = runBlocking {
+    whenever(internalMetricsMock.batchGetMetrics(any()))
+      .thenReturn(
+        internalBatchGetMetricsResponse {
+          metrics +=
+            INTERNAL_SUCCEEDED_INCREMENTAL_REACH_METRIC.copy {
+              weightedMeasurements += weightedMeasurement {
+                weight = 1
+                binaryRepresentation = 3
+                measurement =
+                  INTERNAL_SUCCEEDED_UNION_ALL_REACH_MEASUREMENT.copy {
+                    details =
+                      InternalMeasurementKt.details {
+                        val result =
+                          InternalMeasurementKt.result {
+                            reach =
+                              InternalMeasurementKt.ResultKt.reach {
+                                value = UNION_ALL_REACH_VALUE
+                                noiseMechanism = NoiseMechanism.DISCRETE_GAUSSIAN
+                                reachOnlyLiquidLegionsV2 = reachOnlyLiquidLegionsV2 {
+                                  sketchParams = internalReachOnlyLiquidLegionsSketchParams {
+                                    decayRate = REACH_ONLY_LLV2_DECAY_RATE
+                                    maxSize = REACH_ONLY_LLV2_SKETCH_SIZE
+                                  }
+                                }
+                              }
+                          }
+                        results += result
+                        results += result
+                      }
+                  }
+              }
+            }
+        }
+      )
+
+    val request = getMetricRequest { name = SUCCEEDED_INCREMENTAL_REACH_METRIC.name }
+
+    val exception =
+      assertFailsWith<StatusRuntimeException> {
+        withMeasurementConsumerPrincipal(MEASUREMENT_CONSUMERS.values.first().name, CONFIG) {
+          runBlocking { service.getMetric(request) }
+        }
+      }
+
+    assertThat(exception.status.code).isEqualTo(Status.Code.FAILED_PRECONDITION)
+  }
+
+  @Test
+  fun `getMetric throws StatusRuntimeException when the succeeded metric contains no measurement`():
+    Unit = runBlocking {
+    whenever(internalMetricsMock.batchGetMetrics(any()))
+      .thenReturn(
+        internalBatchGetMetricsResponse {
+          metrics +=
+            INTERNAL_SUCCEEDED_INCREMENTAL_REACH_METRIC.copy {
+              weightedMeasurements += weightedMeasurement {
+                weight = 1
+                binaryRepresentation = 3
+                measurement =
+                  INTERNAL_SUCCEEDED_UNION_ALL_REACH_MEASUREMENT.copy {
+                    details = InternalMeasurement.Details.getDefaultInstance()
+                  }
+              }
+            }
+        }
+      )
+
+    val request = getMetricRequest { name = SUCCEEDED_INCREMENTAL_REACH_METRIC.name }
+
+    val exception =
+      assertFailsWith<StatusRuntimeException> {
+        withMeasurementConsumerPrincipal(MEASUREMENT_CONSUMERS.values.first().name, CONFIG) {
+          runBlocking { service.getMetric(request) }
+        }
+      }
+
+    assertThat(exception.status.code).isEqualTo(Status.Code.FAILED_PRECONDITION)
+  }
+
+  @Test
+  fun `getMetric throws StatusRuntimeException for reach metric when custom direct methodology has frequency`():
+    Unit = runBlocking {
+    whenever(internalMetricsMock.batchGetMetrics(any()))
+      .thenReturn(
+        internalBatchGetMetricsResponse {
+          metrics +=
+            INTERNAL_SUCCEEDED_INCREMENTAL_REACH_METRIC.copy {
+              weightedMeasurements += weightedMeasurement {
+                weight = 1
+                binaryRepresentation = 3
+                measurement =
+                  INTERNAL_SUCCEEDED_UNION_ALL_REACH_MEASUREMENT.copy {
+                    details =
+                      InternalMeasurementKt.details {
+                        results +=
+                          InternalMeasurementKt.result {
+                            reach =
+                              InternalMeasurementKt.ResultKt.reach {
+                                value = UNION_ALL_REACH_VALUE
+                                noiseMechanism = NoiseMechanism.DISCRETE_GAUSSIAN
+                                customDirectMethodology = customDirectMethodology {
+                                  frequency =
+                                    InternalCustomDirectMethodology.FrequencyVariances
+                                      .getDefaultInstance()
+                                }
+                              }
+                          }
+                      }
+                  }
+              }
+            }
+        }
+      )
+
+    val request = getMetricRequest { name = SUCCEEDED_INCREMENTAL_REACH_METRIC.name }
+
+    val exception =
+      assertFailsWith<StatusRuntimeException> {
+        withMeasurementConsumerPrincipal(MEASUREMENT_CONSUMERS.values.first().name, CONFIG) {
+          runBlocking { service.getMetric(request) }
+        }
+      }
+
+    assertThat(exception.status.code).isEqualTo(Status.Code.FAILED_PRECONDITION)
+  }
+
+  @Test
   fun `getMetric calls batchSetMeasurementResults when request number is more than the limit`() =
     runBlocking {
       val weightedMeasurements =
@@ -4966,6 +5454,340 @@ class MetricsServiceTest {
     }
 
   @Test
+  fun `getMetric returns reach frequency metric with statistics not set when reach lacks info for variance`() =
+    runBlocking {
+      whenever(internalMetricsMock.batchGetMetrics(any()))
+        .thenReturn(
+          internalBatchGetMetricsResponse {
+            metrics +=
+              INTERNAL_SUCCEEDED_SINGLE_PUBLISHER_REACH_FREQUENCY_METRIC.copy {
+                weightedMeasurements.clear()
+                weightedMeasurements += weightedMeasurement {
+                  weight = 1
+                  binaryRepresentation = 1
+                  measurement =
+                    INTERNAL_SUCCEEDED_SINGLE_PUBLISHER_REACH_FREQUENCY_MEASUREMENT.copy {
+                      details =
+                        InternalMeasurementKt.details {
+                          results +=
+                            InternalMeasurementKt.result {
+                              reach =
+                                InternalMeasurementKt.ResultKt.reach {
+                                  value = REACH_FREQUENCY_REACH_VALUE
+                                }
+                              frequency =
+                                InternalMeasurementKt.ResultKt.frequency {
+                                  relativeFrequencyDistribution.putAll(
+                                    REACH_FREQUENCY_FREQUENCY_VALUE
+                                  )
+                                  noiseMechanism = NoiseMechanism.CONTINUOUS_LAPLACE
+                                  liquidLegionsDistribution = internalLiquidLegionsDistribution {
+                                    decayRate = LL_DISTRIBUTION_DECAY_RATE
+                                    maxSize = LL_DISTRIBUTION_SKETCH_SIZE
+                                  }
+                                }
+                            }
+                        }
+                    }
+                }
+              }
+          }
+        )
+
+      val request = getMetricRequest {
+        name = SUCCEEDED_SINGLE_PUBLISHER_REACH_FREQUENCY_METRIC.name
+      }
+
+      val result =
+        withMeasurementConsumerPrincipal(MEASUREMENT_CONSUMERS.values.first().name, CONFIG) {
+          runBlocking { service.getMetric(request) }
+        }
+
+      assertThat(result)
+        .isEqualTo(
+          SUCCEEDED_SINGLE_PUBLISHER_REACH_FREQUENCY_METRIC.copy {
+            this.result =
+              this.result.copy {
+                frequencyHistogram =
+                  MetricResultKt.histogramResult {
+                    bins +=
+                      (1..REACH_FREQUENCY_MAXIMUM_FREQUENCY).map { frequency ->
+                        MetricResultKt.HistogramResultKt.bin {
+                          label = frequency.toString()
+                          binResult =
+                            MetricResultKt.HistogramResultKt.binResult {
+                              value =
+                                REACH_FREQUENCY_REACH_VALUE *
+                                  REACH_FREQUENCY_FREQUENCY_VALUE.getOrDefault(
+                                    frequency.toLong(),
+                                    0.0
+                                  )
+                            }
+                        }
+                      }
+                  }
+              }
+          }
+        )
+    }
+
+  @Test
+  fun `getMetric returns reach frequency metric with statistics not set when frequency noise mechanism is unspecified`() =
+    runBlocking {
+      whenever(internalMetricsMock.batchGetMetrics(any()))
+        .thenReturn(
+          internalBatchGetMetricsResponse {
+            metrics +=
+              INTERNAL_SUCCEEDED_SINGLE_PUBLISHER_REACH_FREQUENCY_METRIC.copy {
+                weightedMeasurements.clear()
+                weightedMeasurements += weightedMeasurement {
+                  weight = 1
+                  binaryRepresentation = 1
+                  measurement =
+                    INTERNAL_SUCCEEDED_SINGLE_PUBLISHER_REACH_FREQUENCY_MEASUREMENT.copy {
+                      details =
+                        InternalMeasurementKt.details {
+                          results +=
+                            InternalMeasurementKt.result {
+                              reach =
+                                InternalMeasurementKt.ResultKt.reach {
+                                  value = REACH_FREQUENCY_REACH_VALUE
+                                  noiseMechanism = NoiseMechanism.CONTINUOUS_LAPLACE
+                                  deterministicCountDistinct =
+                                    InternalDeterministicCountDistinct.getDefaultInstance()
+                                }
+                              frequency =
+                                InternalMeasurementKt.ResultKt.frequency {
+                                  relativeFrequencyDistribution.putAll(
+                                    REACH_FREQUENCY_FREQUENCY_VALUE
+                                  )
+                                  liquidLegionsDistribution = internalLiquidLegionsDistribution {
+                                    decayRate = LL_DISTRIBUTION_DECAY_RATE
+                                    maxSize = LL_DISTRIBUTION_SKETCH_SIZE
+                                  }
+                                }
+                            }
+                        }
+                    }
+                }
+              }
+          }
+        )
+
+      val request = getMetricRequest {
+        name = SUCCEEDED_SINGLE_PUBLISHER_REACH_FREQUENCY_METRIC.name
+      }
+
+      val result =
+        withMeasurementConsumerPrincipal(MEASUREMENT_CONSUMERS.values.first().name, CONFIG) {
+          runBlocking { service.getMetric(request) }
+        }
+
+      assertThat(result)
+        .isEqualTo(
+          SUCCEEDED_SINGLE_PUBLISHER_REACH_FREQUENCY_METRIC.copy {
+            this.result =
+              this.result.copy {
+                frequencyHistogram =
+                  MetricResultKt.histogramResult {
+                    bins +=
+                      (1..REACH_FREQUENCY_MAXIMUM_FREQUENCY).map { frequency ->
+                        MetricResultKt.HistogramResultKt.bin {
+                          label = frequency.toString()
+                          binResult =
+                            MetricResultKt.HistogramResultKt.binResult {
+                              value =
+                                REACH_FREQUENCY_REACH_VALUE *
+                                  REACH_FREQUENCY_FREQUENCY_VALUE.getOrDefault(
+                                    frequency.toLong(),
+                                    0.0
+                                  )
+                            }
+                        }
+                      }
+                  }
+              }
+          }
+        )
+    }
+
+  @Test
+  fun `getMetric returns reach frequency metric with statistics not set when frequency methodolgoy is unspecified`() =
+    runBlocking {
+      whenever(internalMetricsMock.batchGetMetrics(any()))
+        .thenReturn(
+          internalBatchGetMetricsResponse {
+            metrics +=
+              INTERNAL_SUCCEEDED_SINGLE_PUBLISHER_REACH_FREQUENCY_METRIC.copy {
+                weightedMeasurements.clear()
+                weightedMeasurements += weightedMeasurement {
+                  weight = 1
+                  binaryRepresentation = 1
+                  measurement =
+                    INTERNAL_SUCCEEDED_SINGLE_PUBLISHER_REACH_FREQUENCY_MEASUREMENT.copy {
+                      details =
+                        InternalMeasurementKt.details {
+                          results +=
+                            InternalMeasurementKt.result {
+                              reach =
+                                InternalMeasurementKt.ResultKt.reach {
+                                  value = REACH_FREQUENCY_REACH_VALUE
+                                  noiseMechanism = NoiseMechanism.CONTINUOUS_LAPLACE
+                                  deterministicCountDistinct =
+                                    InternalDeterministicCountDistinct.getDefaultInstance()
+                                }
+                              frequency =
+                                InternalMeasurementKt.ResultKt.frequency {
+                                  relativeFrequencyDistribution.putAll(
+                                    REACH_FREQUENCY_FREQUENCY_VALUE
+                                  )
+                                  noiseMechanism = NoiseMechanism.CONTINUOUS_LAPLACE
+                                }
+                            }
+                        }
+                    }
+                }
+              }
+          }
+        )
+
+      val request = getMetricRequest {
+        name = SUCCEEDED_SINGLE_PUBLISHER_REACH_FREQUENCY_METRIC.name
+      }
+
+      val result =
+        withMeasurementConsumerPrincipal(MEASUREMENT_CONSUMERS.values.first().name, CONFIG) {
+          runBlocking { service.getMetric(request) }
+        }
+
+      assertThat(result)
+        .isEqualTo(
+          SUCCEEDED_SINGLE_PUBLISHER_REACH_FREQUENCY_METRIC.copy {
+            this.result =
+              this.result.copy {
+                frequencyHistogram =
+                  MetricResultKt.histogramResult {
+                    bins +=
+                      (1..REACH_FREQUENCY_MAXIMUM_FREQUENCY).map { frequency ->
+                        MetricResultKt.HistogramResultKt.bin {
+                          label = frequency.toString()
+                          binResult =
+                            MetricResultKt.HistogramResultKt.binResult {
+                              value =
+                                REACH_FREQUENCY_REACH_VALUE *
+                                  REACH_FREQUENCY_FREQUENCY_VALUE.getOrDefault(
+                                    frequency.toLong(),
+                                    0.0
+                                  )
+                            }
+                        }
+                      }
+                  }
+              }
+          }
+        )
+    }
+
+  @Test
+  fun `getMetric throws StatusRuntimeException when the succeeded metric contains measurement with two reach frequency results`():
+    Unit = runBlocking {
+    whenever(internalMetricsMock.batchGetMetrics(any()))
+      .thenReturn(
+        internalBatchGetMetricsResponse {
+          metrics +=
+            INTERNAL_SUCCEEDED_SINGLE_PUBLISHER_REACH_FREQUENCY_METRIC.copy {
+              weightedMeasurements += weightedMeasurement {
+                weight = 1
+                binaryRepresentation = 1
+                measurement =
+                  INTERNAL_SUCCEEDED_SINGLE_PUBLISHER_REACH_FREQUENCY_MEASUREMENT.copy {
+                    details =
+                      InternalMeasurementKt.details {
+                        val result =
+                          InternalMeasurementKt.result {
+                            reach =
+                              InternalMeasurementKt.ResultKt.reach {
+                                value = REACH_FREQUENCY_REACH_VALUE
+                                noiseMechanism = NoiseMechanism.CONTINUOUS_LAPLACE
+                                deterministicCountDistinct =
+                                  InternalDeterministicCountDistinct.getDefaultInstance()
+                              }
+                            frequency =
+                              InternalMeasurementKt.ResultKt.frequency {
+                                relativeFrequencyDistribution.putAll(
+                                  REACH_FREQUENCY_FREQUENCY_VALUE
+                                )
+                                noiseMechanism = NoiseMechanism.CONTINUOUS_LAPLACE
+                                liquidLegionsDistribution = internalLiquidLegionsDistribution {
+                                  decayRate = LL_DISTRIBUTION_DECAY_RATE
+                                  maxSize = LL_DISTRIBUTION_SKETCH_SIZE
+                                }
+                              }
+                          }
+                        results += result
+                        results += result
+                      }
+                  }
+              }
+            }
+        }
+      )
+
+    val request = getMetricRequest { name = SUCCEEDED_SINGLE_PUBLISHER_REACH_FREQUENCY_METRIC.name }
+
+    val exception =
+      assertFailsWith<StatusRuntimeException> {
+        withMeasurementConsumerPrincipal(MEASUREMENT_CONSUMERS.values.first().name, CONFIG) {
+          runBlocking { service.getMetric(request) }
+        }
+      }
+    assertThat(exception.status.code).isEqualTo(Status.Code.FAILED_PRECONDITION)
+  }
+
+  @Test
+  fun `getMetric throws StatusRuntimeException for reach frueqency metric when custom direct methodology has scalar`():
+    Unit = runBlocking {
+    whenever(internalMetricsMock.batchGetMetrics(any()))
+      .thenReturn(
+        internalBatchGetMetricsResponse {
+          metrics +=
+            INTERNAL_SUCCEEDED_SINGLE_PUBLISHER_REACH_FREQUENCY_METRIC.copy {
+              weightedMeasurements += weightedMeasurement {
+                weight = 1
+                binaryRepresentation = 3
+                measurement =
+                  INTERNAL_SUCCEEDED_UNION_ALL_REACH_MEASUREMENT.copy {
+                    details =
+                      InternalMeasurementKt.details {
+                        results +=
+                          InternalMeasurementKt.result {
+                            reach =
+                              InternalMeasurementKt.ResultKt.reach {
+                                value = UNION_ALL_REACH_VALUE
+                                noiseMechanism = NoiseMechanism.DISCRETE_GAUSSIAN
+                                customDirectMethodology = customDirectMethodology { scalar = 10.0 }
+                              }
+                          }
+                      }
+                  }
+              }
+            }
+        }
+      )
+
+    val request = getMetricRequest { name = SUCCEEDED_SINGLE_PUBLISHER_REACH_FREQUENCY_METRIC.name }
+
+    val exception =
+      assertFailsWith<StatusRuntimeException> {
+        withMeasurementConsumerPrincipal(MEASUREMENT_CONSUMERS.values.first().name, CONFIG) {
+          runBlocking { service.getMetric(request) }
+        }
+      }
+
+    assertThat(exception.status.code).isEqualTo(Status.Code.FAILED_PRECONDITION)
+  }
+
+  @Test
   fun `getMetric returns duration metric with SUCCEEDED when measurements are updated to SUCCEEDED`() =
     runBlocking {
       whenever(
@@ -4989,38 +5811,12 @@ class MetricsServiceTest {
           },
         )
 
-      val succeededUnionAllWatchDurationMeasurement =
-        PENDING_UNION_ALL_WATCH_DURATION_MEASUREMENT.copy {
-          state = Measurement.State.SUCCEEDED
-
-          results +=
-            DATA_PROVIDERS.keys.zip(WATCH_DURATION_LIST).map { (dataProviderKey, watchDuration) ->
-              val dataProvider = DATA_PROVIDERS.getValue(dataProviderKey)
-              resultPair {
-                val result =
-                  MeasurementKt.result {
-                    this.watchDuration =
-                      MeasurementKt.ResultKt.watchDuration {
-                        value = watchDuration
-                        noiseMechanism = ProtocolConfig.NoiseMechanism.CONTINUOUS_LAPLACE
-                        deterministicSum = DeterministicSum.getDefaultInstance()
-                      }
-                  }
-                encryptedResult =
-                  encryptResult(
-                    signResult(result, DATA_PROVIDER_SIGNING_KEY),
-                    MEASUREMENT_CONSUMER_PUBLIC_KEY
-                  )
-                certificate = dataProvider.certificate
-              }
-            }
-        }
       whenever(
           measurementsMock.getMeasurement(
             eq(getMeasurementRequest { name = PENDING_UNION_ALL_WATCH_DURATION_MEASUREMENT.name })
           )
         )
-        .thenReturn(succeededUnionAllWatchDurationMeasurement)
+        .thenReturn(SUCCEEDED_UNION_ALL_WATCH_DURATION_MEASUREMENT)
       whenever(internalMeasurementsMock.batchSetMeasurementResults(any()))
         .thenReturn(
           batchSetCmmsMeasurementResultsResponse {
@@ -5064,6 +5860,83 @@ class MetricsServiceTest {
       }
 
       assertThat(result).isEqualTo(SUCCEEDED_CROSS_PUBLISHER_WATCH_DURATION_METRIC)
+    }
+
+  @Test
+  fun `getMetric returns impression metric with SUCCEEDED when measurements are updated to SUCCEEDED`() =
+    runBlocking {
+      whenever(
+          internalMetricsMock.batchGetMetrics(
+            eq(
+              internalBatchGetMetricsRequest {
+                cmmsMeasurementConsumerId =
+                  INTERNAL_PENDING_SINGLE_PUBLISHER_IMPRESSION_METRIC.cmmsMeasurementConsumerId
+                externalMetricIds +=
+                  INTERNAL_PENDING_SINGLE_PUBLISHER_IMPRESSION_METRIC.externalMetricId
+              }
+            )
+          )
+        )
+        .thenReturn(
+          internalBatchGetMetricsResponse {
+            metrics += INTERNAL_PENDING_SINGLE_PUBLISHER_IMPRESSION_METRIC
+          },
+          internalBatchGetMetricsResponse {
+            metrics += INTERNAL_SUCCEEDED_SINGLE_PUBLISHER_IMPRESSION_METRIC
+          },
+        )
+
+      whenever(
+          measurementsMock.getMeasurement(
+            eq(
+              getMeasurementRequest { name = PENDING_SINGLE_PUBLISHER_IMPRESSION_MEASUREMENT.name }
+            )
+          )
+        )
+        .thenReturn(SUCCEEDED_SINGLE_PUBLISHER_IMPRESSION_MEASUREMENT)
+      whenever(internalMeasurementsMock.batchSetMeasurementResults(any()))
+        .thenReturn(
+          batchSetCmmsMeasurementResultsResponse {
+            measurements += INTERNAL_SUCCEEDED_SINGLE_PUBLISHER_IMPRESSION_MEASUREMENT
+          }
+        )
+
+      val request = getMetricRequest { name = PENDING_SINGLE_PUBLISHER_IMPRESSION_METRIC.name }
+
+      val result =
+        withMeasurementConsumerPrincipal(MEASUREMENT_CONSUMERS.values.first().name, CONFIG) {
+          runBlocking { service.getMetric(request) }
+        }
+
+      // Verify proto argument of internal MeasurementsCoroutineImplBase::batchSetMeasurementResults
+      val batchSetMeasurementResultsCaptor: KArgumentCaptor<BatchSetMeasurementResultsRequest> =
+        argumentCaptor()
+      verifyBlocking(internalMeasurementsMock, times(1)) {
+        batchSetMeasurementResults(batchSetMeasurementResultsCaptor.capture())
+      }
+      assertThat(batchSetMeasurementResultsCaptor.allValues)
+        .containsExactly(
+          batchSetMeasurementResultsRequest {
+            cmmsMeasurementConsumerId =
+              INTERNAL_SUCCEEDED_SINGLE_PUBLISHER_IMPRESSION_MEASUREMENT.cmmsMeasurementConsumerId
+            measurementResults += measurementResult {
+              cmmsMeasurementId =
+                INTERNAL_SUCCEEDED_SINGLE_PUBLISHER_IMPRESSION_MEASUREMENT.cmmsMeasurementId
+              this.results +=
+                INTERNAL_SUCCEEDED_SINGLE_PUBLISHER_IMPRESSION_MEASUREMENT.details.resultsList
+            }
+          }
+        )
+
+      // Verify proto argument of internal
+      // MeasurementsCoroutineImplBase::batchSetMeasurementFailures
+      val batchSetMeasurementFailuresCaptor: KArgumentCaptor<BatchSetMeasurementFailuresRequest> =
+        argumentCaptor()
+      verifyBlocking(internalMeasurementsMock, never()) {
+        batchSetMeasurementFailures(batchSetMeasurementFailuresCaptor.capture())
+      }
+
+      assertThat(result).isEqualTo(SUCCEEDED_SINGLE_PUBLISHER_IMPRESSION_METRIC)
     }
 
   @Test
@@ -5209,6 +6082,223 @@ class MetricsServiceTest {
     }
 
   @Test
+  fun `getMetric returns impression metric without statistics when set expression is not union-only`() =
+    runBlocking {
+      whenever(internalMetricsMock.batchGetMetrics(any()))
+        .thenReturn(
+          internalBatchGetMetricsResponse {
+            metrics +=
+              INTERNAL_SUCCEEDED_SINGLE_PUBLISHER_IMPRESSION_METRIC.copy {
+                weightedMeasurements += weightedMeasurement {
+                  weight = -1
+                  binaryRepresentation = 1
+                  measurement = INTERNAL_SUCCEEDED_SINGLE_PUBLISHER_IMPRESSION_MEASUREMENT
+                }
+              }
+          },
+        )
+
+      val request = getMetricRequest { name = SUCCEEDED_SINGLE_PUBLISHER_IMPRESSION_METRIC.name }
+
+      val result =
+        withMeasurementConsumerPrincipal(MEASUREMENT_CONSUMERS.values.first().name, CONFIG) {
+          runBlocking { service.getMetric(request) }
+        }
+
+      // Verify proto argument of internal MetricsCoroutineImplBase::batchGetMetrics
+      val batchGetInternalMetricsCaptor: KArgumentCaptor<InternalBatchGetMetricsRequest> =
+        argumentCaptor()
+      verifyBlocking(internalMetricsMock, times(1)) {
+        batchGetMetrics(batchGetInternalMetricsCaptor.capture())
+      }
+      val capturedInternalGetMetricRequests = batchGetInternalMetricsCaptor.allValues
+      assertThat(capturedInternalGetMetricRequests)
+        .containsExactly(
+          internalBatchGetMetricsRequest {
+            cmmsMeasurementConsumerId =
+              INTERNAL_PENDING_SINGLE_PUBLISHER_IMPRESSION_METRIC.cmmsMeasurementConsumerId
+            externalMetricIds +=
+              INTERNAL_PENDING_SINGLE_PUBLISHER_IMPRESSION_METRIC.externalMetricId
+          },
+        )
+
+      // Verify proto argument of MeasurementsCoroutineImplBase::getMeasurement
+      val getMeasurementCaptor: KArgumentCaptor<GetMeasurementRequest> = argumentCaptor()
+      verifyBlocking(measurementsMock, never()) { getMeasurement(getMeasurementCaptor.capture()) }
+
+      // Verify proto argument of internal MeasurementsCoroutineImplBase::batchSetMeasurementResults
+      val batchSetMeasurementResultsCaptor: KArgumentCaptor<BatchSetMeasurementResultsRequest> =
+        argumentCaptor()
+      verifyBlocking(internalMeasurementsMock, never()) {
+        batchSetMeasurementResults(batchSetMeasurementResultsCaptor.capture())
+      }
+
+      // Verify proto argument of internal
+      // MeasurementsCoroutineImplBase::batchSetMeasurementFailures
+      val batchSetMeasurementFailuresCaptor: KArgumentCaptor<BatchSetMeasurementFailuresRequest> =
+        argumentCaptor()
+      verifyBlocking(internalMeasurementsMock, never()) {
+        batchSetMeasurementFailures(batchSetMeasurementFailuresCaptor.capture())
+      }
+
+      assertThat(result)
+        .isEqualTo(
+          SUCCEEDED_SINGLE_PUBLISHER_IMPRESSION_METRIC.copy {
+            this.result = metricResult {
+              impressionCount = MetricResultKt.impressionCountResult { value = 0L }
+            }
+          }
+        )
+    }
+
+  @Test
+  fun `getMetric returns impression metric without statistics when noise mechanism is unspecified`() =
+    runBlocking {
+      whenever(internalMetricsMock.batchGetMetrics(any()))
+        .thenReturn(
+          internalBatchGetMetricsResponse {
+            metrics +=
+              INTERNAL_SUCCEEDED_SINGLE_PUBLISHER_IMPRESSION_METRIC.copy {
+                weightedMeasurements.clear()
+                weightedMeasurements += weightedMeasurement {
+                  weight = 1
+                  binaryRepresentation = 1
+                  measurement =
+                    INTERNAL_SUCCEEDED_SINGLE_PUBLISHER_IMPRESSION_MEASUREMENT.copy {
+                      details =
+                        InternalMeasurementKt.details {
+                          results +=
+                            InternalMeasurementKt.result {
+                              impression =
+                                InternalMeasurementKt.ResultKt.impression {
+                                  value = IMPRESSION_VALUE
+                                  deterministicCount =
+                                    InternalDeterministicCount.getDefaultInstance()
+                                }
+                            }
+                        }
+                    }
+                }
+              }
+          },
+        )
+
+      val request = getMetricRequest { name = SUCCEEDED_SINGLE_PUBLISHER_IMPRESSION_METRIC.name }
+
+      val result =
+        withMeasurementConsumerPrincipal(MEASUREMENT_CONSUMERS.values.first().name, CONFIG) {
+          runBlocking { service.getMetric(request) }
+        }
+
+      assertThat(result)
+        .isEqualTo(
+          SUCCEEDED_SINGLE_PUBLISHER_IMPRESSION_METRIC.copy {
+            this.result =
+              this.result.copy {
+                impressionCount = impressionCount.copy { clearUnivariateStatistics() }
+              }
+          }
+        )
+    }
+
+  @Test
+  fun `getMetric returns impression metric without statistics when methodology is not set`() =
+    runBlocking {
+      whenever(internalMetricsMock.batchGetMetrics(any()))
+        .thenReturn(
+          internalBatchGetMetricsResponse {
+            metrics +=
+              INTERNAL_SUCCEEDED_SINGLE_PUBLISHER_IMPRESSION_METRIC.copy {
+                weightedMeasurements.clear()
+                weightedMeasurements += weightedMeasurement {
+                  weight = 1
+                  binaryRepresentation = 1
+                  measurement =
+                    INTERNAL_SUCCEEDED_SINGLE_PUBLISHER_IMPRESSION_MEASUREMENT.copy {
+                      details =
+                        InternalMeasurementKt.details {
+                          results +=
+                            InternalMeasurementKt.result {
+                              impression =
+                                InternalMeasurementKt.ResultKt.impression {
+                                  value = IMPRESSION_VALUE
+                                  noiseMechanism = NoiseMechanism.CONTINUOUS_LAPLACE
+                                }
+                            }
+                        }
+                    }
+                }
+              }
+          },
+        )
+
+      val request = getMetricRequest { name = SUCCEEDED_SINGLE_PUBLISHER_IMPRESSION_METRIC.name }
+
+      val result =
+        withMeasurementConsumerPrincipal(MEASUREMENT_CONSUMERS.values.first().name, CONFIG) {
+          runBlocking { service.getMetric(request) }
+        }
+
+      assertThat(result)
+        .isEqualTo(
+          SUCCEEDED_SINGLE_PUBLISHER_IMPRESSION_METRIC.copy {
+            this.result =
+              this.result.copy {
+                impressionCount = impressionCount.copy { clearUnivariateStatistics() }
+              }
+          }
+        )
+    }
+
+  @Test
+  fun `getMetric throws StatusRuntimeException for impression metric when custom direct methodology has frequency`():
+    Unit = runBlocking {
+    whenever(internalMetricsMock.batchGetMetrics(any()))
+      .thenReturn(
+        internalBatchGetMetricsResponse {
+          metrics +=
+            INTERNAL_SUCCEEDED_SINGLE_PUBLISHER_IMPRESSION_METRIC.copy {
+              weightedMeasurements.clear()
+              weightedMeasurements += weightedMeasurement {
+                weight = 1
+                binaryRepresentation = 1
+                measurement =
+                  INTERNAL_SUCCEEDED_SINGLE_PUBLISHER_IMPRESSION_MEASUREMENT.copy {
+                    details =
+                      InternalMeasurementKt.details {
+                        results +=
+                          InternalMeasurementKt.result {
+                            impression =
+                              InternalMeasurementKt.ResultKt.impression {
+                                value = IMPRESSION_VALUE
+                                noiseMechanism = NoiseMechanism.CONTINUOUS_LAPLACE
+                                customDirectMethodology = customDirectMethodology {
+                                  frequency =
+                                    InternalCustomDirectMethodology.FrequencyVariances
+                                      .getDefaultInstance()
+                                }
+                              }
+                          }
+                      }
+                  }
+              }
+            }
+        },
+      )
+
+    val request = getMetricRequest { name = SUCCEEDED_SINGLE_PUBLISHER_IMPRESSION_METRIC.name }
+
+    val exception =
+      assertFailsWith<StatusRuntimeException> {
+        withMeasurementConsumerPrincipal(MEASUREMENT_CONSUMERS.values.first().name, CONFIG) {
+          runBlocking { service.getMetric(request) }
+        }
+      }
+
+    assertThat(exception.status.code).isEqualTo(Status.Code.FAILED_PRECONDITION)
+  }
+
+  @Test
   fun `getMetric returns duration metric with SUCCEEDED when measurements are already SUCCEEDED`() =
     runBlocking {
       whenever(internalMetricsMock.batchGetMetrics(any()))
@@ -5263,6 +6353,192 @@ class MetricsServiceTest {
 
       assertThat(result).isEqualTo(SUCCEEDED_CROSS_PUBLISHER_WATCH_DURATION_METRIC)
     }
+
+  @Test
+  fun `getMetric returns duration metric without statistics when set expression is not union-only`() =
+    runBlocking {
+      whenever(internalMetricsMock.batchGetMetrics(any()))
+        .thenReturn(
+          internalBatchGetMetricsResponse {
+            metrics +=
+              INTERNAL_SUCCEEDED_CROSS_PUBLISHER_WATCH_DURATION_METRIC.copy {
+                weightedMeasurements += weightedMeasurement {
+                  weight = -1
+                  binaryRepresentation = 1
+                  measurement = INTERNAL_SUCCEEDED_UNION_ALL_WATCH_DURATION_MEASUREMENT
+                }
+              }
+          }
+        )
+
+      val request = getMetricRequest { name = PENDING_CROSS_PUBLISHER_WATCH_DURATION_METRIC.name }
+
+      val result =
+        withMeasurementConsumerPrincipal(MEASUREMENT_CONSUMERS.values.first().name, CONFIG) {
+          runBlocking { service.getMetric(request) }
+        }
+
+      assertThat(result)
+        .isEqualTo(
+          SUCCEEDED_CROSS_PUBLISHER_WATCH_DURATION_METRIC.copy {
+            this.result = metricResult {
+              watchDuration = MetricResultKt.watchDurationResult { value = 0.0 }
+            }
+          }
+        )
+    }
+
+  @Test
+  fun `getMetric returns duration metric without statistics when noise mechanism is unspecified`() =
+    runBlocking {
+      whenever(internalMetricsMock.batchGetMetrics(any()))
+        .thenReturn(
+          internalBatchGetMetricsResponse {
+            metrics +=
+              INTERNAL_SUCCEEDED_CROSS_PUBLISHER_WATCH_DURATION_METRIC.copy {
+                weightedMeasurements.clear()
+                weightedMeasurements += weightedMeasurement {
+                  weight = 1
+                  binaryRepresentation = 1
+                  measurement =
+                    INTERNAL_SUCCEEDED_UNION_ALL_WATCH_DURATION_MEASUREMENT.copy {
+                      details =
+                        InternalMeasurementKt.details {
+                          results +=
+                            WATCH_DURATION_LIST.map { duration ->
+                              InternalMeasurementKt.result {
+                                watchDuration =
+                                  InternalMeasurementKt.ResultKt.watchDuration {
+                                    value = duration
+                                    deterministicSum = InternalDeterministicSum.getDefaultInstance()
+                                  }
+                              }
+                            }
+                        }
+                    }
+                }
+              }
+          }
+        )
+
+      val request = getMetricRequest { name = PENDING_CROSS_PUBLISHER_WATCH_DURATION_METRIC.name }
+
+      val result =
+        withMeasurementConsumerPrincipal(MEASUREMENT_CONSUMERS.values.first().name, CONFIG) {
+          runBlocking { service.getMetric(request) }
+        }
+
+      assertThat(result)
+        .isEqualTo(
+          SUCCEEDED_CROSS_PUBLISHER_WATCH_DURATION_METRIC.copy {
+            this.result =
+              this.result.copy {
+                watchDuration = watchDuration.copy { clearUnivariateStatistics() }
+              }
+          }
+        )
+    }
+
+  @Test
+  fun `getMetric returns duration metric without statistics when methodology is not set`() =
+    runBlocking {
+      whenever(internalMetricsMock.batchGetMetrics(any()))
+        .thenReturn(
+          internalBatchGetMetricsResponse {
+            metrics +=
+              INTERNAL_SUCCEEDED_CROSS_PUBLISHER_WATCH_DURATION_METRIC.copy {
+                weightedMeasurements.clear()
+                weightedMeasurements += weightedMeasurement {
+                  weight = 1
+                  binaryRepresentation = 1
+                  measurement =
+                    INTERNAL_SUCCEEDED_UNION_ALL_WATCH_DURATION_MEASUREMENT.copy {
+                      details =
+                        InternalMeasurementKt.details {
+                          results +=
+                            WATCH_DURATION_LIST.map { duration ->
+                              InternalMeasurementKt.result {
+                                watchDuration =
+                                  InternalMeasurementKt.ResultKt.watchDuration {
+                                    value = duration
+                                    noiseMechanism = NoiseMechanism.CONTINUOUS_LAPLACE
+                                  }
+                              }
+                            }
+                        }
+                    }
+                }
+              }
+          }
+        )
+
+      val request = getMetricRequest { name = PENDING_CROSS_PUBLISHER_WATCH_DURATION_METRIC.name }
+
+      val result =
+        withMeasurementConsumerPrincipal(MEASUREMENT_CONSUMERS.values.first().name, CONFIG) {
+          runBlocking { service.getMetric(request) }
+        }
+
+      assertThat(result)
+        .isEqualTo(
+          SUCCEEDED_CROSS_PUBLISHER_WATCH_DURATION_METRIC.copy {
+            this.result =
+              this.result.copy {
+                watchDuration = watchDuration.copy { clearUnivariateStatistics() }
+              }
+          }
+        )
+    }
+
+  @Test
+  fun `getMetric throws throws StatusRuntimeException for watch duration metric when custom direct methodology has frequency`():
+    Unit = runBlocking {
+    whenever(internalMetricsMock.batchGetMetrics(any()))
+      .thenReturn(
+        internalBatchGetMetricsResponse {
+          metrics +=
+            INTERNAL_SUCCEEDED_CROSS_PUBLISHER_WATCH_DURATION_METRIC.copy {
+              weightedMeasurements.clear()
+              weightedMeasurements += weightedMeasurement {
+                weight = 1
+                binaryRepresentation = 1
+                measurement =
+                  INTERNAL_SUCCEEDED_UNION_ALL_WATCH_DURATION_MEASUREMENT.copy {
+                    details =
+                      InternalMeasurementKt.details {
+                        results +=
+                          WATCH_DURATION_LIST.map { duration ->
+                            InternalMeasurementKt.result {
+                              watchDuration =
+                                InternalMeasurementKt.ResultKt.watchDuration {
+                                  value = duration
+                                  noiseMechanism = NoiseMechanism.CONTINUOUS_LAPLACE
+                                  customDirectMethodology = customDirectMethodology {
+                                    frequency =
+                                      InternalCustomDirectMethodology.FrequencyVariances
+                                        .getDefaultInstance()
+                                  }
+                                }
+                            }
+                          }
+                      }
+                  }
+              }
+            }
+        }
+      )
+
+    val request = getMetricRequest { name = PENDING_CROSS_PUBLISHER_WATCH_DURATION_METRIC.name }
+
+    val exception =
+      assertFailsWith<StatusRuntimeException> {
+        withMeasurementConsumerPrincipal(MEASUREMENT_CONSUMERS.values.first().name, CONFIG) {
+          runBlocking { service.getMetric(request) }
+        }
+      }
+
+    assertThat(exception.status.code).isEqualTo(Status.Code.FAILED_PRECONDITION)
+  }
 
   @Test
   fun `getMetric throws INVALID_ARGUMENT when Report name is invalid`() {


### PR DESCRIPTION
Compute metric variances in a report using the `Variances` library. Any insufficiency of inputs to the variance calculation will not set `univariate_statistics`.

* Reach: compute variances from weighted reach measurements.
* Frequency histogram: compute variances from weighted reach and frequency measurements.
* Impression count: compute variances only when the operation is union-only. The variance of an impression metric is the sum of the weighted impression results.
* Watch duration: compute variances only when the operation is union-only. The variance of a duration metric is the sum of the weighted duration results.