### PR TITLE
Add Create Report to the BFF

### DIFF
--- a/experimental/reporting-ui/src/main/kotlin/org/wfanet/measurement/reporting/bff/deploy/common/server/ReportingApiServerFlags.kt
+++ b/experimental/reporting-ui/src/main/kotlin/org/wfanet/measurement/reporting/bff/deploy/common/server/ReportingApiServerFlags.kt
@@ -45,4 +45,11 @@ class ReportingApiServerFlags {
   )
   var debugVerboseGrpcClientLogging by Delegates.notNull<Boolean>()
     private set
+
+  @set:CommandLine.Option(
+    names = ["--measurement-consumer"],
+    description = ["measurement consumer id of the service owner"],
+    required = true,
+  )
+  lateinit var measurementConsumer: String
 }

--- a/experimental/reporting-ui/src/main/kotlin/org/wfanet/measurement/reporting/bff/deploy/common/server/V1AlphaPublicApiServer.kt
+++ b/experimental/reporting-ui/src/main/kotlin/org/wfanet/measurement/reporting/bff/deploy/common/server/V1AlphaPublicApiServer.kt
@@ -53,7 +53,13 @@ private fun run(
       .withVerboseLogging(reportingApiServerFlags.debugVerboseGrpcClientLogging)
 
   val services: List<ServerServiceDefinition> =
-    listOf(ReportsService(HaloReportsGrpcKt.ReportsCoroutineStub(channel)).bindService())
+    listOf(
+      ReportsService(
+          HaloReportsGrpcKt.ReportsCoroutineStub(channel),
+          reportingApiServerFlags.measurementConsumer
+        )
+        .bindService()
+    )
   CommonServer.fromFlags(commonServerFlags, SERVER_NAME, services).start().blockUntilShutdown()
 }
 

--- a/experimental/reporting-ui/src/main/kotlin/org/wfanet/measurement/reporting/bff/service/api/v1alpha/ReportsService.kt
+++ b/experimental/reporting-ui/src/main/kotlin/org/wfanet/measurement/reporting/bff/service/api/v1alpha/ReportsService.kt
@@ -94,14 +94,9 @@ class ReportsService(
 
     try {
       val resp = runBlocking(Dispatchers.IO) { backendReportsStub.createReport(backendRequest) }
-
-      return createReportResponse {
-        status = CreateReportResponse.Status.SUCCEEDED
-      }
+      return createReportResponse { status = CreateReportResponse.Status.SUCCEEDED }
     } catch (ex: Exception) {
-      return createReportResponse {
-        status = CreateReportResponse.Status.ERRORED
-      }
+      return createReportResponse { status = CreateReportResponse.Status.ERRORED }
     }
   }
 

--- a/src/main/proto/wfa/measurement/reporting/bff/v1alpha/BUILD.bazel
+++ b/src/main/proto/wfa/measurement/reporting/bff/v1alpha/BUILD.bazel
@@ -58,6 +58,7 @@ proto_library(
         "@com_google_googleapis//google/api:client_proto",
         "@com_google_googleapis//google/api:field_behavior_proto",
         "@com_google_googleapis//google/api:resource_proto",
+        "@com_google_protobuf//:timestamp_proto",
     ],
 )
 

--- a/src/main/proto/wfa/measurement/reporting/bff/v1alpha/report.proto
+++ b/src/main/proto/wfa/measurement/reporting/bff/v1alpha/report.proto
@@ -31,7 +31,7 @@ option go_package = "wfa/measurement/reporting/bff/v1alpha/reportingpb";
 message Report {
   option (google.api.resource) = {
     type: "ui.reporting.halo-cmm.org/Report"
-    pattern: "measurementConsumers/{measurement_consumer}/reports/{report}"
+    pattern: "reports/{report}"
   };
 
   string name = 1;

--- a/src/main/proto/wfa/measurement/reporting/bff/v1alpha/reports_service.proto
+++ b/src/main/proto/wfa/measurement/reporting/bff/v1alpha/reports_service.proto
@@ -49,9 +49,7 @@ service Reports {
   rpc CreateReport(CreateReportRequest) returns (CreateReportResponse) {
     option (google.api.http) = {
       post: "/v1alpha/reports"
-      body: "report_id"
     };
-    option (google.api.method_signature) = "report";
   }
 }
 

--- a/src/main/proto/wfa/measurement/reporting/bff/v1alpha/reports_service.proto
+++ b/src/main/proto/wfa/measurement/reporting/bff/v1alpha/reports_service.proto
@@ -20,6 +20,7 @@ import "google/api/client.proto";
 import "google/api/field_behavior.proto";
 import "google/api/annotations.proto";
 import "google/api/resource.proto";
+import "google/protobuf/timestamp.proto";
 import "wfa/measurement/reporting/bff/v1alpha/report.proto";
 
 option java_package = "org.wfanet.measurement.reporting.bff.v1alpha";
@@ -33,18 +34,49 @@ service Reports {
   // Returns the `Report` with the specified resource key.
   rpc GetReport(GetReportRequest) returns (Report) {
     option (google.api.http) = {
-      get: "/v1alpha/{name=measurementConsumers/*/reports/*}"
+      get: "/v1alpha/reports/{report_id}"
     };
-    option (google.api.method_signature) = "name";
   }
 
   // Lists `Report`s.
   rpc ListReports(ListReportsRequest) returns (ListReportsResponse) {
     option (google.api.http) = {
-      get: "/v1alpha/{parent=measurementConsumers/*}/reports"
+      get: "/v1alpha/reports"
     };
-    option (google.api.method_signature) = "parent";
   }
+
+  // Creates a `Report` based on a predefined template.
+  rpc CreateReport(CreateReportRequest) returns (CreateReportResponse) {
+    option (google.api.http) = {
+      post: "/v1alpha/reports"
+      body: "report_id"
+    };
+    option (google.api.method_signature) = "report";
+  }
+}
+
+message CreateReportRequest {
+  string report_id = 1 [(google.api.field_behavior) = REQUIRED];
+
+  repeated string data_providers = 2;
+
+  google.protobuf.Timestamp start_date = 3;
+
+  google.protobuf.Timestamp end_date = 4;
+}
+
+message CreateReportResponse {
+  // Possible statuses from a create report request.
+  // Does not mean the report was successfully created,
+  // just the request was received.
+  enum Status {
+    // Create report request successfully sent.
+    SUCCEEDED = 0;
+    // Error submitting create report request.
+    ERRORED = 1;
+  }
+
+  Status status = 1;
 }
 
 enum ReportView {
@@ -60,9 +92,8 @@ enum ReportView {
 
 // Request message for `GetReport` method.
 message GetReportRequest {
-  // The name of the report to retrieve.
-  // Format: measurementConsumers/{measurement_consumer}/reports/{report}
-  string name = 1 [
+  // The id of the report to retrieve.
+  string report_id = 1 [
     (google.api.field_behavior) = REQUIRED,
     (google.api.resource_reference) = {
       type: "ui.reporting.halo-cmm.org/Report"
@@ -75,29 +106,21 @@ message GetReportRequest {
 
 // Request message for `ListReports` method.
 message ListReportsRequest {
-  // Format: measurementConsumers/{measurement_consumer}
-  string parent = 1 [
-    (google.api.field_behavior) = REQUIRED,
-    (google.api.resource_reference) = {
-      child_type: "ui.reporting.halo-cmm.org/Report"
-    }
-  ];
-
   // Defaults to REPORT_VIEW_BASIC
-  ReportView view = 2;
+  ReportView view = 1;
 
   // The maximum number of reports to return. The service may return fewer than
   // this value.
   // If unspecified, at most 50 reports will be returned.
   // The maximum value is 1000; values above 1000 will be coerced to 1000.
-  int32 page_size = 3;
+  int32 page_size = 2;
 
   // A page token, received from a previous `ListReports` call.
   // Provide this to retrieve the subsequent page.
   //
   // When paginating, all other parameters provided to `ListReports` must match
   // the call that provided the page token.
-  string page_token = 4;
+  string page_token = 3;
 }
 
 // Response message for `ListReports` method.


### PR DESCRIPTION
Adding the Create Report API stub to the BFF.

Also updating the BFF API protos (http annotations and proto messages) to exclude measurementConsumer/parent since that will be built into the service. The protobufs aren't currently used so rearranging the values won't break anything.