### PR TITLE
ci: Fix cache path for update-trivy-cache workflow

### DIFF
--- a/.github/workflows/update-trivy-cache.yml
+++ b/.github/workflows/update-trivy-cache.yml
@@ -23,7 +23,7 @@ jobs:
   update-trivy-cache:
     runs-on: ubuntu-latest
     env:
-      TRIVY_CACHE_PATH: .cache/trivy
+      TRIVY_CACHE_PATH: ${{ github.workspace }}/.cache/trivy
     steps:
       - uses: oras-project/setup-oras@v1
 


### PR DESCRIPTION
The GitHub Actions cache version includes the path and does not disambiguate equivalent paths. Therefore the relative path `.cache/trivy-cache` results in a different version than the absolute path `/home/runner/work/cross-media-measurement/cross-media-measurement/.cache/trivy`.

Closes #1891 