### PR TITLE
Add impression implementation to EDP simulator

### DIFF
--- a/src/main/kotlin/org/wfanet/measurement/api/v2alpha/testing/MeasurementResultSubject.kt
+++ b/src/main/kotlin/org/wfanet/measurement/api/v2alpha/testing/MeasurementResultSubject.kt
@@ -37,6 +37,12 @@ private constructor(failureMetadata: FailureMetadata, subject: Measurement.Resul
       .that(actual.frequency.relativeFrequencyDistributionMap)
   }
 
+  fun impressionValue(): FuzzyLongSubject {
+    return check("impression.value")
+      .about(FuzzyLongSubject.fuzzyLongs())
+      .that(actual.impression.value)
+  }
+
   companion object {
     fun measurementResults():
       (failureMetadata: FailureMetadata, subject: Measurement.Result) -> MeasurementResultSubject =

--- a/src/main/kotlin/org/wfanet/measurement/loadtest/dataprovider/EdpSimulator.kt
+++ b/src/main/kotlin/org/wfanet/measurement/loadtest/dataprovider/EdpSimulator.kt
@@ -46,6 +46,7 @@ import org.wfanet.measurement.api.v2alpha.CertificatesGrpcKt.CertificatesCorouti
 import org.wfanet.measurement.api.v2alpha.CustomDirectMethodologyKt.variance
 import org.wfanet.measurement.api.v2alpha.DataProviderCertificateKey
 import org.wfanet.measurement.api.v2alpha.DataProviderKey
+import org.wfanet.measurement.api.v2alpha.DeterministicCount
 import org.wfanet.measurement.api.v2alpha.DeterministicCountDistinct
 import org.wfanet.measurement.api.v2alpha.DeterministicDistribution
 import org.wfanet.measurement.api.v2alpha.DifferentialPrivacyParams
@@ -140,6 +141,7 @@ import org.wfanet.measurement.eventdataprovider.privacybudgetmanagement.api.v2al
 import org.wfanet.measurement.eventdataprovider.privacybudgetmanagement.api.v2alpha.PrivacyQueryMapper.getLiquidLegionsV2AcdpQuery
 import org.wfanet.measurement.loadtest.config.TestIdentifiers.SIMULATOR_EVENT_GROUP_REFERENCE_ID_PREFIX
 import org.wfanet.measurement.loadtest.config.VidSampling
+import org.wfanet.measurement.loadtest.dataprovider.MeasurementResults.computeImpression
 
 data class EdpData(
   /** The EDP's public API resource name. */
@@ -1164,7 +1166,24 @@ class EdpSimulator(
     )
 
     logger.info("Calculating direct reach and frequency...")
-    val vidSamplingInterval = measurementSpec.vidSamplingInterval
+    val measurementResult =
+      buildDirectMeasurementResult(
+        directProtocol,
+        measurementSpec,
+        sampleVids(eventGroupSpecs, measurementSpec.vidSamplingInterval),
+      )
+
+    fulfillDirectMeasurement(requisition, measurementSpec, nonce, measurementResult)
+  }
+
+  /**
+   * Samples VIDs from multiple [EventQuery.EventGroupSpec]s with a
+   * [MeasurementSpec.VidSamplingInterval].
+   */
+  private fun sampleVids(
+    eventGroupSpecs: Iterable<EventQuery.EventGroupSpec>,
+    vidSamplingInterval: MeasurementSpec.VidSamplingInterval,
+  ): Iterable<Long> {
     val vidSamplingIntervalStart = vidSamplingInterval.start
     val vidSamplingIntervalWidth = vidSamplingInterval.width
 
@@ -1179,35 +1198,29 @@ class EdpSimulator(
     ) {
       "Invalid vidSamplingInterval: $vidSamplingInterval"
     }
-
-    val sampledVids: Sequence<Long> =
-      try {
-        eventGroupSpecs
-          .asSequence()
-          .flatMap { eventQuery.getUserVirtualIds(it) }
-          .filter { vid ->
-            VidSampling.sampler.vidIsInSamplingBucket(
-              vid,
-              vidSamplingIntervalStart,
-              vidSamplingIntervalWidth,
-            )
-          }
-      } catch (e: EventFilterValidationException) {
-        logger.log(
-          Level.WARNING,
-          "RequisitionFulfillmentWorkflow failed due to invalid event filter",
-          e,
-        )
-        throw RequisitionRefusalException(
-          Requisition.Refusal.Justification.SPEC_INVALID,
-          "Invalid event filter (${e.code}): ${e.code.description}",
-        )
-      }
-
-    val measurementResult =
-      buildDirectMeasurementResult(directProtocol, measurementSpec, sampledVids.asIterable())
-
-    fulfillDirectMeasurement(requisition, measurementSpec, nonce, measurementResult)
+    return try {
+      eventGroupSpecs
+        .asSequence()
+        .flatMap { eventQuery.getUserVirtualIds(it) }
+        .filter { vid ->
+          VidSampling.sampler.vidIsInSamplingBucket(
+            vid,
+            vidSamplingIntervalStart,
+            vidSamplingIntervalWidth,
+          )
+        }
+        .asIterable()
+    } catch (e: EventFilterValidationException) {
+      logger.log(
+        Level.WARNING,
+        "RequisitionFulfillmentWorkflow failed due to invalid event filter",
+        e,
+      )
+      throw RequisitionRefusalException(
+        Requisition.Refusal.Justification.SPEC_INVALID,
+        "Invalid event filter (${e.code}): ${e.code.description}",
+      )
+    }
   }
 
   private fun getPublisherNoiser(
@@ -1283,6 +1296,26 @@ class EdpSimulator(
   }
 
   /**
+   * Add publisher noise to calculated impression.
+   *
+   * @param impressionValue Impression value.
+   * @param impressionMeasurementSpec Measurement spec of impression.
+   * @param directNoiseMechanism Selected noise mechanism for impression.
+   * @return Noised non-negative impression value.
+   */
+  private fun addImpressionPublisherNoise(
+    impressionValue: Long,
+    impressionMeasurementSpec: MeasurementSpec.Impression,
+    directNoiseMechanism: DirectNoiseMechanism,
+  ): Long {
+    val noiser: AbstractNoiser =
+      getPublisherNoiser(impressionMeasurementSpec.privacyParams, directNoiseMechanism, random)
+    // Noise needs to be scaled by maximumFrequencyPerUser.
+    val noise = noiser.sample() * impressionMeasurementSpec.maximumFrequencyPerUser
+    return max(0L, impressionValue + noise.roundToInt())
+  }
+
+  /**
    * Build [Measurement.Result] of the measurement type specified in [MeasurementSpec].
    *
    * @param measurementSpec Measurement spec.
@@ -1352,15 +1385,31 @@ class EdpSimulator(
         }
       }
       MeasurementSpec.MeasurementTypeCase.IMPRESSION -> {
+        if (!directProtocolConfig.hasDeterministicCount()) {
+          throw RequisitionRefusalException(
+            Requisition.Refusal.Justification.DECLINED,
+            "No valid methodologies for impression computation.",
+          )
+        }
+
+        val sampledImpressionCount =
+          computeImpression(samples, measurementSpec.impression.maximumFrequencyPerUser)
+
+        logger.info("Adding $directNoiseMechanism publisher noise to impression...")
+        val sampledNoisedImpressionCount =
+          addImpressionPublisherNoise(
+            sampledImpressionCount,
+            measurementSpec.impression,
+            directNoiseMechanism,
+          )
+        val scaledNoisedImpressionCount =
+          (sampledNoisedImpressionCount / measurementSpec.vidSamplingInterval.width).toLong()
+
         MeasurementKt.result {
           impression = impression {
-            // Use externalDataProviderId since it's a known value the FrontendSimulator can verify.
-            // TODO: Calculate impression from data.
-            value = apiIdToExternalId(DataProviderKey.fromName(edpData.name)!!.dataProviderId)
+            value = scaledNoisedImpressionCount
             noiseMechanism = protocolConfigNoiseMechanism
-            customDirectMethodology = customDirectMethodology {
-              variance = variance { scalar = 0.0 }
-            }
+            deterministicCount = DeterministicCount.getDefaultInstance()
           }
         }
       }
@@ -1506,8 +1555,13 @@ class EdpSimulator(
       directProtocol.selectedDirectNoiseMechanism,
     )
 
+    logger.info("Calculating impression...")
     val measurementResult =
-      buildDirectMeasurementResult(directProtocol, measurementSpec, listOf<Long>().asIterable())
+      buildDirectMeasurementResult(
+        directProtocol,
+        measurementSpec,
+        sampleVids(eventGroupSpecs, measurementSpec.vidSamplingInterval),
+      )
 
     fulfillDirectMeasurement(requisition, measurementSpec, requisitionSpec.nonce, measurementResult)
   }

--- a/src/main/kotlin/org/wfanet/measurement/loadtest/dataprovider/MeasurementResults.kt
+++ b/src/main/kotlin/org/wfanet/measurement/loadtest/dataprovider/MeasurementResults.kt
@@ -49,4 +49,11 @@ object MeasurementResults {
   fun computeReach(sampledVids: Iterable<Long>): Int {
     return sampledVids.distinct().size
   }
+
+  /** Computes impression using the "deterministic count" methodology. */
+  fun computeImpression(sampledVids: Iterable<Long>, maxFrequency: Int): Long {
+    val eventsPerVid: Map<Long, Int> = sampledVids.groupingBy { it }.eachCount()
+    // Cap each count at `maxFrequency`.
+    return eventsPerVid.values.sumOf { count -> count.coerceAtMost(maxFrequency).toLong() }
+  }
 }

--- a/src/main/kotlin/org/wfanet/measurement/loadtest/measurementconsumer/MeasurementConsumerSimulator.kt
+++ b/src/main/kotlin/org/wfanet/measurement/loadtest/measurementconsumer/MeasurementConsumerSimulator.kt
@@ -105,6 +105,8 @@ import org.wfanet.measurement.loadtest.dataprovider.MeasurementResults
 import org.wfanet.measurement.measurementconsumer.stats.DeterministicMethodology
 import org.wfanet.measurement.measurementconsumer.stats.FrequencyMeasurementParams
 import org.wfanet.measurement.measurementconsumer.stats.FrequencyMeasurementVarianceParams
+import org.wfanet.measurement.measurementconsumer.stats.ImpressionMeasurementParams
+import org.wfanet.measurement.measurementconsumer.stats.ImpressionMeasurementVarianceParams
 import org.wfanet.measurement.measurementconsumer.stats.LiquidLegionsV2Methodology
 import org.wfanet.measurement.measurementconsumer.stats.Methodology
 import org.wfanet.measurement.measurementconsumer.stats.NoiseMechanism as StatsNoiseMechanism
@@ -162,26 +164,51 @@ class MeasurementConsumerSimulator(
 
   private val MeasurementInfo.sampledVids: Sequence<Long>
     get() {
-      val vidSamplingInterval = measurementSpec.vidSamplingInterval
-
       return requisitions.asSequence().flatMap {
         val eventGroupsMap: Map<String, RequisitionSpec.EventGroupEntry.Value> =
           it.requisitionSpec.eventGroupsMap
         it.eventGroups.flatMap { eventGroup ->
-          eventQuery
-            .getUserVirtualIds(
-              EventQuery.EventGroupSpec(eventGroup, eventGroupsMap.getValue(eventGroup.name))
-            )
-            .filter { vid ->
-              VidSampling.sampler.vidIsInSamplingBucket(
-                vid,
-                vidSamplingInterval.start,
-                vidSamplingInterval.width,
-              )
-            }
+          sampleVids(
+            EventQuery.EventGroupSpec(eventGroup, eventGroupsMap.getValue(eventGroup.name)),
+            measurementSpec.vidSamplingInterval,
+          )
         }
       }
     }
+
+  private fun MeasurementInfo.sampleVidsByDataProvider(
+    targetDataProviderId: String
+  ): Sequence<Long> {
+    return requisitions.asSequence().flatMap { requisitionInfo ->
+      val eventGroupsMap: Map<String, RequisitionSpec.EventGroupEntry.Value> =
+        requisitionInfo.requisitionSpec.eventGroupsMap
+
+      requisitionInfo.eventGroups
+        .filter { eventGroup ->
+          targetDataProviderId ==
+            requireNotNull(EventGroupKey.fromName(eventGroup.name)).dataProviderId
+        }
+        .flatMap { eventGroup ->
+          sampleVids(
+            EventQuery.EventGroupSpec(eventGroup, eventGroupsMap.getValue(eventGroup.name)),
+            measurementSpec.vidSamplingInterval,
+          )
+        }
+    }
+  }
+
+  private fun sampleVids(
+    eventGroupSpec: EventQuery.EventGroupSpec,
+    vidSamplingInterval: VidSamplingInterval,
+  ): Sequence<Long> {
+    return eventQuery.getUserVirtualIds(eventGroupSpec).filter { vid ->
+      VidSampling.sampler.vidIsInSamplingBucket(
+        vid,
+        vidSamplingInterval.start,
+        vidSamplingInterval.width,
+      )
+    }
+  }
 
   data class ExecutionResult(
     val actualResult: Result,
@@ -420,20 +447,25 @@ class MeasurementConsumerSimulator(
     val measurementName = measurementInfo.measurement.name
     logger.info("Created impression Measurement $measurementName.")
 
-    val impressionResults = pollForResults { getImpressionResults(measurementName) }
+    val impressionResults: List<Measurement.ResultOutput> = pollForResults {
+      getImpressionResults(measurementName)
+    }
+    logger.info("Got impression result from Kingdom: $impressionResults")
+
+    val protocol = measurementInfo.measurement.protocolConfig.protocolsList.first()
 
     impressionResults.forEach {
       val result = parseAndVerifyResult(it)
-      assertThat(result.impression.value)
-        .isEqualTo(
-          // EdpSimulator sets it to this value.
-          apiIdToExternalId(DataProviderCertificateKey.fromName(it.certificate)!!.dataProviderId)
-        )
-      assertThat(result.impression.customDirectMethodology)
-        .isEqualTo(
-          customDirectMethodology { variance = CustomDirectMethodologyKt.variance { scalar = 0.0 } }
-        )
+      val dataProviderId = DataProviderCertificateKey.fromName(it.certificate)!!.dataProviderId
+
+      val expectedResult =
+        getExpectedImpressionResultByDataProvider(measurementInfo, dataProviderId)
+
+      val variance = computeImpressionVariance(result, measurementInfo.measurementSpec, protocol)
+      val tolerance = computeErrorMargin(variance)
+      assertThat(result.impression.hasDeterministicCount()).isTrue()
       assertThat(result.impression.noiseMechanism).isEqualTo(expectedDirectNoiseMechanism)
+      assertThat(result).impressionValue().isWithin(tolerance).of(expectedResult.impression.value)
     }
     logger.info("Impression result is equal to the expected result")
   }
@@ -467,6 +499,30 @@ class MeasurementConsumerSimulator(
       assertThat(result.watchDuration.noiseMechanism).isEqualTo(expectedDirectNoiseMechanism)
     }
     logger.info("Duration result is equal to the expected result")
+  }
+
+  /** Computes the tolerance values of an impression [Result] for testing. */
+  private fun computeImpressionVariance(
+    result: Result,
+    measurementSpec: MeasurementSpec,
+    protocol: ProtocolConfig.Protocol,
+  ): Double {
+    val measurementComputationInfo: MeasurementComputationInfo =
+      buildMeasurementComputationInfo(protocol, result.impression.noiseMechanism)
+
+    return VariancesImpl.computeMeasurementVariance(
+      measurementComputationInfo.methodology,
+      ImpressionMeasurementVarianceParams(
+        impression = max(0L, result.impression.value),
+        measurementParams =
+          ImpressionMeasurementParams(
+            vidSamplingInterval = measurementSpec.vidSamplingInterval.toStatsVidSamplingInterval(),
+            dpParams = measurementSpec.impression.privacyParams.toNoiserDpParams(),
+            maximumFrequencyPerUser = measurementSpec.impression.maximumFrequencyPerUser,
+            noiseMechanism = measurementComputationInfo.noiseMechanism.toStatsNoiseMechanism(),
+          ),
+      ),
+    )
   }
 
   /** Computes the tolerance values of a relative frequency distribution [Result] for testing. */
@@ -733,7 +789,7 @@ class MeasurementConsumerSimulator(
       MeasurementSpec.MeasurementTypeCase.REACH -> getExpectedReachResult(measurementInfo)
       MeasurementSpec.MeasurementTypeCase.REACH_AND_FREQUENCY ->
         getExpectedReachAndFrequencyResult(measurementInfo)
-      MeasurementSpec.MeasurementTypeCase.IMPRESSION -> getExpectedImpressionResult()
+      MeasurementSpec.MeasurementTypeCase.IMPRESSION -> error("Should not be reached.")
       MeasurementSpec.MeasurementTypeCase.DURATION -> getExpectedDurationResult()
       MeasurementSpec.MeasurementTypeCase.POPULATION -> getExpectedPopulationResult()
       MeasurementSpec.MeasurementTypeCase.MEASUREMENTTYPE_NOT_SET ->
@@ -745,8 +801,21 @@ class MeasurementConsumerSimulator(
     TODO("Not yet implemented")
   }
 
-  private fun getExpectedImpressionResult(): Result {
-    TODO("Not yet implemented")
+  /** Gets the expected result of impression from a specific data provider. */
+  private fun getExpectedImpressionResultByDataProvider(
+    measurementInfo: MeasurementInfo,
+    targetDataProviderId: String,
+  ): Result {
+    return result {
+      impression =
+        MeasurementKt.ResultKt.impression {
+          value =
+            MeasurementResults.computeImpression(
+              measurementInfo.sampleVidsByDataProvider(targetDataProviderId).asIterable(),
+              measurementInfo.measurementSpec.impression.maximumFrequencyPerUser,
+            )
+        }
+    }
   }
 
   private fun getExpectedPopulationResult(): Result {
@@ -859,7 +928,11 @@ class MeasurementConsumerSimulator(
       measurementPublicKey = packedMeasurementPublicKey
       impression = impression {
         privacyParams = outputDpParams
-        maximumFrequencyPerUser = 1
+        maximumFrequencyPerUser = 10
+      }
+      vidSamplingInterval = vidSamplingInterval {
+        start = 0.0f
+        width = 1.0f
       }
       this.nonceHashes += nonceHashes
     }

--- a/src/test/kotlin/org/wfanet/measurement/loadtest/dataprovider/EdpSimulatorTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/loadtest/dataprovider/EdpSimulatorTest.kt
@@ -69,6 +69,7 @@ import org.wfanet.measurement.api.v2alpha.GetEventGroupRequest
 import org.wfanet.measurement.api.v2alpha.Measurement
 import org.wfanet.measurement.api.v2alpha.MeasurementConsumersGrpcKt
 import org.wfanet.measurement.api.v2alpha.MeasurementConsumersGrpcKt.MeasurementConsumersCoroutineStub
+import org.wfanet.measurement.api.v2alpha.MeasurementSpecKt.impression
 import org.wfanet.measurement.api.v2alpha.MeasurementSpecKt.reach
 import org.wfanet.measurement.api.v2alpha.MeasurementSpecKt.reachAndFrequency
 import org.wfanet.measurement.api.v2alpha.MeasurementSpecKt.vidSamplingInterval
@@ -2339,6 +2340,247 @@ class EdpSimulatorTest {
     verifyBlocking(requisitionsServiceMock, never()) { fulfillDirectRequisition(any()) }
   }
 
+  @Test
+  fun `fulfills impression Requisition`() {
+    val noiseMechanismOption = ProtocolConfig.NoiseMechanism.CONTINUOUS_GAUSSIAN
+    val requisition =
+      REQUISITION.copy {
+        measurementSpec = signMeasurementSpec(IMPRESSION_MEASUREMENT_SPEC, MC_SIGNING_KEY)
+        protocolConfig =
+          protocolConfig.copy {
+            protocols.clear()
+            protocols +=
+              ProtocolConfigKt.protocol {
+                direct =
+                  ProtocolConfigKt.direct {
+                    noiseMechanisms += noiseMechanismOption
+                    deterministicCount =
+                      ProtocolConfig.Direct.DeterministicCount.getDefaultInstance()
+                  }
+              }
+          }
+      }
+    requisitionsServiceMock.stub {
+      onBlocking { listRequisitions(any()) }
+        .thenReturn(listRequisitionsResponse { requisitions += requisition })
+    }
+    val simulator =
+      EdpSimulator(
+        EDP_DATA,
+        MC_NAME,
+        measurementConsumersStub,
+        certificatesStub,
+        eventGroupsStub,
+        eventGroupMetadataDescriptorsStub,
+        requisitionsStub,
+        requisitionFulfillmentStub,
+        syntheticGeneratorEventQuery,
+        dummyThrottler,
+        privacyBudgetManager,
+        TRUSTED_CERTIFICATES,
+        random = Random(RANDOM_SEED),
+        compositionMechanism = COMPOSITION_MECHANISM,
+      )
+
+    runBlocking { simulator.executeRequisitionFulfillingWorkflow() }
+
+    val request: FulfillDirectRequisitionRequest =
+      verifyAndCapture(
+        requisitionsServiceMock,
+        RequisitionsCoroutineImplBase::fulfillDirectRequisition,
+      )
+    val result: Measurement.Result = decryptResult(request.encryptedResult, MC_PRIVATE_KEY).unpack()
+    assertThat(result.impression.noiseMechanism == noiseMechanismOption)
+    assertThat(result.impression.hasDeterministicCount())
+    // Reach VIDs [18000001, 18001000] once and VIDs [18001001, 18002000] twice for one day. The
+    // event lasts for two days. 2 * (1000 + 1000 * 2) = 6000.
+    assertThat(result).impressionValue().isWithin(1.0).of(6000L)
+  }
+
+  @Test
+  fun `fulfills impression requisition with sampling rate less than 1`() {
+    val noiseMechanismOption = ProtocolConfig.NoiseMechanism.CONTINUOUS_GAUSSIAN
+    val vidSamplingWidth = 0.1
+    val measurementSpec =
+      IMPRESSION_MEASUREMENT_SPEC.copy {
+        vidSamplingInterval = vidSamplingInterval.copy { width = vidSamplingWidth.toFloat() }
+      }
+    val requisition =
+      REQUISITION.copy {
+        this.measurementSpec = signMeasurementSpec(measurementSpec, MC_SIGNING_KEY)
+        protocolConfig =
+          protocolConfig.copy {
+            protocols.clear()
+            protocols +=
+              ProtocolConfigKt.protocol {
+                direct =
+                  ProtocolConfigKt.direct {
+                    noiseMechanisms += noiseMechanismOption
+                    deterministicCount =
+                      ProtocolConfig.Direct.DeterministicCount.getDefaultInstance()
+                  }
+              }
+          }
+      }
+    requisitionsServiceMock.stub {
+      onBlocking { listRequisitions(any()) }
+        .thenReturn(listRequisitionsResponse { requisitions += requisition })
+    }
+    val simulator =
+      EdpSimulator(
+        EDP_DATA,
+        MC_NAME,
+        measurementConsumersStub,
+        certificatesStub,
+        eventGroupsStub,
+        eventGroupMetadataDescriptorsStub,
+        requisitionsStub,
+        requisitionFulfillmentStub,
+        syntheticGeneratorEventQuery,
+        dummyThrottler,
+        privacyBudgetManager,
+        TRUSTED_CERTIFICATES,
+        random = Random(RANDOM_SEED),
+        compositionMechanism = COMPOSITION_MECHANISM,
+      )
+
+    runBlocking { simulator.executeRequisitionFulfillingWorkflow() }
+
+    val request: FulfillDirectRequisitionRequest =
+      verifyAndCapture(
+        requisitionsServiceMock,
+        RequisitionsCoroutineImplBase::fulfillDirectRequisition,
+      )
+    val result: Measurement.Result = decryptResult(request.encryptedResult, MC_PRIVATE_KEY).unpack()
+    assertThat(result.impression.noiseMechanism == noiseMechanismOption)
+    assertThat(result.impression.hasDeterministicCount())
+    // Reach VIDs [18000001, 18001000] once and VIDs [18001001, 18002000] twice for one day. The
+    // sampled impression for one day is 289. After scaling back, it's 289 / 0.1 = 2890. The
+    // event lasts for two days. 2 * 2890 = 5780.
+    assertThat(result).impressionValue().isWithin(1.0 / vidSamplingWidth).of(5780L)
+  }
+
+  @Test
+  fun `fails to fulfill impression Requisition when no direct noise mechanism is picked by EDP`() {
+    val noiseMechanismOption = ProtocolConfig.NoiseMechanism.NONE
+    val requisition =
+      REQUISITION.copy {
+        measurementSpec = signMeasurementSpec(IMPRESSION_MEASUREMENT_SPEC, MC_SIGNING_KEY)
+        protocolConfig =
+          protocolConfig.copy {
+            protocols.clear()
+            protocols +=
+              ProtocolConfigKt.protocol {
+                direct =
+                  ProtocolConfigKt.direct {
+                    noiseMechanisms += noiseMechanismOption
+                    deterministicCount =
+                      ProtocolConfig.Direct.DeterministicCount.getDefaultInstance()
+                  }
+              }
+          }
+      }
+    requisitionsServiceMock.stub {
+      onBlocking { listRequisitions(any()) }
+        .thenReturn(listRequisitionsResponse { requisitions += requisition })
+    }
+    val simulator =
+      EdpSimulator(
+        EDP_DATA,
+        MC_NAME,
+        measurementConsumersStub,
+        certificatesStub,
+        eventGroupsStub,
+        eventGroupMetadataDescriptorsStub,
+        requisitionsStub,
+        requisitionFulfillmentStub,
+        syntheticGeneratorEventQuery,
+        dummyThrottler,
+        privacyBudgetManager,
+        TRUSTED_CERTIFICATES,
+        random = Random(RANDOM_SEED),
+        compositionMechanism = COMPOSITION_MECHANISM,
+      )
+
+    runBlocking { simulator.executeRequisitionFulfillingWorkflow() }
+
+    val refuseRequest: RefuseRequisitionRequest =
+      verifyAndCapture(requisitionsServiceMock, RequisitionsCoroutineImplBase::refuseRequisition)
+    assertThat(refuseRequest)
+      .ignoringFieldScope(
+        FieldScopes.allowingFieldDescriptors(
+          Refusal.getDescriptor().findFieldByNumber(Refusal.MESSAGE_FIELD_NUMBER)
+        )
+      )
+      .isEqualTo(
+        refuseRequisitionRequest {
+          name = REQUISITION.name
+          refusal = refusal { justification = Refusal.Justification.SPEC_INVALID }
+        }
+      )
+    assertThat(refuseRequest.refusal.message).contains("No valid noise mechanism option")
+    assertThat(fakeRequisitionFulfillmentService.fullfillRequisitionInvocations).isEmpty()
+    verifyBlocking(requisitionsServiceMock, never()) { fulfillDirectRequisition(any()) }
+  }
+
+  @Test
+  fun `fails to fulfill impression Requisition when no direct methodology is picked by EDP`() {
+    val noiseMechanismOption = ProtocolConfig.NoiseMechanism.CONTINUOUS_GAUSSIAN
+    val requisition =
+      REQUISITION.copy {
+        measurementSpec = signMeasurementSpec(IMPRESSION_MEASUREMENT_SPEC, MC_SIGNING_KEY)
+        protocolConfig =
+          protocolConfig.copy {
+            protocols.clear()
+            protocols +=
+              ProtocolConfigKt.protocol {
+                direct = ProtocolConfigKt.direct { noiseMechanisms += noiseMechanismOption }
+              }
+          }
+      }
+    requisitionsServiceMock.stub {
+      onBlocking { listRequisitions(any()) }
+        .thenReturn(listRequisitionsResponse { requisitions += requisition })
+    }
+    val simulator =
+      EdpSimulator(
+        EDP_DATA,
+        MC_NAME,
+        measurementConsumersStub,
+        certificatesStub,
+        eventGroupsStub,
+        eventGroupMetadataDescriptorsStub,
+        requisitionsStub,
+        requisitionFulfillmentStub,
+        syntheticGeneratorEventQuery,
+        dummyThrottler,
+        privacyBudgetManager,
+        TRUSTED_CERTIFICATES,
+        random = Random(RANDOM_SEED),
+        compositionMechanism = COMPOSITION_MECHANISM,
+      )
+
+    runBlocking { simulator.executeRequisitionFulfillingWorkflow() }
+
+    val refuseRequest: RefuseRequisitionRequest =
+      verifyAndCapture(requisitionsServiceMock, RequisitionsCoroutineImplBase::refuseRequisition)
+    assertThat(refuseRequest)
+      .ignoringFieldScope(
+        FieldScopes.allowingFieldDescriptors(
+          Refusal.getDescriptor().findFieldByNumber(Refusal.MESSAGE_FIELD_NUMBER)
+        )
+      )
+      .isEqualTo(
+        refuseRequisitionRequest {
+          name = REQUISITION.name
+          refusal = refusal { justification = Refusal.Justification.DECLINED }
+        }
+      )
+    assertThat(refuseRequest.refusal.message).contains("No valid methodologies")
+    assertThat(fakeRequisitionFulfillmentService.fullfillRequisitionInvocations).isEmpty()
+    verifyBlocking(requisitionsServiceMock, never()) { fulfillDirectRequisition(any()) }
+  }
+
   private class FakeRequisitionFulfillmentService : RequisitionFulfillmentCoroutineImplBase() {
     data class FulfillRequisitionInvocation(val requests: List<FulfillRequisitionRequest>)
 
@@ -2459,6 +2701,21 @@ class EdpSimulatorTest {
         clearReachAndFrequency()
         reach = reach { privacyParams = OUTPUT_DP_PARAMS }
       }
+    private val IMPRESSION_MEASUREMENT_SPEC = measurementSpec {
+      measurementPublicKey = MC_PUBLIC_KEY.pack()
+      impression = impression {
+        privacyParams = differentialPrivacyParams {
+          epsilon = 10.0
+          delta = 1E-12
+        }
+        maximumFrequencyPerUser = 10
+      }
+      vidSamplingInterval = vidSamplingInterval {
+        start = 0.0f
+        width = 1.0f
+      }
+      nonceHashes += Hashing.hashSha256(REQUISITION_SPEC.nonce)
+    }
 
     private val LIQUID_LEGIONS_SKETCH_PARAMS = liquidLegionsSketchParams {
       decayRate = LLV2_DECAY_RATE


### PR DESCRIPTION
In this PR we added the implementation of the `DeterministicCount` impression to the EDP simulator and a method to compute an expected impression based on reached VIDs and maximum frequency.

For testing, the unit tests in `EdpSimulatorTest` use a known tolerance based on the designed parameters for checking impression results, whereas the integration test in `MeasurementConsumerSimulator` is using scaled standard deviation calculated by the measurement variance library as the tolerance.