### PR TITLE
fix: Set --hmss-maximum-concurrency=5 in dev configuration for GKE

### DIFF
--- a/src/main/k8s/dev/duchy_gke.cue
+++ b/src/main/k8s/dev/duchy_gke.cue
@@ -149,6 +149,7 @@ duchy: #SpannerDuchy & {
 		}
 		"mill-job-scheduler-deployment": {
 			_liquidLegionsV2MaxConcurrency: #Llv2MillMaxConcurrency
+			_shareShuffleMaxConcurrency:    #HmssMillMaxConcurrency
 		}
 		"computation-control-server-deployment": {
 			_container: {


### PR DESCRIPTION
This option was intended to be set in #1707, but was missing on the GKE Duchy configuration.