### PR TITLE
fix!: Ensure default network policies are created

### DIFF
--- a/docs/eks/duchy-deployment.md
+++ b/docs/eks/duchy-deployment.md
@@ -52,7 +52,8 @@ For a Duchy named `worker2`, the cluster will be populated with the following:
 -   CronJob
     -   `worker2-computations-cleaner-cronjob`
 -   NetworkPolicy
-    -   `default-deny-ingress-and-egress`
+    -   `default-deny-network-policy`
+    -   `kube-dns-network-policy`
     -   `worker2-async-computation-controls-server-network-policy`
     -   `worker2-computation-control-server-network-policy`
     -   `worker2-computations-cleaner-network-policy`

--- a/docs/eks/metrics-deployment.md
+++ b/docs/eks/metrics-deployment.md
@@ -27,6 +27,7 @@ use whichever you prefer.
     *   `open-telemetry-java-agent`
 *   NetworkPolicy
     *   `opentelemetry-collector-network-policy`
+    *   `to-opentelemetry-collector-network-policy`
 
 ## Before you start
 

--- a/docs/gke/duchy-deployment.md
+++ b/docs/gke/duchy-deployment.md
@@ -54,7 +54,9 @@ For a Duchy named `worker1`, the cluster will be populated with the following:
 -   CronJob
     -   `worker1-computations-cleaner-cronjob`
 -   NetworkPolicy
-    -   `default-deny-ingress-and-egress`
+    -   `default-deny-network-policy`
+    -   `kube-dns-network-policy`
+    -   `gke-network-policy`
     -   `worker1-async-computation-controls-server-network-policy`
     -   `worker1-computation-control-server-network-policy`
     -   `worker1-computations-cleaner-network-policy`

--- a/docs/gke/kingdom-deployment.md
+++ b/docs/gke/kingdom-deployment.md
@@ -48,7 +48,9 @@ The cluster will be populated with the following:
     -   `pending-measurements-cancellation-cronjob`
     -   `exchanges-deletion-cronjob`
 -   NetworkPolicy
-    -   `default-deny-ingress-and-egress`
+    -   `default-deny-network-policy`
+    -   `kube-dns-network-policy`
+    -   `gke-network-policy`
     -   `internal-data-server-network-policy`
     -   `system-api-server-network-policy`
     -   `public-api-server-network-policy`

--- a/docs/gke/metrics-deployment.md
+++ b/docs/gke/metrics-deployment.md
@@ -23,6 +23,7 @@ free to use whichever you prefer.
     *   `open-telemetry-java-agent`
 *   NetworkPolicy
     *   `opentelemetry-collector-network-policy`
+    *   `to-opentelemetry-collector-network-policy`
 
 ## Before you start
 

--- a/src/main/k8s/base.cue
+++ b/src/main/k8s/base.cue
@@ -710,19 +710,6 @@ objects: [ for objectSet in objectSets for object in objectSet {object}]
 				}]
 			}
 		}
-		dns: {
-			to: [{
-				namespaceSelector: {} // Allow DNS only inside the cluster
-				podSelector: matchLabels: "k8s-app": "kube-dns"
-			}]
-			ports: [{
-				protocol: "UDP"
-				port:     53
-			}, {
-				protocol: "TCP"
-				port:     53
-			}]
-		}
 	}
 
 	apiVersion: "networking.k8s.io/v1"
@@ -738,27 +725,45 @@ objects: [ for objectSet in objectSets for object in objectSet {object}]
 				}
 			}
 		}
-		policyTypes: ["Ingress", "Egress"]
+		policyTypes?: ["Ingress"] | ["Egress"] | ["Ingress", "Egress"]
 		ingress: [ for _, ingress in _ingresses {ingress}]
 		egress: [ for _, egress in _egresses {egress}]
 	}
 }
 
-// This policy will deny ingress and egress traffic at all unconfigured pods.
-default_deny_ingress_and_egress: [{
-	apiVersion: "networking.k8s.io/v1"
-	kind:       "NetworkPolicy"
-	metadata: {
-		name: "default-deny-ingress-and-egress"
-		labels: {
-			"app.kubernetes.io/part-of": #AppName
+defaultNetworkPolicies: [Name=string]: #NetworkPolicy & {
+	_name: Name
+}
+defaultNetworkPolicies: {
+	// This policy will deny ingress and egress traffic at all unconfigured pods.
+	"default-deny": {
+		spec: {
+			podSelector: {}
+			policyTypes: ["Ingress", "Egress"]
 		}
 	}
-	spec: {
-		podSelector: {}
-		policyTypes: ["Ingress", "Egress"]
+	"kube-dns": {
+		_egresses: {
+			dns: {
+				to: [{
+					namespaceSelector: {} // Allow DNS only inside the cluster
+					podSelector: matchLabels: "k8s-app": "kube-dns"
+				}]
+				ports: [{
+					protocol: "UDP"
+					port:     53
+				}, {
+					protocol: "TCP"
+					port:     53
+				}]
+			}
+		}
+		spec: {
+			podSelector: {}
+			policyTypes: ["Egress"]
+		}
 	}
-}]
+}
 
 // A simple fanout Ingress base definition
 #Ingress: {

--- a/src/main/k8s/dev/base_gke.cue
+++ b/src/main/k8s/dev/base_gke.cue
@@ -14,42 +14,37 @@
 
 package k8s
 
-#NetworkPolicy: {
-	_egresses: {
-		// See https://cloud.google.com/kubernetes-engine/docs/how-to/network-policy#network-policy-and-workload-identity
-		gkeMetadataServer: {
-			to: [{ipBlock: cidr: "169.254.169.252/32"}]
-			ports: [{
-				protocol: "TCP"
-				port:     988
-			}]
-		}
-		gkeDataplaneV2: {
-			to: [{ipBlock: cidr: "169.254.169.254/32"}]
-			ports: [{
-				protocol: "TCP"
-				port:     80
-			}]
+defaultNetworkPolicies: {
+	"gke": {
+		_egresses: {
+			// See https://cloud.google.com/kubernetes-engine/docs/how-to/network-policy#network-policy-and-workload-identity
+			gkeMetadataServer: {
+				to: [{ipBlock: cidr: "169.254.169.252/32"}]
+				ports: [{
+					protocol: "TCP"
+					port:     988
+				}]
+			}
+			gkeDataplaneV2: {
+				to: [{ipBlock: cidr: "169.254.169.254/32"}]
+				ports: [{
+					protocol: "TCP"
+					port:     80
+				}]
+			}
 		}
 
-		openTelemetryCollector: {
-			to: [{podSelector: matchLabels: app: "opentelemetry-collector-app"}]
-			ports: [{
-				port: #OpenTelemetryReceiverPort
-			}]
-		}
-	}
-
-	_ingresses: {
-		gmpManagedCollector: {
-			from: [{
-				namespaceSelector: matchLabels: "kubernetes.io/metadata.name": "gmp-system"
-				podSelector: matchLabels: app:                                 "managed-prometheus-collector"
-			}]
-			ports: [{
-				protocol: "TCP"
-				port:     #OpenTelemetryPrometheusExporterPort
-			}]
+		_ingresses: {
+			gmpManagedCollector: {
+				from: [{
+					namespaceSelector: matchLabels: "kubernetes.io/metadata.name": "gmp-system"
+					podSelector: matchLabels: app:                                 "managed-prometheus-collector"
+				}]
+				ports: [{
+					protocol: "TCP"
+					port:     #OpenTelemetryPrometheusExporterPort
+				}]
+			}
 		}
 	}
 }

--- a/src/main/k8s/dev/duchy_eks.cue
+++ b/src/main/k8s/dev/duchy_eks.cue
@@ -89,7 +89,7 @@ _duchyCertName: "duchies/\(_duchyName)/certificates/\(_certificateId)"
 }
 #ControlServiceMaxHeapSize: "320M"
 
-objectSets: [default_deny_ingress_and_egress] + [ for objectSet in duchy {objectSet}]
+objectSets: [defaultNetworkPolicies] + [ for objectSet in duchy {objectSet}]
 
 duchy: #PostgresDuchy & {
 	_imageSuffixes: {

--- a/src/main/k8s/dev/duchy_gke.cue
+++ b/src/main/k8s/dev/duchy_gke.cue
@@ -90,7 +90,7 @@ _duchy_cert_name: "duchies/\(_duchy_name)/certificates/\(_certificateId)"
 }
 #ControlServiceMaxHeapSize: "320M"
 
-objectSets: [default_deny_ingress_and_egress] + [ for objectSet in duchy {objectSet}]
+objectSets: [defaultNetworkPolicies] + [ for objectSet in duchy {objectSet}]
 
 _cloudStorageConfig: #CloudStorageConfig & {
 	bucket: _cloudStorageBucket

--- a/src/main/k8s/dev/kingdom_gke.cue
+++ b/src/main/k8s/dev/kingdom_gke.cue
@@ -40,7 +40,7 @@ _systemApiAddressName: string @tag("system_api_address_name")
 	}
 }
 
-objectSets: [default_deny_ingress_and_egress] + [ for objectSet in kingdom {objectSet}]
+objectSets: [defaultNetworkPolicies] + [ for objectSet in kingdom {objectSet}]
 
 kingdom: #Kingdom & {
 	_kingdom_secret_name: _secret_name

--- a/src/main/k8s/dev/open_telemetry_eks.cue
+++ b/src/main/k8s/dev/open_telemetry_eks.cue
@@ -14,11 +14,7 @@
 
 package k8s
 
-objectSets: [
-	openTelemetry.collectors,
-	openTelemetry.instrumentations,
-	openTelemetry.networkPolicies,
-]
+objectSets: [ for objectSet in openTelemetry {objectSet}]
 
 #OpenTelemetryCollector: {
 	spec: resources: requests: memory: "48Mi"

--- a/src/main/k8s/dev/open_telemetry_gke.cue
+++ b/src/main/k8s/dev/open_telemetry_gke.cue
@@ -17,22 +17,7 @@ package k8s
 // Name of K8s service account for OpenTelemetry collector.
 #CollectorServiceAccount: "open-telemetry"
 
-objectSets: [
-	collectors,
-	openTelemetry.instrumentations,
-	networkPolicies,
-	serviceAccounts,
-]
-
-serviceAccounts: [Name=string]: #ServiceAccount & {
-	metadata: name: Name
-}
-
-serviceAccounts: {
-	"\(#CollectorServiceAccount)": #WorkloadIdentityServiceAccount & {
-		_iamServiceAccountName: "open-telemetry"
-	}
-}
+objectSets: [ for objectSet in openTelemetry {objectSet}]
 
 #OpenTelemetryCollector: {
 	spec: {
@@ -42,6 +27,79 @@ serviceAccounts: {
 }
 
 openTelemetry: #OpenTelemetry & {
+	collectors: {
+		"default": {
+			spec: {
+				serviceAccount: #CollectorServiceAccount
+				config: {
+					processors: {
+						filter: {
+							spans: {
+								exclude: {
+									match_type: "strict"
+									attributes: [{
+										key:   "rpc.method"
+										value: "Check"
+									}]
+								}
+							}
+						}
+						resourcedetection: {
+							detectors: ["gcp"]
+							timeout: "10s"
+						}
+						transform: {
+							// "location", "cluster", "namespace", "job", "instance", and
+							// "project_id" are reserved, and metrics containing these labels
+							// will be rejected.  Prefix them with exported_ to prevent this.
+							metric_statements: [{
+								context: "datapoint"
+								statements: [
+									"set(attributes[\"exported_location\"], attributes[\"location\"])",
+									"delete_key(attributes, \"location\")",
+									"set(attributes[\"exported_cluster\"], attributes[\"cluster\"])",
+									"delete_key(attributes, \"cluster\")",
+									"set(attributes[\"exported_namespace\"], attributes[\"namespace\"])",
+									"delete_key(attributes, \"namespace\")",
+									"set(attributes[\"exported_job\"], attributes[\"job\"])",
+									"delete_key(attributes, \"job\")",
+									"set(attributes[\"exported_instance\"], attributes[\"instance\"])",
+									"delete_key(attributes, \"instance\")",
+									"set(attributes[\"exported_project_id\"], attributes[\"project_id\"])",
+									"delete_key(attributes, \"project_id\")",
+								]
+							}]
+						}
+					}
+
+					exporters: {
+						googlecloud: {}
+					}
+
+					service: {
+						pipelines: {
+							metrics: {
+								receivers: ["otlp"]
+								processors: [
+									"batch",
+									"memory_limiter",
+									"resourcedetection",
+									"transform",
+								]
+								exporters: ["googlecloud"]
+							}
+							traces: {
+								receivers: ["otlp"]
+								processors: ["batch", "memory_limiter", "filter"]
+								exporters: ["googlecloud"]
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+
 	instrumentations: "java-instrumentation": {
 		spec: {
 			_envVars: {
@@ -50,93 +108,19 @@ openTelemetry: #OpenTelemetry & {
 			}
 		}
 	}
-}
 
-collectors: openTelemetry.collectors & {
-	"default": {
-		spec: {
-			serviceAccount: #CollectorServiceAccount
-			config: {
-				processors: {
-					filter: {
-						spans: {
-							exclude: {
-								match_type: "strict"
-								attributes: [{
-									key:   "rpc.method"
-									value: "Check"
-								}]
-							}
-						}
-					}
-					resourcedetection: {
-						detectors: ["gcp"]
-						timeout: "10s"
-					}
-					transform: {
-						// "location", "cluster", "namespace", "job", "instance", and
-						// "project_id" are reserved, and metrics containing these labels
-						// will be rejected.  Prefix them with exported_ to prevent this.
-						metric_statements: [{
-							context: "datapoint"
-							statements: [
-								"set(attributes[\"exported_location\"], attributes[\"location\"])",
-								"delete_key(attributes, \"location\")",
-								"set(attributes[\"exported_cluster\"], attributes[\"cluster\"])",
-								"delete_key(attributes, \"cluster\")",
-								"set(attributes[\"exported_namespace\"], attributes[\"namespace\"])",
-								"delete_key(attributes, \"namespace\")",
-								"set(attributes[\"exported_job\"], attributes[\"job\"])",
-								"delete_key(attributes, \"job\")",
-								"set(attributes[\"exported_instance\"], attributes[\"instance\"])",
-								"delete_key(attributes, \"instance\")",
-								"set(attributes[\"exported_project_id\"], attributes[\"project_id\"])",
-								"delete_key(attributes, \"project_id\")",
-							]
-						}]
-					}
-				}
-
-				exporters: {
-					googlecloud: {}
-				}
-
-				service: {
-					pipelines: {
-						metrics: {
-							receivers: ["otlp"]
-							processors: [
-								"batch",
-								"memory_limiter",
-								"resourcedetection",
-								"transform",
-							]
-							exporters: ["googlecloud"]
-						}
-						traces: {
-							receivers: ["otlp"]
-							processors: ["batch", "memory_limiter", "filter"]
-							exporters: ["googlecloud"]
-						}
-					}
-				}
+	networkPolicies: {
+		"opentelemetry-collector": {
+			_egresses: {
+				// Need to call Google Cloud Monitoring.
+				any: {}
 			}
 		}
 	}
-}
 
-networkPolicies: [Name=_]: #NetworkPolicy & {
-	_policyPodSelectorMatchLabels: "app.kubernetes.io/component": "opentelemetry-collector"
-	_name: Name
-}
-
-networkPolicies: {
-	"opentelemetry-collector": {
-		_ingresses: {
-			any: {}
-		}
-		_egresses: {
-			any: {}
+	serviceAccounts: {
+		"\(#CollectorServiceAccount)": #WorkloadIdentityServiceAccount & {
+			_iamServiceAccountName: "open-telemetry"
 		}
 	}
 }

--- a/src/main/k8s/dev/reporting_gke.cue
+++ b/src/main/k8s/dev/reporting_gke.cue
@@ -41,7 +41,7 @@ _publicApiAddressName:        string @tag("public_api_address_name")
 }
 
 objectSets: [
-	default_deny_ingress_and_egress,
+	defaultNetworkPolicies,
 	reporting.serviceAccounts,
 	reporting.configMaps,
 	reporting.deployments,

--- a/src/main/k8s/dev/reporting_v2_gke.cue
+++ b/src/main/k8s/dev/reporting_v2_gke.cue
@@ -41,7 +41,7 @@ _publicApiAddressName:        string @tag("public_api_address_name")
 }
 
 objectSets: [
-	default_deny_ingress_and_egress,
+	defaultNetworkPolicies,
 	reporting.serviceAccounts,
 	reporting.configMaps,
 	reporting.deployments,

--- a/src/main/k8s/open_telemetry.cue
+++ b/src/main/k8s/open_telemetry.cue
@@ -58,7 +58,6 @@ package k8s
 	collectors: [Name=string]: #OpenTelemetryCollector & {
 		metadata: name: Name
 	}
-
 	collectors: {
 		"default": {
 			spec: {
@@ -142,15 +141,45 @@ package k8s
 	}
 
 	networkPolicies: [Name=_]: #NetworkPolicy & {
-		_policyPodSelectorMatchLabels: "app.kubernetes.io/component": "opentelemetry-collector"
 		_name: Name
 	}
-
 	networkPolicies: {
-		"opentelemetry-collector": {
-			_ingresses: {
-				any: {}
+		"to-opentelemetry-collector": {
+			_egresses: {
+				collector: {
+					to: [{
+						podSelector: {
+							matchLabels: {
+								"app.kubernetes.io/component": "opentelemetry-collector"
+							}
+						}
+					}]
+				}
+			}
+			spec: {
+				podSelector: {}
+				policyTypes: ["Egress"]
 			}
 		}
+		"opentelemetry-collector": {
+			_ingresses: {
+				allPods: {
+					from: [{
+						podSelector: {}
+					}]
+				}
+			}
+			spec: {
+				podSelector: {
+					matchLabels: {
+						"app.kubernetes.io/component": "opentelemetry-collector"
+					}
+				}
+			}
+		}
+	}
+
+	serviceAccounts: [Name=string]: #ServiceAccount & {
+		metadata: name: Name
 	}
 }


### PR DESCRIPTION
The previous behavior was to add some default ingresses and egresses to every NetworkPolicy other than default-deny. The flaw with this behavior is that if no NetworkPolicy matches the pod, the pod will not have these default ingresses and egresses. This instead creates separate NetworkPolicy objects for defaults.

This also fixes an issue where the opentelemetry-collector NetworkPolicy was missing its pod selector and was therefore applying to all pods.