### PR TITLE
Adjust Git tag format for nightly builds.

### DIFF
--- a/.github/workflows/deploy-nightly.yml
+++ b/.github/workflows/deploy-nightly.yml
@@ -25,7 +25,7 @@ jobs:
     - id: get-tag
       run: |
         date_string="$(TZ='America/Los_Angeles' date +'%Y%m%d')"
-        echo "tag=${date_string}.$GITHUB_RUN_NUMBER" >> "$GITHUB_OUTPUT"
+        echo "tag=nightly/${date_string}.$GITHUB_RUN_ATTEMPT" >> "$GITHUB_OUTPUT"
     - name: create-tag
       uses: actions/github-script@v7
       env:


### PR DESCRIPTION
* Prefix with "nightly/".
* Use run attempt number instead of run number for suffix.