### PR TITLE
fix: Set cmmsMeasurements in MetricResult when Metric fails

### DIFF
--- a/src/main/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/MetricsService.kt
+++ b/src/main/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/MetricsService.kt
@@ -1747,6 +1747,17 @@ class MetricsService(
             else -> throw e
           }
         }
+      } else if (state == Metric.State.FAILED) {
+        result = metricResult {
+          cmmsMeasurements +=
+            source.weightedMeasurementsList.map {
+              MeasurementKey(
+                source.cmmsMeasurementConsumerId,
+                it.measurement.cmmsMeasurementId,
+              )
+                .toName()
+            }
+        }
       }
     }
   }

--- a/src/main/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/MetricsService.kt
+++ b/src/main/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/MetricsService.kt
@@ -1751,10 +1751,7 @@ class MetricsService(
         result = metricResult {
           cmmsMeasurements +=
             source.weightedMeasurementsList.map {
-              MeasurementKey(
-                source.cmmsMeasurementConsumerId,
-                it.measurement.cmmsMeasurementId,
-              )
+              MeasurementKey(source.cmmsMeasurementConsumerId, it.measurement.cmmsMeasurementId)
                 .toName()
             }
         }

--- a/src/main/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/MetricsService.kt
+++ b/src/main/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/MetricsService.kt
@@ -1731,7 +1731,11 @@ class MetricsService(
               result = metricResult {
                 cmmsMeasurements +=
                   source.weightedMeasurementsList.map {
-                    MeasurementKey(source.cmmsMeasurementConsumerId, it.measurement.cmmsMeasurementId).toName()
+                    MeasurementKey(
+                        source.cmmsMeasurementConsumerId,
+                        it.measurement.cmmsMeasurementId,
+                      )
+                      .toName()
                   }
               }
               logger.log(

--- a/src/main/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/MetricsService.kt
+++ b/src/main/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/MetricsService.kt
@@ -1719,8 +1719,7 @@ class MetricsService(
           } catch (e: Exception) {
             when (e) {
               is MeasurementVarianceNotComputableException,
-              is NoiseMechanismUnrecognizedException
-              -> {
+              is NoiseMechanismUnrecognizedException -> {
                 result = buildMetricResult(source)
                 logger.log(
                   Level.WARNING,
@@ -1735,9 +1734,9 @@ class MetricsService(
                   cmmsMeasurements +=
                     source.weightedMeasurementsList.map {
                       MeasurementKey(
-                        source.cmmsMeasurementConsumerId,
-                        it.measurement.cmmsMeasurementId,
-                      )
+                          source.cmmsMeasurementConsumerId,
+                          it.measurement.cmmsMeasurementId,
+                        )
                         .toName()
                     }
                 }

--- a/src/main/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/MetricsService.kt
+++ b/src/main/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/MetricsService.kt
@@ -1728,6 +1728,12 @@ class MetricsService(
             }
             is MetricResultNotComputableException -> {
               state = Metric.State.FAILED
+              result = metricResult {
+                cmmsMeasurements +=
+                  source.weightedMeasurementsList.map {
+                    MeasurementKey(source.cmmsMeasurementConsumerId, it.measurement.cmmsMeasurementId).toName()
+                  }
+              }
               logger.log(
                 Level.WARNING,
                 "Failed to calculate metric result for metric with ID ${source.externalMetricId}",

--- a/src/test/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/MetricsServiceTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/MetricsServiceTest.kt
@@ -7686,7 +7686,14 @@ class MetricsServiceTest {
       batchSetMeasurementFailures(batchSetMeasurementFailuresCaptor.capture())
     }
 
-    assertThat(result).isEqualTo(FAILED_SINGLE_PUBLISHER_IMPRESSION_METRIC)
+    assertThat(result).isEqualTo(FAILED_SINGLE_PUBLISHER_IMPRESSION_METRIC.copy {
+      this.result = metricResult {
+        cmmsMeasurements += MeasurementKey(
+          INTERNAL_FAILED_SINGLE_PUBLISHER_IMPRESSION_MEASUREMENT.cmmsMeasurementConsumerId,
+          INTERNAL_FAILED_SINGLE_PUBLISHER_IMPRESSION_MEASUREMENT.cmmsMeasurementId,
+        ).toName()
+      }
+    })
   }
 
   @Test
@@ -8990,7 +8997,14 @@ class MetricsServiceTest {
           }
         )
 
-      assertThat(result).isEqualTo(FAILED_SINGLE_PUBLISHER_IMPRESSION_METRIC)
+      assertThat(result).isEqualTo(FAILED_SINGLE_PUBLISHER_IMPRESSION_METRIC.copy {
+        this.result = metricResult {
+          cmmsMeasurements += MeasurementKey(
+            INTERNAL_FAILED_SINGLE_PUBLISHER_IMPRESSION_MEASUREMENT.cmmsMeasurementConsumerId,
+            INTERNAL_FAILED_SINGLE_PUBLISHER_IMPRESSION_MEASUREMENT.cmmsMeasurementId,
+          ).toName()
+        }
+      })
     }
 
   @Test

--- a/src/test/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/MetricsServiceTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/MetricsServiceTest.kt
@@ -6117,7 +6117,16 @@ class MetricsServiceTest {
 
     val expected = listMetricsResponse {
       metrics += PENDING_INCREMENTAL_REACH_METRIC
-      metrics += PENDING_SINGLE_PUBLISHER_IMPRESSION_METRIC.copy { state = Metric.State.FAILED }
+      metrics += PENDING_SINGLE_PUBLISHER_IMPRESSION_METRIC.copy {
+        state = Metric.State.FAILED
+        this.result = metricResult {
+          cmmsMeasurements +=
+            MeasurementKey(
+              INTERNAL_FAILED_SINGLE_PUBLISHER_IMPRESSION_MEASUREMENT.cmmsMeasurementConsumerId,
+              INTERNAL_FAILED_SINGLE_PUBLISHER_IMPRESSION_MEASUREMENT.cmmsMeasurementId,
+            ).toName()
+        }
+      }
     }
 
     // Verify proto argument of internal MetricsCoroutineImplBase::streamMetrics
@@ -7376,7 +7385,7 @@ class MetricsServiceTest {
     }
 
   @Test
-  fun `getMetric returns failed metric when the succeeded metric contains no result`(): Unit =
+  fun `getMetric returns failed metric when the succeeded measurement contains no result`(): Unit =
     runBlocking {
       whenever(internalMetricsMock.batchGetMetrics(any()))
         .thenReturn(

--- a/src/test/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/MetricsServiceTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/MetricsServiceTest.kt
@@ -7686,14 +7686,19 @@ class MetricsServiceTest {
       batchSetMeasurementFailures(batchSetMeasurementFailuresCaptor.capture())
     }
 
-    assertThat(result).isEqualTo(FAILED_SINGLE_PUBLISHER_IMPRESSION_METRIC.copy {
-      this.result = metricResult {
-        cmmsMeasurements += MeasurementKey(
-          INTERNAL_FAILED_SINGLE_PUBLISHER_IMPRESSION_MEASUREMENT.cmmsMeasurementConsumerId,
-          INTERNAL_FAILED_SINGLE_PUBLISHER_IMPRESSION_MEASUREMENT.cmmsMeasurementId,
-        ).toName()
-      }
-    })
+    assertThat(result)
+      .isEqualTo(
+        FAILED_SINGLE_PUBLISHER_IMPRESSION_METRIC.copy {
+          this.result = metricResult {
+            cmmsMeasurements +=
+              MeasurementKey(
+                  INTERNAL_FAILED_SINGLE_PUBLISHER_IMPRESSION_MEASUREMENT.cmmsMeasurementConsumerId,
+                  INTERNAL_FAILED_SINGLE_PUBLISHER_IMPRESSION_MEASUREMENT.cmmsMeasurementId,
+                )
+                .toName()
+          }
+        }
+      )
   }
 
   @Test
@@ -8997,14 +9002,20 @@ class MetricsServiceTest {
           }
         )
 
-      assertThat(result).isEqualTo(FAILED_SINGLE_PUBLISHER_IMPRESSION_METRIC.copy {
-        this.result = metricResult {
-          cmmsMeasurements += MeasurementKey(
-            INTERNAL_FAILED_SINGLE_PUBLISHER_IMPRESSION_MEASUREMENT.cmmsMeasurementConsumerId,
-            INTERNAL_FAILED_SINGLE_PUBLISHER_IMPRESSION_MEASUREMENT.cmmsMeasurementId,
-          ).toName()
-        }
-      })
+      assertThat(result)
+        .isEqualTo(
+          FAILED_SINGLE_PUBLISHER_IMPRESSION_METRIC.copy {
+            this.result = metricResult {
+              cmmsMeasurements +=
+                MeasurementKey(
+                    INTERNAL_FAILED_SINGLE_PUBLISHER_IMPRESSION_MEASUREMENT
+                      .cmmsMeasurementConsumerId,
+                    INTERNAL_FAILED_SINGLE_PUBLISHER_IMPRESSION_MEASUREMENT.cmmsMeasurementId,
+                  )
+                  .toName()
+            }
+          }
+        )
     }
 
   @Test

--- a/src/test/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/MetricsServiceTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/MetricsServiceTest.kt
@@ -7333,6 +7333,7 @@ class MetricsServiceTest {
           internalBatchGetMetricsResponse {
             metrics +=
               INTERNAL_SUCCEEDED_INCREMENTAL_REACH_METRIC.copy {
+                weightedMeasurements.clear()
                 weightedMeasurements += weightedMeasurement {
                   weight = 1
                   binaryRepresentation = 3
@@ -7371,17 +7372,20 @@ class MetricsServiceTest {
         }
 
       assertThat(response.state).isEqualTo(Metric.State.FAILED)
-      assertThat(response.result).isEqualTo(MetricResult.getDefaultInstance())
+      assertThat(response.result).isEqualTo(metricResult {
+        cmmsMeasurements += SUCCEEDED_UNION_ALL_REACH_MEASUREMENT.name
+      })
     }
 
   @Test
-  fun `getMetric returns failed metric when the succeeded metric contains no measurement`(): Unit =
+  fun `getMetric returns failed metric when the succeeded metric contains no result`(): Unit =
     runBlocking {
       whenever(internalMetricsMock.batchGetMetrics(any()))
         .thenReturn(
           internalBatchGetMetricsResponse {
             metrics +=
               INTERNAL_SUCCEEDED_INCREMENTAL_REACH_METRIC.copy {
+                weightedMeasurements.clear()
                 weightedMeasurements += weightedMeasurement {
                   weight = 1
                   binaryRepresentation = 3
@@ -7402,7 +7406,9 @@ class MetricsServiceTest {
         }
 
       assertThat(response.state).isEqualTo(Metric.State.FAILED)
-      assertThat(response.result).isEqualTo(MetricResult.getDefaultInstance())
+      assertThat(response.result).isEqualTo(metricResult {
+        cmmsMeasurements += SUCCEEDED_UNION_ALL_REACH_MEASUREMENT.name
+      })
     }
 
   @Test
@@ -8403,6 +8409,7 @@ class MetricsServiceTest {
         internalBatchGetMetricsResponse {
           metrics +=
             INTERNAL_SUCCEEDED_SINGLE_PUBLISHER_REACH_FREQUENCY_METRIC.copy {
+              weightedMeasurements.clear()
               weightedMeasurements += weightedMeasurement {
                 weight = 1
                 binaryRepresentation = 1
@@ -8447,8 +8454,10 @@ class MetricsServiceTest {
         runBlocking { service.getMetric(request) }
       }
     assertThat(response.state).isEqualTo(Metric.State.FAILED)
-    assertThat(response.result).isEqualTo(MetricResult.getDefaultInstance())
-  }
+    assertThat(response.result).isEqualTo(metricResult {
+      cmmsMeasurements += SUCCEEDED_SINGLE_PUBLISHER_REACH_FREQUENCY_MEASUREMENT.name
+    })
+    }
 
   @Test
   fun `getMetric returns succeeded metric for rf when custom direct methodology has scalar`():

--- a/src/test/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/MetricsServiceTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/MetricsServiceTest.kt
@@ -214,7 +214,6 @@ import org.wfanet.measurement.reporting.service.api.InMemoryEncryptionKeyPairSto
 import org.wfanet.measurement.reporting.v2alpha.ListMetricsPageTokenKt.previousPageEnd
 import org.wfanet.measurement.reporting.v2alpha.ListMetricsRequest
 import org.wfanet.measurement.reporting.v2alpha.Metric
-import org.wfanet.measurement.reporting.v2alpha.MetricResult
 import org.wfanet.measurement.reporting.v2alpha.MetricResultKt
 import org.wfanet.measurement.reporting.v2alpha.MetricSpec
 import org.wfanet.measurement.reporting.v2alpha.MetricSpecKt
@@ -7372,9 +7371,8 @@ class MetricsServiceTest {
         }
 
       assertThat(response.state).isEqualTo(Metric.State.FAILED)
-      assertThat(response.result).isEqualTo(metricResult {
-        cmmsMeasurements += SUCCEEDED_UNION_ALL_REACH_MEASUREMENT.name
-      })
+      assertThat(response.result)
+        .isEqualTo(metricResult { cmmsMeasurements += SUCCEEDED_UNION_ALL_REACH_MEASUREMENT.name })
     }
 
   @Test
@@ -7406,9 +7404,8 @@ class MetricsServiceTest {
         }
 
       assertThat(response.state).isEqualTo(Metric.State.FAILED)
-      assertThat(response.result).isEqualTo(metricResult {
-        cmmsMeasurements += SUCCEEDED_UNION_ALL_REACH_MEASUREMENT.name
-      })
+      assertThat(response.result)
+        .isEqualTo(metricResult { cmmsMeasurements += SUCCEEDED_UNION_ALL_REACH_MEASUREMENT.name })
     }
 
   @Test
@@ -8454,10 +8451,13 @@ class MetricsServiceTest {
         runBlocking { service.getMetric(request) }
       }
     assertThat(response.state).isEqualTo(Metric.State.FAILED)
-    assertThat(response.result).isEqualTo(metricResult {
-      cmmsMeasurements += SUCCEEDED_SINGLE_PUBLISHER_REACH_FREQUENCY_MEASUREMENT.name
-    })
-    }
+    assertThat(response.result)
+      .isEqualTo(
+        metricResult {
+          cmmsMeasurements += SUCCEEDED_SINGLE_PUBLISHER_REACH_FREQUENCY_MEASUREMENT.name
+        }
+      )
+  }
 
   @Test
   fun `getMetric returns succeeded metric for rf when custom direct methodology has scalar`():

--- a/src/test/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/MetricsServiceTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/MetricsServiceTest.kt
@@ -6117,16 +6117,18 @@ class MetricsServiceTest {
 
     val expected = listMetricsResponse {
       metrics += PENDING_INCREMENTAL_REACH_METRIC
-      metrics += PENDING_SINGLE_PUBLISHER_IMPRESSION_METRIC.copy {
-        state = Metric.State.FAILED
-        this.result = metricResult {
-          cmmsMeasurements +=
-            MeasurementKey(
-              INTERNAL_FAILED_SINGLE_PUBLISHER_IMPRESSION_MEASUREMENT.cmmsMeasurementConsumerId,
-              INTERNAL_FAILED_SINGLE_PUBLISHER_IMPRESSION_MEASUREMENT.cmmsMeasurementId,
-            ).toName()
+      metrics +=
+        PENDING_SINGLE_PUBLISHER_IMPRESSION_METRIC.copy {
+          state = Metric.State.FAILED
+          this.result = metricResult {
+            cmmsMeasurements +=
+              MeasurementKey(
+                  INTERNAL_FAILED_SINGLE_PUBLISHER_IMPRESSION_MEASUREMENT.cmmsMeasurementConsumerId,
+                  INTERNAL_FAILED_SINGLE_PUBLISHER_IMPRESSION_MEASUREMENT.cmmsMeasurementId,
+                )
+                .toName()
+          }
         }
-      }
     }
 
     // Verify proto argument of internal MetricsCoroutineImplBase::streamMetrics


### PR DESCRIPTION
The field is currently not populated in this situation.