### PR TITLE
Add reporting UI to terraform

### DIFF
--- a/src/main/terraform/gcloud/cmms/reporting_ui.tf
+++ b/src/main/terraform/gcloud/cmms/reporting_ui.tf
@@ -1,0 +1,21 @@
+# Copyright 2024 The Cross-Media Measurement Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+module "reporting_v2_cluster" {
+  source = "../modules/reporting_ui"
+
+  iam_service_account_name_ui       = "reporting-ui"
+  iam_service_account_name_gateway  = "reporting-bff"
+  iam_service_account_name_grpc     = "reporting-gateway"
+}

--- a/src/main/terraform/gcloud/modules/reporting-ui/README.md
+++ b/src/main/terraform/gcloud/modules/reporting-ui/README.md
@@ -1,0 +1,3 @@
+# Reporting System
+
+Reusable module for the Halo Reporting UI system on Google Cloud.

--- a/src/main/terraform/gcloud/modules/reporting-ui/main.tf
+++ b/src/main/terraform/gcloud/modules/reporting-ui/main.tf
@@ -1,0 +1,56 @@
+# Copyright 2024 The Cross-Media Measurement Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+data "google_client_config" "default" {}
+
+locals {
+  storage_bucket_location = var.storage_bucket_location == null ? data.google_client_config.default.region : var.storage_bucket_location
+}
+
+module "reporting_ui_user" {
+  source = "../workload-identity-user"
+
+  k8s_service_account_name        = "reporting-ui-server"
+  iam_service_account_name        = var.iam_service_account_name_ui
+  iam_service_account_description = "Reporting UI server."
+}
+
+module "reporting_gateway_user" {
+  source = "../workload-identity-user"
+
+  k8s_service_account_name        = "reporting-gateway-server"
+  iam_service_account_name        = var.iam_service_account_name_gateway
+  iam_service_account_description = "Reporting Gateway server."
+}
+
+module "reporting_grpc_user" {
+  source = "../workload-identity-user"
+
+  k8s_service_account_name        = "reporting-grpc-server"
+  iam_service_account_name        = var.iam_service_account_name_grpc
+  iam_service_account_description = "Reporting GRPC server."
+}
+
+module "ui_server_bucket" {
+  source = "../storage-bucket"
+
+  name     = var.storage_bucket_name
+  location = local.storage_bucket_location
+}
+
+resource "google_storage_bucket_iam_member" "ui_server_bucket_member" {
+  bucket = module.ui_server_bucket.storage_bucket.name
+  role   = "roles/storage.objectViewer"
+  member = module.reporting_ui_user.iam_service_account.member
+}

--- a/src/main/terraform/gcloud/modules/reporting-ui/variables.tf
+++ b/src/main/terraform/gcloud/modules/reporting-ui/variables.tf
@@ -1,0 +1,43 @@
+# Copyright 2023 The Cross-Media Measurement Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+variable "iam_service_account_name_ui" {
+  description = "IAM `google_service_account.name` for the UI server."
+  type        = string
+  nullable    = false
+}
+
+variable "iam_service_account_name_gateway" {
+  description = "IAM `google_service_account.name` for the Gateway server."
+  type        = string
+  nullable    = false
+}
+
+variable "iam_service_account_name_grpc" {
+  description = "IAM `google_service_account.name` for the GRPC server."
+  type        = string
+  nullable    = false
+}
+
+variable "storage_bucket_name" {
+  description = "Name of Google Cloud Storage bucket where the website and server files will be stored."
+  type        = string
+  nullable    = false
+}
+
+variable "storage_bucket_location" {
+  description = "Location of the Google Cloud Storage bucket. Defaults to provider region."
+  type        = string
+  default     = null
+}

--- a/src/main/terraform/gcloud/modules/reporting-ui/versions.tf
+++ b/src/main/terraform/gcloud/modules/reporting-ui/versions.tf
@@ -1,0 +1,22 @@
+# Copyright 2023 The Cross-Media Measurement Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+terraform {
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = ">= 5.4.0"
+    }
+  }
+}


### PR DESCRIPTION
Add Reporting UI and associated services to Terraform. Also added a reporting_ui file to cmms so the Reporting UI resources are created during the GitHub action.

What is created:
* 3 IAM service accounts (UI, GRPC, Gateway)
* S3 bucket