### PR TITLE
Stop reading google_container_cluster after creation.

### DIFF
--- a/src/main/terraform/gcloud/cmms/duchies.tf
+++ b/src/main/terraform/gcloud/cmms/duchies.tf
@@ -22,21 +22,11 @@ module "clusters" {
   secret_key      = module.common.cluster_secret_key
 }
 
-data "google_container_cluster" "clusters" {
-  for_each = local.duchy_names
-
-  name     = "${each.key}-duchy"
-  location = local.cluster_location
-
-  # Defer reading of cluster resource until it exists.
-  depends_on = [module.clusters]
-}
-
 module "default_node_pools" {
   source   = "../modules/node-pool"
-  for_each = data.google_container_cluster.clusters
+  for_each = module.clusters
 
-  cluster         = each.value
+  cluster         = each.value.cluster
   name            = "default"
   service_account = module.common.cluster_service_account
   machine_type    = "e2-standard-2"
@@ -45,9 +35,9 @@ module "default_node_pools" {
 
 module "highmem_node_pools" {
   source   = "../modules/node-pool"
-  for_each = data.google_container_cluster.clusters
+  for_each = module.clusters
 
-  cluster         = each.value
+  cluster         = each.value.cluster
   name            = "highmem"
   service_account = module.common.cluster_service_account
   machine_type    = "c2-standard-4"

--- a/src/main/terraform/gcloud/cmms/kingdom.tf
+++ b/src/main/terraform/gcloud/cmms/kingdom.tf
@@ -21,19 +21,11 @@ module "kingdom_cluster" {
   secret_key      = module.common.cluster_secret_key
 }
 
-data "google_container_cluster" "kingdom" {
-  name     = local.kingdom_cluster_name
-  location = local.cluster_location
-
-  # Defer reading of cluster resource until it exists.
-  depends_on = [module.kingdom_cluster]
-}
-
 module "kingdom_default_node_pool" {
   source = "../modules/node-pool"
 
   name            = "default"
-  cluster         = data.google_container_cluster.kingdom
+  cluster         = module.kingdom_cluster.cluster
   service_account = module.common.cluster_service_account
   machine_type    = "e2-custom-2-4096"
   max_node_count  = 3

--- a/src/main/terraform/gcloud/cmms/reporting.tf
+++ b/src/main/terraform/gcloud/cmms/reporting.tf
@@ -21,19 +21,11 @@ module "reporting_cluster" {
   secret_key      = module.common.cluster_secret_key
 }
 
-data "google_container_cluster" "reporting" {
-  name     = local.reporting_cluster_name
-  location = local.cluster_location
-
-  # Defer reading of cluster resource until it exists.
-  depends_on = [module.reporting_cluster]
-}
-
 module "reporting_default_node_pool" {
   source = "../modules/node-pool"
 
   name            = "default"
-  cluster         = data.google_container_cluster.reporting
+  cluster         = module.reporting_cluster.cluster
   service_account = module.common.cluster_service_account
   machine_type    = "e2-small"
   max_node_count  = 8

--- a/src/main/terraform/gcloud/cmms/reporting_v2.tf
+++ b/src/main/terraform/gcloud/cmms/reporting_v2.tf
@@ -21,19 +21,11 @@ module "reporting_v2_cluster" {
   secret_key      = module.common.cluster_secret_key
 }
 
-data "google_container_cluster" "reporting_v2" {
-  name     = local.reporting_v2_cluster_name
-  location = local.cluster_location
-
-  # Defer reading of cluster resource until it exists.
-  depends_on = [module.reporting_v2_cluster]
-}
-
 module "reporting_v2_default_node_pool" {
   source = "../modules/node-pool"
 
   name            = "default"
-  cluster         = data.google_container_cluster.reporting_v2
+  cluster         = module.reporting_v2_cluster.cluster
   service_account = module.common.cluster_service_account
   machine_type    = "e2-small"
   max_node_count  = 8

--- a/src/main/terraform/gcloud/cmms/simulators.tf
+++ b/src/main/terraform/gcloud/cmms/simulators.tf
@@ -21,19 +21,11 @@ module "simulators_cluster" {
   secret_key      = module.common.cluster_secret_key
 }
 
-data "google_container_cluster" "simulators" {
-  name     = local.simulators_cluster_name
-  location = local.cluster_location
-
-  # Defer reading of cluster resource until it exists.
-  depends_on = [module.simulators_cluster]
-}
-
 module "simulators_default_node_pool" {
   source = "../modules/node-pool"
 
   name            = "default"
-  cluster         = data.google_container_cluster.simulators
+  cluster         = module.simulators_cluster.cluster
   service_account = module.common.cluster_service_account
   machine_type    = "e2-standard-2"
   max_node_count  = 2
@@ -43,7 +35,7 @@ module "simulators_spot_node_pool" {
   source = "../modules/node-pool"
 
   name            = "spot"
-  cluster         = data.google_container_cluster.simulators
+  cluster         = module.simulators_cluster.cluster
   service_account = module.common.cluster_service_account
   machine_type    = "c2-standard-4"
   max_node_count  = 3

--- a/src/main/terraform/gcloud/examples/duchy/main.tf
+++ b/src/main/terraform/gcloud/examples/duchy/main.tf
@@ -53,18 +53,10 @@ module "cluster" {
   secret_key      = module.common.cluster_secret_key
 }
 
-data "google_container_cluster" "cluster" {
-  name     = local.cluster_name
-  location = local.cluster_location
-
-  # Defer reading of cluster resource until it exists.
-  depends_on = [module.cluster]
-}
-
 module "default_node_pool" {
   source = "../../modules/node-pool"
 
-  cluster         = data.google_container_cluster.cluster
+  cluster         = module.cluster.cluster
   name            = "default"
   service_account = module.common.cluster_service_account
   machine_type    = "e2-standard-2"
@@ -74,7 +66,7 @@ module "default_node_pool" {
 module "spot_node_pool" {
   source = "../../modules/node-pool"
 
-  cluster         = data.google_container_cluster.cluster
+  cluster         = module.cluster.cluster
   name            = "spot"
   service_account = module.common.cluster_service_account
   machine_type    = "c2-standard-4"

--- a/src/main/terraform/gcloud/examples/kingdom/main.tf
+++ b/src/main/terraform/gcloud/examples/kingdom/main.tf
@@ -44,19 +44,11 @@ module "kingdom_cluster" {
   secret_key      = module.common.cluster_secret_key
 }
 
-data "google_container_cluster" "kingdom" {
-  name     = var.cluster_name
-  location = local.cluster_location
-
-  # Defer reading of cluster resource until it exists.
-  depends_on = [module.kingdom_cluster]
-}
-
 module "kingdom_default_node_pool" {
   source = "../../modules/node-pool"
 
   name            = "default"
-  cluster         = data.google_container_cluster.kingdom
+  cluster         = module.kingdom_cluster.cluster
   service_account = module.common.cluster_service_account
   machine_type    = "e2-custom-2-4096"
   max_node_count  = 2

--- a/src/main/terraform/gcloud/examples/simulators/main.tf
+++ b/src/main/terraform/gcloud/examples/simulators/main.tf
@@ -37,19 +37,11 @@ module "simulators_cluster" {
   secret_key      = module.common.cluster_secret_key
 }
 
-data "google_container_cluster" "simulators" {
-  name     = var.cluster_name
-  location = local.cluster_location
-
-  # Defer reading of cluster resource until it exists.
-  depends_on = [module.simulators_cluster]
-}
-
 module "simulators_default_node_pool" {
   source = "../../modules/node-pool"
 
   name            = "default"
-  cluster         = data.google_container_cluster.simulators
+  cluster         = module.simulators_cluster.cluster
   service_account = module.common.cluster_service_account
   machine_type    = "e2-standard-2"
   max_node_count  = 2
@@ -59,7 +51,7 @@ module "simulators_spot_node_pool" {
   source = "../../modules/node-pool"
 
   name            = "spot"
-  cluster         = data.google_container_cluster.simulators
+  cluster         = module.simulators_cluster.cluster
   service_account = module.common.cluster_service_account
   machine_type    = "c2-standard-4"
   max_node_count  = 3

--- a/src/main/terraform/gcloud/modules/cluster/outputs.tf
+++ b/src/main/terraform/gcloud/modules/cluster/outputs.tf
@@ -1,0 +1,18 @@
+# Copyright 2024 The Cross-Media Measurement Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+output "cluster" {
+  description = "`google_container_cluster`"
+  value       = google_container_cluster.cluster
+}


### PR DESCRIPTION
This avoids node pool recreation whenever any cluster config changes.