### PR TITLE
Support arbitrary event message types for synthetic event generation.

### DIFF
--- a/src/main/k8s/testing/data/synthetic_population_spec.textproto
+++ b/src/main/k8s/testing/data/synthetic_population_spec.textproto
@@ -1,8 +1,7 @@
 # proto-file: wfa/measurement/api/v2alpha/event_group_metadata/testing/simulator_synthetic_data_spec.proto
 # proto-message: SyntheticPopulationSpec
 
-# UK population by sex, age, and social grade using
-# wfa.measurement.api.v2alpha.event_templates.testing.TestEvent.
+# UK population by sex, age, and social grade.
 #
 # See https://www.ons.gov.uk/peoplepopulationandcommunity/birthsdeathsandmarriages/families/adhocs/005317ct05672011censussexbyagesyoabyapproximatedsocialgradenationaltocountry
 
@@ -10,6 +9,7 @@ vid_range {
   start: 1
   end_exclusive: 34335355  # Age 18-64 with known social grade.
 }
+event_message_type_url: "type.googleapis.com/wfa.measurement.api.v2alpha.event_templates.testing.TestEvent"
 population_fields: "person.gender"
 population_fields: "person.age_group"
 population_fields: "person.social_grade_group"

--- a/src/main/kotlin/org/wfanet/measurement/integration/common/InProcessEdpSimulator.kt
+++ b/src/main/kotlin/org/wfanet/measurement/integration/common/InProcessEdpSimulator.kt
@@ -39,6 +39,7 @@ import org.wfanet.measurement.api.v2alpha.MeasurementConsumersGrpcKt.Measurement
 import org.wfanet.measurement.api.v2alpha.RequisitionFulfillmentGrpcKt.RequisitionFulfillmentCoroutineStub
 import org.wfanet.measurement.api.v2alpha.RequisitionsGrpcKt.RequisitionsCoroutineStub
 import org.wfanet.measurement.api.v2alpha.event_group_metadata.testing.SyntheticEventGroupSpec
+import org.wfanet.measurement.api.v2alpha.event_templates.testing.TestEvent
 import org.wfanet.measurement.common.identity.withPrincipalName
 import org.wfanet.measurement.common.throttler.MinimumIntervalThrottler
 import org.wfanet.measurement.eventdataprovider.privacybudgetmanagement.CompositionMechanism
@@ -89,7 +90,11 @@ class InProcessEdpSimulator(
       requisitionFulfillmentStub =
         RequisitionFulfillmentCoroutineStub(duchyPublicApiChannel).withPrincipalName(resourceName),
       eventQuery =
-        object : SyntheticGeneratorEventQuery(SyntheticGenerationSpecs.POPULATION_SPEC) {
+        object :
+          SyntheticGeneratorEventQuery(
+            SyntheticGenerationSpecs.POPULATION_SPEC,
+            TestEvent.getDescriptor()
+          ) {
           override fun getSyntheticDataSpec(eventGroup: EventGroup) = syntheticDataSpec
         },
       throttler = MinimumIntervalThrottler(Clock.systemUTC(), Duration.ofMillis(1000)),

--- a/src/main/kotlin/org/wfanet/measurement/loadtest/measurementconsumer/MetadataSyntheticGeneratorEventQuery.kt
+++ b/src/main/kotlin/org/wfanet/measurement/loadtest/measurementconsumer/MetadataSyntheticGeneratorEventQuery.kt
@@ -19,6 +19,7 @@ package org.wfanet.measurement.loadtest.measurementconsumer
 import org.wfanet.measurement.api.v2alpha.EventGroup
 import org.wfanet.measurement.api.v2alpha.event_group_metadata.testing.SyntheticEventGroupSpec
 import org.wfanet.measurement.api.v2alpha.event_group_metadata.testing.SyntheticPopulationSpec
+import org.wfanet.measurement.api.v2alpha.event_templates.testing.TestEvent
 import org.wfanet.measurement.common.crypto.PrivateKeyHandle
 import org.wfanet.measurement.consent.client.measurementconsumer.decryptMetadata
 import org.wfanet.measurement.loadtest.dataprovider.SyntheticGeneratorEventQuery
@@ -29,7 +30,7 @@ import org.wfanet.measurement.loadtest.dataprovider.SyntheticGeneratorEventQuery
 class MetadataSyntheticGeneratorEventQuery(
   populationSpec: SyntheticPopulationSpec,
   private val mcPrivateKey: PrivateKeyHandle
-) : SyntheticGeneratorEventQuery(populationSpec) {
+) : SyntheticGeneratorEventQuery(populationSpec, TestEvent.getDescriptor()) {
   override fun getSyntheticDataSpec(eventGroup: EventGroup): SyntheticEventGroupSpec {
     val metadata = decryptMetadata(eventGroup.encryptedMetadata, mcPrivateKey)
     return metadata.metadata.unpack(SyntheticEventGroupSpec::class.java)

--- a/src/main/proto/wfa/measurement/api/v2alpha/event_group_metadata/testing/simulator_synthetic_data_spec.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/event_group_metadata/testing/simulator_synthetic_data_spec.proto
@@ -50,6 +50,12 @@ message SyntheticPopulationSpec {
   // The overall range of VIDs for the synthetic population.
   VidRange vid_range = 1;
 
+  // Type URL of the event message type.
+  //
+  // This is the message type which `population_fields` and
+  // `non_population_fields` refer to.
+  string event_message_type_url = 5;
+
   // Set of field paths within a synthetic event that pertain to the population,
   // with `.` as the traversal operator.
   //

--- a/src/test/kotlin/org/wfanet/measurement/loadtest/dataprovider/EdpSimulatorTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/loadtest/dataprovider/EdpSimulatorTest.kt
@@ -2320,7 +2320,11 @@ class EdpSimulatorTest {
         }
       }
     private val syntheticGeneratorEventQuery =
-      object : SyntheticGeneratorEventQuery(SyntheticGenerationSpecs.POPULATION_SPEC) {
+      object :
+        SyntheticGeneratorEventQuery(
+          SyntheticGenerationSpecs.POPULATION_SPEC,
+          TestEvent.getDescriptor()
+        ) {
         override fun getSyntheticDataSpec(eventGroup: EventGroup): SyntheticEventGroupSpec {
           return SYNTHETIC_DATA_SPEC
         }


### PR DESCRIPTION
This allows overriding the event message used by the EDP simulator when using the synthetic generator event source. This is done by specifying the `event_message_type_url` field in `SyntheticPopulationSpec` and the `--event-message-descriptor-set` command-line option for the EDP simulator.