### PR TITLE
chore: Update EKS clusters to 1.29 in Terraform configs

### DIFF
--- a/src/main/terraform/aws/cmms/duchies.tf
+++ b/src/main/terraform/aws/cmms/duchies.tf
@@ -22,7 +22,7 @@ module "clusters" {
 
   aws_region               = var.aws_region
   cluster_name             = "${each.key}-duchy"
-  cluster_version          = "1.28"
+  cluster_version          = "1.29"
   kms_key_administrators   = ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"]
   control_plane_subnet_ids = module.vpc.intra_subnets
   subnet_ids               = module.vpc.private_subnets

--- a/src/main/terraform/aws/examples/duchy/main.tf
+++ b/src/main/terraform/aws/examples/duchy/main.tf
@@ -79,7 +79,7 @@ module "cluster" {
 
   aws_region               = var.aws_region
   cluster_name             = var.duchy_name
-  cluster_version          = "1.28"
+  cluster_version          = "1.29"
   kms_key_administrators   = ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"]
   control_plane_subnet_ids = module.vpc.intra_subnets
   subnet_ids               = module.vpc.private_subnets


### PR DESCRIPTION
The current 1.28 version will reach end of standard support on November 26, 2024. The latest available version is 1.30, but cluster version upgrades must be done one minor version at a time.

Unlike GKE, EKS does not appear to have support for automatic upgrades.