### PR TITLE
perf: Avoid full table scan of Measurements in Requisitions query

### DIFF
--- a/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/queries/StreamRequisitions.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/queries/StreamRequisitions.kt
@@ -26,13 +26,9 @@ class StreamRequisitions(requestFilter: StreamRequisitionsRequest.Filter, limit:
 
   override val reader =
     RequisitionReader().apply {
-      val orderByClause =
-        "ORDER BY UpdateTime ASC, ExternalDataProviderId ASC, ExternalRequisitionId ASC"
-      this.orderByClause = orderByClause
-
       fillStatementBuilder {
         appendWhereClause(requestFilter)
-        appendClause(orderByClause)
+        appendClause(ORDER_BY_CLAUSE)
         if (limit > 0) {
           appendClause("LIMIT @$LIMIT")
           bind(LIMIT to limit.toLong())
@@ -97,6 +93,9 @@ class StreamRequisitions(requestFilter: StreamRequisitionsRequest.Filter, limit:
   }
 
   companion object {
+    private const val ORDER_BY_CLAUSE =
+      "ORDER BY UpdateTime ASC, ExternalDataProviderId ASC, ExternalRequisitionId ASC"
+
     const val LIMIT = "limit"
     const val EXTERNAL_MEASUREMENT_CONSUMER_ID = "externalMeasurementConsumerId"
     const val EXTERNAL_MEASUREMENT_ID = "externalMeasurementId"


### PR DESCRIPTION
From testing on halo-cmm-dev, we see that ListRequisitions filtering by Measurement State and Requisition State results in a full table scan of the Measurements table. This is the exact call used by EDP simulators once per second.

In addition to making the query itself slow, this can result in locking all Measurement rows. This in turn can result in long lock waits for writes to the Measurements table.