### PR TITLE
Improve Performance of Measurement Creation in Create Report

### DIFF
--- a/src/main/kotlin/org/wfanet/measurement/reporting/deploy/postgres/PostgresMeasurementsService.kt
+++ b/src/main/kotlin/org/wfanet/measurement/reporting/deploy/postgres/PostgresMeasurementsService.kt
@@ -30,7 +30,6 @@ import org.wfanet.measurement.reporting.deploy.postgres.readers.MeasurementReade
 import org.wfanet.measurement.reporting.deploy.postgres.writers.CreateMeasurements
 import org.wfanet.measurement.reporting.deploy.postgres.writers.SetMeasurementFailure
 import org.wfanet.measurement.reporting.deploy.postgres.writers.SetMeasurementResult
-import org.wfanet.measurement.reporting.service.internal.MeasurementAlreadyExistsException
 import org.wfanet.measurement.reporting.service.internal.MeasurementNotFoundException
 import org.wfanet.measurement.reporting.service.internal.MeasurementStateInvalidException
 
@@ -38,7 +37,9 @@ class PostgresMeasurementsService(
   private val idGenerator: IdGenerator,
   private val client: DatabaseClient,
 ) : MeasurementsCoroutineImplBase() {
-  override suspend fun batchCreateMeasurements(request: BatchCreateMeasurementsRequest): BatchCreateMeasurementsResponse {
+  override suspend fun batchCreateMeasurements(
+    request: BatchCreateMeasurementsRequest
+  ): BatchCreateMeasurementsResponse {
     return batchCreateMeasurementsResponse {
       measurements += CreateMeasurements(request.measurementsList).execute(client, idGenerator)
     }

--- a/src/main/kotlin/org/wfanet/measurement/reporting/deploy/postgres/PostgresMeasurementsService.kt
+++ b/src/main/kotlin/org/wfanet/measurement/reporting/deploy/postgres/PostgresMeasurementsService.kt
@@ -18,13 +18,16 @@ import io.grpc.Status
 import org.wfanet.measurement.common.db.r2dbc.DatabaseClient
 import org.wfanet.measurement.common.db.r2dbc.postgres.SerializableErrors
 import org.wfanet.measurement.common.identity.IdGenerator
+import org.wfanet.measurement.internal.reporting.BatchCreateMeasurementsRequest
+import org.wfanet.measurement.internal.reporting.BatchCreateMeasurementsResponse
 import org.wfanet.measurement.internal.reporting.GetMeasurementRequest
 import org.wfanet.measurement.internal.reporting.Measurement
 import org.wfanet.measurement.internal.reporting.MeasurementsGrpcKt.MeasurementsCoroutineImplBase
 import org.wfanet.measurement.internal.reporting.SetMeasurementFailureRequest
 import org.wfanet.measurement.internal.reporting.SetMeasurementResultRequest
+import org.wfanet.measurement.internal.reporting.batchCreateMeasurementsResponse
 import org.wfanet.measurement.reporting.deploy.postgres.readers.MeasurementReader
-import org.wfanet.measurement.reporting.deploy.postgres.writers.CreateMeasurement
+import org.wfanet.measurement.reporting.deploy.postgres.writers.CreateMeasurements
 import org.wfanet.measurement.reporting.deploy.postgres.writers.SetMeasurementFailure
 import org.wfanet.measurement.reporting.deploy.postgres.writers.SetMeasurementResult
 import org.wfanet.measurement.reporting.service.internal.MeasurementAlreadyExistsException
@@ -35,11 +38,9 @@ class PostgresMeasurementsService(
   private val idGenerator: IdGenerator,
   private val client: DatabaseClient,
 ) : MeasurementsCoroutineImplBase() {
-  override suspend fun createMeasurement(request: Measurement): Measurement {
-    return try {
-      CreateMeasurement(request).execute(client, idGenerator)
-    } catch (e: MeasurementAlreadyExistsException) {
-      throw e.asStatusRuntimeException(Status.Code.ALREADY_EXISTS, "Measurement already exists.")
+  override suspend fun batchCreateMeasurements(request: BatchCreateMeasurementsRequest): BatchCreateMeasurementsResponse {
+    return batchCreateMeasurementsResponse {
+      measurements += CreateMeasurements(request.measurementsList).execute(client, idGenerator)
     }
   }
 

--- a/src/main/kotlin/org/wfanet/measurement/reporting/deploy/postgres/writers/CreateMeasurements.kt
+++ b/src/main/kotlin/org/wfanet/measurement/reporting/deploy/postgres/writers/CreateMeasurements.kt
@@ -26,9 +26,9 @@ import org.wfanet.measurement.reporting.service.internal.MeasurementAlreadyExist
  * Throws the following on [execute]:
  * * [MeasurementAlreadyExistsException] Measurement already exists
  */
-class CreateMeasurements(private val measurements: Collection<Measurement>) :
-  PostgresWriter<Collection<Measurement>>() {
-  override suspend fun TransactionScope.runTransaction(): Collection<Measurement> {
+class CreateMeasurements(private val measurements: Iterable<Measurement>) :
+  PostgresWriter<Iterable<Measurement>>() {
+  override suspend fun TransactionScope.runTransaction(): Iterable<Measurement> {
     transactionContext.run {
       for (measurement in measurements) {
         val builder =

--- a/src/main/kotlin/org/wfanet/measurement/reporting/deploy/postgres/writers/CreateMeasurements.kt
+++ b/src/main/kotlin/org/wfanet/measurement/reporting/deploy/postgres/writers/CreateMeasurements.kt
@@ -27,7 +27,8 @@ import org.wfanet.measurement.reporting.service.internal.MeasurementAlreadyExist
  * Throws the following on [execute]:
  * * [MeasurementAlreadyExistsException] Measurement already exists
  */
-class CreateMeasurements(private val measurements: Collection<Measurement>) : PostgresWriter<Collection<Measurement>>() {
+class CreateMeasurements(private val measurements: Collection<Measurement>) :
+  PostgresWriter<Collection<Measurement>>() {
   override suspend fun TransactionScope.runTransaction(): Collection<Measurement> {
     transactionContext.run {
       for (measurement in measurements) {
@@ -44,9 +45,7 @@ class CreateMeasurements(private val measurements: Collection<Measurement>) : Po
             bind("$3", Measurement.State.PENDING_VALUE)
           }
 
-        try {
-          executeStatement(builder)
-        } catch (_: R2dbcDataIntegrityViolationException) { }
+        executeStatement(builder)
       }
     }
 

--- a/src/main/kotlin/org/wfanet/measurement/reporting/deploy/postgres/writers/CreateMeasurements.kt
+++ b/src/main/kotlin/org/wfanet/measurement/reporting/deploy/postgres/writers/CreateMeasurements.kt
@@ -14,7 +14,6 @@
 
 package org.wfanet.measurement.reporting.deploy.postgres.writers
 
-import io.r2dbc.spi.R2dbcDataIntegrityViolationException
 import org.wfanet.measurement.common.db.r2dbc.boundStatement
 import org.wfanet.measurement.common.db.r2dbc.postgres.PostgresWriter
 import org.wfanet.measurement.internal.reporting.Measurement

--- a/src/main/kotlin/org/wfanet/measurement/reporting/service/api/v1alpha/ReportsService.kt
+++ b/src/main/kotlin/org/wfanet/measurement/reporting/service/api/v1alpha/ReportsService.kt
@@ -243,7 +243,6 @@ class ReportsService(
   )
 
   override suspend fun createReport(request: CreateReportRequest): Report {
-    val now = System.currentTimeMillis()
     grpcRequireNotNull(MeasurementConsumerKey.fromName(request.parent)) {
       "Parent is either unspecified or invalid."
     }
@@ -328,7 +327,7 @@ class ReportsService(
         )
       }
 
-    val dataProviderNames = hashSetOf<String>()
+    val dataProviderNames = mutableSetOf<String>()
     for (internalReportingSet in internalReportingSetMap.values) {
       for (eventGroupKey in internalReportingSet.eventGroupKeysList) {
         dataProviderNames.add(DataProviderKey(eventGroupKey.dataProviderReferenceId).toName())
@@ -1116,7 +1115,7 @@ class ReportsService(
     apiAuthenticationKey: String,
     dataProviderNames: Collection<String>
   ): Map<String, DataProviderInfo> {
-    val dataProviderInfoMap = hashMapOf<String, DataProviderInfo>()
+    val dataProviderInfoMap = mutableMapOf<String, DataProviderInfo>()
 
     if (dataProviderNames.isEmpty()) {
       return dataProviderInfoMap

--- a/src/main/kotlin/org/wfanet/measurement/reporting/service/api/v1alpha/ReportsService.kt
+++ b/src/main/kotlin/org/wfanet/measurement/reporting/service/api/v1alpha/ReportsService.kt
@@ -134,6 +134,8 @@ import org.wfanet.measurement.internal.reporting.setMeasurementResultRequest as 
 import org.wfanet.measurement.internal.reporting.streamReportsRequest as streamInternalReportsRequest
 import org.wfanet.measurement.internal.reporting.timeInterval as internalTimeInterval
 import org.wfanet.measurement.internal.reporting.timeIntervals as internalTimeIntervals
+import org.wfanet.measurement.api.v2alpha.SignedData
+import org.wfanet.measurement.internal.reporting.batchCreateMeasurementsRequest
 import org.wfanet.measurement.reporting.service.api.EncryptionKeyPairStore
 import org.wfanet.measurement.reporting.v1alpha.CreateReportRequest
 import org.wfanet.measurement.reporting.v1alpha.GetReportRequest
@@ -234,7 +236,14 @@ class ReportsService(
     val internalMetricDetails: InternalMetricDetails,
   )
 
+  private data class DataProviderInfo(
+    val dataProviderName: String,
+    val publicKey: SignedData,
+    val certificateName: String,
+  )
+
   override suspend fun createReport(request: CreateReportRequest): Report {
+    val now = System.currentTimeMillis()
     grpcRequireNotNull(MeasurementConsumerKey.fromName(request.parent)) {
       "Parent is either unspecified or invalid."
     }
@@ -319,6 +328,15 @@ class ReportsService(
         )
       }
 
+    val dataProviderNames = hashSetOf<String>()
+    for (internalReportingSet in internalReportingSetMap.values) {
+      for (eventGroupKey in internalReportingSet.eventGroupKeysList) {
+        dataProviderNames.add(DataProviderKey(eventGroupKey.dataProviderReferenceId).toName())
+      }
+    }
+    val dataProviderInfoMap: Map<String, DataProviderInfo> =
+      buildDataProviderInfoMap(apiAuthenticationKey, dataProviderNames)
+
     // TODO: Factor this out to a separate class similar to EncryptionKeyPairStore.
     val signingPrivateKeyDer: ByteString =
       signingPrivateKeyDir.resolve(principal.config.signingPrivateKeyPath).readByteString()
@@ -336,6 +354,8 @@ class ReportsService(
         )
       )
 
+    println("Initial processing: ${System.currentTimeMillis() - now}")
+
     createMeasurements(
       request,
       namedSetOperationResults,
@@ -343,8 +363,11 @@ class ReportsService(
       measurementConsumer,
       apiAuthenticationKey,
       signingConfig,
-      internalReportingSetMap
+      internalReportingSetMap,
+      dataProviderInfoMap
     )
+
+    println("Create kingdom measurements: ${System.currentTimeMillis() - now}")
 
     val internalCreateReportRequest: InternalCreateReportRequest =
       buildInternalCreateReportRequest(
@@ -353,7 +376,9 @@ class ReportsService(
         namedSetOperationResults,
       )
     try {
-      return internalReportsStub.createReport(internalCreateReportRequest).toReport()
+      val report = internalReportsStub.createReport(internalCreateReportRequest).toReport()
+      println("Insert report into database: ${System.currentTimeMillis() - now}")
+      return report
     } catch (e: StatusException) {
       throw Exception("Unable to create a report in the reporting database.", e)
     }
@@ -412,7 +437,8 @@ class ReportsService(
     measurementConsumer: MeasurementConsumer,
     apiAuthenticationKey: String,
     signingConfig: SigningConfig,
-    internalReportingSetMap: Map<Long, InternalReportingSet>
+    internalReportingSetMap: Map<Long, InternalReportingSet>,
+    dataProviderInfoMap: Map<String, DataProviderInfo>
   ) = coroutineScope {
     val deferredMeasurements = mutableListOf<Deferred<Measurement>>()
     for (metric in request.report.metricsList) {
@@ -439,7 +465,8 @@ class ReportsService(
                   measurementConsumer,
                   apiAuthenticationKey,
                   signingConfig,
-                  internalReportingSetMap
+                  internalReportingSetMap,
+                  dataProviderInfoMap
                 )
                 .also {
                   weightedMeasurementInfo.kingdomMeasurementId =
@@ -451,25 +478,28 @@ class ReportsService(
       }
     }
 
+    val internalMeasurements = mutableListOf<InternalMeasurement>()
     for (measurement in deferredMeasurements.awaitAll()) {
-      try {
-        val measurementKey = checkNotNull(MeasurementKey.fromName(measurement.name))
-        internalMeasurementsStub.createMeasurement(
-          internalMeasurement {
-            this.measurementConsumerReferenceId = measurementKey.measurementConsumerId
-            this.measurementReferenceId = measurementKey.measurementId
-            state = InternalMeasurement.State.PENDING
-          }
-        )
-      } catch (e: StatusException) {
-        if (!e.status.code.equals(Status.Code.ALREADY_EXISTS)) {
-          throw Exception(
-            "Unable to create the measurement [${measurement.name}] " +
-              "in the reporting database.",
-            e
-          )
+      val measurementKey = checkNotNull(MeasurementKey.fromName(measurement.name))
+      internalMeasurements.add(
+        internalMeasurement {
+          this.measurementConsumerReferenceId = measurementKey.measurementConsumerId
+          this.measurementReferenceId = measurementKey.measurementId
+          state = InternalMeasurement.State.PENDING
         }
-      }
+      )
+    }
+
+    try {
+      internalMeasurementsStub.batchCreateMeasurements(
+        batchCreateMeasurementsRequest {
+          measurements += internalMeasurements
+        }
+      )
+    } catch (e: StatusException) {
+      throw Status.UNKNOWN.withDescription("Unable to create measurement in the reporting database.")
+        .withCause(e)
+        .asRuntimeException()
     }
   }
 
@@ -481,7 +511,8 @@ class ReportsService(
     measurementConsumer: MeasurementConsumer,
     apiAuthenticationKey: String,
     signingConfig: SigningConfig,
-    internalReportingSetMap: Map<Long, InternalReportingSet>
+    internalReportingSetMap: Map<Long, InternalReportingSet>,
+    dataProviderInfoMap: Map<String, DataProviderInfo>
   ): Measurement {
     val eventGroupEntriesByDataProvider =
       groupEventGroupEntriesByDataProvider(
@@ -497,8 +528,8 @@ class ReportsService(
         eventGroupEntriesByDataProvider,
         internalMetricDetails,
         weightedMeasurementInfo.reportingMeasurementId,
-        apiAuthenticationKey,
         signingConfig,
+        dataProviderInfoMap
       )
 
     try {
@@ -994,13 +1025,13 @@ class ReportsService(
   }
 
   /** Builds a [CreateMeasurementRequest]. */
-  private suspend fun buildCreateMeasurementRequest(
+  private fun buildCreateMeasurementRequest(
     measurementConsumer: MeasurementConsumer,
     eventGroupEntriesByDataProvider: Map<DataProviderKey, List<EventGroupEntry>>,
     internalMetricDetails: InternalMetricDetails,
     requestId: String,
-    apiAuthenticationKey: String,
     signingConfig: SigningConfig,
+    dataProviderInfoMap: Map<String, DataProviderInfo>
   ): CreateMeasurementRequest {
     val measurementConsumerCertificate: X509Certificate =
       readCertificate(signingConfig.signingCertificateDer)
@@ -1018,7 +1049,7 @@ class ReportsService(
             eventGroupEntriesByDataProvider,
             measurementEncryptionPublicKey,
             measurementConsumerSigningKey,
-            apiAuthenticationKey,
+            dataProviderInfoMap
           )
 
         val unsignedMeasurementSpec: MeasurementSpec =
@@ -1086,64 +1117,100 @@ class ReportsService(
       )
   }
 
+  /** Builds a [Map] of [DataProvider] name to [DataProviderInfo]. */
+  private suspend fun buildDataProviderInfoMap(
+    apiAuthenticationKey: String,
+    dataProviderNames: Collection<String>
+  ): Map<String, DataProviderInfo> {
+    val dataProviderInfoMap = hashMapOf<String, DataProviderInfo>()
+
+    if (dataProviderNames.isEmpty()) {
+      return dataProviderInfoMap
+    }
+
+    val deferredDataProviderInfoList = mutableListOf<Deferred<DataProviderInfo>>()
+    coroutineScope {
+      for (dataProviderName in dataProviderNames) {
+        deferredDataProviderInfoList.add(
+          async {
+            val dataProvider: DataProvider =
+              try {
+                dataProvidersStub
+                  .withAuthenticationKey(apiAuthenticationKey)
+                  .getDataProvider(getDataProviderRequest { name = dataProviderName })
+              } catch (e: StatusException) {
+                throw when (e.status.code) {
+                  Status.Code.NOT_FOUND ->
+                    Status.FAILED_PRECONDITION.withDescription("$dataProviderName not found")
+
+                  else -> Status.UNKNOWN.withDescription("Unable to retrieve $dataProviderName")
+                }
+                  .withCause(e)
+                  .asRuntimeException()
+              }
+
+            val certificate: Certificate =
+              try {
+                certificateStub
+                  .withAuthenticationKey(apiAuthenticationKey)
+                  .getCertificate(getCertificateRequest { name = dataProvider.certificate })
+              } catch (e: StatusException) {
+                throw Exception("Unable to retrieve Certificate ${dataProvider.certificate}", e)
+              }
+            if (certificate.revocationState != Certificate.RevocationState.REVOCATION_STATE_UNSPECIFIED) {
+              throw Status.FAILED_PRECONDITION.withDescription(
+                "${certificate.name} revocation state is ${certificate.revocationState}"
+              )
+                .asRuntimeException()
+            }
+
+            val x509Certificate: X509Certificate = readCertificate(certificate.x509Der)
+            val trustedIssuer: X509Certificate =
+              trustedCertificates[checkNotNull(x509Certificate.authorityKeyIdentifier)]
+                ?: throw Status.FAILED_PRECONDITION.withDescription(
+                  "${certificate.name} not issued by trusted CA"
+                )
+                  .asRuntimeException()
+            try {
+              verifyEncryptionPublicKey(dataProvider.publicKey, x509Certificate, trustedIssuer)
+            } catch (e: CertPathValidatorException) {
+              throw Status.FAILED_PRECONDITION.withCause(e)
+                .withDescription("Certificate path for ${certificate.name} is invalid")
+                .asRuntimeException()
+            } catch (e: SignatureException) {
+              throw Status.FAILED_PRECONDITION.withCause(e)
+                .withDescription("DataProvider public key signature is invalid")
+                .asRuntimeException()
+            }
+
+            DataProviderInfo(
+              dataProvider.name,
+              dataProvider.publicKey,
+              certificate.name
+            )
+          }
+        )
+      }
+
+      for (deferredDataProviderInfo in deferredDataProviderInfoList.awaitAll()) {
+        dataProviderInfoMap[deferredDataProviderInfo.dataProviderName] = deferredDataProviderInfo
+      }
+    }
+
+    return dataProviderInfoMap
+  }
+
   /** Builds a [List] of [DataProviderEntry] messages from [eventGroupEntriesByDataProvider]. */
-  private suspend fun buildDataProviderEntries(
+  private fun buildDataProviderEntries(
     eventGroupEntriesByDataProvider: Map<DataProviderKey, List<EventGroupEntry>>,
     measurementEncryptionPublicKey: ByteString,
     measurementConsumerSigningKey: SigningKeyHandle,
-    apiAuthenticationKey: String,
+    dataProviderInfoMap: Map<String, DataProviderInfo>,
   ): List<DataProviderEntry> {
     return eventGroupEntriesByDataProvider.map { (dataProviderKey, eventGroupEntriesList) ->
       // TODO(@SanjayVas): Consider caching the public key and certificate.
       val dataProviderName: String = dataProviderKey.toName()
-      val dataProvider: DataProvider =
-        try {
-          dataProvidersStub
-            .withAuthenticationKey(apiAuthenticationKey)
-            .getDataProvider(getDataProviderRequest { name = dataProviderName })
-        } catch (e: StatusException) {
-          throw when (e.status.code) {
-              Status.Code.NOT_FOUND ->
-                Status.FAILED_PRECONDITION.withDescription("$dataProviderName not found")
-              else -> Status.UNKNOWN.withDescription("Unable to retrieve $dataProviderName")
-            }
-            .withCause(e)
-            .asRuntimeException()
-        }
-
-      val certificate: Certificate =
-        try {
-          certificateStub
-            .withAuthenticationKey(apiAuthenticationKey)
-            .getCertificate(getCertificateRequest { name = dataProvider.certificate })
-        } catch (e: StatusException) {
-          throw Exception("Unable to retrieve Certificate ${dataProvider.certificate}", e)
-        }
-      if (certificate.revocationState != Certificate.RevocationState.REVOCATION_STATE_UNSPECIFIED) {
-        throw Status.FAILED_PRECONDITION.withDescription(
-            "${certificate.name} revocation state is ${certificate.revocationState}"
-          )
-          .asRuntimeException()
-      }
-
-      val x509Certificate: X509Certificate = readCertificate(certificate.x509Der)
-      val trustedIssuer: X509Certificate =
-        trustedCertificates[checkNotNull(x509Certificate.authorityKeyIdentifier)]
-          ?: throw Status.FAILED_PRECONDITION.withDescription(
-              "${certificate.name} not issued by trusted CA"
-            )
-            .asRuntimeException()
-      try {
-        verifyEncryptionPublicKey(dataProvider.publicKey, x509Certificate, trustedIssuer)
-      } catch (e: CertPathValidatorException) {
-        throw Status.FAILED_PRECONDITION.withCause(e)
-          .withDescription("Certificate path for ${certificate.name} is invalid")
-          .asRuntimeException()
-      } catch (e: SignatureException) {
-        throw Status.FAILED_PRECONDITION.withCause(e)
-          .withDescription("DataProvider public key signature is invalid")
-          .asRuntimeException()
-      }
+      val dataProviderInfo = dataProviderInfoMap.getValue(dataProviderName)
 
       val requisitionSpec = requisitionSpec {
         events = RequisitionSpecKt.events { eventGroups += eventGroupEntriesList }
@@ -1153,15 +1220,15 @@ class ReportsService(
       val encryptRequisitionSpec =
         encryptRequisitionSpec(
           signRequisitionSpec(requisitionSpec, measurementConsumerSigningKey),
-          EncryptionPublicKey.parseFrom(dataProvider.publicKey.data)
+          EncryptionPublicKey.parseFrom(dataProviderInfo.publicKey.data)
         )
 
       dataProviderEntry {
-        key = dataProvider.name
+        key = dataProviderName
         value =
           DataProviderEntryKt.value {
-            dataProviderCertificate = certificate.name
-            dataProviderPublicKey = dataProvider.publicKey
+            dataProviderCertificate = dataProviderInfo.certificateName
+            dataProviderPublicKey = dataProviderInfo.publicKey
             this.encryptedRequisitionSpec = encryptRequisitionSpec
             nonceHash = Hashing.hashSha256(requisitionSpec.nonce)
           }

--- a/src/main/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/MetricsService.kt
+++ b/src/main/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/MetricsService.kt
@@ -140,6 +140,7 @@ import org.wfanet.measurement.measurementconsumer.stats.LiquidLegionsSketchMetho
 import org.wfanet.measurement.measurementconsumer.stats.LiquidLegionsV2Methodology
 import org.wfanet.measurement.measurementconsumer.stats.Methodology
 import org.wfanet.measurement.measurementconsumer.stats.NoiseMechanism as StatsNoiseMechanism
+import org.wfanet.measurement.api.v2alpha.SignedData
 import org.wfanet.measurement.measurementconsumer.stats.ReachMeasurementParams
 import org.wfanet.measurement.measurementconsumer.stats.ReachMeasurementVarianceParams
 import org.wfanet.measurement.measurementconsumer.stats.ReachMetricVarianceParams
@@ -208,6 +209,12 @@ class MetricsService(
   coroutineContext: @BlockingExecutor CoroutineContext = Dispatchers.IO,
 ) : MetricsCoroutineImplBase() {
 
+  private data class DataProviderInfo(
+    val dataProviderName: String,
+    val publicKey: SignedData,
+    val certificateName: String,
+  )
+
   private val measurementSupplier =
     MeasurementSupplier(
       internalReportingSetsStub,
@@ -275,6 +282,15 @@ class MetricsService(
           .toList()
           .associateBy { it.externalReportingSetId }
 
+      val dataProviderNames = hashSetOf<String>()
+      for (internalPrimitiveReportingSet in internalPrimitiveReportingSetMap.values) {
+        for (eventGroupKey in internalPrimitiveReportingSet.primitive.eventGroupKeysList) {
+          dataProviderNames.add(DataProviderKey(eventGroupKey.cmmsDataProviderId).toName())
+        }
+      }
+      val dataProviderInfoMap: Map<String, DataProviderInfo> =
+        buildDataProviderInfoMap(principal.config.apiKey, dataProviderNames)
+
       val measurementIdsList: Flow<Deferred<MeasurementIds>> = flow {
         for (internalMetric in internalMetricsList) {
           for (weightedMeasurement in internalMetric.weightedMeasurementsList) {
@@ -296,6 +312,7 @@ class MetricsService(
                       internalPrimitiveReportingSetMap,
                       measurementConsumer,
                       principal,
+                      dataProviderInfoMap
                     )
                   cmmsMeasurementId =
                     checkNotNull(MeasurementKey.fromName(measurement.name)).measurementId
@@ -346,6 +363,7 @@ class MetricsService(
       internalPrimitiveReportingSetMap: Map<String, InternalReportingSet>,
       measurementConsumer: MeasurementConsumer,
       principal: MeasurementConsumerPrincipal,
+      dataProviderInfoMap: Map<String, DataProviderInfo>
     ): Measurement {
       val eventGroupEntriesByDataProvider =
         groupEventGroupEntriesByDataProvider(internalMeasurement, internalPrimitiveReportingSetMap)
@@ -357,6 +375,7 @@ class MetricsService(
           measurementConsumer,
           eventGroupEntriesByDataProvider,
           principal,
+          dataProviderInfoMap
         )
 
       try {
@@ -389,6 +408,7 @@ class MetricsService(
       measurementConsumer: MeasurementConsumer,
       eventGroupEntriesByDataProvider: Map<DataProviderKey, List<EventGroupEntry>>,
       principal: MeasurementConsumerPrincipal,
+      dataProviderInfoMap: Map<String, DataProviderInfo>
     ): CreateMeasurementRequest {
       val measurementConsumerSigningKey = getMeasurementConsumerSigningKey(principal)
       val measurementEncryptionPublicKey = measurementConsumer.publicKey.data
@@ -403,7 +423,7 @@ class MetricsService(
               eventGroupEntriesByDataProvider,
               measurementEncryptionPublicKey,
               measurementConsumerSigningKey,
-              principal.config.apiKey,
+              dataProviderInfoMap
             )
 
           val unsignedMeasurementSpec: MeasurementSpec =
@@ -470,78 +490,111 @@ class MetricsService(
       }
     }
 
+    /** Builds a [Map] of [DataProvider] name to [DataProviderInfo]. */
+    private suspend fun buildDataProviderInfoMap(
+      apiAuthenticationKey: String,
+      dataProviderNames: Collection<String>
+    ): Map<String, DataProviderInfo> {
+      val dataProviderInfoMap = hashMapOf<String, DataProviderInfo>()
+
+      if (dataProviderNames.isEmpty()) {
+        return dataProviderInfoMap
+      }
+
+      val deferredDataProviderInfoList = mutableListOf<Deferred<DataProviderInfo>>()
+      coroutineScope {
+        for (dataProviderName in dataProviderNames) {
+          deferredDataProviderInfoList.add(
+            async {
+              val dataProvider: DataProvider =
+                try {
+                  dataProvidersStub
+                    .withAuthenticationKey(apiAuthenticationKey)
+                    .getDataProvider(getDataProviderRequest { name = dataProviderName })
+                } catch (e: StatusException) {
+                  throw when (e.status.code) {
+                    Status.Code.NOT_FOUND ->
+                      Status.FAILED_PRECONDITION.withDescription("$dataProviderName not found")
+
+                    else -> Status.UNKNOWN.withDescription("Unable to retrieve $dataProviderName")
+                  }
+                    .withCause(e)
+                    .asRuntimeException()
+                }
+
+              val certificate: Certificate =
+                try {
+                  certificatesStub
+                    .withAuthenticationKey(apiAuthenticationKey)
+                    .getCertificate(getCertificateRequest { name = dataProvider.certificate })
+                } catch (e: StatusException) {
+                  throw when (e.status.code) {
+                    Status.Code.NOT_FOUND ->
+                      Status.NOT_FOUND.withDescription("${dataProvider.certificate} not found.")
+                    else ->
+                      Status.UNKNOWN.withDescription(
+                        "Unable to retrieve Certificate ${dataProvider.certificate}."
+                      )
+                  }
+                    .withCause(e)
+                    .asRuntimeException()
+                }
+              if (certificate.revocationState != Certificate.RevocationState.REVOCATION_STATE_UNSPECIFIED) {
+                throw Status.FAILED_PRECONDITION.withDescription(
+                  "${certificate.name} revocation state is ${certificate.revocationState}"
+                )
+                  .asRuntimeException()
+              }
+
+              val x509Certificate: X509Certificate = readCertificate(certificate.x509Der)
+              val trustedIssuer: X509Certificate =
+                trustedCertificates[checkNotNull(x509Certificate.authorityKeyIdentifier)]
+                  ?: throw Status.FAILED_PRECONDITION.withDescription(
+                    "${certificate.name} not issued by trusted CA"
+                  )
+                    .asRuntimeException()
+              try {
+                verifyEncryptionPublicKey(dataProvider.publicKey, x509Certificate, trustedIssuer)
+              } catch (e: CertPathValidatorException) {
+                throw Status.FAILED_PRECONDITION.withCause(e)
+                  .withDescription("Certificate path for ${certificate.name} is invalid")
+                  .asRuntimeException()
+              } catch (e: SignatureException) {
+                throw Status.FAILED_PRECONDITION.withCause(e)
+                  .withDescription("DataProvider public key signature is invalid")
+                  .asRuntimeException()
+              }
+
+              DataProviderInfo(
+                dataProvider.name,
+                dataProvider.publicKey,
+                certificate.name
+              )
+            }
+          )
+        }
+
+        for (deferredDataProviderInfo in deferredDataProviderInfoList.awaitAll()) {
+          dataProviderInfoMap[deferredDataProviderInfo.dataProviderName] = deferredDataProviderInfo
+        }
+      }
+
+      return dataProviderInfoMap
+    }
+
     /**
      * Builds a [List] of [Measurement.DataProviderEntry] messages from
      * [eventGroupEntriesByDataProvider].
      */
-    private suspend fun buildDataProviderEntries(
+    private fun buildDataProviderEntries(
       eventGroupEntriesByDataProvider: Map<DataProviderKey, List<EventGroupEntry>>,
       measurementEncryptionPublicKey: ByteString,
       measurementConsumerSigningKey: SigningKeyHandle,
-      apiAuthenticationKey: String,
+      dataProviderInfoMap: Map<String, DataProviderInfo>,
     ): List<Measurement.DataProviderEntry> {
       return eventGroupEntriesByDataProvider.map { (dataProviderKey, eventGroupEntriesList) ->
-        // TODO(@SanjayVas): Consider caching the public key and certificate.
         val dataProviderName: String = dataProviderKey.toName()
-        val dataProvider: DataProvider =
-          try {
-            dataProvidersStub
-              .withAuthenticationKey(apiAuthenticationKey)
-              .getDataProvider(getDataProviderRequest { name = dataProviderName })
-          } catch (e: StatusException) {
-            throw when (e.status.code) {
-                Status.Code.NOT_FOUND ->
-                  Status.FAILED_PRECONDITION.withDescription("$dataProviderName not found.")
-                else -> Status.UNKNOWN.withDescription("Unable to retrieve $dataProviderName.")
-              }
-              .withCause(e)
-              .asRuntimeException()
-          }
-
-        val certificate: Certificate =
-          try {
-            certificatesStub
-              .withAuthenticationKey(apiAuthenticationKey)
-              .getCertificate(getCertificateRequest { name = dataProvider.certificate })
-          } catch (e: StatusException) {
-            throw when (e.status.code) {
-                Status.Code.NOT_FOUND ->
-                  Status.NOT_FOUND.withDescription("${dataProvider.certificate} not found.")
-                else ->
-                  Status.UNKNOWN.withDescription(
-                    "Unable to retrieve Certificate ${dataProvider.certificate}."
-                  )
-              }
-              .withCause(e)
-              .asRuntimeException()
-          }
-        if (
-          certificate.revocationState != Certificate.RevocationState.REVOCATION_STATE_UNSPECIFIED
-        ) {
-          throw Status.FAILED_PRECONDITION.withDescription(
-              "${certificate.name} revocation state is ${certificate.revocationState}"
-            )
-            .asRuntimeException()
-        }
-
-        val x509Certificate: X509Certificate = readCertificate(certificate.x509Der)
-        val trustedIssuer: X509Certificate =
-          trustedCertificates[checkNotNull(x509Certificate.authorityKeyIdentifier)]
-            ?: throw Status.FAILED_PRECONDITION.withDescription(
-                "${certificate.name} not issued by trusted CA"
-              )
-              .asRuntimeException()
-        try {
-          verifyEncryptionPublicKey(dataProvider.publicKey, x509Certificate, trustedIssuer)
-        } catch (e: CertPathValidatorException) {
-          throw Status.FAILED_PRECONDITION.withCause(e)
-            .withDescription("Certificate path for ${certificate.name} is invalid")
-            .asRuntimeException()
-        } catch (e: SignatureException) {
-          throw Status.FAILED_PRECONDITION.withCause(e)
-            .withDescription("DataProvider public key signature is invalid")
-            .asRuntimeException()
-        }
+        val dataProviderInfo = dataProviderInfoMap.getValue(dataProviderName)
 
         val requisitionSpec = requisitionSpec {
           events = RequisitionSpecKt.events { eventGroups += eventGroupEntriesList }
@@ -551,15 +604,15 @@ class MetricsService(
         val encryptRequisitionSpec =
           encryptRequisitionSpec(
             signRequisitionSpec(requisitionSpec, measurementConsumerSigningKey),
-            EncryptionPublicKey.parseFrom(dataProvider.publicKey.data)
+            EncryptionPublicKey.parseFrom(dataProviderInfo.publicKey.data)
           )
 
         dataProviderEntry {
-          key = dataProvider.name
+          key = dataProviderName
           value =
             MeasurementKt.DataProviderEntryKt.value {
-              dataProviderCertificate = certificate.name
-              dataProviderPublicKey = dataProvider.publicKey
+              dataProviderCertificate = dataProviderInfo.certificateName
+              dataProviderPublicKey = dataProviderInfo.publicKey
               this.encryptedRequisitionSpec = encryptRequisitionSpec
               nonceHash = Hashing.hashSha256(requisitionSpec.nonce)
             }

--- a/src/main/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/MetricsService.kt
+++ b/src/main/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/MetricsService.kt
@@ -282,7 +282,7 @@ class MetricsService(
           .toList()
           .associateBy { it.externalReportingSetId }
 
-      val dataProviderNames = hashSetOf<String>()
+      val dataProviderNames = mutableSetOf<String>()
       for (internalPrimitiveReportingSet in internalPrimitiveReportingSetMap.values) {
         for (eventGroupKey in internalPrimitiveReportingSet.primitive.eventGroupKeysList) {
           dataProviderNames.add(DataProviderKey(eventGroupKey.cmmsDataProviderId).toName())
@@ -495,7 +495,7 @@ class MetricsService(
       apiAuthenticationKey: String,
       dataProviderNames: Collection<String>
     ): Map<String, DataProviderInfo> {
-      val dataProviderInfoMap = hashMapOf<String, DataProviderInfo>()
+      val dataProviderInfoMap = mutableMapOf<String, DataProviderInfo>()
 
       if (dataProviderNames.isEmpty()) {
         return dataProviderInfoMap

--- a/src/main/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/MetricsService.kt
+++ b/src/main/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/MetricsService.kt
@@ -64,6 +64,7 @@ import org.wfanet.measurement.api.v2alpha.MeasurementSpec
 import org.wfanet.measurement.api.v2alpha.MeasurementsGrpcKt.MeasurementsCoroutineStub
 import org.wfanet.measurement.api.v2alpha.RequisitionSpec.EventGroupEntry
 import org.wfanet.measurement.api.v2alpha.RequisitionSpecKt
+import org.wfanet.measurement.api.v2alpha.SignedData
 import org.wfanet.measurement.api.v2alpha.createMeasurementRequest
 import org.wfanet.measurement.api.v2alpha.getCertificateRequest
 import org.wfanet.measurement.api.v2alpha.getDataProviderRequest
@@ -140,7 +141,6 @@ import org.wfanet.measurement.measurementconsumer.stats.LiquidLegionsSketchMetho
 import org.wfanet.measurement.measurementconsumer.stats.LiquidLegionsV2Methodology
 import org.wfanet.measurement.measurementconsumer.stats.Methodology
 import org.wfanet.measurement.measurementconsumer.stats.NoiseMechanism as StatsNoiseMechanism
-import org.wfanet.measurement.api.v2alpha.SignedData
 import org.wfanet.measurement.measurementconsumer.stats.ReachMeasurementParams
 import org.wfanet.measurement.measurementconsumer.stats.ReachMeasurementVarianceParams
 import org.wfanet.measurement.measurementconsumer.stats.ReachMetricVarianceParams
@@ -513,11 +513,10 @@ class MetricsService(
                     .getDataProvider(getDataProviderRequest { name = dataProviderName })
                 } catch (e: StatusException) {
                   throw when (e.status.code) {
-                    Status.Code.NOT_FOUND ->
-                      Status.FAILED_PRECONDITION.withDescription("$dataProviderName not found")
-
-                    else -> Status.UNKNOWN.withDescription("Unable to retrieve $dataProviderName")
-                  }
+                      Status.Code.NOT_FOUND ->
+                        Status.FAILED_PRECONDITION.withDescription("$dataProviderName not found")
+                      else -> Status.UNKNOWN.withDescription("Unable to retrieve $dataProviderName")
+                    }
                     .withCause(e)
                     .asRuntimeException()
                 }
@@ -529,20 +528,23 @@ class MetricsService(
                     .getCertificate(getCertificateRequest { name = dataProvider.certificate })
                 } catch (e: StatusException) {
                   throw when (e.status.code) {
-                    Status.Code.NOT_FOUND ->
-                      Status.NOT_FOUND.withDescription("${dataProvider.certificate} not found.")
-                    else ->
-                      Status.UNKNOWN.withDescription(
-                        "Unable to retrieve Certificate ${dataProvider.certificate}."
-                      )
-                  }
+                      Status.Code.NOT_FOUND ->
+                        Status.NOT_FOUND.withDescription("${dataProvider.certificate} not found.")
+                      else ->
+                        Status.UNKNOWN.withDescription(
+                          "Unable to retrieve Certificate ${dataProvider.certificate}."
+                        )
+                    }
                     .withCause(e)
                     .asRuntimeException()
                 }
-              if (certificate.revocationState != Certificate.RevocationState.REVOCATION_STATE_UNSPECIFIED) {
+              if (
+                certificate.revocationState !=
+                  Certificate.RevocationState.REVOCATION_STATE_UNSPECIFIED
+              ) {
                 throw Status.FAILED_PRECONDITION.withDescription(
-                  "${certificate.name} revocation state is ${certificate.revocationState}"
-                )
+                    "${certificate.name} revocation state is ${certificate.revocationState}"
+                  )
                   .asRuntimeException()
               }
 
@@ -550,8 +552,8 @@ class MetricsService(
               val trustedIssuer: X509Certificate =
                 trustedCertificates[checkNotNull(x509Certificate.authorityKeyIdentifier)]
                   ?: throw Status.FAILED_PRECONDITION.withDescription(
-                    "${certificate.name} not issued by trusted CA"
-                  )
+                      "${certificate.name} not issued by trusted CA"
+                    )
                     .asRuntimeException()
               try {
                 verifyEncryptionPublicKey(dataProvider.publicKey, x509Certificate, trustedIssuer)
@@ -565,11 +567,7 @@ class MetricsService(
                   .asRuntimeException()
               }
 
-              DataProviderInfo(
-                dataProvider.name,
-                dataProvider.publicKey,
-                certificate.name
-              )
+              DataProviderInfo(dataProvider.name, dataProvider.publicKey, certificate.name)
             }
           )
         }

--- a/src/main/kotlin/org/wfanet/measurement/reporting/service/internal/testing/MeasurementsServiceTest.kt
+++ b/src/main/kotlin/org/wfanet/measurement/reporting/service/internal/testing/MeasurementsServiceTest.kt
@@ -95,19 +95,21 @@ abstract class MeasurementsServiceTest<T : MeasurementsCoroutineImplBase> {
       measurementReferenceId = MEASUREMENT_REFERENCE_ID + 2
     }
 
-    val createdMeasurements = runBlocking { service.batchCreateMeasurements(
-      batchCreateMeasurementsRequest {
-        measurements += measurement
-        measurements += measurement2
-      }
-    ) }.measurementsList
+    val createdMeasurements =
+      runBlocking {
+          service.batchCreateMeasurements(
+            batchCreateMeasurementsRequest {
+              measurements += measurement
+              measurements += measurement2
+            }
+          )
+        }
+        .measurementsList
 
-    assertThat(createdMeasurements[0]).isEqualTo(measurement.copy {
-      state = Measurement.State.PENDING
-    })
-    assertThat(createdMeasurements[1]).isEqualTo(measurement2.copy {
-      state = Measurement.State.PENDING
-    })
+    assertThat(createdMeasurements[0])
+      .isEqualTo(measurement.copy { state = Measurement.State.PENDING })
+    assertThat(createdMeasurements[1])
+      .isEqualTo(measurement2.copy { state = Measurement.State.PENDING })
 
     val getRequest = getMeasurementRequest {
       measurementConsumerReferenceId = measurement.measurementConsumerReferenceId
@@ -140,17 +142,17 @@ abstract class MeasurementsServiceTest<T : MeasurementsCoroutineImplBase> {
       measurements += measurement
       measurements += measurement2
     }
-    val createdMeasurements = runBlocking {
-      service.batchCreateMeasurements(request)
-      service.batchCreateMeasurements(request)
-    }.measurementsList
+    val createdMeasurements =
+      runBlocking {
+          service.batchCreateMeasurements(request)
+          service.batchCreateMeasurements(request)
+        }
+        .measurementsList
 
-    assertThat(createdMeasurements[0]).isEqualTo(measurement.copy {
-      state = Measurement.State.PENDING
-    })
-    assertThat(createdMeasurements[1]).isEqualTo(measurement2.copy {
-      state = Measurement.State.PENDING
-    })
+    assertThat(createdMeasurements[0])
+      .isEqualTo(measurement.copy { state = Measurement.State.PENDING })
+    assertThat(createdMeasurements[1])
+      .isEqualTo(measurement2.copy { state = Measurement.State.PENDING })
 
     val getRequest = getMeasurementRequest {
       measurementConsumerReferenceId = measurement.measurementConsumerReferenceId
@@ -182,16 +184,19 @@ abstract class MeasurementsServiceTest<T : MeasurementsCoroutineImplBase> {
 
   @Test
   fun `setMeasurementResult stores the result and the succeeded state for a measurement`() {
-    val createdMeasurement = runBlocking {
-      service.batchCreateMeasurements(
-        batchCreateMeasurementsRequest {
-          measurements += measurement {
-            measurementConsumerReferenceId = MEASUREMENT_CONSUMER_REFERENCE_ID
-            measurementReferenceId = MEASUREMENT_REFERENCE_ID
-          }
+    val createdMeasurement =
+      runBlocking {
+          service.batchCreateMeasurements(
+            batchCreateMeasurementsRequest {
+              measurements += measurement {
+                measurementConsumerReferenceId = MEASUREMENT_CONSUMER_REFERENCE_ID
+                measurementReferenceId = MEASUREMENT_REFERENCE_ID
+              }
+            }
+          )
         }
-      )
-    }.measurementsList.first()
+        .measurementsList
+        .first()
 
     val result = MeasurementKt.result { reach = MeasurementKt.ResultKt.reach { value = 100L } }
     val request = setMeasurementResultRequest {
@@ -235,16 +240,19 @@ abstract class MeasurementsServiceTest<T : MeasurementsCoroutineImplBase> {
 
   @Test
   fun `setMeasurementResult fails when the meaurement state isn't PENDING`() {
-    val createdMeasurement = runBlocking {
-      service.batchCreateMeasurements(
-        batchCreateMeasurementsRequest {
-          measurements += measurement {
-            measurementConsumerReferenceId = MEASUREMENT_CONSUMER_REFERENCE_ID
-            measurementReferenceId = MEASUREMENT_REFERENCE_ID
-          }
+    val createdMeasurement =
+      runBlocking {
+          service.batchCreateMeasurements(
+            batchCreateMeasurementsRequest {
+              measurements += measurement {
+                measurementConsumerReferenceId = MEASUREMENT_CONSUMER_REFERENCE_ID
+                measurementReferenceId = MEASUREMENT_REFERENCE_ID
+              }
+            }
+          )
         }
-      )
-    }.measurementsList.first()
+        .measurementsList
+        .first()
 
     val request = setMeasurementResultRequest {
       measurementConsumerReferenceId = createdMeasurement.measurementConsumerReferenceId
@@ -751,16 +759,19 @@ abstract class MeasurementsServiceTest<T : MeasurementsCoroutineImplBase> {
 
   @Test
   fun `setMeasurementFailure stores the failure data and the failed state for a measurement`() {
-    val createdMeasurement = runBlocking {
-      service.batchCreateMeasurements(
-        batchCreateMeasurementsRequest {
-          measurements += measurement {
-            measurementConsumerReferenceId = MEASUREMENT_CONSUMER_REFERENCE_ID
-            measurementReferenceId = MEASUREMENT_REFERENCE_ID
-          }
+    val createdMeasurement =
+      runBlocking {
+          service.batchCreateMeasurements(
+            batchCreateMeasurementsRequest {
+              measurements += measurement {
+                measurementConsumerReferenceId = MEASUREMENT_CONSUMER_REFERENCE_ID
+                measurementReferenceId = MEASUREMENT_REFERENCE_ID
+              }
+            }
+          )
         }
-      )
-    }.measurementsList.first()
+        .measurementsList
+        .first()
 
     val failure =
       MeasurementKt.failure {
@@ -812,16 +823,19 @@ abstract class MeasurementsServiceTest<T : MeasurementsCoroutineImplBase> {
 
   @Test
   fun `setMeasurementFailure fails when the measurement state is not PENDING`() {
-    val createdMeasurement = runBlocking {
-      service.batchCreateMeasurements(
-        batchCreateMeasurementsRequest {
-          measurements += measurement {
-            measurementConsumerReferenceId = MEASUREMENT_CONSUMER_REFERENCE_ID
-            measurementReferenceId = MEASUREMENT_REFERENCE_ID
-          }
+    val createdMeasurement =
+      runBlocking {
+          service.batchCreateMeasurements(
+            batchCreateMeasurementsRequest {
+              measurements += measurement {
+                measurementConsumerReferenceId = MEASUREMENT_CONSUMER_REFERENCE_ID
+                measurementReferenceId = MEASUREMENT_REFERENCE_ID
+              }
+            }
+          )
         }
-      )
-    }.measurementsList.first()
+        .measurementsList
+        .first()
 
     val request = setMeasurementFailureRequest {
       measurementConsumerReferenceId = createdMeasurement.measurementConsumerReferenceId

--- a/src/main/proto/wfa/measurement/internal/reporting/measurements_service.proto
+++ b/src/main/proto/wfa/measurement/internal/reporting/measurements_service.proto
@@ -23,13 +23,22 @@ option java_multiple_files = true;
 
 // Internal service for persistence of Measurement entities.
 service Measurements {
-  rpc CreateMeasurement(Measurement) returns (Measurement);
+  rpc BatchCreateMeasurements(BatchCreateMeasurementsRequest)
+      returns (BatchCreateMeasurementsResponse);
 
   rpc GetMeasurement(GetMeasurementRequest) returns (Measurement);
 
   rpc SetMeasurementResult(SetMeasurementResultRequest) returns (Measurement);
 
   rpc SetMeasurementFailure(SetMeasurementFailureRequest) returns (Measurement);
+}
+
+message BatchCreateMeasurementsRequest {
+  repeated Measurement measurements = 1;
+}
+
+message BatchCreateMeasurementsResponse {
+  repeated Measurement measurements = 1;
 }
 
 message GetMeasurementRequest {

--- a/src/test/kotlin/org/wfanet/measurement/reporting/service/api/v1alpha/ReportsServiceTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/reporting/service/api/v1alpha/ReportsServiceTest.kt
@@ -155,6 +155,7 @@ import org.wfanet.measurement.internal.reporting.ReportingSetsGrpcKt.ReportingSe
 import org.wfanet.measurement.internal.reporting.ReportsGrpcKt.ReportsCoroutineImplBase
 import org.wfanet.measurement.internal.reporting.ReportsGrpcKt.ReportsCoroutineStub as InternalReportsCoroutineStub
 import org.wfanet.measurement.internal.reporting.StreamReportsRequestKt.filter
+import org.wfanet.measurement.internal.reporting.batchCreateMeasurementsRequest
 import org.wfanet.measurement.internal.reporting.batchGetReportingSetRequest
 import org.wfanet.measurement.internal.reporting.copy
 import org.wfanet.measurement.internal.reporting.createReportRequest as internalCreateReportRequest
@@ -170,7 +171,6 @@ import org.wfanet.measurement.internal.reporting.setMeasurementResultRequest
 import org.wfanet.measurement.internal.reporting.streamReportsRequest
 import org.wfanet.measurement.internal.reporting.timeInterval as internalTimeInterval
 import org.wfanet.measurement.internal.reporting.timeIntervals as internalTimeIntervals
-import org.wfanet.measurement.internal.reporting.batchCreateMeasurementsRequest
 import org.wfanet.measurement.reporting.service.api.InMemoryEncryptionKeyPairStore
 import org.wfanet.measurement.reporting.v1alpha.ListReportsPageTokenKt.previousPageEnd
 import org.wfanet.measurement.reporting.v1alpha.ListReportsRequest
@@ -1661,9 +1661,9 @@ class ReportsServiceTest {
         internalMeasurementsMock,
         InternalMeasurementsCoroutineImplBase::batchCreateMeasurements
       )
-      .isEqualTo(batchCreateMeasurementsRequest {
-        measurements += INTERNAL_PENDING_REACH_MEASUREMENT
-      })
+      .isEqualTo(
+        batchCreateMeasurementsRequest { measurements += INTERNAL_PENDING_REACH_MEASUREMENT }
+      )
 
     // Verify proto argument of InternalReportsCoroutineImplBase::createReport
     verifyProtoArgument(internalReportsMock, ReportsCoroutineImplBase::createReport)
@@ -2189,9 +2189,8 @@ class ReportsServiceTest {
         InternalMeasurementsCoroutineImplBase::batchCreateMeasurements
       )
       .isEqualTo(
-        batchCreateMeasurementsRequest {
-          measurements += INTERNAL_PENDING_REACH_MEASUREMENT
-        })
+        batchCreateMeasurementsRequest { measurements += INTERNAL_PENDING_REACH_MEASUREMENT }
+      )
 
     // Verify proto argument of InternalReportsCoroutineImplBase::createReport
     verifyProtoArgument(internalReportsMock, ReportsCoroutineImplBase::createReport)
@@ -2333,9 +2332,8 @@ class ReportsServiceTest {
         InternalMeasurementsCoroutineImplBase::batchCreateMeasurements
       )
       .isEqualTo(
-        batchCreateMeasurementsRequest {
-          measurements += INTERNAL_PENDING_REACH_MEASUREMENT
-        })
+        batchCreateMeasurementsRequest { measurements += INTERNAL_PENDING_REACH_MEASUREMENT }
+      )
 
     // Verify proto argument of InternalReportsCoroutineImplBase::createReport
     verifyProtoArgument(internalReportsMock, ReportsCoroutineImplBase::createReport)
@@ -2475,16 +2473,18 @@ class ReportsServiceTest {
 
     // Verify proto argument of InternalMeasurementsCoroutineImplBase::batchCreateMeasurements
     verifyProtoArgument(
-      internalMeasurementsMock,
-      InternalMeasurementsCoroutineImplBase::batchCreateMeasurements
-    )
+        internalMeasurementsMock,
+        InternalMeasurementsCoroutineImplBase::batchCreateMeasurements
+      )
       .isEqualTo(
         batchCreateMeasurementsRequest {
           measurements += INTERNAL_PENDING_REACH_MEASUREMENT
-          measurements += INTERNAL_PENDING_REACH_MEASUREMENT.copy {
-            measurementReferenceId = REACH_MEASUREMENT_KEY_2.measurementId
-          }
-        })
+          measurements +=
+            INTERNAL_PENDING_REACH_MEASUREMENT.copy {
+              measurementReferenceId = REACH_MEASUREMENT_KEY_2.measurementId
+            }
+        }
+      )
 
     // Verify proto argument of InternalReportsCoroutineImplBase::createReport
     verifyProtoArgument(internalReportsMock, ReportsCoroutineImplBase::createReport)

--- a/src/test/kotlin/org/wfanet/measurement/reporting/service/api/v1alpha/ReportsServiceTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/reporting/service/api/v1alpha/ReportsServiceTest.kt
@@ -170,6 +170,7 @@ import org.wfanet.measurement.internal.reporting.setMeasurementResultRequest
 import org.wfanet.measurement.internal.reporting.streamReportsRequest
 import org.wfanet.measurement.internal.reporting.timeInterval as internalTimeInterval
 import org.wfanet.measurement.internal.reporting.timeIntervals as internalTimeIntervals
+import org.wfanet.measurement.internal.reporting.batchCreateMeasurementsRequest
 import org.wfanet.measurement.reporting.service.api.InMemoryEncryptionKeyPairStore
 import org.wfanet.measurement.reporting.v1alpha.ListReportsPageTokenKt.previousPageEnd
 import org.wfanet.measurement.reporting.v1alpha.ListReportsRequest
@@ -1655,12 +1656,14 @@ class ReportsServiceTest {
       )
     }
 
-    // Verify proto argument of InternalMeasurementsCoroutineImplBase::createMeasurement
+    // Verify proto argument of InternalMeasurementsCoroutineImplBase::batchCreateMeasurements
     verifyProtoArgument(
         internalMeasurementsMock,
-        InternalMeasurementsCoroutineImplBase::createMeasurement
+        InternalMeasurementsCoroutineImplBase::batchCreateMeasurements
       )
-      .isEqualTo(INTERNAL_PENDING_REACH_MEASUREMENT)
+      .isEqualTo(batchCreateMeasurementsRequest {
+        measurements += INTERNAL_PENDING_REACH_MEASUREMENT
+      })
 
     // Verify proto argument of InternalReportsCoroutineImplBase::createReport
     verifyProtoArgument(internalReportsMock, ReportsCoroutineImplBase::createReport)
@@ -2180,12 +2183,15 @@ class ReportsServiceTest {
       )
     }
 
-    // Verify proto argument of InternalMeasurementsCoroutineImplBase::createMeasurement
+    // Verify proto argument of InternalMeasurementsCoroutineImplBase::batchCreateMeasurements
     verifyProtoArgument(
         internalMeasurementsMock,
-        InternalMeasurementsCoroutineImplBase::createMeasurement
+        InternalMeasurementsCoroutineImplBase::batchCreateMeasurements
       )
-      .isEqualTo(INTERNAL_PENDING_REACH_MEASUREMENT)
+      .isEqualTo(
+        batchCreateMeasurementsRequest {
+          measurements += INTERNAL_PENDING_REACH_MEASUREMENT
+        })
 
     // Verify proto argument of InternalReportsCoroutineImplBase::createReport
     verifyProtoArgument(internalReportsMock, ReportsCoroutineImplBase::createReport)
@@ -2321,12 +2327,15 @@ class ReportsServiceTest {
       )
     }
 
-    // Verify proto argument of InternalMeasurementsCoroutineImplBase::createMeasurement
+    // Verify proto argument of InternalMeasurementsCoroutineImplBase::batchCreateMeasurements
     verifyProtoArgument(
         internalMeasurementsMock,
-        InternalMeasurementsCoroutineImplBase::createMeasurement
+        InternalMeasurementsCoroutineImplBase::batchCreateMeasurements
       )
-      .isEqualTo(INTERNAL_PENDING_REACH_MEASUREMENT)
+      .isEqualTo(
+        batchCreateMeasurementsRequest {
+          measurements += INTERNAL_PENDING_REACH_MEASUREMENT
+        })
 
     // Verify proto argument of InternalReportsCoroutineImplBase::createReport
     verifyProtoArgument(internalReportsMock, ReportsCoroutineImplBase::createReport)
@@ -2451,11 +2460,10 @@ class ReportsServiceTest {
 
     // Verify proto argument of DataProvidersCoroutineImplBase::getDataProvider
     val dataProvidersCaptor: KArgumentCaptor<GetDataProviderRequest> = argumentCaptor()
-    verifyBlocking(dataProvidersMock, times(3)) { getDataProvider(dataProvidersCaptor.capture()) }
+    verifyBlocking(dataProvidersMock, times(2)) { getDataProvider(dataProvidersCaptor.capture()) }
     val capturedDataProviderRequests = dataProvidersCaptor.allValues
     assertThat(capturedDataProviderRequests)
       .containsExactly(
-        getDataProviderRequest { name = DATA_PROVIDERS_LIST[1].name },
         getDataProviderRequest { name = DATA_PROVIDERS_LIST[0].name },
         getDataProviderRequest { name = DATA_PROVIDERS_LIST[1].name }
       )
@@ -2465,11 +2473,18 @@ class ReportsServiceTest {
     verifyBlocking(measurementsMock, times(2)) { createMeasurement(measurementCaptor.capture()) }
     assertThat(measurementCaptor.allValues.map { it.measurement }).containsNoDuplicates()
 
-    // Verify proto argument of InternalMeasurementsCoroutineImplBase::createMeasurement
-    val internalMeasurementCaptor: KArgumentCaptor<InternalMeasurement> = argumentCaptor()
-    verifyBlocking(internalMeasurementsMock, times(2)) {
-      createMeasurement(internalMeasurementCaptor.capture())
-    }
+    // Verify proto argument of InternalMeasurementsCoroutineImplBase::batchCreateMeasurements
+    verifyProtoArgument(
+      internalMeasurementsMock,
+      InternalMeasurementsCoroutineImplBase::batchCreateMeasurements
+    )
+      .isEqualTo(
+        batchCreateMeasurementsRequest {
+          measurements += INTERNAL_PENDING_REACH_MEASUREMENT
+          measurements += INTERNAL_PENDING_REACH_MEASUREMENT.copy {
+            measurementReferenceId = REACH_MEASUREMENT_KEY_2.measurementId
+          }
+        })
 
     // Verify proto argument of InternalReportsCoroutineImplBase::createReport
     verifyProtoArgument(internalReportsMock, ReportsCoroutineImplBase::createReport)
@@ -2500,9 +2515,6 @@ class ReportsServiceTest {
   @Test
   fun `createReport succeeds when the internal createMeasurement throws ALREADY_EXISTS`() =
     runBlocking {
-      whenever(internalMeasurementsMock.createMeasurement(any()))
-        .thenThrow(StatusRuntimeException(Status.ALREADY_EXISTS))
-
       val request = createReportRequest {
         parent = MEASUREMENT_CONSUMERS.values.first().name
         report = PENDING_REACH_REPORT.copy { clearState() }
@@ -3297,7 +3309,7 @@ class ReportsServiceTest {
   @Test
   fun `createReport throws exception when the internal createMeasurement throws exception`() =
     runBlocking {
-      whenever(internalMeasurementsMock.createMeasurement(any()))
+      whenever(internalMeasurementsMock.batchCreateMeasurements(any()))
         .thenThrow(StatusRuntimeException(Status.INVALID_ARGUMENT))
 
       val request = createReportRequest {
@@ -3306,14 +3318,13 @@ class ReportsServiceTest {
       }
 
       val exception =
-        assertFailsWith(Exception::class) {
+        assertFailsWith<StatusRuntimeException> {
           withMeasurementConsumerPrincipal(MEASUREMENT_CONSUMERS.values.first().name, CONFIG) {
             runBlocking { service.createReport(request) }
           }
         }
-      val expectedExceptionDescription =
-        "Unable to create the measurement [${REACH_MEASUREMENT_KEY.toName()}] in the reporting database."
-      assertThat(exception.message).isEqualTo(expectedExceptionDescription)
+      assertThat(exception.status.code).isEqualTo(Status.Code.UNKNOWN)
+      assertThat(exception.message).contains("Unable to create measurement")
     }
 
   @Test

--- a/src/test/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/MetricsServiceTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/MetricsServiceTest.kt
@@ -2927,7 +2927,7 @@ class MetricsServiceTest {
 
     // Verify proto argument of DataProvidersCoroutineImplBase::getDataProvider
     val dataProvidersCaptor: KArgumentCaptor<GetDataProviderRequest> = argumentCaptor()
-    verifyBlocking(dataProvidersMock, never()) { getDataProvider(dataProvidersCaptor.capture()) }
+    verifyBlocking(dataProvidersMock, times(3)) { getDataProvider(dataProvidersCaptor.capture()) }
 
     // Verify proto argument of MeasurementsCoroutineImplBase::createMeasurement
     val measurementsCaptor: KArgumentCaptor<CreateMeasurementRequest> = argumentCaptor()
@@ -2975,7 +2975,7 @@ class MetricsServiceTest {
 
     // Verify proto argument of DataProvidersCoroutineImplBase::getDataProvider
     val dataProvidersCaptor: KArgumentCaptor<GetDataProviderRequest> = argumentCaptor()
-    verifyBlocking(dataProvidersMock, never()) { getDataProvider(dataProvidersCaptor.capture()) }
+    verifyBlocking(dataProvidersMock, times(3)) { getDataProvider(dataProvidersCaptor.capture()) }
 
     // Verify proto argument of MeasurementsCoroutineImplBase::createMeasurement
     val measurementsCaptor: KArgumentCaptor<CreateMeasurementRequest> = argumentCaptor()


### PR DESCRIPTION
I tested a Report that created 300 measurements using a PeriodicTimeInterval with 300 increments. On a GKE cluster (e2-standard-2), it originally took ~60 seconds. With this PR, it takes ~30 seconds. Adding BatchCreateMeasurements to the internal Reporting server led to the bulk of the improvement. Caching the GetDataProvider and GetCertificate calls didn't lead to a large improvement. The measurement creation flow (Create Kingdom Measurements -> Create Reporting Measurements) occupies the bulk of the time. The only thing I could think of to further improve the performance is to add BatchCreateMeasurements to the Kingdom Public API.