### PR TITLE
Update google API clients for compatibility with google-api-client.

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -116,6 +116,8 @@ MAVEN_ARTIFACTS_DICT = dict(common_jvm_maven_artifacts_dict().items() + {
     "software.amazon.awssdk:acmpca": AWS_JAVA_SDK_VERSION,
     "com.google.crypto.tink:tink-gcpkms": "1.9.0",
     "com.google.crypto.tink:tink-awskms": "1.9.1",
+    "com.google.apis:google-api-services-storage": "v1-rev20240105-2.0.0",
+    "com.google.apis:google-api-services-sqladmin": "v1-rev20240101-2.0.0",
 }.items())
 
 EXCLUDED_MAVEN_ARTIFACTS = [x for x in COMMON_JVM_EXCLUDED_ARTIFACTS if x != "org.slf4j:slf4j-log4j12"] + ["org.apache.beam:beam-sdks-java-io-kafka"]

--- a/build/versions.bzl
+++ b/build/versions.bzl
@@ -21,6 +21,6 @@
 # * https://cloud.google.com/dataflow/docs/support/sdk-version-support-status#apache-beam-2.x-sdks
 # * https://beam.apache.org/documentation/runners/flink/#flink-version-compatibility
 # * https://docs.aws.amazon.com/kinesisanalytics/latest/java/earlier.html
-APACHE_BEAM_VERSION = "2.38.0"
+APACHE_BEAM_VERSION = "2.40.0"
 
 K8S_CLIENT_VERSION = "16.0.0"


### PR DESCRIPTION
The version compatibility should ideally be handled by Maven artifact resolution (meaning google-api-services-storage < 2 should require google-api-client < 2). Alas it is not, so this works around the issue by specifying the version explicitly.

Closes #1410