### PR TITLE
Use C2 machines by default for LLv2 Mills on GKE.

### DIFF
--- a/src/main/terraform/gcloud/cmms/duchies.tf
+++ b/src/main/terraform/gcloud/cmms/duchies.tf
@@ -49,7 +49,7 @@ module "highmem_node_pools" {
   cluster         = each.value
   name            = "highmem"
   service_account = module.common.cluster_service_account
-  machine_type    = "c3-highcpu-4"
+  machine_type    = "c2-standard-4"
   max_node_count  = 2
   spot            = true
 }

--- a/src/main/terraform/gcloud/examples/duchy/main.tf
+++ b/src/main/terraform/gcloud/examples/duchy/main.tf
@@ -76,7 +76,7 @@ module "spot_node_pool" {
   cluster         = data.google_container_cluster.cluster
   name            = "spot"
   service_account = module.common.cluster_service_account
-  machine_type    = "c3-highcpu-4"
+  machine_type    = "c2-standard-4"
   max_node_count  = 2
   spot            = true
 }


### PR DESCRIPTION
These machines are compute-optimized and more readily available across regions. They are also cheaper in terms of current spot VM pricing.