### PR TITLE
Apply pre- and post-submit workflows to release branches.

### DIFF
--- a/.github/workflows/api-lint.yml
+++ b/.github/workflows/api-lint.yml
@@ -16,7 +16,9 @@ name: API lint
 
 on:
   pull_request:
-    branches: [main]
+    branches:
+      - main
+      - 'releases/**'
     types: [opened, synchronize, edited]
 
 concurrency:

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -16,9 +16,13 @@ name: Build and test
 
 on:
   push:
-    branches: [main]
+    branches:
+      - main
+      - 'releases/**'
   pull_request:
-    branches: [main]
+    branches:
+      - main
+      - 'releases/**'
     types: [opened, synchronize, edited]
   workflow_dispatch:
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,7 +2,9 @@ name: Lint
 
 on:
   pull_request:
-    branches: [main]
+    branches:
+      - main
+      - 'releases/**'
     types: [opened, synchronize, edited]
 
 concurrency:


### PR DESCRIPTION
This is in preparation for using release branches to create patch (AKA "bugfix") releases.