### PR TITLE
Expose Measurements used for Metrics

### DIFF
--- a/src/main/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/MetricsService.kt
+++ b/src/main/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/MetricsService.kt
@@ -1578,6 +1578,10 @@ private fun InternalMetric.toMetric(variances: Variances): Metric {
 /** Builds a [MetricResult] from the given [InternalMetric]. */
 private fun buildMetricResult(metric: InternalMetric, variances: Variances): MetricResult {
   return metricResult {
+    cmmsMeasurements += metric.weightedMeasurementsList.map {
+      MeasurementKey(metric.cmmsMeasurementConsumerId, it.measurement.cmmsMeasurementId).toName()
+    }
+
     @Suppress("WHEN_ENUM_CAN_BE_NULL_IN_JAVA") // Proto enum fields are never null.
     when (metric.metricSpec.typeCase) {
       InternalMetricSpec.TypeCase.REACH -> {

--- a/src/main/proto/wfa/measurement/reporting/v2alpha/metric.proto
+++ b/src/main/proto/wfa/measurement/reporting/v2alpha/metric.proto
@@ -231,6 +231,13 @@ message MetricResult {
     // Watch duration result.
     WatchDurationResult watch_duration = 6;
   }
+
+  // List of resource names representing `Measurement`s from the CMMS public
+  // api that were used to calculate the `result` in this `MetricResult`.
+  repeated string cmms_measurements = 8 [
+    (google.api.resource_reference).type = "halo.wfanet.org/Measurement",
+    (google.api.field_behavior) = OUTPUT_ONLY
+  ];
 }
 
 // A resource that will calculate a particular quantity as defined by

--- a/src/test/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/MetricsServiceTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/MetricsServiceTest.kt
@@ -1638,6 +1638,8 @@ private val SUCCEEDED_INCREMENTAL_REACH_METRIC =
           value = INCREMENTAL_REACH_VALUE
           univariateStatistics = univariateStatistics { standardDeviation = sqrt(VARIANCE_VALUE) }
         }
+      cmmsMeasurements += PENDING_UNION_ALL_REACH_MEASUREMENT.name
+      cmmsMeasurements += PENDING_UNION_ALL_BUT_LAST_PUBLISHER_REACH_MEASUREMENT.name
     }
   }
 
@@ -1685,6 +1687,7 @@ private val SUCCEEDED_SINGLE_PUBLISHER_REACH_FREQUENCY_METRIC =
   PENDING_SINGLE_PUBLISHER_REACH_FREQUENCY_METRIC.copy {
     state = Metric.State.SUCCEEDED
     result = metricResult {
+      cmmsMeasurements += PENDING_SINGLE_PUBLISHER_REACH_FREQUENCY_MEASUREMENT.name
       reachAndFrequency =
         MetricResultKt.reachAndFrequencyResult {
           reach =
@@ -1776,6 +1779,7 @@ private val SUCCEEDED_SINGLE_PUBLISHER_IMPRESSION_METRIC =
           value = IMPRESSION_VALUE
           univariateStatistics = univariateStatistics { standardDeviation = sqrt(VARIANCE_VALUE) }
         }
+      cmmsMeasurements += PENDING_SINGLE_PUBLISHER_IMPRESSION_MEASUREMENT.name
     }
   }
 
@@ -1825,6 +1829,7 @@ private val SUCCEEDED_CROSS_PUBLISHER_WATCH_DURATION_METRIC =
             standardDeviation = sqrt(WATCH_DURATION_LIST.sumOf { VARIANCE_VALUE })
           }
         }
+      cmmsMeasurements += PENDING_UNION_ALL_WATCH_DURATION_MEASUREMENT.name
     }
   }
 
@@ -5085,6 +5090,8 @@ class MetricsServiceTest {
           SUCCEEDED_INCREMENTAL_REACH_METRIC.copy {
             this.result = metricResult {
               reach = MetricResultKt.reachResult { value = INCREMENTAL_REACH_VALUE }
+              cmmsMeasurements += PENDING_UNION_ALL_BUT_LAST_PUBLISHER_REACH_MEASUREMENT.name
+              cmmsMeasurements += PENDING_UNION_ALL_REACH_MEASUREMENT.name
             }
           }
         )
@@ -5169,6 +5176,8 @@ class MetricsServiceTest {
           SUCCEEDED_INCREMENTAL_REACH_METRIC.copy {
             this.result = metricResult {
               reach = MetricResultKt.reachResult { value = INCREMENTAL_REACH_VALUE }
+              cmmsMeasurements += PENDING_UNION_ALL_BUT_LAST_PUBLISHER_REACH_MEASUREMENT.name
+              cmmsMeasurements += PENDING_UNION_ALL_REACH_MEASUREMENT.name
             }
           }
         )
@@ -5234,6 +5243,8 @@ class MetricsServiceTest {
           SUCCEEDED_INCREMENTAL_REACH_METRIC.copy {
             this.result = metricResult {
               reach = MetricResultKt.reachResult { value = INCREMENTAL_REACH_VALUE }
+              cmmsMeasurements += PENDING_UNION_ALL_BUT_LAST_PUBLISHER_REACH_MEASUREMENT.name
+              cmmsMeasurements += PENDING_UNION_ALL_REACH_MEASUREMENT.name
             }
           }
         )
@@ -6643,8 +6654,14 @@ class MetricsServiceTest {
           internalBatchGetMetricsResponse {
             metrics +=
               INTERNAL_SUCCEEDED_SINGLE_PUBLISHER_IMPRESSION_METRIC.copy {
+                weightedMeasurements.clear()
                 weightedMeasurements += weightedMeasurement {
                   weight = -1
+                  binaryRepresentation = 1
+                  measurement = INTERNAL_SUCCEEDED_SINGLE_PUBLISHER_IMPRESSION_MEASUREMENT
+                }
+                weightedMeasurements += weightedMeasurement {
+                  weight = 1
                   binaryRepresentation = 1
                   measurement = INTERNAL_SUCCEEDED_SINGLE_PUBLISHER_IMPRESSION_MEASUREMENT
                 }
@@ -6702,7 +6719,12 @@ class MetricsServiceTest {
         .isEqualTo(
           SUCCEEDED_SINGLE_PUBLISHER_IMPRESSION_METRIC.copy {
             this.result = metricResult {
-              impressionCount = MetricResultKt.impressionCountResult { value = 0L }
+              impressionCount = MetricResultKt.impressionCountResult {
+                clearUnivariateStatistics()
+                value = 0L
+              }
+              cmmsMeasurements += PENDING_SINGLE_PUBLISHER_IMPRESSION_MEASUREMENT.name
+              cmmsMeasurements += PENDING_SINGLE_PUBLISHER_IMPRESSION_MEASUREMENT.name
             }
           }
         )
@@ -6985,6 +7007,12 @@ class MetricsServiceTest {
           internalBatchGetMetricsResponse {
             metrics +=
               INTERNAL_SUCCEEDED_CROSS_PUBLISHER_WATCH_DURATION_METRIC.copy {
+                weightedMeasurements.clear()
+                weightedMeasurements += weightedMeasurement {
+                  weight = 1
+                  binaryRepresentation = 1
+                  measurement = INTERNAL_SUCCEEDED_UNION_ALL_WATCH_DURATION_MEASUREMENT
+                }
                 weightedMeasurements += weightedMeasurement {
                   weight = -1
                   binaryRepresentation = 1
@@ -7005,7 +7033,12 @@ class MetricsServiceTest {
         .isEqualTo(
           SUCCEEDED_CROSS_PUBLISHER_WATCH_DURATION_METRIC.copy {
             this.result = metricResult {
-              watchDuration = MetricResultKt.watchDurationResult { value = 0.0 }
+              watchDuration = MetricResultKt.watchDurationResult {
+                clearUnivariateStatistics()
+                value = 0.0
+              }
+              cmmsMeasurements += PENDING_UNION_ALL_WATCH_DURATION_MEASUREMENT.name
+              cmmsMeasurements += PENDING_UNION_ALL_WATCH_DURATION_MEASUREMENT.name
             }
           }
         )


### PR DESCRIPTION
Measurement resource names are available in Metric results to help with debugging Metric results.