### PR TITLE
Allow retry of Report creation when Metric creation fails and request id is not used

### DIFF
--- a/src/main/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/ReportsService.kt
+++ b/src/main/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/ReportsService.kt
@@ -318,83 +318,87 @@ class ReportsService(
         internalReportsStub.createReport(internalCreateReportRequest)
       } catch (e: StatusException) {
         when (e.status.code) {
-            Status.Code.DEADLINE_EXCEEDED ->
-              throw Status.DEADLINE_EXCEEDED.withDescription("Unable to create Report.")
-                .withCause(e)
-                .asRuntimeException()
-            Status.Code.CANCELLED ->
-              throw Status.CANCELLED.withDescription("Unable to create Report.")
-                .withCause(e)
-                .asRuntimeException()
-            Status.Code.FAILED_PRECONDITION ->
-              throw Status.FAILED_PRECONDITION.withDescription(
+          Status.Code.DEADLINE_EXCEEDED ->
+            throw Status.DEADLINE_EXCEEDED.withDescription("Unable to create Report.")
+              .withCause(e)
+              .asRuntimeException()
+          Status.Code.CANCELLED ->
+            throw Status.CANCELLED.withDescription("Unable to create Report.")
+              .withCause(e)
+              .asRuntimeException()
+          Status.Code.FAILED_PRECONDITION ->
+            throw Status.FAILED_PRECONDITION.withDescription(
                 "Unable to create Report. The measurement consumer not found."
               )
-                .withCause(e)
-                .asRuntimeException()
-            Status.Code.ALREADY_EXISTS -> {
-              var haveMetricsBeenCreated = true
-              val existingInternalReport =
-                try {
-                  internalReportsStub.getReport(
-                    internalGetReportRequest {
-                      cmmsMeasurementConsumerId = internalCreateReportRequest.report.cmmsMeasurementConsumerId
-                      externalReportId = internalCreateReportRequest.externalReportId
-                    }
-                  )
-                } catch (e: StatusException) {
-                  throw Status.UNKNOWN.withDescription("Unable to create Report.")
-                    .withCause(e)
-                    .asRuntimeException()
-                }
+              .withCause(e)
+              .asRuntimeException()
+          Status.Code.ALREADY_EXISTS -> {
+            var haveMetricsBeenCreated = true
+            val existingInternalReport =
+              try {
+                internalReportsStub.getReport(
+                  internalGetReportRequest {
+                    cmmsMeasurementConsumerId =
+                      internalCreateReportRequest.report.cmmsMeasurementConsumerId
+                    externalReportId = internalCreateReportRequest.externalReportId
+                  }
+                )
+              } catch (e: StatusException) {
+                throw Status.UNKNOWN.withDescription("Unable to create Report.")
+                  .withCause(e)
+                  .asRuntimeException()
+              }
 
-              // Check if any Metric for the Report has not been created yet.
-              outer@ for (reportingMetricCalculationSpec in existingInternalReport.reportingMetricEntriesMap.values) {
-                for (reportingMetricCalculationSpecMetrics in reportingMetricCalculationSpec.metricCalculationSpecReportingMetricsList) {
-                  for (reportingMetric in reportingMetricCalculationSpecMetrics.reportingMetricsList) {
-                    if (reportingMetric.externalMetricId.isEmpty()) {
-                      haveMetricsBeenCreated = false
-                      break@outer
-                    }
+            // Check if any Metric for the Report has not been created yet.
+            outer@ for (reportingMetricCalculationSpec in
+              existingInternalReport.reportingMetricEntriesMap.values) {
+              for (reportingMetricCalculationSpecMetrics in
+                reportingMetricCalculationSpec.metricCalculationSpecReportingMetricsList) {
+                for (reportingMetric in
+                  reportingMetricCalculationSpecMetrics.reportingMetricsList) {
+                  if (reportingMetric.externalMetricId.isEmpty()) {
+                    haveMetricsBeenCreated = false
+                    break@outer
                   }
                 }
               }
+            }
 
-              // If the Metric for the Report have already been created, then the error is valid.
-              // Otherwise, continue with the creation of the Metrics.
-              if (haveMetricsBeenCreated) {
-                throw Status.ALREADY_EXISTS.withDescription(
+            // If the Metric for the Report have already been created, then the error is valid.
+            // Otherwise, continue with the creation of the Metrics.
+            if (haveMetricsBeenCreated) {
+              throw Status.ALREADY_EXISTS.withDescription(
                   "Report with ID ${request.reportId} already exists under ${request.parent}"
                 )
-                  .withCause(e)
-                  .asRuntimeException()
-              } else {
-                existingInternalReport
-              }
-            }
-            Status.Code.NOT_FOUND ->
-              if (e.message!!.contains("external_report_schedule_id")) {
-                throw Status.NOT_FOUND.withDescription(
-                  "ReportSchedule associated with the Report not found."
-                )
-                  .withCause(e)
-                  .asRuntimeException()
-              } else if (e.message!!.contains("external_metric_calculation_spec_id")) {
-                throw Status.NOT_FOUND.withDescription(
-                  "MetricCalculationSpec used in the Report not found."
-                )
-                  .withCause(e)
-                  .asRuntimeException()
-              } else {
-                throw Status.NOT_FOUND.withDescription("ReportingSet used in the Report not found.")
-                  .withCause(e)
-                  .asRuntimeException()
-              }
-            else ->
-              throw Status.UNKNOWN.withDescription("Unable to create Report.")
                 .withCause(e)
                 .asRuntimeException()
+            } else {
+              existingInternalReport
+            }
           }
+          Status.Code.NOT_FOUND ->
+            if (e.message!!.contains("external_report_schedule_id")) {
+              throw Status.NOT_FOUND.withDescription(
+                  "ReportSchedule associated with the Report not found."
+                )
+                .withCause(e)
+                .asRuntimeException()
+            } else if (e.message!!.contains("external_metric_calculation_spec_id")) {
+              throw Status.NOT_FOUND.withDescription(
+                  "MetricCalculationSpec used in the Report not found."
+                )
+                .withCause(e)
+                .asRuntimeException()
+            } else {
+              throw Status.NOT_FOUND.withDescription("ReportingSet used in the Report not found.")
+                .withCause(e)
+                .asRuntimeException()
+            }
+          else ->
+            throw Status.UNKNOWN.withDescription("Unable to create Report.")
+              .withCause(e)
+              .asRuntimeException()
+        }
       }
 
     // Create metrics.

--- a/src/test/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/ReportsServiceTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/ReportsServiceTest.kt
@@ -593,39 +593,42 @@ class ReportsServiceTest {
         )
 
       whenever(
-        internalReportsMock.createReport(
-          eq(
-            internalCreateReportRequest {
-              report = internalRequestingReport
-              externalReportId = "report-id"
-            }
+          internalReportsMock.createReport(
+            eq(
+              internalCreateReportRequest {
+                report = internalRequestingReport
+                externalReportId = "report-id"
+              }
+            )
           )
         )
-      )
         .thenThrow(Status.ALREADY_EXISTS.asRuntimeException())
 
       whenever(
-        internalReportsMock.getReport(
-          eq(
-            internalGetReportRequest {
-              cmmsMeasurementConsumerId = internalInitialReport.cmmsMeasurementConsumerId
-              externalReportId = internalInitialReport.externalReportId
-            }
+          internalReportsMock.getReport(
+            eq(
+              internalGetReportRequest {
+                cmmsMeasurementConsumerId = internalInitialReport.cmmsMeasurementConsumerId
+                externalReportId = internalInitialReport.externalReportId
+              }
+            )
           )
         )
-      )
-        .thenReturn(internalPendingReport.copy {
-          val reportingMetricCalculationSpec = reportingMetricEntries.entries.first().value
-          reportingMetricEntries[reportingMetricEntries.entries.first().key] =
-            reportingMetricCalculationSpec.copy {
-              metricCalculationSpecReportingMetrics[0] =
-                reportingMetricCalculationSpec.metricCalculationSpecReportingMetricsList[0].copy {
-                  reportingMetrics[0] = reportingMetricCalculationSpec.metricCalculationSpecReportingMetricsList[0].reportingMetricsList[0].copy {
-                    clearExternalMetricId()
+        .thenReturn(
+          internalPendingReport.copy {
+            val reportingMetricCalculationSpec = reportingMetricEntries.entries.first().value
+            reportingMetricEntries[reportingMetricEntries.entries.first().key] =
+              reportingMetricCalculationSpec.copy {
+                metricCalculationSpecReportingMetrics[0] =
+                  reportingMetricCalculationSpec.metricCalculationSpecReportingMetricsList[0].copy {
+                    reportingMetrics[0] =
+                      reportingMetricCalculationSpec.metricCalculationSpecReportingMetricsList[0]
+                        .reportingMetricsList[0]
+                        .copy { clearExternalMetricId() }
                   }
-                }
-            }
-        })
+              }
+          }
+        )
         .thenReturn(internalPendingReport)
 
       val requestingMetrics: List<Metric> =
@@ -645,9 +648,9 @@ class ReportsServiceTest {
                 metric.copy {
                   name =
                     MetricKey(
-                      MEASUREMENT_CONSUMER_KEYS.first().measurementConsumerId,
-                      ExternalId(REACH_METRIC_ID_BASE_LONG + index).apiId.value
-                    )
+                        MEASUREMENT_CONSUMER_KEYS.first().measurementConsumerId,
+                        ExternalId(REACH_METRIC_ID_BASE_LONG + index).apiId.value
+                      )
                       .toName()
                   state = Metric.State.RUNNING
                   createTime = Instant.now().toProtoTime()


### PR DESCRIPTION
This is an attempt at fixing the situation when only the report id is sent in the create report request, but it fails before the metrics are created. If that happens, retrying the report creation returns an ALREADY_EXISTS.