### PR TITLE
fix: switch Duchy cluster autoscaling profile back to BALANCED

### DIFF
--- a/src/main/terraform/gcloud/cmms/duchies.tf
+++ b/src/main/terraform/gcloud/cmms/duchies.tf
@@ -20,7 +20,7 @@ module "clusters" {
   location            = local.cluster_location
   release_channel     = var.cluster_release_channel
   secret_key          = module.common.cluster_secret_key
-  autoscaling_profile = "OPTIMIZE_UTILIZATION"
+  autoscaling_profile = "BALANCED"
 }
 
 module "default_node_pools" {

--- a/src/main/terraform/gcloud/examples/duchy/main.tf
+++ b/src/main/terraform/gcloud/examples/duchy/main.tf
@@ -51,7 +51,7 @@ module "cluster" {
   location            = local.cluster_location
   release_channel     = var.cluster_release_channel
   secret_key          = module.common.cluster_secret_key
-  autoscaling_profile = "OPTIMIZE_UTILIZATION"
+  autoscaling_profile = "BALANCED"
 }
 
 module "default_node_pool" {


### PR DESCRIPTION
After some testing, the aggressive scale down seems to be less desirable w.r.t. Mill startup latency. In addition, Pod logs are lost when a Node is removed.