### PR TITLE
add fake in process kingdom

### DIFF
--- a/src/main/kotlin/org/wfanet/measurement/integration/common/fake/BUILD.bazel
+++ b/src/main/kotlin/org/wfanet/measurement/integration/common/fake/BUILD.bazel
@@ -1,6 +1,4 @@
-load("@rules_java//java:defs.bzl", "java_library")
 load("@wfa_rules_kotlin_jvm//kotlin:defs.bzl", "kt_jvm_library")
-load("//src/main/proto/wfa/measurement/internal/kingdom:all_protos.bzl", "KINGDOM_INTERNAL_PROTOS")  # buildifier: disable=bzl-visibility
 
 package(
     default_testonly = True,

--- a/src/main/kotlin/org/wfanet/measurement/integration/common/fake/BUILD.bazel
+++ b/src/main/kotlin/org/wfanet/measurement/integration/common/fake/BUILD.bazel
@@ -1,0 +1,29 @@
+load("@rules_java//java:defs.bzl", "java_library")
+load("@wfa_rules_kotlin_jvm//kotlin:defs.bzl", "kt_jvm_library")
+load("//src/main/proto/wfa/measurement/internal/kingdom:all_protos.bzl", "KINGDOM_INTERNAL_PROTOS")  # buildifier: disable=bzl-visibility
+
+package(
+    default_testonly = True,
+    default_visibility = [
+        "//src/main/kotlin/org/wfanet/measurement/integration:__subpackages__",
+        "//src/test/kotlin/org/wfanet/measurement/integration:__subpackages__",
+    ],
+)
+
+kt_jvm_library(
+    name = "fake_services",
+    srcs = glob([
+        "*.kt",
+    ]),
+    visibility = ["//visibility:public"],
+    deps = [
+        "//src/main/proto/wfa/measurement/api/v2alpha:event_group_kt_jvm_proto",
+        "//src/main/proto/wfa/measurement/api/v2alpha:event_groups_service_kt_jvm_grpc_proto",
+        "//src/main/proto/wfa/measurement/api/v2alpha:requisition_kt_jvm_proto",
+        "//src/main/proto/wfa/measurement/api/v2alpha:requisitions_service_kt_jvm_grpc_proto",
+        "@wfa_common_jvm//imports/java/org/junit",
+        "@wfa_common_jvm//src/main/kotlin/org/wfanet/measurement/common/grpc",
+        "@wfa_common_jvm//src/main/kotlin/org/wfanet/measurement/common/grpc/testing",
+        "@wfa_common_jvm//src/main/kotlin/org/wfanet/measurement/common/testing",
+    ],
+)

--- a/src/main/kotlin/org/wfanet/measurement/integration/common/fake/EventGroupsService.kt
+++ b/src/main/kotlin/org/wfanet/measurement/integration/common/fake/EventGroupsService.kt
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2025 The Cross-Media Measurement Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wfanet.measurement.integration.common.fake
+
+import org.wfanet.measurement.api.v2alpha.CreateEventGroupRequest
+import org.wfanet.measurement.api.v2alpha.DeleteEventGroupRequest
+import org.wfanet.measurement.api.v2alpha.EventGroup
+import org.wfanet.measurement.api.v2alpha.EventGroupsGrpcKt.EventGroupsCoroutineImplBase
+import org.wfanet.measurement.api.v2alpha.GetEventGroupRequest
+import org.wfanet.measurement.api.v2alpha.ListEventGroupsRequest
+import org.wfanet.measurement.api.v2alpha.ListEventGroupsResponse
+import org.wfanet.measurement.api.v2alpha.UpdateEventGroupRequest
+import org.wfanet.measurement.api.v2alpha.listEventGroupsResponse
+
+class EventGroupsService(private val eventGroups: List<EventGroup>) :
+  EventGroupsCoroutineImplBase() {
+  private val updatedEventGroups: MutableList<EventGroup> = eventGroups.toMutableList()
+  private var index = 0
+
+  override suspend fun getEventGroup(request: GetEventGroupRequest): EventGroup {
+    return updatedEventGroups.filter { request.name == it.name }.single()
+  }
+
+  override suspend fun createEventGroup(request: CreateEventGroupRequest): EventGroup {
+    updatedEventGroups.add(request.eventGroup)
+
+    return request.eventGroup
+  }
+
+  override suspend fun updateEventGroup(request: UpdateEventGroupRequest): EventGroup {
+    updatedEventGroups.removeIf { request.eventGroup.name == it.name }
+    updatedEventGroups.add(request.eventGroup)
+    return request.eventGroup
+  }
+
+  override suspend fun deleteEventGroup(request: DeleteEventGroupRequest): EventGroup {
+    val deletedEventGroup = updatedEventGroups.filter { request.name == it.name }.single()
+    updatedEventGroups.removeIf { request.name == it.name }
+    return deletedEventGroup
+  }
+
+  override suspend fun listEventGroups(request: ListEventGroupsRequest): ListEventGroupsResponse {
+    return listEventGroupsResponse {
+      val numToReturn = minOf(request.pageSize, updatedEventGroups.size - index)
+      if (numToReturn > 0) {
+        this.eventGroups += updatedEventGroups.subList(index, index + numToReturn)
+        this.nextPageToken = "some-fake-token"
+        index += 1
+      }
+    }
+  }
+}

--- a/src/main/kotlin/org/wfanet/measurement/integration/common/fake/InProcessKingdom.kt
+++ b/src/main/kotlin/org/wfanet/measurement/integration/common/fake/InProcessKingdom.kt
@@ -1,0 +1,59 @@
+// Copyright 2025 The Cross-Media Measurement Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.wfanet.measurement.integration.common.fake
+
+import io.grpc.Channel
+import java.util.logging.Logger
+import org.junit.rules.TestRule
+import org.junit.runner.Description
+import org.junit.runners.model.Statement
+import org.wfanet.measurement.api.v2alpha.EventGroup
+import org.wfanet.measurement.api.v2alpha.Requisition
+import org.wfanet.measurement.common.grpc.testing.GrpcTestServerRule
+import org.wfanet.measurement.common.testing.chainRulesSequentially
+
+/**
+ * TestRule that starts a Data Provider-facing mock Kingdom. Currently, only mocks
+ * EventGroupsService and RequisitionsService
+ *
+ * @requisitions A list of [Requisition]s
+ * @eventGroups A list of [EventGroup]s
+ */
+class InProcessMockKindom(
+  private val requisitions: List<Requisition>,
+  private val eventGroups: List<EventGroup>,
+) : TestRule {
+
+  private val publicApiServer =
+    GrpcTestServerRule() {
+      logger.info("Building Mock Kingdom's public API services")
+
+      listOf(EventGroupsService(eventGroups), RequisitionsService(requisitions)).forEach {
+        addService(it)
+      }
+    }
+
+  /** Provides a gRPC channel to the Kingdom's public API. */
+  val publicApiChannel: Channel
+    get() = publicApiServer.channel
+
+  override fun apply(statement: Statement, description: Description): Statement {
+    return chainRulesSequentially(publicApiServer).apply(statement, description)
+  }
+
+  companion object {
+    private val logger: Logger = Logger.getLogger(this::class.java.name)
+  }
+}

--- a/src/main/kotlin/org/wfanet/measurement/integration/common/fake/RequisitionsService.kt
+++ b/src/main/kotlin/org/wfanet/measurement/integration/common/fake/RequisitionsService.kt
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2020 The Cross-Media Measurement Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wfanet.measurement.integration.common.fake
+
+import org.wfanet.measurement.api.v2alpha.FulfillDirectRequisitionRequest
+import org.wfanet.measurement.api.v2alpha.FulfillDirectRequisitionResponse
+import org.wfanet.measurement.api.v2alpha.ListRequisitionsRequest
+import org.wfanet.measurement.api.v2alpha.ListRequisitionsResponse
+import org.wfanet.measurement.api.v2alpha.RefuseRequisitionRequest
+import org.wfanet.measurement.api.v2alpha.Requisition
+import org.wfanet.measurement.api.v2alpha.Requisition.State
+import org.wfanet.measurement.api.v2alpha.RequisitionsGrpcKt.RequisitionsCoroutineImplBase
+import org.wfanet.measurement.api.v2alpha.fulfillDirectRequisitionResponse
+import org.wfanet.measurement.api.v2alpha.listRequisitionsResponse
+
+class RequisitionsService(private val requisitions: List<Requisition>) :
+  RequisitionsCoroutineImplBase() {
+  private var index = 0
+
+  override suspend fun listRequisitions(
+    request: ListRequisitionsRequest
+  ): ListRequisitionsResponse {
+    return listRequisitionsResponse {
+      val numToReturn = minOf(request.pageSize, requisitions.size - index)
+      if (numToReturn > 0) {
+        this.requisitions += requisitions.subList(index, index + numToReturn)
+        this.nextPageToken = "some-fake-token"
+        index += numToReturn
+      }
+    }
+  }
+
+  override suspend fun refuseRequisition(request: RefuseRequisitionRequest): Requisition {
+    return requisitions.filter { request.name == it.name }.single()
+  }
+
+  override suspend fun fulfillDirectRequisition(
+    request: FulfillDirectRequisitionRequest
+  ): FulfillDirectRequisitionResponse {
+
+    return fulfillDirectRequisitionResponse { state = State.FULFILLED }
+  }
+}


### PR DESCRIPTION
This is meant to be used in scenarios where the kingdom isn't directly controlled in the test.

In the case of the EDP Aggregator End To End Test, the following will occur.
1. The requisition fetcher will fetch requisitions
2. The event group sync will sync event groups
3. The TEE fulfiller app will fulfill to the kingdom

In the EDP Aggregator End to End Test, the fake kingdom is needed for event group registration, fetching and fulfilling requisitions.