### PR TITLE
fix: Increase Reporting cluster resources for Access

### DIFF
--- a/src/main/terraform/gcloud/cmms/reporting_v2.tf
+++ b/src/main/terraform/gcloud/cmms/reporting_v2.tf
@@ -27,8 +27,8 @@ module "reporting_v2_default_node_pool" {
   name            = "default"
   cluster         = module.reporting_v2_cluster.cluster
   service_account = module.common.cluster_service_account
-  machine_type    = "e2-small"
-  max_node_count  = 8
+  machine_type    = "e2-custom-2-4096"
+  max_node_count  = 4
 }
 
 module "reporting_v2" {

--- a/src/main/terraform/gcloud/examples/reporting/main.tf
+++ b/src/main/terraform/gcloud/examples/reporting/main.tf
@@ -85,8 +85,8 @@ module "default_node_pool" {
   name            = "default"
   cluster         = module.cluster.cluster
   service_account = module.common.cluster_service_account
-  machine_type    = "e2-small"
-  max_node_count  = 8
+  machine_type    = "e2-custom-2-4096"
+  max_node_count  = 4
 }
 
 module "reporting" {


### PR DESCRIPTION
As of #1982, Access is deployed in the Reporting cluster. This requires additional machine resources.