### PR TITLE
Update configurations for demo Reporting UI.

### DIFF
--- a/src/main/k8s/dev/synthetic_generator_edp_simulator_gke.cue
+++ b/src/main/k8s/dev/synthetic_generator_edp_simulator_gke.cue
@@ -17,7 +17,7 @@ package k8s
 _resourceRequirements: ResourceRequirements=#ResourceRequirements & {
 	requests: {
 		cpu:    "500m"
-		memory: "288Mi"
+		memory: "768Mi"
 	}
 	limits: {
 		memory: ResourceRequirements.requests.memory
@@ -44,7 +44,7 @@ edp_simulators: {
 			]
 			deployment: {
 				_container: {
-					_javaOptions: maxHeapSize: "96M"
+					_javaOptions: maxHeapSize: "512M"
 					resources: _resourceRequirements
 				}
 				spec: template: spec: {

--- a/src/main/k8s/testing/secretfiles/llv2_protocol_config_config.textproto
+++ b/src/main/k8s/testing/secretfiles/llv2_protocol_config_config.textproto
@@ -1,9 +1,9 @@
-# proto-file: src/main/proto/wfa/measurement/internal/kingdom/protocol_config_config.proto
+# proto-file: wfa/measurement/internal/kingdom/protocol_config_config.proto
 # proto-message: Llv2ProtocolConfigConfig
 protocol_config {
   sketch_params {
-    decay_rate: 7.75
-    max_size: 100000
+    decay_rate: 5.6
+    max_size: 1000000
     sampling_indicator_size: 10000000
   }
   data_provider_noise {

--- a/src/main/terraform/aws/modules/eks-cluster/main.tf
+++ b/src/main/terraform/aws/modules/eks-cluster/main.tf
@@ -14,7 +14,7 @@
 
 module "eks" {
   source  = "terraform-aws-modules/eks/aws"
-  version = "~> 19.16"
+  version = "~> 19.16.0"
 
   cluster_name    = var.cluster_name
   cluster_version = var.cluster_version

--- a/src/main/terraform/gcloud/cmms/reporting.tf
+++ b/src/main/terraform/gcloud/cmms/reporting.tf
@@ -35,7 +35,7 @@ module "reporting_default_node_pool" {
   cluster         = data.google_container_cluster.reporting
   service_account = module.common.cluster_service_account
   machine_type    = "e2-small"
-  max_node_count  = 4
+  max_node_count  = 8
 }
 
 module "reporting" {

--- a/src/main/terraform/gcloud/cmms/simulators.tf
+++ b/src/main/terraform/gcloud/cmms/simulators.tf
@@ -44,7 +44,7 @@ module "simulators_spot_node_pool" {
   name            = "spot"
   cluster         = data.google_container_cluster.simulators
   service_account = module.common.cluster_service_account
-  machine_type    = "c3-highcpu-4"
+  machine_type    = "c2-standard-4"
   max_node_count  = 3
   spot            = true
 }

--- a/src/main/terraform/gcloud/modules/reporting/main.tf
+++ b/src/main/terraform/gcloud/modules/reporting/main.tf
@@ -58,3 +58,15 @@ resource "postgresql_grant" "db" {
   object_type = "database"
   privileges  = local.all_db_privileges
 }
+
+resource "google_sql_database" "db2" {
+  name     = "reporting-v2"
+  instance = var.postgres_instance.name
+}
+
+resource "postgresql_grant" "db2" {
+  role        = google_sql_user.reporting_internal.name
+  database    = google_sql_database.db2.name
+  object_type = "database"
+  privileges  = local.all_db_privileges
+}


### PR DESCRIPTION
* Update default LLv2 protocol configuration including larger sketch size.
  * Update corresponding memory limits to handle this.
* Allow Reporting v2 to be deployed alongside Reporting v1 in the same cluster.