### PR TITLE
Increase Mill and EDP simulator memory sizes for dev configuration.

### DIFF
--- a/src/main/k8s/dev/bigquery_edp_simulator_gke.cue
+++ b/src/main/k8s/dev/bigquery_edp_simulator_gke.cue
@@ -22,7 +22,7 @@ _bigQueryConfig: #BigQueryConfig & {
 _resourceRequirements: ResourceRequirements=#ResourceRequirements & {
 	requests: {
 		cpu:    "100m"
-		memory: "288Mi"
+		memory: "1Gi"
 	}
 	limits: {
 		memory: ResourceRequirements.requests.memory
@@ -37,6 +37,7 @@ edp_simulators: {
 
 			deployment: {
 				_container: {
+					_javaOptions: maxHeapSize: "512M"
 					resources: _resourceRequirements
 				}
 			}

--- a/src/main/k8s/dev/duchy_eks.cue
+++ b/src/main/k8s/dev/duchy_eks.cue
@@ -38,7 +38,7 @@ _duchyCertName: "duchies/\(_duchyName)/certificates/\(_certificateId)"
 #MillResourceRequirements: ResourceRequirements=#ResourceRequirements & {
 	requests: {
 		cpu:    "3"
-		memory: "2Gi"
+		memory: "2.5Gi"
 	}
 	limits: {
 		memory: ResourceRequirements.requests.memory

--- a/src/main/k8s/dev/duchy_gke.cue
+++ b/src/main/k8s/dev/duchy_gke.cue
@@ -38,7 +38,7 @@ _duchy_cert_name: "duchies/\(_duchy_name)/certificates/\(_certificateId)"
 #MillResourceRequirements: ResourceRequirements=#ResourceRequirements & {
 	requests: {
 		cpu:    "3"
-		memory: "2Gi"
+		memory: "2.5Gi"
 	}
 	limits: {
 		memory: ResourceRequirements.requests.memory

--- a/src/main/k8s/dev/synthetic_generator_edp_simulator_gke.cue
+++ b/src/main/k8s/dev/synthetic_generator_edp_simulator_gke.cue
@@ -17,7 +17,7 @@ package k8s
 _resourceRequirements: ResourceRequirements=#ResourceRequirements & {
 	requests: {
 		cpu:    "500m"
-		memory: "768Mi"
+		memory: "1Gi"
 	}
 	limits: {
 		memory: ResourceRequirements.requests.memory


### PR DESCRIPTION
This is to support the currently configured sketch size for LLv2.