### PR TITLE
refactor: Round noise correction output to nearest integer.

### DIFF
--- a/src/main/python/wfa/measurement/reporting/postprocessing/tools/post_process_origin_report.py
+++ b/src/main/python/wfa/measurement/reporting/postprocessing/tools/post_process_origin_report.py
@@ -142,23 +142,23 @@ class ReportSummaryProcessor:
         for index in range(metric_report.get_number_of_periods()):
           entry = metric_report.get_cumulative_measurement(edp_combination,
                                                            index)
-          metric_name_to_value.update({entry.name: int(entry.value)})
+          metric_name_to_value.update({entry.name: round(entry.value)})
       for edp_combination in metric_report.get_whole_campaign_edp_combinations():
         entry = metric_report.get_whole_campaign_measurement(edp_combination)
-        metric_name_to_value.update({entry.name: int(entry.value)})
+        metric_name_to_value.update({entry.name: round(entry.value)})
       for edp_combination in metric_report.get_k_reach_edp_combinations():
         for frequency in range(1,
                                metric_report.get_number_of_frequencies() + 1):
           entry = metric_report.get_k_reach_measurement(edp_combination,
                                                         frequency)
-          metric_name_to_value.update({entry.name: int(entry.value)})
+          metric_name_to_value.update({entry.name: round(entry.value)})
       for edp_combination in metric_report.get_impression_edp_combinations():
         entry = metric_report.get_impression_measurement(edp_combination)
-        metric_name_to_value.update({entry.name: int(entry.value)})
+        metric_name_to_value.update({entry.name: round(entry.value)})
 
     # Updates difference measurements.
     for key, value in self._set_difference_map.items():
-      metric_name_to_value.update({key: int(
+      metric_name_to_value.update({key: round(
           metric_name_to_value[value[0]] - metric_name_to_value[value[1]])})
     return metric_name_to_value
 

--- a/src/test/kotlin/org/wfanet/measurement/reporting/postprocessing/v2alpha/ReportProcessorTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/reporting/postprocessing/v2alpha/ReportProcessorTest.kt
@@ -199,11 +199,12 @@ class ReportProcessorTest {
       for (edpCombination in impression.keys.intersect(kreach.keys)) {
         val kreachWeightedSum =
           kreach[edpCombination]!!.entries.sumOf { (key, value) -> key * value }
+        val totalWeight = kreach[edpCombination]!!.entries.sumOf { (key, value) -> key }
         if (
           !fuzzyLessEqual(
             kreachWeightedSum.toDouble(),
             impression[edpCombination]!!.toDouble(),
-            TOLERANCE,
+            totalWeight*TOLERANCE,
           )
         ) {
           return false


### PR DESCRIPTION
The output of the quadratic solver is a vector of float numbers and they need to be converted to integers. Currently, the conversion is done by casting, e.g. value -> int(value), which is equivalent to truncating the value. It's preferable to use round(value) to round it to the nearest integer.