### PR TITLE
Revert "fix: Update population spec converter"

### DIFF
--- a/src/main/kotlin/org/wfanet/measurement/loadtest/dataprovider/BUILD.bazel
+++ b/src/main/kotlin/org/wfanet/measurement/loadtest/dataprovider/BUILD.bazel
@@ -249,7 +249,5 @@ kt_jvm_library(
     deps = [
         "//src/main/proto/wfa/measurement/api/v2alpha:population_spec_kt_jvm_proto",
         "//src/main/proto/wfa/measurement/api/v2alpha/event_group_metadata/testing:simulator_synthetic_data_spec_kt_jvm_proto",
-        "//src/main/proto/wfa/measurement/api/v2alpha/event_templates/testing:test_event_kt_jvm_proto",
-        "@wfa_common_jvm//src/main/kotlin/org/wfanet/measurement/common",
     ],
 )

--- a/src/main/kotlin/org/wfanet/measurement/loadtest/dataprovider/PopulationSpecConverter.kt
+++ b/src/main/kotlin/org/wfanet/measurement/loadtest/dataprovider/PopulationSpecConverter.kt
@@ -20,10 +20,7 @@ import org.wfanet.measurement.api.v2alpha.PopulationSpec
 import org.wfanet.measurement.api.v2alpha.PopulationSpecKt.subPopulation
 import org.wfanet.measurement.api.v2alpha.PopulationSpecKt.vidRange
 import org.wfanet.measurement.api.v2alpha.event_group_metadata.testing.SyntheticPopulationSpec
-import org.wfanet.measurement.api.v2alpha.event_templates.testing.Person
-import org.wfanet.measurement.api.v2alpha.event_templates.testing.person
 import org.wfanet.measurement.api.v2alpha.populationSpec
-import org.wfanet.measurement.common.pack
 
 fun SyntheticPopulationSpec.toPopulationSpec(): PopulationSpec {
   return populationSpec {
@@ -34,23 +31,6 @@ fun SyntheticPopulationSpec.toPopulationSpec(): PopulationSpec {
             startVid = it.vidSubRange.start
             endVidInclusive = (it.vidSubRange.endExclusive - 1)
           }
-          attributes +=
-            person {
-                gender =
-                  Person.Gender.forNumber(
-                    checkNotNull(it.populationFieldsValuesMap["person.gender"]).enumValue
-                  )
-                ageGroup =
-                  Person.AgeGroup.forNumber(
-                    checkNotNull(it.populationFieldsValuesMap["person.age_group"]).enumValue
-                  )
-                socialGradeGroup =
-                  Person.SocialGradeGroup.forNumber(
-                    checkNotNull(it.populationFieldsValuesMap["person.social_grade_group"])
-                      .enumValue
-                  )
-              }
-              .pack()
         }
       }
   }


### PR DESCRIPTION
Reverts world-federation-of-advertisers/cross-media-measurement#2036

This breaks the EDP simulator when using other event templates (i.e. not Halo test templates).