### PR TITLE
Update cross-media-measurement-api dep for CustomMaximumFrequencyPerUser in DeterministicCount methodology

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -136,14 +136,8 @@ bazel_dep(
 )
 bazel_dep(
     name = "cross-media-measurement-api",
-    version = "0.58.0",
+    version = "0.60.0",
     repo_name = "wfa_measurement_proto",
-)
-# DO_NOT_SUBMIT(world-federation-of-advertisers/cross-media-measurement-api#197): Replace with version once released from main.
-archive_override(
-    module_name = "cross-media-measurement-api",
-    strip_prefix = "cross-media-measurement-api-53ec27aa82aeb392f1494e737ef1ba705d5e5704",
-    urls = ["https://github.com/world-federation-of-advertisers/cross-media-measurement-api/archive/53ec27aa82aeb392f1494e737ef1ba705d5e5704.tar.gz"],
 )
 bazel_dep(
     name = "consent-signaling-client",

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -139,6 +139,12 @@ bazel_dep(
     version = "0.58.0",
     repo_name = "wfa_measurement_proto",
 )
+# DO_NOT_SUBMIT(world-federation-of-advertisers/cross-media-measurement-api#197): Replace with version once released from main.
+archive_override(
+    module_name = "cross-media-measurement-api",
+    strip_prefix = "cross-media-measurement-api-53ec27aa82aeb392f1494e737ef1ba705d5e5704",
+    urls = ["https://github.com/world-federation-of-advertisers/cross-media-measurement-api/archive/53ec27aa82aeb392f1494e737ef1ba705d5e5704.tar.gz"],
+)
 bazel_dep(
     name = "consent-signaling-client",
     version = "0.20.0",

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/service/api/v2alpha/ProtoConversions.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/service/api/v2alpha/ProtoConversions.kt
@@ -162,9 +162,9 @@ val DEFAULT_DIRECT_REACH_PROTOCOL_CONFIG: ProtocolConfig.Direct = direct {
 }
 
 /**
- * Default direct reach-and-freqeuncy protocol config for backward compatibility.
+ * Default direct reach-and-frequency protocol config for backward compatibility.
  *
- * Used when existing direct protocol configs of reach-and-freqeuncy measurements don't have
+ * Used when existing direct protocol configs of reach-and-frequency measurements don't have
  * methodologies.
  */
 val DEFAULT_DIRECT_REACH_AND_FREQUENCY_PROTOCOL_CONFIG: ProtocolConfig.Direct = direct {
@@ -838,7 +838,7 @@ fun ModelShard.toInternal(
   }
 }
 
-/** Converts an internal [InternaPopulation] to a public [Population]. */
+/** Converts an internal [InternalPopulation] to a public [Population]. */
 fun InternalPopulation.toPopulation(): Population {
   val source = this
 

--- a/src/main/kotlin/org/wfanet/measurement/loadtest/measurementconsumer/MeasurementConsumerSimulator.kt
+++ b/src/main/kotlin/org/wfanet/measurement/loadtest/measurementconsumer/MeasurementConsumerSimulator.kt
@@ -515,6 +515,13 @@ class MeasurementConsumerSimulator(
     val measurementComputationInfo: MeasurementComputationInfo =
       buildMeasurementComputationInfo(protocol, result.impression.noiseMechanism)
 
+    val maxFrequencyPerUser =
+      if (result.impression.deterministicCount.customMaximumFrequencyPerUser != 0) {
+        result.impression.deterministicCount.customMaximumFrequencyPerUser
+      } else {
+        measurementSpec.impression.maximumFrequencyPerUser
+      }
+
     return VariancesImpl.computeMeasurementVariance(
       measurementComputationInfo.methodology,
       ImpressionMeasurementVarianceParams(
@@ -523,7 +530,7 @@ class MeasurementConsumerSimulator(
           ImpressionMeasurementParams(
             vidSamplingInterval = measurementSpec.vidSamplingInterval.toStatsVidSamplingInterval(),
             dpParams = measurementSpec.impression.privacyParams.toNoiserDpParams(),
-            maximumFrequencyPerUser = measurementSpec.impression.maximumFrequencyPerUser,
+            maximumFrequencyPerUser = maxFrequencyPerUser,
             noiseMechanism = measurementComputationInfo.noiseMechanism.toStatsNoiseMechanism(),
           ),
       ),

--- a/src/main/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/MetricsService.kt
+++ b/src/main/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/MetricsService.kt
@@ -2094,6 +2094,13 @@ fun buildWeightedImpressionMeasurementVarianceParamsPerResult(
         return@map null
       }
 
+    val maxFrequencyPerUser =
+      if (impressionResult.deterministicCount.customMaximumFrequencyPerUser != 0) {
+        impressionResult.deterministicCount.customMaximumFrequencyPerUser
+      } else {
+        metricSpec.impressionCount.maximumFrequencyPerUser
+      }
+
     WeightedImpressionMeasurementVarianceParams(
       binaryRepresentation = weightedMeasurement.binaryRepresentation,
       weight = weightedMeasurement.weight,
@@ -2104,7 +2111,7 @@ fun buildWeightedImpressionMeasurementVarianceParamsPerResult(
             ImpressionMeasurementParams(
               vidSamplingInterval = metricSpec.vidSamplingInterval.toStatsVidSamplingInterval(),
               dpParams = metricSpec.impressionCount.privacyParams.toNoiserDpParams(),
-              maximumFrequencyPerUser = metricSpec.impressionCount.maximumFrequencyPerUser,
+              maximumFrequencyPerUser = maxFrequencyPerUser,
               noiseMechanism = statsNoiseMechanism,
             ),
         ),

--- a/src/main/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/ProtoConversions.kt
+++ b/src/main/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/ProtoConversions.kt
@@ -43,7 +43,6 @@ import org.wfanet.measurement.config.reporting.MetricSpecConfig
 import org.wfanet.measurement.eventdataprovider.noiser.DpParams as NoiserDpParams
 import org.wfanet.measurement.internal.reporting.v2.CustomDirectMethodology as InternalCustomDirectMethodology
 import org.wfanet.measurement.internal.reporting.v2.CustomDirectMethodologyKt as InternalCustomDirectMethodologyKt
-import org.wfanet.measurement.internal.reporting.v2.DeterministicCount
 import org.wfanet.measurement.internal.reporting.v2.DeterministicCountDistinct
 import org.wfanet.measurement.internal.reporting.v2.DeterministicDistribution
 import org.wfanet.measurement.internal.reporting.v2.DeterministicSum
@@ -69,6 +68,7 @@ import org.wfanet.measurement.internal.reporting.v2.StreamReportsRequest
 import org.wfanet.measurement.internal.reporting.v2.StreamReportsRequestKt
 import org.wfanet.measurement.internal.reporting.v2.TimeIntervals as InternalTimeIntervals
 import org.wfanet.measurement.internal.reporting.v2.customDirectMethodology
+import org.wfanet.measurement.internal.reporting.v2.deterministicCount
 import org.wfanet.measurement.internal.reporting.v2.liquidLegionsCountDistinct
 import org.wfanet.measurement.internal.reporting.v2.liquidLegionsDistribution
 import org.wfanet.measurement.internal.reporting.v2.liquidLegionsSketchParams
@@ -467,7 +467,9 @@ private fun Measurement.Result.Impression.toInternal(
           customDirectMethodology = source.customDirectMethodology.toInternal()
         }
         Measurement.Result.Impression.MethodologyCase.DETERMINISTIC_COUNT -> {
-          deterministicCount = DeterministicCount.getDefaultInstance()
+          deterministicCount = deterministicCount {
+            customMaximumFrequencyPerUser = source.deterministicCount.customMaximumFrequencyPerUser
+          }
         }
       }
     } else {

--- a/src/main/proto/wfa/measurement/internal/reporting/v2/direct_computation.proto
+++ b/src/main/proto/wfa/measurement/internal/reporting/v2/direct_computation.proto
@@ -81,7 +81,12 @@ message DeterministicCountDistinct {}
 message DeterministicDistribution {}
 
 // Parameters used when applying the deterministic count methodology.
-message DeterministicCount {}
+message DeterministicCount {
+  // Custom maximum frequency per user value calculated by the
+  // DataProvider. If this is specified, the maximum_frequency_per_user in
+  // measurement_spec will be ignored.
+  int32 custom_maximum_frequency_per_user = 1;
+}
 
 // Parameters used when applying the deterministic sum methodology.
 message DeterministicSum {}

--- a/src/test/kotlin/org/wfanet/measurement/loadtest/dataprovider/EdpSimulatorTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/loadtest/dataprovider/EdpSimulatorTest.kt
@@ -2372,7 +2372,7 @@ class EdpSimulatorTest {
   }
 
   @Test
-  fun `fails to fulfill impression Requisition when no direct noise mechanism is picked by EDP`() {
+  fun `fails to fulfill impression Requisition when no direct noise mechanism options are provided by Kingdom`() {
     val noiseMechanismOption = ProtocolConfig.NoiseMechanism.NONE
     val requisition =
       REQUISITION.copy {
@@ -2435,7 +2435,7 @@ class EdpSimulatorTest {
   }
 
   @Test
-  fun `fails to fulfill impression Requisition when no direct methodology is picked by EDP`() {
+  fun `fails to fulfill impression Requisition when no direct methodologies are provided by Kingdom`() {
     val noiseMechanismOption = ProtocolConfig.NoiseMechanism.CONTINUOUS_GAUSSIAN
     val requisition =
       REQUISITION.copy {


### PR DESCRIPTION
For API change in https://github.com/world-federation-of-advertisers/cross-media-measurement-api/pull/197