### PR TITLE
fix: Stop throwing error when random_start in MetricSpecConfig is valid

### DIFF
--- a/src/main/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/MetricSpecDefaults.kt
+++ b/src/main/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/MetricSpecDefaults.kt
@@ -221,8 +221,6 @@ fun MetricSpecConfig.VidSamplingInterval.validate() {
       throw IllegalArgumentException(
         "VidSamplingInterval.RandomStart.width must be greater than 0 and less than or equal to 1."
       )
-    } else {
-      throw IllegalArgumentException("VidSamplingInterval.RandomStart.width is missing.")
     }
   } else {
     throw IllegalArgumentException("VidSamplingInterval.start is missing")

--- a/src/test/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/MetricSpecDefaultsTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/MetricSpecDefaultsTest.kt
@@ -298,6 +298,29 @@ class MetricSpecDefaultsTest {
   }
 
   @Test
+  fun `MetricSpecConfig validate does not throw exception with valid config`() {
+    METRIC_SPEC_CONFIG.validate()
+  }
+
+  @Test
+  fun `MetricSpecConfig validate does not throw exception with valid random start`() {
+    val vidSamplingInterval =
+      MetricSpecConfigKt.vidSamplingInterval {
+        randomStart = MetricSpecConfigKt.VidSamplingIntervalKt.randomStart { width = 0.27F }
+      }
+    val metricSpecConfig =
+      METRIC_SPEC_CONFIG.copy {
+        reachParams =
+          reachParams.copy {
+            multipleDataProviderParams =
+              multipleDataProviderParams.copy { this.vidSamplingInterval = vidSamplingInterval }
+          }
+      }
+
+    metricSpecConfig.validate()
+  }
+
+  @Test
   fun `buildMetricSpec builds a reach metric spec when no field is filled in privacy_params`() {
     val result = LEGACY_EMPTY_REACH_METRIC_SPEC.withDefaults(METRIC_SPEC_CONFIG, randomMock)
     val expected = metricSpec {


### PR DESCRIPTION
Closes #2038 