### PR TITLE
ci: Read Spanner processing units from GitHub environment

### DIFF
--- a/.github/workflows/terraform-cmms.yml
+++ b/.github/workflows/terraform-cmms.yml
@@ -77,6 +77,7 @@ jobs:
       env:
         KEY_RING: ${{ vars.KEY_RING }}
         SPANNER_INSTANCE: ${{ vars.SPANNER_INSTANCE }}
+        SPANNER_PROCESSING_UNITS: ${{ vars.SPANNER_PROCESSING_UNITS }}
         STORAGE_BUCKET: ${{ vars.STORAGE_BUCKET }}
         POSTGRES_INSTANCE: ${{ vars.POSTGRES_INSTANCE }}
         POSTGRES_PASSWORD: ${{ secrets.POSTGRES_PASSWORD }}
@@ -86,6 +87,7 @@ jobs:
         -input=false
         -var="key_ring_name=$KEY_RING"
         -var="spanner_instance_name=$SPANNER_INSTANCE"
+        -var="spanner_processing_units=$SPANNER_PROCESSING_UNITS"
         -var="storage_bucket_name=$STORAGE_BUCKET"
         -var="postgres_instance_name=$POSTGRES_INSTANCE"
         -var="postgres_password=$POSTGRES_PASSWORD"

--- a/src/main/terraform/gcloud/examples/duchy/main.tf
+++ b/src/main/terraform/gcloud/examples/duchy/main.tf
@@ -31,10 +31,9 @@ module "common" {
 }
 
 resource "google_spanner_instance" "spanner_instance" {
-  name             = var.spanner_instance_name
-  config           = var.spanner_instance_config
-  display_name     = "Halo CMMS"
-  processing_units = 100
+  name         = var.spanner_instance_name
+  config       = var.spanner_instance_config
+  display_name = "Halo CMMS"
 }
 
 module "storage" {

--- a/src/main/terraform/gcloud/examples/kingdom/main.tf
+++ b/src/main/terraform/gcloud/examples/kingdom/main.tf
@@ -29,10 +29,9 @@ module "common" {
 }
 
 resource "google_spanner_instance" "spanner_instance" {
-  name             = var.spanner_instance_name
-  config           = var.spanner_instance_config
-  display_name     = "Halo CMMS"
-  processing_units = 100
+  name         = var.spanner_instance_name
+  config       = var.spanner_instance_config
+  display_name = "Halo CMMS"
 }
 
 module "kingdom_cluster" {


### PR DESCRIPTION
Different Halo test environments have different Spanner resource needs. For example, the `head` environment tends to have much lower traffic compared to the `qa` environment. Spanner autoscaling only supports whole nodes (multiples of 1000 processing units), whereas some test environments are often idle and do not need a whole node. Spanner nodes are relatively expensive (currently $657/month for the us-central1 region).

This also removes the specification of 100 processing nodes for the example Terraform configuration, as that is far below Spanner recommendations.