### PR TITLE
fix: publish all Maven artifacts, not just one

### DIFF
--- a/.github/workflows/publish-maven-artifacts.yml
+++ b/.github/workflows/publish-maven-artifacts.yml
@@ -100,4 +100,4 @@ jobs:
           MAVEN_USER: ${{ vars.MAVEN_USER }}
           MAVEN_PASSWORD: ${{ secrets.MAVEN_PASSWORD }}
         run: |
-          bazel query "kind('^maven_publish', //src/main/...)" | xargs bazel run
+          bazel query "kind('^maven_publish', //src/main/...)" | xargs -n 1 bazel run


### PR DESCRIPTION
Unlike the `build` subcommand, the `run` subcommand of the Bazel CLI only operates on a single target.