### PR TITLE
fix!: shorten overly long name for HMSS Mill Deployment

### DIFF
--- a/.github/workflows/configure-aws-duchy.yml
+++ b/.github/workflows/configure-aws-duchy.yml
@@ -62,6 +62,7 @@ permissions:
 
 env:
   KUSTOMIZATION_PATH: "k8s/cmms"
+  KUBECTL_APPLYSET: true
   DUCHY_NAME: ${{ inputs.duchy-name }}
 
 jobs:
@@ -163,6 +164,12 @@ jobs:
         echo "$AKID_TO_PRINCIPAL_MAP" | sed $'s/\r$//'  >
         "$KUSTOMIZATION_PATH/src/main/k8s/dev/config_files/authority_key_identifier_to_principal_map.textproto"
 
+    - name: Upload Kustomization artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: kustomization
+        path: ${{ env.KUSTOMIZATION_PATH }}
+
     - name: Export KUSTOMIZE_PATH
       run: echo "KUSTOMIZE_PATH=$KUSTOMIZATION_PATH/src/main/k8s/dev/${DUCHY_NAME}_duchy_aws" >> $GITHUB_ENV
 
@@ -174,7 +181,7 @@ jobs:
 
     - name: kubectl apply
       if: ${{ inputs.apply }}
-      run: kubectl apply -k "$KUSTOMIZE_PATH"
+      run: kubectl apply -k "$KUSTOMIZE_PATH" --namespace=default --prune --applyset=configmaps/kubectl
 
     - name: Wait for rollout
       if: ${{ inputs.apply }}

--- a/.github/workflows/configure-duchy.yml
+++ b/.github/workflows/configure-duchy.yml
@@ -63,6 +63,7 @@ permissions:
 
 env:
   KUSTOMIZATION_PATH: "k8s/cmms"
+  KUBECTL_APPLYSET: true
   DUCHY_NAME: ${{ inputs.duchy-name }}
 
 jobs:
@@ -95,12 +96,15 @@ jobs:
         AGGREGATOR_SYSTEM_API_TARGET: ${{ vars.AGGREGATOR_SYSTEM_API_TARGET }}
         WORKER1_SYSTEM_API_TARGET: ${{ vars.WORKER1_SYSTEM_API_TARGET }}
         WORKER2_SYSTEM_API_TARGET: ${{ vars.WORKER2_SYSTEM_API_TARGET }}
+        SPANNER_INSTANCE: ${{ vars.SPANNER_INSTANCE }}
+        STORAGE_BUCKET: ${{ vars.STORAGE_BUCKET }}
       run: |
         cat << EOF > ~/.bazelrc
         common --config=ci
         common --config=ghcr
         build --define image_tag=$IMAGE_TAG
         build --define google_cloud_project=$GCLOUD_PROJECT
+        build --define spanner_instance=$SPANNER_INSTANCE
         build --define kingdom_system_api_target=$KINGDOM_SYSTEM_API_TARGET
         build --define kingdom_public_api_target=$KINGDOM_PUBLIC_API_TARGET
         build --define aggregator_system_api_target=$AGGREGATOR_SYSTEM_API_TARGET
@@ -109,7 +113,29 @@ jobs:
         build --define duchy_cert_id=$DUCHY_CERT_ID
         build --define duchy_public_api_address_name=${DUCHY_NAME}-duchy-v2alpha
         build --define duchy_system_api_address_name=${DUCHY_NAME}-duchy-system-v1alpha
+        build --define duchy_storage_bucket=$STORAGE_BUCKET
         EOF
+
+    - name: Get Bazel cache params
+      id: get-cache-params
+      run: |
+        cache_path="$(bazelisk info output_base)"
+        echo "cache-path=${cache_path}" >> "$GITHUB_OUTPUT"
+
+        tree_hash="$(git rev-parse HEAD:)"
+        restore_key="duchy-bazel-"
+        echo "restore-key=${restore_key}" >> "$GITHUB_OUTPUT"
+
+        cache_key="${restore_key}${tree_hash}"
+        echo "cache-key=${cache_key}" >> "$GITHUB_OUTPUT"
+
+    - name: Restore Bazel cache
+      uses: actions/cache/restore@v4
+      with:
+        path: ${{ steps.get-cache-params.outputs.cache-path }}
+        key: ${{ steps.get-cache-params.outputs.cache-key }}
+        restore-keys: |
+          ${{ steps.get-cache-params.outputs.restore-key }}
 
     - name: Export BAZEL_BIN
       run: echo "BAZEL_BIN=$(bazelisk info bazel-bin)" >> $GITHUB_ENV
@@ -125,22 +151,17 @@ jobs:
       if: ${{ inputs.apply }}
 
     - name: Generate archives
-      env:
-        IMAGE_TAG: ${{ inputs.image-tag }}
-        SPANNER_INSTANCE: ${{ vars.SPANNER_INSTANCE }}
-        KINGDOM_SYSTEM_API_TARGET: ${{ vars.KINGDOM_SYSTEM_API_TARGET }}
-        STORAGE_BUCKET: ${{ vars.STORAGE_BUCKET }}
       run: >
         bazelisk build 
         "//src/main/k8s/dev:${DUCHY_NAME}_duchy.tar"
         //src/main/k8s/testing/secretfiles:archive
-        --config ghcr
-        --define "image_tag=$IMAGE_TAG"
-        --define "google_cloud_project=$GCLOUD_PROJECT"
-        --define "spanner_instance=$SPANNER_INSTANCE"
-        --define "kingdom_system_api_target=$KINGDOM_SYSTEM_API_TARGET"
-        --define "duchy_storage_bucket=$STORAGE_BUCKET"
-        --define "duchy_cert_id=$DUCHY_CERT_ID"
+
+    - name: Save Bazel cache
+      continue-on-error: true
+      uses: actions/cache/save@v4
+      with:
+        path: ${{ steps.get-cache-params.outputs.cache-path }}
+        key: ${{ steps.get-cache-params.outputs.cache-key }}
 
     - name: Make Kustomization dir
       run: mkdir -p "$KUSTOMIZATION_PATH"
@@ -165,6 +186,13 @@ jobs:
         echo "$AKID_TO_PRINCIPAL_MAP" | sed $'s/\r$//'  >
         "$KUSTOMIZATION_PATH/src/main/k8s/dev/config_files/authority_key_identifier_to_principal_map.textproto"
 
+    - name: Upload Kustomization artifact
+      uses: actions/upload-artifact@v4
+      continue-on-error: true
+      with:
+        name: ${{ env.DUCHY_NAME }}-kustomization
+        path: ${{ env.KUSTOMIZATION_PATH }}
+
     - name: Export KUSTOMIZE_PATH
       run: echo "KUSTOMIZE_PATH=$KUSTOMIZATION_PATH/src/main/k8s/dev/${DUCHY_NAME}_duchy" >> $GITHUB_ENV
 
@@ -176,7 +204,7 @@ jobs:
 
     - name: kubectl apply
       if: ${{ inputs.apply }}
-      run: kubectl apply -k "$KUSTOMIZE_PATH"
+      run: kubectl apply -k "$KUSTOMIZE_PATH" --namespace=default --prune --applyset=configmaps/kubectl
 
     - name: Wait for rollout
       if: ${{ inputs.apply }}

--- a/src/main/k8s/base.cue
+++ b/src/main/k8s/base.cue
@@ -310,7 +310,7 @@ objects: [ for objectSet in objectSets for object in objectSet {object}]
 // K8s LabelSelector.
 #LabelSelector: {
 	matchExpressions?: [...#LabelSelectorRequirement]
-	matchLabels: [string]: string
+	matchLabels?: [string]: string
 }
 
 // K8s ConfigMap.
@@ -577,15 +577,23 @@ objects: [ for objectSet in objectSets for object in objectSet {object}]
 }
 
 // K8s NetworkPolicyEgressRule.
-#EgressRule: {
-	to: [...]
-	ports: [...#NetworkPolicyPort]
+#NetworkPolicyEgressRule: {
+	to?: [...#NetworkPolicyPeer]
+	ports?: [...#NetworkPolicyPort]
 }
 
 // K8s NetworkPolicyIngressRule.
-#IngressRule: {
-	from: [...]
-	ports: [...#NetworkPolicyPort]
+#NetworkPolicyIngressRule: {
+	from?: [...#NetworkPolicyPeer]
+	ports?: [...#NetworkPolicyPort]
+}
+
+// K8s NetworkPolicyPeer.
+#NetworkPolicyPeer: {
+	ipBlock?: {...}
+	namespaceSelector?: #LabelSelector
+	podSelector?:       #LabelSelector
+	ports?: [...#NetworkPolicyPort]
 }
 
 // K8s NetworkPolicy.
@@ -599,8 +607,8 @@ objects: [ for objectSet in objectSets for object in objectSet {object}]
 	_app_label?: string
 	_sourceMatchLabels: [...string]
 	_destinationMatchLabels: [...string]
-	_ingresses: [Name=_]: #IngressRule
-	_egresses: [Name=_]:  #EgressRule
+	_ingresses: [_]: #NetworkPolicyIngressRule
+	_egresses: [_]:  #NetworkPolicyEgressRule
 
 	_ingresses: {
 		if len(_sourceMatchLabels) > 0 {
@@ -640,11 +648,8 @@ objects: [ for objectSet in objectSets for object in objectSet {object}]
 
 	apiVersion: "networking.k8s.io/v1"
 	kind:       "NetworkPolicy"
-	metadata: {
+	metadata:   #ObjectMeta & {
 		name: _name + "-network-policy"
-		labels: {
-			"app.kubernetes.io/part-of": #AppName
-		}
 	}
 	spec: {
 		podSelector: #LabelSelector & {

--- a/src/main/k8s/dev/duchy_eks.cue
+++ b/src/main/k8s/dev/duchy_eks.cue
@@ -99,13 +99,13 @@ objectSets: [
 
 duchy: #PostgresDuchy & {
 	_imageSuffixes: {
-		"herald-daemon":                             "duchy/aws-herald"
-		"computation-control-server":                "duchy/aws-computation-control"
-		"liquid-legions-v2-mill-daemon":             "duchy/aws-liquid-legions-v2-mill"
-		"honest-majority-share-shuffle-mill-daemon": "duchy/aws-honest-majority-share-shuffle-mill"
-		"requisition-fulfillment-server":            "duchy/aws-requisition-fulfillment"
-		"internal-api-server":                       "duchy/aws-postgres-internal-server"
-		"update-duchy-schema":                       "duchy/aws-postgres-update-schema"
+		"herald-daemon":                  "duchy/aws-herald"
+		"computation-control-server":     "duchy/aws-computation-control"
+		"liquid-legions-v2-mill-daemon":  "duchy/aws-liquid-legions-v2-mill"
+		"hmss-mill-daemon":               "duchy/aws-honest-majority-share-shuffle-mill"
+		"requisition-fulfillment-server": "duchy/aws-requisition-fulfillment"
+		"internal-api-server":            "duchy/aws-postgres-internal-server"
+		"update-duchy-schema":            "duchy/aws-postgres-update-schema"
 	}
 	_duchy: {
 		name:                      _duchyName
@@ -151,7 +151,7 @@ duchy: #PostgresDuchy & {
 				}
 			}
 		}
-		"honest-majority-share-shuffle-mill-daemon-deployment": {
+		"hmss-mill-daemon-deployment": {
 			_workLockDuration: "5m"
 			_container: {
 				_javaOptions: maxHeapSize: #HmssMillMaxHeapSize

--- a/src/main/k8s/dev/duchy_gke.cue
+++ b/src/main/k8s/dev/duchy_gke.cue
@@ -168,7 +168,7 @@ duchy: #SpannerDuchy & {
 				}
 			}
 		}
-		"honest-majority-share-shuffle-mill-daemon-deployment": {
+		"hmss-mill-daemon-deployment": {
 			_workLockDuration: "5m"
 			_container: {
 				_javaOptions: maxHeapSize: #HmssMillMaxHeapSize

--- a/src/main/k8s/duchy.cue
+++ b/src/main/k8s/duchy.cue
@@ -45,13 +45,13 @@ import ("strings")
 
 	_imageSuffixes: [string]: string
 	_imageSuffixes: {
-		"async-computation-control-server":          string | *"duchy/async-computation-control"
-		"computation-control-server":                string | *"duchy/computation-control"
-		"herald-daemon":                             string | *"duchy/herald"
-		"liquid-legions-v2-mill-daemon":             string | *"duchy/liquid-legions-v2-mill"
-		"honest-majority-share-shuffle-mill-daemon": string | *"duchy/honest-majority-share-shuffle-mill"
-		"requisition-fulfillment-server":            string | *"duchy/requisition-fulfillment"
-		"computations-cleaner":                      string | *"duchy/computations-cleaner"
+		"async-computation-control-server": string | *"duchy/async-computation-control"
+		"computation-control-server":       string | *"duchy/computation-control"
+		"herald-daemon":                    string | *"duchy/herald"
+		"liquid-legions-v2-mill-daemon":    string | *"duchy/liquid-legions-v2-mill"
+		"hmss-mill-daemon":                 string | *"duchy/honest-majority-share-shuffle-mill"
+		"requisition-fulfillment-server":   string | *"duchy/requisition-fulfillment"
+		"computations-cleaner":             string | *"duchy/computations-cleaner"
 	}
 	_imageConfigs: [string]: #ImageConfig
 	_imageConfigs: {
@@ -161,7 +161,7 @@ import ("strings")
 				"\(_name)-internal-api-server", "\(_name)-computation-control-server",
 			]
 		}
-		"honest-majority-share-shuffle-mill-daemon-deployment": {
+		"hmss-mill-daemon-deployment": {
 			_workLockDuration?: string
 			_container: args: [
 						_duchyInternalApiTargetFlag,
@@ -298,7 +298,7 @@ import ("strings")
 			_sourceMatchLabels: [
 				_object_prefix + "herald-daemon-app",
 				_object_prefix + "liquid-legions-v2-mill-daemon-app",
-				_object_prefix + "honest-majority-share-shuffle-mill-daemon-app",
+				_object_prefix + "hmss-mill-daemon-app",
 				_object_prefix + "async-computation-control-server-app",
 				_object_prefix + "requisition-fulfillment-server-app",
 				_object_prefix + "computations-cleaner-app",
@@ -355,8 +355,8 @@ import ("strings")
 				any: {}
 			}
 		}
-		"honest-majority-share-shuffle-mill-daemon": {
-			_app_label: _object_prefix + "honest-majority-share-shuffle-mill-daemon-app"
+		"hmss-mill-daemon": {
+			_app_label: _object_prefix + "hmss-mill-daemon-app"
 			_egresses: {
 				// Need to send external traffic.
 				any: {}

--- a/src/main/k8s/local/duchies.cue
+++ b/src/main/k8s/local/duchies.cue
@@ -82,11 +82,11 @@ _computationControlTargets: {
 
 _baseDuchyConfig: {
 	_imageSuffixes: {
-		"computation-control-server":                "duchy/local-computation-control"
-		"herald-daemon":                             "duchy/local-herald"
-		"liquid-legions-v2-mill-daemon":             "duchy/local-liquid-legions-v2-mill"
-		"honest-majority-share-shuffle-mill-daemon": "duchy/local-honest-majority-share-shuffle-mill"
-		"requisition-fulfillment-server":            "duchy/local-requisition-fulfillment"
+		"computation-control-server":     "duchy/local-computation-control"
+		"herald-daemon":                  "duchy/local-herald"
+		"liquid-legions-v2-mill-daemon":  "duchy/local-liquid-legions-v2-mill"
+		"hmss-mill-daemon":               "duchy/local-honest-majority-share-shuffle-mill"
+		"requisition-fulfillment-server": "duchy/local-requisition-fulfillment"
 	}
 	_duchy_secret_name:           _secret_name
 	_computation_control_targets: _computationControlTargets


### PR DESCRIPTION
The name is too long for the standard metadata name field.

BREAKING CHANGE: Renames a K8s Deployment in the dev configuration.