### PR TITLE
fix: Ensure that the run-tests job depends on the update-reporting-v2 job

### DIFF
--- a/.github/workflows/update-cmms.yml
+++ b/.github/workflows/update-cmms.yml
@@ -141,6 +141,7 @@ jobs:
       update-worker1-duchy,
       update-worker2-duchy,
       update-simulators,
+      update-reporting-v2,
     ]
     uses: ./.github/workflows/run-k8s-tests.yml
     secrets: inherit


### PR DESCRIPTION
The K8s tests now cover the Reporting system, so the test job should wait for it to be updated.