### PR TITLE
ci: Update aquasecurity/trivy-action to 0.28.0

### DIFF
--- a/.github/workflows/scan-images.yml
+++ b/.github/workflows/scan-images.yml
@@ -94,7 +94,7 @@ jobs:
         run:
           echo "path=${IMAGE//\//_}.sarif" >> $GITHUB_OUTPUT
       - name: Run Trivy image scanner
-        uses: aquasecurity/trivy-action@0.19.0
+        uses: aquasecurity/trivy-action@0.28.0
         with:
           image-ref: ${{ inputs.container-registry }}/${{ inputs.image-repo-prefix }}/${{ matrix.image }}:${{ inputs.image-tag }}
           format: sarif


### PR DESCRIPTION
Newer versions using caching for the vulnerability DB, which should reduce the likelihood of `TOOMANYREQUESTS` errors.