### PR TITLE
Fix configure-simulators workflow not setting google_cloud_project.

### DIFF
--- a/.github/workflows/configure-simulators.yml
+++ b/.github/workflows/configure-simulators.yml
@@ -88,6 +88,7 @@ jobs:
         common --config=ci
         common --config=ghcr
         build --define "image_tag=$IMAGE_TAG"
+        build --define "google_cloud_project=$GCLOUD_PROJECT"
         build --define "kingdom_public_api_target=$KINGDOM_PUBLIC_API_TARGET"
         build --define "duchy_public_api_target=$DUCHY_PUBLIC_API_TARGET"
         build --define "mc_name=$MC_NAME"


### PR DESCRIPTION
This was missed in #1501.