### PR TITLE
refactor: Move the new ID Generator out of access and into common

### DIFF
--- a/src/main/kotlin/org/wfanet/measurement/access/deploy/gcloud/spanner/BUILD.bazel
+++ b/src/main/kotlin/org/wfanet/measurement/access/deploy/gcloud/spanner/BUILD.bazel
@@ -16,7 +16,7 @@ kt_jvm_library(
     deps = [
         "//src/main/kotlin/org/wfanet/measurement/access/common:tls_client_principal_mapping",
         "//src/main/kotlin/org/wfanet/measurement/access/deploy/gcloud/spanner/db",
-        "//src/main/kotlin/org/wfanet/measurement/access/service/internal:id_generator",
+        "//src/main/kotlin/org/wfanet/measurement/common:id_generator",
         "//src/main/proto/wfa/measurement/internal/access:principals_service_kt_jvm_grpc_proto",
         "@wfa_common_jvm//src/main/kotlin/org/wfanet/measurement/gcloud/spanner",
     ],
@@ -39,8 +39,8 @@ kt_jvm_library(
     deps = [
         "//src/main/kotlin/org/wfanet/measurement/access/deploy/gcloud/spanner/db",
         "//src/main/kotlin/org/wfanet/measurement/access/service/internal:errors",
-        "//src/main/kotlin/org/wfanet/measurement/access/service/internal:id_generator",
         "//src/main/kotlin/org/wfanet/measurement/access/service/internal:permission_mapping",
+        "//src/main/kotlin/org/wfanet/measurement/common:id_generator",
         "//src/main/kotlin/org/wfanet/measurement/common/api:etags",
         "//src/main/proto/wfa/measurement/internal/access:roles_service_kt_jvm_grpc_proto",
         "@wfa_common_jvm//src/main/kotlin/org/wfanet/measurement/gcloud/spanner",
@@ -53,7 +53,7 @@ kt_jvm_library(
     deps = [
         "//src/main/kotlin/org/wfanet/measurement/access/common:tls_client_principal_mapping",
         "//src/main/kotlin/org/wfanet/measurement/access/deploy/gcloud/spanner/db",
-        "//src/main/kotlin/org/wfanet/measurement/access/service/internal:id_generator",
+        "//src/main/kotlin/org/wfanet/measurement/common:id_generator",
         "//src/main/kotlin/org/wfanet/measurement/common/api:etags",
         "//src/main/proto/wfa/measurement/internal/access:policies_service_kt_jvm_grpc_proto",
         "@wfa_common_jvm//src/main/kotlin/org/wfanet/measurement/gcloud/spanner",

--- a/src/main/kotlin/org/wfanet/measurement/access/deploy/gcloud/spanner/InternalApiServices.kt
+++ b/src/main/kotlin/org/wfanet/measurement/access/deploy/gcloud/spanner/InternalApiServices.kt
@@ -17,9 +17,9 @@
 package org.wfanet.measurement.access.deploy.gcloud.spanner
 
 import org.wfanet.measurement.access.common.TlsClientPrincipalMapping
-import org.wfanet.measurement.access.service.internal.IdGenerator
 import org.wfanet.measurement.access.service.internal.PermissionMapping
 import org.wfanet.measurement.access.service.internal.Services
+import org.wfanet.measurement.common.IdGenerator
 import org.wfanet.measurement.gcloud.spanner.AsyncDatabaseClient
 
 object InternalApiServices {

--- a/src/main/kotlin/org/wfanet/measurement/access/deploy/gcloud/spanner/SpannerPoliciesService.kt
+++ b/src/main/kotlin/org/wfanet/measurement/access/deploy/gcloud/spanner/SpannerPoliciesService.kt
@@ -33,7 +33,6 @@ import org.wfanet.measurement.access.deploy.gcloud.spanner.db.insertPolicyBindin
 import org.wfanet.measurement.access.deploy.gcloud.spanner.db.policyExists
 import org.wfanet.measurement.access.deploy.gcloud.spanner.db.updatePolicy
 import org.wfanet.measurement.access.service.internal.EtagMismatchException
-import org.wfanet.measurement.access.service.internal.IdGenerator
 import org.wfanet.measurement.access.service.internal.PolicyAlreadyExistsException
 import org.wfanet.measurement.access.service.internal.PolicyBindingMembershipAlreadyExistsException
 import org.wfanet.measurement.access.service.internal.PolicyBindingMembershipNotFoundException
@@ -43,7 +42,8 @@ import org.wfanet.measurement.access.service.internal.PrincipalNotFoundException
 import org.wfanet.measurement.access.service.internal.PrincipalTypeNotSupportedException
 import org.wfanet.measurement.access.service.internal.RequiredFieldNotSetException
 import org.wfanet.measurement.access.service.internal.RoleNotFoundException
-import org.wfanet.measurement.access.service.internal.generateNewId
+import org.wfanet.measurement.common.IdGenerator
+import org.wfanet.measurement.common.generateNewId
 import org.wfanet.measurement.common.api.ETags
 import org.wfanet.measurement.common.toInstant
 import org.wfanet.measurement.gcloud.spanner.AsyncDatabaseClient

--- a/src/main/kotlin/org/wfanet/measurement/access/deploy/gcloud/spanner/SpannerPoliciesService.kt
+++ b/src/main/kotlin/org/wfanet/measurement/access/deploy/gcloud/spanner/SpannerPoliciesService.kt
@@ -43,8 +43,8 @@ import org.wfanet.measurement.access.service.internal.PrincipalTypeNotSupportedE
 import org.wfanet.measurement.access.service.internal.RequiredFieldNotSetException
 import org.wfanet.measurement.access.service.internal.RoleNotFoundException
 import org.wfanet.measurement.common.IdGenerator
-import org.wfanet.measurement.common.generateNewId
 import org.wfanet.measurement.common.api.ETags
+import org.wfanet.measurement.common.generateNewId
 import org.wfanet.measurement.common.toInstant
 import org.wfanet.measurement.gcloud.spanner.AsyncDatabaseClient
 import org.wfanet.measurement.internal.access.AddPolicyBindingMembersRequest

--- a/src/main/kotlin/org/wfanet/measurement/access/deploy/gcloud/spanner/SpannerPrincipalsService.kt
+++ b/src/main/kotlin/org/wfanet/measurement/access/deploy/gcloud/spanner/SpannerPrincipalsService.kt
@@ -31,14 +31,14 @@ import org.wfanet.measurement.access.deploy.gcloud.spanner.db.getPrincipalIdByRe
 import org.wfanet.measurement.access.deploy.gcloud.spanner.db.insertPrincipal
 import org.wfanet.measurement.access.deploy.gcloud.spanner.db.insertUserPrincipal
 import org.wfanet.measurement.access.deploy.gcloud.spanner.db.principalExists
-import org.wfanet.measurement.access.service.internal.IdGenerator
 import org.wfanet.measurement.access.service.internal.PrincipalAlreadyExistsException
 import org.wfanet.measurement.access.service.internal.PrincipalNotFoundException
 import org.wfanet.measurement.access.service.internal.PrincipalNotFoundForTlsClientException
 import org.wfanet.measurement.access.service.internal.PrincipalNotFoundForUserException
 import org.wfanet.measurement.access.service.internal.PrincipalTypeNotSupportedException
 import org.wfanet.measurement.access.service.internal.RequiredFieldNotSetException
-import org.wfanet.measurement.access.service.internal.generateNewId
+import org.wfanet.measurement.common.IdGenerator
+import org.wfanet.measurement.common.generateNewId
 import org.wfanet.measurement.gcloud.spanner.AsyncDatabaseClient
 import org.wfanet.measurement.internal.access.CreateUserPrincipalRequest
 import org.wfanet.measurement.internal.access.DeletePrincipalRequest

--- a/src/main/kotlin/org/wfanet/measurement/access/deploy/gcloud/spanner/SpannerRolesService.kt
+++ b/src/main/kotlin/org/wfanet/measurement/access/deploy/gcloud/spanner/SpannerRolesService.kt
@@ -38,7 +38,6 @@ import org.wfanet.measurement.access.deploy.gcloud.spanner.db.readRoles
 import org.wfanet.measurement.access.deploy.gcloud.spanner.db.roleExists
 import org.wfanet.measurement.access.deploy.gcloud.spanner.db.updateRole
 import org.wfanet.measurement.access.service.internal.EtagMismatchException
-import org.wfanet.measurement.common.IdGenerator
 import org.wfanet.measurement.access.service.internal.InvalidFieldValueException
 import org.wfanet.measurement.access.service.internal.PermissionMapping
 import org.wfanet.measurement.access.service.internal.PermissionNotFoundException
@@ -47,8 +46,9 @@ import org.wfanet.measurement.access.service.internal.RequiredFieldNotSetExcepti
 import org.wfanet.measurement.access.service.internal.ResourceTypeNotFoundInPermissionException
 import org.wfanet.measurement.access.service.internal.RoleAlreadyExistsException
 import org.wfanet.measurement.access.service.internal.RoleNotFoundException
-import org.wfanet.measurement.common.generateNewId
+import org.wfanet.measurement.common.IdGenerator
 import org.wfanet.measurement.common.api.ETags
+import org.wfanet.measurement.common.generateNewId
 import org.wfanet.measurement.common.toInstant
 import org.wfanet.measurement.gcloud.spanner.AsyncDatabaseClient
 import org.wfanet.measurement.internal.access.DeleteRoleRequest

--- a/src/main/kotlin/org/wfanet/measurement/access/deploy/gcloud/spanner/SpannerRolesService.kt
+++ b/src/main/kotlin/org/wfanet/measurement/access/deploy/gcloud/spanner/SpannerRolesService.kt
@@ -38,7 +38,7 @@ import org.wfanet.measurement.access.deploy.gcloud.spanner.db.readRoles
 import org.wfanet.measurement.access.deploy.gcloud.spanner.db.roleExists
 import org.wfanet.measurement.access.deploy.gcloud.spanner.db.updateRole
 import org.wfanet.measurement.access.service.internal.EtagMismatchException
-import org.wfanet.measurement.access.service.internal.IdGenerator
+import org.wfanet.measurement.common.IdGenerator
 import org.wfanet.measurement.access.service.internal.InvalidFieldValueException
 import org.wfanet.measurement.access.service.internal.PermissionMapping
 import org.wfanet.measurement.access.service.internal.PermissionNotFoundException
@@ -47,7 +47,7 @@ import org.wfanet.measurement.access.service.internal.RequiredFieldNotSetExcepti
 import org.wfanet.measurement.access.service.internal.ResourceTypeNotFoundInPermissionException
 import org.wfanet.measurement.access.service.internal.RoleAlreadyExistsException
 import org.wfanet.measurement.access.service.internal.RoleNotFoundException
-import org.wfanet.measurement.access.service.internal.generateNewId
+import org.wfanet.measurement.common.generateNewId
 import org.wfanet.measurement.common.api.ETags
 import org.wfanet.measurement.common.toInstant
 import org.wfanet.measurement.gcloud.spanner.AsyncDatabaseClient

--- a/src/main/kotlin/org/wfanet/measurement/access/service/internal/BUILD.bazel
+++ b/src/main/kotlin/org/wfanet/measurement/access/service/internal/BUILD.bazel
@@ -21,11 +21,6 @@ kt_jvm_library(
 )
 
 kt_jvm_library(
-    name = "id_generator",
-    srcs = ["IdGenerator.kt"],
-)
-
-kt_jvm_library(
     name = "permission_mapping",
     srcs = ["PermissionMapping.kt"],
     deps = [

--- a/src/main/kotlin/org/wfanet/measurement/access/service/internal/testing/BUILD.bazel
+++ b/src/main/kotlin/org/wfanet/measurement/access/service/internal/testing/BUILD.bazel
@@ -26,7 +26,7 @@ kt_jvm_library(
     deps = [
         ":test_config",
         "//src/main/kotlin/org/wfanet/measurement/access/service/internal:errors",
-        "//src/main/kotlin/org/wfanet/measurement/access/service/internal:id_generator",
+        "//src/main/kotlin/org/wfanet/measurement/common:id_generator",
         "//src/main/kotlin/org/wfanet/measurement/common/grpc:error_info",
         "//src/main/proto/wfa/measurement/internal/access:principals_service_kt_jvm_grpc_proto",
         "@wfa_common_jvm//imports/java/com/google/common/truth",
@@ -44,7 +44,7 @@ kt_jvm_library(
     deps = [
         ":test_config",
         "//src/main/kotlin/org/wfanet/measurement/access/service/internal:errors",
-        "//src/main/kotlin/org/wfanet/measurement/access/service/internal:id_generator",
+        "//src/main/kotlin/org/wfanet/measurement/common:id_generator",
         "//src/main/kotlin/org/wfanet/measurement/common/grpc:error_info",
         "//src/main/proto/wfa/measurement/internal/access:permissions_service_kt_jvm_grpc_proto",
         "//src/main/proto/wfa/measurement/internal/access:policies_service_kt_jvm_grpc_proto",
@@ -64,8 +64,8 @@ kt_jvm_library(
     deps = [
         ":test_config",
         "//src/main/kotlin/org/wfanet/measurement/access/service/internal:errors",
-        "//src/main/kotlin/org/wfanet/measurement/access/service/internal:id_generator",
         "//src/main/kotlin/org/wfanet/measurement/access/service/internal:permission_mapping",
+        "//src/main/kotlin/org/wfanet/measurement/common:id_generator",
         "//src/main/kotlin/org/wfanet/measurement/common/grpc:error_info",
         "//src/main/proto/wfa/measurement/internal/access:roles_service_kt_jvm_grpc_proto",
         "@wfa_common_jvm//imports/java/com/google/common/truth",
@@ -84,8 +84,8 @@ kt_jvm_library(
         ":test_config",
         "//src/main/kotlin/org/wfanet/measurement/access/common:tls_client_principal_mapping",
         "//src/main/kotlin/org/wfanet/measurement/access/service/internal:errors",
-        "//src/main/kotlin/org/wfanet/measurement/access/service/internal:id_generator",
         "//src/main/kotlin/org/wfanet/measurement/access/service/internal:permission_mapping",
+        "//src/main/kotlin/org/wfanet/measurement/common:id_generator",
         "//src/main/kotlin/org/wfanet/measurement/common/grpc:error_info",
         "//src/main/proto/wfa/measurement/internal/access:policies_service_kt_jvm_grpc_proto",
         "//src/main/proto/wfa/measurement/internal/access:principals_service_kt_jvm_grpc_proto",

--- a/src/main/kotlin/org/wfanet/measurement/access/service/internal/testing/PermissionsServiceTest.kt
+++ b/src/main/kotlin/org/wfanet/measurement/access/service/internal/testing/PermissionsServiceTest.kt
@@ -29,9 +29,9 @@ import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 import org.wfanet.measurement.access.common.TlsClientPrincipalMapping
 import org.wfanet.measurement.access.service.internal.Errors
-import org.wfanet.measurement.access.service.internal.IdGenerator
 import org.wfanet.measurement.access.service.internal.PermissionMapping
 import org.wfanet.measurement.access.service.internal.toPermission
+import org.wfanet.measurement.common.IdGenerator
 import org.wfanet.measurement.common.grpc.errorInfo
 import org.wfanet.measurement.internal.access.CheckPermissionsResponse
 import org.wfanet.measurement.internal.access.ListPermissionsPageTokenKt

--- a/src/main/kotlin/org/wfanet/measurement/access/service/internal/testing/PoliciesServiceTest.kt
+++ b/src/main/kotlin/org/wfanet/measurement/access/service/internal/testing/PoliciesServiceTest.kt
@@ -29,8 +29,8 @@ import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 import org.wfanet.measurement.access.common.TlsClientPrincipalMapping
 import org.wfanet.measurement.access.service.internal.Errors
-import org.wfanet.measurement.access.service.internal.IdGenerator
 import org.wfanet.measurement.access.service.internal.PermissionMapping
+import org.wfanet.measurement.common.IdGenerator
 import org.wfanet.measurement.common.grpc.errorInfo
 import org.wfanet.measurement.common.toInstant
 import org.wfanet.measurement.internal.access.PoliciesGrpcKt

--- a/src/main/kotlin/org/wfanet/measurement/access/service/internal/testing/PrincipalsServiceTest.kt
+++ b/src/main/kotlin/org/wfanet/measurement/access/service/internal/testing/PrincipalsServiceTest.kt
@@ -32,7 +32,7 @@ import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.wfanet.measurement.access.common.TlsClientPrincipalMapping
 import org.wfanet.measurement.access.service.internal.Errors
-import org.wfanet.measurement.access.service.internal.IdGenerator
+import org.wfanet.measurement.common.IdGenerator
 import org.wfanet.measurement.common.grpc.errorInfo
 import org.wfanet.measurement.common.toInstant
 import org.wfanet.measurement.internal.access.Principal

--- a/src/main/kotlin/org/wfanet/measurement/access/service/internal/testing/RolesServiceTest.kt
+++ b/src/main/kotlin/org/wfanet/measurement/access/service/internal/testing/RolesServiceTest.kt
@@ -31,8 +31,8 @@ import org.mockito.kotlin.mock
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.wfanet.measurement.access.service.internal.Errors
-import org.wfanet.measurement.access.service.internal.IdGenerator
 import org.wfanet.measurement.access.service.internal.PermissionMapping
+import org.wfanet.measurement.common.IdGenerator
 import org.wfanet.measurement.common.grpc.errorInfo
 import org.wfanet.measurement.common.toInstant
 import org.wfanet.measurement.internal.access.ListRolesPageTokenKt

--- a/src/main/kotlin/org/wfanet/measurement/common/BUILD.bazel
+++ b/src/main/kotlin/org/wfanet/measurement/common/BUILD.bazel
@@ -34,3 +34,8 @@ kt_jvm_library(
         "@wfa_common_jvm//imports/kotlin/kotlinx/coroutines:core",
     ],
 )
+
+kt_jvm_library(
+    name = "id_generator",
+    srcs = ["IdGenerator.kt"],
+)

--- a/src/main/kotlin/org/wfanet/measurement/common/IdGenerator.kt
+++ b/src/main/kotlin/org/wfanet/measurement/common/IdGenerator.kt
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.wfanet.measurement.access.service.internal
+package org.wfanet.measurement.common
 
 import kotlin.random.Random
 

--- a/src/test/kotlin/org/wfanet/measurement/access/deploy/gcloud/spanner/SpannerPermissionsServiceTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/access/deploy/gcloud/spanner/SpannerPermissionsServiceTest.kt
@@ -20,9 +20,9 @@ import org.junit.ClassRule
 import org.junit.Rule
 import org.wfanet.measurement.access.common.TlsClientPrincipalMapping
 import org.wfanet.measurement.access.deploy.gcloud.spanner.testing.Schemata
-import org.wfanet.measurement.access.service.internal.IdGenerator
 import org.wfanet.measurement.access.service.internal.PermissionMapping
 import org.wfanet.measurement.access.service.internal.testing.PermissionsServiceTest
+import org.wfanet.measurement.common.IdGenerator
 import org.wfanet.measurement.gcloud.spanner.AsyncDatabaseClient
 import org.wfanet.measurement.gcloud.spanner.testing.SpannerEmulatorDatabaseRule
 import org.wfanet.measurement.gcloud.spanner.testing.SpannerEmulatorRule

--- a/src/test/kotlin/org/wfanet/measurement/access/deploy/gcloud/spanner/SpannerPoliciesServiceTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/access/deploy/gcloud/spanner/SpannerPoliciesServiceTest.kt
@@ -20,9 +20,9 @@ import org.junit.ClassRule
 import org.junit.Rule
 import org.wfanet.measurement.access.common.TlsClientPrincipalMapping
 import org.wfanet.measurement.access.deploy.gcloud.spanner.testing.Schemata
-import org.wfanet.measurement.access.service.internal.IdGenerator
 import org.wfanet.measurement.access.service.internal.PermissionMapping
 import org.wfanet.measurement.access.service.internal.testing.PoliciesServiceTest
+import org.wfanet.measurement.common.IdGenerator
 import org.wfanet.measurement.gcloud.spanner.AsyncDatabaseClient
 import org.wfanet.measurement.gcloud.spanner.testing.SpannerEmulatorDatabaseRule
 import org.wfanet.measurement.gcloud.spanner.testing.SpannerEmulatorRule

--- a/src/test/kotlin/org/wfanet/measurement/access/deploy/gcloud/spanner/SpannerPrincipalsServiceTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/access/deploy/gcloud/spanner/SpannerPrincipalsServiceTest.kt
@@ -20,8 +20,8 @@ import org.junit.ClassRule
 import org.junit.Rule
 import org.wfanet.measurement.access.common.TlsClientPrincipalMapping
 import org.wfanet.measurement.access.deploy.gcloud.spanner.testing.Schemata
-import org.wfanet.measurement.access.service.internal.IdGenerator
 import org.wfanet.measurement.access.service.internal.testing.PrincipalsServiceTest
+import org.wfanet.measurement.common.IdGenerator
 import org.wfanet.measurement.gcloud.spanner.testing.SpannerEmulatorDatabaseRule
 import org.wfanet.measurement.gcloud.spanner.testing.SpannerEmulatorRule
 

--- a/src/test/kotlin/org/wfanet/measurement/access/deploy/gcloud/spanner/SpannerRolesServiceTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/access/deploy/gcloud/spanner/SpannerRolesServiceTest.kt
@@ -19,9 +19,9 @@ package org.wfanet.measurement.access.deploy.gcloud.spanner
 import org.junit.ClassRule
 import org.junit.Rule
 import org.wfanet.measurement.access.deploy.gcloud.spanner.testing.Schemata
-import org.wfanet.measurement.access.service.internal.IdGenerator
 import org.wfanet.measurement.access.service.internal.PermissionMapping
 import org.wfanet.measurement.access.service.internal.testing.RolesServiceTest
+import org.wfanet.measurement.common.IdGenerator
 import org.wfanet.measurement.gcloud.spanner.testing.SpannerEmulatorDatabaseRule
 import org.wfanet.measurement.gcloud.spanner.testing.SpannerEmulatorRule
 


### PR DESCRIPTION
This will be used by the Basic Reports API.