### PR TITLE
test: Add per-test timeout to SpannerModelRolloutsServiceTest

### DIFF
--- a/src/test/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/BUILD.bazel
+++ b/src/test/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/BUILD.bazel
@@ -264,6 +264,7 @@ spanner_emulator_test(
         "//src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner:services",
         "//src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/testing",
         "//src/main/kotlin/org/wfanet/measurement/kingdom/service/internal/testing",
+        "@wfa_common_jvm//imports/kotlin/kotlinx/coroutines/debug",
     ],
 )
 

--- a/src/test/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/SpannerModelRolloutsServiceTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/SpannerModelRolloutsServiceTest.kt
@@ -17,6 +17,7 @@
 package org.wfanet.measurement.kingdom.deploy.gcloud.spanner
 
 import java.time.Clock
+import kotlinx.coroutines.debug.junit4.CoroutinesTimeout
 import org.junit.Rule
 import org.wfanet.measurement.common.identity.IdGenerator
 import org.wfanet.measurement.gcloud.spanner.testing.SpannerEmulatorDatabaseRule
@@ -24,8 +25,9 @@ import org.wfanet.measurement.kingdom.deploy.gcloud.spanner.testing.Schemata
 import org.wfanet.measurement.kingdom.service.internal.testing.ModelRolloutsServiceTest
 
 class SpannerModelRolloutsServiceTest : ModelRolloutsServiceTest<SpannerModelRolloutsService>() {
-
   @get:Rule val spannerDatabase = SpannerEmulatorDatabaseRule(Schemata.KINGDOM_CHANGELOG_PATH)
+
+  @get:Rule val timeout = CoroutinesTimeout.seconds(10)
 
   override fun newServices(
     testClock: Clock,


### PR DESCRIPTION
This test is flaky in such a way that the failures cause the test to hang indefinitely. This change at least allows it to fail faster.

See #1368