### PR TITLE
fix: Remove if check for update time filters when adding shard ID clause in StreamMeasurements

### DIFF
--- a/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/queries/StreamMeasurements.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/queries/StreamMeasurements.kt
@@ -206,10 +206,8 @@ class StreamMeasurements(
         }
       }
 
-      if (filter.hasAfter() || filter.hasUpdatedAfter()) {
-        // Include shard ID to use sharded index on UpdateTime appropriately.
-        conjuncts.add("MeasurementIndexShardId != -1")
-      }
+      // Include shard ID to use sharded index on UpdateTime appropriately.
+      conjuncts.add("MeasurementIndexShardId != -1")
 
       if (conjuncts.isEmpty()) {
         return


### PR DESCRIPTION
fix: Remove if check for update time filters when adding shard ID clause in StreamMeasurements

StreamMeasurements always orders results by Update time so the shard ID clause should always be added. [Testing](https://github.com/world-federation-of-advertisers/cross-media-measurement/pull/1805) revealed that with the if check, setting the after field is required for it to work properly.