### PR TITLE
fix: ensure Mill job should process claimed work item

### DIFF
--- a/src/main/kotlin/org/wfanet/measurement/duchy/deploy/common/daemon/mill/MillJobScheduler.kt
+++ b/src/main/kotlin/org/wfanet/measurement/duchy/deploy/common/daemon/mill/MillJobScheduler.kt
@@ -143,8 +143,9 @@ class MillJobScheduler(
       millType.podTemplate.template.clone().apply {
         val container: V1Container = spec.containers.first()
         container.addArgsItem("--mill-id=$jobName")
-        container.addArgsItem("--computation-type=$computationType")
+        container.addArgsItem("--claimed-computation-type=$computationType")
         container.addArgsItem("--claimed-computation-id=$claimedComputationId")
+        container.addArgsItem("--claimed-computation-version=${claimedToken.version}")
       }
     createJob(jobName, millType, template)
     logger.info { "Scheduled Job $jobName for Computation $claimedComputationId" }

--- a/src/main/kotlin/org/wfanet/measurement/duchy/deploy/common/job/mill/liquidlegionsv2/LiquidLegionsV2MillJob.kt
+++ b/src/main/kotlin/org/wfanet/measurement/duchy/deploy/common/job/mill/liquidlegionsv2/LiquidLegionsV2MillJob.kt
@@ -127,7 +127,7 @@ abstract class LiquidLegionsV2MillJob : Runnable {
     val openTelemetry: OpenTelemetry = GlobalOpenTelemetry.get()
 
     val mill: LiquidLegionsV2Mill =
-      when (flags.computationType) {
+      when (flags.claimedComputationType) {
         ComputationTypeEnum.ComputationType.LIQUID_LEGIONS_SKETCH_AGGREGATION_V2 ->
           ReachFrequencyLiquidLegionsV2Mill(
             millId = millId,
@@ -169,11 +169,11 @@ abstract class LiquidLegionsV2MillJob : Runnable {
         ComputationTypeEnum.ComputationType.HONEST_MAJORITY_SHARE_SHUFFLE,
         ComputationTypeEnum.ComputationType.UNSPECIFIED,
         ComputationTypeEnum.ComputationType.UNRECOGNIZED ->
-          error("Unsupported ComputationType ${flags.computationType}")
+          error("Unsupported ComputationType ${flags.claimedComputationType}")
       }
 
     runBlocking(CoroutineName("Mill $millId")) {
-      mill.processClaimedWork(flags.claimedGlobalComputationId)
+      mill.processClaimedWork(flags.claimedGlobalComputationId, flags.claimedComputationVersion)
 
       // Continue processing until work is exhausted.
       do {

--- a/src/main/kotlin/org/wfanet/measurement/duchy/deploy/common/job/mill/shareshuffle/HonestMajorityShareShuffleMillJob.kt
+++ b/src/main/kotlin/org/wfanet/measurement/duchy/deploy/common/job/mill/shareshuffle/HonestMajorityShareShuffleMillJob.kt
@@ -180,7 +180,7 @@ abstract class HonestMajorityShareShuffleMillJob : Runnable {
       )
 
     runBlocking(CoroutineName("Mill $millId")) {
-      mill.processClaimedWork(flags.claimedGlobalComputationId)
+      mill.processClaimedWork(flags.claimedGlobalComputationId, flags.claimedComputationVersion)
 
       // Continue processing until work is exhausted.
       do {

--- a/src/main/kotlin/org/wfanet/measurement/duchy/mill/MillBase.kt
+++ b/src/main/kotlin/org/wfanet/measurement/duchy/mill/MillBase.kt
@@ -25,6 +25,7 @@ import io.opentelemetry.api.metrics.Meter
 import java.security.cert.X509Certificate
 import java.time.Clock
 import java.time.Duration
+import java.time.Instant
 import java.util.logging.Level
 import java.util.logging.Logger
 import kotlin.math.pow
@@ -47,7 +48,9 @@ import org.wfanet.measurement.common.crypto.SigningKeyHandle
 import org.wfanet.measurement.common.flatten
 import org.wfanet.measurement.common.logAndSuppressExceptionSuspend
 import org.wfanet.measurement.common.protoTimestamp
+import org.wfanet.measurement.common.toInstant
 import org.wfanet.measurement.common.toProtoDuration
+import org.wfanet.measurement.common.toProtoTime
 import org.wfanet.measurement.consent.client.duchy.encryptResult
 import org.wfanet.measurement.consent.client.duchy.signResult
 import org.wfanet.measurement.duchy.db.computation.BlobRef
@@ -76,12 +79,14 @@ import org.wfanet.measurement.system.v1alpha.ComputationControlGrpcKt.Computatio
 import org.wfanet.measurement.system.v1alpha.ComputationKey
 import org.wfanet.measurement.system.v1alpha.ComputationLogEntriesGrpcKt.ComputationLogEntriesCoroutineStub
 import org.wfanet.measurement.system.v1alpha.ComputationLogEntry
+import org.wfanet.measurement.system.v1alpha.ComputationLogEntryKt
 import org.wfanet.measurement.system.v1alpha.ComputationParticipant
 import org.wfanet.measurement.system.v1alpha.ComputationParticipantKey
 import org.wfanet.measurement.system.v1alpha.ComputationParticipantKt
 import org.wfanet.measurement.system.v1alpha.ComputationParticipantsGrpcKt.ComputationParticipantsCoroutineStub
 import org.wfanet.measurement.system.v1alpha.ComputationsGrpcKt
-import org.wfanet.measurement.system.v1alpha.CreateComputationLogEntryRequest
+import org.wfanet.measurement.system.v1alpha.computationLogEntry
+import org.wfanet.measurement.system.v1alpha.createComputationLogEntryRequest
 import org.wfanet.measurement.system.v1alpha.failComputationParticipantRequest
 import org.wfanet.measurement.system.v1alpha.getComputationParticipantRequest
 import org.wfanet.measurement.system.v1alpha.setComputationResultRequest
@@ -161,9 +166,29 @@ abstract class MillBase(
       .setUnit("s")
       .build()
 
+  /** Returns whether this Mill currently holds the lock on [token]. */
+  private fun holdsLock(token: ComputationToken, now: Instant): Boolean {
+    return token.lockOwner == millId && token.lockExpirationTime.toInstant() > now
+  }
+
   /** Process a work item that has already been claimed. */
-  suspend fun processClaimedWork(globalComputationId: String) {
+  suspend fun processClaimedWork(globalComputationId: String, version: Long) {
     val token: ComputationToken = getLatestComputationToken(globalComputationId)
+    val now = clock.instant()
+
+    if (token.version != version) {
+      val message = "Computation version has changed since claimed"
+      logger.warning(message)
+      sendStatusUpdateToKingdom(globalComputationId, buildErrorLogEntry(token, message, now))
+      return
+    }
+    if (!holdsLock(token, now)) {
+      val message = "Mill does not hold lock for Computation $globalComputationId"
+      logger.warning(message)
+      sendStatusUpdateToKingdom(globalComputationId, buildErrorLogEntry(token, message, now))
+      return
+    }
+
     processComputation(token)
   }
 
@@ -198,7 +223,13 @@ abstract class MillBase(
       return false
     }
 
-    processComputation(claimWorkResponse.token)
+    val token: ComputationToken = claimWorkResponse.token
+    logger.info {
+      val globalComputationId = token.globalComputationId
+      val stage = token.computationStage
+      "Claimed work item for Computation $globalComputationId at stage $stage"
+    }
+    processComputation(token)
     return true
   }
 
@@ -252,7 +283,14 @@ abstract class MillBase(
           )
         } else {
           logger.log(Level.WARNING, e) { "$globalId@$millId: TRANSIENT error" }
-          sendStatusUpdateToKingdom(newErrorUpdateRequest(token, e.localizedMessage))
+          sendStatusUpdateToKingdom(
+            globalId,
+            buildErrorLogEntry(
+              token,
+              "Transient error processing Computation $globalId at attempt ${token.attempt} of " +
+                "stage ${token.computationStage}: ${e.message}",
+            ),
+          )
           // Enqueue the computation again for future retry
           enqueueComputation(token)
         }
@@ -406,9 +444,17 @@ abstract class MillBase(
   protected abstract suspend fun processComputationImpl(token: ComputationToken)
 
   /** Sends status update to the Kingdom's ComputationLogEntriesService. */
-  private suspend fun sendStatusUpdateToKingdom(request: CreateComputationLogEntryRequest) {
+  private suspend fun sendStatusUpdateToKingdom(
+    globalComputationId: String,
+    logEntry: ComputationLogEntry,
+  ) {
     try {
-      systemComputationLogEntriesClient.createComputationLogEntry(request)
+      systemComputationLogEntriesClient.createComputationLogEntry(
+        createComputationLogEntryRequest {
+          parent = ComputationParticipantKey(globalComputationId, duchyId).toName()
+          computationLogEntry = logEntry
+        }
+      )
     } catch (e: StatusException) {
       logger.log(Level.WARNING, e) { "Failed to update status change to the kingdom." }
     }
@@ -527,33 +573,24 @@ abstract class MillBase(
     }
   }
 
-  /** Builds a [CreateComputationLogEntryRequest] to update the new error. */
-  private fun newErrorUpdateRequest(
+  private fun buildErrorLogEntry(
     token: ComputationToken,
     message: String,
-  ): CreateComputationLogEntryRequest {
-    val timestamp = clock.protoTimestamp()
-    return CreateComputationLogEntryRequest.newBuilder()
-      .apply {
-        parent = ComputationParticipantKey(token.globalComputationId, duchyId).toName()
-        computationLogEntryBuilder.apply {
-          participantChildReferenceId = millId
-          logMessage =
-            "Computation ${token.globalComputationId} at stage " +
-              "${token.computationStage.name}, attempt ${token.attempt} failed, $message"
-          stageAttemptBuilder.apply {
-            stage = token.computationStage.number
-            stageName = token.computationStage.name
-            stageStartTime = timestamp
-            attemptNumber = token.attempt.toLong()
-          }
-          errorDetailsBuilder.also {
-            it.errorTime = timestamp
-            it.type = ComputationLogEntry.ErrorDetails.Type.TRANSIENT
-          }
-        }
+    now: Instant = clock.instant(),
+  ) = computationLogEntry {
+    participantChildReferenceId = millId
+    logMessage = message
+    stageAttempt = stageAttempt {
+      stage = token.computationStage.number
+      stageName = token.computationStage.name
+      stageStartTime = now.toProtoTime()
+      attemptNumber = token.attempt.toLong()
+    }
+    errorDetails =
+      ComputationLogEntryKt.errorDetails {
+        type = ComputationLogEntry.ErrorDetails.Type.TRANSIENT
+        errorTime = now.toProtoTime()
       }
-      .build()
   }
 
   /** Adds a logging hook to the flow to log the total number of bytes sent out in the rpc. */

--- a/src/main/kotlin/org/wfanet/measurement/duchy/mill/MillFlags.kt
+++ b/src/main/kotlin/org/wfanet/measurement/duchy/mill/MillFlags.kt
@@ -48,12 +48,20 @@ abstract class MillFlags {
   lateinit var claimedGlobalComputationId: String
     private set
 
-  @CommandLine.Option(
-    names = ["--computation-type"],
-    description = ["Type (protocol) of the computation"],
+  @set:CommandLine.Option(
+    names = ["--claimed-computation-version"],
+    description = ["Token version of the the claimed work item"],
     required = true,
   )
-  lateinit var computationType: ComputationType
+  var claimedComputationVersion by Delegates.notNull<Long>()
+    private set
+
+  @CommandLine.Option(
+    names = ["--claimed-computation-type"],
+    description = ["Computation type (protocol) of the claimed work item"],
+    required = true,
+  )
+  lateinit var claimedComputationType: ComputationType
     private set
 
   @CommandLine.Option(


### PR DESCRIPTION
This checks that the work item has not changed since it was claimed and that the Mill instance currently holds the lock for the work item.