### PR TITLE
fix: Extend k8s synthetic test timeout for nightly build.

### DIFF
--- a/src/test/kotlin/org/wfanet/measurement/integration/k8s/BUILD.bazel
+++ b/src/test/kotlin/org/wfanet/measurement/integration/k8s/BUILD.bazel
@@ -132,7 +132,7 @@ java_test(
 
 java_test(
     name = "SyntheticGeneratorCorrectnessTest",
-    timeout = "long",
+    timeout = "eternal",
     data = [
         ":correctness_test_config.textproto",
     ],


### PR DESCRIPTION
The current timeout is 60 minutes. Seems it needs 10 more minutes to complete. Thus, update the timeout to the larger level "eternal", which is 3 hours. 