### PR TITLE
fix: Address compile warnings on custom Truth subjects

### DIFF
--- a/src/main/kotlin/org/wfanet/measurement/api/v2alpha/testing/FuzzyLongSubject.kt
+++ b/src/main/kotlin/org/wfanet/measurement/api/v2alpha/testing/FuzzyLongSubject.kt
@@ -26,14 +26,19 @@ import kotlin.math.abs
  *
  * TODO(@SanjayVas): Move this to common-jvm.
  */
-class FuzzyLongSubject private constructor(failureMetadata: FailureMetadata, subject: Long) :
+class FuzzyLongSubject private constructor(failureMetadata: FailureMetadata, subject: Long?) :
   LongSubject(failureMetadata, subject) {
 
-  private val actual: Long = subject
+  private val actual: Long? = subject
 
   fun isWithinPercent(percent: Double): LongRatioComparison {
     return object : LongRatioComparison() {
       override fun of(expected: Long) {
+        if (actual == null) {
+          failWithActual(Fact.simpleFact("expected not to be null"))
+          return
+        }
+
         val actualRatio: Double = abs(expected - actual) / expected.toDouble()
         val expectedRatio: Double = percent / 100.0
         if (actualRatio > expectedRatio) {
@@ -46,6 +51,11 @@ class FuzzyLongSubject private constructor(failureMetadata: FailureMetadata, sub
   fun isWithin(tolerance: Double): LongRatioComparison {
     return object : LongRatioComparison() {
       override fun of(expected: Long) {
+        if (actual == null) {
+          failWithActual(Fact.simpleFact("expected not to be null"))
+          return
+        }
+
         check("getValue").that(actual.toDouble()).isWithin(tolerance).of(expected.toDouble())
       }
     }
@@ -56,7 +66,7 @@ class FuzzyLongSubject private constructor(failureMetadata: FailureMetadata, sub
   }
 
   companion object {
-    fun fuzzyLongs(): (failureMetadata: FailureMetadata, subject: Long) -> FuzzyLongSubject =
-      ::FuzzyLongSubject
+    fun fuzzyLongs() =
+      Factory<FuzzyLongSubject, Long> { metadata, actual -> FuzzyLongSubject(metadata, actual) }
   }
 }

--- a/src/main/kotlin/org/wfanet/measurement/api/v2alpha/testing/MeasurementResultSubject.kt
+++ b/src/main/kotlin/org/wfanet/measurement/api/v2alpha/testing/MeasurementResultSubject.kt
@@ -22,31 +22,30 @@ import com.google.common.truth.extensions.proto.ProtoSubject
 import org.wfanet.measurement.api.v2alpha.Measurement
 
 class MeasurementResultSubject
-private constructor(failureMetadata: FailureMetadata, subject: Measurement.Result) :
-  ProtoSubject(failureMetadata, subject) {
-
-  private val actual: Measurement.Result = subject
+private constructor(failureMetadata: FailureMetadata, private val actual: Measurement.Result?) :
+  ProtoSubject(failureMetadata, actual) {
 
   fun reachValue(): FuzzyLongSubject {
-    return check("reach.value").about(FuzzyLongSubject.fuzzyLongs()).that(actual.reach.value)
+    return check("reach.value").about(FuzzyLongSubject.fuzzyLongs()).that(actual?.reach?.value)
   }
 
   fun frequencyDistribution(): FrequencyDistributionSubject {
     return check("frequency.relativeFrequencyDistribution")
       .about(FrequencyDistributionSubject.frequencyDistributions())
-      .that(actual.frequency.relativeFrequencyDistributionMap)
+      .that(actual?.frequency?.relativeFrequencyDistributionMap)
   }
 
   fun impressionValue(): FuzzyLongSubject {
     return check("impression.value")
       .about(FuzzyLongSubject.fuzzyLongs())
-      .that(actual.impression.value)
+      .that(actual?.impression?.value)
   }
 
   companion object {
-    fun measurementResults():
-      (failureMetadata: FailureMetadata, subject: Measurement.Result) -> MeasurementResultSubject =
-      ::MeasurementResultSubject
+    fun measurementResults() =
+      Factory<MeasurementResultSubject, Measurement.Result> { metadata, actual ->
+        MeasurementResultSubject(metadata, actual)
+      }
 
     fun assertThat(subject: Measurement.Result): MeasurementResultSubject =
       assertAbout(measurementResults()).that(subject)


### PR DESCRIPTION
These were introduced when the Truth version was upgraded in #1790.