### PR TITLE
fix: Ensure update-cmms workflow can run with ci Bazel configuration

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -84,18 +84,6 @@ jobs:
           build --define bigquery_table=events
           EOF
 
-      - name: Get Bazel cache params
-        id: get-cache-params
-        run: |
-          repo_cache_path="$(bazel info repository_cache)"
-          echo "repo-cache-path=${repo_cache_path}" >> $GITHUB_OUTPUT
-
-      - name: Restore repository cache
-        uses: actions/cache/restore@v4
-        with:
-          path: ${{ steps.get-cache-params.outputs.repo-cache-path }}
-          key: ${{ vars.BAZEL_REPO_CACHE_KEY }}
-
       - name: Check lockfile
         run: bazel mod deps
 
@@ -104,13 +92,6 @@ jobs:
           bazel build --worker_quit_after_build
           //...
           //src/main/k8s/dev:synthetic_generator_edp_simulators
-
-      - name: Save repository cache
-        uses: actions/cache/save@v4
-        continue-on-error: true
-        with:
-          path: ${{ steps.get-cache-params.outputs.repo-cache-path }}
-          key: ${{ vars.BAZEL_REPO_CACHE_KEY }}
 
       - name: Run tests
         id: run-tests

--- a/.github/workflows/configure-aws-duchy.yml
+++ b/.github/workflows/configure-aws-duchy.yml
@@ -112,6 +112,7 @@ jobs:
       run: |
         cat << EOF > ~/.bazelrc
         common --config=ci
+        build --remote_download_outputs=toplevel  # Need build output.
         common --config=ghcr
         build --define image_tag=$IMAGE_TAG
         build --define kingdom_system_api_target=$KINGDOM_SYSTEM_API_TARGET

--- a/.github/workflows/configure-duchy.yml
+++ b/.github/workflows/configure-duchy.yml
@@ -109,6 +109,7 @@ jobs:
       run: |
         cat << EOF > ~/.bazelrc
         common --config=ci
+        build --remote_download_outputs=toplevel  # Need build output.
         common --config=ghcr
         build --define image_tag=$IMAGE_TAG
         build --define google_cloud_project=$GCLOUD_PROJECT

--- a/.github/workflows/configure-kingdom.yml
+++ b/.github/workflows/configure-kingdom.yml
@@ -83,6 +83,7 @@ jobs:
         run: |
           cat << EOF > ~/.bazelrc
           common --config=ci
+          build --remote_download_outputs=toplevel  # Need build output.
           common --config=ghcr
           build --define "image_tag=$IMAGE_TAG"
           build --define "google_cloud_project=$GCLOUD_PROJECT"

--- a/.github/workflows/configure-reporting-v2.yml
+++ b/.github/workflows/configure-reporting-v2.yml
@@ -85,6 +85,7 @@ jobs:
       run: |
         cat << EOF > ~/.bazelrc
         common --config=ci
+        build --remote_download_outputs=toplevel  # Need build output.
         common --config=ghcr
         build --define "image_tag=$IMAGE_TAG"
         build --define "google_cloud_project=$GCLOUD_PROJECT"

--- a/.github/workflows/configure-reporting.yml
+++ b/.github/workflows/configure-reporting.yml
@@ -85,6 +85,7 @@ jobs:
       run: |
         cat << EOF > ~/.bazelrc
         common --config=ci
+        build --remote_download_outputs=toplevel  # Need build output.
         common --config=ghcr
         build --define "image_tag=$IMAGE_TAG"
         build --define "google_cloud_project=$GCLOUD_PROJECT"

--- a/.github/workflows/configure-simulators.yml
+++ b/.github/workflows/configure-simulators.yml
@@ -98,6 +98,7 @@ jobs:
       run: |
         cat << EOF > ~/.bazelrc
         common --config=ci
+        build --remote_download_outputs=toplevel  # Need build output.
         common --config=ghcr
         build --define "image_tag=$IMAGE_TAG"
         build --define "google_cloud_project=$GCLOUD_PROJECT"

--- a/.github/workflows/maybe-push-images.yml
+++ b/.github/workflows/maybe-push-images.yml
@@ -51,5 +51,6 @@ jobs:
     uses: ./.github/workflows/push-images.yml
     if: inputs.existing-image-tag == ''
     needs: [get-image-tag]
+    secrets: inherit
     with:
       image-tag: ${{ needs.get-image-tag.outputs.image-tag }}

--- a/.github/workflows/publish-maven-artifacts.yml
+++ b/.github/workflows/publish-maven-artifacts.yml
@@ -64,18 +64,6 @@ jobs:
           common --config=ci
           EOF
 
-      - name: Get Bazel cache params
-        id: get-cache-params
-        run: |
-          repo_cache_path="$(bazelisk info repository_cache)"
-          echo "repo-cache-path=${repo_cache_path}" >> $GITHUB_OUTPUT
-
-      - name: Restore repository cache
-        uses: actions/cache/restore@v4
-        with:
-          path: ${{ steps.get-cache-params.outputs.repo-cache-path }}
-          key: ${{ vars.BAZEL_REPO_CACHE_KEY }}
-
       # Patch MODULE.bazel and MODULE.bazel.lock to specify version.
       # TODO(bazelbuild/bazel#22919): Use alternative mechanism when available.
       - name: Patch module version

--- a/.github/workflows/push-images.yml
+++ b/.github/workflows/push-images.yml
@@ -51,18 +51,6 @@ jobs:
           build --define image_repo_prefix=$GITHUB_REPOSITORY_OWNER
           build --define image_tag=$IMAGE_TAG
           EOF
-      
-      - name: Get Bazel cache params
-        id: get-cache-params
-        run: |
-          repo_cache_path="$(bazelisk info repository_cache)"
-          echo "repo-cache-path=${repo_cache_path}" >> $GITHUB_OUTPUT
-
-      - name: Restore repository cache
-        uses: actions/cache/restore@v4
-        with:
-          path: ${{ steps.get-cache-params.outputs.repo-cache-path }}
-          key: ${{ vars.BAZEL_REPO_CACHE_KEY }}
 
       - name: Authenticate to GitHub Container Registry
         uses: docker/login-action@v3

--- a/.github/workflows/release-test.yml
+++ b/.github/workflows/release-test.yml
@@ -45,18 +45,6 @@ jobs:
         common --config=ci
         EOF
 
-    - name: Get Bazel cache params
-      id: get-cache-params
-      run: |
-        repo_cache_path="$(bazelisk info repository_cache)"
-        echo "repo-cache-path=${repo_cache_path}" >> $GITHUB_OUTPUT
-
-    - name: Restore repository cache
-      uses: actions/cache/restore@v4
-      with:
-        path: ${{ steps.get-cache-params.outputs.repo-cache-path }}
-        key: ${{ vars.BAZEL_REPO_CACHE_KEY }}
-
     - name: Run tests
       id: run-tests
       run: >

--- a/.github/workflows/run-k8s-tests.yml
+++ b/.github/workflows/run-k8s-tests.yml
@@ -63,18 +63,6 @@ jobs:
         test --test_timeout=3600
         EOF
 
-    - name: Get Bazel cache params
-      id: get-cache-params
-      run: |
-        repo_cache_path="$(bazelisk info repository_cache)"
-        echo "repo-cache-path=${repo_cache_path}" >> $GITHUB_OUTPUT
-
-    - name: Restore repository cache
-      uses: actions/cache/restore@v4
-      with:
-        path: ${{ steps.get-cache-params.outputs.repo-cache-path }}
-        key: ${{ vars.BAZEL_REPO_CACHE_KEY }}
-
     - name: Run tests
       id: run-tests
       run: >

--- a/.github/workflows/update-cmms.yml
+++ b/.github/workflows/update-cmms.yml
@@ -53,6 +53,7 @@ on:
 jobs:
   publish-images:
     uses: ./.github/workflows/maybe-push-images.yml
+    secrets: inherit
     with:
       existing-image-tag: ${{ inputs.existing-image-tag }}
 
@@ -75,6 +76,7 @@ jobs:
   update-kingdom:
     uses: ./.github/workflows/configure-kingdom.yml
     needs: [publish-images, terraform]
+    secrets: inherit
     with:
       image-tag: ${{ needs.publish-images.outputs.image-tag }}
       environment: ${{ inputs.environment }}
@@ -83,6 +85,7 @@ jobs:
   update-aggregator-duchy:
     uses: ./.github/workflows/configure-duchy.yml
     needs: [publish-images, terraform]
+    secrets: inherit
     with:
       duchy-name: aggregator
       image-tag: ${{ needs.publish-images.outputs.image-tag }}
@@ -92,6 +95,7 @@ jobs:
   update-worker1-duchy:
     uses: ./.github/workflows/configure-duchy.yml
     needs: [publish-images, terraform]
+    secrets: inherit
     with:
       duchy-name: worker1
       image-tag: ${{ needs.publish-images.outputs.image-tag }}
@@ -101,6 +105,7 @@ jobs:
   update-worker2-duchy:
     uses: ./.github/workflows/configure-aws-duchy.yml
     needs: [publish-images, terraform]
+    secrets: inherit
     with:
       duchy-name: worker2
       image-tag: ${{ needs.publish-images.outputs.image-tag }}
@@ -110,6 +115,7 @@ jobs:
   update-simulators:
     uses: ./.github/workflows/configure-simulators.yml
     needs: [publish-images, terraform]
+    secrets: inherit
     with:
       image-tag: ${{ needs.publish-images.outputs.image-tag }}
       environment: ${{ inputs.environment }}

--- a/src/main/docker/BUILD.bazel
+++ b/src/main/docker/BUILD.bazel
@@ -23,7 +23,10 @@ package(
         registry = IMAGE_REPOSITORY_SETTINGS.container_registry,
         repository = image_spec.repository,
         tag = IMAGE_REPOSITORY_SETTINGS.image_tag,
-        tags = ["manual"],
+        tags = [
+            "manual",
+            "no-remote",
+        ],
     )
     for image_spec in ALL_IMAGES
 ]
@@ -35,7 +38,10 @@ container_push_all(
         registry = IMAGE_REPOSITORY_SETTINGS.container_registry,
         tag = IMAGE_REPOSITORY_SETTINGS.image_tag,
     ): image_spec.image for image_spec in ALL_LOCAL_IMAGES},
-    tags = ["manual"],
+    tags = [
+        "manual",
+        "no-remote",
+    ],
 )
 
 container_push_all(
@@ -45,7 +51,10 @@ container_push_all(
         registry = IMAGE_REPOSITORY_SETTINGS.container_registry,
         tag = IMAGE_REPOSITORY_SETTINGS.image_tag,
     ): image_spec.image for image_spec in ALL_GKE_IMAGES},
-    tags = ["manual"],
+    tags = [
+        "manual",
+        "no-remote",
+    ],
 )
 
 container_push_all(
@@ -55,7 +64,10 @@ container_push_all(
         registry = IMAGE_REPOSITORY_SETTINGS.container_registry,
         tag = IMAGE_REPOSITORY_SETTINGS.image_tag,
     ): image_spec.image for image_spec in ALL_EKS_IMAGES},
-    tags = ["manual"],
+    tags = [
+        "manual",
+        "no-remote",
+    ],
 )
 
 container_push_all(
@@ -65,7 +77,10 @@ container_push_all(
         registry = IMAGE_REPOSITORY_SETTINGS.container_registry,
         tag = IMAGE_REPOSITORY_SETTINGS.image_tag,
     ): image_spec.image for image_spec in ALL_IMAGES if image_spec.name.startswith("kingdom_")},
-    tags = ["manual"],
+    tags = [
+        "manual",
+        "no-remote",
+    ],
 )
 
 container_push_all(
@@ -75,7 +90,10 @@ container_push_all(
         registry = IMAGE_REPOSITORY_SETTINGS.container_registry,
         tag = IMAGE_REPOSITORY_SETTINGS.image_tag,
     ): image_spec.image for image_spec in ALL_IMAGES if image_spec.name.startswith("duchy_")},
-    tags = ["manual"],
+    tags = [
+        "manual",
+        "no-remote",
+    ],
 )
 
 container_push_all(
@@ -85,7 +103,10 @@ container_push_all(
         registry = IMAGE_REPOSITORY_SETTINGS.container_registry,
         tag = IMAGE_REPOSITORY_SETTINGS.image_tag,
     ): image_spec.image for image_spec in ALL_EKS_IMAGES if image_spec.name.startswith("duchy_")},
-    tags = ["manual"],
+    tags = [
+        "manual",
+        "no-remote",
+    ],
 )
 
 container_push_all(
@@ -95,5 +116,8 @@ container_push_all(
         registry = IMAGE_REPOSITORY_SETTINGS.container_registry,
         tag = IMAGE_REPOSITORY_SETTINGS.image_tag,
     ): image_spec.image for image_spec in ALL_REPORTING_GKE_IMAGES},
-    tags = ["manual"],
+    tags = [
+        "manual",
+        "no-remote",
+    ],
 )

--- a/src/main/docker/macros.bzl
+++ b/src/main/docker/macros.bzl
@@ -35,7 +35,6 @@ def java_image(
     This is a replacement for the java_image rule which sets common attrs.
     """
     tags = tags or []
-    tags.append("no-remote-cache")
 
     _java_image(
         name = name,
@@ -43,7 +42,7 @@ def java_image(
         base = base,
         labels = {"org.opencontainers.image.source": MEASUREMENT_SYSTEM_REPO},
         cmd_args = args,
-        tags = tags,
+        tags = tags + ["no-remote-cache"],
         visibility = visibility,
         **kwargs
     )


### PR DESCRIPTION
The `ci` Bazel configuration enables remote execution and caching via BuildBuddy. There was some missing configuration in #1840 which prevents the `update-cmms` workflow from completing successfully.