### PR TITLE
Add reporting set tags

### DIFF
--- a/src/main/kotlin/org/wfanet/measurement/reporting/deploy/v2/postgres/readers/ReportingSetReader.kt
+++ b/src/main/kotlin/org/wfanet/measurement/reporting/deploy/v2/postgres/readers/ReportingSetReader.kt
@@ -59,6 +59,7 @@ class ReportingSetReader(private val readContext: ReadContext) {
     val setExpressionInfoMap: MutableMap<InternalId, SetExpressionInfo>,
     // Key is weightedSubsetUnionId.
     val weightedSubsetUnionInfoMap: MutableMap<InternalId, WeightedSubsetUnionInfo>,
+    val details: ReportingSet.Details
   )
 
   private data class SetExpressionInfo(
@@ -96,6 +97,7 @@ class ReportingSetReader(private val readContext: ReadContext) {
       ReportingSets.SetExpressionId AS RootSetExpressionId,
       ReportingSets.DisplayName,
       ReportingSets.Filter AS ReportingSetFilter,
+      ReportingSets.ReportingSetDetails,
       WeightedSubsetUnionId,
       WeightedSubsetUnions.Weight,
       WeightedSubsetUnions.BinaryRepresentation,
@@ -248,6 +250,9 @@ class ReportingSetReader(private val readContext: ReadContext) {
       if (!reportingSetInfo.filter.isNullOrBlank()) {
         filter = reportingSetInfo.filter
       }
+      if (reportingSetInfo.details != ReportingSet.Details.getDefaultInstance()) {
+        details = reportingSetInfo.details
+      }
 
       if (reportingSetInfo.cmmsEventGroupIdsSet.size > 0) {
         primitive =
@@ -325,6 +330,8 @@ class ReportingSetReader(private val readContext: ReadContext) {
       val leftHandExternalReportingSetId: String? = row["LeftHandExternalReportingSetId"]
       val rightHandSetExpressionId: InternalId? = row["RightHandSetExpressionId"]
       val rightHandExternalReportingSetId: String? = row["RightHandExternalReportingSetId"]
+      val reportingSetDetails: ReportingSet.Details =
+        row.getProtoMessage("ReportingSetDetails", ReportingSet.Details.parser())
 
       val reportingSetInfo =
         reportingSetInfoMap.computeIfAbsent(externalReportingSetId) {
@@ -339,6 +346,7 @@ class ReportingSetReader(private val readContext: ReadContext) {
             cmmsEventGroupIdsSet = mutableSetOf(),
             setExpressionInfoMap = mutableMapOf(),
             weightedSubsetUnionInfoMap = mutableMapOf(),
+            reportingSetDetails
           )
         }
 

--- a/src/main/kotlin/org/wfanet/measurement/reporting/deploy/v2/postgres/writers/CreateReportingSet.kt
+++ b/src/main/kotlin/org/wfanet/measurement/reporting/deploy/v2/postgres/writers/CreateReportingSet.kt
@@ -22,6 +22,7 @@ import org.wfanet.measurement.common.db.r2dbc.BoundStatement
 import org.wfanet.measurement.common.db.r2dbc.boundStatement
 import org.wfanet.measurement.common.db.r2dbc.postgres.PostgresWriter
 import org.wfanet.measurement.common.identity.InternalId
+import org.wfanet.measurement.common.toJson
 import org.wfanet.measurement.internal.reporting.v2.CreateReportingSetRequest
 import org.wfanet.measurement.internal.reporting.v2.ReportingSet
 import org.wfanet.measurement.internal.reporting.v2.ReportingSet.PrimitiveReportingSetBasis
@@ -68,8 +69,17 @@ class CreateReportingSet(private val request: CreateReportingSetRequest) :
     val statement =
       boundStatement(
         """
-      INSERT INTO ReportingSets (MeasurementConsumerId, ReportingSetId, ExternalReportingSetId, DisplayName, Filter)
-        VALUES ($1, $2, $3, $4, $5)
+      INSERT INTO ReportingSets
+        (
+          MeasurementConsumerId,
+          ReportingSetId,
+          ExternalReportingSetId,
+          DisplayName,
+          Filter,
+          ReportingSetDetails,
+          ReportingSetDetailsJson
+        )
+        VALUES ($1, $2, $3, $4, $5, $6, $7)
       """
       ) {
         bind("$1", measurementConsumerId)
@@ -77,6 +87,8 @@ class CreateReportingSet(private val request: CreateReportingSetRequest) :
         bind("$3", externalReportingSetId)
         bind("$4", request.reportingSet.displayName)
         bind("$5", request.reportingSet.filter)
+        bind("$6", request.reportingSet.details)
+        bind("$7", request.reportingSet.details.toJson())
       }
 
     try {

--- a/src/main/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/ProtoConversions.kt
+++ b/src/main/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/ProtoConversions.kt
@@ -568,6 +568,7 @@ fun InternalReportingSet.toReportingSet(): ReportingSet {
         .toName()
 
     displayName = source.displayName
+    tags.putAll(source.details.tagsMap)
     filter = source.filter
 
     @Suppress("WHEN_ENUM_CAN_BE_NULL_IN_JAVA")

--- a/src/main/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/ReportingSetsService.kt
+++ b/src/main/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/ReportingSetsService.kt
@@ -354,6 +354,8 @@ class ReportingSetsService(private val internalReportingSetsStub: ReportingSetsC
         filter = source.reportingSet.filter
       }
 
+      details = InternalReportingSetKt.details { tags.putAll(source.reportingSet.tagsMap) }
+
       @Suppress("WHEN_ENUM_CAN_BE_NULL_IN_JAVA")
       when (source.reportingSet.valueCase) {
         ReportingSet.ValueCase.PRIMITIVE -> {

--- a/src/main/kotlin/org/wfanet/measurement/reporting/service/internal/testing/v2/ReportingSetsServiceTest.kt
+++ b/src/main/kotlin/org/wfanet/measurement/reporting/service/internal/testing/v2/ReportingSetsServiceTest.kt
@@ -94,6 +94,8 @@ abstract class ReportingSetsServiceTest<T : ReportingSetsCoroutineImplBase> {
               cmmsEventGroupId = "2236"
             }
         }
+
+      details = ReportingSetKt.details { tags.putAll(REPORTING_SET_TAGS) }
     }
 
     val createdReportingSet =
@@ -150,6 +152,7 @@ abstract class ReportingSetsServiceTest<T : ReportingSetsCoroutineImplBase> {
               cmmsEventGroupId = "2236"
             }
         }
+      details = ReportingSetKt.details { tags.putAll(REPORTING_SET_TAGS) }
     }
 
     val createdReportingSet =
@@ -194,6 +197,7 @@ abstract class ReportingSetsServiceTest<T : ReportingSetsCoroutineImplBase> {
               cmmsEventGroupId = "1236"
             }
         }
+      details = ReportingSetKt.details { tags.putAll(REPORTING_SET_TAGS) }
     }
 
     val reportingSet2 = reportingSet {
@@ -209,6 +213,7 @@ abstract class ReportingSetsServiceTest<T : ReportingSetsCoroutineImplBase> {
               cmmsEventGroupId = "1236"
             }
         }
+      details = ReportingSetKt.details { tags.putAll(REPORTING_SET_TAGS) }
     }
 
     service.createReportingSet(
@@ -325,6 +330,7 @@ abstract class ReportingSetsServiceTest<T : ReportingSetsCoroutineImplBase> {
           binaryRepresentation = 1
           weight = 6
         }
+      details = ReportingSetKt.details { tags.putAll(REPORTING_SET_TAGS) }
     }
 
     val createdReportingSet =
@@ -491,6 +497,7 @@ abstract class ReportingSetsServiceTest<T : ReportingSetsCoroutineImplBase> {
               filters += "filter2"
             }
         }
+      details = ReportingSetKt.details { tags.putAll(REPORTING_SET_TAGS) }
     }
 
     val createdOuterCompositeReportingSet =
@@ -528,6 +535,7 @@ abstract class ReportingSetsServiceTest<T : ReportingSetsCoroutineImplBase> {
               cmmsEventGroupId = "2236"
             }
         }
+      details = ReportingSetKt.details { tags.putAll(REPORTING_SET_TAGS) }
     }
 
     val createdReportingSet =
@@ -630,6 +638,7 @@ abstract class ReportingSetsServiceTest<T : ReportingSetsCoroutineImplBase> {
             }
           weight = 6
         }
+      details = ReportingSetKt.details { tags.putAll(REPORTING_SET_TAGS) }
     }
 
     val createdReportingSet =
@@ -1026,6 +1035,7 @@ abstract class ReportingSetsServiceTest<T : ReportingSetsCoroutineImplBase> {
               cmmsEventGroupId = "2236"
             }
         }
+      details = ReportingSetKt.details { tags.putAll(REPORTING_SET_TAGS) }
     }
 
     val createdReportingSet =
@@ -1160,6 +1170,7 @@ abstract class ReportingSetsServiceTest<T : ReportingSetsCoroutineImplBase> {
             }
           weight = 6
         }
+      details = ReportingSetKt.details { tags.putAll(REPORTING_SET_TAGS) }
     }
 
     val createdReportingSet =
@@ -1285,6 +1296,7 @@ abstract class ReportingSetsServiceTest<T : ReportingSetsCoroutineImplBase> {
               }
             weight = 6
           }
+        details = ReportingSetKt.details { tags.putAll(REPORTING_SET_TAGS) }
       }
 
       val createdReportingSet =
@@ -1349,6 +1361,7 @@ abstract class ReportingSetsServiceTest<T : ReportingSetsCoroutineImplBase> {
               cmmsEventGroupId = "1236"
             }
         }
+      details = ReportingSetKt.details { tags.putAll(REPORTING_SET_TAGS) }
     }
 
     val createdPrimitiveReportingSet =
@@ -1436,6 +1449,7 @@ abstract class ReportingSetsServiceTest<T : ReportingSetsCoroutineImplBase> {
                 cmmsEventGroupId = "1236"
               }
           }
+        details = ReportingSetKt.details { tags.putAll(REPORTING_SET_TAGS) }
       }
 
       val createdReportingSet =
@@ -1552,6 +1566,7 @@ abstract class ReportingSetsServiceTest<T : ReportingSetsCoroutineImplBase> {
               cmmsEventGroupId = "1236"
             }
         }
+      details = ReportingSetKt.details { tags.putAll(REPORTING_SET_TAGS) }
     }
 
     val reportingSet2 = reportingSet {
@@ -1642,6 +1657,7 @@ abstract class ReportingSetsServiceTest<T : ReportingSetsCoroutineImplBase> {
                     cmmsEventGroupId = "2236"
                   }
               }
+            details = ReportingSetKt.details { tags.putAll(REPORTING_SET_TAGS) }
           }
         }
       )
@@ -1668,6 +1684,7 @@ abstract class ReportingSetsServiceTest<T : ReportingSetsCoroutineImplBase> {
                     cmmsEventGroupId = "2236"
                   }
               }
+            details = ReportingSetKt.details { tags.putAll(REPORTING_SET_TAGS) }
           }
         }
       )
@@ -1716,6 +1733,7 @@ abstract class ReportingSetsServiceTest<T : ReportingSetsCoroutineImplBase> {
                     cmmsEventGroupId = "2236"
                   }
               }
+            details = ReportingSetKt.details { tags.putAll(REPORTING_SET_TAGS) }
           }
         }
       )
@@ -1741,6 +1759,7 @@ abstract class ReportingSetsServiceTest<T : ReportingSetsCoroutineImplBase> {
                   cmmsEventGroupId = "2236"
                 }
             }
+          details = ReportingSetKt.details { tags.putAll(REPORTING_SET_TAGS) }
         }
       }
     )
@@ -1790,5 +1809,9 @@ abstract class ReportingSetsServiceTest<T : ReportingSetsCoroutineImplBase> {
       }
 
     assertThat(exception.status.code).isEqualTo(Status.Code.INVALID_ARGUMENT)
+  }
+
+  companion object {
+    private val REPORTING_SET_TAGS = mapOf("tag1" to "tag_value1", "tag2" to "tag_value2")
   }
 }

--- a/src/main/proto/wfa/measurement/internal/reporting/v2/reporting_set.proto
+++ b/src/main/proto/wfa/measurement/internal/reporting/v2/reporting_set.proto
@@ -74,4 +74,11 @@ message ReportingSet {
     int32 binary_representation = 3;
   }
   repeated WeightedSubsetUnion weighted_subset_unions = 7;
+
+  message Details {
+    // A map of arbitrary key-value pairs to support tagging of ReportingSets
+    // for upstream use by UIs and other rich clients.
+    map<string, string> tags = 1;
+  }
+  Details details = 8;
 }

--- a/src/main/resources/reporting/postgres/add-details-column-to-reporting-sets.sql
+++ b/src/main/resources/reporting/postgres/add-details-column-to-reporting-sets.sql
@@ -1,0 +1,52 @@
+-- liquibase formatted sql
+
+-- Copyright 2023 The Cross-Media Measurement Authors
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--      http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+-- Postgres database schema for the Reporting server.
+--
+-- Table hierarchy:
+--   Root
+--   └── MeasurementConsumers
+--       ├── EventGroups
+--       ├── ReportingSets
+--       │   ├── ReportingSetEventGroups
+--       │   ├── PrimitiveReportingSetBases
+--       │   │   └── PrimitiveReportingSetBasisFilters
+--       │   ├── SetExpressions
+--       │   └── WeightedSubsetUnions
+--       │       └── WeightedSubsetUnionPrimitiveReportingSetBases
+--       ├── Metrics
+--       │   └── MetricMeasurements
+--       ├── Measurements
+--       │   └── MeasurementPrimitiveReportingSetBases
+--       ├── Reports
+--       │    ├── ReportTimeIntervals
+--       │    └── MetricCalculationSpecs
+--       │        └── MetricCalculationSpecMetrics
+--       └── ReportSchedules
+--           ├── ReportScheduleIterations
+--           └── ReportSchedulesReports
+
+-- changeset riemanli:alter-reporting-sets-table dbms:postgresql
+ALTER TABLE ReportingSets
+  -- Serialized byte string of a proto3 protobuf with details about the
+  -- reporting set which do not need to be indexed by the database.
+  --
+  -- See wfa.measurement.internal.reporting.ReportingSet.Details protobuf message.
+  ADD ReportingSetDetails bytea NOT NULL,
+
+  -- Human-readable copy of the ReportingSetDetails column solely for debugging
+  -- purposes.
+  ADD ReportingSetDetailsJson text NOT NULL

--- a/src/main/resources/reporting/postgres/changelog-v2.yaml
+++ b/src/main/resources/reporting/postgres/changelog-v2.yaml
@@ -31,3 +31,6 @@ databaseChangeLog:
 - include:
     file: add-details-column-to-reports.sql
     relativeToChangeLogFile: true
+- include:
+    file: add-details-column-to-reporting-sets.sql
+    relativeToChangeLogFile: true

--- a/src/test/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/ReportingSetsServiceTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/ReportingSetsServiceTest.kt
@@ -1042,6 +1042,8 @@ class ReportingSetsServiceTest {
               weight = 1
               binaryRepresentation = 1
             }
+          details =
+            InternalReportingSetKt.details { tags.put("name", "PRIMITIVE_REPORTING_SETS$it") }
         }
       }
 
@@ -1077,12 +1079,14 @@ class ReportingSetsServiceTest {
           weight = 1
           binaryRepresentation = 3
         }
+      details = InternalReportingSetKt.details { tags.put("name", "COMPOSITE_REPORTING_SET") }
     }
 
     private val INTERNAL_COMPOSITE_REPORTING_SET2: InternalReportingSet =
       INTERNAL_COMPOSITE_REPORTING_SET.copy {
         externalReportingSetId += "2"
         displayName = "composite_reporting_set_display_name2"
+        details = InternalReportingSetKt.details { tags.put("name", "COMPOSITE_REPORTING_SET2") }
       }
 
     private val INTERNAL_ROOT_COMPOSITE_REPORTING_SET: InternalReportingSet = internalReportingSet {
@@ -1153,6 +1157,7 @@ class ReportingSetsServiceTest {
           weight = -1
           binaryRepresentation = 6
         }
+      details = InternalReportingSetKt.details { tags.put("name", "ROOT_COMPOSITE_REPORTING_SET") }
     }
 
     // Reporting sets
@@ -1162,6 +1167,7 @@ class ReportingSetsServiceTest {
           name = internalReportingSet.resourceName
           filter = internalReportingSet.filter
           displayName = internalReportingSet.displayName
+          tags.putAll(internalReportingSet.details.tagsMap)
           primitive =
             ReportingSetKt.primitive {
               cmmsEventGroups +=
@@ -1176,6 +1182,7 @@ class ReportingSetsServiceTest {
       name = INTERNAL_ROOT_COMPOSITE_REPORTING_SET.resourceName
       filter = INTERNAL_ROOT_COMPOSITE_REPORTING_SET.filter
       displayName = INTERNAL_ROOT_COMPOSITE_REPORTING_SET.displayName
+      tags.putAll(INTERNAL_ROOT_COMPOSITE_REPORTING_SET.details.tagsMap)
       composite =
         ReportingSetKt.composite {
           expression =


### PR DESCRIPTION
This PR implements the tags field which was added to `ReportingSet` in #1251. A change to the DB schema is needed.