### PR TITLE
fix: Use approximated variance for measurements derived from the unique reach ones.

### DIFF
--- a/src/main/python/wfa/measurement/reporting/postprocessing/tools/post_process_origin_report.py
+++ b/src/main/python/wfa/measurement/reporting/postprocessing/tools/post_process_origin_report.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import json
-import math
 import sys
 from typing import FrozenSet
 
@@ -334,17 +333,17 @@ class ReportSummaryProcessor:
         ]
       else:
         # Add the measurement of the edp_comb that is derived from the
-        # incremental_reach(A) and reach(A U subset). As
-        # std(incremental_reach(A) = sqrt(std(rach(A U subset))^2 +
-        # std(reach(subset))^2), we have: std(reach(subset)) =
-        # sqrt(std(incremental_reach(A))^2 - std(reach(A U subset))^2).
+        # incremental_reach(A) and reach(A U subset).
         logging.debug(
             f"Estimating the {measurement_policy} reach of {subset} from "
             f"{superset_measurement.name} and {difference_measurement.name}.")
+        # TODO(@ple13): Use the correct formula to find the standard deviation
+        # of the derived measurement.
+        derived_standard_deviation = max(difference_measurement.sigma,
+                                         superset_measurement.sigma)
         subset_measurement = Measurement(
             superset_measurement.value - difference_measurement.value,
-            math.sqrt(
-                difference_measurement.sigma ** 2 - superset_measurement.sigma ** 2),
+            derived_standard_deviation,
             "union/" + measurement_policy + "/" + "_".join(sorted(subset))
         )
         self._whole_campaign_measurements[measurement_policy][

--- a/src/main/python/wfa/measurement/reporting/postprocessing/tools/post_process_origin_report.py
+++ b/src/main/python/wfa/measurement/reporting/postprocessing/tools/post_process_origin_report.py
@@ -14,15 +14,20 @@
 
 import json
 import sys
+from typing import FrozenSet
+
 from absl import app
 from absl import flags
 from absl import logging
+
 from noiseninja.noised_measurements import Measurement
+
 from report.report import MetricReport
 from report.report import Report
+
 from src.main.proto.wfa.measurement.reporting.postprocessing.v2alpha import \
   report_summary_pb2
-from typing import FrozenSet
+
 
 # This is a demo script that has the following assumptions :
 # 1. Impression results are not corrected.

--- a/src/main/python/wfa/measurement/reporting/postprocessing/tools/post_process_origin_report.py
+++ b/src/main/python/wfa/measurement/reporting/postprocessing/tools/post_process_origin_report.py
@@ -338,8 +338,9 @@ class ReportSummaryProcessor:
         logging.debug(
             f"Estimating the {measurement_policy} reach of {subset} from "
             f"{superset_measurement.name} and {difference_measurement.name}.")
-        # TODO(@ple13): Use the correct formula to find the standard deviation
-        # of the derived metric. (See https://github.com/world-federation-of-advertisers/cross-media-measurement/issues/2136)
+        # TODO(world-federation-of-advertisers/cross-media-measurement#2136):
+        # Use the correct formula to find the standard deviation of the derived
+        # metric.
         derived_standard_deviation = max(difference_measurement.sigma,
                                          superset_measurement.sigma)
         subset_measurement = Measurement(

--- a/src/main/python/wfa/measurement/reporting/postprocessing/tools/post_process_origin_report.py
+++ b/src/main/python/wfa/measurement/reporting/postprocessing/tools/post_process_origin_report.py
@@ -14,19 +14,15 @@
 
 import json
 import sys
-from typing import FrozenSet
-
 from absl import app
 from absl import flags
 from absl import logging
-
 from noiseninja.noised_measurements import Measurement
-
 from report.report import MetricReport
 from report.report import Report
-
 from src.main.proto.wfa.measurement.reporting.postprocessing.v2alpha import \
   report_summary_pb2
+from typing import FrozenSet
 
 # This is a demo script that has the following assumptions :
 # 1. Impression results are not corrected.
@@ -338,7 +334,7 @@ class ReportSummaryProcessor:
             f"Estimating the {measurement_policy} reach of {subset} from "
             f"{superset_measurement.name} and {difference_measurement.name}.")
         # TODO(@ple13): Use the correct formula to find the standard deviation
-        # of the derived measurement.
+        # of the derived metric. (See https://github.com/world-federation-of-advertisers/cross-media-measurement/issues/2136)
         derived_standard_deviation = max(difference_measurement.sigma,
                                          superset_measurement.sigma)
         subset_measurement = Measurement(


### PR DESCRIPTION
In the report post-processing program, when parsing unique reach measurements, e.g. reach(X - Y), sometimes we need to infer the measurement reach(Y) from reach(X - Y) and reach (X union Y). This involves computing the variance of the measurement reach(Y). 

Previously, it was assumed that reach(X - Y) is computed directly from reach(Y) and reach(X union Y), however, this does not seem to be true (e.g. it is computed from primitive regions instead).

A temporary solution is to use the maximum of the variance of reach(X - Y) and reach(X union Y) for reach(Y). This is expected to not have much effect on the output of the report processor program.