### PR TITLE
Limit the number of responses from StreamActiveComputations calls. (#1319)

### DIFF
--- a/src/test/kotlin/org/wfanet/measurement/kingdom/service/system/v1alpha/ComputationsServiceTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/kingdom/service/system/v1alpha/ComputationsServiceTest.kt
@@ -542,6 +542,7 @@ class ComputationsServiceTest {
             }
         }
       }
+      limit = ComputationsService.DEFAULT_STREAMING_LIMIT
     }
 
     inOrder(internalMeasurementsServiceMock) {


### PR DESCRIPTION
This eliminates the issue of a high number of rows being returned, which should be sufficient to address the latency issue. Moving the Duchy ID filtration into the WHERE clause should also help with the number of rows scanned, but there is still potential to have a high number due to the ORDER BY clause.

(cherry picked from commit e8dbecb4c398ebfa20be2a993ff14cb1362ed768)