### PR TITLE
fix: Drop unused UpdatePrincipal method and rename repeated field

### DIFF
--- a/src/main/proto/wfa/measurement/access/v1alpha/principals_service.proto
+++ b/src/main/proto/wfa/measurement/access/v1alpha/principals_service.proto
@@ -38,14 +38,6 @@ service Principals {
     option (google.api.method_signature) = "principal,principal_id";
   }
 
-  // Updates a `Principal`.
-  //
-  // (-- api-linter: core::0134::method-signature=disabled
-  //     aip.dev/not-precedent: Partial update not supported. --)
-  rpc UpdatePrincipal(UpdatePrincipalRequest) returns (Principal) {
-    option (google.api.method_signature) = "principal";
-  }
-
   // Deletes a `Principal`.
   //
   // This will also remove the `Principal` from all `Policy` bindings.
@@ -76,20 +68,6 @@ message CreatePrincipalRequest {
   // This must confirm to RFC-1034 with the following exceptions:
   // * IDs are case-sensitive.
   string principal_id = 2 [(google.api.field_behavior) = REQUIRED];
-}
-
-// Request message for the `UpdatePrincipal` method.
-//
-// `Principal` identity types cannot be changed. This means that a user
-// `Principal` cannot be updated to a TLS client `Principal`, or vice-versa.
-//
-// (-- api-linter: core::0134::request-mask-required=disabled
-//     aip.dev/not-precedent: Partial update not supported. --)
-message UpdatePrincipalRequest {
-  // Resource to update.
-  //
-  // The `name` field is used to identify the resource.
-  Principal principal = 1 [(google.api.field_behavior) = REQUIRED];
 }
 
 // Request message for `DeletePrincipal` method.

--- a/src/main/proto/wfa/measurement/access/v1alpha/role.proto
+++ b/src/main/proto/wfa/measurement/access/v1alpha/role.proto
@@ -45,7 +45,7 @@ message Role {
   //
   // Each of the permissions must have all of the resource types indicated in
   // `resource_type`.
-  repeated string permission = 3 [
+  repeated string permissions = 3 [
     (google.api.field_behavior) = REQUIRED,
     (google.api.field_behavior) = UNORDERED_LIST,
     (google.api.resource_reference).type = "access.halo-cmm.org/Permission"

--- a/src/main/proto/wfa/measurement/internal/access/principals_service.proto
+++ b/src/main/proto/wfa/measurement/internal/access/principals_service.proto
@@ -28,8 +28,6 @@ service Principals {
 
   rpc CreateUserPrincipal(CreateUserPrincipalRequest) returns (Principal);
 
-  rpc UpdateUserPrincipal(UpdateUserPrincipalRequest) returns (Principal);
-
   // Deletes a `Principal`.
   //
   // TLS client principals may not be deleted by this method.
@@ -44,11 +42,6 @@ message GetPrincipalRequest {
 }
 
 message CreateUserPrincipalRequest {
-  string principal_resource_id = 1;
-  Principal.OAuthUser user = 2;
-}
-
-message UpdateUserPrincipalRequest {
   string principal_resource_id = 1;
   Principal.OAuthUser user = 2;
 }


### PR DESCRIPTION
The UpdatePrincipal method does not make sense as all the fields on Principal are immutable.