### PR TITLE
Add a metric reuse mechanism based on timed ReportingMetricEntries

### DIFF
--- a/src/main/kotlin/org/wfanet/measurement/reporting/deploy/v2/postgres/readers/MetricReader.kt
+++ b/src/main/kotlin/org/wfanet/measurement/reporting/deploy/v2/postgres/readers/MetricReader.kt
@@ -21,6 +21,7 @@ import com.google.type.Interval
 import com.google.type.interval
 import io.r2dbc.postgresql.codec.Interval as PostgresInterval
 import java.time.Instant
+import java.time.ZoneOffset
 import java.util.UUID
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.emptyFlow
@@ -30,6 +31,7 @@ import org.wfanet.measurement.common.db.r2dbc.ReadContext
 import org.wfanet.measurement.common.db.r2dbc.ResultRow
 import org.wfanet.measurement.common.db.r2dbc.boundStatement
 import org.wfanet.measurement.common.identity.InternalId
+import org.wfanet.measurement.common.toInstant
 import org.wfanet.measurement.common.toProtoDuration
 import org.wfanet.measurement.common.toProtoTime
 import org.wfanet.measurement.internal.reporting.v2.BatchGetMetricsRequest
@@ -50,6 +52,21 @@ class MetricReader(private val readContext: ReadContext) {
     val metricId: InternalId,
     val createMetricRequestId: String,
     val metric: Metric
+  )
+
+  data class ReportingMetricKey(
+    val reportingSetId: InternalId,
+    val metricCalculationSpecId: InternalId,
+    val timeInterval: Interval,
+  )
+
+  data class ReportingMetric(
+    val reportingMetricKey: ReportingMetricKey,
+    val metricId: InternalId,
+    val createMetricRequestId: String,
+    val externalMetricId: String,
+    val metricSpec: MetricSpec,
+    val metricDetails: Metric.Details
   )
 
   private data class MetricInfo(
@@ -159,9 +176,10 @@ class MetricReader(private val readContext: ReadContext) {
       StringBuilder(
         """
           $baseSqlSelect
-          FROM MeasurementConsumers
+          FROM
+            MeasurementConsumers
             JOIN Metrics USING(MeasurementConsumerId)
-          $baseSqlJoins
+            $baseSqlJoins
           WHERE Metrics.MeasurementConsumerId = $1
             AND CreateMetricRequestId IN
         """
@@ -204,6 +222,264 @@ class MetricReader(private val readContext: ReadContext) {
         )
       }
     }
+  }
+
+  fun readReportingMetricsByReportingMetricKey(
+    measurementConsumerId: InternalId,
+    reportingMetricKeys: Collection<ReportingMetricKey>,
+  ): Flow<ReportingMetric> {
+    if (reportingMetricKeys.isEmpty()) {
+      return emptyFlow()
+    }
+
+    val sqlSelect: String =
+      """
+      SELECT
+        CmmsMeasurementConsumerId,
+        Metrics.MeasurementConsumerId,
+        Metrics.CreateMetricRequestId,
+        ReportingSets.ReportingSetId as MetricsReportingSetId,
+        MetricCalculationSpecReportingMetrics.MetricCalculationSpecId,
+        Metrics.MetricId,
+        Metrics.ExternalMetricId,
+        Metrics.TimeIntervalStart AS MetricsTimeIntervalStart,
+        Metrics.TimeIntervalEndExclusive AS MetricsTimeIntervalEndExclusive,
+        Metrics.MetricType,
+        Metrics.DifferentialPrivacyEpsilon,
+        Metrics.DifferentialPrivacyDelta,
+        Metrics.FrequencyDifferentialPrivacyEpsilon,
+        Metrics.FrequencyDifferentialPrivacyDelta,
+        Metrics.MaximumFrequency,
+        Metrics.MaximumFrequencyPerUser,
+        Metrics.MaximumWatchDurationPerUser,
+        Metrics.VidSamplingIntervalStart,
+        Metrics.VidSamplingIntervalWidth,
+        Metrics.MetricDetails
+      """
+        .trimIndent()
+
+    val sqlJoins: String =
+      """
+      JOIN Metrics USING(MeasurementConsumerId)
+      JOIN ReportingSets USING(MeasurementConsumerId, ReportingSetId)
+      LEFT JOIN MetricCalculationSpecReportingMetrics ON
+        Metrics.MeasurementConsumerId = MetricCalculationSpecReportingMetrics.MeasurementConsumerId
+        AND Metrics.MetricId = MetricCalculationSpecReportingMetrics.MetricId
+      """
+        .trimIndent()
+
+    val sql =
+      StringBuilder(
+        """
+          $sqlSelect
+          FROM
+            MeasurementConsumers
+            $sqlJoins
+          WHERE Metrics.MeasurementConsumerId = $1
+        """
+          .trimIndent()
+      )
+
+    // The index in `sql` ends at $1.
+    var offset = 2
+    val reportingSetIdBindingMap = mutableMapOf<InternalId, String>()
+    val metricCalculationSpecIdBindingMap = mutableMapOf<InternalId, String>()
+    val timeStampBindingMap = mutableMapOf<Timestamp, String>()
+    val sqlWhereConditions =
+      reportingMetricKeys.joinToString(separator = " OR ", prefix = "\nAND (", postfix = ")") {
+        timedReportingMetricKey ->
+        val reportingSetIdIndex =
+          reportingSetIdBindingMap.getOrPut(timedReportingMetricKey.reportingSetId) {
+            "$${offset++}"
+          }
+        val metricCalculationSpecIdIndex =
+          metricCalculationSpecIdBindingMap.getOrPut(
+            timedReportingMetricKey.metricCalculationSpecId
+          ) {
+            "$${offset++}"
+          }
+        val timeIntervalStartIndex =
+          timeStampBindingMap.getOrPut(timedReportingMetricKey.timeInterval.startTime) {
+            "$${offset++}"
+          }
+        val timeIntervalEndExclusiveIndex =
+          timeStampBindingMap.getOrPut(timedReportingMetricKey.timeInterval.endTime) {
+            "$${offset++}"
+          }
+        "(Metrics.ReportingSetId = $reportingSetIdIndex AND " +
+          "MetricCalculationSpecReportingMetrics.MetricCalculationSpecId = $metricCalculationSpecIdIndex AND " +
+          "Metrics.TimeIntervalStart = $timeIntervalStartIndex AND " +
+          "Metrics.TimeIntervalEndExclusive = $timeIntervalEndExclusiveIndex)"
+      }
+
+    sql.append(sqlWhereConditions)
+
+    val statement =
+      boundStatement(sql.toString()) {
+        bind("$1", measurementConsumerId)
+        reportingMetricKeys.forEach { timedReportingMetricKey ->
+          val reportingSetIdIndex =
+            reportingSetIdBindingMap.getValue(timedReportingMetricKey.reportingSetId)
+          val metricCalculationSpecIdIndex =
+            metricCalculationSpecIdBindingMap.getValue(
+              timedReportingMetricKey.metricCalculationSpecId
+            )
+          val timeIntervalStartIndex =
+            timeStampBindingMap.getValue(timedReportingMetricKey.timeInterval.startTime)
+          val timeIntervalEndExclusiveIndex =
+            timeStampBindingMap.getValue(timedReportingMetricKey.timeInterval.endTime)
+          bind(reportingSetIdIndex, timedReportingMetricKey.reportingSetId)
+          bind(metricCalculationSpecIdIndex, timedReportingMetricKey.metricCalculationSpecId)
+          bind(
+            timeIntervalStartIndex,
+            timedReportingMetricKey.timeInterval.startTime.toInstant().atOffset(ZoneOffset.UTC)
+          )
+          bind(
+            timeIntervalEndExclusiveIndex,
+            timedReportingMetricKey.timeInterval.endTime.toInstant().atOffset(ZoneOffset.UTC)
+          )
+        }
+      }
+
+    return flow {
+      val reportingMetricMap: Map<String, ReportingMetric> = buildReportingMetricMap(statement)
+      for (entry in reportingMetricMap) {
+        emit(entry.value)
+      }
+    }
+  }
+
+  /**
+   * Returns a map that maintains the order of the query result for timed reporting metric entry.
+   */
+  private suspend fun buildReportingMetricMap(
+    statement: BoundStatement
+  ): Map<String, ReportingMetric> {
+    // Key is externalMetricId.
+    val reportingMetricMap: MutableMap<String, ReportingMetric> = linkedMapOf()
+
+    val translate: (row: ResultRow) -> Unit = { row: ResultRow ->
+      val createMetricRequestId: String =
+        requireNotNull(row["CreateMetricRequestId"]) {
+          "Metric that is associated with a MetricCalculationSpec must have createMetricRequestId"
+        }
+      val reportingSetId: InternalId = row["MetricsReportingSetId"]
+      val metricCalculationSpecId: InternalId = row["MetricCalculationSpecId"]
+      val metricId: InternalId = row["MetricId"]
+      val externalMetricId: String = row["ExternalMetricId"]
+      val metricTimeIntervalStart: Instant = row["MetricsTimeIntervalStart"]
+      val metricTimeIntervalEnd: Instant = row["MetricsTimeIntervalEndExclusive"]
+      val metricType: MetricSpec.TypeCase = MetricSpec.TypeCase.forNumber(row["MetricType"])
+      val differentialPrivacyEpsilon: Double = row["DifferentialPrivacyEpsilon"]
+      val differentialPrivacyDelta: Double = row["DifferentialPrivacyDelta"]
+      val frequencyDifferentialPrivacyEpsilon: Double? = row["FrequencyDifferentialPrivacyEpsilon"]
+      val frequencyDifferentialPrivacyDelta: Double? = row["FrequencyDifferentialPrivacyDelta"]
+      val maximumFrequency: Int? = row["MaximumFrequency"]
+      val maximumFrequencyPerUser: Int? = row["MaximumFrequencyPerUser"]
+      val maximumWatchDurationPerUser: PostgresInterval? = row["MaximumWatchDurationPerUser"]
+      val vidSamplingStart: Float = row["VidSamplingIntervalStart"]
+      val vidSamplingWidth: Float = row["VidSamplingIntervalWidth"]
+      val metricDetails: Metric.Details =
+        row.getProtoMessage("MetricDetails", Metric.Details.parser())
+
+      reportingMetricMap.computeIfAbsent(externalMetricId) {
+        val metricTimeInterval = interval {
+          startTime = metricTimeIntervalStart.toProtoTime()
+          endTime = metricTimeIntervalEnd.toProtoTime()
+        }
+
+        val vidSamplingInterval =
+          MetricSpecKt.vidSamplingInterval {
+            start = vidSamplingStart
+            width = vidSamplingWidth
+          }
+
+        val metricSpec = metricSpec {
+          when (metricType) {
+            MetricSpec.TypeCase.REACH ->
+              reach =
+                MetricSpecKt.reachParams {
+                  privacyParams =
+                    MetricSpecKt.differentialPrivacyParams {
+                      epsilon = differentialPrivacyEpsilon
+                      delta = differentialPrivacyDelta
+                    }
+                }
+            MetricSpec.TypeCase.REACH_AND_FREQUENCY -> {
+              if (
+                frequencyDifferentialPrivacyDelta == null ||
+                  frequencyDifferentialPrivacyEpsilon == null ||
+                  maximumFrequency == null
+              ) {
+                throw IllegalStateException()
+              }
+
+              reachAndFrequency =
+                MetricSpecKt.reachAndFrequencyParams {
+                  reachPrivacyParams =
+                    MetricSpecKt.differentialPrivacyParams {
+                      epsilon = differentialPrivacyEpsilon
+                      delta = differentialPrivacyDelta
+                    }
+                  frequencyPrivacyParams =
+                    MetricSpecKt.differentialPrivacyParams {
+                      epsilon = frequencyDifferentialPrivacyEpsilon
+                      delta = frequencyDifferentialPrivacyDelta
+                    }
+                  this.maximumFrequency = maximumFrequency
+                }
+            }
+            MetricSpec.TypeCase.IMPRESSION_COUNT -> {
+              if (maximumFrequencyPerUser == null) {
+                throw IllegalStateException()
+              }
+
+              impressionCount =
+                MetricSpecKt.impressionCountParams {
+                  privacyParams =
+                    MetricSpecKt.differentialPrivacyParams {
+                      epsilon = differentialPrivacyEpsilon
+                      delta = differentialPrivacyDelta
+                    }
+                  this.maximumFrequencyPerUser = maximumFrequencyPerUser
+                }
+            }
+            MetricSpec.TypeCase.WATCH_DURATION -> {
+              watchDuration =
+                MetricSpecKt.watchDurationParams {
+                  privacyParams =
+                    MetricSpecKt.differentialPrivacyParams {
+                      epsilon = differentialPrivacyEpsilon
+                      delta = differentialPrivacyDelta
+                    }
+                  this.maximumWatchDurationPerUser =
+                    checkNotNull(maximumWatchDurationPerUser).duration.toProtoDuration()
+                }
+            }
+            MetricSpec.TypeCase.TYPE_NOT_SET -> throw IllegalStateException()
+          }
+          this.vidSamplingInterval = vidSamplingInterval
+        }
+
+        ReportingMetric(
+          reportingMetricKey =
+            ReportingMetricKey(
+              reportingSetId = reportingSetId,
+              metricCalculationSpecId = metricCalculationSpecId,
+              timeInterval = metricTimeInterval,
+            ),
+          createMetricRequestId = createMetricRequestId,
+          metricId = metricId,
+          externalMetricId = externalMetricId,
+          metricSpec = metricSpec,
+          metricDetails = metricDetails,
+        )
+      }
+    }
+
+    readContext.executeQuery(statement).consume(translate).collect {}
+
+    return reportingMetricMap
   }
 
   fun batchGetMetrics(

--- a/src/main/kotlin/org/wfanet/measurement/reporting/service/internal/testing/v2/BUILD.bazel
+++ b/src/main/kotlin/org/wfanet/measurement/reporting/service/internal/testing/v2/BUILD.bazel
@@ -7,6 +7,7 @@ kt_jvm_library(
     testonly = True,
     srcs = glob(["*.kt"]),
     deps = [
+        "//src/main/kotlin/org/wfanet/measurement/reporting/service/api:submit_batch_requests",
         "//src/main/proto/wfa/measurement/internal/reporting/v2:measurement_consumers_service_kt_jvm_grpc_proto",
         "//src/main/proto/wfa/measurement/internal/reporting/v2:measurements_service_kt_jvm_grpc_proto",
         "//src/main/proto/wfa/measurement/internal/reporting/v2:metric_calculation_specs_service_kt_jvm_grpc_proto",

--- a/src/main/kotlin/org/wfanet/measurement/reporting/service/internal/testing/v2/ReportsServiceTest.kt
+++ b/src/main/kotlin/org/wfanet/measurement/reporting/service/internal/testing/v2/ReportsServiceTest.kt
@@ -20,12 +20,15 @@ import com.google.common.truth.Truth.assertThat
 import com.google.common.truth.extensions.proto.ProtoTruth.assertThat
 import com.google.protobuf.duration
 import com.google.protobuf.timestamp
+import com.google.type.Interval
 import com.google.type.interval
 import io.grpc.Status
 import io.grpc.StatusRuntimeException
 import java.time.Clock
 import kotlin.random.Random
 import kotlin.test.assertFailsWith
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.asFlow
 import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.runBlocking
 import org.junit.Before
@@ -34,6 +37,8 @@ import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 import org.wfanet.measurement.common.identity.IdGenerator
 import org.wfanet.measurement.common.identity.RandomIdGenerator
+import org.wfanet.measurement.internal.reporting.v2.BatchCreateMetricsResponse
+import org.wfanet.measurement.internal.reporting.v2.CreateMetricRequest
 import org.wfanet.measurement.internal.reporting.v2.MeasurementConsumersGrpcKt.MeasurementConsumersCoroutineImplBase
 import org.wfanet.measurement.internal.reporting.v2.MetricCalculationSpec
 import org.wfanet.measurement.internal.reporting.v2.MetricCalculationSpecsGrpcKt.MetricCalculationSpecsCoroutineImplBase
@@ -49,6 +54,7 @@ import org.wfanet.measurement.internal.reporting.v2.ReportingSetKt
 import org.wfanet.measurement.internal.reporting.v2.ReportingSetsGrpcKt.ReportingSetsCoroutineImplBase
 import org.wfanet.measurement.internal.reporting.v2.ReportsGrpcKt.ReportsCoroutineImplBase
 import org.wfanet.measurement.internal.reporting.v2.StreamReportsRequestKt
+import org.wfanet.measurement.internal.reporting.v2.batchCreateMetricsRequest
 import org.wfanet.measurement.internal.reporting.v2.copy
 import org.wfanet.measurement.internal.reporting.v2.createMetricRequest
 import org.wfanet.measurement.internal.reporting.v2.createReportRequest
@@ -60,6 +66,9 @@ import org.wfanet.measurement.internal.reporting.v2.periodicTimeInterval
 import org.wfanet.measurement.internal.reporting.v2.report
 import org.wfanet.measurement.internal.reporting.v2.streamReportsRequest
 import org.wfanet.measurement.internal.reporting.v2.timeIntervals
+import org.wfanet.measurement.reporting.service.api.submitBatchRequests
+
+private const val MAX_BATCH_SIZE = 1000
 
 @RunWith(JUnit4::class)
 abstract class ReportsServiceTest<T : ReportsCoroutineImplBase> {
@@ -496,6 +505,181 @@ abstract class ReportsServiceTest<T : ReportsCoroutineImplBase> {
           assertThat(reportingMetric.createMetricRequestId).isNotEmpty()
         }
       }
+    }
+  }
+
+  @Test
+  fun `createReport reuses existing metrics from the other report`() = runBlocking {
+    createMeasurementConsumer(CMMS_MEASUREMENT_CONSUMER_ID, measurementConsumersService)
+    val createdMetricCalculationSpecsByExternalId =
+      (0 until 2).associate {
+        val externalMetricCalculationSpecId = "external-metric-calculation-spec-id$it"
+        externalMetricCalculationSpecId to
+          createMetricCalculationSpec(
+            CMMS_MEASUREMENT_CONSUMER_ID,
+            metricCalculationSpecsService,
+            externalMetricCalculationSpecId
+          )
+      }
+    val createdReportingSetsByExternalId =
+      (0 until 2).associate {
+        val externalReportingSetId = "external-reporting-set-id$it"
+        externalReportingSetId to
+          createReportingSet(
+            CMMS_MEASUREMENT_CONSUMER_ID,
+            reportingSetsService,
+            externalReportingSetId,
+            "data-provider-id${it % 3}",
+            "event-group-id$it"
+          )
+      }
+
+    val groupingPredicatesList = List(3) { listOf("predicate1", "predicate2") }
+
+    val timeIntervals: List<Interval> =
+      listOf(
+        interval {
+          startTime = timestamp { seconds = 100 }
+          endTime = timestamp { seconds = 200 }
+        },
+        interval {
+          startTime = timestamp { seconds = 200 }
+          endTime = timestamp { seconds = 300 }
+        },
+        interval {
+          startTime = timestamp { seconds = 100 }
+          endTime = timestamp { seconds = 300 }
+        }
+      )
+
+    val reportingMetrics =
+      groupingPredicatesList.flatMap { groupingPredicates ->
+        timeIntervals.map { timeInterval ->
+          ReportKt.reportingMetric {
+            details =
+              ReportKt.ReportingMetricKt.details {
+                metricSpec = metricSpec {
+                  reach =
+                    MetricSpecKt.reachParams {
+                      privacyParams =
+                        MetricSpecKt.differentialPrivacyParams {
+                          epsilon = 1.0
+                          delta = 2.0
+                        }
+                    }
+                  vidSamplingInterval =
+                    MetricSpecKt.vidSamplingInterval {
+                      start = 0.1f
+                      width = 0.5f
+                    }
+                }
+                this.timeInterval = timeInterval
+                this.groupingPredicates += groupingPredicates
+              }
+          }
+        }
+      }
+
+    val report = report {
+      cmmsMeasurementConsumerId = CMMS_MEASUREMENT_CONSUMER_ID
+      reportingMetricEntries.putAll(
+        createdReportingSetsByExternalId.keys.associateWith {
+          ReportKt.reportingMetricCalculationSpec {
+            metricCalculationSpecReportingMetrics +=
+              createdMetricCalculationSpecsByExternalId.keys.map { externalMetricCalSpecId ->
+                ReportKt.metricCalculationSpecReportingMetrics {
+                  externalMetricCalculationSpecId = externalMetricCalSpecId
+                  this.reportingMetrics += reportingMetrics
+                }
+              }
+          }
+        }
+      )
+      this.timeIntervals = timeIntervals { this.timeIntervals += timeIntervals }
+      details = ReportKt.details { tags.putAll(REPORT_TAGS) }
+    }
+
+    val createdReport =
+      service.createReport(
+        createReportRequest {
+          this.report = report
+          externalReportId = "external-report-id"
+        }
+      )
+
+    var metricIndex = 0
+    val createMetricsRequests: Flow<CreateMetricRequest> =
+      createdReport.reportingMetricEntriesMap.entries
+        .flatMap { entry ->
+          val reportingSet = createdReportingSetsByExternalId.getValue(entry.key)
+
+          entry.value.metricCalculationSpecReportingMetricsList.flatMap {
+            metricCalculationSpecReportingMetrics ->
+            val metricCalculationSpecFilter =
+              createdMetricCalculationSpecsByExternalId
+                .getValue(metricCalculationSpecReportingMetrics.externalMetricCalculationSpecId)
+                .details
+                .filter
+            metricCalculationSpecReportingMetrics.reportingMetricsList.map { reportingMetric ->
+              val externalMetricId = "externalMetricId$metricIndex"
+              metricIndex++
+              buildCreateMetricRequest(
+                createdReport.cmmsMeasurementConsumerId,
+                externalMetricId,
+                reportingSet,
+                reportingMetric,
+                metricCalculationSpecFilter
+              )
+            }
+          }
+        }
+        .asFlow()
+    val callRpc: suspend (List<CreateMetricRequest>) -> BatchCreateMetricsResponse = { items ->
+      metricsService.batchCreateMetrics(
+        batchCreateMetricsRequest {
+          cmmsMeasurementConsumerId = createdReport.cmmsMeasurementConsumerId
+          requests += items
+        }
+      )
+    }
+    submitBatchRequests(createMetricsRequests, MAX_BATCH_SIZE, callRpc) { response ->
+        response.metricsList
+      }
+      .toList()
+
+    val retrievedReport =
+      service.getReport(
+        getReportRequest {
+          cmmsMeasurementConsumerId = CMMS_MEASUREMENT_CONSUMER_ID
+          externalReportId = createdReport.externalReportId
+        }
+      )
+
+    val createdReportReusingMetrics =
+      service.createReport(
+        createReportRequest {
+          this.report = report
+          externalReportId = "external-report-id2"
+        }
+      )
+
+    for (entry in createdReportReusingMetrics.reportingMetricEntriesMap.entries) {
+      for (metricCalculationSpecReportingMetrics in
+        entry.value.metricCalculationSpecReportingMetricsList) {
+        for (reportingMetric in metricCalculationSpecReportingMetrics.reportingMetricsList) {
+          assertThat(reportingMetric.createMetricRequestId).isNotEmpty()
+          assertThat(reportingMetric.externalMetricId).isNotEmpty()
+        }
+      }
+    }
+
+    // If metric reuse did happen during the second report creation, the second report should have
+    // the same key-value pairs in `reportingMetricEntriesMap` as what the first report has.
+    // Note that metric reuse mechanism won't produce the same order of `ReportingMetric`
+    // internally. This won't impact any immutable fields in public resources.
+    for (entry in createdReportReusingMetrics.reportingMetricEntriesMap.entries) {
+      val expected = retrievedReport.reportingMetricEntriesMap.getValue(entry.key)
+      assertThat(entry.value).ignoringRepeatedFieldOrder().isEqualTo(expected)
     }
   }
 
@@ -1169,39 +1353,14 @@ abstract class ReportsServiceTest<T : ReportsCoroutineImplBase> {
       for (metricCalculationSpecReportingMetrics in
         entry.value.metricCalculationSpecReportingMetricsList) {
         for (reportingMetric in metricCalculationSpecReportingMetrics.reportingMetricsList) {
-          val request = createMetricRequest {
-            requestId = reportingMetric.createMetricRequestId
-            externalMetricId = "externalMetricId"
-            metric = metric {
-              cmmsMeasurementConsumerId = createdReport.cmmsMeasurementConsumerId
-              externalReportingSetId = createdReportingSet.externalReportingSetId
-              timeInterval = reportingMetric.details.timeInterval
-              metricSpec = reportingMetric.details.metricSpec
-              weightedMeasurements +=
-                MetricKt.weightedMeasurement {
-                  weight = 2
-                  measurement = measurement {
-                    cmmsMeasurementConsumerId = CMMS_MEASUREMENT_CONSUMER_ID
-                    timeInterval = interval {
-                      startTime = timestamp { seconds = 10 }
-                      endTime = timestamp { seconds = 100 }
-                    }
-                    primitiveReportingSetBases +=
-                      ReportingSetKt.primitiveReportingSetBasis {
-                        externalReportingSetId = createdReportingSet.externalReportingSetId
-                        filters += "filter1"
-                        filters += "filter2"
-                      }
-                  }
-                }
-              details =
-                MetricKt.details {
-                  filters +=
-                    reportingMetric.details.groupingPredicatesList +
-                      createdMetricCalculationSpec.details.filter
-                }
-            }
-          }
+          val request =
+            buildCreateMetricRequest(
+              createdReport.cmmsMeasurementConsumerId,
+              "externalMetricId",
+              createdReportingSet,
+              reportingMetric,
+              createdMetricCalculationSpec.details.filter
+            )
           metricsService.createMetric(request)
         }
       }
@@ -1524,7 +1683,7 @@ abstract class ReportsServiceTest<T : ReportsCoroutineImplBase> {
     private const val CMMS_MEASUREMENT_CONSUMER_ID = "1234"
     private val REPORT_TAGS = mapOf("tag1" to "tag_value1", "tag2" to "tag_value2")
 
-    private suspend fun createReportForRequest(
+    private fun createReportForRequest(
       reportingSet: ReportingSet,
       metricCalculationSpec: MetricCalculationSpec,
     ): Report {
@@ -1655,6 +1814,45 @@ abstract class ReportsServiceTest<T : ReportsCoroutineImplBase> {
           }
         }
       )
+    }
+
+    private fun buildCreateMetricRequest(
+      cmmsMeasurementConsumerId: String,
+      externalMetricId: String,
+      createdReportingSet: ReportingSet,
+      reportingMetric: Report.ReportingMetric,
+      metricCalculationSpecFilter: String,
+    ): CreateMetricRequest {
+      return createMetricRequest {
+        requestId = reportingMetric.createMetricRequestId
+        this.externalMetricId = externalMetricId
+        metric = metric {
+          this.cmmsMeasurementConsumerId = cmmsMeasurementConsumerId
+          externalReportingSetId = createdReportingSet.externalReportingSetId
+          timeInterval = reportingMetric.details.timeInterval
+          metricSpec = reportingMetric.details.metricSpec
+          weightedMeasurements +=
+            MetricKt.weightedMeasurement {
+              weight = 1
+              measurement = measurement {
+                this.cmmsMeasurementConsumerId = cmmsMeasurementConsumerId
+                timeInterval = reportingMetric.details.timeInterval
+                primitiveReportingSetBases +=
+                  ReportingSetKt.primitiveReportingSetBasis {
+                    externalReportingSetId = createdReportingSet.externalReportingSetId
+                    filters += createdReportingSet.filter
+                    filters += reportingMetric.details.groupingPredicatesList
+                    filters += metricCalculationSpecFilter
+                  }
+              }
+            }
+          details =
+            MetricKt.details {
+              filters +=
+                reportingMetric.details.groupingPredicatesList + metricCalculationSpecFilter
+            }
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
Given the fact that `MetricCalculationSpec` is now an individual resource and can be reused, we can utilize this to identify a set of metrics across reports. Note that the granularity is "a set of metrics" that is associated with `MetricCalculationSpec`.

When a `MetricCalculationSpec` is reused in a different report, by identifying the pair of `MetricCalculationSpec` and the `ReportingSet` and the `TimeInterval`s from the report, we are able to identify the existing set of metrics created from the previous reports. This could be done during the internal report creation by the following:
1. Left join the table `Metrics` and `MetricCalculationSpecReportingMetrics` by `MeasurementConsumerId` and `MetricId`.
2. Find the set of metrics given `MeasurementConsumerId`, `ReportingSetId`, `MetricCalculationSpecId`, a set of `TimeIntervalStart` and `TimeIntervalEndExclusive`.
3. Repeat the process for all `ReportingMetricEntries`, i.e. pairs of `MetricCalculationSpecs` and `ReportingSets`.

At the step (2) above, the reason why we could get a set of metrics is because a `MetricCalculationSpec` could correspond to multiple metrics due to the fan-out of metric types, groupings, and time intervals. 