### PR TITLE
Require maximum_frequency for REACH_AND_FREQUENCY Measurements to be > 1.

### DIFF
--- a/src/main/kotlin/org/wfanet/measurement/duchy/daemon/herald/LiquidLegionsV2Starter.kt
+++ b/src/main/kotlin/org/wfanet/measurement/duchy/daemon/herald/LiquidLegionsV2Starter.kt
@@ -331,7 +331,7 @@ object LiquidLegionsV2Starter {
         @Suppress("DEPRECATION") // For legacy Computations.
         maximumFrequency = protocolConfig.maximumFrequency
       }
-      require(maximumFrequency > 0) { "Maximum frequency must be greater than 0" }
+      require(maximumFrequency > 1) { "Maximum frequency must be greater than 1" }
     }
 
     noise = liquidLegionsV2NoiseConfig {

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/service/api/v2alpha/MeasurementsService.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/service/api/v2alpha/MeasurementsService.kt
@@ -298,8 +298,8 @@ private fun MeasurementSpec.validate() {
       grpcRequire(reachAndFrequency.frequencyPrivacyParams.hasValidEpsilonAndDelta()) {
         "Frequency privacy params are invalid"
       }
-      grpcRequire(reachAndFrequency.maximumFrequency > 0) {
-        "maximum_frequency must be greater than 0"
+      grpcRequire(reachAndFrequency.maximumFrequency > 1) {
+        "maximum_frequency must be greater than 1"
       }
 
       grpcRequire(vidSamplingInterval.width > 0) { "Vid sampling interval is unspecified" }

--- a/src/test/kotlin/org/wfanet/measurement/kingdom/service/api/v2alpha/MeasurementsServiceTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/kingdom/service/api/v2alpha/MeasurementsServiceTest.kt
@@ -1016,6 +1016,34 @@ class MeasurementsServiceTest {
   }
 
   @Test
+  fun `createMeasurement throws INVALID_ARGUMENT when RF spec max frequency is 1`() {
+    val request = createMeasurementRequest {
+      parent = MEASUREMENT_CONSUMER_NAME
+      measurement =
+        MEASUREMENT.copy {
+          measurementSpec =
+            measurementSpec.copy {
+              data =
+                MEASUREMENT_SPEC.copy {
+                    reachAndFrequency = reachAndFrequency.copy { maximumFrequency = 1 }
+                  }
+                  .toByteString()
+            }
+        }
+    }
+
+    val exception =
+      assertFailsWith<StatusRuntimeException> {
+        withMeasurementConsumerPrincipal(MEASUREMENT_CONSUMER_NAME) {
+          runBlocking { service.createMeasurement(request) }
+        }
+      }
+
+    assertThat(exception.status.code).isEqualTo(Status.Code.INVALID_ARGUMENT)
+    assertThat(exception).hasMessageThat().contains("maximum_frequency")
+  }
+
+  @Test
   fun `createMeasurement throws INVALID_ARGUMENT when Reach-only privacy params are missing`() {
     val request = createMeasurementRequest {
       parent = MEASUREMENT_CONSUMER_NAME


### PR DESCRIPTION
This removes a workaround that is no longer needed now that the REACH Measurement type has been released.

Note that this only affects the REACH_AND_FREQUENCY Measurement type. The R/F LLv2 protocol can still be used with a max frequency of 1 in lieu of the reach-only LLv2 protocol for the REACH Measurement type.