### PR TITLE
refactor: Drop JSON debugging columns from Kingdom Spanner DB

### DIFF
--- a/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/readers/DataProviderReader.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/readers/DataProviderReader.kt
@@ -44,7 +44,6 @@ class DataProviderReader : SpannerReader<DataProviderReader.Result>() {
       DataProviders.DataProviderId,
       DataProviders.ExternalDataProviderId,
       DataProviders.DataProviderDetails,
-      DataProviders.DataProviderDetailsJson,
       DataProviderCertificates.ExternalDataProviderCertificateId,
       Certificates.CertificateId,
       Certificates.SubjectKeyIdentifier,

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/readers/ExchangeReader.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/readers/ExchangeReader.kt
@@ -99,7 +99,6 @@ class ExchangeReader : SpannerReader<ExchangeReader.Result>() {
         "Exchanges.Date",
         "Exchanges.State",
         "Exchanges.ExchangeDetails",
-        "Exchanges.ExchangeDetailsJson",
         "RecurringExchanges.ExternalRecurringExchangeId",
       )
 

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/readers/ExchangeStepAttemptReader.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/readers/ExchangeStepAttemptReader.kt
@@ -48,7 +48,6 @@ class ExchangeStepAttemptReader : SpannerReader<ExchangeStepAttemptReader.Result
       ExchangeStepAttempts.AttemptIndex,
       ExchangeStepAttempts.State,
       ExchangeStepAttempts.ExchangeStepAttemptDetails,
-      ExchangeStepAttempts.ExchangeStepAttemptDetailsJson,
       RecurringExchanges.ExternalRecurringExchangeId
     FROM ExchangeStepAttempts
     JOIN RecurringExchanges USING (RecurringExchangeId)

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/readers/MeasurementConsumerReader.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/readers/MeasurementConsumerReader.kt
@@ -35,7 +35,6 @@ class MeasurementConsumerReader : SpannerReader<MeasurementConsumerReader.Result
       MeasurementConsumers.MeasurementConsumerId,
       MeasurementConsumers.ExternalMeasurementConsumerId,
       MeasurementConsumers.MeasurementConsumerDetails,
-      MeasurementConsumers.MeasurementConsumerDetailsJson,
       MeasurementConsumerCertificates.ExternalMeasurementConsumerCertificateId,
       Certificates.SubjectKeyIdentifier,
       Certificates.NotValidBefore,

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/readers/RecurringExchangeReader.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/readers/RecurringExchangeReader.kt
@@ -98,7 +98,6 @@ class RecurringExchangeReader(recurringExchangesIndex: Index = Index.NONE) :
         "RecurringExchanges.State",
         "RecurringExchanges.NextExchangeDate",
         "RecurringExchanges.RecurringExchangeDetails",
-        "RecurringExchanges.RecurringExchangeDetailsJson",
         "DataProviders.ExternalDataProviderId",
         "ModelProviders.ExternalModelProviderId",
       )

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/writers/ClaimReadyExchangeStep.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/writers/ClaimReadyExchangeStep.kt
@@ -27,7 +27,6 @@ import org.wfanet.measurement.gcloud.common.toCloudDate
 import org.wfanet.measurement.gcloud.common.toGcloudTimestamp
 import org.wfanet.measurement.gcloud.spanner.bufferInsertMutation
 import org.wfanet.measurement.gcloud.spanner.set
-import org.wfanet.measurement.gcloud.spanner.setJson
 import org.wfanet.measurement.gcloud.spanner.statement
 import org.wfanet.measurement.internal.kingdom.ClaimReadyExchangeStepRequest
 import org.wfanet.measurement.internal.kingdom.ExchangeStep
@@ -128,7 +127,6 @@ class ClaimReadyExchangeStep(
       set("ExpirationTime" to (now + DEFAULT_EXPIRATION_DURATION).toGcloudTimestamp())
 
       set("ExchangeStepAttemptDetails" to details)
-      setJson("ExchangeStepAttemptDetailsJson" to details)
     }
 
     return attemptIndex

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/writers/CreateCertificate.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/writers/CreateCertificate.kt
@@ -25,7 +25,6 @@ import org.wfanet.measurement.gcloud.spanner.AsyncDatabaseClient
 import org.wfanet.measurement.gcloud.spanner.bufferTo
 import org.wfanet.measurement.gcloud.spanner.insertMutation
 import org.wfanet.measurement.gcloud.spanner.set
-import org.wfanet.measurement.gcloud.spanner.setJson
 import org.wfanet.measurement.internal.kingdom.Certificate
 import org.wfanet.measurement.kingdom.deploy.common.DuchyIds
 import org.wfanet.measurement.kingdom.deploy.gcloud.spanner.common.CertSubjectKeyIdAlreadyExistsException
@@ -144,6 +143,5 @@ fun Certificate.toInsertMutation(internalId: InternalId): Mutation {
     set("NotValidAfter" to notValidAfter.toGcloudTimestamp())
     set("RevocationState" to revocationState)
     set("CertificateDetails" to details)
-    setJson("CertificateDetailsJson" to details)
   }
 }

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/writers/CreateDataProvider.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/writers/CreateDataProvider.kt
@@ -18,7 +18,6 @@ import org.wfanet.measurement.common.identity.InternalId
 import org.wfanet.measurement.gcloud.spanner.bufferInsertMutation
 import org.wfanet.measurement.gcloud.spanner.bufferTo
 import org.wfanet.measurement.gcloud.spanner.set
-import org.wfanet.measurement.gcloud.spanner.setJson
 import org.wfanet.measurement.internal.kingdom.DataProvider
 import org.wfanet.measurement.internal.kingdom.copy
 import org.wfanet.measurement.kingdom.deploy.common.DuchyIds
@@ -39,7 +38,6 @@ class CreateDataProvider(private val dataProvider: DataProvider) :
       set("PublicKeyCertificateId" to internalCertificateId)
       set("ExternalDataProviderId" to externalDataProviderId)
       set("DataProviderDetails" to dataProvider.details)
-      setJson("DataProviderDetailsJson" to dataProvider.details)
     }
 
     for (externalDuchyId in dataProvider.requiredExternalDuchyIdsList) {

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/writers/CreateEventGroup.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/writers/CreateEventGroup.kt
@@ -19,7 +19,6 @@ import org.wfanet.measurement.common.identity.ExternalId
 import org.wfanet.measurement.common.identity.InternalId
 import org.wfanet.measurement.gcloud.spanner.bufferInsertMutation
 import org.wfanet.measurement.gcloud.spanner.set
-import org.wfanet.measurement.gcloud.spanner.setJson
 import org.wfanet.measurement.internal.kingdom.CreateEventGroupRequest
 import org.wfanet.measurement.internal.kingdom.EventGroup
 import org.wfanet.measurement.internal.kingdom.copy
@@ -83,7 +82,6 @@ class CreateEventGroup(private val request: CreateEventGroupRequest) :
       set("UpdateTime" to Value.COMMIT_TIMESTAMP)
       if (request.eventGroup.hasDetails()) {
         set("EventGroupDetails" to request.eventGroup.details)
-        setJson("EventGroupDetailsJson" to request.eventGroup.details)
       }
       set("State" to EventGroup.State.ACTIVE)
     }

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/writers/CreateEventGroupMetadataDescriptor.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/writers/CreateEventGroupMetadataDescriptor.kt
@@ -20,7 +20,6 @@ import org.wfanet.measurement.common.identity.ExternalId
 import org.wfanet.measurement.common.identity.InternalId
 import org.wfanet.measurement.gcloud.spanner.bufferInsertMutation
 import org.wfanet.measurement.gcloud.spanner.set
-import org.wfanet.measurement.gcloud.spanner.setJson
 import org.wfanet.measurement.internal.kingdom.EventGroupMetadataDescriptor
 import org.wfanet.measurement.kingdom.deploy.gcloud.spanner.common.DataProviderNotFoundException
 import org.wfanet.measurement.kingdom.deploy.gcloud.spanner.common.EventGroupMetadataDescriptorAlreadyExistsWithTypeException
@@ -85,7 +84,6 @@ class CreateEventGroupMetadataDescriptor(
       }
 
       set("DescriptorDetails" to eventGroupMetadataDescriptor.details)
-      setJson("DescriptorDetailsJson" to eventGroupMetadataDescriptor.details)
     }
 
     for (protobufTypeName in protobufTypeNames) {

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/writers/CreateExchange.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/writers/CreateExchange.kt
@@ -18,7 +18,6 @@ import org.wfanet.measurement.common.identity.ExternalId
 import org.wfanet.measurement.gcloud.common.toCloudDate
 import org.wfanet.measurement.gcloud.spanner.bufferInsertMutation
 import org.wfanet.measurement.gcloud.spanner.set
-import org.wfanet.measurement.gcloud.spanner.setJson
 import org.wfanet.measurement.internal.kingdom.Exchange
 import org.wfanet.measurement.kingdom.deploy.gcloud.spanner.common.RecurringExchangeNotFoundException
 import org.wfanet.measurement.kingdom.deploy.gcloud.spanner.readers.RecurringExchangeReader
@@ -45,7 +44,6 @@ class CreateExchange(private val exchange: Exchange) : SimpleSpannerWriter<Excha
       set("Date" to exchange.date.toCloudDate())
       set("State" to INITIAL_STATE)
       set("ExchangeDetails" to exchange.details)
-      setJson("ExchangeDetailsJson" to exchange.details)
     }
 
     return exchange.toBuilder().apply { state = INITIAL_STATE }.build()

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/writers/CreateExchangesAndSteps.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/writers/CreateExchangesAndSteps.kt
@@ -26,7 +26,6 @@ import org.wfanet.measurement.gcloud.spanner.bind
 import org.wfanet.measurement.gcloud.spanner.bufferInsertMutation
 import org.wfanet.measurement.gcloud.spanner.bufferUpdateMutation
 import org.wfanet.measurement.gcloud.spanner.set
-import org.wfanet.measurement.gcloud.spanner.setJson
 import org.wfanet.measurement.internal.kingdom.Exchange
 import org.wfanet.measurement.internal.kingdom.ExchangeDetails
 import org.wfanet.measurement.internal.kingdom.ExchangeStep
@@ -129,7 +128,6 @@ class CreateExchangesAndSteps(
       set("Date" to date.toCloudDate())
       set("State" to Exchange.State.ACTIVE)
       set("ExchangeDetails" to exchangeDetails)
-      setJson("ExchangeDetailsJson" to exchangeDetails)
     }
   }
 

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/writers/CreateMeasurementConsumer.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/writers/CreateMeasurementConsumer.kt
@@ -19,7 +19,6 @@ import org.wfanet.measurement.common.identity.ExternalId
 import org.wfanet.measurement.gcloud.spanner.bufferInsertMutation
 import org.wfanet.measurement.gcloud.spanner.bufferTo
 import org.wfanet.measurement.gcloud.spanner.set
-import org.wfanet.measurement.gcloud.spanner.setJson
 import org.wfanet.measurement.internal.kingdom.Account
 import org.wfanet.measurement.internal.kingdom.MeasurementConsumer
 import org.wfanet.measurement.internal.kingdom.copy
@@ -78,7 +77,6 @@ class CreateMeasurementConsumer(
       set("PublicKeyCertificateId" to internalCertificateId)
       set("ExternalMeasurementConsumerId" to externalMeasurementConsumerId)
       set("MeasurementConsumerDetails" to measurementConsumer.details)
-      setJson("MeasurementConsumerDetailsJson" to measurementConsumer.details)
     }
 
     val externalMeasurementConsumerCertificateId = idGenerator.generateExternalId()

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/writers/CreateMeasurements.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/writers/CreateMeasurements.kt
@@ -23,7 +23,6 @@ import org.wfanet.measurement.gcloud.spanner.appendClause
 import org.wfanet.measurement.gcloud.spanner.bind
 import org.wfanet.measurement.gcloud.spanner.bufferInsertMutation
 import org.wfanet.measurement.gcloud.spanner.set
-import org.wfanet.measurement.gcloud.spanner.setJson
 import org.wfanet.measurement.internal.kingdom.ComputationParticipant
 import org.wfanet.measurement.internal.kingdom.ComputationParticipantDetails
 import org.wfanet.measurement.internal.kingdom.CreateMeasurementRequest
@@ -330,7 +329,6 @@ class CreateMeasurements(private val requests: List<CreateMeasurementRequest>) :
       set("CertificateId" to measurementConsumerCertificateId)
       set("State" to initialMeasurementState)
       set("MeasurementDetails" to createMeasurementRequest.measurement.details)
-      setJson("MeasurementDetailsJson" to createMeasurementRequest.measurement.details)
       set("CreateTime" to Value.COMMIT_TIMESTAMP)
       set("UpdateTime" to Value.COMMIT_TIMESTAMP)
     }
@@ -349,7 +347,6 @@ class CreateMeasurements(private val requests: List<CreateMeasurementRequest>) :
       set("UpdateTime" to Value.COMMIT_TIMESTAMP)
       set("State" to ComputationParticipant.State.CREATED)
       set("ParticipantDetails" to participantDetails)
-      setJson("ParticipantDetailsJson" to participantDetails)
     }
   }
 
@@ -417,7 +414,6 @@ class CreateMeasurements(private val requests: List<CreateMeasurementRequest>) :
       set("State" to initialRequisitionState)
       fulfillingDuchyId?.let { set("FulfillingDuchyId" to it) }
       set("RequisitionDetails" to details)
-      setJson("RequisitionDetailsJson" to details)
     }
   }
 

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/writers/CreateRecurringExchange.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/writers/CreateRecurringExchange.kt
@@ -18,7 +18,6 @@ import org.wfanet.measurement.common.identity.ExternalId
 import org.wfanet.measurement.gcloud.common.toCloudDate
 import org.wfanet.measurement.gcloud.spanner.bufferInsertMutation
 import org.wfanet.measurement.gcloud.spanner.set
-import org.wfanet.measurement.gcloud.spanner.setJson
 import org.wfanet.measurement.internal.kingdom.RecurringExchange
 import org.wfanet.measurement.internal.kingdom.copy
 import org.wfanet.measurement.kingdom.deploy.gcloud.spanner.common.DataProviderNotFoundException
@@ -59,7 +58,6 @@ class CreateRecurringExchange(private val recurringExchange: RecurringExchange) 
       set("State" to INITIAL_STATE)
       set("NextExchangeDate" to recurringExchange.nextExchangeDate.toCloudDate())
       set("RecurringExchangeDetails" to recurringExchange.details)
-      setJson("RecurringExchangeDetailsJson" to recurringExchange.details)
     }
 
     return recurringExchange.copy {

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/writers/DeleteEventGroup.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/writers/DeleteEventGroup.kt
@@ -20,7 +20,6 @@ import com.google.cloud.spanner.Value
 import org.wfanet.measurement.common.identity.ExternalId
 import org.wfanet.measurement.gcloud.spanner.bufferUpdateMutation
 import org.wfanet.measurement.gcloud.spanner.set
-import org.wfanet.measurement.gcloud.spanner.setJson
 import org.wfanet.measurement.internal.kingdom.DeleteEventGroupRequest
 import org.wfanet.measurement.internal.kingdom.EventGroup
 import org.wfanet.measurement.internal.kingdom.EventGroupDetails
@@ -60,7 +59,6 @@ class DeleteEventGroup(private val request: DeleteEventGroupRequest) :
       set("MeasurementConsumerCertificateId" to null as Long?)
       set("UpdateTime" to Value.COMMIT_TIMESTAMP)
       set("EventGroupDetails" to null as EventGroupDetails?)
-      setJson("EventGroupDetailsJson" to null as EventGroupDetails?)
       set("State" to EventGroup.State.DELETED)
     }
 

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/writers/FinishExchangeStepAttempt.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/writers/FinishExchangeStepAttempt.kt
@@ -28,9 +28,7 @@ import org.wfanet.measurement.gcloud.common.toCloudDate
 import org.wfanet.measurement.gcloud.spanner.appendClause
 import org.wfanet.measurement.gcloud.spanner.bind
 import org.wfanet.measurement.gcloud.spanner.bufferUpdateMutation
-import org.wfanet.measurement.gcloud.spanner.getProtoEnum
 import org.wfanet.measurement.gcloud.spanner.set
-import org.wfanet.measurement.gcloud.spanner.setJson
 import org.wfanet.measurement.gcloud.spanner.statement
 import org.wfanet.measurement.internal.kingdom.Exchange
 import org.wfanet.measurement.internal.kingdom.ExchangeStep
@@ -233,7 +231,6 @@ class FinishExchangeStepAttempt(
       set("AttemptIndex" to attemptNumber.toLong())
       set("State" to state)
       set("ExchangeStepAttemptDetails" to details)
-      setJson("ExchangeStepAttemptDetailsJson" to details)
     }
 
     return exchangeStepAttempt.copy {

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/writers/MeasurementLogEntries.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/writers/MeasurementLogEntries.kt
@@ -19,7 +19,6 @@ import org.wfanet.measurement.common.identity.ExternalId
 import org.wfanet.measurement.common.identity.InternalId
 import org.wfanet.measurement.gcloud.spanner.bufferInsertMutation
 import org.wfanet.measurement.gcloud.spanner.set
-import org.wfanet.measurement.gcloud.spanner.setJson
 import org.wfanet.measurement.internal.kingdom.DuchyMeasurementLogEntryDetails
 import org.wfanet.measurement.internal.kingdom.Measurement
 import org.wfanet.measurement.internal.kingdom.MeasurementLogEntryDetails
@@ -37,7 +36,6 @@ internal fun SpannerWriter.TransactionScope.insertMeasurementLogEntry(
     set("MeasurementId" to measurementId)
     set("CreateTime" to Value.COMMIT_TIMESTAMP)
     set("MeasurementLogDetails" to logDetails)
-    setJson("MeasurementLogDetailsJson" to logDetails)
   }
 }
 
@@ -74,7 +72,6 @@ internal fun SpannerWriter.TransactionScope.insertDuchyMeasurementLogEntry(
     set("DuchyId" to duchyId)
     set("ExternalComputationLogEntryId" to externalComputationLogEntryId)
     set("DuchyMeasurementLogDetails" to logDetails)
-    setJson("DuchyMeasurementLogDetailsJson" to logDetails)
   }
 
   return externalComputationLogEntryId

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/writers/ReplaceDataAvailabilityInterval.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/writers/ReplaceDataAvailabilityInterval.kt
@@ -19,7 +19,6 @@ package org.wfanet.measurement.kingdom.deploy.gcloud.spanner.writers
 import org.wfanet.measurement.common.identity.ExternalId
 import org.wfanet.measurement.gcloud.spanner.bufferUpdateMutation
 import org.wfanet.measurement.gcloud.spanner.set
-import org.wfanet.measurement.gcloud.spanner.setJson
 import org.wfanet.measurement.internal.kingdom.DataProvider
 import org.wfanet.measurement.internal.kingdom.ReplaceDataAvailabilityIntervalRequest
 import org.wfanet.measurement.internal.kingdom.copy
@@ -43,7 +42,6 @@ class ReplaceDataAvailabilityInterval(private val request: ReplaceDataAvailabili
     transactionContext.bufferUpdateMutation("DataProviders") {
       set("DataProviderId" to dataProviderId)
       set("DataProviderDetails" to updatedDetails)
-      setJson("DataProviderDetailsJson" to updatedDetails)
     }
 
     return dataProvider.copy { details = updatedDetails }

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/writers/ReplaceDataProviderCapabilities.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/writers/ReplaceDataProviderCapabilities.kt
@@ -19,7 +19,6 @@ package org.wfanet.measurement.kingdom.deploy.gcloud.spanner.writers
 import org.wfanet.measurement.common.identity.ExternalId
 import org.wfanet.measurement.gcloud.spanner.bufferUpdateMutation
 import org.wfanet.measurement.gcloud.spanner.set
-import org.wfanet.measurement.gcloud.spanner.setJson
 import org.wfanet.measurement.internal.kingdom.DataProvider
 import org.wfanet.measurement.internal.kingdom.DataProviderDetails
 import org.wfanet.measurement.internal.kingdom.ReplaceDataProviderCapabilitiesRequest
@@ -41,7 +40,6 @@ class ReplaceDataProviderCapabilities(private val request: ReplaceDataProviderCa
     transactionContext.bufferUpdateMutation("DataProviders") {
       set("DataProviderId" to dataProviderResult.dataProviderId)
       set("DataProviderDetails" to updatedDetails)
-      setJson("DataProviderDetailsJson" to updatedDetails)
     }
 
     return dataProviderResult.dataProvider.copy { details = updatedDetails }

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/writers/SetParticipantRequisitionParams.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/writers/SetParticipantRequisitionParams.kt
@@ -29,7 +29,6 @@ import org.wfanet.measurement.gcloud.spanner.bind
 import org.wfanet.measurement.gcloud.spanner.bufferUpdateMutation
 import org.wfanet.measurement.gcloud.spanner.getProtoMessage
 import org.wfanet.measurement.gcloud.spanner.set
-import org.wfanet.measurement.gcloud.spanner.setJson
 import org.wfanet.measurement.gcloud.spanner.statement
 import org.wfanet.measurement.internal.kingdom.ComputationParticipant
 import org.wfanet.measurement.internal.kingdom.ComputationParticipantDetails
@@ -171,7 +170,6 @@ class SetParticipantRequisitionParams(private val request: SetParticipantRequisi
       set("UpdateTime" to Value.COMMIT_TIMESTAMP)
       set("State" to nextState)
       set("ParticipantDetails" to participantDetails)
-      setJson("ParticipantDetailsJson" to participantDetails)
     }
 
     val otherComputationParticipants: List<ComputationParticipantResult> =

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/writers/UpdateEventGroup.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/writers/UpdateEventGroup.kt
@@ -18,7 +18,6 @@ import com.google.cloud.spanner.Value
 import org.wfanet.measurement.common.identity.ExternalId
 import org.wfanet.measurement.gcloud.spanner.bufferUpdateMutation
 import org.wfanet.measurement.gcloud.spanner.set
-import org.wfanet.measurement.gcloud.spanner.setJson
 import org.wfanet.measurement.internal.kingdom.EventGroup
 import org.wfanet.measurement.kingdom.deploy.gcloud.spanner.common.EventGroupInvalidArgsException
 import org.wfanet.measurement.kingdom.deploy.gcloud.spanner.common.EventGroupNotFoundException
@@ -70,7 +69,6 @@ class UpdateEventGroup(private val eventGroup: EventGroup) :
       set("ProvidedEventGroupId" to providedEventGroupId)
       set("UpdateTime" to Value.COMMIT_TIMESTAMP)
       set("EventGroupDetails" to eventGroup.details)
-      setJson("EventGroupDetailsJson" to eventGroup.details)
     }
 
     return eventGroup

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/writers/UpdateEventGroupMetadataDescriptor.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/writers/UpdateEventGroupMetadataDescriptor.kt
@@ -23,7 +23,6 @@ import org.wfanet.measurement.common.identity.ExternalId
 import org.wfanet.measurement.gcloud.spanner.bufferInsertMutation
 import org.wfanet.measurement.gcloud.spanner.bufferUpdateMutation
 import org.wfanet.measurement.gcloud.spanner.set
-import org.wfanet.measurement.gcloud.spanner.setJson
 import org.wfanet.measurement.internal.kingdom.EventGroupMetadataDescriptor
 import org.wfanet.measurement.kingdom.deploy.gcloud.spanner.common.EventGroupMetadataDescriptorAlreadyExistsWithTypeException
 import org.wfanet.measurement.kingdom.deploy.gcloud.spanner.common.EventGroupMetadataDescriptorNotFoundException
@@ -69,7 +68,6 @@ class UpdateEventGroupMetadataDescriptor(
       )
 
       set("DescriptorDetails" to eventGroupMetadataDescriptor.details)
-      setJson("DescriptorDetailsJson" to eventGroupMetadataDescriptor.details)
     }
 
     transactionContext.buffer(

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/writers/UpdateMeasurementState.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/writers/UpdateMeasurementState.kt
@@ -18,7 +18,6 @@ import com.google.cloud.spanner.Value
 import org.wfanet.measurement.common.identity.InternalId
 import org.wfanet.measurement.gcloud.spanner.bufferTo
 import org.wfanet.measurement.gcloud.spanner.set
-import org.wfanet.measurement.gcloud.spanner.setJson
 import org.wfanet.measurement.gcloud.spanner.updateMutation
 import org.wfanet.measurement.internal.kingdom.Measurement
 import org.wfanet.measurement.internal.kingdom.MeasurementDetails
@@ -40,7 +39,6 @@ internal fun SpannerWriter.TransactionScope.updateMeasurementState(
       set("UpdateTime" to Value.COMMIT_TIMESTAMP)
       if (details != null) {
         set("MeasurementDetails" to details)
-        setJson("MeasurementDetailsJson" to details)
       }
     }
     .bufferTo(transactionContext)

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/writers/UpdatePublicKey.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/writers/UpdatePublicKey.kt
@@ -18,7 +18,6 @@ import org.wfanet.measurement.common.identity.ExternalId
 import org.wfanet.measurement.common.identity.InternalId
 import org.wfanet.measurement.gcloud.spanner.bufferUpdateMutation
 import org.wfanet.measurement.gcloud.spanner.set
-import org.wfanet.measurement.gcloud.spanner.setJson
 import org.wfanet.measurement.internal.kingdom.DataProvider
 import org.wfanet.measurement.internal.kingdom.MeasurementConsumer
 import org.wfanet.measurement.internal.kingdom.UpdatePublicKeyRequest
@@ -80,7 +79,6 @@ class UpdatePublicKey(private val request: UpdatePublicKeyRequest) : SimpleSpann
         set("MeasurementConsumerId" to measurementConsumerResult.measurementConsumerId)
         set("PublicKeyCertificateId" to certificateId)
         set("MeasurementConsumerDetails" to measurementConsumerDetails)
-        setJson("MeasurementConsumerDetailsJson" to measurementConsumerDetails)
       }
     } else if (request.externalDataProviderId != 0L) {
       val dataProviderResult =
@@ -114,7 +112,6 @@ class UpdatePublicKey(private val request: UpdatePublicKeyRequest) : SimpleSpann
         set("DataProviderId" to dataProviderResult.dataProviderId)
         set("PublicKeyCertificateId" to certificateId)
         set("DataProviderDetails" to dataProviderDetails)
-        setJson("DataProviderDetailsJson" to dataProviderDetails)
       }
     }
   }

--- a/src/main/resources/kingdom/spanner/changelog.yaml
+++ b/src/main/resources/kingdom/spanner/changelog.yaml
@@ -69,3 +69,6 @@ databaseChangeLog:
 - include:
     file: create-proto-bundle.sql
     relativeToChangeLogFile: true
+- include:
+    file: drop-json-columns.sql
+    relativeToChangeLogFile: true

--- a/src/main/resources/kingdom/spanner/drop-json-columns.sql
+++ b/src/main/resources/kingdom/spanner/drop-json-columns.sql
@@ -1,0 +1,61 @@
+-- liquibase formatted sql
+
+-- Copyright 2024 The Cross-Media Measurement Authors
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+-- changeset sanjayvas:20 dbms:cloudspanner
+-- comment: Drop JSON debugging columns.
+
+START BATCH DDL;
+
+ALTER TABLE Certificates
+DROP COLUMN CertificateDetailsJson;
+
+ALTER TABLE ComputationParticipants
+DROP COLUMN ParticipantDetailsJson;
+
+ALTER TABLE DuchyMeasurementLogEntries
+DROP COLUMN DuchyMeasurementLogDetailsJson;
+
+ALTER TABLE EventGroups
+DROP COLUMN EventGroupDetailsJson;
+
+ALTER TABLE EventGroupMetadataDescriptors
+DROP COLUMN DescriptorDetailsJson;
+
+ALTER TABLE DataProviders
+DROP COLUMN DataProviderDetailsJson;
+
+ALTER TABLE ExchangeStepAttempts
+DROP COLUMN ExchangeStepAttemptDetailsJson;
+
+ALTER TABLE Exchanges
+DROP COLUMN ExchangeDetailsJson;
+
+ALTER TABLE MeasurementConsumers
+DROP COLUMN MeasurementConsumerDetailsJson;
+
+ALTER TABLE MeasurementLogEntries
+DROP COLUMN MeasurementLogDetailsJson;
+
+ALTER TABLE Measurements
+DROP COLUMN MeasurementDetailsJson;
+
+ALTER TABLE RecurringExchanges
+DROP COLUMN RecurringExchangeDetailsJson;
+
+ALTER TABLE Requisitions
+DROP COLUMN RequisitionDetailsJson;
+
+RUN BATCH;

--- a/src/test/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/writers/SpannerWriterTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/writers/SpannerWriterTest.kt
@@ -70,8 +70,6 @@ class SpannerWriterTest : KingdomDatabaseTestBase() {
               .to(1)
               .set("CertificateDetails")
               .to(ByteArray.copyFrom(""))
-              .set("CertificateDetailsJson")
-              .to("irrelevant-certificate-details-json")
               .build()
           )
           return internalId


### PR DESCRIPTION
These are no longer needed now that Cloud Spanner has native protobuf support.