### PR TITLE
feat: Add structured filter criteria to Reporting ListEventGroups

### DIFF
--- a/src/main/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/EventGroupsService.kt
+++ b/src/main/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/EventGroupsService.kt
@@ -89,6 +89,12 @@ class EventGroupsService(
 
     grpcRequire(request.pageSize >= 0) { "page_size cannot be negative" }
 
+    // TODO(world-federation-of-advertisers/cross-media-measurement#2124): Remove once implemented.
+    if (request.hasOrderBy() || request.hasStructuredFilter()) {
+      throw Status.UNIMPLEMENTED.withDescription("Improved EventGroup search not yet implemented")
+        .asRuntimeException()
+    }
+
     val limit =
       if (request.pageSize > 0) request.pageSize.coerceAtMost(MAX_PAGE_SIZE) else DEFAULT_PAGE_SIZE
     val parent = parentKey.toName()

--- a/src/main/proto/wfa/measurement/reporting/v2alpha/BUILD.bazel
+++ b/src/main/proto/wfa/measurement/reporting/v2alpha/BUILD.bazel
@@ -303,10 +303,12 @@ proto_library(
     strip_import_prefix = IMPORT_PREFIX,
     deps = [
         ":event_group_proto",
+        ":media_type_proto",
         "@com_google_googleapis//google/api:annotations_proto",
         "@com_google_googleapis//google/api:client_proto",
         "@com_google_googleapis//google/api:field_behavior_proto",
         "@com_google_googleapis//google/api:resource_proto",
+        "@com_google_protobuf//:timestamp_proto",
     ],
 )
 

--- a/src/main/proto/wfa/measurement/reporting/v2alpha/event_groups_service.proto
+++ b/src/main/proto/wfa/measurement/reporting/v2alpha/event_groups_service.proto
@@ -20,7 +20,9 @@ import "google/api/annotations.proto";
 import "google/api/client.proto";
 import "google/api/field_behavior.proto";
 import "google/api/resource.proto";
+import "google/protobuf/timestamp.proto";
 import "wfa/measurement/reporting/v2alpha/event_group.proto";
+import "wfa/measurement/reporting/v2alpha/media_type.proto";
 
 option java_package = "org.wfanet.measurement.reporting.v2alpha";
 option java_multiple_files = true;
@@ -60,9 +62,75 @@ message ListEventGroupsRequest {
   // https://aip.dev/158.
   string page_token = 3 [(google.api.field_behavior) = OPTIONAL];
 
-  // Result filter. Raw CEL expression that is applied to a message which has a
-  // field for each event group template.
-  string filter = 4 [(google.api.field_behavior) = OPTIONAL];
+  // Structured filter criteria.
+  //
+  // Each field represents a term in a conjunction. If a field is not specified,
+  // its value is not considered as part of the criteria.
+  // (-- api-linter: core::0140::prepositions=disabled
+  //     api-linter: core::0142::time-field-names=disabled
+  //     aip.dev/not-precedent: Using structured filter instead of AIP-160. --)
+  message Filter {
+    // Set of CMMS [DataProvider][wfa.measurement.api.v2alpha.DataProvider]
+    // resource names which [EventGroup.cmms_data_provider][] must be in.
+    repeated string cmms_data_provider_in = 1 [
+      (google.api.resource_reference).type = "halo.wfanet.org/DataProvider",
+      (google.api.field_behavior) = OPTIONAL
+    ];
+    // Set of [MediaType][] values which [EventGroup.media_types][] must
+    // intersect.
+    repeated MediaType media_types_intersect = 2
+        [(google.api.field_behavior) = OPTIONAL];
+    // Time which
+    // [EventGroup.data_availability_interval.start_time][google.type.Interval.start_time]
+    // must be on or after.
+    google.protobuf.Timestamp data_availability_start_time_on_or_after = 3
+        [(google.api.field_behavior) = OPTIONAL];
+    // Time which
+    // [EventGroup.data_availability_interval.end_time][google.type.Interval.end_time]
+    // must be on or before.
+    google.protobuf.Timestamp data_availability_end_time_on_or_before = 4
+        [(google.api.field_behavior) = OPTIONAL];
+    // Query for text search on string fields in
+    // [EventGroup.event_group_metadata][].
+    string metadata_search_query = 5 [(google.api.field_behavior) = OPTIONAL];
+  }
+
+  // Filter criteria for results. Optional.
+  oneof filter_criteria {
+    // Result filter. Raw CEL expression that is applied to a message which has
+    // a field for each event group template.
+    //
+    // Deprecated in favor of [structured_filter][].
+    string filter = 4
+        [(google.api.field_behavior) = OPTIONAL, deprecated = true];
+
+    // Result filter.
+    // (-- api-linter: core::0132::request-unknown-fields=disabled
+    //     aip.dev/not-precedent: Using structured filter instead of AIP-160.
+    //     --)
+    Filter structured_filter = 5 [(google.api.field_behavior) = OPTIONAL];
+  }
+
+  // Structure for ordering results.
+  message OrderBy {
+    // Orderable field.
+    enum Field {
+      // Field unspecified.
+      FIELD_UNSPECIFIED = 0;
+      // [start_time][google.type.Interval.start_time] of
+      // [EventGroup.data_availability_interval][].
+      DATA_AVAILABILITY_START_TIME = 1;
+    }
+    // Field to order by.
+    Field field = 1 [(google.api.field_behavior) = REQUIRED];
+
+    // Whether the sort order is descending.
+    bool descending = 2 [(google.api.field_behavior) = OPTIONAL];
+  }
+  // How results should be ordered.
+  // (-- api-linter: core::0132::request-field-types=disabled
+  //     aip.dev/not-precedent: Only supporting a limited set of orderings. --)
+  OrderBy order_by = 6 [(google.api.field_behavior) = OPTIONAL];
 }
 
 // Response message for `ListEventGroups` method.


### PR DESCRIPTION
This only updates the API definition. If either of the new request fields is specified, the RPC will result in an UNIMPLEMENTED status.