### PR TITLE
depend on output of generate_certificate_step in any export step

### DIFF
--- a/src/main/k8s/panelmatch/testing/workflows/mini_exchange_workflow.textproto
+++ b/src/main/k8s/panelmatch/testing/workflows/mini_exchange_workflow.textproto
@@ -38,6 +38,10 @@ steps {
     }
   }
   input_labels { key: "hkdf-pepper" value: "edp-hkdf-pepper" }
+  input_labels {
+    key: "certificate-resource-name"
+    value: "edp-certificate-resource-name"
+  }
   output_labels { key: "hkdf-pepper" value: "hkdf-pepper" }
 }
 

--- a/src/main/k8s/testing/secretfiles/exchange_workflow.textproto
+++ b/src/main/k8s/testing/secretfiles/exchange_workflow.textproto
@@ -38,6 +38,10 @@ steps {
     }
   }
   input_labels { key: "hkdf-pepper" value: "edp-hkdf-pepper" }
+  input_labels {
+    key: "certificate-resource-name"
+    value: "edp-certificate-resource-name"
+  }
   output_labels { key: "hkdf-pepper" value: "hkdf-pepper" }
 }
 


### PR DESCRIPTION
The export step requires a certificate resource to be present to attach to the `NamedSignature`.

In some exchanges, this value will be pre-computed before the exchange. However, if the exchange, itself, generates a certificate, then any export step should depend on the output of that step to ensure the export doesn't run before the certificate is present.