### PR TITLE
Do not assume that base branch is always `main` when waiting for build.

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -31,22 +31,22 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  wait-for-main:
-    name: Wait for main branch build
+  wait-for-base:
+    name: Wait for base branch build
     runs-on: ubuntu-latest
     steps:
       # This is run in a separate job to avoid invalidating the build cache.
       - uses: lewagon/wait-on-check-action@v1.3.1
         if: github.event_name == 'pull_request'
         with:
-          ref: main
+          ref: ${{ github.base_ref }}
           check-name: Build and test
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           wait-interval: 90
   build-test:
     name: Build and test
     runs-on: ubuntu-20.04
-    needs: wait-for-main
+    needs: wait-for-base
     env:
       CLUSTER_LOGS_PATH: cluster-logs
     steps:


### PR DESCRIPTION
This fixes PRs based on release branches waiting for `main` instead of the release branch.