### PR TITLE
refactor: Update ListResources to handle protobuf message page tokens

### DIFF
--- a/src/main/kotlin/org/wfanet/measurement/access/service/v1alpha/BUILD.bazel
+++ b/src/main/kotlin/org/wfanet/measurement/access/service/v1alpha/BUILD.bazel
@@ -44,6 +44,7 @@ kt_jvm_library(
         "//src/main/kotlin/org/wfanet/measurement/access/service:resource_key",
         "//src/main/kotlin/org/wfanet/measurement/access/service/internal:errors",
         "//src/main/kotlin/org/wfanet/measurement/common/api:resource_ids",
+        "//src/main/kotlin/org/wfanet/measurement/common/api/grpc:list_resources",
         "//src/main/proto/wfa/measurement/access/v1alpha:roles_service_kt_jvm_grpc_proto",
         "//src/main/proto/wfa/measurement/internal/access:roles_service_kt_jvm_grpc_proto",
     ],

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/requisitionfetcher/RequisitionFetcher.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/requisitionfetcher/RequisitionFetcher.kt
@@ -63,7 +63,7 @@ class RequisitionFetcher(
     // a more efficient way to pull only the Requisitions that have not been stored in storage.
     val requisitions: Flow<Requisition> =
       requisitionsStub
-        .listResources { pageToken ->
+        .listResources { pageToken: String ->
           val request = listRequisitionsRequest {
             parent = dataProviderName
             filter = ListRequisitionsRequestKt.filter { states += Requisition.State.UNFULFILLED }

--- a/src/main/kotlin/org/wfanet/measurement/integration/common/InProcessMeasurementSystemProberIntegrationTest.kt
+++ b/src/main/kotlin/org/wfanet/measurement/integration/common/InProcessMeasurementSystemProberIntegrationTest.kt
@@ -138,10 +138,10 @@ abstract class InProcessMeasurementSystemProberIntegrationTest(
   private suspend fun listMeasurements(): List<Measurement> {
     val measurementConsumerData = inProcessCmmsComponents.getMeasurementConsumerData()
 
-    val measurementLists: Flow<ResourceList<Measurement>> =
+    val measurements: Flow<Measurement> =
       publicMeasurementsClient
         .withAuthenticationKey(measurementConsumerData.apiAuthenticationKey)
-        .listResources { pageToken ->
+        .listResources<Measurement, String, MeasurementsCoroutineStub> { pageToken ->
           val response =
             try {
               listMeasurements(
@@ -158,8 +158,9 @@ abstract class InProcessMeasurementSystemProberIntegrationTest(
             }
           ResourceList(response.measurementsList, response.nextPageToken)
         }
+        .flattenConcat()
 
-    return measurementLists.flattenConcat().toList()
+    return measurements.toList()
   }
 
   companion object {

--- a/src/main/kotlin/org/wfanet/measurement/loadtest/dataprovider/EdpSimulator.kt
+++ b/src/main/kotlin/org/wfanet/measurement/loadtest/dataprovider/EdpSimulator.kt
@@ -347,7 +347,7 @@ class EdpSimulator(
   @OptIn(ExperimentalCoroutinesApi::class) // For `flattenConcat`.
   private suspend fun getEventGroupByReferenceId(eventGroupReferenceId: String): EventGroup? {
     return eventGroupsStub
-      .listResources { pageToken ->
+      .listResources { pageToken: String ->
         val response =
           try {
             listEventGroups(

--- a/src/main/kotlin/org/wfanet/measurement/loadtest/measurementconsumer/MeasurementConsumerSimulator.kt
+++ b/src/main/kotlin/org/wfanet/measurement/loadtest/measurementconsumer/MeasurementConsumerSimulator.kt
@@ -1255,7 +1255,7 @@ class MeasurementConsumerSimulator(
   private fun listEventGroups(measurementConsumer: String): Flow<EventGroup> {
     return eventGroupsClient
       .withAuthenticationKey(measurementConsumerData.apiAuthenticationKey)
-      .listResources { pageToken ->
+      .listResources { pageToken: String ->
         val response =
           try {
             listEventGroups(

--- a/src/main/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/EventGroupsService.kt
+++ b/src/main/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/EventGroupsService.kt
@@ -88,7 +88,7 @@ class EventGroupsService(
     val limit =
       if (request.pageSize > 0) request.pageSize.coerceAtMost(MAX_PAGE_SIZE) else DEFAULT_PAGE_SIZE
     val parent = parentKey.toName()
-    val eventGroupLists: Flow<ResourceList<EventGroup>> =
+    val eventGroupLists: Flow<ResourceList<EventGroup, String>> =
       cmmsEventGroupsStub.withAuthenticationKey(apiAuthenticationKey).listResources(
         limit,
         request.pageToken,

--- a/src/test/kotlin/org/wfanet/measurement/access/service/v1alpha/RolesServiceTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/access/service/v1alpha/RolesServiceTest.kt
@@ -169,13 +169,6 @@ class RolesServiceTest {
       permissionResourceIds += "books.list"
       etag = "response-etag"
     }
-    val internalBookWriterRole = internalRole {
-      roleResourceId = "bookWriter"
-      resourceTypes += "library.googleapis.com/Shelf"
-      permissionResourceIds += "books.get"
-      permissionResourceIds += "books.list"
-      etag = "response-etag"
-    }
     val internalListRolesResponse = internalListRolesResponse {
       roles += internalBookReaderRole
       nextPageToken = internalListRolesPageToken {


### PR DESCRIPTION
These are used by internal APIs instead of string tokens.