### PR TITLE
fix: use version for common-jvm dep

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -129,6 +129,7 @@ bazel_dep(
 )
 bazel_dep(
     name = "common-jvm",
+    version = "0.86.0",
     repo_name = "wfa_common_jvm",
 )
 bazel_dep(
@@ -310,14 +311,4 @@ http_archive(
 single_version_override(
     module_name = "boringssl",
     version = BORINGSSL_VERSION,
-)
-
-# DO_NOT_SUBMIT(world-federation-of-advertisers/common-jvm#258): Use version
-archive_override(
-    module_name = "common-jvm",
-    integrity = "sha256-H/f0GJL7rLVL2Tpx4a17AXyqvhVqEx8XP/OJ/Dm44hg=",
-    strip_prefix = "common-jvm-6bba2c4ada6b8ea3de3afc6b270347d185dbede5",
-    urls = [
-        "https://github.com/world-federation-of-advertisers/common-jvm/archive/6bba2c4ada6b8ea3de3afc6b270347d185dbede5.tar.gz",
-    ],
 )


### PR DESCRIPTION
This was missed in #1674 