### PR TITLE
fix: Missing Metrics no longer cause a problem when retrieving Reports

### DIFF
--- a/src/main/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/ReportsService.kt
+++ b/src/main/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/ReportsService.kt
@@ -513,16 +513,15 @@ class ReportsService(
         timeIntervals = internalReport.details.timeIntervals.toTimeIntervals()
       }
 
-      val metrics: List<Metric> =
-        buildList {
-          for (externalMetricId in internalReport.externalMetricIds) {
-            if (externalIdToMetricMap.containsKey(externalMetricId)) {
-              add(externalIdToMetricMap.getValue(externalMetricId))
-            } else {
-              state = Report.State.FAILED
-            }
+      val metrics: List<Metric> = buildList {
+        for (externalMetricId in internalReport.externalMetricIds) {
+          if (externalIdToMetricMap.containsKey(externalMetricId)) {
+            add(externalIdToMetricMap.getValue(externalMetricId))
+          } else {
+            state = Report.State.FAILED
           }
         }
+      }
 
       if (state != Report.State.FAILED) {
         state = inferReportState(metrics)
@@ -583,27 +582,27 @@ class ReportsService(
         ReportKt.metricCalculationResult {
           this.metricCalculationSpec =
             MetricCalculationSpecKey(
-              metricCalculationSpec.cmmsMeasurementConsumerId,
-              metricCalculationSpec.externalMetricCalculationSpecId,
-            )
+                metricCalculationSpec.cmmsMeasurementConsumerId,
+                metricCalculationSpec.externalMetricCalculationSpecId,
+              )
               .toName()
           displayName = metricCalculationSpec.details.displayName
           reportingSet = reportingSetName
           for (reportingMetric in metricCalculationSpecReportingMetrics.reportingMetricsList) {
             if (externalIdToMetricMap.containsKey(reportingMetric.externalMetricId)) {
-              val metric =
-                externalIdToMetricMap.getValue(reportingMetric.externalMetricId)
-              resultAttributes += ReportKt.MetricCalculationResultKt.resultAttribute {
-                this.metric = metric.name
-                groupingPredicates += reportingMetric.details.groupingPredicatesList
-                filter = metricCalculationSpec.details.filter
-                metricSpec = metric.metricSpec
-                timeInterval = metric.timeInterval
-                state = metric.state
-                if (metric.state == Metric.State.SUCCEEDED) {
-                  metricResult = metric.result
+              val metric = externalIdToMetricMap.getValue(reportingMetric.externalMetricId)
+              resultAttributes +=
+                ReportKt.MetricCalculationResultKt.resultAttribute {
+                  this.metric = metric.name
+                  groupingPredicates += reportingMetric.details.groupingPredicatesList
+                  filter = metricCalculationSpec.details.filter
+                  metricSpec = metric.metricSpec
+                  timeInterval = metric.timeInterval
+                  state = metric.state
+                  if (metric.state == Metric.State.SUCCEEDED) {
+                    metricResult = metric.result
+                  }
                 }
-              }
             }
           }
         }

--- a/src/test/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/ReportsServiceTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/ReportsServiceTest.kt
@@ -3328,98 +3328,100 @@ class ReportsServiceTest {
   }
 
   @Test
-  fun `getReport returns FAILED report when report has missing metric`() =
-    runBlocking {
-      val reportId = "123"
-      val reportingSetId = "123"
-      val metricCalculationSpecId = INTERNAL_REACH_METRIC_CALCULATION_SPEC.externalMetricCalculationSpecId
-      val measurementConsumerId = MEASUREMENT_CONSUMER_KEYS.first().measurementConsumerId
-      val reportWithMissingMetricId = internalReport {
-        externalReportId = reportId
-        cmmsMeasurementConsumerId = measurementConsumerId
-        reportingMetricEntries[reportingSetId] =
-          InternalReportKt.reportingMetricCalculationSpec {
-            metricCalculationSpecReportingMetrics +=
-              InternalReportKt.metricCalculationSpecReportingMetrics {
-                externalMetricCalculationSpecId = metricCalculationSpecId
-                reportingMetrics +=
-                  InternalReportKt.reportingMetric {
-                    details =
-                      InternalReportKt.ReportingMetricKt.details {
-                        metricSpec = internalMetricSpec {
-                          reach =
-                            InternalMetricSpecKt.reachParams {
-                              multipleDataProviderParams =
-                                InternalMetricSpecKt.samplingAndPrivacyParams {
-                                  privacyParams =
-                                    InternalMetricSpecKt.differentialPrivacyParams {
-                                      epsilon = 1.0
-                                      delta = 2.0
-                                    }
-                                  vidSamplingInterval =
-                                    InternalMetricSpecKt.vidSamplingInterval {
-                                      start = 0.1f
-                                      width = 0.5f
-                                    }
-                                }
-                            }
-                        }
-                        timeInterval = interval {
-                          startTime = timestamp { seconds = 100 }
-                          endTime = timestamp { seconds = 200 }
-                        }
-                        groupingPredicates += listOf("predicate1", "predicate2")
+  fun `getReport returns FAILED report when report has missing metric`() = runBlocking {
+    val reportId = "123"
+    val reportingSetId = "123"
+    val metricCalculationSpecId =
+      INTERNAL_REACH_METRIC_CALCULATION_SPEC.externalMetricCalculationSpecId
+    val measurementConsumerId = MEASUREMENT_CONSUMER_KEYS.first().measurementConsumerId
+    val reportWithMissingMetricId = internalReport {
+      externalReportId = reportId
+      cmmsMeasurementConsumerId = measurementConsumerId
+      reportingMetricEntries[reportingSetId] =
+        InternalReportKt.reportingMetricCalculationSpec {
+          metricCalculationSpecReportingMetrics +=
+            InternalReportKt.metricCalculationSpecReportingMetrics {
+              externalMetricCalculationSpecId = metricCalculationSpecId
+              reportingMetrics +=
+                InternalReportKt.reportingMetric {
+                  details =
+                    InternalReportKt.ReportingMetricKt.details {
+                      metricSpec = internalMetricSpec {
+                        reach =
+                          InternalMetricSpecKt.reachParams {
+                            multipleDataProviderParams =
+                              InternalMetricSpecKt.samplingAndPrivacyParams {
+                                privacyParams =
+                                  InternalMetricSpecKt.differentialPrivacyParams {
+                                    epsilon = 1.0
+                                    delta = 2.0
+                                  }
+                                vidSamplingInterval =
+                                  InternalMetricSpecKt.vidSamplingInterval {
+                                    start = 0.1f
+                                    width = 0.5f
+                                  }
+                              }
+                          }
                       }
-                  }
-              }
-          }
-        createTime = timestamp { seconds = 50 }
-        details =
-          InternalReportKt.details {
-            timeIntervals = internalTimeIntervals {
-              timeIntervals += interval {
-                startTime = timestamp { seconds = 100 }
-                endTime = timestamp { seconds = 200 }
-              }
+                      timeInterval = interval {
+                        startTime = timestamp { seconds = 100 }
+                        endTime = timestamp { seconds = 200 }
+                      }
+                      groupingPredicates += listOf("predicate1", "predicate2")
+                    }
+                }
+            }
+        }
+      createTime = timestamp { seconds = 50 }
+      details =
+        InternalReportKt.details {
+          timeIntervals = internalTimeIntervals {
+            timeIntervals += interval {
+              startTime = timestamp { seconds = 100 }
+              endTime = timestamp { seconds = 200 }
             }
           }
-      }
+        }
+    }
 
-      whenever(internalReportsMock.getReport(any()))
-        .thenReturn(reportWithMissingMetricId)
+    whenever(internalReportsMock.getReport(any())).thenReturn(reportWithMissingMetricId)
 
-      val request = getReportRequest {
-        name = ReportKey(measurementConsumerId, reportId).toName()
-      }
+    val request = getReportRequest { name = ReportKey(measurementConsumerId, reportId).toName() }
 
-      val result =
-        withPrincipalAndScopes(PRINCIPAL, SCOPES) { runBlocking { service.getReport(request) } }
+    val result =
+      withPrincipalAndScopes(PRINCIPAL, SCOPES) { runBlocking { service.getReport(request) } }
 
-      val expected = report {
-        name = ReportKey(measurementConsumerId, reportId).toName()
-        reportingMetricEntries += ReportKt.reportingMetricEntry {
+    val expected = report {
+      name = ReportKey(measurementConsumerId, reportId).toName()
+      reportingMetricEntries +=
+        ReportKt.reportingMetricEntry {
           key = ReportingSetKey(measurementConsumerId, reportingSetId).toName()
-          value = ReportKt.reportingMetricCalculationSpec {
-            metricCalculationSpecs += MetricCalculationSpecKey(measurementConsumerId, metricCalculationSpecId).toName()
-          }
+          value =
+            ReportKt.reportingMetricCalculationSpec {
+              metricCalculationSpecs +=
+                MetricCalculationSpecKey(measurementConsumerId, metricCalculationSpecId).toName()
+            }
         }
-        state = Report.State.FAILED
-        createTime = timestamp { seconds = 50 }
-        timeIntervals = timeIntervals {
-          timeIntervals += interval {
-            startTime = timestamp { seconds = 100 }
-            endTime = timestamp { seconds = 200 }
-          }
+      state = Report.State.FAILED
+      createTime = timestamp { seconds = 50 }
+      timeIntervals = timeIntervals {
+        timeIntervals += interval {
+          startTime = timestamp { seconds = 100 }
+          endTime = timestamp { seconds = 200 }
         }
-        metricCalculationResults += ReportKt.metricCalculationResult {
-          metricCalculationSpec += MetricCalculationSpecKey(measurementConsumerId, metricCalculationSpecId).toName()
+      }
+      metricCalculationResults +=
+        ReportKt.metricCalculationResult {
+          metricCalculationSpec +=
+            MetricCalculationSpecKey(measurementConsumerId, metricCalculationSpecId).toName()
           displayName = DISPLAY_NAME
           reportingSet = ReportingSetKey(measurementConsumerId, reportingSetId).toName()
         }
-      }
-
-      assertThat(result).ignoringRepeatedFieldOrder().isEqualTo(expected)
     }
+
+    assertThat(result).ignoringRepeatedFieldOrder().isEqualTo(expected)
+  }
 
   @Test
   fun `getReport returns the report when caller has permission on Report resource`() {
@@ -3832,100 +3834,109 @@ class ReportsServiceTest {
     }
 
   @Test
-  fun `listReports returns FAILED report when report has missing metric`() =
-    runBlocking {
-      val reportId = "123"
-      val reportingSetId = "123"
-      val metricCalculationSpecId = INTERNAL_REACH_METRIC_CALCULATION_SPEC.externalMetricCalculationSpecId
-      val measurementConsumerId = MEASUREMENT_CONSUMER_KEYS.first().measurementConsumerId
-      val reportWithMissingMetricId = internalReport {
-        externalReportId = reportId
-        cmmsMeasurementConsumerId = measurementConsumerId
-        reportingMetricEntries[reportingSetId] =
-          InternalReportKt.reportingMetricCalculationSpec {
-            metricCalculationSpecReportingMetrics +=
-              InternalReportKt.metricCalculationSpecReportingMetrics {
-                externalMetricCalculationSpecId = metricCalculationSpecId
-                reportingMetrics +=
-                  InternalReportKt.reportingMetric {
-                    details =
-                      InternalReportKt.ReportingMetricKt.details {
-                        metricSpec = internalMetricSpec {
-                          reach =
-                            InternalMetricSpecKt.reachParams {
-                              multipleDataProviderParams =
-                                InternalMetricSpecKt.samplingAndPrivacyParams {
-                                  privacyParams =
-                                    InternalMetricSpecKt.differentialPrivacyParams {
-                                      epsilon = 1.0
-                                      delta = 2.0
-                                    }
-                                  vidSamplingInterval =
-                                    InternalMetricSpecKt.vidSamplingInterval {
-                                      start = 0.1f
-                                      width = 0.5f
-                                    }
-                                }
-                            }
-                        }
-                        timeInterval = interval {
-                          startTime = timestamp { seconds = 100 }
-                          endTime = timestamp { seconds = 200 }
-                        }
-                        groupingPredicates += listOf("predicate1", "predicate2")
+  fun `listReports returns FAILED report when report has missing metric`() = runBlocking {
+    val reportId = "123"
+    val reportingSetId = "123"
+    val metricCalculationSpecId =
+      INTERNAL_REACH_METRIC_CALCULATION_SPEC.externalMetricCalculationSpecId
+    val measurementConsumerId = MEASUREMENT_CONSUMER_KEYS.first().measurementConsumerId
+    val reportWithMissingMetricId = internalReport {
+      externalReportId = reportId
+      cmmsMeasurementConsumerId = measurementConsumerId
+      reportingMetricEntries[reportingSetId] =
+        InternalReportKt.reportingMetricCalculationSpec {
+          metricCalculationSpecReportingMetrics +=
+            InternalReportKt.metricCalculationSpecReportingMetrics {
+              externalMetricCalculationSpecId = metricCalculationSpecId
+              reportingMetrics +=
+                InternalReportKt.reportingMetric {
+                  details =
+                    InternalReportKt.ReportingMetricKt.details {
+                      metricSpec = internalMetricSpec {
+                        reach =
+                          InternalMetricSpecKt.reachParams {
+                            multipleDataProviderParams =
+                              InternalMetricSpecKt.samplingAndPrivacyParams {
+                                privacyParams =
+                                  InternalMetricSpecKt.differentialPrivacyParams {
+                                    epsilon = 1.0
+                                    delta = 2.0
+                                  }
+                                vidSamplingInterval =
+                                  InternalMetricSpecKt.vidSamplingInterval {
+                                    start = 0.1f
+                                    width = 0.5f
+                                  }
+                              }
+                          }
                       }
-                  }
-              }
-          }
-        createTime = timestamp { seconds = 50 }
-        details =
-          InternalReportKt.details {
-            timeIntervals = internalTimeIntervals {
-              timeIntervals += interval {
-                startTime = timestamp { seconds = 100 }
-                endTime = timestamp { seconds = 200 }
-              }
+                      timeInterval = interval {
+                        startTime = timestamp { seconds = 100 }
+                        endTime = timestamp { seconds = 200 }
+                      }
+                      groupingPredicates += listOf("predicate1", "predicate2")
+                    }
+                }
+            }
+        }
+      createTime = timestamp { seconds = 50 }
+      details =
+        InternalReportKt.details {
+          timeIntervals = internalTimeIntervals {
+            timeIntervals += interval {
+              startTime = timestamp { seconds = 100 }
+              endTime = timestamp { seconds = 200 }
             }
           }
-      }
-
-      whenever(internalReportsMock.streamReports(any()))
-        .thenReturn(flowOf(reportWithMissingMetricId))
-
-      val pageSize = 1
-      val request = listReportsRequest {
-        parent = MEASUREMENT_CONSUMER_KEYS.first().toName()
-        this.pageSize = pageSize
-      }
-
-      val result =
-        withPrincipalAndScopes(PRINCIPAL, SCOPES) { runBlocking { service.listReports(request) } }
-
-      val expected = listReportsResponse { reports.add(report {
-        name = ReportKey(measurementConsumerId, reportId).toName()
-        reportingMetricEntries += ReportKt.reportingMetricEntry {
-          key = ReportingSetKey(measurementConsumerId, reportingSetId).toName()
-          value = ReportKt.reportingMetricCalculationSpec {
-            metricCalculationSpecs += MetricCalculationSpecKey(measurementConsumerId, metricCalculationSpecId).toName()
-          }
         }
-        state = Report.State.FAILED
-        createTime = timestamp { seconds = 50 }
-        timeIntervals = timeIntervals {
-          timeIntervals += interval {
-            startTime = timestamp { seconds = 100 }
-            endTime = timestamp { seconds = 200 }
-          }
-        }
-        metricCalculationResults += ReportKt.metricCalculationResult {
-          metricCalculationSpec += MetricCalculationSpecKey(measurementConsumerId, metricCalculationSpecId).toName()
-          displayName = DISPLAY_NAME
-          reportingSet = ReportingSetKey(measurementConsumerId, reportingSetId).toName()
-        }
-      }) }
-
-      assertThat(result).ignoringRepeatedFieldOrder().isEqualTo(expected)
     }
+
+    whenever(internalReportsMock.streamReports(any())).thenReturn(flowOf(reportWithMissingMetricId))
+
+    val pageSize = 1
+    val request = listReportsRequest {
+      parent = MEASUREMENT_CONSUMER_KEYS.first().toName()
+      this.pageSize = pageSize
+    }
+
+    val result =
+      withPrincipalAndScopes(PRINCIPAL, SCOPES) { runBlocking { service.listReports(request) } }
+
+    val expected = listReportsResponse {
+      reports.add(
+        report {
+          name = ReportKey(measurementConsumerId, reportId).toName()
+          reportingMetricEntries +=
+            ReportKt.reportingMetricEntry {
+              key = ReportingSetKey(measurementConsumerId, reportingSetId).toName()
+              value =
+                ReportKt.reportingMetricCalculationSpec {
+                  metricCalculationSpecs +=
+                    MetricCalculationSpecKey(measurementConsumerId, metricCalculationSpecId)
+                      .toName()
+                }
+            }
+          state = Report.State.FAILED
+          createTime = timestamp { seconds = 50 }
+          timeIntervals = timeIntervals {
+            timeIntervals += interval {
+              startTime = timestamp { seconds = 100 }
+              endTime = timestamp { seconds = 200 }
+            }
+          }
+          metricCalculationResults +=
+            ReportKt.metricCalculationResult {
+              metricCalculationSpec +=
+                MetricCalculationSpecKey(measurementConsumerId, metricCalculationSpecId).toName()
+              displayName = DISPLAY_NAME
+              reportingSet = ReportingSetKey(measurementConsumerId, reportingSetId).toName()
+            }
+        }
+      )
+    }
+
+    assertThat(result).ignoringRepeatedFieldOrder().isEqualTo(expected)
+  }
 
   @Test
   fun `listReports with page size replaced with a valid value and no previous page token`() {

--- a/src/test/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/ReportsServiceTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/ReportsServiceTest.kt
@@ -3328,6 +3328,100 @@ class ReportsServiceTest {
   }
 
   @Test
+  fun `getReport returns FAILED report when report has missing metric`() =
+    runBlocking {
+      val reportId = "123"
+      val reportingSetId = "123"
+      val metricCalculationSpecId = INTERNAL_REACH_METRIC_CALCULATION_SPEC.externalMetricCalculationSpecId
+      val measurementConsumerId = MEASUREMENT_CONSUMER_KEYS.first().measurementConsumerId
+      val reportWithMissingMetricId = internalReport {
+        externalReportId = reportId
+        cmmsMeasurementConsumerId = measurementConsumerId
+        reportingMetricEntries[reportingSetId] =
+          InternalReportKt.reportingMetricCalculationSpec {
+            metricCalculationSpecReportingMetrics +=
+              InternalReportKt.metricCalculationSpecReportingMetrics {
+                externalMetricCalculationSpecId = metricCalculationSpecId
+                reportingMetrics +=
+                  InternalReportKt.reportingMetric {
+                    details =
+                      InternalReportKt.ReportingMetricKt.details {
+                        metricSpec = internalMetricSpec {
+                          reach =
+                            InternalMetricSpecKt.reachParams {
+                              multipleDataProviderParams =
+                                InternalMetricSpecKt.samplingAndPrivacyParams {
+                                  privacyParams =
+                                    InternalMetricSpecKt.differentialPrivacyParams {
+                                      epsilon = 1.0
+                                      delta = 2.0
+                                    }
+                                  vidSamplingInterval =
+                                    InternalMetricSpecKt.vidSamplingInterval {
+                                      start = 0.1f
+                                      width = 0.5f
+                                    }
+                                }
+                            }
+                        }
+                        timeInterval = interval {
+                          startTime = timestamp { seconds = 100 }
+                          endTime = timestamp { seconds = 200 }
+                        }
+                        groupingPredicates += listOf("predicate1", "predicate2")
+                      }
+                  }
+              }
+          }
+        createTime = timestamp { seconds = 50 }
+        details =
+          InternalReportKt.details {
+            timeIntervals = internalTimeIntervals {
+              timeIntervals += interval {
+                startTime = timestamp { seconds = 100 }
+                endTime = timestamp { seconds = 200 }
+              }
+            }
+          }
+      }
+
+      whenever(internalReportsMock.getReport(any()))
+        .thenReturn(reportWithMissingMetricId)
+
+      val request = getReportRequest {
+        name = ReportKey(measurementConsumerId, reportId).toName()
+      }
+
+      val result =
+        withPrincipalAndScopes(PRINCIPAL, SCOPES) { runBlocking { service.getReport(request) } }
+
+      val expected = report {
+        name = ReportKey(measurementConsumerId, reportId).toName()
+        reportingMetricEntries += ReportKt.reportingMetricEntry {
+          key = ReportingSetKey(measurementConsumerId, reportingSetId).toName()
+          value = ReportKt.reportingMetricCalculationSpec {
+            metricCalculationSpecs += MetricCalculationSpecKey(measurementConsumerId, metricCalculationSpecId).toName()
+          }
+        }
+        state = Report.State.FAILED
+        createTime = timestamp { seconds = 50 }
+        timeIntervals = timeIntervals {
+          timeIntervals += interval {
+            startTime = timestamp { seconds = 100 }
+            endTime = timestamp { seconds = 200 }
+          }
+        }
+        metricCalculationResults += ReportKt.metricCalculationResult {
+          metricCalculationSpec += MetricCalculationSpecKey(measurementConsumerId, metricCalculationSpecId).toName()
+          displayName = DISPLAY_NAME
+          reportingSet = ReportingSetKey(measurementConsumerId, reportingSetId).toName()
+        }
+      }
+
+      assertThat(result).ignoringRepeatedFieldOrder().isEqualTo(expected)
+    }
+
+  @Test
   fun `getReport returns the report when caller has permission on Report resource`() {
     reset(permissionsServiceMock)
     wheneverBlocking {
@@ -3733,6 +3827,102 @@ class ReportsServiceTest {
               }
           }
         )
+
+      assertThat(result).ignoringRepeatedFieldOrder().isEqualTo(expected)
+    }
+
+  @Test
+  fun `listReports returns FAILED report when report has missing metric`() =
+    runBlocking {
+      val reportId = "123"
+      val reportingSetId = "123"
+      val metricCalculationSpecId = INTERNAL_REACH_METRIC_CALCULATION_SPEC.externalMetricCalculationSpecId
+      val measurementConsumerId = MEASUREMENT_CONSUMER_KEYS.first().measurementConsumerId
+      val reportWithMissingMetricId = internalReport {
+        externalReportId = reportId
+        cmmsMeasurementConsumerId = measurementConsumerId
+        reportingMetricEntries[reportingSetId] =
+          InternalReportKt.reportingMetricCalculationSpec {
+            metricCalculationSpecReportingMetrics +=
+              InternalReportKt.metricCalculationSpecReportingMetrics {
+                externalMetricCalculationSpecId = metricCalculationSpecId
+                reportingMetrics +=
+                  InternalReportKt.reportingMetric {
+                    details =
+                      InternalReportKt.ReportingMetricKt.details {
+                        metricSpec = internalMetricSpec {
+                          reach =
+                            InternalMetricSpecKt.reachParams {
+                              multipleDataProviderParams =
+                                InternalMetricSpecKt.samplingAndPrivacyParams {
+                                  privacyParams =
+                                    InternalMetricSpecKt.differentialPrivacyParams {
+                                      epsilon = 1.0
+                                      delta = 2.0
+                                    }
+                                  vidSamplingInterval =
+                                    InternalMetricSpecKt.vidSamplingInterval {
+                                      start = 0.1f
+                                      width = 0.5f
+                                    }
+                                }
+                            }
+                        }
+                        timeInterval = interval {
+                          startTime = timestamp { seconds = 100 }
+                          endTime = timestamp { seconds = 200 }
+                        }
+                        groupingPredicates += listOf("predicate1", "predicate2")
+                      }
+                  }
+              }
+          }
+        createTime = timestamp { seconds = 50 }
+        details =
+          InternalReportKt.details {
+            timeIntervals = internalTimeIntervals {
+              timeIntervals += interval {
+                startTime = timestamp { seconds = 100 }
+                endTime = timestamp { seconds = 200 }
+              }
+            }
+          }
+      }
+
+      whenever(internalReportsMock.streamReports(any()))
+        .thenReturn(flowOf(reportWithMissingMetricId))
+
+      val pageSize = 1
+      val request = listReportsRequest {
+        parent = MEASUREMENT_CONSUMER_KEYS.first().toName()
+        this.pageSize = pageSize
+      }
+
+      val result =
+        withPrincipalAndScopes(PRINCIPAL, SCOPES) { runBlocking { service.listReports(request) } }
+
+      val expected = listReportsResponse { reports.add(report {
+        name = ReportKey(measurementConsumerId, reportId).toName()
+        reportingMetricEntries += ReportKt.reportingMetricEntry {
+          key = ReportingSetKey(measurementConsumerId, reportingSetId).toName()
+          value = ReportKt.reportingMetricCalculationSpec {
+            metricCalculationSpecs += MetricCalculationSpecKey(measurementConsumerId, metricCalculationSpecId).toName()
+          }
+        }
+        state = Report.State.FAILED
+        createTime = timestamp { seconds = 50 }
+        timeIntervals = timeIntervals {
+          timeIntervals += interval {
+            startTime = timestamp { seconds = 100 }
+            endTime = timestamp { seconds = 200 }
+          }
+        }
+        metricCalculationResults += ReportKt.metricCalculationResult {
+          metricCalculationSpec += MetricCalculationSpecKey(measurementConsumerId, metricCalculationSpecId).toName()
+          displayName = DISPLAY_NAME
+          reportingSet = ReportingSetKey(measurementConsumerId, reportingSetId).toName()
+        }
+      }) }
 
       assertThat(result).ignoringRepeatedFieldOrder().isEqualTo(expected)
     }


### PR DESCRIPTION
If Report creation fails before Metrics are created, the Report ends up in a broken state. If creation is retried, it will be fixed. If not, the Report will be missing Metrics. This sets the Report to FAILED when Metrics are missing.