### PR TITLE
Shutdown threads properly so Report Scheduling Process can complete

### DIFF
--- a/src/main/kotlin/org/wfanet/measurement/reporting/deploy/v2/common/InProcessServersMethods.kt
+++ b/src/main/kotlin/org/wfanet/measurement/reporting/deploy/v2/common/InProcessServersMethods.kt
@@ -27,10 +27,10 @@ import org.wfanet.measurement.common.grpc.LoggingServerInterceptor
 object InProcessServersMethods {
   fun startInProcessServerWithService(
     serverName: String,
-    executorService: ExecutorService?,
     commonServerFlags: CommonServer.Flags,
-    service: ServerServiceDefinition
-  ): Server {
+    service: ServerServiceDefinition,
+    executorService: ExecutorService? = null
+    ): Server {
     return InProcessServerBuilder.forName(serverName)
       .apply {
         if (executorService != null) {

--- a/src/main/kotlin/org/wfanet/measurement/reporting/deploy/v2/common/InProcessServersMethods.kt
+++ b/src/main/kotlin/org/wfanet/measurement/reporting/deploy/v2/common/InProcessServersMethods.kt
@@ -20,9 +20,6 @@ import io.grpc.Server
 import io.grpc.ServerServiceDefinition
 import io.grpc.inprocess.InProcessServerBuilder
 import java.util.concurrent.ExecutorService
-import java.util.concurrent.LinkedBlockingQueue
-import java.util.concurrent.ThreadPoolExecutor
-import java.util.concurrent.TimeUnit
 import org.wfanet.measurement.common.grpc.CommonServer
 import org.wfanet.measurement.common.grpc.ErrorLoggingServerInterceptor
 import org.wfanet.measurement.common.grpc.LoggingServerInterceptor
@@ -30,21 +27,15 @@ import org.wfanet.measurement.common.grpc.LoggingServerInterceptor
 object InProcessServersMethods {
   fun startInProcessServerWithService(
     serverName: String,
+    executorService: ExecutorService?,
     commonServerFlags: CommonServer.Flags,
     service: ServerServiceDefinition
   ): Server {
-    val executor: ExecutorService =
-      ThreadPoolExecutor(
-        1,
-        commonServerFlags.threadPoolSize,
-        60L,
-        TimeUnit.SECONDS,
-        LinkedBlockingQueue()
-      )
-
     return InProcessServerBuilder.forName(serverName)
       .apply {
-        executor(executor)
+        if (executorService != null) {
+          executor(executorService)
+        }
         addService(service)
         if (commonServerFlags.debugVerboseGrpcLogging) {
           intercept(LoggingServerInterceptor)

--- a/src/main/kotlin/org/wfanet/measurement/reporting/deploy/v2/common/InProcessServersMethods.kt
+++ b/src/main/kotlin/org/wfanet/measurement/reporting/deploy/v2/common/InProcessServersMethods.kt
@@ -35,6 +35,8 @@ object InProcessServersMethods {
       .apply {
         if (executorService != null) {
           executor(executorService)
+        } else {
+          directExecutor()
         }
         addService(service)
         if (commonServerFlags.debugVerboseGrpcLogging) {

--- a/src/main/kotlin/org/wfanet/measurement/reporting/deploy/v2/common/InProcessServersMethods.kt
+++ b/src/main/kotlin/org/wfanet/measurement/reporting/deploy/v2/common/InProcessServersMethods.kt
@@ -30,7 +30,7 @@ object InProcessServersMethods {
     commonServerFlags: CommonServer.Flags,
     service: ServerServiceDefinition,
     executorService: ExecutorService? = null
-    ): Server {
+  ): Server {
     return InProcessServerBuilder.forName(serverName)
       .apply {
         if (executorService != null) {

--- a/src/main/kotlin/org/wfanet/measurement/reporting/deploy/v2/common/InProcessServersMethods.kt
+++ b/src/main/kotlin/org/wfanet/measurement/reporting/deploy/v2/common/InProcessServersMethods.kt
@@ -16,9 +16,8 @@
 
 package org.wfanet.measurement.reporting.deploy.v2.common
 
-import io.grpc.Channel
+import io.grpc.Server
 import io.grpc.ServerServiceDefinition
-import io.grpc.inprocess.InProcessChannelBuilder
 import io.grpc.inprocess.InProcessServerBuilder
 import java.util.concurrent.ExecutorService
 import java.util.concurrent.LinkedBlockingQueue
@@ -30,11 +29,10 @@ import org.wfanet.measurement.common.grpc.LoggingServerInterceptor
 
 object InProcessServersMethods {
   fun startInProcessServerWithService(
+    serverName: String,
     commonServerFlags: CommonServer.Flags,
     service: ServerServiceDefinition
-  ): Channel {
-    val inProcessServerName = InProcessServerBuilder.generateName()
-
+  ): Server {
     val executor: ExecutorService =
       ThreadPoolExecutor(
         1,
@@ -44,7 +42,7 @@ object InProcessServersMethods {
         LinkedBlockingQueue()
       )
 
-    InProcessServerBuilder.forName(inProcessServerName)
+    return InProcessServerBuilder.forName(serverName)
       .apply {
         executor(executor)
         addService(service)
@@ -56,7 +54,5 @@ object InProcessServersMethods {
       }
       .build()
       .start()
-
-    return InProcessChannelBuilder.forName(inProcessServerName).directExecutor().build()
   }
 }

--- a/src/main/kotlin/org/wfanet/measurement/reporting/deploy/v2/common/job/ReportSchedulingJobExecutor.kt
+++ b/src/main/kotlin/org/wfanet/measurement/reporting/deploy/v2/common/job/ReportSchedulingJobExecutor.kt
@@ -129,7 +129,6 @@ private fun run(
   val inProcessMetricsServer: Server =
     startInProcessServerWithService(
       inProcessMetricsServerName,
-      null,
       commonServerFlags,
       metricsService.withMetadataPrincipalIdentities(measurementConsumerConfigs)
     )
@@ -151,7 +150,6 @@ private fun run(
   val inProcessReportsServer: Server =
     startInProcessServerWithService(
       inProcessReportsServerName,
-      null,
       commonServerFlags,
       reportsService
         .withMetadataPrincipalIdentities(measurementConsumerConfigs)

--- a/src/main/kotlin/org/wfanet/measurement/reporting/deploy/v2/common/job/ReportSchedulingJobExecutor.kt
+++ b/src/main/kotlin/org/wfanet/measurement/reporting/deploy/v2/common/job/ReportSchedulingJobExecutor.kt
@@ -21,6 +21,7 @@ import io.grpc.Server
 import io.grpc.inprocess.InProcessChannelBuilder
 import io.grpc.inprocess.InProcessServerBuilder
 import java.security.SecureRandom
+import java.time.Duration
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.runBlocking
 import org.wfanet.measurement.api.v2alpha.CertificatesGrpcKt.CertificatesCoroutineStub as KingdomCertificatesCoroutineStub
@@ -32,6 +33,7 @@ import org.wfanet.measurement.common.commandLineMain
 import org.wfanet.measurement.common.crypto.SigningCerts
 import org.wfanet.measurement.common.grpc.CommonServer
 import org.wfanet.measurement.common.grpc.buildMutualTlsChannel
+import org.wfanet.measurement.common.grpc.withShutdownTimeout
 import org.wfanet.measurement.common.grpc.withVerboseLogging
 import org.wfanet.measurement.common.parseTextProto
 import org.wfanet.measurement.config.reporting.MeasurementConsumerConfigs
@@ -43,8 +45,6 @@ import org.wfanet.measurement.internal.reporting.v2.ReportScheduleIterationsGrpc
 import org.wfanet.measurement.internal.reporting.v2.ReportSchedulesGrpcKt.ReportSchedulesCoroutineStub as InternalReportSchedulesCoroutineStub
 import org.wfanet.measurement.internal.reporting.v2.ReportingSetsGrpcKt.ReportingSetsCoroutineStub as InternalReportingSetsCoroutineStub
 import org.wfanet.measurement.internal.reporting.v2.ReportsGrpcKt.ReportsCoroutineStub as InternalReportsCoroutineStub
-import java.time.Duration
-import org.wfanet.measurement.common.grpc.withShutdownTimeout
 import org.wfanet.measurement.measurementconsumer.stats.VariancesImpl
 import org.wfanet.measurement.reporting.deploy.v2.common.EncryptionKeyPairMap
 import org.wfanet.measurement.reporting.deploy.v2.common.InProcessServersMethods.startInProcessServerWithService
@@ -134,7 +134,10 @@ private fun run(
       metricsService.withMetadataPrincipalIdentities(measurementConsumerConfigs)
     )
   val inProcessMetricsChannel =
-    InProcessChannelBuilder.forName(inProcessMetricsServerName).directExecutor().build().withShutdownTimeout(Duration.ofSeconds(5))
+    InProcessChannelBuilder.forName(inProcessMetricsServerName)
+      .directExecutor()
+      .build()
+      .withShutdownTimeout(Duration.ofSeconds(5))
 
   val reportsService =
     ReportsService(
@@ -155,8 +158,10 @@ private fun run(
         .withReportScheduleInfoInterceptor()
     )
   val inProcessReportsChannel =
-    InProcessChannelBuilder.forName(inProcessReportsServerName).directExecutor().build().withShutdownTimeout(
-      Duration.ofSeconds(5))
+    InProcessChannelBuilder.forName(inProcessReportsServerName)
+      .directExecutor()
+      .build()
+      .withShutdownTimeout(Duration.ofSeconds(5))
 
   val reportSchedulingJob =
     ReportSchedulingJob(

--- a/src/main/kotlin/org/wfanet/measurement/reporting/deploy/v2/common/job/ReportSchedulingJobExecutor.kt
+++ b/src/main/kotlin/org/wfanet/measurement/reporting/deploy/v2/common/job/ReportSchedulingJobExecutor.kt
@@ -40,6 +40,7 @@ import org.wfanet.measurement.internal.reporting.v2.ReportScheduleIterationsGrpc
 import org.wfanet.measurement.internal.reporting.v2.ReportSchedulesGrpcKt.ReportSchedulesCoroutineStub as InternalReportSchedulesCoroutineStub
 import org.wfanet.measurement.internal.reporting.v2.ReportingSetsGrpcKt.ReportingSetsCoroutineStub as InternalReportingSetsCoroutineStub
 import org.wfanet.measurement.internal.reporting.v2.ReportsGrpcKt.ReportsCoroutineStub as InternalReportsCoroutineStub
+import kotlin.system.exitProcess
 import org.wfanet.measurement.measurementconsumer.stats.VariancesImpl
 import org.wfanet.measurement.reporting.deploy.v2.common.EncryptionKeyPairMap
 import org.wfanet.measurement.reporting.deploy.v2.common.InProcessServersMethods.startInProcessServerWithService
@@ -152,6 +153,8 @@ private fun run(
     )
 
   runBlocking { reportSchedulingJob.execute() }
+  // Ensures process is completed so any container running this can mark it as completed.
+  exitProcess(0)
 }
 
 fun main(args: Array<String>) = commandLineMain(::run, args)

--- a/src/main/kotlin/org/wfanet/measurement/reporting/deploy/v2/common/job/ReportSchedulingJobExecutor.kt
+++ b/src/main/kotlin/org/wfanet/measurement/reporting/deploy/v2/common/job/ReportSchedulingJobExecutor.kt
@@ -18,6 +18,7 @@ package org.wfanet.measurement.reporting.deploy.v2.common.job
 
 import io.grpc.Channel
 import java.security.SecureRandom
+import kotlin.system.exitProcess
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.runBlocking
 import org.wfanet.measurement.api.v2alpha.CertificatesGrpcKt.CertificatesCoroutineStub as KingdomCertificatesCoroutineStub
@@ -40,7 +41,6 @@ import org.wfanet.measurement.internal.reporting.v2.ReportScheduleIterationsGrpc
 import org.wfanet.measurement.internal.reporting.v2.ReportSchedulesGrpcKt.ReportSchedulesCoroutineStub as InternalReportSchedulesCoroutineStub
 import org.wfanet.measurement.internal.reporting.v2.ReportingSetsGrpcKt.ReportingSetsCoroutineStub as InternalReportingSetsCoroutineStub
 import org.wfanet.measurement.internal.reporting.v2.ReportsGrpcKt.ReportsCoroutineStub as InternalReportsCoroutineStub
-import kotlin.system.exitProcess
 import org.wfanet.measurement.measurementconsumer.stats.VariancesImpl
 import org.wfanet.measurement.reporting.deploy.v2.common.EncryptionKeyPairMap
 import org.wfanet.measurement.reporting.deploy.v2.common.InProcessServersMethods.startInProcessServerWithService

--- a/src/main/kotlin/org/wfanet/measurement/reporting/deploy/v2/common/job/ReportSchedulingJobExecutor.kt
+++ b/src/main/kotlin/org/wfanet/measurement/reporting/deploy/v2/common/job/ReportSchedulingJobExecutor.kt
@@ -17,6 +17,9 @@
 package org.wfanet.measurement.reporting.deploy.v2.common.job
 
 import io.grpc.Channel
+import io.grpc.Server
+import io.grpc.inprocess.InProcessChannelBuilder
+import io.grpc.inprocess.InProcessServerBuilder
 import java.security.SecureRandom
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.runBlocking
@@ -40,9 +43,6 @@ import org.wfanet.measurement.internal.reporting.v2.ReportScheduleIterationsGrpc
 import org.wfanet.measurement.internal.reporting.v2.ReportSchedulesGrpcKt.ReportSchedulesCoroutineStub as InternalReportSchedulesCoroutineStub
 import org.wfanet.measurement.internal.reporting.v2.ReportingSetsGrpcKt.ReportingSetsCoroutineStub as InternalReportingSetsCoroutineStub
 import org.wfanet.measurement.internal.reporting.v2.ReportsGrpcKt.ReportsCoroutineStub as InternalReportsCoroutineStub
-import io.grpc.Server
-import io.grpc.inprocess.InProcessChannelBuilder
-import io.grpc.inprocess.InProcessServerBuilder
 import org.wfanet.measurement.measurementconsumer.stats.VariancesImpl
 import org.wfanet.measurement.reporting.deploy.v2.common.EncryptionKeyPairMap
 import org.wfanet.measurement.reporting.deploy.v2.common.InProcessServersMethods.startInProcessServerWithService
@@ -128,7 +128,8 @@ private fun run(
       commonServerFlags,
       metricsService.withMetadataPrincipalIdentities(measurementConsumerConfigs)
     )
-  val inProcessMetricsChannel = InProcessChannelBuilder.forName(inProcessMetricsServerName).directExecutor().build()
+  val inProcessMetricsChannel =
+    InProcessChannelBuilder.forName(inProcessMetricsServerName).directExecutor().build()
 
   val reportsService =
     ReportsService(
@@ -147,7 +148,8 @@ private fun run(
         .withMetadataPrincipalIdentities(measurementConsumerConfigs)
         .withReportScheduleInfoInterceptor()
     )
-  val inProcessReportsChannel = InProcessChannelBuilder.forName(inProcessReportsServerName).directExecutor().build()
+  val inProcessReportsChannel =
+    InProcessChannelBuilder.forName(inProcessReportsServerName).directExecutor().build()
 
   val reportSchedulingJob =
     ReportSchedulingJob(

--- a/src/main/kotlin/org/wfanet/measurement/reporting/deploy/v2/common/server/V2AlphaPublicApiServer.kt
+++ b/src/main/kotlin/org/wfanet/measurement/reporting/deploy/v2/common/server/V2AlphaPublicApiServer.kt
@@ -189,7 +189,7 @@ private fun run(
       Dispatchers.IO
     )
 
-  val executorService: ExecutorService =
+  val inProcessExecutorService: ExecutorService =
     ThreadPoolExecutor(
       1,
       commonServerFlags.threadPoolSize,
@@ -202,9 +202,9 @@ private fun run(
   val inProcessServer: Server =
     startInProcessServerWithService(
       inProcessServerName,
-      executorService,
       commonServerFlags,
-      metricsService.withMetadataPrincipalIdentities(measurementConsumerConfigs)
+      metricsService.withMetadataPrincipalIdentities(measurementConsumerConfigs),
+      inProcessExecutorService
     )
   val inProcessChannel =
     InProcessChannelBuilder.forName(inProcessServerName)
@@ -254,9 +254,9 @@ private fun run(
   CommonServer.fromFlags(commonServerFlags, SERVER_NAME, services).start().blockUntilShutdown()
   inProcessChannel.shutdown()
   inProcessServer.shutdown()
-  executorService.shutdown()
+  inProcessExecutorService.shutdown()
   inProcessServer.awaitTermination()
-  executorService.awaitTermination(30, TimeUnit.SECONDS)
+  inProcessExecutorService.awaitTermination(30, TimeUnit.SECONDS)
 }
 
 fun main(args: Array<String>) = commandLineMain(::run, args)

--- a/src/main/kotlin/org/wfanet/measurement/reporting/deploy/v2/common/server/V2AlphaPublicApiServer.kt
+++ b/src/main/kotlin/org/wfanet/measurement/reporting/deploy/v2/common/server/V2AlphaPublicApiServer.kt
@@ -18,9 +18,12 @@ package org.wfanet.measurement.reporting.deploy.v2.common.server
 
 import com.google.protobuf.ByteString
 import io.grpc.Channel
+import io.grpc.Server
 import io.grpc.ServerServiceDefinition
 import io.grpc.Status
 import io.grpc.StatusException
+import io.grpc.inprocess.InProcessChannelBuilder
+import io.grpc.inprocess.InProcessServerBuilder
 import java.io.File
 import java.security.SecureRandom
 import kotlinx.coroutines.Dispatchers
@@ -51,9 +54,6 @@ import org.wfanet.measurement.internal.reporting.v2.ReportScheduleIterationsGrpc
 import org.wfanet.measurement.internal.reporting.v2.ReportSchedulesGrpcKt.ReportSchedulesCoroutineStub as InternalReportSchedulesCoroutineStub
 import org.wfanet.measurement.internal.reporting.v2.ReportingSetsGrpcKt.ReportingSetsCoroutineStub as InternalReportingSetsCoroutineStub
 import org.wfanet.measurement.internal.reporting.v2.ReportsGrpcKt.ReportsCoroutineStub as InternalReportsCoroutineStub
-import io.grpc.Server
-import io.grpc.inprocess.InProcessChannelBuilder
-import io.grpc.inprocess.InProcessServerBuilder
 import org.wfanet.measurement.internal.reporting.v2.measurementConsumer
 import org.wfanet.measurement.measurementconsumer.stats.VariancesImpl
 import org.wfanet.measurement.reporting.deploy.v2.common.EncryptionKeyPairMap
@@ -190,7 +190,8 @@ private fun run(
       commonServerFlags,
       metricsService.withMetadataPrincipalIdentities(measurementConsumerConfigs)
     )
-  val inProcessChannel = InProcessChannelBuilder.forName(inProcessServerName).directExecutor().build()
+  val inProcessChannel =
+    InProcessChannelBuilder.forName(inProcessServerName).directExecutor().build()
 
   val services: List<ServerServiceDefinition> =
     listOf(


### PR DESCRIPTION
When running this in a Kubernetes Cron Job, the job isn't considered completed without this change.