### PR TITLE
docs: Update the release update guide

### DIFF
--- a/docs/operations/updating-release.md
+++ b/docs/operations/updating-release.md
@@ -2,14 +2,12 @@
 
 How to update Halo components to a new release version.
 
-This guide assumes that you maintain all of your Kubernetes object configuration
-files, for example in a Kustomization directory as described in the deployment
-guides.
+## Assumptions
 
-## From a revision after the first release
+You maintain your Kubernetes object configurations, such as the Kustomization
+directory. Keeping these under version control is recommended.
 
-This is the process for updating from a known release version or a revision
-between two known release versions.
+## Process
 
 1.  Read the release notes
 
@@ -25,39 +23,25 @@ between two known release versions.
 2.  Update Kubernetes object configuration files
 
     *   Make any changes indicated in the release notes.
-    *   Update image names for each
+    *   Update `image` field for each
         [`Container`](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#Container)
         in each `PodSpec`.
 
         Pre-built images are published for each release on
         [GitHub Packages](https://github.com/orgs/world-federation-of-advertisers/packages?repo_name=cross-media-measurement).
         Use the release version as the image tag. For example,
-        `ghcr.io/world-federation-of-advertisers/kingdom/v2alpha-public-api:0.3.0`
+        `ghcr.io/world-federation-of-advertisers/kingdom/v2alpha-public-api:0.5.7`
         is the published v2alpha Kingdom public API server image for the
-        [0.3.0 release](https://github.com/world-federation-of-advertisers/cross-media-measurement/releases/tag/v0.3.0).
+        [0.5.7 release](https://github.com/world-federation-of-advertisers/cross-media-measurement/releases/tag/v0.5.7).
 
-3.  Diff the Kubernetes object configuration changes
+3.  Diff the Kubernetes object configuration changes (recommended)
 
     Assuming you have `kubectl` configured to point to your cluster, you can use
     `kubectl diff`. Verify that diff is what you expect.
 
-    Note: You may want to pass `--prune --prune-allowlist=apps/v1/Deployment
-    --selector='app.kubernetes.io/part-of=halo-cmms'` to `kubectl` commands to
-    ensure that old/renamed Deployment resources are pruned.
-
 4.  Apply the new Kubernetes object configuration
 
-    Run `kubectl apply`.
-
-## From a revision before the first release
-
-For revisions prior to the first release
-([0.1.0](https://github.com/world-federation-of-advertisers/cross-media-measurement/releases/tag/v0.1.0)),
-the starting state is basically unknown as are no release notes to determine
-what actions need to be taken. Therefore, the recommended process is to generate
-new configurations and manually edit them with any customizations.
-
-Follow the deployment guide in the [docs](../) folder for the desired component.
-If your existing infrastructure is not managed using Terraform, you can use the
-[`import`](https://developer.hashicorp.com/terraform/cli/import) subcommand of
-the Terraform CLI to import your existing resources.
+    Run `kubectl apply`. You may want to pass the `--prune` option to ensure
+    that object deletions or renames are applied properly. The safest way to do
+    this is using an ApplySet. See
+    https://kubernetes.io/blog/2023/05/09/introducing-kubectl-applyset-pruning/.


### PR DESCRIPTION
* Drop mention of updating from pre-0.1.0.
* Explicitly recommend keeping Kubernetes object configurations under version control.
* Use latest version in example.
* Clarify usage of `--prune` option for kubectl.