### PR TITLE
Fix internal DeleteEventGroup not clearing details.

### DIFF
--- a/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/writers/DeleteEventGroup.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/writers/DeleteEventGroup.kt
@@ -58,15 +58,15 @@ class DeleteEventGroup(private val request: DeleteEventGroupRequest) :
       set("EventGroupId" to result.internalEventGroupId.value)
       set("MeasurementConsumerCertificateId" to null as Long?)
       set("UpdateTime" to Value.COMMIT_TIMESTAMP)
-      set("EventGroupDetails" to EventGroup.Details.getDefaultInstance())
-      setJson("EventGroupDetailsJson" to EventGroup.Details.getDefaultInstance())
+      set("EventGroupDetails" to null as EventGroup.Details?)
+      setJson("EventGroupDetailsJson" to null as EventGroup.Details?)
       set("State" to EventGroup.State.DELETED)
     }
 
     return result.eventGroup.copy {
       this.externalMeasurementConsumerCertificateId = 0L
-      this.details = EventGroup.Details.getDefaultInstance()
       this.state = EventGroup.State.DELETED
+      clearDetails()
     }
   }
 

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/service/internal/testing/EventGroupsServiceTest.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/service/internal/testing/EventGroupsServiceTest.kt
@@ -889,8 +889,8 @@ abstract class EventGroupsServiceTest<T : EventGroupsCoroutineImplBase> {
         eventGroup.copy {
           this.externalMeasurementConsumerCertificateId = 0L
           this.updateTime = response.updateTime
-          this.details = EventGroup.Details.getDefaultInstance()
           this.state = EventGroup.State.DELETED
+          clearDetails()
         }
       )
     assertThat(response)
@@ -996,11 +996,9 @@ abstract class EventGroupsServiceTest<T : EventGroupsCoroutineImplBase> {
       population
         .createMeasurementConsumer(measurementConsumersService, accountsService)
         .externalMeasurementConsumerId
-
     val externalDataProviderId =
       population.createDataProvider(dataProvidersService).externalDataProviderId
-
-    val createdEventGroup =
+    val eventGroup =
       eventGroupsService.createEventGroup(
         createEventGroupRequest {
           eventGroup = eventGroup {
@@ -1009,24 +1007,23 @@ abstract class EventGroupsServiceTest<T : EventGroupsCoroutineImplBase> {
           }
         }
       )
-
-    val deletedEventGroup =
+    val deletedEventGroup: EventGroup =
       eventGroupsService.deleteEventGroup(
         deleteEventGroupRequest {
           this.externalDataProviderId = externalDataProviderId
-          this.externalEventGroupId = createdEventGroup.externalEventGroupId
+          this.externalEventGroupId = eventGroup.externalEventGroupId
         }
       )
 
-    val readEventGroup =
+    val response: EventGroup =
       eventGroupsService.getEventGroup(
         getEventGroupRequest {
           this.externalDataProviderId = externalDataProviderId
-          this.externalEventGroupId = createdEventGroup.externalEventGroupId
+          this.externalEventGroupId = eventGroup.externalEventGroupId
         }
       )
 
-    assertThat(readEventGroup).isEqualTo(deletedEventGroup)
+    assertThat(response).isEqualTo(deletedEventGroup)
   }
 
   @Test


### PR DESCRIPTION
The EventGroupDetails column in the EventGroups table is nullable, and GetEventGroup correctly handles the null case by not having the details field set in the EventGroup message. DeleteEventGroup was incorrectly setting both the column and the response value to an empty EventGroup.Details.