### PR TITLE
Create computeDynamicClipImpression method in MeasurementResults

### DIFF
--- a/src/main/kotlin/org/wfanet/measurement/eventdataprovider/differentialprivacy/DynamicClipping.kt
+++ b/src/main/kotlin/org/wfanet/measurement/eventdataprovider/differentialprivacy/DynamicClipping.kt
@@ -259,6 +259,8 @@ class DynamicClipping(
     /** A helper function to convert frequencyHistogramMap to histogramList for DynamicClipping */
     @VisibleForTesting
     internal fun frequencyHistogramMapToList(frequencyMap: Map<Long, Long>): List<Long> {
+      if (frequencyMap.isEmpty()) return listOf(0L)
+
       // frequencyMap.keys.max().toInt() + 1 since the first element in histogramList should be 0.
       val histogramList = MutableList(frequencyMap.keys.max().toInt() + 1) { 0L }
       for ((frequency, count) in frequencyMap) {

--- a/src/main/kotlin/org/wfanet/measurement/eventdataprovider/privacybudgetmanagement/api/v2alpha/PrivacyQueryMapper.kt
+++ b/src/main/kotlin/org/wfanet/measurement/eventdataprovider/privacybudgetmanagement/api/v2alpha/PrivacyQueryMapper.kt
@@ -25,7 +25,8 @@ import org.wfanet.measurement.eventdataprovider.privacybudgetmanagement.Landscap
 import org.wfanet.measurement.eventdataprovider.privacybudgetmanagement.Reference
 
 object PrivacyQueryMapper {
-  private const val SENSITIVITY = 1.0
+
+  const val SENSITIVITY = 1.0
 
   /**
    * Constructs a pbm specific [AcdpQuery] from given proto messages for LiquidLegionsV2 protocol.

--- a/src/main/kotlin/org/wfanet/measurement/loadtest/dataprovider/BUILD.bazel
+++ b/src/main/kotlin/org/wfanet/measurement/loadtest/dataprovider/BUILD.bazel
@@ -130,6 +130,11 @@ kt_jvm_library(
 kt_jvm_library(
     name = "measurement_results",
     srcs = ["MeasurementResults.kt"],
+    deps = [
+        "//src/main/kotlin/org/wfanet/measurement/eventdataprovider/differentialprivacy:dynamic_clipping",
+        "//src/main/kotlin/org/wfanet/measurement/eventdataprovider/privacybudgetmanagement:privacy_budget_manager",
+        "//src/main/kotlin/org/wfanet/measurement/eventdataprovider/privacybudgetmanagement/api/v2alpha:privacy_query_mapper",
+    ],
 )
 
 kt_jvm_library(

--- a/src/main/kotlin/org/wfanet/measurement/loadtest/dataprovider/MeasurementResults.kt
+++ b/src/main/kotlin/org/wfanet/measurement/loadtest/dataprovider/MeasurementResults.kt
@@ -63,7 +63,7 @@ object MeasurementResults {
   }
 
   /** Computes impression using the "Dynamic Clipping" methodology. */
-  fun computeDynamicClipImpression(
+  fun computeDynamicClippingImpression(
     sampledVids: Iterable<Long>,
     privacyParams: DpParams,
   ): DynamicClipping.Result {

--- a/src/test/kotlin/org/wfanet/measurement/eventdataprovider/differentialprivacy/DynamicClippingTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/eventdataprovider/differentialprivacy/DynamicClippingTest.kt
@@ -21,6 +21,22 @@ import org.junit.runners.JUnit4
 
 @RunWith(JUnit4::class)
 class DynamicClippingTest {
+  @Test
+  fun `computeImpressionCappedHistogram returns expected result when frequencyMap is empty`() {
+    val frequencyMap: Map<Long, Long> = mapOf()
+
+    // Rho should not affect the result when input is empty.
+    val dynamicClipping = DynamicClipping(0.5, IMPRESSION_MEASUREMENT_TYPE)
+    val dynamicClipResult = dynamicClipping.computeImpressionCappedHistogram(frequencyMap)
+
+    // Expected noisedCumulativeHistogramList should be empty.
+    val expectedCumulativeHistogramList: List<Double> = listOf()
+
+    assertAlmostEqualCumulativeHistogram(
+      dynamicClipResult.noisedCumulativeHistogramList,
+      expectedCumulativeHistogramList,
+    )
+  }
 
   @Test
   fun `computeImpressionCappedHistogram returns expected result with small maxThreshold`() {
@@ -178,6 +194,17 @@ class DynamicClippingTest {
 
     // The first element should be zero which means 0 impression/duration has 0 count.
     val expectedHistogramList = listOf(0L, 5L, 0L, 10L, 0L, 3L)
+
+    assertThat(histogramList).isEqualTo(expectedHistogramList)
+  }
+
+  @Test
+  fun `frequencyHistogramMapToList works as expected for empty frequencyHistogramMap`() {
+    val frequencyHistogramMap: Map<Long, Long> = mapOf()
+    val histogramList = DynamicClipping.frequencyHistogramMapToList(frequencyHistogramMap)
+
+    // List of [0L] should be returned.
+    val expectedHistogramList: List<Long> = listOf(0L)
 
     assertThat(histogramList).isEqualTo(expectedHistogramList)
   }

--- a/src/test/kotlin/org/wfanet/measurement/eventdataprovider/privacybudgetmanagement/api/v2alpha/PrivacyQueryMapperTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/eventdataprovider/privacybudgetmanagement/api/v2alpha/PrivacyQueryMapperTest.kt
@@ -80,7 +80,8 @@ class PrivacyQueryMapperTest {
         REACH_AND_FREQ_MEASUREMENT_SPEC.reachAndFrequency.reachPrivacyParams.delta +
           REACH_AND_FREQ_MEASUREMENT_SPEC.reachAndFrequency.frequencyPrivacyParams.delta,
       )
-    val expectedAcdpCharge = AcdpParamsConverter.getDirectAcdpCharge(dpParams, SENSITIVITY)
+    val expectedAcdpCharge =
+      AcdpParamsConverter.getDirectAcdpCharge(dpParams, PrivacyQueryMapper.SENSITIVITY)
 
     assertThat(
         getDirectAcdpQuery(
@@ -142,7 +143,7 @@ class PrivacyQueryMapperTest {
           REACH_MEASUREMENT_SPEC.reach.privacyParams.epsilon,
           REACH_MEASUREMENT_SPEC.reach.privacyParams.delta,
         ),
-        SENSITIVITY,
+        PrivacyQueryMapper.SENSITIVITY,
       )
 
     assertThat(
@@ -175,7 +176,7 @@ class PrivacyQueryMapperTest {
           IMPRESSION_MEASUREMENT_SPEC.impression.privacyParams.epsilon,
           IMPRESSION_MEASUREMENT_SPEC.impression.privacyParams.delta,
         ),
-        SENSITIVITY,
+        PrivacyQueryMapper.SENSITIVITY,
       )
 
     assertThat(
@@ -204,7 +205,7 @@ class PrivacyQueryMapperTest {
           DURATION_MEASUREMENT_SPEC.duration.privacyParams.epsilon,
           DURATION_MEASUREMENT_SPEC.duration.privacyParams.delta,
         ),
-        SENSITIVITY,
+        PrivacyQueryMapper.SENSITIVITY,
       )
 
     assertThat(
@@ -231,7 +232,6 @@ class PrivacyQueryMapperTest {
     private const val FILTER_EXPRESSION =
       "person.gender==0 && person.age_group==0 && banner_ad.gender == 1"
     private const val CONTRIBUTOR_COUNT = 3
-    private const val SENSITIVITY = 1.0
 
     private val REQUISITION_SPEC = requisitionSpec {
       events =


### PR DESCRIPTION
* This enables EDP simulator to support dynamic clip impression
* Minor updates to DynamicClipping library including fixing insecure noiser