### PR TITLE
Default MALLOC_ARENA_MAX to 2.

### DIFF
--- a/src/main/k8s/base.cue
+++ b/src/main/k8s/base.cue
@@ -448,7 +448,10 @@ objects: [ for objectSet in objectSets for object in objectSet {object}]
 	_envVars:     #EnvVarMap
 	_javaOptions: #JavaOptions
 
-	_envVars: "JAVA_TOOL_OPTIONS": value: strings.Join(_javaOptions.options, " ")
+	_envVars: {
+		"JAVA_TOOL_OPTIONS": value: strings.Join(_javaOptions.options, " ")
+		"MALLOC_ARENA_MAX": value:  _ | *"2"
+	}
 
 	name:   string
 	image?: string


### PR DESCRIPTION
This reduces the container overhead for non-JVM memory.