### PR TITLE
Refactor reach-and-frequency metric

### DIFF
--- a/src/main/k8s/testing/secretfiles/metric_spec_config.textproto
+++ b/src/main/k8s/testing/secretfiles/metric_spec_config.textproto
@@ -6,7 +6,7 @@ reach_params {
     delta: 1.0E-12
   }
 }
-frequency_histogram_params {
+reach_and_frequency_params {
   reach_privacy_params {
     epsilon: 0.0033
     delta: 1.0E-12
@@ -36,7 +36,7 @@ watch_duration_params {
 reach_vid_sampling_interval {
   width: 0.01
 }
-frequency_histogram_vid_sampling_interval {
+reach_and_frequency_vid_sampling_interval {
   start: 0.16
   width: 0.016666668
 }

--- a/src/main/kotlin/org/wfanet/measurement/integration/common/reporting/v2/InProcessLifeOfAReportIntegrationTest.kt
+++ b/src/main/kotlin/org/wfanet/measurement/integration/common/reporting/v2/InProcessLifeOfAReportIntegrationTest.kt
@@ -1383,7 +1383,7 @@ abstract class InProcessLifeOfAReportIntegrationTest(
   }
 
   @Test
-  fun `frequency histogram metric has the expected result`() = runBlocking {
+  fun `reach-and-frequency metric has the expected result`() = runBlocking {
     val measurementConsumerData = inProcessCmmsComponents.getMeasurementConsumerData()
     val eventGroups = listEventGroups()
     val eventGroup = eventGroups[0]
@@ -1410,8 +1410,8 @@ abstract class InProcessLifeOfAReportIntegrationTest(
       timeInterval = EVENT_RANGE.toInterval()
       metricSpec =
         metricSpec {
-            frequencyHistogram =
-              MetricSpecKt.frequencyHistogramParams {
+            reachAndFrequency =
+              MetricSpecKt.reachAndFrequencyParams {
                 reachPrivacyParams = DP_PARAMS
                 frequencyPrivacyParams = DP_PARAMS
                 maximumFrequency = 5
@@ -1445,17 +1445,16 @@ abstract class InProcessLifeOfAReportIntegrationTest(
     val expectedResult =
       calculateExpectedReachAndFrequencyMeasurementResult(
         sampledVids,
-        metric.metricSpec.frequencyHistogram.maximumFrequency
+        metric.metricSpec.reachAndFrequency.maximumFrequency
       )
 
-    val reach =
-      retrievedMetric.result.frequencyHistogram.binsList.sumOf { bin -> bin.binResult.value }
+    val reach = retrievedMetric.result.reachAndFrequency.reach.value
     val actualResult =
       MeasurementKt.result {
         frequency =
           MeasurementKt.ResultKt.frequency {
             relativeFrequencyDistribution.putAll(
-              retrievedMetric.result.frequencyHistogram.binsList.associate {
+              retrievedMetric.result.reachAndFrequency.frequencyHistogram.binsList.associate {
                 Pair(it.label.toLong(), it.binResult.value / reach)
               }
             )

--- a/src/main/kotlin/org/wfanet/measurement/integration/common/reporting/v2/InProcessReportingServer.kt
+++ b/src/main/kotlin/org/wfanet/measurement/integration/common/reporting/v2/InProcessReportingServer.kt
@@ -266,8 +266,8 @@ class InProcessReportingServer(
           width = 3.0f / NUMBER_VID_BUCKETS
         }
 
-      frequencyHistogramParams =
-        MetricSpecConfigKt.frequencyHistogramParams {
+      reachAndFrequencyParams =
+        MetricSpecConfigKt.reachAndFrequencyParams {
           reachPrivacyParams =
             MetricSpecConfigKt.differentialPrivacyParams {
               epsilon = 0.0033
@@ -280,7 +280,7 @@ class InProcessReportingServer(
             }
           maximumFrequency = 10
         }
-      frequencyHistogramVidSamplingInterval =
+      reachAndFrequencyVidSamplingInterval =
         MetricSpecConfigKt.vidSamplingInterval {
           start = 48.0f / NUMBER_VID_BUCKETS
           width = 5.0f / NUMBER_VID_BUCKETS

--- a/src/main/kotlin/org/wfanet/measurement/reporting/deploy/v2/postgres/readers/MetricReader.kt
+++ b/src/main/kotlin/org/wfanet/measurement/reporting/deploy/v2/postgres/readers/MetricReader.kt
@@ -418,7 +418,7 @@ class MetricReader(private val readContext: ReadContext) {
                         delta = differentialPrivacyDelta
                       }
                   }
-              MetricSpec.TypeCase.FREQUENCY_HISTOGRAM -> {
+              MetricSpec.TypeCase.REACH_AND_FREQUENCY -> {
                 if (
                   frequencyDifferentialPrivacyDelta == null ||
                     frequencyDifferentialPrivacyEpsilon == null ||
@@ -427,8 +427,8 @@ class MetricReader(private val readContext: ReadContext) {
                   throw IllegalStateException()
                 }
 
-                frequencyHistogram =
-                  MetricSpecKt.frequencyHistogramParams {
+                reachAndFrequency =
+                  MetricSpecKt.reachAndFrequencyParams {
                     reachPrivacyParams =
                       MetricSpecKt.differentialPrivacyParams {
                         epsilon = differentialPrivacyEpsilon

--- a/src/main/kotlin/org/wfanet/measurement/reporting/deploy/v2/postgres/writers/CreateMetrics.kt
+++ b/src/main/kotlin/org/wfanet/measurement/reporting/deploy/v2/postgres/writers/CreateMetrics.kt
@@ -204,15 +204,15 @@ class CreateMetrics(private val requests: List<CreateMetricRequest>) :
               bind("$8", it.metric.metricSpec.typeCase.number)
               @Suppress("WHEN_ENUM_CAN_BE_NULL_IN_JAVA") // Proto enum fields are never null.
               when (it.metric.metricSpec.typeCase) {
-                MetricSpec.TypeCase.FREQUENCY_HISTOGRAM -> {
-                  val frequencyHistogram = it.metric.metricSpec.frequencyHistogram
-                  bind("$9", frequencyHistogram.reachPrivacyParams.epsilon)
-                  bind("$10", frequencyHistogram.reachPrivacyParams.delta)
-                  bind("$11", frequencyHistogram.frequencyPrivacyParams.epsilon)
-                  bind("$12", frequencyHistogram.reachPrivacyParams.delta)
+                MetricSpec.TypeCase.REACH_AND_FREQUENCY -> {
+                  val reachAndFrequency = it.metric.metricSpec.reachAndFrequency
+                  bind("$9", reachAndFrequency.reachPrivacyParams.epsilon)
+                  bind("$10", reachAndFrequency.reachPrivacyParams.delta)
+                  bind("$11", reachAndFrequency.frequencyPrivacyParams.epsilon)
+                  bind("$12", reachAndFrequency.reachPrivacyParams.delta)
                   bind<Long?>("$13", null)
                   bind<PostgresInterval?>("$14", null)
-                  bind("$20", frequencyHistogram.maximumFrequency)
+                  bind("$20", reachAndFrequency.maximumFrequency)
                 }
                 MetricSpec.TypeCase.REACH -> {
                   val reach = it.metric.metricSpec.reach

--- a/src/main/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/MetricSpecDefaults.kt
+++ b/src/main/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/MetricSpecDefaults.kt
@@ -36,9 +36,9 @@ fun MetricSpec.withDefaults(metricSpecConfig: MetricSpecConfig): MetricSpec {
           reach = reach.withDefaults(metricSpecConfig)
           metricSpecConfig.reachVidSamplingInterval
         }
-        MetricSpec.TypeCase.FREQUENCY_HISTOGRAM -> {
-          frequencyHistogram = frequencyHistogram.withDefaults(metricSpecConfig)
-          metricSpecConfig.frequencyHistogramVidSamplingInterval
+        MetricSpec.TypeCase.REACH_AND_FREQUENCY -> {
+          reachAndFrequency = reachAndFrequency.withDefaults(metricSpecConfig)
+          metricSpecConfig.reachAndFrequencyVidSamplingInterval
         }
         MetricSpec.TypeCase.IMPRESSION_COUNT -> {
           impressionCount = impressionCount.withDefaults(metricSpecConfig)
@@ -112,37 +112,37 @@ private fun MetricSpec.ReachParams.withDefaults(
 
 /**
  * Specifies default values using [MetricSpecConfig] when optional fields in the
- * [MetricSpec.FrequencyHistogramParams] are not set.
+ * [MetricSpec.ReachAndFrequencyParams] are not set.
  */
-private fun MetricSpec.FrequencyHistogramParams.withDefaults(
+private fun MetricSpec.ReachAndFrequencyParams.withDefaults(
   metricSpecConfig: MetricSpecConfig
-): MetricSpec.FrequencyHistogramParams {
+): MetricSpec.ReachAndFrequencyParams {
   if (!hasReachPrivacyParams()) {
     throw MetricSpecDefaultsException(
       "Invalid privacy params",
-      IllegalArgumentException("reachPrivacyParams in frequency histogram is not set.")
+      IllegalArgumentException("reachPrivacyParams in reach-and-frequency is not set.")
     )
   }
   if (!hasFrequencyPrivacyParams()) {
     throw MetricSpecDefaultsException(
       "Invalid privacy params",
-      IllegalArgumentException("frequencyPrivacyParams in frequency histogram is not set.")
+      IllegalArgumentException("frequencyPrivacyParams in reach-and-frequency  is not set.")
     )
   }
 
   return copy {
     reachPrivacyParams =
       reachPrivacyParams.withDefaults(
-        metricSpecConfig.frequencyHistogramParams.reachPrivacyParams.epsilon,
-        metricSpecConfig.frequencyHistogramParams.reachPrivacyParams.delta
+        metricSpecConfig.reachAndFrequencyParams.reachPrivacyParams.epsilon,
+        metricSpecConfig.reachAndFrequencyParams.reachPrivacyParams.delta
       )
     frequencyPrivacyParams =
       frequencyPrivacyParams.withDefaults(
-        metricSpecConfig.frequencyHistogramParams.frequencyPrivacyParams.epsilon,
-        metricSpecConfig.frequencyHistogramParams.frequencyPrivacyParams.delta
+        metricSpecConfig.reachAndFrequencyParams.frequencyPrivacyParams.epsilon,
+        metricSpecConfig.reachAndFrequencyParams.frequencyPrivacyParams.delta
       )
     if (maximumFrequency == 0) {
-      maximumFrequency = metricSpecConfig.frequencyHistogramParams.maximumFrequency
+      maximumFrequency = metricSpecConfig.reachAndFrequencyParams.maximumFrequency
     }
   }
 }

--- a/src/main/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/ProtoConversions.kt
+++ b/src/main/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/ProtoConversions.kt
@@ -155,8 +155,8 @@ fun MetricSpec.toInternal(): InternalMetricSpec {
       MetricSpec.TypeCase.REACH -> {
         reach = source.reach.toInternal()
       }
-      MetricSpec.TypeCase.FREQUENCY_HISTOGRAM -> {
-        frequencyHistogram = source.frequencyHistogram.toInternal()
+      MetricSpec.TypeCase.REACH_AND_FREQUENCY -> {
+        reachAndFrequency = source.reachAndFrequency.toInternal()
       }
       MetricSpec.TypeCase.IMPRESSION_COUNT -> {
         impressionCount = source.impressionCount.toInternal()
@@ -214,24 +214,24 @@ fun MetricSpec.ImpressionCountParams.toInternal(): InternalMetricSpec.Impression
 }
 
 /**
- * Converts a [MetricSpec.FrequencyHistogramParams] to an
- * [InternalMetricSpec.FrequencyHistogramParams].
+ * Converts a [MetricSpec.ReachAndFrequencyParams] to an
+ * [InternalMetricSpec.ReachAndFrequencyParams].
  */
-fun MetricSpec.FrequencyHistogramParams.toInternal(): InternalMetricSpec.FrequencyHistogramParams {
+fun MetricSpec.ReachAndFrequencyParams.toInternal(): InternalMetricSpec.ReachAndFrequencyParams {
   val source = this
   if (!source.hasReachPrivacyParams()) {
     throw MetricSpecDefaultsException(
       "Invalid privacy params",
-      IllegalArgumentException("reachPrivacyParams in frequency histogram is not set.")
+      IllegalArgumentException("reachPrivacyParams in reach-and-frequency is not set.")
     )
   }
   if (!source.hasFrequencyPrivacyParams()) {
     throw MetricSpecDefaultsException(
       "Invalid privacy params",
-      IllegalArgumentException("frequencyPrivacyParams in frequency histogram is not set.")
+      IllegalArgumentException("frequencyPrivacyParams in reach-and-frequency is not set.")
     )
   }
-  return InternalMetricSpecKt.frequencyHistogramParams {
+  return InternalMetricSpecKt.reachAndFrequencyParams {
     reachPrivacyParams = source.reachPrivacyParams.toInternal()
     frequencyPrivacyParams = source.frequencyPrivacyParams.toInternal()
     maximumFrequency = source.maximumFrequency
@@ -289,13 +289,13 @@ fun InternalMetricSpec.toMetricSpec(): MetricSpec {
       InternalMetricSpec.TypeCase.REACH ->
         reach =
           MetricSpecKt.reachParams { privacyParams = source.reach.privacyParams.toPrivacyParams() }
-      InternalMetricSpec.TypeCase.FREQUENCY_HISTOGRAM ->
-        frequencyHistogram =
-          MetricSpecKt.frequencyHistogramParams {
-            maximumFrequency = source.frequencyHistogram.maximumFrequency
-            reachPrivacyParams = source.frequencyHistogram.reachPrivacyParams.toPrivacyParams()
+      InternalMetricSpec.TypeCase.REACH_AND_FREQUENCY ->
+        reachAndFrequency =
+          MetricSpecKt.reachAndFrequencyParams {
+            maximumFrequency = source.reachAndFrequency.maximumFrequency
+            reachPrivacyParams = source.reachAndFrequency.reachPrivacyParams.toPrivacyParams()
             frequencyPrivacyParams =
-              source.frequencyHistogram.frequencyPrivacyParams.toPrivacyParams()
+              source.reachAndFrequency.frequencyPrivacyParams.toPrivacyParams()
           }
       InternalMetricSpec.TypeCase.IMPRESSION_COUNT ->
         impressionCount =
@@ -347,10 +347,10 @@ fun InternalMetricSpec.ReachParams.toReach(): MeasurementSpec.Reach {
 }
 
 /**
- * Converts an [InternalMetricSpec.FrequencyHistogramParams] to a
+ * Converts an [InternalMetricSpec.ReachAndFrequencyParams] to a
  * [MeasurementSpec.ReachAndFrequency].
  */
-fun InternalMetricSpec.FrequencyHistogramParams.toReachAndFrequency():
+fun InternalMetricSpec.ReachAndFrequencyParams.toReachAndFrequency():
   MeasurementSpec.ReachAndFrequency {
   val source = this
   return MeasurementSpecKt.reachAndFrequency {

--- a/src/main/kotlin/org/wfanet/measurement/reporting/service/internal/testing/v2/MetricsServiceTest.kt
+++ b/src/main/kotlin/org/wfanet/measurement/reporting/service/internal/testing/v2/MetricsServiceTest.kt
@@ -183,7 +183,7 @@ abstract class MetricsServiceTest<T : MetricsCoroutineImplBase> {
   }
 
   @Test
-  fun `createMetric succeeds when MetricSpec type is FrequencyHistogram`() = runBlocking {
+  fun `createMetric succeeds when MetricSpec type is reachAndFrequency`() = runBlocking {
     createMeasurementConsumer(CMMS_MEASUREMENT_CONSUMER_ID, measurementConsumersService)
     val createdReportingSet = createReportingSet(CMMS_MEASUREMENT_CONSUMER_ID, reportingSetsService)
 
@@ -195,8 +195,8 @@ abstract class MetricsServiceTest<T : MetricsCoroutineImplBase> {
         endTime = timestamp { seconds = 100 }
       }
       metricSpec = metricSpec {
-        frequencyHistogram =
-          MetricSpecKt.frequencyHistogramParams {
+        reachAndFrequency =
+          MetricSpecKt.reachAndFrequencyParams {
             reachPrivacyParams =
               MetricSpecKt.differentialPrivacyParams {
                 epsilon = 1.0
@@ -560,8 +560,8 @@ abstract class MetricsServiceTest<T : MetricsCoroutineImplBase> {
         endTime = timestamp { seconds = 100 }
       }
       metricSpec = metricSpec {
-        frequencyHistogram =
-          MetricSpecKt.frequencyHistogramParams {
+        reachAndFrequency =
+          MetricSpecKt.reachAndFrequencyParams {
             reachPrivacyParams =
               MetricSpecKt.differentialPrivacyParams {
                 epsilon = 1.0
@@ -673,8 +673,8 @@ abstract class MetricsServiceTest<T : MetricsCoroutineImplBase> {
           endTime = timestamp { seconds = 100 }
         }
         metricSpec = metricSpec {
-          frequencyHistogram =
-            MetricSpecKt.frequencyHistogramParams {
+          reachAndFrequency =
+            MetricSpecKt.reachAndFrequencyParams {
               reachPrivacyParams =
                 MetricSpecKt.differentialPrivacyParams {
                   epsilon = 1.0
@@ -785,8 +785,8 @@ abstract class MetricsServiceTest<T : MetricsCoroutineImplBase> {
         endTime = timestamp { seconds = 100 }
       }
       metricSpec = metricSpec {
-        frequencyHistogram =
-          MetricSpecKt.frequencyHistogramParams {
+        reachAndFrequency =
+          MetricSpecKt.reachAndFrequencyParams {
             reachPrivacyParams =
               MetricSpecKt.differentialPrivacyParams {
                 epsilon = 1.0
@@ -857,8 +857,8 @@ abstract class MetricsServiceTest<T : MetricsCoroutineImplBase> {
         endTime = timestamp { seconds = 100 }
       }
       metricSpec = metricSpec {
-        frequencyHistogram =
-          MetricSpecKt.frequencyHistogramParams {
+        reachAndFrequency =
+          MetricSpecKt.reachAndFrequencyParams {
             reachPrivacyParams =
               MetricSpecKt.differentialPrivacyParams {
                 epsilon = 1.0
@@ -1175,8 +1175,8 @@ abstract class MetricsServiceTest<T : MetricsCoroutineImplBase> {
         endTime = timestamp { seconds = 100 }
       }
       metricSpec = metricSpec {
-        frequencyHistogram =
-          MetricSpecKt.frequencyHistogramParams {
+        reachAndFrequency =
+          MetricSpecKt.reachAndFrequencyParams {
             reachPrivacyParams =
               MetricSpecKt.differentialPrivacyParams {
                 epsilon = 1.0
@@ -1247,8 +1247,8 @@ abstract class MetricsServiceTest<T : MetricsCoroutineImplBase> {
         endTime = timestamp { seconds = 100 }
       }
       metricSpec = metricSpec {
-        frequencyHistogram =
-          MetricSpecKt.frequencyHistogramParams {
+        reachAndFrequency =
+          MetricSpecKt.reachAndFrequencyParams {
             reachPrivacyParams =
               MetricSpecKt.differentialPrivacyParams {
                 epsilon = 1.0
@@ -1325,8 +1325,8 @@ abstract class MetricsServiceTest<T : MetricsCoroutineImplBase> {
         endTime = timestamp { seconds = 100 }
       }
       metricSpec = metricSpec {
-        frequencyHistogram =
-          MetricSpecKt.frequencyHistogramParams {
+        reachAndFrequency =
+          MetricSpecKt.reachAndFrequencyParams {
             reachPrivacyParams =
               MetricSpecKt.differentialPrivacyParams {
                 epsilon = 1.0
@@ -1414,8 +1414,8 @@ abstract class MetricsServiceTest<T : MetricsCoroutineImplBase> {
           endTime = timestamp { seconds = 100 }
         }
         metricSpec = metricSpec {
-          frequencyHistogram =
-            MetricSpecKt.frequencyHistogramParams {
+          reachAndFrequency =
+            MetricSpecKt.reachAndFrequencyParams {
               reachPrivacyParams =
                 MetricSpecKt.differentialPrivacyParams {
                   epsilon = 1.0
@@ -1512,8 +1512,8 @@ abstract class MetricsServiceTest<T : MetricsCoroutineImplBase> {
           endTime = timestamp { seconds = 100 }
         }
         metricSpec = metricSpec {
-          frequencyHistogram =
-            MetricSpecKt.frequencyHistogramParams {
+          reachAndFrequency =
+            MetricSpecKt.reachAndFrequencyParams {
               reachPrivacyParams =
                 MetricSpecKt.differentialPrivacyParams {
                   epsilon = 1.0
@@ -1603,8 +1603,8 @@ abstract class MetricsServiceTest<T : MetricsCoroutineImplBase> {
           endTime = timestamp { seconds = 100 }
         }
         metricSpec = metricSpec {
-          frequencyHistogram =
-            MetricSpecKt.frequencyHistogramParams {
+          reachAndFrequency =
+            MetricSpecKt.reachAndFrequencyParams {
               reachPrivacyParams =
                 MetricSpecKt.differentialPrivacyParams {
                   epsilon = 1.0
@@ -1683,8 +1683,8 @@ abstract class MetricsServiceTest<T : MetricsCoroutineImplBase> {
           endTime = timestamp { seconds = 100 }
         }
         metricSpec = metricSpec {
-          frequencyHistogram =
-            MetricSpecKt.frequencyHistogramParams {
+          reachAndFrequency =
+            MetricSpecKt.reachAndFrequencyParams {
               reachPrivacyParams =
                 MetricSpecKt.differentialPrivacyParams {
                   epsilon = 1.0
@@ -1762,8 +1762,8 @@ abstract class MetricsServiceTest<T : MetricsCoroutineImplBase> {
         endTime = timestamp { seconds = 100 }
       }
       metricSpec = metricSpec {
-        frequencyHistogram =
-          MetricSpecKt.frequencyHistogramParams {
+        reachAndFrequency =
+          MetricSpecKt.reachAndFrequencyParams {
             reachPrivacyParams =
               MetricSpecKt.differentialPrivacyParams {
                 epsilon = 1.0
@@ -1843,8 +1843,8 @@ abstract class MetricsServiceTest<T : MetricsCoroutineImplBase> {
           endTime = timestamp { seconds = 100 }
         }
         metricSpec = metricSpec {
-          frequencyHistogram =
-            MetricSpecKt.frequencyHistogramParams {
+          reachAndFrequency =
+            MetricSpecKt.reachAndFrequencyParams {
               reachPrivacyParams =
                 MetricSpecKt.differentialPrivacyParams {
                   epsilon = 1.0
@@ -1925,8 +1925,8 @@ abstract class MetricsServiceTest<T : MetricsCoroutineImplBase> {
           endTime = timestamp { seconds = 100 }
         }
         metricSpec = metricSpec {
-          frequencyHistogram =
-            MetricSpecKt.frequencyHistogramParams {
+          reachAndFrequency =
+            MetricSpecKt.reachAndFrequencyParams {
               reachPrivacyParams =
                 MetricSpecKt.differentialPrivacyParams {
                   epsilon = 1.0
@@ -2006,8 +2006,8 @@ abstract class MetricsServiceTest<T : MetricsCoroutineImplBase> {
           endTime = timestamp { seconds = 100 }
         }
         metricSpec = metricSpec {
-          frequencyHistogram =
-            MetricSpecKt.frequencyHistogramParams {
+          reachAndFrequency =
+            MetricSpecKt.reachAndFrequencyParams {
               reachPrivacyParams =
                 MetricSpecKt.differentialPrivacyParams {
                   epsilon = 1.0
@@ -2086,8 +2086,8 @@ abstract class MetricsServiceTest<T : MetricsCoroutineImplBase> {
         endTime = timestamp { seconds = 100 }
       }
       metricSpec = metricSpec {
-        frequencyHistogram =
-          MetricSpecKt.frequencyHistogramParams {
+        reachAndFrequency =
+          MetricSpecKt.reachAndFrequencyParams {
             reachPrivacyParams =
               MetricSpecKt.differentialPrivacyParams {
                 epsilon = 1.0
@@ -2199,8 +2199,8 @@ abstract class MetricsServiceTest<T : MetricsCoroutineImplBase> {
         metric =
           metric.copy {
             metricSpec = metricSpec {
-              frequencyHistogram =
-                MetricSpecKt.frequencyHistogramParams {
+              reachAndFrequency =
+                MetricSpecKt.reachAndFrequencyParams {
                   reachPrivacyParams =
                     MetricSpecKt.differentialPrivacyParams {
                       epsilon = 1.0

--- a/src/main/proto/wfa/measurement/config/reporting/metric_spec_config.proto
+++ b/src/main/proto/wfa/measurement/config/reporting/metric_spec_config.proto
@@ -40,13 +40,13 @@ message MetricSpecConfig {
     // Differential privacy parameters for reach.
     DifferentialPrivacyParams privacy_params = 1;
   }
-  // Parameters that are used to generate `Frequency Histogram` metric.
-  message FrequencyHistogramParams {
+  // Parameters that are used to generate `ReachAndFrequency` metric.
+  message ReachAndFrequencyParams {
     // Differential privacy parameters for reach.
     DifferentialPrivacyParams reach_privacy_params = 1;
     // Differential privacy parameters for frequency.
     DifferentialPrivacyParams frequency_privacy_params = 2;
-    // Maximum frequency cut-off value in the frequency histogram.
+    // Maximum frequency cut-off value in frequency histogram.
     //
     // Counts with frequency higher than `maximum_frequency` will be aggregated
     // together.
@@ -78,9 +78,8 @@ message MetricSpecConfig {
   // Parameters for generating the count of unique audiences reached given a set
   // of event groups.
   ReachParams reach_params = 1;
-  // Parameters for generating the reach frequency histogram given a set of
-  // event groups.
-  FrequencyHistogramParams frequency_histogram_params = 2;
+  // Parameters for generating reach-and-frequency given a set of event groups.
+  ReachAndFrequencyParams reach_and_frequency_params = 2;
   // Parameters for generating the impression count given a set of event groups.
   ImpressionCountParams impression_count_params = 3;
   // Parameters for generating the watch duration given a set of event groups.
@@ -95,8 +94,8 @@ message MetricSpecConfig {
   }
   // Range of VIDs that will be included for reach measurements.
   VidSamplingInterval reach_vid_sampling_interval = 5;
-  // Range of VIDs that will be included for frequency histogram measurements.
-  VidSamplingInterval frequency_histogram_vid_sampling_interval = 6;
+  // Range of VIDs that will be included for reach-and-frequency measurements.
+  VidSamplingInterval reach_and_frequency_vid_sampling_interval = 6;
   // Range of VIDs that will be included for impression count measurements.
   VidSamplingInterval impression_count_vid_sampling_interval = 7;
   // Range of VIDs that will be included for watch duration measurements.

--- a/src/main/proto/wfa/measurement/internal/reporting/v2/metric.proto
+++ b/src/main/proto/wfa/measurement/internal/reporting/v2/metric.proto
@@ -33,7 +33,7 @@ message MetricSpec {
   message ReachParams {
     DifferentialPrivacyParams privacy_params = 1;
   }
-  message FrequencyHistogramParams {
+  message ReachAndFrequencyParams {
     DifferentialPrivacyParams reach_privacy_params = 1;
     DifferentialPrivacyParams frequency_privacy_params = 2;
     int32 maximum_frequency = 3;
@@ -49,7 +49,7 @@ message MetricSpec {
 
   oneof type {
     ReachParams reach = 1;
-    FrequencyHistogramParams frequency_histogram = 2;
+    ReachAndFrequencyParams reach_and_frequency = 2;
     ImpressionCountParams impression_count = 3;
     WatchDurationParams watch_duration = 4;
   }

--- a/src/main/proto/wfa/measurement/reporting/v2alpha/metric.proto
+++ b/src/main/proto/wfa/measurement/reporting/v2alpha/metric.proto
@@ -47,15 +47,15 @@ message MetricSpec {
     DifferentialPrivacyParams privacy_params = 1
         [(google.api.field_behavior) = REQUIRED];
   }
-  // Parameters that are used to generate `Frequency Histogram` metric.
-  message FrequencyHistogramParams {
+  // Parameters that are used to generate `ReachAndFrequency` metric.
+  message ReachAndFrequencyParams {
     // Differential privacy parameters for reach.
     DifferentialPrivacyParams reach_privacy_params = 1
         [(google.api.field_behavior) = REQUIRED];
     // Differential privacy parameters for frequency distribution.
     DifferentialPrivacyParams frequency_privacy_params = 2
         [(google.api.field_behavior) = REQUIRED];
-    // Maximum frequency cut-off value in the frequency histogram.
+    // Maximum frequency cut-off value in frequency histogram.
     //
     // Counts with frequency higher than `maximum_frequency` will be aggregated
     // together. If not set, the default value will be used and outputted here.
@@ -97,11 +97,11 @@ message MetricSpec {
   oneof type {
     // The count of unique audiences reached given a set of event groups.
     ReachParams reach = 1 [(google.api.field_behavior) = IMMUTABLE];
-    // The reach frequency histogram given a set of event groups.
+    // The reach-and-frequency given a set of event groups.
     //
-    // Currently, we only support union operations for frequency histograms. Any
+    // Currently, we only support union operations for reach-and-frequency. Any
     // other types of operations won't guarantee the correctness of the result.
-    FrequencyHistogramParams frequency_histogram = 2
+    ReachAndFrequencyParams reach_and_frequency = 2
         [(google.api.field_behavior) = IMMUTABLE];
     // The impression count given a set of event groups.
     ImpressionCountParams impression_count = 3
@@ -190,6 +190,13 @@ message MetricResult {
     // The bins that form a histogram. Ordering is not guaranteed.
     repeated Bin bins = 1;
   }
+
+  // Reach-and-frequency result format.
+  message ReachAndFrequencyResult {
+    ReachResult reach = 1;
+    HistogramResult frequency_histogram = 2;
+  }
+
   // Impression count result format.
   message ImpressionCountResult {
     // Impression value.
@@ -217,8 +224,8 @@ message MetricResult {
   oneof result {
     // Reach result.
     ReachResult reach = 3;
-    // Histogram result.
-    HistogramResult frequency_histogram = 4;
+    // Reach-and-frequency result.
+    ReachAndFrequencyResult reach_and_frequency = 4;
     // Impression count result.
     ImpressionCountResult impression_count = 5;
     // Watch duration result.

--- a/src/main/resources/reporting/postgres/create-v2-reporting-schema.sql
+++ b/src/main/resources/reporting/postgres/create-v2-reporting-schema.sql
@@ -238,7 +238,7 @@ CREATE TABLE Metrics (
   FrequencyDifferentialPrivacyEpsilon DOUBLE PRECISION,
   FrequencyDifferentialPrivacyDelta DOUBLE PRECISION,
 
-  -- Must not be NULL if MetricType is FREQUENCY_HISTOGRAM
+  -- Must not be NULL if MetricType is REACH_AND_FREQUENCY
   MaximumFrequency bigint,
   -- Must not be NULL if MetricType is IMPRESSION_COUNT
   MaximumFrequencyPerUser bigint,

--- a/src/test/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/MetricCalculationSpecsServiceTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/MetricCalculationSpecsServiceTest.kt
@@ -1001,8 +1001,8 @@ class MetricCalculationSpecsServiceTest {
           width = REACH_ONLY_VID_SAMPLING_WIDTH
         }
 
-      frequencyHistogramParams =
-        MetricSpecConfigKt.frequencyHistogramParams {
+      reachAndFrequencyParams =
+        MetricSpecConfigKt.reachAndFrequencyParams {
           reachPrivacyParams =
             MetricSpecConfigKt.differentialPrivacyParams {
               epsilon = REACH_FREQUENCY_REACH_EPSILON
@@ -1015,7 +1015,7 @@ class MetricCalculationSpecsServiceTest {
             }
           maximumFrequency = REACH_FREQUENCY_MAXIMUM_FREQUENCY
         }
-      frequencyHistogramVidSamplingInterval =
+      reachAndFrequencyVidSamplingInterval =
         MetricSpecConfigKt.vidSamplingInterval {
           start = REACH_FREQUENCY_VID_SAMPLING_START
           width = REACH_FREQUENCY_VID_SAMPLING_WIDTH

--- a/src/test/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/MetricSpecDefaultsTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/MetricSpecDefaultsTest.kt
@@ -26,8 +26,8 @@ import org.wfanet.measurement.config.reporting.MetricSpecConfigKt
 import org.wfanet.measurement.config.reporting.metricSpecConfig
 import org.wfanet.measurement.reporting.v2alpha.MetricSpec
 import org.wfanet.measurement.reporting.v2alpha.MetricSpecKt
-import org.wfanet.measurement.reporting.v2alpha.MetricSpecKt.frequencyHistogramParams
 import org.wfanet.measurement.reporting.v2alpha.MetricSpecKt.impressionCountParams
+import org.wfanet.measurement.reporting.v2alpha.MetricSpecKt.reachAndFrequencyParams
 import org.wfanet.measurement.reporting.v2alpha.MetricSpecKt.reachParams
 import org.wfanet.measurement.reporting.v2alpha.MetricSpecKt.watchDurationParams
 import org.wfanet.measurement.reporting.v2alpha.copy
@@ -102,51 +102,51 @@ class MetricSpecDefaultsTest {
   }
 
   @Test
-  fun `buildMetricSpec builds a frequency histogram metric spec when no field is filled`() {
-    val result = FREQUENCY_HISTOGRAM_METRIC_SPEC.withDefaults(METRIC_SPEC_CONFIG)
+  fun `buildMetricSpec builds a reach and frequency metric spec when no field is filled`() {
+    val result = REACH_AND_FREQUENCY_METRIC_SPEC.withDefaults(METRIC_SPEC_CONFIG)
     val expect = metricSpec {
-      frequencyHistogram = frequencyHistogramParams {
+      reachAndFrequency = reachAndFrequencyParams {
         reachPrivacyParams =
           MetricSpecKt.differentialPrivacyParams {
-            epsilon = METRIC_SPEC_CONFIG.frequencyHistogramParams.reachPrivacyParams.epsilon
-            delta = METRIC_SPEC_CONFIG.frequencyHistogramParams.reachPrivacyParams.delta
+            epsilon = METRIC_SPEC_CONFIG.reachAndFrequencyParams.reachPrivacyParams.epsilon
+            delta = METRIC_SPEC_CONFIG.reachAndFrequencyParams.reachPrivacyParams.delta
           }
         frequencyPrivacyParams =
           MetricSpecKt.differentialPrivacyParams {
-            epsilon = METRIC_SPEC_CONFIG.frequencyHistogramParams.frequencyPrivacyParams.epsilon
-            delta = METRIC_SPEC_CONFIG.frequencyHistogramParams.frequencyPrivacyParams.delta
+            epsilon = METRIC_SPEC_CONFIG.reachAndFrequencyParams.frequencyPrivacyParams.epsilon
+            delta = METRIC_SPEC_CONFIG.reachAndFrequencyParams.frequencyPrivacyParams.delta
           }
-        maximumFrequency = METRIC_SPEC_CONFIG.frequencyHistogramParams.maximumFrequency
+        maximumFrequency = METRIC_SPEC_CONFIG.reachAndFrequencyParams.maximumFrequency
       }
       vidSamplingInterval =
         MetricSpecKt.vidSamplingInterval {
-          start = METRIC_SPEC_CONFIG.frequencyHistogramVidSamplingInterval.start
-          width = METRIC_SPEC_CONFIG.frequencyHistogramVidSamplingInterval.width
+          start = METRIC_SPEC_CONFIG.reachAndFrequencyVidSamplingInterval.start
+          width = METRIC_SPEC_CONFIG.reachAndFrequencyVidSamplingInterval.width
         }
     }
     assertThat(result).isEqualTo(expect)
   }
 
   @Test
-  fun `buildMetricSpec builds a frequency histogram metric spec when all fields are filled`() {
+  fun `buildMetricSpec builds a reach and frequency metric spec when all fields are filled`() {
     val expect = metricSpec {
-      frequencyHistogram = frequencyHistogramParams {
+      reachAndFrequency = reachAndFrequencyParams {
         reachPrivacyParams =
           MetricSpecKt.differentialPrivacyParams {
-            epsilon = METRIC_SPEC_CONFIG.frequencyHistogramParams.reachPrivacyParams.epsilon * 2
-            delta = METRIC_SPEC_CONFIG.frequencyHistogramParams.reachPrivacyParams.delta * 2
+            epsilon = METRIC_SPEC_CONFIG.reachAndFrequencyParams.reachPrivacyParams.epsilon * 2
+            delta = METRIC_SPEC_CONFIG.reachAndFrequencyParams.reachPrivacyParams.delta * 2
           }
         frequencyPrivacyParams =
           MetricSpecKt.differentialPrivacyParams {
-            epsilon = METRIC_SPEC_CONFIG.frequencyHistogramParams.frequencyPrivacyParams.epsilon * 2
-            delta = METRIC_SPEC_CONFIG.frequencyHistogramParams.frequencyPrivacyParams.delta * 2
+            epsilon = METRIC_SPEC_CONFIG.reachAndFrequencyParams.frequencyPrivacyParams.epsilon * 2
+            delta = METRIC_SPEC_CONFIG.reachAndFrequencyParams.frequencyPrivacyParams.delta * 2
           }
-        maximumFrequency = METRIC_SPEC_CONFIG.frequencyHistogramParams.maximumFrequency * 2
+        maximumFrequency = METRIC_SPEC_CONFIG.reachAndFrequencyParams.maximumFrequency * 2
       }
       vidSamplingInterval =
         MetricSpecKt.vidSamplingInterval {
-          start = METRIC_SPEC_CONFIG.frequencyHistogramVidSamplingInterval.start + 0.001f
-          width = METRIC_SPEC_CONFIG.frequencyHistogramVidSamplingInterval.width / 2
+          start = METRIC_SPEC_CONFIG.reachAndFrequencyVidSamplingInterval.start + 0.001f
+          width = METRIC_SPEC_CONFIG.reachAndFrequencyVidSamplingInterval.width / 2
         }
     }
     val result = expect.withDefaults(METRIC_SPEC_CONFIG)
@@ -269,10 +269,10 @@ class MetricSpecDefaultsTest {
   }
 
   @Test
-  fun `buildMetricSpec throw MetricSpecBuildingException when reach privacy params in frequency histogram is not set`() {
+  fun `buildMetricSpec throw MetricSpecBuildingException when reach privacy params in reach and frequency is not set`() {
     val metricSpecWithoutPrivacyParams =
-      FREQUENCY_HISTOGRAM_METRIC_SPEC.copy {
-        frequencyHistogram = frequencyHistogram.copy { clearReachPrivacyParams() }
+      REACH_AND_FREQUENCY_METRIC_SPEC.copy {
+        reachAndFrequency = reachAndFrequency.copy { clearReachPrivacyParams() }
       }
 
     val exception =
@@ -285,10 +285,10 @@ class MetricSpecDefaultsTest {
   }
 
   @Test
-  fun `buildMetricSpec throw MetricSpecBuildingException when frequency histogram privacy params is not set`() {
+  fun `buildMetricSpec throw MetricSpecBuildingException when frequency privacy params in reach and frequency is not set`() {
     val metricSpecWithoutPrivacyParams =
-      FREQUENCY_HISTOGRAM_METRIC_SPEC.copy {
-        frequencyHistogram = frequencyHistogram.copy { clearFrequencyPrivacyParams() }
+      REACH_AND_FREQUENCY_METRIC_SPEC.copy {
+        reachAndFrequency = reachAndFrequency.copy { clearFrequencyPrivacyParams() }
       }
 
     val exception =
@@ -410,8 +410,8 @@ class MetricSpecDefaultsTest {
           width = REACH_ONLY_VID_SAMPLING_WIDTH
         }
 
-      frequencyHistogramParams =
-        MetricSpecConfigKt.frequencyHistogramParams {
+      reachAndFrequencyParams =
+        MetricSpecConfigKt.reachAndFrequencyParams {
           reachPrivacyParams =
             MetricSpecConfigKt.differentialPrivacyParams {
               epsilon = REACH_FREQUENCY_REACH_EPSILON
@@ -424,7 +424,7 @@ class MetricSpecDefaultsTest {
             }
           maximumFrequency = REACH_FREQUENCY_MAXIMUM_FREQUENCY
         }
-      frequencyHistogramVidSamplingInterval =
+      reachAndFrequencyVidSamplingInterval =
         MetricSpecConfigKt.vidSamplingInterval {
           start = REACH_FREQUENCY_VID_SAMPLING_START
           width = REACH_FREQUENCY_VID_SAMPLING_WIDTH
@@ -468,8 +468,8 @@ class MetricSpecDefaultsTest {
         privacyParams = MetricSpec.DifferentialPrivacyParams.getDefaultInstance()
       }
     }
-    private val FREQUENCY_HISTOGRAM_METRIC_SPEC: MetricSpec = metricSpec {
-      frequencyHistogram = frequencyHistogramParams {
+    private val REACH_AND_FREQUENCY_METRIC_SPEC: MetricSpec = metricSpec {
+      reachAndFrequency = reachAndFrequencyParams {
         reachPrivacyParams = MetricSpec.DifferentialPrivacyParams.getDefaultInstance()
         frequencyPrivacyParams = MetricSpec.DifferentialPrivacyParams.getDefaultInstance()
       }

--- a/src/test/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/ReportsServiceTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/ReportsServiceTest.kt
@@ -707,9 +707,9 @@ class ReportsServiceTest {
   fun `createReport returns report with two metrics when there are two metricSpecs`() =
     runBlocking {
       val targetReportingSet = PRIMITIVE_REPORTING_SETS.first()
-      val metricSpecs = listOf(REACH_METRIC_SPEC, FREQUENCY_HISTOGRAM_METRIC_SPEC)
+      val metricSpecs = listOf(REACH_METRIC_SPEC, REACH_AND_FREQUENCY_METRIC_SPEC)
       val internalMetricSpecs =
-        listOf(INTERNAL_REACH_METRIC_SPEC, INTERNAL_FREQUENCY_HISTOGRAM_METRIC_SPEC)
+        listOf(INTERNAL_REACH_METRIC_SPEC, INTERNAL_REACH_AND_FREQUENCY_METRIC_SPEC)
       val timeInterval = interval {
         startTime = START_TIME
         endTime = END_TIME
@@ -725,7 +725,7 @@ class ReportsServiceTest {
           InternalMetricCalculationSpecKt.details {
             displayName = DISPLAY_NAME
             this.metricSpecs += INTERNAL_REACH_METRIC_SPEC
-            this.metricSpecs += INTERNAL_FREQUENCY_HISTOGRAM_METRIC_SPEC
+            this.metricSpecs += INTERNAL_REACH_AND_FREQUENCY_METRIC_SPEC
             cumulative = false
           }
       }
@@ -863,9 +863,9 @@ class ReportsServiceTest {
       val filter = "device == MOBILE"
 
       // Metric specs
-      val metricSpecs = listOf(REACH_METRIC_SPEC, FREQUENCY_HISTOGRAM_METRIC_SPEC)
+      val metricSpecs = listOf(REACH_METRIC_SPEC, REACH_AND_FREQUENCY_METRIC_SPEC)
       val internalMetricSpecs =
-        listOf(INTERNAL_REACH_METRIC_SPEC, INTERNAL_FREQUENCY_HISTOGRAM_METRIC_SPEC)
+        listOf(INTERNAL_REACH_METRIC_SPEC, INTERNAL_REACH_AND_FREQUENCY_METRIC_SPEC)
 
       // Time intervals
       val timeIntervalsList =
@@ -901,7 +901,7 @@ class ReportsServiceTest {
           InternalMetricCalculationSpecKt.details {
             displayName = DISPLAY_NAME
             this.metricSpecs +=
-              listOf(INTERNAL_REACH_METRIC_SPEC, INTERNAL_FREQUENCY_HISTOGRAM_METRIC_SPEC)
+              listOf(INTERNAL_REACH_METRIC_SPEC, INTERNAL_REACH_AND_FREQUENCY_METRIC_SPEC)
             groupings += InternalMetricCalculationSpecKt.grouping { predicates += predicates1 }
             groupings += InternalMetricCalculationSpecKt.grouping { predicates += predicates2 }
             this.filter = filter
@@ -3263,8 +3263,8 @@ class ReportsServiceTest {
           width = REACH_ONLY_VID_SAMPLING_WIDTH
         }
 
-      frequencyHistogramParams =
-        MetricSpecConfigKt.frequencyHistogramParams {
+      reachAndFrequencyParams =
+        MetricSpecConfigKt.reachAndFrequencyParams {
           reachPrivacyParams =
             MetricSpecConfigKt.differentialPrivacyParams {
               epsilon = REACH_FREQUENCY_REACH_EPSILON
@@ -3277,7 +3277,7 @@ class ReportsServiceTest {
             }
           maximumFrequency = REACH_FREQUENCY_MAXIMUM_FREQUENCY
         }
-      frequencyHistogramVidSamplingInterval =
+      reachAndFrequencyVidSamplingInterval =
         MetricSpecConfigKt.vidSamplingInterval {
           start = REACH_FREQUENCY_VID_SAMPLING_START
           width = REACH_FREQUENCY_VID_SAMPLING_WIDTH
@@ -3344,9 +3344,9 @@ class ReportsServiceTest {
           width = REACH_ONLY_VID_SAMPLING_WIDTH
         }
     }
-    private val FREQUENCY_HISTOGRAM_METRIC_SPEC: MetricSpec = metricSpec {
-      frequencyHistogram =
-        MetricSpecKt.frequencyHistogramParams {
+    private val REACH_AND_FREQUENCY_METRIC_SPEC: MetricSpec = metricSpec {
+      reachAndFrequency =
+        MetricSpecKt.reachAndFrequencyParams {
           reachPrivacyParams =
             MetricSpecKt.differentialPrivacyParams {
               epsilon = REACH_FREQUENCY_REACH_EPSILON
@@ -3365,9 +3365,9 @@ class ReportsServiceTest {
           width = REACH_FREQUENCY_VID_SAMPLING_WIDTH
         }
     }
-    private val INTERNAL_FREQUENCY_HISTOGRAM_METRIC_SPEC: InternalMetricSpec = internalMetricSpec {
-      frequencyHistogram =
-        InternalMetricSpecKt.frequencyHistogramParams {
+    private val INTERNAL_REACH_AND_FREQUENCY_METRIC_SPEC: InternalMetricSpec = internalMetricSpec {
+      reachAndFrequency =
+        InternalMetricSpecKt.reachAndFrequencyParams {
           reachPrivacyParams =
             InternalMetricSpecKt.differentialPrivacyParams {
               epsilon = REACH_FREQUENCY_REACH_EPSILON


### PR DESCRIPTION
In Report V2 the `FrequencyHistogramParams` will be renamed to `ReachAndFrequencyParams`. Note the `FrequencyHistogramParams` already includes `ReachParams`. Setting this new Params structure cause a Reach and Frequency Results to be created. As such, metric result for `ReachAndFrequency` will be updated to replace `HistogramResult` with a `ReachAndFrequencyResult` that includes a `HistogramResult` and a `ReachResult` as sub-messages.

Note:
* This PR changes an existing Liquibase changeset, meaning the DB will need to be wiped.
* This PR renames a field in `MetricSpecConfig`, so anyone with an existing deployment will need to update their config.

Report V1 will not be updated.