### PR TITLE
fix java deprecated build waring

### DIFF
--- a/experimental/reporting-ui/src/main/kotlin/org/wfanet/measurement/reporting/bff/service/api/v1alpha/ReportsService.kt
+++ b/experimental/reporting-ui/src/main/kotlin/org/wfanet/measurement/reporting/bff/service/api/v1alpha/ReportsService.kt
@@ -58,7 +58,7 @@ class ReportsService(private val backendReportsStub: BackendReportsGrpcKt.Report
       else request.view
     val results = listReportsResponse {
       resp.reportsList
-        .filter { it.tags.containsKey("ui.halo-cmm.org") }
+        .filter { it.tagsMap.containsKey("ui.halo-cmm.org") }
         .forEach { reports += it.toBffReport(view) }
     }
     return results


### PR DESCRIPTION
Supposed to use `tagsMap` instead of `tags`

Verified the warning. Verified the warning was resolved.
Also cleared bazel cache. Not clearing sometimes hid the warning.