### PR TITLE
test: Update confidence interval for integration tests.

### DIFF
--- a/src/main/kotlin/org/wfanet/measurement/loadtest/measurementconsumer/MeasurementConsumerSimulator.kt
+++ b/src/main/kotlin/org/wfanet/measurement/loadtest/measurementconsumer/MeasurementConsumerSimulator.kt
@@ -1205,8 +1205,8 @@ class MeasurementConsumerSimulator(
     private val DEFAULT_EVENT_RANGE =
       OpenEndTimeRange.fromClosedDateRange(LocalDate.of(2021, 3, 15)..LocalDate.of(2021, 3, 17))
 
-    // For a 99.9% Confidence Interval.
-    private const val CONFIDENCE_INTERVAL_MULTIPLIER = 3.291
+    // For a 99.9999% Confidence Interval.
+    private const val CONFIDENCE_INTERVAL_MULTIPLIER = 5.0
     private val logger: Logger = Logger.getLogger(this::class.java.name)
   }
 }


### PR DESCRIPTION
The current threshold (3.291 x sigma) guarantees that each noisy measurement is 99.9% within the confidence interval. However, the integration tests consist of at least 30 independent noisy values. This pushes the failure rate to (1-0.999^30 ~ 0.03), which is a bit high and causes the presubmit test to be flaky. Increasing this threshold to 5 x sigma will bring the failure rate down to below 0.0001.