### PR TITLE
feat!: Update cross-media-measurement-api dep for Requisition.State.WITHDRAWN

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -139,7 +139,7 @@ bazel_dep(
 )
 bazel_dep(
     name = "cross-media-measurement-api",
-    version = "0.64.0",
+    version = "0.65.0",
     repo_name = "wfa_measurement_proto",
 )
 bazel_dep(

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/readers/ComputationParticipantReader.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/readers/ComputationParticipantReader.kt
@@ -26,6 +26,7 @@ import org.wfanet.measurement.common.identity.InternalId
 import org.wfanet.measurement.gcloud.spanner.AsyncDatabaseClient
 import org.wfanet.measurement.gcloud.spanner.appendClause
 import org.wfanet.measurement.gcloud.spanner.bind
+import org.wfanet.measurement.gcloud.spanner.getInternalId
 import org.wfanet.measurement.gcloud.spanner.getProtoEnum
 import org.wfanet.measurement.gcloud.spanner.getProtoMessage
 import org.wfanet.measurement.internal.kingdom.ComputationParticipant
@@ -92,8 +93,8 @@ private val BASE_SQL =
 class ComputationParticipantReader : BaseSpannerReader<ComputationParticipantReader.Result>() {
   data class Result(
     val computationParticipant: ComputationParticipant,
-    val measurementId: Long,
-    val measurementConsumerId: Long,
+    val measurementId: InternalId,
+    val measurementConsumerId: InternalId,
     val measurementState: Measurement.State,
     val measurementDetails: Measurement.Details,
   )
@@ -140,8 +141,8 @@ class ComputationParticipantReader : BaseSpannerReader<ComputationParticipantRea
   override suspend fun translate(struct: Struct) =
     Result(
       buildComputationParticipant(struct),
-      struct.getLong("MeasurementId"),
-      struct.getLong("MeasurementConsumerId"),
+      struct.getInternalId("MeasurementId"),
+      struct.getInternalId("MeasurementConsumerId"),
       struct.getProtoEnum("MeasurementState", Measurement.State::forNumber),
       struct.getProtoMessage("MeasurementDetails", Measurement.Details.parser()),
     )

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/writers/BatchCancelMeasurements.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/writers/BatchCancelMeasurements.kt
@@ -111,6 +111,7 @@ class BatchCancelMeasurements(private val requests: BatchCancelMeasurementsReque
         previousState = result.measurement.state,
         measurementLogEntryDetails = measurementLogEntryDetails,
       )
+      withdrawRequisitions(result.measurementConsumerId, result.measurementId)
     }
 
     return batchCancelMeasurementsResponse {

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/writers/CancelMeasurement.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/writers/CancelMeasurement.kt
@@ -15,6 +15,7 @@
 package org.wfanet.measurement.kingdom.deploy.gcloud.spanner.writers
 
 import org.wfanet.measurement.common.identity.ExternalId
+import org.wfanet.measurement.gcloud.spanner.set
 import org.wfanet.measurement.internal.kingdom.Measurement
 import org.wfanet.measurement.internal.kingdom.MeasurementLogEntryKt
 import org.wfanet.measurement.internal.kingdom.copy
@@ -50,7 +51,8 @@ class CancelMeasurement(
 
     when (val state = measurement.state) {
       Measurement.State.PENDING_REQUISITION_PARAMS,
-      Measurement.State.PENDING_REQUISITION_FULFILLMENT,
+      Measurement.State.PENDING_REQUISITION_FULFILLMENT ->
+        withdrawRequisitions(measurementConsumerId, measurementId)
       Measurement.State.PENDING_PARTICIPANT_CONFIRMATION,
       Measurement.State.PENDING_COMPUTATION -> {}
       Measurement.State.SUCCEEDED,

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/writers/ConfirmComputationParticipant.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/writers/ConfirmComputationParticipant.kt
@@ -117,18 +117,16 @@ class ConfirmComputationParticipant(private val request: ConfirmComputationParti
     }
 
     val duchyIds: List<InternalId> =
-      getComputationParticipantsDuchyIds(
-          InternalId(measurementConsumerId),
-          InternalId(measurementId),
-        )
-        .filter { it.value != duchyId }
+      getComputationParticipantsDuchyIds(measurementConsumerId, measurementId).filter {
+        it.value != duchyId
+      }
 
     if (
       computationParticipantsInState(
         transactionContext,
         duchyIds,
-        InternalId(measurementConsumerId),
-        InternalId(measurementId),
+        measurementConsumerId,
+        measurementId,
         NEXT_COMPUTATION_PARTICIPANT_STATE,
       )
     ) {
@@ -139,8 +137,8 @@ class ConfirmComputationParticipant(private val request: ConfirmComputationParti
         }
 
       updateMeasurementState(
-        measurementConsumerId = InternalId(measurementConsumerId),
-        measurementId = InternalId(measurementId),
+        measurementConsumerId = measurementConsumerId,
+        measurementId = measurementId,
         nextState = Measurement.State.PENDING_COMPUTATION,
         previousState = measurementState,
         measurementLogEntryDetails = measurementLogEntryDetails,

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/writers/FailComputationParticipant.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/writers/FailComputationParticipant.kt
@@ -85,7 +85,8 @@ class FailComputationParticipant(private val request: FailComputationParticipant
 
     when (measurementState) {
       Measurement.State.PENDING_REQUISITION_PARAMS,
-      Measurement.State.PENDING_REQUISITION_FULFILLMENT,
+      Measurement.State.PENDING_REQUISITION_FULFILLMENT ->
+        withdrawRequisitions(measurementConsumerId, measurementId)
       Measurement.State.PENDING_PARTICIPANT_CONFIRMATION,
       Measurement.State.PENDING_COMPUTATION -> {}
       Measurement.State.FAILED,
@@ -142,8 +143,8 @@ class FailComputationParticipant(private val request: FailComputationParticipant
     }
 
     updateMeasurementState(
-      measurementConsumerId = InternalId(measurementConsumerId),
-      measurementId = InternalId(measurementId),
+      measurementConsumerId = measurementConsumerId,
+      measurementId = measurementId,
       nextState = Measurement.State.FAILED,
       previousState = measurementState,
       measurementLogEntryDetails = measurementLogEntryDetails,
@@ -151,8 +152,8 @@ class FailComputationParticipant(private val request: FailComputationParticipant
     )
 
     insertDuchyMeasurementLogEntry(
-      InternalId(measurementId),
-      InternalId(measurementConsumerId),
+      measurementId,
+      measurementConsumerId,
       InternalId(duchyId),
       duchyMeasurementLogEntry.details,
     )

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/writers/RefuseRequisition.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/writers/RefuseRequisition.kt
@@ -45,7 +45,8 @@ class RefuseRequisition(private val request: RefuseRequisitionRequest) :
   SpannerWriter<Requisition, Requisition>() {
   override suspend fun TransactionScope.runTransaction(): Requisition {
     val readResult: RequisitionReader.Result = readRequisition()
-    val (measurementConsumerId, measurementId, _, requisition, measurementDetails) = readResult
+    val (measurementConsumerId, measurementId, requisitionId, requisition, measurementDetails) =
+      readResult
 
     val state = requisition.state
     if (state != Requisition.State.UNFULFILLED) {
@@ -96,6 +97,8 @@ class RefuseRequisition(private val request: RefuseRequisitionRequest) :
       measurementLogEntryDetails = measurementLogEntryDetails,
       details = updatedMeasurementDetails,
     )
+
+    withdrawRequisitions(measurementConsumerId, measurementId, requisitionId)
 
     return requisition.copy {
       this.state = Requisition.State.REFUSED

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/writers/RevokeCertificate.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/writers/RevokeCertificate.kt
@@ -252,5 +252,7 @@ class RevokeCertificate(private val request: RevokeCertificateRequest) :
       measurementLogEntryDetails = measurementLogEntryDetails,
       details = details,
     )
+
+    withdrawRequisitions(measurementConsumerId, measurementId)
   }
 }

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/writers/SetParticipantRequisitionParams.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/writers/SetParticipantRequisitionParams.kt
@@ -113,8 +113,8 @@ class SetParticipantRequisitionParams(private val request: SetParticipantRequisi
       )
     }
 
-    val measurementId = InternalId(computationParticipantResult.measurementId)
-    val measurementConsumerId = InternalId(computationParticipantResult.measurementConsumerId)
+    val measurementId = computationParticipantResult.measurementId
+    val measurementConsumerId = computationParticipantResult.measurementConsumerId
 
     if (computationParticipant.state != ComputationParticipant.State.CREATED) {
       throw ComputationParticipantStateIllegalException(

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/service/api/v2alpha/ProtoConversions.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/service/api/v2alpha/ProtoConversions.kt
@@ -1252,6 +1252,7 @@ fun InternalRequisition.State.toRequisitionState(): Requisition.State =
     InternalRequisition.State.UNFULFILLED -> Requisition.State.UNFULFILLED
     InternalRequisition.State.FULFILLED -> Requisition.State.FULFILLED
     InternalRequisition.State.REFUSED -> Requisition.State.REFUSED
+    InternalRequisition.State.WITHDRAWN -> Requisition.State.WITHDRAWN
     InternalRequisition.State.STATE_UNSPECIFIED,
     InternalRequisition.State.UNRECOGNIZED -> Requisition.State.STATE_UNSPECIFIED
   }

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/service/api/v2alpha/RequisitionsService.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/service/api/v2alpha/RequisitionsService.kt
@@ -409,6 +409,7 @@ private fun State.toInternal(): InternalState =
     State.UNFULFILLED -> InternalState.UNFULFILLED
     State.FULFILLED -> InternalState.FULFILLED
     State.REFUSED -> InternalState.REFUSED
+    State.WITHDRAWN -> InternalState.WITHDRAWN
     State.STATE_UNSPECIFIED,
     State.UNRECOGNIZED -> InternalState.STATE_UNSPECIFIED
   }
@@ -527,6 +528,7 @@ private fun buildInternalStreamRequisitionsRequest(
           states += InternalState.UNFULFILLED
           states += InternalState.FULFILLED
           states += InternalState.REFUSED
+          states += InternalState.WITHDRAWN
         } else {
           states += requestStates.map { it.toInternal() }
         }

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/service/internal/testing/MeasurementsServiceTest.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/service/internal/testing/MeasurementsServiceTest.kt
@@ -43,10 +43,12 @@ import org.wfanet.measurement.internal.kingdom.CancelMeasurementRequest
 import org.wfanet.measurement.internal.kingdom.Certificate
 import org.wfanet.measurement.internal.kingdom.CertificatesGrpcKt
 import org.wfanet.measurement.internal.kingdom.ComputationParticipant
+import org.wfanet.measurement.internal.kingdom.DataProvider
 import org.wfanet.measurement.internal.kingdom.DataProvidersGrpcKt.DataProvidersCoroutineImplBase
 import org.wfanet.measurement.internal.kingdom.DeleteMeasurementRequest
 import org.wfanet.measurement.internal.kingdom.DuchyProtocolConfig
 import org.wfanet.measurement.internal.kingdom.Measurement
+import org.wfanet.measurement.internal.kingdom.MeasurementConsumer
 import org.wfanet.measurement.internal.kingdom.MeasurementConsumersGrpcKt.MeasurementConsumersCoroutineImplBase
 import org.wfanet.measurement.internal.kingdom.MeasurementKt
 import org.wfanet.measurement.internal.kingdom.MeasurementKt.resultInfo
@@ -1184,6 +1186,46 @@ abstract class MeasurementsServiceTest<T : MeasurementsCoroutineImplBase> {
   }
 
   @Test
+  fun `cancelMeasurement transitions Requisition state`(): Unit = runBlocking {
+    val measurementConsumer =
+      population.createMeasurementConsumer(measurementConsumersService, accountsService)
+    val dataProviders = (1..2).map { population.createDataProvider(dataProvidersService) }
+    val measurement =
+      population.createLlv2Measurement(
+        measurementsService,
+        measurementConsumer,
+        PROVIDED_MEASUREMENT_ID,
+        *dataProviders.toTypedArray(),
+      )
+
+    measurementsService.cancelMeasurement(
+      cancelMeasurementRequest {
+        externalMeasurementConsumerId = measurement.externalMeasurementConsumerId
+        externalMeasurementId = measurement.externalMeasurementId
+      }
+    )
+
+    val requisitions: List<Requisition> =
+      requisitionsService
+        .streamRequisitions(
+          streamRequisitionsRequest {
+            filter =
+              StreamRequisitionsRequestKt.filter {
+                externalMeasurementConsumerId = measurement.externalMeasurementConsumerId
+                externalMeasurementId = measurement.externalMeasurementId
+              }
+          }
+        )
+        .toList()
+    assertThat(requisitions)
+      .comparingExpectedFieldsOnly()
+      .containsExactly(
+        requisition { state = Requisition.State.WITHDRAWN },
+        requisition { state = Requisition.State.WITHDRAWN },
+      )
+  }
+
+  @Test
   fun `cancelMeasurement throws FAILED_PRECONDITION when Measurement in illegal state`() =
     runBlocking {
       val measurementConsumer =
@@ -1829,6 +1871,55 @@ abstract class MeasurementsServiceTest<T : MeasurementsCoroutineImplBase> {
     assertThat(cancelledMeasurements)
       .containsExactly(cancelledMeasurement1, cancelledMeasurement2)
       .inOrder()
+  }
+
+  @Test
+  fun `batchCancelMeasurements withdraws Requisitions`(): Unit = runBlocking {
+    val measurementCount = 2
+    val dataProviderCount = 2
+    val requisitionCount = dataProviderCount * measurementCount
+    val measurementConsumer: MeasurementConsumer =
+      population.createMeasurementConsumer(measurementConsumersService, accountsService)
+    val dataProviders: List<DataProvider> =
+      (1..dataProviderCount).map { population.createDataProvider(dataProvidersService) }
+    val measurements: List<Measurement> =
+      (1..measurementCount).map {
+        population.createLlv2Measurement(
+          measurementsService,
+          measurementConsumer,
+          "measurement-$it",
+          *dataProviders.toTypedArray(),
+        )
+      }
+
+    measurementsService.batchCancelMeasurements(
+      batchCancelMeasurementsRequest {
+        requests +=
+          measurements.map {
+            cancelMeasurementRequest {
+              externalMeasurementConsumerId = it.externalMeasurementConsumerId
+              externalMeasurementId = it.externalMeasurementId
+            }
+          }
+      }
+    )
+
+    val requisitions =
+      requisitionsService
+        .streamRequisitions(
+          streamRequisitionsRequest {
+            filter =
+              StreamRequisitionsRequestKt.filter {
+                externalMeasurementConsumerId = measurementConsumer.externalMeasurementConsumerId
+              }
+          }
+        )
+        .toList()
+    assertThat(requisitions)
+      .comparingExpectedFieldsOnly()
+      .containsExactlyElementsIn(
+        (1..requisitionCount).map { requisition { state = Requisition.State.WITHDRAWN } }
+      )
   }
 
   @Test

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/service/internal/testing/RequisitionsServiceTest.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/service/internal/testing/RequisitionsServiceTest.kt
@@ -1236,7 +1236,7 @@ abstract class RequisitionsServiceTest<T : RequisitionsCoroutineService> {
         }
       )
     }
-    val requisition =
+    val requisitions =
       service
         .streamRequisitions(
           streamRequisitionsRequest {
@@ -1246,9 +1246,10 @@ abstract class RequisitionsServiceTest<T : RequisitionsCoroutineService> {
             }
           }
         )
-        .first()
+        .toList()
+    val requisition: Requisition = requisitions.first()
 
-    val response =
+    val response: Requisition =
       service.refuseRequisition(
         refuseRequisitionRequest {
           externalDataProviderId = requisition.externalDataProviderId
@@ -1270,6 +1271,18 @@ abstract class RequisitionsServiceTest<T : RequisitionsCoroutineService> {
           }
         )
       )
+    val otherRequisition: Requisition = requisitions[1]
+    assertThat(
+        service
+          .getRequisition(
+            getRequisitionRequest {
+              externalDataProviderId = otherRequisition.externalDataProviderId
+              externalRequisitionId = otherRequisition.externalRequisitionId
+            }
+          )
+          .state
+      )
+      .isEqualTo(Requisition.State.WITHDRAWN)
     val updatedMeasurement =
       dataServices.measurementsService.getMeasurement(
         getMeasurementRequest {

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/service/system/v1alpha/ProtoConversions.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/service/system/v1alpha/ProtoConversions.kt
@@ -81,6 +81,7 @@ fun InternalRequisition.State.toSystemRequisitionState(): Requisition.State {
     InternalRequisition.State.UNFULFILLED -> Requisition.State.UNFULFILLED
     InternalRequisition.State.FULFILLED -> Requisition.State.FULFILLED
     InternalRequisition.State.REFUSED -> Requisition.State.REFUSED
+    InternalRequisition.State.WITHDRAWN -> Requisition.State.WITHDRAWN
     InternalRequisition.State.STATE_UNSPECIFIED,
     InternalRequisition.State.UNRECOGNIZED -> error("Invalid requisition state.")
   }

--- a/src/main/proto/wfa/measurement/internal/kingdom/measurement.proto
+++ b/src/main/proto/wfa/measurement/internal/kingdom/measurement.proto
@@ -183,6 +183,7 @@ message Requisition {
     UNFULFILLED = 2;
     FULFILLED = 3;
     REFUSED = 4;
+    WITHDRAWN = 5;
   }
   State state = 7;
 

--- a/src/main/proto/wfa/measurement/system/v1alpha/requisition.proto
+++ b/src/main/proto/wfa/measurement/system/v1alpha/requisition.proto
@@ -60,6 +60,8 @@ message Requisition {
     //
     // The parent `Computation` will be in the `FAILED` state.
     REFUSED = 3;
+    // The `Requisition` has been withdrawn. Terminal state.
+    WITHDRAWN = 4;
   }
   // The state of this `Requisition`.
   State state = 4 [(google.api.field_behavior) = OUTPUT_ONLY];

--- a/src/test/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/SpannerCertificatesServiceTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/SpannerCertificatesServiceTest.kt
@@ -41,6 +41,7 @@ class SpannerCertificatesServiceTest : CertificatesServiceTest<SpannerCertificat
       spannerServices.modelProvidersService,
       spannerServices.computationParticipantsService,
       spannerServices.accountsService,
+      spannerServices.requisitionsService,
     )
   }
 }

--- a/src/test/kotlin/org/wfanet/measurement/kingdom/service/api/v2alpha/RequisitionsServiceTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/kingdom/service/api/v2alpha/RequisitionsServiceTest.kt
@@ -168,6 +168,7 @@ private val VISIBLE_REQUISITION_STATES: Set<InternalRequisition.State> =
     InternalRequisition.State.UNFULFILLED,
     InternalRequisition.State.FULFILLED,
     InternalRequisition.State.REFUSED,
+    InternalRequisition.State.WITHDRAWN,
   )
 
 @RunWith(JUnit4::class)


### PR DESCRIPTION
This sets the Requisition state to WITHDRAWN when a Measurement is cancelled or failed.