### PR TITLE
Add proto for HonestMajorityShareShuffle protocol.

### DIFF
--- a/src/main/cc/wfa/measurement/internal/duchy/protocol/liquid_legions_v2/BUILD.bazel
+++ b/src/main/cc/wfa/measurement/internal/duchy/protocol/liquid_legions_v2/BUILD.bazel
@@ -25,6 +25,7 @@ cc_library(
         "//src/main/cc/wfa/measurement/common/crypto:constants",
         "//src/main/cc/wfa/measurement/common/crypto:encryption_utility_helper",
         "//src/main/cc/wfa/measurement/common/crypto:protocol_cryptor",
+        "//src/main/proto/wfa/measurement/internal/duchy:noise_mechanism_cc_proto",
         "//src/main/proto/wfa/measurement/internal/duchy/protocol:liquid_legions_v2_encryption_methods_cc_proto",
         "@any_sketch//src/main/cc/estimation:estimators",
         "@any_sketch//src/main/cc/math:distributed_discrete_gaussian_noiser",
@@ -109,6 +110,7 @@ cc_library(
     strip_include_prefix = _INCLUDE_PREFIX,
     deps = [
         "//src/main/proto/wfa/measurement/internal/duchy:differential_privacy_cc_proto",
+        "//src/main/proto/wfa/measurement/internal/duchy:noise_mechanism_cc_proto",
         "//src/main/proto/wfa/measurement/internal/duchy/protocol:liquid_legions_v2_noise_config_cc_proto",
         "@any_sketch//src/main/cc/math:distributed_discrete_gaussian_noiser",
         "@any_sketch//src/main/cc/math:distributed_geometric_noiser",

--- a/src/main/cc/wfa/measurement/internal/duchy/protocol/liquid_legions_v2/liquid_legions_v2_encryption_utility.cc
+++ b/src/main/cc/wfa/measurement/internal/duchy/protocol/liquid_legions_v2/liquid_legions_v2_encryption_utility.cc
@@ -34,6 +34,7 @@
 #include "wfa/measurement/common/crypto/encryption_utility_helper.h"
 #include "wfa/measurement/common/crypto/protocol_cryptor.h"
 #include "wfa/measurement/common/string_block_sorter.h"
+#include "wfa/measurement/internal/duchy/noise_mechanism.pb.h"
 #include "wfa/measurement/internal/duchy/protocol/liquid_legions_v2/multithreading_helper.h"
 #include "wfa/measurement/internal/duchy/protocol/liquid_legions_v2/noise_parameters_computation.h"
 
@@ -73,7 +74,7 @@ using ::wfa::measurement::common::crypto::MultiplyEcPointPairByScalar;
 using ::wfa::measurement::common::crypto::ProtocolCryptor;
 using ::wfa::measurement::common::crypto::ProtocolCryptorOptions;
 using ::wfa::measurement::internal::duchy::ElGamalPublicKey;
-using ::wfa::measurement::internal::duchy::protocol::LiquidLegionsV2NoiseConfig;
+using ::wfa::measurement::internal::duchy::NoiseMechanism;
 
 // Blinds the last layer of ElGamal Encryption of register indexes, and return
 // the deterministically encrypted results.
@@ -619,8 +620,7 @@ absl::Status ValidateFrequencyNoiseParameters(
 absl::Status AddAllFrequencyNoise(
     MultithreadingHelper& helper, int curve_id,
     const FlagCountTupleNoiseGenerationParameters& noise_parameters,
-    const LiquidLegionsV2NoiseConfig::NoiseMechanism& noise_mechanism,
-    std::string& data) {
+    const NoiseMechanism& noise_mechanism, std::string& data) {
   RETURN_IF_ERROR(ValidateFrequencyNoiseParameters(noise_parameters));
 
   auto noiser = GetFrequencyNoiser(noise_parameters.dp_params(),

--- a/src/main/cc/wfa/measurement/internal/duchy/protocol/liquid_legions_v2/noise_parameters_computation.cc
+++ b/src/main/cc/wfa/measurement/internal/duchy/protocol/liquid_legions_v2/noise_parameters_computation.cc
@@ -89,18 +89,16 @@ GetDiscreteGaussianNoiseOptions(
 
 std::unique_ptr<math::DistributedNoiser> GetBlindHistogramNoiser(
     const wfa::measurement::internal::duchy::DifferentialPrivacyParams& params,
-    int uncorrupted_party_count,
-    LiquidLegionsV2NoiseConfig::NoiseMechanism noise_mechanism) {
-  ABSL_ASSERT(noise_mechanism ==
-                  LiquidLegionsV2NoiseConfig::DISCRETE_GAUSSIAN ||
-              noise_mechanism == LiquidLegionsV2NoiseConfig::GEOMETRIC);
+    int uncorrupted_party_count, NoiseMechanism noise_mechanism) {
+  ABSL_ASSERT(noise_mechanism == NoiseMechanism::DISCRETE_GAUSSIAN ||
+              noise_mechanism == NoiseMechanism::GEOMETRIC);
 
-  if (noise_mechanism == LiquidLegionsV2NoiseConfig::GEOMETRIC) {
+  if (noise_mechanism == NoiseMechanism::GEOMETRIC) {
     auto noiseOptions =
         GetGeometricNoiseOptions(params, 2, uncorrupted_party_count);
     return std::make_unique<math::DistributedGeometricNoiser>(noiseOptions);
   } else {
-    // noise_mechanism == LiquidLegionsV2NoiseConfig::DISCRETE_GAUSSIAN
+    // noise_mechanism == NoiseMechanism::DISCRETE_GAUSSIAN
     auto noiseOptions =
         GetDiscreteGaussianNoiseOptions(params, uncorrupted_party_count);
     return std::make_unique<math::DistributedDiscreteGaussianNoiser>(
@@ -111,17 +109,16 @@ std::unique_ptr<math::DistributedNoiser> GetBlindHistogramNoiser(
 std::unique_ptr<math::DistributedNoiser> GetPublisherNoiser(
     const wfa::measurement::internal::duchy::DifferentialPrivacyParams& params,
     int publisher_count, int uncorrupted_party_count,
-    LiquidLegionsV2NoiseConfig::NoiseMechanism noise_mechanism) {
-  ABSL_ASSERT(noise_mechanism ==
-                  LiquidLegionsV2NoiseConfig::DISCRETE_GAUSSIAN ||
-              noise_mechanism == LiquidLegionsV2NoiseConfig::GEOMETRIC);
+    NoiseMechanism noise_mechanism) {
+  ABSL_ASSERT(noise_mechanism == NoiseMechanism::DISCRETE_GAUSSIAN ||
+              noise_mechanism == NoiseMechanism::GEOMETRIC);
 
-  if (noise_mechanism == LiquidLegionsV2NoiseConfig::GEOMETRIC) {
+  if (noise_mechanism == NoiseMechanism::GEOMETRIC) {
     auto noiseOptions = GetGeometricNoiseOptions(params, publisher_count,
                                                  uncorrupted_party_count);
     return std::make_unique<math::DistributedGeometricNoiser>(noiseOptions);
   } else {
-    // noise_mechanism == LiquidLegionsV2NoiseConfig::DISCRETE_GAUSSIAN
+    // noise_mechanism == NoiseMechanism::DISCRETE_GAUSSIAN
     auto noiseOptions =
         GetDiscreteGaussianNoiseOptions(params, uncorrupted_party_count);
     return std::make_unique<math::DistributedDiscreteGaussianNoiser>(
@@ -131,18 +128,16 @@ std::unique_ptr<math::DistributedNoiser> GetPublisherNoiser(
 
 std::unique_ptr<math::DistributedNoiser> GetGlobalReachDpNoiser(
     const wfa::measurement::internal::duchy::DifferentialPrivacyParams& params,
-    int uncorrupted_party_count,
-    LiquidLegionsV2NoiseConfig::NoiseMechanism noise_mechanism) {
-  ABSL_ASSERT(noise_mechanism ==
-                  LiquidLegionsV2NoiseConfig::DISCRETE_GAUSSIAN ||
-              noise_mechanism == LiquidLegionsV2NoiseConfig::GEOMETRIC);
+    int uncorrupted_party_count, NoiseMechanism noise_mechanism) {
+  ABSL_ASSERT(noise_mechanism == NoiseMechanism::DISCRETE_GAUSSIAN ||
+              noise_mechanism == NoiseMechanism::GEOMETRIC);
 
-  if (noise_mechanism == LiquidLegionsV2NoiseConfig::GEOMETRIC) {
+  if (noise_mechanism == NoiseMechanism::GEOMETRIC) {
     auto noiseOptions =
         GetGeometricNoiseOptions(params, 1, uncorrupted_party_count);
     return std::make_unique<math::DistributedGeometricNoiser>(noiseOptions);
   } else {
-    // noise_mechanism == LiquidLegionsV2NoiseConfig::DISCRETE_GAUSSIAN
+    // noise_mechanism == NoiseMechanism::DISCRETE_GAUSSIAN
     auto noiseOptions =
         GetDiscreteGaussianNoiseOptions(params, uncorrupted_party_count);
     return std::make_unique<math::DistributedDiscreteGaussianNoiser>(
@@ -152,19 +147,17 @@ std::unique_ptr<math::DistributedNoiser> GetGlobalReachDpNoiser(
 
 std::unique_ptr<math::DistributedNoiser> GetFrequencyNoiser(
     const wfa::measurement::internal::duchy::DifferentialPrivacyParams& params,
-    int uncorrupted_party_count,
-    LiquidLegionsV2NoiseConfig::NoiseMechanism noise_mechanism) {
-  ABSL_ASSERT(noise_mechanism ==
-                  LiquidLegionsV2NoiseConfig::DISCRETE_GAUSSIAN ||
-              noise_mechanism == LiquidLegionsV2NoiseConfig::GEOMETRIC);
+    int uncorrupted_party_count, NoiseMechanism noise_mechanism) {
+  ABSL_ASSERT(noise_mechanism == NoiseMechanism::DISCRETE_GAUSSIAN ||
+              noise_mechanism == NoiseMechanism::GEOMETRIC);
 
-  if (noise_mechanism == LiquidLegionsV2NoiseConfig::GEOMETRIC) {
+  if (noise_mechanism == NoiseMechanism::GEOMETRIC) {
     auto noiseOptions =
         GetGeometricNoiseOptions(params, 2, uncorrupted_party_count);
     return std::make_unique<math::DistributedGeometricNoiser>(noiseOptions);
   }
   {
-    // noise_mechanism == LiquidLegionsV2NoiseConfig::DISCRETE_GAUSSIAN
+    // noise_mechanism == NoiseMechanism::DISCRETE_GAUSSIAN
     auto noiseOptions =
         GetDiscreteGaussianNoiseOptions(params, uncorrupted_party_count);
     return std::make_unique<math::DistributedDiscreteGaussianNoiser>(

--- a/src/main/cc/wfa/measurement/internal/duchy/protocol/liquid_legions_v2/noise_parameters_computation.h
+++ b/src/main/cc/wfa/measurement/internal/duchy/protocol/liquid_legions_v2/noise_parameters_computation.h
@@ -19,31 +19,28 @@
 
 #include "math/distributed_noiser.h"
 #include "wfa/measurement/internal/duchy/differential_privacy.pb.h"
-#include "wfa/measurement/internal/duchy/protocol/liquid_legions_v2_noise_config.pb.h"
+#include "wfa/measurement/internal/duchy/noise_mechanism.pb.h"
 
 namespace wfa::measurement::internal::duchy::protocol::liquid_legions_v2 {
 
-using ::wfa::measurement::internal::duchy::protocol::LiquidLegionsV2NoiseConfig;
+using ::wfa::measurement::internal::duchy::NoiseMechanism;
 
 std::unique_ptr<math::DistributedNoiser> GetBlindHistogramNoiser(
     const wfa::measurement::internal::duchy::DifferentialPrivacyParams& params,
-    int uncorrupted_party_count,
-    LiquidLegionsV2NoiseConfig::NoiseMechanism noise_mechanism);
+    int uncorrupted_party_count, NoiseMechanism noise_mechanism);
 
 std::unique_ptr<math::DistributedNoiser> GetPublisherNoiser(
     const wfa::measurement::internal::duchy::DifferentialPrivacyParams& params,
     int publisher_count, int uncorrupted_party_count,
-    LiquidLegionsV2NoiseConfig::NoiseMechanism noise_mechanism);
+    NoiseMechanism noise_mechanism);
 
 std::unique_ptr<math::DistributedNoiser> GetGlobalReachDpNoiser(
     const wfa::measurement::internal::duchy::DifferentialPrivacyParams& params,
-    int uncorrupted_party_count,
-    LiquidLegionsV2NoiseConfig::NoiseMechanism noise_mechanism);
+    int uncorrupted_party_count, NoiseMechanism noise_mechanism);
 
 std::unique_ptr<math::DistributedNoiser> GetFrequencyNoiser(
     const wfa::measurement::internal::duchy::DifferentialPrivacyParams& params,
-    int uncorrupted_party_count,
-    LiquidLegionsV2NoiseConfig::NoiseMechanism noise_mechanism);
+    int uncorrupted_party_count, NoiseMechanism noise_mechanism);
 
 }  // namespace wfa::measurement::internal::duchy::protocol::liquid_legions_v2
 

--- a/src/main/kotlin/org/wfanet/measurement/duchy/daemon/herald/BUILD.bazel
+++ b/src/main/kotlin/org/wfanet/measurement/duchy/daemon/herald/BUILD.bazel
@@ -40,6 +40,7 @@ kt_jvm_library(
         "//src/main/proto/wfa/measurement/api/v2alpha:measurement_kt_jvm_proto",
         "//src/main/proto/wfa/measurement/api/v2alpha:measurement_spec_kt_jvm_proto",
         "//src/main/proto/wfa/measurement/internal/duchy:computations_service_kt_jvm_grpc_proto",
+        "//src/main/proto/wfa/measurement/internal/duchy:noise_mechanism_kt_jvm_proto",
         "//src/main/proto/wfa/measurement/internal/duchy/config:protocols_setup_config_kt_jvm_proto",
         "//src/main/proto/wfa/measurement/system/v1alpha:computation_kt_jvm_proto",
         "//src/main/proto/wfa/measurement/system/v1alpha:computation_participants_service_kt_jvm_grpc_proto",

--- a/src/main/kotlin/org/wfanet/measurement/duchy/daemon/herald/LiquidLegionsV2Starter.kt
+++ b/src/main/kotlin/org/wfanet/measurement/duchy/daemon/herald/LiquidLegionsV2Starter.kt
@@ -31,6 +31,7 @@ import org.wfanet.measurement.internal.duchy.ComputationDetails
 import org.wfanet.measurement.internal.duchy.ComputationToken
 import org.wfanet.measurement.internal.duchy.ComputationTypeEnum
 import org.wfanet.measurement.internal.duchy.ComputationsGrpcKt.ComputationsCoroutineStub
+import org.wfanet.measurement.internal.duchy.NoiseMechanism
 import org.wfanet.measurement.internal.duchy.config.LiquidLegionsV2SetupConfig
 import org.wfanet.measurement.internal.duchy.createComputationRequest
 import org.wfanet.measurement.internal.duchy.protocol.LiquidLegionsSketchAggregationV2.ComputationDetails.ComputationParticipant
@@ -39,7 +40,6 @@ import org.wfanet.measurement.internal.duchy.protocol.LiquidLegionsSketchAggrega
 import org.wfanet.measurement.internal.duchy.protocol.LiquidLegionsSketchAggregationV2Kt.ComputationDetailsKt.ParametersKt
 import org.wfanet.measurement.internal.duchy.protocol.LiquidLegionsSketchAggregationV2Kt.ComputationDetailsKt.computationParticipant
 import org.wfanet.measurement.internal.duchy.protocol.LiquidLegionsSketchAggregationV2Kt.ComputationDetailsKt.parameters
-import org.wfanet.measurement.internal.duchy.protocol.LiquidLegionsV2NoiseConfig.NoiseMechanism
 import org.wfanet.measurement.internal.duchy.protocol.LiquidLegionsV2NoiseConfigKt.reachNoiseConfig
 import org.wfanet.measurement.internal.duchy.protocol.liquidLegionsSketchParameters
 import org.wfanet.measurement.internal.duchy.protocol.liquidLegionsV2NoiseConfig

--- a/src/main/kotlin/org/wfanet/measurement/duchy/daemon/herald/ReachOnlyLiquidLegionsV2Starter.kt
+++ b/src/main/kotlin/org/wfanet/measurement/duchy/daemon/herald/ReachOnlyLiquidLegionsV2Starter.kt
@@ -29,13 +29,13 @@ import org.wfanet.measurement.duchy.toProtocolStage
 import org.wfanet.measurement.internal.duchy.ComputationToken
 import org.wfanet.measurement.internal.duchy.ComputationTypeEnum
 import org.wfanet.measurement.internal.duchy.ComputationsGrpcKt
+import org.wfanet.measurement.internal.duchy.NoiseMechanism
 import org.wfanet.measurement.internal.duchy.computationDetails
 import org.wfanet.measurement.internal.duchy.config.LiquidLegionsV2SetupConfig
 import org.wfanet.measurement.internal.duchy.copy
 import org.wfanet.measurement.internal.duchy.createComputationRequest
 import org.wfanet.measurement.internal.duchy.protocol.LiquidLegionsSketchAggregationV2
 import org.wfanet.measurement.internal.duchy.protocol.LiquidLegionsSketchAggregationV2Kt
-import org.wfanet.measurement.internal.duchy.protocol.LiquidLegionsV2NoiseConfig
 import org.wfanet.measurement.internal.duchy.protocol.LiquidLegionsV2NoiseConfigKt
 import org.wfanet.measurement.internal.duchy.protocol.ReachOnlyLiquidLegionsSketchAggregationV2
 import org.wfanet.measurement.internal.duchy.protocol.ReachOnlyLiquidLegionsSketchAggregationV2Kt
@@ -273,12 +273,11 @@ object ReachOnlyLiquidLegionsV2Starter {
   }
 
   private fun Computation.MpcProtocolConfig.NoiseMechanism.toInternalNoiseMechanism():
-    LiquidLegionsV2NoiseConfig.NoiseMechanism {
+    NoiseMechanism {
     return when (this) {
-      Computation.MpcProtocolConfig.NoiseMechanism.GEOMETRIC ->
-        LiquidLegionsV2NoiseConfig.NoiseMechanism.GEOMETRIC
+      Computation.MpcProtocolConfig.NoiseMechanism.GEOMETRIC -> NoiseMechanism.GEOMETRIC
       Computation.MpcProtocolConfig.NoiseMechanism.DISCRETE_GAUSSIAN ->
-        LiquidLegionsV2NoiseConfig.NoiseMechanism.DISCRETE_GAUSSIAN
+        NoiseMechanism.DISCRETE_GAUSSIAN
       Computation.MpcProtocolConfig.NoiseMechanism.UNRECOGNIZED,
       Computation.MpcProtocolConfig.NoiseMechanism.NOISE_MECHANISM_UNSPECIFIED ->
         error("Invalid system NoiseMechanism")

--- a/src/main/kotlin/org/wfanet/measurement/duchy/daemon/mill/liquidlegionsv2/ReachFrequencyLiquidLegionsV2Mill.kt
+++ b/src/main/kotlin/org/wfanet/measurement/duchy/daemon/mill/liquidlegionsv2/ReachFrequencyLiquidLegionsV2Mill.kt
@@ -49,10 +49,10 @@ import org.wfanet.measurement.internal.duchy.ComputationToken
 import org.wfanet.measurement.internal.duchy.ComputationTypeEnum.ComputationType
 import org.wfanet.measurement.internal.duchy.ElGamalPublicKey
 import org.wfanet.measurement.internal.duchy.UpdateComputationDetailsRequest
-import org.wfanet.measurement.internal.duchy.config.LiquidLegionsV2SetupConfig.RoleInComputation.AGGREGATOR
-import org.wfanet.measurement.internal.duchy.config.LiquidLegionsV2SetupConfig.RoleInComputation.NON_AGGREGATOR
-import org.wfanet.measurement.internal.duchy.config.LiquidLegionsV2SetupConfig.RoleInComputation.UNKNOWN
-import org.wfanet.measurement.internal.duchy.config.LiquidLegionsV2SetupConfig.RoleInComputation.UNRECOGNIZED
+import org.wfanet.measurement.internal.duchy.config.RoleInComputation.AGGREGATOR
+import org.wfanet.measurement.internal.duchy.config.RoleInComputation.NON_AGGREGATOR
+import org.wfanet.measurement.internal.duchy.config.RoleInComputation.UNKNOWN
+import org.wfanet.measurement.internal.duchy.config.RoleInComputation.UNRECOGNIZED
 import org.wfanet.measurement.internal.duchy.protocol.CompleteExecutionPhaseOneAtAggregatorResponse
 import org.wfanet.measurement.internal.duchy.protocol.CompleteExecutionPhaseOneRequest
 import org.wfanet.measurement.internal.duchy.protocol.CompleteExecutionPhaseOneResponse

--- a/src/main/kotlin/org/wfanet/measurement/duchy/daemon/mill/liquidlegionsv2/ReachOnlyLiquidLegionsV2Mill.kt
+++ b/src/main/kotlin/org/wfanet/measurement/duchy/daemon/mill/liquidlegionsv2/ReachOnlyLiquidLegionsV2Mill.kt
@@ -47,10 +47,10 @@ import org.wfanet.measurement.internal.duchy.ComputationToken
 import org.wfanet.measurement.internal.duchy.ComputationTypeEnum.ComputationType
 import org.wfanet.measurement.internal.duchy.ElGamalPublicKey
 import org.wfanet.measurement.internal.duchy.computationDetails
-import org.wfanet.measurement.internal.duchy.config.LiquidLegionsV2SetupConfig.RoleInComputation.AGGREGATOR
-import org.wfanet.measurement.internal.duchy.config.LiquidLegionsV2SetupConfig.RoleInComputation.NON_AGGREGATOR
-import org.wfanet.measurement.internal.duchy.config.LiquidLegionsV2SetupConfig.RoleInComputation.UNKNOWN
-import org.wfanet.measurement.internal.duchy.config.LiquidLegionsV2SetupConfig.RoleInComputation.UNRECOGNIZED
+import org.wfanet.measurement.internal.duchy.config.RoleInComputation.AGGREGATOR
+import org.wfanet.measurement.internal.duchy.config.RoleInComputation.NON_AGGREGATOR
+import org.wfanet.measurement.internal.duchy.config.RoleInComputation.UNKNOWN
+import org.wfanet.measurement.internal.duchy.config.RoleInComputation.UNRECOGNIZED
 import org.wfanet.measurement.internal.duchy.protocol.CompleteReachOnlyExecutionPhaseAtAggregatorResponse
 import org.wfanet.measurement.internal.duchy.protocol.CompleteReachOnlyExecutionPhaseResponse
 import org.wfanet.measurement.internal.duchy.protocol.CompleteReachOnlySetupPhaseRequest

--- a/src/main/kotlin/org/wfanet/measurement/duchy/db/computation/LiquidLegionsSketchAggregationV2Protocol.kt
+++ b/src/main/kotlin/org/wfanet/measurement/duchy/db/computation/LiquidLegionsSketchAggregationV2Protocol.kt
@@ -19,7 +19,7 @@ import org.wfanet.measurement.duchy.toProtocolStage
 import org.wfanet.measurement.internal.duchy.ComputationDetails
 import org.wfanet.measurement.internal.duchy.ComputationStage
 import org.wfanet.measurement.internal.duchy.ComputationStageDetails
-import org.wfanet.measurement.internal.duchy.config.LiquidLegionsV2SetupConfig.RoleInComputation
+import org.wfanet.measurement.internal.duchy.config.RoleInComputation
 import org.wfanet.measurement.internal.duchy.protocol.LiquidLegionsSketchAggregationV2
 import org.wfanet.measurement.internal.duchy.protocol.LiquidLegionsSketchAggregationV2.Stage.COMPLETE
 import org.wfanet.measurement.internal.duchy.protocol.LiquidLegionsSketchAggregationV2.Stage.CONFIRMATION_PHASE

--- a/src/main/kotlin/org/wfanet/measurement/duchy/db/computation/ReachOnlyLiquidLegionsSketchAggregationV2Protocol.kt
+++ b/src/main/kotlin/org/wfanet/measurement/duchy/db/computation/ReachOnlyLiquidLegionsSketchAggregationV2Protocol.kt
@@ -20,7 +20,7 @@ import org.wfanet.measurement.internal.duchy.ComputationDetails
 import org.wfanet.measurement.internal.duchy.ComputationStage
 import org.wfanet.measurement.internal.duchy.ComputationStageDetails
 import org.wfanet.measurement.internal.duchy.computationStageDetails
-import org.wfanet.measurement.internal.duchy.config.LiquidLegionsV2SetupConfig.RoleInComputation
+import org.wfanet.measurement.internal.duchy.config.RoleInComputation
 import org.wfanet.measurement.internal.duchy.protocol.ReachOnlyLiquidLegionsSketchAggregationV2
 import org.wfanet.measurement.internal.duchy.protocol.ReachOnlyLiquidLegionsSketchAggregationV2.Stage.COMPLETE
 import org.wfanet.measurement.internal.duchy.protocol.ReachOnlyLiquidLegionsSketchAggregationV2.Stage.CONFIRMATION_PHASE

--- a/src/main/kotlin/org/wfanet/measurement/duchy/deploy/gcloud/spanner/computation/ComputationTokenProtoQuery.kt
+++ b/src/main/kotlin/org/wfanet/measurement/duchy/deploy/gcloud/spanner/computation/ComputationTokenProtoQuery.kt
@@ -156,7 +156,10 @@ class ComputationTokenProtoQuery(
               externalRequisitionId = it.getString("ExternalRequisitionId")
               requisitionFingerprint = it.getBytesAsByteString("RequisitionFingerprint")
             }
-            path = it.getString("PathToBlob")
+            val dataPath = it.getString("PathToBlob")
+            if (!dataPath.isNullOrBlank()) {
+              path = it.getString("PathToBlob")
+            }
             details = it.getProtoMessage("RequisitionDetails", RequisitionDetails.parser())
           }
         }

--- a/src/main/kotlin/org/wfanet/measurement/duchy/service/internal/testing/ComputationStatsServiceTest.kt
+++ b/src/main/kotlin/org/wfanet/measurement/duchy/service/internal/testing/ComputationStatsServiceTest.kt
@@ -30,8 +30,7 @@ import org.wfanet.measurement.internal.duchy.CreateComputationStatRequest
 import org.wfanet.measurement.internal.duchy.CreateComputationStatResponse
 import org.wfanet.measurement.internal.duchy.claimWorkRequest
 import org.wfanet.measurement.internal.duchy.computationDetails
-import org.wfanet.measurement.internal.duchy.computationStage
-import org.wfanet.measurement.internal.duchy.config.LiquidLegionsV2SetupConfig
+import org.wfanet.measurement.internal.duchy.config.RoleInComputation
 import org.wfanet.measurement.internal.duchy.createComputationRequest
 import org.wfanet.measurement.internal.duchy.createComputationStatRequest
 import org.wfanet.measurement.internal.duchy.protocol.LiquidLegionsSketchAggregationV2Kt
@@ -62,7 +61,7 @@ abstract class ComputationStatsServiceTest<T : ComputationStatsCoroutineImplBase
     private val AGGREGATOR_COMPUTATION_DETAILS = computationDetails {
       liquidLegionsV2 =
         LiquidLegionsSketchAggregationV2Kt.computationDetails {
-          role = LiquidLegionsV2SetupConfig.RoleInComputation.AGGREGATOR
+          role = RoleInComputation.AGGREGATOR
         }
     }
     private val DEFAULT_CREATE_COMPUTATION_REQUEST = createComputationRequest {

--- a/src/main/kotlin/org/wfanet/measurement/duchy/service/internal/testing/ComputationsServiceTest.kt
+++ b/src/main/kotlin/org/wfanet/measurement/duchy/service/internal/testing/ComputationsServiceTest.kt
@@ -50,7 +50,7 @@ import org.wfanet.measurement.internal.duchy.claimWorkRequest
 import org.wfanet.measurement.internal.duchy.computationDetails
 import org.wfanet.measurement.internal.duchy.computationStage
 import org.wfanet.measurement.internal.duchy.computationToken
-import org.wfanet.measurement.internal.duchy.config.LiquidLegionsV2SetupConfig
+import org.wfanet.measurement.internal.duchy.config.RoleInComputation
 import org.wfanet.measurement.internal.duchy.copy
 import org.wfanet.measurement.internal.duchy.createComputationRequest
 import org.wfanet.measurement.internal.duchy.deleteComputationRequest
@@ -95,7 +95,7 @@ abstract class ComputationsServiceTest<T : ComputationsCoroutineImplBase> {
     private val AGGREGATOR_COMPUTATION_DETAILS = computationDetails {
       liquidLegionsV2 =
         LiquidLegionsSketchAggregationV2Kt.computationDetails {
-          role = LiquidLegionsV2SetupConfig.RoleInComputation.AGGREGATOR
+          role = RoleInComputation.AGGREGATOR
         }
     }
     private val DEFAULT_REQUISITION_ENTRY = requisitionEntry {

--- a/src/main/proto/wfa/measurement/internal/duchy/BUILD.bazel
+++ b/src/main/proto/wfa/measurement/internal/duchy/BUILD.bazel
@@ -226,3 +226,20 @@ kt_jvm_proto_library(
     srcs = [":error_code_proto"],
     deps = [":error_code_java_proto"],
 )
+
+proto_library(
+    name = "noise_mechanism_proto",
+    srcs = ["noise_mechanism.proto"],
+    strip_import_prefix = IMPORT_PREFIX,
+)
+
+java_proto_library(
+    name = "noise_mechanism_java_proto",
+    deps = [":noise_mechanism_proto"],
+)
+
+kt_jvm_proto_library(
+    name = "noise_mechanism_kt_jvm_proto",
+    srcs = [":noise_mechanism_proto"],
+    deps = [":noise_mechanism_java_proto"],
+)

--- a/src/main/proto/wfa/measurement/internal/duchy/BUILD.bazel
+++ b/src/main/proto/wfa/measurement/internal/duchy/BUILD.bazel
@@ -243,3 +243,8 @@ kt_jvm_proto_library(
     srcs = [":noise_mechanism_proto"],
     deps = [":noise_mechanism_java_proto"],
 )
+
+cc_proto_library(
+    name = "noise_mechanism_cc_proto",
+    deps = [":noise_mechanism_proto"],
+)

--- a/src/main/proto/wfa/measurement/internal/duchy/computation_token.proto
+++ b/src/main/proto/wfa/measurement/internal/duchy/computation_token.proto
@@ -89,8 +89,15 @@ message ComputationStageBlobMetadata {
 message RequisitionMetadata {
   // Lookup key using external IDs.
   ExternalRequisitionKey external_key = 1;
-  // The path to the blob if fulfilled locally. Otherwise empty.
-  string path = 2;
   // Detail of the requisition.
-  RequisitionDetails details = 3;
+  RequisitionDetails details = 2;
+  // The requisition data in format of either a path to the BLOB or a seed
+  // that can be expanded into data.
+  // The requisition is fulfilled when one of them is specified.
+  oneof data {
+    // The path to the blob.
+    string path = 3;
+    // The seed that can be expanded into the a deterministic blob.
+    bytes seed = 4;
+  }
 }

--- a/src/main/proto/wfa/measurement/internal/duchy/config/protocols_setup_config.proto
+++ b/src/main/proto/wfa/measurement/internal/duchy/config/protocols_setup_config.proto
@@ -29,21 +29,28 @@ message ProtocolsSetupConfig {
   LiquidLegionsV2SetupConfig reach_only_liquid_legions_v2 = 2;
 }
 
+// Role in Computations assigned to Duchies.
+enum RoleInComputation {
+  // Never set intentionally
+  UNKNOWN = 0;
+
+  // The aggregator duchy for the computation.
+  AGGREGATOR = 1;
+
+  // A non-aggregator duchy for the computation.
+  //
+  // For LiquidLegionsV2, this duchy has to do many crypto operations, but is
+  // not responsible for joining sketch positions together, nor computing the
+  // final results.
+  //
+  // For HonestMajorityShareShuffle, this duchy needs to exchange seeds,
+  // add noise, and shuffle.
+  NON_AGGREGATOR = 2;
+}
+
 // LiquidLegionsV2 protocols specific configuration. Also used for reach-only
 // llv2.
 message LiquidLegionsV2SetupConfig {
-  enum RoleInComputation {
-    // Never set intentionally
-    UNKNOWN = 0;
-
-    // The aggregator duchy for the computation.
-    AGGREGATOR = 1;
-
-    // A non-aggregator duchy for the computation. This duchy has to do many
-    // crypto operations, but is not responsible for joining sketch positions
-    // together, nor computing the final results.
-    NON_AGGREGATOR = 2;
-  }
   RoleInComputation role = 1;
 
   // The external id of the aggregator duchy.

--- a/src/main/proto/wfa/measurement/internal/duchy/noise_mechanism.proto
+++ b/src/main/proto/wfa/measurement/internal/duchy/noise_mechanism.proto
@@ -14,17 +14,14 @@
 
 syntax = "proto3";
 
-package wfa.measurement.internal.duchy.protocol;
+package wfa.measurement.internal.duchy;
 
-option java_package = "org.wfanet.measurement.internal.duchy.protocol";
+option java_package = "org.wfanet.measurement.internal.duchy";
 option java_multiple_files = true;
 
-// Parameters used for the sketch of HonestMajorityShareShuffle protocol
-// creation and estimation.
-message ShareShuffleSketchParameters {
-  // The size of the sketch.
-  int64 sketch_size = 1;
-  // Length of each item in bytes. #_EDPs * max_frequency should be no more than
-  // 2^(bytes_per_item*8).
-  int32 bytes_per_item = 2;
+// The mechanism used to generate noise in computations.
+enum NoiseMechanism {
+  NOISE_MECHANISM_UNSPECIFIED = 0;
+  GEOMETRIC = 1;
+  DISCRETE_GAUSSIAN = 2;
 }

--- a/src/main/proto/wfa/measurement/internal/duchy/protocol/BUILD.bazel
+++ b/src/main/proto/wfa/measurement/internal/duchy/protocol/BUILD.bazel
@@ -13,6 +13,7 @@ proto_library(
     strip_import_prefix = "/src/main/proto",
     deps = [
         "//src/main/proto/wfa/measurement/internal/duchy:differential_privacy_proto",
+        "//src/main/proto/wfa/measurement/internal/duchy:noise_mechanism_proto",
     ],
 )
 
@@ -40,6 +41,7 @@ proto_library(
         ":liquid_legions_sketch_parameter_proto",
         "//src/main/proto/wfa/measurement/internal/duchy:crypto_proto",
         "//src/main/proto/wfa/measurement/internal/duchy:differential_privacy_proto",
+        "//src/main/proto/wfa/measurement/internal/duchy:noise_mechanism_proto",
         "//src/main/proto/wfa/measurement/internal/duchy/protocol:liquid_legions_v2_noise_config_proto",
     ],
 )
@@ -86,6 +88,7 @@ proto_library(
         ":liquid_legions_v2_noise_config_proto",
         "//src/main/proto/wfa/measurement/internal/duchy:crypto_proto",
         "//src/main/proto/wfa/measurement/internal/duchy:differential_privacy_proto",
+        "//src/main/proto/wfa/measurement/internal/duchy:noise_mechanism_proto",
         "//src/main/proto/wfa/measurement/internal/duchy/config:protocols_setup_config_proto",
     ],
 )
@@ -110,6 +113,7 @@ proto_library(
         ":liquid_legions_v2_encryption_methods_proto",
         "//src/main/proto/wfa/measurement/internal/duchy:crypto_proto",
         "//src/main/proto/wfa/measurement/internal/duchy:differential_privacy_proto",
+        "//src/main/proto/wfa/measurement/internal/duchy:noise_mechanism_proto",
         "//src/main/proto/wfa/measurement/internal/duchy/protocol:liquid_legions_v2_noise_config_proto",
     ],
 )

--- a/src/main/proto/wfa/measurement/internal/duchy/protocol/liquid_legions_sketch_aggregation_v2.proto
+++ b/src/main/proto/wfa/measurement/internal/duchy/protocol/liquid_legions_sketch_aggregation_v2.proto
@@ -111,8 +111,7 @@ message LiquidLegionsSketchAggregationV2 {
   // Computation details specific to the LiquidLegions V2 protocol.
   message ComputationDetails {
     // The duchy's role in the computation.
-    org.wfa.measurement.config.LiquidLegionsV2SetupConfig.RoleInComputation
-        role = 1;
+    org.wfa.measurement.config.RoleInComputation role = 1;
 
     // Parameters used in this computation.
     message Parameters {

--- a/src/main/proto/wfa/measurement/internal/duchy/protocol/liquid_legions_v2_encryption_methods.proto
+++ b/src/main/proto/wfa/measurement/internal/duchy/protocol/liquid_legions_v2_encryption_methods.proto
@@ -18,6 +18,7 @@ package wfa.measurement.internal.duchy.protocol;
 
 import "wfa/measurement/internal/duchy/crypto.proto";
 import "wfa/measurement/internal/duchy/differential_privacy.proto";
+import "wfa/measurement/internal/duchy/noise_mechanism.proto";
 import "wfa/measurement/internal/duchy/protocol/liquid_legions_sketch_parameter.proto";
 import "wfa/measurement/internal/duchy/protocol/liquid_legions_v2_noise_config.proto";
 
@@ -119,7 +120,7 @@ message CompleteSetupPhaseRequest {
   // If set to 1, then no frequency histogram is returned.
   int32 maximum_frequency = 4;
   // The mechanism used to generate noise.
-  LiquidLegionsV2NoiseConfig.NoiseMechanism noise_mechanism = 5;
+  NoiseMechanism noise_mechanism = 5;
   // The maximum number of threads used by crypto actions.
   int32 parallelism = 6;
 }
@@ -186,7 +187,7 @@ message CompleteExecutionPhaseOneAtAggregatorRequest {
   // The total number of sketches across all workers for this computation.
   int32 total_sketches_count = 6;
   // The mechanism used to generate noise.
-  LiquidLegionsV2NoiseConfig.NoiseMechanism noise_mechanism = 7;
+  NoiseMechanism noise_mechanism = 7;
   // The maximum number of threads used by crypto actions.
   int32 parallelism = 8;
 }
@@ -222,7 +223,7 @@ message CompleteExecutionPhaseTwoRequest {
   // if unset, no noise would be added.
   FlagCountTupleNoiseGenerationParameters noise_parameters = 6;
   // The mechanism used to generate noise.
-  LiquidLegionsV2NoiseConfig.NoiseMechanism noise_mechanism = 7;
+  NoiseMechanism noise_mechanism = 7;
   // The maximum number of threads used by crypto actions.
   int32 parallelism = 8;
 }
@@ -269,7 +270,7 @@ message CompleteExecutionPhaseTwoAtAggregatorRequest {
   // MeasurementSpec.
   float vid_sampling_interval_width = 9;
   // The mechanism used to generate noise in previous phases.
-  LiquidLegionsV2NoiseConfig.NoiseMechanism noise_mechanism = 10;
+  NoiseMechanism noise_mechanism = 10;
 }
 
 // The response of the CompleteExecutionPhaseTwoAtAggregator method.
@@ -330,7 +331,7 @@ message CompleteExecutionPhaseThreeAtAggregatorRequest {
   // added. The baseline is subtracted before frequency is estimated.
   PerBucketFrequencyDpNoiseBaseline global_frequency_dp_noise_per_bucket = 5;
   // The mechanism used to generate noise in previous phases.
-  LiquidLegionsV2NoiseConfig.NoiseMechanism noise_mechanism = 6;
+  NoiseMechanism noise_mechanism = 6;
 }
 
 // The response of the CompleteExecutionPhaseThreeAtAggregator method.

--- a/src/main/proto/wfa/measurement/internal/duchy/protocol/liquid_legions_v2_noise_config.proto
+++ b/src/main/proto/wfa/measurement/internal/duchy/protocol/liquid_legions_v2_noise_config.proto
@@ -17,6 +17,7 @@ syntax = "proto3";
 package wfa.measurement.internal.duchy.protocol;
 
 import "wfa/measurement/internal/duchy/differential_privacy.proto";
+import "wfa/measurement/internal/duchy/noise_mechanism.proto";
 
 option java_package = "org.wfanet.measurement.internal.duchy.protocol";
 option java_multiple_files = true;
@@ -47,11 +48,5 @@ message LiquidLegionsV2NoiseConfig {
   // Ignored by reach-only protocol.
   DifferentialPrivacyParams frequency_noise_config = 2;
 
-  // The mechanism used to generate noise in computations.
-  enum NoiseMechanism {
-    NOISE_MECHANISM_UNSPECIFIED = 0;
-    GEOMETRIC = 1;
-    DISCRETE_GAUSSIAN = 2;
-  }
   NoiseMechanism noise_mechanism = 3;
 }

--- a/src/main/proto/wfa/measurement/internal/duchy/protocol/reach_only_liquid_legions_sketch_aggregation_v2.proto
+++ b/src/main/proto/wfa/measurement/internal/duchy/protocol/reach_only_liquid_legions_sketch_aggregation_v2.proto
@@ -88,15 +88,14 @@ message ReachOnlyLiquidLegionsSketchAggregationV2 {
     EXECUTION_PHASE = 8;
 
     // The computation is done the worker can remove BLOBs that are no longer
-    // needed and zero out the excessive noise stored in the database.
+    // needed and zero out the excessive noise stored in` the database.
     COMPLETE = 9;
   }
 
   // Computation details specific to the Reach Only LiquidLegions V2 protocol.
   message ComputationDetails {
     // The duchy's role in the computation.
-    org.wfa.measurement.config.LiquidLegionsV2SetupConfig.RoleInComputation
-        role = 1;
+    org.wfa.measurement.config.RoleInComputation role = 1;
 
     // Parameters used in this computation.
     message Parameters {

--- a/src/main/proto/wfa/measurement/internal/duchy/protocol/reach_only_liquid_legions_v2_encryption_methods.proto
+++ b/src/main/proto/wfa/measurement/internal/duchy/protocol/reach_only_liquid_legions_v2_encryption_methods.proto
@@ -17,6 +17,7 @@ syntax = "proto3";
 package wfa.measurement.internal.duchy.protocol;
 
 import "wfa/measurement/internal/duchy/crypto.proto";
+import "wfa/measurement/internal/duchy/noise_mechanism.proto";
 import "wfa/measurement/internal/duchy/protocol/liquid_legions_sketch_parameter.proto";
 import "wfa/measurement/internal/duchy/protocol/liquid_legions_v2_encryption_methods.proto";
 import "wfa/measurement/internal/duchy/protocol/liquid_legions_v2_noise_config.proto";
@@ -58,7 +59,7 @@ message CompleteReachOnlySetupPhaseRequest {
   // if unset, the worker only shuffles the register without adding any noise.
   RegisterNoiseGenerationParameters noise_parameters = 3;
   // The mechanism used to generate noise.
-  LiquidLegionsV2NoiseConfig.NoiseMechanism noise_mechanism = 4;
+  NoiseMechanism noise_mechanism = 4;
   // Public Key of the composite ElGamal cipher. Used to encrypt the excessive
   // noise (which is zero) when noise_parameters is not available.
   ElGamalPublicKey composite_el_gamal_public_key = 5;
@@ -142,7 +143,7 @@ message CompleteReachOnlyExecutionPhaseAtAggregatorRequest {
   // if unset, the worker only shuffles the register without adding any noise.
   RegisterNoiseGenerationParameters noise_parameters = 8;
   // The mechanism used to generate noise in previous phases.
-  LiquidLegionsV2NoiseConfig.NoiseMechanism noise_mechanism = 9;
+  NoiseMechanism noise_mechanism = 9;
   // The maximum number of threads used by crypto actions.
   int32 parallelism = 10;
 }

--- a/src/main/proto/wfa/measurement/internal/duchy/protocol/secretsharing/BUILD.bazel
+++ b/src/main/proto/wfa/measurement/internal/duchy/protocol/secretsharing/BUILD.bazel
@@ -1,0 +1,8 @@
+load("@rules_cc//cc:defs.bzl", "cc_proto_library")
+load("@rules_java//java:defs.bzl", "java_proto_library")
+load("@wfa_common_jvm//build/kt_jvm_proto:defs.bzl", "kt_jvm_proto_library")
+load("@rules_proto//proto:defs.bzl", "proto_library")
+
+package(default_visibility = ["//:__subpackages__"])
+
+IMPORT_PREFIX = "/src/main/proto"

--- a/src/main/proto/wfa/measurement/internal/duchy/protocol/secretsharing/BUILD.bazel
+++ b/src/main/proto/wfa/measurement/internal/duchy/protocol/secretsharing/BUILD.bazel
@@ -1,4 +1,3 @@
-load("@rules_cc//cc:defs.bzl", "cc_proto_library")
 load("@rules_java//java:defs.bzl", "java_proto_library")
 load("@wfa_common_jvm//build/kt_jvm_proto:defs.bzl", "kt_jvm_proto_library")
 load("@rules_proto//proto:defs.bzl", "proto_library")
@@ -6,3 +5,42 @@ load("@rules_proto//proto:defs.bzl", "proto_library")
 package(default_visibility = ["//:__subpackages__"])
 
 IMPORT_PREFIX = "/src/main/proto"
+
+proto_library(
+    name = "share_shuffle_sketch_parameter_proto",
+    srcs = ["share_shuffle_sketch_params.proto"],
+    strip_import_prefix = IMPORT_PREFIX,
+)
+
+java_proto_library(
+    name = "share_shuffle_sketch_parameter_java_proto",
+    deps = [":share_shuffle_sketch_parameter_proto"],
+)
+
+kt_jvm_proto_library(
+    name = "share_shuffle_sketch_parameter_kt_jvm_proto",
+    srcs = [":share_shuffle_sketch_parameter_proto"],
+    deps = [":share_shuffle_sketch_parameter_java_proto"],
+)
+
+proto_library(
+    name = "honest_majority_share_shuffle_proto",
+    srcs = ["honest_majority_share_shuffle.proto"],
+    strip_import_prefix = IMPORT_PREFIX,
+    deps = [
+        ":share_shuffle_sketch_parameter_proto",
+        "//src/main/proto/wfa/measurement/internal/duchy:noise_mechanism_proto",
+        "//src/main/proto/wfa/measurement/internal/duchy/config:protocols_setup_config_proto",
+    ],
+)
+
+java_proto_library(
+    name = "honest_majority_share_shuffle_java_proto",
+    deps = [":honest_majority_share_shuffle_proto"],
+)
+
+kt_jvm_proto_library(
+    name = "honest_majority_share_shuffle_kt_jvm_proto",
+    srcs = [":honest_majority_share_shuffle_proto"],
+    deps = [":honest_majority_share_shuffle_java_proto"],
+)

--- a/src/main/proto/wfa/measurement/internal/duchy/protocol/secretsharing/honest_majority_share_shuffle.proto
+++ b/src/main/proto/wfa/measurement/internal/duchy/protocol/secretsharing/honest_majority_share_shuffle.proto
@@ -17,7 +17,8 @@ syntax = "proto3";
 package wfa.measurement.internal.duchy.protocol;
 
 import "wfa/measurement/internal/duchy/config/protocols_setup_config.proto";
-import "wfa/measurement/internal/duchy/protocol/secretsharing/secret_sharing_sketch_parameter.proto";
+import "wfa/measurement/internal/duchy/noise_mechanism.proto";
+import "wfa/measurement/internal/duchy/protocol/secretsharing/share_shuffle_sketch_params.proto";
 
 option java_package = "org.wfanet.measurement.internal.duchy.protocol.secretsharing";
 option java_multiple_files = true;
@@ -85,7 +86,7 @@ message HonestMajorityShareShuffle {
       // The maximum frequency to reveal in the histogram.
       int32 maximum_frequency = 1;
       // Parameters for secret sharing sketches.
-      SecretSharingSketchParams sketch_parameters = 2;
+      ShareShuffleSketchParams sketch_parameters = 2;
       // Noise mechanism used for generating noise.
       NoiseMechanism noise_mechanism = 3;
     }

--- a/src/main/proto/wfa/measurement/internal/duchy/protocol/secretsharing/honest_majority_share_shuffle.proto
+++ b/src/main/proto/wfa/measurement/internal/duchy/protocol/secretsharing/honest_majority_share_shuffle.proto
@@ -1,0 +1,106 @@
+// Copyright 2023 The Cross-Media Measurement Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package wfa.measurement.internal.duchy.protocol;
+
+import "wfa/measurement/internal/duchy/config/protocols_setup_config.proto";
+import "wfa/measurement/internal/duchy/protocol/secretsharing/secret_sharing_sketch_parameter.proto";
+
+option java_package = "org.wfanet.measurement.internal.duchy.protocol.secretsharing";
+option java_multiple_files = true;
+
+message HonestMajorityShareShuffle {
+  // Stages of the HonestMajorityShareShuffle computation.
+  //
+  // For non-aggregators, the normal stage transition is:
+  // INITIALIZED -> SETUP_PHASE -> WAIT_ON_INPUT -> SHUFFLE_PHASE -> COMPLETE
+  //
+  // For the aggregator, the normal stage transition is:
+  // WAIT_ON_INPUT -> AGGREGATION_PHASE -> COMPLETE
+  enum Stage {
+    // The computation stage is unknown. This is never set intentionally.
+    STAGE_UNSPECIFIED = 0;
+
+    // Computation is created by the non-aggregator.
+    //
+    // Non-aggregators are ready to accept requisitions. Mills of
+    // non-aggregators will pick up computations in this stage.
+    INITIALIZED = 1;
+
+    // Non-aggregator samples seeds, then sends them to the peer. Seeds are used
+    // for generating either noise or permutation.
+    SETUP_PHASE = 2;
+
+    // Non-aggregators wait for input of seeds from the peer as well as
+    // requisition from EDPs.
+    //
+    // The aggregator waits for input of combined shares from
+    // non-aggregators.
+    WAIT_ON_INPUT = 3;
+
+    // Non-aggregators execute following steps:
+    //
+    // 1. Combine sketch shares from EDPs: Expand all requisition seeds
+    // into shares. Combine all requisition shares.
+    //
+    // 2. Add noise: Expands own noise seed into noise share N_0. Generate
+    // noise N and calculate N_1 = N - N_0. Expanding peer noise seed into noise
+    // share M_0. Append N_1 and M_0 into combined shares from step 1.
+    //
+    // 3. Shuffle: Combine shuffle seeds from own and peer. Generate a
+    // permutation based on the combined seed. Shuffle the shares.
+    //
+    // 4. Send the result of the share to the aggregator.
+    SHUFFLE_PHASE = 4;
+
+    // The aggregator adds up shares from non-aggregators, subtracts noise
+    // offset, and calculates the reach and the frequency histogram, then
+    // reports the encrypted result to the kingdom.
+    AGGREGATION_PHASE = 5;
+
+    // The computation is completed or failed. The worker can remove BLOBs that
+    // are no longer needed.
+    COMPLETE = 6;
+  }
+
+  message ComputationDetails {
+    // The role of either aggregator or non-aggregator in Computations.
+    org.wfa.measurement.config.RoleInComputation role = 1;
+
+    // Parameters used in this computation.
+    message Parameters {
+      // The maximum frequency to reveal in the histogram.
+      int32 maximum_frequency = 1;
+      // Parameters for secret sharing sketches.
+      SecretSharingSketchParams sketch_parameters = 2;
+      // Noise mechanism used for generating noise.
+      NoiseMechanism noise_mechanism = 3;
+    }
+    Parameters parameters = 2;
+    // Seeds used by non-aggregators to generate shares.
+    message RandomSeeds {
+      // Shuffling seed from the worker itself.
+      bytes shuffling_seed = 1;
+      // Shuffling seed from the peer worker.
+      bytes shuffling_seed_from_peer = 2;
+      // Noise seed from the worker itself.
+      bytes noise_share_seed = 3;
+      // Noise seed from the peer worker.
+      bytes noise_seed_from_peer = 4;
+    }
+    RandomSeeds seeds = 3;
+  }
+}

--- a/src/main/proto/wfa/measurement/internal/duchy/protocol/secretsharing/honest_majority_share_shuffle_methods.proto
+++ b/src/main/proto/wfa/measurement/internal/duchy/protocol/secretsharing/honest_majority_share_shuffle_methods.proto
@@ -17,7 +17,8 @@ syntax = "proto3";
 package wfa.measurement.internal.duchy.protocol;
 
 import "wfa/measurement/internal/duchy/differential_privacy.proto";
-import "wfa/measurement/internal/duchy/protocol/secretsharing/share_shuffle_sketch_parameter.proto";
+import "wfa/measurement/internal/duchy/noise_mechanism.proto";
+import "wfa/measurement/internal/duchy/protocol/secretsharing/share_shuffle_sketch_params.proto";
 
 option java_package = "org.wfanet.measurement.internal.duchy.protocol.secretsharing";
 option java_multiple_files = true;

--- a/src/main/proto/wfa/measurement/internal/duchy/protocol/secretsharing/honest_majority_share_shuffle_methods.proto
+++ b/src/main/proto/wfa/measurement/internal/duchy/protocol/secretsharing/honest_majority_share_shuffle_methods.proto
@@ -1,0 +1,109 @@
+// Copyright 2020 The Cross-Media Measurement Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package wfa.measurement.internal.duchy.protocol;
+
+import "wfa/measurement/internal/duchy/differential_privacy.proto";
+import "wfa/measurement/internal/duchy/protocol/secretsharing/share_shuffle_sketch_parameter.proto";
+
+option java_package = "org.wfanet.measurement.internal.duchy.protocol.secretsharing";
+option java_multiple_files = true;
+
+// Proto messages wrapping the input arguments or output results of the honest
+// majority share shuffle protocol methods, which are to be
+// called via kotlin or JNI in the Mill.
+
+// Request of SETUP_PHASE for non-aggregator only.
+message CompleteSetupPhaseRequest {
+  // No parameters needed for generating seeds.
+}
+
+// For non-aggregator.
+//
+// The content will be stored and sent to the peer worker.
+message CompleteSetupPhaseResponse {
+  // The seed used to generate permutation for shuffling between non-aggregators
+  // Both non-aggregators will generate a shuffling seed. They combine these
+  // two seeds into a combined seed, thus generates the same permutation.
+  bytes shuffling_seed = 1;
+  // The seed to generate a noise used in ShufflePhase.
+  bytes noise_share_seed = 2;
+}
+
+// For non-aggregator.
+message CompleteShufflePhaseRequest {
+  // Size of the sketch.
+  int64 sketch_size = 1;
+  // Length of each item in the sketch.
+  int32 bit_per_item = 2;
+
+  // Noise seed from the worker itself.
+  bytes noise_share_seed = 3;
+  // Noise seed from the peer worker.
+  bytes noise_share_seed_from_peer = 4;
+  // Differential privacy parameters for the noise.
+  DifferentialPrivacyParams dp_params = 5;
+  // Noise mechanism used for generating noise.
+  NoiseMechanism noise_mechanism = 6;
+
+  // Shuffling seed from the worker itself.
+  bytes shuffling_seed = 7;
+  // Shuffling seed from the peer worker.
+  bytes shuffling_seed_from_peer = 8;
+
+  // Sketches from EDPs of either data or seed.
+  message SketchShare {
+    oneof share_type {
+      bytes data = 1;
+      bytes seed = 2;
+    }
+  }
+  // Sketch shares ordered by the external key.
+  repeated SketchShare sketch_shares = 9;
+}
+
+// For non-aggregator.
+// The content will be sent to the aggregator.
+message CompleteShufflePhaseResponse {
+  // Combination of sketches. It is combined, noisy, and shuffled.
+  bytes combined_sketch = 1;
+}
+
+// For aggregators.
+message CompleteAggregationPhaseRequest {
+  // Size of the sketch.
+  int64 sketch_size = 1;
+  // Length of each item in the sketch.
+  int32 bit_per_item = 2;
+  // The maximum frequency to reveal in the histogram.
+  int32 max_frequency = 3;
+
+  // Combined sketches from non-aggregators.
+  repeated bytes combined_sketches = 4;
+  // Differential privacy parameters used to calculate the offset of noise.
+  DifferentialPrivacyParams dp_params = 5;
+  // Noise mechanism used to calculate the offset of noise.
+  NoiseMechanism noise_mechanism = 6;
+}
+
+// For aggregators.
+// The content will be sent to the kingdom.
+message CompleteAggregationPhaseResponse {
+  // Estimated reach.
+  int64 reach = 1;
+  // Histogram of frequency.
+  map<int64, double> frequency_distribution = 2;
+}

--- a/src/main/proto/wfa/measurement/internal/duchy/protocol/secretsharing/secret_sharing_sketch_parameter.proto
+++ b/src/main/proto/wfa/measurement/internal/duchy/protocol/secretsharing/secret_sharing_sketch_parameter.proto
@@ -1,0 +1,30 @@
+// Copyright 2023 The Cross-Media Measurement Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package wfa.measurement.internal.duchy.protocol;
+
+option java_package = "org.wfanet.measurement.internal.duchy.protocol";
+option java_multiple_files = true;
+
+// Parameters used for the sketch of HonestMajorityShareShuffle protocol
+// creation and estimation.
+message ShareShuffleSketchParameters {
+  // The size of the sketch.
+  int64 sketch_size = 1;
+  // Length of each item in bytes. #_EDPs * max_frequency should be no more than
+  // 2^(bytes_per_item*8).
+  int32 bytes_per_item = 2;
+}

--- a/src/main/proto/wfa/measurement/internal/duchy/protocol/secretsharing/share_shuffle_sketch_params.proto
+++ b/src/main/proto/wfa/measurement/internal/duchy/protocol/secretsharing/share_shuffle_sketch_params.proto
@@ -1,0 +1,30 @@
+// Copyright 2023 The Cross-Media Measurement Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package wfa.measurement.internal.duchy.protocol;
+
+option java_package = "org.wfanet.measurement.internal.duchy.protocol";
+option java_multiple_files = true;
+
+// Parameters used for the sketch of HonestMajorityShareShuffle protocol
+// creation and estimation.
+message ShareShuffleSketchParams {
+  // The size of the sketch.
+  int64 sketch_size = 1;
+  // Length of each item in bytes. #_EDPs * max_frequency should be no more than
+  // 2^(bytes_per_item*8).
+  int32 bytes_per_item = 2;
+}

--- a/src/main/proto/wfa/measurement/system/v1alpha/computation_control_service.proto
+++ b/src/main/proto/wfa/measurement/system/v1alpha/computation_control_service.proto
@@ -51,6 +51,9 @@ message AdvanceComputationRequest {
 
       // The ReachOnlyLiquidLegionsV2 (one-round) protocol.
       ReachOnlyLiquidLegionsV2 reach_only_liquid_legions_v2 = 3;
+
+      // The HonestMajorityShareShuffle protocol.
+      HonestMajorityShareShuffle honest_majority_share_shuffle = 4;
     }
   }
 
@@ -106,6 +109,28 @@ message ReachOnlyLiquidLegionsV2 {
   }
   // Payload data description
   Description description = 1;
+}
+
+// Parameters for the Honest Majority Shuffle Based Secret Sharing protocol.
+//
+// (-- api-linter: core::0123::resource-annotation=disabled
+//     aip.dev/not-precedent: This is not a resource message. --)
+message HonestMajorityShareShuffle {
+  // Input for SHUFFLE_PHASE.
+  message ShufflePhaseInput {
+    bytes noise_seed = 1;
+    bytes shuffling_seed = 2;
+  }
+  // Input for AGGREGATION_PHASE.
+  message AggregationPhaseInput {}
+
+  // Type of the input for a specific stage.
+  oneof InputType {
+    // Input for SHUFFLE_PHASE.
+    ShufflePhaseInput shuffle_phase_input = 1;
+    // Input for AGGREGATION_PHASE.
+    AggregationPhaseInput aggregation_phase_input = 2;
+  }
 }
 
 // Response message for the `AdvanceComputation` method.

--- a/src/main/proto/wfa/measurement/system/v1alpha/computation_control_service.proto
+++ b/src/main/proto/wfa/measurement/system/v1alpha/computation_control_service.proto
@@ -118,7 +118,9 @@ message ReachOnlyLiquidLegionsV2 {
 message HonestMajorityShareShuffle {
   // Input for SHUFFLE_PHASE.
   message ShufflePhaseInput {
+    // Seed to expand into noise share.
     bytes noise_seed = 1;
+    // Seed to generate permutation.
     bytes shuffling_seed = 2;
   }
   // Input for AGGREGATION_PHASE.

--- a/src/main/resources/duchy/postgres/add-requisition-random-seed.sql
+++ b/src/main/resources/duchy/postgres/add-requisition-random-seed.sql
@@ -1,0 +1,21 @@
+-- liquibase formatted sql
+
+-- Copyright 2023 The Cross-Media Measurement Authors
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--      http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+-- changeset renjiez:2 dbms:postgresql
+
+ALTER TABLE Requisitions
+    -- A random seed to expand into the deterministic requisition blob.
+    ADD COLUMN RandomSeed bytea;

--- a/src/main/resources/duchy/postgres/changelog.yaml
+++ b/src/main/resources/duchy/postgres/changelog.yaml
@@ -22,3 +22,6 @@ databaseChangeLog:
 - include:
     file: create-duchy-schema.sql
     relativeToChangeLogFile: true
+- include:
+    file: add-requisition-random-seed.sql
+    relativeToChangeLogFile: true

--- a/src/main/resources/duchy/spanner/add-requisition-random-seed.sql
+++ b/src/main/resources/duchy/spanner/add-requisition-random-seed.sql
@@ -1,0 +1,21 @@
+-- liquibase formatted sql
+
+-- Copyright 2023 The Cross-Media Measurement Authors
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--      http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+-- changeset renjiez:4 dbms:cloudspanner
+
+ALTER TABLE Requisitions
+    -- A random seed to expand into the deterministic requisition blob.
+    ADD COLUMN RandomSeed BYTES(MAX);

--- a/src/main/resources/duchy/spanner/changelog.yaml
+++ b/src/main/resources/duchy/spanner/changelog.yaml
@@ -24,3 +24,7 @@ databaseChangeLog:
 - include:
     file: add-computation-creation-time.sql
     relativeToChangeLogFile: true
+- include:
+    file: add-requisition-random-seed.sql
+    relativeToChangeLogFile: true
+

--- a/src/test/cc/wfa/measurement/internal/duchy/protocol/liquid_legions_v2/BUILD.bazel
+++ b/src/test/cc/wfa/measurement/internal/duchy/protocol/liquid_legions_v2/BUILD.bazel
@@ -10,7 +10,7 @@ cc_test(
     deps = [
         "//src/main/cc/wfa/measurement/internal/duchy/protocol/liquid_legions_v2:liquid_legions_v2_encryption_utility",
         "//src/main/cc/wfa/measurement/internal/duchy/protocol/liquid_legions_v2/testing:liquid_legions_v2_encryption_utility_helper",
-        "//src/main/proto/wfa/measurement/internal/duchy/protocol:liquid_legions_v2_noise_config_cc_proto",
+        "//src/main/proto/wfa/measurement/internal/duchy:noise_mechanism_cc_proto",
         "@any_sketch//src/main/cc/any_sketch/crypto:sketch_encrypter",
         "@any_sketch//src/main/cc/estimation:estimators",
         "@any_sketch//src/main/proto/wfa/any_sketch:sketch_cc_proto",
@@ -30,7 +30,7 @@ cc_test(
     deps = [
         "//src/main/cc/wfa/measurement/internal/duchy/protocol/liquid_legions_v2:reach_only_liquid_legions_v2_encryption_utility",
         "//src/main/cc/wfa/measurement/internal/duchy/protocol/liquid_legions_v2/testing:liquid_legions_v2_encryption_utility_helper",
-        "//src/main/proto/wfa/measurement/internal/duchy/protocol:liquid_legions_v2_noise_config_cc_proto",
+        "//src/main/proto/wfa/measurement/internal/duchy:noise_mechanism_cc_proto",
         "@any_sketch//src/main/cc/any_sketch/crypto:sketch_encrypter",
         "@any_sketch//src/main/cc/estimation:estimators",
         "@any_sketch//src/main/proto/wfa/any_sketch:sketch_cc_proto",

--- a/src/test/cc/wfa/measurement/internal/duchy/protocol/liquid_legions_v2/noise_parameters_computation_test.cc
+++ b/src/test/cc/wfa/measurement/internal/duchy/protocol/liquid_legions_v2/noise_parameters_computation_test.cc
@@ -17,12 +17,14 @@
 #include "gtest/gtest.h"
 #include "math/distributed_discrete_gaussian_noiser.h"
 #include "math/distributed_geometric_noiser.h"
+#include "wfa/measurement/internal/duchy/noise_mechanism.pb.h"
 #include "wfa/measurement/internal/duchy/protocol/liquid_legions_v2_noise_config.pb.h"
 
 namespace wfa::measurement::internal::duchy::protocol::liquid_legions_v2 {
 namespace {
 
 using ::wfa::measurement::internal::duchy::DifferentialPrivacyParams;
+using ::wfa::measurement::internal::duchy::NoiseMechanism;
 using ::wfa::measurement::internal::duchy::protocol::LiquidLegionsV2NoiseConfig;
 
 TEST(GetBlindHistogramNoiser, GeometricOptionsResultShouldBeCorrect) {
@@ -32,7 +34,7 @@ TEST(GetBlindHistogramNoiser, GeometricOptionsResultShouldBeCorrect) {
   int uncorrupted_party_count = 2;
 
   auto noiser = GetBlindHistogramNoiser(test_params, uncorrupted_party_count,
-                                        LiquidLegionsV2NoiseConfig::GEOMETRIC);
+                                        NoiseMechanism::GEOMETRIC);
   const auto& options = noiser->options();
 
   EXPECT_EQ(options.contributor_count, uncorrupted_party_count);
@@ -46,9 +48,8 @@ TEST(GetBlindHistogramNoiser, GaussianOptionsResultShouldBeCorrect) {
   dp_params.set_delta(0.2 / 100000);
   int uncorrupted_party_count = 2;
 
-  auto noiser =
-      GetBlindHistogramNoiser(dp_params, uncorrupted_party_count,
-                              LiquidLegionsV2NoiseConfig::DISCRETE_GAUSSIAN);
+  auto noiser = GetBlindHistogramNoiser(dp_params, uncorrupted_party_count,
+                                        NoiseMechanism::DISCRETE_GAUSSIAN);
   const auto& options = noiser->options();
 
   EXPECT_EQ(options.contributor_count, uncorrupted_party_count);
@@ -65,7 +66,7 @@ TEST(GetPublisherNoiser, GeometricOptionsExampleResultShouldBeCorrect) {
 
   auto noiser =
       GetPublisherNoiser(test_params, publisher_count, uncorrupted_party_count,
-                         LiquidLegionsV2NoiseConfig::GEOMETRIC);
+                         NoiseMechanism::GEOMETRIC);
   const auto& options = noiser->options();
 
   EXPECT_EQ(options.contributor_count, uncorrupted_party_count);
@@ -82,7 +83,7 @@ TEST(GetPublisherNoiser, GaussianOptionsExampleResultShouldBeCorrect) {
 
   auto noiser =
       GetPublisherNoiser(test_params, publisher_count, uncorrupted_party_count,
-                         LiquidLegionsV2NoiseConfig::DISCRETE_GAUSSIAN);
+                         NoiseMechanism::DISCRETE_GAUSSIAN);
   const auto& options = noiser->options();
 
   EXPECT_EQ(options.contributor_count, uncorrupted_party_count);
@@ -97,7 +98,7 @@ TEST(GetGlobalReachDpNoiser, GeometricOptionsExampleResultShouldBeCorrect) {
   int uncorrupted_party_count = 2;
 
   auto noiser = GetGlobalReachDpNoiser(test_params, uncorrupted_party_count,
-                                       LiquidLegionsV2NoiseConfig::GEOMETRIC);
+                                       NoiseMechanism::GEOMETRIC);
   const auto& options = noiser->options();
 
   EXPECT_EQ(options.contributor_count, uncorrupted_party_count);
@@ -111,9 +112,8 @@ TEST(GetGlobalReachDpNoiser, GaussianOptionsExampleResultShouldBeCorrect) {
   test_params.set_delta(0.2 / 100000);
   int uncorrupted_party_count = 2;
 
-  auto noiser =
-      GetGlobalReachDpNoiser(test_params, uncorrupted_party_count,
-                             LiquidLegionsV2NoiseConfig::DISCRETE_GAUSSIAN);
+  auto noiser = GetGlobalReachDpNoiser(test_params, uncorrupted_party_count,
+                                       NoiseMechanism::DISCRETE_GAUSSIAN);
   const auto& options = noiser->options();
 
   EXPECT_EQ(options.contributor_count, uncorrupted_party_count);
@@ -128,7 +128,7 @@ TEST(GetFrequencyNoiser, GeometricOptionsExampleResultShouldBeCorrect) {
   int uncorrupted_party_count = 2;
 
   auto noiser = GetFrequencyNoiser(test_params, uncorrupted_party_count,
-                                   LiquidLegionsV2NoiseConfig::GEOMETRIC);
+                                   NoiseMechanism::GEOMETRIC);
   const auto& options = noiser->options();
 
   EXPECT_EQ(options.contributor_count, uncorrupted_party_count);
@@ -142,9 +142,8 @@ TEST(GetFrequencyNoiser, GaussianOptionsExampleResultShouldBeCorrect) {
   test_params.set_delta(0.2 / 100000);
   int uncorrupted_party_count = 3;
 
-  auto noiser =
-      GetFrequencyNoiser(test_params, uncorrupted_party_count,
-                         LiquidLegionsV2NoiseConfig::DISCRETE_GAUSSIAN);
+  auto noiser = GetFrequencyNoiser(test_params, uncorrupted_party_count,
+                                   NoiseMechanism::DISCRETE_GAUSSIAN);
   const auto& options = noiser->options();
 
   EXPECT_EQ(options.contributor_count, uncorrupted_party_count);

--- a/src/test/cc/wfa/measurement/internal/duchy/protocol/liquid_legions_v2/reach_only_liquid_legions_v2_encryption_utility_test.cc
+++ b/src/test/cc/wfa/measurement/internal/duchy/protocol/liquid_legions_v2/reach_only_liquid_legions_v2_encryption_utility_test.cc
@@ -30,8 +30,8 @@
 #include "wfa/measurement/common/crypto/constants.h"
 #include "wfa/measurement/common/crypto/ec_point_util.h"
 #include "wfa/measurement/common/crypto/encryption_utility_helper.h"
+#include "wfa/measurement/internal/duchy/noise_mechanism.pb.h"
 #include "wfa/measurement/internal/duchy/protocol/liquid_legions_v2/testing/liquid_legions_v2_encryption_utility_helper.h"
-#include "wfa/measurement/internal/duchy/protocol/liquid_legions_v2_encryption_methods.pb.h"
 
 namespace wfa::measurement::internal::duchy::protocol::liquid_legions_v2 {
 namespace {
@@ -59,7 +59,7 @@ using ::wfa::measurement::common::crypto::kPublisherNoiseRegisterId;
 using ::wfa::measurement::internal::duchy::DifferentialPrivacyParams;
 using ::wfa::measurement::internal::duchy::ElGamalKeyPair;
 using ::wfa::measurement::internal::duchy::ElGamalPublicKey;
-using ::wfa::measurement::internal::duchy::protocol::LiquidLegionsV2NoiseConfig;
+using ::wfa::measurement::internal::duchy::NoiseMechanism;
 
 constexpr int kWorkerCount = 3;
 constexpr int kPublisherCount = 3;
@@ -164,7 +164,7 @@ class ReachOnlyTest {
   absl::StatusOr<ReachOnlyMpcResult> GoThroughEntireMpcProtocol(
       const std::string& encrypted_sketch,
       RegisterNoiseGenerationParameters* reach_noise_parameters,
-      LiquidLegionsV2NoiseConfig::NoiseMechanism noise_mechanism) {
+      NoiseMechanism noise_mechanism) {
     // Setup phase at Duchy 1.
     // We assume all test data comes from duchy 1 in the test.
     CompleteReachOnlySetupPhaseRequest
@@ -449,7 +449,7 @@ TEST(CompleteReachOnlySetupPhase, SetupPhaseWorksAsExpectedWithGeometricNoise) {
   // resulted p ~= 0 , offset = 4
   *noise_parameters->mutable_dp_params()->mutable_global_reach_dp_noise() =
       MakeDifferentialPrivacyParams(40, std::exp(-80));
-  request.set_noise_mechanism(LiquidLegionsV2NoiseConfig::GEOMETRIC);
+  request.set_noise_mechanism(NoiseMechanism::GEOMETRIC);
   request.set_parallelism(kParallelism);
 
   ASSERT_OK_AND_ASSIGN(CompleteReachOnlySetupPhaseResponse response,
@@ -499,7 +499,7 @@ TEST(CompleteReachOnlySetupPhase, SetupPhaseWorksAsExpectedWithGaussianNoise) {
   // resulted sigma_distributed ~= 0.18, offset = 3
   *noise_parameters->mutable_dp_params()->mutable_global_reach_dp_noise() =
       MakeDifferentialPrivacyParams(40, std::exp(-80));
-  request.set_noise_mechanism(LiquidLegionsV2NoiseConfig::DISCRETE_GAUSSIAN);
+  request.set_noise_mechanism(NoiseMechanism::DISCRETE_GAUSSIAN);
   request.set_parallelism(kParallelism);
 
   ASSERT_OK_AND_ASSIGN(CompleteReachOnlySetupPhaseResponse response,
@@ -551,14 +551,14 @@ TEST(EndToEnd, SumOfCountsShouldBeCorrectWithoutNoise) {
   ASSERT_OK_AND_ASSIGN(ReachOnlyMpcResult result_with_geometric_noise,
                        test_data.GoThroughEntireMpcProtocol(
                            encrypted_sketch, /*reach_noise=*/nullptr,
-                           LiquidLegionsV2NoiseConfig::GEOMETRIC));
+                           NoiseMechanism::GEOMETRIC));
 
   EXPECT_EQ(result_with_geometric_noise.reach, expected_reach);
 
   ASSERT_OK_AND_ASSIGN(ReachOnlyMpcResult result_with_gaussian_noise,
                        test_data.GoThroughEntireMpcProtocol(
                            encrypted_sketch, /*reach_noise=*/nullptr,
-                           LiquidLegionsV2NoiseConfig::DISCRETE_GAUSSIAN));
+                           NoiseMechanism::DISCRETE_GAUSSIAN));
   EXPECT_EQ(result_with_gaussian_noise.reach, expected_reach);
 }
 
@@ -600,14 +600,14 @@ TEST(EndToEnd, CombinedCasesWithDeterministicReachDpNoises) {
   ASSERT_OK_AND_ASSIGN(ReachOnlyMpcResult result_with_geometric_noise,
                        test_data.GoThroughEntireMpcProtocol(
                            encrypted_sketch, &reach_noise_parameters,
-                           LiquidLegionsV2NoiseConfig::GEOMETRIC));
+                           NoiseMechanism::GEOMETRIC));
 
   EXPECT_EQ(result_with_geometric_noise.reach, expected_reach);
 
   ASSERT_OK_AND_ASSIGN(ReachOnlyMpcResult result_with_gaussian_noise,
                        test_data.GoThroughEntireMpcProtocol(
                            encrypted_sketch, &reach_noise_parameters,
-                           LiquidLegionsV2NoiseConfig::DISCRETE_GAUSSIAN));
+                           NoiseMechanism::DISCRETE_GAUSSIAN));
 
   EXPECT_EQ(result_with_gaussian_noise.reach, expected_reach);
 }
@@ -650,13 +650,13 @@ TEST(ReachEstimation, NonDpNoiseShouldNotImpactTheResult) {
   ASSERT_OK_AND_ASSIGN(ReachOnlyMpcResult result_with_geometric_noise,
                        test_data.GoThroughEntireMpcProtocol(
                            encrypted_sketch, &reach_noise_parameters,
-                           LiquidLegionsV2NoiseConfig::GEOMETRIC));
+                           NoiseMechanism::GEOMETRIC));
   EXPECT_EQ(result_with_geometric_noise.reach, expected_reach);
 
   ASSERT_OK_AND_ASSIGN(ReachOnlyMpcResult result_with_gaussian_noise,
                        test_data.GoThroughEntireMpcProtocol(
                            encrypted_sketch, &reach_noise_parameters,
-                           LiquidLegionsV2NoiseConfig::DISCRETE_GAUSSIAN));
+                           NoiseMechanism::DISCRETE_GAUSSIAN));
   EXPECT_EQ(result_with_gaussian_noise.reach, expected_reach);
 }
 

--- a/src/test/kotlin/org/wfanet/measurement/duchy/daemon/herald/BUILD.bazel
+++ b/src/test/kotlin/org/wfanet/measurement/duchy/daemon/herald/BUILD.bazel
@@ -14,6 +14,7 @@ kt_jvm_test(
         "//src/main/kotlin/org/wfanet/measurement/duchy/service/internal/computations",
         "//src/main/kotlin/org/wfanet/measurement/duchy/service/internal/testing",
         "//src/main/kotlin/org/wfanet/measurement/system/v1alpha:resource_key",
+        "//src/main/proto/wfa/measurement/internal/duchy:noise_mechanism_kt_jvm_proto",
         "//src/main/proto/wfa/measurement/internal/duchy:requisition_details_kt_jvm_proto",
         "//src/main/proto/wfa/measurement/system/v1alpha:computation_kt_jvm_proto",
         "//src/main/proto/wfa/measurement/system/v1alpha:requisition_kt_jvm_proto",

--- a/src/test/kotlin/org/wfanet/measurement/duchy/daemon/herald/HeraldTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/duchy/daemon/herald/HeraldTest.kt
@@ -78,7 +78,7 @@ import org.wfanet.measurement.internal.duchy.FinishComputationResponse
 import org.wfanet.measurement.internal.duchy.GetComputationTokenRequest
 import org.wfanet.measurement.internal.duchy.computationDetails
 import org.wfanet.measurement.internal.duchy.computationToken
-import org.wfanet.measurement.internal.duchy.config.LiquidLegionsV2SetupConfig.RoleInComputation
+import org.wfanet.measurement.internal.duchy.config.RoleInComputation
 import org.wfanet.measurement.internal.duchy.config.liquidLegionsV2SetupConfig
 import org.wfanet.measurement.internal.duchy.config.protocolsSetupConfig
 import org.wfanet.measurement.internal.duchy.deleteComputationRequest

--- a/src/test/kotlin/org/wfanet/measurement/duchy/daemon/herald/HeraldTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/duchy/daemon/herald/HeraldTest.kt
@@ -76,6 +76,7 @@ import org.wfanet.measurement.internal.duchy.ContinuationTokensGrpcKt.Continuati
 import org.wfanet.measurement.internal.duchy.DeleteComputationRequest
 import org.wfanet.measurement.internal.duchy.FinishComputationResponse
 import org.wfanet.measurement.internal.duchy.GetComputationTokenRequest
+import org.wfanet.measurement.internal.duchy.NoiseMechanism
 import org.wfanet.measurement.internal.duchy.computationDetails
 import org.wfanet.measurement.internal.duchy.computationToken
 import org.wfanet.measurement.internal.duchy.config.RoleInComputation
@@ -88,7 +89,6 @@ import org.wfanet.measurement.internal.duchy.getComputationTokenResponse
 import org.wfanet.measurement.internal.duchy.getContinuationTokenResponse
 import org.wfanet.measurement.internal.duchy.protocol.LiquidLegionsSketchAggregationV2
 import org.wfanet.measurement.internal.duchy.protocol.LiquidLegionsSketchAggregationV2Kt
-import org.wfanet.measurement.internal.duchy.protocol.LiquidLegionsV2NoiseConfig
 import org.wfanet.measurement.internal.duchy.protocol.LiquidLegionsV2NoiseConfigKt.reachNoiseConfig
 import org.wfanet.measurement.internal.duchy.protocol.ReachOnlyLiquidLegionsSketchAggregationV2
 import org.wfanet.measurement.internal.duchy.protocol.ReachOnlyLiquidLegionsSketchAggregationV2Kt
@@ -487,7 +487,7 @@ class HeraldTest {
                       epsilon = 2.1
                       delta = 2.2
                     }
-                    noiseMechanism = LiquidLegionsV2NoiseConfig.NoiseMechanism.GEOMETRIC
+                    noiseMechanism = NoiseMechanism.GEOMETRIC
                   }
                   ellipticCurveId = 415
                 }
@@ -571,7 +571,7 @@ class HeraldTest {
                     size = 100_000L
                   }
                   noise = liquidLegionsV2NoiseConfig {
-                    noiseMechanism = LiquidLegionsV2NoiseConfig.NoiseMechanism.GEOMETRIC
+                    noiseMechanism = NoiseMechanism.GEOMETRIC
                     reachNoiseConfig = reachNoiseConfig {
                       blindHistogramNoise = duchyDifferentialPrivacyParams {
                         epsilon = 3.1
@@ -672,7 +672,7 @@ class HeraldTest {
                     size = 100_000L
                   }
                   noise = liquidLegionsV2NoiseConfig {
-                    noiseMechanism = LiquidLegionsV2NoiseConfig.NoiseMechanism.GEOMETRIC
+                    noiseMechanism = NoiseMechanism.GEOMETRIC
                     reachNoiseConfig = reachNoiseConfig {
                       blindHistogramNoise = duchyDifferentialPrivacyParams {
                         epsilon = 3.1

--- a/src/test/kotlin/org/wfanet/measurement/duchy/daemon/mill/liquidlegionsv2/ReachFrequencyLiquidLegionsV2MillTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/duchy/daemon/mill/liquidlegionsv2/ReachFrequencyLiquidLegionsV2MillTest.kt
@@ -91,7 +91,7 @@ import org.wfanet.measurement.internal.duchy.ElGamalPublicKey
 import org.wfanet.measurement.internal.duchy.computationDetails
 import org.wfanet.measurement.internal.duchy.computationStageBlobMetadata
 import org.wfanet.measurement.internal.duchy.computationToken
-import org.wfanet.measurement.internal.duchy.config.LiquidLegionsV2SetupConfig.RoleInComputation
+import org.wfanet.measurement.internal.duchy.config.RoleInComputation
 import org.wfanet.measurement.internal.duchy.copy
 import org.wfanet.measurement.internal.duchy.protocol.CompleteExecutionPhaseOneAtAggregatorRequest
 import org.wfanet.measurement.internal.duchy.protocol.CompleteExecutionPhaseOneAtAggregatorResponse

--- a/src/test/kotlin/org/wfanet/measurement/duchy/daemon/mill/liquidlegionsv2/ReachOnlyLiquidLegionsV2MillTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/duchy/daemon/mill/liquidlegionsv2/ReachOnlyLiquidLegionsV2MillTest.kt
@@ -91,7 +91,7 @@ import org.wfanet.measurement.internal.duchy.computationDetails
 import org.wfanet.measurement.internal.duchy.computationStageBlobMetadata
 import org.wfanet.measurement.internal.duchy.computationStageDetails
 import org.wfanet.measurement.internal.duchy.computationToken
-import org.wfanet.measurement.internal.duchy.config.LiquidLegionsV2SetupConfig.RoleInComputation
+import org.wfanet.measurement.internal.duchy.config.RoleInComputation
 import org.wfanet.measurement.internal.duchy.copy
 import org.wfanet.measurement.internal.duchy.differentialPrivacyParams
 import org.wfanet.measurement.internal.duchy.elGamalKeyPair

--- a/src/test/kotlin/org/wfanet/measurement/duchy/db/computation/ComputationDataClientsTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/duchy/db/computation/ComputationDataClientsTest.kt
@@ -46,7 +46,7 @@ import org.wfanet.measurement.internal.duchy.CreateComputationRequest
 import org.wfanet.measurement.internal.duchy.EnqueueComputationRequest
 import org.wfanet.measurement.internal.duchy.FinishComputationRequest
 import org.wfanet.measurement.internal.duchy.RecordOutputBlobPathRequest
-import org.wfanet.measurement.internal.duchy.config.LiquidLegionsV2SetupConfig
+import org.wfanet.measurement.internal.duchy.config.RoleInComputation
 import org.wfanet.measurement.internal.duchy.protocol.LiquidLegionsSketchAggregationV2
 import org.wfanet.measurement.internal.duchy.protocol.LiquidLegionsSketchAggregationV2.Stage
 import org.wfanet.measurement.storage.StorageClient
@@ -106,7 +106,7 @@ class ComputationDataClientsTest {
           storageClient = dummyStorageClient
         ),
         ID_WHERE_ALSACE_IS_NOT_PRIMARY,
-        LiquidLegionsV2SetupConfig.RoleInComputation.NON_AGGREGATOR,
+        RoleInComputation.NON_AGGREGATOR,
         testClock
       )
     val fakeRpcService = computation.FakeRpcService()
@@ -153,7 +153,7 @@ class ComputationDataClientsTest {
           storageClient = dummyStorageClient
         ),
         ID_WHERE_ALSACE_IS_PRIMARY,
-        LiquidLegionsV2SetupConfig.RoleInComputation.AGGREGATOR,
+        RoleInComputation.AGGREGATOR,
         testClock
       )
     val fakeRpcService = computation.FakeRpcService()
@@ -220,7 +220,7 @@ data class ComputationStep(
 class SingleLiquidLegionsV2Computation(
   private val dataClients: ComputationDataClients,
   globalId: String,
-  roleInComputation: LiquidLegionsV2SetupConfig.RoleInComputation,
+  roleInComputation: RoleInComputation,
   private val testClock: TestClockWithNamedInstants
 ) {
 

--- a/src/test/kotlin/org/wfanet/measurement/duchy/deploy/gcloud/spanner/computation/GcpSpannerComputationsDatabaseReaderTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/duchy/deploy/gcloud/spanner/computation/GcpSpannerComputationsDatabaseReaderTest.kt
@@ -39,7 +39,7 @@ import org.wfanet.measurement.internal.duchy.ComputationStage
 import org.wfanet.measurement.internal.duchy.ComputationToken
 import org.wfanet.measurement.internal.duchy.ComputationTypeEnum.ComputationType
 import org.wfanet.measurement.internal.duchy.RequisitionDetails
-import org.wfanet.measurement.internal.duchy.config.LiquidLegionsV2SetupConfig
+import org.wfanet.measurement.internal.duchy.config.RoleInComputation
 import org.wfanet.measurement.internal.duchy.externalRequisitionKey
 import org.wfanet.measurement.internal.duchy.protocol.LiquidLegionsSketchAggregationV2.Stage
 
@@ -50,17 +50,13 @@ class GcpSpannerComputationsDatabaseReaderTest :
   companion object {
     val DETAILS_WHEN_NON_AGGREGATOR: ComputationDetails =
       ComputationDetails.newBuilder()
-        .apply {
-          liquidLegionsV2Builder.apply {
-            role = LiquidLegionsV2SetupConfig.RoleInComputation.NON_AGGREGATOR
-          }
-        }
+        .apply { liquidLegionsV2Builder.apply { role = RoleInComputation.NON_AGGREGATOR } }
         .build()
     val DETAILS_WHEN_AGGREGATOR: ComputationDetails =
       ComputationDetails.newBuilder()
         .apply {
           liquidLegionsV2Builder.apply {
-            role = LiquidLegionsV2SetupConfig.RoleInComputation.AGGREGATOR
+            role = RoleInComputation.AGGREGATOR
             addParticipantBuilder().apply { duchyId = "non_aggregator_1" }
             addParticipantBuilder().apply { duchyId = "non_aggregator_2" }
             addParticipantBuilder().apply { duchyId = "aggregator" }
@@ -302,7 +298,6 @@ class GcpSpannerComputationsDatabaseReaderTest :
           }
           addRequisitionsBuilder().apply {
             externalKey = requisition3Key
-            path = ""
             details = RequisitionDetails.getDefaultInstance()
           }
         }

--- a/src/test/kotlin/org/wfanet/measurement/duchy/service/internal/computationcontrol/AsyncComputationControlServiceTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/duchy/service/internal/computationcontrol/AsyncComputationControlServiceTest.kt
@@ -49,7 +49,7 @@ import org.wfanet.measurement.internal.duchy.RecordOutputBlobPathRequest
 import org.wfanet.measurement.internal.duchy.computationStageBlobMetadata
 import org.wfanet.measurement.internal.duchy.computationStageDetails
 import org.wfanet.measurement.internal.duchy.computationToken
-import org.wfanet.measurement.internal.duchy.config.LiquidLegionsV2SetupConfig.RoleInComputation
+import org.wfanet.measurement.internal.duchy.config.RoleInComputation
 import org.wfanet.measurement.internal.duchy.getOutputBlobMetadataRequest
 import org.wfanet.measurement.internal.duchy.protocol.LiquidLegionsSketchAggregationV2.Stage
 import org.wfanet.measurement.internal.duchy.protocol.LiquidLegionsSketchAggregationV2Kt

--- a/src/test/kotlin/org/wfanet/measurement/duchy/service/internal/computations/ComputationsServiceTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/duchy/service/internal/computations/ComputationsServiceTest.kt
@@ -49,7 +49,7 @@ import org.wfanet.measurement.internal.duchy.RequisitionDetails
 import org.wfanet.measurement.internal.duchy.UpdateComputationDetailsRequest
 import org.wfanet.measurement.internal.duchy.computationStage
 import org.wfanet.measurement.internal.duchy.computationToken
-import org.wfanet.measurement.internal.duchy.config.LiquidLegionsV2SetupConfig.RoleInComputation
+import org.wfanet.measurement.internal.duchy.config.RoleInComputation
 import org.wfanet.measurement.internal.duchy.copy
 import org.wfanet.measurement.internal.duchy.deleteComputationRequest
 import org.wfanet.measurement.internal.duchy.externalRequisitionKey


### PR DESCRIPTION
- Added HonestMajorityShareShuffle protocol in duchy's proto.
- Update proto and database schema for Requisition and RequisitionService to accept either blob or a seed.
- Update ControlService to accept input for a certain stage of new protocol.
- Extract `RoleInComputation` and duchy `NoiseMechanism` from LLv2 specific message.