### PR TITLE
build: Use bazel-remote for Bazel remote caching

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -25,8 +25,6 @@ build --noremote_upload_local_results
 common:ci --lockfile_mode=error
 build:ci --compilation_mode=opt
 build:ci --host_platform //build/platforms:ubuntu_22_04
-common:remote-cache --remote_cache=https://storage.googleapis.com/halo-cmm-build-cache/cross-media-measurement
-common:remote-cache --google_default_credentials
 
 # Configuration for GitHub Container Registry
 build:ghcr --define container_registry=ghcr.io

--- a/.github/actions/setup-bazel-remote/action.yml
+++ b/.github/actions/setup-bazel-remote/action.yml
@@ -1,0 +1,73 @@
+# Copyright 2024 The Cross-Media Measurement Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Set up bazel-remote
+description: Sets up remote caching via bazel-remote
+
+inputs:
+  host:
+    description: Host
+    required: true
+  port:
+    description: gRPC port
+    default: "9092"
+    required: false
+  certificate:
+    description: Trusted TLS server certificate in PEM format
+    required: true
+  username:
+    description: Basic auth username
+    default: "github"
+    required: false
+  password:
+    description: Basic auth password
+    required: true
+
+runs:
+  using: composite
+  steps:
+  - name: Write netrc
+    shell: bash
+    env:
+      BAZEL_REMOTE_CACHE_HOST: ${{ inputs.host }}
+      BAZEL_REMOTE_CACHE_USER: ${{ inputs.username }}
+      BAZEL_REMOTE_CACHE_PASSWORD: ${{ inputs.password }}
+    run: |
+      cat << EOF >> ~/.netrc
+      machine $BAZEL_REMOTE_CACHE_HOST
+      login $BAZEL_REMOTE_CACHE_USER
+      password $BAZEL_REMOTE_CACHE_PASSWORD
+      EOF
+
+  - name: Write certificate
+    shell: bash
+    env:
+      BAZEL_REMOTE_CACHE_CERT: ${{ inputs.certificate }}
+    # Since it appears that GitHub configuration variables use DOS (CRLF) line
+    # endings, we convert these to Unix (LF) line endings.
+    run: |
+      printf '%s' "$BAZEL_REMOTE_CACHE_CERT" | sed $'s/\r$//' > "$HOME/bazel_remote_root.pem"
+
+  - name: Write bazelrc
+    shell: bash
+    env:
+      BAZEL_REMOTE_CACHE_HOST: ${{ inputs.host }}
+      BAZEL_REMOTE_CACHE_PORT: ${{ inputs.port }}
+    run: |
+      cat << EOF >> ~/.bazelrc
+      build --remote_cache=grpcs://$BAZEL_REMOTE_CACHE_HOST:$BAZEL_REMOTE_CACHE_PORT
+      build --tls_certificate=$HOME/bazel_remote_root.pem
+      EOF
+
+

--- a/.github/workflows/api-lint.yml
+++ b/.github/workflows/api-lint.yml
@@ -29,8 +29,6 @@ jobs:
   lint:
     name: API lint
     runs-on: ubuntu-22.04
-    permissions:
-      id-token: write
     defaults:
       run:
         shell: bash
@@ -41,20 +39,20 @@ jobs:
       with:
         version: 1.67.2
         sha256: 260064fad8c38feae402595b6cefef51d70e72b0b5968359c79ee8f3ad33ab27
-        
-    # Authenticate to Google Cloud for access to remote cache.
-    - name: Authenticate to Google Cloud
-      uses: google-github-actions/auth@v2
-      with:
-        workload_identity_provider: ${{ vars.BAZEL_BUILD_WORKLOAD_IDENTITY_PROVIDER }}
-        service_account: ${{ vars.BAZEL_BUILD_SERVICE_ACCOUNT }}
 
     - name: Write ~/.bazelrc
       run: |
         cat << EOF > ~/.bazelrc
         common --config=ci
-        common --config=remote-cache
         EOF
+
+    - uses: ./.github/actions/setup-bazel-remote
+      with:
+        host: ${{ vars.BAZEL_REMOTE_CACHE_HOST }}
+        port: ${{ vars.BAZEL_REMOTE_CACHE_PORT }}
+        certificate: ${{ vars.BAZEL_REMOTE_CACHE_CERT }}
+        username: ${{ vars.BAZEL_REMOTE_CACHE_USER }}
+        password: ${{ secrets.BAZEL_REMOTE_CACHE_PASSWORD }}
 
     - env:
         BAZEL: bazelisk

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -47,18 +47,10 @@ jobs:
 
       - uses: ./.github/actions/free-disk-space
 
-      # Authenticate to Google Cloud for access to remote cache.
-      - name: Authenticate to Google Cloud
-        uses: google-github-actions/auth@v2
-        with:
-          workload_identity_provider: ${{ vars.BAZEL_BUILD_WORKLOAD_IDENTITY_PROVIDER }}
-          service_account: ${{ vars.BAZEL_BUILD_SERVICE_ACCOUNT }}
-
       - name: Write ~/.bazelrc
         run: |
           cat << EOF > ~/.bazelrc
           common --config=ci
-          common --config=remote-cache
           build --remote_upload_local_results
           build --define container_registry=localhost:5001
           build --define image_repo_prefix=halo
@@ -85,6 +77,14 @@ jobs:
           build --define bigquery_dataset=example-dataset
           build --define bigquery_table=events
           EOF
+
+      - uses: ./.github/actions/setup-bazel-remote
+        with:
+          host: ${{ vars.BAZEL_REMOTE_CACHE_HOST }}
+          port: ${{ vars.BAZEL_REMOTE_CACHE_PORT }}
+          certificate: ${{ vars.BAZEL_REMOTE_CACHE_CERT }}
+          username: ${{ vars.BAZEL_REMOTE_CACHE_USER }}
+          password: ${{ secrets.BAZEL_REMOTE_CACHE_PASSWORD }}
 
       - name: Get Bazel cache params
         id: get-cache-params

--- a/.github/workflows/configure-aws-duchy.yml
+++ b/.github/workflows/configure-aws-duchy.yml
@@ -122,6 +122,14 @@ jobs:
         build --define duchy_system_api_eip_allocs=$DUCHY_SYSTEM_API_EIP_ALLOCS
         EOF
 
+    - uses: ./.github/actions/setup-bazel-remote
+      with:
+        host: ${{ vars.BAZEL_REMOTE_CACHE_HOST }}
+        port: ${{ vars.BAZEL_REMOTE_CACHE_PORT }}
+        certificate: ${{ vars.BAZEL_REMOTE_CACHE_CERT }}
+        username: ${{ vars.BAZEL_REMOTE_CACHE_USER }}
+        password: ${{ secrets.BAZEL_REMOTE_CACHE_PASSWORD }}
+
     - name: Get EKS cluster credentials
       run: aws eks update-kubeconfig --region $AWS_REGION --name ${DUCHY_NAME}-duchy
 

--- a/.github/workflows/configure-duchy.yml
+++ b/.github/workflows/configure-duchy.yml
@@ -116,26 +116,13 @@ jobs:
         build --define duchy_storage_bucket=$STORAGE_BUCKET
         EOF
 
-    - name: Get Bazel cache params
-      id: get-cache-params
-      run: |
-        cache_path="$(bazelisk info output_base)"
-        echo "cache-path=${cache_path}" >> "$GITHUB_OUTPUT"
-
-        tree_hash="$(git rev-parse HEAD:)"
-        restore_key="duchy-bazel-"
-        echo "restore-key=${restore_key}" >> "$GITHUB_OUTPUT"
-
-        cache_key="${restore_key}${tree_hash}"
-        echo "cache-key=${cache_key}" >> "$GITHUB_OUTPUT"
-
-    - name: Restore Bazel cache
-      uses: actions/cache/restore@v4
+    - uses: ./.github/actions/setup-bazel-remote
       with:
-        path: ${{ steps.get-cache-params.outputs.cache-path }}
-        key: ${{ steps.get-cache-params.outputs.cache-key }}
-        restore-keys: |
-          ${{ steps.get-cache-params.outputs.restore-key }}
+        host: ${{ vars.BAZEL_REMOTE_CACHE_HOST }}
+        port: ${{ vars.BAZEL_REMOTE_CACHE_PORT }}
+        certificate: ${{ vars.BAZEL_REMOTE_CACHE_CERT }}
+        username: ${{ vars.BAZEL_REMOTE_CACHE_USER }}
+        password: ${{ secrets.BAZEL_REMOTE_CACHE_PASSWORD }}
 
     - name: Export BAZEL_BIN
       run: echo "BAZEL_BIN=$(bazelisk info bazel-bin)" >> $GITHUB_ENV
@@ -155,13 +142,6 @@ jobs:
         bazelisk build 
         "//src/main/k8s/dev:${DUCHY_NAME}_duchy.tar"
         //src/main/k8s/testing/secretfiles:archive
-
-    - name: Save Bazel cache
-      continue-on-error: true
-      uses: actions/cache/save@v4
-      with:
-        path: ${{ steps.get-cache-params.outputs.cache-path }}
-        key: ${{ steps.get-cache-params.outputs.cache-key }}
 
     - name: Make Kustomization dir
       run: mkdir -p "$KUSTOMIZATION_PATH"

--- a/.github/workflows/configure-kingdom.yml
+++ b/.github/workflows/configure-kingdom.yml
@@ -83,6 +83,14 @@ jobs:
           build --define kingdom_system_api_address_name=kingdom-system-v1alpha
           EOF
 
+      - uses: ./.github/actions/setup-bazel-remote
+        with:
+          host: ${{ vars.BAZEL_REMOTE_CACHE_HOST }}
+          port: ${{ vars.BAZEL_REMOTE_CACHE_PORT }}
+          certificate: ${{ vars.BAZEL_REMOTE_CACHE_CERT }}
+          username: ${{ vars.BAZEL_REMOTE_CACHE_USER }}
+          password: ${{ secrets.BAZEL_REMOTE_CACHE_PASSWORD }}
+
       - name: Export BAZEL_BIN
         run: echo "BAZEL_BIN=$(bazelisk info bazel-bin)" >> $GITHUB_ENV
 

--- a/.github/workflows/configure-reporting-v2.yml
+++ b/.github/workflows/configure-reporting-v2.yml
@@ -86,6 +86,14 @@ jobs:
         build --define reporting_public_api_address_name=reporting-v2alpha
         EOF
 
+    - uses: ./.github/actions/setup-bazel-remote
+      with:
+        host: ${{ vars.BAZEL_REMOTE_CACHE_HOST }}
+        port: ${{ vars.BAZEL_REMOTE_CACHE_PORT }}
+        certificate: ${{ vars.BAZEL_REMOTE_CACHE_CERT }}
+        username: ${{ vars.BAZEL_REMOTE_CACHE_USER }}
+        password: ${{ secrets.BAZEL_REMOTE_CACHE_PASSWORD }}
+
     - name: Export BAZEL_BIN
       run: echo "BAZEL_BIN=$(bazelisk info bazel-bin)" >> $GITHUB_ENV
 

--- a/.github/workflows/configure-simulators.yml
+++ b/.github/workflows/configure-simulators.yml
@@ -113,6 +113,14 @@ jobs:
         build --define "edp6_cert_name=$EDP6_CERT_NAME"
         EOF
 
+    - uses: ./.github/actions/setup-bazel-remote
+      with:
+        host: ${{ vars.BAZEL_REMOTE_CACHE_HOST }}
+        port: ${{ vars.BAZEL_REMOTE_CACHE_PORT }}
+        certificate: ${{ vars.BAZEL_REMOTE_CACHE_CERT }}
+        username: ${{ vars.BAZEL_REMOTE_CACHE_USER }}
+        password: ${{ secrets.BAZEL_REMOTE_CACHE_PASSWORD }}
+
     - name: Export BAZEL_BIN
       run: echo "BAZEL_BIN=$(bazelisk info bazel-bin)" >> $GITHUB_ENV
 

--- a/.github/workflows/publish-maven-artifacts.yml
+++ b/.github/workflows/publish-maven-artifacts.yml
@@ -25,8 +25,6 @@ jobs:
   publish-artifacts:
     name: Publish Maven artifacts
     runs-on: ubuntu-22.04
-    permissions:
-      id-token: write
     steps:
       - uses: actions/checkout@v4
 
@@ -52,19 +50,19 @@ jobs:
           version: 7.1.2
           sha256: 8d5c459ab21b411b8be059a8bdf59f0d3eabf9dff943d5eccb80e36e525cc09d
 
-      # Authenticate to Google Cloud for access to remote cache.
-      - name: Authenticate to Google Cloud
-        uses: google-github-actions/auth@v2
-        with:
-          workload_identity_provider: ${{ vars.BAZEL_BUILD_WORKLOAD_IDENTITY_PROVIDER }}
-          service_account: ${{ vars.BAZEL_BUILD_SERVICE_ACCOUNT }}
-
       - name: Write ~/.bazelrc
         run: |
           cat << EOF > ~/.bazelrc
           common --config=ci
-          common --config=remote-cache
           EOF
+
+      - uses: ./.github/actions/setup-bazel-remote
+        with:
+          host: ${{ vars.BAZEL_REMOTE_CACHE_HOST }}
+          port: ${{ vars.BAZEL_REMOTE_CACHE_PORT }}
+          certificate: ${{ vars.BAZEL_REMOTE_CACHE_CERT }}
+          username: ${{ vars.BAZEL_REMOTE_CACHE_USER }}
+          password: ${{ secrets.BAZEL_REMOTE_CACHE_PASSWORD }}
 
       - name: Get Bazel cache params
         id: get-cache-params

--- a/.github/workflows/push-images.yml
+++ b/.github/workflows/push-images.yml
@@ -25,7 +25,6 @@ jobs:
   push-images:
     runs-on: ubuntu-22.04
     permissions:
-      id-token: write
       packages: write
     env:
       CONTAINER_REGISTRY: ghcr.io
@@ -33,13 +32,6 @@ jobs:
       - uses: actions/checkout@v4
 
       - uses: ./.github/actions/free-disk-space
-      
-      # Authenticate to Google Cloud for access to remote cache.
-      - name: Authenticate to Google Cloud
-        uses: google-github-actions/auth@v2
-        with:
-          workload_identity_provider: ${{ vars.BAZEL_BUILD_WORKLOAD_IDENTITY_PROVIDER }}
-          service_account: ${{ vars.BAZEL_BUILD_SERVICE_ACCOUNT }}
 
       - name: Write ~/.bazelrc
         env:
@@ -47,11 +39,18 @@ jobs:
         run: |
           cat << EOF > ~/.bazelrc
           common --config=ci
-          common --config=remote-cache
           build --define container_registry=$CONTAINER_REGISTRY
           build --define image_repo_prefix=$GITHUB_REPOSITORY_OWNER
           build --define image_tag=$IMAGE_TAG
           EOF
+
+      - uses: ./.github/actions/setup-bazel-remote
+        with:
+          host: ${{ vars.BAZEL_REMOTE_CACHE_HOST }}
+          port: ${{ vars.BAZEL_REMOTE_CACHE_PORT }}
+          certificate: ${{ vars.BAZEL_REMOTE_CACHE_CERT }}
+          username: ${{ vars.BAZEL_REMOTE_CACHE_USER }}
+          password: ${{ secrets.BAZEL_REMOTE_CACHE_PASSWORD }}
       
       - name: Get Bazel cache params
         id: get-cache-params

--- a/.github/workflows/release-test.yml
+++ b/.github/workflows/release-test.yml
@@ -23,8 +23,6 @@ jobs:
   build-test:
     name: Build and test
     runs-on: ubuntu-22.04
-    permissions:
-      id-token: write
     env:
       CLUSTER_LOGS_PATH: cluster-logs
     steps:
@@ -33,19 +31,19 @@ jobs:
 
     - uses: ./.github/actions/free-disk-space
 
-    # Authenticate to Google Cloud for access to remote cache.
-    - name: Authenticate to Google Cloud
-      uses: google-github-actions/auth@v2
-      with:
-        workload_identity_provider: ${{ vars.BAZEL_BUILD_WORKLOAD_IDENTITY_PROVIDER }}
-        service_account: ${{ vars.BAZEL_BUILD_SERVICE_ACCOUNT }}
-
     - name: Write ~/.bazelrc
       run: |
         cat << EOF > ~/.bazelrc
         common --config=ci
-        common --config=remote-cache
         EOF
+
+    - uses: ./.github/actions/setup-bazel-remote
+      with:
+        host: ${{ vars.BAZEL_REMOTE_CACHE_HOST }}
+        port: ${{ vars.BAZEL_REMOTE_CACHE_PORT }}
+        certificate: ${{ vars.BAZEL_REMOTE_CACHE_CERT }}
+        username: ${{ vars.BAZEL_REMOTE_CACHE_USER }}
+        password: ${{ secrets.BAZEL_REMOTE_CACHE_PASSWORD }}
 
     - name: Get Bazel cache params
       id: get-cache-params

--- a/.github/workflows/run-k8s-tests.yml
+++ b/.github/workflows/run-k8s-tests.yml
@@ -31,22 +31,12 @@ on:
         - qa
         - head
 
-permissions:
-  id-token: write
-
 jobs:
   run-tests:
     runs-on: ubuntu-22.04
     environment: ${{ inputs.environment }}
     steps:
     - uses: actions/checkout@v4
-
-    # Authenticate to Google Cloud for access to remote cache.
-    - name: Authenticate to Google Cloud for remote cache
-      uses: google-github-actions/auth@v2
-      with:
-        workload_identity_provider: ${{ vars.BAZEL_BUILD_WORKLOAD_IDENTITY_PROVIDER }}
-        service_account: ${{ vars.BAZEL_BUILD_SERVICE_ACCOUNT }}
 
     - name: Write ~/.bazelrc
       env:
@@ -57,7 +47,6 @@ jobs:
       run: |
         cat << EOF > ~/.bazelrc
         common --config=ci
-        common --config=remote-cache
         build --define kingdom_public_api_target=$KINGDOM_PUBLIC_API_TARGET
         build --define mc_name=$MC_NAME
         build --define mc_api_key=$MC_API_KEY
@@ -65,6 +54,14 @@ jobs:
         test --test_output=streamed
         test --test_timeout=3600
         EOF
+
+    - uses: ./.github/actions/setup-bazel-remote
+      with:
+        host: ${{ vars.BAZEL_REMOTE_CACHE_HOST }}
+        port: ${{ vars.BAZEL_REMOTE_CACHE_PORT }}
+        certificate: ${{ vars.BAZEL_REMOTE_CACHE_CERT }}
+        username: ${{ vars.BAZEL_REMOTE_CACHE_USER }}
+        password: ${{ secrets.BAZEL_REMOTE_CACHE_PASSWORD }}
 
     - name: Get Bazel cache params
       id: get-cache-params

--- a/src/main/kotlin/org/wfanet/measurement/eventdataprovider/shareshuffle/BUILD.bazel
+++ b/src/main/kotlin/org/wfanet/measurement/eventdataprovider/shareshuffle/BUILD.bazel
@@ -26,6 +26,9 @@ maven_export(
     name = "native_maven",
     lib_name = "native",
     maven_coordinates = MAVEN_COORDINATES,
-    tags = ["no-javadocs"],
+    tags = [
+        "no-javadocs",
+        "no-remote-cache",
+    ],
     visibility = ["//visibility:private"],
 )

--- a/src/main/kotlin/org/wfanet/measurement/eventdataprovider/shareshuffle/v2alpha/BUILD.bazel
+++ b/src/main/kotlin/org/wfanet/measurement/eventdataprovider/shareshuffle/v2alpha/BUILD.bazel
@@ -31,6 +31,9 @@ maven_export(
     name = "shareshuffle_maven",
     lib_name = "shareshuffle",
     maven_coordinates = MAVEN_COORDINATES,
-    tags = ["no-javadocs"],
+    tags = [
+        "no-javadocs",
+        "no-remote-cache",
+    ],
     visibility = ["//visibility:private"],
 )

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/queries/StreamModelRollouts.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/queries/StreamModelRollouts.kt
@@ -33,17 +33,18 @@ class StreamModelRollouts(
       appendWhereClause(requestFilter)
       appendClause(
         """
-          ORDER BY ModelRollouts.RolloutPeriodStartTime ASC,
+        ORDER BY
+          ModelRollouts.RolloutPeriodStartTime ASC,
           ModelProviders.ExternalModelProviderId ASC,
           ModelSuites.ExternalModelSuiteId ASC,
           ModelLines.ExternalModelLineId ASC,
           ModelRollouts.ExternalModelRolloutId ASC
-          """
+        """
           .trimIndent()
       )
       if (limit > 0) {
-        appendClause("LIMIT @${LIMIT_PARAM}")
-        bind(LIMIT_PARAM to limit.toLong())
+        appendClause("LIMIT @${Params.LIMIT}")
+        bind(Params.LIMIT to limit.toLong())
       }
     }
 
@@ -51,62 +52,82 @@ class StreamModelRollouts(
     val conjuncts = mutableListOf<String>()
 
     if (filter.externalModelProviderId != 0L) {
-      conjuncts.add("ExternalModelProviderId = @${EXTERNAL_MODEL_PROVIDER_ID}")
-      bind(EXTERNAL_MODEL_PROVIDER_ID to filter.externalModelProviderId)
+      conjuncts.add("ExternalModelProviderId = @${Params.EXTERNAL_MODEL_PROVIDER_ID}")
+      bind(Params.EXTERNAL_MODEL_PROVIDER_ID to filter.externalModelProviderId)
     }
 
     if (filter.externalModelSuiteId != 0L) {
-      conjuncts.add("ExternalModelSuiteId = @${EXTERNAL_MODEL_SUITE_ID}")
-      bind(EXTERNAL_MODEL_SUITE_ID to filter.externalModelSuiteId)
+      conjuncts.add("ExternalModelSuiteId = @${Params.EXTERNAL_MODEL_SUITE_ID}")
+      bind(Params.EXTERNAL_MODEL_SUITE_ID to filter.externalModelSuiteId)
     }
 
     if (filter.externalModelLineId != 0L) {
-      conjuncts.add("ExternalModelLineId = @${EXTERNAL_MODEL_LINE_ID}")
-      bind(EXTERNAL_MODEL_LINE_ID to filter.externalModelLineId)
+      conjuncts.add("ExternalModelLineId = @${Params.EXTERNAL_MODEL_LINE_ID}")
+      bind(Params.EXTERNAL_MODEL_LINE_ID to filter.externalModelLineId)
     }
 
     if (filter.hasRolloutPeriod()) {
       conjuncts.add(
         """
-          ModelRollouts.RolloutPeriodStartTime >= @${ROLLOUT_PERIOD_START_TIME}
-          AND ModelRollouts.RolloutPeriodEndTime < @${ROLLOUT_PERIOD_END_TIME}
+          ModelRollouts.RolloutPeriodStartTime >= @${Params.ROLLOUT_PERIOD_START_TIME}
+          AND ModelRollouts.RolloutPeriodEndTime < @${Params.ROLLOUT_PERIOD_END_TIME}
         """
           .trimIndent()
       )
       bind(
-        ROLLOUT_PERIOD_START_TIME to filter.rolloutPeriod.rolloutPeriodStartTime.toGcloudTimestamp()
+        Params.ROLLOUT_PERIOD_START_TIME to
+          filter.rolloutPeriod.rolloutPeriodStartTime.toGcloudTimestamp()
       )
-      bind(ROLLOUT_PERIOD_END_TIME to filter.rolloutPeriod.rolloutPeriodEndTime.toGcloudTimestamp())
+      bind(
+        Params.ROLLOUT_PERIOD_END_TIME to
+          filter.rolloutPeriod.rolloutPeriodEndTime.toGcloudTimestamp()
+      )
     }
 
     if (filter.hasAfter()) {
+      // CASE implements short-circuiting.
       conjuncts.add(
         """
-          ((ModelRollouts.RolloutPeriodStartTime > @${ROLLOUT_PERIOD_START_TIME_AFTER})
-          OR (ModelRollouts.RolloutPeriodStartTime = @${ROLLOUT_PERIOD_START_TIME_AFTER}
-          AND ModelProviders.ExternalModelProviderId > @${EXTERNAL_MODEL_PROVIDER_ID})
-          OR (ModelRollouts.RolloutPeriodStartTime = @${ROLLOUT_PERIOD_START_TIME_AFTER}
-          AND ModelProviders.ExternalModelProviderId = @${EXTERNAL_MODEL_PROVIDER_ID}
-          AND ModelSuites.ExternalModelSuiteId > @${EXTERNAL_MODEL_SUITE_ID})
-          OR (ModelRollouts.RolloutPeriodStartTime = @${ROLLOUT_PERIOD_START_TIME_AFTER}
-          AND ModelProviders.ExternalModelProviderId = @${EXTERNAL_MODEL_PROVIDER_ID}
-          AND ModelSuites.ExternalModelSuiteId = @${EXTERNAL_MODEL_SUITE_ID}
-          AND ModelLines.ExternalModelLineId > @${EXTERNAL_MODEL_LINE_ID})
-          OR (ModelRollouts.RolloutPeriodStartTime = @${ROLLOUT_PERIOD_START_TIME_AFTER}
-          AND ModelProviders.ExternalModelProviderId = @${EXTERNAL_MODEL_PROVIDER_ID}
-          AND ModelSuites.ExternalModelSuiteId = @${EXTERNAL_MODEL_SUITE_ID}
-          AND ModelLines.ExternalModelLineId = @${EXTERNAL_MODEL_LINE_ID}
-          AND ModelRollouts.ExternalModelRolloutId > @${EXTERNAL_MODEL_ROLLOUT_ID}))
+        CASE
+          WHEN
+            ModelRollouts.RolloutPeriodStartTime > @${AfterParams.ROLLOUT_PERIOD_START_TIME}
+            THEN TRUE
+          WHEN
+            ModelRollouts.RolloutPeriodStartTime = @${AfterParams.ROLLOUT_PERIOD_START_TIME}
+            AND ModelProviders.ExternalModelProviderId > @${AfterParams.EXTERNAL_MODEL_PROVIDER_ID}
+            THEN TRUE
+          WHEN
+            ModelRollouts.RolloutPeriodStartTime = @${AfterParams.ROLLOUT_PERIOD_START_TIME}
+            AND ModelProviders.ExternalModelProviderId = @${AfterParams.EXTERNAL_MODEL_PROVIDER_ID}
+            AND ModelSuites.ExternalModelSuiteId > @${AfterParams.EXTERNAL_MODEL_SUITE_ID}
+            THEN TRUE
+          WHEN
+            ModelRollouts.RolloutPeriodStartTime = @${AfterParams.ROLLOUT_PERIOD_START_TIME}
+            AND ModelProviders.ExternalModelProviderId = @${AfterParams.EXTERNAL_MODEL_PROVIDER_ID}
+            AND ModelSuites.ExternalModelSuiteId = @${AfterParams.EXTERNAL_MODEL_SUITE_ID}
+            AND ModelLines.ExternalModelLineId > @${AfterParams.EXTERNAL_MODEL_LINE_ID}
+            THEN TRUE
+          WHEN
+            ModelRollouts.RolloutPeriodStartTime = @${AfterParams.ROLLOUT_PERIOD_START_TIME}
+            AND ModelProviders.ExternalModelProviderId = @${AfterParams.EXTERNAL_MODEL_PROVIDER_ID}
+            AND ModelSuites.ExternalModelSuiteId = @${AfterParams.EXTERNAL_MODEL_SUITE_ID}
+            AND ModelLines.ExternalModelLineId = @${AfterParams.EXTERNAL_MODEL_LINE_ID}
+            AND ModelRollouts.ExternalModelRolloutId > @${AfterParams.EXTERNAL_MODEL_ROLLOUT_ID}
+            THEN TRUE
+          ELSE
+            FALSE
+        END
         """
           .trimIndent()
       )
       bind(
-        ROLLOUT_PERIOD_START_TIME_AFTER to filter.after.rolloutPeriodStartTime.toGcloudTimestamp()
+        AfterParams.ROLLOUT_PERIOD_START_TIME to
+          filter.after.rolloutPeriodStartTime.toGcloudTimestamp()
       )
-      bind(EXTERNAL_MODEL_PROVIDER_ID to filter.after.externalModelProviderId)
-      bind(EXTERNAL_MODEL_SUITE_ID to filter.after.externalModelSuiteId)
-      bind(EXTERNAL_MODEL_LINE_ID to filter.after.externalModelLineId)
-      bind(EXTERNAL_MODEL_ROLLOUT_ID to filter.after.externalModelRolloutId)
+      bind(AfterParams.EXTERNAL_MODEL_PROVIDER_ID to filter.after.externalModelProviderId)
+      bind(AfterParams.EXTERNAL_MODEL_SUITE_ID to filter.after.externalModelSuiteId)
+      bind(AfterParams.EXTERNAL_MODEL_LINE_ID to filter.after.externalModelLineId)
+      bind(AfterParams.EXTERNAL_MODEL_ROLLOUT_ID to filter.after.externalModelRolloutId)
     }
 
     if (conjuncts.isEmpty()) {
@@ -118,13 +139,21 @@ class StreamModelRollouts(
   }
 
   companion object {
-    const val LIMIT_PARAM = "limit"
-    const val EXTERNAL_MODEL_PROVIDER_ID = "externalModelProviderId"
-    const val EXTERNAL_MODEL_SUITE_ID = "externalModelSuiteId"
-    const val EXTERNAL_MODEL_LINE_ID = "externalModelLineId"
-    const val EXTERNAL_MODEL_ROLLOUT_ID = "externalModelRolloutId"
-    const val ROLLOUT_PERIOD_START_TIME_AFTER = "rolloutPeriodStartTimeAfter"
-    const val ROLLOUT_PERIOD_START_TIME = "rolloutPeriodStartTime"
-    const val ROLLOUT_PERIOD_END_TIME = "rolloutPeriodEndTime"
+    private object Params {
+      const val LIMIT = "limit"
+      const val EXTERNAL_MODEL_PROVIDER_ID = "externalModelProviderId"
+      const val EXTERNAL_MODEL_SUITE_ID = "externalModelSuiteId"
+      const val EXTERNAL_MODEL_LINE_ID = "externalModelLineId"
+      const val ROLLOUT_PERIOD_START_TIME = "rolloutPeriodStartTime"
+      const val ROLLOUT_PERIOD_END_TIME = "rolloutPeriodEndTime"
+    }
+
+    private object AfterParams {
+      const val ROLLOUT_PERIOD_START_TIME = "after_rolloutPeriodStartTime"
+      const val EXTERNAL_MODEL_PROVIDER_ID = "after_externalModelProviderId"
+      const val EXTERNAL_MODEL_SUITE_ID = "after_externalModelSuiteId"
+      const val EXTERNAL_MODEL_LINE_ID = "after_externalModelLineId"
+      const val EXTERNAL_MODEL_ROLLOUT_ID = "after_externalModelRolloutId"
+    }
   }
 }

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/readers/ModelRolloutReader.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/readers/ModelRolloutReader.kt
@@ -53,20 +53,20 @@ class ModelRolloutReader : SpannerReader<ModelRolloutReader.Result>() {
       ModelProviders.ExternalModelProviderId,
       PreviousModelRollout.ExternalModelRolloutId AS PreviousExternalModelRolloutId,
       ModelReleases.ExternalModelReleaseId
-      FROM ModelRollouts
-      JOIN ModelLines USING (ModelProviderId, ModelSuiteId, ModelLineId)
-      JOIN ModelSuites USING (ModelProviderId, ModelSuiteId)
-      JOIN ModelProviders USING (ModelProviderId)
-      LEFT JOIN ModelRollouts as PreviousModelRollout ON (
-        ModelRollouts.ModelProviderId = PreviousModelRollout.ModelProviderId
-        AND ModelRollouts.ModelSuiteId = PreviousModelRollout.ModelSuiteId
-        AND ModelRollouts.PreviousModelRolloutId = PreviousModelRollout.ModelRolloutId
-      )
-      JOIN ModelReleases ON (
-        ModelRollouts.ModelProviderId = ModelReleases.ModelProviderId
-        AND ModelRollouts.ModelSuiteId = ModelReleases.ModelSuiteId
-        AND ModelRollouts.ModelReleaseId = ModelReleases.ModelReleaseId
-      )
+    FROM ModelRollouts
+    JOIN ModelLines USING (ModelProviderId, ModelSuiteId, ModelLineId)
+    JOIN ModelSuites USING (ModelProviderId, ModelSuiteId)
+    JOIN ModelProviders USING (ModelProviderId)
+    LEFT JOIN ModelRollouts AS PreviousModelRollout ON (
+      ModelRollouts.ModelProviderId = PreviousModelRollout.ModelProviderId
+      AND ModelRollouts.ModelSuiteId = PreviousModelRollout.ModelSuiteId
+      AND ModelRollouts.PreviousModelRolloutId = PreviousModelRollout.ModelRolloutId
+    )
+    JOIN ModelReleases ON (
+      ModelRollouts.ModelProviderId = ModelReleases.ModelProviderId
+      AND ModelRollouts.ModelSuiteId = ModelReleases.ModelSuiteId
+      AND ModelRollouts.ModelReleaseId = ModelReleases.ModelReleaseId
+    )
     """
       .trimIndent()
 

--- a/src/main/kotlin/org/wfanet/panelmatch/client/deploy/BUILD.bazel
+++ b/src/main/kotlin/org/wfanet/panelmatch/client/deploy/BUILD.bazel
@@ -47,6 +47,9 @@ maven_export(
     name = "maven",
     lib_name = "deploy",
     maven_coordinates = MAVEN_COORDINATES,
-    tags = ["no-javadocs"],
+    tags = [
+        "no-javadocs",
+        "no-remote-cache",
+    ],
     visibility = ["//visibility:private"],
 )

--- a/src/main/kotlin/org/wfanet/panelmatch/client/testing/BUILD.bazel
+++ b/src/main/kotlin/org/wfanet/panelmatch/client/testing/BUILD.bazel
@@ -46,6 +46,9 @@ maven_export(
     testonly = None,
     lib_name = "testing",
     maven_coordinates = MAVEN_COORDINATES,
-    tags = ["no-javadocs"],
+    tags = [
+        "no-javadocs",
+        "no-remote-cache",
+    ],
     visibility = ["//visibility:private"],
 )

--- a/src/main/proto/wfa/measurement/api/v2alpha/BUILD.bazel
+++ b/src/main/proto/wfa/measurement/api/v2alpha/BUILD.bazel
@@ -142,7 +142,10 @@ maven_export(
     name = "maven",
     lib_name = "api_kt_jvm_proto",
     maven_coordinates = MAVEN_COORDINATES,
-    tags = ["no-javadocs"],
+    tags = [
+        "no-javadocs",
+        "no-remote-cache",
+    ],
     visibility = ["//visibility:private"],
 )
 
@@ -159,6 +162,9 @@ maven_export(
     name = "grpc_maven",
     lib_name = "api_kt_jvm_grpc_proto",
     maven_coordinates = GRPC_MAVEN_COORDINATES,
-    tags = ["no-javadocs"],
+    tags = [
+        "no-javadocs",
+        "no-remote-cache",
+    ],
     visibility = ["//visibility:private"],
 )

--- a/src/test/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/BUILD.bazel
+++ b/src/test/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/BUILD.bazel
@@ -264,6 +264,7 @@ spanner_emulator_test(
         "//src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner:services",
         "//src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/testing",
         "//src/main/kotlin/org/wfanet/measurement/kingdom/service/internal/testing",
+        "@wfa_common_jvm//imports/kotlin/kotlinx/coroutines/debug",
     ],
 )
 

--- a/src/test/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/SpannerModelRolloutsServiceTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/SpannerModelRolloutsServiceTest.kt
@@ -17,6 +17,7 @@
 package org.wfanet.measurement.kingdom.deploy.gcloud.spanner
 
 import java.time.Clock
+import kotlinx.coroutines.debug.junit4.CoroutinesTimeout
 import org.junit.Rule
 import org.wfanet.measurement.common.identity.IdGenerator
 import org.wfanet.measurement.gcloud.spanner.testing.SpannerEmulatorDatabaseRule
@@ -26,6 +27,7 @@ import org.wfanet.measurement.kingdom.service.internal.testing.ModelRolloutsServ
 class SpannerModelRolloutsServiceTest : ModelRolloutsServiceTest<SpannerModelRolloutsService>() {
 
   @get:Rule val spannerDatabase = SpannerEmulatorDatabaseRule(Schemata.KINGDOM_CHANGELOG_PATH)
+  @get:Rule val timeout = CoroutinesTimeout.seconds(30, true)
 
   override fun newServices(
     testClock: Clock,


### PR DESCRIPTION
This should be more efficient as it uses gRPC over HTTP/2. It has the additional benefit that it does not depend on Google Cloud credentials, so it can be used in cases where different credentials are already in use (e.g. applying K8s configs).