### PR TITLE
perf: Force index when reading Requisition by ExternalComputationId

### DIFF
--- a/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/common/KingdomInternalException.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/common/KingdomInternalException.kt
@@ -410,19 +410,20 @@ class ComputationParticipantNotFoundByMeasurementException(
     get() = emptyMap<String, String>()
 }
 
-open class RequisitionNotFoundException(
+abstract class RequisitionNotFoundException(
   val externalRequisitionId: ExternalId,
-  provideDescription: () -> String = { "Requisition not found" },
-) : KingdomInternalException(ErrorCode.REQUISITION_NOT_FOUND, provideDescription) {
-  override val context
-    get() = mapOf("external_requisition_id" to externalRequisitionId.value.toString())
-}
+  message: String,
+  cause: Throwable?,
+) : KingdomInternalException(ErrorCode.REQUISITION_NOT_FOUND, message, cause)
 
 class RequisitionNotFoundByComputationException(
   val externalComputationId: ExternalId,
   externalRequisitionId: ExternalId,
-  provideDescription: () -> String = { "Requisition not found by Computation" },
-) : RequisitionNotFoundException(externalRequisitionId, provideDescription) {
+  message: String =
+    "Requisition with external Computation ID ${externalComputationId.value} and external " +
+      "Requisition ID ${externalRequisitionId.value} not found",
+  cause: Throwable? = null,
+) : RequisitionNotFoundException(externalRequisitionId, message, cause) {
   override val context
     get() =
       mapOf(
@@ -434,8 +435,11 @@ class RequisitionNotFoundByComputationException(
 class RequisitionNotFoundByDataProviderException(
   val externalDataProviderId: ExternalId,
   externalRequisitionId: ExternalId,
-  provideDescription: () -> String = { "Requisition not found by DataProvider" },
-) : RequisitionNotFoundException(externalRequisitionId, provideDescription) {
+  message: String =
+    "Requisition with external DataProvider ID ${externalDataProviderId.value} and external " +
+      "Requisition ID ${externalRequisitionId.value} not found",
+  cause: Throwable? = null,
+) : RequisitionNotFoundException(externalRequisitionId, message, cause) {
   override val context
     get() =
       mapOf(

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/readers/RequisitionReader.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/readers/RequisitionReader.kt
@@ -16,10 +16,11 @@ package org.wfanet.measurement.kingdom.deploy.gcloud.spanner.readers
 
 import com.google.cloud.spanner.Struct
 import kotlinx.coroutines.flow.singleOrNull
+import org.wfanet.measurement.common.identity.ExternalId
 import org.wfanet.measurement.common.identity.InternalId
 import org.wfanet.measurement.gcloud.spanner.AsyncDatabaseClient
 import org.wfanet.measurement.gcloud.spanner.appendClause
-import org.wfanet.measurement.gcloud.spanner.bind
+import org.wfanet.measurement.gcloud.spanner.to
 import org.wfanet.measurement.internal.kingdom.ComputationParticipantDetails
 import org.wfanet.measurement.internal.kingdom.Measurement
 import org.wfanet.measurement.internal.kingdom.MeasurementDetails
@@ -30,7 +31,8 @@ import org.wfanet.measurement.internal.kingdom.RequisitionKt.parentMeasurement
 import org.wfanet.measurement.internal.kingdom.requisition
 import org.wfanet.measurement.kingdom.deploy.common.DuchyIds
 
-class RequisitionReader : SpannerReader<RequisitionReader.Result>() {
+class RequisitionReader(measurementsIndex: MeasurementsIndex = MeasurementsIndex.NONE) :
+  SpannerReader<RequisitionReader.Result>() {
   data class Result(
     val measurementConsumerId: InternalId,
     val measurementId: InternalId,
@@ -39,8 +41,70 @@ class RequisitionReader : SpannerReader<RequisitionReader.Result>() {
     val measurementDetails: MeasurementDetails,
   )
 
-  override val baseSql: String
-    get() = BASE_SQL
+  enum class MeasurementsIndex(val sql: String) {
+    NONE(""),
+    EXTERNAL_COMPUTATION_ID("@{FORCE_INDEX=MeasurementsByExternalComputationId}"),
+  }
+
+  override val baseSql: String =
+    """
+    @{spanner_emulator.disable_query_null_filtered_index_check=TRUE}
+    SELECT
+      MeasurementConsumerId,
+      MeasurementId,
+      RequisitionId,
+      Requisitions.UpdateTime,
+      ExternalRequisitionId,
+      Requisitions.State AS RequisitionState,
+      FulfillingDuchyId,
+      RequisitionDetails,
+      ExternalMeasurementId,
+      ExternalMeasurementConsumerId,
+      ExternalMeasurementConsumerCertificateId,
+      ExternalComputationId,
+      ExternalDataProviderId,
+      ExternalDataProviderCertificateId,
+      SubjectKeyIdentifier,
+      NotValidBefore,
+      NotValidAfter,
+      RevocationState,
+      CertificateDetails,
+      Measurements.State AS MeasurementState,
+      MeasurementDetails,
+      Measurements.CreateTime,
+      (
+        SELECT
+          COUNT(DataProviderId),
+        FROM
+          Requisitions
+        WHERE
+          Requisitions.MeasurementConsumerId = Measurements.MeasurementConsumerId
+          AND Requisitions.MeasurementId = Measurements.MeasurementId
+      ) AS MeasurementRequisitionCount,
+      ARRAY(
+        SELECT AS STRUCT
+          ComputationParticipants.DuchyId,
+          ComputationParticipants.ParticipantDetails,
+          ExternalDuchyCertificateId
+        FROM
+          ComputationParticipants
+          LEFT JOIN DuchyCertificates USING (DuchyId, CertificateId)
+        WHERE
+          ComputationParticipants.MeasurementConsumerId = Requisitions.MeasurementConsumerId
+          AND ComputationParticipants.MeasurementId = Requisitions.MeasurementId
+      ) AS ComputationParticipants
+    FROM
+      Requisitions
+      JOIN DataProviders USING (DataProviderId)
+      JOIN Measurements${measurementsIndex.sql} USING (MeasurementConsumerId, MeasurementId)
+      JOIN MeasurementConsumers USING (MeasurementConsumerId)
+      JOIN MeasurementConsumerCertificates USING (MeasurementConsumerId, CertificateId)
+      JOIN DataProviderCertificates ON (
+        DataProviderCertificates.CertificateId = Requisitions.DataProviderCertificateId
+      )
+      JOIN Certificates ON (Certificates.CertificateId = DataProviderCertificates.CertificateId)
+    """
+      .trimIndent()
 
   override suspend fun translate(struct: Struct): Result {
     return Result(
@@ -52,48 +116,6 @@ class RequisitionReader : SpannerReader<RequisitionReader.Result>() {
     )
   }
 
-  suspend fun readByExternalDataProviderId(
-    readContext: AsyncDatabaseClient.ReadContext,
-    externalDataProviderId: Long,
-    externalRequisitionId: Long,
-  ): Result? {
-    return fillStatementBuilder {
-        appendClause(
-          """
-          WHERE
-            ExternalRequisitionId = @${Params.EXTERNAL_REQUISITION_ID}
-            AND ExternalDataProviderId = @${Params.EXTERNAL_DATA_PROVIDER_ID}
-          """
-            .trimIndent()
-        )
-        bind(Params.EXTERNAL_DATA_PROVIDER_ID to externalDataProviderId)
-        bind(Params.EXTERNAL_REQUISITION_ID to externalRequisitionId)
-      }
-      .execute(readContext)
-      .singleOrNull()
-  }
-
-  suspend fun readByExternalComputationId(
-    readContext: AsyncDatabaseClient.ReadContext,
-    externalComputationId: Long,
-    externalRequisitionId: Long,
-  ): Result? {
-    return fillStatementBuilder {
-        appendClause(
-          """
-          WHERE
-            ExternalComputationId = @${Params.EXTERNAL_COMPUTATION_ID}
-            AND ExternalRequisitionId = @${Params.EXTERNAL_REQUISITION_ID}
-          """
-            .trimIndent()
-        )
-        bind(Params.EXTERNAL_COMPUTATION_ID to externalComputationId)
-        bind(Params.EXTERNAL_REQUISITION_ID to externalRequisitionId)
-      }
-      .execute(readContext)
-      .singleOrNull()
-  }
-
   companion object {
     private object Params {
       const val EXTERNAL_COMPUTATION_ID = "externalComputationId"
@@ -101,65 +123,49 @@ class RequisitionReader : SpannerReader<RequisitionReader.Result>() {
       const val EXTERNAL_REQUISITION_ID = "externalRequisitionId"
     }
 
-    private val BASE_SQL =
-      """
-      @{spanner_emulator.disable_query_null_filtered_index_check=TRUE}
-      SELECT
-        MeasurementConsumerId,
-        MeasurementId,
-        RequisitionId,
-        Requisitions.UpdateTime,
-        ExternalRequisitionId,
-        Requisitions.State AS RequisitionState,
-        FulfillingDuchyId,
-        RequisitionDetails,
-        ExternalMeasurementId,
-        ExternalMeasurementConsumerId,
-        ExternalMeasurementConsumerCertificateId,
-        ExternalComputationId,
-        ExternalDataProviderId,
-        ExternalDataProviderCertificateId,
-        SubjectKeyIdentifier,
-        NotValidBefore,
-        NotValidAfter,
-        RevocationState,
-        CertificateDetails,
-        Measurements.State AS MeasurementState,
-        MeasurementDetails,
-        Measurements.CreateTime,
-        (
-          SELECT
-            COUNT(DataProviderId),
-          FROM
-            Requisitions
-          WHERE
-            Requisitions.MeasurementConsumerId = Measurements.MeasurementConsumerId
-            AND Requisitions.MeasurementId = Measurements.MeasurementId
-        ) AS MeasurementRequisitionCount,
-        ARRAY(
-          SELECT AS STRUCT
-            ComputationParticipants.DuchyId,
-            ComputationParticipants.ParticipantDetails,
-            ExternalDuchyCertificateId
-          FROM
-            ComputationParticipants
-            LEFT JOIN DuchyCertificates USING (DuchyId, CertificateId)
-          WHERE
-            ComputationParticipants.MeasurementConsumerId = Requisitions.MeasurementConsumerId
-            AND ComputationParticipants.MeasurementId = Requisitions.MeasurementId
-        ) AS ComputationParticipants
-      FROM
-        Requisitions
-        JOIN DataProviders USING (DataProviderId)
-        JOIN Measurements USING (MeasurementConsumerId, MeasurementId)
-        JOIN MeasurementConsumers USING (MeasurementConsumerId)
-        JOIN MeasurementConsumerCertificates USING (MeasurementConsumerId, CertificateId)
-        JOIN DataProviderCertificates ON (
-          DataProviderCertificates.CertificateId = Requisitions.DataProviderCertificateId
-        )
-        JOIN Certificates ON (Certificates.CertificateId = DataProviderCertificates.CertificateId)
-      """
-        .trimIndent()
+    suspend fun readByExternalDataProviderId(
+      readContext: AsyncDatabaseClient.ReadContext,
+      externalDataProviderId: ExternalId,
+      externalRequisitionId: ExternalId,
+    ): Result? {
+      return RequisitionReader()
+        .fillStatementBuilder {
+          appendClause(
+            """
+            WHERE
+              ExternalRequisitionId = @${Params.EXTERNAL_REQUISITION_ID}
+              AND ExternalDataProviderId = @${Params.EXTERNAL_DATA_PROVIDER_ID}
+            """
+              .trimIndent()
+          )
+          bind(Params.EXTERNAL_DATA_PROVIDER_ID).to(externalDataProviderId)
+          bind(Params.EXTERNAL_REQUISITION_ID).to(externalRequisitionId)
+        }
+        .execute(readContext)
+        .singleOrNull()
+    }
+
+    suspend fun readByExternalComputationId(
+      readContext: AsyncDatabaseClient.ReadContext,
+      externalComputationId: ExternalId,
+      externalRequisitionId: ExternalId,
+    ): Result? {
+      return RequisitionReader(MeasurementsIndex.EXTERNAL_COMPUTATION_ID)
+        .fillStatementBuilder {
+          appendClause(
+            """
+            WHERE
+              ExternalComputationId = @${Params.EXTERNAL_COMPUTATION_ID}
+              AND ExternalRequisitionId = @${Params.EXTERNAL_REQUISITION_ID}
+            """
+              .trimIndent()
+          )
+          bind(Params.EXTERNAL_COMPUTATION_ID).to(externalComputationId)
+          bind(Params.EXTERNAL_REQUISITION_ID).to(externalRequisitionId)
+        }
+        .execute(readContext)
+        .singleOrNull()
+    }
 
     /** Builds a [Requisition] from [struct]. */
     private fun buildRequisition(struct: Struct): Requisition {
@@ -231,9 +237,11 @@ class RequisitionReader : SpannerReader<RequisitionReader.Result>() {
         ComputationParticipantDetails.ProtocolCase.LIQUID_LEGIONS_V2 -> {
           liquidLegionsV2 = participantDetails.liquidLegionsV2
         }
+
         ComputationParticipantDetails.ProtocolCase.REACH_ONLY_LIQUID_LEGIONS_V2 -> {
           reachOnlyLiquidLegionsV2 = participantDetails.reachOnlyLiquidLegionsV2
         }
+
         ComputationParticipantDetails.ProtocolCase.HONEST_MAJORITY_SHARE_SHUFFLE -> {
           honestMajorityShareShuffle = participantDetails.honestMajorityShareShuffle
         }

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/writers/FulfillRequisition.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/writers/FulfillRequisition.kt
@@ -136,37 +136,29 @@ class FulfillRequisition(private val request: FulfillRequisitionRequest) :
   }
 
   private suspend fun TransactionScope.readRequisition(): RequisitionReader.Result {
-    val externalRequisitionId = request.externalRequisitionId
+    val externalRequisitionId = ExternalId(request.externalRequisitionId)
     if (request.hasComputedParams()) {
-      val externalComputationId = request.computedParams.externalComputationId
-      return RequisitionReader()
-        .readByExternalComputationId(
-          transactionContext,
-          externalComputationId = externalComputationId,
-          externalRequisitionId = externalRequisitionId,
-        )
+      val externalComputationId = ExternalId(request.computedParams.externalComputationId)
+      return RequisitionReader.readByExternalComputationId(
+        transactionContext,
+        externalComputationId = externalComputationId,
+        externalRequisitionId = externalRequisitionId,
+      )
         ?: throw RequisitionNotFoundByComputationException(
-          ExternalId(externalComputationId),
-          ExternalId(externalRequisitionId),
-        ) {
-          "Requisition with external Computation ID $externalComputationId and external " +
-            "Requisition ID $externalRequisitionId not found"
-        }
-    } else {
-      val externalDataProviderId = request.directParams.externalDataProviderId
-      return RequisitionReader()
-        .readByExternalDataProviderId(
-          transactionContext,
-          externalDataProviderId = externalDataProviderId,
-          externalRequisitionId = externalRequisitionId,
+          externalComputationId,
+          externalRequisitionId,
         )
+    } else {
+      val externalDataProviderId = ExternalId(request.directParams.externalDataProviderId)
+      return RequisitionReader.readByExternalDataProviderId(
+        transactionContext,
+        externalDataProviderId = externalDataProviderId,
+        externalRequisitionId = externalRequisitionId,
+      )
         ?: throw RequisitionNotFoundByDataProviderException(
-          ExternalId(externalDataProviderId),
-          ExternalId(externalRequisitionId),
-        ) {
-          "Requisition with external DataProvider ID $externalDataProviderId and external " +
-            "Requisition ID $externalRequisitionId not found"
-        }
+          externalDataProviderId,
+          externalRequisitionId,
+        )
     }
   }
 

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/writers/RefuseRequisition.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/writers/RefuseRequisition.kt
@@ -110,23 +110,17 @@ class RefuseRequisition(private val request: RefuseRequisitionRequest) :
   }
 
   private suspend fun TransactionScope.readRequisition(): RequisitionReader.Result {
-    val externalDataProviderId = request.externalDataProviderId
-    val externalRequisitionId = request.externalRequisitionId
+    val externalDataProviderId = ExternalId(request.externalDataProviderId)
+    val externalRequisitionId = ExternalId(request.externalRequisitionId)
 
-    val readResult: RequisitionReader.Result =
-      RequisitionReader()
-        .readByExternalDataProviderId(
-          transactionContext,
-          externalDataProviderId = externalDataProviderId,
-          externalRequisitionId = externalRequisitionId,
-        )
-        ?: throw RequisitionNotFoundByDataProviderException(
-          ExternalId(externalDataProviderId),
-          ExternalId(externalRequisitionId),
-        ) {
-          "Requisition with external DataProvider ID $externalDataProviderId and external " +
-            "Requisition ID $externalRequisitionId not found"
-        }
-    return readResult
+    return RequisitionReader.readByExternalDataProviderId(
+      transactionContext,
+      externalDataProviderId = externalDataProviderId,
+      externalRequisitionId = externalRequisitionId,
+    )
+      ?: throw RequisitionNotFoundByDataProviderException(
+        externalDataProviderId,
+        externalRequisitionId,
+      )
   }
 }

--- a/src/test/kotlin/org/wfanet/measurement/kingdom/service/api/v2alpha/RequisitionsServiceTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/kingdom/service/api/v2alpha/RequisitionsServiceTest.kt
@@ -1017,7 +1017,7 @@ class RequisitionsServiceTest {
               ExternalId(EXTERNAL_DATA_PROVIDER_ID),
               ExternalId(EXTERNAL_REQUISITION_ID),
             )
-            .asStatusRuntimeException(Status.Code.NOT_FOUND, "Requisition not found.")
+            .asStatusRuntimeException(Status.Code.NOT_FOUND)
         )
     }
     val exception =
@@ -1109,7 +1109,7 @@ class RequisitionsServiceTest {
               ExternalId(EXTERNAL_DATA_PROVIDER_ID),
               ExternalId(EXTERNAL_REQUISITION_ID),
             )
-            .asStatusRuntimeException(Status.Code.NOT_FOUND, "Requisition not found.")
+            .asStatusRuntimeException(Status.Code.NOT_FOUND)
         )
     }
     val exception =


### PR DESCRIPTION
This should avoid a full scan of the Requisitions table when fulfilling a Requisition via a Duchy.