### PR TITLE
chore: Avoid changing individual bytes in SecretData

### DIFF
--- a/src/main/cc/wfa/panelmatch/common/crypto/BUILD.bazel
+++ b/src/main/cc/wfa/panelmatch/common/crypto/BUILD.bazel
@@ -101,9 +101,9 @@ cc_library(
     hdrs = ["random_bytes_key_generator.h"],
     strip_include_prefix = _INCLUDE_PREFIX,
     deps = [
-        "@boringssl//:crypto",
         "@com_google_absl//absl/status",
         "@com_google_absl//absl/status:statusor",
+        "@tink_cc//tink/subtle:random",
         "@tink_cc//tink/util:secret_data",
     ],
 )

--- a/src/main/cc/wfa/panelmatch/common/crypto/random_bytes_key_generator.cc
+++ b/src/main/cc/wfa/panelmatch/common/crypto/random_bytes_key_generator.cc
@@ -15,7 +15,7 @@
 #include "wfa/panelmatch/common/crypto/random_bytes_key_generator.h"
 
 #include "absl/status/statusor.h"
-#include "openssl/rand.h"
+#include "tink/subtle/random.h"
 #include "tink/util/secret_data.h"
 
 namespace wfa::panelmatch::common::crypto {
@@ -27,12 +27,7 @@ absl::StatusOr<SecretData> RandomBytesKeyGenerator::GenerateKey(
   if (size <= 0)
     return absl::InvalidArgumentError("Size must be greater than 0");
 
-  SecretData key;
-  key.resize(size);
-  // In BoringSSL, this call is guaranteed to return 1 so we do not need to
-  // check the return value.
-  RAND_bytes(key.data(), size);
-  return key;
+  return ::crypto::tink::subtle::Random::GetRandomKeyBytes(size);
 }
 
 }  // namespace wfa::panelmatch::common::crypto


### PR DESCRIPTION
This prepares for Tink 3.0.

SecretData will become a container which can only be manipulated in Bulk. See https://github.com/tink-crypto/tink-cc/blob/main/tink/util/secret_data_internal_class.h for the API.

Unfortunately it is a little bit difficult for me as Tink maintainer to deprecate these functions since currently SecretData is an alias for std::vector<uint8_t, SecretAllocator>. This will however change.