### PR TITLE
Prepare example Kingdom-less exchange daemon for GKE.

### DIFF
--- a/build/variables.bzl
+++ b/build/variables.bzl
@@ -140,6 +140,13 @@ EXAMPLE_PANEL_EXCHANGE_CLIENT_DAEMON_CONFIG = struct(
     mp_name = "$(mp_name)",
 )
 
+# Config for Kingdom-less Panel Exchange Client Example Daemon.
+EXAMPLE_KINGDOMLESS_PANEL_EXCHANGE_CLIENT_DAEMON_CONFIG = struct(
+    edp_id = "$(edp_id)",
+    mp_id = "$(mp_id)",
+    recurring_exchange_ids = "$(recurring_exchange_ids)",
+)
+
 # Settings for deploying tests to Google Cloud.
 PANEL_EXCHANGE_CLIENT_TEST_GOOGLE_CLOUD_SETTINGS = struct(
     secret_name = "$(k8s_secret_name)",

--- a/src/main/k8s/panelmatch/base.cue
+++ b/src/main/k8s/panelmatch/base.cue
@@ -103,18 +103,20 @@ objects: [ for objectSet in objectSets for object in objectSet {object}]
 }
 
 #Deployment: Deployment={
-	_name:       string
-	_secretName: string
-	_ports:      [{containerPort: #GrpcServicePort}] | *[]
-	_component:  string
-	_jvmFlags:   string | *""
+	_name:        string
+	_secretName?: string
+	_ports:       [{containerPort: #GrpcServicePort}] | *[]
+	_component:   string
+	_jvmFlags:    string | *""
 	_dependencies: [...string]
 	_configMapMounts: [...#ConfigMapMount]
 	_podSpec: #PodSpec & {
-		_secretMounts: [{
-			name:       _name + "-files"
-			secretName: _secretName
-		}]
+		if _secretName != _|_ {
+			_secretMounts: [{
+				name:       _name + "-files"
+				secretName: _secretName
+			}]
+		}
 		_configMapMounts: Deployment._configMapMounts
 
 		restartPolicy?: string | "Always"

--- a/src/main/k8s/panelmatch/dev/BUILD.bazel
+++ b/src/main/k8s/panelmatch/dev/BUILD.bazel
@@ -1,7 +1,7 @@
-load("//build:variables.bzl", "EXAMPLE_PANEL_EXCHANGE_CLIENT_DAEMON_CONFIG")
 load("@wfa_rules_cue//cue:defs.bzl", "cue_library")
-load("//src/main/k8s:macros.bzl", "cue_dump")
+load("//build:variables.bzl", "EXAMPLE_KINGDOMLESS_PANEL_EXCHANGE_CLIENT_DAEMON_CONFIG", "EXAMPLE_PANEL_EXCHANGE_CLIENT_DAEMON_CONFIG")
 load("//build/k8s:defs.bzl", "kustomization_dir")
+load("//src/main/k8s:macros.bzl", "cue_dump")
 
 SECRET_NAME = "certs-and-configs"
 
@@ -130,4 +130,58 @@ kustomization_dir(
     generate_kustomization = True,
     tags = ["manual"],
     deps = [":mp_daemon_secret"],
+)
+
+cue_library(
+    name = "example_kingdomless_daemon_gke",
+    srcs = ["example_kingdomless_daemon_gke.cue"],
+    deps = [":base_gke"],
+)
+
+cue_dump(
+    name = "example_kingdomless_edp_daemon_gke",
+    srcs = ["example_kingdomless_edp_daemon_gke.cue"],
+    cue_tags = {
+        "party_id": EXAMPLE_KINGDOMLESS_PANEL_EXCHANGE_CLIENT_DAEMON_CONFIG.edp_id,
+        "recurring_exchange_ids": EXAMPLE_KINGDOMLESS_PANEL_EXCHANGE_CLIENT_DAEMON_CONFIG.recurring_exchange_ids,
+    },
+    tags = ["manual"],
+    deps = [
+        ":example_kingdomless_daemon_gke",
+        "//src/main/k8s:config",
+    ],
+)
+
+kustomization_dir(
+    name = "edp_kingdomless_daemon_gke",
+    srcs = [
+        "resource_requirements.yaml",
+        ":example_kingdomless_edp_daemon_gke",
+    ],
+    generate_kustomization = True,
+    tags = ["manual"],
+)
+
+cue_dump(
+    name = "example_kingdomless_mp_daemon_gke",
+    srcs = ["example_kingdomless_mp_daemon_gke.cue"],
+    cue_tags = {
+        "party_id": EXAMPLE_KINGDOMLESS_PANEL_EXCHANGE_CLIENT_DAEMON_CONFIG.mp_id,
+        "recurring_exchange_ids": EXAMPLE_KINGDOMLESS_PANEL_EXCHANGE_CLIENT_DAEMON_CONFIG.recurring_exchange_ids,
+    },
+    tags = ["manual"],
+    deps = [
+        ":example_kingdomless_daemon_gke",
+        "//src/main/k8s:config",
+    ],
+)
+
+kustomization_dir(
+    name = "mp_kingdomless_daemon_gke",
+    srcs = [
+        "resource_requirements.yaml",
+        ":example_kingdomless_mp_daemon_gke",
+    ],
+    generate_kustomization = True,
+    tags = ["manual"],
 )

--- a/src/main/k8s/panelmatch/dev/example_kingdomless_daemon_gke.cue
+++ b/src/main/k8s/panelmatch/dev/example_kingdomless_daemon_gke.cue
@@ -1,0 +1,135 @@
+// Copyright 2024 The Cross-Media Measurement Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package k8s
+
+#GCloudProject:           "halo-cmm-dev"
+#ContainerRegistryPrefix: "gcr.io/" + #GCloudProject
+#DefaultResourceConfig: {
+	replicas:  1
+	resources: #ResourceRequirements & {
+		requests: {
+			cpu:    "100m"
+			memory: "1Gi"
+		}
+		limits: {
+			cpu:    "400m"
+			memory: "4Gi"
+		}
+	}
+}
+
+#ExchangeDaemonConfig: {
+	partyType:            "DATA_PROVIDER" | "MODEL_PROVIDER"
+	partyId:              string
+	recurringExchangeIds: string
+	cloudStorageBucket:   string
+	serviceAccountName:   string
+
+	tinkKeyUri: string
+
+	privateCa: {
+		name:     string
+		poolId:   string
+		location: string
+	}
+
+	dataflow: {
+		projectId:                         *#GCloudProject | string
+		region:                            string
+		serviceAccount:                    string
+		tempLocation:                      *"gs://\(cloudStorageBucket)/dataflow-temp/" | string
+		workerMachineType:                 *"n1-standard-1" | string
+		diskSize:                          *"30" | string
+		dataflowWorkerLoggingOptionsLevel: *"INFO" | string
+		sdkHarnessOptionsLogLevel:         *"INFO" | string
+	}
+
+	args: [
+		"--id=\(partyId)",
+		"--party-type=\(partyType)",
+		"--kingdomless-recurring-exchange-ids=\(recurringExchangeIds)",
+		"--google-cloud-storage-bucket=\(cloudStorageBucket)",
+		"--tink-key-uri=\(tinkKeyUri)",
+		"--privateca-ca-name=\(privateCa.name)",
+		"--privateca-pool-id=\(privateCa.poolId)",
+		"--privateca-ca-location=\(privateCa.location)",
+		"--dataflow-project-id=\(dataflow.projectId)",
+		"--dataflow-region=\(dataflow.region)",
+		"--dataflow-service-account=\(dataflow.serviceAccount)",
+		"--dataflow-temp-location=\(dataflow.tempLocation)",
+		"--dataflow-worker-machine-type=\(dataflow.workerMachineType)",
+		"--dataflow-disk-size=\(dataflow.diskSize)",
+		"--dataflow-worker-logging-options-level=\(dataflow.dataflowWorkerLoggingOptionsLevel)",
+		"--sdk-harness-options-log-level=\(dataflow.sdkHarnessOptionsLogLevel)",
+	]
+}
+_exchangeDaemonConfig: #ExchangeDaemonConfig
+
+objectSets: [deployments, networkPolicies]
+
+deployments: [Name=_]: #Deployment & {
+	_name:      Name
+	_component: "workflow-daemon"
+	_podSpec: _container: resources: #DefaultResourceConfig.resources
+
+	spec: {
+		replicas: #DefaultResourceConfig.replicas
+	}
+}
+deployments: {
+	"example-kingdomless-panel-exchange-daemon": {
+		_jvmFlags: "-Xmx3584m" // 4GiB - 512MiB overhead.
+		_podSpec: {
+			serviceAccountName: _exchangeDaemonConfig.serviceAccountName
+			nodeSelector: "iam.gke.io/gke-metadata-server-enabled": "true"
+		}
+		_podSpec: _container: {
+			image:           #ContainerRegistryPrefix + "/panel-exchange/gcloud-example-daemon"
+			imagePullPolicy: "Always"
+			args:            _exchangeDaemonConfig.args + [
+						"--blob-size-limit-bytes=1000000000",
+						"--storage-signing-algorithm=EC",
+						"--checkpoint-signing-algorithm=SHA256withECDSA",
+						"--lookback-window=14d",
+						"--task-timeout=24h",
+						"--google-cloud-storage-project=" + #GCloudProject,
+						"--polling-interval=1m",
+						"--preprocessing-max-byte-size=1000000",
+						"--preprocessing-file-count=1000",
+						"--x509-common-name=SomeCommonName",
+						"--x509-organization=SomeOrganization",
+						"--x509-dns-name=example.com",
+						"--x509-valid-days=365",
+						"--privateca-project-id=" + #GCloudProject,
+			]
+		}
+	}
+}
+
+networkPolicies: [Name=_]: #NetworkPolicy & {
+	_name:    Name
+	_appName: Name
+}
+networkPolicies: {
+	"example-kingdomless-panel-exchange-daemon": {
+		_ingresses: {
+			// No ingress.
+		}
+		_egresses: {
+			// Need to be able to send traffic to storage.
+			any: {}
+		}
+	}
+}

--- a/src/main/k8s/panelmatch/dev/example_kingdomless_edp_daemon_gke.cue
+++ b/src/main/k8s/panelmatch/dev/example_kingdomless_edp_daemon_gke.cue
@@ -1,0 +1,33 @@
+// Copyright 2024 The Cross-Media Measurement Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package k8s
+
+_exchangeDaemonConfig: {
+	partyType:            "DATA_PROVIDER"
+	partyId:              string @tag("party_id")
+	recurringExchangeIds: string @tag("recurring_exchange_ids")
+	cloudStorageBucket:   "halo-edp-test-bucket"
+	serviceAccountName:   "edp-workflow"
+	tinkKeyUri:           "gcp-kms://projects/halo-cmm-dev/locations/us-central1/keyRings/edp-test-key-ring/cryptoKeys/edp-test-key"
+	privateCa: {
+		name:     "20220302-51i-yj4"
+		poolId:   "EdpTestPool"
+		location: "us-central1"
+	}
+	dataflow: {
+		region:         "us-central1"
+		serviceAccount: "edp-test-service-account@halo-cmm-dev.iam.gserviceaccount.com"
+	}
+}

--- a/src/main/k8s/panelmatch/dev/example_kingdomless_mp_daemon_gke.cue
+++ b/src/main/k8s/panelmatch/dev/example_kingdomless_mp_daemon_gke.cue
@@ -1,0 +1,33 @@
+// Copyright 2024 The Cross-Media Measurement Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package k8s
+
+_exchangeDaemonConfig: {
+	partyType:            "MODEL_PROVIDER"
+	partyId:              string @tag("party_id")
+	recurringExchangeIds: string @tag("recurring_exchange_ids")
+	cloudStorageBucket:   "halo-mp-test-bucket"
+	serviceAccountName:   "mp-workflow"
+	tinkKeyUri:           "gcp-kms://projects/halo-cmm-dev/locations/us-central1/keyRings/mp-test-key-ring/cryptoKeys/mp-test-key"
+	privateCa: {
+		name:     "20220302-o2a-1xh"
+		poolId:   "MpTestPool"
+		location: "us-central1"
+	}
+	dataflow: {
+		region:         "us-central1"
+		serviceAccount: "mp-test-service-account@halo-cmm-dev.iam.gserviceaccount.com"
+	}
+}

--- a/src/main/kotlin/org/wfanet/panelmatch/client/deploy/ExchangeWorkflowDaemonFromFlags.kt
+++ b/src/main/kotlin/org/wfanet/panelmatch/client/deploy/ExchangeWorkflowDaemonFromFlags.kt
@@ -22,6 +22,7 @@ import org.wfanet.measurement.api.v2alpha.DataProviderKey
 import org.wfanet.measurement.api.v2alpha.ExchangeStepAttemptsGrpcKt.ExchangeStepAttemptsCoroutineStub
 import org.wfanet.measurement.api.v2alpha.ExchangeStepsGrpcKt.ExchangeStepsCoroutineStub
 import org.wfanet.measurement.api.v2alpha.ModelProviderKey
+import org.wfanet.measurement.common.crypto.SignatureAlgorithm
 import org.wfanet.measurement.common.crypto.SigningCerts
 import org.wfanet.measurement.common.grpc.buildMutualTlsChannel
 import org.wfanet.measurement.common.grpc.withShutdownTimeout
@@ -35,11 +36,13 @@ import org.wfanet.panelmatch.client.exchangetasks.ExchangeTaskMapper
 import org.wfanet.panelmatch.client.internal.ExchangeWorkflow.Party
 import org.wfanet.panelmatch.client.launcher.ApiClient
 import org.wfanet.panelmatch.client.launcher.GrpcApiClient
+import org.wfanet.panelmatch.client.launcher.KingdomlessApiClient
 import org.wfanet.panelmatch.client.launcher.withMaxParallelClaimedExchangeSteps
 import org.wfanet.panelmatch.common.Timeout
 import org.wfanet.panelmatch.common.asTimeout
 import org.wfanet.panelmatch.common.certificates.CertificateAuthority
 import org.wfanet.panelmatch.common.certificates.CertificateManager
+import org.wfanet.panelmatch.common.certificates.KingdomlessCertificateManager
 import org.wfanet.panelmatch.common.certificates.V2AlphaCertificateManager
 import org.wfanet.panelmatch.common.loggerFor
 import org.wfanet.panelmatch.common.secrets.MutableSecretMap
@@ -80,29 +83,21 @@ abstract class ExchangeWorkflowDaemonFromFlags : ExchangeWorkflowDaemon() {
 
   private val channel: Channel by lazy {
     logger.info("Connecting to Kingdom")
-    buildMutualTlsChannel(flags.exchangeApiTarget, clientCerts, flags.exchangeApiCertHost)
-      .withShutdownTimeout(flags.channelShutdownTimeout)
-      .withVerboseLogging(flags.debugVerboseGrpcClientLogging)
+    val kingdomBasedExchangeFlags = checkNotNull(flags.protocolOptions.kingdomBasedExchangeFlags)
+    buildMutualTlsChannel(
+        kingdomBasedExchangeFlags.exchangeApiTarget,
+        clientCerts,
+        kingdomBasedExchangeFlags.exchangeApiCertHost,
+      )
+      .withShutdownTimeout(kingdomBasedExchangeFlags.channelShutdownTimeout)
+      .withVerboseLogging(kingdomBasedExchangeFlags.debugVerboseGrpcClientLogging)
   }
 
   override val certificateManager: CertificateManager by lazy {
-    val certificateService = CertificatesCoroutineStub(channel)
-    val resourceName =
-      when (identity.party) {
-        Party.DATA_PROVIDER -> DataProviderKey(identity.id).toName()
-        Party.MODEL_PROVIDER -> ModelProviderKey(identity.id).toName()
-        else -> error("Invalid Identity: $identity")
-      }
-
-    V2AlphaCertificateManager(
-      certificateService = certificateService,
-      rootCerts = rootCertificates,
-      privateKeys = privateKeys,
-      algorithm = flags.certAlgorithm,
-      certificateAuthority = certificateAuthority,
-      localName = resourceName,
-      fallbackPrivateKeyBlobKey = flags.fallbackPrivateKeyBlobKey,
-    )
+    when (flags.protocolOptions.protocolSpecificFlags) {
+      is KingdomBasedExchangeFlags -> createKingdomBasedCertificateManager()
+      is KingdomlessExchangeFlags -> createKingdomlessCertificateManager()
+    }
   }
 
   override val throttler: Throttler by lazy { createThrottler() }
@@ -131,10 +126,11 @@ abstract class ExchangeWorkflowDaemonFromFlags : ExchangeWorkflowDaemon() {
   }
 
   override val apiClient: ApiClient by lazy {
-    val exchangeStepsClient = ExchangeStepsCoroutineStub(channel)
-    val exchangeStepAttemptsClient = ExchangeStepAttemptsCoroutineStub(channel)
     val client =
-      GrpcApiClient(identity, exchangeStepsClient, exchangeStepAttemptsClient, Clock.systemUTC())
+      when (val protocolFlags = flags.protocolOptions.protocolSpecificFlags) {
+        is KingdomBasedExchangeFlags -> createKingdomBasedApiClient()
+        is KingdomlessExchangeFlags -> createKingdomlessApiClient(protocolFlags)
+      }
     if (maxParallelClaimedExchangeSteps != null) {
       client.withMaxParallelClaimedExchangeSteps(maxParallelClaimedExchangeSteps!!)
     } else {
@@ -147,6 +143,74 @@ abstract class ExchangeWorkflowDaemonFromFlags : ExchangeWorkflowDaemon() {
   override val identity: Identity by lazy { Identity(flags.id, flags.partyType) }
 
   private fun createThrottler(): Throttler = MinimumIntervalThrottler(clock, flags.pollingInterval)
+
+  private fun createKingdomBasedCertificateManager(): CertificateManager {
+    val certificateService = CertificatesCoroutineStub(channel)
+    val resourceName =
+      when (identity.party) {
+        Party.DATA_PROVIDER -> DataProviderKey(identity.id).toName()
+        Party.MODEL_PROVIDER -> ModelProviderKey(identity.id).toName()
+        Party.PARTY_UNSPECIFIED,
+        Party.UNRECOGNIZED -> error("Invalid Identity: $identity")
+      }
+    return V2AlphaCertificateManager(
+      certificateService = certificateService,
+      rootCerts = rootCertificates,
+      privateKeys = privateKeys,
+      algorithm = flags.certAlgorithm,
+      certificateAuthority = certificateAuthority,
+      localName = resourceName,
+      fallbackPrivateKeyBlobKey = flags.fallbackPrivateKeyBlobKey,
+    )
+  }
+
+  private fun createKingdomBasedApiClient(): ApiClient {
+    val exchangeStepsClient = ExchangeStepsCoroutineStub(channel)
+    val exchangeStepAttemptsClient = ExchangeStepAttemptsCoroutineStub(channel)
+    return GrpcApiClient(
+      identity = identity,
+      exchangeStepsClient = exchangeStepsClient,
+      exchangeStepAttemptsClient = exchangeStepAttemptsClient,
+      clock = Clock.systemUTC(),
+    )
+  }
+
+  private fun createKingdomlessCertificateManager(): CertificateManager {
+    return KingdomlessCertificateManager(
+      identity = identity,
+      validExchangeWorkflows = validExchangeWorkflows,
+      rootCerts = rootCertificates,
+      privateKeys = privateKeys,
+      algorithm = flags.certAlgorithm,
+      certificateAuthority = certificateAuthority,
+      fallbackPrivateKeyBlobKey = flags.fallbackPrivateKeyBlobKey,
+    ) {
+      sharedStorageSelector.getStorageClient(it)
+    }
+  }
+
+  private fun createKingdomlessApiClient(
+    kingdomlessExchangeFlags: KingdomlessExchangeFlags
+  ): ApiClient {
+    val signatureAlgorithm =
+      requireNotNull(
+        SignatureAlgorithm.fromJavaName(kingdomlessExchangeFlags.checkpointSigningAlgorithm)
+      ) {
+        "Invalid signing algorithm: ${kingdomlessExchangeFlags.checkpointSigningAlgorithm}"
+      }
+    return KingdomlessApiClient(
+      identity = identity,
+      recurringExchangeIds = kingdomlessExchangeFlags.kingdomlessRecurringExchangeIds,
+      validExchangeWorkflows = validExchangeWorkflows,
+      certificateManager = certificateManager,
+      algorithm = signatureAlgorithm,
+      lookbackWindow = kingdomlessExchangeFlags.lookbackWindow,
+      stepTimeout = flags.taskTimeout,
+      clock = Clock.systemUTC(),
+    ) {
+      sharedStorageSelector.getStorageClient(it)
+    }
+  }
 
   companion object {
     @JvmStatic protected val logger by loggerFor()

--- a/src/main/kotlin/org/wfanet/panelmatch/client/deploy/ExchangeWorkflowFlags.kt
+++ b/src/main/kotlin/org/wfanet/panelmatch/client/deploy/ExchangeWorkflowFlags.kt
@@ -18,7 +18,7 @@ import java.time.Duration
 import kotlin.properties.Delegates
 import org.wfanet.measurement.common.grpc.TlsFlags
 import org.wfanet.panelmatch.client.internal.ExchangeWorkflow.Party
-import picocli.CommandLine
+import picocli.CommandLine.ArgGroup
 import picocli.CommandLine.Model.CommandSpec
 import picocli.CommandLine.Option
 import picocli.CommandLine.ParameterException
@@ -27,6 +27,10 @@ import picocli.CommandLine.Spec
 class ExchangeWorkflowFlags {
 
   @Spec lateinit var spec: CommandSpec
+
+  @ArgGroup(exclusive = true, multiplicity = "1")
+  lateinit var protocolOptions: ProtocolOptions
+    private set
 
   @Option(names = ["--id"], description = ["Id of the provider"], required = true)
   lateinit var id: String
@@ -40,17 +44,8 @@ class ExchangeWorkflowFlags {
   lateinit var partyType: Party
     private set
 
-  @CommandLine.Mixin
+  @ArgGroup(exclusive = false, multiplicity = "0..1")
   lateinit var tlsFlags: TlsFlags
-    private set
-
-  @Option(
-    names = ["--channel-shutdown-timeout"],
-    defaultValue = "3s",
-    description = ["How long to allow for the gRPC channel to shutdown."],
-    required = true,
-  )
-  lateinit var channelShutdownTimeout: Duration
     private set
 
   @Option(
@@ -78,30 +73,6 @@ class ExchangeWorkflowFlags {
     required = true,
   )
   lateinit var taskTimeout: Duration
-    private set
-
-  @Option(
-    names = ["--exchange-api-target"],
-    description =
-      ["Address and port for servers hosting /ExchangeSteps and /ExchangeStepAttempts services"],
-    required = true,
-  )
-  lateinit var exchangeApiTarget: String
-    private set
-
-  @Option(
-    names = ["--exchange-api-cert-host"],
-    description = ["Expected hostname in the TLS certificate for --exchange-api-target"],
-    required = true,
-  )
-  lateinit var exchangeApiCertHost: String
-    private set
-
-  @Option(
-    names = ["--debug-verbose-grpc-client-logging"],
-    description = ["Enables full gRPC request and response logging for outgoing gRPCs"],
-  )
-  var debugVerboseGrpcClientLogging = false
     private set
 
   @set:Option(
@@ -150,5 +121,93 @@ class ExchangeWorkflowFlags {
     required = true,
   )
   lateinit var fallbackPrivateKeyBlobKey: String
+    private set
+}
+
+class ProtocolOptions {
+
+  @ArgGroup(exclusive = false, multiplicity = "0..1")
+  var kingdomBasedExchangeFlags: KingdomBasedExchangeFlags? = null
+    private set
+
+  @ArgGroup(exclusive = false, multiplicity = "0..1")
+  var kingdomlessExchangeFlags: KingdomlessExchangeFlags? = null
+    private set
+
+  val protocolSpecificFlags: ProtocolSpecificFlags
+    get() {
+      return when {
+        kingdomBasedExchangeFlags != null -> kingdomBasedExchangeFlags!!
+        kingdomlessExchangeFlags != null -> kingdomlessExchangeFlags!!
+        else -> error("Missing protocol-specific flags")
+      }
+    }
+}
+
+sealed interface ProtocolSpecificFlags
+
+class KingdomBasedExchangeFlags : ProtocolSpecificFlags {
+
+  @Option(
+    names = ["--channel-shutdown-timeout"],
+    defaultValue = "3s",
+    description = ["How long to allow for the gRPC channel to shutdown."],
+    required = true,
+  )
+  lateinit var channelShutdownTimeout: Duration
+    private set
+
+  @Option(
+    names = ["--exchange-api-target"],
+    description =
+      ["Address and port for servers hosting /ExchangeSteps and /ExchangeStepAttempts services"],
+    required = true,
+  )
+  lateinit var exchangeApiTarget: String
+    private set
+
+  @Option(
+    names = ["--exchange-api-cert-host"],
+    description = ["Expected hostname in the TLS certificate for --exchange-api-target"],
+    required = true,
+  )
+  lateinit var exchangeApiCertHost: String
+    private set
+
+  @Option(
+    names = ["--debug-verbose-grpc-client-logging"],
+    description = ["Enables full gRPC request and response logging for outgoing gRPCs"],
+  )
+  var debugVerboseGrpcClientLogging = false
+    private set
+}
+
+class KingdomlessExchangeFlags : ProtocolSpecificFlags {
+
+  @Option(
+    names = ["--kingdomless-recurring-exchange-ids"],
+    description = ["IDs of recurring exchanges to run using the Kingdom-less protocol"],
+    split = ",",
+    required = true,
+  )
+  lateinit var kingdomlessRecurringExchangeIds: List<String>
+    private set
+
+  @Option(
+    names = ["--checkpoint-signing-algorithm"],
+    description = ["Algorithm to use for signing exchange checkpoints"],
+    defaultValue = "SHA256withECDSA",
+    required = true,
+  )
+  lateinit var checkpointSigningAlgorithm: String
+    private set
+
+  @Option(
+    names = ["--lookback-window"],
+    description = ["When claiming exchange tasks, how far back to look for available tasks"],
+    defaultValue = "14d",
+    required = true,
+  )
+  lateinit var lookbackWindow: Duration
     private set
 }

--- a/src/main/kotlin/org/wfanet/panelmatch/client/deploy/example/gcloud/GoogleCloudExampleDaemon.kt
+++ b/src/main/kotlin/org/wfanet/panelmatch/client/deploy/example/gcloud/GoogleCloudExampleDaemon.kt
@@ -204,7 +204,7 @@ private class GoogleCloudExampleDaemon : ExampleDaemon() {
     DaemonStorageClientDefaults(
       rootStorageClient,
       tinkKeyUri,
-      TinkKeyStorageProvider(GcpKmsClient()),
+      TinkKeyStorageProvider(GcpKmsClient().withDefaultCredentials()),
     )
   }
 

--- a/src/main/kotlin/org/wfanet/panelmatch/common/certificates/KingomlessCertificateManager.kt
+++ b/src/main/kotlin/org/wfanet/panelmatch/common/certificates/KingomlessCertificateManager.kt
@@ -44,7 +44,7 @@ class KingdomlessCertificateManager(
   private val algorithm: String,
   private val certificateAuthority: CertificateAuthority,
   private val fallbackPrivateKeyBlobKey: String? = null,
-  private val getSharedStorage: (ExchangeDateKey) -> StorageClient,
+  private val getSharedStorage: suspend (ExchangeDateKey) -> StorageClient,
 ) : CertificateManager {
 
   private val x509CertCache = ConcurrentHashMap<String, X509Certificate>()


### PR DESCRIPTION
Summary:
* Creates `.cue` files for deploying Kingdom-less daemon to GKE.
* Adds Kingdom-less daemon flags.
    * Uses `@ArgGroup` to ensure mutual exclusitivity between Kingdom-based flags and Kingdom-less flags.
    * Updates the example daemon main class to build the correct type of `ApiClient` and `CertificateManager` based on which group of flags was set.
* Several other tweaks to make the deployment work:
    * Factory function for building a shared storage client needed to be `suspend`ing.
    * Explicitly call `withDefaultCredentails()` when building `GcpKmsClient`. This used to happen by default, but seems to have been (inadvertently?) removed in a previous PR.
    * In `KingdomlessApiClient.kt`:
        * Make sure that `ExchangeWorkflowDependencyGraph` is built in step order. The dependency graph will throw if e.g. you try to mark a step as completed before its prerequisite steps.
        * Add retries when loading checkpoints from shared storage, as a temporary measure to mitigate race conditions. A longer term solution will be to add a direct upload option to `StorageClient`, but need to investigate this further.