### PR TITLE
Improve performance of batch create measurements

### DIFF
--- a/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/readers/DataProviderReader.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/readers/DataProviderReader.kt
@@ -34,7 +34,7 @@ class DataProviderReader : SpannerReader<DataProviderReader.Result>() {
     val dataProvider: DataProvider,
     val dataProviderId: Long,
     val certificateId: Long,
-    val isValid: Boolean,
+    val certificateValid: Boolean,
   )
 
   override val baseSql: String =

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/readers/DataProviderReader.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/readers/DataProviderReader.kt
@@ -24,12 +24,18 @@ import org.wfanet.measurement.gcloud.spanner.AsyncDatabaseClient
 import org.wfanet.measurement.gcloud.spanner.appendClause
 import org.wfanet.measurement.gcloud.spanner.getInternalId
 import org.wfanet.measurement.gcloud.spanner.getProtoMessage
+import org.wfanet.measurement.internal.kingdom.Certificate
 import org.wfanet.measurement.internal.kingdom.DataProvider
 import org.wfanet.measurement.kingdom.deploy.common.DuchyIds
 import org.wfanet.measurement.kingdom.deploy.gcloud.spanner.common.DataProviderNotFoundException
 
 class DataProviderReader : SpannerReader<DataProviderReader.Result>() {
-  data class Result(val dataProvider: DataProvider, val dataProviderId: Long)
+  data class Result(
+    val dataProvider: DataProvider,
+    val dataProviderId: Long,
+    val certificateId: Long,
+    val isValid: Boolean,
+  )
 
   override val baseSql: String =
     """
@@ -39,11 +45,13 @@ class DataProviderReader : SpannerReader<DataProviderReader.Result>() {
       DataProviders.DataProviderDetails,
       DataProviders.DataProviderDetailsJson,
       DataProviderCertificates.ExternalDataProviderCertificateId,
+      Certificates.CertificateId,
       Certificates.SubjectKeyIdentifier,
       Certificates.NotValidBefore,
       Certificates.NotValidAfter,
       Certificates.RevocationState,
       Certificates.CertificateDetails,
+      RevocationState = ${Certificate.RevocationState.REVOCATION_STATE_UNSPECIFIED.number} AND CURRENT_TIMESTAMP() >= NotValidBefore AND CURRENT_TIMESTAMP() <= NotValidAfter AS IsValid,
       ARRAY(
         SELECT AS STRUCT
           DataProviderRequiredDuchies.DuchyId
@@ -62,7 +70,12 @@ class DataProviderReader : SpannerReader<DataProviderReader.Result>() {
       .trimIndent()
 
   override suspend fun translate(struct: Struct): Result =
-    Result(buildDataProvider(struct), struct.getLong("DataProviderId"))
+    Result(
+      buildDataProvider(struct),
+      struct.getLong("DataProviderId"),
+      struct.getLong("CertificateId"),
+      struct.getBoolean("IsValid"),
+    )
 
   suspend fun readByExternalDataProviderId(
     readContext: AsyncDatabaseClient.ReadContext,

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/readers/MeasurementReader.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/readers/MeasurementReader.kt
@@ -50,6 +50,7 @@ class MeasurementReader(private val view: Measurement.View) :
   data class Result(
     val measurementConsumerId: InternalId,
     val measurementId: InternalId,
+    val createRequestId: String?,
     val measurement: Measurement,
   )
 
@@ -68,6 +69,7 @@ class MeasurementReader(private val view: Measurement.View) :
     Result(
       struct.getInternalId("MeasurementConsumerId"),
       struct.getInternalId("MeasurementId"),
+      if (struct.isNull("CreateRequestId")) null else struct.getString("CreateRequestId"),
       buildMeasurement(struct),
     )
 
@@ -234,6 +236,7 @@ class MeasurementReader(private val view: Measurement.View) :
       Measurements.ExternalMeasurementId,
       Measurements.ExternalComputationId,
       Measurements.ProvidedMeasurementId,
+      Measurements.CreateRequestId,
       Measurements.MeasurementDetails,
       Measurements.CreateTime,
       Measurements.UpdateTime,
@@ -286,6 +289,7 @@ class MeasurementReader(private val view: Measurement.View) :
       Measurements.ExternalMeasurementId,
       Measurements.ExternalComputationId,
       Measurements.ProvidedMeasurementId,
+      Measurements.CreateRequestId,
       Measurements.MeasurementDetails,
       Measurements.CreateTime,
       Measurements.UpdateTime,

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/writers/CancelMeasurement.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/writers/CancelMeasurement.kt
@@ -37,7 +37,7 @@ class CancelMeasurement(
   private val externalMeasurementId: ExternalId,
 ) : SpannerWriter<Measurement, Measurement>() {
   override suspend fun TransactionScope.runTransaction(): Measurement {
-    val (measurementConsumerId, measurementId, measurement) =
+    val (measurementConsumerId, measurementId, _, measurement) =
       MeasurementReader(Measurement.View.DEFAULT)
         .readByExternalIds(transactionContext, externalMeasurementConsumerId, externalMeasurementId)
         ?: throw MeasurementNotFoundByMeasurementConsumerException(

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/writers/CreateMeasurements.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/writers/CreateMeasurements.kt
@@ -121,7 +121,7 @@ class CreateMeasurements(private val requests: List<CreateMeasurementRequest>) :
             it.measurement.externalMeasurementConsumerCertificateId]
             ?: throw MeasurementConsumerCertificateNotFoundException(
               ExternalId(it.measurement.externalMeasurementConsumerId),
-              ExternalId(it.measurement.externalMeasurementId),
+              ExternalId(it.measurement.externalMeasurementConsumerCertificateId),
             )
 
         @Suppress("WHEN_ENUM_CAN_BE_NULL_IN_JAVA") // Protobuf enum fields are never null.

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/writers/CreateMeasurements.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/writers/CreateMeasurements.kt
@@ -101,7 +101,7 @@ class CreateMeasurements(private val requests: List<CreateMeasurementRequest>) :
       DataProviderReader()
         .readByExternalDataProviderIds(transactionContext, externalDataProviderIdsSet)
         .associateBy {
-          if (!it.isValid) {
+          if (!it.certificateValid) {
             throw CertificateIsInvalidException()
           }
           it.dataProvider.externalDataProviderId

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/writers/CreateMeasurements.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/writers/CreateMeasurements.kt
@@ -128,8 +128,7 @@ class CreateMeasurements(private val requests: List<CreateMeasurementRequest>) :
         when (it.measurement.details.protocolConfig.protocolCase) {
           ProtocolConfig.ProtocolCase.LIQUID_LEGIONS_V2,
           ProtocolConfig.ProtocolCase.REACH_ONLY_LIQUID_LEGIONS_V2,
-          ProtocolConfig.ProtocolCase.HONEST_MAJORITY_SHARE_SHUFFLE
-          -> {
+          ProtocolConfig.ProtocolCase.HONEST_MAJORITY_SHARE_SHUFFLE -> {
             createComputedMeasurement(
               createMeasurementRequest = it,
               measurementConsumerId = measurementConsumerId,
@@ -137,7 +136,6 @@ class CreateMeasurements(private val requests: List<CreateMeasurementRequest>) :
               dataProvideReaderResultsMap = dataProvideReaderResultsMap,
             )
           }
-
           ProtocolConfig.ProtocolCase.DIRECT ->
             createDirectMeasurement(
               createMeasurementRequest = it,
@@ -145,7 +143,6 @@ class CreateMeasurements(private val requests: List<CreateMeasurementRequest>) :
               measurementConsumerCertificateId = certificateId,
               dataProvideReaderResultsMap = dataProvideReaderResultsMap,
             )
-
           ProtocolConfig.ProtocolCase.PROTOCOL_NOT_SET -> error("Protocol is not set.")
         }
       }
@@ -166,13 +163,10 @@ class CreateMeasurements(private val requests: List<CreateMeasurementRequest>) :
         ProtocolConfig.ProtocolCase.LIQUID_LEGIONS_V2 -> Llv2ProtocolConfig.requiredExternalDuchyIds
         ProtocolConfig.ProtocolCase.REACH_ONLY_LIQUID_LEGIONS_V2 ->
           RoLlv2ProtocolConfig.requiredExternalDuchyIds
-
         ProtocolConfig.ProtocolCase.HONEST_MAJORITY_SHARE_SHUFFLE ->
           HmssProtocolConfig.requiredExternalDuchyIds
-
         ProtocolConfig.ProtocolCase.DIRECT,
-        ProtocolConfig.ProtocolCase.PROTOCOL_NOT_SET
-        -> error("Invalid protocol.")
+        ProtocolConfig.ProtocolCase.PROTOCOL_NOT_SET -> error("Invalid protocol.")
       }
     val requiredDuchyIds: Set<String> =
       requiredExternalDuchyIds +
@@ -191,16 +185,12 @@ class CreateMeasurements(private val requests: List<CreateMeasurementRequest>) :
       when (createMeasurementRequest.measurement.details.protocolConfig.protocolCase) {
         ProtocolConfig.ProtocolCase.LIQUID_LEGIONS_V2 ->
           Llv2ProtocolConfig.minimumNumberOfRequiredDuchies
-
         ProtocolConfig.ProtocolCase.REACH_ONLY_LIQUID_LEGIONS_V2 ->
           RoLlv2ProtocolConfig.minimumNumberOfRequiredDuchies
-
         ProtocolConfig.ProtocolCase.HONEST_MAJORITY_SHARE_SHUFFLE ->
           HmssProtocolConfig.requiredExternalDuchyIds.size
-
         ProtocolConfig.ProtocolCase.DIRECT,
-        ProtocolConfig.ProtocolCase.PROTOCOL_NOT_SET
-        -> error("Invalid protocol.")
+        ProtocolConfig.ProtocolCase.PROTOCOL_NOT_SET -> error("Invalid protocol.")
       }
 
     val includedDuchyEntries =
@@ -241,8 +231,7 @@ class CreateMeasurements(private val requests: List<CreateMeasurementRequest>) :
     @Suppress("WHEN_ENUM_CAN_BE_NULL_IN_JAVA") // Protobuf enum fields are never null.
     when (createMeasurementRequest.measurement.details.protocolConfig.protocolCase) {
       ProtocolConfig.ProtocolCase.LIQUID_LEGIONS_V2,
-      ProtocolConfig.ProtocolCase.REACH_ONLY_LIQUID_LEGIONS_V2
-      -> {
+      ProtocolConfig.ProtocolCase.REACH_ONLY_LIQUID_LEGIONS_V2 -> {
         // For each EDP, insert a Requisition.
         insertRequisitions(
           measurementConsumerId = measurementConsumerId,
@@ -252,7 +241,6 @@ class CreateMeasurements(private val requests: List<CreateMeasurementRequest>) :
           initialRequisitionState = Requisition.State.PENDING_PARAMS,
         )
       }
-
       ProtocolConfig.ProtocolCase.HONEST_MAJORITY_SHARE_SHUFFLE -> {
         // For each EDP, insert a Requisition for each non-aggregator Duchy.
         insertRequisitions(
@@ -264,10 +252,8 @@ class CreateMeasurements(private val requests: List<CreateMeasurementRequest>) :
           fulfillingDuchies = includedDuchyEntries.drop(1),
         )
       }
-
       ProtocolConfig.ProtocolCase.DIRECT,
-      ProtocolConfig.ProtocolCase.PROTOCOL_NOT_SET
-      -> error("Invalid protocol,")
+      ProtocolConfig.ProtocolCase.PROTOCOL_NOT_SET -> error("Invalid protocol,")
     }
 
     return createMeasurementRequest.measurement.copy {
@@ -450,7 +436,8 @@ class CreateMeasurements(private val requests: List<CreateMeasurementRequest>) :
         .fillStatementBuilder {
           appendClause(whereClause)
           bind(params.MEASUREMENT_CONSUMER_ID to measurementConsumerId)
-          bind(params.CREATE_REQUEST_ID).toStringArray(createMeasurementRequests.map { it.requestId })
+          bind(params.CREATE_REQUEST_ID)
+            .toStringArray(createMeasurementRequests.map { it.requestId })
         }
         .execute(transactionContext)
         .collect { put(it.createRequestId, it.measurement) }

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/writers/CreateMeasurements.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/writers/CreateMeasurements.kt
@@ -17,12 +17,7 @@ package org.wfanet.measurement.kingdom.deploy.gcloud.spanner.writers
 import com.google.cloud.spanner.Key
 import com.google.cloud.spanner.Value
 import java.time.Clock
-import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.flow.asFlow
-import kotlinx.coroutines.flow.flattenConcat
-import kotlinx.coroutines.flow.map
-import kotlinx.coroutines.flow.singleOrNull
-import kotlinx.coroutines.flow.toSet
+import kotlinx.coroutines.flow.toList
 import org.wfanet.measurement.common.identity.ExternalId
 import org.wfanet.measurement.common.identity.InternalId
 import org.wfanet.measurement.gcloud.spanner.appendClause
@@ -43,13 +38,11 @@ import org.wfanet.measurement.kingdom.deploy.common.HmssProtocolConfig
 import org.wfanet.measurement.kingdom.deploy.common.Llv2ProtocolConfig
 import org.wfanet.measurement.kingdom.deploy.common.RoLlv2ProtocolConfig
 import org.wfanet.measurement.kingdom.deploy.gcloud.spanner.common.CertificateIsInvalidException
-import org.wfanet.measurement.kingdom.deploy.gcloud.spanner.common.DataProviderCertificateNotFoundException
 import org.wfanet.measurement.kingdom.deploy.gcloud.spanner.common.DataProviderNotFoundException
 import org.wfanet.measurement.kingdom.deploy.gcloud.spanner.common.DuchyNotActiveException
 import org.wfanet.measurement.kingdom.deploy.gcloud.spanner.common.KingdomInternalException
 import org.wfanet.measurement.kingdom.deploy.gcloud.spanner.common.MeasurementConsumerCertificateNotFoundException
 import org.wfanet.measurement.kingdom.deploy.gcloud.spanner.common.MeasurementConsumerNotFoundException
-import org.wfanet.measurement.kingdom.deploy.gcloud.spanner.queries.StreamDataProviders
 import org.wfanet.measurement.kingdom.deploy.gcloud.spanner.readers.CertificateReader
 import org.wfanet.measurement.kingdom.deploy.gcloud.spanner.readers.DataProviderReader
 import org.wfanet.measurement.kingdom.deploy.gcloud.spanner.readers.MeasurementReader
@@ -78,24 +71,96 @@ class CreateMeasurements(private val requests: List<CreateMeasurementRequest>) :
         ExternalId(requests.first().measurement.externalMeasurementConsumerId)
       )
 
+    val existingMeasurementsMap = findExistingMeasurements(requests, measurementConsumerId)
+
+    val externalMeasurementConsumerCertificateIds: Set<ExternalId> = buildSet {
+      requests.forEach {
+        add(ExternalId(it.measurement.externalMeasurementConsumerCertificateId))
+      }
+    }
+
+    val reader =
+      CertificateReader(CertificateReader.ParentType.MEASUREMENT_CONSUMER)
+        .bindWhereClause(measurementConsumerId, externalMeasurementConsumerCertificateIds)
+
+    val measurementConsumerCertificateIdsMap: Map<Long, InternalId> =
+      buildMap {
+        reader.execute(transactionContext)
+          .toList()
+          .forEach {
+            validateCertificate(it)
+            put(it.certificate.externalCertificateId, it.certificateId)
+          }
+      }
+
+    val externalDataProviderIdsSet = buildSet {
+      requests.map { request ->
+        if (existingMeasurementsMap[request.requestId] == null) {
+          addAll(request.measurement.dataProvidersMap.keys.map { ExternalId(it) })
+        }
+      }
+    }
+
+    // Map of external data provider ID to DataProviderReader.Result
+    val dataProvideReaderResultsMap =
+      DataProviderReader()
+        .readByExternalDataProviderIds(transactionContext, externalDataProviderIdsSet)
+        .associateBy {
+          if (!it.isValid) {
+            throw CertificateIsInvalidException()
+          }
+          it.dataProvider.externalDataProviderId
+        }
+
+    externalDataProviderIdsSet.forEach {
+      if (dataProvideReaderResultsMap[it.value] == null) {
+        throw DataProviderNotFoundException(it)
+      }
+    }
+
     return requests.map {
-      findExistingMeasurement(it, measurementConsumerId)
-        ?: @Suppress("WHEN_ENUM_CAN_BE_NULL_IN_JAVA") // Protobuf enum fields are never null.
+      if (existingMeasurementsMap.containsKey(it.requestId)) {
+        existingMeasurementsMap.getValue(it.requestId)
+      } else {
+        val certificateId = measurementConsumerCertificateIdsMap[it.measurement.externalMeasurementConsumerCertificateId]
+          ?: throw MeasurementConsumerCertificateNotFoundException(
+            ExternalId(it.measurement.externalMeasurementConsumerId),
+            ExternalId(it.measurement.externalMeasurementId),
+          )
+
+        @Suppress("WHEN_ENUM_CAN_BE_NULL_IN_JAVA") // Protobuf enum fields are never null.
         when (it.measurement.details.protocolConfig.protocolCase) {
           ProtocolConfig.ProtocolCase.LIQUID_LEGIONS_V2,
           ProtocolConfig.ProtocolCase.REACH_ONLY_LIQUID_LEGIONS_V2,
-          ProtocolConfig.ProtocolCase.HONEST_MAJORITY_SHARE_SHUFFLE -> {
-            createComputedMeasurement(it, measurementConsumerId)
+          ProtocolConfig.ProtocolCase.HONEST_MAJORITY_SHARE_SHUFFLE
+          -> {
+            createComputedMeasurement(
+              createMeasurementRequest = it,
+              measurementConsumerId = measurementConsumerId,
+              measurementConsumerCertificateId = certificateId,
+              dataProvideReaderResultsMap = dataProvideReaderResultsMap,
+            )
           }
-          ProtocolConfig.ProtocolCase.DIRECT -> createDirectMeasurement(it, measurementConsumerId)
+
+          ProtocolConfig.ProtocolCase.DIRECT ->
+            createDirectMeasurement(
+              createMeasurementRequest = it,
+              measurementConsumerId = measurementConsumerId,
+              measurementConsumerCertificateId = certificateId,
+              dataProvideReaderResultsMap = dataProvideReaderResultsMap,
+            )
+
           ProtocolConfig.ProtocolCase.PROTOCOL_NOT_SET -> error("Protocol is not set.")
         }
+      }
     }
   }
 
-  private suspend fun TransactionScope.createComputedMeasurement(
+  private fun TransactionScope.createComputedMeasurement(
     createMeasurementRequest: CreateMeasurementRequest,
     measurementConsumerId: InternalId,
+    measurementConsumerCertificateId: InternalId,
+    dataProvideReaderResultsMap: Map<Long, DataProviderReader.Result>,
   ): Measurement {
     val initialMeasurementState = Measurement.State.PENDING_REQUISITION_PARAMS
 
@@ -110,11 +175,11 @@ class CreateMeasurements(private val requests: List<CreateMeasurementRequest>) :
         ProtocolConfig.ProtocolCase.DIRECT,
         ProtocolConfig.ProtocolCase.PROTOCOL_NOT_SET -> error("Invalid protocol.")
       }
-    val requiredDuchyIds =
+    val requiredDuchyIds: Set<String> =
       requiredExternalDuchyIds +
-        readDataProviderRequiredDuchies(
-          createMeasurementRequest.measurement.dataProvidersMap.keys.map { ExternalId(it) }.toSet()
-        )
+        createMeasurementRequest.measurement.dataProvidersMap.keys.flatMap {
+          dataProvideReaderResultsMap.getValue(it).dataProvider.requiredExternalDuchyIdsList
+        }
     val now = Clock.systemUTC().instant()
     val requiredDuchyEntries = DuchyIds.entries.filter { it.externalDuchyId in requiredDuchyIds }
     requiredDuchyEntries.forEach {
@@ -159,6 +224,7 @@ class CreateMeasurements(private val requests: List<CreateMeasurementRequest>) :
       externalMeasurementId,
       externalComputationId,
       initialMeasurementState,
+      measurementConsumerCertificateId,
     )
 
     includedDuchyEntries.forEach { entry ->
@@ -175,20 +241,22 @@ class CreateMeasurements(private val requests: List<CreateMeasurementRequest>) :
       ProtocolConfig.ProtocolCase.REACH_ONLY_LIQUID_LEGIONS_V2 -> {
         // For each EDP, insert a Requisition.
         insertRequisitions(
-          measurementConsumerId,
-          measurementId,
-          createMeasurementRequest.measurement.dataProvidersMap,
-          Requisition.State.PENDING_PARAMS,
+          measurementConsumerId = measurementConsumerId,
+          measurementId = measurementId,
+          dataProvidersMap = createMeasurementRequest.measurement.dataProvidersMap,
+          dataProvideReaderResultsMap = dataProvideReaderResultsMap,
+          initialRequisitionState = Requisition.State.PENDING_PARAMS,
         )
       }
       ProtocolConfig.ProtocolCase.HONEST_MAJORITY_SHARE_SHUFFLE -> {
         // For each EDP, insert a Requisition for each non-aggregator Duchy.
         insertRequisitions(
-          measurementConsumerId,
-          measurementId,
-          createMeasurementRequest.measurement.dataProvidersMap,
-          Requisition.State.PENDING_PARAMS,
-          includedDuchyEntries.drop(1),
+          measurementConsumerId = measurementConsumerId,
+          measurementId = measurementId,
+          dataProvidersMap = createMeasurementRequest.measurement.dataProvidersMap,
+          dataProvideReaderResultsMap = dataProvideReaderResultsMap,
+          initialRequisitionState = Requisition.State.PENDING_PARAMS,
+          fulfillingDuchies = includedDuchyEntries.drop(1),
         )
       }
       ProtocolConfig.ProtocolCase.DIRECT,
@@ -202,9 +270,11 @@ class CreateMeasurements(private val requests: List<CreateMeasurementRequest>) :
     }
   }
 
-  private suspend fun TransactionScope.createDirectMeasurement(
+  private fun TransactionScope.createDirectMeasurement(
     createMeasurementRequest: CreateMeasurementRequest,
     measurementConsumerId: InternalId,
+    measurementConsumerCertificateId: InternalId,
+    dataProvideReaderResultsMap: Map<Long, DataProviderReader.Result>,
   ): Measurement {
     val initialMeasurementState = Measurement.State.PENDING_REQUISITION_FULFILLMENT
 
@@ -217,14 +287,16 @@ class CreateMeasurements(private val requests: List<CreateMeasurementRequest>) :
       externalMeasurementId,
       null,
       initialMeasurementState,
+      measurementConsumerCertificateId,
     )
 
     // Insert into Requisitions for each EDP
     insertRequisitions(
-      measurementConsumerId,
-      measurementId,
-      createMeasurementRequest.measurement.dataProvidersMap,
-      Requisition.State.UNFULFILLED,
+      measurementConsumerId = measurementConsumerId,
+      measurementId = measurementId,
+      dataProvidersMap = createMeasurementRequest.measurement.dataProvidersMap,
+      dataProvideReaderResultsMap = dataProvideReaderResultsMap,
+      initialRequisitionState = Requisition.State.UNFULFILLED,
     )
 
     return createMeasurementRequest.measurement.copy {
@@ -233,26 +305,15 @@ class CreateMeasurements(private val requests: List<CreateMeasurementRequest>) :
     }
   }
 
-  private suspend fun TransactionScope.insertMeasurement(
+  private fun TransactionScope.insertMeasurement(
     createMeasurementRequest: CreateMeasurementRequest,
     measurementConsumerId: InternalId,
     measurementId: InternalId,
     externalMeasurementId: ExternalId,
     externalComputationId: ExternalId?,
     initialMeasurementState: Measurement.State,
+    measurementConsumerCertificateId: InternalId,
   ) {
-    val externalMeasurementConsumerId =
-      ExternalId(createMeasurementRequest.measurement.externalMeasurementConsumerCertificateId)
-    val reader =
-      CertificateReader(CertificateReader.ParentType.MEASUREMENT_CONSUMER)
-        .bindWhereClause(measurementConsumerId, externalMeasurementConsumerId)
-    val measurementConsumerCertificateId =
-      reader.execute(transactionContext).singleOrNull()?.let { validateCertificate(it) }
-        ?: throw MeasurementConsumerCertificateNotFoundException(
-          externalMeasurementConsumerId,
-          externalMeasurementId,
-        )
-
     transactionContext.bufferInsertMutation("Measurements") {
       set("MeasurementConsumerId" to measurementConsumerId)
       set("MeasurementId" to measurementId)
@@ -292,50 +353,37 @@ class CreateMeasurements(private val requests: List<CreateMeasurementRequest>) :
     }
   }
 
-  private suspend fun TransactionScope.insertRequisitions(
+  private fun TransactionScope.insertRequisitions(
     measurementConsumerId: InternalId,
     measurementId: InternalId,
     dataProvidersMap: Map<Long, Measurement.DataProviderValue>,
+    dataProvideReaderResultsMap: Map<Long, DataProviderReader.Result>,
     initialRequisitionState: Requisition.State,
     fulfillingDuchies: List<DuchyIds.Entry> = emptyList(),
   ) {
     for ((externalDataProviderId, dataProviderValue) in dataProvidersMap) {
+      val dataProviderReaderResult = dataProvideReaderResultsMap.getValue(externalDataProviderId)
       insertRequisition(
-        measurementConsumerId,
-        measurementId,
-        ExternalId(externalDataProviderId),
-        dataProviderValue,
-        initialRequisitionState,
-        fulfillingDuchies,
+        measurementConsumerId = measurementConsumerId,
+        measurementId = measurementId,
+        dataProviderId = InternalId(dataProviderReaderResult.dataProviderId),
+        dataProviderValue = dataProviderValue,
+        dataProviderCertificateId = InternalId(dataProviderReaderResult.certificateId),
+        initialRequisitionState = initialRequisitionState,
+        fulfillingDuchies = fulfillingDuchies,
       )
     }
   }
 
-  private suspend fun TransactionScope.insertRequisition(
+  private fun TransactionScope.insertRequisition(
     measurementConsumerId: InternalId,
     measurementId: InternalId,
-    externalDataProviderId: ExternalId,
+    dataProviderId: InternalId,
     dataProviderValue: Measurement.DataProviderValue,
+    dataProviderCertificateId: InternalId,
     initialRequisitionState: Requisition.State,
     fulfillingDuchies: List<DuchyIds.Entry> = emptyList(),
   ) {
-    val dataProviderId =
-      DataProviderReader.readDataProviderId(transactionContext, externalDataProviderId)
-        ?: throw DataProviderNotFoundException(externalDataProviderId)
-    val reader =
-      CertificateReader(CertificateReader.ParentType.DATA_PROVIDER)
-        .bindWhereClause(
-          dataProviderId,
-          ExternalId(dataProviderValue.externalDataProviderCertificateId),
-        )
-
-    val dataProviderCertificateId =
-      reader.execute(transactionContext).singleOrNull()?.let { validateCertificate(it) }
-        ?: throw DataProviderCertificateNotFoundException(
-          externalDataProviderId,
-          ExternalId(dataProviderValue.externalDataProviderCertificateId),
-        )
-
     val requisitionId = idGenerator.generateInternalId()
     val externalRequisitionId = idGenerator.generateExternalId()
     val details: Requisition.Details =
@@ -374,10 +422,10 @@ class CreateMeasurements(private val requests: List<CreateMeasurementRequest>) :
     }
   }
 
-  private suspend fun TransactionScope.findExistingMeasurement(
-    createMeasurementRequest: CreateMeasurementRequest,
+  private suspend fun TransactionScope.findExistingMeasurements(
+    createMeasurementRequests: List<CreateMeasurementRequest>,
     measurementConsumerId: InternalId,
-  ): Measurement? {
+  ): Map<String?, Measurement> {
     val params =
       object {
         val MEASUREMENT_CONSUMER_ID = "measurementConsumerId"
@@ -386,7 +434,7 @@ class CreateMeasurements(private val requests: List<CreateMeasurementRequest>) :
     val whereClause =
       """
       WHERE MeasurementConsumerId = @${params.MEASUREMENT_CONSUMER_ID}
-        AND CreateRequestId = @${params.CREATE_REQUEST_ID}
+        AND CreateRequestId IN UNNEST(@${params.CREATE_REQUEST_ID})
       """
         .trimIndent()
 
@@ -394,11 +442,11 @@ class CreateMeasurements(private val requests: List<CreateMeasurementRequest>) :
       .fillStatementBuilder {
         appendClause(whereClause)
         bind(params.MEASUREMENT_CONSUMER_ID to measurementConsumerId)
-        bind(params.CREATE_REQUEST_ID to createMeasurementRequest.requestId)
+        bind(params.CREATE_REQUEST_ID).toStringArray(createMeasurementRequests.map { it.requestId })
       }
       .execute(transactionContext)
-      .map { it.measurement }
-      .singleOrNull()
+      .toList()
+      .associate { result -> Pair(result.createRequestId, result.measurement) }
   }
 
   override fun ResultScope<List<Measurement>>.buildResult(): List<Measurement> {
@@ -433,17 +481,6 @@ private suspend fun TransactionScope.readMeasurementConsumerId(
     ?: throw MeasurementConsumerNotFoundException(externalMeasurementConsumerId) {
       "MeasurementConsumer with external ID $externalMeasurementConsumerId not found"
     }
-}
-
-@OptIn(ExperimentalCoroutinesApi::class) // For `flattenConcat`.
-private suspend fun TransactionScope.readDataProviderRequiredDuchies(
-  externalDataProviderIds: Set<ExternalId>
-): Set<String> {
-  return StreamDataProviders(externalDataProviderIds)
-    .execute(transactionContext)
-    .map { it.dataProvider.requiredExternalDuchyIdsList.asFlow() }
-    .flattenConcat()
-    .toSet()
 }
 
 /**

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/writers/SetMeasurementResult.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/writers/SetMeasurementResult.kt
@@ -49,7 +49,7 @@ class SetMeasurementResult(private val request: SetMeasurementResultRequest) :
   SpannerWriter<Measurement, Measurement>() {
 
   override suspend fun TransactionScope.runTransaction(): Measurement {
-    val (measurementConsumerId, measurementId, measurement) =
+    val (measurementConsumerId, measurementId, _, measurement) =
       MeasurementReader(Measurement.View.DEFAULT)
         .readByExternalComputationId(transactionContext, ExternalId(request.externalComputationId))
         ?: throw MeasurementNotFoundByComputationException(

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/service/internal/testing/MeasurementsServiceTest.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/service/internal/testing/MeasurementsServiceTest.kt
@@ -2395,7 +2395,8 @@ abstract class MeasurementsServiceTest<T : MeasurementsCoroutineImplBase> {
       val measurement2 =
         REACH_ONLY_MEASUREMENT.copy {
           externalMeasurementConsumerId = measurementConsumer.externalMeasurementConsumerId
-          externalMeasurementConsumerCertificateId = measurementConsumerCertificate2.externalCertificateId
+          externalMeasurementConsumerCertificateId =
+            measurementConsumerCertificate2.externalCertificateId
           dataProviders[dataProvider2.externalDataProviderId] = dataProvider2.toDataProviderValue()
         }
       val createMeasurementRequest2 = createMeasurementRequest { this.measurement = measurement2 }
@@ -2459,7 +2460,7 @@ abstract class MeasurementsServiceTest<T : MeasurementsCoroutineImplBase> {
           Measurement.EXTERNAL_MEASUREMENT_ID_FIELD_NUMBER,
           Measurement.EXTERNAL_COMPUTATION_ID_FIELD_NUMBER,
           Measurement.STATE_FIELD_NUMBER,
-          Measurement.ETAG_FIELD_NUMBER
+          Measurement.ETAG_FIELD_NUMBER,
         )
         .ignoringRepeatedFieldOrder()
         .containsExactly(measurement, measurement2)

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/service/internal/testing/MeasurementsServiceTest.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/service/internal/testing/MeasurementsServiceTest.kt
@@ -2303,7 +2303,7 @@ abstract class MeasurementsServiceTest<T : MeasurementsCoroutineImplBase> {
   }
 
   @Test
-  fun `batchCreateMeasurements with 2 create requests creates 2 measurements`() = runBlocking {
+  fun `batchCreateMeasurements with 2 same create requests creates 2 measurements`() = runBlocking {
     val measurementConsumer =
       population.createMeasurementConsumer(measurementConsumersService, accountsService)
     val dataProvider = population.createDataProvider(dataProvidersService)
@@ -2372,6 +2372,98 @@ abstract class MeasurementsServiceTest<T : MeasurementsCoroutineImplBase> {
 
     assertThat(measurements).hasSize(2)
   }
+
+  @Test
+  fun `batchCreateMeasurements with requests with diff edps, certs creates 2 measurements`(): Unit =
+    runBlocking {
+      val measurementConsumer =
+        population.createMeasurementConsumer(measurementConsumersService, accountsService)
+      val measurementConsumerCertificate2 =
+        population.createMeasurementConsumerCertificate(certificatesService, measurementConsumer)
+      val dataProvider = population.createDataProvider(dataProvidersService)
+      val dataProvider2 = population.createDataProvider(dataProvidersService)
+
+      val measurement =
+        REACH_ONLY_MEASUREMENT.copy {
+          externalMeasurementConsumerId = measurementConsumer.externalMeasurementConsumerId
+          externalMeasurementConsumerCertificateId =
+            measurementConsumer.certificate.externalCertificateId
+          dataProviders[dataProvider.externalDataProviderId] = dataProvider.toDataProviderValue()
+        }
+      val createMeasurementRequest = createMeasurementRequest { this.measurement = measurement }
+
+      val measurement2 =
+        REACH_ONLY_MEASUREMENT.copy {
+          externalMeasurementConsumerId = measurementConsumer.externalMeasurementConsumerId
+          externalMeasurementConsumerCertificateId = measurementConsumerCertificate2.externalCertificateId
+          dataProviders[dataProvider2.externalDataProviderId] = dataProvider2.toDataProviderValue()
+        }
+      val createMeasurementRequest2 = createMeasurementRequest { this.measurement = measurement2 }
+
+      val createdMeasurements =
+        measurementsService
+          .batchCreateMeasurements(
+            batchCreateMeasurementsRequest {
+              externalMeasurementConsumerId = measurementConsumer.externalMeasurementConsumerId
+              requests += createMeasurementRequest
+              requests += createMeasurementRequest2
+            }
+          )
+          .measurementsList
+
+      assertThat(createdMeasurements).hasSize(2)
+      assertThat(createdMeasurements[0].externalMeasurementId).isNotEqualTo(0L)
+      assertThat(createdMeasurements[0].externalComputationId).isNotEqualTo(0L)
+      assertThat(createdMeasurements[0].createTime.seconds).isGreaterThan(0L)
+      assertThat(createdMeasurements[0].updateTime).isEqualTo(createdMeasurements[0].createTime)
+      assertThat(createdMeasurements[0])
+        .ignoringFields(
+          Measurement.EXTERNAL_MEASUREMENT_ID_FIELD_NUMBER,
+          Measurement.EXTERNAL_COMPUTATION_ID_FIELD_NUMBER,
+          Measurement.CREATE_TIME_FIELD_NUMBER,
+          Measurement.UPDATE_TIME_FIELD_NUMBER,
+          Measurement.ETAG_FIELD_NUMBER,
+        )
+        .isEqualTo(measurement.copy { state = Measurement.State.PENDING_REQUISITION_PARAMS })
+      assertThat(createdMeasurements[1].externalMeasurementId).isNotEqualTo(0L)
+      assertThat(createdMeasurements[1].externalComputationId).isNotEqualTo(0L)
+      assertThat(createdMeasurements[1].createTime.seconds).isGreaterThan(0L)
+      assertThat(createdMeasurements[1].updateTime).isEqualTo(createdMeasurements[1].createTime)
+      assertThat(createdMeasurements[1])
+        .ignoringFields(
+          Measurement.EXTERNAL_MEASUREMENT_ID_FIELD_NUMBER,
+          Measurement.EXTERNAL_COMPUTATION_ID_FIELD_NUMBER,
+          Measurement.CREATE_TIME_FIELD_NUMBER,
+          Measurement.UPDATE_TIME_FIELD_NUMBER,
+          Measurement.ETAG_FIELD_NUMBER,
+        )
+        .isEqualTo(measurement2.copy { state = Measurement.State.PENDING_REQUISITION_PARAMS })
+      assertThat(createdMeasurements[0].createTime).isEqualTo(createdMeasurements[1].createTime)
+
+      val measurements =
+        measurementsService
+          .streamMeasurements(
+            streamMeasurementsRequest {
+              filter = filter {
+                externalMeasurementConsumerId = measurement.externalMeasurementConsumerId
+              }
+              measurementView = Measurement.View.DEFAULT
+            }
+          )
+          .toList()
+
+      assertThat(measurements)
+        .ignoringFields(
+          Measurement.CREATE_TIME_FIELD_NUMBER,
+          Measurement.UPDATE_TIME_FIELD_NUMBER,
+          Measurement.EXTERNAL_MEASUREMENT_ID_FIELD_NUMBER,
+          Measurement.EXTERNAL_COMPUTATION_ID_FIELD_NUMBER,
+          Measurement.STATE_FIELD_NUMBER,
+          Measurement.ETAG_FIELD_NUMBER
+        )
+        .ignoringRepeatedFieldOrder()
+        .containsExactly(measurement, measurement2)
+    }
 
   @Test
   fun `batchCreateMeasurements with 2 requests with same request id creates 0 measurements`() =
@@ -2457,6 +2549,46 @@ abstract class MeasurementsServiceTest<T : MeasurementsCoroutineImplBase> {
         }
 
       assertThat(exception.status.code).isEqualTo(Status.Code.INVALID_ARGUMENT)
+    }
+
+  @Test
+  fun `batchCreateMeasurement throws FAILED_PRECONDITION if mc certificate not found`() =
+    runBlocking {
+      val measurementConsumer =
+        population.createMeasurementConsumer(measurementConsumersService, accountsService)
+      val dataProvider = population.createDataProvider(dataProvidersService)
+
+      val measurement =
+        REACH_ONLY_MEASUREMENT.copy {
+          externalMeasurementConsumerId = measurementConsumer.externalMeasurementConsumerId
+          externalMeasurementConsumerCertificateId =
+            measurementConsumer.certificate.externalCertificateId
+          dataProviders[dataProvider.externalDataProviderId] = dataProvider.toDataProviderValue()
+        }
+
+      val measurement2 =
+        REACH_ONLY_MEASUREMENT.copy {
+          externalMeasurementConsumerId = measurementConsumer.externalMeasurementConsumerId
+          externalMeasurementConsumerCertificateId = 123
+          dataProviders[dataProvider.externalDataProviderId] = dataProvider.toDataProviderValue()
+        }
+
+      val createMeasurementRequest = createMeasurementRequest { this.measurement = measurement }
+
+      val createMeasurementRequest2 = createMeasurementRequest { this.measurement = measurement2 }
+
+      val request = batchCreateMeasurementsRequest {
+        externalMeasurementConsumerId = measurementConsumer.externalMeasurementConsumerId
+        requests += createMeasurementRequest
+        requests += createMeasurementRequest2
+      }
+
+      val exception =
+        assertFailsWith<StatusRuntimeException> {
+          measurementsService.batchCreateMeasurements(request)
+        }
+
+      assertThat(exception.status.code).isEqualTo(Status.Code.FAILED_PRECONDITION)
     }
 
   @Test


### PR DESCRIPTION
The current implementation doesn't take advantage of batching and has separate reads for each create.