### PR TITLE
feat: Create results fulfiller

### DIFF
--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/resultsfulfiller/BUILD.bazel
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/resultsfulfiller/BUILD.bazel
@@ -37,7 +37,6 @@ kt_jvm_library(
         "//src/main/proto/wfa/measurement/api/v2alpha:requisition_kt_jvm_proto",
         "//src/main/proto/wfa/measurement/api/v2alpha:requisitions_service_kt_jvm_grpc_proto",
         "//src/main/proto/wfa/measurement/edpaggregator/v1alpha:blob_details_kt_jvm_proto",
-        "//src/main/proto/wfa/measurement/edpaggregator/v1alpha:encrypted_dek_kt_jvm_proto",
         "//src/main/proto/wfa/measurement/edpaggregator/v1alpha:labeled_impression_kt_jvm_proto",
         "@any_sketch_java//src/main/java/org/wfanet/anysketch",
         "@any_sketch_java//src/main/java/org/wfanet/frequencycount",

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/resultsfulfiller/BUILD.bazel
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/resultsfulfiller/BUILD.bazel
@@ -1,0 +1,61 @@
+load("@wfa_rules_kotlin_jvm//kotlin:defs.bzl", "kt_jvm_library")
+
+package(
+    default_testonly = True,
+    default_visibility = ["//visibility:public"],
+)
+
+kt_jvm_library(
+    name = "results_fulfiller",
+    srcs = ["ResultsFulfiller.kt"],
+    deps = [
+        ":measurement_results",
+        "//imports/java/com/google/crypto/tink/integration/gcpkms",
+        "//src/main/kotlin/org/wfanet/measurement/api/v2alpha:packed_messages",
+        "//src/main/kotlin/org/wfanet/measurement/api/v2alpha:resource_key",
+        "//src/main/kotlin/org/wfanet/measurement/common:health",
+        "//src/main/kotlin/org/wfanet/measurement/common/api/grpc:list_resources",
+        "//src/main/kotlin/org/wfanet/measurement/eventdataprovider/eventfiltration:event_filters",
+        "//src/main/kotlin/org/wfanet/measurement/eventdataprovider/noiser",
+        "//src/main/kotlin/org/wfanet/measurement/eventdataprovider/privacybudgetmanagement:privacy_budget_manager",
+        "//src/main/kotlin/org/wfanet/measurement/eventdataprovider/privacybudgetmanagement/api/v2alpha:privacy_query_mapper",
+        "//src/main/kotlin/org/wfanet/measurement/eventdataprovider/shareshuffle/v2alpha:shareshuffle",
+        "//src/main/kotlin/org/wfanet/measurement/securecomputation/teesdk:base_tee_application",
+        "//src/main/kotlin/org/wfanet/panelmatch/client/storage/gcloud/gcs",
+        "//src/main/proto/wfa/any_sketch:frequency_vector_kt_jvm_proto",
+        "//src/main/proto/wfa/any_sketch:sketch_kt_jvm_proto",
+        "//src/main/proto/wfa/frequency_count:secret_share_kt_jvm_proto",
+        "//src/main/proto/wfa/frequency_count:secret_share_methods_kt_jvm__proto",
+        "//src/main/proto/wfa/measurement/api/v2alpha:certificates_service_kt_jvm_grpc_proto",
+        "//src/main/proto/wfa/measurement/api/v2alpha:crypto_kt_jvm_proto",
+        "//src/main/proto/wfa/measurement/api/v2alpha:data_providers_service_kt_jvm_grpc_proto",
+        "//src/main/proto/wfa/measurement/api/v2alpha:direct_computation_kt_jvm_proto",
+        "//src/main/proto/wfa/measurement/api/v2alpha:event_group_kt_jvm_proto",
+        "//src/main/proto/wfa/measurement/api/v2alpha:event_group_metadata_descriptors_service_kt_jvm_grpc_proto",
+        "//src/main/proto/wfa/measurement/api/v2alpha:event_groups_service_kt_jvm_grpc_proto",
+        "//src/main/proto/wfa/measurement/api/v2alpha:requisition_fulfillment_service_kt_jvm_grpc_proto",
+        "//src/main/proto/wfa/measurement/api/v2alpha:requisition_kt_jvm_proto",
+        "//src/main/proto/wfa/measurement/api/v2alpha:requisitions_service_kt_jvm_grpc_proto",
+        "//src/main/proto/wfa/measurement/edpaggregator/v1alpha:blob_details_kt_jvm_proto",
+        "//src/main/proto/wfa/measurement/edpaggregator/v1alpha:encrypted_dek_kt_jvm_proto",
+        "//src/main/proto/wfa/measurement/edpaggregator/v1alpha:labeled_impression_kt_jvm_proto",
+        "@any_sketch_java//src/main/java/org/wfanet/anysketch",
+        "@any_sketch_java//src/main/java/org/wfanet/frequencycount",
+        "@any_sketch_java//src/main/java/org/wfanet/sampling",
+        "@wfa_common_jvm//imports/java/com/google/protobuf",
+        "@wfa_common_jvm//imports/kotlin/kotlinx/coroutines:core",
+        "@wfa_common_jvm//src/main/kotlin/org/wfanet/measurement/storage:mesos_recordio_storage_client",
+        "@wfa_common_jvm//src/main/kotlin/org/wfanet/measurement/storage:selected_storage_client",
+        "@wfa_common_jvm//src/main/kotlin/org/wfanet/measurement/storage/testing",
+        "@wfa_consent_signaling_client//src/main/kotlin/org/wfanet/measurement/consent/client/measurementconsumer",
+    ],
+)
+
+kt_jvm_library(
+    name = "measurement_results",
+    srcs = ["MeasurementResults.kt"],
+    deps = [
+        "//imports/java/org/projectnessie/cel",
+        "@wfa_common_jvm//imports/java/com/google/protobuf",
+    ],
+)

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/resultsfulfiller/MeasurementResults.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/resultsfulfiller/MeasurementResults.kt
@@ -49,11 +49,4 @@ object MeasurementResults {
   fun computeReach(filteredVids: Iterable<Long>): Int {
     return filteredVids.distinct().size
   }
-
-  /** Computes impression using the "deterministic count" methodology. */
-  fun computeImpression(filteredVids: Iterable<Long>, maxFrequency: Int): Long {
-    val eventsPerVid: Map<Long, Int> = filteredVids.groupingBy { it }.eachCount()
-    // Cap each count at `maxFrequency`.
-    return eventsPerVid.values.sumOf { count -> count.coerceAtMost(maxFrequency).toLong() }
-  }
 }

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/resultsfulfiller/MeasurementResults.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/resultsfulfiller/MeasurementResults.kt
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2025 The Cross-Media Measurement Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wfanet.measurement.edpaggregator.resultsfulfiller
+
+/** Utilities for computing Measurement results. */
+object MeasurementResults {
+  data class ReachAndFrequency(val reach: Int, val relativeFrequencyDistribution: Map<Int, Double>)
+
+  /**
+   * Computes reach and frequency using the "deterministic count distinct" methodology and the
+   * "deterministic distribution" methodology.
+   */
+  fun computeReachAndFrequency(filteredVids: Iterable<Long>, maxFrequency: Int): ReachAndFrequency {
+    val eventsPerVid: Map<Long, Int> = filteredVids.groupingBy { it }.eachCount()
+    val reach: Int = eventsPerVid.keys.size
+
+    // If the filtered VIDs is empty, set the distribution with all 0s up to maxFrequency.
+    if (reach == 0) {
+      return ReachAndFrequency(reach, (1..maxFrequency).associateWith { 0.0 })
+    }
+
+    // Build frequency histogram as a 0-based array.
+    val frequencyArray = IntArray(maxFrequency)
+    for (count in eventsPerVid.values) {
+      val bucket = count.coerceAtMost(maxFrequency)
+      frequencyArray[bucket - 1]++
+    }
+
+    val frequencyDistribution: Map<Int, Double> =
+      frequencyArray.withIndex().associateBy({ it.index + 1 }, { it.value.toDouble() / reach })
+    return ReachAndFrequency(reach, frequencyDistribution)
+  }
+
+  /** Computes reach using the "deterministic count distinct" methodology. */
+  fun computeReach(filteredVids: Iterable<Long>): Int {
+    return filteredVids.distinct().size
+  }
+
+  /** Computes impression using the "deterministic count" methodology. */
+  fun computeImpression(filteredVids: Iterable<Long>, maxFrequency: Int): Long {
+    val eventsPerVid: Map<Long, Int> = filteredVids.groupingBy { it }.eachCount()
+    // Cap each count at `maxFrequency`.
+    return eventsPerVid.values.sumOf { count -> count.coerceAtMost(maxFrequency).toLong() }
+  }
+}

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/resultsfulfiller/ResultsFulfiller.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/resultsfulfiller/ResultsFulfiller.kt
@@ -1,10 +1,7 @@
 package org.wfanet.measurement.edpaggregator.resultsfulfiller
-
-
 import com.google.common.hash.HashFunction
 import com.google.common.hash.Hashing
 import com.google.crypto.tink.KmsClient
-import org.wfanet.measurement.common.crypto.tink.withEnvelopeEncryption
 import com.google.protobuf.Descriptors.Descriptor
 import com.google.protobuf.DynamicMessage
 import com.google.protobuf.TextFormat
@@ -12,6 +9,7 @@ import com.google.protobuf.TypeRegistry
 import com.google.protobuf.kotlin.unpack
 import com.google.type.Interval
 import io.grpc.StatusException
+import java.io.File
 import java.security.GeneralSecurityException
 import java.util.logging.Level
 import java.util.logging.Logger
@@ -43,620 +41,573 @@ import org.wfanet.measurement.api.v2alpha.fulfillDirectRequisitionRequest
 import org.wfanet.measurement.api.v2alpha.unpack
 import org.wfanet.measurement.common.crypto.PrivateKeyHandle
 import org.wfanet.measurement.common.crypto.SigningKeyHandle
+import org.wfanet.measurement.common.crypto.tink.withEnvelopeEncryption
 import org.wfanet.measurement.common.toInstant
 import org.wfanet.measurement.consent.client.dataprovider.decryptRequisitionSpec
 import org.wfanet.measurement.consent.client.dataprovider.encryptResult
 import org.wfanet.measurement.consent.client.dataprovider.signResult
+import org.wfanet.measurement.edpaggregator.v1alpha.BlobDetails
+import org.wfanet.measurement.edpaggregator.v1alpha.LabeledImpression
 import org.wfanet.measurement.eventdataprovider.eventfiltration.EventFilters
 import org.wfanet.measurement.eventdataprovider.noiser.AbstractNoiser
 import org.wfanet.measurement.eventdataprovider.noiser.DirectNoiseMechanism
 import org.wfanet.measurement.eventdataprovider.noiser.DpParams
 import org.wfanet.measurement.eventdataprovider.noiser.GaussianNoiser
 import org.wfanet.measurement.eventdataprovider.noiser.LaplaceNoiser
-import org.wfanet.measurement.edpaggregator.v1alpha.BlobDetails
-import org.wfanet.measurement.edpaggregator.v1alpha.LabeledImpression
-import org.wfanet.measurement.storage.StorageClient
-import org.wfanet.sampling.VidSampler
 import org.wfanet.measurement.storage.MesosRecordIoStorageClient
 import org.wfanet.measurement.storage.SelectedStorageClient
-import java.io.File
-
+import org.wfanet.sampling.VidSampler
 
 data class StorageConfig(
- val rootDirectory: File? = null,
- val projectId: String? = null,
+  val rootDirectory: File? = null,
+  val projectId: String? = null,
 )
 
-
 class ResultsFulfiller(
-        private val privateEncryptionKey: PrivateKeyHandle,
-        private val requisitionsStub: RequisitionsGrpcKt.RequisitionsCoroutineStub,
-        private val dataProviderCertificateKey: DataProviderCertificateKey,
-        private val dataProviderSigningKeyHandle: SigningKeyHandle,
-        private val typeRegistry: TypeRegistry,
-        private val requisitionsBlobUri: String,
-        private val labeledImpressionMetadataPrefix: String,
-        private val kmsClient: KmsClient,
-        private val impressionsStorageConfig: StorageConfig,
-        private val impressionMetadataStorageConfig: StorageConfig,
-        private val requisitionsStorageConfig: StorageConfig,
-        private val random: Random = Random,
- ) {
- suspend fun fulfillRequisitions() {
-   val requisitions = getRequisitions(requisitionsPath)
+  private val privateEncryptionKey: PrivateKeyHandle,
+  private val requisitionsStub: RequisitionsGrpcKt.RequisitionsCoroutineStub,
+  private val dataProviderCertificateKey: DataProviderCertificateKey,
+  private val dataProviderSigningKeyHandle: SigningKeyHandle,
+  private val typeRegistry: TypeRegistry,
+  private val requisitionsBlobUri: String,
+  private val labeledImpressionMetadataPrefix: String,
+  private val kmsClient: KmsClient,
+  private val impressionsStorageConfig: StorageConfig,
+  private val impressionMetadataStorageConfig: StorageConfig,
+  private val requisitionsStorageConfig: StorageConfig,
+  private val random: Random = Random,
+) {
+  suspend fun fulfillRequisitions() {
+    val requisitions = getRequisitions()
+    for (requisition in requisitions) {
+      val signedRequisitionSpec: SignedMessage =
+        try {
+          decryptRequisitionSpec(
+            requisition.encryptedRequisitionSpec,
+            // TODO: CREATE THIS WITH fulfiller config
+            privateEncryptionKey,
+          )
+        } catch (e: GeneralSecurityException) {
+          throw Exception("RequisitionSpec decryption failed", e)
+        }
+      val requisitionSpec: RequisitionSpec = signedRequisitionSpec.unpack()
+      val measurementSpec: MeasurementSpec = requisition.measurementSpec.message.unpack()
 
+      val sampledVids = getSampledVids(
+        requisitionSpec,
+        measurementSpec.vidSamplingInterval
+      )
+      val protocols: List<ProtocolConfig.Protocol> = requisition.protocolConfig.protocolsList
 
-   for(requisition in requisitions) {
-     val signedRequisitionSpec: SignedMessage =
-       try {
-         decryptRequisitionSpec(
-           requisition.encryptedRequisitionSpec,
-           // TODO: CREATE THIS WITH fulfiller config
-           privateEncryptionKey,
-           )
-       } catch (e: GeneralSecurityException) {
-         throw Exception("RequisitionSpec decryption failed", e)
-       }
-     val requisitionSpec: RequisitionSpec = signedRequisitionSpec.unpack()
-     val measurementSpec: MeasurementSpec = requisition.measurementSpec.message.unpack()
+      if (protocols.any { it.hasDirect() }) {
+        val directProtocolConfig =
+          requisition.protocolConfig.protocolsList.first { it.hasDirect() }.direct
+        val directNoiseMechanismOptions =
+          directProtocolConfig.noiseMechanismsList
+            .mapNotNull { protocolConfigNoiseMechanism ->
+              protocolConfigNoiseMechanism.toDirectNoiseMechanism()
+            }
+            .toSet()
+        if (measurementSpec.hasReach() || measurementSpec.hasReachAndFrequency()) {
+          fulfillDirectReachAndFrequencyMeasurement(
+            requisition,
+            measurementSpec,
+            sampledVids,
+            directProtocolConfig,
+            selectReachAndFrequencyNoiseMechanism(directNoiseMechanismOptions),
+            requisitionSpec.nonce,
+          )
+        } else if (measurementSpec.hasDuration()) {
+          // TODO
+        } else if (measurementSpec.hasImpression()) {
+          // TODO
+        } else {
+          throw RequisitionRefusalException(
+            Requisition.Refusal.Justification.SPEC_INVALID,
+            "Measurement type not supported for direct fulfillment.",
+          )
+        }
+      } else if (protocols.any { it.hasLiquidLegionsV2() }) {
+        // TODO
+      } else if (protocols.any { it.hasReachOnlyLiquidLegionsV2() }) {
+        // TODO
+      } else if (protocols.any { it.hasHonestMajorityShareShuffle() }) {
+        // TODO
+      } else {
+        throw Exception("Protocol not supported")
+      }
+    }
+  }
 
+  /**
+   * Selects the most preferred [DirectNoiseMechanism] for reach and frequency measurements from the
+   * overlap of a list of preferred [DirectNoiseMechanism] and a set of [DirectNoiseMechanism]
+   * [options].
+   */
+  private fun selectReachAndFrequencyNoiseMechanism(
+    options: Set<DirectNoiseMechanism>
+  ): DirectNoiseMechanism {
+    val preferences = listOf(DirectNoiseMechanism.CONTINUOUS_GAUSSIAN)
+    return preferences.firstOrNull { preference -> options.contains(preference) }
+      ?: throw Exception(
+        "No valid noise mechanism option for reach or frequency measurements.",
+      )
+  }
 
-     val sampledVids = getSampledVids(
-       requisitionSpec,
-       measurementSpec.vidSamplingInterval
-     )
-     val protocols: List<ProtocolConfig.Protocol> = requisition.protocolConfig.protocolsList
+  private suspend fun fulfillDirectReachAndFrequencyMeasurement(
+    requisition: Requisition,
+    measurementSpec: MeasurementSpec,
+    sampledVids: List<Long>,
+    directProtocolConfig: ProtocolConfig.Direct,
+    directNoiseMechanism: DirectNoiseMechanism,
+    nonce: Long,
+  ) {
+    logger.info("Calculating direct reach and frequency...")
+    val measurementResult = buildDirectMeasurementResult(
+      directProtocolConfig,
+      directNoiseMechanism,
+      measurementSpec,
+      sampledVids,
+    )
 
+    fulfillDirectMeasurement(requisition, measurementSpec, nonce, measurementResult)
+  }
 
-     if (protocols.any { it.hasDirect() }) {
-       val directProtocolConfig =
-         requisition.protocolConfig.protocolsList.first { it.hasDirect() }.direct
-       val directNoiseMechanismOptions =
-         directProtocolConfig.noiseMechanismsList
-           .mapNotNull { protocolConfigNoiseMechanism ->
-             protocolConfigNoiseMechanism.toDirectNoiseMechanism()
-           }
-           .toSet()
-       if (measurementSpec.hasReach() || measurementSpec.hasReachAndFrequency()) {
-         fulfillDirectReachAndFrequencyMeasurement(
-           requisition,
-           measurementSpec,
-           sampledVids,
-           directProtocolConfig,
-           selectReachAndFrequencyNoiseMechanism(directNoiseMechanismOptions),
-           requisitionSpec.nonce,
-         )
-       } else if (measurementSpec.hasDuration()) {
-         // TODO
-       } else if (measurementSpec.hasImpression()) {
-         // TODO
-       } else {
-         throw RequisitionRefusalException(
-           Requisition.Refusal.Justification.SPEC_INVALID,
-           "Measurement type not supported for direct fulfillment.",
-         )
-       }
-     } else if (protocols.any { it.hasLiquidLegionsV2() }) {
-       // TODO
-     } else if  (protocols.any { it.hasReachOnlyLiquidLegionsV2() }) {
-       // TODO
-     } else if (protocols.any { it.hasHonestMajorityShareShuffle() }) {
-       // TODO
-     } else {
-       throw Exception("Protocol not supported")
-     }
-   }
- }
+  protected suspend fun fulfillDirectMeasurement(
+    requisition: Requisition,
+    measurementSpec: MeasurementSpec,
+    nonce: Long,
+    measurementResult: Measurement.Result,
+  ) {
+    logger.log(Level.INFO, "Direct MeasurementSpec:\n$measurementSpec")
+    logger.log(Level.INFO, "Direct MeasurementResult:\n$measurementResult")
 
+    DataProviderCertificateKey.fromName(requisition.dataProviderCertificate)
+      ?: throw Exception(
+        "Invalid data provider certificate"
+      )
+    val measurementEncryptionPublicKey: EncryptionPublicKey =
+      if (measurementSpec.hasMeasurementPublicKey()) {
+        measurementSpec.measurementPublicKey.unpack()
+      } else {
+        @Suppress("DEPRECATION") // Handle legacy resources.
+        EncryptionPublicKey.parseFrom(measurementSpec.serializedMeasurementPublicKey)
+      }
+    val signedResult: SignedMessage =
+      signResult(measurementResult, dataProviderSigningKeyHandle)
+    val encryptedResult: EncryptedMessage =
+      encryptResult(signedResult, measurementEncryptionPublicKey)
 
- /**
-  * Selects the most preferred [DirectNoiseMechanism] for reach and frequency measurements from the
-  * overlap of a list of preferred [DirectNoiseMechanism] and a set of [DirectNoiseMechanism]
-  * [options].
-  */
- private fun selectReachAndFrequencyNoiseMechanism(
-   options: Set<DirectNoiseMechanism>
- ): DirectNoiseMechanism {
-   val preferences = listOf(DirectNoiseMechanism.CONTINUOUS_GAUSSIAN)
-   return preferences.firstOrNull { preference -> options.contains(preference) }
-     ?: throw Exception(
-       "No valid noise mechanism option for reach or frequency measurements.",
-     )
- }
+    try {
+      requisitionsStub.fulfillDirectRequisition(
+        fulfillDirectRequisitionRequest {
+          name = requisition.name
+          this.encryptedResult = encryptedResult
+          this.nonce = nonce
+          this.certificate = dataProviderCertificateKey.toName()
+        }
+      )
+    } catch (e: StatusException) {
+      throw Exception("Error fulfilling direct requisition ${requisition.name}", e)
+    }
+  }
 
+  /**
+   * Build [Measurement.Result] of the measurement type specified in [MeasurementSpec].
+   *
+   * @param measurementSpec Measurement spec.
+   * @param samples sampled events.
+   * @return [Measurement.Result].
+   */
+  private fun buildDirectMeasurementResult(
+    directProtocolConfig: ProtocolConfig.Direct,
+    directNoiseMechanism: DirectNoiseMechanism,
+    measurementSpec: MeasurementSpec,
+    samples: Iterable<Long>,
+  ): Measurement.Result {
+    val protocolConfigNoiseMechanism = when (directNoiseMechanism) {
+      DirectNoiseMechanism.NONE -> {
+        NoiseMechanism.NONE
+      }
+      DirectNoiseMechanism.CONTINUOUS_LAPLACE -> {
+        NoiseMechanism.CONTINUOUS_LAPLACE
+      }
+      else -> {
+        NoiseMechanism.CONTINUOUS_GAUSSIAN
+      }
+    }
 
- private suspend fun fulfillDirectReachAndFrequencyMeasurement(
-   requisition: Requisition,
-   measurementSpec: MeasurementSpec,
-   sampledVids: List<Long>,
-   directProtocolConfig: ProtocolConfig.Direct,
-   directNoiseMechanism: DirectNoiseMechanism,
-   nonce: Long,
- ) {
-   logger.info("Calculating direct reach and frequency...")
-   val measurementResult = buildDirectMeasurementResult(
-     directProtocolConfig,
-     directNoiseMechanism,
-     measurementSpec,
-     sampledVids,
-   )
+    @Suppress("WHEN_ENUM_CAN_BE_NULL_IN_JAVA") // Protobuf enum fields cannot be null.
+    return when (measurementSpec.measurementTypeCase) {
+      MeasurementSpec.MeasurementTypeCase.REACH_AND_FREQUENCY -> {
+        if (!directProtocolConfig.hasDeterministicCountDistinct()) {
+          throw RequisitionRefusalException(
+            Requisition.Refusal.Justification.DECLINED,
+            "No valid methodologies for direct reach computation.",
+          )
+        }
+        if (!directProtocolConfig.hasDeterministicDistribution()) {
+          throw RequisitionRefusalException(
+            Requisition.Refusal.Justification.DECLINED,
+            "No valid methodologies for direct frequency distribution computation.",
+          )
+        }
 
+        val (sampledReachValue, frequencyMap) =
+          MeasurementResults.computeReachAndFrequency(
+            samples,
+            measurementSpec.reachAndFrequency.maximumFrequency,
+          )
 
-   fulfillDirectMeasurement(requisition, measurementSpec, nonce, measurementResult)
- }
+        logger.info("Adding $directNoiseMechanism publisher noise to direct reach and frequency...")
+        val sampledNoisedReachValue =
+          addReachPublisherNoise(
+            sampledReachValue,
+            measurementSpec.reachAndFrequency.reachPrivacyParams,
+            directNoiseMechanism,
+          )
+        val noisedFrequencyMap =
+          addFrequencyPublisherNoise(
+            sampledReachValue,
+            frequencyMap,
+            measurementSpec.reachAndFrequency.frequencyPrivacyParams,
+            directNoiseMechanism,
+          )
 
+        val scaledNoisedReachValue =
+          (sampledNoisedReachValue / measurementSpec.vidSamplingInterval.width).toLong()
 
- protected suspend fun fulfillDirectMeasurement(
-   requisition: Requisition,
-   measurementSpec: MeasurementSpec,
-   nonce: Long,
-   measurementResult: Measurement.Result,
- ) {
-   logger.log(Level.INFO, "Direct MeasurementSpec:\n$measurementSpec")
-   logger.log(Level.INFO, "Direct MeasurementResult:\n$measurementResult")
+        MeasurementKt.result {
+          reach = MeasurementKt.ResultKt.reach {
+            value = scaledNoisedReachValue
+            this.noiseMechanism = protocolConfigNoiseMechanism
+            deterministicCountDistinct = DeterministicCountDistinct.getDefaultInstance()
+          }
+          frequency = MeasurementKt.ResultKt.frequency {
+            relativeFrequencyDistribution.putAll(noisedFrequencyMap.mapKeys { it.key.toLong() })
+            this.noiseMechanism = protocolConfigNoiseMechanism
+            deterministicDistribution = DeterministicDistribution.getDefaultInstance()
+          }
+        }
+      }
 
+      MeasurementSpec.MeasurementTypeCase.IMPRESSION -> {
+        MeasurementKt.result {
+          // TODO
+        }
+      }
 
-   DataProviderCertificateKey.fromName(requisition.dataProviderCertificate)
-     ?: throw Exception(
-       "Invalid data provider certificate"
-     )
-   val measurementEncryptionPublicKey: EncryptionPublicKey =
-     if (measurementSpec.hasMeasurementPublicKey()) {
-       measurementSpec.measurementPublicKey.unpack()
-     } else {
-       @Suppress("DEPRECATION") // Handle legacy resources.
-       EncryptionPublicKey.parseFrom(measurementSpec.serializedMeasurementPublicKey)
-     }
-   val signedResult: SignedMessage =
-     signResult(measurementResult, dataProviderSigningKeyHandle!!)
-   val encryptedResult: EncryptedMessage =
-     encryptResult(signedResult, measurementEncryptionPublicKey)
+      MeasurementSpec.MeasurementTypeCase.DURATION -> {
+        MeasurementKt.result {
+          // TODO
+        }
+      }
 
+      MeasurementSpec.MeasurementTypeCase.POPULATION -> {
+        MeasurementKt.result {
+          // TODO
+        }
+      }
 
-   try {
-     requisitionsStub.fulfillDirectRequisition(
-       fulfillDirectRequisitionRequest {
-         name = requisition.name
-         this.encryptedResult = encryptedResult
-         this.nonce = nonce
-         this.certificate = dataProviderCertificateKey!!.toName()
-       }
-     )
-   } catch (e: StatusException) {
-     throw Exception("Error fulfilling direct requisition ${requisition.name}", e)
-   }
- }
+      MeasurementSpec.MeasurementTypeCase.REACH -> {
+        MeasurementKt.result {
+          // TODO
+        }
+      }
 
+      MeasurementSpec.MeasurementTypeCase.MEASUREMENTTYPE_NOT_SET -> {
+        error("Measurement type not set.")
+      }
+    }
+  }
 
- /**
-  * Build [Measurement.Result] of the measurement type specified in [MeasurementSpec].
-  *
-  * @param measurementSpec Measurement spec.
-  * @param samples sampled events.
-  * @return [Measurement.Result].
-  */
- private fun buildDirectMeasurementResult(
-   directProtocolConfig: ProtocolConfig.Direct,
-   directNoiseMechanism: DirectNoiseMechanism,
-   measurementSpec: MeasurementSpec,
-   samples: Iterable<Long>,
- ): Measurement.Result {
-   val protocolConfigNoiseMechanism = when (directNoiseMechanism) {
-       DirectNoiseMechanism.NONE -> {
-         NoiseMechanism.NONE
-       }
-       DirectNoiseMechanism.CONTINUOUS_LAPLACE -> {
-         NoiseMechanism.CONTINUOUS_LAPLACE
-       }
-       else -> {
-         NoiseMechanism.CONTINUOUS_GAUSSIAN
-       }
-   }
+  private fun getPublisherNoiser(
+    privacyParams: DifferentialPrivacyParams,
+    directNoiseMechanism: DirectNoiseMechanism,
+    random: Random,
+  ): AbstractNoiser =
+    when (directNoiseMechanism) {
+      DirectNoiseMechanism.NONE ->
+        object : AbstractNoiser() {
+          override val distribution = ConstantRealDistribution(0.0)
+          override val variance: Double
+            get() = distribution.numericalVariance
+        }
 
+      DirectNoiseMechanism.CONTINUOUS_LAPLACE ->
+        LaplaceNoiser(DpParams(privacyParams.epsilon, privacyParams.delta), random.asJavaRandom())
 
-   @Suppress("WHEN_ENUM_CAN_BE_NULL_IN_JAVA") // Protobuf enum fields cannot be null.
-   return when (measurementSpec.measurementTypeCase) {
-     MeasurementSpec.MeasurementTypeCase.REACH_AND_FREQUENCY -> {
-       if (!directProtocolConfig.hasDeterministicCountDistinct()) {
-         throw RequisitionRefusalException(
-           Requisition.Refusal.Justification.DECLINED,
-           "No valid methodologies for direct reach computation.",
-         )
-       }
-       if (!directProtocolConfig.hasDeterministicDistribution()) {
-         throw RequisitionRefusalException(
-           Requisition.Refusal.Justification.DECLINED,
-           "No valid methodologies for direct frequency distribution computation.",
-         )
-       }
+      DirectNoiseMechanism.CONTINUOUS_GAUSSIAN ->
+        GaussianNoiser(DpParams(privacyParams.epsilon, privacyParams.delta), random.asJavaRandom())
+    }
 
+  /**
+   * Add publisher noise to calculated direct reach.
+   *
+   * @param reachValue Direct reach value.
+   * @param privacyParams Differential privacy params for reach.
+   * @param directNoiseMechanism Selected noise mechanism for direct reach.
+   * @return Noised non-negative reach value.
+   */
+  private fun addReachPublisherNoise(
+    reachValue: Int,
+    privacyParams: DifferentialPrivacyParams,
+    directNoiseMechanism: DirectNoiseMechanism,
+  ): Int {
+    val reachNoiser: AbstractNoiser =
+      getPublisherNoiser(privacyParams, directNoiseMechanism, random)
 
-       val (sampledReachValue, frequencyMap) =
-         MeasurementResults.computeReachAndFrequency(
-           samples,
-           measurementSpec.reachAndFrequency.maximumFrequency,
-         )
+    return max(0, reachValue + reachNoiser.sample().toInt())
+  }
+  /**
+   * Add publisher noise to calculated direct frequency.
+   *
+   * @param reachValue Direct reach value.
+   * @param frequencyMap Direct frequency.
+   * @param privacyParams Differential privacy params for frequency map.
+   * @param directNoiseMechanism Selected noise mechanism for direct frequency.
+   * @return Noised non-negative frequency map.
+   */
+  private fun addFrequencyPublisherNoise(
+    reachValue: Int,
+    frequencyMap: Map<Int, Double>,
+    privacyParams: DifferentialPrivacyParams,
+    directNoiseMechanism: DirectNoiseMechanism,
+  ): Map<Int, Double> {
+    val frequencyNoiser: AbstractNoiser =
+      getPublisherNoiser(privacyParams, directNoiseMechanism, random)
 
+    // Add noise to the histogram and cap negative values to zeros.
+    val frequencyHistogram: Map<Int, Int> =
+      frequencyMap.mapValues { (_, percentage) ->
+        // Round the noise for privacy.
+        val noisedCount: Int =
+          (percentage * reachValue).roundToInt() + (frequencyNoiser.sample()).roundToInt()
+        max(0, noisedCount)
+      }
+    val normalizationTerm: Double = frequencyHistogram.values.sum().toDouble()
+    // Normalize to get the distribution
+    return if (normalizationTerm != 0.0) {
+      frequencyHistogram.mapValues { (_, count) -> count / normalizationTerm }
+    } else {
+      frequencyHistogram.mapValues { 0.0 }
+    }
+  }
 
-       logger.info("Adding $directNoiseMechanism publisher noise to direct reach and frequency...")
-       val sampledNoisedReachValue =
-         addReachPublisherNoise(
-           sampledReachValue,
-           measurementSpec.reachAndFrequency.reachPrivacyParams,
-           directNoiseMechanism,
-         )
-       val noisedFrequencyMap =
-         addFrequencyPublisherNoise(
-           sampledReachValue,
-           frequencyMap,
-           measurementSpec.reachAndFrequency.frequencyPrivacyParams,
-           directNoiseMechanism,
-         )
+  /**
+   * Converts a [NoiseMechanism] to a nullable [DirectNoiseMechanism].
+   *
+   * @return [DirectNoiseMechanism] when there is a matched, otherwise null.
+   */
+  private fun NoiseMechanism.toDirectNoiseMechanism(): DirectNoiseMechanism? {
+    return when (this) {
+      NoiseMechanism.NONE -> DirectNoiseMechanism.NONE
+      NoiseMechanism.CONTINUOUS_LAPLACE -> DirectNoiseMechanism.CONTINUOUS_LAPLACE
+      NoiseMechanism.CONTINUOUS_GAUSSIAN -> DirectNoiseMechanism.CONTINUOUS_GAUSSIAN
+      NoiseMechanism.NOISE_MECHANISM_UNSPECIFIED,
+      NoiseMechanism.GEOMETRIC,
+      NoiseMechanism.DISCRETE_GAUSSIAN,
+      NoiseMechanism.UNRECOGNIZED -> {
+        null
+      }
+    }
+  }
 
+  fun compileProgram(
+    eventFilter: RequisitionSpec.EventFilter,
+    eventMessageDescriptor: Descriptor,
+  ): Program {
+    // EventFilters should take care of this, but checking here is an optimization that can skip
+    // creation of a CEL Env.
+    if (eventFilter.expression.isEmpty()) {
+      return Program { TRUE_EVAL_RESULT }
+    }
+    return EventFilters.compileProgram(eventMessageDescriptor, eventFilter.expression)
+  }
 
-       val scaledNoisedReachValue =
-         (sampledNoisedReachValue / measurementSpec.vidSamplingInterval.width).toLong()
+  private suspend fun getRequisitions(): List<Requisition> {
+    // Gets path to list of new requisitions in blob storage
+    val storageClientUri = SelectedStorageClient.parseBlobUri(requisitionsBlobUri)
+    val requisitionsStorageClient = createStorageClient(storageClientUri, requisitionsStorageConfig)
+    val requisitionBlob = requisitionsStorageClient.getBlob(storageClientUri.key)!!
+    val requisitionData = requisitionBlob.read().reduce { acc, byteString -> acc.concat(byteString) }.toStringUtf8()
+    val requisition = Requisition.getDefaultInstance()
+      .newBuilderForType()
+      .apply {
+        TextFormat.Parser.newBuilder()
+          .build()
+          .merge(requisitionData, this)
+      }
+      .build() as Requisition
 
+    return listOf(requisition)
+  }
 
-       MeasurementKt.result {
-         reach = MeasurementKt.ResultKt.reach {
-           value = scaledNoisedReachValue
-           this.noiseMechanism = protocolConfigNoiseMechanism
-           deterministicCountDistinct = DeterministicCountDistinct.getDefaultInstance()
-         }
-         frequency = MeasurementKt.ResultKt.frequency {
-           relativeFrequencyDistribution.putAll(noisedFrequencyMap.mapKeys { it.key.toLong() })
-           this.noiseMechanism = protocolConfigNoiseMechanism
-           deterministicDistribution = DeterministicDistribution.getDefaultInstance()
-         }
-       }
-     }
-     MeasurementSpec.MeasurementTypeCase.IMPRESSION -> {
-       MeasurementKt.result {
-           // TODO
-       }
-     }
-     MeasurementSpec.MeasurementTypeCase.DURATION -> {
-         MeasurementKt.result {
-             // TODO
-         }
-     }
-     MeasurementSpec.MeasurementTypeCase.POPULATION -> {
-         MeasurementKt.result {
-             // TODO
-         }
-     }
-     MeasurementSpec.MeasurementTypeCase.REACH -> {
-         MeasurementKt.result {
-             // TODO
-         }
-     }
-     MeasurementSpec.MeasurementTypeCase.MEASUREMENTTYPE_NOT_SET -> {
-       error("Measurement type not set.")
-     }
-   }
- }
+  private suspend fun getSampledVids(
+    requisitionSpec: RequisitionSpec,
+    vidSamplingInterval: MeasurementSpec.VidSamplingInterval,
+  ): List<Long> {
+    val vidSamplingIntervalStart = vidSamplingInterval.start
+    val vidSamplingIntervalWidth = vidSamplingInterval.width
+    require(vidSamplingIntervalWidth > 0 && vidSamplingIntervalWidth <= 1.0) {
+      "Invalid vidSamplingIntervalWidth $vidSamplingIntervalWidth"
+    }
+    require(
+      vidSamplingIntervalStart < 1 &&
+        vidSamplingIntervalStart >= 0 &&
+        vidSamplingIntervalWidth > 0 &&
+        vidSamplingIntervalStart + vidSamplingIntervalWidth <= 1
+    ) {
+      "Invalid vidSamplingInterval: start = $vidSamplingIntervalStart, width = " +
+        "$vidSamplingIntervalWidth"
+    }
 
+    return requisitionSpec.events.eventGroupsList.map { eventGroup ->
+      val collectionInterval = eventGroup.value.collectionInterval
+      val blobDetails = getBlobDetails(collectionInterval, eventGroup.key)
 
- private fun getPublisherNoiser(
-   privacyParams: DifferentialPrivacyParams,
-   directNoiseMechanism: DirectNoiseMechanism,
-   random: Random,
- ): AbstractNoiser =
-   when (directNoiseMechanism) {
-     DirectNoiseMechanism.NONE ->
-       object : AbstractNoiser() {
-         override val distribution = ConstantRealDistribution(0.0)
-         override val variance: Double
-           get() = distribution.numericalVariance
-       }
-     DirectNoiseMechanism.CONTINUOUS_LAPLACE ->
-       LaplaceNoiser(DpParams(privacyParams.epsilon, privacyParams.delta), random.asJavaRandom())
-     DirectNoiseMechanism.CONTINUOUS_GAUSSIAN ->
-       GaussianNoiser(DpParams(privacyParams.epsilon, privacyParams.delta), random.asJavaRandom())
-   }
+      val labeledImpressions = getLabeledImpressions(blobDetails)
 
+      labeledImpressions.filter { labeledImpression ->
+        isValidImpression(labeledImpression, collectionInterval, eventGroup, vidSamplingIntervalStart, vidSamplingIntervalWidth)
+      }.map { labeledImpression ->
+        labeledImpression.vid
+      }
+    }.flatten()
+  }
 
- /**
-  * Add publisher noise to calculated direct reach.
-  *
-  * @param reachValue Direct reach value.
-  * @param privacyParams Differential privacy params for reach.
-  * @param directNoiseMechanism Selected noise mechanism for direct reach.
-  * @return Noised non-negative reach value.
-  */
- private fun addReachPublisherNoise(
-   reachValue: Int,
-   privacyParams: DifferentialPrivacyParams,
-   directNoiseMechanism: DirectNoiseMechanism,
- ): Int {
-   val reachNoiser: AbstractNoiser =
-     getPublisherNoiser(privacyParams, directNoiseMechanism, random)
-
-
-   return max(0, reachValue + reachNoiser.sample().toInt())
- }
-
-
- /**
-  * Add publisher noise to calculated direct frequency.
-  *
-  * @param reachValue Direct reach value.
-  * @param frequencyMap Direct frequency.
-  * @param privacyParams Differential privacy params for frequency map.
-  * @param directNoiseMechanism Selected noise mechanism for direct frequency.
-  * @return Noised non-negative frequency map.
-  */
- private fun addFrequencyPublisherNoise(
-   reachValue: Int,
-   frequencyMap: Map<Int, Double>,
-   privacyParams: DifferentialPrivacyParams,
-   directNoiseMechanism: DirectNoiseMechanism,
- ): Map<Int, Double> {
-   val frequencyNoiser: AbstractNoiser =
-     getPublisherNoiser(privacyParams, directNoiseMechanism, random)
-
-
-   // Add noise to the histogram and cap negative values to zeros.
-   val frequencyHistogram: Map<Int, Int> =
-     frequencyMap.mapValues { (_, percentage) ->
-       // Round the noise for privacy.
-       val noisedCount: Int =
-         (percentage * reachValue).roundToInt() + (frequencyNoiser.sample()).roundToInt()
-       max(0, noisedCount)
-     }
-   val normalizationTerm: Double = frequencyHistogram.values.sum().toDouble()
-   // Normalize to get the distribution
-   return if (normalizationTerm != 0.0) {
-     frequencyHistogram.mapValues { (_, count) -> count / normalizationTerm }
-   } else {
-     frequencyHistogram.mapValues { 0.0 }
-   }
- }
-
-
- /**
-  * Converts a [NoiseMechanism] to a nullable [DirectNoiseMechanism].
-  *
-  * @return [DirectNoiseMechanism] when there is a matched, otherwise null.
-  */
- private fun NoiseMechanism.toDirectNoiseMechanism(): DirectNoiseMechanism? {
-   return when (this) {
-     NoiseMechanism.NONE -> DirectNoiseMechanism.NONE
-     NoiseMechanism.CONTINUOUS_LAPLACE -> DirectNoiseMechanism.CONTINUOUS_LAPLACE
-     NoiseMechanism.CONTINUOUS_GAUSSIAN -> DirectNoiseMechanism.CONTINUOUS_GAUSSIAN
-     NoiseMechanism.NOISE_MECHANISM_UNSPECIFIED,
-     NoiseMechanism.GEOMETRIC,
-     NoiseMechanism.DISCRETE_GAUSSIAN,
-     NoiseMechanism.UNRECOGNIZED -> {
-       null
-     }
-   }
- }
-
-
-
-
- fun compileProgram(
-   eventFilter: RequisitionSpec.EventFilter,
-   eventMessageDescriptor: Descriptor,
- ): Program {
-   // EventFilters should take care of this, but checking here is an optimization that can skip
-   // creation of a CEL Env.
-   if (eventFilter.expression.isEmpty()) {
-     return Program { TRUE_EVAL_RESULT }
-   }
-   return EventFilters.compileProgram(eventMessageDescriptor, eventFilter.expression)
- }
-
-
- private suspend fun getRequisitions(blobKey: String): List<Requisition> {
-     // Gets path to list of new requisitions in blob storage
-     val storageClientUri = SelectedStorageClient.parseBlobUri(requisitionsBlobUri)
-     val requisitionsStorageClient = createStorageClient(storageClientUri, requisitionsStorageConfig)
-     val requisitionBlob = requisitionsStorageClient.getBlob(storageClientUri.key)!!
-     val requisitionData = requisitionBlob.read().reduce { acc, byteString -> acc.concat(byteString) }.toStringUtf8()
-   val requisition = Requisition.getDefaultInstance()
-     .newBuilderForType()
-     .apply {
-       TextFormat.Parser.newBuilder()
-         .build()
-         .merge(requisitionData, this)
-     }
-     .build() as Requisition
-
-   return listOf(requisition)
- }
-
-
- private suspend fun getSampledVids(
-   requisitionSpec: RequisitionSpec,
-   vidSamplingInterval: MeasurementSpec.VidSamplingInterval,
- ): List<Long> {
-   val vidSamplingIntervalStart = vidSamplingInterval.start
-   val vidSamplingIntervalWidth = vidSamplingInterval.width
-   require(vidSamplingIntervalWidth > 0 && vidSamplingIntervalWidth <= 1.0) {
-     "Invalid vidSamplingIntervalWidth $vidSamplingIntervalWidth"
-   }
-   require(
-     vidSamplingIntervalStart < 1 &&
-       vidSamplingIntervalStart >= 0 &&
-       vidSamplingIntervalWidth > 0 &&
-       vidSamplingIntervalStart + vidSamplingIntervalWidth <= 1
-   ) {
-     "Invalid vidSamplingInterval: start = $vidSamplingIntervalStart, width = " +
-       "$vidSamplingIntervalWidth"
-   }
-
-
-   return requisitionSpec.events.eventGroupsList.map { eventGroup ->
-     val collectionInterval = eventGroup.value.collectionInterval
-     val blobDetails = getBlobDetails(collectionInterval, eventGroup.key)
-
-     val labeledImpressions = getLabeledImpressions(blobDetails)
-
-
-     labeledImpressions.filter { labeledImpression ->
-       isValidImpression(labeledImpression, collectionInterval,eventGroup, vidSamplingIntervalStart, vidSamplingIntervalWidth)
-     }.map {labeledImpression ->
-       labeledImpression.vid
-     }
-   }.flatten()
- }
-
-
- /**
-  * Retrieves a list of labeled impressions from the specified storage.
-  *
-  * This method handles retrieving encrypted impression data from storage,
-  * setting up the appropriate encryption, and parsing the raw data into
-  * LabeledImpression protocol buffer messages.
-  *
-  * @param encryptedDek The encrypted data encryption key information
-  * @param impressionsStorageConfig Storage configuration for impressions
-  * @param kmsClient KMS client for handling encryption
-  * @return List of parsed LabeledImpression objects
-  * @throws IllegalStateException if impression data cannot be read or parsed
-  */
- private suspend fun getLabeledImpressions(
-   blobDetails: BlobDetails,
- ): List<LabeledImpression> {
-   // Get blob URI from encrypted DEK
-   val storageClientUri = SelectedStorageClient.parseBlobUri(blobDetails.blobUri)
-
+  /**
+   * Retrieves a list of labeled impressions from the specified storage.
+   *
+   * This method handles retrieving encrypted impression data from storage,
+   * setting up the appropriate encryption, and parsing the raw data into
+   * LabeledImpression protocol buffer messages.
+   *
+   * @param encryptedDek The encrypted data encryption key information
+   * @param impressionsStorageConfig Storage configuration for impressions
+   * @param kmsClient KMS client for handling encryption
+   * @return List of parsed LabeledImpression objects
+   * @throws IllegalStateException if impression data cannot be read or parsed
+   */
+  private suspend fun getLabeledImpressions(
+    blobDetails: BlobDetails,
+  ): List<LabeledImpression> {
+    // Get blob URI from encrypted DEK
+    val storageClientUri = SelectedStorageClient.parseBlobUri(blobDetails.blobUri)
 
 // Create and configure storage client with encryption
-     val encryptedDek = blobDetails.encryptedDek
-     val encryptedImpressionsClient = createStorageClient(storageClientUri, impressionsStorageConfig)
-   val impressionsAeadStorageClient = encryptedImpressionsClient.withEnvelopeEncryption(
-     kmsClient,
-     encryptedDek.kekUri,
-     encryptedDek.encryptedDek
-   )
-
+    val encryptedDek = blobDetails.encryptedDek
+    val encryptedImpressionsClient = createStorageClient(storageClientUri, impressionsStorageConfig)
+    val impressionsAeadStorageClient = encryptedImpressionsClient.withEnvelopeEncryption(
+      kmsClient,
+      encryptedDek.kekUri,
+      encryptedDek.encryptedDek
+    )
 
 // Access blob storage
-   val impressionsMesosStorage = MesosRecordIoStorageClient(impressionsAeadStorageClient)
-   val impressionBlob = impressionsMesosStorage.getBlob(storageClientUri.key)
-     ?: throw IllegalStateException("Could not retrieve impression blob from ${storageClientUri.key}")
+    val impressionsMesosStorage = MesosRecordIoStorageClient(impressionsAeadStorageClient)
+    val impressionBlob = impressionsMesosStorage.getBlob(storageClientUri.key)
+      ?: throw IllegalStateException("Could not retrieve impression blob from ${storageClientUri.key}")
 
 
-   // Parse raw data into LabeledImpression objects
-   val readResult = impressionBlob.read()
+    // Parse raw data into LabeledImpression objects
+    val readResult = impressionBlob.read()
 
+    val impressionRecords = readResult.toList()
 
-   val impressionRecords = readResult.toList()
+    return impressionRecords.map { impressionByteString ->
+      val labeledImpression = LabeledImpression.parseFrom(impressionByteString)
+        ?: throw IllegalStateException("Failed to parse LabeledImpression from bytes")
+      labeledImpression
+    }
+  }
 
+  /**
+   * Determines if a labeled impression is valid based on collection interval, filter criteria,
+   * and sampling bucket.
+   *
+   * @param labeledImpression The impression to validate
+   * @param collectionInterval Time interval for valid impressions
+   * @param eventTemplateTypeUrl Type URL for the event template
+   * @param typeRegistry Registry for protocol buffer types
+   * @param eventGroup Event group containing filter criteria
+   * @param sampler VID sampler implementation
+   * @param vidSamplingIntervalStart Start of sampling interval
+   * @param vidSamplingIntervalWidth Width of sampling interval
+   * @return true if the impression meets all validity criteria, false otherwise
+   */
+  private fun isValidImpression(
+    labeledImpression: LabeledImpression,
+    collectionInterval: Interval,
+    eventGroup: RequisitionSpec.EventGroupEntry,
+    vidSamplingIntervalStart: Float,
+    vidSamplingIntervalWidth: Float,
+  ): Boolean {
+    // Check if impression is within collection time interval
+    val isInCollectionInterval =
+      labeledImpression.impressionTime.toInstant() >= collectionInterval.startTime.toInstant() &&
+        labeledImpression.impressionTime.toInstant() < collectionInterval.endTime.toInstant()
+    // Check if VID is in sampling bucket
+    val isInSamplingInterval = sampler.vidIsInSamplingBucket(
+      labeledImpression.vid,
+      vidSamplingIntervalStart,
+      vidSamplingIntervalWidth
+    )
 
-   return impressionRecords.map { impressionByteString ->
-     val labeledImpression = LabeledImpression.parseFrom(impressionByteString)
-       ?: throw IllegalStateException("Failed to parse LabeledImpression from bytes")
-     labeledImpression
-   }
- }
+    // Process event template filter
+    val eventMessageData = labeledImpression.event!!
+    val eventTemplateDescriptor = typeRegistry.getDescriptorForTypeUrl(eventMessageData.typeUrl)
+    val eventMessage = DynamicMessage.parseFrom(eventTemplateDescriptor, eventMessageData.value)
+    val program = compileProgram(eventGroup.value.filter, eventTemplateDescriptor)
 
+    val passesFilter = EventFilters.matches(eventMessage, program)
+    // Return true only if all conditions are met
+    return isInCollectionInterval && passesFilter && isInSamplingInterval
+  }
+  private suspend fun getBlobDetails(collectionInterval: Interval, eventGroupId: String): BlobDetails {
+    val ds = collectionInterval.startTime.toInstant().toString()
+    val metadataBlobKey = "ds/$ds/event-group-id/$eventGroupId/metadata"
+    val metadataBlobUri = "$labeledImpressionMetadataPrefix/$metadataBlobKey"
+    val metadataStorageClientUri = SelectedStorageClient.parseBlobUri(metadataBlobUri)
+    val impressionsMetadataStorageClient = createStorageClient(metadataStorageClientUri, impressionMetadataStorageConfig)
+    // Get EncryptedDek message from storage using the blobKey made up of the ds and eventGroupId
+    val blobDetailsBlob = impressionsMetadataStorageClient.getBlob(metadataBlobKey)!! // SELECTED STORAGE CLIENT
+    val blobDetailsData =
+      blobDetailsBlob.read().reduce { acc, byteString -> acc.concat(byteString) }.toStringUtf8()
+    return BlobDetails.getDefaultInstance()
+      .newBuilderForType()
+      .apply { TextFormat.Parser.newBuilder().build().merge(blobDetailsData, this) }
+      .build() as BlobDetails
+  }
+  /**
+   * Creates a storage client for accessing blob data.
+   *
+   * This function constructs a [SelectedStorageClient] using the provided blob key
+   * and storage configuration. It parses the blob URI and initializes the appropriate
+   * client based on the storage configuration properties.
+   *
+   * @param blobKey The URI or path identifying the blob to access
+   * @param storageConfig Configuration containing settings for storage access,
+   *        including root directory and project ID
+   * @return A configured [SelectedStorageClient] instance ready to access the specified blob
+   */
+  fun createStorageClient(blobUri: org.wfanet.measurement.storage.BlobUri, storageConfig: StorageConfig): SelectedStorageClient {
+    return SelectedStorageClient(blobUri, storageConfig.rootDirectory, storageConfig.projectId)
+  }
+  companion object {
+    private val logger: Logger = Logger.getLogger(this::class.java.name)
+    private val VID_SAMPLER_HASH_FUNCTION: HashFunction = Hashing.farmHashFingerprint64()
+    private val TRUE_EVAL_RESULT = Program.newEvalResult(BoolT.True, null)
+    val sampler = VidSampler(VID_SAMPLER_HASH_FUNCTION)
 
- /**
-  * Determines if a labeled impression is valid based on collection interval, filter criteria,
-  * and sampling bucket.
-  *
-  * @param labeledImpression The impression to validate
-  * @param collectionInterval Time interval for valid impressions
-  * @param eventTemplateTypeUrl Type URL for the event template
-  * @param typeRegistry Registry for protocol buffer types
-  * @param eventGroup Event group containing filter criteria
-  * @param sampler VID sampler implementation
-  * @param vidSamplingIntervalStart Start of sampling interval
-  * @param vidSamplingIntervalWidth Width of sampling interval
-  * @return true if the impression meets all validity criteria, false otherwise
-  */
- private fun isValidImpression(
-   labeledImpression: LabeledImpression,
-   collectionInterval: Interval,
-   eventGroup:  RequisitionSpec.EventGroupEntry,
-   vidSamplingIntervalStart: Float,
-   vidSamplingIntervalWidth: Float,
- ): Boolean {
-   // Check if impression is within collection time interval
-   val isInCollectionInterval =
-     labeledImpression.impressionTime.toInstant() >= collectionInterval.startTime.toInstant() &&
-       labeledImpression.impressionTime.toInstant() < collectionInterval.endTime.toInstant()
-
-   // Check if VID is in sampling bucket
-   val isInSamplingInterval = sampler.vidIsInSamplingBucket(
-     labeledImpression.vid,
-     vidSamplingIntervalStart,
-     vidSamplingIntervalWidth
-   )
-
-     // Process event template filter
-     val eventMessageData = labeledImpression.event!!
-     val eventTemplateDescriptor = typeRegistry.getDescriptorForTypeUrl(eventMessageData.typeUrl)
-     val eventMessage = DynamicMessage.parseFrom(eventTemplateDescriptor, eventMessageData.value)
-     val program = compileProgram(eventGroup.value.filter, eventTemplateDescriptor)
-
-     val passesFilter = EventFilters.matches(eventMessage, program)
-
-
-
-     // Return true only if all conditions are met
-   return isInCollectionInterval && passesFilter && isInSamplingInterval
- }
-
-
- private suspend fun getBlobDetails(collectionInterval: Interval, eventGroupId: String): BlobDetails {
-   val ds = collectionInterval.startTime.toInstant().toString()
-   val metadataBlobKey = "ds/$ds/event-group-id/$eventGroupId/metadata"
-   val metadataBlobUri = "$labeledImpressionMetadataPrefix/$metadataBlobKey"
-   val metadataStorageClientUri = SelectedStorageClient.parseBlobUri(metadataBlobUri)
-
-
-   val impressionsMetadataStorageClient = createStorageClient(metadataStorageClientUri, impressionMetadataStorageConfig)
-   // Get EncryptedDek message from storage using the blobKey made up of the ds and eventGroupId
-   val blobDetailsBlob = impressionsMetadataStorageClient.getBlob(metadataBlobKey)!! // SELECTED STORAGE CLIENT
-   val blobDetailsData =
-     blobDetailsBlob.read().reduce { acc, byteString -> acc.concat(byteString) }.toStringUtf8()
-
-
-   return BlobDetails.getDefaultInstance()
-     .newBuilderForType()
-     .apply { TextFormat.Parser.newBuilder().build().merge(blobDetailsData, this) }
-     .build() as BlobDetails
- }
-
-
- /**
-  * Creates a storage client for accessing blob data.
-  *
-  * This function constructs a [SelectedStorageClient] using the provided blob key
-  * and storage configuration. It parses the blob URI and initializes the appropriate
-  * client based on the storage configuration properties.
-  *
-  * @param blobKey The URI or path identifying the blob to access
-  * @param storageConfig Configuration containing settings for storage access,
-  *        including root directory and project ID
-  * @return A configured [SelectedStorageClient] instance ready to access the specified blob
-  */
- fun createStorageClient(blobUri: org.wfanet.measurement.storage.BlobUri, storageConfig: StorageConfig): SelectedStorageClient {
-   return SelectedStorageClient(blobUri, storageConfig.rootDirectory, storageConfig.projectId)
- }
-
-
- companion object {
-   private val logger: Logger = Logger.getLogger(this::class.java.name)
-   private val VID_SAMPLER_HASH_FUNCTION: HashFunction = Hashing.farmHashFingerprint64()
-   private val TRUE_EVAL_RESULT = Program.newEvalResult(BoolT.True, null)
-
-
-   val sampler = VidSampler(VID_SAMPLER_HASH_FUNCTION)
-   /** [RequisitionRefusalException] for EventGroups. */
-   protected open class RequisitionRefusalException(
-     val justification: Requisition.Refusal.Justification,
-     message: String,
-     cause: Throwable? = null,
-   ) : Exception(message, cause) {
-     override val message: String
-       get() = super.message!!
-   }
- }
+    /** [RequisitionRefusalException] for EventGroups. */
+    protected open class RequisitionRefusalException(
+      val justification: Requisition.Refusal.Justification,
+      message: String,
+      cause: Throwable? = null,
+    ) : Exception(message, cause) {
+      override val message: String
+        get() = super.message!!
+    }
+  }
 }

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/resultsfulfiller/ResultsFulfiller.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/resultsfulfiller/ResultsFulfiller.kt
@@ -1,0 +1,679 @@
+package org.wfanet.measurement.edpaggregator.resultsfulfiller
+
+
+import com.google.common.hash.HashFunction
+import com.google.common.hash.Hashing
+import com.google.crypto.tink.KmsClient
+import org.wfanet.measurement.common.crypto.tink.withEnvelopeEncryption
+import com.google.protobuf.Descriptors.Descriptor
+import com.google.protobuf.DynamicMessage
+import com.google.protobuf.TextFormat
+import com.google.protobuf.TypeRegistry
+import com.google.protobuf.kotlin.unpack
+import com.google.type.Interval
+import io.grpc.StatusException
+import java.security.GeneralSecurityException
+import java.util.logging.Level
+import java.util.logging.Logger
+import kotlin.math.max
+import kotlin.math.roundToInt
+import kotlin.random.Random
+import kotlin.random.asJavaRandom
+import kotlinx.coroutines.flow.reduce
+import kotlinx.coroutines.flow.toList
+import org.apache.commons.math3.distribution.ConstantRealDistribution
+import org.projectnessie.cel.Program
+import org.projectnessie.cel.common.types.BoolT
+import org.wfanet.measurement.api.v2alpha.DataProviderCertificateKey
+import org.wfanet.measurement.api.v2alpha.DeterministicCountDistinct
+import org.wfanet.measurement.api.v2alpha.DeterministicDistribution
+import org.wfanet.measurement.api.v2alpha.DifferentialPrivacyParams
+import org.wfanet.measurement.api.v2alpha.EncryptedMessage
+import org.wfanet.measurement.api.v2alpha.EncryptionPublicKey
+import org.wfanet.measurement.api.v2alpha.Measurement
+import org.wfanet.measurement.api.v2alpha.MeasurementKt
+import org.wfanet.measurement.api.v2alpha.MeasurementSpec
+import org.wfanet.measurement.api.v2alpha.ProtocolConfig
+import org.wfanet.measurement.api.v2alpha.ProtocolConfig.NoiseMechanism
+import org.wfanet.measurement.api.v2alpha.Requisition
+import org.wfanet.measurement.api.v2alpha.RequisitionSpec
+import org.wfanet.measurement.api.v2alpha.RequisitionsGrpcKt
+import org.wfanet.measurement.api.v2alpha.SignedMessage
+import org.wfanet.measurement.api.v2alpha.fulfillDirectRequisitionRequest
+import org.wfanet.measurement.api.v2alpha.unpack
+import org.wfanet.measurement.common.crypto.PrivateKeyHandle
+import org.wfanet.measurement.common.crypto.SigningKeyHandle
+import org.wfanet.measurement.common.toInstant
+import org.wfanet.measurement.consent.client.dataprovider.decryptRequisitionSpec
+import org.wfanet.measurement.consent.client.dataprovider.encryptResult
+import org.wfanet.measurement.consent.client.dataprovider.signResult
+import org.wfanet.measurement.eventdataprovider.eventfiltration.EventFilters
+import org.wfanet.measurement.eventdataprovider.noiser.AbstractNoiser
+import org.wfanet.measurement.eventdataprovider.noiser.DirectNoiseMechanism
+import org.wfanet.measurement.eventdataprovider.noiser.DpParams
+import org.wfanet.measurement.eventdataprovider.noiser.GaussianNoiser
+import org.wfanet.measurement.eventdataprovider.noiser.LaplaceNoiser
+import org.wfanet.measurement.edpaggregator.v1alpha.BlobDetails
+import org.wfanet.measurement.edpaggregator.v1alpha.EncryptedDek
+import org.wfanet.measurement.edpaggregator.v1alpha.LabeledImpression
+import org.wfanet.measurement.storage.StorageClient
+import org.wfanet.sampling.VidSampler
+import org.wfanet.measurement.storage.MesosRecordIoStorageClient
+import org.wfanet.measurement.storage.SelectedStorageClient
+import java.io.File
+
+
+data class StorageConfig(
+ val rootDirectory: File? = null,
+ val projectId: String? = null,
+)
+
+
+class ResultsFulfiller(
+       private val privateEncryptionKey: PrivateKeyHandle,
+       private val requisitionsStub: RequisitionsGrpcKt.RequisitionsCoroutineStub,
+       private val dataProviderCertificateKey: DataProviderCertificateKey,
+       private val dataProviderSigningKeyHandle: SigningKeyHandle,
+       private val typeRegistry: TypeRegistry,
+       private val requisitionsPath: String,
+       private val labeledImpressionMetadataPrefix: String,
+       private val eventTemplateTypeUrl: String,
+       private val requisitionsStorageClient: StorageClient,
+       private val impressionsMetadataStorageClient: StorageClient,
+       private val kmsClient: KmsClient,
+       private val impressionsStorageConfig: StorageConfig,
+       private val impressionMetadataStorageConfig: StorageConfig,
+       private val random: Random = Random,
+ ) {
+ suspend fun fulfillRequisitions() {
+   val requisitions = getRequisitions(requisitionsPath)
+
+
+   for(requisition in requisitions) {
+     val signedRequisitionSpec: SignedMessage =
+       try {
+         decryptRequisitionSpec(
+           requisition.encryptedRequisitionSpec,
+           // TODO: CREATE THIS WITH fulfiller config
+           privateEncryptionKey,
+           )
+       } catch (e: GeneralSecurityException) {
+         throw Exception("RequisitionSpec decryption failed", e)
+       }
+     val requisitionSpec: RequisitionSpec = signedRequisitionSpec.unpack()
+     val measurementSpec: MeasurementSpec = requisition.measurementSpec.message.unpack()
+
+
+     val sampledVids = getSampledVids(
+       requisitionSpec,
+       measurementSpec.vidSamplingInterval
+     )
+     val protocols: List<ProtocolConfig.Protocol> = requisition.protocolConfig.protocolsList
+
+
+     if (protocols.any { it.hasDirect() }) {
+       val directProtocolConfig =
+         requisition.protocolConfig.protocolsList.first { it.hasDirect() }.direct
+       val directNoiseMechanismOptions =
+         directProtocolConfig.noiseMechanismsList
+           .mapNotNull { protocolConfigNoiseMechanism ->
+             protocolConfigNoiseMechanism.toDirectNoiseMechanism()
+           }
+           .toSet()
+       if (measurementSpec.hasReach() || measurementSpec.hasReachAndFrequency()) {
+         fulfillDirectReachAndFrequencyMeasurement(
+           requisition,
+           measurementSpec,
+           sampledVids,
+           directProtocolConfig,
+           selectReachAndFrequencyNoiseMechanism(directNoiseMechanismOptions),
+           requisitionSpec.nonce,
+         )
+       } else if (measurementSpec.hasDuration()) {
+         // TODO
+       } else if (measurementSpec.hasImpression()) {
+         // TODO
+       } else {
+         throw RequisitionRefusalException(
+           Requisition.Refusal.Justification.SPEC_INVALID,
+           "Measurement type not supported for direct fulfillment.",
+         )
+       }
+     } else if (protocols.any { it.hasLiquidLegionsV2() }) {
+       // TODO
+
+
+     } else if  (protocols.any { it.hasReachOnlyLiquidLegionsV2() }) {
+       // TODO
+
+
+     } else if (protocols.any { it.hasHonestMajorityShareShuffle() }) {
+       // TODO
+
+
+     } else {
+       throw Exception("Protocol not supported")
+     }
+   }
+ }
+
+
+ /**
+  * Selects the most preferred [DirectNoiseMechanism] for reach and frequency measurements from the
+  * overlap of a list of preferred [DirectNoiseMechanism] and a set of [DirectNoiseMechanism]
+  * [options].
+  */
+ private fun selectReachAndFrequencyNoiseMechanism(
+   options: Set<DirectNoiseMechanism>
+ ): DirectNoiseMechanism {
+   val preferences = listOf(DirectNoiseMechanism.CONTINUOUS_GAUSSIAN)
+   return preferences.firstOrNull { preference -> options.contains(preference) }
+     ?: throw Exception(
+       "No valid noise mechanism option for reach or frequency measurements.",
+     )
+ }
+
+
+ private suspend fun fulfillDirectReachAndFrequencyMeasurement(
+   requisition: Requisition,
+   measurementSpec: MeasurementSpec,
+   sampledVids: List<Long>,
+   directProtocolConfig: ProtocolConfig.Direct,
+   directNoiseMechanism: DirectNoiseMechanism,
+   nonce: Long,
+ ) {
+   logger.info("Calculating direct reach and frequency...")
+   val measurementResult = buildDirectMeasurementResult(
+     directProtocolConfig,
+     directNoiseMechanism,
+     measurementSpec,
+     sampledVids,
+   )
+
+
+   fulfillDirectMeasurement(requisition, measurementSpec, nonce, measurementResult)
+ }
+
+
+ protected suspend fun fulfillDirectMeasurement(
+   requisition: Requisition,
+   measurementSpec: MeasurementSpec,
+   nonce: Long,
+   measurementResult: Measurement.Result,
+ ) {
+   logger.log(Level.INFO, "Direct MeasurementSpec:\n$measurementSpec")
+   logger.log(Level.INFO, "Direct MeasurementResult:\n$measurementResult")
+
+
+   DataProviderCertificateKey.fromName(requisition.dataProviderCertificate)
+     ?: throw Exception(
+       "Invalid data provider certificate"
+     )
+   val measurementEncryptionPublicKey: EncryptionPublicKey =
+     if (measurementSpec.hasMeasurementPublicKey()) {
+       measurementSpec.measurementPublicKey.unpack()
+     } else {
+       @Suppress("DEPRECATION") // Handle legacy resources.
+       EncryptionPublicKey.parseFrom(measurementSpec.serializedMeasurementPublicKey)
+     }
+   val signedResult: SignedMessage =
+     signResult(measurementResult, dataProviderSigningKeyHandle!!)
+   val encryptedResult: EncryptedMessage =
+     encryptResult(signedResult, measurementEncryptionPublicKey)
+
+
+   try {
+     requisitionsStub.fulfillDirectRequisition(
+       fulfillDirectRequisitionRequest {
+         name = requisition.name
+         this.encryptedResult = encryptedResult
+         this.nonce = nonce
+         this.certificate = dataProviderCertificateKey!!.toName()
+       }
+     )
+   } catch (e: StatusException) {
+     throw Exception("Error fulfilling direct requisition ${requisition.name}", e)
+   }
+ }
+
+
+ /**
+  * Build [Measurement.Result] of the measurement type specified in [MeasurementSpec].
+  *
+  * @param measurementSpec Measurement spec.
+  * @param samples sampled events.
+  * @return [Measurement.Result].
+  */
+ private fun buildDirectMeasurementResult(
+   directProtocolConfig: ProtocolConfig.Direct,
+   directNoiseMechanism: DirectNoiseMechanism,
+   measurementSpec: MeasurementSpec,
+   samples: Iterable<Long>,
+ ): Measurement.Result {
+   val protocolConfigNoiseMechanism = when (directNoiseMechanism) {
+       DirectNoiseMechanism.NONE -> {
+         NoiseMechanism.NONE
+       }
+       DirectNoiseMechanism.CONTINUOUS_LAPLACE -> {
+         NoiseMechanism.CONTINUOUS_LAPLACE
+       }
+       else -> {
+         NoiseMechanism.CONTINUOUS_GAUSSIAN
+       }
+   }
+
+
+   @Suppress("WHEN_ENUM_CAN_BE_NULL_IN_JAVA") // Protobuf enum fields cannot be null.
+   return when (measurementSpec.measurementTypeCase) {
+     MeasurementSpec.MeasurementTypeCase.REACH_AND_FREQUENCY -> {
+       if (!directProtocolConfig.hasDeterministicCountDistinct()) {
+         throw RequisitionRefusalException(
+           Requisition.Refusal.Justification.DECLINED,
+           "No valid methodologies for direct reach computation.",
+         )
+       }
+       if (!directProtocolConfig.hasDeterministicDistribution()) {
+         throw RequisitionRefusalException(
+           Requisition.Refusal.Justification.DECLINED,
+           "No valid methodologies for direct frequency distribution computation.",
+         )
+       }
+
+
+       val (sampledReachValue, frequencyMap) =
+         MeasurementResults.computeReachAndFrequency(
+           samples,
+           measurementSpec.reachAndFrequency.maximumFrequency,
+         )
+
+
+       logger.info("Adding $directNoiseMechanism publisher noise to direct reach and frequency...")
+       val sampledNoisedReachValue =
+         addReachPublisherNoise(
+           sampledReachValue,
+           measurementSpec.reachAndFrequency.reachPrivacyParams,
+           directNoiseMechanism,
+         )
+       val noisedFrequencyMap =
+         addFrequencyPublisherNoise(
+           sampledReachValue,
+           frequencyMap,
+           measurementSpec.reachAndFrequency.frequencyPrivacyParams,
+           directNoiseMechanism,
+         )
+
+
+       val scaledNoisedReachValue =
+         (sampledNoisedReachValue / measurementSpec.vidSamplingInterval.width).toLong()
+
+
+       MeasurementKt.result {
+         reach = MeasurementKt.ResultKt.reach {
+           value = scaledNoisedReachValue
+           this.noiseMechanism = protocolConfigNoiseMechanism
+           deterministicCountDistinct = DeterministicCountDistinct.getDefaultInstance()
+         }
+         frequency = MeasurementKt.ResultKt.frequency {
+           relativeFrequencyDistribution.putAll(noisedFrequencyMap.mapKeys { it.key.toLong() })
+           this.noiseMechanism = protocolConfigNoiseMechanism
+           deterministicDistribution = DeterministicDistribution.getDefaultInstance()
+         }
+       }
+     }
+     MeasurementSpec.MeasurementTypeCase.IMPRESSION -> {
+       // TODO
+       MeasurementKt.result {
+
+
+       }
+     }
+     MeasurementSpec.MeasurementTypeCase.DURATION -> {
+       // TODO
+       MeasurementKt.result {
+
+
+       }
+     }
+     MeasurementSpec.MeasurementTypeCase.POPULATION -> {
+       // TODO
+       MeasurementKt.result {
+
+
+       }
+     }
+     MeasurementSpec.MeasurementTypeCase.REACH -> {
+       // TODO
+       MeasurementKt.result {
+
+
+       }
+     }
+     MeasurementSpec.MeasurementTypeCase.MEASUREMENTTYPE_NOT_SET -> {
+       error("Measurement type not set.")
+     }
+   }
+ }
+
+
+ private fun getPublisherNoiser(
+   privacyParams: DifferentialPrivacyParams,
+   directNoiseMechanism: DirectNoiseMechanism,
+   random: Random,
+ ): AbstractNoiser =
+   when (directNoiseMechanism) {
+     DirectNoiseMechanism.NONE ->
+       object : AbstractNoiser() {
+         override val distribution = ConstantRealDistribution(0.0)
+         override val variance: Double
+           get() = distribution.numericalVariance
+       }
+     DirectNoiseMechanism.CONTINUOUS_LAPLACE ->
+       LaplaceNoiser(DpParams(privacyParams.epsilon, privacyParams.delta), random.asJavaRandom())
+     DirectNoiseMechanism.CONTINUOUS_GAUSSIAN ->
+       GaussianNoiser(DpParams(privacyParams.epsilon, privacyParams.delta), random.asJavaRandom())
+   }
+
+
+ /**
+  * Add publisher noise to calculated direct reach.
+  *
+  * @param reachValue Direct reach value.
+  * @param privacyParams Differential privacy params for reach.
+  * @param directNoiseMechanism Selected noise mechanism for direct reach.
+  * @return Noised non-negative reach value.
+  */
+ private fun addReachPublisherNoise(
+   reachValue: Int,
+   privacyParams: DifferentialPrivacyParams,
+   directNoiseMechanism: DirectNoiseMechanism,
+ ): Int {
+   val reachNoiser: AbstractNoiser =
+     getPublisherNoiser(privacyParams, directNoiseMechanism, random)
+
+
+   return max(0, reachValue + reachNoiser.sample().toInt())
+ }
+
+
+ /**
+  * Add publisher noise to calculated direct frequency.
+  *
+  * @param reachValue Direct reach value.
+  * @param frequencyMap Direct frequency.
+  * @param privacyParams Differential privacy params for frequency map.
+  * @param directNoiseMechanism Selected noise mechanism for direct frequency.
+  * @return Noised non-negative frequency map.
+  */
+ private fun addFrequencyPublisherNoise(
+   reachValue: Int,
+   frequencyMap: Map<Int, Double>,
+   privacyParams: DifferentialPrivacyParams,
+   directNoiseMechanism: DirectNoiseMechanism,
+ ): Map<Int, Double> {
+   val frequencyNoiser: AbstractNoiser =
+     getPublisherNoiser(privacyParams, directNoiseMechanism, random)
+
+
+   // Add noise to the histogram and cap negative values to zeros.
+   val frequencyHistogram: Map<Int, Int> =
+     frequencyMap.mapValues { (_, percentage) ->
+       // Round the noise for privacy.
+       val noisedCount: Int =
+         (percentage * reachValue).roundToInt() + (frequencyNoiser.sample()).roundToInt()
+       max(0, noisedCount)
+     }
+   val normalizationTerm: Double = frequencyHistogram.values.sum().toDouble()
+   // Normalize to get the distribution
+   return if (normalizationTerm != 0.0) {
+     frequencyHistogram.mapValues { (_, count) -> count / normalizationTerm }
+   } else {
+     frequencyHistogram.mapValues { 0.0 }
+   }
+ }
+
+
+ /**
+  * Converts a [NoiseMechanism] to a nullable [DirectNoiseMechanism].
+  *
+  * @return [DirectNoiseMechanism] when there is a matched, otherwise null.
+  */
+ private fun NoiseMechanism.toDirectNoiseMechanism(): DirectNoiseMechanism? {
+   return when (this) {
+     NoiseMechanism.NONE -> DirectNoiseMechanism.NONE
+     NoiseMechanism.CONTINUOUS_LAPLACE -> DirectNoiseMechanism.CONTINUOUS_LAPLACE
+     NoiseMechanism.CONTINUOUS_GAUSSIAN -> DirectNoiseMechanism.CONTINUOUS_GAUSSIAN
+     NoiseMechanism.NOISE_MECHANISM_UNSPECIFIED,
+     NoiseMechanism.GEOMETRIC,
+     NoiseMechanism.DISCRETE_GAUSSIAN,
+     NoiseMechanism.UNRECOGNIZED -> {
+       null
+     }
+   }
+ }
+
+
+
+
+ fun compileProgram(
+   eventFilter: RequisitionSpec.EventFilter,
+   eventMessageDescriptor: Descriptor,
+ ): Program {
+   // EventFilters should take care of this, but checking here is an optimization that can skip
+   // creation of a CEL Env.
+   if (eventFilter.expression.isEmpty()) {
+     return Program { TRUE_EVAL_RESULT }
+   }
+   return EventFilters.compileProgram(eventMessageDescriptor, eventFilter.expression)
+ }
+
+
+ private suspend fun getRequisitions(blobKey: String): List<Requisition> {
+   // Gets path to list of new requisitions in blob storage
+   val requisitionBlob = requisitionsStorageClient.getBlob(blobKey)!!
+   val requisitionData = requisitionBlob.read().reduce { acc, byteString -> acc.concat(byteString) }.toStringUtf8()
+   val requisition = Requisition.getDefaultInstance()
+     .newBuilderForType()
+     .apply {
+       TextFormat.Parser.newBuilder()
+         .build()
+         .merge(requisitionData, this)
+     }
+     .build() as Requisition
+
+
+   return listOf(requisition)
+ }
+
+
+ private suspend fun getSampledVids(
+   requisitionSpec: RequisitionSpec,
+   vidSamplingInterval: MeasurementSpec.VidSamplingInterval,
+ ): List<Long> {
+   val vidSamplingIntervalStart = vidSamplingInterval.start
+   val vidSamplingIntervalWidth = vidSamplingInterval.width
+   require(vidSamplingIntervalWidth > 0 && vidSamplingIntervalWidth <= 1.0) {
+     "Invalid vidSamplingIntervalWidth $vidSamplingIntervalWidth"
+   }
+   require(
+     vidSamplingIntervalStart < 1 &&
+       vidSamplingIntervalStart >= 0 &&
+       vidSamplingIntervalWidth > 0 &&
+       vidSamplingIntervalStart + vidSamplingIntervalWidth <= 1
+   ) {
+     "Invalid vidSamplingInterval: start = $vidSamplingIntervalStart, width = " +
+       "$vidSamplingIntervalWidth"
+   }
+
+
+   return requisitionSpec.events.eventGroupsList.map { eventGroup ->
+     val collectionInterval = eventGroup.value.collectionInterval
+     val encryptedDek = getEncryptedDek(collectionInterval, eventGroup.key)
+     val labeledImpressions = getLabeledImpressions(encryptedDek)
+
+
+     labeledImpressions.filter { labeledImpression ->
+       isValidImpression(labeledImpression, collectionInterval,eventGroup, vidSamplingIntervalStart, vidSamplingIntervalWidth)
+     }.map {labeledImpression ->
+       labeledImpression.vid
+     }
+   }.flatten()
+ }
+
+
+ /**
+  * Retrieves a list of labeled impressions from the specified storage.
+  *
+  * This method handles retrieving encrypted impression data from storage,
+  * setting up the appropriate encryption, and parsing the raw data into
+  * LabeledImpression protocol buffer messages.
+  *
+  * @param encryptedDek The encrypted data encryption key information
+  * @param impressionsStorageConfig Storage configuration for impressions
+  * @param kmsClient KMS client for handling encryption
+  * @return List of parsed LabeledImpression objects
+  * @throws IllegalStateException if impression data cannot be read or parsed
+  */
+ private suspend fun getLabeledImpressions(
+   encryptedDek: EncryptedDEK,
+ ): List<LabeledImpression> {
+   // Get blob URI from encrypted DEK
+   val impressionsBlobUri = encryptedDek.blobKey
+   val storageClientUri = SelectedStorageClient.parseBlobUri(impressionsBlobUri)
+
+
+// Create and configure storage client with encryption
+   val encryptedImpressionsClient = createStorageClient(storageClientUri, impressionsStorageConfig)
+   val impressionsAeadStorageClient = encryptedImpressionsClient.withEnvelopeEncryption(
+     kmsClient,
+     encryptedDek.kekUri,
+     encryptedDek.encryptedDek
+   )
+
+
+// Access blob storage
+   val impressionsMesosStorage = MesosRecordIoStorageClient(impressionsAeadStorageClient)
+   val impressionBlob = impressionsMesosStorage.getBlob(storageClientUri.key)
+     ?: throw IllegalStateException("Could not retrieve impression blob from ${storageClientUri.key}")
+
+
+   // Parse raw data into LabeledImpression objects
+   val readResult = impressionBlob.read()
+
+
+   val impressionRecords = readResult.toList()
+
+
+   return impressionRecords.map { impressionByteString ->
+     val labeledImpression = LabeledImpression.parseFrom(impressionByteString)
+       ?: throw IllegalStateException("Failed to parse LabeledImpression from bytes")
+     labeledImpression
+   }
+ }
+
+
+ /**
+  * Determines if a labeled impression is valid based on collection interval, filter criteria,
+  * and sampling bucket.
+  *
+  * @param labeledImpression The impression to validate
+  * @param collectionInterval Time interval for valid impressions
+  * @param eventTemplateTypeUrl Type URL for the event template
+  * @param typeRegistry Registry for protocol buffer types
+  * @param eventGroup Event group containing filter criteria
+  * @param sampler VID sampler implementation
+  * @param vidSamplingIntervalStart Start of sampling interval
+  * @param vidSamplingIntervalWidth Width of sampling interval
+  * @return true if the impression meets all validity criteria, false otherwise
+  */
+ private fun isValidImpression(
+   labeledImpression: LabeledImpression,
+   collectionInterval: Interval,
+   eventGroup:  RequisitionSpec.EventGroupEntry,
+   vidSamplingIntervalStart: Float,
+   vidSamplingIntervalWidth: Float,
+ ): Boolean {
+   // Check if impression is within collection time interval
+   val isInCollectionInterval =
+     labeledImpression.impressionTime.toInstant() >= collectionInterval.startTime.toInstant() &&
+       labeledImpression.impressionTime.toInstant() < collectionInterval.endTime.toInstant()
+
+
+   // Process event template filter
+   val eventTemplateDescriptor = typeRegistry.getDescriptorForTypeUrl(eventTemplateTypeUrl)
+   val eventMessageData = labeledImpression.eventTemplateMapMap[eventTemplateTypeUrl]
+   val eventMessage = DynamicMessage.parseFrom(eventTemplateDescriptor, eventMessageData?.value)
+   val program = compileProgram(eventGroup.value.filter, eventTemplateDescriptor)
+
+
+   val passesFilter = EventFilters.matches(eventMessage, program)
+
+
+   // Check if VID is in sampling bucket
+   val isInSamplingInterval = sampler.vidIsInSamplingBucket(
+     labeledImpression.vid,
+     vidSamplingIntervalStart,
+     vidSamplingIntervalWidth
+   )
+
+
+   // Return true only if all conditions are met
+   return isInCollectionInterval && passesFilter && isInSamplingInterval
+ }
+
+
+ private suspend fun getEncryptedDek(collectionInterval: Interval, eventGroupId: String): EncryptedDEK {
+   val ds = collectionInterval.startTime.toInstant().toString()
+   val metadataBlobKey = "ds/$ds/event-group-id/$eventGroupId/metadata"
+   val metadataBlobUri = "$labeledImpressionMetadataPrefix/$metadataBlobKey"
+   val metadataStorageClientUri = SelectedStorageClient.parseBlobUri(metadataBlobUri)
+
+
+   val impressionsMetadataStorageClient = createStorageClient(metadataStorageClientUri, impressionMetadataStorageConfig)
+   // Get EncryptedDek message from storage using the blobKey made up of the ds and eventGroupId
+   val encryptedDekBlob = impressionsMetadataStorageClient.getBlob(metadataBlobKey)!! // SELECTED STORAGE CLIENT
+   val encryptedDekData =
+     encryptedDekBlob.read().reduce { acc, byteString -> acc.concat(byteString) }.toStringUtf8()
+
+
+   return EncryptedDEK.getDefaultInstance()
+     .newBuilderForType()
+     .apply { TextFormat.Parser.newBuilder().build().merge(encryptedDekData, this) }
+     .build() as EncryptedDEK
+ }
+
+
+ /**
+  * Creates a storage client for accessing blob data.
+  *
+  * This function constructs a [SelectedStorageClient] using the provided blob key
+  * and storage configuration. It parses the blob URI and initializes the appropriate
+  * client based on the storage configuration properties.
+  *
+  * @param blobKey The URI or path identifying the blob to access
+  * @param storageConfig Configuration containing settings for storage access,
+  *        including root directory and project ID
+  * @return A configured [SelectedStorageClient] instance ready to access the specified blob
+  */
+ fun createStorageClient(blobUri: org.wfanet.measurement.storage.BlobUri, storageConfig: StorageConfig): SelectedStorageClient {
+   return SelectedStorageClient(blobUri, storageConfig.rootDirectory, storageConfig.projectId)
+ }
+
+
+ companion object {
+   private val logger: Logger = Logger.getLogger(this::class.java.name)
+   private val VID_SAMPLER_HASH_FUNCTION: HashFunction = Hashing.farmHashFingerprint64()
+   private val TRUE_EVAL_RESULT = Program.newEvalResult(BoolT.True, null)
+
+
+   val sampler = VidSampler(VID_SAMPLER_HASH_FUNCTION)
+   /** [RequisitionRefusalException] for EventGroups. */
+   protected open class RequisitionRefusalException(
+     val justification: Requisition.Refusal.Justification,
+     message: String,
+     cause: Throwable? = null,
+   ) : Exception(message, cause) {
+     override val message: String
+       get() = super.message!!
+   }
+ }
+}

--- a/src/test/kotlin/org/wfanet/measurement/edpaggregator/resultsfulfiller/BUILD.bazel
+++ b/src/test/kotlin/org/wfanet/measurement/edpaggregator/resultsfulfiller/BUILD.bazel
@@ -1,0 +1,50 @@
+load("@wfa_rules_kotlin_jvm//kotlin:defs.bzl", "kt_jvm_test")
+
+package(
+    default_testonly = True,
+    default_visibility = ["//visibility:public"],
+)
+
+kt_jvm_test(
+    name = "ResultsFulfillerTest",
+    srcs = ["ResultsFulfillerTest.kt"],
+    data = [
+        "//src/main/k8s/testing/secretfiles:all_configs",
+        "//src/main/k8s/testing/secretfiles:all_der_files",
+        "//src/main/k8s/testing/secretfiles:all_tink_keysets",
+        "//src/main/k8s/testing/secretfiles:edp_trusted_certs.pem",
+    ],
+    test_class = "org.wfanet.measurement.edpaggregator.resultsfulfiller.ResultsFulfillerTest",
+    deps = [
+        "//src/main/kotlin/org/wfanet/measurement/api/v2alpha/testing",
+        "//src/main/kotlin/org/wfanet/measurement/edpaggregator/resultsfulfiller:results_fulfiller",
+        "//src/main/kotlin/org/wfanet/measurement/eventdataprovider/eventfiltration:event_filters",
+        "//src/main/kotlin/org/wfanet/measurement/integration/common:configs",
+        "//src/main/kotlin/org/wfanet/measurement/integration/common:synthetic_generation_specs",
+        "//src/main/kotlin/org/wfanet/measurement/loadtest/common:sample_vids",
+        "//src/main/kotlin/org/wfanet/measurement/loadtest/config:test_identifiers",
+        "//src/main/kotlin/org/wfanet/measurement/loadtest/dataprovider:synthetic_generator_event_query",
+        "//src/main/proto/wfa/measurement/api/v2alpha:protocol_config_kt_jvm_proto",
+        "//src/main/proto/wfa/measurement/api/v2alpha/event_templates/testing:test_event_kt_jvm_proto",
+        "//src/main/proto/wfa/measurement/securecomputation/impressions:encrypted_dek_kt_jvm_proto",
+        "//src/main/proto/wfa/measurement/securecomputation/impressions:labeled_impression_kt_jvm_proto",
+        "@wfa_common_jvm//imports/java/com/google/cloud/storage/contrib/nio",
+        "@wfa_common_jvm//imports/java/com/google/common/truth",
+        "@wfa_common_jvm//imports/java/com/google/common/truth/extensions/proto",
+        "@wfa_common_jvm//imports/java/org/junit",
+        "@wfa_common_jvm//imports/kotlin/kotlin/test",
+        "@wfa_common_jvm//imports/kotlin/kotlinx/coroutines:core",
+        "@wfa_common_jvm//imports/kotlin/org/mockito/kotlin",
+        "@wfa_common_jvm//src/main/kotlin/org/wfanet/measurement/common",
+        "@wfa_common_jvm//src/main/kotlin/org/wfanet/measurement/common/crypto/testing",
+        "@wfa_common_jvm//src/main/kotlin/org/wfanet/measurement/common/crypto/tink",
+        "@wfa_common_jvm//src/main/kotlin/org/wfanet/measurement/common/crypto/tink/testing",
+        "@wfa_common_jvm//src/main/kotlin/org/wfanet/measurement/common/grpc/testing",
+        "@wfa_common_jvm//src/main/kotlin/org/wfanet/measurement/common/testing",
+        "@wfa_common_jvm//src/main/kotlin/org/wfanet/measurement/queue:queue_subscriber",
+        "@wfa_common_jvm//src/main/kotlin/org/wfanet/measurement/storage:selected_storage_client",
+        "@wfa_common_jvm//src/main/kotlin/org/wfanet/measurement/storage/testing",
+        "@wfa_consent_signaling_client//src/main/kotlin/org/wfanet/measurement/consent/client/duchy",
+        "@wfa_consent_signaling_client//src/main/kotlin/org/wfanet/measurement/consent/client/measurementconsumer",
+    ],
+)

--- a/src/test/kotlin/org/wfanet/measurement/edpaggregator/resultsfulfiller/ResultsFulfillerTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/edpaggregator/resultsfulfiller/ResultsFulfillerTest.kt
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2025 The Cross-Media Measurement Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.wfanet.measurement.edpaggregator.resultsfulfiller
 
 import com.google.common.truth.Truth.assertThat

--- a/src/test/kotlin/org/wfanet/measurement/edpaggregator/resultsfulfiller/ResultsFulfillerTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/edpaggregator/resultsfulfiller/ResultsFulfillerTest.kt
@@ -1,12 +1,12 @@
 package org.wfanet.measurement.edpaggregator.resultsfulfiller
 
 import com.google.common.truth.Truth.assertThat
-import com.google.crypto.tink.aead.AeadConfig
-import com.google.crypto.tink.streamingaead.StreamingAeadConfig
 import com.google.crypto.tink.Aead
 import com.google.crypto.tink.KeyTemplates
 import com.google.crypto.tink.KeysetHandle
 import com.google.crypto.tink.TinkProtoKeysetFormat
+import com.google.crypto.tink.aead.AeadConfig
+import com.google.crypto.tink.streamingaead.StreamingAeadConfig
 import com.google.protobuf.ByteString
 import com.google.protobuf.Timestamp
 import com.google.protobuf.TypeRegistry
@@ -88,7 +88,8 @@ class ResultsFulfillerTest {
     onBlocking { fulfillDirectRequisition(any()) }.thenReturn(fulfillDirectRequisitionResponse {})
   }
 
-  @get:Rule val grpcTestServerRule = GrpcTestServerRule { addService(requisitionsServiceMock) }
+  @get:Rule
+  val grpcTestServerRule = GrpcTestServerRule { addService(requisitionsServiceMock) }
   private val requisitionsStub: RequisitionsCoroutineStub by lazy {
     RequisitionsCoroutineStub(grpcTestServerRule.channel)
   }
@@ -172,17 +173,17 @@ class ResultsFulfillerTest {
     val typeRegistry = TypeRegistry.newBuilder().add(TestEvent.getDescriptor()).build()
 
     val resultsFulfiller = ResultsFulfiller(
-            PRIVATE_ENCRYPTION_KEY,
-            requisitionsStub,
-            DATA_PROVIDER_CERTIFICATE_KEY,
-            EDP_RESULT_SIGNING_KEY,
-            typeRegistry,
-            REQUISITIONS_FILE_URI,
-            IMPRESSIONS_METADATA_FILE_URI_PREFIX,
-            kmsClient,
-            StorageConfig(rootDirectory = impressionsTmpPath),
-            StorageConfig(rootDirectory = metadataTmpPath),
-            StorageConfig(rootDirectory = requisitionsTmpPath)
+      PRIVATE_ENCRYPTION_KEY,
+      requisitionsStub,
+      DATA_PROVIDER_CERTIFICATE_KEY,
+      EDP_RESULT_SIGNING_KEY,
+      typeRegistry,
+      REQUISITIONS_FILE_URI,
+      IMPRESSIONS_METADATA_FILE_URI_PREFIX,
+      kmsClient,
+      StorageConfig(rootDirectory = impressionsTmpPath),
+      StorageConfig(rootDirectory = metadataTmpPath),
+      StorageConfig(rootDirectory = requisitionsTmpPath)
     )
 
     resultsFulfiller.fulfillRequisitions()


### PR DESCRIPTION
Creates results fulfiller that will be used by the TEE app to fullfill requisitions. This fulfiller will:
1. Pull in new requisitions from storage
2. Pull in relevant labeled impressions based on collection interval and event group of requisition
3. Filter out labeled impressions based on collection interval, sampling interval, and filter expression in requisition
4. Calculate results using sampled vids(from filtered labeled impressions)
5. Fulfill requistiions to kingdom with result

This PR only handles direct protocol. Other protocols will be added later