### PR TITLE
fix: Integration tests support fractional sampling widths.

### DIFF
--- a/src/main/kotlin/org/wfanet/measurement/integration/common/reporting/v2/InProcessLifeOfAReportIntegrationTest.kt
+++ b/src/main/kotlin/org/wfanet/measurement/integration/common/reporting/v2/InProcessLifeOfAReportIntegrationTest.kt
@@ -1720,11 +1720,13 @@ abstract class InProcessLifeOfAReportIntegrationTest(
   }
 
   private fun calculateExpectedReachMeasurementResult(
-    eventGroupSpecs: Iterable<EventQuery.EventGroupSpec>,
+    eventGroupSpecs: Iterable<EventQuery.EventGroupSpec>
   ): Measurement.Result {
     val reach =
       MeasurementResults.computeReach(
-        eventGroupSpecs.asSequence().flatMap { SYNTHETIC_EVENT_QUERY.getUserVirtualIds(it) }
+        eventGroupSpecs
+          .asSequence()
+          .flatMap { SYNTHETIC_EVENT_QUERY.getUserVirtualIds(it) }
           .asIterable()
       )
     return MeasurementKt.result {
@@ -1738,7 +1740,9 @@ abstract class InProcessLifeOfAReportIntegrationTest(
   ): Measurement.Result {
     val reachAndFrequency =
       MeasurementResults.computeReachAndFrequency(
-        eventGroupSpecs.asSequence().flatMap { SYNTHETIC_EVENT_QUERY.getUserVirtualIds(it) }
+        eventGroupSpecs
+          .asSequence()
+          .flatMap { SYNTHETIC_EVENT_QUERY.getUserVirtualIds(it) }
           .asIterable(),
         maxFrequency,
       )
@@ -1759,7 +1763,9 @@ abstract class InProcessLifeOfAReportIntegrationTest(
   ): Measurement.Result {
     val impression =
       MeasurementResults.computeImpression(
-        eventGroupSpecs.asSequence().flatMap { SYNTHETIC_EVENT_QUERY.getUserVirtualIds(it) }
+        eventGroupSpecs
+          .asSequence()
+          .flatMap { SYNTHETIC_EVENT_QUERY.getUserVirtualIds(it) }
           .asIterable(),
         maxFrequency,
       )

--- a/src/main/kotlin/org/wfanet/measurement/integration/common/reporting/v2/InProcessLifeOfAReportIntegrationTest.kt
+++ b/src/main/kotlin/org/wfanet/measurement/integration/common/reporting/v2/InProcessLifeOfAReportIntegrationTest.kt
@@ -73,7 +73,6 @@ import org.wfanet.measurement.integration.common.InProcessDuchy
 import org.wfanet.measurement.integration.common.SyntheticGenerationSpecs
 import org.wfanet.measurement.integration.common.reporting.v2.identity.withPrincipalName
 import org.wfanet.measurement.kingdom.deploy.common.service.DataServices
-import org.wfanet.measurement.loadtest.common.sampleVids
 import org.wfanet.measurement.loadtest.config.VidSampling
 import org.wfanet.measurement.loadtest.dataprovider.EventQuery
 import org.wfanet.measurement.loadtest.dataprovider.MeasurementResults
@@ -1725,7 +1724,7 @@ abstract class InProcessLifeOfAReportIntegrationTest(
   ): Measurement.Result {
     val reach =
       MeasurementResults.computeReach(
-        sampleVids(eventGroupSpecs, FULL_VID_SAMPLING_INTERVAL).asIterable()
+        eventGroupSpecs.asSequence().flatMap { eventQuery.getUserVirtualIds(it) }.asIterable()
       )
     return MeasurementKt.result {
       this.reach = MeasurementKt.ResultKt.reach { value = reach.toLong() }
@@ -1738,7 +1737,7 @@ abstract class InProcessLifeOfAReportIntegrationTest(
   ): Measurement.Result {
     val reachAndFrequency =
       MeasurementResults.computeReachAndFrequency(
-        sampleVids(eventGroupSpecs, FULL_VID_SAMPLING_INTERVAL).asIterable(),
+        eventGroupSpecs.asSequence().flatMap { eventQuery.getUserVirtualIds(it) }.asIterable(),
         maxFrequency,
       )
     return MeasurementKt.result {
@@ -1758,7 +1757,7 @@ abstract class InProcessLifeOfAReportIntegrationTest(
   ): Measurement.Result {
     val impression =
       MeasurementResults.computeImpression(
-        sampleVids(eventGroupSpecs, FULL_VID_SAMPLING_INTERVAL).asIterable(),
+        eventGroupSpecs.asSequence().flatMap { eventQuery.getUserVirtualIds(it) }.asIterable(),
         maxFrequency,
       )
     return MeasurementKt.result {
@@ -1816,19 +1815,6 @@ abstract class InProcessLifeOfAReportIntegrationTest(
         },
       )
     )
-  }
-
-  private fun sampleVids(
-    eventGroupSpecs: Iterable<EventQuery.EventGroupSpec>,
-    vidSamplingInterval: VidSamplingInterval,
-  ): Sequence<Long> {
-    return sampleVids(
-        SYNTHETIC_EVENT_QUERY,
-        eventGroupSpecs,
-        vidSamplingInterval.start,
-        vidSamplingInterval.width,
-      )
-      .asSequence()
   }
 
   private fun Sequence<Long>.calculateSampledVids(
@@ -1895,12 +1881,6 @@ abstract class InProcessLifeOfAReportIntegrationTest(
       MetricSpecKt.vidSamplingInterval {
         start = 0.0f
         width = 0.9f
-      }
-
-    private val FULL_VID_SAMPLING_INTERVAL =
-      MetricSpecKt.vidSamplingInterval {
-        start = 0.0f
-        width = 1.0f
       }
 
     // For a 99.9% Confidence Interval.

--- a/src/main/kotlin/org/wfanet/measurement/integration/common/reporting/v2/InProcessLifeOfAReportIntegrationTest.kt
+++ b/src/main/kotlin/org/wfanet/measurement/integration/common/reporting/v2/InProcessLifeOfAReportIntegrationTest.kt
@@ -16,6 +16,8 @@
 
 package org.wfanet.measurement.integration.common.reporting.v2
 
+import com.google.common.truth.Truth.assertThat
+import com.google.common.truth.extensions.proto.ProtoTruth.assertThat
 import com.google.protobuf.timestamp
 import com.google.type.Interval
 import com.google.type.date

--- a/src/main/kotlin/org/wfanet/measurement/integration/common/reporting/v2/InProcessLifeOfAReportIntegrationTest.kt
+++ b/src/main/kotlin/org/wfanet/measurement/integration/common/reporting/v2/InProcessLifeOfAReportIntegrationTest.kt
@@ -1720,11 +1720,12 @@ abstract class InProcessLifeOfAReportIntegrationTest(
   }
 
   private fun calculateExpectedReachMeasurementResult(
-    eventGroupSpecs: Iterable<EventQuery.EventGroupSpec>
+    eventGroupSpecs: Iterable<EventQuery.EventGroupSpec>,
   ): Measurement.Result {
     val reach =
       MeasurementResults.computeReach(
-        eventGroupSpecs.asSequence().flatMap { eventQuery.getUserVirtualIds(it) }.asIterable()
+        eventGroupSpecs.asSequence().flatMap { SYNTHETIC_EVENT_QUERY.getUserVirtualIds(it) }
+          .asIterable()
       )
     return MeasurementKt.result {
       this.reach = MeasurementKt.ResultKt.reach { value = reach.toLong() }
@@ -1737,7 +1738,8 @@ abstract class InProcessLifeOfAReportIntegrationTest(
   ): Measurement.Result {
     val reachAndFrequency =
       MeasurementResults.computeReachAndFrequency(
-        eventGroupSpecs.asSequence().flatMap { eventQuery.getUserVirtualIds(it) }.asIterable(),
+        eventGroupSpecs.asSequence().flatMap { SYNTHETIC_EVENT_QUERY.getUserVirtualIds(it) }
+          .asIterable(),
         maxFrequency,
       )
     return MeasurementKt.result {
@@ -1757,7 +1759,8 @@ abstract class InProcessLifeOfAReportIntegrationTest(
   ): Measurement.Result {
     val impression =
       MeasurementResults.computeImpression(
-        eventGroupSpecs.asSequence().flatMap { eventQuery.getUserVirtualIds(it) }.asIterable(),
+        eventGroupSpecs.asSequence().flatMap { SYNTHETIC_EVENT_QUERY.getUserVirtualIds(it) }
+          .asIterable(),
         maxFrequency,
       )
     return MeasurementKt.result {

--- a/src/main/kotlin/org/wfanet/measurement/integration/common/reporting/v2/InProcessLifeOfAReportIntegrationTest.kt
+++ b/src/main/kotlin/org/wfanet/measurement/integration/common/reporting/v2/InProcessLifeOfAReportIntegrationTest.kt
@@ -16,8 +16,6 @@
 
 package org.wfanet.measurement.integration.common.reporting.v2
 
-import com.google.common.truth.Truth.assertThat
-import com.google.common.truth.extensions.proto.ProtoTruth.assertThat
 import com.google.protobuf.timestamp
 import com.google.type.Interval
 import com.google.type.date
@@ -369,12 +367,7 @@ abstract class InProcessLifeOfAReportIntegrationTest(
       eventGroupEntries.map { (eventGroup, filter) ->
         buildEventGroupSpec(eventGroup, filter, EVENT_RANGE.toInterval())
       }
-    val sampledVids =
-      sampleVids(
-        eventGroupSpecs,
-        createdMetricCalculationSpec.metricSpecsList.single().vidSamplingInterval,
-      )
-    val expectedResult = calculateExpectedReachMeasurementResult(sampledVids)
+    val expectedResult = calculateExpectedReachMeasurementResult(eventGroupSpecs)
 
     val reachResult =
       retrievedReport.metricCalculationResultsList
@@ -494,12 +487,7 @@ abstract class InProcessLifeOfAReportIntegrationTest(
         "person.age_group == ${Person.Gender.FEMALE_VALUE}"
     val eventGroupSpecs: Iterable<EventQuery.EventGroupSpec> =
       listOf(buildEventGroupSpec(eventGroup, equivalentFilter, EVENT_RANGE.toInterval()))
-    val sampledVids =
-      sampleVids(
-        eventGroupSpecs,
-        createdMetricCalculationSpec.metricSpecsList.single().vidSamplingInterval,
-      )
-    val expectedResult = calculateExpectedReachMeasurementResult(sampledVids)
+    val expectedResult = calculateExpectedReachMeasurementResult(eventGroupSpecs)
 
     val reachResult =
       retrievedReport.metricCalculationResultsList
@@ -606,12 +594,7 @@ abstract class InProcessLifeOfAReportIntegrationTest(
       "(${createdPrimitiveReportingSets[0].filter}) && (${createdPrimitiveReportingSets[1].filter})"
     val eventGroupSpecs: Iterable<EventQuery.EventGroupSpec> =
       listOf(buildEventGroupSpec(eventGroup, equivalentFilter, EVENT_RANGE.toInterval()))
-    val sampledVids =
-      sampleVids(
-        eventGroupSpecs,
-        createdMetricCalculationSpec.metricSpecsList.single().vidSamplingInterval,
-      )
-    val expectedResult = calculateExpectedReachMeasurementResult(sampledVids)
+    val expectedResult = calculateExpectedReachMeasurementResult(eventGroupSpecs)
 
     val reachResult =
       retrievedReport.metricCalculationResultsList
@@ -693,12 +676,7 @@ abstract class InProcessLifeOfAReportIntegrationTest(
       eventGroupEntries.map { (eventGroup, filter) ->
         buildEventGroupSpec(eventGroup, filter, EVENT_RANGE.toInterval())
       }
-    val sampledVids =
-      sampleVids(
-        eventGroupSpecs,
-        createdMetricCalculationSpec.metricSpecsList.single().vidSamplingInterval,
-      )
-    val expectedResult = calculateExpectedReachMeasurementResult(sampledVids)
+    val expectedResult = calculateExpectedReachMeasurementResult(eventGroupSpecs)
 
     for (resultAttribute in
       retrievedReport.metricCalculationResultsList.single().resultAttributesList) {
@@ -781,12 +759,7 @@ abstract class InProcessLifeOfAReportIntegrationTest(
         eventGroupEntries.map { (eventGroup, filter) ->
           buildEventGroupSpec(eventGroup, filter, resultAttribute.timeInterval)
         }
-      val sampledVids =
-        sampleVids(
-          eventGroupSpecs,
-          createdMetricCalculationSpec.metricSpecsList.single().vidSamplingInterval,
-        )
-      val expectedResult = calculateExpectedReachMeasurementResult(sampledVids)
+      val expectedResult = calculateExpectedReachMeasurementResult(eventGroupSpecs)
 
       assertThat(actualResult).reachValue().isWithin(tolerance).of(expectedResult.reach.value)
     }
@@ -879,12 +852,7 @@ abstract class InProcessLifeOfAReportIntegrationTest(
         eventGroupEntries.map { (eventGroup, filter) ->
           buildEventGroupSpec(eventGroup, filter, resultAttribute.timeInterval)
         }
-      val sampledVids =
-        sampleVids(
-          eventGroupSpecs,
-          createdMetricCalculationSpec.metricSpecsList.single().vidSamplingInterval,
-        )
-      val expectedResult = calculateExpectedReachMeasurementResult(sampledVids)
+      val expectedResult = calculateExpectedReachMeasurementResult(eventGroupSpecs)
 
       assertThat(actualResult).reachValue().isWithin(tolerance).of(expectedResult.reach.value)
     }
@@ -1082,12 +1050,7 @@ abstract class InProcessLifeOfAReportIntegrationTest(
               .joinToString(" && ")
           buildEventGroupSpec(eventGroup, allFilters, EVENT_RANGE.toInterval())
         }
-      val sampledVids =
-        sampleVids(
-          eventGroupSpecs,
-          createdMetricCalculationSpec.metricSpecsList.single().vidSamplingInterval,
-        )
-      val expectedResult = calculateExpectedReachMeasurementResult(sampledVids)
+      val expectedResult = calculateExpectedReachMeasurementResult(eventGroupSpecs)
 
       assertThat(actualResult).reachValue().isWithin(tolerance).of(expectedResult.reach.value)
     }
@@ -1222,8 +1185,7 @@ abstract class InProcessLifeOfAReportIntegrationTest(
       eventGroupEntries.map { (eventGroup, filter) ->
         buildEventGroupSpec(eventGroup, filter, EVENT_RANGE.toInterval())
       }
-    val sampledVids = sampleVids(eventGroupSpecs, metric.metricSpec.vidSamplingInterval)
-    val expectedResult = calculateExpectedReachMeasurementResult(sampledVids)
+    val expectedResult = calculateExpectedReachMeasurementResult(eventGroupSpecs)
 
     val reachResult = retrievedMetric.result.reach
     val actualResult =
@@ -1282,12 +1244,7 @@ abstract class InProcessLifeOfAReportIntegrationTest(
       eventGroupEntries.map { (eventGroup, filter) ->
         buildEventGroupSpec(eventGroup, filter, EVENT_RANGE.toInterval())
       }
-    val sampledVids =
-      sampleVids(
-        eventGroupSpecs,
-        metric.metricSpec.reach.singleDataProviderParams.vidSamplingInterval,
-      )
-    val expectedResult = calculateExpectedReachMeasurementResult(sampledVids)
+    val expectedResult = calculateExpectedReachMeasurementResult(eventGroupSpecs)
 
     val reachResult = retrievedMetric.result.reach
     val actualResult =
@@ -1340,10 +1297,9 @@ abstract class InProcessLifeOfAReportIntegrationTest(
       eventGroupEntries.map { (eventGroup, filter) ->
         buildEventGroupSpec(eventGroup, filter, EVENT_RANGE.toInterval())
       }
-    val sampledVids = sampleVids(eventGroupSpecs, metric.metricSpec.vidSamplingInterval)
     val expectedResult =
       calculateExpectedReachAndFrequencyMeasurementResult(
-        sampledVids,
+        eventGroupSpecs,
         metric.metricSpec.reachAndFrequency.maximumFrequency,
       )
 
@@ -1413,10 +1369,9 @@ abstract class InProcessLifeOfAReportIntegrationTest(
       eventGroupEntries.map { (eventGroup, filter) ->
         buildEventGroupSpec(eventGroup, filter, EVENT_RANGE.toInterval())
       }
-    val sampledVids = sampleVids(eventGroupSpecs, metric.metricSpec.vidSamplingInterval)
     val expectedResult =
       calculateExpectedImpressionMeasurementResult(
-        sampledVids,
+        eventGroupSpecs,
         metric.metricSpec.impressionCount.maximumFrequencyPerUser,
       )
 
@@ -1513,8 +1468,7 @@ abstract class InProcessLifeOfAReportIntegrationTest(
           (metric.filtersList + filter).filter { it.isNotBlank() }.joinToString(" && ")
         buildEventGroupSpec(eventGroup, allFilters, EVENT_RANGE.toInterval())
       }
-    val sampledVids = sampleVids(eventGroupSpecs, metric.metricSpec.vidSamplingInterval)
-    val expectedResult = calculateExpectedReachMeasurementResult(sampledVids)
+    val expectedResult = calculateExpectedReachMeasurementResult(eventGroupSpecs)
 
     val reachResult = retrievedMetric.result.reach
     val actualResult =
@@ -1765,20 +1719,26 @@ abstract class InProcessLifeOfAReportIntegrationTest(
   }
 
   private fun calculateExpectedReachMeasurementResult(
-    sampledVids: Sequence<Long>
+    eventGroupSpecs: Iterable<EventQuery.EventGroupSpec>
   ): Measurement.Result {
-    val reach = MeasurementResults.computeReach(sampledVids.asIterable())
+    val reach =
+      MeasurementResults.computeReach(
+        sampleVids(eventGroupSpecs, FULL_VID_SAMPLING_INTERVAL).asIterable()
+      )
     return MeasurementKt.result {
       this.reach = MeasurementKt.ResultKt.reach { value = reach.toLong() }
     }
   }
 
   private fun calculateExpectedReachAndFrequencyMeasurementResult(
-    sampledVids: Sequence<Long>,
+    eventGroupSpecs: Iterable<EventQuery.EventGroupSpec>,
     maxFrequency: Int,
   ): Measurement.Result {
     val reachAndFrequency =
-      MeasurementResults.computeReachAndFrequency(sampledVids.asIterable(), maxFrequency)
+      MeasurementResults.computeReachAndFrequency(
+        sampleVids(eventGroupSpecs, FULL_VID_SAMPLING_INTERVAL).asIterable(),
+        maxFrequency,
+      )
     return MeasurementKt.result {
       reach = MeasurementKt.ResultKt.reach { value = reachAndFrequency.reach.toLong() }
       frequency =
@@ -1791,10 +1751,14 @@ abstract class InProcessLifeOfAReportIntegrationTest(
   }
 
   private fun calculateExpectedImpressionMeasurementResult(
-    sampledVids: Sequence<Long>,
+    eventGroupSpecs: Iterable<EventQuery.EventGroupSpec>,
     maxFrequency: Int,
   ): Measurement.Result {
-    val impression = MeasurementResults.computeImpression(sampledVids.asIterable(), maxFrequency)
+    val impression =
+      MeasurementResults.computeImpression(
+        sampleVids(eventGroupSpecs, FULL_VID_SAMPLING_INTERVAL).asIterable(),
+        maxFrequency,
+      )
     return MeasurementKt.result {
       this.impression = MeasurementKt.ResultKt.impression { value = impression }
     }
@@ -1929,6 +1893,12 @@ abstract class InProcessLifeOfAReportIntegrationTest(
       MetricSpecKt.vidSamplingInterval {
         start = 0.0f
         width = 0.9f
+      }
+
+    private val FULL_VID_SAMPLING_INTERVAL =
+      MetricSpecKt.vidSamplingInterval {
+        start = 0.0f
+        width = 1.0f
       }
 
     // For a 99.9% Confidence Interval.

--- a/src/main/kotlin/org/wfanet/measurement/loadtest/dataprovider/MeasurementResults.kt
+++ b/src/main/kotlin/org/wfanet/measurement/loadtest/dataprovider/MeasurementResults.kt
@@ -29,11 +29,11 @@ object MeasurementResults {
    * Computes reach and frequency using the "deterministic count distinct" methodology and the
    * "deterministic distribution" methodology.
    */
-  fun computeReachAndFrequency(sampledVids: Iterable<Long>, maxFrequency: Int): ReachAndFrequency {
-    val eventsPerVid: Map<Long, Int> = sampledVids.groupingBy { it }.eachCount()
+  fun computeReachAndFrequency(filteredVids: Iterable<Long>, maxFrequency: Int): ReachAndFrequency {
+    val eventsPerVid: Map<Long, Int> = filteredVids.groupingBy { it }.eachCount()
     val reach: Int = eventsPerVid.keys.size
 
-    // If the sampled VIDs is empty, set the distribution with all 0s up to maxFrequency.
+    // If the filtered VIDs is empty, set the distribution with all 0s up to maxFrequency.
     if (reach == 0) {
       return ReachAndFrequency(reach, (1..maxFrequency).associateWith { 0.0 })
     }
@@ -51,13 +51,13 @@ object MeasurementResults {
   }
 
   /** Computes reach using the "deterministic count distinct" methodology. */
-  fun computeReach(sampledVids: Iterable<Long>): Int {
-    return sampledVids.distinct().size
+  fun computeReach(filteredVids: Iterable<Long>): Int {
+    return filteredVids.distinct().size
   }
 
   /** Computes impression using the "deterministic count" methodology. */
-  fun computeImpression(sampledVids: Iterable<Long>, maxFrequency: Int): Long {
-    val eventsPerVid: Map<Long, Int> = sampledVids.groupingBy { it }.eachCount()
+  fun computeImpression(filteredVids: Iterable<Long>, maxFrequency: Int): Long {
+    val eventsPerVid: Map<Long, Int> = filteredVids.groupingBy { it }.eachCount()
     // Cap each count at `maxFrequency`.
     return eventsPerVid.values.sumOf { count -> count.coerceAtMost(maxFrequency).toLong() }
   }

--- a/src/main/kotlin/org/wfanet/measurement/loadtest/measurementconsumer/MeasurementConsumerSimulator.kt
+++ b/src/main/kotlin/org/wfanet/measurement/loadtest/measurementconsumer/MeasurementConsumerSimulator.kt
@@ -196,7 +196,7 @@ class MeasurementConsumerSimulator(
     val noiseMechanism: NoiseMechanism,
   )
 
-  private val MeasurementInfo.sampledVids: Sequence<Long>
+  private val MeasurementInfo.filteredVids: Sequence<Long>
     get() {
       val eventGroupSpecs =
         requisitions
@@ -208,7 +208,7 @@ class MeasurementConsumerSimulator(
             }
           }
           .asIterable()
-      return sampleVids(eventGroupSpecs, measurementSpec.vidSamplingInterval)
+      return sampleVids(eventGroupSpecs, FULL_VID_SAMPLING_INTERVAL)
     }
 
   private fun MeasurementInfo.sampleVidsByDataProvider(
@@ -1123,14 +1123,14 @@ class MeasurementConsumerSimulator(
   }
 
   private fun getExpectedReachResult(measurementInfo: MeasurementInfo): Result {
-    val reach = MeasurementResults.computeReach(measurementInfo.sampledVids.asIterable())
+    val reach = MeasurementResults.computeReach(measurementInfo.filteredVids.asIterable())
     return result { this.reach = reach { value = reach.toLong() } }
   }
 
   private fun getExpectedReachAndFrequencyResult(measurementInfo: MeasurementInfo): Result {
     val (reach, relativeFrequencyDistribution) =
       MeasurementResults.computeReachAndFrequency(
-        measurementInfo.sampledVids.asIterable(),
+        measurementInfo.filteredVids.asIterable(),
         measurementInfo.measurementSpec.reachAndFrequency.maximumFrequency,
       )
     return result {
@@ -1163,7 +1163,7 @@ class MeasurementConsumerSimulator(
       reach = MeasurementSpecKt.reach { privacyParams = outputDpParams }
       vidSamplingInterval = vidSamplingInterval {
         start = 0.0f
-        width = 1.0f
+        width = 0.27f
       }
       this.nonceHashes += nonceHashes
     }
@@ -1182,7 +1182,7 @@ class MeasurementConsumerSimulator(
       }
       vidSamplingInterval = vidSamplingInterval {
         start = 0.0f
-        width = 1.0f
+        width = 0.27f
       }
       this.nonceHashes += nonceHashes
     }
@@ -1197,7 +1197,7 @@ class MeasurementConsumerSimulator(
       reach = MeasurementSpecKt.reach { privacyParams = outputDpParams }
       vidSamplingInterval = vidSamplingInterval {
         start = 0.0f
-        width = 1.0f
+        width = 0.27f
       }
       this.nonceHashes += nonceHashes
     }
@@ -1232,7 +1232,7 @@ class MeasurementConsumerSimulator(
       }
       vidSamplingInterval = vidSamplingInterval {
         start = 0.0f
-        width = 1.0f
+        width = 0.27f
       }
       this.nonceHashes += nonceHashes
     }
@@ -1396,6 +1396,11 @@ class MeasurementConsumerSimulator(
   }
 
   companion object {
+    private val FULL_VID_SAMPLING_INTERVAL = vidSamplingInterval {
+      start = 0.0f
+      width = 1.0f
+    }
+
     private const val DEFAULT_FILTER_EXPRESSION =
       "person.gender == ${Person.Gender.MALE_VALUE} && " +
         "(video_ad.viewed_fraction > 0.25 || video_ad.viewed_fraction == 0.25)"

--- a/src/main/kotlin/org/wfanet/measurement/loadtest/measurementconsumer/MeasurementConsumerSimulator.kt
+++ b/src/main/kotlin/org/wfanet/measurement/loadtest/measurementconsumer/MeasurementConsumerSimulator.kt
@@ -211,7 +211,7 @@ class MeasurementConsumerSimulator(
       return sampleVids(eventGroupSpecs, FULL_VID_SAMPLING_INTERVAL)
     }
 
-  private fun MeasurementInfo.sampleVidsByDataProvider(
+  private fun MeasurementInfo.filterVidsByDataProvider(
     targetDataProviderId: String
   ): Sequence<Long> {
     val eventGroupSpecs =
@@ -229,7 +229,7 @@ class MeasurementConsumerSimulator(
             }
         }
         .asIterable()
-    return sampleVids(eventGroupSpecs, measurementSpec.vidSamplingInterval)
+    return sampleVids(eventGroupSpecs, FULL_VID_SAMPLING_INTERVAL)
   }
 
   private fun sampleVids(
@@ -1072,7 +1072,7 @@ class MeasurementConsumerSimulator(
         MeasurementKt.ResultKt.impression {
           value =
             MeasurementResults.computeImpression(
-              measurementInfo.sampleVidsByDataProvider(targetDataProviderId).asIterable(),
+              measurementInfo.filterVidsByDataProvider(targetDataProviderId).asIterable(),
               measurementInfo.measurementSpec.impression.maximumFrequencyPerUser,
             )
         }

--- a/src/main/kotlin/org/wfanet/measurement/loadtest/measurementconsumer/MeasurementConsumerSimulator.kt
+++ b/src/main/kotlin/org/wfanet/measurement/loadtest/measurementconsumer/MeasurementConsumerSimulator.kt
@@ -114,7 +114,6 @@ import org.wfanet.measurement.consent.client.measurementconsumer.signRequisition
 import org.wfanet.measurement.consent.client.measurementconsumer.verifyResult
 import org.wfanet.measurement.eventdataprovider.eventfiltration.EventFilters
 import org.wfanet.measurement.eventdataprovider.noiser.DpParams as NoiserDpParams
-import org.wfanet.measurement.loadtest.common.sampleVids
 import org.wfanet.measurement.loadtest.config.TestIdentifiers
 import org.wfanet.measurement.loadtest.dataprovider.EventQuery
 import org.wfanet.measurement.loadtest.dataprovider.MeasurementResults

--- a/src/main/kotlin/org/wfanet/measurement/loadtest/measurementconsumer/MeasurementConsumerSimulator.kt
+++ b/src/main/kotlin/org/wfanet/measurement/loadtest/measurementconsumer/MeasurementConsumerSimulator.kt
@@ -207,8 +207,9 @@ class MeasurementConsumerSimulator(
               EventQuery.EventGroupSpec(eventGroup, eventGroupsMap.getValue(eventGroup.name))
             }
           }
-          .asIterable()
-      return sampleVids(eventGroupSpecs, FULL_VID_SAMPLING_INTERVAL)
+          .asSequence()
+
+      return eventGroupSpecs.flatMap { eventQuery.getUserVirtualIds(it) }
     }
 
   private fun MeasurementInfo.filterVidsByDataProvider(
@@ -228,21 +229,8 @@ class MeasurementConsumerSimulator(
               EventQuery.EventGroupSpec(eventGroup, eventGroupsMap.getValue(eventGroup.name))
             }
         }
-        .asIterable()
-    return sampleVids(eventGroupSpecs, FULL_VID_SAMPLING_INTERVAL)
-  }
-
-  private fun sampleVids(
-    eventGroupSpecs: Iterable<EventQuery.EventGroupSpec>,
-    vidSamplingInterval: VidSamplingInterval,
-  ): Sequence<Long> {
-    return sampleVids(
-        eventQuery,
-        eventGroupSpecs,
-        vidSamplingInterval.start,
-        vidSamplingInterval.width,
-      )
-      .asSequence()
+        .asSequence()
+    return eventGroupSpecs.flatMap { eventQuery.getUserVirtualIds(it) }
   }
 
   data class ExecutionResult(
@@ -1396,11 +1384,6 @@ class MeasurementConsumerSimulator(
   }
 
   companion object {
-    private val FULL_VID_SAMPLING_INTERVAL = vidSamplingInterval {
-      start = 0.0f
-      width = 1.0f
-    }
-
     private const val DEFAULT_FILTER_EXPRESSION =
       "person.gender == ${Person.Gender.MALE_VALUE} && " +
         "(video_ad.viewed_fraction > 0.25 || video_ad.viewed_fraction == 0.25)"


### PR DESCRIPTION
In the integration tests, the expected reach and frequency should be calculated from the full set of vids (filtered by the requsition's eventGroupSpecs).