### PR TITLE
Add additional filter to MetricCalculationSpec

### DIFF
--- a/src/main/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/ProtoConversions.kt
+++ b/src/main/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/ProtoConversions.kt
@@ -696,6 +696,7 @@ fun InternalReport.MetricCalculationSpec.toMetricCalculationSpec(): Report.Metri
       source.details.groupingsList.map { grouping ->
         ReportKt.grouping { predicates += grouping.predicatesList }
       }
+    filter = source.details.filter
     cumulative = source.details.cumulative
   }
 }
@@ -734,7 +735,8 @@ fun PeriodicTimeInterval.toInternal(): InternalPeriodicTimeInterval {
 
 /** Converts an [InternalReport.ReportingMetric] to a public [CreateMetricRequest]. */
 fun InternalReport.ReportingMetric.toCreateMetricRequest(
-  measurementConsumerKey: MeasurementConsumerKey
+  measurementConsumerKey: MeasurementConsumerKey,
+  filter: String,
 ): CreateMetricRequest {
   val source = this
   return createMetricRequest {
@@ -748,7 +750,7 @@ fun InternalReport.ReportingMetric.toCreateMetricRequest(
           .toName()
       timeInterval = source.details.timeInterval
       metricSpec = source.details.metricSpec.toMetricSpec()
-      filters += source.details.filtersList
+      filters += (source.details.groupingPredicatesList + filter).filter { it.isNotBlank() }
     }
     requestId = source.createMetricRequestId
     metricId = "a" + source.createMetricRequestId

--- a/src/main/kotlin/org/wfanet/measurement/reporting/service/internal/testing/v2/ReportsServiceTest.kt
+++ b/src/main/kotlin/org/wfanet/measurement/reporting/service/internal/testing/v2/ReportsServiceTest.kt
@@ -203,6 +203,7 @@ abstract class ReportsServiceTest<T : ReportsGrpcKt.ReportsCoroutineImplBase> {
                       startTime = timestamp { seconds = 100 }
                       endTime = timestamp { seconds = 200 }
                     }
+                    groupingPredicates += listOf("predicate1", "predicate2")
                   }
               }
             details =
@@ -224,6 +225,7 @@ abstract class ReportsServiceTest<T : ReportsGrpcKt.ReportsCoroutineImplBase> {
                     }
                 }
                 groupings += ReportKt.MetricCalculationSpecKt.grouping { predicates += "age > 10" }
+                filter = "filter"
                 cumulative = false
               }
           }
@@ -257,6 +259,7 @@ abstract class ReportsServiceTest<T : ReportsGrpcKt.ReportsCoroutineImplBase> {
                       startTime = timestamp { seconds = 100 }
                       endTime = timestamp { seconds = 200 }
                     }
+                    groupingPredicates += listOf("predicate3", "predicate4")
                   }
               }
             details =
@@ -278,6 +281,7 @@ abstract class ReportsServiceTest<T : ReportsGrpcKt.ReportsCoroutineImplBase> {
                     }
                 }
                 groupings += ReportKt.MetricCalculationSpecKt.grouping { predicates += "age > 10" }
+                filter = "filter"
                 cumulative = false
               }
           }
@@ -358,6 +362,7 @@ abstract class ReportsServiceTest<T : ReportsGrpcKt.ReportsCoroutineImplBase> {
                       startTime = timestamp { seconds = 100 }
                       endTime = timestamp { seconds = 200 }
                     }
+                    groupingPredicates += listOf("predicate1", "predicate2")
                   }
               }
             reportingMetrics +=
@@ -384,6 +389,7 @@ abstract class ReportsServiceTest<T : ReportsGrpcKt.ReportsCoroutineImplBase> {
                       startTime = timestamp { seconds = 100 }
                       endTime = timestamp { seconds = 200 }
                     }
+                    groupingPredicates += listOf("predicate3", "predicate4")
                   }
               }
             details =
@@ -405,6 +411,7 @@ abstract class ReportsServiceTest<T : ReportsGrpcKt.ReportsCoroutineImplBase> {
                     }
                 }
                 groupings += ReportKt.MetricCalculationSpecKt.grouping { predicates += "age > 10" }
+                filter = "filter"
                 cumulative = false
               }
           }
@@ -946,6 +953,7 @@ abstract class ReportsServiceTest<T : ReportsGrpcKt.ReportsCoroutineImplBase> {
                         startTime = timestamp { seconds = 100 }
                         endTime = timestamp { seconds = 200 }
                       }
+                      groupingPredicates += listOf("predicate1", "predicate2")
                     }
                 }
               details =
@@ -968,6 +976,7 @@ abstract class ReportsServiceTest<T : ReportsGrpcKt.ReportsCoroutineImplBase> {
                   }
                   groupings +=
                     ReportKt.MetricCalculationSpecKt.grouping { predicates += "age > 10" }
+                  filter = "filter1"
                   cumulative = false
                 }
             }
@@ -1001,6 +1010,7 @@ abstract class ReportsServiceTest<T : ReportsGrpcKt.ReportsCoroutineImplBase> {
                         startTime = timestamp { seconds = 100 }
                         endTime = timestamp { seconds = 200 }
                       }
+                      groupingPredicates += listOf("predicate3", "predicate4")
                     }
                 }
               details =
@@ -1023,6 +1033,7 @@ abstract class ReportsServiceTest<T : ReportsGrpcKt.ReportsCoroutineImplBase> {
                   }
                   groupings +=
                     ReportKt.MetricCalculationSpecKt.grouping { predicates += "age > 10" }
+                  filter = "filter2"
                   cumulative = false
                 }
             }
@@ -1104,7 +1115,11 @@ abstract class ReportsServiceTest<T : ReportsGrpcKt.ReportsCoroutineImplBase> {
                       }
                   }
                 }
-              details = MetricKt.details { filters += it.details.filtersList }
+              details =
+                MetricKt.details {
+                  filters +=
+                    it.details.groupingPredicatesList + metricCalculationSpec.details.filter
+                }
             }
           }
           metricsService.createMetric(request)
@@ -1362,6 +1377,7 @@ abstract class ReportsServiceTest<T : ReportsGrpcKt.ReportsCoroutineImplBase> {
                           startTime = timestamp { seconds = 100 }
                           endTime = timestamp { seconds = 200 }
                         }
+                        groupingPredicates += listOf("predicate1", "predicate2")
                       }
                   }
                 details =
@@ -1384,6 +1400,7 @@ abstract class ReportsServiceTest<T : ReportsGrpcKt.ReportsCoroutineImplBase> {
                     }
                     groupings +=
                       ReportKt.MetricCalculationSpecKt.grouping { predicates += "age > 10" }
+                    filter = "filter"
                     cumulative = false
                   }
               }
@@ -1443,6 +1460,7 @@ abstract class ReportsServiceTest<T : ReportsGrpcKt.ReportsCoroutineImplBase> {
                         startTime = timestamp { seconds = 100 }
                         endTime = timestamp { seconds = 200 }
                       }
+                      groupingPredicates += listOf("predicate1", "predicate2")
                     }
                 }
               details =
@@ -1465,6 +1483,7 @@ abstract class ReportsServiceTest<T : ReportsGrpcKt.ReportsCoroutineImplBase> {
                   }
                   groupings +=
                     ReportKt.MetricCalculationSpecKt.grouping { predicates += "age > 10" }
+                  filter = "filter"
                   cumulative = false
                 }
             }

--- a/src/main/proto/wfa/measurement/internal/reporting/v2/report.proto
+++ b/src/main/proto/wfa/measurement/internal/reporting/v2/report.proto
@@ -53,7 +53,7 @@ message Report {
       string external_reporting_set_id = 1;
       MetricSpec metric_spec = 2;
       google.type.Interval time_interval = 3;
-      repeated string filters = 4;
+      repeated string grouping_predicates = 4;
     }
 
     Details details = 3;
@@ -72,6 +72,7 @@ message Report {
       repeated MetricSpec metric_specs = 2;
       repeated Grouping groupings = 3;
       bool cumulative = 4;
+      string filter = 5;
     }
     Details details = 2;
   }

--- a/src/main/proto/wfa/measurement/reporting/v2alpha/report.proto
+++ b/src/main/proto/wfa/measurement/reporting/v2alpha/report.proto
@@ -68,8 +68,8 @@ message Report {
     // A collection of metrics.
     repeated MetricSpec metric_specs = 2
         [(google.api.field_behavior) = REQUIRED];
-    // An additional event filter that will be conjoined to any filters
-    // present on the ReportingSet provided as part of the
+    // An additional event filter that will be conjoined to grouping filters and
+    // any filters present on the ReportingSet provided as part of the
     // ReportingMetricEntry below.
     string filter = 5 [(google.api.field_behavior) = IMMUTABLE];
     // The final set of groups is the Cartesian product of `groupings` and will
@@ -164,6 +164,10 @@ message Report {
 
       // The metric spec that is associated with the metric calculation.
       MetricSpec metric_spec = 2;
+
+      // An additional event filter that was conjoined to the grouping
+      // predicates and any filters present on the ReportingSet.
+      string filter = 5;
 
       // The time interval associated with the metric calculation.
       //

--- a/src/test/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/ReportsServiceTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/ReportsServiceTest.kt
@@ -326,11 +326,12 @@ class ReportsServiceTest {
 
       val (internalRequestingReport, internalInitialReport, internalPendingReport) =
         buildInternalReports(
-          MEASUREMENT_CONSUMER_KEYS.first().measurementConsumerId,
-          intervals,
-          targetReportingSet.resourceId,
-          initialReportingMetrics,
-          listOf(),
+          cmmsMeasurementConsumerId = MEASUREMENT_CONSUMER_KEYS.first().measurementConsumerId,
+          timeIntervals = intervals,
+          reportingSetId = targetReportingSet.resourceId,
+          reportingMetrics = initialReportingMetrics,
+          groupings = listOf(),
+          filter = null,
         )
 
       whenever(
@@ -439,7 +440,7 @@ class ReportsServiceTest {
     }
 
   @Test
-  fun `createReport returns report with two metrics when there are two groupings`() = runBlocking {
+  fun `createReport returns report with two metrics when multiple filters`() = runBlocking {
     val displayName = DISPLAY_NAME
     val targetReportingSet = PRIMITIVE_REPORTING_SETS.first()
 
@@ -453,6 +454,7 @@ class ReportsServiceTest {
     val groupingsCartesianProduct: List<List<String>> =
       predicates1.flatMap { filter1 -> predicates2.map { filter2 -> listOf(filter1, filter2) } }
 
+    val filter = "device == MOBILE"
     val timeInterval = interval {
       startTime = START_TIME
       endTime = END_TIME
@@ -464,22 +466,23 @@ class ReportsServiceTest {
     }
 
     val initialReportingMetrics: List<InternalReport.ReportingMetric> =
-      groupingsCartesianProduct.map { filters ->
+      groupingsCartesianProduct.map { groupingPredicates ->
         buildInitialReportingMetric(
           targetReportingSet.resourceId,
           interval,
           INTERNAL_REACH_METRIC_SPEC,
-          filters
+          groupingPredicates
         )
       }
 
     val (internalRequestingReport, internalInitialReport, internalPendingReport) =
       buildInternalReports(
-        MEASUREMENT_CONSUMER_KEYS.first().measurementConsumerId,
-        listOf(interval),
-        targetReportingSet.resourceId,
-        initialReportingMetrics,
-        internalGroupings,
+        cmmsMeasurementConsumerId = MEASUREMENT_CONSUMER_KEYS.first().measurementConsumerId,
+        timeIntervals = listOf(interval),
+        reportingSetId = targetReportingSet.resourceId,
+        reportingMetrics = initialReportingMetrics,
+        groupings = internalGroupings,
+        filter = filter,
       )
 
     whenever(
@@ -507,12 +510,13 @@ class ReportsServiceTest {
       .thenReturn(internalPendingReport)
 
     val requestingMetrics: List<Metric> =
-      groupingsCartesianProduct.map { filters ->
+      groupingsCartesianProduct.map { groupingPredicates ->
         metric {
           reportingSet = targetReportingSet.name
           this.timeInterval = timeInterval
           metricSpec = REACH_METRIC_SPEC
-          this.filters += filters
+          this.filters += groupingPredicates
+          this.filters += filter
         }
       }
 
@@ -550,6 +554,7 @@ class ReportsServiceTest {
                       ReportKt.grouping { predicates += predicates1 },
                       ReportKt.grouping { predicates += predicates2 }
                     )
+                  this.filter = filter
                   cumulative = false
                 }
             }
@@ -617,11 +622,12 @@ class ReportsServiceTest {
 
       val (internalRequestingReport, internalInitialReport, internalPendingReport) =
         buildInternalReports(
-          MEASUREMENT_CONSUMER_KEYS.first().measurementConsumerId,
-          listOf(interval),
-          targetReportingSet.resourceId,
-          initialReportingMetrics,
-          listOf(),
+          cmmsMeasurementConsumerId = MEASUREMENT_CONSUMER_KEYS.first().measurementConsumerId,
+          timeIntervals = listOf(interval),
+          reportingSetId = targetReportingSet.resourceId,
+          reportingMetrics = initialReportingMetrics,
+          groupings = listOf(),
+          filter = null,
         )
 
       whenever(
@@ -734,6 +740,7 @@ class ReportsServiceTest {
     runBlocking {
       val displayName = DISPLAY_NAME
       val targetReportingSet = PRIMITIVE_REPORTING_SETS.first()
+      val filter = "device == MOBILE"
 
       // Metric specs
       val metricSpecs = listOf(REACH_METRIC_SPEC, FREQUENCY_HISTOGRAM_METRIC_SPEC)
@@ -828,11 +835,12 @@ class ReportsServiceTest {
 
       val (internalRequestingReport, internalInitialReport, internalPendingReport) =
         buildInternalReports(
-          MEASUREMENT_CONSUMER_KEYS.first().measurementConsumerId,
-          intervals,
-          targetReportingSet.resourceId,
-          initialReportingMetrics,
-          internalGroupings,
+          cmmsMeasurementConsumerId = MEASUREMENT_CONSUMER_KEYS.first().measurementConsumerId,
+          timeIntervals = intervals,
+          reportingSetId = targetReportingSet.resourceId,
+          reportingMetrics = initialReportingMetrics,
+          groupings = internalGroupings,
+          filter = filter,
         )
 
       whenever(
@@ -866,6 +874,7 @@ class ReportsServiceTest {
             timeInterval = metricConfig.timeInterval
             metricSpec = metricConfig.metricSpec
             filters += metricConfig.filters
+            filters += filter
           }
         }
 
@@ -899,6 +908,7 @@ class ReportsServiceTest {
                     this.displayName = displayName
                     this.metricSpecs += metricSpecs
                     this.groupings += groupings
+                    this.filter = filter
                     cumulative = false
                   }
               }
@@ -973,11 +983,12 @@ class ReportsServiceTest {
           val initialReportingMetrics = listOf(reportingMetric)
           reportingMetricEntries.putAll(
             buildInternalReportingMetricEntryWithOneMetricCalculationSpec(
-              reportingSet.resourceId,
-              initialReportingMetrics,
-              reportingSet.name + displayName,
-              listOf(),
-              false
+              reportingSetId = reportingSet.resourceId,
+              reportingMetrics = initialReportingMetrics,
+              displayName = reportingSet.name + displayName,
+              groupings = listOf(),
+              filter = null,
+              cumulative = false
             )
           )
         }
@@ -991,16 +1002,17 @@ class ReportsServiceTest {
 
           var requestId = 0
           reportingSetToCreateMetricRequestMap.map { (reportingSet, createMetricRequest) ->
-            val updatedReportingCreateMetricRequests =
+            val updatedReportingMetrics =
               listOf(createMetricRequest.copy { this.createMetricRequestId = requestId.toString() })
             requestId++
             reportingMetricEntries.putAll(
               buildInternalReportingMetricEntryWithOneMetricCalculationSpec(
-                reportingSet.resourceId,
-                updatedReportingCreateMetricRequests,
-                reportingSet.name + displayName,
-                listOf(),
-                false
+                reportingSetId = reportingSet.resourceId,
+                reportingMetrics = updatedReportingMetrics,
+                displayName = reportingSet.name + displayName,
+                groupings = listOf(),
+                filter = null,
+                cumulative = false
               )
             )
           }
@@ -1012,7 +1024,7 @@ class ReportsServiceTest {
 
           var requestId = 0
           reportingSetToCreateMetricRequestMap.map { (reportingSet, createMetricRequest) ->
-            val updatedReportingCreateMetricRequests =
+            val updatedReportingMetrics =
               listOf(
                 createMetricRequest.copy {
                   this.createMetricRequestId = requestId.toString()
@@ -1022,11 +1034,12 @@ class ReportsServiceTest {
             requestId++
             reportingMetricEntries.putAll(
               buildInternalReportingMetricEntryWithOneMetricCalculationSpec(
-                reportingSet.resourceId,
-                updatedReportingCreateMetricRequests,
-                reportingSet.name + displayName,
-                listOf(),
-                false
+                reportingSetId = reportingSet.resourceId,
+                reportingMetrics = updatedReportingMetrics,
+                displayName = reportingSet.name + displayName,
+                groupings = listOf(),
+                filter = null,
+                cumulative = false
               )
             )
           }
@@ -1368,7 +1381,7 @@ class ReportsServiceTest {
           }
         }
 
-      val reportingCreateMetricRequests =
+      val reportingMetrics =
         intervals.map { timeInterval ->
           buildInitialReportingMetric(
             PRIMITIVE_REPORTING_SETS.first().resourceId,
@@ -1389,11 +1402,12 @@ class ReportsServiceTest {
 
         reportingMetricEntries.putAll(
           buildInternalReportingMetricEntryWithOneMetricCalculationSpec(
-            PRIMITIVE_REPORTING_SETS.first().resourceId,
-            reportingCreateMetricRequests,
-            DISPLAY_NAME,
-            listOf(),
-            true
+            reportingSetId = PRIMITIVE_REPORTING_SETS.first().resourceId,
+            reportingMetrics = reportingMetrics,
+            displayName = DISPLAY_NAME,
+            groupings = listOf(),
+            filter = null,
+            cumulative = true
           )
         )
       }
@@ -1403,26 +1417,27 @@ class ReportsServiceTest {
           externalReportId = "report-id"
           createTime = Instant.now().toProtoTime()
 
-          val updatedReportingCreateMetricRequests =
-            reportingCreateMetricRequests.mapIndexed { requestId, request ->
+          val updatedReportingMetrics =
+            reportingMetrics.mapIndexed { requestId, request ->
               request.copy { this.createMetricRequestId = requestId.toString() }
             }
 
           reportingMetricEntries.putAll(
             buildInternalReportingMetricEntryWithOneMetricCalculationSpec(
-              PRIMITIVE_REPORTING_SETS.first().resourceId,
-              updatedReportingCreateMetricRequests,
-              DISPLAY_NAME,
-              listOf(),
-              true
+              reportingSetId = PRIMITIVE_REPORTING_SETS.first().resourceId,
+              reportingMetrics = updatedReportingMetrics,
+              displayName = DISPLAY_NAME,
+              groupings = listOf(),
+              filter = null,
+              cumulative = true
             )
           )
         }
 
       val internalPendingReport =
         internalInitialReport.copy {
-          val updatedReportingCreateMetricRequests =
-            reportingCreateMetricRequests.mapIndexed { requestId, request ->
+          val updatedReportingMetrics =
+            reportingMetrics.mapIndexed { requestId, request ->
               request.copy {
                 this.createMetricRequestId = requestId.toString()
                 externalMetricId = ExternalId(REACH_METRIC_ID_BASE_LONG + requestId).apiId.value
@@ -1431,11 +1446,12 @@ class ReportsServiceTest {
 
           reportingMetricEntries.putAll(
             buildInternalReportingMetricEntryWithOneMetricCalculationSpec(
-              PRIMITIVE_REPORTING_SETS.first().resourceId,
-              updatedReportingCreateMetricRequests,
-              DISPLAY_NAME,
-              listOf(),
-              true
+              reportingSetId = PRIMITIVE_REPORTING_SETS.first().resourceId,
+              reportingMetrics = updatedReportingMetrics,
+              displayName = DISPLAY_NAME,
+              groupings = listOf(),
+              filter = null,
+              cumulative = true
             )
           )
         }
@@ -2375,7 +2391,7 @@ class ReportsServiceTest {
         }
       }
 
-    val reportingCreateMetricRequests =
+    val reportingMetrics =
       intervals.map { timeInterval ->
         buildInitialReportingMetric(
           PRIMITIVE_REPORTING_SETS.first().resourceId,
@@ -2397,8 +2413,8 @@ class ReportsServiceTest {
       externalReportId = "report-id"
       createTime = Instant.now().toProtoTime()
 
-      val updatedReportingCreateMetricRequests =
-        reportingCreateMetricRequests.mapIndexed { requestId, request ->
+      val updatedReportingMetrics =
+        reportingMetrics.mapIndexed { requestId, request ->
           request.copy {
             this.createMetricRequestId = requestId.toString()
             externalMetricId = ExternalId(REACH_METRIC_ID_BASE_LONG + requestId).apiId.value
@@ -2407,11 +2423,12 @@ class ReportsServiceTest {
 
       reportingMetricEntries.putAll(
         buildInternalReportingMetricEntryWithOneMetricCalculationSpec(
-          PRIMITIVE_REPORTING_SETS.first().resourceId,
-          updatedReportingCreateMetricRequests,
-          DISPLAY_NAME,
-          listOf(),
-          true
+          reportingSetId = PRIMITIVE_REPORTING_SETS.first().resourceId,
+          reportingMetrics = updatedReportingMetrics,
+          displayName = DISPLAY_NAME,
+          groupings = listOf(),
+          filter = null,
+          cumulative = true
         )
       )
     }
@@ -3018,7 +3035,7 @@ class ReportsServiceTest {
       reportingSetId: String,
       timeInterval: Interval,
       metricSpec: InternalMetricSpec,
-      filters: List<String>,
+      groupingPredicates: List<String>,
     ): InternalReport.ReportingMetric {
       return InternalReportKt.reportingMetric {
         details =
@@ -3026,7 +3043,7 @@ class ReportsServiceTest {
             this.externalReportingSetId = reportingSetId
             this.metricSpec = metricSpec
             this.timeInterval = timeInterval
-            this.filters += filters
+            this.groupingPredicates += groupingPredicates
           }
       }
     }
@@ -3036,6 +3053,7 @@ class ReportsServiceTest {
       reportingMetrics: List<InternalReport.ReportingMetric>,
       displayName: String,
       groupings: List<InternalReport.MetricCalculationSpec.Grouping>,
+      filter: String?,
       cumulative: Boolean,
     ): Map<String, InternalReport.ReportingMetricCalculationSpec> {
       return mapOf(
@@ -3049,6 +3067,9 @@ class ReportsServiceTest {
                     this.displayName = displayName
                     metricSpecs += reportingMetrics.map { it.details.metricSpec }.distinct()
                     this.groupings += groupings
+                    if (filter != null) {
+                      this.filter = filter
+                    }
                     this.cumulative = cumulative
                   }
               }
@@ -3062,6 +3083,7 @@ class ReportsServiceTest {
       reportingSetId: String,
       reportingMetrics: List<InternalReport.ReportingMetric>,
       groupings: List<InternalReport.MetricCalculationSpec.Grouping>,
+      filter: String?,
       reportIdBase: String = "",
       metricIdBaseLong: Long = REACH_METRIC_ID_BASE_LONG
     ): InternalReports {
@@ -3072,11 +3094,12 @@ class ReportsServiceTest {
 
         reportingMetricEntries.putAll(
           buildInternalReportingMetricEntryWithOneMetricCalculationSpec(
-            reportingSetId,
-            reportingMetrics,
-            DISPLAY_NAME,
-            groupings,
-            false
+            reportingSetId = reportingSetId,
+            reportingMetrics = reportingMetrics,
+            displayName = DISPLAY_NAME,
+            groupings = groupings,
+            filter = filter,
+            cumulative = false
           )
         )
       }
@@ -3085,7 +3108,7 @@ class ReportsServiceTest {
           externalReportId = reportIdBase + "report-id"
           createTime = Instant.now().toProtoTime()
 
-          val reportingCreateMetricRequests =
+          val initialReportingMetrics =
             reportingMetrics.mapIndexed { requestId, request ->
               request.copy {
                 createMetricRequestId = ExternalId(metricIdBaseLong + requestId).apiId.value
@@ -3094,17 +3117,18 @@ class ReportsServiceTest {
 
           reportingMetricEntries.putAll(
             buildInternalReportingMetricEntryWithOneMetricCalculationSpec(
-              reportingSetId,
-              reportingCreateMetricRequests,
-              DISPLAY_NAME,
-              groupings,
-              false
+              reportingSetId = reportingSetId,
+              reportingMetrics = initialReportingMetrics,
+              displayName = DISPLAY_NAME,
+              groupings = groupings,
+              filter = filter,
+              cumulative = false
             )
           )
         }
       val internalPendingReport =
         internalInitialReport.copy {
-          val reportingCreateMetricRequests =
+          val pendingReportingMetrics =
             reportingMetrics.mapIndexed { requestId, request ->
               request.copy {
                 createMetricRequestId = ExternalId(metricIdBaseLong + requestId).apiId.value
@@ -3114,11 +3138,12 @@ class ReportsServiceTest {
 
           reportingMetricEntries.putAll(
             buildInternalReportingMetricEntryWithOneMetricCalculationSpec(
-              reportingSetId,
-              reportingCreateMetricRequests,
-              DISPLAY_NAME,
-              groupings,
-              false
+              reportingSetId = reportingSetId,
+              reportingMetrics = pendingReportingMetrics,
+              displayName = DISPLAY_NAME,
+              groupings = groupings,
+              filter = filter,
+              cumulative = false
             )
           )
         }
@@ -3396,17 +3421,19 @@ class ReportsServiceTest {
 
     private val INTERNAL_REACH_REPORTS =
       buildInternalReports(
-        MEASUREMENT_CONSUMER_KEYS.first().measurementConsumerId,
-        listOf(
-          interval {
-            startTime = START_TIME
-            endTime = END_TIME
-          }
-        ),
-        PRIMITIVE_REPORTING_SETS.first().resourceId,
-        listOf(INITIAL_REACH_REPORTING_METRIC),
-        listOf(),
-        "reach-"
+        cmmsMeasurementConsumerId = MEASUREMENT_CONSUMER_KEYS.first().measurementConsumerId,
+        timeIntervals =
+          listOf(
+            interval {
+              startTime = START_TIME
+              endTime = END_TIME
+            }
+          ),
+        reportingSetId = PRIMITIVE_REPORTING_SETS.first().resourceId,
+        reportingMetrics = listOf(INITIAL_REACH_REPORTING_METRIC),
+        groupings = listOf(),
+        filter = null,
+        reportIdBase = "reach-"
       )
 
     private val INITIAL_WATCH_DURATION_REPORTING_METRIC =
@@ -3421,17 +3448,19 @@ class ReportsServiceTest {
       )
     private val INTERNAL_WATCH_DURATION_REPORTS =
       buildInternalReports(
-        MEASUREMENT_CONSUMER_KEYS.first().measurementConsumerId,
-        listOf(
-          interval {
-            startTime = START_TIME
-            endTime = END_TIME
-          }
-        ),
-        PRIMITIVE_REPORTING_SETS.first().resourceId,
-        listOf(INITIAL_WATCH_DURATION_REPORTING_METRIC),
-        listOf(),
-        "duration-",
+        cmmsMeasurementConsumerId = MEASUREMENT_CONSUMER_KEYS.first().measurementConsumerId,
+        timeIntervals =
+          listOf(
+            interval {
+              startTime = START_TIME
+              endTime = END_TIME
+            }
+          ),
+        reportingSetId = PRIMITIVE_REPORTING_SETS.first().resourceId,
+        reportingMetrics = listOf(INITIAL_WATCH_DURATION_REPORTING_METRIC),
+        groupings = listOf(),
+        filter = null,
+        reportIdBase = "duration-",
         metricIdBaseLong = WATCH_DURATION_METRIC_ID_BASE_LONG
       )
 


### PR DESCRIPTION
An addition filter was added to `MetricCalculationSpec` in #1250.  This PR further added the filter to `MetricCalculationResult` and implements the API changes.
