### PR TITLE
feat: Add data_availability_interval to Reporting EventGroup

### DIFF
--- a/src/main/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/EventGroupsService.kt
+++ b/src/main/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/EventGroupsService.kt
@@ -271,6 +271,9 @@ class EventGroupsService(
       eventTemplates +=
         source.eventTemplatesList.map { EventGroupKt.eventTemplate { type = it.type } }
       mediaTypes += source.mediaTypesList.map { it.toMediaType() }
+      if (source.hasDataAvailabilityInterval()) {
+        dataAvailabilityInterval = source.dataAvailabilityInterval
+      }
       if (source.hasEventGroupMetadata()) {
         eventGroupMetadata =
           EventGroupKt.eventGroupMetadata {

--- a/src/main/proto/wfa/measurement/reporting/v2alpha/BUILD.bazel
+++ b/src/main/proto/wfa/measurement/reporting/v2alpha/BUILD.bazel
@@ -71,6 +71,7 @@ proto_library(
         ":media_type_proto",
         "@com_google_googleapis//google/api:field_behavior_proto",
         "@com_google_googleapis//google/api:resource_proto",
+        "@com_google_googleapis//google/type:interval_proto",
         "@com_google_protobuf//:any_proto",
     ],
 )

--- a/src/main/proto/wfa/measurement/reporting/v2alpha/event_group.proto
+++ b/src/main/proto/wfa/measurement/reporting/v2alpha/event_group.proto
@@ -19,6 +19,7 @@ package wfa.measurement.reporting.v2alpha;
 import "google/api/field_behavior.proto";
 import "google/api/resource.proto";
 import "google/protobuf/any.proto";
+import "google/type/interval.proto";
 import "wfa/measurement/reporting/v2alpha/media_type.proto";
 
 option java_package = "org.wfanet.measurement.reporting.v2alpha";
@@ -70,6 +71,12 @@ message EventGroup {
   // Possible media types for events in this [EventGroup][].
   repeated MediaType media_types = 7
       [(google.api.field_behavior) = UNORDERED_LIST];
+
+  // Interval for which this [EventGroup][] is known to have events, subject to
+  // [DataProvider.data_availability_intervals][wfa.measurement.api.v2alpha.DataProvider.data_availability_intervals].
+  //
+  // If this field is set then [google.type.Interval.start_time][] is required.
+  google.type.Interval data_availability_interval = 9;
 
   // Common metadata structure for an [EventGroup][].
   message EventGroupMetadata {

--- a/src/test/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/EventGroupsServiceTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/EventGroupsServiceTest.kt
@@ -19,12 +19,15 @@ package org.wfanet.measurement.reporting.service.api.v2alpha
 import com.google.common.truth.Truth.assertThat
 import com.google.common.truth.extensions.proto.ProtoTruth.assertThat
 import com.google.protobuf.Any
+import com.google.type.interval
 import io.grpc.Deadline
 import io.grpc.Status
 import io.grpc.StatusRuntimeException
 import java.nio.file.Path
 import java.nio.file.Paths
 import java.time.Duration
+import java.time.LocalDate
+import java.time.ZoneOffset
 import java.util.concurrent.TimeUnit
 import kotlin.test.assertFailsWith
 import kotlinx.coroutines.runBlocking
@@ -80,6 +83,7 @@ import org.wfanet.measurement.common.grpc.testing.GrpcTestServerRule
 import org.wfanet.measurement.common.grpc.testing.mockService
 import org.wfanet.measurement.common.pack
 import org.wfanet.measurement.common.testing.verifyProtoArgument
+import org.wfanet.measurement.common.toProtoTime
 import org.wfanet.measurement.config.reporting.measurementConsumerConfig
 import org.wfanet.measurement.config.reporting.measurementConsumerConfigs
 import org.wfanet.measurement.consent.client.common.toEncryptionPublicKey
@@ -791,6 +795,10 @@ class EventGroupsServiceTest {
       eventGroupReferenceId = EVENT_GROUP_REFERENCE_ID
       measurementConsumerPublicKey = ENCRYPTION_PUBLIC_KEY.toEncryptionPublicKey().pack()
       eventTemplates += CmmsEventGroupKt.eventTemplate { type = TestEvent.getDescriptor().fullName }
+      dataAvailabilityInterval = interval {
+        startTime = LocalDate.of(2025, 1, 11).atStartOfDay().toInstant(ZoneOffset.UTC).toProtoTime()
+        endTime = LocalDate.of(2025, 4, 11).atStartOfDay().toInstant(ZoneOffset.UTC).toProtoTime()
+      }
       mediaTypes += CmmsMediaType.VIDEO
       eventGroupMetadata = eventGroupMetadata {
         adMetadata =
@@ -840,6 +848,7 @@ class EventGroupsServiceTest {
       cmmsDataProvider = DATA_PROVIDER_NAME
       eventGroupReferenceId = EVENT_GROUP_REFERENCE_ID
       eventTemplates += EventGroupKt.eventTemplate { type = TestEvent.getDescriptor().fullName }
+      dataAvailabilityInterval = CMMS_EVENT_GROUP.dataAvailabilityInterval
       mediaTypes += MediaType.VIDEO
       eventGroupMetadata =
         EventGroupKt.eventGroupMetadata {


### PR DESCRIPTION
This plumbs through the corresponding field from the CMMS API.