### PR TITLE
fix: Add missing reporting_root.pem to Reporting secret

### DIFF
--- a/src/main/k8s/testing/secretfiles/reporting_secrets_kustomization.yaml
+++ b/src/main/k8s/testing/secretfiles/reporting_secrets_kustomization.yaml
@@ -18,6 +18,7 @@ secretGenerator:
   - all_root_certs.pem
   - reporting_tls.key
   - reporting_tls.pem
+  - reporting_root.pem
   - mc_enc_public.tink
   - mc_enc_private.tink
   - mc_cs_private.der


### PR DESCRIPTION
This was missed in #1982