### PR TITLE
Fix normalizing frequency distribution

### DIFF
--- a/src/main/kotlin/org/wfanet/measurement/loadtest/dataprovider/EdpSimulator.kt
+++ b/src/main/kotlin/org/wfanet/measurement/loadtest/dataprovider/EdpSimulator.kt
@@ -28,6 +28,8 @@ import java.security.cert.X509Certificate
 import java.util.logging.Level
 import java.util.logging.Logger
 import kotlin.math.log2
+import kotlin.math.max
+import kotlin.math.roundToInt
 import kotlin.random.Random
 import kotlin.random.asJavaRandom
 import kotlinx.coroutines.flow.Flow
@@ -83,7 +85,6 @@ import org.wfanet.measurement.api.v2alpha.RequisitionKt.refusal
 import org.wfanet.measurement.api.v2alpha.RequisitionSpec
 import org.wfanet.measurement.api.v2alpha.RequisitionsGrpcKt.RequisitionsCoroutineStub
 import org.wfanet.measurement.api.v2alpha.SignedMessage
-import org.wfanet.measurement.api.v2alpha.certificate
 import org.wfanet.measurement.api.v2alpha.copy
 import org.wfanet.measurement.api.v2alpha.createEventGroupMetadataDescriptorRequest
 import org.wfanet.measurement.api.v2alpha.createEventGroupRequest
@@ -1222,7 +1223,7 @@ class EdpSimulator(
    * @param reachValue Direct reach value.
    * @param privacyParams Differential privacy params for reach.
    * @param directNoiseMechanism Selected noise mechanism for direct reach.
-   * @return Noised reach value.
+   * @return Noised non-negative reach value.
    */
   private fun addReachPublisherNoise(
     reachValue: Int,
@@ -1232,7 +1233,7 @@ class EdpSimulator(
     val reachNoiser: AbstractNoiser =
       getPublisherNoiser(privacyParams, directNoiseMechanism, random)
 
-    return reachValue + reachNoiser.sample().toInt()
+    return max(0, reachValue + reachNoiser.sample().toInt())
   }
 
   /**
@@ -1242,7 +1243,7 @@ class EdpSimulator(
    * @param frequencyMap Direct frequency.
    * @param privacyParams Differential privacy params for frequency map.
    * @param directNoiseMechanism Selected noise mechanism for direct frequency.
-   * @return Noised frequency map.
+   * @return Noised non-negative frequency map.
    */
   private fun addFrequencyPublisherNoise(
     reachValue: Int,
@@ -1253,8 +1254,20 @@ class EdpSimulator(
     val frequencyNoiser: AbstractNoiser =
       getPublisherNoiser(privacyParams, directNoiseMechanism, random)
 
-    return frequencyMap.mapValues { (_, percentage) ->
-      (percentage * reachValue.toDouble() + frequencyNoiser.sample()) / reachValue.toDouble()
+    // Add noise to the histogram and cap negative values to zeros.
+    val frequencyHistogram: Map<Int, Int> =
+      frequencyMap.mapValues { (_, percentage) ->
+        // Round the noise for privacy.
+        val noisedCount: Int =
+          (percentage * reachValue).roundToInt() + (frequencyNoiser.sample()).roundToInt()
+        max(0, noisedCount)
+      }
+    val normalizationTerm: Double = frequencyHistogram.values.sum().toDouble()
+    // Normalize to get the distribution
+    return if (normalizationTerm != 0.0) {
+      frequencyHistogram.mapValues { (_, count) -> count / normalizationTerm }
+    } else {
+      frequencyHistogram.mapValues { 0.0 }
     }
   }
 
@@ -1514,12 +1527,11 @@ class EdpSimulator(
     nonce: Long,
     measurementResult: Measurement.Result
   ) {
-    val requisitionCertificateKey =
-      DataProviderCertificateKey.fromName(requisition.dataProviderCertificate)
-        ?: throw RequisitionRefusalException(
-          Requisition.Refusal.Justification.UNFULFILLABLE,
-          "Invalid data provider certificate"
-        )
+    DataProviderCertificateKey.fromName(requisition.dataProviderCertificate)
+      ?: throw RequisitionRefusalException(
+        Requisition.Refusal.Justification.UNFULFILLABLE,
+        "Invalid data provider certificate"
+      )
     val measurementEncryptionPublicKey: EncryptionPublicKey =
       if (measurementSpec.hasMeasurementPublicKey()) {
         measurementSpec.measurementPublicKey.unpack()

--- a/src/main/kotlin/org/wfanet/measurement/loadtest/dataprovider/MeasurementResults.kt
+++ b/src/main/kotlin/org/wfanet/measurement/loadtest/dataprovider/MeasurementResults.kt
@@ -28,6 +28,11 @@ object MeasurementResults {
     val eventsPerVid: Map<Long, Int> = sampledVids.groupingBy { it }.eachCount()
     val reach: Int = eventsPerVid.keys.size
 
+    // If the sampled VIDs is empty, set the distribution with all 0s up to maxFrequency.
+    if (reach == 0) {
+      return ReachAndFrequency(reach, (1..maxFrequency).associateWith { 0.0 })
+    }
+
     // Build frequency histogram as a 0-based array.
     val frequencyArray = IntArray(maxFrequency)
     for (count in eventsPerVid.values) {


### PR DESCRIPTION
This is a fix PR for #1384. In this PR, 
1. fix the frequency normalization in `MeasurementResults.computeReachAndFrequency` by early returning when reach is 0.
2. Round the noise added to the frequency histogram during the process of noising frequency distribution.
3. cap negative values to 0 for direct reach and frequency.
4. fix the frequency normalization.
5. adding new unit test to capture the case when direct reach is 0.
