### PR TITLE
add maxCoroutines parameter to CoroutineLauncher (#1383)

### DIFF
--- a/src/main/kotlin/org/wfanet/panelmatch/client/deploy/ExchangeWorkflowDaemon.kt
+++ b/src/main/kotlin/org/wfanet/panelmatch/client/deploy/ExchangeWorkflowDaemon.kt
@@ -91,9 +91,7 @@ abstract class ExchangeWorkflowDaemon : Runnable {
     SharedStorageSelector(certificateManager, sharedStorageFactories, sharedStorageInfo)
   }
 
-  override fun run() = runBlocking { runSuspending() }
-
-  suspend fun runSuspending() {
+  protected open val launcher by lazy {
     val stepExecutor =
       ExchangeTaskExecutor(
         apiClient = apiClient,
@@ -101,8 +99,12 @@ abstract class ExchangeWorkflowDaemon : Runnable {
         privateStorageSelector = privateStorageSelector,
         exchangeTaskMapper = exchangeTaskMapper
       )
+    CoroutineLauncher(stepExecutor = stepExecutor)
+  }
 
-    val launcher = CoroutineLauncher(stepExecutor = stepExecutor)
+  override fun run() = runBlocking { runSuspending() }
+
+  suspend fun runSuspending() {
 
     val exchangeStepLauncher =
       ExchangeStepLauncher(

--- a/src/main/kotlin/org/wfanet/panelmatch/client/deploy/example/aws/AwsExampleDaemon.kt
+++ b/src/main/kotlin/org/wfanet/panelmatch/client/deploy/example/aws/AwsExampleDaemon.kt
@@ -28,6 +28,8 @@ import org.wfanet.measurement.storage.StorageClient
 import org.wfanet.panelmatch.client.deploy.CertificateAuthorityFlags
 import org.wfanet.panelmatch.client.deploy.DaemonStorageClientDefaults
 import org.wfanet.panelmatch.client.deploy.example.ExampleDaemon
+import org.wfanet.panelmatch.client.launcher.CoroutineLauncher
+import org.wfanet.panelmatch.client.launcher.ExchangeTaskExecutor
 import org.wfanet.panelmatch.client.storage.StorageDetailsProvider
 import org.wfanet.panelmatch.common.beam.BeamOptions
 import org.wfanet.panelmatch.common.certificates.aws.CertificateAuthority
@@ -142,6 +144,17 @@ private class AwsExampleDaemon : ExampleDaemon() {
       certificateAuthorityArn,
       PrivateCaClient(),
     )
+  }
+
+  override val launcher by lazy {
+    val stepExecutor =
+      ExchangeTaskExecutor(
+        apiClient = apiClient,
+        timeout = taskTimeout,
+        privateStorageSelector = privateStorageSelector,
+        exchangeTaskMapper = exchangeTaskMapper
+      )
+    CoroutineLauncher(stepExecutor = stepExecutor, maxCoroutines = 1)
   }
 }
 

--- a/src/main/kotlin/org/wfanet/panelmatch/client/launcher/CoroutineLauncher.kt
+++ b/src/main/kotlin/org/wfanet/panelmatch/client/launcher/CoroutineLauncher.kt
@@ -20,6 +20,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.plus
+import kotlinx.coroutines.sync.Semaphore
 import org.wfanet.measurement.api.v2alpha.ExchangeStep
 import org.wfanet.measurement.api.v2alpha.ExchangeStepAttemptKey
 import org.wfanet.panelmatch.client.launcher.ExchangeStepValidator.ValidatedExchangeStep
@@ -27,11 +28,20 @@ import org.wfanet.panelmatch.client.launcher.ExchangeStepValidator.ValidatedExch
 /** Executes an [ExchangeStep] in a new coroutine in [scope]. */
 class CoroutineLauncher(
   private val scope: CoroutineScope = CoroutineScope(Dispatchers.Default),
-  private val stepExecutor: ExchangeStepExecutor
+  private val stepExecutor: ExchangeStepExecutor,
+  maxCoroutines: Int? = null
 ) : JobLauncher {
-  override suspend fun execute(step: ValidatedExchangeStep, attemptKey: ExchangeStepAttemptKey) {
+
+  private val semaphore = if (maxCoroutines !== null) Semaphore(maxCoroutines) else null
+
+  override suspend fun execute(
+    step: ValidatedExchangeStep,
+    attemptKey: ExchangeStepAttemptKey
+  ) {
     (scope + SupervisorJob()).launch(CoroutineName(attemptKey.toName())) {
+      if (semaphore !== null) semaphore.acquire()
       stepExecutor.execute(step, attemptKey)
+      if (semaphore !== null) semaphore.release()
     }
   }
 }

--- a/src/test/kotlin/org/wfanet/panelmatch/client/launcher/CoroutineLauncherTest.kt
+++ b/src/test/kotlin/org/wfanet/panelmatch/client/launcher/CoroutineLauncherTest.kt
@@ -15,14 +15,20 @@
 package org.wfanet.panelmatch.client.launcher
 
 import com.google.common.truth.Truth.assertThat
+import java.time.Duration
 import java.time.LocalDate
+import kotlin.test.assertFailsWith
+import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.time.withTimeout
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 import org.mockito.kotlin.any
 import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.wfanet.measurement.api.v2alpha.ExchangeStepAttemptKey
@@ -36,41 +42,102 @@ import org.wfanet.panelmatch.common.testing.runBlockingTest
 @RunWith(JUnit4::class)
 class CoroutineLauncherTest {
   private val stepExecutor = mock<ExchangeStepExecutor>()
-  private val launcher = CoroutineLauncher(stepExecutor = stepExecutor)
 
   @Test
   fun launches() = runBlockingTest {
+    val launcher = CoroutineLauncher(stepExecutor = stepExecutor, maxCoroutines = 2)
     val workflowStep = step {
       this.commutativeDeterministicEncryptStep = commutativeDeterministicEncryptStep {}
     }
     val workflow = buildWorkflow(workflowStep, "some-edp", "some-mp")
 
-    val startLatch = CountDownLatch(1)
-    val middleLatch = CountDownLatch(1)
-    val endLatch = CountDownLatch(1)
-    whenever(stepExecutor.execute(any(), any())).thenAnswer {
+    val startLatch1 = CountDownLatch(1)
+    val middleLatch1 = CountDownLatch(1)
+    val endLatch1 = CountDownLatch(1)
+    val startLatch2 = CountDownLatch(1)
+    val middleLatch2 = CountDownLatch(1)
+    val endLatch2 = CountDownLatch(1)
+
+    val attemptKey1 = ExchangeStepAttemptKey("a", "b", "c", "d")
+    val attemptKey2 = ExchangeStepAttemptKey("w", "x", "y", "z")
+
+    whenever(stepExecutor.execute(any(), eq(attemptKey1))).thenAnswer {
       runBlocking {
-        startLatch.countDown()
-        middleLatch.await()
-        endLatch.countDown()
+        startLatch1.countDown()
+        middleLatch1.await()
+        endLatch1.countDown()
       }
     }
-
+    whenever(stepExecutor.execute(any(), eq(attemptKey2))).thenAnswer {
+      runBlocking {
+        startLatch2.countDown()
+        middleLatch2.await()
+        endLatch2.countDown()
+      }
+    }
     val attemptKey = ExchangeStepAttemptKey("w", "x", "y", "z")
     val date = LocalDate.of(2021, 11, 29)
 
     val validatedExchangeStep = ValidatedExchangeStep(workflow, workflow.getSteps(0), date)
 
-    launcher.execute(validatedExchangeStep, attemptKey)
+    launcher.execute(validatedExchangeStep, attemptKey1)
+    launcher.execute(validatedExchangeStep, attemptKey2)
 
-    startLatch.await()
-    middleLatch.countDown()
-    endLatch.await()
+    startLatch1.await()
+    startLatch2.await()
+    middleLatch1.countDown()
+    middleLatch2.countDown()
+    endLatch1.await()
+    endLatch2.await()
 
     val stepCaptor = argumentCaptor<ValidatedExchangeStep>()
     val attemptKeyCaptor = argumentCaptor<ExchangeStepAttemptKey>()
-    verify(stepExecutor).execute(stepCaptor.capture(), attemptKeyCaptor.capture())
+    verify(stepExecutor, times(2)).execute(stepCaptor.capture(), attemptKeyCaptor.capture())
+  }
+
+  @Test
+  fun timesOutWithSingleCoroutineThatNeverCompletes() = runBlockingTest {
+    val launcher = CoroutineLauncher(stepExecutor = stepExecutor, maxCoroutines = 1)
+    val workflowStep = step {
+      this.commutativeDeterministicEncryptStep = commutativeDeterministicEncryptStep {}
+    }
+    val workflow = buildWorkflow(workflowStep, "some-edp", "some-mp")
+
+    val startLatch1 = CountDownLatch(1)
+    val startLatch2 = CountDownLatch(1)
+    val endLatch1 = CountDownLatch(1)
+    val endLatch2 = CountDownLatch(1)
+
+    val attemptKey1 = ExchangeStepAttemptKey("a", "b", "c", "d")
+    val attemptKey2 = ExchangeStepAttemptKey("w", "x", "y", "z")
+
+    whenever(stepExecutor.execute(any(), eq(attemptKey1))).thenAnswer {
+      runBlocking {
+        startLatch1.countDown()
+        endLatch1.await()
+      }
+    }
+    whenever(stepExecutor.execute(any(), eq(attemptKey2))).thenAnswer {
+      runBlocking {
+        startLatch2.countDown()
+        endLatch2.await()
+      }
+    }
+    val date = LocalDate.of(2021, 11, 29)
+
+    val validatedExchangeStep = ValidatedExchangeStep(workflow, workflow.getSteps(0), date)
+
+    launcher.execute(validatedExchangeStep, attemptKey1)
+    launcher.execute(validatedExchangeStep, attemptKey2)
+
+    startLatch1.await()
+    assertFailsWith<TimeoutCancellationException> {
+      withTimeout(Duration.ofSeconds(10)) { startLatch2.await() }
+    }
+    val stepCaptor = argumentCaptor<ValidatedExchangeStep>()
+    val attemptKeyCaptor = argumentCaptor<ExchangeStepAttemptKey>()
+    verify(stepExecutor, times(1)).execute(stepCaptor.capture(), attemptKeyCaptor.capture())
     assertThat(stepCaptor.firstValue).isEqualTo(validatedExchangeStep)
-    assertThat(attemptKeyCaptor.firstValue).isEqualTo(attemptKey)
+    assertThat(attemptKeyCaptor.firstValue).isEqualTo(attemptKey1)
   }
 }


### PR DESCRIPTION
The current CoroutineLauncher has not limit on the number of coroutines it launches. This works well on a platform like DataflowRunner but performs poorly with the DirectExecutor. This PR
1. Adds a parameter to specify the max number of jobs that should be executed in parallel with the CoroutineLauncher.
2. Sets the max number of jobs to 1 for the Aws example daemon.