### PR TITLE
cherry pick 3 commits for max exchange steps parallel

### DIFF
--- a/src/main/k8s/panelmatch/dev/example_daemon_aws.cue
+++ b/src/main/k8s/panelmatch/dev/example_daemon_aws.cue
@@ -114,6 +114,7 @@ deployments: {
 						"--polling-interval=1m",
 						"--preprocessing-max-byte-size=1000000",
 						"--preprocessing-file-count=1000",
+						"--max-parallel-claimed-exchange-steps=1",
 						"--x509-common-name=" + _defaultAwsConfig.commonName,
 						"--x509-organization=" + _defaultAwsConfig.orgName,
 						"--x509-dns-name=" + _defaultAwsConfig.dns,

--- a/src/main/kotlin/org/wfanet/panelmatch/client/deploy/ExchangeWorkflowDaemon.kt
+++ b/src/main/kotlin/org/wfanet/panelmatch/client/deploy/ExchangeWorkflowDaemon.kt
@@ -97,7 +97,7 @@ abstract class ExchangeWorkflowDaemon : Runnable {
         apiClient = apiClient,
         timeout = taskTimeout,
         privateStorageSelector = privateStorageSelector,
-        exchangeTaskMapper = exchangeTaskMapper
+        exchangeTaskMapper = exchangeTaskMapper,
       )
     CoroutineLauncher(stepExecutor = stepExecutor)
   }
@@ -110,7 +110,7 @@ abstract class ExchangeWorkflowDaemon : Runnable {
       ExchangeStepLauncher(
         apiClient = apiClient,
         validator = ExchangeStepValidatorImpl(identity.party, validExchangeWorkflows, clock),
-        jobLauncher = launcher
+        jobLauncher = launcher,
       )
 
     runDaemon(exchangeStepLauncher)

--- a/src/main/kotlin/org/wfanet/panelmatch/client/deploy/ExchangeWorkflowDaemon.kt
+++ b/src/main/kotlin/org/wfanet/panelmatch/client/deploy/ExchangeWorkflowDaemon.kt
@@ -91,9 +91,7 @@ abstract class ExchangeWorkflowDaemon : Runnable {
     SharedStorageSelector(certificateManager, sharedStorageFactories, sharedStorageInfo)
   }
 
-  override fun run() = runBlocking { runSuspending() }
-
-  suspend fun runSuspending() {
+  protected open val launcher by lazy {
     val stepExecutor =
       ExchangeTaskExecutor(
         apiClient = apiClient,
@@ -101,8 +99,12 @@ abstract class ExchangeWorkflowDaemon : Runnable {
         privateStorageSelector = privateStorageSelector,
         exchangeTaskMapper = exchangeTaskMapper
       )
+    CoroutineLauncher(stepExecutor = stepExecutor)
+  }
 
-    val launcher = CoroutineLauncher(stepExecutor = stepExecutor)
+  override fun run() = runBlocking { runSuspending() }
+
+  suspend fun runSuspending() {
 
     val exchangeStepLauncher =
       ExchangeStepLauncher(

--- a/src/main/kotlin/org/wfanet/panelmatch/client/deploy/ExchangeWorkflowDaemon.kt
+++ b/src/main/kotlin/org/wfanet/panelmatch/client/deploy/ExchangeWorkflowDaemon.kt
@@ -91,7 +91,7 @@ abstract class ExchangeWorkflowDaemon : Runnable {
     SharedStorageSelector(certificateManager, sharedStorageFactories, sharedStorageInfo)
   }
 
-  protected open val launcher by lazy {
+  private val launcher by lazy {
     val stepExecutor =
       ExchangeTaskExecutor(
         apiClient = apiClient,

--- a/src/main/kotlin/org/wfanet/panelmatch/client/deploy/ExchangeWorkflowDaemonFromFlags.kt
+++ b/src/main/kotlin/org/wfanet/panelmatch/client/deploy/ExchangeWorkflowDaemonFromFlags.kt
@@ -111,10 +111,18 @@ abstract class ExchangeWorkflowDaemonFromFlags : ExchangeWorkflowDaemon() {
     )
   }
 
+  private val maxParallelClaimedExchangeSteps: Int by lazy { flags.maxParallelClaimedExchangeSteps }
+
   override val apiClient: ApiClient by lazy {
     val exchangeStepsClient = ExchangeStepsCoroutineStub(channel)
     val exchangeStepAttemptsClient = ExchangeStepAttemptsCoroutineStub(channel)
-    GrpcApiClient(identity, exchangeStepsClient, exchangeStepAttemptsClient, Clock.systemUTC())
+    GrpcApiClient(
+      identity,
+      exchangeStepsClient,
+      exchangeStepAttemptsClient,
+      Clock.systemUTC(),
+      maxParallelClaimedExchangeSteps
+    )
   }
 
   override val taskTimeout: Timeout by lazy { flags.taskTimeout.asTimeout() }

--- a/src/main/kotlin/org/wfanet/panelmatch/client/deploy/ExchangeWorkflowDaemonFromFlags.kt
+++ b/src/main/kotlin/org/wfanet/panelmatch/client/deploy/ExchangeWorkflowDaemonFromFlags.kt
@@ -62,7 +62,7 @@ abstract class ExchangeWorkflowDaemonFromFlags : ExchangeWorkflowDaemon() {
     SigningCerts.fromPemFiles(
       certificateFile = flags.tlsFlags.certFile,
       privateKeyFile = flags.tlsFlags.privateKeyFile,
-      trustedCertCollectionFile = flags.tlsFlags.certCollectionFile
+      trustedCertCollectionFile = flags.tlsFlags.certCollectionFile,
     )
   }
 
@@ -82,7 +82,7 @@ abstract class ExchangeWorkflowDaemonFromFlags : ExchangeWorkflowDaemon() {
       privateKeys = privateKeys,
       algorithm = flags.certAlgorithm,
       certificateAuthority = certificateAuthority,
-      localName = identity.toName()
+      localName = identity.toName(),
     )
   }
 
@@ -121,7 +121,7 @@ abstract class ExchangeWorkflowDaemonFromFlags : ExchangeWorkflowDaemon() {
       exchangeStepsClient,
       exchangeStepAttemptsClient,
       Clock.systemUTC(),
-      maxParallelClaimedExchangeSteps
+      maxParallelClaimedExchangeSteps,
     )
   }
 

--- a/src/main/kotlin/org/wfanet/panelmatch/client/deploy/ExchangeWorkflowFlags.kt
+++ b/src/main/kotlin/org/wfanet/panelmatch/client/deploy/ExchangeWorkflowFlags.kt
@@ -42,7 +42,7 @@ class ExchangeWorkflowFlags {
     names = ["--channel-shutdown-timeout"],
     defaultValue = "3s",
     description = ["How long to allow for the gRPC channel to shutdown."],
-    required = true
+    required = true,
   )
   lateinit var channelShutdownTimeout: Duration
     private set
@@ -51,7 +51,7 @@ class ExchangeWorkflowFlags {
     names = ["--storage-signing-algorithm"],
     defaultValue = "EC",
     description = ["The algorithm used in signing data written to shared storage."],
-    required = true
+    required = true,
   )
   lateinit var certAlgorithm: String
     private set
@@ -60,7 +60,7 @@ class ExchangeWorkflowFlags {
     names = ["--polling-interval"],
     defaultValue = "1m",
     description = ["How long to sleep between finding and running an ExchangeStep."],
-    required = true
+    required = true,
   )
   lateinit var pollingInterval: Duration
     private set
@@ -69,7 +69,7 @@ class ExchangeWorkflowFlags {
     names = ["--task-timeout"],
     defaultValue = "24h",
     description = ["How long to sleep between finding and running an ExchangeStep."],
-    required = true
+    required = true,
   )
   lateinit var taskTimeout: Duration
     private set
@@ -78,7 +78,7 @@ class ExchangeWorkflowFlags {
     names = ["--exchange-api-target"],
     description =
       ["Address and port for servers hosting /ExchangeSteps and /ExchangeStepAttempts services"],
-    required = true
+    required = true,
   )
   lateinit var exchangeApiTarget: String
     private set
@@ -86,7 +86,7 @@ class ExchangeWorkflowFlags {
   @Option(
     names = ["--exchange-api-cert-host"],
     description = ["Expected hostname in the TLS certificate for --exchange-api-target"],
-    required = true
+    required = true,
   )
   lateinit var exchangeApiCertHost: String
     private set
@@ -102,7 +102,7 @@ class ExchangeWorkflowFlags {
     names = ["--preprocessing-max-byte-size"],
     defaultValue = "1000000",
     description = ["Max batch size for processing"],
-    required = true
+    required = true,
   )
   var preProcessingMaxByteSize by Delegates.notNull<Long>()
     private set
@@ -111,7 +111,7 @@ class ExchangeWorkflowFlags {
     names = ["--preprocessing-file-count"],
     defaultValue = "1000",
     description = ["Number of output files from event preprocessing step"],
-    required = true
+    required = true,
   )
   var preProcessingFileCount by Delegates.notNull<Int>()
     private set
@@ -120,7 +120,7 @@ class ExchangeWorkflowFlags {
     names = ["--max-parallel-claimed-exchange-steps"],
     defaultValue = "-1",
     description = ["Maximum number of exchange steps to claim in parallel"],
-    required = true
+    required = true,
   )
   var maxParallelClaimedExchangeSteps by Delegates.notNull<Int>()
     private set

--- a/src/main/kotlin/org/wfanet/panelmatch/client/deploy/ExchangeWorkflowFlags.kt
+++ b/src/main/kotlin/org/wfanet/panelmatch/client/deploy/ExchangeWorkflowFlags.kt
@@ -98,7 +98,7 @@ class ExchangeWorkflowFlags {
   var debugVerboseGrpcClientLogging = false
     private set
 
-  @set:CommandLine.Option(
+  @set:Option(
     names = ["--preprocessing-max-byte-size"],
     defaultValue = "1000000",
     description = ["Max batch size for processing"],
@@ -107,12 +107,21 @@ class ExchangeWorkflowFlags {
   var preProcessingMaxByteSize by Delegates.notNull<Long>()
     private set
 
-  @set:CommandLine.Option(
+  @set:Option(
     names = ["--preprocessing-file-count"],
     defaultValue = "1000",
     description = ["Number of output files from event preprocessing step"],
     required = true
   )
   var preProcessingFileCount by Delegates.notNull<Int>()
+    private set
+
+  @set:Option(
+    names = ["--max-parallel-claimed-exchange-steps"],
+    defaultValue = "-1",
+    description = ["Maximum number of exchange steps to claim in parallel"],
+    required = true
+  )
+  var maxParallelClaimedExchangeSteps by Delegates.notNull<Int>()
     private set
 }

--- a/src/main/kotlin/org/wfanet/panelmatch/client/deploy/ExchangeWorkflowFlags.kt
+++ b/src/main/kotlin/org/wfanet/panelmatch/client/deploy/ExchangeWorkflowFlags.kt
@@ -29,7 +29,7 @@ class ExchangeWorkflowFlags {
   @Option(
     names = ["--party-type"],
     description = ["Type of the party: \${COMPLETION-CANDIDATES}"],
-    required = true
+    required = true,
   )
   lateinit var partyType: Party
     private set

--- a/src/main/kotlin/org/wfanet/panelmatch/client/deploy/example/aws/AwsExampleDaemon.kt
+++ b/src/main/kotlin/org/wfanet/panelmatch/client/deploy/example/aws/AwsExampleDaemon.kt
@@ -28,8 +28,6 @@ import org.wfanet.measurement.storage.StorageClient
 import org.wfanet.panelmatch.client.deploy.CertificateAuthorityFlags
 import org.wfanet.panelmatch.client.deploy.DaemonStorageClientDefaults
 import org.wfanet.panelmatch.client.deploy.example.ExampleDaemon
-import org.wfanet.panelmatch.client.launcher.CoroutineLauncher
-import org.wfanet.panelmatch.client.launcher.ExchangeTaskExecutor
 import org.wfanet.panelmatch.client.storage.StorageDetailsProvider
 import org.wfanet.panelmatch.common.beam.BeamOptions
 import org.wfanet.panelmatch.common.certificates.aws.CertificateAuthority
@@ -144,17 +142,6 @@ private class AwsExampleDaemon : ExampleDaemon() {
       certificateAuthorityArn,
       PrivateCaClient(),
     )
-  }
-
-  override val launcher by lazy {
-    val stepExecutor =
-      ExchangeTaskExecutor(
-        apiClient = apiClient,
-        timeout = taskTimeout,
-        privateStorageSelector = privateStorageSelector,
-        exchangeTaskMapper = exchangeTaskMapper
-      )
-    CoroutineLauncher(stepExecutor = stepExecutor, maxCoroutines = 1)
   }
 }
 

--- a/src/main/kotlin/org/wfanet/panelmatch/client/deploy/example/aws/AwsExampleDaemon.kt
+++ b/src/main/kotlin/org/wfanet/panelmatch/client/deploy/example/aws/AwsExampleDaemon.kt
@@ -28,6 +28,8 @@ import org.wfanet.measurement.storage.StorageClient
 import org.wfanet.panelmatch.client.deploy.CertificateAuthorityFlags
 import org.wfanet.panelmatch.client.deploy.DaemonStorageClientDefaults
 import org.wfanet.panelmatch.client.deploy.example.ExampleDaemon
+import org.wfanet.panelmatch.client.launcher.CoroutineLauncher
+import org.wfanet.panelmatch.client.launcher.ExchangeTaskExecutor
 import org.wfanet.panelmatch.client.storage.StorageDetailsProvider
 import org.wfanet.panelmatch.common.beam.BeamOptions
 import org.wfanet.panelmatch.common.certificates.aws.CertificateAuthority
@@ -142,6 +144,17 @@ private class AwsExampleDaemon : ExampleDaemon() {
       certificateAuthorityArn,
       PrivateCaClient(),
     )
+  }
+
+  override val launcher by lazy {
+    val stepExecutor =
+      ExchangeTaskExecutor(
+        apiClient = apiClient,
+        timeout = taskTimeout,
+        privateStorageSelector = privateStorageSelector,
+        exchangeTaskMapper = exchangeTaskMapper
+      )
+    CoroutineLauncher(stepExecutor = stepExecutor, maxCoroutines = 1)
   }
 }
 

--- a/src/main/kotlin/org/wfanet/panelmatch/client/launcher/CoroutineLauncher.kt
+++ b/src/main/kotlin/org/wfanet/panelmatch/client/launcher/CoroutineLauncher.kt
@@ -20,7 +20,6 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.plus
-import kotlinx.coroutines.sync.Semaphore
 import org.wfanet.measurement.api.v2alpha.ExchangeStep
 import org.wfanet.measurement.api.v2alpha.ExchangeStepAttemptKey
 import org.wfanet.panelmatch.client.launcher.ExchangeStepValidator.ValidatedExchangeStep
@@ -28,20 +27,12 @@ import org.wfanet.panelmatch.client.launcher.ExchangeStepValidator.ValidatedExch
 /** Executes an [ExchangeStep] in a new coroutine in [scope]. */
 class CoroutineLauncher(
   private val scope: CoroutineScope = CoroutineScope(Dispatchers.Default),
-  private val stepExecutor: ExchangeStepExecutor,
-  maxCoroutines: Int? = null
+  private val stepExecutor: ExchangeStepExecutor
 ) : JobLauncher {
 
-  private val semaphore = if (maxCoroutines !== null) Semaphore(maxCoroutines) else null
-
-  override suspend fun execute(
-    step: ValidatedExchangeStep,
-    attemptKey: ExchangeStepAttemptKey
-  ) {
+  override suspend fun execute(step: ValidatedExchangeStep, attemptKey: ExchangeStepAttemptKey) {
     (scope + SupervisorJob()).launch(CoroutineName(attemptKey.toName())) {
-      if (semaphore !== null) semaphore.acquire()
       stepExecutor.execute(step, attemptKey)
-      if (semaphore !== null) semaphore.release()
     }
   }
 }

--- a/src/main/kotlin/org/wfanet/panelmatch/client/launcher/CoroutineLauncher.kt
+++ b/src/main/kotlin/org/wfanet/panelmatch/client/launcher/CoroutineLauncher.kt
@@ -20,6 +20,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.plus
+import kotlinx.coroutines.sync.Semaphore
 import org.wfanet.measurement.api.v2alpha.ExchangeStep
 import org.wfanet.measurement.api.v2alpha.ExchangeStepAttemptKey
 import org.wfanet.panelmatch.client.launcher.ExchangeStepValidator.ValidatedExchangeStep
@@ -27,11 +28,20 @@ import org.wfanet.panelmatch.client.launcher.ExchangeStepValidator.ValidatedExch
 /** Executes an [ExchangeStep] in a new coroutine in [scope]. */
 class CoroutineLauncher(
   private val scope: CoroutineScope = CoroutineScope(Dispatchers.Default),
-  private val stepExecutor: ExchangeStepExecutor
+  private val stepExecutor: ExchangeStepExecutor,
+  maxCoroutines: Int? = null
 ) : JobLauncher {
-  override suspend fun execute(step: ValidatedExchangeStep, attemptKey: ExchangeStepAttemptKey) {
+
+  private val semaphore = if (maxCoroutines !== null) Semaphore(maxCoroutines) else null
+
+  override suspend fun execute(
+    step: ValidatedExchangeStep,
+    attemptKey: ExchangeStepAttemptKey
+  ) {
     (scope + SupervisorJob()).launch(CoroutineName(attemptKey.toName())) {
+      if (semaphore !== null) semaphore.acquire()
       stepExecutor.execute(step, attemptKey)
+      if (semaphore !== null) semaphore.release()
     }
   }
 }

--- a/src/main/kotlin/org/wfanet/panelmatch/client/launcher/CoroutineLauncher.kt
+++ b/src/main/kotlin/org/wfanet/panelmatch/client/launcher/CoroutineLauncher.kt
@@ -27,7 +27,7 @@ import org.wfanet.panelmatch.client.launcher.ExchangeStepValidator.ValidatedExch
 /** Executes an [ExchangeStep] in a new coroutine in [scope]. */
 class CoroutineLauncher(
   private val scope: CoroutineScope = CoroutineScope(Dispatchers.Default),
-  private val stepExecutor: ExchangeStepExecutor
+  private val stepExecutor: ExchangeStepExecutor,
 ) : JobLauncher {
 
   override suspend fun execute(step: ValidatedExchangeStep, attemptKey: ExchangeStepAttemptKey) {

--- a/src/main/kotlin/org/wfanet/panelmatch/client/launcher/GrpcApiClient.kt
+++ b/src/main/kotlin/org/wfanet/panelmatch/client/launcher/GrpcApiClient.kt
@@ -16,7 +16,6 @@ package org.wfanet.panelmatch.client.launcher
 
 import java.time.Clock
 import kotlinx.coroutines.sync.Semaphore
-import org.wfanet.measurement.api.v2alpha.ClaimReadyExchangeStepResponse
 import org.wfanet.measurement.api.v2alpha.DataProviderKey
 import org.wfanet.measurement.api.v2alpha.ExchangeStepAttempt
 import org.wfanet.measurement.api.v2alpha.ExchangeStepAttemptKey
@@ -79,7 +78,7 @@ class GrpcApiClient(
   override suspend fun finishExchangeStepAttempt(
     key: ExchangeStepAttemptKey,
     finalState: ExchangeStepAttempt.State,
-    logEntryMessages: Iterable<String>
+    logEntryMessages: Iterable<String>,
   ) {
     semaphore?.release()
     val request = finishExchangeStepAttemptRequest {

--- a/src/main/kotlin/org/wfanet/panelmatch/client/launcher/GrpcApiClient.kt
+++ b/src/main/kotlin/org/wfanet/panelmatch/client/launcher/GrpcApiClient.kt
@@ -15,6 +15,8 @@
 package org.wfanet.panelmatch.client.launcher
 
 import java.time.Clock
+import kotlinx.coroutines.sync.Semaphore
+import org.wfanet.measurement.api.v2alpha.ClaimReadyExchangeStepResponse
 import org.wfanet.measurement.api.v2alpha.DataProviderKey
 import org.wfanet.measurement.api.v2alpha.ExchangeStepAttempt
 import org.wfanet.measurement.api.v2alpha.ExchangeStepAttemptKey
@@ -35,8 +37,12 @@ class GrpcApiClient(
   private val identity: Identity,
   private val exchangeStepsClient: ExchangeStepsCoroutineStub,
   private val exchangeStepAttemptsClient: ExchangeStepAttemptsCoroutineStub,
-  private val clock: Clock = Clock.systemUTC()
+  private val clock: Clock = Clock.systemUTC(),
+  val maxClaimedExchangeSteps: Int,
 ) : ApiClient {
+  private val semaphore =
+    if (maxClaimedExchangeSteps != -1) Semaphore(maxClaimedExchangeSteps) else null
+
   private val claimReadyExchangeStepRequest = claimReadyExchangeStepRequest {
     when (identity.party) {
       Party.DATA_PROVIDER -> dataProvider = DataProviderKey(identity.id).toName()
@@ -46,6 +52,10 @@ class GrpcApiClient(
   }
 
   override suspend fun claimExchangeStep(): ClaimedExchangeStep? {
+    if (semaphore !== null) {
+      val semaphoreAcquired = semaphore.tryAcquire()
+      if (!semaphoreAcquired) return null
+    }
     val response = exchangeStepsClient.claimReadyExchangeStep(claimReadyExchangeStepRequest)
     if (response.hasExchangeStep()) {
       val exchangeStepAttemptKey =
@@ -78,6 +88,7 @@ class GrpcApiClient(
       }
     }
     exchangeStepAttemptsClient.finishExchangeStepAttempt(request)
+    if (semaphore !== null) semaphore.release()
   }
 
   private fun makeLogEntry(message: String): ExchangeStepAttempt.DebugLogEntry {

--- a/src/main/kotlin/org/wfanet/panelmatch/client/launcher/GrpcApiClient.kt
+++ b/src/main/kotlin/org/wfanet/panelmatch/client/launcher/GrpcApiClient.kt
@@ -52,7 +52,7 @@ class GrpcApiClient(
   }
 
   override suspend fun claimExchangeStep(): ClaimedExchangeStep? {
-    if (semaphore !== null) {
+    if (semaphore != null) {
       val semaphoreAcquired = semaphore.tryAcquire()
       if (!semaphoreAcquired) return null
     }
@@ -62,6 +62,7 @@ class GrpcApiClient(
         grpcRequireNotNull(ExchangeStepAttemptKey.fromName(response.exchangeStepAttempt))
       return ClaimedExchangeStep(response.exchangeStep, exchangeStepAttemptKey)
     }
+    semaphore?.release()
     return null
   }
 
@@ -80,6 +81,7 @@ class GrpcApiClient(
     finalState: ExchangeStepAttempt.State,
     logEntryMessages: Iterable<String>
   ) {
+    semaphore?.release()
     val request = finishExchangeStepAttemptRequest {
       name = key.toName()
       this.finalState = finalState
@@ -88,7 +90,6 @@ class GrpcApiClient(
       }
     }
     exchangeStepAttemptsClient.finishExchangeStepAttempt(request)
-    if (semaphore !== null) semaphore.release()
   }
 
   private fun makeLogEntry(message: String): ExchangeStepAttempt.DebugLogEntry {

--- a/src/main/kotlin/org/wfanet/panelmatch/integration/ExchangeWorkflowDaemonForTest.kt
+++ b/src/main/kotlin/org/wfanet/panelmatch/integration/ExchangeWorkflowDaemonForTest.kt
@@ -101,7 +101,7 @@ class ExchangeWorkflowDaemonForTest(
     val exchangeStepAttemptsClient =
       ExchangeStepAttemptsCoroutineStub(v2alphaChannel).withPrincipalName(providerName)
 
-    GrpcApiClient(identity, exchangeStepsClient, exchangeStepAttemptsClient, clock)
+    GrpcApiClient(identity, exchangeStepsClient, exchangeStepAttemptsClient, clock, -1)
   }
 
   override val throttler: Throttler = MinimumIntervalThrottler(clock, pollingInterval)

--- a/src/main/kotlin/org/wfanet/panelmatch/integration/ExchangeWorkflowDaemonForTest.kt
+++ b/src/main/kotlin/org/wfanet/panelmatch/integration/ExchangeWorkflowDaemonForTest.kt
@@ -60,7 +60,7 @@ class ExchangeWorkflowDaemonForTest(
   privateDirectory: Path,
   override val clock: Clock = Clock.systemUTC(),
   pollingInterval: Duration = Duration.ofMillis(100),
-  taskTimeoutDuration: Duration = Duration.ofMinutes(2)
+  taskTimeoutDuration: Duration = Duration.ofMinutes(2),
 ) : ExchangeWorkflowDaemon() {
 
   private val rootStorageClient: StorageClient by lazy {
@@ -107,10 +107,7 @@ class ExchangeWorkflowDaemonForTest(
   override val throttler: Throttler = MinimumIntervalThrottler(clock, pollingInterval)
 
   private val preprocessingParameters =
-    PreprocessingParameters(
-      maxByteSize = 1024 * 1024,
-      fileCount = 1,
-    )
+    PreprocessingParameters(maxByteSize = 1024 * 1024, fileCount = 1)
 
   private val taskContext: TaskParameters = TaskParameters(setOf(preprocessingParameters))
 

--- a/src/test/kotlin/org/wfanet/panelmatch/client/launcher/CoroutineLauncherTest.kt
+++ b/src/test/kotlin/org/wfanet/panelmatch/client/launcher/CoroutineLauncherTest.kt
@@ -88,5 +88,4 @@ class CoroutineLauncherTest {
     val attemptKeyCaptor = argumentCaptor<ExchangeStepAttemptKey>()
     verify(stepExecutor, times(2)).execute(stepCaptor.capture(), attemptKeyCaptor.capture())
   }
-
 }

--- a/src/test/kotlin/org/wfanet/panelmatch/client/launcher/CoroutineLauncherTest.kt
+++ b/src/test/kotlin/org/wfanet/panelmatch/client/launcher/CoroutineLauncherTest.kt
@@ -14,13 +14,8 @@
 
 package org.wfanet.panelmatch.client.launcher
 
-import com.google.common.truth.Truth.assertThat
-import java.time.Duration
 import java.time.LocalDate
-import kotlin.test.assertFailsWith
-import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.runBlocking
-import kotlinx.coroutines.time.withTimeout
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
@@ -45,7 +40,7 @@ class CoroutineLauncherTest {
 
   @Test
   fun launches() = runBlockingTest {
-    val launcher = CoroutineLauncher(stepExecutor = stepExecutor, maxCoroutines = 2)
+    val launcher = CoroutineLauncher(stepExecutor = stepExecutor)
     val workflowStep = step {
       this.commutativeDeterministicEncryptStep = commutativeDeterministicEncryptStep {}
     }
@@ -75,7 +70,6 @@ class CoroutineLauncherTest {
         endLatch2.countDown()
       }
     }
-    val attemptKey = ExchangeStepAttemptKey("w", "x", "y", "z")
     val date = LocalDate.of(2021, 11, 29)
 
     val validatedExchangeStep = ValidatedExchangeStep(workflow, workflow.getSteps(0), date)
@@ -95,49 +89,4 @@ class CoroutineLauncherTest {
     verify(stepExecutor, times(2)).execute(stepCaptor.capture(), attemptKeyCaptor.capture())
   }
 
-  @Test
-  fun timesOutWithSingleCoroutineThatNeverCompletes() = runBlockingTest {
-    val launcher = CoroutineLauncher(stepExecutor = stepExecutor, maxCoroutines = 1)
-    val workflowStep = step {
-      this.commutativeDeterministicEncryptStep = commutativeDeterministicEncryptStep {}
-    }
-    val workflow = buildWorkflow(workflowStep, "some-edp", "some-mp")
-
-    val startLatch1 = CountDownLatch(1)
-    val startLatch2 = CountDownLatch(1)
-    val endLatch1 = CountDownLatch(1)
-    val endLatch2 = CountDownLatch(1)
-
-    val attemptKey1 = ExchangeStepAttemptKey("a", "b", "c", "d")
-    val attemptKey2 = ExchangeStepAttemptKey("w", "x", "y", "z")
-
-    whenever(stepExecutor.execute(any(), eq(attemptKey1))).thenAnswer {
-      runBlocking {
-        startLatch1.countDown()
-        endLatch1.await()
-      }
-    }
-    whenever(stepExecutor.execute(any(), eq(attemptKey2))).thenAnswer {
-      runBlocking {
-        startLatch2.countDown()
-        endLatch2.await()
-      }
-    }
-    val date = LocalDate.of(2021, 11, 29)
-
-    val validatedExchangeStep = ValidatedExchangeStep(workflow, workflow.getSteps(0), date)
-
-    launcher.execute(validatedExchangeStep, attemptKey1)
-    launcher.execute(validatedExchangeStep, attemptKey2)
-
-    startLatch1.await()
-    assertFailsWith<TimeoutCancellationException> {
-      withTimeout(Duration.ofSeconds(10)) { startLatch2.await() }
-    }
-    val stepCaptor = argumentCaptor<ValidatedExchangeStep>()
-    val attemptKeyCaptor = argumentCaptor<ExchangeStepAttemptKey>()
-    verify(stepExecutor, times(1)).execute(stepCaptor.capture(), attemptKeyCaptor.capture())
-    assertThat(stepCaptor.firstValue).isEqualTo(validatedExchangeStep)
-    assertThat(attemptKeyCaptor.firstValue).isEqualTo(attemptKey1)
-  }
 }

--- a/src/test/kotlin/org/wfanet/panelmatch/client/launcher/CoroutineLauncherTest.kt
+++ b/src/test/kotlin/org/wfanet/panelmatch/client/launcher/CoroutineLauncherTest.kt
@@ -15,14 +15,20 @@
 package org.wfanet.panelmatch.client.launcher
 
 import com.google.common.truth.Truth.assertThat
+import java.time.Duration
 import java.time.LocalDate
+import kotlin.test.assertFailsWith
+import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.time.withTimeout
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 import org.mockito.kotlin.any
 import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.wfanet.measurement.api.v2alpha.ExchangeStepAttemptKey
@@ -36,41 +42,102 @@ import org.wfanet.panelmatch.common.testing.runBlockingTest
 @RunWith(JUnit4::class)
 class CoroutineLauncherTest {
   private val stepExecutor = mock<ExchangeStepExecutor>()
-  private val launcher = CoroutineLauncher(stepExecutor = stepExecutor)
 
   @Test
   fun launches() = runBlockingTest {
+    val launcher = CoroutineLauncher(stepExecutor = stepExecutor, maxCoroutines = 2)
     val workflowStep = step {
       this.commutativeDeterministicEncryptStep = commutativeDeterministicEncryptStep {}
     }
     val workflow = buildWorkflow(workflowStep, "some-edp", "some-mp")
 
-    val startLatch = CountDownLatch(1)
-    val middleLatch = CountDownLatch(1)
-    val endLatch = CountDownLatch(1)
-    whenever(stepExecutor.execute(any(), any())).thenAnswer {
+    val startLatch1 = CountDownLatch(1)
+    val middleLatch1 = CountDownLatch(1)
+    val endLatch1 = CountDownLatch(1)
+    val startLatch2 = CountDownLatch(1)
+    val middleLatch2 = CountDownLatch(1)
+    val endLatch2 = CountDownLatch(1)
+
+    val attemptKey1 = ExchangeStepAttemptKey("a", "b", "c", "d")
+    val attemptKey2 = ExchangeStepAttemptKey("w", "x", "y", "z")
+
+    whenever(stepExecutor.execute(any(), eq(attemptKey1))).thenAnswer {
       runBlocking {
-        startLatch.countDown()
-        middleLatch.await()
-        endLatch.countDown()
+        startLatch1.countDown()
+        middleLatch1.await()
+        endLatch1.countDown()
       }
     }
-
+    whenever(stepExecutor.execute(any(), eq(attemptKey2))).thenAnswer {
+      runBlocking {
+        startLatch2.countDown()
+        middleLatch2.await()
+        endLatch2.countDown()
+      }
+    }
     val attemptKey = ExchangeStepAttemptKey("w", "x", "y", "z")
     val date = LocalDate.of(2021, 11, 29)
 
     val validatedExchangeStep = ValidatedExchangeStep(workflow, workflow.getSteps(0), date)
 
-    launcher.execute(validatedExchangeStep, attemptKey)
+    launcher.execute(validatedExchangeStep, attemptKey1)
+    launcher.execute(validatedExchangeStep, attemptKey2)
 
-    startLatch.await()
-    middleLatch.countDown()
-    endLatch.await()
+    startLatch1.await()
+    startLatch2.await()
+    middleLatch1.countDown()
+    middleLatch2.countDown()
+    endLatch1.await()
+    endLatch2.await()
 
     val stepCaptor = argumentCaptor<ValidatedExchangeStep>()
     val attemptKeyCaptor = argumentCaptor<ExchangeStepAttemptKey>()
-    verify(stepExecutor).execute(stepCaptor.capture(), attemptKeyCaptor.capture())
+    verify(stepExecutor, times(2)).execute(stepCaptor.capture(), attemptKeyCaptor.capture())
+  }
+
+  @Test
+  fun timesOutWithSingleCoroutineThatNeverCompletes() = runBlockingTest {
+    val launcher = CoroutineLauncher(stepExecutor = stepExecutor, maxCoroutines = 1)
+    val workflowStep = step {
+      this.commutativeDeterministicEncryptStep = commutativeDeterministicEncryptStep {}
+    }
+    val workflow = buildWorkflow(workflowStep, "some-edp", "some-mp")
+
+    val startLatch1 = CountDownLatch(1)
+    val startLatch2 = CountDownLatch(1)
+    val endLatch1 = CountDownLatch(1)
+    val endLatch2 = CountDownLatch(1)
+
+    val attemptKey1 = ExchangeStepAttemptKey("a", "b", "c", "d")
+    val attemptKey2 = ExchangeStepAttemptKey("w", "x", "y", "z")
+
+    whenever(stepExecutor.execute(any(), eq(attemptKey1))).thenAnswer {
+      runBlocking {
+        startLatch1.countDown()
+        endLatch1.await()
+      }
+    }
+    whenever(stepExecutor.execute(any(), eq(attemptKey2))).thenAnswer {
+      runBlocking {
+        startLatch2.countDown()
+        endLatch2.await()
+      }
+    }
+    val date = LocalDate.of(2021, 11, 29)
+
+    val validatedExchangeStep = ValidatedExchangeStep(workflow, workflow.getSteps(0), date)
+
+    launcher.execute(validatedExchangeStep, attemptKey1)
+    launcher.execute(validatedExchangeStep, attemptKey2)
+
+    startLatch1.await()
+    assertFailsWith<TimeoutCancellationException> {
+      withTimeout(Duration.ofSeconds(10)) { startLatch2.await() }
+    }
+    val stepCaptor = argumentCaptor<ValidatedExchangeStep>()
+    val attemptKeyCaptor = argumentCaptor<ExchangeStepAttemptKey>()
+    verify(stepExecutor, times(1)).execute(stepCaptor.capture(), attemptKeyCaptor.capture())
     assertThat(stepCaptor.firstValue).isEqualTo(validatedExchangeStep)
-    assertThat(attemptKeyCaptor.firstValue).isEqualTo(attemptKey)
+    assertThat(attemptKeyCaptor.firstValue).isEqualTo(attemptKey1)
   }
 }

--- a/src/test/kotlin/org/wfanet/panelmatch/client/launcher/GrpcApiClientTest.kt
+++ b/src/test/kotlin/org/wfanet/panelmatch/client/launcher/GrpcApiClientTest.kt
@@ -113,7 +113,11 @@ class GrpcApiClientTest {
   private val clock = Clock.fixed(Instant.ofEpochSecond(123456789), ZoneOffset.UTC)
 
   private fun makeClient(identity: Identity = DATA_PROVIDER_IDENTITY): GrpcApiClient {
-    return GrpcApiClient(identity, exchangeStepsStub, exchangeStepAttemptsStub, clock)
+    return GrpcApiClient(identity, exchangeStepsStub, exchangeStepAttemptsStub, clock, -1)
+  }
+
+  private fun makeLimitedClient(identity: Identity = DATA_PROVIDER_IDENTITY): GrpcApiClient {
+    return GrpcApiClient(identity, exchangeStepsStub, exchangeStepAttemptsStub, clock, 1)
   }
 
   private fun makeLogEntry(message: String): ExchangeStepAttempt.DebugLogEntry {
@@ -253,6 +257,71 @@ class GrpcApiClientTest {
             finalState = ExchangeStepAttempt.State.FAILED_STEP
           }
         )
+    }
+  }
+
+  @Test
+  fun `claimExchangeStep skips for multiple requests to limited client`() {
+    exchangeStepsServiceMock.stub {
+      onBlocking { claimReadyExchangeStep(any()) }
+        .thenReturn(FULL_CLAIM_READY_EXCHANGE_STEP_RESPONSE)
+    }
+
+    val client = makeLimitedClient(DATA_PROVIDER_IDENTITY)
+
+    runBlocking {
+      client.claimExchangeStep()
+      client.claimExchangeStep()
+    }
+
+    val stepCaptor = argumentCaptor<ClaimReadyExchangeStepRequest>()
+    verifyBlocking(exchangeStepsServiceMock, times(1)) {
+      claimReadyExchangeStep(stepCaptor.capture())
+    }
+  }
+
+  @Test
+  fun `claimExchangeStep succeeds out for multiple requests to unlimited client`() {
+    exchangeStepsServiceMock.stub {
+      onBlocking { claimReadyExchangeStep(any()) }
+        .thenReturn(FULL_CLAIM_READY_EXCHANGE_STEP_RESPONSE)
+    }
+
+    val client = makeClient(DATA_PROVIDER_IDENTITY)
+
+    runBlocking {
+      client.claimExchangeStep()
+      client.claimExchangeStep()
+    }
+
+    val stepCaptor = argumentCaptor<ClaimReadyExchangeStepRequest>()
+    verifyBlocking(exchangeStepsServiceMock, times(2)) {
+      claimReadyExchangeStep(stepCaptor.capture())
+    }
+  }
+
+  @Test
+  fun `claimExchangeStep succeeds for multiple claims and finishes to limited client`() {
+    exchangeStepsServiceMock.stub {
+      onBlocking { claimReadyExchangeStep(any()) }
+        .thenReturn(FULL_CLAIM_READY_EXCHANGE_STEP_RESPONSE)
+    }
+
+    val client = makeLimitedClient(DATA_PROVIDER_IDENTITY)
+
+    runBlocking {
+      client.claimExchangeStep()
+      client.finishExchangeStepAttempt(
+        EXCHANGE_STEP_ATTEMPT_KEY,
+        ExchangeStepAttempt.State.SUCCEEDED,
+        listOf("message-1", "message-2")
+      )
+      client.claimExchangeStep()
+    }
+
+    val stepCaptor = argumentCaptor<ClaimReadyExchangeStepRequest>()
+    verifyBlocking(exchangeStepsServiceMock, times(2)) {
+      claimReadyExchangeStep(stepCaptor.capture())
     }
   }
 }

--- a/src/test/kotlin/org/wfanet/panelmatch/client/launcher/GrpcApiClientTest.kt
+++ b/src/test/kotlin/org/wfanet/panelmatch/client/launcher/GrpcApiClientTest.kt
@@ -70,7 +70,7 @@ private val EXCHANGE_STEP_KEY =
   ExchangeStepKey(
     recurringExchangeId = RECURRING_EXCHANGE_ID,
     exchangeId = EXCHANGE_ID,
-    exchangeStepId = EXCHANGE_STEP_ID
+    exchangeStepId = EXCHANGE_STEP_ID,
   )
 
 private val EXCHANGE_STEP: ExchangeStep = exchangeStep {
@@ -83,7 +83,7 @@ private val EXCHANGE_STEP_ATTEMPT_KEY: ExchangeStepAttemptKey =
     recurringExchangeId = RECURRING_EXCHANGE_ID,
     exchangeId = EXCHANGE_ID,
     exchangeStepId = EXCHANGE_STEP_ID,
-    exchangeStepAttemptId = EXCHANGE_STEP_ATTEMPT_ID
+    exchangeStepAttemptId = EXCHANGE_STEP_ATTEMPT_ID,
   )
 
 private val FULL_CLAIM_READY_EXCHANGE_STEP_RESPONSE = claimReadyExchangeStepResponse {
@@ -231,7 +231,7 @@ class GrpcApiClientTest {
         .finishExchangeStepAttempt(
           EXCHANGE_STEP_ATTEMPT_KEY,
           ExchangeStepAttempt.State.SUCCEEDED,
-          listOf("message-1", "message-2")
+          listOf("message-1", "message-2"),
         )
       makeClient()
         .finishExchangeStepAttempt(EXCHANGE_STEP_ATTEMPT_KEY, ExchangeStepAttempt.State.FAILED_STEP)
@@ -314,7 +314,7 @@ class GrpcApiClientTest {
       client.finishExchangeStepAttempt(
         EXCHANGE_STEP_ATTEMPT_KEY,
         ExchangeStepAttempt.State.SUCCEEDED,
-        listOf("message-1", "message-2")
+        listOf("message-1", "message-2"),
       )
       client.claimExchangeStep()
     }


### PR DESCRIPTION
- add maxCoroutines parameter to CoroutineLauncher (#1383)

  The current CoroutineLauncher has not limit on the number of coroutines
  it launches. This works well on a platform like DataflowRunner but
  performs poorly with the DirectExecutor. This PR
  1. Adds a parameter to specify the max number of jobs that should be
  executed in parallel with the CoroutineLauncher.
  2. Sets the max number of jobs to 1 for the Aws example daemon.

  cherry picked from 2c1bbc698d1e551901cee183f59bde8cb8f193b4

- 75b40ba: move exchange limiter to GrpcApiClient (#1392)

  cherry-picked from 6702c271c17f83a516c39936b2c4c0f38936162e

- 97465bb: release semaphore if no exchange step is found (#1460)
  
  cherry picked from 96b2ca37f3e82b0b9bfabf34c03b9abe6f93792b