### PR TITLE
fix: filter out no-protocol duchy in requisition conversion from internal to public

### DIFF
--- a/src/main/kotlin/org/wfanet/measurement/kingdom/service/api/v2alpha/RequisitionsService.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/service/api/v2alpha/RequisitionsService.kt
@@ -16,10 +16,6 @@
 
 package org.wfanet.measurement.kingdom.service.api.v2alpha
 
-import org.wfanet.measurement.internal.kingdom.Requisition as InternalRequisition
-import org.wfanet.measurement.internal.kingdom.Requisition.State as InternalState
-import org.wfanet.measurement.internal.kingdom.RequisitionRefusal as InternalRefusal
-import org.wfanet.measurement.internal.kingdom.requisitionRefusal as internalRequisitionRefusal
 import com.google.protobuf.any
 import com.google.protobuf.kotlin.unpack
 import io.grpc.Status
@@ -75,13 +71,17 @@ import org.wfanet.measurement.common.identity.externalIdToApiId
 import org.wfanet.measurement.internal.kingdom.FulfillRequisitionRequestKt.directRequisitionParams
 import org.wfanet.measurement.internal.kingdom.HonestMajorityShareShuffleParams
 import org.wfanet.measurement.internal.kingdom.LiquidLegionsV2Params
+import org.wfanet.measurement.internal.kingdom.Requisition as InternalRequisition
 import org.wfanet.measurement.internal.kingdom.Requisition.DuchyValue
+import org.wfanet.measurement.internal.kingdom.Requisition.State as InternalState
 import org.wfanet.measurement.internal.kingdom.RequisitionDetailsKt
+import org.wfanet.measurement.internal.kingdom.RequisitionRefusal as InternalRefusal
 import org.wfanet.measurement.internal.kingdom.RequisitionsGrpcKt.RequisitionsCoroutineStub
 import org.wfanet.measurement.internal.kingdom.StreamRequisitionsRequest
 import org.wfanet.measurement.internal.kingdom.StreamRequisitionsRequestKt
 import org.wfanet.measurement.internal.kingdom.fulfillRequisitionRequest
 import org.wfanet.measurement.internal.kingdom.refuseRequisitionRequest
+import org.wfanet.measurement.internal.kingdom.requisitionRefusal as internalRequisitionRefusal
 import org.wfanet.measurement.internal.kingdom.streamRequisitionsRequest
 
 private const val DEFAULT_PAGE_SIZE = 10

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/service/api/v2alpha/RequisitionsService.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/service/api/v2alpha/RequisitionsService.kt
@@ -460,7 +460,7 @@ private fun DuchyValue.toDuchyEntryValue(
             DuchyEntry.HonestMajorityShareShuffle.getDefaultInstance()
           }
       }
-      DuchyValue.ProtocolCase.PROTOCOL_NOT_SET -> Unit
+      DuchyValue.ProtocolCase.PROTOCOL_NOT_SET -> error("protocol not set")
     }
   }
 }

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/service/api/v2alpha/RequisitionsService.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/service/api/v2alpha/RequisitionsService.kt
@@ -16,6 +16,10 @@
 
 package org.wfanet.measurement.kingdom.service.api.v2alpha
 
+import org.wfanet.measurement.internal.kingdom.Requisition as InternalRequisition
+import org.wfanet.measurement.internal.kingdom.Requisition.State as InternalState
+import org.wfanet.measurement.internal.kingdom.RequisitionRefusal as InternalRefusal
+import org.wfanet.measurement.internal.kingdom.requisitionRefusal as internalRequisitionRefusal
 import com.google.protobuf.any
 import com.google.protobuf.kotlin.unpack
 import io.grpc.Status
@@ -71,17 +75,13 @@ import org.wfanet.measurement.common.identity.externalIdToApiId
 import org.wfanet.measurement.internal.kingdom.FulfillRequisitionRequestKt.directRequisitionParams
 import org.wfanet.measurement.internal.kingdom.HonestMajorityShareShuffleParams
 import org.wfanet.measurement.internal.kingdom.LiquidLegionsV2Params
-import org.wfanet.measurement.internal.kingdom.Requisition as InternalRequisition
 import org.wfanet.measurement.internal.kingdom.Requisition.DuchyValue
-import org.wfanet.measurement.internal.kingdom.Requisition.State as InternalState
 import org.wfanet.measurement.internal.kingdom.RequisitionDetailsKt
-import org.wfanet.measurement.internal.kingdom.RequisitionRefusal as InternalRefusal
 import org.wfanet.measurement.internal.kingdom.RequisitionsGrpcKt.RequisitionsCoroutineStub
 import org.wfanet.measurement.internal.kingdom.StreamRequisitionsRequest
 import org.wfanet.measurement.internal.kingdom.StreamRequisitionsRequestKt
 import org.wfanet.measurement.internal.kingdom.fulfillRequisitionRequest
 import org.wfanet.measurement.internal.kingdom.refuseRequisitionRequest
-import org.wfanet.measurement.internal.kingdom.requisitionRefusal as internalRequisitionRefusal
 import org.wfanet.measurement.internal.kingdom.streamRequisitionsRequest
 
 private const val DEFAULT_PAGE_SIZE = 10
@@ -387,7 +387,7 @@ private fun DuchyValue.availableForFulfillment(): Boolean {
     DuchyValue.ProtocolCase.HONEST_MAJORITY_SHARE_SHUFFLE -> {
       !honestMajorityShareShuffle.tinkPublicKey.isEmpty
     }
-    DuchyValue.ProtocolCase.PROTOCOL_NOT_SET -> error("protocol not set")
+    DuchyValue.ProtocolCase.PROTOCOL_NOT_SET -> false
   }
 }
 
@@ -460,7 +460,7 @@ private fun DuchyValue.toDuchyEntryValue(
             DuchyEntry.HonestMajorityShareShuffle.getDefaultInstance()
           }
       }
-      DuchyValue.ProtocolCase.PROTOCOL_NOT_SET -> error("protocol not set")
+      DuchyValue.ProtocolCase.PROTOCOL_NOT_SET -> Unit
     }
   }
 }

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/service/internal/testing/MeasurementsServiceTest.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/service/internal/testing/MeasurementsServiceTest.kt
@@ -1224,7 +1224,6 @@ abstract class MeasurementsServiceTest<T : MeasurementsCoroutineImplBase> {
           }
         )
         .toList()
-    println("debug requisitions: " + requisitions)
     assertThat(requisitions)
       .comparingExpectedFieldsOnly()
       .containsExactly(

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/service/internal/testing/MeasurementsServiceTest.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/service/internal/testing/MeasurementsServiceTest.kt
@@ -58,7 +58,6 @@ import org.wfanet.measurement.internal.kingdom.MeasurementsGrpcKt.MeasurementsCo
 import org.wfanet.measurement.internal.kingdom.ProtocolConfig
 import org.wfanet.measurement.internal.kingdom.Requisition
 import org.wfanet.measurement.internal.kingdom.Requisition.DuchyValue
-import org.wfanet.measurement.internal.kingdom.RequisitionKt.duchyValue
 import org.wfanet.measurement.internal.kingdom.RequisitionKt.parentMeasurement
 import org.wfanet.measurement.internal.kingdom.RequisitionsGrpcKt.RequisitionsCoroutineImplBase
 import org.wfanet.measurement.internal.kingdom.StreamMeasurementsRequestKt
@@ -1231,13 +1230,12 @@ abstract class MeasurementsServiceTest<T : MeasurementsCoroutineImplBase> {
         requisition { state = Requisition.State.WITHDRAWN },
       )
 
-    val requisitionDuchyMap1 = requisitions[0].duchiesMap
-    for (entry in requisitionDuchyMap1) {
-      assertThat(entry.value).comparingExpectedFieldsOnly().isEqualTo(duchyValue {})
-    }
-    val requisitionDuchyMap2 = requisitions[1].duchiesMap
-    for (entry in requisitionDuchyMap2) {
-      assertThat(entry.value).comparingExpectedFieldsOnly().isEqualTo(duchyValue {})
+    for (requisition in requisitions) {
+      for (duchyValue in requisition.duchiesMap.values) {
+        assertThat(duchyValue)
+          .comparingExpectedFieldsOnly()
+          .isEqualTo(DuchyValue.getDefaultInstance())
+      }
     }
   }
 

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/service/internal/testing/MeasurementsServiceTest.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/service/internal/testing/MeasurementsServiceTest.kt
@@ -57,6 +57,8 @@ import org.wfanet.measurement.internal.kingdom.MeasurementLogEntryError
 import org.wfanet.measurement.internal.kingdom.MeasurementsGrpcKt.MeasurementsCoroutineImplBase
 import org.wfanet.measurement.internal.kingdom.ProtocolConfig
 import org.wfanet.measurement.internal.kingdom.Requisition
+import org.wfanet.measurement.internal.kingdom.Requisition.DuchyValue
+import org.wfanet.measurement.internal.kingdom.RequisitionKt.duchyValue
 import org.wfanet.measurement.internal.kingdom.RequisitionKt.parentMeasurement
 import org.wfanet.measurement.internal.kingdom.RequisitionsGrpcKt.RequisitionsCoroutineImplBase
 import org.wfanet.measurement.internal.kingdom.StreamMeasurementsRequestKt
@@ -1222,12 +1224,22 @@ abstract class MeasurementsServiceTest<T : MeasurementsCoroutineImplBase> {
           }
         )
         .toList()
+    println("debug requisitions: " + requisitions)
     assertThat(requisitions)
       .comparingExpectedFieldsOnly()
       .containsExactly(
         requisition { state = Requisition.State.WITHDRAWN },
         requisition { state = Requisition.State.WITHDRAWN },
       )
+
+    val requisitionDuchyMap1 = requisitions[0].duchiesMap
+    for (entry in requisitionDuchyMap1) {
+      assertThat(entry.value).comparingExpectedFieldsOnly().isEqualTo(duchyValue {})
+    }
+    val requisitionDuchyMap2 = requisitions[1].duchiesMap
+    for (entry in requisitionDuchyMap2) {
+      assertThat(entry.value).comparingExpectedFieldsOnly().isEqualTo(duchyValue {})
+    }
   }
 
   @Test


### PR DESCRIPTION
RequistionsService incorrectly throws an error when `DuchyValue` doesn't have the `protocol` field specified, in cases where it may be expected to be absent. For example, if a Measurement is cancelled before the Duchy sets its requisition params.