### PR TITLE
Support creation of multiple synthetic generation EventGroups in EDP simulator

### DIFF
--- a/src/main/k8s/dev/synthetic_generator_edp_simulator_gke.cue
+++ b/src/main/k8s/dev/synthetic_generator_edp_simulator_gke.cue
@@ -40,7 +40,7 @@ edp_simulators: {
 			_imageConfig: repoSuffix: "simulator/synthetic-generator-edp"
 			_additional_args: [
 				"--population-spec=\(_populationSpec)",
-				"--event-group-spec=\(EventGroupSpec)",
+				"--event-group-spec==\(EventGroupSpec)",
 			]
 			deployment: {
 				_container: {

--- a/src/main/k8s/local/edp_simulators.cue
+++ b/src/main/k8s/local/edp_simulators.cue
@@ -71,7 +71,7 @@ edpSimulators: {
 			_kingdom_public_api_target: #KingdomPublicApiTarget
 			_additional_args: [
 				"--population-spec=\(_populationSpec)",
-				"--event-group-spec=\(edpConfig.eventGroupSpec)",
+				"--event-group-spec==\(edpConfig.eventGroupSpec)",
 			]
 
 			deployment: spec: template: spec: {

--- a/src/main/kotlin/org/wfanet/measurement/loadtest/dataprovider/BigQueryEdpSimulatorRunner.kt
+++ b/src/main/kotlin/org/wfanet/measurement/loadtest/dataprovider/BigQueryEdpSimulatorRunner.kt
@@ -71,7 +71,7 @@ class BigQueryEdpSimulatorRunner : EdpSimulatorRunner() {
         publisherId
       )
 
-    run(eventQuery, EventGroupMetadata.testMetadata(publisherId))
+    run(eventQuery, mapOf("" to EventGroupMetadata.testMetadata(publisherId)))
   }
 }
 

--- a/src/main/kotlin/org/wfanet/measurement/loadtest/dataprovider/CsvEdpSimulatorRunner.kt
+++ b/src/main/kotlin/org/wfanet/measurement/loadtest/dataprovider/CsvEdpSimulatorRunner.kt
@@ -47,7 +47,7 @@ class CsvEdpSimulatorRunner : EdpSimulatorRunner() {
 
   override fun run() {
     val eventQuery = CsvEventQuery(publisherId, eventsCsv)
-    run(eventQuery, EventGroupMetadata.testMetadata(publisherId))
+    run(eventQuery, mapOf("" to EventGroupMetadata.testMetadata(publisherId)))
   }
 }
 

--- a/src/main/kotlin/org/wfanet/measurement/loadtest/dataprovider/EdpSimulatorRunner.kt
+++ b/src/main/kotlin/org/wfanet/measurement/loadtest/dataprovider/EdpSimulatorRunner.kt
@@ -40,7 +40,10 @@ abstract class EdpSimulatorRunner : Runnable {
   protected lateinit var flags: EdpSimulatorFlags
     private set
 
-  protected fun run(eventQuery: EventQuery<Message>, eventGroupMetadata: Message) {
+  protected fun run(
+    eventQuery: EventQuery<Message>,
+    metadataByReferenceIdSuffix: Map<String, Message>
+  ) {
     val clientCerts =
       SigningCerts.fromPemFiles(
         certificateFile = flags.tlsFlags.certFile,
@@ -108,7 +111,7 @@ abstract class EdpSimulatorRunner : Runnable {
         compositionMechanism = flags.compositionMechanism,
       )
     runBlocking {
-      edpSimulator.ensureEventGroup(eventGroupMetadata)
+      edpSimulator.ensureEventGroups(metadataByReferenceIdSuffix)
       edpSimulator.run()
     }
   }

--- a/src/main/kotlin/org/wfanet/measurement/loadtest/dataprovider/SyntheticGeneratorEdpSimulatorRunner.kt
+++ b/src/main/kotlin/org/wfanet/measurement/loadtest/dataprovider/SyntheticGeneratorEdpSimulatorRunner.kt
@@ -55,26 +55,34 @@ class SyntheticGeneratorEdpSimulatorRunner : EdpSimulatorRunner() {
 
   @CommandLine.Option(
     names = ["--event-group-spec"],
-    description = ["Path to SyntheticEventGroupSpec message in text format."],
+    description =
+      [
+        "Key-value pair of EventGroup reference ID suffix and file path of " +
+          "SyntheticEventGroupSpec message in text format. This can be specified multiple times."
+      ],
     required = true,
   )
-  private lateinit var eventGroupSpecFile: File
+  private lateinit var eventGroupSpecFileByReferenceIdSuffix: Map<String, File>
 
   override fun run() {
     val populationSpec =
       parseTextProto(populationSpecFile, SyntheticPopulationSpec.getDefaultInstance())
-    val eventGroupSpec =
-      parseTextProto(eventGroupSpecFile, SyntheticEventGroupSpec.getDefaultInstance())
+    val eventGroupSpecByReferenceIdSuffix =
+      eventGroupSpecFileByReferenceIdSuffix.mapValues {
+        parseTextProto(it.value, SyntheticEventGroupSpec.getDefaultInstance())
+      }
     val eventMessageRegistry: TypeRegistry = buildEventMessageRegistry()
 
     val eventQuery =
       object : SyntheticGeneratorEventQuery(populationSpec, eventMessageRegistry) {
         override fun getSyntheticDataSpec(eventGroup: EventGroup): SyntheticEventGroupSpec {
-          return eventGroupSpec
+          val suffix =
+            EdpSimulator.getEventGroupReferenceIdSuffix(eventGroup, flags.dataProviderDisplayName)
+          return eventGroupSpecByReferenceIdSuffix.getValue(suffix)
         }
       }
 
-    run(eventQuery, eventGroupSpec)
+    run(eventQuery, eventGroupSpecByReferenceIdSuffix)
   }
 
   private fun buildEventMessageRegistry(): TypeRegistry {


### PR DESCRIPTION
The `--event-group-spec` option of `SyntheticGeneratorEdpSimulatorRunner` can now be specified multiple times, taking a key-value pair of `EventGroup` reference ID suffix to `SyntheticEventGroupSpec` file path.