### PR TITLE
Add variables for specifying existing IP addresses in gcloud Terraform modules.

### DIFF
--- a/src/main/terraform/gcloud/modules/duchy/main.tf
+++ b/src/main/terraform/gcloud/modules/duchy/main.tf
@@ -58,9 +58,11 @@ resource "google_storage_bucket_iam_member" "storage" {
 }
 
 resource "google_compute_address" "v2alpha" {
-  name = "${var.name}-duchy-v2alpha"
+  name    = "${var.name}-duchy-v2alpha"
+  address = var.v2alpha_ip_address
 }
 
 resource "google_compute_address" "system_v1alpha" {
-  name = "${var.name}-duchy-system-v1alpha"
+  name    = "${var.name}-duchy-system-v1alpha"
+  address = var.system_v1alpha_ip_address
 }

--- a/src/main/terraform/gcloud/modules/duchy/variables.tf
+++ b/src/main/terraform/gcloud/modules/duchy/variables.tf
@@ -37,3 +37,17 @@ variable "spanner_instance" {
   })
   nullable = false
 }
+
+variable "v2alpha_ip_address" {
+  description = "IP address for v2alpha public API"
+  type        = string
+  nullable    = true
+  default     = null
+}
+
+variable "system_v1alpha_ip_address" {
+  description = "IP address for v1alpha system API"
+  type        = string
+  nullable    = true
+  default     = null
+}

--- a/src/main/terraform/gcloud/modules/kingdom/main.tf
+++ b/src/main/terraform/gcloud/modules/kingdom/main.tf
@@ -34,9 +34,11 @@ resource "google_spanner_database_iam_member" "kingdom_internal" {
 }
 
 resource "google_compute_address" "v2alpha" {
-  name = "kingdom-v2alpha"
+  name    = "kingdom-v2alpha"
+  address = var.v2alpha_ip_address
 }
 
 resource "google_compute_address" "system_v1alpha" {
-  name = "kingdom-system-v1alpha"
+  name    = "kingdom-system-v1alpha"
+  address = var.system_v1alpha_ip_address
 }

--- a/src/main/terraform/gcloud/modules/kingdom/variables.tf
+++ b/src/main/terraform/gcloud/modules/kingdom/variables.tf
@@ -26,3 +26,17 @@ variable "spanner_database_name" {
   default     = "kingdom"
   nullable    = false
 }
+
+variable "v2alpha_ip_address" {
+  description = "IP address for v2alpha public API"
+  type        = string
+  nullable    = true
+  default     = null
+}
+
+variable "system_v1alpha_ip_address" {
+  description = "IP address for v1alpha system API"
+  type        = string
+  nullable    = true
+  default     = null
+}


### PR DESCRIPTION
Import of `google_compute_address` not sufficient to keep any existing IP addresses unless the resource can be updated in-place. Specifying the `address` field in addition will ensure the actual IP address remains reserved.