### PR TITLE
fix: don't export OpenTelemetry traces using prometheus exporter

### DIFF
--- a/src/main/k8s/dev/open_telemetry_gke.cue
+++ b/src/main/k8s/dev/open_telemetry_gke.cue
@@ -45,6 +45,7 @@ openTelemetry: #OpenTelemetry & {
 	instrumentations: "java-instrumentation": {
 		spec: {
 			_envVars: {
+				OTEL_TRACES_EXPORTER:                                     "otlp"
 				OTEL_EXPORTER_OTLP_METRICS_DEFAULT_HISTOGRAM_AGGREGATION: "base2_exponential_bucket_histogram"
 			}
 		}

--- a/src/main/k8s/open_telemetry.cue
+++ b/src/main/k8s/open_telemetry.cue
@@ -123,7 +123,7 @@ package k8s
 				_envVars: [string]: string
 				_envVars: {
 					OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT: "256"
-					OTEL_TRACES_EXPORTER:                   "otlp"
+					OTEL_TRACES_EXPORTER:                   _ | *"none"
 					OTEL_EXPORTER_OTLP_TRACES_PROTOCOL:     "grpc"
 					OTEL_EXPORTER_OTLP_ENDPOINT:            "http://default-collector-headless.default.svc:\(#OpenTelemetryReceiverPort)"
 					OTEL_EXPORTER_OTLP_TIMEOUT:             "20000"


### PR DESCRIPTION
This avoids warnings about trace exporting not being supported.