### PR TITLE
ci: Mark webpack_bundle target as no-remote-exec

### DIFF
--- a/experimental/reporting-ui/src/main/react/reporting-ui/BUILD.bazel
+++ b/experimental/reporting-ui/src/main/react/reporting-ui/BUILD.bazel
@@ -70,6 +70,9 @@ webpack_bundle(
     ],
     node_modules = "//:node_modules",
     output_dir = True,
+    tags = [
+        "no-remote-exec",
+    ],
     webpack_config = ":webpack_config",
     deps = [
         ":node_deps",


### PR DESCRIPTION
This target can fail when built remotely, e.g. using BuildBuddy.