### PR TITLE
fix: Specify K8s ServiceAccount for internal Access Deployment

### DIFF
--- a/src/main/k8s/dev/reporting_v2_gke.cue
+++ b/src/main/k8s/dev/reporting_v2_gke.cue
@@ -87,6 +87,11 @@ reporting: #Reporting & {
 		"reporting-v2alpha-public-api-server": {
 			_container: resources: #PublicServerResourceRequirements
 		}
+		"access-internal-api-server": {
+			spec: template: spec: #ServiceAccountPodSpec & {
+				serviceAccountName: #InternalAccessServerServiceAccount
+			}
+		}
 	}
 
 	services: {


### PR DESCRIPTION
This was missed in #1982.