### PR TITLE
feat: Add flag for specifying the the VID model line

### DIFF
--- a/experimental/reporting-ui/src/main/kotlin/org/wfanet/measurement/reporting/bff/deploy/common/server/ReportingApiServerFlags.kt
+++ b/experimental/reporting-ui/src/main/kotlin/org/wfanet/measurement/reporting/bff/deploy/common/server/ReportingApiServerFlags.kt
@@ -41,7 +41,7 @@ class ReportingApiServerFlags {
   @set:CommandLine.Option(
     names = ["--debug-verbose-grpc-client-logging"],
     description = ["Enables full gRPC request and response logging for outgoing gRPCs"],
-    defaultValue = "false"
+    defaultValue = "false",
   )
   var debugVerboseGrpcClientLogging by Delegates.notNull<Boolean>()
     private set

--- a/src/main/kotlin/org/wfanet/measurement/integration/common/reporting/v2/InProcessReportingServer.kt
+++ b/src/main/kotlin/org/wfanet/measurement/integration/common/reporting/v2/InProcessReportingServer.kt
@@ -219,10 +219,12 @@ class InProcessReportingServer(
                 SecureRandom().asKotlinRandom(),
                 signingPrivateKeyDir,
                 trustedCertificates,
-                Duration.ofMinutes(60),
-                Duration.ofMinutes(60),
-                Dispatchers.IO,
-                Dispatchers.Default,
+                defaultVidModelLine = "",
+                measurementConsumerModelLines = mapOf(),
+                certificateCacheExpirationDuration = Duration.ofMinutes(60),
+                dataProviderCacheExpirationDuration = Duration.ofMinutes(60),
+                keyReaderContext = Dispatchers.IO,
+                cacheLoaderContext = Dispatchers.Default,
               )
               .withMetadataPrincipalIdentities(measurementConsumerConfigs),
             ReportingSetsService(internalReportingSetsClient)

--- a/src/main/kotlin/org/wfanet/measurement/reporting/deploy/v2/common/ReportingApiServerFlags.kt
+++ b/src/main/kotlin/org/wfanet/measurement/reporting/deploy/v2/common/ReportingApiServerFlags.kt
@@ -44,4 +44,26 @@ class ReportingApiServerFlags {
   )
   lateinit var eventGroupMetadataDescriptorCacheDuration: Duration
     private set
+
+  @CommandLine.Option(
+    names = ["--default-vid-model-line"],
+    description = ["The default VID model line to be used by EDPs when fulfilling requisitions."],
+    defaultValue = "",
+    required = false,
+  )
+  lateinit var defaultVidModelLine: String
+    private set
+
+  @CommandLine.Option(
+    names = ["--measurement-consumer-model-lines"],
+    description =
+      [
+        "A map of measurement consumer names to model lines. This map indicates which model line " +
+          "to use each measurement consumer. Entries in this map override the default."
+      ],
+    defaultValue = "",
+    required = false,
+  )
+  lateinit var measurementConsumerModelLines: Map<String, String>
+    private set
 }

--- a/src/main/kotlin/org/wfanet/measurement/reporting/deploy/v2/common/ReportingApiServerFlags.kt
+++ b/src/main/kotlin/org/wfanet/measurement/reporting/deploy/v2/common/ReportingApiServerFlags.kt
@@ -55,11 +55,12 @@ class ReportingApiServerFlags {
     private set
 
   @CommandLine.Option(
-    names = ["--measurement-consumer-model-lines"],
+    names = ["--measurement-consumer-model-line"],
     description =
       [
-        "A map of measurement consumer names to model lines. This map indicates which model line " +
-          "to use each measurement consumer. Entries in this map override the default."
+        "Key-value pair of MeasurementConsumer resource name and VID ModelLine resource name. " +
+          "This can be specified multiple times. Entries in this map override the default VID " +
+          "ModelLine."
       ],
     defaultValue = "",
     required = false,

--- a/src/main/kotlin/org/wfanet/measurement/reporting/deploy/v2/common/ReportingApiServerFlags.kt
+++ b/src/main/kotlin/org/wfanet/measurement/reporting/deploy/v2/common/ReportingApiServerFlags.kt
@@ -45,6 +45,8 @@ class ReportingApiServerFlags {
   lateinit var eventGroupMetadataDescriptorCacheDuration: Duration
     private set
 
+  // TODO(world-federation-of-advertisers/cross-media-measurement#1937): Remove these flags as
+  // part of determining a better way to set the model line.
   @CommandLine.Option(
     names = ["--default-vid-model-line"],
     description = ["The default VID model line to be used by EDPs when fulfilling requisitions."],

--- a/src/main/kotlin/org/wfanet/measurement/reporting/deploy/v2/common/ReportingApiServerFlags.kt
+++ b/src/main/kotlin/org/wfanet/measurement/reporting/deploy/v2/common/ReportingApiServerFlags.kt
@@ -66,6 +66,6 @@ class ReportingApiServerFlags {
       ],
     required = false,
   )
-  lateinit var measurementConsumerModelLines: Map<String, String>
+  var measurementConsumerModelLines: Map<String, String> = emptyMap()
     private set
 }

--- a/src/main/kotlin/org/wfanet/measurement/reporting/deploy/v2/common/ReportingApiServerFlags.kt
+++ b/src/main/kotlin/org/wfanet/measurement/reporting/deploy/v2/common/ReportingApiServerFlags.kt
@@ -64,7 +64,6 @@ class ReportingApiServerFlags {
           "This can be specified multiple times. Entries in this map override the default VID " +
           "ModelLine."
       ],
-    defaultValue = "",
     required = false,
   )
   lateinit var measurementConsumerModelLines: Map<String, String>

--- a/src/main/kotlin/org/wfanet/measurement/reporting/deploy/v2/common/ReportingApiServerFlags.kt
+++ b/src/main/kotlin/org/wfanet/measurement/reporting/deploy/v2/common/ReportingApiServerFlags.kt
@@ -46,7 +46,7 @@ class ReportingApiServerFlags {
     private set
 
   // TODO(world-federation-of-advertisers/cross-media-measurement#1937): Remove these flags as
-  // part of determining a better way to set the model line.
+  // part of determining a better way to set the model line when the VID Model Repo is adopted.
   @CommandLine.Option(
     names = ["--default-vid-model-line"],
     description = ["The default VID model line to be used by EDPs when fulfilling requisitions."],

--- a/src/main/kotlin/org/wfanet/measurement/reporting/deploy/v2/common/job/ReportSchedulingJobExecutor.kt
+++ b/src/main/kotlin/org/wfanet/measurement/reporting/deploy/v2/common/job/ReportSchedulingJobExecutor.kt
@@ -125,10 +125,10 @@ private fun run(
       commonServerFlags.tlsFlags.signingCerts.trustedCertificates,
       defaultVidModelLine = "",
       measurementConsumerModelLines = mapOf(),
-      Duration.ofMinutes(60),
-      Duration.ofMinutes(60),
-      Dispatchers.IO,
-      Dispatchers.Default,
+      certificateCacheExpirationDuration = Duration.ofMinutes(60),
+      dataProviderCacheExpirationDuration = Duration.ofMinutes(60),
+      keyReaderContext = Dispatchers.IO,
+      cacheLoaderContext = Dispatchers.Default,
     )
 
   val inProcessMetricsServerName = InProcessServerBuilder.generateName()

--- a/src/main/kotlin/org/wfanet/measurement/reporting/deploy/v2/common/job/ReportSchedulingJobExecutor.kt
+++ b/src/main/kotlin/org/wfanet/measurement/reporting/deploy/v2/common/job/ReportSchedulingJobExecutor.kt
@@ -123,6 +123,8 @@ private fun run(
       SecureRandom().asKotlinRandom(),
       v2AlphaFlags.signingPrivateKeyStoreDir,
       commonServerFlags.tlsFlags.signingCerts.trustedCertificates,
+      defaultVidModelLine = "",
+      measurementConsumerModelLines = mapOf(),
       Duration.ofMinutes(60),
       Duration.ofMinutes(60),
       Dispatchers.IO,

--- a/src/main/kotlin/org/wfanet/measurement/reporting/deploy/v2/common/server/V2AlphaPublicApiServer.kt
+++ b/src/main/kotlin/org/wfanet/measurement/reporting/deploy/v2/common/server/V2AlphaPublicApiServer.kt
@@ -196,6 +196,8 @@ private object V2AlphaPublicApiServer {
         SecureRandom().asKotlinRandom(),
         v2AlphaFlags.signingPrivateKeyStoreDir,
         commonServerFlags.tlsFlags.signingCerts.trustedCertificates,
+        reportingApiServerFlags.defaultVidModelLine,
+        reportingApiServerFlags.measurementConsumerModelLines,
         certificateCacheExpirationDuration =
           v2AlphaPublicServerFlags.certificateCacheExpirationDuration,
         dataProviderCacheExpirationDuration =

--- a/src/main/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/MetricsService.kt
+++ b/src/main/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/MetricsService.kt
@@ -543,7 +543,7 @@ class MetricsService(
               "Unset metric type should've already raised error."
             }
         }
-        // TODO(@jojijac0b): Finish support for modelLine
+        // TODO(@jojijac0b): Complete support for VID Model Line
         modelLine =
           measurementConsumerModelLines.getOrDefault(measurementConsumerName, defaultModelLine)
       }

--- a/src/test/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/MetricsServiceTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/MetricsServiceTest.kt
@@ -490,6 +490,10 @@ private val ENCRYPTION_KEY_PAIR_STORE =
     )
   )
 
+private val DEFAULT_VID_MODEL_LINE = "the-model-line"
+private val MEASUREMENT_CONSUMER_MODEL_LINES =
+  mapOf<String, String>(MEASUREMENT_CONSUMERS.values.first().name to "mc-model-line")
+
 private val DATA_PROVIDER_PUBLIC_KEY = encryptionPublicKey {
   format = EncryptionPublicKey.Format.TINK_KEYSET
   data = SECRETS_DIR.resolve("edp1_enc_public.tink").readByteString()
@@ -1000,6 +1004,7 @@ private val BASE_MEASUREMENT_SPEC = measurementSpec {
   measurementPublicKey = MEASUREMENT_CONSUMER_PUBLIC_KEY.pack()
   // TODO(world-federation-of-advertisers/cross-media-measurement#1301): Stop setting this field.
   serializedMeasurementPublicKey = measurementPublicKey.value
+  modelLine = MEASUREMENT_CONSUMER_MODEL_LINES[MEASUREMENT_CONSUMERS.values.first().name]!!
 }
 
 // CMMS incremental reach measurements
@@ -2449,6 +2454,8 @@ class MetricsServiceTest {
         listOf(AGGREGATOR_ROOT_CERTIFICATE, DATA_PROVIDER_ROOT_CERTIFICATE).associateBy {
           it.subjectKeyIdentifier!!
         },
+        DEFAULT_VID_MODEL_LINE,
+        MEASUREMENT_CONSUMER_MODEL_LINES,
       )
   }
 

--- a/src/test/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/MetricsServiceTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/MetricsServiceTest.kt
@@ -2478,7 +2478,7 @@ class MetricsServiceTest {
           it.subjectKeyIdentifier!!
         },
         DEFAULT_VID_MODEL_LINE,
-        mapOf<String, String>(),
+        measurementConsumerModelLines = mapOf<String, String>(),
       )
   }
 


### PR DESCRIPTION
Support VID Model Line rollout using Reporting Server flags. Two flags are added:

–default-vid-model-line=<String>
Specifies the VID model line value to be used for the “model_line” field in MeasurementSpec This in turn determines what VID model line that EDPs will use to fulfill Requisitions. If empty EDPs must agree offline what the default is. Once enabled we encourage that this case become an error.

–measurement-consumer-vid-model-line=Map<String, String>
A map of MC names to model lines. When a Metric is created, if the Metric is for an MC present in this map, then the model line provided as the value will be used for the  “model_line” field in MeasurementSpec.