### PR TITLE
fix: Wait for EDP simulator to initialize before considering it ready

### DIFF
--- a/src/main/k8s/base.cue
+++ b/src/main/k8s/base.cue
@@ -488,8 +488,11 @@ objects: [ for objectSet in objectSets for object in objectSet {object}]
 
 // K8s Probe.
 #Probe: {
-	grpc: {
+	grpc?: {
 		port: uint32
+	}
+	exec?: {
+		command: [...string]
 	}
 	initialDelaySeconds?: uint32
 	periodSeconds?:       uint32
@@ -535,6 +538,8 @@ objects: [ for objectSet in objectSets for object in objectSet {object}]
 	volumeMounts: [ for _, volumeMount in _volumeMounts {volumeMount}]
 	resources?:      #ResourceRequirements
 	readinessProbe?: #Probe
+	startupProbe?:   #Probe
+	restartPolicy?:  "Always" // For sidecar containers.
 	env: [ for _, envVar in _envVars {envVar}]
 }
 

--- a/src/main/k8s/edp_simulator.cue
+++ b/src/main/k8s/edp_simulator.cue
@@ -51,6 +51,7 @@ import "list"
 	}
 
 	deployment: #Deployment & {
+		let HealthFile = "/run/probe/healthy"
 		_name:       DisplayName + "-simulator"
 		_secretName: _edp_secret_name
 		_system:     "simulator"
@@ -70,7 +71,34 @@ import "list"
 				"--kingdom-public-api-target=\(_kingdom_public_api_target)",
 				"--kingdom-public-api-cert-host=localhost",
 				"--log-sketch-details=\(_logSketchDetails)",
+				"--health-file=\(HealthFile)",
 			] + _requisitionFulfillmentServiceFlags + _additional_args
+		}
+		spec: template: spec: {
+			_mounts: {
+				"probe": {
+					volume: emptyDir: {}
+				}
+			}
+			_containers: {
+				"probe-sidecar": {
+					image: "registry.k8s.io/busybox"
+					args: ["/bin/sh", "-c", "while true; do sleep 30; done"]
+					startupProbe: {
+						exec: command: ["cat", HealthFile]
+						initialDelaySeconds: 10
+						periodSeconds:       1
+						failureThreshold:    30
+					}
+					resources: Resources={
+						requests: {
+							cpu:    "1m"
+							memory: "10Mi"
+						}
+						limits: memory: _ | *Resources.requests.memory
+					}
+				}
+			}
 		}
 	}
 

--- a/src/main/kotlin/org/wfanet/measurement/common/BUILD.bazel
+++ b/src/main/kotlin/org/wfanet/measurement/common/BUILD.bazel
@@ -25,3 +25,12 @@ kt_jvm_library(
         "@wfa_common_jvm//imports/kotlin/com/google/protobuf/kotlin",
     ],
 )
+
+kt_jvm_library(
+    name = "health",
+    srcs = ["Health.kt"],
+    deps = [
+        "@wfa_common_jvm//imports/java/org/jetbrains/annotations",
+        "@wfa_common_jvm//imports/kotlin/kotlinx/coroutines:core",
+    ],
+)

--- a/src/main/kotlin/org/wfanet/measurement/common/Health.kt
+++ b/src/main/kotlin/org/wfanet/measurement/common/Health.kt
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2024 The Cross-Media Measurement Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wfanet.measurement.common
+
+import java.io.File
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.first
+import org.jetbrains.annotations.Blocking
+
+/** An object which exposes whether it is healthy. */
+interface Health {
+  /** Whether this instance is healthy. */
+  val healthy: Boolean
+
+  /** Suspends while [healthy] is `false`. */
+  suspend fun waitUntilHealthy()
+}
+
+/** [Health] with the ability to set the value of [healthy]. */
+open class SettableHealth(healthy: Boolean = false) : Health {
+  private val healthState = MutableStateFlow(healthy)
+
+  override val healthy: Boolean
+    get() = healthState.value
+
+  /**
+   * Sets the value of [healthy] to [value].
+   *
+   * The base implementation does not block, but implementations may override this to be blocking.
+   */
+  @Blocking
+  open fun setHealthy(value: Boolean) {
+    healthState.value = value
+  }
+
+  override suspend fun waitUntilHealthy() {
+    healthState.first { it }
+  }
+}
+
+/**
+ * [Health] where [file] is used to track whether [healthy] is `true`.
+ *
+ * This assumes that the existence of [file] never changes while this object exists other than by
+ * [setHealthy].
+ */
+class FileExistsHealth @Blocking constructor(private val file: File) :
+  SettableHealth(file.exists()) {
+  override fun setHealthy(value: Boolean) {
+    if (value) {
+      file.createNewFile()
+    } else {
+      file.delete()
+    }
+    super.setHealthy(value)
+  }
+}

--- a/src/main/kotlin/org/wfanet/measurement/integration/common/InProcessCmmsComponents.kt
+++ b/src/main/kotlin/org/wfanet/measurement/integration/common/InProcessCmmsComponents.kt
@@ -199,6 +199,7 @@ class InProcessCmmsComponents(
       it.startMill(duchyCertMap)
     }
     edpSimulators.forEach { it.start() }
+    edpSimulators.forEach { it.waitUntilHealthy() }
   }
 
   fun stopEdpSimulators() = runBlocking { edpSimulators.forEach { it.stop() } }

--- a/src/main/kotlin/org/wfanet/measurement/integration/common/InProcessEdpSimulator.kt
+++ b/src/main/kotlin/org/wfanet/measurement/integration/common/InProcessEdpSimulator.kt
@@ -43,6 +43,7 @@ import org.wfanet.measurement.api.v2alpha.RequisitionsGrpcKt.RequisitionsCorouti
 import org.wfanet.measurement.api.v2alpha.event_group_metadata.testing.SyntheticEventGroupSpec
 import org.wfanet.measurement.api.v2alpha.event_group_metadata.testing.SyntheticPopulationSpec
 import org.wfanet.measurement.api.v2alpha.event_templates.testing.TestEvent
+import org.wfanet.measurement.common.Health
 import org.wfanet.measurement.common.identity.withPrincipalName
 import org.wfanet.measurement.common.throttler.MinimumIntervalThrottler
 import org.wfanet.measurement.dataprovider.DataProviderData
@@ -67,7 +68,7 @@ class InProcessEdpSimulator(
   private val syntheticDataSpec: SyntheticEventGroupSpec,
   coroutineContext: CoroutineContext = Dispatchers.Default,
   honestMajorityShareShuffleSupported: Boolean = true,
-) {
+) : Health {
   private val loggingName = "${javaClass.simpleName} $displayName"
   private val backgroundScope =
     CoroutineScope(
@@ -138,6 +139,11 @@ class InProcessEdpSimulator(
   }
 
   private lateinit var edpJob: Job
+
+  override val healthy: Boolean
+    get() = delegate.healthy
+
+  override suspend fun waitUntilHealthy() = delegate.waitUntilHealthy()
 
   fun start() {
     edpJob = backgroundScope.launch { delegate.run() }

--- a/src/main/kotlin/org/wfanet/measurement/loadtest/dataprovider/BUILD.bazel
+++ b/src/main/kotlin/org/wfanet/measurement/loadtest/dataprovider/BUILD.bazel
@@ -146,6 +146,7 @@ kt_jvm_library(
         ":vid_to_index_map_generator",
         "//src/main/kotlin/org/wfanet/measurement/api/v2alpha:packed_messages",
         "//src/main/kotlin/org/wfanet/measurement/api/v2alpha:resource_key",
+        "//src/main/kotlin/org/wfanet/measurement/common:health",
         "//src/main/kotlin/org/wfanet/measurement/dataprovider:requisition_fulfiller",
         "//src/main/kotlin/org/wfanet/measurement/eventdataprovider/noiser",
         "//src/main/kotlin/org/wfanet/measurement/eventdataprovider/privacybudgetmanagement:privacy_budget_manager",

--- a/src/main/kotlin/org/wfanet/measurement/loadtest/dataprovider/EdpSimulator.kt
+++ b/src/main/kotlin/org/wfanet/measurement/loadtest/dataprovider/EdpSimulator.kt
@@ -29,16 +29,20 @@ import java.security.cert.X509Certificate
 import java.time.Instant
 import java.util.logging.Level
 import java.util.logging.Logger
+import kotlin.coroutines.CoroutineContext
 import kotlin.math.log2
 import kotlin.math.max
 import kotlin.math.roundToInt
 import kotlin.random.Random
 import kotlin.random.asJavaRandom
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.emitAll
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.withContext
 import org.apache.commons.math3.distribution.ConstantRealDistribution
+import org.jetbrains.annotations.BlockingExecutor
 import org.wfanet.anysketch.Sketch
 import org.wfanet.anysketch.SketchConfig
 import org.wfanet.anysketch.crypto.ElGamalPublicKey as AnySketchElGamalPublicKey
@@ -109,7 +113,9 @@ import org.wfanet.measurement.api.v2alpha.replaceDataProviderCapabilitiesRequest
 import org.wfanet.measurement.api.v2alpha.unpack
 import org.wfanet.measurement.api.v2alpha.updateEventGroupMetadataDescriptorRequest
 import org.wfanet.measurement.api.v2alpha.updateEventGroupRequest
+import org.wfanet.measurement.common.Health
 import org.wfanet.measurement.common.ProtoReflection
+import org.wfanet.measurement.common.SettableHealth
 import org.wfanet.measurement.common.asBufferedFlow
 import org.wfanet.measurement.common.crypto.authorityKeyIdentifier
 import org.wfanet.measurement.common.crypto.readCertificate
@@ -174,6 +180,8 @@ class EdpSimulator(
   private val sketchEncrypter: SketchEncrypter = SketchEncrypter.Default,
   private val random: Random = Random,
   private val logSketchDetails: Boolean = false,
+  private val health: SettableHealth = SettableHealth(),
+  private val blockingCoroutineContext: @BlockingExecutor CoroutineContext = Dispatchers.IO,
 ) :
   RequisitionFulfiller(
     edpData,
@@ -182,7 +190,8 @@ class EdpSimulator(
     throttler,
     trustedCertificates,
     measurementConsumerName,
-  ) {
+  ),
+  Health by health {
   val eventGroupReferenceIdPrefix = getEventGroupReferenceIdPrefix(edpData.displayName)
 
   val supportedProtocols = buildSet {
@@ -217,6 +226,7 @@ class EdpSimulator(
       }
     )
 
+    withContext(blockingCoroutineContext) { health.setHealthy(true) }
     throttler.loopOnReady { executeRequisitionFulfillingWorkflow() }
   }
 

--- a/src/main/kotlin/org/wfanet/measurement/loadtest/dataprovider/EdpSimulatorFlags.kt
+++ b/src/main/kotlin/org/wfanet/measurement/loadtest/dataprovider/EdpSimulatorFlags.kt
@@ -123,4 +123,12 @@ class EdpSimulatorFlags {
   )
   var logSketchDetails: Boolean = false
     private set
+
+  @CommandLine.Option(
+    names = ["--health-file"],
+    description = ["File indicating whether the process is healthy"],
+    required = false,
+  )
+  var healthFile: File? = null
+    private set
 }

--- a/src/main/kotlin/org/wfanet/measurement/loadtest/dataprovider/EdpSimulatorRunner.kt
+++ b/src/main/kotlin/org/wfanet/measurement/loadtest/dataprovider/EdpSimulatorRunner.kt
@@ -29,6 +29,8 @@ import org.wfanet.measurement.api.v2alpha.EventGroupsGrpcKt.EventGroupsCoroutine
 import org.wfanet.measurement.api.v2alpha.MeasurementConsumersGrpcKt.MeasurementConsumersCoroutineStub
 import org.wfanet.measurement.api.v2alpha.RequisitionFulfillmentGrpcKt.RequisitionFulfillmentCoroutineStub
 import org.wfanet.measurement.api.v2alpha.RequisitionsGrpcKt.RequisitionsCoroutineStub
+import org.wfanet.measurement.common.FileExistsHealth
+import org.wfanet.measurement.common.SettableHealth
 import org.wfanet.measurement.common.crypto.SigningCerts
 import org.wfanet.measurement.common.crypto.testing.loadSigningKey
 import org.wfanet.measurement.common.crypto.tink.loadPrivateKey
@@ -100,6 +102,9 @@ abstract class EdpSimulatorRunner : Runnable {
         Random.Default
       }
 
+    val healthFile = flags.healthFile
+    val health = if (healthFile == null) SettableHealth() else FileExistsHealth(healthFile)
+
     val edpSimulator =
       EdpSimulator(
         edpData,
@@ -119,6 +124,7 @@ abstract class EdpSimulatorRunner : Runnable {
         knownEventGroupMetadataTypes = knownEventGroupMetadataTypes,
         random = random,
         logSketchDetails = flags.logSketchDetails,
+        health = health,
       )
     runBlocking {
       edpSimulator.ensureEventGroups(eventTemplates, metadataByReferenceIdSuffix)

--- a/src/test/kotlin/org/wfanet/measurement/integration/k8s/EmptyClusterCorrectnessTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/integration/k8s/EmptyClusterCorrectnessTest.kt
@@ -18,7 +18,6 @@ package org.wfanet.measurement.integration.k8s
 
 import io.grpc.Channel
 import io.grpc.ManagedChannel
-import io.grpc.StatusException
 import io.kubernetes.client.common.KubernetesObject
 import io.kubernetes.client.openapi.Configuration
 import io.kubernetes.client.openapi.models.V1Deployment
@@ -33,10 +32,7 @@ import java.time.Duration
 import java.util.UUID
 import java.util.logging.Logger
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.currentCoroutineContext
-import kotlinx.coroutines.isActive
 import kotlinx.coroutines.runBlocking
-import kotlinx.coroutines.time.delay
 import kotlinx.coroutines.time.withTimeout
 import kotlinx.coroutines.withContext
 import org.jetbrains.annotations.Blocking
@@ -51,12 +47,9 @@ import org.wfanet.measurement.api.v2alpha.ApiKeysGrpcKt
 import org.wfanet.measurement.api.v2alpha.CertificatesGrpcKt
 import org.wfanet.measurement.api.v2alpha.DataProvidersGrpcKt
 import org.wfanet.measurement.api.v2alpha.EventGroupsGrpcKt
-import org.wfanet.measurement.api.v2alpha.ListEventGroupsRequestKt
 import org.wfanet.measurement.api.v2alpha.MeasurementConsumersGrpcKt
 import org.wfanet.measurement.api.v2alpha.MeasurementsGrpcKt
 import org.wfanet.measurement.api.v2alpha.ProtocolConfig
-import org.wfanet.measurement.api.v2alpha.listEventGroupsRequest
-import org.wfanet.measurement.api.withAuthenticationKey
 import org.wfanet.measurement.common.crypto.jceProvider
 import org.wfanet.measurement.common.crypto.tink.TinkPrivateKeyHandle
 import org.wfanet.measurement.common.grpc.buildMutualTlsChannel
@@ -250,30 +243,20 @@ class EmptyClusterCorrectnessTest : AbstractCorrectnessTest(measurementSystem) {
       val eventGroupsClient = EventGroupsGrpcKt.EventGroupsCoroutineStub(publicApiChannel)
 
       return MeasurementConsumerSimulator(
-          measurementConsumerData,
-          OUTPUT_DP_PARAMS,
-          DataProvidersGrpcKt.DataProvidersCoroutineStub(publicApiChannel),
-          eventGroupsClient,
-          MeasurementsGrpcKt.MeasurementsCoroutineStub(publicApiChannel),
-          MeasurementConsumersGrpcKt.MeasurementConsumersCoroutineStub(publicApiChannel),
-          CertificatesGrpcKt.CertificatesCoroutineStub(publicApiChannel),
-          MEASUREMENT_CONSUMER_SIGNING_CERTS.trustedCertificates,
-          MetadataSyntheticGeneratorEventQuery(
-            SyntheticGenerationSpecs.SYNTHETIC_POPULATION_SPEC_SMALL,
-            MC_ENCRYPTION_PRIVATE_KEY,
-          ),
-          ProtocolConfig.NoiseMechanism.CONTINUOUS_GAUSSIAN,
-        )
-        .also {
-          try {
-            eventGroupsClient.waitForEventGroups(
-              measurementConsumerData.name,
-              measurementConsumerData.apiAuthenticationKey,
-            )
-          } catch (e: StatusException) {
-            throw Exception("Error waiting for EventGroups", e)
-          }
-        }
+        measurementConsumerData,
+        OUTPUT_DP_PARAMS,
+        DataProvidersGrpcKt.DataProvidersCoroutineStub(publicApiChannel),
+        eventGroupsClient,
+        MeasurementsGrpcKt.MeasurementsCoroutineStub(publicApiChannel),
+        MeasurementConsumersGrpcKt.MeasurementConsumersCoroutineStub(publicApiChannel),
+        CertificatesGrpcKt.CertificatesCoroutineStub(publicApiChannel),
+        MEASUREMENT_CONSUMER_SIGNING_CERTS.trustedCertificates,
+        MetadataSyntheticGeneratorEventQuery(
+          SyntheticGenerationSpecs.SYNTHETIC_POPULATION_SPEC_SMALL,
+          MC_ENCRYPTION_PRIVATE_KEY,
+        ),
+        ProtocolConfig.NoiseMechanism.CONTINUOUS_GAUSSIAN,
+      )
     }
 
     fun stopPortForwarding() {
@@ -494,34 +477,6 @@ class EmptyClusterCorrectnessTest : AbstractCorrectnessTest(measurementSystem) {
     @ClassRule
     @JvmField
     val chainedRule = chainRulesSequentially(tempDir, Images(), measurementSystem)
-
-    private suspend fun EventGroupsGrpcKt.EventGroupsCoroutineStub.waitForEventGroups(
-      measurementConsumer: String,
-      apiKey: String,
-    ) {
-      logger.info { "Waiting for all event groups to be created..." }
-      while (currentCoroutineContext().isActive) {
-        val eventGroups =
-          withAuthenticationKey(apiKey)
-            .listEventGroups(
-              listEventGroupsRequest {
-                parent = measurementConsumer
-                filter =
-                  ListEventGroupsRequestKt.filter { measurementConsumers += measurementConsumer }
-              }
-            )
-            .eventGroupsList
-
-        // Each EDP simulator creates one event group, so we wait until there are as many event
-        // groups as EDP simulators.
-        if (eventGroups.size == NUM_DATA_PROVIDERS) {
-          logger.info { "All event groups created" }
-          return
-        }
-
-        delay(Duration.ofSeconds(1))
-      }
-    }
   }
 }
 


### PR DESCRIPTION
This introduces a health check to the EDP simulator, where it is considered healthy only after its initialization items (e.g. updating capabilities). This is used by a Kubernetes startup probe.

Fixes #1728