### PR TITLE
fix: Shard MeasurementsByContinuationToken index to avoid hotspotting

### DIFF
--- a/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/queries/StreamMeasurements.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/queries/StreamMeasurements.kt
@@ -206,6 +206,11 @@ class StreamMeasurements(
         }
       }
 
+      if (filter.hasAfter() || filter.hasUpdatedAfter()) {
+        // Include shard ID to use sharded index on UpdateTime appropriately.
+        conjuncts.add("MeasurementIndexShardId != -1")
+      }
+
       if (conjuncts.isEmpty()) {
         return
       }

--- a/src/main/resources/kingdom/spanner/changelog.yaml
+++ b/src/main/resources/kingdom/spanner/changelog.yaml
@@ -72,3 +72,6 @@ databaseChangeLog:
 - include:
     file: drop-json-columns.sql
     relativeToChangeLogFile: true
+- include:
+    file: shard-measurements-by-continuation-token.sql
+    relativeToChangeLogFile: true

--- a/src/main/resources/kingdom/spanner/shard-measurements-by-continuation-token.sql
+++ b/src/main/resources/kingdom/spanner/shard-measurements-by-continuation-token.sql
@@ -1,0 +1,36 @@
+-- liquibase formatted sql
+
+-- Copyright 2024 The Cross-Media Measurement Authors
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+-- changeset sanjayvas:21 dbms:cloudspanner
+-- comment: Shard the MeasurementsByContinuationToken index to avoid hotspotting.
+
+START BATCH DDL;
+
+ALTER TABLE Measurements
+ADD COLUMN MeasurementIndexShardId INT64 NOT NULL AS (
+  MOD(FARM_FINGERPRINT(CAST(MeasurementId AS STRING)), 64)
+) STORED;
+
+DROP INDEX MeasurementsByContinuationToken;
+
+CREATE INDEX MeasurementsByContinuationToken ON Measurements(
+  MeasurementIndexShardId,
+  UpdateTime,
+  ExternalComputationId,
+  State
+);
+
+RUN BATCH;


### PR DESCRIPTION
From the [Cloud Spanner documentation on secondary indexes](https://cloud.google.com/spanner/docs/secondary-indexes):

> Be aware that using the commit timestamp column as the first part of the secondary index can create hotspots and reduce write performance.

Sharding is one of the recommendations given for how to avoid hotspotting.