### PR TITLE
Make max parallel claimed exchange step logic reusable.

### DIFF
--- a/src/main/kotlin/org/wfanet/panelmatch/client/deploy/ExchangeWorkflowDaemonFromFlags.kt
+++ b/src/main/kotlin/org/wfanet/panelmatch/client/deploy/ExchangeWorkflowDaemonFromFlags.kt
@@ -35,6 +35,7 @@ import org.wfanet.panelmatch.client.exchangetasks.ExchangeTaskMapper
 import org.wfanet.panelmatch.client.internal.ExchangeWorkflow.Party
 import org.wfanet.panelmatch.client.launcher.ApiClient
 import org.wfanet.panelmatch.client.launcher.GrpcApiClient
+import org.wfanet.panelmatch.client.launcher.withMaxParallelClaimedExchangeSteps
 import org.wfanet.panelmatch.common.Timeout
 import org.wfanet.panelmatch.common.asTimeout
 import org.wfanet.panelmatch.common.certificates.CertificateAuthority
@@ -132,13 +133,13 @@ abstract class ExchangeWorkflowDaemonFromFlags : ExchangeWorkflowDaemon() {
   override val apiClient: ApiClient by lazy {
     val exchangeStepsClient = ExchangeStepsCoroutineStub(channel)
     val exchangeStepAttemptsClient = ExchangeStepAttemptsCoroutineStub(channel)
-    GrpcApiClient(
-      identity,
-      exchangeStepsClient,
-      exchangeStepAttemptsClient,
-      Clock.systemUTC(),
-      maxParallelClaimedExchangeSteps,
-    )
+    val client =
+      GrpcApiClient(identity, exchangeStepsClient, exchangeStepAttemptsClient, Clock.systemUTC())
+    if (maxParallelClaimedExchangeSteps != null) {
+      client.withMaxParallelClaimedExchangeSteps(maxParallelClaimedExchangeSteps!!)
+    } else {
+      client
+    }
   }
 
   override val taskTimeout: Timeout by lazy { flags.taskTimeout.asTimeout() }

--- a/src/main/kotlin/org/wfanet/panelmatch/client/launcher/ApiClients.kt
+++ b/src/main/kotlin/org/wfanet/panelmatch/client/launcher/ApiClients.kt
@@ -1,0 +1,67 @@
+// Copyright 2024 The Cross-Media Measurement Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.wfanet.panelmatch.client.launcher
+
+import kotlinx.coroutines.sync.Semaphore
+import org.wfanet.panelmatch.client.common.ExchangeStepAttemptKey
+import org.wfanet.panelmatch.client.internal.ExchangeStepAttempt
+
+/**
+ * Returns a new [ApiClient] that delegates to this client, but enforces that no more than
+ * [maxParallelClaimedExchangeSteps] steps are claimed at any given time. If this limit would be
+ * exceeded, then attempting to claim a new exchange step instead returns null immediately.
+ */
+fun ApiClient.withMaxParallelClaimedExchangeSteps(maxParallelClaimedExchangeSteps: Int): ApiClient {
+  require(maxParallelClaimedExchangeSteps > 0) {
+    "maxParallelClaimedExchangeSteps must be at least 1, but was $maxParallelClaimedExchangeSteps"
+  }
+  return ApiClientWithMaxParallelClaimedExchangeSteps(
+    this,
+    Semaphore(permits = maxParallelClaimedExchangeSteps),
+  )
+}
+
+private class ApiClientWithMaxParallelClaimedExchangeSteps(
+  private val delegate: ApiClient,
+  private val semaphore: Semaphore,
+) : ApiClient by delegate {
+
+  override suspend fun claimExchangeStep(): ApiClient.ClaimedExchangeStep? {
+    val acquired = semaphore.tryAcquire()
+    if (!acquired) {
+      return null
+    }
+    val step =
+      try {
+        delegate.claimExchangeStep()
+      } catch (e: Exception) {
+        semaphore.release()
+        throw e
+      }
+    if (step == null) {
+      semaphore.release()
+    }
+    return step
+  }
+
+  override suspend fun finishExchangeStepAttempt(
+    key: ExchangeStepAttemptKey,
+    finalState: ExchangeStepAttempt.State,
+    logEntryMessages: Iterable<String>,
+  ) {
+    semaphore.release()
+    delegate.finishExchangeStepAttempt(key, finalState, logEntryMessages)
+  }
+}

--- a/src/test/kotlin/org/wfanet/panelmatch/client/launcher/ApiClientsTest.kt
+++ b/src/test/kotlin/org/wfanet/panelmatch/client/launcher/ApiClientsTest.kt
@@ -1,0 +1,190 @@
+// Copyright 2024 The Cross-Media Measurement Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.wfanet.panelmatch.client.launcher
+
+import com.google.common.truth.Truth.assertThat
+import com.google.protobuf.ByteString
+import java.time.LocalDate
+import kotlin.test.assertFailsWith
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.verify
+import org.mockito.kotlin.any
+import org.mockito.kotlin.times
+import org.mockito.kotlin.whenever
+import org.wfanet.panelmatch.client.common.ExchangeStepAttemptKey
+import org.wfanet.panelmatch.client.internal.ExchangeStepAttempt
+import org.wfanet.panelmatch.client.internal.exchangeWorkflow
+import org.wfanet.panelmatch.common.testing.runBlockingTest
+
+@RunWith(JUnit4::class)
+class ApiClientsTest {
+
+  private val mockClient = mock<ApiClient>()
+
+  @Test
+  fun withMaxParallelClaimedExchangeStepsThrowsWhenStepsIsLessThanOne() {
+    val exception =
+      assertFailsWith<IllegalArgumentException> {
+        mockClient.withMaxParallelClaimedExchangeSteps(0)
+      }
+    assertThat(exception)
+      .hasMessageThat()
+      .contains("maxParallelClaimedExchangeSteps must be at least 1, but was 0")
+  }
+
+  @Test
+  fun withMaxParallelClaimedExchangeSteps_claimExchangeStepCallsDelegate() = runBlockingTest {
+    whenever(mockClient.claimExchangeStep()).thenReturn(STEP)
+    val client = mockClient.withMaxParallelClaimedExchangeSteps(100)
+
+    val step = client.claimExchangeStep()
+
+    assertThat(step).isEqualTo(STEP)
+    verify(mockClient).claimExchangeStep()
+  }
+
+  @Test
+  fun withMaxParallelClaimedExchangeSteps_appendLogEntryCallsDelegate() = runBlockingTest {
+    whenever(mockClient.appendLogEntry(any(), any())).thenReturn(null)
+    val client = mockClient.withMaxParallelClaimedExchangeSteps(100)
+
+    client.appendLogEntry(STEP.attemptKey, listOf("Some log message"))
+
+    verify(mockClient).appendLogEntry(STEP.attemptKey, listOf("Some log message"))
+  }
+
+  @Test
+  fun withMaxParallelClaimedExchangeSteps_finishExchangeStepAttemptCallsDelegate() =
+    runBlockingTest {
+      whenever(mockClient.claimExchangeStep()).thenReturn(STEP)
+      whenever(mockClient.finishExchangeStepAttempt(any(), any(), any())).thenReturn(null)
+      val client = mockClient.withMaxParallelClaimedExchangeSteps(100)
+      client.claimExchangeStep()
+
+      client.finishExchangeStepAttempt(STEP.attemptKey, ExchangeStepAttempt.State.SUCCEEDED)
+
+      verify(mockClient)
+        .finishExchangeStepAttempt(
+          STEP.attemptKey,
+          ExchangeStepAttempt.State.SUCCEEDED,
+          emptyList(),
+        )
+    }
+
+  @Test
+  fun withMaxParallelClaimedExchangeSteps_canClaimExchangeStepsUpToSpecifiedMax() =
+    runBlockingTest {
+      whenever(mockClient.claimExchangeStep()).thenReturn(STEP)
+      val client = mockClient.withMaxParallelClaimedExchangeSteps(3)
+
+      val step1 = client.claimExchangeStep()
+      val step2 = client.claimExchangeStep()
+      val step3 = client.claimExchangeStep()
+      val step4 = client.claimExchangeStep()
+
+      assertThat(step1).isEqualTo(STEP)
+      assertThat(step2).isEqualTo(STEP)
+      assertThat(step3).isEqualTo(STEP)
+      assertThat(step4).isNull()
+      verify(mockClient, times(3)).claimExchangeStep()
+    }
+
+  @Test
+  fun withMaxParallelClaimedExchangeSteps_whenDelegateReturnsNullNoPermitsAreExhausted() =
+    runBlockingTest {
+      whenever(mockClient.claimExchangeStep()).thenReturn(null).thenReturn(null).thenReturn(STEP)
+      val client = mockClient.withMaxParallelClaimedExchangeSteps(1)
+
+      val step1 = client.claimExchangeStep()
+      val step2 = client.claimExchangeStep()
+      val step3 = client.claimExchangeStep()
+      val step4 = client.claimExchangeStep()
+
+      assertThat(step1).isNull()
+      assertThat(step2).isNull()
+      assertThat(step3).isEqualTo(STEP)
+      assertThat(step4).isNull()
+      verify(mockClient, times(3)).claimExchangeStep()
+    }
+
+  @Test
+  fun withMaxParallelClaimedExchangeSteps_finishingStepsAllowsAdditionalStepsToBeClaimed() =
+    runBlockingTest {
+      whenever(mockClient.claimExchangeStep()).thenReturn(STEP)
+      whenever(mockClient.finishExchangeStepAttempt(any(), any(), any())).thenReturn(null)
+      val client = mockClient.withMaxParallelClaimedExchangeSteps(1)
+
+      val step1 = client.claimExchangeStep()
+      val step2 = client.claimExchangeStep()
+
+      assertThat(step1).isEqualTo(STEP)
+      assertThat(step2).isNull()
+
+      client.finishExchangeStepAttempt(STEP.attemptKey, ExchangeStepAttempt.State.SUCCEEDED)
+
+      val step3 = client.claimExchangeStep()
+      val step4 = client.claimExchangeStep()
+
+      assertThat(step3).isEqualTo(STEP)
+      assertThat(step4).isNull()
+    }
+
+  @Test
+  fun withMaxParallelClaimedExchangeSteps_propagatesExceptionFromBaseClient() = runBlockingTest {
+    val exception = IllegalStateException("Something went wrong")
+    whenever(mockClient.claimExchangeStep()).thenThrow(exception)
+    val client = mockClient.withMaxParallelClaimedExchangeSteps(100)
+
+    val actual = assertFailsWith<IllegalStateException> { client.claimExchangeStep() }
+    assertThat(actual).isEqualTo(exception)
+  }
+
+  @Test
+  fun withMaxParallelClaimedExchangeSteps_doesNotExhaustPermitsWhenAnExceptionIsThrown() =
+    runBlockingTest {
+      val exception = IllegalStateException("Something went wrong")
+      whenever(mockClient.claimExchangeStep()).thenThrow(exception).thenReturn(STEP)
+      val client = mockClient.withMaxParallelClaimedExchangeSteps(1)
+
+      assertFailsWith<IllegalStateException> { client.claimExchangeStep() }
+
+      val step1 = client.claimExchangeStep()
+      val step2 = client.claimExchangeStep()
+
+      assertThat(step1).isEqualTo(STEP)
+      assertThat(step2).isNull()
+      verify(mockClient, times(2)).claimExchangeStep()
+    }
+
+  companion object {
+    private val STEP =
+      ApiClient.ClaimedExchangeStep(
+        attemptKey =
+          ExchangeStepAttemptKey(
+            recurringExchangeId = "some-recurring-exchange-id",
+            exchangeId = "2024-07-01",
+            stepId = "some-step-id",
+            attemptId = "1",
+          ),
+        exchangeDate = LocalDate.parse("2024-07-01"),
+        stepIndex = 0,
+        workflow = exchangeWorkflow {},
+        workflowFingerprint = ByteString.EMPTY,
+      )
+  }
+}

--- a/src/test/kotlin/org/wfanet/panelmatch/client/launcher/BUILD.bazel
+++ b/src/test/kotlin/org/wfanet/panelmatch/client/launcher/BUILD.bazel
@@ -1,6 +1,24 @@
 load("@wfa_rules_kotlin_jvm//kotlin:defs.bzl", "kt_jvm_test")
 
 kt_jvm_test(
+    name = "ApiClientsTest",
+    timeout = "short",
+    srcs = ["ApiClientsTest.kt"],
+    test_class = "org.wfanet.panelmatch.client.launcher.ApiClientsTest",
+    deps = [
+        "//src/main/kotlin/org/wfanet/panelmatch/client/launcher",
+        "//src/main/kotlin/org/wfanet/panelmatch/common/testing",
+        "//src/main/proto/wfa/panelmatch/client/internal:exchange_step_attempt_kt_jvm_proto",
+        "//src/main/proto/wfa/panelmatch/client/internal:exchange_workflow_kt_jvm_proto",
+        "@wfa_common_jvm//imports/java/com/google/common/truth",
+        "@wfa_common_jvm//imports/java/org/junit",
+        "@wfa_common_jvm//imports/java/org/mockito",
+        "@wfa_common_jvm//imports/kotlin/kotlin/test",
+        "@wfa_common_jvm//imports/kotlin/org/mockito/kotlin",
+    ],
+)
+
+kt_jvm_test(
     name = "ExchangeStepLauncherTest",
     timeout = "short",
     srcs = ["ExchangeStepLauncherTest.kt"],

--- a/src/test/kotlin/org/wfanet/panelmatch/client/launcher/GrpcApiClientTest.kt
+++ b/src/test/kotlin/org/wfanet/panelmatch/client/launcher/GrpcApiClientTest.kt
@@ -185,8 +185,9 @@ class GrpcApiClientTest {
     return GrpcApiClient(identity, exchangeStepsStub, exchangeStepAttemptsStub, clock)
   }
 
-  private fun makeLimitedClient(identity: Identity = DATA_PROVIDER_IDENTITY): GrpcApiClient {
-    return GrpcApiClient(identity, exchangeStepsStub, exchangeStepAttemptsStub, clock, 1)
+  private fun makeLimitedClient(identity: Identity = DATA_PROVIDER_IDENTITY): ApiClient {
+    return GrpcApiClient(identity, exchangeStepsStub, exchangeStepAttemptsStub, clock)
+      .withMaxParallelClaimedExchangeSteps(1)
   }
 
   private fun makeLogEntry(message: String): V2AlphaExchangeStepAttempt.DebugLogEntry {


### PR DESCRIPTION
Creates a wrapper `ApiClient` that can perform the "max parallel claimed exchange step" logic and delegates to another client for all other logic.

This allows the Kingdom-less flow to support the max parallel steps flag trivially.