### PR TITLE
build: Add python test coverage report

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -99,7 +99,20 @@ jobs:
 
       - name: Run tests
         id: run-tests
-        run: bazel test //...
+        run: bazel test -- //... -//src/test/python/...
+
+      - name: Run tests with coverage
+        id: run-coverage
+        run: bazel coverage --experimental_split_coverage_postprocessing --experimental_fetch_all_coverage_outputs --remote_download_outputs=all --strategy=CoverageReport=local --combined_report=lcov --instrumentation_filter="//src/main/python/.*,-@.*" //src/test/python/...
+
+      - name: Export bazel output path
+        run: echo "BAZEL_OUTPUT_PATH=$(bazel info output_path)" >> $GITHUB_ENV
+
+      - name: Upload coverage report
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-report
+          path: ${{ env.BAZEL_OUTPUT_PATH }}/_coverage/_coverage_report.dat
 
       - name: Create cluster
         id: create-cluster
@@ -149,4 +162,4 @@ jobs:
       - name: Upload Bazel testlogs
         continue-on-error: true
         uses: world-federation-of-advertisers/actions/bazel-upload-testlogs@v2
-        if: failure() && (steps.run-tests.outcome == 'failure' || steps.run-correctness-test.outcome == 'failure' || steps.run-panelmatch-correctness-test.outcome == 'failure')
+        if: failure() && (steps.run-tests.outcome == 'failure' || steps.run-coverage.outcome == 'failure' || steps.run-correctness-test.outcome == 'failure' || steps.run-panelmatch-correctness-test.outcome == 'failure')

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -140,6 +140,7 @@ bazel_dep(
     name = "rules_python",
     version = "0.33.2",
 )
+# Must be compatible with the protobuf version declared in requirements.txt
 bazel_dep(
     name = "protobuf",
     version = "29.3",
@@ -307,6 +308,7 @@ python.toolchain(
     # See https://github.com/bazelbuild/rules_python/pull/713#issuecomment-1885628496
     ignore_root_user_error = True,
     python_version = "3.11",
+    configure_coverage_tool = True,
 )
 
 pip = use_extension("@rules_python//python/extensions:pip.bzl", "pip")

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,4 +17,7 @@ pandas~=2.2.2
 pytest~=8.3.2
 lxml~=5.3.0
 googleapis-common-protos~=1.65.0
+# Must be compatible with the protobuf version declared with bazel_dep in MODULE.bazel
+# See https://github.com/protocolbuffers/protobuf/blob/v29.3/python/google/protobuf/__init__.py#L10
+protobuf~=5.29.3
 black

--- a/src/test/python/wfa/measurement/reporting/postprocessing/tools/BUILD.bazel
+++ b/src/test/python/wfa/measurement/reporting/postprocessing/tools/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@pip//:requirements.bzl", "requirement")
 load("@rules_python//python:defs.bzl", "py_test")
 
 py_test(
@@ -7,6 +8,7 @@ py_test(
     deps = [
         "//src/main/proto/wfa/measurement/reporting/postprocessing/v2alpha:report_summary_py_pb2",
         "//src/main/python/wfa/measurement/reporting/postprocessing/tools:post_process_origin_report",
+        requirement("protobuf"),
     ],
 )
 


### PR DESCRIPTION
All Python tests work fine with bazel test, but [this test](https://github.com/world-federation-of-advertisers/cross-media-measurement/blob/main/src/test/python/wfa/measurement/reporting/postprocessing/tools/test_post_process_origin_report.py) fails with bazel coverage because it cannot find the protobuf dependency:

```
from google.protobuf.json_format import Parse
ModuleNotFoundError: No module named 'google'

```
It seems that bazel test and bazel coverage handle the PYTHONPATH differently.

**bazel test adds:**
```
.../protobuf~
.../protobuf~/python (where the protobuf library is, with the structure that the test expects)
.../protobuf~/python/python
and directories like:
/rules_pythonpip~pip_311_<<dependency declared in the requirements.txt>>
/rules_pythonpip~pip_311_<<dependency declared in the requirements.txt>>/site-packages

```
That protobuf~ directory has this structure:
```
protobuf~/
└── python
    └── google
        └── protobuf

```
**bazel coverage adds:**
```
.../protobuf~
and directories like:
/rules_pythonpip~pip_311_<<dependency declared in the requirements.txt>>
/rules_pythonpip~pip_311_<<dependency declared in the requirements.txt>>/site-packages

```
By adding the dependency in the requirements.txt file, both bazel test and bazel coverage find protobuf and work fine.
