### PR TITLE
refactor: Extract Details message type definitions in Kingdom internal API

### DIFF
--- a/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/SpannerMeasurementLogEntriesService.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/SpannerMeasurementLogEntriesService.kt
@@ -24,7 +24,7 @@ import org.wfanet.measurement.gcloud.spanner.AsyncDatabaseClient
 import org.wfanet.measurement.internal.kingdom.CreateDuchyMeasurementLogEntryRequest
 import org.wfanet.measurement.internal.kingdom.DuchyMeasurementLogEntry
 import org.wfanet.measurement.internal.kingdom.MeasurementLogEntriesGrpcKt.MeasurementLogEntriesCoroutineImplBase
-import org.wfanet.measurement.internal.kingdom.MeasurementLogEntry.ErrorDetails.Type.TRANSIENT
+import org.wfanet.measurement.internal.kingdom.MeasurementLogEntryError
 import org.wfanet.measurement.internal.kingdom.StateTransitionMeasurementLogEntry
 import org.wfanet.measurement.internal.kingdom.StreamStateTransitionMeasurementLogEntriesRequest
 import org.wfanet.measurement.kingdom.deploy.gcloud.spanner.common.DuchyNotFoundException
@@ -43,7 +43,9 @@ class SpannerMeasurementLogEntriesService(
   ): DuchyMeasurementLogEntry {
 
     if (request.measurementLogEntryDetails.hasError()) {
-      grpcRequire(request.measurementLogEntryDetails.error.type == TRANSIENT) {
+      grpcRequire(
+        request.measurementLogEntryDetails.error.type == MeasurementLogEntryError.Type.TRANSIENT
+      ) {
         "MeasurementLogEntries Service only supports TRANSIENT errors, " +
           "use FailComputationParticipant instead."
       }

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/SpannerRequisitionsService.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/SpannerRequisitionsService.kt
@@ -25,7 +25,7 @@ import org.wfanet.measurement.internal.kingdom.FulfillRequisitionRequest
 import org.wfanet.measurement.internal.kingdom.GetRequisitionRequest
 import org.wfanet.measurement.internal.kingdom.RefuseRequisitionRequest
 import org.wfanet.measurement.internal.kingdom.Requisition
-import org.wfanet.measurement.internal.kingdom.Requisition.Refusal
+import org.wfanet.measurement.internal.kingdom.RequisitionRefusal
 import org.wfanet.measurement.internal.kingdom.RequisitionsGrpcKt.RequisitionsCoroutineImplBase
 import org.wfanet.measurement.internal.kingdom.StreamRequisitionsRequest
 import org.wfanet.measurement.kingdom.deploy.gcloud.spanner.common.DuchyNotFoundException
@@ -117,10 +117,12 @@ class SpannerRequisitionsService(
     with(request) {
       grpcRequire(externalDataProviderId != 0L) { "external_data_provider_id not specified" }
       grpcRequire(externalRequisitionId != 0L) { "external_requisition_id not specified" }
-      grpcRequire(refusal.justification != Refusal.Justification.UNRECOGNIZED) {
+      grpcRequire(refusal.justification != RequisitionRefusal.Justification.UNRECOGNIZED) {
         "Unrecognized refusal justification ${refusal.justificationValue}"
       }
-      grpcRequire(refusal.justification != Refusal.Justification.JUSTIFICATION_UNSPECIFIED) {
+      grpcRequire(
+        refusal.justification != RequisitionRefusal.Justification.JUSTIFICATION_UNSPECIFIED
+      ) {
         "refusal justification not specified"
       }
     }

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/readers/CertificateReader.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/readers/CertificateReader.kt
@@ -24,9 +24,9 @@ import org.wfanet.measurement.gcloud.spanner.appendClause
 import org.wfanet.measurement.gcloud.spanner.bind
 import org.wfanet.measurement.gcloud.spanner.getBytesAsByteString
 import org.wfanet.measurement.gcloud.spanner.getInternalId
-import org.wfanet.measurement.gcloud.spanner.getProtoEnum
 import org.wfanet.measurement.gcloud.spanner.getProtoMessage
 import org.wfanet.measurement.internal.kingdom.Certificate
+import org.wfanet.measurement.internal.kingdom.CertificateDetails
 import org.wfanet.measurement.internal.kingdom.CertificateKt
 import org.wfanet.measurement.internal.kingdom.certificate
 import org.wfanet.measurement.kingdom.deploy.common.DuchyIds
@@ -297,7 +297,7 @@ class CertificateReader(private val parentType: ParentType) :
       notValidAfter = struct.getTimestamp("NotValidAfter").toProto()
       revocationState =
         struct.getProtoEnum("RevocationState", Certificate.RevocationState::forNumber)
-      details = struct.getProtoMessage("CertificateDetails", Certificate.Details.parser())
+      details = struct.getProtoMessage("CertificateDetails", CertificateDetails.parser())
     }
 
     /** Returns the internal Certificate ID for a Duchy Certificate, or `null` if not found. */

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/readers/ComputationParticipantReader.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/readers/ComputationParticipantReader.kt
@@ -27,12 +27,14 @@ import org.wfanet.measurement.gcloud.spanner.AsyncDatabaseClient
 import org.wfanet.measurement.gcloud.spanner.appendClause
 import org.wfanet.measurement.gcloud.spanner.bind
 import org.wfanet.measurement.gcloud.spanner.getInternalId
-import org.wfanet.measurement.gcloud.spanner.getProtoEnum
 import org.wfanet.measurement.gcloud.spanner.getProtoMessage
 import org.wfanet.measurement.internal.kingdom.ComputationParticipant
+import org.wfanet.measurement.internal.kingdom.ComputationParticipantDetails
 import org.wfanet.measurement.internal.kingdom.DuchyMeasurementLogEntry
+import org.wfanet.measurement.internal.kingdom.DuchyMeasurementLogEntryDetails
 import org.wfanet.measurement.internal.kingdom.Measurement
-import org.wfanet.measurement.internal.kingdom.MeasurementLogEntry
+import org.wfanet.measurement.internal.kingdom.MeasurementDetails
+import org.wfanet.measurement.internal.kingdom.MeasurementLogEntryDetails
 import org.wfanet.measurement.internal.kingdom.computationParticipant
 import org.wfanet.measurement.internal.kingdom.duchyMeasurementLogEntry
 import org.wfanet.measurement.internal.kingdom.measurementLogEntry
@@ -96,7 +98,7 @@ class ComputationParticipantReader : BaseSpannerReader<ComputationParticipantRea
     val measurementId: InternalId,
     val measurementConsumerId: InternalId,
     val measurementState: Measurement.State,
-    val measurementDetails: Measurement.Details,
+    val measurementDetails: MeasurementDetails,
   )
 
   override val builder: Statement.Builder = Statement.newBuilder(BASE_SQL)
@@ -144,7 +146,7 @@ class ComputationParticipantReader : BaseSpannerReader<ComputationParticipantRea
       struct.getInternalId("MeasurementId"),
       struct.getInternalId("MeasurementConsumerId"),
       struct.getProtoEnum("MeasurementState", Measurement.State::forNumber),
-      struct.getProtoMessage("MeasurementDetails", Measurement.Details.parser()),
+      struct.getProtoMessage("MeasurementDetails", MeasurementDetails.parser()),
     )
 
   private fun buildComputationParticipant(struct: Struct): ComputationParticipant {
@@ -152,7 +154,7 @@ class ComputationParticipantReader : BaseSpannerReader<ComputationParticipantRea
     val externalMeasurementId = ExternalId(struct.getLong("ExternalMeasurementId"))
     val externalComputationId = ExternalId(struct.getLong("ExternalComputationId"))
     val measurementDetails =
-      struct.getProtoMessage("MeasurementDetails", Measurement.Details.parser())
+      struct.getProtoMessage("MeasurementDetails", MeasurementDetails.parser())
 
     val duchyId = struct.getLong("DuchyId")
     val externalDuchyId =
@@ -174,7 +176,7 @@ class ComputationParticipantReader : BaseSpannerReader<ComputationParticipantRea
       externalMeasurementId: ExternalId,
       externalDuchyId: String,
       externalComputationId: ExternalId,
-      measurementDetails: Measurement.Details,
+      measurementDetails: MeasurementDetails,
       struct: Struct,
     ): ComputationParticipant {
       val failureLogEntry: DuchyMeasurementLogEntry? =
@@ -198,7 +200,7 @@ class ComputationParticipantReader : BaseSpannerReader<ComputationParticipantRea
         this.etag = etag
         state = struct.getProtoEnum("State", ComputationParticipant.State::forNumber)
         details =
-          struct.getProtoMessage("ParticipantDetails", ComputationParticipant.Details.parser())
+          struct.getProtoMessage("ParticipantDetails", ComputationParticipantDetails.parser())
         apiVersion = measurementDetails.apiVersion
 
         if (failureLogEntry != null) {
@@ -216,7 +218,7 @@ class ComputationParticipantReader : BaseSpannerReader<ComputationParticipantRea
       return logEntryStructs
         .asSequence()
         .map {
-          it to it.getProtoMessage("MeasurementLogDetails", MeasurementLogEntry.Details.parser())
+          it to it.getProtoMessage("MeasurementLogDetails", MeasurementLogEntryDetails.parser())
         }
         .find { (_, logEntryDetails) -> logEntryDetails.hasError() }
         ?.let { (struct, logEntryDetails) ->
@@ -232,7 +234,7 @@ class ComputationParticipantReader : BaseSpannerReader<ComputationParticipantRea
             details =
               struct.getProtoMessage(
                 "DuchyMeasurementLogDetails",
-                DuchyMeasurementLogEntry.Details.parser(),
+                DuchyMeasurementLogEntryDetails.parser(),
               )
           }
         }

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/readers/DataProviderReader.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/readers/DataProviderReader.kt
@@ -26,6 +26,7 @@ import org.wfanet.measurement.gcloud.spanner.getInternalId
 import org.wfanet.measurement.gcloud.spanner.getProtoMessage
 import org.wfanet.measurement.internal.kingdom.Certificate
 import org.wfanet.measurement.internal.kingdom.DataProvider
+import org.wfanet.measurement.internal.kingdom.DataProviderDetails
 import org.wfanet.measurement.kingdom.deploy.common.DuchyIds
 import org.wfanet.measurement.kingdom.deploy.gcloud.spanner.common.DataProviderNotFoundException
 
@@ -118,7 +119,7 @@ class DataProviderReader : SpannerReader<DataProviderReader.Result>() {
     DataProvider.newBuilder()
       .apply {
         externalDataProviderId = struct.getLong("ExternalDataProviderId")
-        details = struct.getProtoMessage("DataProviderDetails", DataProvider.Details.parser())
+        details = struct.getProtoMessage("DataProviderDetails", DataProviderDetails.parser())
         certificate = CertificateReader.buildDataProviderCertificate(struct)
         addAllRequiredExternalDuchyIds(buildExternalDuchyIdList(struct))
       }

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/readers/EventGroupMetadataDescriptorReader.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/readers/EventGroupMetadataDescriptorReader.kt
@@ -23,6 +23,7 @@ import org.wfanet.measurement.gcloud.spanner.appendClause
 import org.wfanet.measurement.gcloud.spanner.bind
 import org.wfanet.measurement.gcloud.spanner.getProtoMessage
 import org.wfanet.measurement.internal.kingdom.EventGroupMetadataDescriptor
+import org.wfanet.measurement.internal.kingdom.EventGroupMetadataDescriptorDetails
 import org.wfanet.measurement.internal.kingdom.eventGroupMetadataDescriptor
 
 class EventGroupMetadataDescriptorReader :
@@ -120,7 +121,7 @@ class EventGroupMetadataDescriptorReader :
       }
       if (!struct.isNull("DescriptorDetails")) {
         details =
-          struct.getProtoMessage("DescriptorDetails", EventGroupMetadataDescriptor.Details.parser())
+          struct.getProtoMessage("DescriptorDetails", EventGroupMetadataDescriptorDetails.parser())
       }
     }
   }

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/readers/EventGroupReader.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/readers/EventGroupReader.kt
@@ -22,9 +22,9 @@ import org.wfanet.measurement.common.identity.InternalId
 import org.wfanet.measurement.gcloud.spanner.AsyncDatabaseClient
 import org.wfanet.measurement.gcloud.spanner.appendClause
 import org.wfanet.measurement.gcloud.spanner.bind
-import org.wfanet.measurement.gcloud.spanner.getProtoEnum
 import org.wfanet.measurement.gcloud.spanner.getProtoMessage
 import org.wfanet.measurement.internal.kingdom.EventGroup
+import org.wfanet.measurement.internal.kingdom.EventGroupDetails
 import org.wfanet.measurement.internal.kingdom.eventGroup
 
 class EventGroupReader : BaseSpannerReader<EventGroupReader.Result>() {
@@ -124,7 +124,7 @@ class EventGroupReader : BaseSpannerReader<EventGroupReader.Result>() {
     createTime = struct.getTimestamp("CreateTime").toProto()
     updateTime = struct.getTimestamp("UpdateTime").toProto()
     if (!struct.isNull("EventGroupDetails")) {
-      details = struct.getProtoMessage("EventGroupDetails", EventGroup.Details.parser())
+      details = struct.getProtoMessage("EventGroupDetails", EventGroupDetails.parser())
     }
     state = struct.getProtoEnum("State", EventGroup.State::forNumber)
   }

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/readers/MeasurementConsumerReader.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/readers/MeasurementConsumerReader.kt
@@ -24,6 +24,7 @@ import org.wfanet.measurement.gcloud.spanner.appendClause
 import org.wfanet.measurement.gcloud.spanner.getInternalId
 import org.wfanet.measurement.gcloud.spanner.getProtoMessage
 import org.wfanet.measurement.internal.kingdom.MeasurementConsumer
+import org.wfanet.measurement.internal.kingdom.MeasurementConsumerDetails
 
 class MeasurementConsumerReader : SpannerReader<MeasurementConsumerReader.Result>() {
   data class Result(val measurementConsumer: MeasurementConsumer, val measurementConsumerId: Long)
@@ -58,7 +59,7 @@ class MeasurementConsumerReader : SpannerReader<MeasurementConsumerReader.Result
       .apply {
         externalMeasurementConsumerId = struct.getLong("ExternalMeasurementConsumerId")
         details =
-          struct.getProtoMessage("MeasurementConsumerDetails", MeasurementConsumer.Details.parser())
+          struct.getProtoMessage("MeasurementConsumerDetails", MeasurementConsumerDetails.parser())
         certificate = CertificateReader.buildMeasurementConsumerCertificate(struct)
       }
       .build()

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/readers/MeasurementDetailsReader.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/readers/MeasurementDetailsReader.kt
@@ -18,14 +18,14 @@ import com.google.cloud.spanner.Struct
 import org.wfanet.measurement.common.identity.InternalId
 import org.wfanet.measurement.gcloud.spanner.getInternalId
 import org.wfanet.measurement.gcloud.spanner.getProtoMessage
-import org.wfanet.measurement.internal.kingdom.Measurement
+import org.wfanet.measurement.internal.kingdom.MeasurementDetails
 
 class MeasurementDetailsReader() : SpannerReader<MeasurementDetailsReader.Result>() {
 
   data class Result(
     val measurementConsumerId: InternalId,
     val measurementId: InternalId,
-    val measurementDetails: Measurement.Details,
+    val measurementDetails: MeasurementDetails,
   )
 
   override val baseSql =
@@ -43,6 +43,6 @@ class MeasurementDetailsReader() : SpannerReader<MeasurementDetailsReader.Result
     Result(
       struct.getInternalId("MeasurementConsumerId"),
       struct.getInternalId("MeasurementId"),
-      struct.getProtoMessage("MeasurementDetails", Measurement.Details.parser()),
+      struct.getProtoMessage("MeasurementDetails", MeasurementDetails.parser()),
     )
 }

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/readers/MeasurementReader.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/readers/MeasurementReader.kt
@@ -27,14 +27,14 @@ import org.wfanet.measurement.gcloud.spanner.AsyncDatabaseClient
 import org.wfanet.measurement.gcloud.spanner.appendClause
 import org.wfanet.measurement.gcloud.spanner.getBytesAsByteString
 import org.wfanet.measurement.gcloud.spanner.getInternalId
-import org.wfanet.measurement.gcloud.spanner.getProtoEnum
 import org.wfanet.measurement.gcloud.spanner.getProtoMessage
 import org.wfanet.measurement.gcloud.spanner.statement
 import org.wfanet.measurement.internal.kingdom.Measurement
+import org.wfanet.measurement.internal.kingdom.MeasurementDetails
 import org.wfanet.measurement.internal.kingdom.MeasurementKt
 import org.wfanet.measurement.internal.kingdom.MeasurementKt.dataProviderValue
 import org.wfanet.measurement.internal.kingdom.MeasurementKt.resultInfo
-import org.wfanet.measurement.internal.kingdom.Requisition
+import org.wfanet.measurement.internal.kingdom.RequisitionDetails
 import org.wfanet.measurement.internal.kingdom.measurement
 import org.wfanet.measurement.kingdom.deploy.common.DuchyIds
 import org.wfanet.measurement.kingdom.deploy.gcloud.spanner.common.ETags
@@ -414,7 +414,7 @@ private fun MeasurementKt.Dsl.fillMeasurementCommon(struct: Struct) {
   createTime = struct.getTimestamp("CreateTime").toProto()
   updateTime = struct.getTimestamp("UpdateTime").toProto()
   state = struct.getProtoEnum("MeasurementState", Measurement.State::forNumber)
-  details = struct.getProtoMessage("MeasurementDetails", Measurement.Details.parser())
+  details = struct.getProtoMessage("MeasurementDetails", MeasurementDetails.parser())
   if (state == Measurement.State.SUCCEEDED) {
     for (duchyResultStruct in struct.getStructList("DuchyResults")) {
       results += resultInfo {
@@ -438,7 +438,7 @@ private fun MeasurementKt.Dsl.fillDefaultView(struct: Struct) {
   val measurementSucceeded = state == Measurement.State.SUCCEEDED
   for (requisitionStruct in struct.getStructList("Requisitions")) {
     val requisitionDetails =
-      requisitionStruct.getProtoMessage("RequisitionDetails", Requisition.Details.parser())
+      requisitionStruct.getProtoMessage("RequisitionDetails", RequisitionDetails.parser())
     val externalDataProviderId = requisitionStruct.getLong("ExternalDataProviderId")
     val externalDataProviderCertificateId =
       requisitionStruct.getLong("ExternalDataProviderCertificateId")

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/readers/StateTransitionMeasurementLogEntryReader.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/readers/StateTransitionMeasurementLogEntryReader.kt
@@ -15,10 +15,9 @@
 package org.wfanet.measurement.kingdom.deploy.gcloud.spanner.readers
 
 import com.google.cloud.spanner.Struct
-import org.wfanet.measurement.gcloud.spanner.getProtoEnum
 import org.wfanet.measurement.gcloud.spanner.getProtoMessage
 import org.wfanet.measurement.internal.kingdom.Measurement
-import org.wfanet.measurement.internal.kingdom.MeasurementLogEntry
+import org.wfanet.measurement.internal.kingdom.MeasurementLogEntryDetails
 import org.wfanet.measurement.internal.kingdom.StateTransitionMeasurementLogEntry
 import org.wfanet.measurement.internal.kingdom.measurementLogEntry
 import org.wfanet.measurement.internal.kingdom.stateTransitionMeasurementLogEntry
@@ -61,7 +60,7 @@ class StateTransitionMeasurementLogEntryReader :
         externalMeasurementId = struct.getLong("ExternalMeasurementId")
         externalMeasurementConsumerId = struct.getLong("ExternalMeasurementConsumerId")
         details =
-          struct.getProtoMessage("MeasurementLogDetails", MeasurementLogEntry.Details.parser())
+          struct.getProtoMessage("MeasurementLogDetails", MeasurementLogEntryDetails.parser())
       }
     }
   }

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/writers/BatchCancelMeasurements.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/writers/BatchCancelMeasurements.kt
@@ -21,9 +21,9 @@ import org.wfanet.measurement.common.identity.ExternalId
 import org.wfanet.measurement.internal.kingdom.BatchCancelMeasurementsRequest
 import org.wfanet.measurement.internal.kingdom.BatchCancelMeasurementsResponse
 import org.wfanet.measurement.internal.kingdom.Measurement
-import org.wfanet.measurement.internal.kingdom.MeasurementLogEntryKt
 import org.wfanet.measurement.internal.kingdom.batchCancelMeasurementsResponse
 import org.wfanet.measurement.internal.kingdom.copy
+import org.wfanet.measurement.internal.kingdom.measurementLogEntryDetails
 import org.wfanet.measurement.kingdom.deploy.gcloud.spanner.common.ETags
 import org.wfanet.measurement.kingdom.deploy.gcloud.spanner.common.KingdomInternalException
 import org.wfanet.measurement.kingdom.deploy.gcloud.spanner.common.MeasurementEtagMismatchException
@@ -91,8 +91,8 @@ class BatchCancelMeasurements(private val requests: BatchCancelMeasurementsReque
           )
         if (actualEtag != request.etag) {
           throw MeasurementEtagMismatchException(actualEtag, request.etag) {
-            "Requested Measurement etag ${request.etag} does not match actual measurement etag" +
-              "$actualEtag"
+            "Requested Measurement etag ${request.etag} does not match actual measurement etag " +
+              actualEtag
           }
         }
       }
@@ -100,8 +100,9 @@ class BatchCancelMeasurements(private val requests: BatchCancelMeasurementsReque
       resultsList.add(result)
     }
 
-    val measurementLogEntryDetails =
-      MeasurementLogEntryKt.details { logMessage = "Measurement was cancelled" }
+    val measurementLogEntryDetails = measurementLogEntryDetails {
+      logMessage = "Measurement was cancelled"
+    }
 
     for (result in resultsList) {
       updateMeasurementState(

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/writers/CancelMeasurement.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/writers/CancelMeasurement.kt
@@ -15,10 +15,9 @@
 package org.wfanet.measurement.kingdom.deploy.gcloud.spanner.writers
 
 import org.wfanet.measurement.common.identity.ExternalId
-import org.wfanet.measurement.gcloud.spanner.set
 import org.wfanet.measurement.internal.kingdom.Measurement
-import org.wfanet.measurement.internal.kingdom.MeasurementLogEntryKt
 import org.wfanet.measurement.internal.kingdom.copy
+import org.wfanet.measurement.internal.kingdom.measurementLogEntryDetails
 import org.wfanet.measurement.kingdom.deploy.gcloud.spanner.common.ETags
 import org.wfanet.measurement.kingdom.deploy.gcloud.spanner.common.KingdomInternalException
 import org.wfanet.measurement.kingdom.deploy.gcloud.spanner.common.MeasurementNotFoundByMeasurementConsumerException
@@ -70,8 +69,9 @@ class CancelMeasurement(
       }
     }
 
-    val measurementLogEntryDetails =
-      MeasurementLogEntryKt.details { logMessage = "Measurement was cancelled" }
+    val measurementLogEntryDetails = measurementLogEntryDetails {
+      logMessage = "Measurement was cancelled"
+    }
 
     updateMeasurementState(
       measurementConsumerId = measurementConsumerId,

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/writers/ConfirmComputationParticipant.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/writers/ConfirmComputationParticipant.kt
@@ -27,8 +27,8 @@ import org.wfanet.measurement.gcloud.spanner.statement
 import org.wfanet.measurement.internal.kingdom.ComputationParticipant
 import org.wfanet.measurement.internal.kingdom.ConfirmComputationParticipantRequest
 import org.wfanet.measurement.internal.kingdom.Measurement
-import org.wfanet.measurement.internal.kingdom.MeasurementLogEntryKt
 import org.wfanet.measurement.internal.kingdom.copy
+import org.wfanet.measurement.internal.kingdom.measurementLogEntryDetails
 import org.wfanet.measurement.kingdom.deploy.common.DuchyIds
 import org.wfanet.measurement.kingdom.deploy.gcloud.spanner.common.ComputationParticipantETagMismatchException
 import org.wfanet.measurement.kingdom.deploy.gcloud.spanner.common.ComputationParticipantNotFoundByComputationException
@@ -131,10 +131,9 @@ class ConfirmComputationParticipant(private val request: ConfirmComputationParti
       )
     ) {
 
-      val measurementLogEntryDetails =
-        MeasurementLogEntryKt.details {
-          logMessage = "All participants are in status == READY. Measurement.STATE is now PENDING"
-        }
+      val measurementLogEntryDetails = measurementLogEntryDetails {
+        logMessage = "All participants are in status == READY. Measurement.STATE is now PENDING"
+      }
 
       updateMeasurementState(
         measurementConsumerId = measurementConsumerId,

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/writers/CreateMeasurements.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/writers/CreateMeasurements.kt
@@ -25,13 +25,15 @@ import org.wfanet.measurement.gcloud.spanner.bufferInsertMutation
 import org.wfanet.measurement.gcloud.spanner.set
 import org.wfanet.measurement.gcloud.spanner.setJson
 import org.wfanet.measurement.internal.kingdom.ComputationParticipant
+import org.wfanet.measurement.internal.kingdom.ComputationParticipantDetails
 import org.wfanet.measurement.internal.kingdom.CreateMeasurementRequest
 import org.wfanet.measurement.internal.kingdom.ErrorCode
 import org.wfanet.measurement.internal.kingdom.Measurement
 import org.wfanet.measurement.internal.kingdom.ProtocolConfig
 import org.wfanet.measurement.internal.kingdom.Requisition
-import org.wfanet.measurement.internal.kingdom.RequisitionKt
+import org.wfanet.measurement.internal.kingdom.RequisitionDetails
 import org.wfanet.measurement.internal.kingdom.copy
+import org.wfanet.measurement.internal.kingdom.requisitionDetails
 import org.wfanet.measurement.kingdom.deploy.common.DuchyIds
 import org.wfanet.measurement.kingdom.deploy.common.HmssProtocolConfig
 import org.wfanet.measurement.kingdom.deploy.common.Llv2ProtocolConfig
@@ -339,7 +341,7 @@ class CreateMeasurements(private val requests: List<CreateMeasurementRequest>) :
     measurementId: InternalId,
     duchyId: InternalId,
   ) {
-    val participantDetails = ComputationParticipant.Details.getDefaultInstance()
+    val participantDetails = ComputationParticipantDetails.getDefaultInstance()
     transactionContext.bufferInsertMutation("ComputationParticipants") {
       set("MeasurementConsumerId" to measurementConsumerId)
       set("MeasurementId" to measurementId)
@@ -384,18 +386,17 @@ class CreateMeasurements(private val requests: List<CreateMeasurementRequest>) :
   ) {
     val requisitionId = idGenerator.generateInternalId()
     val externalRequisitionId = idGenerator.generateExternalId()
-    val details: Requisition.Details =
-      RequisitionKt.details {
-        dataProviderPublicKey = dataProviderValue.dataProviderPublicKey
-        encryptedRequisitionSpec = dataProviderValue.encryptedRequisitionSpec
-        nonceHash = dataProviderValue.nonceHash
+    val details: RequisitionDetails = requisitionDetails {
+      dataProviderPublicKey = dataProviderValue.dataProviderPublicKey
+      encryptedRequisitionSpec = dataProviderValue.encryptedRequisitionSpec
+      nonceHash = dataProviderValue.nonceHash
 
-        // TODO(world-federation-of-advertisers/cross-media-measurement#1301): Stop setting these
-        // fields.
-        dataProviderPublicKeySignature = dataProviderValue.dataProviderPublicKeySignature
-        dataProviderPublicKeySignatureAlgorithmOid =
-          dataProviderValue.dataProviderPublicKeySignatureAlgorithmOid
-      }
+      // TODO(world-federation-of-advertisers/cross-media-measurement#1301): Stop setting these
+      // fields.
+      dataProviderPublicKeySignature = dataProviderValue.dataProviderPublicKeySignature
+      dataProviderPublicKeySignatureAlgorithmOid =
+        dataProviderValue.dataProviderPublicKeySignatureAlgorithmOid
+    }
     val fulfillingDuchyId =
       if (fulfillingDuchies.isNotEmpty()) {
         // Requisitions for the same measurement might go to different duchies.

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/writers/DeleteEventGroup.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/writers/DeleteEventGroup.kt
@@ -23,6 +23,7 @@ import org.wfanet.measurement.gcloud.spanner.set
 import org.wfanet.measurement.gcloud.spanner.setJson
 import org.wfanet.measurement.internal.kingdom.DeleteEventGroupRequest
 import org.wfanet.measurement.internal.kingdom.EventGroup
+import org.wfanet.measurement.internal.kingdom.EventGroupDetails
 import org.wfanet.measurement.internal.kingdom.copy
 import org.wfanet.measurement.kingdom.deploy.gcloud.spanner.common.EventGroupNotFoundException
 import org.wfanet.measurement.kingdom.deploy.gcloud.spanner.common.EventGroupStateIllegalException
@@ -58,8 +59,8 @@ class DeleteEventGroup(private val request: DeleteEventGroupRequest) :
       set("EventGroupId" to result.internalEventGroupId.value)
       set("MeasurementConsumerCertificateId" to null as Long?)
       set("UpdateTime" to Value.COMMIT_TIMESTAMP)
-      set("EventGroupDetails" to null as EventGroup.Details?)
-      setJson("EventGroupDetailsJson" to null as EventGroup.Details?)
+      set("EventGroupDetails" to null as EventGroupDetails?)
+      setJson("EventGroupDetailsJson" to null as EventGroupDetails?)
       set("State" to EventGroup.State.DELETED)
     }
 

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/writers/FulfillRequisition.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/writers/FulfillRequisition.kt
@@ -23,9 +23,9 @@ import org.wfanet.measurement.gcloud.spanner.bind
 import org.wfanet.measurement.gcloud.spanner.statement
 import org.wfanet.measurement.internal.kingdom.FulfillRequisitionRequest
 import org.wfanet.measurement.internal.kingdom.Measurement
-import org.wfanet.measurement.internal.kingdom.MeasurementLogEntryKt
 import org.wfanet.measurement.internal.kingdom.Requisition
 import org.wfanet.measurement.internal.kingdom.copy
+import org.wfanet.measurement.internal.kingdom.measurementLogEntryDetails
 import org.wfanet.measurement.kingdom.deploy.common.DuchyIds
 import org.wfanet.measurement.kingdom.deploy.gcloud.spanner.common.DuchyNotFoundException
 import org.wfanet.measurement.kingdom.deploy.gcloud.spanner.common.KingdomInternalException
@@ -98,8 +98,9 @@ class FulfillRequisition(private val request: FulfillRequisitionRequest) :
               Measurement.State.PENDING_PARTICIPANT_CONFIRMATION
             }
           } else Measurement.State.SUCCEEDED
-        val measurementLogEntryDetails =
-          MeasurementLogEntryKt.details { logMessage = "All requisitions fulfilled" }
+        val measurementLogEntryDetails = measurementLogEntryDetails {
+          logMessage = "All requisitions fulfilled"
+        }
         // All other Requisitions are already FULFILLED, so update Measurement state.
         nextState.also {
           updateMeasurementState(

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/writers/MeasurementLogEntries.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/writers/MeasurementLogEntries.kt
@@ -20,17 +20,17 @@ import org.wfanet.measurement.common.identity.InternalId
 import org.wfanet.measurement.gcloud.spanner.bufferInsertMutation
 import org.wfanet.measurement.gcloud.spanner.set
 import org.wfanet.measurement.gcloud.spanner.setJson
-import org.wfanet.measurement.internal.kingdom.DuchyMeasurementLogEntry
+import org.wfanet.measurement.internal.kingdom.DuchyMeasurementLogEntryDetails
 import org.wfanet.measurement.internal.kingdom.Measurement
-import org.wfanet.measurement.internal.kingdom.MeasurementLogEntry.Details
+import org.wfanet.measurement.internal.kingdom.MeasurementLogEntryDetails
 
 internal fun SpannerWriter.TransactionScope.insertMeasurementLogEntry(
   measurementId: InternalId,
   measurementConsumerId: InternalId,
-  logDetails: Details,
+  logDetails: MeasurementLogEntryDetails,
 ) {
 
-  require(logDetails.logMessage != null && !logDetails.logMessage.isEmpty())
+  require(logDetails.logMessage.isNotEmpty())
 
   transactionContext.bufferInsertMutation("MeasurementLogEntries") {
     set("MeasurementConsumerId" to measurementConsumerId)
@@ -63,7 +63,7 @@ internal fun SpannerWriter.TransactionScope.insertDuchyMeasurementLogEntry(
   measurementId: InternalId,
   measurementConsumerId: InternalId,
   duchyId: InternalId,
-  logDetails: DuchyMeasurementLogEntry.Details,
+  logDetails: DuchyMeasurementLogEntryDetails,
 ): ExternalId {
   val externalComputationLogEntryId = idGenerator.generateExternalId()
 

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/writers/ReplaceDataProviderCapabilities.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/writers/ReplaceDataProviderCapabilities.kt
@@ -21,6 +21,7 @@ import org.wfanet.measurement.gcloud.spanner.bufferUpdateMutation
 import org.wfanet.measurement.gcloud.spanner.set
 import org.wfanet.measurement.gcloud.spanner.setJson
 import org.wfanet.measurement.internal.kingdom.DataProvider
+import org.wfanet.measurement.internal.kingdom.DataProviderDetails
 import org.wfanet.measurement.internal.kingdom.ReplaceDataProviderCapabilitiesRequest
 import org.wfanet.measurement.internal.kingdom.copy
 import org.wfanet.measurement.kingdom.deploy.gcloud.spanner.common.DataProviderNotFoundException
@@ -34,7 +35,7 @@ class ReplaceDataProviderCapabilities(private val request: ReplaceDataProviderCa
       DataProviderReader().readByExternalDataProviderId(transactionContext, externalDataProviderId)
         ?: throw DataProviderNotFoundException(externalDataProviderId)
 
-    val updatedDetails: DataProvider.Details =
+    val updatedDetails: DataProviderDetails =
       dataProviderResult.dataProvider.details.copy { capabilities = request.capabilities }
 
     transactionContext.bufferUpdateMutation("DataProviders") {

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/writers/RevokeCertificate.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/writers/RevokeCertificate.kt
@@ -25,12 +25,15 @@ import org.wfanet.measurement.gcloud.spanner.set
 import org.wfanet.measurement.internal.kingdom.Certificate
 import org.wfanet.measurement.internal.kingdom.Certificate.RevocationState
 import org.wfanet.measurement.internal.kingdom.Measurement
-import org.wfanet.measurement.internal.kingdom.MeasurementKt
-import org.wfanet.measurement.internal.kingdom.MeasurementLogEntry
-import org.wfanet.measurement.internal.kingdom.MeasurementLogEntryKt
+import org.wfanet.measurement.internal.kingdom.MeasurementDetails
+import org.wfanet.measurement.internal.kingdom.MeasurementFailure
+import org.wfanet.measurement.internal.kingdom.MeasurementLogEntryError
 import org.wfanet.measurement.internal.kingdom.RevokeCertificateRequest
 import org.wfanet.measurement.internal.kingdom.StreamMeasurementsRequestKt
 import org.wfanet.measurement.internal.kingdom.copy
+import org.wfanet.measurement.internal.kingdom.measurementFailure
+import org.wfanet.measurement.internal.kingdom.measurementLogEntryDetails
+import org.wfanet.measurement.internal.kingdom.measurementLogEntryError
 import org.wfanet.measurement.kingdom.deploy.common.DuchyIds
 import org.wfanet.measurement.kingdom.deploy.gcloud.spanner.common.CertificateRevocationStateIllegalException
 import org.wfanet.measurement.kingdom.deploy.gcloud.spanner.common.DataProviderCertificateNotFoundException
@@ -161,11 +164,10 @@ class RevokeCertificate(private val request: RevokeCertificateRequest) :
         StreamMeasurements(Measurement.View.DEFAULT, filter).execute(transactionContext).collect {
           val details =
             it.measurement.details.copy {
-              failure =
-                MeasurementKt.failure {
-                  reason = Measurement.Failure.Reason.CERTIFICATE_REVOKED
-                  message = "The associated Measurement Consumer certificate has been revoked."
-                }
+              failure = measurementFailure {
+                reason = MeasurementFailure.Reason.CERTIFICATE_REVOKED
+                message = "The associated Measurement Consumer certificate has been revoked."
+              }
             }
 
           failMeasurement(it.measurementConsumerId, it.measurementId, details)
@@ -180,11 +182,10 @@ class RevokeCertificate(private val request: RevokeCertificateRequest) :
           .collect {
             val details =
               it.measurementDetails.copy {
-                failure =
-                  MeasurementKt.failure {
-                    reason = Measurement.Failure.Reason.CERTIFICATE_REVOKED
-                    message = "An associated Data Provider certificate has been revoked."
-                  }
+                failure = measurementFailure {
+                  reason = MeasurementFailure.Reason.CERTIFICATE_REVOKED
+                  message = "An associated Data Provider certificate has been revoked."
+                }
               }
 
             failMeasurement(it.measurementConsumerId, it.measurementId, details)
@@ -199,11 +200,10 @@ class RevokeCertificate(private val request: RevokeCertificateRequest) :
           .collect {
             val details =
               it.measurementDetails.copy {
-                failure =
-                  MeasurementKt.failure {
-                    reason = Measurement.Failure.Reason.CERTIFICATE_REVOKED
-                    message = "An associated Duchy certificate has been revoked."
-                  }
+                failure = measurementFailure {
+                  reason = MeasurementFailure.Reason.CERTIFICATE_REVOKED
+                  message = "An associated Duchy certificate has been revoked."
+                }
               }
 
             failMeasurement(it.measurementConsumerId, it.measurementId, details)
@@ -222,7 +222,7 @@ class RevokeCertificate(private val request: RevokeCertificateRequest) :
   private suspend fun TransactionScope.failMeasurement(
     measurementConsumerId: InternalId,
     measurementId: InternalId,
-    details: Measurement.Details,
+    details: MeasurementDetails,
   ) {
 
     val measurementState =
@@ -232,17 +232,15 @@ class RevokeCertificate(private val request: RevokeCertificateRequest) :
         measurementId,
       )
 
-    val measurementLogEntryDetails =
-      MeasurementLogEntryKt.details {
-        logMessage = "Measurement failed due to a certificate revoked"
-        this.error =
-          MeasurementLogEntryKt.errorDetails {
-            this.type = MeasurementLogEntry.ErrorDetails.Type.PERMANENT
-            // TODO(@marcopremier): plumb in a clock instance dependency not to hardcode the system
-            // one
-            this.errorTime = Clock.systemUTC().protoTimestamp()
-          }
+    val measurementLogEntryDetails = measurementLogEntryDetails {
+      logMessage = "Measurement failed due to a certificate revoked"
+      this.error = measurementLogEntryError {
+        this.type = MeasurementLogEntryError.Type.PERMANENT
+        // TODO(@marcopremier): plumb in a clock instance dependency not to hardcode the system
+        // one
+        this.errorTime = Clock.systemUTC().protoTimestamp()
       }
+    }
 
     updateMeasurementState(
       measurementConsumerId = measurementConsumerId,

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/writers/SetMeasurementResult.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/writers/SetMeasurementResult.kt
@@ -23,9 +23,9 @@ import org.wfanet.measurement.gcloud.spanner.bufferUpdateMutation
 import org.wfanet.measurement.gcloud.spanner.set
 import org.wfanet.measurement.internal.kingdom.Measurement
 import org.wfanet.measurement.internal.kingdom.MeasurementKt.resultInfo
-import org.wfanet.measurement.internal.kingdom.MeasurementLogEntryKt
 import org.wfanet.measurement.internal.kingdom.SetMeasurementResultRequest
 import org.wfanet.measurement.internal.kingdom.copy
+import org.wfanet.measurement.internal.kingdom.measurementLogEntryDetails
 import org.wfanet.measurement.kingdom.deploy.common.DuchyIds
 import org.wfanet.measurement.kingdom.deploy.gcloud.spanner.common.DuchyCertificateNotFoundException
 import org.wfanet.measurement.kingdom.deploy.gcloud.spanner.common.DuchyNotFoundException
@@ -99,7 +99,7 @@ class SetMeasurementResult(private val request: SetMeasurementResultRequest) :
       nextState = NEXT_MEASUREMENT_STATE,
       previousState = measurement.state,
       measurementLogEntryDetails =
-        MeasurementLogEntryKt.details { logMessage = "Measurement succeeded" },
+        measurementLogEntryDetails { logMessage = "Measurement succeeded" },
     )
 
     return measurement.copy {

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/writers/SetParticipantRequisitionParams.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/writers/SetParticipantRequisitionParams.kt
@@ -32,11 +32,12 @@ import org.wfanet.measurement.gcloud.spanner.set
 import org.wfanet.measurement.gcloud.spanner.setJson
 import org.wfanet.measurement.gcloud.spanner.statement
 import org.wfanet.measurement.internal.kingdom.ComputationParticipant
+import org.wfanet.measurement.internal.kingdom.ComputationParticipantDetails
 import org.wfanet.measurement.internal.kingdom.Measurement
-import org.wfanet.measurement.internal.kingdom.MeasurementLogEntryKt
 import org.wfanet.measurement.internal.kingdom.Requisition
 import org.wfanet.measurement.internal.kingdom.SetParticipantRequisitionParamsRequest
 import org.wfanet.measurement.internal.kingdom.copy
+import org.wfanet.measurement.internal.kingdom.measurementLogEntryDetails
 import org.wfanet.measurement.kingdom.deploy.common.DuchyIds
 import org.wfanet.measurement.kingdom.deploy.gcloud.spanner.common.CertificateIsInvalidException
 import org.wfanet.measurement.kingdom.deploy.gcloud.spanner.common.ComputationParticipantETagMismatchException
@@ -173,7 +174,7 @@ class SetParticipantRequisitionParams(private val request: SetParticipantRequisi
       setJson("ParticipantDetailsJson" to participantDetails)
     }
 
-    val otherComputationParticipants: List<ComputationParticipantDetails> =
+    val otherComputationParticipants: List<ComputationParticipantResult> =
       findComputationParticipants(externalComputationId)
         .filter { it.duchyId.value != duchyId }
         .toList()
@@ -187,8 +188,9 @@ class SetParticipantRequisitionParams(private val request: SetParticipantRequisi
         nextState,
       )
     ) {
-      val measurementLogEntryDetails =
-        MeasurementLogEntryKt.details { logMessage = "Pending requisition fulfillment" }
+      val measurementLogEntryDetails = measurementLogEntryDetails {
+        logMessage = "Pending requisition fulfillment"
+      }
       updateMeasurementState(
         measurementConsumerId = measurementConsumerId,
         measurementId = measurementId,
@@ -251,14 +253,14 @@ class SetParticipantRequisitionParams(private val request: SetParticipantRequisi
       }
   }
 
-  private data class ComputationParticipantDetails(
+  private data class ComputationParticipantResult(
     val duchyId: InternalId,
-    val details: ComputationParticipant.Details,
+    val details: ComputationParticipantDetails,
   )
 
   private fun TransactionScope.findComputationParticipants(
     externalComputationId: ExternalId
-  ): Flow<ComputationParticipantDetails> {
+  ): Flow<ComputationParticipantResult> {
     val sql =
       """
       SELECT
@@ -273,42 +275,8 @@ class SetParticipantRequisitionParams(private val request: SetParticipantRequisi
 
     return transactionContext.executeQuery(statement).map {
       val duchyId = InternalId(it.getLong("DuchyId"))
-      val details =
-        it.getProtoMessage("ParticipantDetails", ComputationParticipant.Details.parser())
-      ComputationParticipantDetails(duchyId, details)
+      val details = it.getProtoMessage("ParticipantDetails", ComputationParticipantDetails.parser())
+      ComputationParticipantResult(duchyId, details)
     }
-  }
-
-  private fun selectFulfillingDuchyId(
-    requisitionId: Long,
-    currentDuchyId: Long,
-    currentParticipantDetails: ComputationParticipant.Details,
-    otherParticipantDetails: List<ComputationParticipantDetails>,
-  ): Long {
-    // TODO(@renjiez): Set the fulfullingDuchyId during Measurement creation by adding duchy roles
-    // into HMSS config.
-    val candidateDuchyIds = mutableListOf<Long>()
-
-    require(currentParticipantDetails.hasHonestMajorityShareShuffle()) {
-      "ComputationParticipantDetails does not have HonestMajorityShareShuffle."
-    }
-    if (!currentParticipantDetails.honestMajorityShareShuffle.tinkPublicKey.isEmpty) {
-      candidateDuchyIds += currentDuchyId
-    }
-    for (participant in otherParticipantDetails) {
-      require(participant.details.hasHonestMajorityShareShuffle()) {
-        "ComputationParticipantDetails does not have HonestMajorityShareShuffle."
-      }
-      if (!participant.details.honestMajorityShareShuffle.tinkPublicKey.isEmpty) {
-        candidateDuchyIds += participant.duchyId.value
-      }
-    }
-
-    require(candidateDuchyIds.size == 2) {
-      "Number of computation participant to fulfill requisition is ${candidateDuchyIds.size}."
-    }
-
-    candidateDuchyIds.sort()
-    return candidateDuchyIds[(requisitionId % candidateDuchyIds.size).toInt()]
   }
 }

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/writers/UpdateMeasurementState.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/writers/UpdateMeasurementState.kt
@@ -21,15 +21,16 @@ import org.wfanet.measurement.gcloud.spanner.set
 import org.wfanet.measurement.gcloud.spanner.setJson
 import org.wfanet.measurement.gcloud.spanner.updateMutation
 import org.wfanet.measurement.internal.kingdom.Measurement
-import org.wfanet.measurement.internal.kingdom.MeasurementLogEntry
+import org.wfanet.measurement.internal.kingdom.MeasurementDetails
+import org.wfanet.measurement.internal.kingdom.MeasurementLogEntryDetails
 
 internal fun SpannerWriter.TransactionScope.updateMeasurementState(
   measurementConsumerId: InternalId,
   measurementId: InternalId,
   nextState: Measurement.State,
   previousState: Measurement.State,
-  measurementLogEntryDetails: MeasurementLogEntry.Details,
-  details: Measurement.Details? = null,
+  measurementLogEntryDetails: MeasurementLogEntryDetails,
+  details: MeasurementDetails? = null,
 ) {
 
   updateMutation("Measurements") {

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/writers/UpdateRequisition.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/writers/UpdateRequisition.kt
@@ -20,16 +20,16 @@ import com.google.cloud.spanner.Value
 import org.wfanet.measurement.common.identity.InternalId
 import org.wfanet.measurement.gcloud.spanner.bufferUpdateMutation
 import org.wfanet.measurement.gcloud.spanner.getInternalId
-import org.wfanet.measurement.gcloud.spanner.getProtoEnum
 import org.wfanet.measurement.gcloud.spanner.set
 import org.wfanet.measurement.gcloud.spanner.toProtoEnum
 import org.wfanet.measurement.internal.kingdom.Requisition
+import org.wfanet.measurement.internal.kingdom.RequisitionDetails
 import org.wfanet.measurement.kingdom.deploy.gcloud.spanner.readers.RequisitionReader
 
 internal fun SpannerWriter.TransactionScope.updateRequisition(
   readResult: RequisitionReader.Result,
   state: Requisition.State,
-  details: Requisition.Details,
+  details: RequisitionDetails,
   fulfillingDuchyId: InternalId? = null,
 ) {
   transactionContext.bufferUpdateMutation("Requisitions") {

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/tools/CreateResource.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/tools/CreateResource.kt
@@ -44,7 +44,6 @@ import org.wfanet.measurement.common.toProtoDate
 import org.wfanet.measurement.internal.kingdom.AccountsGrpcKt.AccountsCoroutineStub
 import org.wfanet.measurement.internal.kingdom.Certificate
 import org.wfanet.measurement.internal.kingdom.CertificatesGrpcKt.CertificatesCoroutineStub
-import org.wfanet.measurement.internal.kingdom.DataProviderKt
 import org.wfanet.measurement.internal.kingdom.DataProvidersGrpcKt.DataProvidersCoroutineStub
 import org.wfanet.measurement.internal.kingdom.ModelProvidersGrpcKt.ModelProvidersCoroutineStub
 import org.wfanet.measurement.internal.kingdom.RecurringExchange
@@ -54,6 +53,7 @@ import org.wfanet.measurement.internal.kingdom.certificate
 import org.wfanet.measurement.internal.kingdom.createMeasurementConsumerCreationTokenRequest
 import org.wfanet.measurement.internal.kingdom.createRecurringExchangeRequest
 import org.wfanet.measurement.internal.kingdom.dataProvider
+import org.wfanet.measurement.internal.kingdom.dataProviderDetails
 import org.wfanet.measurement.internal.kingdom.modelProvider
 import org.wfanet.measurement.internal.kingdom.recurringExchange
 import org.wfanet.measurement.internal.kingdom.recurringExchangeDetails
@@ -173,13 +173,12 @@ private class CreateDataProviderCommand : Runnable {
     val dataProvider = dataProvider {
       certificate = this@CreateDataProviderCommand.certificate
 
-      details =
-        DataProviderKt.details {
-          apiVersion = publicKeyApiVersion.string
-          publicKey = serializedEncryptionPublicKey
-          publicKeySignature = encryptionPublicKeySignature
-          publicKeySignatureAlgorithmOid = signatureAlgorithm.oid
-        }
+      details = dataProviderDetails {
+        apiVersion = publicKeyApiVersion.string
+        publicKey = serializedEncryptionPublicKey
+        publicKeySignature = encryptionPublicKeySignature
+        publicKeySignatureAlgorithmOid = signatureAlgorithm.oid
+      }
 
       requiredExternalDuchyIds += requiredDuchies
     }

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/service/api/v2alpha/Certificates.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/service/api/v2alpha/Certificates.kt
@@ -26,8 +26,8 @@ import org.wfanet.measurement.common.grpc.grpcRequireNotNull
 import org.wfanet.measurement.common.toProtoTime
 import org.wfanet.measurement.internal.kingdom.Certificate as InternalCertificate
 import org.wfanet.measurement.internal.kingdom.CertificateKt
-import org.wfanet.measurement.internal.kingdom.CertificateKt.details
 import org.wfanet.measurement.internal.kingdom.certificate as internalCertificate
+import org.wfanet.measurement.internal.kingdom.certificateDetails as internalCertificateDetails
 
 private const val CERTIFICATE_DER_FIELD_NAME = "certificate_der"
 
@@ -64,5 +64,7 @@ fun CertificateKt.Dsl.fillFromX509(x509Certificate: X509Certificate, encoded: By
   subjectKeyIdentifier = skid
   notValidBefore = x509Certificate.notBefore.toInstant().toProtoTime()
   notValidAfter = x509Certificate.notAfter.toInstant().toProtoTime()
-  details = details { x509Der = encoded ?: x509Certificate.encoded.toByteString() }
+  details = internalCertificateDetails {
+    x509Der = encoded ?: x509Certificate.encoded.toByteString()
+  }
 }

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/service/api/v2alpha/DataProvidersService.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/service/api/v2alpha/DataProvidersService.kt
@@ -46,8 +46,9 @@ import org.wfanet.measurement.common.identity.ApiId
 import org.wfanet.measurement.common.identity.apiIdToExternalId
 import org.wfanet.measurement.common.identity.externalIdToApiId
 import org.wfanet.measurement.internal.kingdom.DataProvider as InternalDataProvider
-import org.wfanet.measurement.internal.kingdom.DataProviderKt as InternalDataProviderKt
+import org.wfanet.measurement.internal.kingdom.DataProviderCapabilities as InternalDataProviderCapabilities
 import org.wfanet.measurement.internal.kingdom.DataProvidersGrpcKt.DataProvidersCoroutineStub
+import org.wfanet.measurement.internal.kingdom.dataProviderCapabilities as internalDataProviderCapabilities
 import org.wfanet.measurement.internal.kingdom.getDataProviderRequest
 import org.wfanet.measurement.internal.kingdom.replaceDataAvailabilityIntervalRequest
 import org.wfanet.measurement.internal.kingdom.replaceDataProviderCapabilitiesRequest
@@ -245,16 +246,16 @@ private fun InternalDataProvider.toDataProvider(): DataProvider {
   }
 }
 
-private fun InternalDataProvider.Capabilities.toCapabilities(): DataProvider.Capabilities {
+private fun InternalDataProviderCapabilities.toCapabilities(): DataProvider.Capabilities {
   val source = this
   return DataProviderKt.capabilities {
     honestMajorityShareShuffleSupported = source.honestMajorityShareShuffleSupported
   }
 }
 
-private fun DataProvider.Capabilities.toInternal(): InternalDataProvider.Capabilities {
+private fun DataProvider.Capabilities.toInternal(): InternalDataProviderCapabilities {
   val source = this
-  return InternalDataProviderKt.capabilities {
+  return internalDataProviderCapabilities {
     honestMajorityShareShuffleSupported = source.honestMajorityShareShuffleSupported
   }
 }

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/service/api/v2alpha/EventGroupMetadataDescriptorsService.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/service/api/v2alpha/EventGroupMetadataDescriptorsService.kt
@@ -52,11 +52,11 @@ import org.wfanet.measurement.common.grpc.grpcRequireNotNull
 import org.wfanet.measurement.common.identity.apiIdToExternalId
 import org.wfanet.measurement.common.identity.externalIdToApiId
 import org.wfanet.measurement.internal.kingdom.EventGroupMetadataDescriptor as InternalEventGroupMetadataDescriptor
-import org.wfanet.measurement.internal.kingdom.EventGroupMetadataDescriptorKt.details
 import org.wfanet.measurement.internal.kingdom.EventGroupMetadataDescriptorsGrpcKt.EventGroupMetadataDescriptorsCoroutineStub
 import org.wfanet.measurement.internal.kingdom.StreamEventGroupMetadataDescriptorsRequest
 import org.wfanet.measurement.internal.kingdom.StreamEventGroupMetadataDescriptorsRequestKt.filter
 import org.wfanet.measurement.internal.kingdom.eventGroupMetadataDescriptor as internalEventGroupMetadataDescriptor
+import org.wfanet.measurement.internal.kingdom.eventGroupMetadataDescriptorDetails
 import org.wfanet.measurement.internal.kingdom.eventGroupMetadataDescriptorKey
 import org.wfanet.measurement.internal.kingdom.getEventGroupMetadataDescriptorRequest
 import org.wfanet.measurement.internal.kingdom.streamEventGroupMetadataDescriptorsRequest
@@ -375,7 +375,7 @@ private fun EventGroupMetadataDescriptor.toInternal(
       this.idempotencyKey = idempotencyKey
     }
 
-    details = details {
+    details = eventGroupMetadataDescriptorDetails {
       apiVersion = API_VERSION.string
       descriptorSet = this@toInternal.descriptorSet
     }

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/service/api/v2alpha/EventGroupsService.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/service/api/v2alpha/EventGroupsService.kt
@@ -51,7 +51,6 @@ import org.wfanet.measurement.api.v2alpha.listEventGroupsResponse
 import org.wfanet.measurement.api.v2alpha.packedValue
 import org.wfanet.measurement.api.v2alpha.principalFromCurrentContext
 import org.wfanet.measurement.api.v2alpha.signedMessage
-import org.wfanet.measurement.api.v2alpha.unpack
 import org.wfanet.measurement.common.ProtoReflection
 import org.wfanet.measurement.common.api.ChildResourceKey
 import org.wfanet.measurement.common.api.ResourceKey
@@ -65,7 +64,6 @@ import org.wfanet.measurement.common.identity.apiIdToExternalId
 import org.wfanet.measurement.common.identity.externalIdToApiId
 import org.wfanet.measurement.internal.kingdom.CreateEventGroupRequest as InternalCreateEventGroupRequest
 import org.wfanet.measurement.internal.kingdom.EventGroup as InternalEventGroup
-import org.wfanet.measurement.internal.kingdom.EventGroupKt.details
 import org.wfanet.measurement.internal.kingdom.EventGroupsGrpcKt.EventGroupsCoroutineStub as InternalEventGroupsCoroutineStub
 import org.wfanet.measurement.internal.kingdom.GetEventGroupRequest as InternalGetEventGroupRequest
 import org.wfanet.measurement.internal.kingdom.StreamEventGroupsRequest
@@ -73,6 +71,7 @@ import org.wfanet.measurement.internal.kingdom.StreamEventGroupsRequestKt as Int
 import org.wfanet.measurement.internal.kingdom.createEventGroupRequest as internalCreateEventGroupRequest
 import org.wfanet.measurement.internal.kingdom.deleteEventGroupRequest
 import org.wfanet.measurement.internal.kingdom.eventGroup as internalEventGroup
+import org.wfanet.measurement.internal.kingdom.eventGroupDetails
 import org.wfanet.measurement.internal.kingdom.eventGroupKey
 import org.wfanet.measurement.internal.kingdom.eventTemplate as internalEventTemplate
 import org.wfanet.measurement.internal.kingdom.getEventGroupRequest as internalGetEventGroupRequest
@@ -532,7 +531,7 @@ private fun EventGroup.toInternal(
     externalMeasurementConsumerId = apiIdToExternalId(measurementConsumerKey.measurementConsumerId)
 
     providedEventGroupId = source.eventGroupReferenceId
-    details = details {
+    details = eventGroupDetails {
       apiVersion = Version.V2_ALPHA.string
       // TODO(world-federation-of-advertisers/cross-media-measurement#1301): Stop reading this
       // field.

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/service/api/v2alpha/MeasurementConsumersService.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/service/api/v2alpha/MeasurementConsumersService.kt
@@ -46,12 +46,12 @@ import org.wfanet.measurement.common.grpc.grpcRequireNotNull
 import org.wfanet.measurement.common.identity.apiIdToExternalId
 import org.wfanet.measurement.common.identity.externalIdToApiId
 import org.wfanet.measurement.internal.kingdom.MeasurementConsumer as InternalMeasurementConsumer
-import org.wfanet.measurement.internal.kingdom.MeasurementConsumerKt.details
 import org.wfanet.measurement.internal.kingdom.MeasurementConsumersGrpcKt.MeasurementConsumersCoroutineStub as InternalMeasurementConsumersCoroutineStub
 import org.wfanet.measurement.internal.kingdom.addMeasurementConsumerOwnerRequest
 import org.wfanet.measurement.internal.kingdom.createMeasurementConsumerRequest
 import org.wfanet.measurement.internal.kingdom.getMeasurementConsumerRequest
 import org.wfanet.measurement.internal.kingdom.measurementConsumer as internalMeasurementConsumer
+import org.wfanet.measurement.internal.kingdom.measurementConsumerDetails
 import org.wfanet.measurement.internal.kingdom.removeMeasurementConsumerOwnerRequest
 
 private val API_VERSION = Version.V2_ALPHA
@@ -86,7 +86,7 @@ class MeasurementConsumersService(
     val createRequest = createMeasurementConsumerRequest {
       this.measurementConsumer = internalMeasurementConsumer {
         certificate = parseCertificateDer(measurementConsumer.certificateDer)
-        details = details {
+        details = measurementConsumerDetails {
           apiVersion = API_VERSION.string
           publicKey = measurementConsumer.publicKey.message.value
           publicKeySignature = measurementConsumer.publicKey.signature

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/service/api/v2alpha/MeasurementsService.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/service/api/v2alpha/MeasurementsService.kt
@@ -67,7 +67,7 @@ import org.wfanet.measurement.common.identity.ApiId
 import org.wfanet.measurement.common.identity.ExternalId
 import org.wfanet.measurement.common.identity.apiIdToExternalId
 import org.wfanet.measurement.internal.kingdom.CreateMeasurementRequest as InternalCreateMeasurementRequest
-import org.wfanet.measurement.internal.kingdom.DataProvider as InternalDataProvider
+import org.wfanet.measurement.internal.kingdom.DataProviderCapabilities as InternalDataProviderCapabilities
 import org.wfanet.measurement.internal.kingdom.DataProvidersGrpcKt.DataProvidersCoroutineStub as InternalDataProvidersCoroutineStub
 import org.wfanet.measurement.internal.kingdom.Measurement as InternalMeasurement
 import org.wfanet.measurement.internal.kingdom.Measurement.DataProviderValue
@@ -161,7 +161,7 @@ class MeasurementsService(
           }
         ApiId(key.dataProviderId).externalId
       }
-    val dataProviderCapabilities: List<InternalDataProvider.Capabilities> =
+    val dataProviderCapabilities: List<InternalDataProviderCapabilities> =
       try {
           internalDataProvidersStub.batchGetDataProviders(
             batchGetDataProvidersRequest {
@@ -316,7 +316,7 @@ class MeasurementsService(
             }
           ApiId(key.dataProviderId).externalId
         }
-    val allDataProviderCapabilities: Map<ExternalId, InternalDataProvider.Capabilities> =
+    val allDataProviderCapabilities: Map<ExternalId, InternalDataProviderCapabilities> =
       try {
           internalDataProvidersStub.batchGetDataProviders(
             batchGetDataProvidersRequest {
@@ -470,7 +470,7 @@ class MeasurementsService(
 
   private fun buildInternalProtocolConfig(
     measurementSpec: MeasurementSpec,
-    dataProviderCapabilities: Collection<InternalDataProvider.Capabilities>,
+    dataProviderCapabilities: Collection<InternalDataProviderCapabilities>,
     measurementConsumerName: String,
   ): InternalProtocolConfig {
     val dataProvidersCount = dataProviderCapabilities.size
@@ -587,7 +587,7 @@ class MeasurementsService(
   }
 
   private fun CreateMeasurementRequest.buildInternalCreateMeasurementRequest(
-    dataProviderCapabilities: Collection<InternalDataProvider.Capabilities>,
+    dataProviderCapabilities: Collection<InternalDataProviderCapabilities>,
     parentKey: MeasurementConsumerKey,
   ): InternalCreateMeasurementRequest {
     val measurementConsumerCertificateKey =

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/service/api/v2alpha/ProtoConversions.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/service/api/v2alpha/ProtoConversions.kt
@@ -116,7 +116,7 @@ import org.wfanet.measurement.internal.kingdom.ExchangeWorkflow as InternalExcha
 import org.wfanet.measurement.internal.kingdom.ExchangeWorkflowKt
 import org.wfanet.measurement.internal.kingdom.Measurement as InternalMeasurement
 import org.wfanet.measurement.internal.kingdom.Measurement.DataProviderValue
-import org.wfanet.measurement.internal.kingdom.MeasurementKt.details
+import org.wfanet.measurement.internal.kingdom.MeasurementFailure as InternalMeasurementFailure
 import org.wfanet.measurement.internal.kingdom.ModelLine as InternalModelLine
 import org.wfanet.measurement.internal.kingdom.ModelOutage as InternalModelOutage
 import org.wfanet.measurement.internal.kingdom.ModelRelease as InternalModelRelease
@@ -132,6 +132,7 @@ import org.wfanet.measurement.internal.kingdom.duchyProtocolConfig
 import org.wfanet.measurement.internal.kingdom.eventTemplate as internalEventTemplate
 import org.wfanet.measurement.internal.kingdom.exchangeWorkflow
 import org.wfanet.measurement.internal.kingdom.measurement as internalMeasurement
+import org.wfanet.measurement.internal.kingdom.measurementDetails as internalMeasurementDetails
 import org.wfanet.measurement.internal.kingdom.modelLine as internalModelLine
 import org.wfanet.measurement.internal.kingdom.modelOutage as internalModelOutage
 import org.wfanet.measurement.internal.kingdom.modelRelease as internalModelRelease
@@ -250,15 +251,15 @@ fun State.toInternalState(): List<InternalMeasurement.State> {
   }
 }
 
-/** Converts an internal [InternalMeasurement.Failure.Reason] to a public [Failure.Reason]. */
-fun InternalMeasurement.Failure.Reason.toReason(): Failure.Reason =
+/** Converts an internal [InternalMeasurementFailure.Reason] to a public [Failure.Reason]. */
+fun InternalMeasurementFailure.Reason.toReason(): Failure.Reason =
   when (this) {
-    InternalMeasurement.Failure.Reason.CERTIFICATE_REVOKED -> Failure.Reason.CERTIFICATE_REVOKED
-    InternalMeasurement.Failure.Reason.REQUISITION_REFUSED -> Failure.Reason.REQUISITION_REFUSED
-    InternalMeasurement.Failure.Reason.COMPUTATION_PARTICIPANT_FAILED ->
+    InternalMeasurementFailure.Reason.CERTIFICATE_REVOKED -> Failure.Reason.CERTIFICATE_REVOKED
+    InternalMeasurementFailure.Reason.REQUISITION_REFUSED -> Failure.Reason.REQUISITION_REFUSED
+    InternalMeasurementFailure.Reason.COMPUTATION_PARTICIPANT_FAILED ->
       Failure.Reason.COMPUTATION_PARTICIPANT_FAILED
-    InternalMeasurement.Failure.Reason.REASON_UNSPECIFIED,
-    InternalMeasurement.Failure.Reason.UNRECOGNIZED -> Failure.Reason.REASON_UNSPECIFIED
+    InternalMeasurementFailure.Reason.REASON_UNSPECIFIED,
+    InternalMeasurementFailure.Reason.UNRECOGNIZED -> Failure.Reason.REASON_UNSPECIFIED
   }
 
 fun InternalDifferentialPrivacyParams.toDifferentialPrivacyParams(): DifferentialPrivacyParams {
@@ -1010,7 +1011,7 @@ fun Measurement.toInternal(
     externalMeasurementConsumerCertificateId =
       apiIdToExternalId(measurementConsumerCertificateKey.certificateId)
     dataProviders.putAll(dataProviderValues.mapKeys { it.key.value })
-    details = details {
+    details = internalMeasurementDetails {
       apiVersion = Version.V2_ALPHA.string
       measurementSpec = source.measurementSpec.message.value
       measurementSpecSignature = source.measurementSpec.signature

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/service/api/v2alpha/RequisitionsService.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/service/api/v2alpha/RequisitionsService.kt
@@ -67,18 +67,19 @@ import org.wfanet.measurement.common.grpc.grpcRequireNotNull
 import org.wfanet.measurement.common.identity.ApiId
 import org.wfanet.measurement.common.identity.apiIdToExternalId
 import org.wfanet.measurement.common.identity.externalIdToApiId
-import org.wfanet.measurement.internal.kingdom.ComputationParticipant
 import org.wfanet.measurement.internal.kingdom.FulfillRequisitionRequestKt.directRequisitionParams
+import org.wfanet.measurement.internal.kingdom.HonestMajorityShareShuffleParams
+import org.wfanet.measurement.internal.kingdom.LiquidLegionsV2Params
 import org.wfanet.measurement.internal.kingdom.Requisition as InternalRequisition
 import org.wfanet.measurement.internal.kingdom.Requisition.DuchyValue
-import org.wfanet.measurement.internal.kingdom.Requisition.Refusal as InternalRefusal
 import org.wfanet.measurement.internal.kingdom.Requisition.State as InternalState
-import org.wfanet.measurement.internal.kingdom.RequisitionKt as InternalRequisitionKt
+import org.wfanet.measurement.internal.kingdom.RequisitionRefusal as InternalRefusal
 import org.wfanet.measurement.internal.kingdom.RequisitionsGrpcKt.RequisitionsCoroutineStub
 import org.wfanet.measurement.internal.kingdom.StreamRequisitionsRequest
 import org.wfanet.measurement.internal.kingdom.StreamRequisitionsRequestKt
 import org.wfanet.measurement.internal.kingdom.fulfillRequisitionRequest
 import org.wfanet.measurement.internal.kingdom.refuseRequisitionRequest
+import org.wfanet.measurement.internal.kingdom.requisitionRefusal as internalRequisitionRefusal
 import org.wfanet.measurement.internal.kingdom.streamRequisitionsRequest
 
 private const val DEFAULT_PAGE_SIZE = 50
@@ -182,11 +183,10 @@ class RequisitionsService(private val internalRequisitionStub: RequisitionsCorou
     val refuseRequest = refuseRequisitionRequest {
       externalDataProviderId = apiIdToExternalId(key.dataProviderId)
       externalRequisitionId = apiIdToExternalId(key.requisitionId)
-      refusal =
-        InternalRequisitionKt.refusal {
-          justification = request.refusal.justification.toInternal()
-          message = request.refusal.message
-        }
+      refusal = internalRequisitionRefusal {
+        justification = request.refusal.justification.toInternal()
+        message = request.refusal.message
+      }
     }
 
     val result =
@@ -448,7 +448,7 @@ private fun DuchyValue.toDuchyEntryValue(
   }
 }
 
-private fun ComputationParticipant.LiquidLegionsV2Details.toLlv2DuchyEntry(
+private fun LiquidLegionsV2Params.toLlv2DuchyEntry(
   apiVersion: Version
 ): DuchyEntry.LiquidLegionsV2 {
   val source = this
@@ -469,7 +469,7 @@ private fun ComputationParticipant.LiquidLegionsV2Details.toLlv2DuchyEntry(
   }
 }
 
-private fun ComputationParticipant.HonestMajorityShareShuffleDetails.toHmssDuchyEntryWithPublicKey(
+private fun HonestMajorityShareShuffleParams.toHmssDuchyEntryWithPublicKey(
   apiVersion: Version
 ): DuchyEntry.HonestMajorityShareShuffle {
   val source = this

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/service/internal/testing/DataProvidersServiceTest.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/service/internal/testing/DataProvidersServiceTest.kt
@@ -33,15 +33,16 @@ import org.wfanet.measurement.common.identity.IdGenerator
 import org.wfanet.measurement.common.identity.InternalId
 import org.wfanet.measurement.common.identity.RandomIdGenerator
 import org.wfanet.measurement.internal.kingdom.Certificate
-import org.wfanet.measurement.internal.kingdom.CertificateKt
 import org.wfanet.measurement.internal.kingdom.DataProvider
-import org.wfanet.measurement.internal.kingdom.DataProviderKt
 import org.wfanet.measurement.internal.kingdom.DataProvidersGrpcKt.DataProvidersCoroutineImplBase
 import org.wfanet.measurement.internal.kingdom.GetDataProviderRequest
 import org.wfanet.measurement.internal.kingdom.batchGetDataProvidersRequest
 import org.wfanet.measurement.internal.kingdom.certificate
+import org.wfanet.measurement.internal.kingdom.certificateDetails
 import org.wfanet.measurement.internal.kingdom.copy
 import org.wfanet.measurement.internal.kingdom.dataProvider
+import org.wfanet.measurement.internal.kingdom.dataProviderCapabilities
+import org.wfanet.measurement.internal.kingdom.dataProviderDetails
 import org.wfanet.measurement.internal.kingdom.getDataProviderRequest
 import org.wfanet.measurement.internal.kingdom.replaceDataAvailabilityIntervalRequest
 import org.wfanet.measurement.internal.kingdom.replaceDataProviderCapabilitiesRequest
@@ -240,16 +241,15 @@ abstract class DataProvidersServiceTest<T : DataProvidersCoroutineImplBase> {
           certificate {
             notValidBefore = timestamp { seconds = 12345 }
             notValidAfter = timestamp { seconds = 23456 }
-            details = CertificateKt.details { x509Der = CERTIFICATE_DER }
+            details = certificateDetails { x509Der = CERTIFICATE_DER }
           }
-          details =
-            DataProviderKt.details {
-              apiVersion = "v2alpha"
-              publicKey = PUBLIC_KEY
-              publicKeySignature = PUBLIC_KEY_SIGNATURE
-              publicKeySignatureAlgorithmOid = PUBLIC_KEY_SIGNATURE_ALGORITHM_OID
-              this.dataAvailabilityInterval = dataAvailabilityInterval
-            }
+          details = dataProviderDetails {
+            apiVersion = "v2alpha"
+            publicKey = PUBLIC_KEY
+            publicKeySignature = PUBLIC_KEY_SIGNATURE
+            publicKeySignatureAlgorithmOid = PUBLIC_KEY_SIGNATURE_ALGORITHM_OID
+            this.dataAvailabilityInterval = dataAvailabilityInterval
+          }
           requiredExternalDuchyIds += DUCHIES.map { it.externalDuchyId }
         }
       )
@@ -313,7 +313,7 @@ abstract class DataProvidersServiceTest<T : DataProvidersCoroutineImplBase> {
   fun `replaceDataProviderCapabilites updates DataProvider`() = runBlocking {
     val dataProvider: DataProvider =
       dataProvidersService.createDataProvider(CREATE_DATA_PROVIDER_REQUEST)
-    val capabilities = DataProviderKt.capabilities { honestMajorityShareShuffleSupported = true }
+    val capabilities = dataProviderCapabilities { honestMajorityShareShuffleSupported = true }
 
     val response: DataProvider =
       dataProvidersService.replaceDataProviderCapabilities(
@@ -381,15 +381,14 @@ abstract class DataProvidersServiceTest<T : DataProvidersCoroutineImplBase> {
         notValidBefore = timestamp { seconds = 12345 }
         notValidAfter = timestamp { seconds = 23456 }
         subjectKeyIdentifier = CERTIFICATE_SKID
-        details = CertificateKt.details { x509Der = CERTIFICATE_DER }
+        details = certificateDetails { x509Der = CERTIFICATE_DER }
       }
-      details =
-        DataProviderKt.details {
-          apiVersion = "v2alpha"
-          publicKey = PUBLIC_KEY
-          publicKeySignature = PUBLIC_KEY_SIGNATURE
-          publicKeySignatureAlgorithmOid = PUBLIC_KEY_SIGNATURE_ALGORITHM_OID
-        }
+      details = dataProviderDetails {
+        apiVersion = "v2alpha"
+        publicKey = PUBLIC_KEY
+        publicKeySignature = PUBLIC_KEY_SIGNATURE
+        publicKeySignatureAlgorithmOid = PUBLIC_KEY_SIGNATURE_ALGORITHM_OID
+      }
       requiredExternalDuchyIds += DUCHIES.map { it.externalDuchyId }
     }
   }

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/service/internal/testing/EventGroupMetadataDescriptorsServiceTest.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/service/internal/testing/EventGroupMetadataDescriptorsServiceTest.kt
@@ -36,11 +36,11 @@ import org.wfanet.measurement.common.identity.IdGenerator
 import org.wfanet.measurement.common.identity.RandomIdGenerator
 import org.wfanet.measurement.internal.kingdom.DataProvidersGrpcKt.DataProvidersCoroutineImplBase
 import org.wfanet.measurement.internal.kingdom.EventGroupMetadataDescriptor
-import org.wfanet.measurement.internal.kingdom.EventGroupMetadataDescriptorKt.details
 import org.wfanet.measurement.internal.kingdom.EventGroupMetadataDescriptorsGrpcKt.EventGroupMetadataDescriptorsCoroutineImplBase
 import org.wfanet.measurement.internal.kingdom.StreamEventGroupMetadataDescriptorsRequestKt.filter
 import org.wfanet.measurement.internal.kingdom.copy
 import org.wfanet.measurement.internal.kingdom.eventGroupMetadataDescriptor
+import org.wfanet.measurement.internal.kingdom.eventGroupMetadataDescriptorDetails
 import org.wfanet.measurement.internal.kingdom.eventGroupMetadataDescriptorKey
 import org.wfanet.measurement.internal.kingdom.getEventGroupMetadataDescriptorRequest
 import org.wfanet.measurement.internal.kingdom.streamEventGroupMetadataDescriptorsRequest
@@ -48,11 +48,11 @@ import org.wfanet.measurement.internal.kingdom.updateEventGroupMetadataDescripto
 import org.wfanet.measurement.kingdom.deploy.common.testing.DuchyIdSetter
 
 private const val RANDOM_SEED = 1
-private val DETAILS = details {
+private val DETAILS = eventGroupMetadataDescriptorDetails {
   apiVersion = Version.V2_ALPHA.string
   descriptorSet = ProtoReflection.buildFileDescriptorSet(TestMetadataMessage.getDescriptor())
 }
-private val DETAILS_2 = details {
+private val DETAILS_2 = eventGroupMetadataDescriptorDetails {
   apiVersion = Version.V2_ALPHA.string
   descriptorSet = ProtoReflection.buildFileDescriptorSet(TestMetadataMessage2.getDescriptor())
 }
@@ -259,7 +259,7 @@ abstract class EventGroupMetadataDescriptorsServiceTest<
 
     val modifyEventGroupMetadataDescriptor =
       createdEventGroupMetadataDescriptor.copy {
-        details = details { apiVersion = "alternate version" }
+        details = eventGroupMetadataDescriptorDetails { apiVersion = "alternate version" }
       }
 
     val updatedEventGroupMetadataDescriptor =

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/service/internal/testing/EventGroupsServiceTest.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/service/internal/testing/EventGroupsServiceTest.kt
@@ -36,7 +36,6 @@ import org.wfanet.measurement.common.identity.RandomIdGenerator
 import org.wfanet.measurement.internal.kingdom.AccountsGrpcKt.AccountsCoroutineImplBase
 import org.wfanet.measurement.internal.kingdom.DataProvidersGrpcKt.DataProvidersCoroutineImplBase
 import org.wfanet.measurement.internal.kingdom.EventGroup
-import org.wfanet.measurement.internal.kingdom.EventGroupKt.details
 import org.wfanet.measurement.internal.kingdom.EventGroupsGrpcKt.EventGroupsCoroutineImplBase
 import org.wfanet.measurement.internal.kingdom.GetEventGroupRequest
 import org.wfanet.measurement.internal.kingdom.MeasurementConsumersGrpcKt.MeasurementConsumersCoroutineImplBase
@@ -45,6 +44,7 @@ import org.wfanet.measurement.internal.kingdom.copy
 import org.wfanet.measurement.internal.kingdom.createEventGroupRequest
 import org.wfanet.measurement.internal.kingdom.deleteEventGroupRequest
 import org.wfanet.measurement.internal.kingdom.eventGroup
+import org.wfanet.measurement.internal.kingdom.eventGroupDetails
 import org.wfanet.measurement.internal.kingdom.eventGroupKey
 import org.wfanet.measurement.internal.kingdom.getEventGroupRequest
 import org.wfanet.measurement.internal.kingdom.streamEventGroupsRequest
@@ -55,7 +55,7 @@ private const val RANDOM_SEED = 1
 private const val EXTERNAL_EVENT_GROUP_ID = 123L
 private const val FIXED_EXTERNAL_ID = 6789L
 private const val PROVIDED_EVENT_GROUP_ID = "ProvidedEventGroupId"
-private val DETAILS = details {
+private val DETAILS = eventGroupDetails {
   apiVersion = Version.V2_ALPHA.string
   encryptedMetadata = ByteString.copyFromUtf8("somedata")
 }
@@ -358,7 +358,7 @@ abstract class EventGroupsServiceTest<T : EventGroupsCoroutineImplBase> {
 
     val modifyEventGroup =
       createdEventGroup.copy {
-        details = details { encryptedMetadata = ByteString.copyFromUtf8("metadata") }
+        details = eventGroupDetails { encryptedMetadata = ByteString.copyFromUtf8("metadata") }
       }
 
     val updatedEventGroup =
@@ -833,7 +833,7 @@ abstract class EventGroupsServiceTest<T : EventGroupsCoroutineImplBase> {
 
     val modifyEventGroup =
       deletedEventGroup.copy {
-        details = details { encryptedMetadata = ByteString.copyFromUtf8("metadata") }
+        details = eventGroupDetails { encryptedMetadata = ByteString.copyFromUtf8("metadata") }
       }
 
     val exception =

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/service/internal/testing/ExchangeStepAttemptsServiceTest.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/service/internal/testing/ExchangeStepAttemptsServiceTest.kt
@@ -37,8 +37,6 @@ import org.wfanet.measurement.common.identity.InternalId
 import org.wfanet.measurement.common.identity.testing.FixedIdGenerator
 import org.wfanet.measurement.common.toProtoTime
 import org.wfanet.measurement.gcloud.common.toGcloudTimestamp
-import org.wfanet.measurement.internal.kingdom.CertificateKt
-import org.wfanet.measurement.internal.kingdom.DataProviderKt.details
 import org.wfanet.measurement.internal.kingdom.DataProvidersGrpcKt.DataProvidersCoroutineImplBase
 import org.wfanet.measurement.internal.kingdom.Exchange
 import org.wfanet.measurement.internal.kingdom.ExchangeStep
@@ -55,10 +53,12 @@ import org.wfanet.measurement.internal.kingdom.ModelProvidersGrpcKt.ModelProvide
 import org.wfanet.measurement.internal.kingdom.RecurringExchange
 import org.wfanet.measurement.internal.kingdom.RecurringExchangesGrpcKt.RecurringExchangesCoroutineImplBase
 import org.wfanet.measurement.internal.kingdom.certificate
+import org.wfanet.measurement.internal.kingdom.certificateDetails
 import org.wfanet.measurement.internal.kingdom.claimReadyExchangeStepRequest
 import org.wfanet.measurement.internal.kingdom.copy
 import org.wfanet.measurement.internal.kingdom.createRecurringExchangeRequest
 import org.wfanet.measurement.internal.kingdom.dataProvider
+import org.wfanet.measurement.internal.kingdom.dataProviderDetails
 import org.wfanet.measurement.internal.kingdom.exchangeStepAttempt
 import org.wfanet.measurement.internal.kingdom.exchangeStepAttemptDetails
 import org.wfanet.measurement.internal.kingdom.exchangeWorkflow
@@ -118,10 +118,9 @@ private val DATA_PROVIDER = dataProvider {
   certificate = certificate {
     notValidBefore = Instant.ofEpochSecond(12345).toProtoTime()
     notValidAfter = Instant.ofEpochSecond(23456).toProtoTime()
-    details =
-      CertificateKt.details { x509Der = ByteString.copyFromUtf8("This is a certificate der.") }
+    details = certificateDetails { x509Der = ByteString.copyFromUtf8("This is a certificate der.") }
   }
-  details = details {
+  details = dataProviderDetails {
     apiVersion = Version.V2_ALPHA.string
     publicKey = ByteString.copyFromUtf8("This is a  public key.")
     publicKeySignature = ByteString.copyFromUtf8("This is a  public key signature.")

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/service/internal/testing/ExchangeStepsServiceTest.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/service/internal/testing/ExchangeStepsServiceTest.kt
@@ -42,9 +42,7 @@ import org.wfanet.measurement.common.testing.TestClockWithNamedInstants
 import org.wfanet.measurement.common.toLocalDate
 import org.wfanet.measurement.common.toProtoDate
 import org.wfanet.measurement.common.toProtoTime
-import org.wfanet.measurement.internal.kingdom.CertificateKt
 import org.wfanet.measurement.internal.kingdom.ClaimReadyExchangeStepResponse
-import org.wfanet.measurement.internal.kingdom.DataProviderKt.details
 import org.wfanet.measurement.internal.kingdom.DataProvidersGrpcKt.DataProvidersCoroutineImplBase
 import org.wfanet.measurement.internal.kingdom.Exchange
 import org.wfanet.measurement.internal.kingdom.ExchangeDetails
@@ -62,11 +60,13 @@ import org.wfanet.measurement.internal.kingdom.RecurringExchangesGrpcKt.Recurrin
 import org.wfanet.measurement.internal.kingdom.StreamExchangeStepsRequestKt.filter
 import org.wfanet.measurement.internal.kingdom.StreamExchangeStepsRequestKt.orderedKey
 import org.wfanet.measurement.internal.kingdom.certificate
+import org.wfanet.measurement.internal.kingdom.certificateDetails
 import org.wfanet.measurement.internal.kingdom.claimReadyExchangeStepRequest
 import org.wfanet.measurement.internal.kingdom.claimReadyExchangeStepResponse
 import org.wfanet.measurement.internal.kingdom.copy
 import org.wfanet.measurement.internal.kingdom.createRecurringExchangeRequest
 import org.wfanet.measurement.internal.kingdom.dataProvider
+import org.wfanet.measurement.internal.kingdom.dataProviderDetails
 import org.wfanet.measurement.internal.kingdom.exchange
 import org.wfanet.measurement.internal.kingdom.exchangeStep
 import org.wfanet.measurement.internal.kingdom.exchangeStepAttempt
@@ -153,10 +153,9 @@ private val DATA_PROVIDER = dataProvider {
   certificate = certificate {
     notValidBefore = Instant.ofEpochSecond(12345).toProtoTime()
     notValidAfter = Instant.ofEpochSecond(23456).toProtoTime()
-    details =
-      CertificateKt.details { x509Der = ByteString.copyFromUtf8("This is a certificate der.") }
+    details = certificateDetails { x509Der = ByteString.copyFromUtf8("This is a certificate der.") }
   }
-  details = details {
+  details = dataProviderDetails {
     apiVersion = Version.V2_ALPHA.string
     publicKey = ByteString.copyFromUtf8("This is a  public key.")
     publicKeySignature = ByteString.copyFromUtf8("This is a  public key signature.")

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/service/internal/testing/MeasurementConsumersServiceTest.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/service/internal/testing/MeasurementConsumersServiceTest.kt
@@ -34,19 +34,19 @@ import org.wfanet.measurement.common.identity.InternalId
 import org.wfanet.measurement.common.identity.testing.FixedIdGenerator
 import org.wfanet.measurement.internal.kingdom.AccountsGrpcKt
 import org.wfanet.measurement.internal.kingdom.Certificate
-import org.wfanet.measurement.internal.kingdom.CertificateKt
 import org.wfanet.measurement.internal.kingdom.GetMeasurementConsumerRequest
 import org.wfanet.measurement.internal.kingdom.MeasurementConsumer
-import org.wfanet.measurement.internal.kingdom.MeasurementConsumerKt.details
 import org.wfanet.measurement.internal.kingdom.MeasurementConsumersGrpcKt.MeasurementConsumersCoroutineImplBase
 import org.wfanet.measurement.internal.kingdom.account
 import org.wfanet.measurement.internal.kingdom.addMeasurementConsumerOwnerRequest
 import org.wfanet.measurement.internal.kingdom.authenticateAccountRequest
 import org.wfanet.measurement.internal.kingdom.certificate
+import org.wfanet.measurement.internal.kingdom.certificateDetails
 import org.wfanet.measurement.internal.kingdom.copy
 import org.wfanet.measurement.internal.kingdom.createMeasurementConsumerRequest
 import org.wfanet.measurement.internal.kingdom.getMeasurementConsumerRequest
 import org.wfanet.measurement.internal.kingdom.measurementConsumer
+import org.wfanet.measurement.internal.kingdom.measurementConsumerDetails
 import org.wfanet.measurement.internal.kingdom.removeMeasurementConsumerOwnerRequest
 
 private const val FIXED_GENERATED_INTERNAL_ID = 2345L
@@ -60,9 +60,9 @@ private val MEASUREMENT_CONSUMER = measurementConsumer {
   certificate = certificate {
     notValidBefore = timestamp { seconds = 12345 }
     notValidAfter = timestamp { seconds = 23456 }
-    details = CertificateKt.details { x509Der = CERTIFICATE_DER }
+    details = certificateDetails { x509Der = CERTIFICATE_DER }
   }
-  details = details {
+  details = measurementConsumerDetails {
     apiVersion = "v2alpha"
     publicKey = PUBLIC_KEY
     publicKeySignature = PUBLIC_KEY_SIGNATURE

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/service/internal/testing/MeasurementLogEntriesServiceTest.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/service/internal/testing/MeasurementLogEntriesServiceTest.kt
@@ -33,20 +33,22 @@ import org.wfanet.measurement.common.identity.IdGenerator
 import org.wfanet.measurement.common.identity.RandomIdGenerator
 import org.wfanet.measurement.internal.kingdom.AccountsGrpcKt.AccountsCoroutineImplBase
 import org.wfanet.measurement.internal.kingdom.DataProvidersGrpcKt.DataProvidersCoroutineImplBase
-import org.wfanet.measurement.internal.kingdom.DuchyMeasurementLogEntryKt
 import org.wfanet.measurement.internal.kingdom.DuchyProtocolConfig
 import org.wfanet.measurement.internal.kingdom.Measurement
 import org.wfanet.measurement.internal.kingdom.MeasurementConsumersGrpcKt.MeasurementConsumersCoroutineImplBase
 import org.wfanet.measurement.internal.kingdom.MeasurementLogEntriesGrpcKt.MeasurementLogEntriesCoroutineImplBase
-import org.wfanet.measurement.internal.kingdom.MeasurementLogEntry
-import org.wfanet.measurement.internal.kingdom.MeasurementLogEntryKt
+import org.wfanet.measurement.internal.kingdom.MeasurementLogEntryError
 import org.wfanet.measurement.internal.kingdom.MeasurementsGrpcKt.MeasurementsCoroutineImplBase
 import org.wfanet.measurement.internal.kingdom.ProtocolConfig
 import org.wfanet.measurement.internal.kingdom.StateTransitionMeasurementLogEntry
 import org.wfanet.measurement.internal.kingdom.cancelMeasurementRequest
 import org.wfanet.measurement.internal.kingdom.createDuchyMeasurementLogEntryRequest
 import org.wfanet.measurement.internal.kingdom.duchyMeasurementLogEntry
+import org.wfanet.measurement.internal.kingdom.duchyMeasurementLogEntryDetails
+import org.wfanet.measurement.internal.kingdom.duchyMeasurementLogEntryStageAttempt
 import org.wfanet.measurement.internal.kingdom.measurementLogEntry
+import org.wfanet.measurement.internal.kingdom.measurementLogEntryDetails
+import org.wfanet.measurement.internal.kingdom.measurementLogEntryError
 import org.wfanet.measurement.internal.kingdom.streamStateTransitionMeasurementLogEntriesRequest
 import org.wfanet.measurement.kingdom.deploy.common.Llv2ProtocolConfig
 import org.wfanet.measurement.kingdom.deploy.common.testing.DuchyIdSetter
@@ -105,13 +107,9 @@ abstract class MeasurementLogEntriesServiceTest<T : MeasurementLogEntriesCorouti
           createDuchyMeasurementLogEntryRequest {
             externalComputationId = 1234L // WrongID
             externalDuchyId = DUCHIES[0].externalDuchyId
-            measurementLogEntryDetails =
-              MeasurementLogEntryKt.details {
-                error =
-                  MeasurementLogEntryKt.errorDetails {
-                    type = MeasurementLogEntry.ErrorDetails.Type.TRANSIENT
-                  }
-              }
+            measurementLogEntryDetails = measurementLogEntryDetails {
+              error = measurementLogEntryError { type = MeasurementLogEntryError.Type.TRANSIENT }
+            }
           }
         )
       }
@@ -140,13 +138,9 @@ abstract class MeasurementLogEntriesServiceTest<T : MeasurementLogEntriesCorouti
           createDuchyMeasurementLogEntryRequest {
             externalComputationId = measurement.externalComputationId
             externalDuchyId = "wrong duchy id" // WrongID
-            measurementLogEntryDetails =
-              MeasurementLogEntryKt.details {
-                error =
-                  MeasurementLogEntryKt.errorDetails {
-                    type = MeasurementLogEntry.ErrorDetails.Type.TRANSIENT
-                  }
-              }
+            measurementLogEntryDetails = measurementLogEntryDetails {
+              error = measurementLogEntryError { type = MeasurementLogEntryError.Type.TRANSIENT }
+            }
           }
         )
       }
@@ -163,13 +157,9 @@ abstract class MeasurementLogEntriesServiceTest<T : MeasurementLogEntriesCorouti
           createDuchyMeasurementLogEntryRequest {
             externalComputationId = 1L
             externalDuchyId = DUCHIES[0].externalDuchyId
-            measurementLogEntryDetails =
-              MeasurementLogEntryKt.details {
-                error =
-                  MeasurementLogEntryKt.errorDetails {
-                    type = MeasurementLogEntry.ErrorDetails.Type.PERMANENT
-                  }
-              }
+            measurementLogEntryDetails = measurementLogEntryDetails {
+              error = measurementLogEntryError { type = MeasurementLogEntryError.Type.PERMANENT }
+            }
           }
         )
       }
@@ -191,20 +181,15 @@ abstract class MeasurementLogEntriesServiceTest<T : MeasurementLogEntriesCorouti
         dataProvider,
       )
 
-    val measurementLogEntryDetails =
-      MeasurementLogEntryKt.details {
-        error =
-          MeasurementLogEntryKt.errorDetails {
-            type = MeasurementLogEntry.ErrorDetails.Type.TRANSIENT
-          }
-        logMessage = "some log message"
-      }
+    val measurementLogEntryDetails = measurementLogEntryDetails {
+      error = measurementLogEntryError { type = MeasurementLogEntryError.Type.TRANSIENT }
+      logMessage = "some log message"
+    }
 
-    val duchyMeasurementLogEntryDetails =
-      DuchyMeasurementLogEntryKt.details {
-        duchyChildReferenceId = "some child reference"
-        stageAttempt = DuchyMeasurementLogEntryKt.stageAttempt { stage = 1 }
-      }
+    val duchyMeasurementLogEntryDetails = duchyMeasurementLogEntryDetails {
+      duchyChildReferenceId = "some child reference"
+      stageAttempt = duchyMeasurementLogEntryStageAttempt { stage = 1 }
+    }
 
     val createdDuchyMeasurementLogEntry =
       measurementLogEntriesService.createDuchyMeasurementLogEntry(
@@ -247,13 +232,12 @@ abstract class MeasurementLogEntriesServiceTest<T : MeasurementLogEntriesCorouti
         dataProvider,
       )
 
-    val measurementLogEntryDetails = MeasurementLogEntryKt.details { logMessage = "This is a log." }
+    val measurementLogEntryDetails = measurementLogEntryDetails { logMessage = "This is a log." }
 
-    val duchyMeasurementLogEntryDetails =
-      DuchyMeasurementLogEntryKt.details {
-        duchyChildReferenceId = "some child reference"
-        stageAttempt = DuchyMeasurementLogEntryKt.stageAttempt { stage = 1 }
-      }
+    val duchyMeasurementLogEntryDetails = duchyMeasurementLogEntryDetails {
+      duchyChildReferenceId = "some child reference"
+      stageAttempt = duchyMeasurementLogEntryStageAttempt { stage = 1 }
+    }
 
     val createdDuchyMeasurementLogEntry =
       measurementLogEntriesService.createDuchyMeasurementLogEntry(
@@ -302,18 +286,13 @@ abstract class MeasurementLogEntriesServiceTest<T : MeasurementLogEntriesCorouti
       }
     )
 
-    val measurementLogEntryDetails =
-      MeasurementLogEntryKt.details {
-        error =
-          MeasurementLogEntryKt.errorDetails {
-            type = MeasurementLogEntry.ErrorDetails.Type.TRANSIENT
-          }
-      }
-    val duchyMeasurementLogEntryDetails =
-      DuchyMeasurementLogEntryKt.details {
-        duchyChildReferenceId = "some child reference"
-        stageAttempt = DuchyMeasurementLogEntryKt.stageAttempt { stage = 1 }
-      }
+    val measurementLogEntryDetails = measurementLogEntryDetails {
+      error = measurementLogEntryError { type = MeasurementLogEntryError.Type.TRANSIENT }
+    }
+    val duchyMeasurementLogEntryDetails = duchyMeasurementLogEntryDetails {
+      duchyChildReferenceId = "some child reference"
+      stageAttempt = duchyMeasurementLogEntryStageAttempt { stage = 1 }
+    }
 
     val exception =
       assertFailsWith<StatusRuntimeException> {

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/service/internal/testing/MeasurementsServiceTest.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/service/internal/testing/MeasurementsServiceTest.kt
@@ -43,6 +43,7 @@ import org.wfanet.measurement.internal.kingdom.CancelMeasurementRequest
 import org.wfanet.measurement.internal.kingdom.Certificate
 import org.wfanet.measurement.internal.kingdom.CertificatesGrpcKt
 import org.wfanet.measurement.internal.kingdom.ComputationParticipant
+import org.wfanet.measurement.internal.kingdom.ComputationParticipantDetails
 import org.wfanet.measurement.internal.kingdom.DataProvider
 import org.wfanet.measurement.internal.kingdom.DataProvidersGrpcKt.DataProvidersCoroutineImplBase
 import org.wfanet.measurement.internal.kingdom.DeleteMeasurementRequest
@@ -50,14 +51,11 @@ import org.wfanet.measurement.internal.kingdom.DuchyProtocolConfig
 import org.wfanet.measurement.internal.kingdom.Measurement
 import org.wfanet.measurement.internal.kingdom.MeasurementConsumer
 import org.wfanet.measurement.internal.kingdom.MeasurementConsumersGrpcKt.MeasurementConsumersCoroutineImplBase
-import org.wfanet.measurement.internal.kingdom.MeasurementKt
 import org.wfanet.measurement.internal.kingdom.MeasurementKt.resultInfo
 import org.wfanet.measurement.internal.kingdom.MeasurementLogEntriesGrpcKt.MeasurementLogEntriesCoroutineImplBase
-import org.wfanet.measurement.internal.kingdom.MeasurementLogEntryKt
 import org.wfanet.measurement.internal.kingdom.MeasurementsGrpcKt.MeasurementsCoroutineImplBase
 import org.wfanet.measurement.internal.kingdom.ProtocolConfig
 import org.wfanet.measurement.internal.kingdom.Requisition
-import org.wfanet.measurement.internal.kingdom.RequisitionKt.details
 import org.wfanet.measurement.internal.kingdom.RequisitionKt.parentMeasurement
 import org.wfanet.measurement.internal.kingdom.RequisitionsGrpcKt.RequisitionsCoroutineImplBase
 import org.wfanet.measurement.internal.kingdom.StreamMeasurementsRequestKt
@@ -76,10 +74,13 @@ import org.wfanet.measurement.internal.kingdom.duchyProtocolConfig
 import org.wfanet.measurement.internal.kingdom.getMeasurementByComputationIdRequest
 import org.wfanet.measurement.internal.kingdom.getMeasurementRequest
 import org.wfanet.measurement.internal.kingdom.measurement
+import org.wfanet.measurement.internal.kingdom.measurementDetails
 import org.wfanet.measurement.internal.kingdom.measurementKey
 import org.wfanet.measurement.internal.kingdom.measurementLogEntry
+import org.wfanet.measurement.internal.kingdom.measurementLogEntryDetails
 import org.wfanet.measurement.internal.kingdom.protocolConfig
 import org.wfanet.measurement.internal.kingdom.requisition
+import org.wfanet.measurement.internal.kingdom.requisitionDetails
 import org.wfanet.measurement.internal.kingdom.revokeCertificateRequest
 import org.wfanet.measurement.internal.kingdom.setMeasurementResultRequest
 import org.wfanet.measurement.internal.kingdom.stateTransitionMeasurementLogEntry
@@ -101,19 +102,18 @@ private const val MAX_BATCH_CANCEL = 1000
 
 private val MEASUREMENT = measurement {
   providedMeasurementId = PROVIDED_MEASUREMENT_ID
-  details =
-    MeasurementKt.details {
-      apiVersion = API_VERSION
-      measurementSpec = ByteString.copyFromUtf8("MeasurementSpec")
-      measurementSpecSignature = ByteString.copyFromUtf8("MeasurementSpec signature")
-      measurementSpecSignatureAlgorithmOid = "2.9999"
-      duchyProtocolConfig = duchyProtocolConfig {
-        liquidLegionsV2 = DuchyProtocolConfig.LiquidLegionsV2.getDefaultInstance()
-      }
-      protocolConfig = protocolConfig {
-        liquidLegionsV2 = ProtocolConfig.LiquidLegionsV2.getDefaultInstance()
-      }
+  details = measurementDetails {
+    apiVersion = API_VERSION
+    measurementSpec = ByteString.copyFromUtf8("MeasurementSpec")
+    measurementSpecSignature = ByteString.copyFromUtf8("MeasurementSpec signature")
+    measurementSpecSignatureAlgorithmOid = "2.9999"
+    duchyProtocolConfig = duchyProtocolConfig {
+      liquidLegionsV2 = DuchyProtocolConfig.LiquidLegionsV2.getDefaultInstance()
     }
+    protocolConfig = protocolConfig {
+      liquidLegionsV2 = ProtocolConfig.LiquidLegionsV2.getDefaultInstance()
+    }
+  }
 }
 
 private val REACH_ONLY_MEASUREMENT =
@@ -131,16 +131,15 @@ private val REACH_ONLY_MEASUREMENT =
 
 private val HMSS_MEASUREMENT = measurement {
   providedMeasurementId = PROVIDED_MEASUREMENT_ID
-  details =
-    MeasurementKt.details {
-      apiVersion = API_VERSION
-      measurementSpec = ByteString.copyFromUtf8("MeasurementSpec")
-      measurementSpecSignature = ByteString.copyFromUtf8("MeasurementSpec signature")
-      measurementSpecSignatureAlgorithmOid = "2.9999"
-      protocolConfig = protocolConfig {
-        honestMajorityShareShuffle = ProtocolConfig.HonestMajorityShareShuffle.getDefaultInstance()
-      }
+  details = measurementDetails {
+    apiVersion = API_VERSION
+    measurementSpec = ByteString.copyFromUtf8("MeasurementSpec")
+    measurementSpecSignature = ByteString.copyFromUtf8("MeasurementSpec signature")
+    measurementSpecSignatureAlgorithmOid = "2.9999"
+    protocolConfig = protocolConfig {
+      honestMajorityShareShuffle = ProtocolConfig.HonestMajorityShareShuffle.getDefaultInstance()
     }
+  }
 }
 
 private val INVALID_WORKER_DUCHY =
@@ -973,7 +972,7 @@ abstract class MeasurementsServiceTest<T : MeasurementsCoroutineImplBase> {
               }
               dataProvidersCount = 1
             }
-            details = details {
+            details = requisitionDetails {
               dataProviderPublicKey = dataProviderValue.dataProviderPublicKey
               encryptedRequisitionSpec = dataProviderValue.encryptedRequisitionSpec
               nonceHash = dataProviderValue.nonceHash
@@ -1003,7 +1002,7 @@ abstract class MeasurementsServiceTest<T : MeasurementsCoroutineImplBase> {
         externalComputationId = createdMeasurement.externalComputationId
         updateTime = createdMeasurement.createTime
         state = ComputationParticipant.State.CREATED
-        details = ComputationParticipant.Details.getDefaultInstance()
+        details = ComputationParticipantDetails.getDefaultInstance()
         apiVersion = createdMeasurement.details.apiVersion
       }
       assertThat(measurement.computationParticipantsList)
@@ -1140,7 +1139,7 @@ abstract class MeasurementsServiceTest<T : MeasurementsCoroutineImplBase> {
             externalMeasurementConsumerId = measurement.externalMeasurementConsumerId
             externalMeasurementId = measurement.externalMeasurementId
             createTime = succeededMeasurement.updateTime
-            details = MeasurementLogEntryKt.details { logMessage = "Measurement succeeded" }
+            details = measurementLogEntryDetails { logMessage = "Measurement succeeded" }
           }
           previousState = measurement.state
           currentState = Measurement.State.SUCCEEDED

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/service/internal/testing/PopulationsServiceTest.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/service/internal/testing/PopulationsServiceTest.kt
@@ -29,8 +29,6 @@ import kotlinx.coroutines.runBlocking
 import org.junit.Before
 import org.junit.Test
 import org.wfanet.measurement.common.identity.IdGenerator
-import org.wfanet.measurement.internal.kingdom.CertificateKt
-import org.wfanet.measurement.internal.kingdom.DataProviderKt
 import org.wfanet.measurement.internal.kingdom.DataProvidersGrpcKt.DataProvidersCoroutineImplBase
 import org.wfanet.measurement.internal.kingdom.Population
 import org.wfanet.measurement.internal.kingdom.PopulationKt.populationBlob
@@ -38,7 +36,9 @@ import org.wfanet.measurement.internal.kingdom.PopulationsGrpcKt.PopulationsCoro
 import org.wfanet.measurement.internal.kingdom.StreamPopulationsRequestKt.afterFilter
 import org.wfanet.measurement.internal.kingdom.StreamPopulationsRequestKt.filter
 import org.wfanet.measurement.internal.kingdom.certificate
+import org.wfanet.measurement.internal.kingdom.certificateDetails
 import org.wfanet.measurement.internal.kingdom.dataProvider
+import org.wfanet.measurement.internal.kingdom.dataProviderDetails
 import org.wfanet.measurement.internal.kingdom.eventTemplate
 import org.wfanet.measurement.internal.kingdom.getPopulationRequest
 import org.wfanet.measurement.internal.kingdom.population
@@ -279,15 +279,15 @@ abstract class PopulationsServiceTest<T : PopulationsCoroutineImplBase> {
       certificate {
         notValidBefore = timestamp { seconds = 12345 }
         notValidAfter = timestamp { seconds = 23456 }
-        details =
-          CertificateKt.details { x509Der = ByteString.copyFromUtf8("This is a certificate der.") }
-      }
-      details =
-        DataProviderKt.details {
-          apiVersion = "v2alpha"
-          publicKey = ByteString.copyFromUtf8("This is a  public key.")
-          publicKeySignature = ByteString.copyFromUtf8("This is a  public key signature.")
+        details = certificateDetails {
+          x509Der = ByteString.copyFromUtf8("This is a certificate der.")
         }
+      }
+      details = dataProviderDetails {
+        apiVersion = "v2alpha"
+        publicKey = ByteString.copyFromUtf8("This is a  public key.")
+        publicKeySignature = ByteString.copyFromUtf8("This is a  public key signature.")
+      }
     }
   }
 }

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/service/system/v1alpha/ComputationParticipantsService.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/service/system/v1alpha/ComputationParticipantsService.kt
@@ -25,17 +25,19 @@ import org.wfanet.measurement.common.identity.DuchyIdentity
 import org.wfanet.measurement.common.identity.apiIdToExternalId
 import org.wfanet.measurement.common.identity.duchyIdentityFromContext
 import org.wfanet.measurement.internal.kingdom.ComputationParticipant as InternalComputationParticipant
-import org.wfanet.measurement.internal.kingdom.ComputationParticipantKt.honestMajorityShareShuffleDetails
-import org.wfanet.measurement.internal.kingdom.ComputationParticipantKt.liquidLegionsV2Details
 import org.wfanet.measurement.internal.kingdom.ComputationParticipantsGrpcKt.ComputationParticipantsCoroutineStub as InternalComputationParticipantsCoroutineStub
 import org.wfanet.measurement.internal.kingdom.ConfirmComputationParticipantRequest as InternalConfirmComputationParticipantRequest
 import org.wfanet.measurement.internal.kingdom.FailComputationParticipantRequest as InternalFailComputationParticipantRequest
-import org.wfanet.measurement.internal.kingdom.MeasurementLogEntry as InternalMeasurementLogEntry
-import org.wfanet.measurement.internal.kingdom.MeasurementLogEntryKt as InternalMeasurementLogEntryKt
+import org.wfanet.measurement.internal.kingdom.HonestMajorityShareShuffleParams
+import org.wfanet.measurement.internal.kingdom.LiquidLegionsV2Params
+import org.wfanet.measurement.internal.kingdom.MeasurementLogEntryError as InternalMeasurementLogEntryError
 import org.wfanet.measurement.internal.kingdom.SetParticipantRequisitionParamsRequest as InternalSetParticipantRequisitionParamsRequest
 import org.wfanet.measurement.internal.kingdom.confirmComputationParticipantRequest as internalConfirmComputationParticipantRequest
 import org.wfanet.measurement.internal.kingdom.failComputationParticipantRequest as internalFailComputationParticipantRequest
 import org.wfanet.measurement.internal.kingdom.getComputationParticipantRequest as internalGetComputationParticipantRequest
+import org.wfanet.measurement.internal.kingdom.honestMajorityShareShuffleParams
+import org.wfanet.measurement.internal.kingdom.liquidLegionsV2Params
+import org.wfanet.measurement.internal.kingdom.measurementLogEntryError as internalMeasurementLogEntryError
 import org.wfanet.measurement.internal.kingdom.setParticipantRequisitionParamsRequest as internalSetParticipantRequisitionParamsRequest
 import org.wfanet.measurement.system.v1alpha.ComputationParticipant
 import org.wfanet.measurement.system.v1alpha.ComputationParticipant.RequisitionParams.ProtocolCase
@@ -165,9 +167,9 @@ class ComputationParticipantsService(
   }
 
   private fun ComputationParticipant.RequisitionParams.LiquidLegionsV2.toLlV2Details():
-    InternalComputationParticipant.LiquidLegionsV2Details {
+    LiquidLegionsV2Params {
     val source = this
-    return liquidLegionsV2Details {
+    return liquidLegionsV2Params {
       elGamalPublicKey = source.elGamalPublicKey
       elGamalPublicKeySignature = source.elGamalPublicKeySignature
       elGamalPublicKeySignatureAlgorithmOid = source.elGamalPublicKeySignatureAlgorithmOid
@@ -175,9 +177,9 @@ class ComputationParticipantsService(
   }
 
   private fun ComputationParticipant.RequisitionParams.HonestMajorityShareShuffle.toHmssDetails():
-    InternalComputationParticipant.HonestMajorityShareShuffleDetails {
+    HonestMajorityShareShuffleParams {
     val source = this
-    return honestMajorityShareShuffleDetails {
+    return honestMajorityShareShuffleParams {
       tinkPublicKey = source.tinkPublicKey
       tinkPublicKeySignature = source.tinkPublicKeySignature
       tinkPublicKeySignatureAlgorithmOid = source.tinkPublicKeySignatureAlgorithmOid
@@ -204,15 +206,14 @@ class ComputationParticipantsService(
     return internalFailComputationParticipantRequest {
       externalComputationId = apiIdToExternalId(computationParticipantKey.computationId)
       externalDuchyId = computationParticipantKey.duchyId
-      errorMessage = failure.errorMessage
+      logMessage = failure.errorMessage
       duchyChildReferenceId = failure.participantChildReferenceId
       if (failure.hasStageAttempt()) {
         stageAttempt = failure.stageAttempt.toInternalStageAttempt()
-        errorDetails =
-          InternalMeasurementLogEntryKt.errorDetails {
-            type = InternalMeasurementLogEntry.ErrorDetails.Type.PERMANENT
-            errorTime = failure.errorTime
-          }
+        error = internalMeasurementLogEntryError {
+          type = InternalMeasurementLogEntryError.Type.PERMANENT
+          errorTime = failure.errorTime
+        }
       }
       etag = source.etag
     }

--- a/src/main/kotlin/org/wfanet/measurement/loadtest/panelmatchresourcesetup/PanelMatchResourceSetup.kt
+++ b/src/main/kotlin/org/wfanet/measurement/loadtest/panelmatchresourcesetup/PanelMatchResourceSetup.kt
@@ -37,13 +37,13 @@ import org.wfanet.measurement.common.identity.externalIdToApiId
 import org.wfanet.measurement.config.AuthorityKeyToPrincipalMapKt
 import org.wfanet.measurement.config.authorityKeyToPrincipalMap
 import org.wfanet.measurement.consent.client.measurementconsumer.signEncryptionPublicKey
-import org.wfanet.measurement.internal.kingdom.DataProviderKt
 import org.wfanet.measurement.internal.kingdom.DataProvidersGrpcKt
 import org.wfanet.measurement.internal.kingdom.ModelProvidersGrpcKt
 import org.wfanet.measurement.internal.kingdom.RecurringExchange
 import org.wfanet.measurement.internal.kingdom.RecurringExchangesGrpcKt
 import org.wfanet.measurement.internal.kingdom.createRecurringExchangeRequest
 import org.wfanet.measurement.internal.kingdom.dataProvider
+import org.wfanet.measurement.internal.kingdom.dataProviderDetails
 import org.wfanet.measurement.internal.kingdom.modelProvider
 import org.wfanet.measurement.internal.kingdom.recurringExchange
 import org.wfanet.measurement.internal.kingdom.recurringExchangeDetails
@@ -202,12 +202,11 @@ class PanelMatchResourceSetup(
           dataProvider {
             certificate =
               parseCertificateDer(dataProviderContent.signingKey.certificate.encoded.toByteString())
-            details =
-              DataProviderKt.details {
-                apiVersion = API_VERSION.string
-                publicKey = signedPublicKey.message.value
-                publicKeySignature = signedPublicKey.signature
-              }
+            details = dataProviderDetails {
+              apiVersion = API_VERSION.string
+              publicKey = signedPublicKey.message.value
+              publicKeySignature = signedPublicKey.signature
+            }
           }
         )
       } catch (e: StatusException) {

--- a/src/main/kotlin/org/wfanet/measurement/loadtest/resourcesetup/ResourceSetup.kt
+++ b/src/main/kotlin/org/wfanet/measurement/loadtest/resourcesetup/ResourceSetup.kt
@@ -60,12 +60,12 @@ import org.wfanet.measurement.internal.kingdom.Account as InternalAccount
 import org.wfanet.measurement.internal.kingdom.AccountsGrpcKt
 import org.wfanet.measurement.internal.kingdom.CertificatesGrpcKt
 import org.wfanet.measurement.internal.kingdom.DataProvider as InternalDataProvider
-import org.wfanet.measurement.internal.kingdom.DataProviderKt as InternalDataProviderKt
 import org.wfanet.measurement.internal.kingdom.DataProvidersGrpcKt
 import org.wfanet.measurement.internal.kingdom.account as internalAccount
 import org.wfanet.measurement.internal.kingdom.certificate as internalCertificate
 import org.wfanet.measurement.internal.kingdom.createMeasurementConsumerCreationTokenRequest
 import org.wfanet.measurement.internal.kingdom.dataProvider as internalDataProvider
+import org.wfanet.measurement.internal.kingdom.dataProviderDetails
 import org.wfanet.measurement.kingdom.service.api.v2alpha.fillCertificateFromDer
 import org.wfanet.measurement.kingdom.service.api.v2alpha.parseCertificateDer
 import org.wfanet.measurement.loadtest.common.ConsoleOutput
@@ -256,13 +256,12 @@ class ResourceSetup(
         internalDataProvider {
           certificate =
             parseCertificateDer(dataProviderContent.signingKey.certificate.encoded.toByteString())
-          details =
-            InternalDataProviderKt.details {
-              apiVersion = API_VERSION.string
-              publicKey = signedPublicKey.message.value
-              publicKeySignature = signedPublicKey.signature
-              publicKeySignatureAlgorithmOid = signedPublicKey.signatureAlgorithmOid
-            }
+          details = dataProviderDetails {
+            apiVersion = API_VERSION.string
+            publicKey = signedPublicKey.message.value
+            publicKeySignature = signedPublicKey.signature
+            publicKeySignatureAlgorithmOid = signedPublicKey.signatureAlgorithmOid
+          }
           requiredExternalDuchyIds += requiredDuchies
         }
       )

--- a/src/main/proto/wfa/measurement/internal/README.md
+++ b/src/main/proto/wfa/measurement/internal/README.md
@@ -1,0 +1,27 @@
+# Internal API Service Definitions
+
+gRPC service definitions for internal APIs, which are those that have access to
+underlying databases. All database access is done through these services.
+
+## Conventions
+
+### Keys and IDs
+
+Service implementations may use separate "internal" IDs for database primary
+keys. These are not exposed in the API, which is why the ID fields tend to be
+prefixed with `external`. Within the API, the unique key to identify an entity
+may be made of up multiple external IDs. Unless otherwise stated, each ID
+component of the key is only guaranteed to be unique within the scope of its
+parent key.
+
+For example, the key of a `Measurement` in the Kingdom internal API is
+(`external_measurement_consumer_id`, `external_measurement_id`). The
+`external_measurement_id` is only guaranteed to be unique within the parent
+`MeasurementConsumer`.
+
+### Details message types
+
+Message types which have a name ending in `Details` may be persisted in the
+underlying database using binary serialization. Care must be taken to ensure
+that any changes to these message types remain binary-compatible with existing
+persisted values.

--- a/src/main/proto/wfa/measurement/internal/kingdom/BUILD.bazel
+++ b/src/main/proto/wfa/measurement/internal/kingdom/BUILD.bazel
@@ -1,15 +1,104 @@
 load("@rules_proto//proto:defs.bzl", "proto_library")
-load("@wfa_rules_kotlin_jvm//kotlin:defs.bzl", "kt_jvm_grpc_proto_library")
+load(
+    "@wfa_rules_kotlin_jvm//kotlin:defs.bzl",
+    "kt_jvm_grpc_proto_library",
+    "kt_jvm_proto_library",
+)
 load(
     "//src/main/proto/wfa/measurement/internal/common:macros.bzl",
     "IMPORT_PREFIX",
-    "proto_and_kt_jvm_proto_library",
 )
 
 package(default_visibility = ["//:__subpackages__"])
 
-proto_and_kt_jvm_proto_library(
-    name = "account",
+LIBS = [
+    "account",
+    "api_key",
+    "certificate",
+    "computation_participant",
+    "crypto",
+    "data_provider_capabilities",
+    "data_provider",
+    "differential_privacy",
+    "duchy_id_config",
+    "duchy_measurement_log_entry_stage_attempt",
+    "duchy_measurement_log_entry",
+    "duchy_protocol_config",
+    "error_code",
+    "event_group_metadata_descriptor",
+    "event_group",
+    "event_template",
+    "exchange_details",
+    "exchange",
+    "exchange_step_attempt_details",
+    "exchange_step_attempt",
+    "exchange_step",
+    "exchange_workflow",
+    "measurement_consumer",
+    "measurement_log_entry_error",
+    "measurement_log_entry",
+    "measurement_failure",
+    "measurement",
+    "model_line",
+    "model_outage",
+    "model_provider",
+    "model_release",
+    "model_rollout",
+    "model_shard",
+    "model_suite",
+    "population",
+    "protocol_config_config",
+    "protocol_config",
+    "recurring_exchange_details",
+    "recurring_exchange",
+    "requisition_refusal",
+    "state_transition_measurement_log_entry",
+]
+
+DETAILS_LIBS = [
+    "certificate",
+    "computation_participant",
+    "data_provider",
+    "duchy_measurement_log_entry",
+    "event_group_metadata_descriptor",
+    "event_group",
+    "requisition",
+    "measurement_consumer",
+    "measurement_log_entry",
+    "measurement",
+]
+
+SERVICES = [
+    "accounts",
+    "api_keys",
+    "certificates",
+    "computation_participants",
+    "data_providers",
+    "event_group_metadata_descriptors",
+    "event_groups",
+    "exchanges",
+    "exchange_step_attempts",
+    "exchange_steps",
+    "measurement_consumers",
+    "measurement_log_entries",
+    "measurements",
+    "model_lines",
+    "model_outages",
+    "model_providers",
+    "model_releases",
+    "model_rollouts",
+    "model_shards",
+    "model_suites",
+    "populations",
+    "public_keys",
+    "recurring_exchanges",
+    "requisitions",
+]
+
+proto_library(
+    name = "account_proto",
+    srcs = ["account.proto"],
+    strip_import_prefix = IMPORT_PREFIX,
 )
 
 proto_library(
@@ -21,13 +110,10 @@ proto_library(
     ],
 )
 
-kt_jvm_grpc_proto_library(
-    name = "accounts_service_kt_jvm_grpc_proto",
-    deps = [":accounts_service_proto"],
-)
-
-proto_and_kt_jvm_proto_library(
-    name = "api_key",
+proto_library(
+    name = "api_key_proto",
+    srcs = ["api_key.proto"],
+    strip_import_prefix = IMPORT_PREFIX,
 )
 
 proto_library(
@@ -40,30 +126,63 @@ proto_library(
     ],
 )
 
-kt_jvm_grpc_proto_library(
-    name = "api_keys_service_kt_jvm_grpc_proto",
-    deps = [":api_keys_service_proto"],
+proto_library(
+    name = "participant_requisition_params_proto",
+    srcs = ["participant_requisition_params.proto"],
+    strip_import_prefix = IMPORT_PREFIX,
 )
 
-proto_and_kt_jvm_proto_library(
-    name = "computation_participant",
+proto_library(
+    name = "computation_participant_details_proto",
+    srcs = ["computation_participant_details.proto"],
+    strip_import_prefix = IMPORT_PREFIX,
+    deps = [
+        ":participant_requisition_params_proto",
+    ],
+)
+
+proto_library(
+    name = "computation_participant_proto",
+    srcs = ["computation_participant.proto"],
+    strip_import_prefix = IMPORT_PREFIX,
     deps = [
         ":certificate_proto",
+        ":computation_participant_details_proto",
         ":duchy_measurement_log_entry_proto",
         "@com_google_protobuf//:timestamp_proto",
     ],
 )
 
-proto_and_kt_jvm_proto_library(
-    name = "data_provider",
+proto_library(
+    name = "data_provider_capabilities_proto",
+    srcs = ["data_provider_capabilities.proto"],
+    strip_import_prefix = IMPORT_PREFIX,
+)
+
+proto_library(
+    name = "data_provider_details_proto",
+    srcs = ["data_provider_details.proto"],
+    strip_import_prefix = IMPORT_PREFIX,
     deps = [
-        ":certificate_proto",
+        ":data_provider_capabilities_proto",
         "@com_google_googleapis//google/type:interval_proto",
     ],
 )
 
-proto_and_kt_jvm_proto_library(
-    name = "model_provider",
+proto_library(
+    name = "data_provider_proto",
+    srcs = ["data_provider.proto"],
+    strip_import_prefix = IMPORT_PREFIX,
+    deps = [
+        ":certificate_proto",
+        ":data_provider_details_proto",
+    ],
+)
+
+proto_library(
+    name = "model_provider_proto",
+    srcs = ["model_provider.proto"],
+    strip_import_prefix = IMPORT_PREFIX,
     deps = [":certificate_proto"],
 )
 
@@ -73,14 +192,10 @@ proto_library(
     strip_import_prefix = IMPORT_PREFIX,
     deps = [
         ":computation_participant_proto",
-        ":duchy_measurement_log_entry_proto",
-        ":measurement_log_entry_proto",
+        ":duchy_measurement_log_entry_stage_attempt_proto",
+        ":measurement_log_entry_error_proto",
+        ":participant_requisition_params_proto",
     ],
-)
-
-kt_jvm_grpc_proto_library(
-    name = "computation_participants_service_kt_jvm_grpc_proto",
-    deps = [":computation_participants_service_proto"],
 )
 
 proto_library(
@@ -88,14 +203,10 @@ proto_library(
     srcs = ["data_providers_service.proto"],
     strip_import_prefix = IMPORT_PREFIX,
     deps = [
+        ":data_provider_capabilities_proto",
         ":data_provider_proto",
         "@com_google_googleapis//google/type:interval_proto",
     ],
-)
-
-kt_jvm_grpc_proto_library(
-    name = "data_providers_service_kt_jvm_grpc_proto",
-    deps = [":data_providers_service_proto"],
 )
 
 proto_library(
@@ -107,14 +218,18 @@ proto_library(
     ],
 )
 
-kt_jvm_grpc_proto_library(
-    name = "model_providers_service_kt_jvm_grpc_proto",
-    deps = [":model_providers_service_proto"],
+proto_library(
+    name = "certificate_details_proto",
+    srcs = ["certificate_details.proto"],
+    strip_import_prefix = IMPORT_PREFIX,
 )
 
-proto_and_kt_jvm_proto_library(
-    name = "certificate",
+proto_library(
+    name = "certificate_proto",
+    srcs = ["certificate.proto"],
+    strip_import_prefix = IMPORT_PREFIX,
     deps = [
+        "certificate_details_proto",
         "@com_google_protobuf//:timestamp_proto",
     ],
 )
@@ -129,53 +244,71 @@ proto_library(
     ],
 )
 
-kt_jvm_grpc_proto_library(
-    name = "certificates_service_kt_jvm_grpc_proto",
-    deps = [":certificates_service_proto"],
+proto_library(
+    name = "crypto_proto",
+    srcs = ["crypto.proto"],
+    strip_import_prefix = IMPORT_PREFIX,
 )
 
-proto_and_kt_jvm_proto_library(
-    name = "crypto",
+proto_library(
+    name = "differential_privacy_proto",
+    srcs = ["differential_privacy.proto"],
+    strip_import_prefix = IMPORT_PREFIX,
 )
 
-proto_and_kt_jvm_proto_library(
-    name = "differential_privacy",
-)
-
-proto_and_kt_jvm_proto_library(
-    name = "duchy_protocol_config",
+proto_library(
+    name = "duchy_protocol_config_proto",
+    srcs = ["duchy_protocol_config.proto"],
+    strip_import_prefix = IMPORT_PREFIX,
     deps = [
         ":differential_privacy_proto",
     ],
 )
 
-proto_and_kt_jvm_proto_library(
-    name = "protocol_config",
+proto_library(
+    name = "protocol_config_proto",
+    srcs = ["protocol_config.proto"],
+    strip_import_prefix = IMPORT_PREFIX,
     deps = [
         ":differential_privacy_proto",
     ],
 )
 
-proto_and_kt_jvm_proto_library(
-    name = "duchy_id_config",
+proto_library(
+    name = "duchy_id_config_proto",
+    srcs = ["duchy_id_config.proto"],
+    strip_import_prefix = IMPORT_PREFIX,
     deps = [
         "@com_google_protobuf//:timestamp_proto",
     ],
 )
 
-proto_and_kt_jvm_proto_library(
-    name = "protocol_config_config",
+proto_library(
+    name = "protocol_config_config_proto",
+    srcs = ["protocol_config_config.proto"],
+    strip_import_prefix = IMPORT_PREFIX,
     deps = [
         ":duchy_protocol_config_proto",
         ":protocol_config_proto",
     ],
 )
 
-proto_and_kt_jvm_proto_library(
-    name = "event_group",
+proto_library(
+    name = "event_group_details_proto",
+    srcs = ["event_group_details.proto"],
+    strip_import_prefix = IMPORT_PREFIX,
     deps = [
         ":event_template_proto",
         "@com_google_googleapis//google/type:interval_proto",
+    ],
+)
+
+proto_library(
+    name = "event_group_proto",
+    srcs = ["event_group.proto"],
+    strip_import_prefix = IMPORT_PREFIX,
+    deps = [
+        ":event_group_details_proto",
         "@com_google_protobuf//:timestamp_proto",
     ],
 )
@@ -190,14 +323,22 @@ proto_library(
     ],
 )
 
-kt_jvm_grpc_proto_library(
-    name = "event_groups_service_kt_jvm_grpc_proto",
-    deps = [":event_groups_service_proto"],
+proto_library(
+    name = "event_group_metadata_descriptor_details_proto",
+    srcs = ["event_group_metadata_descriptor_details.proto"],
+    strip_import_prefix = IMPORT_PREFIX,
+    deps = [
+        "@com_google_protobuf//:descriptor_proto",
+    ],
 )
 
-proto_and_kt_jvm_proto_library(
-    name = "event_group_metadata_descriptor",
-    deps = ["@com_google_protobuf//:descriptor_proto"],
+proto_library(
+    name = "event_group_metadata_descriptor_proto",
+    srcs = ["event_group_metadata_descriptor.proto"],
+    strip_import_prefix = IMPORT_PREFIX,
+    deps = [
+        "event_group_metadata_descriptor_details_proto",
+    ],
 )
 
 proto_library(
@@ -209,21 +350,20 @@ proto_library(
     ],
 )
 
-kt_jvm_grpc_proto_library(
-    name = "event_group_metadata_descriptors_service_kt_jvm_grpc_proto",
-    deps = [":event_group_metadata_descriptors_service_proto"],
-)
-
-proto_and_kt_jvm_proto_library(
-    name = "exchange",
+proto_library(
+    name = "exchange_proto",
+    srcs = ["exchange.proto"],
+    strip_import_prefix = IMPORT_PREFIX,
     deps = [
         ":exchange_details_proto",
         "@com_google_googleapis//google/type:date_proto",
     ],
 )
 
-proto_and_kt_jvm_proto_library(
-    name = "exchange_details",
+proto_library(
+    name = "exchange_details_proto",
+    srcs = ["exchange_details.proto"],
+    strip_import_prefix = IMPORT_PREFIX,
 )
 
 proto_library(
@@ -237,13 +377,10 @@ proto_library(
     ],
 )
 
-kt_jvm_grpc_proto_library(
-    name = "exchanges_service_kt_jvm_grpc_proto",
-    deps = [":exchanges_service_proto"],
-)
-
-proto_and_kt_jvm_proto_library(
-    name = "exchange_step",
+proto_library(
+    name = "exchange_step_proto",
+    srcs = ["exchange_step.proto"],
+    strip_import_prefix = IMPORT_PREFIX,
     deps = [
         "@com_google_googleapis//google/type:date_proto",
         "@com_google_protobuf//:timestamp_proto",
@@ -260,21 +397,20 @@ proto_library(
     ],
 )
 
-kt_jvm_grpc_proto_library(
-    name = "exchange_steps_service_kt_jvm_grpc_proto",
-    deps = [":exchange_steps_service_proto"],
-)
-
-proto_and_kt_jvm_proto_library(
-    name = "exchange_step_attempt",
+proto_library(
+    name = "exchange_step_attempt_proto",
+    srcs = ["exchange_step_attempt.proto"],
+    strip_import_prefix = IMPORT_PREFIX,
     deps = [
         ":exchange_step_attempt_details_proto",
         "@com_google_googleapis//google/type:date_proto",
     ],
 )
 
-proto_and_kt_jvm_proto_library(
-    name = "exchange_step_attempt_details",
+proto_library(
+    name = "exchange_step_attempt_details_proto",
+    srcs = ["exchange_step_attempt_details.proto"],
+    strip_import_prefix = IMPORT_PREFIX,
     deps = [
         "@com_google_protobuf//:timestamp_proto",
     ],
@@ -291,18 +427,49 @@ proto_library(
     ],
 )
 
-kt_jvm_grpc_proto_library(
-    name = "exchange_step_attempts_service_kt_jvm_grpc_proto",
-    deps = [":exchange_step_attempts_service_proto"],
+proto_library(
+    name = "requisition_refusal_proto",
+    srcs = ["requisition_refusal.proto"],
+    strip_import_prefix = IMPORT_PREFIX,
 )
 
-proto_and_kt_jvm_proto_library(
-    name = "measurement",
+proto_library(
+    name = "requisition_details_proto",
+    srcs = ["requisition_details.proto"],
+    strip_import_prefix = IMPORT_PREFIX,
+    deps = [
+        ":requisition_refusal_proto",
+    ],
+)
+
+proto_library(
+    name = "measurement_failure_proto",
+    srcs = ["measurement_failure.proto"],
+    strip_import_prefix = IMPORT_PREFIX,
+)
+
+proto_library(
+    name = "measurement_details_proto",
+    srcs = ["measurement_details.proto"],
+    strip_import_prefix = IMPORT_PREFIX,
+    deps = [
+        ":duchy_protocol_config_proto",
+        ":measurement_failure_proto",
+        ":protocol_config_proto",
+    ],
+)
+
+proto_library(
+    name = "measurement_proto",
+    srcs = ["measurement.proto"],
+    strip_import_prefix = IMPORT_PREFIX,
     deps = [
         ":certificate_proto",
         ":computation_participant_proto",
-        ":duchy_protocol_config_proto",
+        ":measurement_details_proto",
+        ":participant_requisition_params_proto",
         ":protocol_config_proto",
+        ":requisition_details_proto",
         "@com_google_protobuf//:timestamp_proto",
     ],
 )
@@ -318,14 +485,20 @@ proto_library(
     ],
 )
 
-kt_jvm_grpc_proto_library(
-    name = "measurements_service_kt_jvm_grpc_proto",
-    deps = [":measurements_service_proto"],
+proto_library(
+    name = "measurement_consumer_details_proto",
+    srcs = ["measurement_consumer_details.proto"],
+    strip_import_prefix = IMPORT_PREFIX,
 )
 
-proto_and_kt_jvm_proto_library(
-    name = "measurement_consumer",
-    deps = [":certificate_proto"],
+proto_library(
+    name = "measurement_consumer_proto",
+    srcs = ["measurement_consumer.proto"],
+    strip_import_prefix = IMPORT_PREFIX,
+    deps = [
+        ":certificate_proto",
+        ":measurement_consumer_details_proto",
+    ],
 )
 
 proto_library(
@@ -337,28 +510,66 @@ proto_library(
     ],
 )
 
-kt_jvm_grpc_proto_library(
-    name = "measurement_consumers_service_kt_jvm_grpc_proto",
-    deps = [":measurement_consumers_service_proto"],
-)
-
-proto_and_kt_jvm_proto_library(
-    name = "measurement_log_entry",
+proto_library(
+    name = "measurement_log_entry_error_proto",
+    srcs = ["measurement_log_entry_error.proto"],
+    strip_import_prefix = IMPORT_PREFIX,
     deps = [
         "@com_google_protobuf//:timestamp_proto",
     ],
 )
 
-proto_and_kt_jvm_proto_library(
-    name = "duchy_measurement_log_entry",
+proto_library(
+    name = "measurement_log_entry_details_proto",
+    srcs = ["measurement_log_entry_details.proto"],
+    strip_import_prefix = IMPORT_PREFIX,
     deps = [
+        ":measurement_log_entry_error_proto",
+    ],
+)
+
+proto_library(
+    name = "measurement_log_entry_proto",
+    srcs = ["measurement_log_entry.proto"],
+    strip_import_prefix = IMPORT_PREFIX,
+    deps = [
+        ":measurement_log_entry_details_proto",
+        "@com_google_protobuf//:timestamp_proto",
+    ],
+)
+
+proto_library(
+    name = "duchy_measurement_log_entry_stage_attempt_proto",
+    srcs = ["duchy_measurement_log_entry_stage_attempt.proto"],
+    strip_import_prefix = IMPORT_PREFIX,
+    deps = [
+        "@com_google_protobuf//:timestamp_proto",
+    ],
+)
+
+proto_library(
+    name = "duchy_measurement_log_entry_details_proto",
+    srcs = ["duchy_measurement_log_entry_details.proto"],
+    strip_import_prefix = IMPORT_PREFIX,
+    deps = [
+        ":duchy_measurement_log_entry_stage_attempt_proto",
+    ],
+)
+
+proto_library(
+    name = "duchy_measurement_log_entry_proto",
+    srcs = ["duchy_measurement_log_entry.proto"],
+    strip_import_prefix = IMPORT_PREFIX,
+    deps = [
+        ":duchy_measurement_log_entry_details_proto",
         ":measurement_log_entry_proto",
-        "@com_google_protobuf//:timestamp_proto",
     ],
 )
 
-proto_and_kt_jvm_proto_library(
-    name = "state_transition_measurement_log_entry",
+proto_library(
+    name = "state_transition_measurement_log_entry_proto",
+    srcs = ["state_transition_measurement_log_entry.proto"],
+    strip_import_prefix = IMPORT_PREFIX,
     deps = [
         ":measurement_log_entry_proto",
         ":measurement_proto",
@@ -371,15 +582,11 @@ proto_library(
     srcs = ["measurement_log_entries_service.proto"],
     strip_import_prefix = IMPORT_PREFIX,
     deps = [
+        ":duchy_measurement_log_entry_details_proto",
         ":duchy_measurement_log_entry_proto",
-        ":measurement_log_entry_proto",
+        ":measurement_log_entry_details_proto",
         ":state_transition_measurement_log_entry_proto",
     ],
-)
-
-kt_jvm_grpc_proto_library(
-    name = "measurement_log_entries_service_kt_jvm_grpc_proto",
-    deps = [":measurement_log_entries_service_proto"],
 )
 
 proto_library(
@@ -388,21 +595,20 @@ proto_library(
     strip_import_prefix = IMPORT_PREFIX,
 )
 
-kt_jvm_grpc_proto_library(
-    name = "public_keys_service_kt_jvm_grpc_proto",
-    deps = [":public_keys_service_proto"],
-)
-
-proto_and_kt_jvm_proto_library(
-    name = "recurring_exchange",
+proto_library(
+    name = "recurring_exchange_proto",
+    srcs = ["recurring_exchange.proto"],
+    strip_import_prefix = IMPORT_PREFIX,
     deps = [
         ":recurring_exchange_details_proto",
         "@com_google_googleapis//google/type:date_proto",
     ],
 )
 
-proto_and_kt_jvm_proto_library(
-    name = "recurring_exchange_details",
+proto_library(
+    name = "recurring_exchange_details_proto",
+    srcs = ["recurring_exchange_details.proto"],
+    strip_import_prefix = IMPORT_PREFIX,
     deps = [
         ":exchange_workflow_proto",
     ],
@@ -415,36 +621,33 @@ proto_library(
     deps = [":recurring_exchange_proto"],
 )
 
-kt_jvm_grpc_proto_library(
-    name = "recurring_exchanges_service_kt_jvm_grpc_proto",
-    deps = [":recurring_exchanges_service_proto"],
-)
-
 proto_library(
     name = "requisitions_service_proto",
     srcs = ["requisitions_service.proto"],
     strip_import_prefix = IMPORT_PREFIX,
     deps = [
         ":measurement_proto",
+        ":requisition_refusal_proto",
         "@com_google_protobuf//:timestamp_proto",
     ],
 )
 
-kt_jvm_grpc_proto_library(
-    name = "requisitions_service_kt_jvm_grpc_proto",
-    deps = [":requisitions_service_proto"],
+proto_library(
+    name = "exchange_workflow_proto",
+    srcs = ["exchange_workflow.proto"],
+    strip_import_prefix = IMPORT_PREFIX,
 )
 
-proto_and_kt_jvm_proto_library(
-    name = "exchange_workflow",
+proto_library(
+    name = "error_code_proto",
+    srcs = ["error_code.proto"],
+    strip_import_prefix = IMPORT_PREFIX,
 )
 
-proto_and_kt_jvm_proto_library(
-    name = "error_code",
-)
-
-proto_and_kt_jvm_proto_library(
-    name = "model_suite",
+proto_library(
+    name = "model_suite_proto",
+    srcs = ["model_suite.proto"],
+    strip_import_prefix = IMPORT_PREFIX,
     deps = [
         "@com_google_protobuf//:timestamp_proto",
     ],
@@ -460,13 +663,10 @@ proto_library(
     ],
 )
 
-kt_jvm_grpc_proto_library(
-    name = "model_suites_service_kt_jvm_grpc_proto",
-    deps = [":model_suites_service_proto"],
-)
-
-proto_and_kt_jvm_proto_library(
-    name = "model_line",
+proto_library(
+    name = "model_line_proto",
+    srcs = ["model_line.proto"],
+    strip_import_prefix = IMPORT_PREFIX,
     deps = [
         "@com_google_protobuf//:timestamp_proto",
     ],
@@ -482,13 +682,10 @@ proto_library(
     ],
 )
 
-kt_jvm_grpc_proto_library(
-    name = "model_lines_service_kt_jvm_grpc_proto",
-    deps = [":model_lines_service_proto"],
-)
-
-proto_and_kt_jvm_proto_library(
-    name = "model_release",
+proto_library(
+    name = "model_release_proto",
+    srcs = ["model_release.proto"],
+    strip_import_prefix = IMPORT_PREFIX,
     deps = [
         "@com_google_protobuf//:timestamp_proto",
     ],
@@ -504,13 +701,10 @@ proto_library(
     ],
 )
 
-kt_jvm_grpc_proto_library(
-    name = "model_releases_service_kt_jvm_grpc_proto",
-    deps = [":model_releases_service_proto"],
-)
-
-proto_and_kt_jvm_proto_library(
-    name = "model_outage",
+proto_library(
+    name = "model_outage_proto",
+    srcs = ["model_outage.proto"],
+    strip_import_prefix = IMPORT_PREFIX,
     deps = [
         "@com_google_protobuf//:timestamp_proto",
     ],
@@ -526,13 +720,10 @@ proto_library(
     ],
 )
 
-kt_jvm_grpc_proto_library(
-    name = "model_outages_service_kt_jvm_grpc_proto",
-    deps = [":model_outages_service_proto"],
-)
-
-proto_and_kt_jvm_proto_library(
-    name = "model_shard",
+proto_library(
+    name = "model_shard_proto",
+    srcs = ["model_shard.proto"],
+    strip_import_prefix = IMPORT_PREFIX,
     deps = ["@com_google_protobuf//:timestamp_proto"],
 )
 
@@ -546,13 +737,10 @@ proto_library(
     ],
 )
 
-kt_jvm_grpc_proto_library(
-    name = "model_shards_service_kt_jvm_grpc_proto",
-    deps = [":model_shards_service_proto"],
-)
-
-proto_and_kt_jvm_proto_library(
-    name = "model_rollout",
+proto_library(
+    name = "model_rollout_proto",
+    srcs = ["model_rollout.proto"],
+    strip_import_prefix = IMPORT_PREFIX,
     deps = ["@com_google_protobuf//:timestamp_proto"],
 )
 
@@ -566,17 +754,16 @@ proto_library(
     ],
 )
 
-kt_jvm_grpc_proto_library(
-    name = "model_rollouts_service_kt_jvm_grpc_proto",
-    deps = [":model_rollouts_service_proto"],
+proto_library(
+    name = "event_template_proto",
+    srcs = ["event_template.proto"],
+    strip_import_prefix = IMPORT_PREFIX,
 )
 
-proto_and_kt_jvm_proto_library(
-    name = "event_template",
-)
-
-proto_and_kt_jvm_proto_library(
-    name = "population",
+proto_library(
+    name = "population_proto",
+    srcs = ["population.proto"],
+    strip_import_prefix = IMPORT_PREFIX,
     deps = [
         ":event_template_proto",
         "@com_google_protobuf//:timestamp_proto",
@@ -593,7 +780,26 @@ proto_library(
     ],
 )
 
-kt_jvm_grpc_proto_library(
-    name = "populations_service_kt_jvm_grpc_proto",
-    deps = [":populations_service_proto"],
-)
+[
+    kt_jvm_proto_library(
+        name = "{name}_kt_jvm_proto".format(name = name),
+        deps = [":{name}_proto".format(name = name)],
+    )
+    for name in LIBS
+]
+
+[
+    kt_jvm_proto_library(
+        name = "{name}_details_kt_jvm_proto".format(name = name),
+        deps = [":{name}_details_proto".format(name = name)],
+    )
+    for name in DETAILS_LIBS
+]
+
+[
+    kt_jvm_grpc_proto_library(
+        name = "{name}_service_kt_jvm_grpc_proto".format(name = name),
+        deps = [":{name}_service_proto".format(name = name)],
+    )
+    for name in SERVICES
+]

--- a/src/main/proto/wfa/measurement/internal/kingdom/certificate.proto
+++ b/src/main/proto/wfa/measurement/internal/kingdom/certificate.proto
@@ -17,6 +17,7 @@ syntax = "proto3";
 package wfa.measurement.internal.kingdom;
 
 import "google/protobuf/timestamp.proto";
+import "wfa/measurement/internal/kingdom/certificate_details.proto";
 
 option java_package = "org.wfanet.measurement.internal.kingdom";
 option java_multiple_files = true;
@@ -55,9 +56,5 @@ message Certificate {
   // determined by the issuing certificate authority.
   RevocationState revocation_state = 9;
 
-  message Details {
-    // X.509 certificate in DER format.
-    bytes x509_der = 1;
-  }
-  Details details = 10;
+  CertificateDetails details = 10;
 }

--- a/src/main/proto/wfa/measurement/internal/kingdom/certificate_details.proto
+++ b/src/main/proto/wfa/measurement/internal/kingdom/certificate_details.proto
@@ -1,0 +1,25 @@
+// Copyright 2024 The Cross-Media Measurement Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package wfa.measurement.internal.kingdom;
+
+option java_package = "org.wfanet.measurement.internal.kingdom";
+option java_multiple_files = true;
+
+message CertificateDetails {
+  // X.509 certificate in DER format.
+  bytes x509_der = 1;
+}

--- a/src/main/proto/wfa/measurement/internal/kingdom/computation_participant.proto
+++ b/src/main/proto/wfa/measurement/internal/kingdom/computation_participant.proto
@@ -18,6 +18,7 @@ package wfa.measurement.internal.kingdom;
 
 import "google/protobuf/timestamp.proto";
 import "wfa/measurement/internal/kingdom/certificate.proto";
+import "wfa/measurement/internal/kingdom/computation_participant_details.proto";
 import "wfa/measurement/internal/kingdom/duchy_measurement_log_entry.proto";
 
 option java_package = "org.wfanet.measurement.internal.kingdom";
@@ -53,31 +54,7 @@ message ComputationParticipant {
   }
   State state = 6;
 
-  // Details of Liquid Legions V2 protocols.
-  message LiquidLegionsV2Details {
-    // Serialized `ElGamalPublicKey` message from public API.
-    bytes el_gamal_public_key = 1;
-    bytes el_gamal_public_key_signature = 2;
-    string el_gamal_public_key_signature_algorithm_oid = 3;
-  }
-
-  message HonestMajorityShareShuffleDetails {
-    // Serialized Keyset of TinkPublicKeyHandle.
-    bytes tink_public_key = 1;
-    bytes tink_public_key_signature = 2;
-    string tink_public_key_signature_algorithm_oid = 3;
-  }
-
-  message Details {
-    oneof protocol {
-      LiquidLegionsV2Details liquid_legions_v2 = 1;
-
-      LiquidLegionsV2Details reach_only_liquid_legions_v2 = 2;
-
-      HonestMajorityShareShuffleDetails honest_majority_share_shuffle = 3;
-    }
-  }
-  Details details = 7;
+  ComputationParticipantDetails details = 7;
 
   DuchyMeasurementLogEntry failure_log_entry = 8;
 

--- a/src/main/proto/wfa/measurement/internal/kingdom/computation_participant_details.proto
+++ b/src/main/proto/wfa/measurement/internal/kingdom/computation_participant_details.proto
@@ -1,0 +1,32 @@
+// Copyright 2024 The Cross-Media Measurement Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package wfa.measurement.internal.kingdom;
+
+import "wfa/measurement/internal/kingdom/participant_requisition_params.proto";
+
+option java_package = "org.wfanet.measurement.internal.kingdom";
+option java_multiple_files = true;
+
+message ComputationParticipantDetails {
+  oneof protocol {
+    LiquidLegionsV2Params liquid_legions_v2 = 1;
+
+    LiquidLegionsV2Params reach_only_liquid_legions_v2 = 2;
+
+    HonestMajorityShareShuffleParams honest_majority_share_shuffle = 3;
+  }
+}

--- a/src/main/proto/wfa/measurement/internal/kingdom/computation_participants_service.proto
+++ b/src/main/proto/wfa/measurement/internal/kingdom/computation_participants_service.proto
@@ -17,8 +17,9 @@ syntax = "proto3";
 package wfa.measurement.internal.kingdom;
 
 import "wfa/measurement/internal/kingdom/computation_participant.proto";
-import "wfa/measurement/internal/kingdom/duchy_measurement_log_entry.proto";
-import "wfa/measurement/internal/kingdom/measurement_log_entry.proto";
+import "wfa/measurement/internal/kingdom/duchy_measurement_log_entry_stage_attempt.proto";
+import "wfa/measurement/internal/kingdom/measurement_log_entry_error.proto";
+import "wfa/measurement/internal/kingdom/participant_requisition_params.proto";
 
 option java_package = "org.wfanet.measurement.internal.kingdom";
 option java_multiple_files = true;
@@ -56,13 +57,11 @@ message SetParticipantRequisitionParamsRequest {
   fixed64 external_duchy_certificate_id = 3;
 
   oneof protocol {
-    ComputationParticipant.LiquidLegionsV2Details liquid_legions_v2 = 4;
+    LiquidLegionsV2Params liquid_legions_v2 = 4;
 
-    ComputationParticipant.LiquidLegionsV2Details reach_only_liquid_legions_v2 =
-        5;
+    LiquidLegionsV2Params reach_only_liquid_legions_v2 = 5;
 
-    ComputationParticipant.HonestMajorityShareShuffleDetails
-        honest_majority_share_shuffle = 6;
+    HonestMajorityShareShuffleParams honest_majority_share_shuffle = 6;
   }
 
   // `etag` of the `ComputationParticipant`.
@@ -76,11 +75,11 @@ message FailComputationParticipantRequest {
   fixed64 external_computation_id = 1;
   string external_duchy_id = 2;
 
-  // Human-readable error message. This should not include any sensitive info.
-  string error_message = 3;
+  // Human-readable log message. This should not include any sensitive info.
+  string log_message = 3;
 
   // Details about an error.
-  MeasurementLogEntry.ErrorDetails error_details = 4;
+  MeasurementLogEntryError error = 4;
 
   // ID of some child of the Duchy from an external system.
   //
@@ -88,7 +87,7 @@ message FailComputationParticipantRequest {
   string duchy_child_reference_id = 5;
 
   // Details about the computation stage during which the error occurred.
-  DuchyMeasurementLogEntry.StageAttempt stage_attempt = 6;
+  DuchyMeasurementLogEntryStageAttempt stage_attempt = 6;
 
   // `etag` of the `ComputationParticipant`.
   //

--- a/src/main/proto/wfa/measurement/internal/kingdom/data_provider.proto
+++ b/src/main/proto/wfa/measurement/internal/kingdom/data_provider.proto
@@ -16,8 +16,8 @@ syntax = "proto3";
 
 package wfa.measurement.internal.kingdom;
 
-import "google/type/interval.proto";
 import "wfa/measurement/internal/kingdom/certificate.proto";
+import "wfa/measurement/internal/kingdom/data_provider_details.proto";
 
 option java_package = "org.wfanet.measurement.internal.kingdom";
 option java_multiple_files = true;
@@ -30,23 +30,7 @@ message DataProvider {
   // verification.
   Certificate certificate = 2;
 
-  message Capabilities {
-    // Whether the Honest Majority Share Shuffle (HMSS) protocol is supported.
-    bool honest_majority_share_shuffle_supported = 1;
-  }
-  message Details {
-    // Version the public API for serialized message definitions.
-    string api_version = 1;
-
-    // Serialized `EncryptionPublicKey` from public API.
-    bytes public_key = 2;
-    bytes public_key_signature = 3;
-    string public_key_signature_algorithm_oid = 4;
-
-    google.type.Interval data_availability_interval = 5;
-    Capabilities capabilities = 6;
-  }
-  Details details = 3;
+  DataProviderDetails details = 3;
 
   // The list of duchies that must be included in all computations involving the
   // DataProvider

--- a/src/main/proto/wfa/measurement/internal/kingdom/data_provider_capabilities.proto
+++ b/src/main/proto/wfa/measurement/internal/kingdom/data_provider_capabilities.proto
@@ -1,0 +1,25 @@
+// Copyright 2024 The Cross-Media Measurement Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package wfa.measurement.internal.kingdom;
+
+option java_package = "org.wfanet.measurement.internal.kingdom";
+option java_multiple_files = true;
+
+message DataProviderCapabilities {
+  // Whether the Honest Majority Share Shuffle (HMSS) protocol is supported.
+  bool honest_majority_share_shuffle_supported = 1;
+}

--- a/src/main/proto/wfa/measurement/internal/kingdom/data_provider_details.proto
+++ b/src/main/proto/wfa/measurement/internal/kingdom/data_provider_details.proto
@@ -1,0 +1,36 @@
+// Copyright 2024 The Cross-Media Measurement Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package wfa.measurement.internal.kingdom;
+
+import "google/type/interval.proto";
+import "wfa/measurement/internal/kingdom/data_provider_capabilities.proto";
+
+option java_package = "org.wfanet.measurement.internal.kingdom";
+option java_multiple_files = true;
+
+message DataProviderDetails {
+  // Version the public API for serialized message definitions.
+  string api_version = 1;
+
+  // Serialized `EncryptionPublicKey` from public API.
+  bytes public_key = 2;
+  bytes public_key_signature = 3;
+  string public_key_signature_algorithm_oid = 4;
+
+  google.type.Interval data_availability_interval = 5;
+  DataProviderCapabilities capabilities = 6;
+}

--- a/src/main/proto/wfa/measurement/internal/kingdom/data_providers_service.proto
+++ b/src/main/proto/wfa/measurement/internal/kingdom/data_providers_service.proto
@@ -18,6 +18,7 @@ package wfa.measurement.internal.kingdom;
 
 import "google/type/interval.proto";
 import "wfa/measurement/internal/kingdom/data_provider.proto";
+import "wfa/measurement/internal/kingdom/data_provider_capabilities.proto";
 
 option java_package = "org.wfanet.measurement.internal.kingdom";
 option java_multiple_files = true;
@@ -67,5 +68,5 @@ message ReplaceDataProviderCapabilitiesRequest {
   fixed64 external_data_provider_id = 1;
 
   // New value for `capabilities`.
-  DataProvider.Capabilities capabilities = 2;
+  DataProviderCapabilities capabilities = 2;
 }

--- a/src/main/proto/wfa/measurement/internal/kingdom/duchy_measurement_log_entry.proto
+++ b/src/main/proto/wfa/measurement/internal/kingdom/duchy_measurement_log_entry.proto
@@ -16,7 +16,7 @@ syntax = "proto3";
 
 package wfa.measurement.internal.kingdom;
 
-import "google/protobuf/timestamp.proto";
+import "wfa/measurement/internal/kingdom/duchy_measurement_log_entry_details.proto";
 import "wfa/measurement/internal/kingdom/measurement_log_entry.proto";
 
 option java_package = "org.wfanet.measurement.internal.kingdom";
@@ -28,33 +28,5 @@ message DuchyMeasurementLogEntry {
 
   fixed64 external_computation_log_entry_id = 3;
 
-  message StageAttempt {
-    // Tag number of the stage enum value from an external system.
-    int32 stage = 1;
-
-    // Name of the stage enum value from an external system.
-    //
-    // This is for human readability only.
-    string stage_name = 2;
-
-    // Time the stage started.
-    google.protobuf.Timestamp stage_start_time = 3;
-
-    // The attempt number for this stage, with 1 being the first attempt.
-    //
-    // This value should be strictly monotonically increasing for each
-    // subsequent log entry for a Duchy with the same stage.
-    int64 attempt_number = 4;
-  }
-  message Details {
-    // ID of some child of the Duchy from an external system.
-    //
-    // For example, this may identify a specific job or task.
-    string duchy_child_reference_id = 1;
-
-    // Details about the computation stage that the log event occurred during.
-    // Only set if the event happened during computation.
-    StageAttempt stage_attempt = 2;
-  }
-  Details details = 4;
+  DuchyMeasurementLogEntryDetails details = 4;
 }

--- a/src/main/proto/wfa/measurement/internal/kingdom/duchy_measurement_log_entry_details.proto
+++ b/src/main/proto/wfa/measurement/internal/kingdom/duchy_measurement_log_entry_details.proto
@@ -1,0 +1,33 @@
+// Copyright 2021 The Cross-Media Measurement Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package wfa.measurement.internal.kingdom;
+
+import "wfa/measurement/internal/kingdom/duchy_measurement_log_entry_stage_attempt.proto";
+
+option java_package = "org.wfanet.measurement.internal.kingdom";
+option java_multiple_files = true;
+
+message DuchyMeasurementLogEntryDetails {
+  // ID of some child of the Duchy from an external system.
+  //
+  // For example, this may identify a specific job or task.
+  string duchy_child_reference_id = 1;
+
+  // Details about the computation stage that the log event occurred during.
+  // Only set if the event happened during computation.
+  DuchyMeasurementLogEntryStageAttempt stage_attempt = 2;
+}

--- a/src/main/proto/wfa/measurement/internal/kingdom/duchy_measurement_log_entry_stage_attempt.proto
+++ b/src/main/proto/wfa/measurement/internal/kingdom/duchy_measurement_log_entry_stage_attempt.proto
@@ -1,0 +1,41 @@
+// Copyright 2021 The Cross-Media Measurement Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package wfa.measurement.internal.kingdom;
+
+import "google/protobuf/timestamp.proto";
+
+option java_package = "org.wfanet.measurement.internal.kingdom";
+option java_multiple_files = true;
+
+message DuchyMeasurementLogEntryStageAttempt {
+  // Tag number of the stage enum value from an external system.
+  int32 stage = 1;
+
+  // Name of the stage enum value from an external system.
+  //
+  // This is for human readability only.
+  string stage_name = 2;
+
+  // Time the stage started.
+  google.protobuf.Timestamp stage_start_time = 3;
+
+  // The attempt number for this stage, with 1 being the first attempt.
+  //
+  // This value should be strictly monotonically increasing for each
+  // subsequent log entry for a Duchy with the same stage.
+  int64 attempt_number = 4;
+}

--- a/src/main/proto/wfa/measurement/internal/kingdom/event_group.proto
+++ b/src/main/proto/wfa/measurement/internal/kingdom/event_group.proto
@@ -17,8 +17,7 @@ syntax = "proto3";
 package wfa.measurement.internal.kingdom;
 
 import "google/protobuf/timestamp.proto";
-import "google/type/interval.proto";
-import "wfa/measurement/internal/kingdom/event_template.proto";
+import "wfa/measurement/internal/kingdom/event_group_details.proto";
 
 option java_package = "org.wfanet.measurement.internal.kingdom";
 option java_multiple_files = true;
@@ -36,29 +35,7 @@ message EventGroup {
   google.protobuf.Timestamp create_time = 6;
   google.protobuf.Timestamp update_time = 7;
 
-  message Details {
-    // Version of the public API for serialized message definitions.
-    string api_version = 1;
-
-    // Serialized `EncryptionPublicKey` message from the public API.
-    bytes measurement_consumer_public_key = 2;
-    bytes measurement_consumer_public_key_signature = 3 [deprecated = true];
-    string measurement_consumer_public_key_signature_algorithm_oid = 7
-        [deprecated = true];
-
-    // The set of VID model lines used to label events in this Event Group.
-    repeated string vid_model_lines = 4;
-
-    // The Event Templates that this Event Group conforms to.
-    repeated EventTemplate event_templates = 5;
-
-    // Data Provider-specific encrypted Event Group metadata.
-    bytes encrypted_metadata = 6;
-
-    google.type.Interval data_availability_interval = 8;
-  }
-
-  Details details = 8;
+  EventGroupDetails details = 8;
 
   // Possible states of Event Group.
   enum State {

--- a/src/main/proto/wfa/measurement/internal/kingdom/event_group_details.proto
+++ b/src/main/proto/wfa/measurement/internal/kingdom/event_group_details.proto
@@ -1,0 +1,45 @@
+// Copyright 2024 The Cross-Media Measurement Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package wfa.measurement.internal.kingdom;
+
+import "google/type/interval.proto";
+import "wfa/measurement/internal/kingdom/event_template.proto";
+
+option java_package = "org.wfanet.measurement.internal.kingdom";
+option java_multiple_files = true;
+
+message EventGroupDetails {
+  // Version of the public API for serialized message definitions.
+  string api_version = 1;
+
+  // Serialized `EncryptionPublicKey` message from the public API.
+  bytes measurement_consumer_public_key = 2;
+  bytes measurement_consumer_public_key_signature = 3 [deprecated = true];
+  string measurement_consumer_public_key_signature_algorithm_oid = 7
+      [deprecated = true];
+
+  // The set of VID model lines used to label events in this Event Group.
+  repeated string vid_model_lines = 4;
+
+  // The Event Templates that this Event Group conforms to.
+  repeated EventTemplate event_templates = 5;
+
+  // Data Provider-specific encrypted Event Group metadata.
+  bytes encrypted_metadata = 6;
+
+  google.type.Interval data_availability_interval = 8;
+}

--- a/src/main/proto/wfa/measurement/internal/kingdom/event_group_metadata_descriptor.proto
+++ b/src/main/proto/wfa/measurement/internal/kingdom/event_group_metadata_descriptor.proto
@@ -16,7 +16,7 @@ syntax = "proto3";
 
 package wfa.measurement.internal.kingdom;
 
-import "google/protobuf/descriptor.proto";
+import "wfa/measurement/internal/kingdom/event_group_metadata_descriptor_details.proto";
 
 option java_package = "org.wfanet.measurement.internal.kingdom";
 option java_multiple_files = true;
@@ -27,13 +27,5 @@ message EventGroupMetadataDescriptor {
 
   string idempotency_key = 4;
 
-  message Details {
-    // Version of the public API for serialized message definitions.
-    string api_version = 1;
-
-    // FileDescriptorSet of the original metadata proto message.
-    google.protobuf.FileDescriptorSet descriptor_set = 2;
-  }
-
-  Details details = 3;
+  EventGroupMetadataDescriptorDetails details = 3;
 }

--- a/src/main/proto/wfa/measurement/internal/kingdom/event_group_metadata_descriptor_details.proto
+++ b/src/main/proto/wfa/measurement/internal/kingdom/event_group_metadata_descriptor_details.proto
@@ -1,0 +1,30 @@
+// Copyright 2024 The Cross-Media Measurement Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package wfa.measurement.internal.kingdom;
+
+import "google/protobuf/descriptor.proto";
+
+option java_package = "org.wfanet.measurement.internal.kingdom";
+option java_multiple_files = true;
+
+message EventGroupMetadataDescriptorDetails {
+  // Version of the public API for serialized message definitions.
+  string api_version = 1;
+
+  // FileDescriptorSet of the original metadata proto message.
+  google.protobuf.FileDescriptorSet descriptor_set = 2;
+}

--- a/src/main/proto/wfa/measurement/internal/kingdom/measurement.proto
+++ b/src/main/proto/wfa/measurement/internal/kingdom/measurement.proto
@@ -19,8 +19,10 @@ package wfa.measurement.internal.kingdom;
 import "google/protobuf/timestamp.proto";
 import "wfa/measurement/internal/kingdom/certificate.proto";
 import "wfa/measurement/internal/kingdom/computation_participant.proto";
-import "wfa/measurement/internal/kingdom/duchy_protocol_config.proto";
+import "wfa/measurement/internal/kingdom/measurement_details.proto";
+import "wfa/measurement/internal/kingdom/participant_requisition_params.proto";
 import "wfa/measurement/internal/kingdom/protocol_config.proto";
+import "wfa/measurement/internal/kingdom/requisition_details.proto";
 
 option java_package = "org.wfanet.measurement.internal.kingdom";
 option java_multiple_files = true;
@@ -83,22 +85,6 @@ message Measurement {
   }
   State state = 8;
 
-  message Failure {
-    enum Reason {
-      REASON_UNSPECIFIED = 0;
-      // An associated certificate was revoked.
-      CERTIFICATE_REVOKED = 1;
-      // Requisition state was set to REFUSED.
-      REQUISITION_REFUSED = 2;
-      // ComputationParticipant state was set to FAILED.
-      COMPUTATION_PARTICIPANT_FAILED = 3;
-    }
-    Reason reason = 1;
-    // Human-readable message. This should not contain any sensitive
-    // information.
-    string message = 2;
-  }
-
   message DataProviderValue {
     fixed64 external_data_provider_certificate_id = 1;
 
@@ -116,23 +102,7 @@ message Measurement {
   // Only set for DEFAULT view.
   map<fixed64, DataProviderValue> data_providers = 9;
 
-  message Details {
-    // Version the public API for serialized message definitions.
-    string api_version = 1;
-
-    // Serialized `MeasurementSpec` from public API.
-    bytes measurement_spec = 2;
-    bytes measurement_spec_signature = 3;
-    string measurement_spec_signature_algorithm_oid = 9;
-
-    // The protocol config used in this measurement.
-    ProtocolConfig protocol_config = 6;
-    DuchyProtocolConfig duchy_protocol_config = 7;
-
-    // Set when the state is set to FAILED.
-    Failure failure = 8;
-  }
-  Details details = 10;
+  MeasurementDetails details = 10;
 
   message ResultInfo {
     oneof certificate_parent {
@@ -191,102 +161,22 @@ message Requisition {
   // to this Requisition as as `FULFILLED` or being assigned to fulfill.
   string external_fulfilling_duchy_id = 8;
 
-  message Refusal {
-    enum Justification {
-      // Default value if a `Justification` field has not been specified. Should
-      // never be used.
-      JUSTIFICATION_UNSPECIFIED = 0;
-
-      // At least one cryptographic consent signal (digital signature or
-      // encrypted value) in the `Requisition` is invalid.
-      //
-      // This means either that a digital signature cannot be verified using the
-      // specified certificate or an encrypted value cannot be decrypted using
-      // the specified key.
-      CONSENT_SIGNAL_INVALID = 1;
-
-      // The specification/configuration for the `Requisition` is invalid.
-      //
-      // For example, `encrypted_requisition_spec` includes an invalid
-      // `TimeInterval` (with `end_time` before `start_time`) or some
-      // configuration that the `DataProvider` does not support.
-      SPECIFICATION_INVALID = 2;
-
-      // There is insufficient remaining privacy budget to fulfill the
-      // `Requisition`.
-      INSUFFICIENT_PRIVACY_BUDGET = 3;
-
-      // The `Requisition` cannot be fulfilled by the `DataProvider` for a
-      // reason that is not more clearly indicated by another `Justification`.
-      //
-      // This implies that the `DataProvider` *should* be able to fulfill the
-      // `Requisition`, but something went irrecoverably wrong. For example, the
-      // `DataProvider` encountered corruption of the underlying data.
-      UNFULFILLABLE = 4;
-
-      // The `DataProvider` has declined to fulfill this `Requisition`
-      // regardless of whether any of the other `Justification` conditions
-      // apply.
-      DECLINED = 5;
-    }
-    Justification justification = 1;
-
-    // Human-readable string adding more context to the provided
-    // `Justification`. This should NOT include sensitive information.
-    //
-    // Example: "Data Provider X does not support Virtual ID model line Y".
-    string message = 2;
-  }
-
   message DuchyValue {
     // External ID of Certificate used to verify signatures in protocol field.
     fixed64 external_duchy_certificate_id = 1;
 
     oneof protocol {
-      ComputationParticipant.LiquidLegionsV2Details liquid_legions_v2 = 2;
+      LiquidLegionsV2Params liquid_legions_v2 = 2;
 
-      ComputationParticipant.LiquidLegionsV2Details
-          reach_only_liquid_legions_v2 = 3;
+      LiquidLegionsV2Params reach_only_liquid_legions_v2 = 3;
 
-      ComputationParticipant.HonestMajorityShareShuffleDetails
-          honest_majority_share_shuffle = 4;
+      HonestMajorityShareShuffleParams honest_majority_share_shuffle = 4;
     }
   }
   // Map of external Duchy ID to DuchyValue.
   map<string, DuchyValue> duchies = 9;
 
-  message Details {
-    // Serialized `EncryptionPublicKey` message from the public API.
-    bytes data_provider_public_key = 1;
-    bytes data_provider_public_key_signature = 2 [deprecated = true];
-    string data_provider_public_key_signature_algorithm_oid = 8
-        [deprecated = true];
-
-    bytes encrypted_requisition_spec = 3;
-    bytes nonce_hash = 4;
-
-    // Actual nonce value. Set when Requisition state is FULFILLED.
-    fixed64 nonce = 5;
-
-    // Refusal information. Set when Requisition state is REFUSED.
-    Refusal refusal = 6;
-
-    // Encrypted SignedData containing the Measurement.Result for this
-    // Requisition. Set when Requisition state is FULFILLED and the protocol is
-    // Direct.
-    bytes encrypted_data = 7;
-
-    // Version of the public API for `encrypted_data`.
-    //
-    // If not specified, assume "v2alpha".
-    string encrypted_data_api_version = 9;
-
-    // Used to verify the decrypted Measurement.Result. If not present,
-    // `data_provider_certificate` should be used. Set when Requisition
-    // state is FULFILLED and the protocol is Direct.
-    fixed64 external_certificate_id = 10;
-  }
-  Details details = 10;
+  RequisitionDetails details = 10;
 
   // Denormalized DataProvider Certificate. Output-only.
   Certificate data_provider_certificate = 11;

--- a/src/main/proto/wfa/measurement/internal/kingdom/measurement_consumer.proto
+++ b/src/main/proto/wfa/measurement/internal/kingdom/measurement_consumer.proto
@@ -17,6 +17,7 @@ syntax = "proto3";
 package wfa.measurement.internal.kingdom;
 
 import "wfa/measurement/internal/kingdom/certificate.proto";
+import "wfa/measurement/internal/kingdom/measurement_consumer_details.proto";
 
 option java_package = "org.wfanet.measurement.internal.kingdom";
 option java_multiple_files = true;
@@ -29,14 +30,5 @@ message MeasurementConsumer {
   // signature verification.
   Certificate certificate = 2;
 
-  message Details {
-    // Version the public API for serialized message definitions.
-    string api_version = 1;
-
-    // Serialized `EncryptionPublicKey` from public API.
-    bytes public_key = 2;
-    bytes public_key_signature = 3;
-    string public_key_signature_algorithm_oid = 4;
-  }
-  Details details = 3;
+  MeasurementConsumerDetails details = 3;
 }

--- a/src/main/proto/wfa/measurement/internal/kingdom/measurement_consumer_details.proto
+++ b/src/main/proto/wfa/measurement/internal/kingdom/measurement_consumer_details.proto
@@ -1,0 +1,30 @@
+// Copyright 2024 The Cross-Media Measurement Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package wfa.measurement.internal.kingdom;
+
+option java_package = "org.wfanet.measurement.internal.kingdom";
+option java_multiple_files = true;
+
+message MeasurementConsumerDetails {
+  // Version the public API for serialized message definitions.
+  string api_version = 1;
+
+  // Serialized `EncryptionPublicKey` from public API.
+  bytes public_key = 2;
+  bytes public_key_signature = 3;
+  string public_key_signature_algorithm_oid = 4;
+}

--- a/src/main/proto/wfa/measurement/internal/kingdom/measurement_details.proto
+++ b/src/main/proto/wfa/measurement/internal/kingdom/measurement_details.proto
@@ -1,0 +1,41 @@
+// Copyright 2024 The Cross-Media Measurement Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package wfa.measurement.internal.kingdom;
+
+import "wfa/measurement/internal/kingdom/duchy_protocol_config.proto";
+import "wfa/measurement/internal/kingdom/measurement_failure.proto";
+import "wfa/measurement/internal/kingdom/protocol_config.proto";
+
+option java_package = "org.wfanet.measurement.internal.kingdom";
+option java_multiple_files = true;
+
+message MeasurementDetails {
+  // Version the public API for serialized message definitions.
+  string api_version = 1;
+
+  // Serialized `MeasurementSpec` from public API.
+  bytes measurement_spec = 2;
+  bytes measurement_spec_signature = 3;
+  string measurement_spec_signature_algorithm_oid = 9;
+
+  // The protocol config used in this measurement.
+  ProtocolConfig protocol_config = 6;
+  DuchyProtocolConfig duchy_protocol_config = 7;
+
+  // Set when the state is set to FAILED.
+  MeasurementFailure failure = 8;
+}

--- a/src/main/proto/wfa/measurement/internal/kingdom/measurement_failure.proto
+++ b/src/main/proto/wfa/measurement/internal/kingdom/measurement_failure.proto
@@ -1,0 +1,36 @@
+// Copyright 2024 The Cross-Media Measurement Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package wfa.measurement.internal.kingdom;
+
+option java_package = "org.wfanet.measurement.internal.kingdom";
+option java_multiple_files = true;
+
+message MeasurementFailure {
+  enum Reason {
+    REASON_UNSPECIFIED = 0;
+    // An associated certificate was revoked.
+    CERTIFICATE_REVOKED = 1;
+    // Requisition state was set to REFUSED.
+    REQUISITION_REFUSED = 2;
+    // ComputationParticipant state was set to FAILED.
+    COMPUTATION_PARTICIPANT_FAILED = 3;
+  }
+  Reason reason = 1;
+  // Human-readable message. This should not contain any sensitive
+  // information.
+  string message = 2;
+}

--- a/src/main/proto/wfa/measurement/internal/kingdom/measurement_log_entries_service.proto
+++ b/src/main/proto/wfa/measurement/internal/kingdom/measurement_log_entries_service.proto
@@ -17,7 +17,8 @@ syntax = "proto3";
 package wfa.measurement.internal.kingdom;
 
 import "wfa/measurement/internal/kingdom/duchy_measurement_log_entry.proto";
-import "wfa/measurement/internal/kingdom/measurement_log_entry.proto";
+import "wfa/measurement/internal/kingdom/duchy_measurement_log_entry_details.proto";
+import "wfa/measurement/internal/kingdom/measurement_log_entry_details.proto";
 import "wfa/measurement/internal/kingdom/state_transition_measurement_log_entry.proto";
 
 option java_package = "org.wfanet.measurement.internal.kingdom";
@@ -43,8 +44,8 @@ message CreateDuchyMeasurementLogEntryRequest {
   fixed64 external_computation_id = 1;
   string external_duchy_id = 2;
 
-  MeasurementLogEntry.Details measurement_log_entry_details = 3;
-  DuchyMeasurementLogEntry.Details details = 4;
+  MeasurementLogEntryDetails measurement_log_entry_details = 3;
+  DuchyMeasurementLogEntryDetails details = 4;
 }
 
 message StreamStateTransitionMeasurementLogEntriesRequest {

--- a/src/main/proto/wfa/measurement/internal/kingdom/measurement_log_entry.proto
+++ b/src/main/proto/wfa/measurement/internal/kingdom/measurement_log_entry.proto
@@ -17,6 +17,7 @@ syntax = "proto3";
 package wfa.measurement.internal.kingdom;
 
 import "google/protobuf/timestamp.proto";
+import "wfa/measurement/internal/kingdom/measurement_log_entry_details.proto";
 
 option java_package = "org.wfanet.measurement.internal.kingdom";
 option java_multiple_files = true;
@@ -33,24 +34,5 @@ message MeasurementLogEntry {
   fixed64 external_measurement_id = 2;
   google.protobuf.Timestamp create_time = 3;
 
-  message ErrorDetails {
-    enum Type {
-      TYPE_UNSPECIFIED = 0;
-      TRANSIENT = 1;
-      PERMANENT = 2;
-    }
-    Type type = 1;
-
-    // Time that the error occurred.
-    google.protobuf.Timestamp error_time = 2;
-  }
-
-  message Details {
-    // Human-readable log message. This should not include any sensitive info.
-    string log_message = 1;
-
-    // Details about an error. Only set if the log entry is for an error event.
-    ErrorDetails error = 2;
-  }
-  Details details = 4;
+  MeasurementLogEntryDetails details = 4;
 }

--- a/src/main/proto/wfa/measurement/internal/kingdom/measurement_log_entry_details.proto
+++ b/src/main/proto/wfa/measurement/internal/kingdom/measurement_log_entry_details.proto
@@ -1,0 +1,30 @@
+// Copyright 2021 The Cross-Media Measurement Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package wfa.measurement.internal.kingdom;
+
+import "wfa/measurement/internal/kingdom/measurement_log_entry_error.proto";
+
+option java_package = "org.wfanet.measurement.internal.kingdom";
+option java_multiple_files = true;
+
+message MeasurementLogEntryDetails {
+  // Human-readable log message. This should not include any sensitive info.
+  string log_message = 1;
+
+  // Details about an error. Only set if the log entry is for an error event.
+  MeasurementLogEntryError error = 2;
+}

--- a/src/main/proto/wfa/measurement/internal/kingdom/measurement_log_entry_error.proto
+++ b/src/main/proto/wfa/measurement/internal/kingdom/measurement_log_entry_error.proto
@@ -1,0 +1,34 @@
+// Copyright 2024 The Cross-Media Measurement Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package wfa.measurement.internal.kingdom;
+
+import "google/protobuf/timestamp.proto";
+
+option java_package = "org.wfanet.measurement.internal.kingdom";
+option java_multiple_files = true;
+
+message MeasurementLogEntryError {
+  enum Type {
+    TYPE_UNSPECIFIED = 0;
+    TRANSIENT = 1;
+    PERMANENT = 2;
+  }
+  Type type = 1;
+
+  // Time that the error occurred.
+  google.protobuf.Timestamp error_time = 2;
+}

--- a/src/main/proto/wfa/measurement/internal/kingdom/participant_requisition_params.proto
+++ b/src/main/proto/wfa/measurement/internal/kingdom/participant_requisition_params.proto
@@ -1,0 +1,36 @@
+// Copyright 2024 The Cross-Media Measurement Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package wfa.measurement.internal.kingdom;
+
+option java_package = "org.wfanet.measurement.internal.kingdom";
+option java_multiple_files = true;
+
+// Requisition parameters for Liquid Legions V2 protocols.
+message LiquidLegionsV2Params {
+  // Serialized `ElGamalPublicKey` message from public API.
+  bytes el_gamal_public_key = 1;
+  bytes el_gamal_public_key_signature = 2;
+  string el_gamal_public_key_signature_algorithm_oid = 3;
+}
+
+// Requisition parameters for HMSS protocol.
+message HonestMajorityShareShuffleParams {
+  // Serialized Keyset of TinkPublicKeyHandle.
+  bytes tink_public_key = 1;
+  bytes tink_public_key_signature = 2;
+  string tink_public_key_signature_algorithm_oid = 3;
+}

--- a/src/main/proto/wfa/measurement/internal/kingdom/requisition_details.proto
+++ b/src/main/proto/wfa/measurement/internal/kingdom/requisition_details.proto
@@ -1,0 +1,54 @@
+// Copyright 2024 The Cross-Media Measurement Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package wfa.measurement.internal.kingdom;
+
+import "wfa/measurement/internal/kingdom/requisition_refusal.proto";
+
+option java_package = "org.wfanet.measurement.internal.kingdom";
+option java_multiple_files = true;
+
+message RequisitionDetails {
+  // Serialized `EncryptionPublicKey` message from the public API.
+  bytes data_provider_public_key = 1;
+  bytes data_provider_public_key_signature = 2 [deprecated = true];
+  string data_provider_public_key_signature_algorithm_oid = 8
+      [deprecated = true];
+
+  bytes encrypted_requisition_spec = 3;
+  bytes nonce_hash = 4;
+
+  // Actual nonce value. Set when Requisition state is FULFILLED.
+  fixed64 nonce = 5;
+
+  // Refusal information. Set when Requisition state is REFUSED.
+  RequisitionRefusal refusal = 6;
+
+  // Encrypted SignedData containing the Measurement.Result for this
+  // Requisition. Set when Requisition state is FULFILLED and the protocol is
+  // Direct.
+  bytes encrypted_data = 7;
+
+  // Version of the public API for `encrypted_data`.
+  //
+  // If not specified, assume "v2alpha".
+  string encrypted_data_api_version = 9;
+
+  // Used to verify the decrypted Measurement.Result. If not present,
+  // `data_provider_certificate` should be used. Set when Requisition
+  // state is FULFILLED and the protocol is Direct.
+  fixed64 external_certificate_id = 10;
+}

--- a/src/main/proto/wfa/measurement/internal/kingdom/requisition_refusal.proto
+++ b/src/main/proto/wfa/measurement/internal/kingdom/requisition_refusal.proto
@@ -1,0 +1,67 @@
+// Copyright 2024 The Cross-Media Measurement Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package wfa.measurement.internal.kingdom;
+
+option java_package = "org.wfanet.measurement.internal.kingdom";
+option java_multiple_files = true;
+
+message RequisitionRefusal {
+  enum Justification {
+    // Default value if a `Justification` field has not been specified. Should
+    // never be used.
+    JUSTIFICATION_UNSPECIFIED = 0;
+
+    // At least one cryptographic consent signal (digital signature or
+    // encrypted value) in the `Requisition` is invalid.
+    //
+    // This means either that a digital signature cannot be verified using the
+    // specified certificate or an encrypted value cannot be decrypted using
+    // the specified key.
+    CONSENT_SIGNAL_INVALID = 1;
+
+    // The specification/configuration for the `Requisition` is invalid.
+    //
+    // For example, `encrypted_requisition_spec` includes an invalid
+    // `TimeInterval` (with `end_time` before `start_time`) or some
+    // configuration that the `DataProvider` does not support.
+    SPECIFICATION_INVALID = 2;
+
+    // There is insufficient remaining privacy budget to fulfill the
+    // `Requisition`.
+    INSUFFICIENT_PRIVACY_BUDGET = 3;
+
+    // The `Requisition` cannot be fulfilled by the `DataProvider` for a
+    // reason that is not more clearly indicated by another `Justification`.
+    //
+    // This implies that the `DataProvider` *should* be able to fulfill the
+    // `Requisition`, but something went irrecoverably wrong. For example, the
+    // `DataProvider` encountered corruption of the underlying data.
+    UNFULFILLABLE = 4;
+
+    // The `DataProvider` has declined to fulfill this `Requisition`
+    // regardless of whether any of the other `Justification` conditions
+    // apply.
+    DECLINED = 5;
+  }
+  Justification justification = 1;
+
+  // Human-readable string adding more context to the provided
+  // `Justification`. This should NOT include sensitive information.
+  //
+  // Example: "Data Provider X does not support Virtual ID model line Y".
+  string message = 2;
+}

--- a/src/main/proto/wfa/measurement/internal/kingdom/requisitions_service.proto
+++ b/src/main/proto/wfa/measurement/internal/kingdom/requisitions_service.proto
@@ -18,6 +18,7 @@ package wfa.measurement.internal.kingdom;
 
 import "google/protobuf/timestamp.proto";
 import "wfa/measurement/internal/kingdom/measurement.proto";
+import "wfa/measurement/internal/kingdom/requisition_refusal.proto";
 
 option java_package = "org.wfanet.measurement.internal.kingdom";
 option java_multiple_files = true;
@@ -97,5 +98,5 @@ message RefuseRequisitionRequest {
   fixed64 external_data_provider_id = 1;
   fixed64 external_requisition_id = 2;
 
-  Requisition.Refusal refusal = 3;
+  RequisitionRefusal refusal = 3;
 }

--- a/src/test/kotlin/org/wfanet/measurement/kingdom/service/api/v2alpha/CertificatesServiceTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/kingdom/service/api/v2alpha/CertificatesServiceTest.kt
@@ -77,7 +77,6 @@ import org.wfanet.measurement.common.identity.apiIdToExternalId
 import org.wfanet.measurement.common.testing.verifyProtoArgument
 import org.wfanet.measurement.common.toProtoTime
 import org.wfanet.measurement.internal.kingdom.Certificate as InternalCertificate
-import org.wfanet.measurement.internal.kingdom.CertificateKt.details
 import org.wfanet.measurement.internal.kingdom.CertificatesGrpcKt.CertificatesCoroutineImplBase as InternalCertificatesCoroutineService
 import org.wfanet.measurement.internal.kingdom.CertificatesGrpcKt.CertificatesCoroutineStub as InternalCertificatesCoroutineStub
 import org.wfanet.measurement.internal.kingdom.GetCertificateRequest as InternalGetCertificateRequest
@@ -85,6 +84,7 @@ import org.wfanet.measurement.internal.kingdom.ReleaseCertificateHoldRequest as 
 import org.wfanet.measurement.internal.kingdom.RevokeCertificateRequest as InternalRevokeCertificateRequest
 import org.wfanet.measurement.internal.kingdom.StreamCertificatesRequestKt
 import org.wfanet.measurement.internal.kingdom.certificate as internalCertificate
+import org.wfanet.measurement.internal.kingdom.certificateDetails
 import org.wfanet.measurement.internal.kingdom.copy
 import org.wfanet.measurement.internal.kingdom.getCertificateRequest as internalGetCertificateRequest
 import org.wfanet.measurement.internal.kingdom.releaseCertificateHoldRequest as internalReleaseCertificateHoldRequest
@@ -1523,7 +1523,7 @@ class CertificatesServiceTest {
       subjectKeyIdentifier = SERVER_CERTIFICATE.subjectKeyIdentifier!!
       notValidBefore = SERVER_CERTIFICATE.notBefore.toInstant().toProtoTime()
       notValidAfter = SERVER_CERTIFICATE.notAfter.toInstant().toProtoTime()
-      details = details { x509Der = SERVER_CERTIFICATE_DER }
+      details = certificateDetails { x509Der = SERVER_CERTIFICATE_DER }
     }
     private val CERTIFICATE: Certificate = certificate {
       name = DATA_PROVIDER_CERTIFICATE_NAME

--- a/src/test/kotlin/org/wfanet/measurement/kingdom/service/api/v2alpha/DataProvidersServiceTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/kingdom/service/api/v2alpha/DataProvidersServiceTest.kt
@@ -62,14 +62,14 @@ import org.wfanet.measurement.common.pack
 import org.wfanet.measurement.common.testing.verifyProtoArgument
 import org.wfanet.measurement.common.toProtoTime
 import org.wfanet.measurement.consent.client.common.toEncryptionPublicKey
-import org.wfanet.measurement.internal.kingdom.CertificateKt
 import org.wfanet.measurement.internal.kingdom.DataProvider as InternalDataProvider
-import org.wfanet.measurement.internal.kingdom.DataProviderKt as InternalDataProviderKt
 import org.wfanet.measurement.internal.kingdom.DataProvidersGrpcKt.DataProvidersCoroutineImplBase as InternalDataProvidersService
 import org.wfanet.measurement.internal.kingdom.DataProvidersGrpcKt.DataProvidersCoroutineStub as InternalDataProvidersClient
 import org.wfanet.measurement.internal.kingdom.certificate as internalCertificate
+import org.wfanet.measurement.internal.kingdom.certificateDetails
 import org.wfanet.measurement.internal.kingdom.copy
 import org.wfanet.measurement.internal.kingdom.dataProvider as internalDataProvider
+import org.wfanet.measurement.internal.kingdom.dataProviderDetails
 import org.wfanet.measurement.internal.kingdom.getDataProviderRequest as internalGetDataProviderRequest
 import org.wfanet.measurement.internal.kingdom.replaceDataAvailabilityIntervalRequest as internalReplaceDataAvailabilityIntervalRequest
 import org.wfanet.measurement.internal.kingdom.replaceDataProviderCapabilitiesRequest as internalReplaceDataProviderCapabilitiesRequest
@@ -707,24 +707,23 @@ class DataProvidersServiceTest {
 
     private val INTERNAL_DATA_PROVIDER: InternalDataProvider = internalDataProvider {
       externalDataProviderId = DATA_PROVIDER_ID
-      details =
-        InternalDataProviderKt.details {
-          apiVersion = API_VERSION.string
-          publicKey = SIGNED_PUBLIC_KEY.message.value
-          publicKeySignature = SIGNED_PUBLIC_KEY.signature
-          publicKeySignatureAlgorithmOid = SIGNED_PUBLIC_KEY.signatureAlgorithmOid
-          dataAvailabilityInterval = interval {
-            startTime = timestamp { seconds = 100 }
-            endTime = timestamp { seconds = 200 }
-          }
+      details = dataProviderDetails {
+        apiVersion = API_VERSION.string
+        publicKey = SIGNED_PUBLIC_KEY.message.value
+        publicKeySignature = SIGNED_PUBLIC_KEY.signature
+        publicKeySignatureAlgorithmOid = SIGNED_PUBLIC_KEY.signatureAlgorithmOid
+        dataAvailabilityInterval = interval {
+          startTime = timestamp { seconds = 100 }
+          endTime = timestamp { seconds = 200 }
         }
+      }
       certificate = internalCertificate {
         externalDataProviderId = DATA_PROVIDER_ID
         externalCertificateId = CERTIFICATE_ID
         subjectKeyIdentifier = serverCertificate.subjectKeyIdentifier!!
         notValidBefore = serverCertificate.notBefore.toInstant().toProtoTime()
         notValidAfter = serverCertificate.notAfter.toInstant().toProtoTime()
-        details = CertificateKt.details { x509Der = SERVER_CERTIFICATE_DER }
+        details = certificateDetails { x509Der = SERVER_CERTIFICATE_DER }
       }
       requiredExternalDuchyIds += EXTERNAL_DUCHY_ID
     }

--- a/src/test/kotlin/org/wfanet/measurement/kingdom/service/api/v2alpha/EventGroupMetadataDescriptorsServiceTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/kingdom/service/api/v2alpha/EventGroupMetadataDescriptorsServiceTest.kt
@@ -57,13 +57,13 @@ import org.wfanet.measurement.common.identity.ExternalId
 import org.wfanet.measurement.common.testing.captureFirst
 import org.wfanet.measurement.common.testing.verifyProtoArgument
 import org.wfanet.measurement.internal.kingdom.EventGroupMetadataDescriptor as InternalEventGroupMetadataDescriptor
-import org.wfanet.measurement.internal.kingdom.EventGroupMetadataDescriptorKt.details
 import org.wfanet.measurement.internal.kingdom.EventGroupMetadataDescriptorsGrpcKt.EventGroupMetadataDescriptorsCoroutineImplBase
 import org.wfanet.measurement.internal.kingdom.EventGroupMetadataDescriptorsGrpcKt.EventGroupMetadataDescriptorsCoroutineStub
 import org.wfanet.measurement.internal.kingdom.StreamEventGroupMetadataDescriptorsRequest
 import org.wfanet.measurement.internal.kingdom.StreamEventGroupMetadataDescriptorsRequestKt
 import org.wfanet.measurement.internal.kingdom.copy
 import org.wfanet.measurement.internal.kingdom.eventGroupMetadataDescriptor as internalEventGroupMetadataDescriptor
+import org.wfanet.measurement.internal.kingdom.eventGroupMetadataDescriptorDetails
 import org.wfanet.measurement.internal.kingdom.eventGroupMetadataDescriptorKey
 import org.wfanet.measurement.internal.kingdom.getEventGroupMetadataDescriptorRequest as internalGetEventGroupMetadataDescriptorRequest
 import org.wfanet.measurement.internal.kingdom.streamEventGroupMetadataDescriptorsRequest
@@ -928,7 +928,7 @@ class EventGroupMetadataDescriptorsServiceTest {
         externalDataProviderId = DATA_PROVIDER_EXTERNAL_ID.value
         externalEventGroupMetadataDescriptorId = EVENT_GROUP_METADATA_DESCRIPTOR_EXTERNAL_ID.value
 
-        details = details {
+        details = eventGroupMetadataDescriptorDetails {
           apiVersion = API_VERSION.string
           descriptorSet = FILE_DESCRIPTOR_SET
         }

--- a/src/test/kotlin/org/wfanet/measurement/kingdom/service/api/v2alpha/EventGroupsServiceTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/kingdom/service/api/v2alpha/EventGroupsServiceTest.kt
@@ -78,7 +78,6 @@ import org.wfanet.measurement.common.testing.captureFirst
 import org.wfanet.measurement.common.testing.verifyProtoArgument
 import org.wfanet.measurement.common.toProtoTime
 import org.wfanet.measurement.internal.kingdom.EventGroup as InternalEventGroup
-import org.wfanet.measurement.internal.kingdom.EventGroupKt.details
 import org.wfanet.measurement.internal.kingdom.EventGroupsGrpcKt.EventGroupsCoroutineImplBase
 import org.wfanet.measurement.internal.kingdom.EventGroupsGrpcKt.EventGroupsCoroutineStub
 import org.wfanet.measurement.internal.kingdom.StreamEventGroupsRequest
@@ -87,6 +86,7 @@ import org.wfanet.measurement.internal.kingdom.copy
 import org.wfanet.measurement.internal.kingdom.createEventGroupRequest as internalCreateEventGroupRequest
 import org.wfanet.measurement.internal.kingdom.deleteEventGroupRequest as internalDeleteEventGroupRequest
 import org.wfanet.measurement.internal.kingdom.eventGroup as internalEventGroup
+import org.wfanet.measurement.internal.kingdom.eventGroupDetails
 import org.wfanet.measurement.internal.kingdom.eventGroupKey
 import org.wfanet.measurement.internal.kingdom.eventTemplate
 import org.wfanet.measurement.internal.kingdom.getEventGroupRequest as internalGetEventGroupRequest
@@ -113,10 +113,8 @@ private val EVENT_GROUP_NAME_2 = "$DATA_PROVIDER_NAME/eventGroups/AAAAAAAAAJs"
 private val EVENT_GROUP_NAME_3 = "$DATA_PROVIDER_NAME/eventGroups/AAAAAAAAAKs"
 private const val MEASUREMENT_CONSUMER_NAME = "measurementConsumers/AAAAAAAAAHs"
 private const val MEASUREMENT_CONSUMER_NAME_2 = "measurementConsumers/BBBBBBBBBHs"
-private val MEASUREMENT_CONSUMER_EVENT_GROUP_NAME =
+private const val MEASUREMENT_CONSUMER_EVENT_GROUP_NAME =
   "$MEASUREMENT_CONSUMER_NAME/eventGroups/AAAAAAAAAHs"
-private const val MEASUREMENT_CONSUMER_CERTIFICATE_NAME =
-  "$MEASUREMENT_CONSUMER_NAME/certificates/AAAAAAAAAcg"
 private val ENCRYPTED_METADATA = encryptedMessage {
   ciphertext = ByteString.copyFromUtf8("encryptedMetadata")
   typeUrl = ProtoReflection.getTypeUrl(EventGroup.Metadata.getDescriptor())
@@ -179,7 +177,7 @@ private val INTERNAL_EVENT_GROUP: InternalEventGroup = internalEventGroup {
   externalMeasurementConsumerId = MEASUREMENT_CONSUMER_EXTERNAL_ID
   providedEventGroupId = EVENT_GROUP.eventGroupReferenceId
   createTime = CREATE_TIME
-  details = details {
+  details = eventGroupDetails {
     apiVersion = API_VERSION.string
     measurementConsumerPublicKey = EVENT_GROUP.measurementConsumerPublicKey.value
     vidModelLines.addAll(VID_MODEL_LINES)

--- a/src/test/kotlin/org/wfanet/measurement/kingdom/service/api/v2alpha/MeasurementConsumersServiceTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/kingdom/service/api/v2alpha/MeasurementConsumersServiceTest.kt
@@ -62,18 +62,18 @@ import org.wfanet.measurement.common.testing.verifyProtoArgument
 import org.wfanet.measurement.common.toProtoTime
 import org.wfanet.measurement.consent.client.common.toEncryptionPublicKey
 import org.wfanet.measurement.internal.kingdom.Account as InternalAccount
-import org.wfanet.measurement.internal.kingdom.CertificateKt
 import org.wfanet.measurement.internal.kingdom.MeasurementConsumer as InternalMeasurementConsumer
-import org.wfanet.measurement.internal.kingdom.MeasurementConsumerKt.details
 import org.wfanet.measurement.internal.kingdom.MeasurementConsumersGrpcKt.MeasurementConsumersCoroutineImplBase as InternalMeasurementConsumersService
 import org.wfanet.measurement.internal.kingdom.MeasurementConsumersGrpcKt.MeasurementConsumersCoroutineStub as InternalMeasurementConsumersClient
 import org.wfanet.measurement.internal.kingdom.account
 import org.wfanet.measurement.internal.kingdom.addMeasurementConsumerOwnerRequest as internalAddMeasurementConsumerOwnerRequest
 import org.wfanet.measurement.internal.kingdom.certificate
+import org.wfanet.measurement.internal.kingdom.certificateDetails
 import org.wfanet.measurement.internal.kingdom.copy
 import org.wfanet.measurement.internal.kingdom.createMeasurementConsumerRequest as internalCreateMeasurementConsumerRequest
 import org.wfanet.measurement.internal.kingdom.getMeasurementConsumerRequest as internalGetMeasurementConsumerRequest
 import org.wfanet.measurement.internal.kingdom.measurementConsumer as internalMeasurementConsumer
+import org.wfanet.measurement.internal.kingdom.measurementConsumerDetails
 import org.wfanet.measurement.internal.kingdom.removeMeasurementConsumerOwnerRequest as internalRemoveMeasurementConsumerOwnerRequest
 import org.wfanet.measurement.kingdom.deploy.gcloud.spanner.common.AccountActivationStateIllegalException
 import org.wfanet.measurement.kingdom.deploy.gcloud.spanner.common.AccountNotFoundException
@@ -762,7 +762,7 @@ class MeasurementConsumersServiceTest {
     private val INTERNAL_MEASUREMENT_CONSUMER: InternalMeasurementConsumer =
       internalMeasurementConsumer {
         externalMeasurementConsumerId = MEASUREMENT_CONSUMER_ID
-        details = details {
+        details = measurementConsumerDetails {
           apiVersion = API_VERSION.string
           publicKey = SIGNED_PUBLIC_KEY.message.value
           publicKeySignature = SIGNED_PUBLIC_KEY.signature
@@ -774,7 +774,7 @@ class MeasurementConsumersServiceTest {
           subjectKeyIdentifier = serverCertificate.subjectKeyIdentifier!!
           notValidBefore = serverCertificate.notBefore.toInstant().toProtoTime()
           notValidAfter = serverCertificate.notAfter.toInstant().toProtoTime()
-          details = CertificateKt.details { x509Der = SERVER_CERTIFICATE_DER }
+          details = certificateDetails { x509Der = SERVER_CERTIFICATE_DER }
         }
       }
 

--- a/src/test/kotlin/org/wfanet/measurement/kingdom/service/api/v2alpha/MeasurementsServiceTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/kingdom/service/api/v2alpha/MeasurementsServiceTest.kt
@@ -106,11 +106,10 @@ import org.wfanet.measurement.common.toByteString
 import org.wfanet.measurement.common.toProtoTime
 import org.wfanet.measurement.internal.kingdom.BatchGetDataProvidersRequest
 import org.wfanet.measurement.internal.kingdom.DataProvider as InternalDataProvider
-import org.wfanet.measurement.internal.kingdom.DataProviderKt as InternalDataProviderKt
 import org.wfanet.measurement.internal.kingdom.DataProvidersGrpcKt
 import org.wfanet.measurement.internal.kingdom.DuchyProtocolConfig
-import org.wfanet.measurement.internal.kingdom.Measurement as InternalMeasurement
 import org.wfanet.measurement.internal.kingdom.Measurement.State as InternalState
+import org.wfanet.measurement.internal.kingdom.MeasurementFailure as InternalMeasurementFailure
 import org.wfanet.measurement.internal.kingdom.MeasurementKt as InternalMeasurementKt
 import org.wfanet.measurement.internal.kingdom.MeasurementKt.resultInfo
 import org.wfanet.measurement.internal.kingdom.MeasurementsGrpcKt
@@ -129,11 +128,14 @@ import org.wfanet.measurement.internal.kingdom.cancelMeasurementRequest as inter
 import org.wfanet.measurement.internal.kingdom.copy
 import org.wfanet.measurement.internal.kingdom.createMeasurementRequest as internalCreateMeasurementRequest
 import org.wfanet.measurement.internal.kingdom.dataProvider as internalDataProvider
+import org.wfanet.measurement.internal.kingdom.dataProviderCapabilities as internalDataProviderCapabilities
 import org.wfanet.measurement.internal.kingdom.differentialPrivacyParams as internalDifferentialPrivacyParams
 import org.wfanet.measurement.internal.kingdom.duchyProtocolConfig
 import org.wfanet.measurement.internal.kingdom.getMeasurementRequest as internalGetMeasurementRequest
 import org.wfanet.measurement.internal.kingdom.liquidLegionsSketchParams as internalLiquidLegionsSketchParams
 import org.wfanet.measurement.internal.kingdom.measurement as internalMeasurement
+import org.wfanet.measurement.internal.kingdom.measurementDetails
+import org.wfanet.measurement.internal.kingdom.measurementFailure as internalMeasurementFailure
 import org.wfanet.measurement.internal.kingdom.measurementKey
 import org.wfanet.measurement.internal.kingdom.protocolConfig as internalProtocolConfig
 import org.wfanet.measurement.internal.kingdom.streamMeasurementsRequest
@@ -789,10 +791,9 @@ class MeasurementsServiceTest {
                 this.externalDataProviderId = externalDataProviderId.value
                 details =
                   details.copy {
-                    capabilities =
-                      InternalDataProviderKt.capabilities {
-                        honestMajorityShareShuffleSupported = true
-                      }
+                    capabilities = internalDataProviderCapabilities {
+                      honestMajorityShareShuffleSupported = true
+                    }
                   }
               }
             }
@@ -2933,20 +2934,18 @@ class MeasurementsServiceTest {
           },
         )
       )
-      details =
-        InternalMeasurementKt.details {
-          apiVersion = API_VERSION.string
-          measurementSpec = MEASUREMENT.measurementSpec.message.value
-          measurementSpecSignature = MEASUREMENT.measurementSpec.signature
-          measurementSpecSignatureAlgorithmOid = MEASUREMENT.measurementSpec.signatureAlgorithmOid
-          protocolConfig = LLV2_INTERNAL_PROTOCOL_CONFIG
-          duchyProtocolConfig = LLV2_DUCHY_PROTOCOL_CONFIG
-          failure =
-            InternalMeasurementKt.failure {
-              reason = InternalMeasurement.Failure.Reason.CERTIFICATE_REVOKED
-              message = MEASUREMENT.failure.message
-            }
+      details = measurementDetails {
+        apiVersion = API_VERSION.string
+        measurementSpec = MEASUREMENT.measurementSpec.message.value
+        measurementSpecSignature = MEASUREMENT.measurementSpec.signature
+        measurementSpecSignatureAlgorithmOid = MEASUREMENT.measurementSpec.signatureAlgorithmOid
+        protocolConfig = LLV2_INTERNAL_PROTOCOL_CONFIG
+        duchyProtocolConfig = LLV2_DUCHY_PROTOCOL_CONFIG
+        failure = internalMeasurementFailure {
+          reason = InternalMeasurementFailure.Reason.CERTIFICATE_REVOKED
+          message = MEASUREMENT.failure.message
         }
+      }
       results += resultInfo {
         externalAggregatorDuchyId = DuchyCertificateKey.fromName(DUCHY_CERTIFICATE_NAME)!!.duchyId
         externalCertificateId =
@@ -2984,21 +2983,19 @@ class MeasurementsServiceTest {
 
     private val REACH_ONLY_INTERNAL_MEASUREMENT =
       INTERNAL_MEASUREMENT.copy {
-        details =
-          InternalMeasurementKt.details {
-            apiVersion = API_VERSION.string
-            measurementSpec = REACH_ONLY_MEASUREMENT.measurementSpec.message.value
-            measurementSpecSignature = REACH_ONLY_MEASUREMENT.measurementSpec.signature
-            measurementSpecSignatureAlgorithmOid =
-              REACH_ONLY_MEASUREMENT.measurementSpec.signatureAlgorithmOid
-            protocolConfig = RO_LLV2_INTERNAL_PROTOCOL_CONFIG
-            duchyProtocolConfig = RO_LLV2_DUCHY_PROTOCOL_CONFIG
-            failure =
-              InternalMeasurementKt.failure {
-                reason = InternalMeasurement.Failure.Reason.CERTIFICATE_REVOKED
-                message = MEASUREMENT.failure.message
-              }
+        details = measurementDetails {
+          apiVersion = API_VERSION.string
+          measurementSpec = REACH_ONLY_MEASUREMENT.measurementSpec.message.value
+          measurementSpecSignature = REACH_ONLY_MEASUREMENT.measurementSpec.signature
+          measurementSpecSignatureAlgorithmOid =
+            REACH_ONLY_MEASUREMENT.measurementSpec.signatureAlgorithmOid
+          protocolConfig = RO_LLV2_INTERNAL_PROTOCOL_CONFIG
+          duchyProtocolConfig = RO_LLV2_DUCHY_PROTOCOL_CONFIG
+          failure = internalMeasurementFailure {
+            reason = InternalMeasurementFailure.Reason.CERTIFICATE_REVOKED
+            message = MEASUREMENT.failure.message
           }
+        }
       }
     private val DEFAULT_INTERNAL_DIRECT_NOISE_MECHANISMS: List<InternalNoiseMechanism> =
       listOf(

--- a/src/test/kotlin/org/wfanet/measurement/kingdom/service/system/v1alpha/ComputationLogEntriesServiceTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/kingdom/service/system/v1alpha/ComputationLogEntriesServiceTest.kt
@@ -37,6 +37,7 @@ import org.wfanet.measurement.internal.kingdom.DuchyMeasurementLogEntry
 import org.wfanet.measurement.internal.kingdom.MeasurementLogEntriesGrpcKt.MeasurementLogEntriesCoroutineImplBase
 import org.wfanet.measurement.internal.kingdom.MeasurementLogEntriesGrpcKt.MeasurementLogEntriesCoroutineStub
 import org.wfanet.measurement.internal.kingdom.MeasurementLogEntry
+import org.wfanet.measurement.internal.kingdom.MeasurementLogEntryError
 import org.wfanet.measurement.system.v1alpha.ComputationLogEntry
 import org.wfanet.measurement.system.v1alpha.ComputationLogEntryKey
 import org.wfanet.measurement.system.v1alpha.CreateComputationLogEntryRequest
@@ -78,7 +79,7 @@ private val MEASUREMENT_LOG_ENTRY =
       detailsBuilder.apply {
         logMessage = DUCHY_ERROR_MESSAGE
         errorBuilder.apply {
-          type = MeasurementLogEntry.ErrorDetails.Type.TRANSIENT
+          type = MeasurementLogEntryError.Type.TRANSIENT
           errorTimeBuilder.apply {
             seconds = 3
             nanos = 4
@@ -180,7 +181,7 @@ class ComputationLogEntriesServiceTest {
             measurementLogEntryDetailsBuilder.apply {
               logMessage = DUCHY_ERROR_MESSAGE
               errorBuilder.apply {
-                type = MeasurementLogEntry.ErrorDetails.Type.TRANSIENT
+                type = MeasurementLogEntryError.Type.TRANSIENT
                 errorTimeBuilder.apply {
                   seconds = 3
                   nanos = 4

--- a/src/test/kotlin/org/wfanet/measurement/kingdom/service/system/v1alpha/ComputationsServiceTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/kingdom/service/system/v1alpha/ComputationsServiceTest.kt
@@ -39,12 +39,10 @@ import org.wfanet.measurement.common.identity.externalIdToApiId
 import org.wfanet.measurement.common.identity.testing.DuchyIdSetter
 import org.wfanet.measurement.common.testing.verifyProtoArgument
 import org.wfanet.measurement.internal.kingdom.ComputationParticipant as InternalComputationParticipant
-import org.wfanet.measurement.internal.kingdom.ComputationParticipantKt as InternalComputationParticipantKt
 import org.wfanet.measurement.internal.kingdom.DuchyProtocolConfigKt
 import org.wfanet.measurement.internal.kingdom.DuchyProtocolConfigKt.LiquidLegionsV2Kt.mpcNoise
 import org.wfanet.measurement.internal.kingdom.GetMeasurementByComputationIdRequest
 import org.wfanet.measurement.internal.kingdom.Measurement as InternalMeasurement
-import org.wfanet.measurement.internal.kingdom.MeasurementKt.details
 import org.wfanet.measurement.internal.kingdom.MeasurementKt.resultInfo
 import org.wfanet.measurement.internal.kingdom.MeasurementsGrpcKt.MeasurementsCoroutineImplBase as InternalMeasurementsCoroutineService
 import org.wfanet.measurement.internal.kingdom.MeasurementsGrpcKt.MeasurementsCoroutineStub as InternalMeasurementsCoroutineStub
@@ -56,12 +54,15 @@ import org.wfanet.measurement.internal.kingdom.StreamMeasurementsRequest
 import org.wfanet.measurement.internal.kingdom.StreamMeasurementsRequestKt
 import org.wfanet.measurement.internal.kingdom.StreamMeasurementsRequestKt.filter
 import org.wfanet.measurement.internal.kingdom.computationKey
+import org.wfanet.measurement.internal.kingdom.computationParticipantDetails
 import org.wfanet.measurement.internal.kingdom.copy
 import org.wfanet.measurement.internal.kingdom.differentialPrivacyParams as internalDifferentialPrivacyParams
 import org.wfanet.measurement.internal.kingdom.duchyProtocolConfig
 import org.wfanet.measurement.internal.kingdom.getMeasurementByComputationIdRequest
 import org.wfanet.measurement.internal.kingdom.liquidLegionsSketchParams
+import org.wfanet.measurement.internal.kingdom.liquidLegionsV2Params
 import org.wfanet.measurement.internal.kingdom.measurement as internalMeasurement
+import org.wfanet.measurement.internal.kingdom.measurementDetails
 import org.wfanet.measurement.internal.kingdom.protocolConfig
 import org.wfanet.measurement.internal.kingdom.streamMeasurementsRequest
 import org.wfanet.measurement.system.v1alpha.Computation
@@ -186,20 +187,18 @@ private val INTERNAL_COMPUTATION_PARTICIPANT =
 
 private val INTERNAL_RO_LLV2_COMPUTATION_PARTICIPANT =
   INTERNAL_COMPUTATION_PARTICIPANT.copy {
-    details =
-      InternalComputationParticipantKt.details {
-        reachOnlyLiquidLegionsV2 =
-          InternalComputationParticipantKt.liquidLegionsV2Details {
-            elGamalPublicKey = DUCHY_ELGAMAL_KEY
-            elGamalPublicKeySignature = DUCHY_ELGAMAL_KEY_SIGNATURE
-          }
+    details = computationParticipantDetails {
+      reachOnlyLiquidLegionsV2 = liquidLegionsV2Params {
+        elGamalPublicKey = DUCHY_ELGAMAL_KEY
+        elGamalPublicKeySignature = DUCHY_ELGAMAL_KEY_SIGNATURE
       }
+    }
   }
 
 private val INTERNAL_MEASUREMENT = internalMeasurement {
   externalComputationId = EXTERNAL_COMPUTATION_ID
   state = InternalMeasurement.State.FAILED
-  details = details {
+  details = measurementDetails {
     apiVersion = PUBLIC_API_VERSION
     measurementSpec = MEASUREMENT_SPEC
     duchyProtocolConfig = duchyProtocolConfig {
@@ -242,7 +241,7 @@ private val INTERNAL_MEASUREMENT = internalMeasurement {
 
 private val INTERNAL_RO_LLV2_MEASUREMENT =
   INTERNAL_MEASUREMENT.copy {
-    details = details {
+    details = measurementDetails {
       apiVersion = PUBLIC_API_VERSION
       measurementSpec = MEASUREMENT_SPEC
       duchyProtocolConfig = duchyProtocolConfig {

--- a/src/test/kotlin/org/wfanet/measurement/kingdom/service/system/v1alpha/RequisitionsServiceTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/kingdom/service/system/v1alpha/RequisitionsServiceTest.kt
@@ -34,15 +34,16 @@ import org.wfanet.measurement.common.identity.DuchyIdentity
 import org.wfanet.measurement.common.identity.externalIdToApiId
 import org.wfanet.measurement.common.identity.testing.DuchyIdSetter
 import org.wfanet.measurement.common.testing.verifyProtoArgument
-import org.wfanet.measurement.internal.kingdom.CertificateKt as InternalCertificateKt
 import org.wfanet.measurement.internal.kingdom.FulfillRequisitionRequestKt.computedRequisitionParams
 import org.wfanet.measurement.internal.kingdom.Requisition as InternalRequisition
 import org.wfanet.measurement.internal.kingdom.RequisitionKt as InternalRequisitionKt
 import org.wfanet.measurement.internal.kingdom.RequisitionsGrpcKt.RequisitionsCoroutineImplBase as InternalRequisitionsCoroutineService
 import org.wfanet.measurement.internal.kingdom.RequisitionsGrpcKt.RequisitionsCoroutineStub as InternalRequisitionsCoroutineStub
 import org.wfanet.measurement.internal.kingdom.certificate as internalCertificate
+import org.wfanet.measurement.internal.kingdom.certificateDetails
 import org.wfanet.measurement.internal.kingdom.fulfillRequisitionRequest as internalFulfillRequisitionRequest
 import org.wfanet.measurement.internal.kingdom.requisition as internalRequisition
+import org.wfanet.measurement.internal.kingdom.requisitionDetails
 import org.wfanet.measurement.system.v1alpha.FulfillRequisitionRequest
 import org.wfanet.measurement.system.v1alpha.Requisition
 
@@ -71,16 +72,15 @@ private val INTERNAL_REQUISITION = internalRequisition {
   externalDataProviderId = EXTERNAL_DATA_PROVIDER_ID
   externalFulfillingDuchyId = DUCHY_ID
   state = InternalRequisition.State.FULFILLED
-  details =
-    InternalRequisitionKt.details {
-      encryptedRequisitionSpec = ByteString.copyFromUtf8("foo")
-      nonceHash = NONCE_HASH.bytes
-      nonce = NONCE
-    }
+  details = requisitionDetails {
+    encryptedRequisitionSpec = ByteString.copyFromUtf8("foo")
+    nonceHash = NONCE_HASH.bytes
+    nonce = NONCE
+  }
   dataProviderCertificate = internalCertificate {
     externalDataProviderId = EXTERNAL_DATA_PROVIDER_ID
     externalCertificateId = EXTERNAL_DATA_PROVIDER_CERTIFICATE_ID
-    details = InternalCertificateKt.details { x509Der = DATA_PROVIDER_CERTIFICATE_DER }
+    details = certificateDetails { x509Der = DATA_PROVIDER_CERTIFICATE_DER }
   }
   parentMeasurement = InternalRequisitionKt.parentMeasurement { apiVersion = PUBLIC_API_VERSION }
 }


### PR DESCRIPTION
The Details messages are persisted in the underlying Spanner database. Extracting them simplifies the migration to native protobuf types in Cloud Spanner.

This change maintains binary compatibility for all existing serialized message types.