### PR TITLE
build: Update common-jvm dep to 0.92.0

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -22,7 +22,7 @@ K8S_CLIENT_VERSION = "21.0.1"
 # See https://github.com/bazelbuild/bazel/discussions/23075.
 bazel_dep(
     name = "rules_kotlin_jvm",
-    version = "0.3.0",
+    version = "0.4.0",
     repo_name = "wfa_rules_kotlin_jvm",
 )
 bazel_dep(
@@ -37,7 +37,7 @@ bazel_dep(
 )
 bazel_dep(
     name = "common-jvm",
-    version = "0.91.0",
+    version = "0.92.0",
     repo_name = "wfa_common_jvm",
 )
 bazel_dep(
@@ -125,11 +125,11 @@ bazel_dep(
 )
 bazel_dep(
     name = "rules_java",
-    version = "7.9.1",
+    version = "7.11.1",
 )
 bazel_dep(
     name = "rules_jvm_external",
-    version = "6.2.bzlmod.1",
+    version = "6.4",
 )
 bazel_dep(
     name = "rules_python",

--- a/src/main/kotlin/org/wfanet/measurement/duchy/deploy/gcloud/spanner/computation/ComputationMutations.kt
+++ b/src/main/kotlin/org/wfanet/measurement/duchy/deploy/gcloud/spanner/computation/ComputationMutations.kt
@@ -25,7 +25,7 @@ import org.wfanet.measurement.duchy.db.computation.ComputationTypeEnumHelper
 import org.wfanet.measurement.gcloud.common.toGcloudByteArray
 import org.wfanet.measurement.gcloud.spanner.set
 import org.wfanet.measurement.gcloud.spanner.setJson
-import org.wfanet.measurement.gcloud.spanner.toProtoEnum
+import org.wfanet.measurement.gcloud.spanner.toInt64
 import org.wfanet.measurement.gcloud.spanner.toProtoJson
 import org.wfanet.measurement.internal.duchy.ComputationBlobDependency
 import org.wfanet.measurement.internal.duchy.ComputationStageAttemptDetails
@@ -325,7 +325,7 @@ class ComputationMutations<
     m.set("ComputationStage").to(computationStageEnumToLongValues(stage).stage)
     m.set("BlobId").to(blobId)
     pathToBlob?.let { m.set("PathToBlob").to(nonNullValueString(it)) }
-    dependencyType?.let { m.set("DependencyType").toProtoEnum(it) }
+    dependencyType?.let { m.set("DependencyType").toInt64(it) }
     return m.build()
   }
 

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/queries/StreamEventGroups.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/queries/StreamEventGroups.kt
@@ -17,7 +17,7 @@ package org.wfanet.measurement.kingdom.deploy.gcloud.spanner.queries
 import com.google.cloud.spanner.Statement
 import org.wfanet.measurement.gcloud.spanner.appendClause
 import org.wfanet.measurement.gcloud.spanner.bind
-import org.wfanet.measurement.gcloud.spanner.toProtoEnum
+import org.wfanet.measurement.gcloud.spanner.toInt64
 import org.wfanet.measurement.internal.kingdom.EventGroup
 import org.wfanet.measurement.internal.kingdom.StreamEventGroupsRequest
 import org.wfanet.measurement.kingdom.deploy.gcloud.spanner.readers.EventGroupReader
@@ -57,7 +57,7 @@ class StreamEventGroups(requestFilter: StreamEventGroupsRequest.Filter, limit: I
 
     if (!filter.showDeleted) {
       conjuncts.add("State != @$DELETED_STATE")
-      bind(DELETED_STATE).toProtoEnum(EventGroup.State.DELETED)
+      bind(DELETED_STATE).toInt64(EventGroup.State.DELETED)
     }
 
     if (filter.hasAfter()) {

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/queries/StreamExchangeSteps.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/queries/StreamExchangeSteps.kt
@@ -18,7 +18,7 @@ import com.google.cloud.spanner.Statement
 import org.wfanet.measurement.gcloud.common.toCloudDate
 import org.wfanet.measurement.gcloud.spanner.appendClause
 import org.wfanet.measurement.gcloud.spanner.bind
-import org.wfanet.measurement.gcloud.spanner.toProtoEnumArray
+import org.wfanet.measurement.gcloud.spanner.toInt64Array
 import org.wfanet.measurement.internal.kingdom.ExchangeStep
 import org.wfanet.measurement.internal.kingdom.StreamExchangeStepsRequest
 import org.wfanet.measurement.kingdom.deploy.gcloud.spanner.readers.ExchangeStepReader
@@ -59,7 +59,7 @@ class StreamExchangeSteps(requestFilter: StreamExchangeStepsRequest.Filter, limi
 
     if (filter.statesList.isNotEmpty()) {
       conjuncts.add("ExchangeSteps.State IN UNNEST(@${Params.STATES})")
-      bind(Params.STATES).toProtoEnumArray(filter.statesList)
+      bind(Params.STATES).toInt64Array(filter.statesList)
     }
 
     if (filter.externalDataProviderId != 0L) {

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/queries/StreamMeasurementsByDataProviderCertificate.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/queries/StreamMeasurementsByDataProviderCertificate.kt
@@ -16,7 +16,7 @@ package org.wfanet.measurement.kingdom.deploy.gcloud.spanner.queries
 
 import org.wfanet.measurement.common.identity.InternalId
 import org.wfanet.measurement.gcloud.spanner.appendClause
-import org.wfanet.measurement.gcloud.spanner.toProtoEnumArray
+import org.wfanet.measurement.gcloud.spanner.toInt64Array
 import org.wfanet.measurement.internal.kingdom.Measurement
 import org.wfanet.measurement.internal.kingdom.Requisition
 import org.wfanet.measurement.kingdom.deploy.gcloud.spanner.readers.MeasurementDetailsReader
@@ -38,7 +38,7 @@ class StreamMeasurementsByDataProviderCertificate(
       )
       bind("dataProviderCertificateId").to(dataProviderCertificateId.value)
       bind("requisitionStates")
-        .toProtoEnumArray(listOf(Requisition.State.PENDING_PARAMS, Requisition.State.UNFULFILLED))
-      bind("pendingStates").toProtoEnumArray(pendingMeasurementStates)
+        .toInt64Array(listOf(Requisition.State.PENDING_PARAMS, Requisition.State.UNFULFILLED))
+      bind("pendingStates").toInt64Array(pendingMeasurementStates)
     }
 }

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/queries/StreamMeasurementsByDuchyCertificate.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/queries/StreamMeasurementsByDuchyCertificate.kt
@@ -16,8 +16,8 @@ package org.wfanet.measurement.kingdom.deploy.gcloud.spanner.queries
 
 import org.wfanet.measurement.common.identity.InternalId
 import org.wfanet.measurement.gcloud.spanner.appendClause
-import org.wfanet.measurement.gcloud.spanner.toProtoEnum
-import org.wfanet.measurement.gcloud.spanner.toProtoEnumArray
+import org.wfanet.measurement.gcloud.spanner.toInt64
+import org.wfanet.measurement.gcloud.spanner.toInt64Array
 import org.wfanet.measurement.internal.kingdom.ComputationParticipant
 import org.wfanet.measurement.internal.kingdom.Measurement
 import org.wfanet.measurement.kingdom.deploy.gcloud.spanner.readers.MeasurementDetailsReader
@@ -39,7 +39,7 @@ class StreamMeasurementsByDuchyCertificate(
       )
       bind("duchyCertificateId").to(duchyCertificateId.value)
       bind("computationParticipantState")
-        .toProtoEnum(ComputationParticipant.State.REQUISITION_PARAMS_SET)
-      bind("pendingStates").toProtoEnumArray(pendingMeasurementStates)
+        .toInt64(ComputationParticipant.State.REQUISITION_PARAMS_SET)
+      bind("pendingStates").toInt64Array(pendingMeasurementStates)
     }
 }

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/queries/StreamModelOutages.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/queries/StreamModelOutages.kt
@@ -20,7 +20,7 @@ import com.google.cloud.spanner.Statement
 import org.wfanet.measurement.gcloud.common.toGcloudTimestamp
 import org.wfanet.measurement.gcloud.spanner.appendClause
 import org.wfanet.measurement.gcloud.spanner.bind
-import org.wfanet.measurement.gcloud.spanner.toProtoEnum
+import org.wfanet.measurement.gcloud.spanner.toInt64
 import org.wfanet.measurement.internal.kingdom.ModelOutage
 import org.wfanet.measurement.internal.kingdom.StreamModelOutagesRequest.Filter
 import org.wfanet.measurement.kingdom.deploy.gcloud.spanner.readers.ModelOutageReader
@@ -67,7 +67,7 @@ class StreamModelOutages(private val requestFilter: Filter, limit: Int = 0) :
 
     if (!filter.showDeleted) {
       conjuncts.add("State != @${DELETED_STATE}")
-      bind(DELETED_STATE).toProtoEnum(ModelOutage.State.DELETED)
+      bind(DELETED_STATE).toInt64(ModelOutage.State.DELETED)
     }
 
     if (filter.hasOutageInterval()) {

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/readers/ExchangeStepAttemptReader.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/readers/ExchangeStepAttemptReader.kt
@@ -25,7 +25,7 @@ import org.wfanet.measurement.gcloud.common.toProtoDate
 import org.wfanet.measurement.gcloud.spanner.AsyncDatabaseClient
 import org.wfanet.measurement.gcloud.spanner.appendClause
 import org.wfanet.measurement.gcloud.spanner.bind
-import org.wfanet.measurement.gcloud.spanner.toProtoEnum
+import org.wfanet.measurement.gcloud.spanner.toInt64
 import org.wfanet.measurement.internal.kingdom.ExchangeStep
 import org.wfanet.measurement.internal.kingdom.ExchangeStepAttempt
 import org.wfanet.measurement.internal.kingdom.ExchangeStepAttemptDetails
@@ -120,8 +120,8 @@ class ExchangeStepAttemptReader : SpannerReader<ExchangeStepAttemptReader.Result
             "ExchangeStepAttempts.State = @${Params.EXCHANGE_STEP_ATTEMPT_STATE}",
             "ExchangeStepAttempts.ExpirationTime <= @${Params.NOW}",
           )
-        bind(Params.EXCHANGE_STEP_STATE).toProtoEnum(ExchangeStep.State.IN_PROGRESS)
-        bind(Params.EXCHANGE_STEP_ATTEMPT_STATE).toProtoEnum(ExchangeStepAttempt.State.ACTIVE)
+        bind(Params.EXCHANGE_STEP_STATE).toInt64(ExchangeStep.State.IN_PROGRESS)
+        bind(Params.EXCHANGE_STEP_ATTEMPT_STATE).toInt64(ExchangeStepAttempt.State.ACTIVE)
         // Due to the fact that we set ExpirationTime using the application clock, we should to be
         // consistent and use the application clock for comparisons rather than DB time.
         bind(Params.NOW).to(clock.instant().toGcloudTimestamp())

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/writers/ActivateAccount.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/writers/ActivateAccount.kt
@@ -20,6 +20,7 @@ import org.wfanet.measurement.common.identity.InternalId
 import org.wfanet.measurement.gcloud.spanner.bufferInsertMutation
 import org.wfanet.measurement.gcloud.spanner.bufferUpdateMutation
 import org.wfanet.measurement.gcloud.spanner.set
+import org.wfanet.measurement.gcloud.spanner.toInt64
 import org.wfanet.measurement.internal.kingdom.Account
 import org.wfanet.measurement.internal.kingdom.AccountKt.openIdConnectIdentity
 import org.wfanet.measurement.internal.kingdom.copy
@@ -79,7 +80,7 @@ class ActivateAccount(
 
     transactionContext.bufferUpdateMutation("Accounts") {
       set("AccountId" to readAccountResult.accountId)
-      set("ActivationState" to Account.ActivationState.ACTIVATED)
+      set("ActivationState").toInt64(Account.ActivationState.ACTIVATED)
       set("UpdateTime" to Value.COMMIT_TIMESTAMP)
     }
 

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/writers/ClaimReadyExchangeStep.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/writers/ClaimReadyExchangeStep.kt
@@ -28,6 +28,7 @@ import org.wfanet.measurement.gcloud.common.toGcloudTimestamp
 import org.wfanet.measurement.gcloud.spanner.bufferInsertMutation
 import org.wfanet.measurement.gcloud.spanner.set
 import org.wfanet.measurement.gcloud.spanner.statement
+import org.wfanet.measurement.gcloud.spanner.toInt64
 import org.wfanet.measurement.internal.kingdom.ClaimReadyExchangeStepRequest
 import org.wfanet.measurement.internal.kingdom.ExchangeStep
 import org.wfanet.measurement.internal.kingdom.ExchangeStepAttempt
@@ -121,7 +122,7 @@ class ClaimReadyExchangeStep(
       set("Date" to date.toCloudDate())
       set("StepIndex" to stepIndex)
       set("AttemptIndex" to attemptIndex)
-      set("State" to ExchangeStepAttempt.State.ACTIVE)
+      set("State").toInt64(ExchangeStepAttempt.State.ACTIVE)
 
       // TODO(@efoxepstein): make this variable based on the step type or something.
       set("ExpirationTime" to (now + DEFAULT_EXPIRATION_DURATION).toGcloudTimestamp())

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/writers/ConfirmComputationParticipant.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/writers/ConfirmComputationParticipant.kt
@@ -24,6 +24,7 @@ import org.wfanet.measurement.gcloud.spanner.bind
 import org.wfanet.measurement.gcloud.spanner.bufferUpdateMutation
 import org.wfanet.measurement.gcloud.spanner.set
 import org.wfanet.measurement.gcloud.spanner.statement
+import org.wfanet.measurement.gcloud.spanner.toInt64
 import org.wfanet.measurement.internal.kingdom.ComputationParticipant
 import org.wfanet.measurement.internal.kingdom.ConfirmComputationParticipantRequest
 import org.wfanet.measurement.internal.kingdom.Measurement
@@ -113,7 +114,7 @@ class ConfirmComputationParticipant(private val request: ConfirmComputationParti
       set("MeasurementId" to measurementId)
       set("DuchyId" to duchyId)
       set("UpdateTime" to Value.COMMIT_TIMESTAMP)
-      set("State" to NEXT_COMPUTATION_PARTICIPANT_STATE)
+      set("State").toInt64(NEXT_COMPUTATION_PARTICIPANT_STATE)
     }
 
     val duchyIds: List<InternalId> =

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/writers/CreateAccount.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/writers/CreateAccount.kt
@@ -18,6 +18,7 @@ import com.google.cloud.spanner.Value
 import org.wfanet.measurement.common.identity.ExternalId
 import org.wfanet.measurement.gcloud.spanner.bufferInsertMutation
 import org.wfanet.measurement.gcloud.spanner.set
+import org.wfanet.measurement.gcloud.spanner.toInt64
 import org.wfanet.measurement.internal.kingdom.Account
 import org.wfanet.measurement.internal.kingdom.account
 import org.wfanet.measurement.kingdom.deploy.gcloud.spanner.common.AccountNotFoundException
@@ -69,7 +70,7 @@ class CreateAccount(
 
         set("AccountId" to internalAccountId)
         set("ExternalAccountId" to externalAccountId)
-        set("ActivationState" to Account.ActivationState.UNACTIVATED)
+        set("ActivationState").toInt64(Account.ActivationState.UNACTIVATED)
         set("ActivationToken" to activationToken)
         set("CreateTime" to Value.COMMIT_TIMESTAMP)
         set("UpdateTime" to Value.COMMIT_TIMESTAMP)

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/writers/CreateCertificate.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/writers/CreateCertificate.kt
@@ -25,6 +25,7 @@ import org.wfanet.measurement.gcloud.spanner.AsyncDatabaseClient
 import org.wfanet.measurement.gcloud.spanner.bufferTo
 import org.wfanet.measurement.gcloud.spanner.insertMutation
 import org.wfanet.measurement.gcloud.spanner.set
+import org.wfanet.measurement.gcloud.spanner.toInt64
 import org.wfanet.measurement.internal.kingdom.Certificate
 import org.wfanet.measurement.kingdom.deploy.common.DuchyIds
 import org.wfanet.measurement.kingdom.deploy.gcloud.spanner.common.CertSubjectKeyIdAlreadyExistsException
@@ -141,7 +142,7 @@ fun Certificate.toInsertMutation(internalId: InternalId): Mutation {
     set("SubjectKeyIdentifier" to subjectKeyIdentifier.toGcloudByteArray())
     set("NotValidBefore" to notValidBefore.toGcloudTimestamp())
     set("NotValidAfter" to notValidAfter.toGcloudTimestamp())
-    set("RevocationState" to revocationState)
+    set("RevocationState").toInt64(revocationState)
     set("CertificateDetails").to(details)
   }
 }

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/writers/CreateEventGroup.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/writers/CreateEventGroup.kt
@@ -19,6 +19,7 @@ import org.wfanet.measurement.common.identity.ExternalId
 import org.wfanet.measurement.common.identity.InternalId
 import org.wfanet.measurement.gcloud.spanner.bufferInsertMutation
 import org.wfanet.measurement.gcloud.spanner.set
+import org.wfanet.measurement.gcloud.spanner.toInt64
 import org.wfanet.measurement.internal.kingdom.CreateEventGroupRequest
 import org.wfanet.measurement.internal.kingdom.EventGroup
 import org.wfanet.measurement.internal.kingdom.copy
@@ -83,7 +84,7 @@ class CreateEventGroup(private val request: CreateEventGroupRequest) :
       if (request.eventGroup.hasDetails()) {
         set("EventGroupDetails").to(request.eventGroup.details)
       }
-      set("State" to EventGroup.State.ACTIVE)
+      set("State").toInt64(EventGroup.State.ACTIVE)
     }
 
     return request.eventGroup.copy {

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/writers/CreateExchange.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/writers/CreateExchange.kt
@@ -18,6 +18,7 @@ import org.wfanet.measurement.common.identity.ExternalId
 import org.wfanet.measurement.gcloud.common.toCloudDate
 import org.wfanet.measurement.gcloud.spanner.bufferInsertMutation
 import org.wfanet.measurement.gcloud.spanner.set
+import org.wfanet.measurement.gcloud.spanner.toInt64
 import org.wfanet.measurement.internal.kingdom.Exchange
 import org.wfanet.measurement.kingdom.deploy.gcloud.spanner.common.RecurringExchangeNotFoundException
 import org.wfanet.measurement.kingdom.deploy.gcloud.spanner.readers.RecurringExchangeReader
@@ -42,7 +43,7 @@ class CreateExchange(private val exchange: Exchange) : SimpleSpannerWriter<Excha
     transactionContext.bufferInsertMutation("Exchanges") {
       set("RecurringExchangeId" to recurringExchangeId)
       set("Date" to exchange.date.toCloudDate())
-      set("State" to INITIAL_STATE)
+      set("State").toInt64(INITIAL_STATE)
       set("ExchangeDetails").to(exchange.details)
     }
 

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/writers/CreateExchangesAndSteps.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/writers/CreateExchangesAndSteps.kt
@@ -26,6 +26,7 @@ import org.wfanet.measurement.gcloud.spanner.bind
 import org.wfanet.measurement.gcloud.spanner.bufferInsertMutation
 import org.wfanet.measurement.gcloud.spanner.bufferUpdateMutation
 import org.wfanet.measurement.gcloud.spanner.set
+import org.wfanet.measurement.gcloud.spanner.toInt64
 import org.wfanet.measurement.internal.kingdom.Exchange
 import org.wfanet.measurement.internal.kingdom.ExchangeDetails
 import org.wfanet.measurement.internal.kingdom.ExchangeStep
@@ -96,8 +97,8 @@ class CreateExchangesAndSteps(
             """
               .trimIndent(),
           )
-        bind(Params.RECURRING_EXCHANGE_STATE to RecurringExchange.State.ACTIVE)
-        bind(Params.EXCHANGE_STATE to Exchange.State.FAILED)
+        bind(Params.RECURRING_EXCHANGE_STATE).toInt64(RecurringExchange.State.ACTIVE)
+        bind(Params.EXCHANGE_STATE).toInt64(Exchange.State.FAILED)
 
         when (party) {
           ExchangeWorkflow.Party.MODEL_PROVIDER -> {
@@ -126,7 +127,7 @@ class CreateExchangesAndSteps(
     transactionContext.bufferInsertMutation("Exchanges") {
       set("RecurringExchangeId" to recurringExchangeId)
       set("Date" to date.toCloudDate())
-      set("State" to Exchange.State.ACTIVE)
+      set("State").toInt64(Exchange.State.ACTIVE)
       set("ExchangeDetails").to(exchangeDetails)
     }
   }
@@ -153,7 +154,7 @@ class CreateExchangesAndSteps(
         set("RecurringExchangeId" to recurringExchangeId)
         set("Date" to date.toCloudDate())
         set("StepIndex" to step.stepIndex.toLong())
-        set("State" to ExchangeStep.State.BLOCKED)
+        set("State").toInt64(ExchangeStep.State.BLOCKED)
         set("UpdateTime" to Value.COMMIT_TIMESTAMP)
         set(
           "ModelProviderId" to

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/writers/CreateMeasurements.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/writers/CreateMeasurements.kt
@@ -23,6 +23,7 @@ import org.wfanet.measurement.gcloud.spanner.appendClause
 import org.wfanet.measurement.gcloud.spanner.bind
 import org.wfanet.measurement.gcloud.spanner.bufferInsertMutation
 import org.wfanet.measurement.gcloud.spanner.set
+import org.wfanet.measurement.gcloud.spanner.toInt64
 import org.wfanet.measurement.internal.kingdom.ComputationParticipant
 import org.wfanet.measurement.internal.kingdom.ComputationParticipantDetails
 import org.wfanet.measurement.internal.kingdom.CreateMeasurementRequest
@@ -327,7 +328,7 @@ class CreateMeasurements(private val requests: List<CreateMeasurementRequest>) :
         set("ProvidedMeasurementId" to createMeasurementRequest.measurement.providedMeasurementId)
       }
       set("CertificateId" to measurementConsumerCertificateId)
-      set("State" to initialMeasurementState)
+      set("State").toInt64(initialMeasurementState)
       set("MeasurementDetails").to(createMeasurementRequest.measurement.details)
       set("CreateTime" to Value.COMMIT_TIMESTAMP)
       set("UpdateTime" to Value.COMMIT_TIMESTAMP)
@@ -345,7 +346,7 @@ class CreateMeasurements(private val requests: List<CreateMeasurementRequest>) :
       set("MeasurementId" to measurementId)
       set("DuchyId" to duchyId)
       set("UpdateTime" to Value.COMMIT_TIMESTAMP)
-      set("State" to ComputationParticipant.State.CREATED)
+      set("State").toInt64(ComputationParticipant.State.CREATED)
       set("ParticipantDetails").to(participantDetails)
     }
   }
@@ -411,7 +412,7 @@ class CreateMeasurements(private val requests: List<CreateMeasurementRequest>) :
       set("UpdateTime" to Value.COMMIT_TIMESTAMP)
       set("ExternalRequisitionId" to externalRequisitionId)
       set("DataProviderCertificateId" to dataProviderCertificateId)
-      set("State" to initialRequisitionState)
+      set("State").toInt64(initialRequisitionState)
       fulfillingDuchyId?.let { set("FulfillingDuchyId" to it) }
       set("RequisitionDetails").to(details)
     }

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/writers/CreateModelLine.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/writers/CreateModelLine.kt
@@ -30,6 +30,7 @@ import org.wfanet.measurement.gcloud.spanner.bind
 import org.wfanet.measurement.gcloud.spanner.bufferInsertMutation
 import org.wfanet.measurement.gcloud.spanner.set
 import org.wfanet.measurement.gcloud.spanner.statement
+import org.wfanet.measurement.gcloud.spanner.toInt64
 import org.wfanet.measurement.internal.kingdom.ModelLine
 import org.wfanet.measurement.internal.kingdom.copy
 import org.wfanet.measurement.kingdom.deploy.gcloud.spanner.common.ModelLineInvalidArgsException
@@ -93,7 +94,7 @@ class CreateModelLine(private val modelLine: ModelLine, private val clock: Clock
       if (modelLine.hasActiveEndTime()) {
         set("ActiveEndTime" to modelLine.activeEndTime.toGcloudTimestamp())
       }
-      set("Type" to modelLine.type)
+      set("Type").toInt64(modelLine.type)
       if (modelLine.externalHoldbackModelLineId != 0L) {
         val holdbackModelLineResult =
           ModelLineReader()

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/writers/CreateModelOutage.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/writers/CreateModelOutage.kt
@@ -28,6 +28,7 @@ import org.wfanet.measurement.gcloud.spanner.bind
 import org.wfanet.measurement.gcloud.spanner.bufferInsertMutation
 import org.wfanet.measurement.gcloud.spanner.set
 import org.wfanet.measurement.gcloud.spanner.statement
+import org.wfanet.measurement.gcloud.spanner.toInt64
 import org.wfanet.measurement.internal.kingdom.ModelLine
 import org.wfanet.measurement.internal.kingdom.ModelOutage
 import org.wfanet.measurement.internal.kingdom.copy
@@ -94,7 +95,7 @@ class CreateModelOutage(private val modelOutage: ModelOutage) :
       set("ExternalModelOutageId" to externalModelOutageId)
       set("OutageStartTime" to modelOutage.modelOutageStartTime.toGcloudTimestamp())
       set("OutageEndTime" to modelOutage.modelOutageEndTime.toGcloudTimestamp())
-      set("State" to ModelOutage.State.ACTIVE)
+      set("State").toInt64(ModelOutage.State.ACTIVE)
       set("CreateTime" to Value.COMMIT_TIMESTAMP)
     }
 

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/writers/CreateRecurringExchange.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/writers/CreateRecurringExchange.kt
@@ -18,6 +18,7 @@ import org.wfanet.measurement.common.identity.ExternalId
 import org.wfanet.measurement.gcloud.common.toCloudDate
 import org.wfanet.measurement.gcloud.spanner.bufferInsertMutation
 import org.wfanet.measurement.gcloud.spanner.set
+import org.wfanet.measurement.gcloud.spanner.toInt64
 import org.wfanet.measurement.internal.kingdom.RecurringExchange
 import org.wfanet.measurement.internal.kingdom.copy
 import org.wfanet.measurement.kingdom.deploy.gcloud.spanner.common.DataProviderNotFoundException
@@ -55,7 +56,7 @@ class CreateRecurringExchange(private val recurringExchange: RecurringExchange) 
       set("ExternalRecurringExchangeId" to externalId)
       set("ModelProviderId" to modelProviderId)
       set("DataProviderId" to dataProviderId)
-      set("State" to INITIAL_STATE)
+      set("State").toInt64(INITIAL_STATE)
       set("NextExchangeDate" to recurringExchange.nextExchangeDate.toCloudDate())
       set("RecurringExchangeDetails").to(recurringExchange.details)
     }

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/writers/DeleteEventGroup.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/writers/DeleteEventGroup.kt
@@ -20,6 +20,7 @@ import com.google.cloud.spanner.Value
 import org.wfanet.measurement.common.identity.ExternalId
 import org.wfanet.measurement.gcloud.spanner.bufferUpdateMutation
 import org.wfanet.measurement.gcloud.spanner.set
+import org.wfanet.measurement.gcloud.spanner.toInt64
 import org.wfanet.measurement.internal.kingdom.DeleteEventGroupRequest
 import org.wfanet.measurement.internal.kingdom.EventGroup
 import org.wfanet.measurement.internal.kingdom.EventGroupDetails
@@ -59,7 +60,7 @@ class DeleteEventGroup(private val request: DeleteEventGroupRequest) :
       set("MeasurementConsumerCertificateId" to null as Long?)
       set("UpdateTime" to Value.COMMIT_TIMESTAMP)
       set("EventGroupDetails").to(null, EventGroupDetails.getDescriptor())
-      set("State" to EventGroup.State.DELETED)
+      set("State").toInt64(EventGroup.State.DELETED)
     }
 
     return result.eventGroup.copy {

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/writers/DeleteModelOutage.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/writers/DeleteModelOutage.kt
@@ -20,6 +20,7 @@ import com.google.cloud.spanner.Value
 import org.wfanet.measurement.common.identity.ExternalId
 import org.wfanet.measurement.gcloud.spanner.bufferUpdateMutation
 import org.wfanet.measurement.gcloud.spanner.set
+import org.wfanet.measurement.gcloud.spanner.toInt64
 import org.wfanet.measurement.internal.kingdom.ModelOutage
 import org.wfanet.measurement.internal.kingdom.copy
 import org.wfanet.measurement.kingdom.deploy.gcloud.spanner.common.KingdomInternalException
@@ -69,7 +70,7 @@ class DeleteModelOutage(private val modelOutage: ModelOutage) :
       set("ModelSuiteId" to internalModelOutageResult.modelSuiteId.value)
       set("ModelLineId" to internalModelOutageResult.modelLineId.value)
       set("ModelOutageId" to internalModelOutageResult.modelOutageId.value)
-      set("State" to ModelOutage.State.DELETED)
+      set("State").toInt64(ModelOutage.State.DELETED)
       set("DeleteTime" to Value.COMMIT_TIMESTAMP)
     }
 

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/writers/FailComputationParticipant.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/writers/FailComputationParticipant.kt
@@ -19,6 +19,7 @@ import org.wfanet.measurement.common.identity.ExternalId
 import org.wfanet.measurement.common.identity.InternalId
 import org.wfanet.measurement.gcloud.spanner.bufferUpdateMutation
 import org.wfanet.measurement.gcloud.spanner.set
+import org.wfanet.measurement.gcloud.spanner.toInt64
 import org.wfanet.measurement.internal.kingdom.ComputationParticipant
 import org.wfanet.measurement.internal.kingdom.FailComputationParticipantRequest
 import org.wfanet.measurement.internal.kingdom.Measurement
@@ -111,7 +112,7 @@ class FailComputationParticipant(private val request: FailComputationParticipant
       set("MeasurementId" to measurementId)
       set("DuchyId" to duchyId)
       set("UpdateTime" to Value.COMMIT_TIMESTAMP)
-      set("State" to NEXT_COMPUTATION_PARTICIPANT_STATE)
+      set("State").toInt64(NEXT_COMPUTATION_PARTICIPANT_STATE)
     }
 
     val updatedMeasurementDetails =

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/writers/FinishExchangeStepAttempt.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/writers/FinishExchangeStepAttempt.kt
@@ -30,6 +30,7 @@ import org.wfanet.measurement.gcloud.spanner.bind
 import org.wfanet.measurement.gcloud.spanner.bufferUpdateMutation
 import org.wfanet.measurement.gcloud.spanner.set
 import org.wfanet.measurement.gcloud.spanner.statement
+import org.wfanet.measurement.gcloud.spanner.toInt64
 import org.wfanet.measurement.internal.kingdom.Exchange
 import org.wfanet.measurement.internal.kingdom.ExchangeStep
 import org.wfanet.measurement.internal.kingdom.ExchangeStepAttempt
@@ -203,7 +204,7 @@ class FinishExchangeStepAttempt(
     transactionContext.bufferUpdateMutation("Exchanges") {
       set("RecurringExchangeId" to recurringExchangeId)
       set("Date" to exchangeDate.toCloudDate())
-      set("State" to state)
+      set("State").toInt64(state)
     }
   }
 
@@ -229,7 +230,7 @@ class FinishExchangeStepAttempt(
       set("Date" to exchangeDate.toCloudDate())
       set("StepIndex" to stepIndex.toLong())
       set("AttemptIndex" to attemptNumber.toLong())
-      set("State" to state)
+      set("State").toInt64(state)
       set("ExchangeStepAttemptDetails").to(details)
     }
 
@@ -254,7 +255,7 @@ class FinishExchangeStepAttempt(
       statement(sql) {
         bind("recurring_exchange_id" to recurringExchangeId)
         bind("date" to exchangeDate.toCloudDate())
-        bind("state" to ExchangeStep.State.SUCCEEDED)
+        bind("state").toInt64(ExchangeStep.State.SUCCEEDED)
       }
     val row: Struct = transactionContext.executeQuery(statement).single()
 

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/writers/FulfillRequisition.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/writers/FulfillRequisition.kt
@@ -21,6 +21,7 @@ import org.wfanet.measurement.common.identity.ExternalId
 import org.wfanet.measurement.common.identity.InternalId
 import org.wfanet.measurement.gcloud.spanner.bind
 import org.wfanet.measurement.gcloud.spanner.statement
+import org.wfanet.measurement.gcloud.spanner.toInt64
 import org.wfanet.measurement.internal.kingdom.FulfillRequisitionRequest
 import org.wfanet.measurement.internal.kingdom.Measurement
 import org.wfanet.measurement.internal.kingdom.Requisition
@@ -197,7 +198,7 @@ class FulfillRequisition(private val request: FulfillRequisitionRequest) :
         statement(sql) {
           bind(Params.MEASUREMENT_CONSUMER_ID to measurementConsumerId)
           bind(Params.MEASUREMENT_ID to measurementId)
-          bind(Params.REQUISITION_STATE to state)
+          bind(Params.REQUISITION_STATE).toInt64(state)
         }
       return transactionContext.executeQuery(query).map { struct ->
         InternalId(struct.getLong("RequisitionId"))

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/writers/MeasurementLogEntries.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/writers/MeasurementLogEntries.kt
@@ -19,6 +19,7 @@ import org.wfanet.measurement.common.identity.ExternalId
 import org.wfanet.measurement.common.identity.InternalId
 import org.wfanet.measurement.gcloud.spanner.bufferInsertMutation
 import org.wfanet.measurement.gcloud.spanner.set
+import org.wfanet.measurement.gcloud.spanner.toInt64
 import org.wfanet.measurement.internal.kingdom.DuchyMeasurementLogEntryDetails
 import org.wfanet.measurement.internal.kingdom.Measurement
 import org.wfanet.measurement.internal.kingdom.MeasurementLogEntryDetails
@@ -52,8 +53,8 @@ internal fun SpannerWriter.TransactionScope.insertStateTransitionMeasurementLogE
     set("MeasurementConsumerId" to measurementConsumerId)
     set("MeasurementId" to measurementId)
     set("CreateTime" to Value.COMMIT_TIMESTAMP)
-    set("CurrentMeasurementState" to currentMeasurementState)
-    set("PreviousMeasurementState" to previousMeasurementState)
+    set("CurrentMeasurementState").toInt64(currentMeasurementState)
+    set("PreviousMeasurementState").toInt64(previousMeasurementState)
   }
 }
 

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/writers/ReleaseCertificateHold.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/writers/ReleaseCertificateHold.kt
@@ -20,6 +20,7 @@ import org.wfanet.measurement.common.identity.ExternalId
 import org.wfanet.measurement.common.identity.InternalId
 import org.wfanet.measurement.gcloud.spanner.bufferUpdateMutation
 import org.wfanet.measurement.gcloud.spanner.set
+import org.wfanet.measurement.gcloud.spanner.toInt64
 import org.wfanet.measurement.internal.kingdom.Certificate
 import org.wfanet.measurement.internal.kingdom.Certificate.RevocationState
 import org.wfanet.measurement.internal.kingdom.ReleaseCertificateHoldRequest
@@ -121,7 +122,7 @@ class ReleaseCertificateHold(private val request: ReleaseCertificateHoldRequest)
       RevocationState.HOLD -> {
         transactionContext.bufferUpdateMutation("Certificates") {
           set("CertificateId" to certificateResult.certificateId.value)
-          set("RevocationState" to RevocationState.REVOCATION_STATE_UNSPECIFIED)
+          set("RevocationState").toInt64(RevocationState.REVOCATION_STATE_UNSPECIFIED)
         }
         certificateResult.certificate.copy {
           revocationState = RevocationState.REVOCATION_STATE_UNSPECIFIED

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/writers/RevokeCertificate.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/writers/RevokeCertificate.kt
@@ -22,6 +22,7 @@ import org.wfanet.measurement.common.identity.InternalId
 import org.wfanet.measurement.common.protoTimestamp
 import org.wfanet.measurement.gcloud.spanner.bufferUpdateMutation
 import org.wfanet.measurement.gcloud.spanner.set
+import org.wfanet.measurement.gcloud.spanner.toInt64
 import org.wfanet.measurement.internal.kingdom.Certificate
 import org.wfanet.measurement.internal.kingdom.Certificate.RevocationState
 import org.wfanet.measurement.internal.kingdom.Measurement
@@ -148,7 +149,7 @@ class RevokeCertificate(private val request: RevokeCertificateRequest) :
 
     transactionContext.bufferUpdateMutation("Certificates") {
       set("CertificateId" to certificateResult.certificateId.value)
-      set("RevocationState" to request.revocationState)
+      set("RevocationState").toInt64(request.revocationState)
     }
 
     when (request.parentCase) {

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/writers/SetMeasurementResult.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/writers/SetMeasurementResult.kt
@@ -21,6 +21,7 @@ import org.wfanet.measurement.gcloud.common.toGcloudByteArray
 import org.wfanet.measurement.gcloud.spanner.bufferInsertMutation
 import org.wfanet.measurement.gcloud.spanner.bufferUpdateMutation
 import org.wfanet.measurement.gcloud.spanner.set
+import org.wfanet.measurement.gcloud.spanner.toInt64
 import org.wfanet.measurement.internal.kingdom.Measurement
 import org.wfanet.measurement.internal.kingdom.MeasurementKt.resultInfo
 import org.wfanet.measurement.internal.kingdom.SetMeasurementResultRequest
@@ -90,7 +91,7 @@ class SetMeasurementResult(private val request: SetMeasurementResultRequest) :
       set("MeasurementConsumerId" to measurementConsumerId)
       set("MeasurementId" to measurementId)
       set("UpdateTime" to Value.COMMIT_TIMESTAMP)
-      set("State" to NEXT_MEASUREMENT_STATE)
+      set("State").toInt64(NEXT_MEASUREMENT_STATE)
     }
 
     updateMeasurementState(

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/writers/SetParticipantRequisitionParams.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/writers/SetParticipantRequisitionParams.kt
@@ -29,6 +29,7 @@ import org.wfanet.measurement.gcloud.spanner.bind
 import org.wfanet.measurement.gcloud.spanner.bufferUpdateMutation
 import org.wfanet.measurement.gcloud.spanner.set
 import org.wfanet.measurement.gcloud.spanner.statement
+import org.wfanet.measurement.gcloud.spanner.toInt64
 import org.wfanet.measurement.internal.kingdom.ComputationParticipant
 import org.wfanet.measurement.internal.kingdom.ComputationParticipantDetails
 import org.wfanet.measurement.internal.kingdom.Measurement
@@ -167,7 +168,7 @@ class SetParticipantRequisitionParams(private val request: SetParticipantRequisi
       set("DuchyId" to duchyId)
       set("CertificateId" to duchyCertificateId)
       set("UpdateTime" to Value.COMMIT_TIMESTAMP)
-      set("State" to nextState)
+      set("State").toInt64(nextState)
       set("ParticipantDetails").to(participantDetails)
     }
 
@@ -213,7 +214,7 @@ class SetParticipantRequisitionParams(private val request: SetParticipantRequisi
             set("MeasurementId" to measurementId)
             set("RequisitionId" to requisitionId)
             set("UpdateTime" to Value.COMMIT_TIMESTAMP)
-            set("State" to Requisition.State.UNFULFILLED)
+            set("State").toInt64(Requisition.State.UNFULFILLED)
           }
         }
     }

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/writers/UpdateExchangeStep.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/writers/UpdateExchangeStep.kt
@@ -19,6 +19,7 @@ import com.google.type.Date
 import org.wfanet.measurement.gcloud.common.toCloudDate
 import org.wfanet.measurement.gcloud.spanner.bufferUpdateMutation
 import org.wfanet.measurement.gcloud.spanner.set
+import org.wfanet.measurement.gcloud.spanner.toInt64
 import org.wfanet.measurement.internal.kingdom.ExchangeStep
 import org.wfanet.measurement.internal.kingdom.ExchangeWorkflow
 
@@ -32,7 +33,7 @@ internal fun SpannerWriter.TransactionScope.updateExchangeStepsToReady(
       set("RecurringExchangeId" to recurringExchangeId)
       set("Date" to date.toCloudDate())
       set("StepIndex" to step.stepIndex.toLong())
-      set("State" to ExchangeStep.State.READY)
+      set("State").toInt64(ExchangeStep.State.READY)
       set("UpdateTime" to Value.COMMIT_TIMESTAMP)
     }
   }
@@ -54,7 +55,7 @@ internal fun SpannerWriter.TransactionScope.updateExchangeStepState(
     set("RecurringExchangeId" to recurringExchangeId)
     set("Date" to exchangeStep.date.toCloudDate())
     set("StepIndex" to exchangeStep.stepIndex.toLong())
-    set("State" to state)
+    set("State").toInt64(state)
     set("UpdateTime" to Value.COMMIT_TIMESTAMP)
   }
 }

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/writers/UpdateMeasurementState.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/writers/UpdateMeasurementState.kt
@@ -18,6 +18,7 @@ import com.google.cloud.spanner.Value
 import org.wfanet.measurement.common.identity.InternalId
 import org.wfanet.measurement.gcloud.spanner.bufferTo
 import org.wfanet.measurement.gcloud.spanner.set
+import org.wfanet.measurement.gcloud.spanner.toInt64
 import org.wfanet.measurement.gcloud.spanner.updateMutation
 import org.wfanet.measurement.internal.kingdom.Measurement
 import org.wfanet.measurement.internal.kingdom.MeasurementDetails
@@ -35,7 +36,7 @@ internal fun SpannerWriter.TransactionScope.updateMeasurementState(
   updateMutation("Measurements") {
       set("MeasurementConsumerId" to measurementConsumerId)
       set("MeasurementId" to measurementId)
-      set("State" to nextState)
+      set("State").toInt64(nextState)
       set("UpdateTime" to Value.COMMIT_TIMESTAMP)
       if (details != null) {
         set("MeasurementDetails").to(details)

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/writers/UpdateRequisition.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/writers/UpdateRequisition.kt
@@ -21,7 +21,7 @@ import org.wfanet.measurement.common.identity.InternalId
 import org.wfanet.measurement.gcloud.spanner.bufferUpdateMutation
 import org.wfanet.measurement.gcloud.spanner.getInternalId
 import org.wfanet.measurement.gcloud.spanner.set
-import org.wfanet.measurement.gcloud.spanner.toProtoEnum
+import org.wfanet.measurement.gcloud.spanner.toInt64
 import org.wfanet.measurement.internal.kingdom.Requisition
 import org.wfanet.measurement.internal.kingdom.RequisitionDetails
 import org.wfanet.measurement.kingdom.deploy.gcloud.spanner.readers.RequisitionReader
@@ -37,7 +37,7 @@ internal fun SpannerWriter.TransactionScope.updateRequisition(
     set("MeasurementConsumerId" to readResult.measurementConsumerId.value)
     set("RequisitionId" to readResult.requisitionId.value)
     set("UpdateTime" to Value.COMMIT_TIMESTAMP)
-    set("State" to state)
+    set("State").toInt64(state)
     set("RequisitionDetails").to(details)
     if (fulfillingDuchyId != null) {
       set("FulfillingDuchyId" to fulfillingDuchyId)
@@ -77,7 +77,7 @@ internal suspend fun SpannerWriter.TransactionScope.withdrawRequisitions(
         set("MeasurementConsumerId" to measurementConsumerId)
         set("MeasurementId" to measurementId)
         set("RequisitionId" to requisitionId)
-        set("State").toProtoEnum(Requisition.State.WITHDRAWN)
+        set("State").toInt64(Requisition.State.WITHDRAWN)
         set("UpdateTime").to(Value.COMMIT_TIMESTAMP)
       }
     }

--- a/src/test/kotlin/org/wfanet/measurement/duchy/deploy/gcloud/spanner/computation/GcpSpannerComputationsDatabaseTransactorTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/duchy/deploy/gcloud/spanner/computation/GcpSpannerComputationsDatabaseTransactorTest.kt
@@ -56,8 +56,8 @@ import org.wfanet.measurement.gcloud.common.toGcloudTimestamp
 import org.wfanet.measurement.gcloud.spanner.struct
 import org.wfanet.measurement.gcloud.spanner.testing.UsingSpannerEmulator
 import org.wfanet.measurement.gcloud.spanner.testing.assertQueryReturns
+import org.wfanet.measurement.gcloud.spanner.toInt64
 import org.wfanet.measurement.gcloud.spanner.toProtoBytes
-import org.wfanet.measurement.gcloud.spanner.toProtoEnum
 import org.wfanet.measurement.gcloud.spanner.toProtoJson
 import org.wfanet.measurement.internal.db.gcp.FakeComputationDetails
 import org.wfanet.measurement.internal.db.gcp.FakeProtocolStageDetails
@@ -1250,7 +1250,7 @@ class GcpSpannerComputationsDatabaseTransactorTest :
             set("ComputationStage").toFakeStage(token.stage)
             set("BlobId").to(1234L)
             set("PathToBlob").to("/wrote/something/there")
-            set("DependencyType").toProtoEnum(ComputationBlobDependency.OUTPUT)
+            set("DependencyType").toInt64(ComputationBlobDependency.OUTPUT)
             set("UpdateTime").to(testClock["write-blob-ref"].toGcloudTimestamp())
           }
           .build(),
@@ -1260,7 +1260,7 @@ class GcpSpannerComputationsDatabaseTransactorTest :
             set("ComputationStage").toFakeStage(token.stage)
             set("BlobId").to(5678L)
             set("PathToBlob").to("/path/to/input/blob")
-            set("DependencyType").toProtoEnum(ComputationBlobDependency.INPUT)
+            set("DependencyType").toInt64(ComputationBlobDependency.INPUT)
             set("UpdateTime").to(testClock["write-blob-ref"].toGcloudTimestamp())
           }
           .build(),


### PR DESCRIPTION
The update deprecates some Spanner function calls, so this change also addresses those.