### PR TITLE
feat: Add new view for retrieving additional log entries

### DIFF
--- a/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/queries/StreamMeasurements.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/queries/StreamMeasurements.kt
@@ -74,7 +74,8 @@ class StreamMeasurements(
 
     private fun getOrderByClause(view: Measurement.View): String {
       return when (view) {
-        Measurement.View.COMPUTATION ->
+        Measurement.View.COMPUTATION,
+        Measurement.View.COMPUTATION_ALTERNATIVE ->
           "ORDER BY Measurements.UpdateTime ASC, ExternalComputationId ASC"
         Measurement.View.DEFAULT ->
           "ORDER BY Measurements.UpdateTime ASC, ExternalMeasurementConsumerId ASC, " +

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/service/internal/testing/MeasurementsServiceTest.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/service/internal/testing/MeasurementsServiceTest.kt
@@ -53,6 +53,7 @@ import org.wfanet.measurement.internal.kingdom.MeasurementConsumer
 import org.wfanet.measurement.internal.kingdom.MeasurementConsumersGrpcKt.MeasurementConsumersCoroutineImplBase
 import org.wfanet.measurement.internal.kingdom.MeasurementKt.resultInfo
 import org.wfanet.measurement.internal.kingdom.MeasurementLogEntriesGrpcKt.MeasurementLogEntriesCoroutineImplBase
+import org.wfanet.measurement.internal.kingdom.MeasurementLogEntryError
 import org.wfanet.measurement.internal.kingdom.MeasurementsGrpcKt.MeasurementsCoroutineImplBase
 import org.wfanet.measurement.internal.kingdom.ProtocolConfig
 import org.wfanet.measurement.internal.kingdom.Requisition
@@ -68,8 +69,11 @@ import org.wfanet.measurement.internal.kingdom.batchGetMeasurementsRequest
 import org.wfanet.measurement.internal.kingdom.cancelMeasurementRequest
 import org.wfanet.measurement.internal.kingdom.computationParticipant
 import org.wfanet.measurement.internal.kingdom.copy
+import org.wfanet.measurement.internal.kingdom.createDuchyMeasurementLogEntryRequest
 import org.wfanet.measurement.internal.kingdom.createMeasurementRequest
 import org.wfanet.measurement.internal.kingdom.deleteMeasurementRequest
+import org.wfanet.measurement.internal.kingdom.duchyMeasurementLogEntryDetails
+import org.wfanet.measurement.internal.kingdom.duchyMeasurementLogEntryStageAttempt
 import org.wfanet.measurement.internal.kingdom.duchyProtocolConfig
 import org.wfanet.measurement.internal.kingdom.getMeasurementByComputationIdRequest
 import org.wfanet.measurement.internal.kingdom.getMeasurementRequest
@@ -78,6 +82,7 @@ import org.wfanet.measurement.internal.kingdom.measurementDetails
 import org.wfanet.measurement.internal.kingdom.measurementKey
 import org.wfanet.measurement.internal.kingdom.measurementLogEntry
 import org.wfanet.measurement.internal.kingdom.measurementLogEntryDetails
+import org.wfanet.measurement.internal.kingdom.measurementLogEntryError
 import org.wfanet.measurement.internal.kingdom.protocolConfig
 import org.wfanet.measurement.internal.kingdom.requisition
 import org.wfanet.measurement.internal.kingdom.requisitionDetails
@@ -1493,6 +1498,114 @@ abstract class MeasurementsServiceTest<T : MeasurementsCoroutineImplBase> {
       .containsExactly(computationMeasurement1, computationMeasurement3)
       .inOrder()
   }
+
+  @Test
+  fun `streamMeasurements with computation view only returns failure log`(): Unit = runBlocking {
+    val measurementConsumer =
+      population.createMeasurementConsumer(measurementConsumersService, accountsService)
+
+    val measurement =
+      measurementsService.createMeasurement(
+        createMeasurementRequest {
+          measurement =
+            MEASUREMENT.copy {
+              externalMeasurementConsumerId = measurementConsumer.externalMeasurementConsumerId
+              externalMeasurementConsumerCertificateId =
+                measurementConsumer.certificate.externalCertificateId
+            }
+        }
+      )
+
+    val stageOne = "stage_one"
+    val stageOneLogEntryRequest = createDuchyMeasurementLogEntryRequest {
+      externalComputationId = measurement.externalComputationId
+      externalDuchyId = DUCHIES.first().externalDuchyId
+      measurementLogEntryDetails = measurementLogEntryDetails { logMessage = "good" }
+      details = duchyMeasurementLogEntryDetails {
+        stageAttempt = duchyMeasurementLogEntryStageAttempt { stageName = stageOne }
+      }
+    }
+    measurementLogEntriesService.createDuchyMeasurementLogEntry(stageOneLogEntryRequest)
+
+    val failureLogEntryRequest = createDuchyMeasurementLogEntryRequest {
+      externalComputationId = measurement.externalComputationId
+      externalDuchyId = DUCHIES.first().externalDuchyId
+      measurementLogEntryDetails = measurementLogEntryDetails {
+        logMessage = "bad"
+        error = measurementLogEntryError { type = MeasurementLogEntryError.Type.TRANSIENT }
+      }
+      details = duchyMeasurementLogEntryDetails {
+        stageAttempt = duchyMeasurementLogEntryStageAttempt { stageName = stageOne }
+      }
+    }
+    measurementLogEntriesService.createDuchyMeasurementLogEntry(failureLogEntryRequest)
+
+    val streamMeasurementsRequest = streamMeasurementsRequest {
+      limit = 2
+      filter = filter {
+        externalMeasurementConsumerId = measurementConsumer.externalMeasurementConsumerId
+      }
+      measurementView = Measurement.View.COMPUTATION
+    }
+
+    val response: List<Measurement> =
+      measurementsService.streamMeasurements(streamMeasurementsRequest).toList()
+
+    assertThat(response.first().logEntriesList).hasSize(0)
+  }
+
+  @Test
+  fun `streamMeasurements with computation alternative view returns log entries`(): Unit =
+    runBlocking {
+      val measurementConsumer =
+        population.createMeasurementConsumer(measurementConsumersService, accountsService)
+
+      val measurement =
+        measurementsService.createMeasurement(
+          createMeasurementRequest {
+            measurement =
+              MEASUREMENT.copy {
+                externalMeasurementConsumerId = measurementConsumer.externalMeasurementConsumerId
+                externalMeasurementConsumerCertificateId =
+                  measurementConsumer.certificate.externalCertificateId
+              }
+          }
+        )
+
+      val stageOne = "stage_one"
+      val stageOneLogEntryRequest = createDuchyMeasurementLogEntryRequest {
+        externalComputationId = measurement.externalComputationId
+        externalDuchyId = DUCHIES[0].externalDuchyId
+        measurementLogEntryDetails = measurementLogEntryDetails { logMessage = "good" }
+        details = duchyMeasurementLogEntryDetails {
+          stageAttempt = duchyMeasurementLogEntryStageAttempt { stageName = stageOne }
+        }
+      }
+      measurementLogEntriesService.createDuchyMeasurementLogEntry(stageOneLogEntryRequest)
+
+      val stageOneLogEntryRequest2 = createDuchyMeasurementLogEntryRequest {
+        externalComputationId = measurement.externalComputationId
+        externalDuchyId = DUCHIES[1].externalDuchyId
+        measurementLogEntryDetails = measurementLogEntryDetails { logMessage = "good" }
+        details = duchyMeasurementLogEntryDetails {
+          stageAttempt = duchyMeasurementLogEntryStageAttempt { stageName = stageOne }
+        }
+      }
+      measurementLogEntriesService.createDuchyMeasurementLogEntry(stageOneLogEntryRequest2)
+
+      val streamMeasurementsRequest = streamMeasurementsRequest {
+        limit = 2
+        filter = filter {
+          externalMeasurementConsumerId = measurementConsumer.externalMeasurementConsumerId
+        }
+        measurementView = Measurement.View.COMPUTATION_ALTERNATIVE
+      }
+
+      val response: List<Measurement> =
+        measurementsService.streamMeasurements(streamMeasurementsRequest).toList()
+
+      assertThat(response.first().logEntriesList).hasSize(2)
+    }
 
   @Test
   fun `streamMeasurements respects limit`(): Unit = runBlocking {

--- a/src/main/proto/wfa/measurement/internal/kingdom/BUILD.bazel
+++ b/src/main/proto/wfa/measurement/internal/kingdom/BUILD.bazel
@@ -466,6 +466,7 @@ proto_library(
     deps = [
         ":certificate_proto",
         ":computation_participant_proto",
+        ":duchy_measurement_log_entry_proto",
         ":measurement_details_proto",
         ":participant_requisition_params_proto",
         ":protocol_config_proto",

--- a/src/main/proto/wfa/measurement/internal/kingdom/measurement.proto
+++ b/src/main/proto/wfa/measurement/internal/kingdom/measurement.proto
@@ -19,6 +19,7 @@ package wfa.measurement.internal.kingdom;
 import "google/protobuf/timestamp.proto";
 import "wfa/measurement/internal/kingdom/certificate.proto";
 import "wfa/measurement/internal/kingdom/computation_participant.proto";
+import "wfa/measurement/internal/kingdom/duchy_measurement_log_entry.proto";
 import "wfa/measurement/internal/kingdom/measurement_details.proto";
 import "wfa/measurement/internal/kingdom/participant_requisition_params.proto";
 import "wfa/measurement/internal/kingdom/protocol_config.proto";
@@ -36,6 +37,11 @@ message Measurement {
     // View for computation, which includes child Requisitions and
     // ComputationParticipants.
     COMPUTATION = 1;
+
+    // Alternative view for computation that includes ComputationParticipants
+    // and additional log entries for ComputationParticipants, but does not
+    // include child Requisitions.
+    COMPUTATION_ALTERNATIVE = 2;
   }
 
   fixed64 external_measurement_consumer_id = 1;
@@ -124,12 +130,17 @@ message Measurement {
 
   // Child ComputationParticipants of this Measurement. Output-only.
   //
-  // Only set for COMPUTATION view.
+  // Only set for COMPUTATION and COMPUTATION_ALTERNATIVE views.
   repeated ComputationParticipant computation_participants = 13;
 
   // Output only. This may be sent on cancel and delete requests to ensure the
   // client has an up-to-date Measurement before proceeding.
   string etag = 14;
+
+  // All log entries across all child ComputationParticipants. Output-only.
+  //
+  // Only set for COMPUTATION_ALTERNATIVE view.
+  repeated DuchyMeasurementLogEntry log_entries = 15;
 }
 
 message Requisition {

--- a/src/main/proto/wfa/measurement/internal/kingdom/measurements_service.proto
+++ b/src/main/proto/wfa/measurement/internal/kingdom/measurements_service.proto
@@ -98,7 +98,8 @@ message StreamMeasurementsRequest {
       oneof key {
         // Key of the `Measurement`, used when view is DEFAULT.
         MeasurementKey measurement = 2;
-        // Computation key of the `Measurement`, used when view is COMPUTATION.
+        // Computation key of the `Measurement`, used when view is COMPUTATION
+        // or COMPUTATION_ALTERNATIVE.
         ComputationKey computation = 3;
       }
     }


### PR DESCRIPTION
feat: Add new view for retrieving additional log entries

Supports [#1805 ](https://github.com/world-federation-of-advertisers/cross-media-measurement/pull/1805)