### PR TITLE
chore: Add new Amazon EDP root cert for Halo QA

### DIFF
--- a/src/main/k8s/testing/secretfiles/amazon_edp_root_old.pem
+++ b/src/main/k8s/testing/secretfiles/amazon_edp_root_old.pem
@@ -19,3 +19,4 @@ k2PWahbYXs7kPLw1XrliEpFpTPob2YIeCPlF3zhSppIGf+bN9/KdvdBDDZQoBx7j
 SFwEm2Xh05Xh0vpgktlw27WdxJAjHx7+jVWBBAvoe0bQM/RaCrY1qKB7/Gf2XOa4
 nG/OMYN+33rx+kyq+g/f3htIhy0BF2V53XyRuG4=
 -----END CERTIFICATE-----
+


### PR DESCRIPTION
After the API resources are updated, the AKID mapping config for Halo QA can be changed.