### PR TITLE
Added method to batch search privacy entries to the interface

### DIFF
--- a/src/main/kotlin/org/wfanet/measurement/eventdataprovider/privacybudgetmanagement/PrivacyBudgetLedger.kt
+++ b/src/main/kotlin/org/wfanet/measurement/eventdataprovider/privacybudgetmanagement/PrivacyBudgetLedger.kt
@@ -114,12 +114,13 @@ class PrivacyBudgetLedger(
     context: PrivacyBudgetLedgerTransactionContext,
     privacyBucketGroups: Set<PrivacyBucketGroup>,
     acdpCharges: Set<AcdpCharge>,
-  ): List<PrivacyBucketGroup> =
-    privacyBucketGroups.filter { privacyBucketGroup ->
-      val acdpBalanceEntries = setOf(context.findAcdpBalanceEntry(privacyBucketGroup))
-      val balanceAcdpCharges = acdpBalanceEntries.map { it.acdpCharge }
-      exceedsUnderAcdpComposition(balanceAcdpCharges + acdpCharges)
+  ): List<PrivacyBucketGroup> {
+    val acdpBalanceEntries = context.findAcdpBalanceEntries(privacyBucketGroups)
+    val exceededEntries = acdpBalanceEntries.filter {
+      exceedsUnderAcdpComposition(listOf(it.acdpCharge) + acdpCharges)
     }
+    return exceededEntries.map { it.privacyBucketGroup }
+  }
 
   private fun exceedsUnderAcdpComposition(acdpCharges: List<AcdpCharge>) =
     (Composition.totalPrivacyBudgetUsageUnderAcdpComposition(

--- a/src/main/kotlin/org/wfanet/measurement/eventdataprovider/privacybudgetmanagement/PrivacyBudgetLedgerBackingStore.kt
+++ b/src/main/kotlin/org/wfanet/measurement/eventdataprovider/privacybudgetmanagement/PrivacyBudgetLedgerBackingStore.kt
@@ -91,6 +91,21 @@ interface PrivacyBudgetLedgerTransactionContext : AutoCloseable {
     return AcdpCharge(totalRho, totalTheta)
   }
 
+
+  /**
+   * Returns a set of exceeded balance entries.
+   * For each PrivacyBucketGroup, one PrivacyBudgetAcdpBalanceEntry should be generated.
+   *
+   * Override this method to increase the performance by batching search for PrivacyBucketGroup,
+   * instead of looking for each entry individually.
+   * The default implementation calls the findAcdpBalanceEntry method individually.
+   */
+  suspend fun findAcdpBalanceEntries(
+    privacyBucketGroup: Set<PrivacyBucketGroup>
+  ): Set<PrivacyBudgetAcdpBalanceEntry> = privacyBucketGroup.map {
+    findAcdpBalanceEntry(it)
+  }.toSet()
+
   /**
    * Returns whether this backing store has a ledger entry for [reference].
    *


### PR DESCRIPTION
At Meta we were facing some performance issues when trying to find privacy bucket groups one by one. We created internally some methods to batch the select queries and that helped. We think this should be added to the interface so other EDP implementing the PBM can also create methods to batch their entries.