### PR TITLE
fix: Pass spanner_instance var to Reporting v2 GKE deployment

### DIFF
--- a/.github/workflows/configure-reporting-v2.yml
+++ b/.github/workflows/configure-reporting-v2.yml
@@ -79,6 +79,7 @@ jobs:
     - name: Write ~/.bazelrc
       env:
         IMAGE_TAG: ${{ inputs.image-tag }}
+        SPANNER_INSTANCE: ${{ vars.SPANNER_INSTANCE }}
         POSTGRES_INSTANCE: ${{ vars.POSTGRES_INSTANCE }}
         GCLOUD_REGION: ${{ vars.GCLOUD_REGION }}
         KINGDOM_PUBLIC_API_TARGET: ${{ vars.KINGDOM_PUBLIC_API_TARGET }}
@@ -89,6 +90,7 @@ jobs:
         common --config=ghcr
         build --define "image_tag=$IMAGE_TAG"
         build --define "google_cloud_project=$GCLOUD_PROJECT"
+        build --define "spanner_instance=$SPANNER_INSTANCE"
         build --define "postgres_instance=$POSTGRES_INSTANCE"
         build --define "postgres_region=$GCLOUD_REGION"
         build --define "kingdom_public_api_target=$KINGDOM_PUBLIC_API_TARGET"

--- a/src/main/k8s/dev/BUILD.bazel
+++ b/src/main/k8s/dev/BUILD.bazel
@@ -430,6 +430,7 @@ cue_dump(
         "image_tag": IMAGE_REPOSITORY_SETTINGS.image_tag,
         "public_api_address_name": REPORTING_K8S_SETTINGS.public_api_address_name,
         "google_cloud_project": GCLOUD_SETTINGS.project,
+        "spanner_instance": GCLOUD_SETTINGS.spanner_instance,
         "postgres_instance": GCLOUD_SETTINGS.postgres_instance,
         "postgres_region": GCLOUD_SETTINGS.postgres_region,
         "kingdom_public_api_target": KINGDOM_K8S_SETTINGS.public_api_target,


### PR DESCRIPTION
This addresses a build breakage for this target introduced in #1982, causing the nightly build to fail.