### PR TITLE
fix: Read all EventGroups from simulators rather than stopping at first page

### DIFF
--- a/src/main/kotlin/org/wfanet/measurement/loadtest/dataprovider/EdpSimulator.kt
+++ b/src/main/kotlin/org/wfanet/measurement/loadtest/dataprovider/EdpSimulator.kt
@@ -36,9 +36,11 @@ import kotlin.math.roundToInt
 import kotlin.random.Random
 import kotlin.random.asJavaRandom
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.asFlow
 import kotlinx.coroutines.flow.emitAll
+import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.withContext
@@ -109,6 +111,9 @@ import org.wfanet.measurement.api.v2alpha.updateEventGroupRequest
 import org.wfanet.measurement.common.Health
 import org.wfanet.measurement.common.ProtoReflection
 import org.wfanet.measurement.common.SettableHealth
+import org.wfanet.measurement.common.api.grpc.ResourceList
+import org.wfanet.measurement.common.api.grpc.flattenConcat
+import org.wfanet.measurement.common.api.grpc.listResources
 import org.wfanet.measurement.common.asBufferedFlow
 import org.wfanet.measurement.common.crypto.authorityKeyIdentifier
 import org.wfanet.measurement.common.crypto.readCertificate
@@ -339,27 +344,29 @@ class EdpSimulator(
    * Returns the first [EventGroup] for this `DataProvider` and [MeasurementConsumer] with
    * [eventGroupReferenceId], or `null` if not found.
    */
+  @OptIn(ExperimentalCoroutinesApi::class) // For `flattenConcat`.
   private suspend fun getEventGroupByReferenceId(eventGroupReferenceId: String): EventGroup? {
-    val response =
-      try {
-        eventGroupsStub.listEventGroups(
-          listEventGroupsRequest {
-            parent = edpData.name
-            filter =
-              ListEventGroupsRequestKt.filter { measurementConsumers += measurementConsumerName }
-            pageSize = Int.MAX_VALUE
+    return eventGroupsStub
+      .listResources { pageToken ->
+        val response =
+          try {
+            listEventGroups(
+              listEventGroupsRequest {
+                parent = edpData.name
+                filter =
+                  ListEventGroupsRequestKt.filter {
+                    measurementConsumers += measurementConsumerName
+                  }
+                this.pageToken = pageToken
+              }
+            )
+          } catch (e: StatusException) {
+            throw Exception("Error listing EventGroups", e)
           }
-        )
-      } catch (e: StatusException) {
-        throw Exception("Error listing EventGroups", e)
+        ResourceList(response.eventGroupsList, response.nextPageToken)
       }
-
-    // TODO(@SanjayVas): Support filtering by reference ID so we don't need to handle multiple pages
-    // of EventGroups.
-    check(response.nextPageToken.isEmpty()) {
-      "Too many EventGroups for ${edpData.name} and $measurementConsumerName"
-    }
-    return response.eventGroupsList.find { it.eventGroupReferenceId == eventGroupReferenceId }
+      .flattenConcat()
+      .firstOrNull { it.eventGroupReferenceId == eventGroupReferenceId }
   }
 
   private suspend fun ensureMetadataDescriptor(

--- a/src/main/kotlin/org/wfanet/measurement/loadtest/measurementconsumer/BUILD.bazel
+++ b/src/main/kotlin/org/wfanet/measurement/loadtest/measurementconsumer/BUILD.bazel
@@ -28,6 +28,7 @@ kt_jvm_library(
         "//src/main/kotlin/org/wfanet/measurement/api/v2alpha:packed_messages",
         "//src/main/kotlin/org/wfanet/measurement/api/v2alpha:resource_key",
         "//src/main/kotlin/org/wfanet/measurement/api/v2alpha/testing",
+        "//src/main/kotlin/org/wfanet/measurement/common/api/grpc:list_resources",
         "//src/main/kotlin/org/wfanet/measurement/common/identity",
         "//src/main/kotlin/org/wfanet/measurement/integration/common:configs",
         "//src/main/kotlin/org/wfanet/measurement/kingdom/service/api/v2alpha:api_key_authentication_server_interceptor",


### PR DESCRIPTION
The MC and EDP simulators were only reading the first page of results from ListEventGroups. This means that in environments with more EventGroups, not all test EventGroups would be read. This is exacerbated by #1916, as the default page size is now smaller.