### PR TITLE
feat: update tee sdk to consume new ControlPlane API

### DIFF
--- a/src/main/kotlin/org/wfanet/measurement/securecomputation/controlplane/v1alpha/WorkItemsService.kt
+++ b/src/main/kotlin/org/wfanet/measurement/securecomputation/controlplane/v1alpha/WorkItemsService.kt
@@ -65,10 +65,15 @@ abstract class WorkItemsService(private val internalWorkItemsStub: InternalWorkI
     }
 
     val workItem = request.workItem
+
+    val workItemName = WorkItemKey(request.workItemId).toName()
+    val finalizedWorkItem = workItem.copy {
+      name = workItemName
+    }
     val topicId = workItem.queue
 
     try {
-      publishMessage(topicId, workItem.workItemParams)
+      publishMessage(topicId, finalizedWorkItem)
     } catch (e: Exception) {
       throw when {
         e.message?.contains("Topic id: $topicId does not exist") == true -> {

--- a/src/main/kotlin/org/wfanet/measurement/securecomputation/teesdk/BUILD.bazel
+++ b/src/main/kotlin/org/wfanet/measurement/securecomputation/teesdk/BUILD.bazel
@@ -6,6 +6,9 @@ kt_jvm_library(
     name = "base_tee_application",
     srcs = ["BaseTeeApplication.kt"],
     deps = [
+        "//src/main/kotlin/org/wfanet/measurement/securecomputation/controlplane/v1alpha:work_item_attempts_service",
+        "//src/main/kotlin/org/wfanet/measurement/securecomputation/controlplane/v1alpha:work_items_service",
+        "//src/main/proto/wfa/measurement/securecomputation/controlplane/v1alpha:work_item_kt_jvm_proto",
         "@wfa_common_jvm//imports/java/com/google/protobuf",
         "@wfa_common_jvm//imports/kotlin/kotlinx/coroutines:core",
         "@wfa_common_jvm//src/main/kotlin/org/wfanet/measurement/queue:queue_subscriber",

--- a/src/main/kotlin/org/wfanet/measurement/securecomputation/teesdk/BaseTeeApplication.kt
+++ b/src/main/kotlin/org/wfanet/measurement/securecomputation/teesdk/BaseTeeApplication.kt
@@ -17,11 +17,11 @@
 package org.wfanet.measurement.securecomputation.teesdk
 
 import com.google.protobuf.InvalidProtocolBufferException
-import com.google.protobuf.Message
 import com.google.protobuf.Parser
 import java.util.UUID
 import java.util.logging.Level
 import java.util.logging.Logger
+import com.google.protobuf.Any
 import kotlinx.coroutines.channels.ReceiveChannel
 import org.wfanet.measurement.queue.QueueSubscriber
 import org.wfanet.measurement.securecomputation.controlplane.v1alpha.WorkItem
@@ -30,7 +30,6 @@ import org.wfanet.measurement.securecomputation.controlplane.v1alpha.WorkItemAtt
 import org.wfanet.measurement.securecomputation.controlplane.v1alpha.WorkItemsService
 import org.wfanet.measurement.securecomputation.controlplane.v1alpha.completeWorkItemAttemptRequest
 import org.wfanet.measurement.securecomputation.controlplane.v1alpha.createWorkItemAttemptRequest
-import org.wfanet.measurement.securecomputation.controlplane.v1alpha.createWorkItemRequest
 import org.wfanet.measurement.securecomputation.controlplane.v1alpha.failWorkItemAttemptRequest
 import org.wfanet.measurement.securecomputation.controlplane.v1alpha.failWorkItemRequest
 
@@ -73,7 +72,7 @@ abstract class BaseTeeApplication(
    * If parsing fails, the message is negatively acknowledged and discarded. If processing fails,
    * the message is negatively acknowledged and optionally requeued.
    *
-   * @param queueMessage The raw message received from the queue.
+   * @param queueMessage The raw message received from the queue of type [WorkItem].
    */
   private suspend fun processMessage(queueMessage: QueueSubscriber.QueueMessage<WorkItem>) {
     val body = queueMessage.body

--- a/src/test/kotlin/org/wfanet/measurement/securecomputation/teesdk/BUILD.bazel
+++ b/src/test/kotlin/org/wfanet/measurement/securecomputation/teesdk/BUILD.bazel
@@ -11,6 +11,7 @@ kt_jvm_test(
         "//src/main/kotlin/org/wfanet/measurement/securecomputation/teesdk:base_tee_application",
         "@wfa_common_jvm//imports/java/com/google/common/truth",
         "@wfa_common_jvm//imports/kotlin/kotlin/test",
+        "@wfa_common_jvm//imports/kotlin/org/mockito/kotlin",
         "@wfa_common_jvm//src/main/kotlin/org/wfanet/measurement/gcloud/pubsub:google_pub_sub_client",
         "@wfa_common_jvm//src/main/kotlin/org/wfanet/measurement/gcloud/pubsub:publisher",
         "@wfa_common_jvm//src/main/kotlin/org/wfanet/measurement/gcloud/pubsub:subscriber",


### PR DESCRIPTION
Depends on #2126 

`BaseTeeApplication` now only accepts messages of type `WorkItem` and forward to TEE Application `workItemParams` of type Any.