### PR TITLE
Increase test timeout for K8s test workflow.

### DIFF
--- a/.github/workflows/run-k8s-tests.yml
+++ b/.github/workflows/run-k8s-tests.yml
@@ -36,33 +36,35 @@ jobs:
     runs-on: ubuntu-20.04
     environment: ${{ inputs.environment }}
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
-    # Authenticate to Google Cloud. This will export some environment
-    # variables, including GCLOUD_PROJECT.
-    - name: Authenticate to Google Cloud
+    # Authenticate to Google Cloud for access to remote cache.
+    - name: Authenticate to Google Cloud for remote cache
       uses: google-github-actions/auth@v2
       with:
-        workload_identity_provider: ${{ vars.WORKLOAD_IDENTITY_PROVIDER }}
-        service_account: ${{ vars.SIMULATOR_SERVICE_ACCOUNT }}
+        workload_identity_provider: ${{ vars.BAZEL_BUILD_WORKLOAD_IDENTITY_PROVIDER }}
+        service_account: ${{ vars.BAZEL_BUILD_SERVICE_ACCOUNT }}
 
     - name: Write ~/.bazelrc
       env:
         KINGDOM_PUBLIC_API_TARGET: ${{ vars.KINGDOM_PUBLIC_API_TARGET }}
         MC_NAME: ${{ vars.MC_NAME }}
         MC_API_KEY: ${{ secrets.MC_API_KEY }}
+        GCLOUD_PROJECT: ${{ vars.GCLOUD_PROJECT }}
         BIGQUERY_DATASET: ${{ vars.BIGQUERY_DATASET }}
         BIGQUERY_TABLE: ${{ vars.BIGQUERY_TABLE }}
       run: |
         cat << EOF > ~/.bazelrc
         common --config=ci
+        common --config=remote-cache
         build --define kingdom_public_api_target=$KINGDOM_PUBLIC_API_TARGET
         build --define mc_name=$MC_NAME
         build --define mc_api_key=$MC_API_KEY
         build --define google_cloud_project=$GCLOUD_PROJECT
         build --define bigquery_dataset=$BIGQUERY_DATASET
         build --define bigquery_table=$BIGQUERY_TABLE
-        build --test_env=GOOGLE_APPLICATION_CREDENTIALS
+        test --test_output=streamed
+        test --test_timeout=3600
         EOF
 
     - name: Get Bazel cache params
@@ -82,8 +84,7 @@ jobs:
       run: >
         bazelisk test
         //src/test/kotlin/org/wfanet/measurement/integration/k8s:SyntheticGeneratorCorrectnessTest
-        --test_output=streamed
-
+        
     - name: Upload Bazel testlogs
       continue-on-error: true
       uses: world-federation-of-advertisers/actions/bazel-upload-testlogs@v2

--- a/src/main/kotlin/org/wfanet/measurement/common/ExponentialBackoff.kt
+++ b/src/main/kotlin/org/wfanet/measurement/common/ExponentialBackoff.kt
@@ -78,3 +78,7 @@ data class ExponentialBackoff(
     }
   }
 }
+
+fun Duration.coerceAtMost(maximumValue: Duration): Duration {
+  return if (this <= maximumValue) this else maximumValue
+}

--- a/src/main/kotlin/org/wfanet/measurement/integration/common/InProcessLifeOfAMeasurementIntegrationTest.kt
+++ b/src/main/kotlin/org/wfanet/measurement/integration/common/InProcessLifeOfAMeasurementIntegrationTest.kt
@@ -14,7 +14,6 @@
 
 package org.wfanet.measurement.integration.common
 
-import java.time.Duration
 import kotlinx.coroutines.runBlocking
 import org.junit.After
 import org.junit.Before
@@ -100,7 +99,6 @@ abstract class InProcessLifeOfAMeasurementIntegrationTest(
         publicMeasurementsClient,
         publicMeasurementConsumersClient,
         publicCertificatesClient,
-        RESULT_POLLING_DELAY,
         InProcessCmmsComponents.TRUSTED_CERTIFICATES,
         eventQuery,
         NoiseMechanism.CONTINUOUS_GAUSSIAN,
@@ -178,7 +176,6 @@ abstract class InProcessLifeOfAMeasurementIntegrationTest(
       epsilon = 1.0
       delta = 1e-15
     }
-    private val RESULT_POLLING_DELAY = Duration.ofSeconds(10)
 
     @BeforeClass
     @JvmStatic

--- a/src/main/kotlin/org/wfanet/measurement/integration/common/InProcessReachMeasurementAccuracyTest.kt
+++ b/src/main/kotlin/org/wfanet/measurement/integration/common/InProcessReachMeasurementAccuracyTest.kt
@@ -15,7 +15,6 @@
 package org.wfanet.measurement.integration.common
 
 import com.google.common.truth.Truth.assertThat
-import java.time.Duration
 import java.util.logging.Level
 import java.util.logging.Logger
 import kotlin.math.abs
@@ -125,7 +124,6 @@ abstract class InProcessReachMeasurementAccuracyTest(
         publicMeasurementsClient,
         publicMeasurementConsumersClient,
         publicCertificatesClient,
-        RESULT_POLLING_DELAY,
         InProcessCmmsComponents.TRUSTED_CERTIFICATES,
         eventQuery,
         NoiseMechanism.CONTINUOUS_GAUSSIAN,
@@ -271,7 +269,6 @@ abstract class InProcessReachMeasurementAccuracyTest(
       epsilon = 0.0033
       delta = 0.00001
     }
-    private val RESULT_POLLING_DELAY = Duration.ofSeconds(10)
 
     @BeforeClass
     @JvmStatic

--- a/src/main/kotlin/org/wfanet/measurement/loadtest/measurementconsumer/BUILD.bazel
+++ b/src/main/kotlin/org/wfanet/measurement/loadtest/measurementconsumer/BUILD.bazel
@@ -39,6 +39,7 @@ kt_jvm_library(
         "//src/main/kotlin/org/wfanet/measurement/api/v2alpha:packed_messages",
         "//src/main/kotlin/org/wfanet/measurement/api/v2alpha:resource_key",
         "//src/main/kotlin/org/wfanet/measurement/api/v2alpha/testing",
+        "//src/main/kotlin/org/wfanet/measurement/common:exponential_backoff",
         "//src/main/kotlin/org/wfanet/measurement/common/identity",
         "//src/main/kotlin/org/wfanet/measurement/kingdom/service/api/v2alpha:api_key_authentication_server_interceptor",
         "//src/main/kotlin/org/wfanet/measurement/loadtest/common:sample_vids",

--- a/src/main/kotlin/org/wfanet/measurement/loadtest/measurementconsumer/MeasurementConsumerSimulator.kt
+++ b/src/main/kotlin/org/wfanet/measurement/loadtest/measurementconsumer/MeasurementConsumerSimulator.kt
@@ -84,7 +84,9 @@ import org.wfanet.measurement.api.v2alpha.requisitionSpec
 import org.wfanet.measurement.api.v2alpha.testing.MeasurementResultSubject.Companion.assertThat
 import org.wfanet.measurement.api.v2alpha.unpack
 import org.wfanet.measurement.api.withAuthenticationKey
+import org.wfanet.measurement.common.ExponentialBackoff
 import org.wfanet.measurement.common.OpenEndTimeRange
+import org.wfanet.measurement.common.coerceAtMost
 import org.wfanet.measurement.common.crypto.Hashing
 import org.wfanet.measurement.common.crypto.PrivateKeyHandle
 import org.wfanet.measurement.common.crypto.SigningKeyHandle
@@ -135,12 +137,13 @@ class MeasurementConsumerSimulator(
   private val measurementsClient: MeasurementsCoroutineStub,
   private val measurementConsumersClient: MeasurementConsumersCoroutineStub,
   private val certificatesClient: CertificatesCoroutineStub,
-  private val resultPollingDelay: Duration,
   private val trustedCertificates: Map<ByteString, X509Certificate>,
   private val eventQuery: EventQuery<Message>,
   private val expectedDirectNoiseMechanism: NoiseMechanism,
   private val filterExpression: String = DEFAULT_FILTER_EXPRESSION,
   private val eventRange: OpenEndTimeRange = DEFAULT_EVENT_RANGE,
+  private val initialResultPollingDelay: Duration = Duration.ofSeconds(1),
+  private val maximumResultPollingDelay: Duration = Duration.ofMinutes(1),
 ) {
   /** Cache of resource name to [Certificate]. */
   private val certificateCache = mutableMapOf<String, Certificate>()
@@ -1035,26 +1038,28 @@ class MeasurementConsumerSimulator(
   }
 
   private suspend inline fun pollForResult(getResult: () -> Result?): Result {
-    while (true) {
-      val result = getResult()
-      if (result != null) {
-        return result
-      }
-
-      logger.info("Result not yet available. Waiting for ${resultPollingDelay.seconds} seconds.")
-      delay(resultPollingDelay)
-    }
+    return pollForResult(getResult) { it != null }!!
   }
 
   private suspend inline fun <T> pollForResults(getResults: () -> List<T>): List<T> {
+    return pollForResult(getResults) { it.isNotEmpty() }
+  }
+
+  private suspend inline fun <T> pollForResult(getResult: () -> T, done: (T) -> Boolean): T {
+    val backoff =
+      ExponentialBackoff(initialDelay = initialResultPollingDelay, randomnessFactor = 0.0)
+    var attempt = 1
     while (true) {
-      val result = getResults()
-      if (result.isNotEmpty()) {
+      val result = getResult()
+      if (done(result)) {
         return result
       }
 
-      logger.info("Result not yet available. Waiting for ${resultPollingDelay.seconds} seconds.")
+      val resultPollingDelay =
+        backoff.durationForAttempt(attempt).coerceAtMost(maximumResultPollingDelay)
+      logger.info { "Result not yet available. Waiting for ${resultPollingDelay.seconds} seconds." }
       delay(resultPollingDelay)
+      attempt++
     }
   }
 

--- a/src/test/kotlin/org/wfanet/measurement/integration/k8s/AbstractCorrectnessTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/integration/k8s/AbstractCorrectnessTest.kt
@@ -46,7 +46,7 @@ abstract class AbstractCorrectnessTest(private val measurementSystem: Measuremen
     testHarness.testDuration("$runId-duration")
   }
 
-  @Test(timeout = 10 * 60 * 1000)
+  @Test
   fun `reach and frequency measurement completes with expected result`() = runBlocking {
     testHarness.testReachAndFrequency("$runId-reach-and-freq")
   }

--- a/src/test/kotlin/org/wfanet/measurement/integration/k8s/BigQueryCorrectnessTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/integration/k8s/BigQueryCorrectnessTest.kt
@@ -110,7 +110,6 @@ class BigQueryCorrectnessTest : AbstractCorrectnessTest(measurementSystem) {
         MeasurementsGrpcKt.MeasurementsCoroutineStub(publicApiChannel),
         MeasurementConsumersGrpcKt.MeasurementConsumersCoroutineStub(publicApiChannel),
         CertificatesGrpcKt.CertificatesCoroutineStub(publicApiChannel),
-        RESULT_POLLING_DELAY,
         MEASUREMENT_CONSUMER_SIGNING_CERTS.trustedCertificates,
         eventQuery,
         ProtocolConfig.NoiseMechanism.CONTINUOUS_GAUSSIAN,
@@ -125,7 +124,6 @@ class BigQueryCorrectnessTest : AbstractCorrectnessTest(measurementSystem) {
   }
 
   companion object {
-    private val RESULT_POLLING_DELAY = Duration.ofSeconds(10)
     private val RPC_DEADLINE_DURATION = Duration.ofSeconds(30)
     private val CONFIG_PATH =
       Paths.get("src", "test", "kotlin", "org", "wfanet", "measurement", "integration", "k8s")

--- a/src/test/kotlin/org/wfanet/measurement/integration/k8s/EmptyClusterCorrectnessTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/integration/k8s/EmptyClusterCorrectnessTest.kt
@@ -260,7 +260,6 @@ class EmptyClusterCorrectnessTest : AbstractCorrectnessTest(measurementSystem) {
           MeasurementsGrpcKt.MeasurementsCoroutineStub(publicApiChannel),
           MeasurementConsumersGrpcKt.MeasurementConsumersCoroutineStub(publicApiChannel),
           CertificatesGrpcKt.CertificatesCoroutineStub(publicApiChannel),
-          Duration.ofSeconds(10L),
           MEASUREMENT_CONSUMER_SIGNING_CERTS.trustedCertificates,
           MetadataSyntheticGeneratorEventQuery(
             SyntheticGenerationSpecs.POPULATION_SPEC,

--- a/src/test/kotlin/org/wfanet/measurement/integration/k8s/SyntheticGeneratorCorrectnessTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/integration/k8s/SyntheticGeneratorCorrectnessTest.kt
@@ -104,7 +104,6 @@ class SyntheticGeneratorCorrectnessTest : AbstractCorrectnessTest(measurementSys
         MeasurementsGrpcKt.MeasurementsCoroutineStub(publicApiChannel),
         MeasurementConsumersGrpcKt.MeasurementConsumersCoroutineStub(publicApiChannel),
         CertificatesGrpcKt.CertificatesCoroutineStub(publicApiChannel),
-        RESULT_POLLING_DELAY,
         MEASUREMENT_CONSUMER_SIGNING_CERTS.trustedCertificates,
         eventQuery,
         ProtocolConfig.NoiseMechanism.CONTINUOUS_GAUSSIAN,
@@ -119,7 +118,6 @@ class SyntheticGeneratorCorrectnessTest : AbstractCorrectnessTest(measurementSys
   }
 
   companion object {
-    private val RESULT_POLLING_DELAY = Duration.ofSeconds(10)
     private val RPC_DEADLINE_DURATION = Duration.ofSeconds(30)
     private val CONFIG_PATH =
       Paths.get("src", "test", "kotlin", "org", "wfanet", "measurement", "integration", "k8s")


### PR DESCRIPTION
When running against a test cloud environment, the sketch size and number of events means that R/F tests using LLv2 may take up to an hour.