### PR TITLE
feat!: Persist EventGroup data availability interval in DB columns

### DIFF
--- a/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/readers/EventGroupReader.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/readers/EventGroupReader.kt
@@ -14,14 +14,17 @@
 
 package org.wfanet.measurement.kingdom.deploy.gcloud.spanner.readers
 
+import com.google.cloud.Timestamp as CloudTimestamp
 import com.google.cloud.spanner.Statement
 import com.google.cloud.spanner.Struct
+import com.google.type.interval
 import kotlinx.coroutines.flow.singleOrNull
 import org.wfanet.measurement.common.identity.ExternalId
 import org.wfanet.measurement.common.identity.InternalId
 import org.wfanet.measurement.gcloud.spanner.AsyncDatabaseClient
 import org.wfanet.measurement.gcloud.spanner.appendClause
 import org.wfanet.measurement.gcloud.spanner.bind
+import org.wfanet.measurement.gcloud.spanner.getNullableTimestamp
 import org.wfanet.measurement.internal.kingdom.EventGroup
 import org.wfanet.measurement.internal.kingdom.EventGroupDetails
 import org.wfanet.measurement.internal.kingdom.MediaType
@@ -114,20 +117,36 @@ class EventGroupReader : BaseSpannerReader<EventGroupReader.Result>() {
       InternalId(struct.getLong("DataProviderId")),
     )
 
-  private fun buildEventGroup(struct: Struct): EventGroup = eventGroup {
-    externalEventGroupId = struct.getLong("ExternalEventGroupId")
-    externalDataProviderId = struct.getLong("ExternalDataProviderId")
-    externalMeasurementConsumerId = struct.getLong("ExternalMeasurementConsumerId")
-    if (!struct.isNull("ProvidedEventGroupId")) {
-      providedEventGroupId = struct.getString("ProvidedEventGroupId")
+  private fun buildEventGroup(struct: Struct): EventGroup {
+    val dataAvailabilityStartTime: CloudTimestamp? =
+      struct.getNullableTimestamp("DataAvailabilityStartTime")
+    val dataAvailabilityEndTime: CloudTimestamp? =
+      struct.getNullableTimestamp("DataAvailabilityEndTime")
+
+    return eventGroup {
+      externalEventGroupId = struct.getLong("ExternalEventGroupId")
+      externalDataProviderId = struct.getLong("ExternalDataProviderId")
+      externalMeasurementConsumerId = struct.getLong("ExternalMeasurementConsumerId")
+      if (!struct.isNull("ProvidedEventGroupId")) {
+        providedEventGroupId = struct.getString("ProvidedEventGroupId")
+      }
+      createTime = struct.getTimestamp("CreateTime").toProto()
+      updateTime = struct.getTimestamp("UpdateTime").toProto()
+      mediaTypes += struct.getProtoEnumList("MediaTypes", MediaType::forNumber)
+      if (dataAvailabilityStartTime != null) {
+        dataAvailabilityInterval = interval {
+          startTime = dataAvailabilityStartTime.toProto()
+          if (dataAvailabilityEndTime != null) {
+            endTime = dataAvailabilityEndTime.toProto()
+          }
+        }
+      }
+      if (!struct.isNull("EventGroupDetails")) {
+        details =
+          struct.getProtoMessage("EventGroupDetails", EventGroupDetails.getDefaultInstance())
+      }
+      state = struct.getProtoEnum("State", EventGroup.State::forNumber)
     }
-    createTime = struct.getTimestamp("CreateTime").toProto()
-    updateTime = struct.getTimestamp("UpdateTime").toProto()
-    mediaTypes += struct.getProtoEnumList("MediaTypes", MediaType::forNumber)
-    if (!struct.isNull("EventGroupDetails")) {
-      details = struct.getProtoMessage("EventGroupDetails", EventGroupDetails.getDefaultInstance())
-    }
-    state = struct.getProtoEnum("State", EventGroup.State::forNumber)
   }
 
   companion object {
@@ -141,6 +160,8 @@ class EventGroupReader : BaseSpannerReader<EventGroupReader.Result>() {
         EventGroups.ProvidedEventGroupId,
         EventGroups.CreateTime,
         EventGroups.UpdateTime,
+        EventGroups.DataAvailabilityStartTime,
+        EventGroups.DataAvailabilityEndTime,
         EventGroups.EventGroupDetails,
         MeasurementConsumers.ExternalMeasurementConsumerId,
         DataProviders.ExternalDataProviderId,

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/writers/CreateEventGroup.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/writers/CreateEventGroup.kt
@@ -17,6 +17,7 @@ package org.wfanet.measurement.kingdom.deploy.gcloud.spanner.writers
 import com.google.cloud.spanner.Value
 import org.wfanet.measurement.common.identity.ExternalId
 import org.wfanet.measurement.common.identity.InternalId
+import org.wfanet.measurement.gcloud.common.toGcloudTimestamp
 import org.wfanet.measurement.gcloud.spanner.bufferInsertMutation
 import org.wfanet.measurement.gcloud.spanner.set
 import org.wfanet.measurement.gcloud.spanner.to
@@ -82,6 +83,14 @@ class CreateEventGroup(private val request: CreateEventGroupRequest) :
       }
       set("CreateTime" to Value.COMMIT_TIMESTAMP)
       set("UpdateTime" to Value.COMMIT_TIMESTAMP)
+      if (request.eventGroup.dataAvailabilityInterval.hasStartTime()) {
+        set("DataAvailabilityStartTime")
+          .to(request.eventGroup.dataAvailabilityInterval.startTime.toGcloudTimestamp())
+      }
+      if (request.eventGroup.dataAvailabilityInterval.hasEndTime()) {
+        set("DataAvailabilityEndTime")
+          .to(request.eventGroup.dataAvailabilityInterval.endTime.toGcloudTimestamp())
+      }
       if (request.eventGroup.hasDetails()) {
         set("EventGroupDetails").to(request.eventGroup.details)
       }

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/writers/UpdateEventGroup.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/writers/UpdateEventGroup.kt
@@ -18,10 +18,13 @@ import com.google.cloud.spanner.Key
 import com.google.cloud.spanner.KeySet
 import com.google.cloud.spanner.Mutation
 import com.google.cloud.spanner.Value
+import com.google.type.endTimeOrNull
+import com.google.type.startTimeOrNull
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.toSet
 import org.wfanet.measurement.common.identity.ExternalId
 import org.wfanet.measurement.common.identity.InternalId
+import org.wfanet.measurement.gcloud.common.toGcloudTimestamp
 import org.wfanet.measurement.gcloud.spanner.AsyncDatabaseClient
 import org.wfanet.measurement.gcloud.spanner.bufferInsertMutation
 import org.wfanet.measurement.gcloud.spanner.bufferUpdateMutation
@@ -75,6 +78,10 @@ class UpdateEventGroup(private val eventGroup: EventGroup) :
       set("EventGroupId" to internalEventGroupResult.internalEventGroupId.value)
       set("ProvidedEventGroupId" to providedEventGroupId)
       set("UpdateTime" to Value.COMMIT_TIMESTAMP)
+      set("DataAvailabilityStartTime")
+        .to(eventGroup.dataAvailabilityInterval.startTimeOrNull?.toGcloudTimestamp())
+      set("DataAvailabilityEndTime")
+        .to(eventGroup.dataAvailabilityInterval.endTimeOrNull?.toGcloudTimestamp())
       set("EventGroupDetails").to(eventGroup.details)
     }
 

--- a/src/main/proto/wfa/measurement/internal/kingdom/BUILD.bazel
+++ b/src/main/proto/wfa/measurement/internal/kingdom/BUILD.bazel
@@ -309,7 +309,6 @@ proto_library(
     strip_import_prefix = IMPORT_PREFIX,
     deps = [
         ":event_template_proto",
-        "@com_google_googleapis//google/type:interval_proto",
     ],
 )
 
@@ -320,6 +319,7 @@ proto_library(
     deps = [
         ":event_group_details_proto",
         ":media_type_proto",
+        "@com_google_googleapis//google/type:interval_proto",
         "@com_google_protobuf//:timestamp_proto",
     ],
 )

--- a/src/main/proto/wfa/measurement/internal/kingdom/event_group.proto
+++ b/src/main/proto/wfa/measurement/internal/kingdom/event_group.proto
@@ -17,6 +17,7 @@ syntax = "proto3";
 package wfa.measurement.internal.kingdom;
 
 import "google/protobuf/timestamp.proto";
+import "google/type/interval.proto";
 import "wfa/measurement/internal/kingdom/event_group_details.proto";
 import "wfa/measurement/internal/kingdom/media_type.proto";
 
@@ -37,6 +38,7 @@ message EventGroup {
   google.protobuf.Timestamp update_time = 7;
 
   repeated MediaType media_types = 10;
+  google.type.Interval data_availability_interval = 11;
   EventGroupDetails details = 8;
 
   // Possible states of Event Group.

--- a/src/main/proto/wfa/measurement/internal/kingdom/event_group_details.proto
+++ b/src/main/proto/wfa/measurement/internal/kingdom/event_group_details.proto
@@ -16,13 +16,14 @@ syntax = "proto3";
 
 package wfa.measurement.internal.kingdom;
 
-import "google/type/interval.proto";
 import "wfa/measurement/internal/kingdom/event_template.proto";
 
 option java_package = "org.wfanet.measurement.internal.kingdom";
 option java_multiple_files = true;
 
 message EventGroupDetails {
+  reserved 8;
+
   // Version of the public API for serialized message definitions.
   string api_version = 1;
 
@@ -63,6 +64,4 @@ message EventGroupDetails {
   // Data Provider-specific encrypted Event Group metadata. This will eventually
   // be deprecated in favor of [metadata][].
   bytes encrypted_metadata = 6;
-
-  google.type.Interval data_availability_interval = 8;
 }

--- a/src/main/resources/kingdom/spanner/add-event-group-data-availability.sql
+++ b/src/main/resources/kingdom/spanner/add-event-group-data-availability.sql
@@ -1,0 +1,28 @@
+-- liquibase formatted sql
+
+-- Copyright 2025 The Cross-Media Measurement Authors
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+-- changeset sanjayvas:25 dbms:cloudspanner
+-- comment: Add columns for data availability to EventGroups table.
+
+START BATCH DDL;
+
+ALTER TABLE EventGroups
+ADD COLUMN DataAvailabilityStartTime TIMESTAMP;
+
+ALTER TABLE EventGroups
+ADD COLUMN DataAvailabilityEndTime TIMESTAMP;
+
+RUN BATCH;

--- a/src/main/resources/kingdom/spanner/changelog.yaml
+++ b/src/main/resources/kingdom/spanner/changelog.yaml
@@ -84,3 +84,6 @@ databaseChangeLog:
 - include:
     file: create-data-provider-availability.sql
     relativeToChangeLogFile: true
+- include:
+    file: add-event-group-data-availability.sql
+    relativeToChangeLogFile: true

--- a/src/test/kotlin/org/wfanet/measurement/kingdom/service/api/v2alpha/EventGroupsServiceTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/kingdom/service/api/v2alpha/EventGroupsServiceTest.kt
@@ -426,12 +426,7 @@ class EventGroupsServiceTest {
     runBlocking {
       whenever(internalEventGroupsMock.createEventGroup(any()))
         .thenReturn(
-          INTERNAL_EVENT_GROUP.copy {
-            details =
-              INTERNAL_EVENT_GROUP.details.copy {
-                this.dataAvailabilityInterval = dataAvailabilityInterval
-              }
-          }
+          INTERNAL_EVENT_GROUP.copy { this.dataAvailabilityInterval = dataAvailabilityInterval }
         )
     }
 
@@ -453,10 +448,7 @@ class EventGroupsServiceTest {
               clearCreateTime()
               clearExternalEventGroupId()
               clearState()
-              details =
-                INTERNAL_EVENT_GROUP.details.copy {
-                  this.dataAvailabilityInterval = dataAvailabilityInterval
-                }
+              this.dataAvailabilityInterval = dataAvailabilityInterval
             }
         }
       )
@@ -474,12 +466,7 @@ class EventGroupsServiceTest {
     runBlocking {
       whenever(internalEventGroupsMock.createEventGroup(any()))
         .thenReturn(
-          INTERNAL_EVENT_GROUP.copy {
-            details =
-              INTERNAL_EVENT_GROUP.details.copy {
-                this.dataAvailabilityInterval = dataAvailabilityInterval
-              }
-          }
+          INTERNAL_EVENT_GROUP.copy { this.dataAvailabilityInterval = dataAvailabilityInterval }
         )
     }
 
@@ -501,10 +488,7 @@ class EventGroupsServiceTest {
               clearCreateTime()
               clearExternalEventGroupId()
               clearState()
-              details =
-                INTERNAL_EVENT_GROUP.details.copy {
-                  this.dataAvailabilityInterval = dataAvailabilityInterval
-                }
+              this.dataAvailabilityInterval = dataAvailabilityInterval
             }
         }
       )
@@ -686,12 +670,7 @@ class EventGroupsServiceTest {
     runBlocking {
       whenever(internalEventGroupsMock.updateEventGroup(any()))
         .thenReturn(
-          INTERNAL_EVENT_GROUP.copy {
-            details =
-              INTERNAL_EVENT_GROUP.details.copy {
-                this.dataAvailabilityInterval = dataAvailabilityInterval
-              }
-          }
+          INTERNAL_EVENT_GROUP.copy { this.dataAvailabilityInterval = dataAvailabilityInterval }
         )
     }
 
@@ -711,10 +690,7 @@ class EventGroupsServiceTest {
             INTERNAL_EVENT_GROUP.copy {
               clearCreateTime()
               clearState()
-              details =
-                INTERNAL_EVENT_GROUP.details.copy {
-                  this.dataAvailabilityInterval = dataAvailabilityInterval
-                }
+              this.dataAvailabilityInterval = dataAvailabilityInterval
             }
         }
       )
@@ -732,12 +708,7 @@ class EventGroupsServiceTest {
     runBlocking {
       whenever(internalEventGroupsMock.updateEventGroup(any()))
         .thenReturn(
-          INTERNAL_EVENT_GROUP.copy {
-            details =
-              INTERNAL_EVENT_GROUP.details.copy {
-                this.dataAvailabilityInterval = dataAvailabilityInterval
-              }
-          }
+          INTERNAL_EVENT_GROUP.copy { this.dataAvailabilityInterval = dataAvailabilityInterval }
         )
     }
 
@@ -757,10 +728,7 @@ class EventGroupsServiceTest {
             INTERNAL_EVENT_GROUP.copy {
               clearCreateTime()
               clearState()
-              details =
-                INTERNAL_EVENT_GROUP.details.copy {
-                  this.dataAvailabilityInterval = dataAvailabilityInterval
-                }
+              this.dataAvailabilityInterval = dataAvailabilityInterval
             }
         }
       )


### PR DESCRIPTION
This moves persistence of EventGroup.data_availability_interval from EventGroupDetails to DB columns of type TIMESTAMP. Doing so allows for comparison operators in queries, which is necessary for #2124. This results in data loss of existing data availability values, which should be fine as the field is not yet being used.

BREAKING CHANGE: Any existing EventGroup data availability intervals will be lost