### PR TITLE
Add BUILD_PRIVATE_MEMBERSHIP_QUERIES_STEP to the supported steps when using panel match on Beam.

### DIFF
--- a/src/main/kotlin/org/wfanet/panelmatch/client/tools/BeamJobsMain.kt
+++ b/src/main/kotlin/org/wfanet/panelmatch/client/tools/BeamJobsMain.kt
@@ -208,8 +208,9 @@ class BeamJobsMain : Runnable {
 
     require(
       step.stepCase == ExchangeWorkflow.Step.StepCase.DECRYPT_PRIVATE_MEMBERSHIP_QUERY_RESULTS_STEP
-    ) {
-      "The only step type currently supported is DECRYPT_PRIVATE_MEMBERSHIP_QUERY_RESULTS_STEP"
+      || step.stepCase == ExchangeWorkflow.Step.StepCase.BUILD_PRIVATE_MEMBERSHIP_QUERIES_STEP
+      ) {
+      "The only step types currently supported are DECRYPT_PRIVATE_MEMBERSHIP_QUERY_RESULTS_STEP and BUILD_PRIVATE_MEMBERSHIP_QUERIES_STEP"
     }
 
     val v2AlphaAttemptKey =


### PR DESCRIPTION
Adding the option for running the query building step as a standalone Beam job.