### PR TITLE
Add CreateUiReport to the CLI

### DIFF
--- a/src/main/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/tools/README.md
+++ b/src/main/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/tools/README.md
@@ -115,6 +115,50 @@ protobuf message in text format. You can use shell quoting for a multiline strin
 use command substitution to read the message from a file e.g. `--reporting-metric-entry=$(cat
 reporting_metric_entry.textproto)`.
 
+#### create ui
+```shell
+Reporting \
+  --tls-cert-file=secretfiles/mc_tls.pem \
+  --tls-key-file=secretfiles/mc_tls.key \
+  --cert-collection-file=secretfiles/reporting_root.pem \
+  --reporting-server-api-target=v2alpha.reporting.dev.halo-cmm.org:8443 \
+  reports create-ui-report\
+  --parent=measurementConsumers/VCTqwV_vFXw \
+  --id=abcd \
+  --request-id=abcd \
+  --display-name=TESTDISPLAYREPORT \
+  --cmms-event-group=1 \
+  --primitive-rs-display-name='EDP 1' \
+  --primitive-rs-id=abc \
+  --cmms-event-group=2 \
+  --primitive-rs-display-name='EDP 2' \
+  --primitive-rs-id=def \
+  --cmms-event-group=3 \
+  --primitive-rs-display-name='EDP 3' \
+  --primitive-rs-id=ghi \
+  --prim-metric-id='mcs-2',
+  --prim-metric-display-name='primitive calc spec 1',
+  --comp-metric-id='mcs-2',
+  --comp-metric-display-name='primitive calc spec 2',
+  --union-rs-id=union-rs-1,
+  --union-rs-display-name='EDP Union',
+  --reporting-interval-report-start-time='2000-01-01T00:00:00',
+  --reporting-interval-report-end='2000-01-30',
+  --daily-frequency=true,
+```
+
+There currently needs to be three groups of primitive reporting sets defined by the arg group: --cmms-event-group, --primitive-rs-id, and --primitive-rs-display-name. You can pass in multiple event groups, but be sure to specify them first. There is a parsing issue if they are specified later in the arg group. This is similar to creating a reporting set.
+
+The union reporting set is created automatically from the primitives, but just require an id and name: --union-rs-id and --union-rs-display-name.
+
+The unique reporting sets are created automatically from the primitives and union. They are not explicitly used in the UI and require no input. They are post-fixed with "unique."
+
+The actual values of the metric calculation specs are hardcoded for user simplicity as the combinations have to be very specific. What the user will define are the ids and names for the specs. There are two different configurations of specs so they each need to be defined: --prim-metric-id and --prim-metric-display-name as well as --comp-metric-id and --comp-metric-display-name. These aren't use in the UI so they can be any valid value for creation purposes.
+
+The time range of the report must be specified through the start time and end (date): --reporting-interval-report-start-time and --reporting-interval-report-end. These are formatted as the example above and are the same as in create report. We force incremental to simplify the input.
+
+The user must specify the interval frequency: --daily-frequency, --day-of-the-week, or --day-of-the-month. This is used in combination with the interval time range.
+
 #### list
 
 ```shell

--- a/src/main/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/tools/README.md
+++ b/src/main/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/tools/README.md
@@ -148,9 +148,9 @@ Reporting \
   --predicate='person.age == 3'
 ```
 
-There currently needs to be at least two groups of primitive reporting sets defined by the arg group: --cmms-event-group, --reporting-set-id, and --reporting-set-display-name. You can pass in multiple event groups, but be sure to specify the display name or id first. There is a parsing issue if the id and display name are specified later in the arg group. This is similar to creating a reporting set.
+There currently needs to be at least two groups of primitive reporting sets defined by the arg group: --cmms-event-group, --reporting-set-id, and --reporting-set-display-name. You can pass in multiple event groups, but be sure to specify the display name or ID first. There is a parsing issue if the ID and display name are specified later in the arg group. This is similar to creating a reporting set.
 
-The union and unique reporting sets are created automatically from the provided reporting sets. Ids and display names are derived.
+The union and unique reporting sets are created automatically from the provided reporting sets. IDs and display names are derived.
 
 Metric Calculation Specs are automatically created in the command to generate the proper report for the UI, but there is no input by the user.
 

--- a/src/main/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/tools/README.md
+++ b/src/main/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/tools/README.md
@@ -136,7 +136,7 @@ Reporting \
   --cmms-event-group=3 \
   --primitive-rs-display-name='EDP 3' \
   --primitive-rs-id=ghi \
-  --prim-metric-id='mcs-2',
+  --prim-metric-id='mcs-1',
   --prim-metric-display-name='primitive calc spec 1',
   --comp-metric-id='mcs-2',
   --comp-metric-display-name='primitive calc spec 2',

--- a/src/main/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/tools/README.md
+++ b/src/main/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/tools/README.md
@@ -128,36 +128,32 @@ Reporting \
   --request-id=abcd \
   --display-name=TESTDISPLAYREPORT \
   --cmms-event-group=1 \
-  --primitive-rs-display-name='EDP 1' \
-  --primitive-rs-id=abc \
+  --reporting-set-id=abc \
+  --reporting-set-display-name='EDP 1' \
   --cmms-event-group=2 \
-  --primitive-rs-display-name='EDP 2' \
-  --primitive-rs-id=def \
+  --reporting-set-id=def \
+  --reporting-set-display-name='EDP 2' \
   --cmms-event-group=3 \
-  --primitive-rs-display-name='EDP 3' \
-  --primitive-rs-id=ghi \
-  --prim-metric-id='mcs-1',
-  --prim-metric-display-name='primitive calc spec 1',
-  --comp-metric-id='mcs-2',
-  --comp-metric-display-name='primitive calc spec 2',
-  --union-rs-id=union-rs-1,
-  --union-rs-display-name='EDP Union',
-  --reporting-interval-report-start-time='2000-01-01T00:00:00',
-  --reporting-interval-report-end='2000-01-30',
-  --daily-frequency=true,
+  --reporting-set-id=ghi \
+  --reporting-set-display-name='EDP 3' \
+  --report-start='2000-01-01T00:00:00' \
+  --report-end='2000-01-30' \
+  --daily-frequency=true \
+  --grouping='person.gender == 1,person.gender == 2' \
+  --grouping='person.age_group == 1,person.age_group == 2,person.age_group == 3'
 ```
 
-There currently needs to be three groups of primitive reporting sets defined by the arg group: --cmms-event-group, --primitive-rs-id, and --primitive-rs-display-name. You can pass in multiple event groups, but be sure to specify them first. There is a parsing issue if they are specified later in the arg group. This is similar to creating a reporting set.
+There currently needs to be three groups of primitive reporting sets defined by the arg group: --cmms-event-group, --reporting-set-id, and --reporting-set-display-name. You can pass in multiple event groups, but be sure to specify them first. There is a parsing issue if they are specified later in the arg group. This is similar to creating a reporting set.
 
-The union reporting set is created automatically from the primitives, but just require an id and name: --union-rs-id and --union-rs-display-name.
+The union and unique reporting sets are created automatically from the provided reporting sets. Ids and display names are derived.
 
-The unique reporting sets are created automatically from the primitives and union. They are not explicitly used in the UI and require no input. They are post-fixed with "unique."
+The user will not specify metric calculation specs although they will be automatically created. They are not used in the UI.
 
-The actual values of the metric calculation specs are hardcoded for user simplicity as the combinations have to be very specific. What the user will define are the ids and names for the specs. There are two different configurations of specs so they each need to be defined: --prim-metric-id and --prim-metric-display-name as well as --comp-metric-id and --comp-metric-display-name. These aren't use in the UI so they can be any valid value for creation purposes.
-
-The time range of the report must be specified through the start time and end (date): --reporting-interval-report-start-time and --reporting-interval-report-end. These are formatted as the example above and are the same as in create report. We force incremental to simplify the input.
+The time range of the report must be specified through the start time and end (date): --report-start and --report-end as an interval time range. These are formatted as the example above and are the same as in create report.
 
 The user must specify the interval frequency: --daily-frequency, --day-of-the-week, or --day-of-the-month. This is used in combination with the interval time range.
+
+The user must specify the grouping predicates using --grouping. Each is a comma delimited string like the example above.
 
 #### list
 

--- a/src/main/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/tools/README.md
+++ b/src/main/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/tools/README.md
@@ -147,9 +147,7 @@ There currently needs to be three groups of primitive reporting sets defined by 
 
 The union and unique reporting sets are created automatically from the provided reporting sets. Ids and display names are derived.
 
-The user will not specify metric calculation specs although they will be automatically created. They are not used in the UI.
-
-The time range of the report must be specified through the start time and end (date): --report-start and --report-end as an interval time range. These are formatted as the example above and are the same as in create report.
+The time range of the report must be specified through the start time and end (date): --report-start and --report-end as an interval time range. These are formatted as the example above and are the same as in create report. The user may optionally pass the desired time zone with --report-time-zone. If unspecified, it will use the user's default system time zone.
 
 The user must specify the interval frequency: --daily-frequency, --day-of-the-week, or --day-of-the-month. This is used in combination with the interval time range.
 

--- a/src/main/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/tools/README.md
+++ b/src/main/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/tools/README.md
@@ -139,8 +139,13 @@ Reporting \
   --report-start='2000-01-01T00:00:00' \
   --report-end='2000-01-30' \
   --daily-frequency=true \
-  --grouping='person.gender == 1,person.gender == 2' \
-  --grouping='person.age_group == 1,person.age_group == 2,person.age_group == 3'
+  --has-group=true \
+  --grouping='person.gender == 1' \
+  --grouping='person.gender == 2' \
+  --has-group=true \
+  --grouping='person.age == 1' \
+  --grouping='person.age == 2' \
+  --grouping='person.age == 3'
 ```
 
 There currently needs to be three groups of primitive reporting sets defined by the arg group: --cmms-event-group, --reporting-set-id, and --reporting-set-display-name. You can pass in multiple event groups, but be sure to specify them first. There is a parsing issue if they are specified later in the arg group. This is similar to creating a reporting set.

--- a/src/main/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/tools/README.md
+++ b/src/main/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/tools/README.md
@@ -148,7 +148,7 @@ Reporting \
   --predicate='person.age == 3'
 ```
 
-There currently needs to be at least two groups of primitive reporting sets defined by the arg group: --cmms-event-group, --reporting-set-id, and --reporting-set-display-name. You can pass in multiple event groups, but be sure to specify the display name or id first. There is a parsing issue if the event groups are specified later in the arg group. This is similar to creating a reporting set.
+There currently needs to be at least two groups of primitive reporting sets defined by the arg group: --cmms-event-group, --reporting-set-id, and --reporting-set-display-name. You can pass in multiple event groups, but be sure to specify the display name or id first. There is a parsing issue if the id and display name are specified later in the arg group. This is similar to creating a reporting set.
 
 The union and unique reporting sets are created automatically from the provided reporting sets. Ids and display names are derived.
 

--- a/src/main/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/tools/README.md
+++ b/src/main/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/tools/README.md
@@ -139,13 +139,13 @@ Reporting \
   --report-start='2000-01-01T00:00:00' \
   --report-end='2000-01-30' \
   --daily-frequency=true \
-  --has-group=true \
-  --grouping='person.gender == 1' \
-  --grouping='person.gender == 2' \
-  --has-group=true \
-  --grouping='person.age == 1' \
-  --grouping='person.age == 2' \
-  --grouping='person.age == 3'
+  --grouping \
+  --predicate='person.gender == 1' \
+  --predicate='person.gender == 2' \
+  --grouping \
+  --predicate='person.age == 1' \
+  --predicate='person.age == 2' \
+  --predicate='person.age == 3'
 ```
 
 There currently needs to be three groups of primitive reporting sets defined by the arg group: --cmms-event-group, --reporting-set-id, and --reporting-set-display-name. You can pass in multiple event groups, but be sure to specify them first. There is a parsing issue if they are specified later in the arg group. This is similar to creating a reporting set.

--- a/src/main/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/tools/README.md
+++ b/src/main/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/tools/README.md
@@ -147,11 +147,13 @@ There currently needs to be three groups of primitive reporting sets defined by 
 
 The union and unique reporting sets are created automatically from the provided reporting sets. Ids and display names are derived.
 
+Metric Calculation Specs are automatically created in the command to generate the proper report for the UI, but there is no input by the user.
+
 The time range of the report must be specified through the start time and end (date): --report-start and --report-end as an interval time range. These are formatted as the example above and are the same as in create report. The user may optionally pass the desired time zone with --report-time-zone. If unspecified, it will use the user's default system time zone.
 
 The user must specify the interval frequency: --daily-frequency, --day-of-the-week, or --day-of-the-month. This is used in combination with the interval time range.
 
-The user must specify the grouping predicates using --grouping. Each is a comma delimited string like the example above.
+The user must specify the grouping predicates using --has-group to denote a new set and --grouping for each predicate within the set.
 
 #### list
 

--- a/src/main/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/tools/README.md
+++ b/src/main/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/tools/README.md
@@ -148,7 +148,7 @@ Reporting \
   --predicate='person.age == 3'
 ```
 
-There currently needs to be three groups of primitive reporting sets defined by the arg group: --cmms-event-group, --reporting-set-id, and --reporting-set-display-name. You can pass in multiple event groups, but be sure to specify them first. There is a parsing issue if they are specified later in the arg group. This is similar to creating a reporting set.
+There currently needs to be at least two groups of primitive reporting sets defined by the arg group: --cmms-event-group, --reporting-set-id, and --reporting-set-display-name. You can pass in multiple event groups, but be sure to specify the display name or id first. There is a parsing issue if the event groups are specified later in the arg group. This is similar to creating a reporting set.
 
 The union and unique reporting sets are created automatically from the provided reporting sets. Ids and display names are derived.
 

--- a/src/main/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/tools/Reporting.kt
+++ b/src/main/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/tools/Reporting.kt
@@ -379,7 +379,8 @@ class CreateUiReportCommand : Runnable {
 
     @CommandLine.Option(
       names = ["--report-time-zone"],
-      description = ["IANA Time zone. If unspecified, it will use the user's default system time zone."],
+      description =
+        ["IANA Time zone. If unspecified, it will use the user's default system time zone."],
       required = false,
     )
     var timeZone: String = ZoneId.systemDefault().toString()
@@ -407,7 +408,11 @@ class CreateUiReportCommand : Runnable {
       private set
   }
 
-  @CommandLine.ArgGroup(exclusive = false, multiplicity = "0..*", heading = "Grouping Specification\n",)
+  @CommandLine.ArgGroup(
+    exclusive = false,
+    multiplicity = "0..*",
+    heading = "Grouping Specification\n",
+  )
   private lateinit var groupings: List<Grouping>
 
   private fun createPrimitiveReportingSet(
@@ -442,9 +447,10 @@ class CreateUiReportCommand : Runnable {
       return ReportingSetKt.setExpression {
         operation = ReportingSet.SetExpression.Operation.UNION
         lhs = ReportingSetKt.SetExpressionKt.operand { reportingSet = edpNames[0] }
-        rhs = ReportingSetKt.SetExpressionKt.operand {
-          expression = createUnionExpression(edpNames.subList(1, edpNames.size))
-        }
+        rhs =
+          ReportingSetKt.SetExpressionKt.operand {
+            expression = createUnionExpression(edpNames.subList(1, edpNames.size))
+          }
       }
     }
   }
@@ -455,7 +461,7 @@ class CreateUiReportCommand : Runnable {
     measurementConsumerName: String,
   ): ReportingSet {
     val edpNames = edps.map { it.reportingSetName }
-    val edpDisplayNames = edps.map{it.reportingSetDisplayName}
+    val edpDisplayNames = edps.map { it.reportingSetDisplayName }
     val edpFullNames = primitiveRs.map { it.name }
     val unionName = "union-" + edpNames.joinToString(separator = "-")
     val unionDisplayName = "Union (${edpDisplayNames.joinToString()})"
@@ -466,10 +472,7 @@ class CreateUiReportCommand : Runnable {
         name = unionName
         displayName = unionDisplayName
         tags.put("ui.halo-cmm.org/reporting_set_type", "union")
-        composite =
-          ReportingSetKt.composite {
-            expression = createUnionExpression(edpFullNames)
-          }
+        composite = ReportingSetKt.composite { expression = createUnionExpression(edpFullNames) }
       }
     }
 
@@ -672,9 +675,8 @@ class CreateUiReportCommand : Runnable {
           metricSpecs += spec
         }
         for (grouping in groupings) {
-          this.groupings +=
-            MetricCalculationSpecKt.grouping { predicates += grouping.groups }
-        }
+          this.groupings += MetricCalculationSpecKt.grouping { predicates += grouping.groups }
+       }
       }
     }
 

--- a/src/main/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/tools/Reporting.kt
+++ b/src/main/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/tools/Reporting.kt
@@ -335,7 +335,7 @@ class CreateUiReportCommand : Runnable {
 
     @CommandLine.Option(
       names = ["--day-of-week"],
-      description = ["""Day of the week for weekly frequency."""],
+      description = ["Day of the week for weekly frequency."],
     )
     var dayOfWeek: DayOfWeek = DayOfWeek.DAY_OF_WEEK_UNSPECIFIED
       private set
@@ -392,19 +392,19 @@ class CreateUiReportCommand : Runnable {
 
   class Grouping {
     @CommandLine.Option(
-      names = ["--has-group"],
+      names = ["--grouping"],
       description = ["Boolean to indicate the start of a new grouping list."],
       required = true,
     )
-    var hasGroup: Boolean = false
+    var grouping: Boolean = false
       private set
 
     @CommandLine.Option(
-      names = ["--grouping"],
+      names = ["--predicate"],
       description = ["A list of predicates for this grouping."],
       required = true,
     )
-    lateinit var groups: List<String>
+    lateinit var predicates: List<String>
       private set
   }
 
@@ -675,7 +675,7 @@ class CreateUiReportCommand : Runnable {
           metricSpecs += spec
         }
         for (grouping in groupings) {
-          this.groupings += MetricCalculationSpecKt.grouping { predicates += grouping.groups }
+          this.groupings += MetricCalculationSpecKt.grouping { predicates += grouping.predicates }
         }
       }
     }

--- a/src/main/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/tools/Reporting.kt
+++ b/src/main/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/tools/Reporting.kt
@@ -391,12 +391,26 @@ class CreateUiReportCommand : Runnable {
   @CommandLine.ArgGroup(exclusive = false, multiplicity = "1", heading = "Time intervals\n")
   private lateinit var interval: ReportingIntervalInput
 
-  @CommandLine.Option(
-    names = ["--grouping"],
-    description = ["Each grouping is a list of comma-separated predicates"],
-    required = true,
-  )
-  lateinit var groupings: List<String>
+  class Grouping {
+    @CommandLine.Option(
+      names = ["--has-group"],
+      description = [""],
+      required = true,
+    )
+    lateinit var hasGroup: Boolean
+      private set
+
+    @CommandLine.Option(
+      names = ["--grouping"],
+      description = [""],
+      required = true,
+    )
+    lateinit var groups: List<String>
+      private set
+  }
+
+  @CommandLine.ArgGroup(heading = "Grouping Specification\n",)
+  lateinit var groupings: List<Grouping>
 
   private fun createPrimitiveReportingSet(
     edp: ReportingSetParams,

--- a/src/main/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/tools/Reporting.kt
+++ b/src/main/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/tools/Reporting.kt
@@ -293,7 +293,7 @@ class CreateUiReportCommand : Runnable {
   class ReportingSetParams {
     @CommandLine.Option(
       names = ["--cmms-event-group"],
-      description = ["List of CMMS EventGroup resource names"],
+      description = ["EventGroup resource name from the CMMS API. This can be specified multiple times"],
       required = true,
     )
     lateinit var eventGroupNames: List<String>
@@ -1089,7 +1089,7 @@ class CreateMetricCalculationSpecCommand : Runnable {
       """
         ],
     )
-    var dayOfTheWeek: Int = 0
+    var dayOfTheWeek: DayOfWeek = 0
       private set
 
     @CommandLine.Option(

--- a/src/main/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/tools/Reporting.kt
+++ b/src/main/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/tools/Reporting.kt
@@ -294,7 +294,8 @@ class CreateUiReportCommand : Runnable {
   class ReportingSetParams {
     @CommandLine.Option(
       names = ["--cmms-event-group"],
-      description = ["EventGroup resource name from the CMMS API. This can be specified multiple times"],
+      description =
+        ["EventGroup resource name from the CMMS API. This can be specified multiple times"],
       required = true,
     )
     lateinit var eventGroupNames: List<String>
@@ -334,12 +335,9 @@ class CreateUiReportCommand : Runnable {
 
     @CommandLine.Option(
       names = ["--day-of-week"],
-      description =
-        [
-          """
+      description = ["""
           Day of the week for weekly frequency.
-          """
-        ],
+          """],
     )
     var dayOfWeek: DayOfWeek = DayOfWeek.DAY_OF_WEEK_UNSPECIFIED
       private set

--- a/src/main/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/tools/Reporting.kt
+++ b/src/main/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/tools/Reporting.kt
@@ -553,9 +553,9 @@ class CreateUiReportCommand : Runnable {
                         rhs =
                           ReportingSetKt.SetExpressionKt.operand {
                             reportingSet = complement.elementAt(1).name
-                           }
-                       }
-                   }
+                          }
+                      }
+                  }
               }
           }
       }

--- a/src/main/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/tools/Reporting.kt
+++ b/src/main/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/tools/Reporting.kt
@@ -508,6 +508,7 @@ class CreateUiReportCommand : Runnable {
               }
           }
       }
+    }
 
     return runBlocking(Dispatchers.IO) { parent.reportingSetStub.createReportingSet(rsRequest) }
   }

--- a/src/main/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/tools/Reporting.kt
+++ b/src/main/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/tools/Reporting.kt
@@ -553,13 +553,13 @@ class CreateUiReportCommand : Runnable {
                         rhs =
                           ReportingSetKt.SetExpressionKt.operand {
                             reportingSet = complement.elementAt(1).name
-                          }
-                      }
-                  }
-               }
-           }
-       }
-     }
+                           }
+                       }
+                   }
+              }
+          }
+      }
+    }
 
     return runBlocking(Dispatchers.IO) { parent.reportingSetStub.createReportingSet(request) }
   }
@@ -602,7 +602,7 @@ class CreateUiReportCommand : Runnable {
           vidSamplingInterval = MetricSpecKt.vidSamplingInterval { width = 1.0f }
         },
       )
- 
+
     return this.createMetricSpecs(name, displayName, measurementConsumerName, specs, frequencySpec)
   }
 
@@ -638,7 +638,7 @@ class CreateUiReportCommand : Runnable {
           vidSamplingInterval = MetricSpecKt.vidSamplingInterval { width = 1.0f }
         },
       )
- 
+
     return this.createMetricSpecs(name, displayName, measurementConsumerName, specs, frequencySpec)
   }
 

--- a/src/main/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/tools/Reporting.kt
+++ b/src/main/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/tools/Reporting.kt
@@ -335,9 +335,7 @@ class CreateUiReportCommand : Runnable {
 
     @CommandLine.Option(
       names = ["--day-of-week"],
-      description = ["""
-          Day of the week for weekly frequency.
-          """],
+      description = ["""Day of the week for weekly frequency."""],
     )
     var dayOfWeek: DayOfWeek = DayOfWeek.DAY_OF_WEEK_UNSPECIFIED
       private set
@@ -381,7 +379,7 @@ class CreateUiReportCommand : Runnable {
 
     @CommandLine.Option(
       names = ["--report-time-zone"],
-      description = ["IANA Time zone"],
+      description = ["IANA Time zone. If unspecified, it will use the user's default system time zone."],
       required = false,
     )
     var timeZone: String = ZoneId.systemDefault().toString()
@@ -394,23 +392,23 @@ class CreateUiReportCommand : Runnable {
   class Grouping {
     @CommandLine.Option(
       names = ["--has-group"],
-      description = [""],
+      description = ["Boolean to indicate the start of a new grouping list."],
       required = true,
     )
-    lateinit var hasGroup: Boolean
+    var hasGroup: Boolean = false
       private set
 
     @CommandLine.Option(
       names = ["--grouping"],
-      description = [""],
+      description = ["A list of predicates for this grouping."],
       required = true,
     )
     lateinit var groups: List<String>
       private set
   }
 
-  @CommandLine.ArgGroup(heading = "Grouping Specification\n",)
-  lateinit var groupings: List<Grouping>
+  @CommandLine.ArgGroup(exclusive = false, multiplicity = "0..*", heading = "Grouping Specification\n",)
+  private lateinit var groupings: List<Grouping>
 
   private fun createPrimitiveReportingSet(
     edp: ReportingSetParams,
@@ -537,7 +535,7 @@ class CreateUiReportCommand : Runnable {
   private fun createPrimitiveMetricSpecs(
     frequencySpec: MetricFrequencySpecInput,
     measurementConsumerName: String,
-    groupings: List<String>,
+    groupings: List<Grouping>,
   ): MetricCalculationSpec {
     val baseName = "basic-metric-spec"
     val specs =
@@ -585,7 +583,7 @@ class CreateUiReportCommand : Runnable {
   private fun createCompositeMetricSpecs(
     frequencySpec: MetricFrequencySpecInput,
     measurementConsumerName: String,
-    groupings: List<String>,
+    groupings: List<Grouping>,
   ): MetricCalculationSpec {
     val baseName = "other-metric-spec"
     val specs =
@@ -629,7 +627,7 @@ class CreateUiReportCommand : Runnable {
     measurementConsumerName: String,
     specs: List<MetricSpec>,
     frequencySpec: MetricFrequencySpecInput,
-    groupings: List<String>,
+    groupings: List<Grouping>,
   ): MetricCalculationSpec {
     // Add random string to the end of the name to help with uniqueness.
     // This only helps so still need to make sure it's actually unique.
@@ -675,7 +673,7 @@ class CreateUiReportCommand : Runnable {
         }
         for (grouping in groupings) {
           this.groupings +=
-            MetricCalculationSpecKt.grouping { predicates += grouping.trim().split(',') }
+            MetricCalculationSpecKt.grouping { predicates += grouping.groups }
         }
       }
     }

--- a/src/main/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/tools/Reporting.kt
+++ b/src/main/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/tools/Reporting.kt
@@ -624,7 +624,7 @@ class CreateUiReportCommand : Runnable {
     while (retry) {
       randomString = getRandomString(6)
       newName = name + "-" + randomString
-val getMetricSpecRequest = getMetricCalculationSpecRequest { this.name = newName }
+      val getMetricSpecRequest = getMetricCalculationSpecRequest { this.name = newName }
       try {
         runBlocking(Dispatchers.IO) {
           parent.metricCalculationSpecStub.getMetricCalculationSpec(getMetricSpecRequest)
@@ -660,7 +660,8 @@ val getMetricSpecRequest = getMetricCalculationSpecRequest { this.name = newName
         }
         for (grouping in groupings) {
           this.groupings +=
-            MetricCalculationSpecKt.grouping { predicates += grouping.trim().split(',') }        }
+            MetricCalculationSpecKt.grouping { predicates += grouping.trim().split(',') }
+        }
       }
     }
 

--- a/src/main/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/tools/Reporting.kt
+++ b/src/main/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/tools/Reporting.kt
@@ -27,6 +27,7 @@ import java.time.Duration
 import java.time.Instant
 import java.time.LocalDate
 import java.time.LocalDateTime
+import java.time.ZoneId
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.runBlocking
 import org.wfanet.measurement.api.v2alpha.DataProvidersGrpcKt.DataProvidersCoroutineStub
@@ -336,12 +337,11 @@ class CreateUiReportCommand : Runnable {
       description =
         [
           """
-          Day of the week for weekly frequency. Represented by a number between 1 and 7, inclusive,
-          where Monday is 1 and Sunday is 7.
+          Day of the week for weekly frequency.
           """
         ],
     )
-    var dayOfWeek: Int = 0
+    var dayOfWeek: DayOfWeek = DayOfWeek.DAY_OF_WEEK_UNSPECIFIED
       private set
 
     @CommandLine.Option(
@@ -386,7 +386,7 @@ class CreateUiReportCommand : Runnable {
       description = ["IANA Time zone"],
       required = false,
     )
-    var timeZone: String = "Hello"
+    var timeZone: String = ZoneId.systemDefault().toString()
       private set
   }
 
@@ -642,10 +642,10 @@ class CreateUiReportCommand : Runnable {
           MetricCalculationSpecKt.metricFrequencySpec {
             if (frequencySpec.daily) {
               daily = MetricCalculationSpec.MetricFrequencySpec.Daily.getDefaultInstance()
-            } else if (frequencySpec.dayOfWeek > 0) {
+            } else if (frequencySpec.dayOfWeek != DayOfWeek.DAY_OF_WEEK_UNSPECIFIED) {
               weekly =
                 MetricCalculationSpecKt.MetricFrequencySpecKt.weekly {
-                  dayOfWeek = DayOfWeek.forNumber(frequencySpec.dayOfWeek)
+                  this.dayOfWeek = frequencySpec.dayOfWeek
                 }
             } else if (frequencySpec.dayOfMonth > 0) {
               monthly =
@@ -732,7 +732,7 @@ class CreateUiReportCommand : Runnable {
             hours = interval.reportingIntervalReportStartTime.hour
             minutes = interval.reportingIntervalReportStartTime.minute
             seconds = interval.reportingIntervalReportStartTime.second
-            // timeZone = interval.timeZone
+            this.timeZone = timeZone { id = interval.timeZone }
           }
           reportEnd = date {
             year = interval.reportingIntervalReportEnd.year
@@ -1089,7 +1089,7 @@ class CreateMetricCalculationSpecCommand : Runnable {
       """
         ],
     )
-    var dayOfTheWeek: DayOfWeek = 0
+    var dayOfTheWeek: Int = 0
       private set
 
     @CommandLine.Option(

--- a/src/main/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/tools/Reporting.kt
+++ b/src/main/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/tools/Reporting.kt
@@ -676,7 +676,7 @@ class CreateUiReportCommand : Runnable {
         }
         for (grouping in groupings) {
           this.groupings += MetricCalculationSpecKt.grouping { predicates += grouping.groups }
-       }
+        }
       }
     }
 

--- a/src/test/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/tools/ReportingTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/tools/ReportingTest.kt
@@ -1021,8 +1021,10 @@ class ReportingTest {
           "--has-group=true",
           "--grouping='person.gender == 1'",
           "--grouping='person.gender == 2'",
-          // "--grouping='person.gender == 1,person.gender == 2'",
-          // "--grouping='person.age_group == 1,person.age_group == 2,person.age_group == 3'",
+          "--has-group=true",
+          "--grouping='person.age == 1'",
+          "--grouping='person.age == 2'",
+          "--grouping='person.age == 3'",
         )
 
     val output = callCli(args)
@@ -1116,6 +1118,15 @@ class ReportingTest {
       createMetricCalculationSpec(metricSpecCaptor.capture())
     }
 
+    val groupings = listOf(MetricCalculationSpecKt.grouping {
+      predicates += "'person.gender == 1'"
+      predicates += "'person.gender == 2'"
+    }, MetricCalculationSpecKt.grouping {
+      predicates += "'person.age == 1'"
+      predicates += "'person.age == 2'"
+      predicates += "'person.age == 3'"
+    })
+
     // Spec for primitives and union
     // reach & frequency and impression count
     val mcs1 =
@@ -1123,6 +1134,7 @@ class ReportingTest {
         it.metricCalculationSpec.name.startsWith("basic-metric-spec-")
       }
     assertThat(mcs1.size).isEqualTo(1)
+    assertThat(mcs1[0].metricCalculationSpec.groupingsList).isEqualTo(groupings)
     val rAndFSpec =
       mcs1[0].metricCalculationSpec.metricSpecsList.filter { it.hasReachAndFrequency() }
     assertThat(rAndFSpec.size).isEqualTo(1)
@@ -1136,6 +1148,7 @@ class ReportingTest {
         it.metricCalculationSpec.name.startsWith("other-metric-spec-")
       }
     assertThat(mcs2.size).isEqualTo(1)
+    assertThat(mcs2[0].metricCalculationSpec.groupingsList).isEqualTo(groupings)
     val rSpec = mcs2[0].metricCalculationSpec.metricSpecsList.filter { it.hasReach() }
     assertThat(rSpec.size).isEqualTo(1)
     val impSpec2 = mcs2[0].metricCalculationSpec.metricSpecsList.filter { it.hasImpressionCount() }

--- a/src/test/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/tools/ReportingTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/tools/ReportingTest.kt
@@ -35,7 +35,13 @@ import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
+import org.mockito.kotlin.KArgumentCaptor
 import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.Mockito.verify;
+import org.mockito.kotlin.stub
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verifyBlocking
 import org.wfanet.measurement.api.v2alpha.BatchGetEventGroupMetadataDescriptorsResponse
 import org.wfanet.measurement.api.v2alpha.DataProvider
 import org.wfanet.measurement.api.v2alpha.DataProvidersGrpcKt.DataProvidersCoroutineImplBase
@@ -57,6 +63,9 @@ import org.wfanet.measurement.common.testing.CommandLineTesting.assertThat
 import org.wfanet.measurement.common.testing.ExitInterceptingSecurityManager
 import org.wfanet.measurement.common.testing.verifyProtoArgument
 import org.wfanet.measurement.common.toProtoTime
+import org.wfanet.measurement.reporting.v2alpha.CreateMetricCalculationSpecRequest
+import org.wfanet.measurement.reporting.v2alpha.CreateReportRequest
+import org.wfanet.measurement.reporting.v2alpha.CreateReportingSetRequest
 import org.wfanet.measurement.reporting.v2alpha.EventGroupsGrpcKt.EventGroupsCoroutineImplBase
 import org.wfanet.measurement.reporting.v2alpha.ListEventGroupsResponse
 import org.wfanet.measurement.reporting.v2alpha.ListReportingSetsResponse
@@ -931,6 +940,310 @@ class ReportingTest {
         parseTextProto(output.out.reader(), EventGroupMetadataDescriptor.getDefaultInstance())
       )
       .isEqualTo(EVENT_GROUP_METADATA_DESCRIPTOR)
+  }
+
+  class Edp(
+    val eventGroups: List<String>,
+    val reportingSetName: String,
+    val reportingSetDisplayName: String)
+  { }
+
+  @Test
+  fun `test`() {
+    val testReportId = "TESTREPORT"
+    val edps = listOf(
+      Edp(listOf("1"), "A", "REPORT A"),
+      Edp(listOf("2"), "B", "REPORT B"),
+      Edp(listOf("3"), "C", "REPORT C"),
+    )
+    val eventGroupArgs1 = edps[0].eventGroups.map{"--cmms-event-group=${it}"}
+    val eventGroupArgs2 = edps[1].eventGroups.map{"--cmms-event-group=${it}"}
+    val eventGroupArgs3 = edps[2].eventGroups.map{"--cmms-event-group=${it}"}
+    val metric1Name = "MC1"
+    val metric1DisplayName = "Metric Spec 1"
+    val metric2Name = "MC2"
+    val metric2DisplayName = "Metric Spec 2"
+    val unionRsName = "union"
+
+    metricCalculationSpecsServiceMock.stub {
+      onBlocking { createMetricCalculationSpec(any()) }
+        .thenAnswer {
+          val request = it.arguments[0] as CreateMetricCalculationSpecRequest
+          when (request.metricCalculationSpec.name) {
+            metric1Name -> metricCalculationSpec { name = MEASUREMENT_CONSUMER_NAME + "/metricCalculationSpecs/${metric1Name}"}
+            metric2Name -> metricCalculationSpec { name = MEASUREMENT_CONSUMER_NAME + "/metricCalculationSpecs/${metric2Name}"}
+            else -> metricCalculationSpec { name = MEASUREMENT_CONSUMER_NAME + "/metricCalculationSpecs/UNKNOWN"}
+          }
+        }
+    }
+
+    reportingSetsServiceMock.stub {
+      onBlocking { createReportingSet(any()) }
+        .thenAnswer {
+          val request = it.arguments[0] as CreateReportingSetRequest
+          when (request.reportingSet.name) {
+            "A" -> reportingSet { name = MEASUREMENT_CONSUMER_NAME + "/reportingSets/A" }
+            "B" -> reportingSet { name = MEASUREMENT_CONSUMER_NAME + "/reportingSets/B" }
+            "C" -> reportingSet { name = MEASUREMENT_CONSUMER_NAME + "/reportingSets/C" }
+            "union" -> reportingSet { name = MEASUREMENT_CONSUMER_NAME + "/reportingSets/union" }
+            "A-unique" -> reportingSet { name = MEASUREMENT_CONSUMER_NAME + "/reportingSets/A-unique" }
+            "B-unique" -> reportingSet { name = MEASUREMENT_CONSUMER_NAME + "/reportingSets/B-unique" }
+            "C-unique" -> reportingSet { name = MEASUREMENT_CONSUMER_NAME + "/reportingSets/C-unique" }
+            else -> reportingSet { name = MEASUREMENT_CONSUMER_NAME + "/reportingSets/UNKNOWN" }
+          }
+        }
+    }
+
+    val args = 
+      arrayOf(
+        "--tls-cert-file=$SECRETS_DIR/mc_tls.pem",
+        "--tls-key-file=$SECRETS_DIR/mc_tls.key",
+        "--cert-collection-file=$SECRETS_DIR/reporting_root.pem",
+        "--reporting-server-api-target=$HOST:${server.port}",
+        "reports",
+        "create-ui-report",
+        "--parent=${MEASUREMENT_CONSUMER_NAME}",
+        "--id=${testReportId}",
+        "--display-name=TESTDISPLAYREPORT",
+        "--primitive-rs-id=${edps[0].reportingSetName}"
+      ) + eventGroupArgs1 +
+      arrayOf(
+        "--primitive-rs-display-name=${edps[0].reportingSetDisplayName}",
+        "--primitive-rs-id=${edps[1].reportingSetName}"
+      ) + eventGroupArgs2 +
+      arrayOf(
+        "--primitive-rs-display-name=${edps[1].reportingSetDisplayName}",
+        "--primitive-rs-id=${edps[2].reportingSetName}"
+      ) + eventGroupArgs3 +
+      arrayOf(
+        "--primitive-rs-display-name=${edps[2].reportingSetDisplayName}",
+        "--prim-metric-id=${metric1Name}",
+        "--prim-metric-display-name=${metric1DisplayName}",
+        "--comp-metric-id=${metric2Name}",
+        "--comp-metric-display-name=${metric2DisplayName}",
+        "--union-rs-id=${unionRsName}",
+        "--union-rs-display-name=EDP Union",
+        "--reporting-interval-report-start-time=2000-01-01T00:00:00",
+        "--reporting-interval-report-end=2000-01-30",
+        "--daily-frequency=true"
+      )
+
+    val output = callCli(args)
+    assertThat(output).status().isEqualTo(0)
+
+    // Verify reporting sets
+    val reportingSetCaptor: KArgumentCaptor<CreateReportingSetRequest> = argumentCaptor()
+    verifyBlocking(reportingSetsServiceMock, times(7)) {
+      createReportingSet(reportingSetCaptor.capture())
+    }
+
+    // primitive A
+    val rsa = reportingSetCaptor.allValues.filter { it.reportingSet.name == "A" }
+    assertThat(rsa.size).isEqualTo(1)
+    assertPrimitiveRs(rsa[0], edps[0])
+
+    // primitive B
+    val rsb = reportingSetCaptor.allValues.filter { it.reportingSet.name == "B" }
+    assertThat(rsa.size).isEqualTo(1)
+    assertPrimitiveRs(rsb[0], edps[1])
+
+    // primitive C
+    val rsc = reportingSetCaptor.allValues.filter { it.reportingSet.name == "C" }
+    assertThat(rsa.size).isEqualTo(1)
+    assertPrimitiveRs(rsc[0], edps[2])
+
+    // union
+    assertThat(reportingSetCaptor.allValues[3]).isEqualTo(
+      createReportingSetRequest {
+        parent = MEASUREMENT_CONSUMER_NAME
+        reportingSet = reportingSet {
+          name = "union"
+          displayName = "EDP Union"
+          composite = ReportingSetKt.composite {
+            expression = ReportingSetKt.setExpression {
+              operation = ReportingSet.SetExpression.Operation.UNION
+              lhs = ReportingSetKt.SetExpressionKt.operand {
+                reportingSet = MEASUREMENT_CONSUMER_NAME + "/reportingSets/" + edps[0].reportingSetName
+              }
+              rhs = ReportingSetKt.SetExpressionKt.operand {
+                expression = ReportingSetKt.setExpression {
+                  operation = ReportingSet.SetExpression.Operation.UNION
+                  lhs = ReportingSetKt.SetExpressionKt.operand {
+                    reportingSet =  MEASUREMENT_CONSUMER_NAME + "/reportingSets/" + edps[1].reportingSetName
+                  }
+                  rhs = ReportingSetKt.SetExpressionKt.operand {
+                    reportingSet = MEASUREMENT_CONSUMER_NAME + "/reportingSets/" +  edps[2].reportingSetName
+                  }
+                }
+              }
+            }
+          }
+          tags.put("ui.halo-cmm.org/reporting_set_type", "union")
+        }
+      }
+    )
+
+    // unique A
+    val ursa = reportingSetCaptor.allValues.filter { it.reportingSet.name == "A-unique" }
+    assertThat(ursa.size).isEqualTo(1)
+    assertUniqueRs(ursa[0], edps[0], "union", edps)
+
+    // unique B
+    val ursb = reportingSetCaptor.allValues.filter { it.reportingSet.name == "B-unique" }
+    assertThat(ursb.size).isEqualTo(1)
+    assertUniqueRs(ursb[0], edps[1], "union", edps)
+
+    // unique C
+    val ursc = reportingSetCaptor.allValues.filter { it.reportingSet.name == "C-unique" }
+    assertThat(ursc.size).isEqualTo(1)
+    assertUniqueRs(ursc[0], edps[2], "union", edps)
+
+    // Verify metric calc specs
+    val metricSpecCaptor: KArgumentCaptor<CreateMetricCalculationSpecRequest> = argumentCaptor()
+    verifyBlocking(metricCalculationSpecsServiceMock, times(2)) {
+      createMetricCalculationSpec(metricSpecCaptor.capture())
+    }
+
+    // Spec for primitives and union
+    // reach & frequency and impression count
+    val mcs1 = metricSpecCaptor.allValues.filter { it.metricCalculationSpec.name == metric1Name }
+    assertThat(mcs1.size).isEqualTo(1)
+    val rAndFSpec = mcs1[0].metricCalculationSpec.metricSpecsList.filter { it.hasReachAndFrequency() }
+    assertThat(rAndFSpec.size).isEqualTo(1)
+    val impSpec = mcs1[0].metricCalculationSpec.metricSpecsList.filter { it.hasImpressionCount() }
+    assertThat(impSpec.size).isEqualTo(1)
+
+    // Spec for uniques
+    // reach & frequency and impression count
+    val mcs2 = metricSpecCaptor.allValues.filter { it.metricCalculationSpec.name == metric2Name }
+    assertThat(mcs2.size).isEqualTo(1)
+    val rSpec = mcs2[0].metricCalculationSpec.metricSpecsList.filter { it.hasReach() }
+    assertThat(rSpec.size).isEqualTo(1)
+    val impSpec2 = mcs2[0].metricCalculationSpec.metricSpecsList.filter { it.hasImpressionCount() }
+    assertThat(impSpec2.size).isEqualTo(1)
+
+    // Verify report
+    val reportCaptor: KArgumentCaptor<CreateReportRequest> = argumentCaptor()
+    verifyBlocking(reportsServiceMock, times(1)) {
+      createReport(reportCaptor.capture())
+    }
+    assertThat(reportCaptor.firstValue).isEqualTo(
+      createReportRequest {
+        parent = MEASUREMENT_CONSUMER_NAME
+        reportId = testReportId
+        report = report {
+          name = testReportId
+          reportingInterval = ReportKt.reportingInterval {
+            reportStart = dateTime {
+              year = 2000
+              month = 1
+              day = 1
+            }
+            reportEnd = date {
+              year = 2000
+              month = 1
+              day = 30
+            }
+          }
+          reportingMetricEntries += ReportKt.reportingMetricEntry {
+            key = MEASUREMENT_CONSUMER_NAME + "/reportingSets/" + "A"
+            value = ReportKt.reportingMetricCalculationSpec {
+              metricCalculationSpecs += "measurementConsumers/1/metricCalculationSpecs/${metric1Name}"
+            }
+          }
+          reportingMetricEntries += ReportKt.reportingMetricEntry {
+            key = MEASUREMENT_CONSUMER_NAME + "/reportingSets/" + "B"
+            value = ReportKt.reportingMetricCalculationSpec {
+              metricCalculationSpecs += MEASUREMENT_CONSUMER_NAME + "/metricCalculationSpecs/${metric1Name}"
+            }
+          }
+          reportingMetricEntries += ReportKt.reportingMetricEntry {
+            key = MEASUREMENT_CONSUMER_NAME + "/reportingSets/" + "C"
+            value = ReportKt.reportingMetricCalculationSpec {
+              metricCalculationSpecs += MEASUREMENT_CONSUMER_NAME + "/metricCalculationSpecs/${metric1Name}"
+            }
+          }
+          reportingMetricEntries += ReportKt.reportingMetricEntry {
+            key = MEASUREMENT_CONSUMER_NAME + "/reportingSets/" + "union"
+            value = ReportKt.reportingMetricCalculationSpec {
+              metricCalculationSpecs += MEASUREMENT_CONSUMER_NAME + "/metricCalculationSpecs/${metric1Name}"
+            }
+          }
+          reportingMetricEntries += ReportKt.reportingMetricEntry {
+            key = MEASUREMENT_CONSUMER_NAME + "/reportingSets/" + "A-unique"
+            value = ReportKt.reportingMetricCalculationSpec {
+              metricCalculationSpecs += MEASUREMENT_CONSUMER_NAME + "/metricCalculationSpecs/${metric2Name}"
+            }
+          }
+          reportingMetricEntries += ReportKt.reportingMetricEntry {
+            key = MEASUREMENT_CONSUMER_NAME + "/reportingSets/" + "B-unique"
+            value = ReportKt.reportingMetricCalculationSpec {
+              metricCalculationSpecs += MEASUREMENT_CONSUMER_NAME + "/metricCalculationSpecs/${metric2Name}"
+            }
+          }
+          reportingMetricEntries += ReportKt.reportingMetricEntry {
+            key = MEASUREMENT_CONSUMER_NAME + "/reportingSets/" + "C-unique"
+            value = ReportKt.reportingMetricCalculationSpec {
+              metricCalculationSpecs +=MEASUREMENT_CONSUMER_NAME + "/metricCalculationSpecs/${metric2Name}"
+            }
+          }
+          tags.put("ui.halo-cmm.org", "true")
+          tags.put("ui.halo-cmm.org/display_name", "TESTDISPLAYREPORT")
+        }
+      }
+    )
+  }
+
+  fun assertPrimitiveRs(expected: CreateReportingSetRequest, props: Edp) {
+    assertThat(expected).isEqualTo(
+      createReportingSetRequest {
+        parent = MEASUREMENT_CONSUMER_NAME
+        reportingSet = reportingSet {
+          name = props.reportingSetName
+          displayName = props.reportingSetDisplayName
+          primitive = ReportingSetKt.primitive {
+            for (eventGroup in props.eventGroups) {
+              cmmsEventGroups += eventGroup
+            }
+          }
+          tags.put("ui.halo-cmm.org/reporting_set_type", "individual")
+        }
+      }
+    )
+  }
+
+  fun assertUniqueRs(expected: CreateReportingSetRequest, props: Edp, unionName: String, edps: List<Edp>) {
+    val complement = edps.subtract(listOf(props))
+    assertThat(expected).isEqualTo(
+      createReportingSetRequest {
+        parent = MEASUREMENT_CONSUMER_NAME
+        reportingSet = reportingSet {
+          name = props.reportingSetName + "-unique"
+          displayName = props.reportingSetDisplayName + " Unique"
+          composite = ReportingSetKt.composite {
+            expression = ReportingSetKt.setExpression {
+              operation = ReportingSet.SetExpression.Operation.UNION
+              lhs = ReportingSetKt.SetExpressionKt.operand {
+                reportingSet = MEASUREMENT_CONSUMER_NAME + "/reportingSets/" + unionName
+              }
+              rhs = ReportingSetKt.SetExpressionKt.operand {
+                expression = ReportingSetKt.setExpression {
+                  operation = ReportingSet.SetExpression.Operation.UNION
+                  lhs = ReportingSetKt.SetExpressionKt.operand {
+                    reportingSet = MEASUREMENT_CONSUMER_NAME + "/reportingSets/" + complement.elementAt(0).reportingSetName
+                  }
+                  rhs = ReportingSetKt.SetExpressionKt.operand {
+                    reportingSet = MEASUREMENT_CONSUMER_NAME + "/reportingSets/" + complement.elementAt(1).reportingSetName
+                  }
+                }
+              }
+            }
+          }
+          tags.put("ui.halo-cmm.org/reporting_set_type", "unique")
+          tags.put("ui.halo-cmm.org/reporting_set_id", "${MEASUREMENT_CONSUMER_NAME}/reportingSets/${props.reportingSetName}")
+        }
+      }
+    )
   }
 
   @Test

--- a/src/test/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/tools/ReportingTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/tools/ReportingTest.kt
@@ -38,7 +38,6 @@ import org.junit.runners.JUnit4
 import org.mockito.kotlin.KArgumentCaptor
 import org.mockito.kotlin.any
 import org.mockito.kotlin.argumentCaptor
-import org.mockito.Mockito.verify;
 import org.mockito.kotlin.stub
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verifyBlocking
@@ -945,20 +944,21 @@ class ReportingTest {
   class Edp(
     val eventGroups: List<String>,
     val reportingSetName: String,
-    val reportingSetDisplayName: String)
-  { }
+    val reportingSetDisplayName: String,
+  ) {}
 
   @Test
-  fun `test`() {
+  fun `create ui report calls apis with valid requests`() {
     val testReportId = "TESTREPORT"
-    val edps = listOf(
-      Edp(listOf("1"), "A", "REPORT A"),
-      Edp(listOf("2"), "B", "REPORT B"),
-      Edp(listOf("3"), "C", "REPORT C"),
-    )
-    val eventGroupArgs1 = edps[0].eventGroups.map{"--cmms-event-group=${it}"}
-    val eventGroupArgs2 = edps[1].eventGroups.map{"--cmms-event-group=${it}"}
-    val eventGroupArgs3 = edps[2].eventGroups.map{"--cmms-event-group=${it}"}
+    val edps =
+      listOf(
+        Edp(listOf("1"), "A", "REPORT A"),
+        Edp(listOf("2"), "B", "REPORT B"),
+        Edp(listOf("3"), "C", "REPORT C"),
+      )
+    val eventGroupArgs1 = edps[0].eventGroups.map { "--cmms-event-group=${it}" }
+    val eventGroupArgs2 = edps[1].eventGroups.map { "--cmms-event-group=${it}" }
+    val eventGroupArgs3 = edps[2].eventGroups.map { "--cmms-event-group=${it}" }
     val metric1Name = "MC1"
     val metric1DisplayName = "Metric Spec 1"
     val metric2Name = "MC2"
@@ -970,9 +970,18 @@ class ReportingTest {
         .thenAnswer {
           val request = it.arguments[0] as CreateMetricCalculationSpecRequest
           when (request.metricCalculationSpec.name) {
-            metric1Name -> metricCalculationSpec { name = MEASUREMENT_CONSUMER_NAME + "/metricCalculationSpecs/${metric1Name}"}
-            metric2Name -> metricCalculationSpec { name = MEASUREMENT_CONSUMER_NAME + "/metricCalculationSpecs/${metric2Name}"}
-            else -> metricCalculationSpec { name = MEASUREMENT_CONSUMER_NAME + "/metricCalculationSpecs/UNKNOWN"}
+            metric1Name ->
+              metricCalculationSpec {
+                name = MEASUREMENT_CONSUMER_NAME + "/metricCalculationSpecs/${metric1Name}"
+              }
+            metric2Name ->
+              metricCalculationSpec {
+                name = MEASUREMENT_CONSUMER_NAME + "/metricCalculationSpecs/${metric2Name}"
+              }
+            else ->
+              metricCalculationSpec {
+                name = MEASUREMENT_CONSUMER_NAME + "/metricCalculationSpecs/UNKNOWN"
+              }
           }
         }
     }
@@ -986,15 +995,18 @@ class ReportingTest {
             "B" -> reportingSet { name = MEASUREMENT_CONSUMER_NAME + "/reportingSets/B" }
             "C" -> reportingSet { name = MEASUREMENT_CONSUMER_NAME + "/reportingSets/C" }
             "union" -> reportingSet { name = MEASUREMENT_CONSUMER_NAME + "/reportingSets/union" }
-            "A-unique" -> reportingSet { name = MEASUREMENT_CONSUMER_NAME + "/reportingSets/A-unique" }
-            "B-unique" -> reportingSet { name = MEASUREMENT_CONSUMER_NAME + "/reportingSets/B-unique" }
-            "C-unique" -> reportingSet { name = MEASUREMENT_CONSUMER_NAME + "/reportingSets/C-unique" }
+            "A-unique" ->
+              reportingSet { name = MEASUREMENT_CONSUMER_NAME + "/reportingSets/A-unique" }
+            "B-unique" ->
+              reportingSet { name = MEASUREMENT_CONSUMER_NAME + "/reportingSets/B-unique" }
+            "C-unique" ->
+              reportingSet { name = MEASUREMENT_CONSUMER_NAME + "/reportingSets/C-unique" }
             else -> reportingSet { name = MEASUREMENT_CONSUMER_NAME + "/reportingSets/UNKNOWN" }
           }
         }
     }
 
-    val args = 
+    val args =
       arrayOf(
         "--tls-cert-file=$SECRETS_DIR/mc_tls.pem",
         "--tls-key-file=$SECRETS_DIR/mc_tls.key",
@@ -1005,28 +1017,31 @@ class ReportingTest {
         "--parent=${MEASUREMENT_CONSUMER_NAME}",
         "--id=${testReportId}",
         "--display-name=TESTDISPLAYREPORT",
-        "--primitive-rs-id=${edps[0].reportingSetName}"
-      ) + eventGroupArgs1 +
-      arrayOf(
-        "--primitive-rs-display-name=${edps[0].reportingSetDisplayName}",
-        "--primitive-rs-id=${edps[1].reportingSetName}"
-      ) + eventGroupArgs2 +
-      arrayOf(
-        "--primitive-rs-display-name=${edps[1].reportingSetDisplayName}",
-        "--primitive-rs-id=${edps[2].reportingSetName}"
-      ) + eventGroupArgs3 +
-      arrayOf(
-        "--primitive-rs-display-name=${edps[2].reportingSetDisplayName}",
-        "--prim-metric-id=${metric1Name}",
-        "--prim-metric-display-name=${metric1DisplayName}",
-        "--comp-metric-id=${metric2Name}",
-        "--comp-metric-display-name=${metric2DisplayName}",
-        "--union-rs-id=${unionRsName}",
-        "--union-rs-display-name=EDP Union",
-        "--reporting-interval-report-start-time=2000-01-01T00:00:00",
-        "--reporting-interval-report-end=2000-01-30",
-        "--daily-frequency=true"
-      )
+        "--primitive-rs-id=${edps[0].reportingSetName}",
+      ) +
+        eventGroupArgs1 +
+        arrayOf(
+          "--primitive-rs-display-name=${edps[0].reportingSetDisplayName}",
+          "--primitive-rs-id=${edps[1].reportingSetName}",
+        ) +
+        eventGroupArgs2 +
+        arrayOf(
+          "--primitive-rs-display-name=${edps[1].reportingSetDisplayName}",
+          "--primitive-rs-id=${edps[2].reportingSetName}",
+        ) +
+        eventGroupArgs3 +
+        arrayOf(
+          "--primitive-rs-display-name=${edps[2].reportingSetDisplayName}",
+          "--prim-metric-id=${metric1Name}",
+          "--prim-metric-display-name=${metric1DisplayName}",
+          "--comp-metric-id=${metric2Name}",
+          "--comp-metric-display-name=${metric2DisplayName}",
+          "--union-rs-id=${unionRsName}",
+          "--union-rs-display-name=EDP Union",
+          "--reporting-interval-report-start-time=2000-01-01T00:00:00",
+          "--reporting-interval-report-end=2000-01-30",
+          "--daily-frequency=true",
+        )
 
     val output = callCli(args)
     assertThat(output).status().isEqualTo(0)
@@ -1053,35 +1068,50 @@ class ReportingTest {
     assertPrimitiveRs(rsc[0], edps[2])
 
     // union
-    assertThat(reportingSetCaptor.allValues[3]).isEqualTo(
-      createReportingSetRequest {
-        parent = MEASUREMENT_CONSUMER_NAME
-        reportingSet = reportingSet {
-          name = "union"
-          displayName = "EDP Union"
-          composite = ReportingSetKt.composite {
-            expression = ReportingSetKt.setExpression {
-              operation = ReportingSet.SetExpression.Operation.UNION
-              lhs = ReportingSetKt.SetExpressionKt.operand {
-                reportingSet = MEASUREMENT_CONSUMER_NAME + "/reportingSets/" + edps[0].reportingSetName
+    assertThat(reportingSetCaptor.allValues[3])
+      .isEqualTo(
+        createReportingSetRequest {
+          parent = MEASUREMENT_CONSUMER_NAME
+          reportingSet = reportingSet {
+            name = "union"
+            displayName = "EDP Union"
+            composite =
+              ReportingSetKt.composite {
+                expression =
+                  ReportingSetKt.setExpression {
+                    operation = ReportingSet.SetExpression.Operation.UNION
+                    lhs =
+                      ReportingSetKt.SetExpressionKt.operand {
+                        reportingSet =
+                          MEASUREMENT_CONSUMER_NAME + "/reportingSets/" + edps[0].reportingSetName
+                      }
+                    rhs =
+                      ReportingSetKt.SetExpressionKt.operand {
+                        expression =
+                          ReportingSetKt.setExpression {
+                            operation = ReportingSet.SetExpression.Operation.UNION
+                            lhs =
+                              ReportingSetKt.SetExpressionKt.operand {
+                                reportingSet =
+                                  MEASUREMENT_CONSUMER_NAME +
+                                    "/reportingSets/" +
+                                    edps[1].reportingSetName
+                              }
+                            rhs =
+                              ReportingSetKt.SetExpressionKt.operand {
+                                reportingSet =
+                                  MEASUREMENT_CONSUMER_NAME +
+                                    "/reportingSets/" +
+                                    edps[2].reportingSetName
+                              }
+                          }
+                      }
+                   }
               }
-              rhs = ReportingSetKt.SetExpressionKt.operand {
-                expression = ReportingSetKt.setExpression {
-                  operation = ReportingSet.SetExpression.Operation.UNION
-                  lhs = ReportingSetKt.SetExpressionKt.operand {
-                    reportingSet =  MEASUREMENT_CONSUMER_NAME + "/reportingSets/" + edps[1].reportingSetName
-                  }
-                  rhs = ReportingSetKt.SetExpressionKt.operand {
-                    reportingSet = MEASUREMENT_CONSUMER_NAME + "/reportingSets/" +  edps[2].reportingSetName
-                  }
-                }
-              }
-            }
+            tags.put("ui.halo-cmm.org/reporting_set_type", "union")
           }
-          tags.put("ui.halo-cmm.org/reporting_set_type", "union")
         }
-      }
-    )
+      )
 
     // unique A
     val ursa = reportingSetCaptor.allValues.filter { it.reportingSet.name == "A-unique" }
@@ -1108,7 +1138,8 @@ class ReportingTest {
     // reach & frequency and impression count
     val mcs1 = metricSpecCaptor.allValues.filter { it.metricCalculationSpec.name == metric1Name }
     assertThat(mcs1.size).isEqualTo(1)
-    val rAndFSpec = mcs1[0].metricCalculationSpec.metricSpecsList.filter { it.hasReachAndFrequency() }
+    val rAndFSpec =
+      mcs1[0].metricCalculationSpec.metricSpecsList.filter { it.hasReachAndFrequency() }
     assertThat(rAndFSpec.size).isEqualTo(1)
     val impSpec = mcs1[0].metricCalculationSpec.metricSpecsList.filter { it.hasImpressionCount() }
     assertThat(impSpec.size).isEqualTo(1)
@@ -1124,126 +1155,171 @@ class ReportingTest {
 
     // Verify report
     val reportCaptor: KArgumentCaptor<CreateReportRequest> = argumentCaptor()
-    verifyBlocking(reportsServiceMock, times(1)) {
-      createReport(reportCaptor.capture())
-    }
-    assertThat(reportCaptor.firstValue).isEqualTo(
-      createReportRequest {
-        parent = MEASUREMENT_CONSUMER_NAME
-        reportId = testReportId
-        report = report {
-          name = testReportId
-          reportingInterval = ReportKt.reportingInterval {
-            reportStart = dateTime {
-              year = 2000
-              month = 1
-              day = 1
-            }
-            reportEnd = date {
-              year = 2000
-              month = 1
-              day = 30
-            }
-          }
-          reportingMetricEntries += ReportKt.reportingMetricEntry {
-            key = MEASUREMENT_CONSUMER_NAME + "/reportingSets/" + "A"
-            value = ReportKt.reportingMetricCalculationSpec {
-              metricCalculationSpecs += "measurementConsumers/1/metricCalculationSpecs/${metric1Name}"
-            }
-          }
-          reportingMetricEntries += ReportKt.reportingMetricEntry {
-            key = MEASUREMENT_CONSUMER_NAME + "/reportingSets/" + "B"
-            value = ReportKt.reportingMetricCalculationSpec {
-              metricCalculationSpecs += MEASUREMENT_CONSUMER_NAME + "/metricCalculationSpecs/${metric1Name}"
-            }
-          }
-          reportingMetricEntries += ReportKt.reportingMetricEntry {
-            key = MEASUREMENT_CONSUMER_NAME + "/reportingSets/" + "C"
-            value = ReportKt.reportingMetricCalculationSpec {
-              metricCalculationSpecs += MEASUREMENT_CONSUMER_NAME + "/metricCalculationSpecs/${metric1Name}"
-            }
-          }
-          reportingMetricEntries += ReportKt.reportingMetricEntry {
-            key = MEASUREMENT_CONSUMER_NAME + "/reportingSets/" + "union"
-            value = ReportKt.reportingMetricCalculationSpec {
-              metricCalculationSpecs += MEASUREMENT_CONSUMER_NAME + "/metricCalculationSpecs/${metric1Name}"
-            }
-          }
-          reportingMetricEntries += ReportKt.reportingMetricEntry {
-            key = MEASUREMENT_CONSUMER_NAME + "/reportingSets/" + "A-unique"
-            value = ReportKt.reportingMetricCalculationSpec {
-              metricCalculationSpecs += MEASUREMENT_CONSUMER_NAME + "/metricCalculationSpecs/${metric2Name}"
-            }
-          }
-          reportingMetricEntries += ReportKt.reportingMetricEntry {
-            key = MEASUREMENT_CONSUMER_NAME + "/reportingSets/" + "B-unique"
-            value = ReportKt.reportingMetricCalculationSpec {
-              metricCalculationSpecs += MEASUREMENT_CONSUMER_NAME + "/metricCalculationSpecs/${metric2Name}"
-            }
-          }
-          reportingMetricEntries += ReportKt.reportingMetricEntry {
-            key = MEASUREMENT_CONSUMER_NAME + "/reportingSets/" + "C-unique"
-            value = ReportKt.reportingMetricCalculationSpec {
-              metricCalculationSpecs +=MEASUREMENT_CONSUMER_NAME + "/metricCalculationSpecs/${metric2Name}"
-            }
-          }
-          tags.put("ui.halo-cmm.org", "true")
-          tags.put("ui.halo-cmm.org/display_name", "TESTDISPLAYREPORT")
-        }
-      }
-    )
-  }
-
-  fun assertPrimitiveRs(expected: CreateReportingSetRequest, props: Edp) {
-    assertThat(expected).isEqualTo(
-      createReportingSetRequest {
-        parent = MEASUREMENT_CONSUMER_NAME
-        reportingSet = reportingSet {
-          name = props.reportingSetName
-          displayName = props.reportingSetDisplayName
-          primitive = ReportingSetKt.primitive {
-            for (eventGroup in props.eventGroups) {
-              cmmsEventGroups += eventGroup
-            }
-          }
-          tags.put("ui.halo-cmm.org/reporting_set_type", "individual")
-        }
-      }
-    )
-  }
-
-  fun assertUniqueRs(expected: CreateReportingSetRequest, props: Edp, unionName: String, edps: List<Edp>) {
-    val complement = edps.subtract(listOf(props))
-    assertThat(expected).isEqualTo(
-      createReportingSetRequest {
-        parent = MEASUREMENT_CONSUMER_NAME
-        reportingSet = reportingSet {
-          name = props.reportingSetName + "-unique"
-          displayName = props.reportingSetDisplayName + " Unique"
-          composite = ReportingSetKt.composite {
-            expression = ReportingSetKt.setExpression {
-              operation = ReportingSet.SetExpression.Operation.UNION
-              lhs = ReportingSetKt.SetExpressionKt.operand {
-                reportingSet = MEASUREMENT_CONSUMER_NAME + "/reportingSets/" + unionName
-              }
-              rhs = ReportingSetKt.SetExpressionKt.operand {
-                expression = ReportingSetKt.setExpression {
-                  operation = ReportingSet.SetExpression.Operation.UNION
-                  lhs = ReportingSetKt.SetExpressionKt.operand {
-                    reportingSet = MEASUREMENT_CONSUMER_NAME + "/reportingSets/" + complement.elementAt(0).reportingSetName
-                  }
-                  rhs = ReportingSetKt.SetExpressionKt.operand {
-                    reportingSet = MEASUREMENT_CONSUMER_NAME + "/reportingSets/" + complement.elementAt(1).reportingSetName
-                  }
+    verifyBlocking(reportsServiceMock, times(1)) { createReport(reportCaptor.capture()) }
+    assertThat(reportCaptor.firstValue)
+      .isEqualTo(
+        createReportRequest {
+          parent = MEASUREMENT_CONSUMER_NAME
+          reportId = testReportId
+          report = report {
+            name = testReportId
+            reportingInterval =
+              ReportKt.reportingInterval {
+                reportStart = dateTime {
+                  year = 2000
+                  month = 1
+                  day = 1
+                }
+                reportEnd = date {
+                  year = 2000
+                  month = 1
+                  day = 30
                 }
               }
-            }
+            reportingMetricEntries +=
+              ReportKt.reportingMetricEntry {
+                key = MEASUREMENT_CONSUMER_NAME + "/reportingSets/" + "A"
+                value =
+                  ReportKt.reportingMetricCalculationSpec {
+                    metricCalculationSpecs +=
+                      "measurementConsumers/1/metricCalculationSpecs/${metric1Name}"
+                  }
+              }
+            reportingMetricEntries +=
+              ReportKt.reportingMetricEntry {
+                key = MEASUREMENT_CONSUMER_NAME + "/reportingSets/" + "B"
+                value =
+                  ReportKt.reportingMetricCalculationSpec {
+                    metricCalculationSpecs +=
+                      MEASUREMENT_CONSUMER_NAME + "/metricCalculationSpecs/${metric1Name}"
+                  }
+              }
+            reportingMetricEntries +=
+              ReportKt.reportingMetricEntry {
+                key = MEASUREMENT_CONSUMER_NAME + "/reportingSets/" + "C"
+                value =
+                  ReportKt.reportingMetricCalculationSpec {
+                    metricCalculationSpecs +=
+                      MEASUREMENT_CONSUMER_NAME + "/metricCalculationSpecs/${metric1Name}"
+                  }
+              }
+            reportingMetricEntries +=
+              ReportKt.reportingMetricEntry {
+                key = MEASUREMENT_CONSUMER_NAME + "/reportingSets/" + "union"
+                value =
+                  ReportKt.reportingMetricCalculationSpec {
+                    metricCalculationSpecs +=
+                      MEASUREMENT_CONSUMER_NAME + "/metricCalculationSpecs/${metric1Name}"
+                  }
+              }
+            reportingMetricEntries +=
+              ReportKt.reportingMetricEntry {
+                key = MEASUREMENT_CONSUMER_NAME + "/reportingSets/" + "A-unique"
+                value =
+                  ReportKt.reportingMetricCalculationSpec {
+                    metricCalculationSpecs +=
+                      MEASUREMENT_CONSUMER_NAME + "/metricCalculationSpecs/${metric2Name}"
+                  }
+              }
+            reportingMetricEntries +=
+              ReportKt.reportingMetricEntry {
+                key = MEASUREMENT_CONSUMER_NAME + "/reportingSets/" + "B-unique"
+                value =
+                  ReportKt.reportingMetricCalculationSpec {
+                    metricCalculationSpecs +=
+                      MEASUREMENT_CONSUMER_NAME + "/metricCalculationSpecs/${metric2Name}"
+                  }
+              }
+            reportingMetricEntries +=
+              ReportKt.reportingMetricEntry {
+                key = MEASUREMENT_CONSUMER_NAME + "/reportingSets/" + "C-unique"
+                value =
+                  ReportKt.reportingMetricCalculationSpec {
+                    metricCalculationSpecs +=
+                      MEASUREMENT_CONSUMER_NAME + "/metricCalculationSpecs/${metric2Name}"
+                  }
+              }
+            tags.put("ui.halo-cmm.org", "true")
+            tags.put("ui.halo-cmm.org/display_name", "TESTDISPLAYREPORT")
           }
-          tags.put("ui.halo-cmm.org/reporting_set_type", "unique")
-          tags.put("ui.halo-cmm.org/reporting_set_id", "${MEASUREMENT_CONSUMER_NAME}/reportingSets/${props.reportingSetName}")
         }
-      }
-    )
+      )
+   }
+
+  fun assertPrimitiveRs(expected: CreateReportingSetRequest, props: Edp) {
+    assertThat(expected)
+      .isEqualTo(
+        createReportingSetRequest {
+          parent = MEASUREMENT_CONSUMER_NAME
+          reportingSet = reportingSet {
+            name = props.reportingSetName
+            displayName = props.reportingSetDisplayName
+            primitive =
+              ReportingSetKt.primitive {
+                for (eventGroup in props.eventGroups) {
+                  cmmsEventGroups += eventGroup
+                }
+              }
+            tags.put("ui.halo-cmm.org/reporting_set_type", "individual")
+          }
+        }
+      )
+  }
+
+  fun assertUniqueRs(
+    expected: CreateReportingSetRequest,
+    props: Edp,
+    unionName: String,
+    edps: List<Edp>,
+  ) {
+    val complement = edps.subtract(listOf(props))
+    assertThat(expected)
+      .isEqualTo(
+        createReportingSetRequest {
+          parent = MEASUREMENT_CONSUMER_NAME
+          reportingSet = reportingSet {
+            name = props.reportingSetName + "-unique"
+            displayName = props.reportingSetDisplayName + " Unique"
+            composite =
+              ReportingSetKt.composite {
+                expression =
+                  ReportingSetKt.setExpression {
+                    operation = ReportingSet.SetExpression.Operation.UNION
+                    lhs =
+                      ReportingSetKt.SetExpressionKt.operand {
+                        reportingSet = MEASUREMENT_CONSUMER_NAME + "/reportingSets/" + unionName
+                      }
+                    rhs =
+                      ReportingSetKt.SetExpressionKt.operand {
+                        expression =
+                          ReportingSetKt.setExpression {
+                            operation = ReportingSet.SetExpression.Operation.UNION
+                            lhs =
+                              ReportingSetKt.SetExpressionKt.operand {
+                                reportingSet =
+                                  MEASUREMENT_CONSUMER_NAME +
+                                    "/reportingSets/" +
+                                    complement.elementAt(0).reportingSetName
+                              }
+                            rhs =
+                              ReportingSetKt.SetExpressionKt.operand {
+                                reportingSet =
+                                  MEASUREMENT_CONSUMER_NAME +
+                                    "/reportingSets/" +
+                                    complement.elementAt(1).reportingSetName
+                              }
+                          }
+                      }
+                  }
+               }
+            tags.put("ui.halo-cmm.org/reporting_set_type", "unique")
+            tags.put(
+              "ui.halo-cmm.org/reporting_set_id",
+              "${MEASUREMENT_CONSUMER_NAME}/reportingSets/${props.reportingSetName}",
+            )
+          }
+        }
+      )
   }
 
   @Test

--- a/src/test/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/tools/ReportingTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/tools/ReportingTest.kt
@@ -974,7 +974,8 @@ class ReportingTest {
           metricCalculationSpec {
             name =
               MEASUREMENT_CONSUMER_NAME +
-                "/metricCalculationSpecs/${request.metricCalculationSpec.name}"          }
+                "/metricCalculationSpecs/${request.metricCalculationSpec.name}"
+          }
         }
     }
 
@@ -984,7 +985,8 @@ class ReportingTest {
           val request = it.arguments[0] as CreateReportingSetRequest
           reportingSet {
             name = MEASUREMENT_CONSUMER_NAME + "/reportingSets/${request.reportingSet.name}"
-          }        }
+          }
+        }
     }
 
     val args =
@@ -1210,7 +1212,7 @@ class ReportingTest {
           .size
       )
       .isEqualTo(1)
-    
+
     //  - verify union reporting set
     val meUnion =
       metricEntries.filter { it.key == MEASUREMENT_CONSUMER_NAME + "/reportingSets/union-A-B-C" }

--- a/src/test/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/tools/ReportingTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/tools/ReportingTest.kt
@@ -1018,13 +1018,13 @@ class ReportingTest {
           "--report-start=2000-01-01T00:00:00",
           "--report-end=2000-01-30",
           "--daily-frequency=true",
-          "--has-group=true",
-          "--grouping='person.gender == 1'",
-          "--grouping='person.gender == 2'",
-          "--has-group=true",
-          "--grouping='person.age == 1'",
-          "--grouping='person.age == 2'",
-          "--grouping='person.age == 3'",
+          "--grouping",
+          "--predicate='person.gender == 1'",
+          "--predicate='person.gender == 2'",
+          "--grouping",
+          "--predicate='person.age == 1'",
+          "--predicate='person.age == 2'",
+          "--predicate='person.age == 3'",
         )
 
     val output = callCli(args)

--- a/src/test/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/tools/ReportingTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/tools/ReportingTest.kt
@@ -1118,14 +1118,18 @@ class ReportingTest {
       createMetricCalculationSpec(metricSpecCaptor.capture())
     }
 
-    val groupings = listOf(MetricCalculationSpecKt.grouping {
-      predicates += "'person.gender == 1'"
-      predicates += "'person.gender == 2'"
-    }, MetricCalculationSpecKt.grouping {
-      predicates += "'person.age == 1'"
-      predicates += "'person.age == 2'"
-      predicates += "'person.age == 3'"
-    })
+    val groupings =
+      listOf(
+        MetricCalculationSpecKt.grouping {
+          predicates += "'person.gender == 1'"
+          predicates += "'person.gender == 2'"
+        },
+        MetricCalculationSpecKt.grouping {
+          predicates += "'person.age == 1'"
+          predicates += "'person.age == 2'"
+          predicates += "'person.age == 3'"
+        },
+      )
 
     // Spec for primitives and union
     // reach & frequency and impression count

--- a/src/test/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/tools/ReportingTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/tools/ReportingTest.kt
@@ -1106,7 +1106,7 @@ class ReportingTest {
                               }
                           }
                       }
-                   }
+                  }
               }
             tags.put("ui.halo-cmm.org/reporting_set_type", "union")
           }
@@ -1244,7 +1244,7 @@ class ReportingTest {
           }
         }
       )
-   }
+  }
 
   fun assertPrimitiveRs(expected: CreateReportingSetRequest, props: Edp) {
     assertThat(expected)
@@ -1311,7 +1311,7 @@ class ReportingTest {
                           }
                       }
                   }
-               }
+              }
             tags.put("ui.halo-cmm.org/reporting_set_type", "unique")
             tags.put(
               "ui.halo-cmm.org/reporting_set_id",

--- a/src/test/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/tools/ReportingTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/tools/ReportingTest.kt
@@ -1152,9 +1152,7 @@ class ReportingTest {
             year = 2000
             month = 1
             day = 1
-            this.timeZone = timeZone {
-              id = "UTC"
-            }
+            this.timeZone = timeZone { id = "UTC" }
           }
           reportEnd = date {
             year = 2000

--- a/src/test/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/tools/ReportingTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/tools/ReportingTest.kt
@@ -1152,6 +1152,9 @@ class ReportingTest {
             year = 2000
             month = 1
             day = 1
+            this.timeZone = timeZone {
+              id = "UTC"
+            }
           }
           reportEnd = date {
             year = 2000

--- a/src/test/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/tools/ReportingTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/tools/ReportingTest.kt
@@ -1018,8 +1018,11 @@ class ReportingTest {
           "--report-start=2000-01-01T00:00:00",
           "--report-end=2000-01-30",
           "--daily-frequency=true",
-          "--grouping='person.gender == 1,person.gender == 2'",
-          "--grouping='person.age_group == 1,person.age_group == 2,person.age_group == 3'",
+          "--has-group=true",
+          "--grouping='person.gender == 1'",
+          "--grouping='person.gender == 2'",
+          // "--grouping='person.gender == 1,person.gender == 2'",
+          // "--grouping='person.age_group == 1,person.age_group == 2,person.age_group == 3'",
         )
 
     val output = callCli(args)


### PR DESCRIPTION
Update the Reporting CLI tool to create a UI readable report. It is moderately hardcoded to limit the amount of configuration required by the user. There are a number of steps to complete this process:
1. Create 3 primitive Reporting Sets (with a number of event groups).
2. Create 1 union Reporting Set - the union of all 3 primitives.
3. Create 3 unique Reporting Sets (difference between the union and the union of the other two. eg. unique A = ABC - BC)
4. Create 1 metric calculation spec for the primitives.
5. Create 1 metric calculation spec for the composites.
6. Create a report mapping the reporting sets and metric calculation specs and include the other report parameters (like date range and frequency).

All the reporting sets and the report will be tagged appropriately so the Reporting BFF can process the report correctly.