### PR TITLE
Allow custom methodology not to provide variance but with a reason

### DIFF
--- a/build/repositories.bzl
+++ b/build/repositories.bzl
@@ -41,8 +41,8 @@ def wfa_measurement_system_repositories():
     wfa_repo_archive(
         name = "wfa_measurement_proto",
         repo = "cross-media-measurement-api",
-        sha256 = "929cfe5953b139a61f24b264a75a8c830ed010e4f661d5703eef57bd6c24e6aa",
-        version = "0.48.0",
+        sha256 = "00085554004989f970bdf8f963d381bf9978a34fb5d119e94ef505a182470b48",
+        version = "0.50.0",
     )
 
     wfa_repo_archive(

--- a/src/main/kotlin/org/wfanet/measurement/loadtest/dataprovider/EdpSimulator.kt
+++ b/src/main/kotlin/org/wfanet/measurement/loadtest/dataprovider/EdpSimulator.kt
@@ -41,6 +41,7 @@ import org.wfanet.anysketch.crypto.ElGamalPublicKey as AnySketchElGamalPublicKey
 import org.wfanet.anysketch.crypto.elGamalPublicKey as anySketchElGamalPublicKey
 import org.wfanet.measurement.api.v2alpha.Certificate
 import org.wfanet.measurement.api.v2alpha.CertificatesGrpcKt.CertificatesCoroutineStub
+import org.wfanet.measurement.api.v2alpha.CustomDirectMethodologyKt.variance
 import org.wfanet.measurement.api.v2alpha.DataProviderKey
 import org.wfanet.measurement.api.v2alpha.DeterministicCountDistinct
 import org.wfanet.measurement.api.v2alpha.DeterministicDistribution
@@ -1326,7 +1327,9 @@ class EdpSimulator(
             // TODO: Calculate impression from data.
             value = apiIdToExternalId(DataProviderKey.fromName(edpData.name)!!.dataProviderId)
             noiseMechanism = protocolConfigNoiseMechanism
-            customDirectMethodology = customDirectMethodology { scalar = 0.0 }
+            customDirectMethodology = customDirectMethodology {
+              variance = variance { scalar = 0.0 }
+            }
           }
         }
       }
@@ -1341,7 +1344,9 @@ class EdpSimulator(
               seconds = log2(externalDataProviderId.toDouble()).toLong()
             }
             noiseMechanism = protocolConfigNoiseMechanism
-            customDirectMethodology = customDirectMethodology { scalar = 0.0 }
+            customDirectMethodology = customDirectMethodology {
+              variance = variance { scalar = 0.0 }
+            }
           }
         }
       }

--- a/src/main/kotlin/org/wfanet/measurement/loadtest/measurementconsumer/MeasurementConsumerSimulator.kt
+++ b/src/main/kotlin/org/wfanet/measurement/loadtest/measurementconsumer/MeasurementConsumerSimulator.kt
@@ -34,6 +34,7 @@ import kotlin.random.Random
 import kotlinx.coroutines.time.delay
 import org.wfanet.measurement.api.v2alpha.Certificate
 import org.wfanet.measurement.api.v2alpha.CertificatesGrpcKt.CertificatesCoroutineStub
+import org.wfanet.measurement.api.v2alpha.CustomDirectMethodologyKt
 import org.wfanet.measurement.api.v2alpha.DataProvider
 import org.wfanet.measurement.api.v2alpha.DataProviderCertificateKey
 import org.wfanet.measurement.api.v2alpha.DataProviderKey
@@ -428,7 +429,9 @@ class MeasurementConsumerSimulator(
           apiIdToExternalId(DataProviderCertificateKey.fromName(it.certificate)!!.dataProviderId)
         )
       assertThat(result.impression.customDirectMethodology)
-        .isEqualTo(customDirectMethodology { scalar = 0.0 })
+        .isEqualTo(
+          customDirectMethodology { variance = CustomDirectMethodologyKt.variance { scalar = 0.0 } }
+        )
       assertThat(result.impression.noiseMechanism).isEqualTo(expectedDirectNoiseMechanism)
     }
     logger.info("Impression result is equal to the expected result")
@@ -457,7 +460,9 @@ class MeasurementConsumerSimulator(
         )
       // EdpSimulator hasn't had an implementation for watch duration.
       assertThat(result.watchDuration.customDirectMethodology)
-        .isEqualTo(customDirectMethodology { scalar = 0.0 })
+        .isEqualTo(
+          customDirectMethodology { variance = CustomDirectMethodologyKt.variance { scalar = 0.0 } }
+        )
       assertThat(result.watchDuration.noiseMechanism).isEqualTo(expectedDirectNoiseMechanism)
     }
     logger.info("Duration result is equal to the expected result")

--- a/src/main/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/MetricsService.kt
+++ b/src/main/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/MetricsService.kt
@@ -1770,7 +1770,7 @@ fun buildWeightedWatchDurationMeasurementVarianceParamsPerResult(
     val methodology: Methodology =
       try {
         buildStatsMethodology(watchDurationResult)
-      } catch (e: MethodologyNotSetException) {
+      } catch (e: MeasurementVarianceNotComputableException) {
         return@map null
       }
 
@@ -1802,18 +1802,23 @@ fun buildStatsMethodology(
   return when (watchDurationResult.methodologyCase) {
     InternalMeasurement.Result.WatchDuration.MethodologyCase.CUSTOM_DIRECT_METHODOLOGY -> {
       @Suppress("WHEN_ENUM_CAN_BE_NULL_IN_JAVA")
-      when (watchDurationResult.customDirectMethodology.varianceCase) {
-        CustomDirectMethodology.VarianceCase.SCALAR -> {
-          CustomDirectScalarMethodology(watchDurationResult.customDirectMethodology.scalar)
+      when (watchDurationResult.customDirectMethodology.variance.typeCase) {
+        CustomDirectMethodology.Variance.TypeCase.SCALAR -> {
+          CustomDirectScalarMethodology(watchDurationResult.customDirectMethodology.variance.scalar)
         }
-        CustomDirectMethodology.VarianceCase.FREQUENCY -> {
+        CustomDirectMethodology.Variance.TypeCase.FREQUENCY -> {
           failGrpc(status = Status.FAILED_PRECONDITION, cause = IllegalStateException()) {
             "Custom direct methodology for frequency is not supported for watch duration."
           }
         }
-        CustomDirectMethodology.VarianceCase.VARIANCE_NOT_SET -> {
+        CustomDirectMethodology.Variance.TypeCase.UNAVAILABLE -> {
+          throw MeasurementVarianceNotComputableException(
+            "Watch duration computed from a custom methodology doesn't have variance."
+          )
+        }
+        CustomDirectMethodology.Variance.TypeCase.TYPE_NOT_SET -> {
           failGrpc(status = Status.FAILED_PRECONDITION, cause = IllegalStateException()) {
-            "Variance case in CustomDirectMethodology should've been set."
+            "Variance in CustomDirectMethodology should've been set."
           }
         }
       }
@@ -1822,7 +1827,7 @@ fun buildStatsMethodology(
       DeterministicMethodology
     }
     InternalMeasurement.Result.WatchDuration.MethodologyCase.METHODOLOGY_NOT_SET -> {
-      throw MethodologyNotSetException("Watch duration methodology is not set.")
+      throw MeasurementVarianceNotComputableException("Watch duration methodology is not set.")
     }
   }
 }
@@ -1926,7 +1931,7 @@ fun buildWeightedImpressionMeasurementVarianceParamsPerResult(
     val methodology: Methodology =
       try {
         buildStatsMethodology(impressionResult)
-      } catch (e: MethodologyNotSetException) {
+      } catch (e: MeasurementVarianceNotComputableException) {
         return@map null
       }
 
@@ -1955,16 +1960,21 @@ fun buildStatsMethodology(impressionResult: InternalMeasurement.Result.Impressio
   return when (impressionResult.methodologyCase) {
     InternalMeasurement.Result.Impression.MethodologyCase.CUSTOM_DIRECT_METHODOLOGY -> {
       @Suppress("WHEN_ENUM_CAN_BE_NULL_IN_JAVA")
-      when (impressionResult.customDirectMethodology.varianceCase) {
-        CustomDirectMethodology.VarianceCase.SCALAR -> {
-          CustomDirectScalarMethodology(impressionResult.customDirectMethodology.scalar)
+      when (impressionResult.customDirectMethodology.variance.typeCase) {
+        CustomDirectMethodology.Variance.TypeCase.SCALAR -> {
+          CustomDirectScalarMethodology(impressionResult.customDirectMethodology.variance.scalar)
         }
-        CustomDirectMethodology.VarianceCase.FREQUENCY -> {
+        CustomDirectMethodology.Variance.TypeCase.FREQUENCY -> {
           failGrpc(status = Status.FAILED_PRECONDITION, cause = IllegalStateException()) {
             "Custom direct methodology for frequency is not supported for impression."
           }
         }
-        CustomDirectMethodology.VarianceCase.VARIANCE_NOT_SET -> {
+        CustomDirectMethodology.Variance.TypeCase.UNAVAILABLE -> {
+          throw MeasurementVarianceNotComputableException(
+            "Impression computed from a custom methodology doesn't have variance."
+          )
+        }
+        CustomDirectMethodology.Variance.TypeCase.TYPE_NOT_SET -> {
           failGrpc(status = Status.FAILED_PRECONDITION, cause = IllegalStateException()) {
             "Variance case in CustomDirectMethodology should've been set."
           }
@@ -1975,7 +1985,7 @@ fun buildStatsMethodology(impressionResult: InternalMeasurement.Result.Impressio
       DeterministicMethodology
     }
     InternalMeasurement.Result.Impression.MethodologyCase.METHODOLOGY_NOT_SET -> {
-      throw MethodologyNotSetException("Impression methodology is not set.")
+      throw MeasurementVarianceNotComputableException("Impression methodology is not set.")
     }
   }
 }
@@ -2136,7 +2146,7 @@ fun buildWeightedFrequencyMeasurementVarianceParams(
   val frequencyMethodology: Methodology =
     try {
       buildStatsMethodology(frequencyResult)
-    } catch (e: MethodologyNotSetException) {
+    } catch (e: MeasurementVarianceNotComputableException) {
       return null
     }
 
@@ -2167,23 +2177,28 @@ fun buildStatsMethodology(frequencyResult: InternalMeasurement.Result.Frequency)
   return when (frequencyResult.methodologyCase) {
     InternalMeasurement.Result.Frequency.MethodologyCase.CUSTOM_DIRECT_METHODOLOGY -> {
       @Suppress("WHEN_ENUM_CAN_BE_NULL_IN_JAVA")
-      when (frequencyResult.customDirectMethodology.varianceCase) {
-        CustomDirectMethodology.VarianceCase.SCALAR -> {
+      when (frequencyResult.customDirectMethodology.variance.typeCase) {
+        CustomDirectMethodology.Variance.TypeCase.SCALAR -> {
           failGrpc(status = Status.FAILED_PRECONDITION, cause = IllegalStateException()) {
             "Custom direct methodology for scalar is not supported for frequency."
           }
         }
-        CustomDirectMethodology.VarianceCase.FREQUENCY -> {
+        CustomDirectMethodology.Variance.TypeCase.FREQUENCY -> {
           CustomDirectFrequencyMethodology(
-            frequencyResult.customDirectMethodology.frequency.variancesMap.mapKeys {
+            frequencyResult.customDirectMethodology.variance.frequency.variancesMap.mapKeys {
               it.key.toInt()
             },
-            frequencyResult.customDirectMethodology.frequency.kPlusVariancesMap.mapKeys {
+            frequencyResult.customDirectMethodology.variance.frequency.kPlusVariancesMap.mapKeys {
               it.key.toInt()
             },
           )
         }
-        CustomDirectMethodology.VarianceCase.VARIANCE_NOT_SET -> {
+        CustomDirectMethodology.Variance.TypeCase.UNAVAILABLE -> {
+          throw MeasurementVarianceNotComputableException(
+            "Frequency computed from a custom methodology doesn't have variance."
+          )
+        }
+        CustomDirectMethodology.Variance.TypeCase.TYPE_NOT_SET -> {
           failGrpc(status = Status.FAILED_PRECONDITION, cause = IllegalStateException()) {
             "Variance case in CustomDirectMethodology should've been set."
           }
@@ -2207,7 +2222,7 @@ fun buildStatsMethodology(frequencyResult: InternalMeasurement.Result.Frequency)
       )
     }
     InternalMeasurement.Result.Frequency.MethodologyCase.METHODOLOGY_NOT_SET -> {
-      throw MethodologyNotSetException("Frequency methodology is not set.")
+      throw MeasurementVarianceNotComputableException("Frequency methodology is not set.")
     }
   }
 }
@@ -2312,7 +2327,7 @@ private fun buildWeightedReachMeasurementVarianceParams(
   val methodology: Methodology =
     try {
       buildStatsMethodology(reachResult)
-    } catch (e: MethodologyNotSetException) {
+    } catch (e: MeasurementVarianceNotComputableException) {
       return null
     }
 
@@ -2339,16 +2354,21 @@ fun buildStatsMethodology(reachResult: InternalMeasurement.Result.Reach): Method
   return when (reachResult.methodologyCase) {
     InternalMeasurement.Result.Reach.MethodologyCase.CUSTOM_DIRECT_METHODOLOGY -> {
       @Suppress("WHEN_ENUM_CAN_BE_NULL_IN_JAVA")
-      when (reachResult.customDirectMethodology.varianceCase) {
-        CustomDirectMethodology.VarianceCase.SCALAR -> {
-          CustomDirectScalarMethodology(reachResult.customDirectMethodology.scalar)
+      when (reachResult.customDirectMethodology.variance.typeCase) {
+        CustomDirectMethodology.Variance.TypeCase.SCALAR -> {
+          CustomDirectScalarMethodology(reachResult.customDirectMethodology.variance.scalar)
         }
-        CustomDirectMethodology.VarianceCase.FREQUENCY -> {
+        CustomDirectMethodology.Variance.TypeCase.FREQUENCY -> {
           failGrpc(status = Status.FAILED_PRECONDITION, cause = IllegalStateException()) {
             "Custom direct methodology for frequency is not supported for reach."
           }
         }
-        CustomDirectMethodology.VarianceCase.VARIANCE_NOT_SET -> {
+        CustomDirectMethodology.Variance.TypeCase.UNAVAILABLE -> {
+          throw MeasurementVarianceNotComputableException(
+            "Reach computed from a custom methodology doesn't have variance."
+          )
+        }
+        CustomDirectMethodology.Variance.TypeCase.TYPE_NOT_SET -> {
           failGrpc(status = Status.FAILED_PRECONDITION, cause = IllegalStateException()) {
             "Variance case in CustomDirectMethodology should've been set."
           }
@@ -2379,7 +2399,7 @@ fun buildStatsMethodology(reachResult: InternalMeasurement.Result.Reach): Method
       )
     }
     InternalMeasurement.Result.Reach.MethodologyCase.METHODOLOGY_NOT_SET -> {
-      throw MethodologyNotSetException("Reach methodology is not set.")
+      throw MeasurementVarianceNotComputableException("Reach methodology is not set.")
     }
   }
 }

--- a/src/main/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/ProtoConversions.kt
+++ b/src/main/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/ProtoConversions.kt
@@ -34,7 +34,7 @@ import org.wfanet.measurement.api.v2alpha.differentialPrivacyParams
 import org.wfanet.measurement.config.reporting.MetricSpecConfig
 import org.wfanet.measurement.eventdataprovider.noiser.DpParams as NoiserDpParams
 import org.wfanet.measurement.internal.reporting.v2.CustomDirectMethodology as InternalCustomDirectMethodology
-import org.wfanet.measurement.internal.reporting.v2.CustomDirectMethodologyKt
+import org.wfanet.measurement.internal.reporting.v2.CustomDirectMethodologyKt as InternalCustomDirectMethodologyKt
 import org.wfanet.measurement.internal.reporting.v2.DeterministicCount
 import org.wfanet.measurement.internal.reporting.v2.DeterministicCountDistinct
 import org.wfanet.measurement.internal.reporting.v2.DeterministicDistribution
@@ -829,22 +829,56 @@ fun ProtocolConfig.NoiseMechanism.toInternal(): InternalNoiseMechanism {
 /** Converts a CMMS [CustomDirectMethodology] to an internal [InternalCustomDirectMethodology]. */
 fun CustomDirectMethodology.toInternal(): InternalCustomDirectMethodology {
   val source = this
+  require(source.hasVariance()) { "Variance in CustomDirectMethodology is not set." }
   return customDirectMethodology {
-    @Suppress("WHEN_ENUM_CAN_BE_NULL_IN_JAVA")
-    when (source.varianceCase) {
-      CustomDirectMethodology.VarianceCase.SCALAR -> {
-        scalar = source.scalar
-      }
-      CustomDirectMethodology.VarianceCase.FREQUENCY -> {
-        frequency =
-          CustomDirectMethodologyKt.frequencyVariances {
-            variances.putAll(source.frequency.variancesMap)
-            kPlusVariances.putAll(source.frequency.kPlusVariancesMap)
+    variance =
+      InternalCustomDirectMethodologyKt.variance {
+        @Suppress("WHEN_ENUM_CAN_BE_NULL_IN_JAVA")
+        when (source.variance.typeCase) {
+          CustomDirectMethodology.Variance.TypeCase.SCALAR -> {
+            scalar = source.variance.scalar
           }
+          CustomDirectMethodology.Variance.TypeCase.FREQUENCY -> {
+            frequency =
+              InternalCustomDirectMethodologyKt.VarianceKt.frequencyVariances {
+                variances.putAll(source.variance.frequency.variancesMap)
+                kPlusVariances.putAll(source.variance.frequency.kPlusVariancesMap)
+              }
+          }
+          CustomDirectMethodology.Variance.TypeCase.UNAVAILABLE -> {
+            unavailable =
+              InternalCustomDirectMethodologyKt.VarianceKt.unavailable {
+                reason = source.variance.unavailable.reason.toInternal()
+              }
+          }
+          CustomDirectMethodology.Variance.TypeCase.TYPE_NOT_SET -> {
+            error("Variance in CustomDirectMethodology is not set.")
+          }
+        }
       }
-      CustomDirectMethodology.VarianceCase.VARIANCE_NOT_SET -> {
-        error("Variance in CustomDirectMethodology is not set.")
-      }
+  }
+}
+
+/**
+ * Converts a CMMS [CustomDirectMethodology.Variance.Unavailable.Reason] to an internal
+ * [InternalCustomDirectMethodology.Variance.Unavailable.Reason].
+ */
+private fun CustomDirectMethodology.Variance.Unavailable.Reason.toInternal():
+  InternalCustomDirectMethodology.Variance.Unavailable.Reason {
+  return when (this) {
+    CustomDirectMethodology.Variance.Unavailable.Reason.REASON_UNSPECIFIED -> {
+      error(
+        "There is no reason specified about the unavailable variance in CustomDirectMethodology."
+      )
+    }
+    CustomDirectMethodology.Variance.Unavailable.Reason.UNDERIVABLE -> {
+      InternalCustomDirectMethodology.Variance.Unavailable.Reason.UNDERIVABLE
+    }
+    CustomDirectMethodology.Variance.Unavailable.Reason.INACCESSIBLE -> {
+      InternalCustomDirectMethodology.Variance.Unavailable.Reason.INACCESSIBLE
+    }
+    CustomDirectMethodology.Variance.Unavailable.Reason.UNRECOGNIZED -> {
+      error("Unrecognized reason of unavailable variance in CustomDirectMethodology.")
     }
   }
 }

--- a/src/main/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/ReportingExceptions.kt
+++ b/src/main/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/ReportingExceptions.kt
@@ -24,6 +24,6 @@ class NoiseMechanismUnspecifiedException(message: String? = null, cause: Throwab
 class NoiseMechanismUnrecognizedException(message: String? = null, cause: Throwable? = null) :
   Exception(message, cause)
 
-/** [Exception] which indicates an error that measurement methodology is not set. */
-class MethodologyNotSetException(message: String? = null, cause: Throwable? = null) :
+/** [Exception] which indicates an error that measurement variance is not computable. */
+class MeasurementVarianceNotComputableException(message: String? = null, cause: Throwable? = null) :
   Exception(message, cause)

--- a/src/main/proto/wfa/measurement/internal/reporting/v2/direct_computation.proto
+++ b/src/main/proto/wfa/measurement/internal/reporting/v2/direct_computation.proto
@@ -21,23 +21,57 @@ option java_multiple_files = true;
 
 // Information about the custom direct methodology.
 message CustomDirectMethodology {
-  // Different types of variances of a frequency distribution result.
-  message FrequencyVariances {
-    // The variances of a frequency distribution from frequency 1 to maximum
-    // frequency specified in the measurement spec.
-    map<int64, double> variances = 1;
-    // The variances of a k+ frequency distribution from frequency 1 to
-    // maximum frequency specified in the measurement spec.
-    map<int64, double> k_plus_variances = 2;
+  // The information about a variance.
+  message Variance {
+    // Different types of variances of a frequency distribution result.
+    message FrequencyVariances {
+      // The variances of a frequency distribution from frequency 1 to maximum
+      // frequency specified in the measurement spec.
+      map<int64, double> variances = 1;
+      // The variances of a k+ frequency distribution from frequency 1 to
+      // maximum frequency specified in the measurement spec.
+      //
+      // A K+ frequency distribution is derived from the frequency distribution
+      // by calculating the reach ratio of frequency K and above, i.e. reversed
+      // cumulative sum of the frequency distribution. For example, a frequency
+      // distribution {1: 0.4, 2: 0.3, 3: 0.2, 4:0.1, 5: 0.0} will have a K+
+      // frequency distribution {1: 1.0, 2: 0.6, 3: 0.3, 4:0.1, 5: 0.0}.
+      map<int64, double> k_plus_variances = 2;
+    }
+
+    // Information about lack of variance.
+    message Unavailable {
+      // Reason for a `Unavailable`.
+      enum Reason {
+        // Default value used if the reason is omitted.
+        //
+        // Used to capture unset reason which is invalid. This enum constant
+        // should never be set.
+        REASON_UNSPECIFIED = 0;
+        // When the variance is mathematically not derivable from a custom
+        // direct methodology.
+        UNDERIVABLE = 1;
+        // When the variance is obtained by upstream providers and not
+        // accessible.
+        INACCESSIBLE = 2;
+      }
+      // Reason for this `Unavailable`.
+      Reason reason = 1;
+    }
+
+    // The type of variance associated with a result. Required.
+    oneof type {
+      // The variance when the computation result is a scalar type.
+      double scalar = 1;
+      // The variance when the computation result is a frequency type.
+      FrequencyVariances frequency = 2;
+      // The variance is unavailable for a custom direct methodology.
+      Unavailable unavailable = 3;
+    }
   }
 
-  // The variance of the result computed from the custom direct methodology.
-  oneof variance {
-    // The variance when the result is a scalar type.
-    double scalar = 1;
-    // The variance when the result is a frequency type.
-    FrequencyVariances frequency = 2;
-  }
+  // The variance of the result computed from this custom direct methodology.
+  Variance variance = 1;
 }
 
 // Parameters used when applying the deterministic count distinct methodology.


### PR DESCRIPTION
This PR accommodate the API change from [cmm-api PR186](https://github.com/world-federation-of-advertisers/cross-media-measurement-api/pull/186) that allows EDPs not to provide variances of custom direct methodology instead a reason.
In addition to the changes due to refactoring, there are two main changes:
1. If the reason of not having variance in custom direct methodology is not specified, raise error.
2. If the variance field in custom direct methodology is not set, raise error.
3. MetricsService will not set `UnivariateStatistics` when the custom direct methodology has no variance with a reason.