### PR TITLE
Specify auto_minor_version_upgrade = false for AWS Postgres DB.

### DIFF
--- a/src/main/terraform/aws/modules/rds-postgres/main.tf
+++ b/src/main/terraform/aws/modules/rds-postgres/main.tf
@@ -39,9 +39,10 @@ module "db" {
   identifier = var.name
 
   # All available versions: https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_PostgreSQL.html#PostgreSQL.Concepts
-  engine         = "postgres"
-  engine_version = "15.4"
-  instance_class = var.instance_class
+  engine                     = "postgres"
+  engine_version             = "15.5"
+  auto_minor_version_upgrade = false
+  instance_class             = var.instance_class
 
   allocated_storage = 20
 


### PR DESCRIPTION
This avoids issues where the engine version is upgraded outside of Terraform, causing future Terraforming to fail unless engine_version is updated.