### PR TITLE
add always charging privacy bucket mapper support

### DIFF
--- a/src/main/cc/wfa/panelmatch/common/crypto/peppered_fingerprinter.cc
+++ b/src/main/cc/wfa/panelmatch/common/crypto/peppered_fingerprinter.cc
@@ -17,6 +17,8 @@
 #include <memory>
 
 #include "absl/status/status.h"
+#include "absl/strings/str_cat.h"
+#include "absl/strings/string_view.h"
 #include "common_cpp/fingerprinters/fingerprinters.h"
 #include "glog/logging.h"
 #include "tink/util/secret_data.h"

--- a/src/main/kotlin/org/wfanet/measurement/eventdataprovider/eventfiltration/EventFilters.kt
+++ b/src/main/kotlin/org/wfanet/measurement/eventdataprovider/eventfiltration/EventFilters.kt
@@ -44,7 +44,8 @@ object EventFilters {
    *   operation. If provided, [celExpr] is normalized to operative negation normal form by bubbling
    *   down all the negation operations to the leafs by applying De Morgan's laws recursively and by
    *   setting all the leaf comparison nodes (e.g. x == 47 ) that contain any field other than the
-   *   operative fields to true.
+   *   operative fields to true. If not provided or empty, the normalization operation will not be
+   *   performed.
    * @throws [EventFilterValidationException] if [celExpr] is not valid.
    */
   fun compileProgram(

--- a/src/main/kotlin/org/wfanet/measurement/eventdataprovider/privacybudgetmanagement/PrivacyBucketFilter.kt
+++ b/src/main/kotlin/org/wfanet/measurement/eventdataprovider/privacybudgetmanagement/PrivacyBucketFilter.kt
@@ -17,7 +17,6 @@ import java.time.Clock
 import java.time.ZoneOffset
 import org.wfanet.measurement.common.OpenEndTimeRange
 import org.wfanet.measurement.common.rangeTo
-import org.wfanet.measurement.eventdataprovider.eventfiltration.EventFilters
 
 class PrivacyBucketFilter(
   private val privacyBucketMapper: PrivacyBucketMapper,
@@ -84,12 +83,7 @@ class PrivacyBucketFilter(
                   vidsIntervalStartPoint,
                   PrivacyLandscape.PRIVACY_BUCKET_VID_SAMPLE_WIDTH
                 )
-              if (
-                EventFilters.matches(
-                  privacyBucketMapper.toEventMessage(privacyBucketGroup),
-                  program
-                )
-              ) {
+              if (privacyBucketMapper.matches(privacyBucketGroup, program)) {
                 yield(privacyBucketGroup)
               }
             }

--- a/src/main/kotlin/org/wfanet/measurement/eventdataprovider/privacybudgetmanagement/PrivacyBucketMapper.kt
+++ b/src/main/kotlin/org/wfanet/measurement/eventdataprovider/privacybudgetmanagement/PrivacyBucketMapper.kt
@@ -15,13 +15,31 @@ package org.wfanet.measurement.eventdataprovider.privacybudgetmanagement
 
 import com.google.protobuf.Message
 import org.projectnessie.cel.Program
+import org.wfanet.measurement.eventdataprovider.eventfiltration.EventFilters
 
 /** Maps Privacy bucket related objects to event filter related objects and vice versa. */
 interface PrivacyBucketMapper {
+
+  /**
+   * Fields in the cel expression that will not be altered by normalization. If left empty, it is
+   * assumed that all buckets will be charged.
+   */
+  val operativeFields: Set<String>
 
   /** Maps [filterExpression] to a [Program] by using privacy related fields and [Message] */
   fun toPrivacyFilterProgram(filterExpression: String): Program
 
   /** Maps [privacyBucketGroup] to an event [Message] */
   fun toEventMessage(privacyBucketGroup: PrivacyBucketGroup): Message
+
+  /**
+   * Returns if a [privacyBucketGroup] matches for a given cel [program]. Always returns true if
+   * [operativeFields] are empty.
+   */
+  fun matches(privacyBucketGroup: PrivacyBucketGroup, program: Program): Boolean {
+    if (operativeFields.isEmpty()) {
+      return true
+    }
+    return EventFilters.matches(toEventMessage(privacyBucketGroup), program)
+  }
 }

--- a/src/main/kotlin/org/wfanet/measurement/loadtest/config/PrivacyBudgets.kt
+++ b/src/main/kotlin/org/wfanet/measurement/loadtest/config/PrivacyBudgets.kt
@@ -29,14 +29,12 @@ import org.wfanet.measurement.loadtest.config.LoadTestEventKt.privacy
 
 class TestPrivacyBucketMapper : PrivacyBucketMapper {
 
+  override val operativeFields = setOf("privacy.filterable")
+
   /** This mapper does not charge any bucket [filterExpression] is ignored. */
   override fun toPrivacyFilterProgram(filterExpression: String): Program =
     try {
-      compileProgram(
-        LoadTestEvent.getDescriptor(),
-        "privacy.filterable == true",
-        setOf("privacy.filterable")
-      )
+      compileProgram(LoadTestEvent.getDescriptor(), "privacy.filterable == true", operativeFields)
     } catch (e: EventFilterValidationException) {
       throw PrivacyBudgetManagerException(
         PrivacyBudgetManagerExceptionType.INVALID_PRIVACY_BUCKET_FILTER,

--- a/src/test/kotlin/org/wfanet/measurement/eventdataprovider/privacybudgetmanagement/PrivacyBucketFilterTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/eventdataprovider/privacybudgetmanagement/PrivacyBucketFilterTest.kt
@@ -22,6 +22,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 import org.wfanet.measurement.common.OpenEndTimeRange
+import org.wfanet.measurement.eventdataprovider.privacybudgetmanagement.testing.AlwaysChargingPrivacyBucketMapper
 import org.wfanet.measurement.eventdataprovider.privacybudgetmanagement.testing.TestPrivacyBucketMapper
 
 private const val MEASUREMENT_CONSUMER_ID = "ACME"
@@ -30,6 +31,8 @@ private const val MEASUREMENT_CONSUMER_ID = "ACME"
 class PrivacyBucketFilterTest {
 
   private val privacyBucketFilter = PrivacyBucketFilter(TestPrivacyBucketMapper())
+  private val alwaysChargingPrivacyBucketFilter =
+    PrivacyBucketFilter(AlwaysChargingPrivacyBucketMapper())
   private val today: LocalDateTime = LocalDate.now().atTime(4, 20)
   private val yesterday: LocalDateTime = today.minusDays(1)
   private val startOfTomorrow: LocalDateTime = today.plusDays(1).toLocalDate().atStartOfDay()
@@ -265,5 +268,240 @@ class PrivacyBucketFilterTest {
         privacyBucketFilter.getPrivacyBucketGroups(MEASUREMENT_CONSUMER_ID, privacyLandscapeMask)
       )
       .hasSize(24)
+  }
+
+  @Test
+  fun `Mapper succeeds with empty operative fields`() {
+    val privacyLandscapeMask =
+      LandscapeMask(
+        listOf(EventGroupSpec("person.age_group in [1] ", timeRange)),
+        0.0f,
+        PrivacyLandscape.PRIVACY_BUCKET_VID_SAMPLE_WIDTH
+      )
+
+    assertThat(
+        alwaysChargingPrivacyBucketFilter.getPrivacyBucketGroups(
+          MEASUREMENT_CONSUMER_ID,
+          privacyLandscapeMask
+        )
+      )
+      .containsExactly(
+        PrivacyBucketGroup(
+          measurementConsumerId = "ACME",
+          startingDate = yesterday.toLocalDate(),
+          endingDate = yesterday.toLocalDate(),
+          ageGroup = AgeGroup.RANGE_18_34,
+          gender = Gender.MALE,
+          vidSampleStart = 0.0f,
+          vidSampleWidth = PrivacyLandscape.PRIVACY_BUCKET_VID_SAMPLE_WIDTH
+        ),
+        PrivacyBucketGroup(
+          measurementConsumerId = "ACME",
+          startingDate = yesterday.toLocalDate(),
+          endingDate = yesterday.toLocalDate(),
+          ageGroup = AgeGroup.RANGE_18_34,
+          gender = Gender.FEMALE,
+          vidSampleStart = 0.0f,
+          vidSampleWidth = PrivacyLandscape.PRIVACY_BUCKET_VID_SAMPLE_WIDTH
+        ),
+        PrivacyBucketGroup(
+          measurementConsumerId = "ACME",
+          startingDate = yesterday.toLocalDate(),
+          endingDate = yesterday.toLocalDate(),
+          ageGroup = AgeGroup.RANGE_35_54,
+          gender = Gender.MALE,
+          vidSampleStart = 0.0f,
+          vidSampleWidth = PrivacyLandscape.PRIVACY_BUCKET_VID_SAMPLE_WIDTH
+        ),
+        PrivacyBucketGroup(
+          measurementConsumerId = "ACME",
+          startingDate = yesterday.toLocalDate(),
+          endingDate = yesterday.toLocalDate(),
+          ageGroup = AgeGroup.RANGE_35_54,
+          gender = Gender.FEMALE,
+          vidSampleStart = 0.0f,
+          vidSampleWidth = PrivacyLandscape.PRIVACY_BUCKET_VID_SAMPLE_WIDTH
+        ),
+        PrivacyBucketGroup(
+          measurementConsumerId = "ACME",
+          startingDate = yesterday.toLocalDate(),
+          endingDate = yesterday.toLocalDate(),
+          ageGroup = AgeGroup.ABOVE_54,
+          gender = Gender.MALE,
+          vidSampleStart = 0.0f,
+          vidSampleWidth = PrivacyLandscape.PRIVACY_BUCKET_VID_SAMPLE_WIDTH
+        ),
+        PrivacyBucketGroup(
+          measurementConsumerId = "ACME",
+          startingDate = yesterday.toLocalDate(),
+          endingDate = yesterday.toLocalDate(),
+          ageGroup = AgeGroup.ABOVE_54,
+          gender = Gender.FEMALE,
+          vidSampleStart = 0.0f,
+          vidSampleWidth = PrivacyLandscape.PRIVACY_BUCKET_VID_SAMPLE_WIDTH
+        ),
+        PrivacyBucketGroup(
+          measurementConsumerId = "ACME",
+          startingDate = today.toLocalDate(),
+          endingDate = today.toLocalDate(),
+          ageGroup = AgeGroup.RANGE_18_34,
+          gender = Gender.MALE,
+          vidSampleStart = 0.0f,
+          vidSampleWidth = PrivacyLandscape.PRIVACY_BUCKET_VID_SAMPLE_WIDTH
+        ),
+        PrivacyBucketGroup(
+          measurementConsumerId = "ACME",
+          startingDate = today.toLocalDate(),
+          endingDate = today.toLocalDate(),
+          ageGroup = AgeGroup.RANGE_18_34,
+          gender = Gender.FEMALE,
+          vidSampleStart = 0.0f,
+          vidSampleWidth = PrivacyLandscape.PRIVACY_BUCKET_VID_SAMPLE_WIDTH
+        ),
+        PrivacyBucketGroup(
+          measurementConsumerId = "ACME",
+          startingDate = today.toLocalDate(),
+          endingDate = today.toLocalDate(),
+          ageGroup = AgeGroup.RANGE_35_54,
+          gender = Gender.MALE,
+          vidSampleStart = 0.0f,
+          vidSampleWidth = PrivacyLandscape.PRIVACY_BUCKET_VID_SAMPLE_WIDTH
+        ),
+        PrivacyBucketGroup(
+          measurementConsumerId = "ACME",
+          startingDate = today.toLocalDate(),
+          endingDate = today.toLocalDate(),
+          ageGroup = AgeGroup.RANGE_35_54,
+          gender = Gender.FEMALE,
+          vidSampleStart = 0.0f,
+          vidSampleWidth = PrivacyLandscape.PRIVACY_BUCKET_VID_SAMPLE_WIDTH
+        ),
+        PrivacyBucketGroup(
+          measurementConsumerId = "ACME",
+          startingDate = today.toLocalDate(),
+          endingDate = today.toLocalDate(),
+          ageGroup = AgeGroup.ABOVE_54,
+          gender = Gender.MALE,
+          vidSampleStart = 0.0f,
+          vidSampleWidth = PrivacyLandscape.PRIVACY_BUCKET_VID_SAMPLE_WIDTH
+        ),
+        PrivacyBucketGroup(
+          measurementConsumerId = "ACME",
+          startingDate = today.toLocalDate(),
+          endingDate = today.toLocalDate(),
+          ageGroup = AgeGroup.ABOVE_54,
+          gender = Gender.FEMALE,
+          vidSampleStart = 0.0f,
+          vidSampleWidth = PrivacyLandscape.PRIVACY_BUCKET_VID_SAMPLE_WIDTH
+        ),
+        PrivacyBucketGroup(
+          measurementConsumerId = "ACME",
+          startingDate = yesterday.toLocalDate(),
+          endingDate = yesterday.toLocalDate(),
+          ageGroup = AgeGroup.RANGE_18_34,
+          gender = Gender.MALE,
+          vidSampleStart = PrivacyLandscape.PRIVACY_BUCKET_VID_SAMPLE_WIDTH,
+          vidSampleWidth = PrivacyLandscape.PRIVACY_BUCKET_VID_SAMPLE_WIDTH
+        ),
+        PrivacyBucketGroup(
+          measurementConsumerId = "ACME",
+          startingDate = yesterday.toLocalDate(),
+          endingDate = yesterday.toLocalDate(),
+          ageGroup = AgeGroup.RANGE_18_34,
+          gender = Gender.FEMALE,
+          vidSampleStart = PrivacyLandscape.PRIVACY_BUCKET_VID_SAMPLE_WIDTH,
+          vidSampleWidth = PrivacyLandscape.PRIVACY_BUCKET_VID_SAMPLE_WIDTH
+        ),
+        PrivacyBucketGroup(
+          measurementConsumerId = "ACME",
+          startingDate = yesterday.toLocalDate(),
+          endingDate = yesterday.toLocalDate(),
+          ageGroup = AgeGroup.RANGE_35_54,
+          gender = Gender.MALE,
+          vidSampleStart = PrivacyLandscape.PRIVACY_BUCKET_VID_SAMPLE_WIDTH,
+          vidSampleWidth = PrivacyLandscape.PRIVACY_BUCKET_VID_SAMPLE_WIDTH
+        ),
+        PrivacyBucketGroup(
+          measurementConsumerId = "ACME",
+          startingDate = yesterday.toLocalDate(),
+          endingDate = yesterday.toLocalDate(),
+          ageGroup = AgeGroup.RANGE_35_54,
+          gender = Gender.FEMALE,
+          vidSampleStart = PrivacyLandscape.PRIVACY_BUCKET_VID_SAMPLE_WIDTH,
+          vidSampleWidth = PrivacyLandscape.PRIVACY_BUCKET_VID_SAMPLE_WIDTH
+        ),
+        PrivacyBucketGroup(
+          measurementConsumerId = "ACME",
+          startingDate = yesterday.toLocalDate(),
+          endingDate = yesterday.toLocalDate(),
+          ageGroup = AgeGroup.ABOVE_54,
+          gender = Gender.MALE,
+          vidSampleStart = PrivacyLandscape.PRIVACY_BUCKET_VID_SAMPLE_WIDTH,
+          vidSampleWidth = PrivacyLandscape.PRIVACY_BUCKET_VID_SAMPLE_WIDTH
+        ),
+        PrivacyBucketGroup(
+          measurementConsumerId = "ACME",
+          startingDate = yesterday.toLocalDate(),
+          endingDate = yesterday.toLocalDate(),
+          ageGroup = AgeGroup.ABOVE_54,
+          gender = Gender.FEMALE,
+          vidSampleStart = PrivacyLandscape.PRIVACY_BUCKET_VID_SAMPLE_WIDTH,
+          vidSampleWidth = PrivacyLandscape.PRIVACY_BUCKET_VID_SAMPLE_WIDTH
+        ),
+        PrivacyBucketGroup(
+          measurementConsumerId = "ACME",
+          startingDate = today.toLocalDate(),
+          endingDate = today.toLocalDate(),
+          ageGroup = AgeGroup.RANGE_18_34,
+          gender = Gender.MALE,
+          vidSampleStart = PrivacyLandscape.PRIVACY_BUCKET_VID_SAMPLE_WIDTH,
+          vidSampleWidth = PrivacyLandscape.PRIVACY_BUCKET_VID_SAMPLE_WIDTH
+        ),
+        PrivacyBucketGroup(
+          measurementConsumerId = "ACME",
+          startingDate = today.toLocalDate(),
+          endingDate = today.toLocalDate(),
+          ageGroup = AgeGroup.RANGE_18_34,
+          gender = Gender.FEMALE,
+          vidSampleStart = PrivacyLandscape.PRIVACY_BUCKET_VID_SAMPLE_WIDTH,
+          vidSampleWidth = PrivacyLandscape.PRIVACY_BUCKET_VID_SAMPLE_WIDTH
+        ),
+        PrivacyBucketGroup(
+          measurementConsumerId = "ACME",
+          startingDate = today.toLocalDate(),
+          endingDate = today.toLocalDate(),
+          ageGroup = AgeGroup.RANGE_35_54,
+          gender = Gender.MALE,
+          vidSampleStart = PrivacyLandscape.PRIVACY_BUCKET_VID_SAMPLE_WIDTH,
+          vidSampleWidth = PrivacyLandscape.PRIVACY_BUCKET_VID_SAMPLE_WIDTH
+        ),
+        PrivacyBucketGroup(
+          measurementConsumerId = "ACME",
+          startingDate = today.toLocalDate(),
+          endingDate = today.toLocalDate(),
+          ageGroup = AgeGroup.RANGE_35_54,
+          gender = Gender.FEMALE,
+          vidSampleStart = PrivacyLandscape.PRIVACY_BUCKET_VID_SAMPLE_WIDTH,
+          vidSampleWidth = PrivacyLandscape.PRIVACY_BUCKET_VID_SAMPLE_WIDTH
+        ),
+        PrivacyBucketGroup(
+          measurementConsumerId = "ACME",
+          startingDate = today.toLocalDate(),
+          endingDate = today.toLocalDate(),
+          ageGroup = AgeGroup.ABOVE_54,
+          gender = Gender.MALE,
+          vidSampleStart = PrivacyLandscape.PRIVACY_BUCKET_VID_SAMPLE_WIDTH,
+          vidSampleWidth = PrivacyLandscape.PRIVACY_BUCKET_VID_SAMPLE_WIDTH
+        ),
+        PrivacyBucketGroup(
+          measurementConsumerId = "ACME",
+          startingDate = today.toLocalDate(),
+          endingDate = today.toLocalDate(),
+          ageGroup = AgeGroup.ABOVE_54,
+          gender = Gender.FEMALE,
+          vidSampleStart = PrivacyLandscape.PRIVACY_BUCKET_VID_SAMPLE_WIDTH,
+          vidSampleWidth = PrivacyLandscape.PRIVACY_BUCKET_VID_SAMPLE_WIDTH
+        )
+      )
   }
 }


### PR DESCRIPTION
This is cherry picked because its needed for Origin event templates that do not have age or demographic fields.