### PR TITLE
ci: Set TCP keepalive for Bazel test workflows

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -82,6 +82,10 @@ jobs:
           build --define google_cloud_project=example-project
           EOF
 
+      # Reduce chance of disconnection from the Build Event Service.
+      - name: Set TCP keepalive
+        run: sudo sysctl -w net.ipv4.tcp_keepalive_time=60
+
       - name: Check lockfile
         run: bazel mod deps
 

--- a/.github/workflows/run-k8s-tests.yml
+++ b/.github/workflows/run-k8s-tests.yml
@@ -63,6 +63,10 @@ jobs:
         test --test_timeout=3600
         EOF
 
+    # Reduce chance of disconnection from the Build Event Service.
+    - name: Set TCP keepalive
+      run: sudo sysctl -w net.ipv4.tcp_keepalive_time=60
+
     - name: Run tests
       id: run-tests
       run: >


### PR DESCRIPTION
This should reduce the likelihood of having disconnections from the BuildBuddy Build Event Service (BES).