### PR TITLE
Clean up workflow access of environment vars/secrets.

### DIFF
--- a/.github/workflows/configure-reporting-v2.yml
+++ b/.github/workflows/configure-reporting-v2.yml
@@ -139,7 +139,7 @@ jobs:
 
     - name: Write measurement consumer config
       env:
-        MEASUREMENT_CONSUMER_CONFIG: ${{ vars.MEASUREMENT_CONSUMER_CONFIG }}
+        MEASUREMENT_CONSUMER_CONFIG: ${{ secrets.MEASUREMENT_CONSUMER_CONFIG }}
       run: >
         echo "$MEASUREMENT_CONSUMER_CONFIG" | sed $'s/\r$//'  >
         "$KUSTOMIZATION_PATH/src/main/k8s/dev/reporting_v2_secrets/measurement_consumer_config.textproto"

--- a/.github/workflows/configure-reporting.yml
+++ b/.github/workflows/configure-reporting.yml
@@ -140,7 +140,7 @@ jobs:
 
     - name: Write measurement consumer config
       env:
-        MEASUREMENT_CONSUMER_CONFIG: ${{ vars.MEASUREMENT_CONSUMER_CONFIG }}
+        MEASUREMENT_CONSUMER_CONFIG: ${{ secrets.MEASUREMENT_CONSUMER_CONFIG }}
       run: >
         echo "$MEASUREMENT_CONSUMER_CONFIG" | sed $'s/\r$//'  >
         "$KUSTOMIZATION_PATH/src/main/k8s/dev/reporting_secrets/measurement_consumer_config.textproto"

--- a/.github/workflows/run-k8s-tests.yml
+++ b/.github/workflows/run-k8s-tests.yml
@@ -51,8 +51,6 @@ jobs:
         MC_NAME: ${{ vars.MC_NAME }}
         MC_API_KEY: ${{ secrets.MC_API_KEY }}
         GCLOUD_PROJECT: ${{ vars.GCLOUD_PROJECT }}
-        BIGQUERY_DATASET: ${{ vars.BIGQUERY_DATASET }}
-        BIGQUERY_TABLE: ${{ vars.BIGQUERY_TABLE }}
       run: |
         cat << EOF > ~/.bazelrc
         common --config=ci
@@ -61,8 +59,6 @@ jobs:
         build --define mc_name=$MC_NAME
         build --define mc_api_key=$MC_API_KEY
         build --define google_cloud_project=$GCLOUD_PROJECT
-        build --define bigquery_dataset=$BIGQUERY_DATASET
-        build --define bigquery_table=$BIGQUERY_TABLE
         test --test_output=streamed
         test --test_timeout=3600
         EOF

--- a/.github/workflows/terraform-cmms.yml
+++ b/.github/workflows/terraform-cmms.yml
@@ -50,7 +50,7 @@ jobs:
       AWS_MODULE_PATH: src/main/terraform/aws/cmms
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     # Authenticate to Google Cloud. This will export some environment
     # variables, including GCLOUD_PROJECT.
@@ -75,8 +75,6 @@ jobs:
         KEY_RING: ${{ vars.KEY_RING }}
         SPANNER_INSTANCE: ${{ vars.SPANNER_INSTANCE }}
         STORAGE_BUCKET: ${{ vars.STORAGE_BUCKET }}
-        BIGQUERY_DATASET: ${{ vars.BIGQUERY_DATASET }}
-        BIGQUERY_TABLE: ${{ vars.BIGQUERY_TABLE }}
         POSTGRES_INSTANCE: ${{ vars.POSTGRES_INSTANCE }}
         POSTGRES_PASSWORD: ${{ secrets.POSTGRES_PASSWORD }}
       working-directory: ${{ env.GCLOUD_MODULE_PATH }}
@@ -86,8 +84,6 @@ jobs:
         -var="key_ring_name=$KEY_RING"
         -var="spanner_instance_name=$SPANNER_INSTANCE"
         -var="storage_bucket_name=$STORAGE_BUCKET"
-        -var="bigquery_dataset_id=$BIGQUERY_DATASET"
-        -var="bigquery_table_id=$BIGQUERY_TABLE"
         -var="postgres_instance_name=$POSTGRES_INSTANCE"
         -var="postgres_password=$POSTGRES_PASSWORD"
         -out=tfplan

--- a/.github/workflows/update-cmms.yml
+++ b/.github/workflows/update-cmms.yml
@@ -95,6 +95,7 @@ jobs:
   # This isn't technically part of the CMMS, but we do it here for simplicity.
   update-reporting:
     uses: ./.github/workflows/configure-reporting.yml
+    secrets: inherit
     needs: [publish-images, terraform]
     with:
       image-tag: ${{ needs.publish-images.outputs.image-tag }}
@@ -103,6 +104,7 @@ jobs:
 
   update-reporting-v2:
     uses: ./.github/workflows/configure-reporting-v2.yml
+    secrets: inherit
     needs: [ publish-images, terraform ]
     with:
       image-tag: ${{ needs.publish-images.outputs.image-tag }}


### PR DESCRIPTION
* Read MEASUREMENT_CONSUMER_CONFIG from secrets instead of vars.
  * It contains the MC API key, which should be secret.
* Stop reading BigQuery vars for K8s tests.