### PR TITLE
ci: Use BuildBuddy for Bazel results, remote caching, and remote execution

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -18,15 +18,22 @@ build --java_language_version=11
 # Pass environment variables.
 test --test_env TESTCONTAINERS_RYUK_DISABLED=true
 
-# Disable remote cache upload by default.
-build --noremote_upload_local_results
+# Configuration for remote cache.
+build --noremote_upload_local_results  # Do not upload by default
+build --remote_download_outputs=minimal
+build --remote_timeout=3600
+build:remote-cache --remote_cache=grpcs://halo-cmm.buildbuddy.io
+build:remote-cache --experimental_remote_cache_compression
+build:remote-cache --experimental_remote_cache_compression_threshold=100
 
 # Configuration for continuous integration (CI).
 common:ci --lockfile_mode=error
 build:ci --compilation_mode=opt
-build:ci --host_platform //build/platforms:ubuntu_22_04
-common:remote-cache --remote_cache=https://storage.googleapis.com/halo-cmm-build-cache/cross-media-measurement
-common:remote-cache --google_default_credentials
+build:ci --build_metadata=ROLE=CI
+build:ci --build_metadata=VISIBILITY=PUBLIC
+build:ci --config=remote-cache
+build:ci --config=results
+build:ci --config=remote
 
 # Configuration for GitHub Container Registry
 build:ghcr --define container_registry=ghcr.io
@@ -40,3 +47,4 @@ import %workspace%/container.bazelrc
 import %workspace%/maven.bazelrc
 import %workspace%/remote.bazelrc
 import %workspace%/results.bazelrc
+try-import %workspace%/auth.bazelrc

--- a/.github/workflows/api-lint.yml
+++ b/.github/workflows/api-lint.yml
@@ -29,8 +29,6 @@ jobs:
   lint:
     name: API lint
     runs-on: ubuntu-22.04
-    permissions:
-      id-token: write
     defaults:
       run:
         shell: bash
@@ -42,22 +40,22 @@ jobs:
         version: 1.67.2
         sha256: 260064fad8c38feae402595b6cefef51d70e72b0b5968359c79ee8f3ad33ab27
 
-    # Authenticate to Google Cloud for access to remote cache.
-    - name: Authenticate to Google Cloud
-      uses: google-github-actions/auth@v2
-      with:
-        workload_identity_provider: ${{ vars.BAZEL_BUILD_WORKLOAD_IDENTITY_PROVIDER }}
-        service_account: ${{ vars.BAZEL_BUILD_SERVICE_ACCOUNT }}
+    - name: Write auth.bazelrc
+      env:
+        BUILDBUDDY_API_KEY: ${{ secrets.BUILDBUDDY_API_KEY }}
+      run: |
+        cat << EOF > auth.bazelrc
+        build --remote_header=x-buildbuddy-api-key=$BUILDBUDDY_API_KEY
+        EOF
 
     - name: Write ~/.bazelrc
       run: |
         cat << EOF > ~/.bazelrc
         common --config=ci
-        common --config=remote-cache
+        build --remote_download_outputs=toplevel  # Need descriptor set output.
         EOF
 
-    - env:
-        BAZEL: bazelisk
-      run: |
-        tools/api-lint wfa/measurement/system
-        tools/api-lint wfa/measurement/securecomputation
+    - uses: world-federation-of-advertisers/actions/setup-bazel@v2
+
+    - run: tools/api-lint wfa/measurement/system
+    - run: tools/api-lint wfa/measurement/securecomputation

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -34,8 +34,6 @@ jobs:
   build-test:
     name: Build and test
     runs-on: ubuntu-22.04
-    permissions:
-      id-token: write
     env:
       CLUSTER_LOGS_PATH: cluster-logs
     steps:
@@ -47,18 +45,18 @@ jobs:
 
       - uses: ./.github/actions/free-disk-space
 
-      # Authenticate to Google Cloud for access to remote cache.
-      - name: Authenticate to Google Cloud
-        uses: google-github-actions/auth@v2
-        with:
-          workload_identity_provider: ${{ vars.BAZEL_BUILD_WORKLOAD_IDENTITY_PROVIDER }}
-          service_account: ${{ vars.BAZEL_BUILD_SERVICE_ACCOUNT }}
+      - name: Write auth.bazelrc
+        env:
+          BUILDBUDDY_API_KEY: ${{ secrets.BUILDBUDDY_API_KEY }}
+        run: |
+          cat << EOF > auth.bazelrc
+          build --remote_header=x-buildbuddy-api-key=$BUILDBUDDY_API_KEY
+          EOF
 
       - name: Write ~/.bazelrc
         run: |
           cat << EOF > ~/.bazelrc
           common --config=ci
-          common --config=remote-cache
           build --remote_upload_local_results
           build --define container_registry=localhost:5001
           build --define image_repo_prefix=halo

--- a/.github/workflows/configure-aws-duchy.yml
+++ b/.github/workflows/configure-aws-duchy.yml
@@ -88,6 +88,14 @@ jobs:
         WORKER2_DUCHY_CERT_ID: ${{ vars.WORKER2_DUCHY_CERT_ID }}
       run: ./.github/workflows/export-duchy-cert-id.sh
 
+    - name: Write auth.bazelrc
+      env:
+        BUILDBUDDY_API_KEY: ${{ secrets.BUILDBUDDY_API_KEY }}
+      run: |
+        cat << EOF > auth.bazelrc
+        build --remote_header=x-buildbuddy-api-key=$BUILDBUDDY_API_KEY
+        EOF
+
     - name: Write ~/.bazelrc
       env:
         IMAGE_TAG: ${{ inputs.image-tag }}

--- a/.github/workflows/configure-duchy.yml
+++ b/.github/workflows/configure-duchy.yml
@@ -88,6 +88,14 @@ jobs:
         WORKER2_DUCHY_CERT_ID: ${{ vars.WORKER2_DUCHY_CERT_ID }}
       run: ./.github/workflows/export-duchy-cert-id.sh
 
+    - name: Write auth.bazelrc
+      env:
+        BUILDBUDDY_API_KEY: ${{ secrets.BUILDBUDDY_API_KEY }}
+      run: |
+        cat << EOF > auth.bazelrc
+        build --remote_header=x-buildbuddy-api-key=$BUILDBUDDY_API_KEY
+        EOF
+
     - name: Write ~/.bazelrc
       env:
         IMAGE_TAG: ${{ inputs.image-tag }}
@@ -116,27 +124,6 @@ jobs:
         build --define duchy_storage_bucket=$STORAGE_BUCKET
         EOF
 
-    - name: Get Bazel cache params
-      id: get-cache-params
-      run: |
-        cache_path="$(bazelisk info output_base)"
-        echo "cache-path=${cache_path}" >> "$GITHUB_OUTPUT"
-
-        tree_hash="$(git rev-parse HEAD:)"
-        restore_key="duchy-bazel-"
-        echo "restore-key=${restore_key}" >> "$GITHUB_OUTPUT"
-
-        cache_key="${restore_key}${tree_hash}"
-        echo "cache-key=${cache_key}" >> "$GITHUB_OUTPUT"
-
-    - name: Restore Bazel cache
-      uses: actions/cache/restore@v4
-      with:
-        path: ${{ steps.get-cache-params.outputs.cache-path }}
-        key: ${{ steps.get-cache-params.outputs.cache-key }}
-        restore-keys: |
-          ${{ steps.get-cache-params.outputs.restore-key }}
-
     - name: Export BAZEL_BIN
       run: echo "BAZEL_BIN=$(bazelisk info bazel-bin)" >> $GITHUB_ENV
 
@@ -155,13 +142,6 @@ jobs:
         bazelisk build 
         "//src/main/k8s/dev:${DUCHY_NAME}_duchy.tar"
         //src/main/k8s/testing/secretfiles:archive
-
-    - name: Save Bazel cache
-      continue-on-error: true
-      uses: actions/cache/save@v4
-      with:
-        path: ${{ steps.get-cache-params.outputs.cache-path }}
-        key: ${{ steps.get-cache-params.outputs.cache-key }}
 
     - name: Make Kustomization dir
       run: mkdir -p "$KUSTOMIZATION_PATH"

--- a/.github/workflows/configure-kingdom.yml
+++ b/.github/workflows/configure-kingdom.yml
@@ -68,6 +68,14 @@ jobs:
           workload_identity_provider: ${{ vars.WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ vars.GKE_CONFIG_SERVICE_ACCOUNT }}
 
+      - name: Write auth.bazelrc
+        env:
+          BUILDBUDDY_API_KEY: ${{ secrets.BUILDBUDDY_API_KEY }}
+        run: |
+          cat << EOF > auth.bazelrc
+          build --remote_header=x-buildbuddy-api-key=$BUILDBUDDY_API_KEY
+          EOF
+
       - name: Write ~/.bazelrc
         env:
           IMAGE_TAG: ${{ inputs.image-tag }}

--- a/.github/workflows/configure-reporting-v2.yml
+++ b/.github/workflows/configure-reporting-v2.yml
@@ -68,6 +68,14 @@ jobs:
         workload_identity_provider: ${{ vars.WORKLOAD_IDENTITY_PROVIDER }}
         service_account: ${{ vars.GKE_CONFIG_SERVICE_ACCOUNT }}
 
+    - name: Write auth.bazelrc
+      env:
+        BUILDBUDDY_API_KEY: ${{ secrets.BUILDBUDDY_API_KEY }}
+      run: |
+        cat << EOF > auth.bazelrc
+        build --remote_header=x-buildbuddy-api-key=$BUILDBUDDY_API_KEY
+        EOF
+
     - name: Write ~/.bazelrc
       env:
         IMAGE_TAG: ${{ inputs.image-tag }}

--- a/.github/workflows/configure-reporting.yml
+++ b/.github/workflows/configure-reporting.yml
@@ -68,6 +68,14 @@ jobs:
         workload_identity_provider: ${{ vars.WORKLOAD_IDENTITY_PROVIDER }}
         service_account: ${{ vars.GKE_CONFIG_SERVICE_ACCOUNT }}
 
+    - name: Write auth.bazelrc
+      env:
+        BUILDBUDDY_API_KEY: ${{ secrets.BUILDBUDDY_API_KEY }}
+      run: |
+        cat << EOF > auth.bazelrc
+        build --remote_header=x-buildbuddy-api-key=$BUILDBUDDY_API_KEY
+        EOF
+
     - name: Write ~/.bazelrc
       env:
         IMAGE_TAG: ${{ inputs.image-tag }}

--- a/.github/workflows/configure-simulators.yml
+++ b/.github/workflows/configure-simulators.yml
@@ -68,6 +68,14 @@ jobs:
         workload_identity_provider: ${{ vars.WORKLOAD_IDENTITY_PROVIDER }}
         service_account: ${{ vars.GKE_CONFIG_SERVICE_ACCOUNT }}
 
+    - name: Write auth.bazelrc
+      env:
+        BUILDBUDDY_API_KEY: ${{ secrets.BUILDBUDDY_API_KEY }}
+      run: |
+        cat << EOF > auth.bazelrc
+        build --remote_header=x-buildbuddy-api-key=$BUILDBUDDY_API_KEY
+        EOF
+
     - name: Write ~/.bazelrc
       env:
         IMAGE_TAG: ${{ inputs.image-tag }}

--- a/.github/workflows/publish-maven-artifacts.yml
+++ b/.github/workflows/publish-maven-artifacts.yml
@@ -25,8 +25,6 @@ jobs:
   publish-artifacts:
     name: Publish Maven artifacts
     runs-on: ubuntu-22.04
-    permissions:
-      id-token: write
     steps:
       - uses: actions/checkout@v4
 
@@ -52,18 +50,18 @@ jobs:
           version: 7.1.2
           sha256: 8d5c459ab21b411b8be059a8bdf59f0d3eabf9dff943d5eccb80e36e525cc09d
 
-      # Authenticate to Google Cloud for access to remote cache.
-      - name: Authenticate to Google Cloud
-        uses: google-github-actions/auth@v2
-        with:
-          workload_identity_provider: ${{ vars.BAZEL_BUILD_WORKLOAD_IDENTITY_PROVIDER }}
-          service_account: ${{ vars.BAZEL_BUILD_SERVICE_ACCOUNT }}
+      - name: Write auth.bazelrc
+        env:
+          BUILDBUDDY_API_KEY: ${{ secrets.BUILDBUDDY_API_KEY }}
+        run: |
+          cat << EOF > auth.bazelrc
+          build --remote_header=x-buildbuddy-api-key=$BUILDBUDDY_API_KEY
+          EOF
 
       - name: Write ~/.bazelrc
         run: |
           cat << EOF > ~/.bazelrc
           common --config=ci
-          common --config=remote-cache
           EOF
 
       - name: Get Bazel cache params

--- a/.github/workflows/push-images.yml
+++ b/.github/workflows/push-images.yml
@@ -25,7 +25,6 @@ jobs:
   push-images:
     runs-on: ubuntu-22.04
     permissions:
-      id-token: write
       packages: write
     env:
       CONTAINER_REGISTRY: ghcr.io
@@ -33,13 +32,14 @@ jobs:
       - uses: actions/checkout@v4
 
       - uses: ./.github/actions/free-disk-space
-      
-      # Authenticate to Google Cloud for access to remote cache.
-      - name: Authenticate to Google Cloud
-        uses: google-github-actions/auth@v2
-        with:
-          workload_identity_provider: ${{ vars.BAZEL_BUILD_WORKLOAD_IDENTITY_PROVIDER }}
-          service_account: ${{ vars.BAZEL_BUILD_SERVICE_ACCOUNT }}
+
+      - name: Write auth.bazelrc
+        env:
+          BUILDBUDDY_API_KEY: ${{ secrets.BUILDBUDDY_API_KEY }}
+        run: |
+          cat << EOF > auth.bazelrc
+          build --remote_header=x-buildbuddy-api-key=$BUILDBUDDY_API_KEY
+          EOF
 
       - name: Write ~/.bazelrc
         env:
@@ -47,7 +47,6 @@ jobs:
         run: |
           cat << EOF > ~/.bazelrc
           common --config=ci
-          common --config=remote-cache
           build --define container_registry=$CONTAINER_REGISTRY
           build --define image_repo_prefix=$GITHUB_REPOSITORY_OWNER
           build --define image_tag=$IMAGE_TAG

--- a/.github/workflows/release-test.yml
+++ b/.github/workflows/release-test.yml
@@ -23,8 +23,6 @@ jobs:
   build-test:
     name: Build and test
     runs-on: ubuntu-22.04
-    permissions:
-      id-token: write
     env:
       CLUSTER_LOGS_PATH: cluster-logs
     steps:
@@ -33,18 +31,18 @@ jobs:
 
     - uses: ./.github/actions/free-disk-space
 
-    # Authenticate to Google Cloud for access to remote cache.
-    - name: Authenticate to Google Cloud
-      uses: google-github-actions/auth@v2
-      with:
-        workload_identity_provider: ${{ vars.BAZEL_BUILD_WORKLOAD_IDENTITY_PROVIDER }}
-        service_account: ${{ vars.BAZEL_BUILD_SERVICE_ACCOUNT }}
+    - name: Write auth.bazelrc
+      env:
+        BUILDBUDDY_API_KEY: ${{ secrets.BUILDBUDDY_API_KEY }}
+      run: |
+        cat << EOF > auth.bazelrc
+        build --remote_header=x-buildbuddy-api-key=$BUILDBUDDY_API_KEY
+        EOF
 
     - name: Write ~/.bazelrc
       run: |
         cat << EOF > ~/.bazelrc
         common --config=ci
-        common --config=remote-cache
         EOF
 
     - name: Get Bazel cache params

--- a/.github/workflows/run-k8s-tests.yml
+++ b/.github/workflows/run-k8s-tests.yml
@@ -31,9 +31,6 @@ on:
         - qa
         - head
 
-permissions:
-  id-token: write
-
 jobs:
   run-tests:
     runs-on: ubuntu-22.04
@@ -41,12 +38,13 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
-    # Authenticate to Google Cloud for access to remote cache.
-    - name: Authenticate to Google Cloud for remote cache
-      uses: google-github-actions/auth@v2
-      with:
-        workload_identity_provider: ${{ vars.BAZEL_BUILD_WORKLOAD_IDENTITY_PROVIDER }}
-        service_account: ${{ vars.BAZEL_BUILD_SERVICE_ACCOUNT }}
+    - name: Write auth.bazelrc
+      env:
+        BUILDBUDDY_API_KEY: ${{ secrets.BUILDBUDDY_API_KEY }}
+      run: |
+        cat << EOF > auth.bazelrc
+        build --remote_header=x-buildbuddy-api-key=$BUILDBUDDY_API_KEY
+        EOF
 
     - name: Write ~/.bazelrc
       env:
@@ -57,7 +55,6 @@ jobs:
       run: |
         cat << EOF > ~/.bazelrc
         common --config=ci
-        common --config=remote-cache
         build --define kingdom_public_api_target=$KINGDOM_PUBLIC_API_TARGET
         build --define mc_name=$MC_NAME
         build --define mc_api_key=$MC_API_KEY

--- a/.gitignore
+++ b/.gitignore
@@ -17,4 +17,7 @@
 # Terraform directories
 .terraform/
 
+# Authentication credentials
+/auth.bazelrc
+
 **/node_modules

--- a/container.bazelrc
+++ b/container.bazelrc
@@ -2,9 +2,6 @@
 # ghcr.io/world-federation-of-advertisers/bazel image.
 
 # Toolchain configuration.
-build:container --java_runtime_version=rbe_jdk
-build:container --tool_java_runtime_version=rbe_jdk
-build:container --extra_toolchains=//third_party/rbe_configs/java:all
 build:container --crosstool_top=//third_party/rbe_configs/cc:toolchain
 build:container --action_env=BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN=1
 build:container --extra_toolchains=//third_party/rbe_configs/config:cc-toolchain

--- a/remote.bazelrc
+++ b/remote.bazelrc
@@ -1,35 +1,19 @@
-# Configuration for remote building.
-# See https://cloud.google.com/remote-build-execution/docs/overview
-# Adapted from https://github.com/bazelbuild/bazel-toolchains/blob/master/bazelrc/bazel-2.0.0.bazelrc
+ # Remote Build Execution (RBE)
+
+build:remote --remote_executor=grpcs://halo-cmm.buildbuddy.io
+build:remote --define=EXECUTOR=remote
+
+# Include container toolchain/platform configuration.
+build:remote --config=container
 
 # Depending on how many machines are in the remote execution instance, setting
 # this higher can make builds faster by allowing more jobs to run in parallel.
 # Setting it too high can result in jobs that timeout, however, while waiting
 # for a remote machine to execute them.
-build:remote --jobs=200
-
-# Include container toolchain/platform configuration.
-build:remote --config=container
-
-# Starting with Bazel 0.27.0 strategies do not need to be explicitly
-# defined. See https://github.com/bazelbuild/bazel/issues/7480
-build:remote --define=EXECUTOR=remote
-
-# Enable remote execution so actions are performed on the remote systems.
-build:remote --remote_executor=grpcs://remotebuildexecution.googleapis.com
+build:remote --jobs=50
 
 # Enforce stricter environment rules, which eliminates some non-hermetic
 # behavior and therefore improves both the remote cache hit rate and the
 # correctness and repeatability of the build.
 build:remote --incompatible_strict_action_env=true
 
-# Set a higher timeout value, just in case.
-build:remote --remote_timeout=3600
-
-# Enable caching.
-build:remote --remote_cache=remotebuildexecution.googleapis.com
-
-# Enable authentication. This will pick up application default credentials by
-# default. You can use --google_credentials=some_file.json to use a service
-# account credential instead.
-build:remote --google_default_credentials=true

--- a/results.bazelrc
+++ b/results.bazelrc
@@ -1,14 +1,6 @@
-# Bazel Results UI
-# See https://cloud.google.com/remote-build-execution/docs/results-ui/result-ui-overview
+# Build Results export for tracking/visualization.
 
-build:results --bes_backend="buildeventservice.googleapis.com"
+build:results --bes_backend=grpcs://halo-cmm.buildbuddy.io
+build:results --bes_results_url=https://halo-cmm.buildbuddy.io/invocation/
 build:results --bes_timeout=60s
-build:results --bes_results_url="https://source.cloud.google.com/results/invocations/"
-
-# Enable remote caching. This is necessary for target details to be accessible.
-build:results --remote_cache=remotebuildexecution.googleapis.com
-
-# Enable authentication. This will pick up application default credentials by
-# default. You can use --google_credentials=some_file.json to use a service
-# account credential instead.
-build:results --google_default_credentials=true
+build:results --nolegacy_important_outputs

--- a/src/main/kotlin/org/wfanet/measurement/eventdataprovider/shareshuffle/BUILD.bazel
+++ b/src/main/kotlin/org/wfanet/measurement/eventdataprovider/shareshuffle/BUILD.bazel
@@ -26,6 +26,9 @@ maven_export(
     name = "native_maven",
     lib_name = "native",
     maven_coordinates = MAVEN_COORDINATES,
-    tags = ["no-javadocs"],
+    tags = [
+        "no-javadocs",
+        "no-remote-cache",
+    ],
     visibility = ["//visibility:private"],
 )

--- a/src/main/kotlin/org/wfanet/measurement/eventdataprovider/shareshuffle/v2alpha/BUILD.bazel
+++ b/src/main/kotlin/org/wfanet/measurement/eventdataprovider/shareshuffle/v2alpha/BUILD.bazel
@@ -31,6 +31,9 @@ maven_export(
     name = "shareshuffle_maven",
     lib_name = "shareshuffle",
     maven_coordinates = MAVEN_COORDINATES,
-    tags = ["no-javadocs"],
+    tags = [
+        "no-javadocs",
+        "no-remote-cache",
+    ],
     visibility = ["//visibility:private"],
 )

--- a/src/main/kotlin/org/wfanet/panelmatch/client/deploy/BUILD.bazel
+++ b/src/main/kotlin/org/wfanet/panelmatch/client/deploy/BUILD.bazel
@@ -47,6 +47,9 @@ maven_export(
     name = "maven",
     lib_name = "deploy",
     maven_coordinates = MAVEN_COORDINATES,
-    tags = ["no-javadocs"],
+    tags = [
+        "no-javadocs",
+        "no-remote-cache",
+    ],
     visibility = ["//visibility:private"],
 )

--- a/src/main/kotlin/org/wfanet/panelmatch/client/testing/BUILD.bazel
+++ b/src/main/kotlin/org/wfanet/panelmatch/client/testing/BUILD.bazel
@@ -46,6 +46,9 @@ maven_export(
     testonly = None,
     lib_name = "testing",
     maven_coordinates = MAVEN_COORDINATES,
-    tags = ["no-javadocs"],
+    tags = [
+        "no-javadocs",
+        "no-remote-cache",
+    ],
     visibility = ["//visibility:private"],
 )

--- a/src/main/proto/wfa/measurement/api/v2alpha/BUILD.bazel
+++ b/src/main/proto/wfa/measurement/api/v2alpha/BUILD.bazel
@@ -142,7 +142,10 @@ maven_export(
     name = "maven",
     lib_name = "api_kt_jvm_proto",
     maven_coordinates = MAVEN_COORDINATES,
-    tags = ["no-javadocs"],
+    tags = [
+        "no-javadocs",
+        "no-remote-cache",
+    ],
     visibility = ["//visibility:private"],
 )
 
@@ -159,6 +162,9 @@ maven_export(
     name = "grpc_maven",
     lib_name = "api_kt_jvm_grpc_proto",
     maven_coordinates = GRPC_MAVEN_COORDINATES,
-    tags = ["no-javadocs"],
+    tags = [
+        "no-javadocs",
+        "no-remote-cache",
+    ],
     visibility = ["//visibility:private"],
 )

--- a/src/test/kotlin/org/wfanet/measurement/duchy/deploy/common/postgres/BUILD.bazel
+++ b/src/test/kotlin/org/wfanet/measurement/duchy/deploy/common/postgres/BUILD.bazel
@@ -3,6 +3,9 @@ load("@wfa_rules_kotlin_jvm//kotlin:defs.bzl", "kt_jvm_test")
 kt_jvm_test(
     name = "DuchySchemaTest",
     srcs = ["DuchySchemaTest.kt"],
+    tags = [
+        "no-remote-exec",
+    ],
     test_class = "org.wfanet.measurement.duchy.deploy.common.postgres.DuchySchemaTest",
     deps = [
         "//src/main/kotlin/org/wfanet/measurement/duchy/deploy/common/postgres/testing",
@@ -15,6 +18,9 @@ kt_jvm_test(
 kt_jvm_test(
     name = "PostgresContinuationTokensServiceTest",
     srcs = ["PostgresContinuationTokensServiceTest.kt"],
+    tags = [
+        "no-remote-exec",
+    ],
     test_class = "org.wfanet.measurement.duchy.deploy.common.postgres.PostgresContinuationTokensServiceTest",
     deps = [
         "//src/main/kotlin/org/wfanet/measurement/duchy/deploy/common/postgres:services",
@@ -29,6 +35,9 @@ kt_jvm_test(
 kt_jvm_test(
     name = "PostgresComputationStatsServiceTest",
     srcs = ["PostgresComputationStatsServiceTest.kt"],
+    tags = [
+        "no-remote-exec",
+    ],
     test_class = "org.wfanet.measurement.duchy.deploy.common.postgres.PostgresComputationStatsServiceTest",
     deps = [
         "//src/main/kotlin/org/wfanet/measurement/duchy/db/computation/testing",
@@ -46,6 +55,9 @@ kt_jvm_test(
 kt_jvm_test(
     name = "PostgresComputationsServiceTest",
     srcs = ["PostgresComputationsServiceTest.kt"],
+    tags = [
+        "no-remote-exec",
+    ],
     test_class = "org.wfanet.measurement.duchy.deploy.common.postgres.PostgresComputationsServiceTest",
     deps = [
         "//src/main/kotlin/org/wfanet/measurement/duchy/db/computation/testing",

--- a/src/test/kotlin/org/wfanet/measurement/eventdataprovider/privacybudgetmanagement/deploy/common/postgres/BUILD.bazel
+++ b/src/test/kotlin/org/wfanet/measurement/eventdataprovider/privacybudgetmanagement/deploy/common/postgres/BUILD.bazel
@@ -5,6 +5,9 @@ kt_jvm_test(
     srcs = [
         "PrivacyBudgetPostgresSchemaTest.kt",
     ],
+    tags = [
+        "no-remote-exec",
+    ],
     test_class = "org.wfanet.measurement.eventdataprovider.privacybudgetmanagement.deploy.common.postgres.PrivacyBudgetPostgresSchemaTest",
     runtime_deps = ["@wfa_common_jvm//imports/java/org/postgresql:j2dbc"],
     deps = [
@@ -19,6 +22,9 @@ kt_jvm_test(
 kt_jvm_test(
     name = "PostgresBackingStoreTest",
     srcs = ["PostgresBackingStoreTest.kt"],
+    tags = [
+        "no-remote-exec",
+    ],
     test_class = "org.wfanet.measurement.eventdataprovider.privacybudgetmanagement.deploy.common.postgres.PostgresBackingStoreTest",
     runtime_deps = [
         "@wfa_common_jvm//imports/java/org/postgresql:j2dbc",

--- a/src/test/kotlin/org/wfanet/measurement/integration/deploy/common/postgres/BUILD.bazel
+++ b/src/test/kotlin/org/wfanet/measurement/integration/deploy/common/postgres/BUILD.bazel
@@ -3,7 +3,10 @@ load("@wfa_rules_kotlin_jvm//kotlin:defs.bzl", "kt_jvm_test")
 kt_jvm_test(
     name = "PostgresInProcessLifeOfAReportIntegrationTest",
     srcs = ["PostgresInProcessLifeOfAReportIntegrationTest.kt"],
-    tags = ["cpu:2"],
+    tags = [
+        "cpu:2",
+        "no-remote-exec",
+    ],
     test_class = "org.wfanet.measurement.integration.deploy.common.postgres.PostgresInProcessLifeOfAReportIntegrationTest",
     runtime_deps = [
         "@wfa_common_jvm//imports/java/org/yaml:snakeyaml",

--- a/src/test/kotlin/org/wfanet/measurement/integration/deploy/gcloud/BUILD.bazel
+++ b/src/test/kotlin/org/wfanet/measurement/integration/deploy/gcloud/BUILD.bazel
@@ -8,7 +8,10 @@ spanner_emulator_test(
     name = "GCloudInProcessLifeOfAnEventGroupIntegrationTest",
     size = "large",
     srcs = ["GCloudInProcessLifeOfAnEventGroupIntegrationTest.kt"],
-    tags = ["cpu:2"],
+    tags = [
+        "cpu:2",
+        "no-remote-exec",
+    ],
     test_class = "org.wfanet.measurement.integration.deploy.gcloud.GCloudInProcessLifeOfAnEventGroupIntegrationTest",
     deps = [
         "//src/main/kotlin/org/wfanet/measurement/integration/common:in_process_event_group_components",
@@ -32,7 +35,10 @@ kt_jvm_library(
 java_test(
     name = "GCloudSpannerInProcessLifeOfAMeasurementIntegrationTest",
     size = "large",
-    tags = ["cpu:2"],
+    tags = [
+        "cpu:2",
+        "no-remote-exec",
+    ],
     test_class = "org.wfanet.measurement.integration.deploy.gcloud.GCloudSpannerInProcessLifeOfAMeasurementIntegrationTest",
     runtime_deps = [":gcloud_spanner_in_process_life_of_a_measurement_integration_test"],
 )
@@ -55,7 +61,10 @@ java_test(
     size = "large",
     # TODO(world-federation-of-advertisers/cross-media-measurement#827): Remove when flakiness is resolved.
     flaky = True,
-    tags = ["cpu:2"],
+    tags = [
+        "cpu:2",
+        "no-remote-exec",
+    ],
     test_class = "org.wfanet.measurement.integration.deploy.gcloud.GCloudPostgresInProcessLifeOfAMeasurementIntegrationTest",
     runtime_deps = [":gcloud_postgres_in_process_life_of_a_measurement_integration_test"],
 )
@@ -86,7 +95,10 @@ java_test(
     size = "large",
     # TODO(world-federation-of-advertisers/cross-media-measurement#827): Remove when flakiness is resolved.
     flaky = True,
-    tags = ["cpu:2"],
+    tags = [
+        "cpu:2",
+        "no-remote-exec",
+    ],
     test_class = "org.wfanet.measurement.integration.deploy.gcloud.GCloudInProcessLifeOfAReportV2IntegrationTest",
     runtime_deps = [":gcloud_in_process_life_of_a_report_v2_integration_test"],
 )

--- a/src/test/kotlin/org/wfanet/measurement/integration/k8s/BUILD.bazel
+++ b/src/test/kotlin/org/wfanet/measurement/integration/k8s/BUILD.bazel
@@ -125,6 +125,7 @@ java_test(
     tags = [
         "cpu:8",
         "manual",
+        "no-remote-exec",
     ],
     test_class = "org.wfanet.measurement.integration.k8s.EmptyClusterCorrectnessTest",
     runtime_deps = [":empty_cluster_correctness_test"],
@@ -140,6 +141,7 @@ java_test(
         "exclusive",
         "external",
         "manual",
+        "no-remote-exec",
     ],
     test_class = "org.wfanet.measurement.integration.k8s.SyntheticGeneratorCorrectnessTest",
     runtime_deps = [":synthetic_data_generator_correctness_test"],
@@ -156,6 +158,7 @@ java_test(
         "exclusive",
         "external",
         "manual",
+        "no-remote-exec",
     ],
     test_class = "org.wfanet.measurement.integration.k8s.BigQueryCorrectnessTest",
     runtime_deps = [":bigquery_correctness_test"],

--- a/src/test/kotlin/org/wfanet/measurement/reporting/deploy/postgres/BUILD.bazel
+++ b/src/test/kotlin/org/wfanet/measurement/reporting/deploy/postgres/BUILD.bazel
@@ -3,7 +3,10 @@ load("@wfa_rules_kotlin_jvm//kotlin:defs.bzl", "kt_jvm_test")
 kt_jvm_test(
     name = "PostgresMeasurementsServiceTest",
     srcs = ["PostgresMeasurementsServiceTest.kt"],
-    tags = ["cpu:2"],
+    tags = [
+        "cpu:2",
+        "no-remote-exec",
+    ],
     test_class = "org.wfanet.measurement.reporting.deploy.postgres.PostgresMeasurementsServiceTest",
     runtime_deps = [
         "@wfa_common_jvm//imports/java/org/yaml:snakeyaml",
@@ -19,7 +22,10 @@ kt_jvm_test(
 kt_jvm_test(
     name = "PostgresReportingSetsServiceTest",
     srcs = ["PostgresReportingSetsServiceTest.kt"],
-    tags = ["cpu:2"],
+    tags = [
+        "cpu:2",
+        "no-remote-exec",
+    ],
     test_class = "org.wfanet.measurement.reporting.deploy.postgres.PostgresReportingSetsServiceTest",
     runtime_deps = [
         "@wfa_common_jvm//imports/java/org/yaml:snakeyaml",
@@ -35,7 +41,10 @@ kt_jvm_test(
 kt_jvm_test(
     name = "PostgresReportsServiceTest",
     srcs = ["PostgresReportsServiceTest.kt"],
-    tags = ["cpu:2"],
+    tags = [
+        "cpu:2",
+        "no-remote-exec",
+    ],
     test_class = "org.wfanet.measurement.reporting.deploy.postgres.PostgresReportsServiceTest",
     runtime_deps = [
         "@wfa_common_jvm//imports/java/org/yaml:snakeyaml",

--- a/src/test/kotlin/org/wfanet/measurement/reporting/deploy/v2/postgres/BUILD.bazel
+++ b/src/test/kotlin/org/wfanet/measurement/reporting/deploy/v2/postgres/BUILD.bazel
@@ -5,7 +5,10 @@ kt_jvm_test(
     srcs = ["PostgresMeasurementConsumersServiceTest.kt"],
     # TODO(world-federation-of-advertisers/cross-media-measurement#827): Remove when flakiness is resolved.
     flaky = True,
-    tags = ["cpu:2"],
+    tags = [
+        "cpu:2",
+        "no-remote-exec",
+    ],
     test_class = "org.wfanet.measurement.reporting.deploy.v2.postgres.PostgresMeasurementConsumersServiceTest",
     runtime_deps = [
         "@wfa_common_jvm//imports/java/org/yaml:snakeyaml",
@@ -23,7 +26,10 @@ kt_jvm_test(
     srcs = ["PostgresMeasurementsServiceTest.kt"],
     # TODO(world-federation-of-advertisers/cross-media-measurement#827): Remove when flakiness is resolved.
     flaky = True,
-    tags = ["cpu:2"],
+    tags = [
+        "cpu:2",
+        "no-remote-exec",
+    ],
     test_class = "org.wfanet.measurement.reporting.deploy.v2.postgres.PostgresMeasurementsServiceTest",
     runtime_deps = [
         "@wfa_common_jvm//imports/java/org/yaml:snakeyaml",
@@ -41,7 +47,10 @@ kt_jvm_test(
     srcs = ["PostgresMetricsServiceTest.kt"],
     # TODO(world-federation-of-advertisers/cross-media-measurement#827): Remove when flakiness is resolved.
     flaky = True,
-    tags = ["cpu:2"],
+    tags = [
+        "cpu:2",
+        "no-remote-exec",
+    ],
     test_class = "org.wfanet.measurement.reporting.deploy.v2.postgres.PostgresMetricsServiceTest",
     runtime_deps = [
         "@wfa_common_jvm//imports/java/org/yaml:snakeyaml",
@@ -59,7 +68,10 @@ kt_jvm_test(
     srcs = ["PostgresReportingSetsServiceTest.kt"],
     # TODO(world-federation-of-advertisers/cross-media-measurement#827): Remove when flakiness is resolved.
     flaky = True,
-    tags = ["cpu:2"],
+    tags = [
+        "cpu:2",
+        "no-remote-exec",
+    ],
     test_class = "org.wfanet.measurement.reporting.deploy.v2.postgres.PostgresReportingSetsServiceTest",
     runtime_deps = [
         "@wfa_common_jvm//imports/java/org/yaml:snakeyaml",
@@ -77,7 +89,10 @@ kt_jvm_test(
     srcs = ["PostgresReportsServiceTest.kt"],
     # TODO(world-federation-of-advertisers/cross-media-measurement#827): Remove when flakiness is resolved.
     flaky = True,
-    tags = ["cpu:2"],
+    tags = [
+        "cpu:2",
+        "no-remote-exec",
+    ],
     test_class = "org.wfanet.measurement.reporting.deploy.v2.postgres.PostgresReportsServiceTest",
     runtime_deps = [
         "@wfa_common_jvm//imports/java/org/yaml:snakeyaml",
@@ -95,7 +110,10 @@ kt_jvm_test(
     srcs = ["PostgresMetricCalculationSpecsServiceTest.kt"],
     # TODO(world-federation-of-advertisers/cross-media-measurement#827): Remove when flakiness is resolved.
     flaky = True,
-    tags = ["cpu:2"],
+    tags = [
+        "cpu:2",
+        "no-remote-exec",
+    ],
     test_class = "org.wfanet.measurement.reporting.deploy.v2.postgres.PostgresMetricCalculationSpecsServiceTest",
     runtime_deps = [
         "@wfa_common_jvm//imports/java/org/yaml:snakeyaml",
@@ -113,7 +131,10 @@ kt_jvm_test(
     srcs = ["PostgresReportSchedulesServiceTest.kt"],
     # TODO(world-federation-of-advertisers/cross-media-measurement#827): Remove when flakiness is resolved.
     flaky = True,
-    tags = ["cpu:2"],
+    tags = [
+        "cpu:2",
+        "no-remote-exec",
+    ],
     test_class = "org.wfanet.measurement.reporting.deploy.v2.postgres.PostgresReportSchedulesServiceTest",
     runtime_deps = [
         "@wfa_common_jvm//imports/java/org/yaml:snakeyaml",
@@ -131,7 +152,10 @@ kt_jvm_test(
     srcs = ["PostgresReportScheduleIterationsServiceTest.kt"],
     # TODO(world-federation-of-advertisers/cross-media-measurement#827): Remove when flakiness is resolved.
     flaky = True,
-    tags = ["cpu:2"],
+    tags = [
+        "cpu:2",
+        "no-remote-exec",
+    ],
     test_class = "org.wfanet.measurement.reporting.deploy.v2.postgres.PostgresReportScheduleIterationsServiceTest",
     runtime_deps = [
         "@wfa_common_jvm//imports/java/org/yaml:snakeyaml",

--- a/src/test/kotlin/org/wfanet/panelmatch/integration/BUILD.bazel
+++ b/src/test/kotlin/org/wfanet/panelmatch/integration/BUILD.bazel
@@ -5,6 +5,10 @@ spanner_emulator_test(
     size = "small",
     srcs = ["MiniWorkflowTest.kt"],
     resources = ["//src/test/kotlin/org/wfanet/panelmatch/integration/config"],
+    tags = [
+        "cpu:2",
+        "no-remote-exec",
+    ],
     test_class = "org.wfanet.panelmatch.integration.MiniWorkflowTest",
     deps = [
         "//src/main/kotlin/org/wfanet/panelmatch/integration",
@@ -24,6 +28,10 @@ spanner_emulator_test(
         "//src/main/kotlin/org/wfanet/panelmatch/integration/fixtures/shared",
     ],
     resources = ["//src/test/kotlin/org/wfanet/panelmatch/integration/config"],
+    tags = [
+        "cpu:2",
+        "no-remote-exec",
+    ],
     test_class = "org.wfanet.panelmatch.integration.SingleStepTest",
     deps = [
         "//src/main/kotlin/org/wfanet/panelmatch/integration",
@@ -38,6 +46,10 @@ spanner_emulator_test(
     size = "small",
     srcs = ["DoubleBlindWorkflowTest.kt"],
     resources = ["//src/test/kotlin/org/wfanet/panelmatch/integration/config"],
+    tags = [
+        "cpu:2",
+        "no-remote-exec",
+    ],
     test_class = "org.wfanet.panelmatch.integration.DoubleBlindWorkflowTest",
     deps = [
         "//src/main/kotlin/org/wfanet/panelmatch/integration",
@@ -53,6 +65,10 @@ spanner_emulator_test(
     size = "medium",
     srcs = ["FullWorkflowTest.kt"],
     resources = ["//src/test/kotlin/org/wfanet/panelmatch/integration/config"],
+    tags = [
+        "cpu:2",
+        "no-remote-exec",
+    ],
     test_class = "org.wfanet.panelmatch.integration.FullWorkflowTest",
     deps = [
         "//src/main/kotlin/org/wfanet/panelmatch/client/common",
@@ -74,6 +90,10 @@ spanner_emulator_test(
     size = "medium",
     srcs = ["FullWithPreprocessingTest.kt"],
     resources = ["//src/test/kotlin/org/wfanet/panelmatch/integration/config"],
+    tags = [
+        "cpu:2",
+        "no-remote-exec",
+    ],
     test_class = "org.wfanet.panelmatch.integration.FullWithPreprocessingTest",
     deps = [
         "//src/main/kotlin/org/wfanet/panelmatch/client/common",

--- a/src/test/kotlin/org/wfanet/panelmatch/integration/k8s/BUILD.bazel
+++ b/src/test/kotlin/org/wfanet/panelmatch/integration/k8s/BUILD.bazel
@@ -79,6 +79,7 @@ java_test(
     tags = [
         "cpu:8",
         "manual",
+        "no-remote-exec",
     ],
     test_class = "org.wfanet.panelmatch.integration.k8s.EmptyClusterPanelMatchCorrectnessTest",
     runtime_deps = [":empty_cluster_panel_match_correctness_test"],


### PR DESCRIPTION
This greatly speeds up builds and provides a detailed UI for results. See https://buildbuddy.io/