### PR TITLE
Output a dense frequency distribution for Direct protocol.

### DIFF
--- a/src/main/kotlin/org/wfanet/measurement/loadtest/dataprovider/MeasurementResults.kt
+++ b/src/main/kotlin/org/wfanet/measurement/loadtest/dataprovider/MeasurementResults.kt
@@ -28,13 +28,16 @@ object MeasurementResults {
     val eventsPerVid: Map<Long, Int> = sampledVids.groupingBy { it }.eachCount()
     val reach: Int = eventsPerVid.keys.size
 
-    val frequencyHistogram = mutableMapOf<Int, Int>()
+    // Build frequency histogram as a 0-based array.
+    val frequencyArray = IntArray(maxFrequency)
     for (count in eventsPerVid.values) {
       val bucket = count.coerceAtMost(maxFrequency)
-      frequencyHistogram[bucket] = frequencyHistogram.getOrDefault(bucket, 0) + 1
+      frequencyArray[bucket - 1]++
     }
 
-    return ReachAndFrequency(reach, frequencyHistogram.mapValues { it.value.toDouble() / reach })
+    val frequencyDistribution: Map<Int, Double> =
+      frequencyArray.withIndex().associateBy({ it.index + 1 }, { it.value.toDouble() / reach })
+    return ReachAndFrequency(reach, frequencyDistribution)
   }
 
   /** Computes reach using the "deterministic count distinct" methodology. */

--- a/src/test/kotlin/org/wfanet/measurement/loadtest/dataprovider/EdpSimulatorTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/loadtest/dataprovider/EdpSimulatorTest.kt
@@ -1712,11 +1712,8 @@ class EdpSimulatorTest {
     assertThat(result.reach.hasDeterministicCountDistinct())
     assertThat(result.frequency.noiseMechanism == noiseMechanismOption)
     assertThat(result.frequency.hasDeterministicDistribution())
-    assertThat(result).reachValue().isEqualTo(2001L)
-    assertThat(result)
-      .frequencyDistribution()
-      .isWithin(0.001)
-      .of(mapOf(2L to 0.5011303262418495, 4L to 0.5062662903291533))
+    assertThat(result).reachValue().isWithin(2.0).of(2000L)
+    assertThat(result).frequencyDistribution().isWithin(0.01).of(mapOf(2L to 0.5, 4L to 0.5))
   }
 
   @Test
@@ -1778,11 +1775,11 @@ class EdpSimulatorTest {
     assertThat(result.reach.hasDeterministicCountDistinct())
     assertThat(result.frequency.noiseMechanism == noiseMechanismOption)
     assertThat(result.frequency.hasDeterministicDistribution())
-    assertThat(result).reachValue().isEqualTo(1930)
+    assertThat(result).reachValue().isWithin(10.0).of(1920)
     assertThat(result)
       .frequencyDistribution()
-      .isWithin(0.00001)
-      .of(mapOf(2L to 0.5065658983525991, 4L to 0.5704821909286802))
+      .isWithin(0.07)
+      .of(mapOf(2L to 0.49479664833057146, 4L to 0.5052080336866532))
   }
 
   @Test
@@ -1960,7 +1957,7 @@ class EdpSimulatorTest {
 
     assertThat(result.reach.noiseMechanism == noiseMechanismOption)
     assertThat(result.reach.hasDeterministicCountDistinct())
-    assertThat(result).reachValue().isEqualTo(2001L)
+    assertThat(result).reachValue().isWithin(2.0).of(2000L)
     assertThat(result.hasFrequency()).isFalse()
   }
 
@@ -2021,7 +2018,7 @@ class EdpSimulatorTest {
 
     assertThat(result.reach.noiseMechanism == noiseMechanismOption)
     assertThat(result.reach.hasDeterministicCountDistinct())
-    assertThat(result).reachValue().isEqualTo(1930)
+    assertThat(result).reachValue().isWithin(10.0).of(1920L)
     assertThat(result.hasFrequency()).isFalse()
   }
 


### PR DESCRIPTION
This addresses an issue where the EDP simulator may output a "sparse" relative frequency distribution for the Direct protocol where not all buckets are included.