### PR TITLE
refactor: Metric State is set to FAILED when Measurement Result issues are present

### DIFF
--- a/src/main/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/MetricsService.kt
+++ b/src/main/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/MetricsService.kt
@@ -34,7 +34,6 @@ import java.security.cert.CertPathValidatorException
 import java.security.cert.X509Certificate
 import java.time.Duration
 import java.util.concurrent.TimeUnit
-import java.util.logging.Level
 import java.util.logging.Logger
 import kotlin.coroutines.ContinuationInterceptor
 import kotlin.coroutines.CoroutineContext
@@ -1852,9 +1851,7 @@ class MetricsService(
               }
 
               else -> {
-                failure = failure {
-                  reason = Metric.Failure.Reason.MEASUREMENT_RESULT_INVALID
-                }
+                failure = failure { reason = Metric.Failure.Reason.MEASUREMENT_RESULT_INVALID }
               }
             }
           }
@@ -1867,9 +1864,7 @@ class MetricsService(
                   .toName()
               }
           }
-          failure = failure {
-            reason = Metric.Failure.Reason.MEASUREMENT_FAILED
-          }
+          failure = failure { reason = Metric.Failure.Reason.MEASUREMENT_FAILED }
         }
         Metric.State.INVALID -> {
           result = metricResult {

--- a/src/main/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/MetricsService.kt
+++ b/src/main/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/MetricsService.kt
@@ -893,7 +893,9 @@ class MetricsService(
           failedMeasurementsList.map { measurement ->
             measurementFailure {
               cmmsMeasurementId = MeasurementKey.fromName(measurement.name)!!.measurementId
-              failure = measurement.failure.toInternal()
+              if (measurement.hasFailure()) {
+                failure = measurement.failure.toInternal()
+              }
             }
           }
       }
@@ -1864,7 +1866,7 @@ class MetricsService(
                   .toName()
               }
           }
-          failure = failure { reason = Metric.Failure.Reason.MEASUREMENT_FAILED }
+          failure = failure { reason = Metric.Failure.Reason.MEASUREMENT_STATE_INVALID }
         }
         Metric.State.INVALID -> {
           result = metricResult {

--- a/src/main/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/MetricsService.kt
+++ b/src/main/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/MetricsService.kt
@@ -2281,9 +2281,7 @@ fun buildStatsMethodology(
       DeterministicMethodology
     }
     InternalMeasurement.Result.WatchDuration.MethodologyCase.METHODOLOGY_NOT_SET -> {
-      throw MeasurementVarianceNotComputableException(
-        "Methodology not set."
-      )
+      throw MeasurementVarianceNotComputableException("Methodology not set.")
     }
   }
 }
@@ -2441,9 +2439,7 @@ fun buildStatsMethodology(impressionResult: InternalMeasurement.Result.Impressio
       DeterministicMethodology
     }
     InternalMeasurement.Result.Impression.MethodologyCase.METHODOLOGY_NOT_SET -> {
-      throw MeasurementVarianceNotComputableException(
-        "Methodology not set."
-      )
+      throw MeasurementVarianceNotComputableException("Methodology not set.")
     }
   }
 }
@@ -2720,9 +2716,7 @@ fun buildStatsMethodology(frequencyResult: InternalMeasurement.Result.Frequency)
       )
     }
     InternalMeasurement.Result.Frequency.MethodologyCase.METHODOLOGY_NOT_SET -> {
-      throw MeasurementVarianceNotComputableException(
-        "Methodology not set."
-      )
+      throw MeasurementVarianceNotComputableException("Methodology not set.")
     }
   }
 }
@@ -2975,9 +2969,7 @@ fun buildStatsMethodology(reachResult: InternalMeasurement.Result.Reach): Method
       )
     }
     InternalMeasurement.Result.Reach.MethodologyCase.METHODOLOGY_NOT_SET -> {
-      throw MeasurementVarianceNotComputableException(
-        "Methodology not set."
-      )
+      throw MeasurementVarianceNotComputableException("Methodology not set.")
     }
   }
 }

--- a/src/main/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/MetricsService.kt
+++ b/src/main/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/MetricsService.kt
@@ -2281,7 +2281,9 @@ fun buildStatsMethodology(
       DeterministicMethodology
     }
     InternalMeasurement.Result.WatchDuration.MethodologyCase.METHODOLOGY_NOT_SET -> {
-      return null
+      throw MeasurementVarianceNotComputableException(
+        "Methodology not set."
+      )
     }
   }
 }
@@ -2439,7 +2441,9 @@ fun buildStatsMethodology(impressionResult: InternalMeasurement.Result.Impressio
       DeterministicMethodology
     }
     InternalMeasurement.Result.Impression.MethodologyCase.METHODOLOGY_NOT_SET -> {
-      return null
+      throw MeasurementVarianceNotComputableException(
+        "Methodology not set."
+      )
     }
   }
 }
@@ -2716,7 +2720,9 @@ fun buildStatsMethodology(frequencyResult: InternalMeasurement.Result.Frequency)
       )
     }
     InternalMeasurement.Result.Frequency.MethodologyCase.METHODOLOGY_NOT_SET -> {
-      return null
+      throw MeasurementVarianceNotComputableException(
+        "Methodology not set."
+      )
     }
   }
 }
@@ -2969,7 +2975,9 @@ fun buildStatsMethodology(reachResult: InternalMeasurement.Result.Reach): Method
       )
     }
     InternalMeasurement.Result.Reach.MethodologyCase.METHODOLOGY_NOT_SET -> {
-      return null
+      throw MeasurementVarianceNotComputableException(
+        "Methodology not set."
+      )
     }
   }
 }

--- a/src/main/proto/wfa/measurement/reporting/v2alpha/metric.proto
+++ b/src/main/proto/wfa/measurement/reporting/v2alpha/metric.proto
@@ -442,4 +442,26 @@ message Metric {
 
   // The result of calculating the metric.
   MetricResult result = 8 [(google.api.field_behavior) = OUTPUT_ONLY];
+
+  // Information about a failure.
+  message Failure {
+    // Reason for a `Failure`.
+    enum Reason {
+      // Default value used if the reason is omitted.
+      REASON_UNSPECIFIED = 0;
+      // An associated `Measurement` has `state` `FAILED`.
+      MEASUREMENT_FAILED = 1;
+      // An associated `Measurement` has invalid `results`.
+      MEASUREMENT_RESULT_INVALID = 2;
+    }
+    // Reason for this `Failure`.
+    Reason reason = 1 [(google.api.field_behavior) = REQUIRED];
+
+    // Human-readable message. This should not contain any sensitive
+    // information.
+    string message = 2 [(google.api.field_behavior) = OPTIONAL];
+  }
+  // Information about the failure of this `Metric`. Set when the `state`
+  // is set to `FAILED`.
+  Failure failure = 10 [(google.api.field_behavior) = OUTPUT_ONLY];
 }

--- a/src/main/proto/wfa/measurement/reporting/v2alpha/metric.proto
+++ b/src/main/proto/wfa/measurement/reporting/v2alpha/metric.proto
@@ -455,8 +455,8 @@ message Metric {
     enum Reason {
       // Default value used if the reason is omitted.
       REASON_UNSPECIFIED = 0;
-      // An associated `Measurement` has `state` `FAILED`.
-      MEASUREMENT_FAILED = 1;
+      // An associated `Measurement` has `state` `FAILED` or `CANCELLED`.
+      MEASUREMENT_STATE_INVALID = 1;
       // An associated `Measurement` has invalid `results`.
       MEASUREMENT_RESULT_INVALID = 2;
     }

--- a/src/test/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/MetricsServiceTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/MetricsServiceTest.kt
@@ -8478,10 +8478,7 @@ class MetricsServiceTest {
               this.result.copy {
                 reachAndFrequency =
                   MetricResultKt.reachAndFrequencyResult {
-                    reach =
-                      MetricResultKt.reachResult {
-                        value = REACH_FREQUENCY_REACH_VALUE
-                      }
+                    reach = MetricResultKt.reachResult { value = REACH_FREQUENCY_REACH_VALUE }
                     frequencyHistogram =
                       MetricResultKt.histogramResult {
                         bins +=
@@ -9425,60 +9422,59 @@ class MetricsServiceTest {
     }
 
   @Test
-  fun `getMetric returns failed impression metric when methodology is not set`() =
-    runBlocking {
-      wheneverBlocking {
-        permissionsServiceMock.checkPermissions(hasPrincipal(PRINCIPAL.name))
-      } doReturn checkPermissionsResponse { permissions += PermissionName.GET }
-      whenever(internalMetricsMock.batchGetMetrics(any()))
-        .thenReturn(
-          internalBatchGetMetricsResponse {
-            metrics +=
-              INTERNAL_SUCCEEDED_SINGLE_PUBLISHER_IMPRESSION_METRIC.copy {
-                weightedMeasurements.clear()
-                weightedMeasurements += weightedMeasurement {
-                  weight = 1
-                  binaryRepresentation = 1
-                  measurement =
-                    INTERNAL_SUCCEEDED_SINGLE_PUBLISHER_IMPRESSION_MEASUREMENT.copy {
-                      details =
-                        InternalMeasurementKt.details {
-                          results +=
-                            InternalMeasurementKt.result {
-                              impression =
-                                InternalMeasurementKt.ResultKt.impression {
-                                  value = IMPRESSION_VALUE
-                                  noiseMechanism = NoiseMechanism.CONTINUOUS_LAPLACE
-                                }
-                            }
-                        }
-                    }
-                }
+  fun `getMetric returns failed impression metric when methodology is not set`() = runBlocking {
+    wheneverBlocking {
+      permissionsServiceMock.checkPermissions(hasPrincipal(PRINCIPAL.name))
+    } doReturn checkPermissionsResponse { permissions += PermissionName.GET }
+    whenever(internalMetricsMock.batchGetMetrics(any()))
+      .thenReturn(
+        internalBatchGetMetricsResponse {
+          metrics +=
+            INTERNAL_SUCCEEDED_SINGLE_PUBLISHER_IMPRESSION_METRIC.copy {
+              weightedMeasurements.clear()
+              weightedMeasurements += weightedMeasurement {
+                weight = 1
+                binaryRepresentation = 1
+                measurement =
+                  INTERNAL_SUCCEEDED_SINGLE_PUBLISHER_IMPRESSION_MEASUREMENT.copy {
+                    details =
+                      InternalMeasurementKt.details {
+                        results +=
+                          InternalMeasurementKt.result {
+                            impression =
+                              InternalMeasurementKt.ResultKt.impression {
+                                value = IMPRESSION_VALUE
+                                noiseMechanism = NoiseMechanism.CONTINUOUS_LAPLACE
+                              }
+                          }
+                      }
+                  }
               }
-          }
-        )
+            }
+        }
+      )
 
-      val request = getMetricRequest { name = SUCCEEDED_SINGLE_PUBLISHER_IMPRESSION_METRIC.name }
+    val request = getMetricRequest { name = SUCCEEDED_SINGLE_PUBLISHER_IMPRESSION_METRIC.name }
 
-      val result =
-        withPrincipalAndScopes(PRINCIPAL, SCOPES) { runBlocking { service.getMetric(request) } }
+    val result =
+      withPrincipalAndScopes(PRINCIPAL, SCOPES) { runBlocking { service.getMetric(request) } }
 
-      assertThat(result)
-        .isEqualTo(
-          SUCCEEDED_SINGLE_PUBLISHER_IMPRESSION_METRIC.copy {
-            state = Metric.State.FAILED
-            failure =
-              MetricKt.failure {
-                reason = Metric.Failure.Reason.MEASUREMENT_RESULT_INVALID
-                message = "Problem with variance calculation"
-              }
-            this.result =
-              this.result.copy {
-                impressionCount = impressionCount.copy { clearUnivariateStatistics() }
-              }
-          }
-        )
-    }
+    assertThat(result)
+      .isEqualTo(
+        SUCCEEDED_SINGLE_PUBLISHER_IMPRESSION_METRIC.copy {
+          state = Metric.State.FAILED
+          failure =
+            MetricKt.failure {
+              reason = Metric.Failure.Reason.MEASUREMENT_RESULT_INVALID
+              message = "Problem with variance calculation"
+            }
+          this.result =
+            this.result.copy {
+              impressionCount = impressionCount.copy { clearUnivariateStatistics() }
+            }
+        }
+      )
+  }
 
   @Test
   fun `getMetric returns impression metric without statistics when variance in custom methodology is unavailable`() =
@@ -9759,62 +9755,59 @@ class MetricsServiceTest {
     }
 
   @Test
-  fun `getMetric returns failed duration metric when methodology is not set`() =
-    runBlocking {
-      wheneverBlocking {
-        permissionsServiceMock.checkPermissions(hasPrincipal(PRINCIPAL.name))
-      } doReturn checkPermissionsResponse { permissions += PermissionName.GET }
-      whenever(internalMetricsMock.batchGetMetrics(any()))
-        .thenReturn(
-          internalBatchGetMetricsResponse {
-            metrics +=
-              INTERNAL_SUCCEEDED_CROSS_PUBLISHER_WATCH_DURATION_METRIC.copy {
-                weightedMeasurements.clear()
-                weightedMeasurements += weightedMeasurement {
-                  weight = 1
-                  binaryRepresentation = 1
-                  measurement =
-                    INTERNAL_SUCCEEDED_UNION_ALL_WATCH_DURATION_MEASUREMENT.copy {
-                      details =
-                        InternalMeasurementKt.details {
-                          results +=
-                            WATCH_DURATION_LIST.map { duration ->
-                              InternalMeasurementKt.result {
-                                watchDuration =
-                                  InternalMeasurementKt.ResultKt.watchDuration {
-                                    value = duration
-                                    noiseMechanism = NoiseMechanism.CONTINUOUS_LAPLACE
-                                  }
-                              }
+  fun `getMetric returns failed duration metric when methodology is not set`() = runBlocking {
+    wheneverBlocking {
+      permissionsServiceMock.checkPermissions(hasPrincipal(PRINCIPAL.name))
+    } doReturn checkPermissionsResponse { permissions += PermissionName.GET }
+    whenever(internalMetricsMock.batchGetMetrics(any()))
+      .thenReturn(
+        internalBatchGetMetricsResponse {
+          metrics +=
+            INTERNAL_SUCCEEDED_CROSS_PUBLISHER_WATCH_DURATION_METRIC.copy {
+              weightedMeasurements.clear()
+              weightedMeasurements += weightedMeasurement {
+                weight = 1
+                binaryRepresentation = 1
+                measurement =
+                  INTERNAL_SUCCEEDED_UNION_ALL_WATCH_DURATION_MEASUREMENT.copy {
+                    details =
+                      InternalMeasurementKt.details {
+                        results +=
+                          WATCH_DURATION_LIST.map { duration ->
+                            InternalMeasurementKt.result {
+                              watchDuration =
+                                InternalMeasurementKt.ResultKt.watchDuration {
+                                  value = duration
+                                  noiseMechanism = NoiseMechanism.CONTINUOUS_LAPLACE
+                                }
                             }
-                        }
-                    }
-                }
+                          }
+                      }
+                  }
               }
-          }
-        )
+            }
+        }
+      )
 
-      val request = getMetricRequest { name = PENDING_CROSS_PUBLISHER_WATCH_DURATION_METRIC.name }
+    val request = getMetricRequest { name = PENDING_CROSS_PUBLISHER_WATCH_DURATION_METRIC.name }
 
-      val result =
-        withPrincipalAndScopes(PRINCIPAL, SCOPES) { runBlocking { service.getMetric(request) } }
+    val result =
+      withPrincipalAndScopes(PRINCIPAL, SCOPES) { runBlocking { service.getMetric(request) } }
 
-      assertThat(result)
-        .isEqualTo(
-          SUCCEEDED_CROSS_PUBLISHER_WATCH_DURATION_METRIC.copy {
-            state = Metric.State.FAILED
-            failure =
-              MetricKt.failure {
-                reason = Metric.Failure.Reason.MEASUREMENT_RESULT_INVALID
-                message = "Problem with variance calculation"
-              }
-            this.result =
-              this.result.copy {
-                watchDuration = watchDuration.copy { clearUnivariateStatistics() }
-              }
-          }
-        )
-    }
+    assertThat(result)
+      .isEqualTo(
+        SUCCEEDED_CROSS_PUBLISHER_WATCH_DURATION_METRIC.copy {
+          state = Metric.State.FAILED
+          failure =
+            MetricKt.failure {
+              reason = Metric.Failure.Reason.MEASUREMENT_RESULT_INVALID
+              message = "Problem with variance calculation"
+            }
+          this.result =
+            this.result.copy { watchDuration = watchDuration.copy { clearUnivariateStatistics() } }
+        }
+      )
+  }
 
   @Test
   fun `getMetric returns duration metric without statistics when variance in custom methodology is unavailable`() =

--- a/src/test/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/MetricsServiceTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/MetricsServiceTest.kt
@@ -6180,9 +6180,7 @@ class MetricsServiceTest {
                 )
                 .toName()
           }
-          failure = MetricKt.failure {
-            reason = Metric.Failure.Reason.MEASUREMENT_FAILED
-          }
+          failure = MetricKt.failure { reason = Metric.Failure.Reason.MEASUREMENT_FAILED }
         }
     }
 
@@ -7528,10 +7526,13 @@ class MetricsServiceTest {
         withPrincipalAndScopes(PRINCIPAL, SCOPES) { runBlocking { service.getMetric(request) } }
 
       assertThat(response.state).isEqualTo(Metric.State.FAILED)
-      assertThat(response.failure).isEqualTo(MetricKt.failure {
-        reason = Metric.Failure.Reason.MEASUREMENT_RESULT_INVALID
-        message = "Problem with result"
-      })
+      assertThat(response.failure)
+        .isEqualTo(
+          MetricKt.failure {
+            reason = Metric.Failure.Reason.MEASUREMENT_RESULT_INVALID
+            message = "Problem with result"
+          }
+        )
       assertThat(response.result)
         .isEqualTo(metricResult { cmmsMeasurements += SUCCEEDED_UNION_ALL_REACH_MEASUREMENT.name })
     }
@@ -7566,10 +7567,13 @@ class MetricsServiceTest {
         withPrincipalAndScopes(PRINCIPAL, SCOPES) { runBlocking { service.getMetric(request) } }
 
       assertThat(response.state).isEqualTo(Metric.State.FAILED)
-      assertThat(response.failure).isEqualTo(MetricKt.failure {
-        reason = Metric.Failure.Reason.MEASUREMENT_RESULT_INVALID
-        message = "Problem with result"
-      })
+      assertThat(response.failure)
+        .isEqualTo(
+          MetricKt.failure {
+            reason = Metric.Failure.Reason.MEASUREMENT_RESULT_INVALID
+            message = "Problem with result"
+          }
+        )
       assertThat(response.result)
         .isEqualTo(metricResult { cmmsMeasurements += SUCCEEDED_UNION_ALL_REACH_MEASUREMENT.name })
     }
@@ -7624,10 +7628,11 @@ class MetricsServiceTest {
       .isEqualTo(
         SUCCEEDED_INCREMENTAL_REACH_METRIC.copy {
           state = Metric.State.FAILED
-          failure = MetricKt.failure {
-            reason = Metric.Failure.Reason.MEASUREMENT_RESULT_INVALID
-            message = "Problem with variance calculation"
-          }
+          failure =
+            MetricKt.failure {
+              reason = Metric.Failure.Reason.MEASUREMENT_RESULT_INVALID
+              message = "Problem with variance calculation"
+            }
           result =
             result.copy {
               cmmsMeasurements += SUCCEEDED_UNION_ALL_REACH_MEASUREMENT.name
@@ -7853,9 +7858,7 @@ class MetricsServiceTest {
     assertThat(result)
       .isEqualTo(
         FAILED_SINGLE_PUBLISHER_IMPRESSION_METRIC.copy {
-          failure = MetricKt.failure {
-            reason = Metric.Failure.Reason.MEASUREMENT_FAILED
-          }
+          failure = MetricKt.failure { reason = Metric.Failure.Reason.MEASUREMENT_FAILED }
           this.result = metricResult {
             cmmsMeasurements +=
               MeasurementKey(
@@ -8648,10 +8651,13 @@ class MetricsServiceTest {
     val response =
       withPrincipalAndScopes(PRINCIPAL, SCOPES) { runBlocking { service.getMetric(request) } }
     assertThat(response.state).isEqualTo(Metric.State.FAILED)
-    assertThat(response.failure).isEqualTo(MetricKt.failure {
-      reason = Metric.Failure.Reason.MEASUREMENT_RESULT_INVALID
-      message = "Problem with result"
-    })
+    assertThat(response.failure)
+      .isEqualTo(
+        MetricKt.failure {
+          reason = Metric.Failure.Reason.MEASUREMENT_RESULT_INVALID
+          message = "Problem with result"
+        }
+      )
     assertThat(response.result)
       .isEqualTo(
         metricResult {
@@ -8661,89 +8667,96 @@ class MetricsServiceTest {
   }
 
   @Test
-  fun `getMetric returns failed metric for rf when custom direct methodology has scalar`():
-    Unit = runBlocking {
-    wheneverBlocking {
-      permissionsServiceMock.checkPermissions(hasPrincipal(PRINCIPAL.name))
-    } doReturn checkPermissionsResponse { permissions += PermissionName.GET }
-    whenever(internalMetricsMock.batchGetMetrics(any()))
-      .thenReturn(
-        internalBatchGetMetricsResponse {
-          metrics +=
-            INTERNAL_SUCCEEDED_SINGLE_PUBLISHER_REACH_FREQUENCY_METRIC.copy {
-              weightedMeasurements.clear()
-              weightedMeasurements += weightedMeasurement {
-                weight = 1
-                binaryRepresentation = 3
-                measurement =
-                  INTERNAL_SUCCEEDED_SINGLE_PUBLISHER_REACH_FREQUENCY_MEASUREMENT.copy {
-                    details =
-                      INTERNAL_SUCCEEDED_SINGLE_PUBLISHER_REACH_FREQUENCY_MEASUREMENT.details.copy {
-                        results.clear()
-                        results +=
-                          INTERNAL_SUCCEEDED_SINGLE_PUBLISHER_REACH_FREQUENCY_MEASUREMENT.details
-                            .resultsList
-                            .first()
-                            .copy {
-                              frequency =
-                                INTERNAL_SUCCEEDED_SINGLE_PUBLISHER_REACH_FREQUENCY_MEASUREMENT
-                                  .details
-                                  .resultsList
-                                  .first()
-                                  .frequency
-                                  .copy {
-                                    customDirectMethodology = internalCustomDirectMethodology {
-                                      variance =
-                                        InternalCustomDirectMethodologyKt.variance { scalar = 10.0 }
-                                    }
-                                  }
-                            }
+  fun `getMetric returns failed metric for rf when custom direct methodology has scalar`(): Unit =
+    runBlocking {
+      wheneverBlocking {
+        permissionsServiceMock.checkPermissions(hasPrincipal(PRINCIPAL.name))
+      } doReturn checkPermissionsResponse { permissions += PermissionName.GET }
+      whenever(internalMetricsMock.batchGetMetrics(any()))
+        .thenReturn(
+          internalBatchGetMetricsResponse {
+            metrics +=
+              INTERNAL_SUCCEEDED_SINGLE_PUBLISHER_REACH_FREQUENCY_METRIC.copy {
+                weightedMeasurements.clear()
+                weightedMeasurements += weightedMeasurement {
+                  weight = 1
+                  binaryRepresentation = 3
+                  measurement =
+                    INTERNAL_SUCCEEDED_SINGLE_PUBLISHER_REACH_FREQUENCY_MEASUREMENT.copy {
+                      details =
+                        INTERNAL_SUCCEEDED_SINGLE_PUBLISHER_REACH_FREQUENCY_MEASUREMENT.details
+                          .copy {
+                            results.clear()
+                            results +=
+                              INTERNAL_SUCCEEDED_SINGLE_PUBLISHER_REACH_FREQUENCY_MEASUREMENT
+                                .details
+                                .resultsList
+                                .first()
+                                .copy {
+                                  frequency =
+                                    INTERNAL_SUCCEEDED_SINGLE_PUBLISHER_REACH_FREQUENCY_MEASUREMENT
+                                      .details
+                                      .resultsList
+                                      .first()
+                                      .frequency
+                                      .copy {
+                                        customDirectMethodology = internalCustomDirectMethodology {
+                                          variance =
+                                            InternalCustomDirectMethodologyKt.variance {
+                                              scalar = 10.0
+                                            }
+                                        }
+                                      }
+                                }
+                          }
+                    }
+                }
+              }
+          }
+        )
+
+      val request = getMetricRequest {
+        name = SUCCEEDED_SINGLE_PUBLISHER_REACH_FREQUENCY_METRIC.name
+      }
+
+      val response =
+        withPrincipalAndScopes(PRINCIPAL, SCOPES) { runBlocking { service.getMetric(request) } }
+
+      assertThat(response)
+        .isEqualTo(
+          SUCCEEDED_SINGLE_PUBLISHER_REACH_FREQUENCY_METRIC.copy {
+            state = Metric.State.FAILED
+            failure =
+              MetricKt.failure {
+                reason = Metric.Failure.Reason.MEASUREMENT_RESULT_INVALID
+                message = "Problem with variance calculation"
+              }
+            result =
+              result.copy {
+                reachAndFrequency =
+                  reachAndFrequency.copy {
+                    reach = reach.copy { clearUnivariateStatistics() }
+                    frequencyHistogram =
+                      frequencyHistogram.copy {
+                        bins.clear()
+                        SUCCEEDED_SINGLE_PUBLISHER_REACH_FREQUENCY_METRIC.result.reachAndFrequency
+                          .frequencyHistogram
+                          .binsList
+                          .forEach {
+                            bins +=
+                              it.copy {
+                                clearKPlusUnivariateStatistics()
+                                clearResultUnivariateStatistics()
+                                clearRelativeUnivariateStatistics()
+                                clearRelativeKPlusUnivariateStatistics()
+                              }
+                          }
                       }
                   }
               }
-            }
-        }
-      )
-
-    val request = getMetricRequest { name = SUCCEEDED_SINGLE_PUBLISHER_REACH_FREQUENCY_METRIC.name }
-
-    val response =
-      withPrincipalAndScopes(PRINCIPAL, SCOPES) { runBlocking { service.getMetric(request) } }
-
-    assertThat(response)
-      .isEqualTo(
-        SUCCEEDED_SINGLE_PUBLISHER_REACH_FREQUENCY_METRIC.copy {
-          state = Metric.State.FAILED
-          failure = MetricKt.failure {
-            reason = Metric.Failure.Reason.MEASUREMENT_RESULT_INVALID
-            message = "Problem with variance calculation"
           }
-          result =
-            result.copy {
-              reachAndFrequency =
-                reachAndFrequency.copy {
-                  reach = reach.copy { clearUnivariateStatistics() }
-                  frequencyHistogram =
-                    frequencyHistogram.copy {
-                      bins.clear()
-                      SUCCEEDED_SINGLE_PUBLISHER_REACH_FREQUENCY_METRIC.result.reachAndFrequency
-                        .frequencyHistogram
-                        .binsList
-                        .forEach {
-                          bins +=
-                            it.copy {
-                              clearKPlusUnivariateStatistics()
-                              clearResultUnivariateStatistics()
-                              clearRelativeUnivariateStatistics()
-                              clearRelativeKPlusUnivariateStatistics()
-                            }
-                        }
-                    }
-                }
-            }
-        }
-      )
-  }
+        )
+    }
 
   @Test
   fun `getMetric returns duration metric with SUCCEEDED when measurements are updated to SUCCEEDED`() =
@@ -9195,9 +9208,7 @@ class MetricsServiceTest {
       assertThat(result)
         .isEqualTo(
           FAILED_SINGLE_PUBLISHER_IMPRESSION_METRIC.copy {
-            failure = MetricKt.failure {
-              reason = Metric.Failure.Reason.MEASUREMENT_FAILED
-            }
+            failure = MetricKt.failure { reason = Metric.Failure.Reason.MEASUREMENT_FAILED }
             this.result = metricResult {
               cmmsMeasurements +=
                 MeasurementKey(
@@ -9566,10 +9577,11 @@ class MetricsServiceTest {
       .isEqualTo(
         SUCCEEDED_SINGLE_PUBLISHER_IMPRESSION_METRIC.copy {
           state = Metric.State.FAILED
-          failure = MetricKt.failure {
-            reason = Metric.Failure.Reason.MEASUREMENT_RESULT_INVALID
-            message = "Problem with variance calculation"
-          }
+          failure =
+            MetricKt.failure {
+              reason = Metric.Failure.Reason.MEASUREMENT_RESULT_INVALID
+              message = "Problem with variance calculation"
+            }
           result =
             result.copy { impressionCount = impressionCount.copy { clearUnivariateStatistics() } }
         }
@@ -9901,10 +9913,11 @@ class MetricsServiceTest {
       .isEqualTo(
         SUCCEEDED_CROSS_PUBLISHER_WATCH_DURATION_METRIC.copy {
           state = Metric.State.FAILED
-          failure = MetricKt.failure {
-            reason = Metric.Failure.Reason.MEASUREMENT_RESULT_INVALID
-            message = "Problem with variance calculation"
-          }
+          failure =
+            MetricKt.failure {
+              reason = Metric.Failure.Reason.MEASUREMENT_RESULT_INVALID
+              message = "Problem with variance calculation"
+            }
           result =
             result.copy { watchDuration = watchDuration.copy { clearUnivariateStatistics() } }
         }
@@ -10180,83 +10193,80 @@ class MetricsServiceTest {
   }
 
   @Test
-  fun `batchGetMetrics returns failed metrics when variance calculation fails`() =
-    runBlocking {
-      wheneverBlocking {
-        permissionsServiceMock.checkPermissions(hasPrincipal(PRINCIPAL.name))
-      } doReturn checkPermissionsResponse { permissions += PermissionName.GET }
-      whenever(variancesMock.computeMetricVariance(any<ReachMetricVarianceParams>()))
-        .thenThrow(IllegalArgumentException("Negative"))
+  fun `batchGetMetrics returns failed metrics when variance calculation fails`() = runBlocking {
+    wheneverBlocking {
+      permissionsServiceMock.checkPermissions(hasPrincipal(PRINCIPAL.name))
+    } doReturn checkPermissionsResponse { permissions += PermissionName.GET }
+    whenever(variancesMock.computeMetricVariance(any<ReachMetricVarianceParams>()))
+      .thenThrow(IllegalArgumentException("Negative"))
 
-      whenever(internalMetricsMock.batchGetMetrics(any()))
-        .thenReturn(
-          internalBatchGetMetricsResponse {
-            metrics += INTERNAL_SUCCEEDED_INCREMENTAL_REACH_METRIC
-            metrics += INTERNAL_PENDING_SINGLE_PUBLISHER_IMPRESSION_METRIC
-          }
-        )
-
-      val request = batchGetMetricsRequest {
-        parent = MEASUREMENT_CONSUMERS.values.first().name
-        names += SUCCEEDED_INCREMENTAL_REACH_METRIC.name
-        names += PENDING_SINGLE_PUBLISHER_IMPRESSION_METRIC.name
-      }
-
-      val response =
-        withPrincipalAndScopes(PRINCIPAL, SCOPES) {
-          runBlocking { service.batchGetMetrics(request) }
+    whenever(internalMetricsMock.batchGetMetrics(any()))
+      .thenReturn(
+        internalBatchGetMetricsResponse {
+          metrics += INTERNAL_SUCCEEDED_INCREMENTAL_REACH_METRIC
+          metrics += INTERNAL_PENDING_SINGLE_PUBLISHER_IMPRESSION_METRIC
         }
+      )
 
-      // Verify proto argument of internal MetricsCoroutineImplBase::batchGetMetrics
-      val batchGetInternalMetricsCaptor: KArgumentCaptor<InternalBatchGetMetricsRequest> =
-        argumentCaptor()
-      verifyBlocking(internalMetricsMock, times(1)) {
-        batchGetMetrics(batchGetInternalMetricsCaptor.capture())
-      }
-      val capturedInternalGetMetricRequests = batchGetInternalMetricsCaptor.allValues
-      assertThat(capturedInternalGetMetricRequests)
-        .containsExactly(
-          internalBatchGetMetricsRequest {
-            cmmsMeasurementConsumerId =
-              INTERNAL_SUCCEEDED_INCREMENTAL_REACH_METRIC.cmmsMeasurementConsumerId
-            externalMetricIds += INTERNAL_SUCCEEDED_INCREMENTAL_REACH_METRIC.externalMetricId
-            externalMetricIds +=
-              INTERNAL_PENDING_SINGLE_PUBLISHER_IMPRESSION_METRIC.externalMetricId
-          }
-        )
+    val request = batchGetMetricsRequest {
+      parent = MEASUREMENT_CONSUMERS.values.first().name
+      names += SUCCEEDED_INCREMENTAL_REACH_METRIC.name
+      names += PENDING_SINGLE_PUBLISHER_IMPRESSION_METRIC.name
+    }
 
-      // Verify proto argument of internal MeasurementsCoroutineImplBase::batchSetMeasurementResults
-      val batchSetMeasurementResultsCaptor: KArgumentCaptor<BatchSetMeasurementResultsRequest> =
-        argumentCaptor()
-      verifyBlocking(internalMeasurementsMock, never()) {
-        batchSetMeasurementResults(batchSetMeasurementResultsCaptor.capture())
-      }
+    val response =
+      withPrincipalAndScopes(PRINCIPAL, SCOPES) { runBlocking { service.batchGetMetrics(request) } }
 
-      // Verify proto argument of internal
-      // MeasurementsCoroutineImplBase::batchSetMeasurementFailures
-      val batchSetMeasurementFailuresCaptor: KArgumentCaptor<BatchSetMeasurementFailuresRequest> =
-        argumentCaptor()
-      verifyBlocking(internalMeasurementsMock, never()) {
-        batchSetMeasurementFailures(batchSetMeasurementFailuresCaptor.capture())
-      }
+    // Verify proto argument of internal MetricsCoroutineImplBase::batchGetMetrics
+    val batchGetInternalMetricsCaptor: KArgumentCaptor<InternalBatchGetMetricsRequest> =
+      argumentCaptor()
+    verifyBlocking(internalMetricsMock, times(1)) {
+      batchGetMetrics(batchGetInternalMetricsCaptor.capture())
+    }
+    val capturedInternalGetMetricRequests = batchGetInternalMetricsCaptor.allValues
+    assertThat(capturedInternalGetMetricRequests)
+      .containsExactly(
+        internalBatchGetMetricsRequest {
+          cmmsMeasurementConsumerId =
+            INTERNAL_SUCCEEDED_INCREMENTAL_REACH_METRIC.cmmsMeasurementConsumerId
+          externalMetricIds += INTERNAL_SUCCEEDED_INCREMENTAL_REACH_METRIC.externalMetricId
+          externalMetricIds += INTERNAL_PENDING_SINGLE_PUBLISHER_IMPRESSION_METRIC.externalMetricId
+        }
+      )
 
-      assertThat(response)
-        .ignoringRepeatedFieldOrder()
-        .isEqualTo(
-          batchGetMetricsResponse {
-            metrics +=
-              SUCCEEDED_INCREMENTAL_REACH_METRIC.copy {
-                state = Metric.State.FAILED
-                failure = MetricKt.failure {
+    // Verify proto argument of internal MeasurementsCoroutineImplBase::batchSetMeasurementResults
+    val batchSetMeasurementResultsCaptor: KArgumentCaptor<BatchSetMeasurementResultsRequest> =
+      argumentCaptor()
+    verifyBlocking(internalMeasurementsMock, never()) {
+      batchSetMeasurementResults(batchSetMeasurementResultsCaptor.capture())
+    }
+
+    // Verify proto argument of internal
+    // MeasurementsCoroutineImplBase::batchSetMeasurementFailures
+    val batchSetMeasurementFailuresCaptor: KArgumentCaptor<BatchSetMeasurementFailuresRequest> =
+      argumentCaptor()
+    verifyBlocking(internalMeasurementsMock, never()) {
+      batchSetMeasurementFailures(batchSetMeasurementFailuresCaptor.capture())
+    }
+
+    assertThat(response)
+      .ignoringRepeatedFieldOrder()
+      .isEqualTo(
+        batchGetMetricsResponse {
+          metrics +=
+            SUCCEEDED_INCREMENTAL_REACH_METRIC.copy {
+              state = Metric.State.FAILED
+              failure =
+                MetricKt.failure {
                   reason = Metric.Failure.Reason.MEASUREMENT_RESULT_INVALID
                   message = "Problem with variance calculation"
                 }
-                result = result.copy { reach = reach.copy { clearUnivariateStatistics() } }
-              }
-            metrics += PENDING_SINGLE_PUBLISHER_IMPRESSION_METRIC
-          }
-        )
-    }
+              result = result.copy { reach = reach.copy { clearUnivariateStatistics() } }
+            }
+          metrics += PENDING_SINGLE_PUBLISHER_IMPRESSION_METRIC
+        }
+      )
+  }
 
   @Test
   fun `batchGetMetrics throws INVALID_ARGUMENT when number of requests exceeds limit`() =

--- a/src/test/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/MetricsServiceTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/MetricsServiceTest.kt
@@ -230,6 +230,7 @@ import org.wfanet.measurement.reporting.service.internal.MetricNotFoundException
 import org.wfanet.measurement.reporting.v2alpha.ListMetricsPageTokenKt.previousPageEnd
 import org.wfanet.measurement.reporting.v2alpha.ListMetricsRequest
 import org.wfanet.measurement.reporting.v2alpha.Metric
+import org.wfanet.measurement.reporting.v2alpha.MetricKt
 import org.wfanet.measurement.reporting.v2alpha.MetricResultKt
 import org.wfanet.measurement.reporting.v2alpha.MetricSpec
 import org.wfanet.measurement.reporting.v2alpha.MetricSpecKt
@@ -6179,6 +6180,9 @@ class MetricsServiceTest {
                 )
                 .toName()
           }
+          failure = MetricKt.failure {
+            reason = Metric.Failure.Reason.MEASUREMENT_FAILED
+          }
         }
     }
 
@@ -7524,6 +7528,10 @@ class MetricsServiceTest {
         withPrincipalAndScopes(PRINCIPAL, SCOPES) { runBlocking { service.getMetric(request) } }
 
       assertThat(response.state).isEqualTo(Metric.State.FAILED)
+      assertThat(response.failure).isEqualTo(MetricKt.failure {
+        reason = Metric.Failure.Reason.MEASUREMENT_RESULT_INVALID
+        message = "Problem with result"
+      })
       assertThat(response.result)
         .isEqualTo(metricResult { cmmsMeasurements += SUCCEEDED_UNION_ALL_REACH_MEASUREMENT.name })
     }
@@ -7558,12 +7566,16 @@ class MetricsServiceTest {
         withPrincipalAndScopes(PRINCIPAL, SCOPES) { runBlocking { service.getMetric(request) } }
 
       assertThat(response.state).isEqualTo(Metric.State.FAILED)
+      assertThat(response.failure).isEqualTo(MetricKt.failure {
+        reason = Metric.Failure.Reason.MEASUREMENT_RESULT_INVALID
+        message = "Problem with result"
+      })
       assertThat(response.result)
         .isEqualTo(metricResult { cmmsMeasurements += SUCCEEDED_UNION_ALL_REACH_MEASUREMENT.name })
     }
 
   @Test
-  fun `getMetric returns succeeded metric for reach metric when custom direct methodology has freq`():
+  fun `getMetric returns failed metric for reach metric when custom direct methodology has freq`():
     Unit = runBlocking {
     wheneverBlocking {
       permissionsServiceMock.checkPermissions(hasPrincipal(PRINCIPAL.name))
@@ -7611,6 +7623,11 @@ class MetricsServiceTest {
     assertThat(response)
       .isEqualTo(
         SUCCEEDED_INCREMENTAL_REACH_METRIC.copy {
+          state = Metric.State.FAILED
+          failure = MetricKt.failure {
+            reason = Metric.Failure.Reason.MEASUREMENT_RESULT_INVALID
+            message = "Problem with variance calculation"
+          }
           result =
             result.copy {
               cmmsMeasurements += SUCCEEDED_UNION_ALL_REACH_MEASUREMENT.name
@@ -7836,6 +7853,9 @@ class MetricsServiceTest {
     assertThat(result)
       .isEqualTo(
         FAILED_SINGLE_PUBLISHER_IMPRESSION_METRIC.copy {
+          failure = MetricKt.failure {
+            reason = Metric.Failure.Reason.MEASUREMENT_FAILED
+          }
           this.result = metricResult {
             cmmsMeasurements +=
               MeasurementKey(
@@ -8628,6 +8648,10 @@ class MetricsServiceTest {
     val response =
       withPrincipalAndScopes(PRINCIPAL, SCOPES) { runBlocking { service.getMetric(request) } }
     assertThat(response.state).isEqualTo(Metric.State.FAILED)
+    assertThat(response.failure).isEqualTo(MetricKt.failure {
+      reason = Metric.Failure.Reason.MEASUREMENT_RESULT_INVALID
+      message = "Problem with result"
+    })
     assertThat(response.result)
       .isEqualTo(
         metricResult {
@@ -8637,7 +8661,7 @@ class MetricsServiceTest {
   }
 
   @Test
-  fun `getMetric returns succeeded metric for rf when custom direct methodology has scalar`():
+  fun `getMetric returns failed metric for rf when custom direct methodology has scalar`():
     Unit = runBlocking {
     wheneverBlocking {
       permissionsServiceMock.checkPermissions(hasPrincipal(PRINCIPAL.name))
@@ -8689,6 +8713,11 @@ class MetricsServiceTest {
     assertThat(response)
       .isEqualTo(
         SUCCEEDED_SINGLE_PUBLISHER_REACH_FREQUENCY_METRIC.copy {
+          state = Metric.State.FAILED
+          failure = MetricKt.failure {
+            reason = Metric.Failure.Reason.MEASUREMENT_RESULT_INVALID
+            message = "Problem with variance calculation"
+          }
           result =
             result.copy {
               reachAndFrequency =
@@ -9166,6 +9195,9 @@ class MetricsServiceTest {
       assertThat(result)
         .isEqualTo(
           FAILED_SINGLE_PUBLISHER_IMPRESSION_METRIC.copy {
+            failure = MetricKt.failure {
+              reason = Metric.Failure.Reason.MEASUREMENT_FAILED
+            }
             this.result = metricResult {
               cmmsMeasurements +=
                 MeasurementKey(
@@ -9485,7 +9517,7 @@ class MetricsServiceTest {
     }
 
   @Test
-  fun `getMetric returns succeeded metric for impression when custom direct methodology has freq`():
+  fun `getMetric returns failed metric for impression when custom direct methodology has freq`():
     Unit = runBlocking {
     wheneverBlocking {
       permissionsServiceMock.checkPermissions(hasPrincipal(PRINCIPAL.name))
@@ -9533,6 +9565,11 @@ class MetricsServiceTest {
     assertThat(response)
       .isEqualTo(
         SUCCEEDED_SINGLE_PUBLISHER_IMPRESSION_METRIC.copy {
+          state = Metric.State.FAILED
+          failure = MetricKt.failure {
+            reason = Metric.Failure.Reason.MEASUREMENT_RESULT_INVALID
+            message = "Problem with variance calculation"
+          }
           result =
             result.copy { impressionCount = impressionCount.copy { clearUnivariateStatistics() } }
         }
@@ -9813,7 +9850,7 @@ class MetricsServiceTest {
     }
 
   @Test
-  fun `getMetric return succeeded metric for dur metric when custom direct methodology has freq`():
+  fun `getMetric return failed metric for dur metric when custom direct methodology has freq`():
     Unit = runBlocking {
     wheneverBlocking {
       permissionsServiceMock.checkPermissions(hasPrincipal(PRINCIPAL.name))
@@ -9863,6 +9900,11 @@ class MetricsServiceTest {
     assertThat(response)
       .isEqualTo(
         SUCCEEDED_CROSS_PUBLISHER_WATCH_DURATION_METRIC.copy {
+          state = Metric.State.FAILED
+          failure = MetricKt.failure {
+            reason = Metric.Failure.Reason.MEASUREMENT_RESULT_INVALID
+            message = "Problem with variance calculation"
+          }
           result =
             result.copy { watchDuration = watchDuration.copy { clearUnivariateStatistics() } }
         }
@@ -10138,7 +10180,7 @@ class MetricsServiceTest {
   }
 
   @Test
-  fun `batchGetMetrics returns metrics with SUCCEEDED when variance calculation fails`() =
+  fun `batchGetMetrics returns failed metrics when variance calculation fails`() =
     runBlocking {
       wheneverBlocking {
         permissionsServiceMock.checkPermissions(hasPrincipal(PRINCIPAL.name))
@@ -10204,6 +10246,11 @@ class MetricsServiceTest {
           batchGetMetricsResponse {
             metrics +=
               SUCCEEDED_INCREMENTAL_REACH_METRIC.copy {
+                state = Metric.State.FAILED
+                failure = MetricKt.failure {
+                  reason = Metric.Failure.Reason.MEASUREMENT_RESULT_INVALID
+                  message = "Problem with variance calculation"
+                }
                 result = result.copy { reach = reach.copy { clearUnivariateStatistics() } }
               }
             metrics += PENDING_SINGLE_PUBLISHER_IMPRESSION_METRIC

--- a/src/test/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/MetricsServiceTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/MetricsServiceTest.kt
@@ -9235,17 +9235,17 @@ class MetricsServiceTest {
         permissionsServiceMock.checkPermissions(hasPrincipal(PRINCIPAL.name))
       } doReturn checkPermissionsResponse { permissions += PermissionName.GET }
       whenever(
-        internalMetricsMock.batchGetMetrics(
-          eq(
-            internalBatchGetMetricsRequest {
-              cmmsMeasurementConsumerId =
-                INTERNAL_PENDING_SINGLE_PUBLISHER_IMPRESSION_METRIC.cmmsMeasurementConsumerId
-              externalMetricIds +=
-                INTERNAL_PENDING_SINGLE_PUBLISHER_IMPRESSION_METRIC.externalMetricId
-            }
+          internalMetricsMock.batchGetMetrics(
+            eq(
+              internalBatchGetMetricsRequest {
+                cmmsMeasurementConsumerId =
+                  INTERNAL_PENDING_SINGLE_PUBLISHER_IMPRESSION_METRIC.cmmsMeasurementConsumerId
+                externalMetricIds +=
+                  INTERNAL_PENDING_SINGLE_PUBLISHER_IMPRESSION_METRIC.externalMetricId
+              }
+            )
           )
         )
-      )
         .thenReturn(
           internalBatchGetMetricsResponse {
             metrics += INTERNAL_PENDING_SINGLE_PUBLISHER_IMPRESSION_METRIC
@@ -9256,9 +9256,7 @@ class MetricsServiceTest {
         )
 
       val cancelledSinglePublisherImpressionMeasurement =
-        PENDING_SINGLE_PUBLISHER_IMPRESSION_MEASUREMENT.copy {
-          state = Measurement.State.CANCELLED
-        }
+        PENDING_SINGLE_PUBLISHER_IMPRESSION_MEASUREMENT.copy { state = Measurement.State.CANCELLED }
 
       whenever(measurementsMock.batchGetMeasurements(any())).thenAnswer {
         val batchGetMeasurementsRequest = it.arguments[0] as BatchGetMeasurementsRequest
@@ -9314,10 +9312,10 @@ class MetricsServiceTest {
             this.result = metricResult {
               cmmsMeasurements +=
                 MeasurementKey(
-                  INTERNAL_FAILED_SINGLE_PUBLISHER_IMPRESSION_MEASUREMENT
-                    .cmmsMeasurementConsumerId,
-                  INTERNAL_FAILED_SINGLE_PUBLISHER_IMPRESSION_MEASUREMENT.cmmsMeasurementId,
-                )
+                    INTERNAL_FAILED_SINGLE_PUBLISHER_IMPRESSION_MEASUREMENT
+                      .cmmsMeasurementConsumerId,
+                    INTERNAL_FAILED_SINGLE_PUBLISHER_IMPRESSION_MEASUREMENT.cmmsMeasurementId,
+                  )
                   .toName()
             }
           }

--- a/src/test/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/MetricsServiceTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/MetricsServiceTest.kt
@@ -7132,7 +7132,7 @@ class MetricsServiceTest {
     }
 
   @Test
-  fun `getMetric returns reach metric without statistics when reach methodology is unspecified`() =
+  fun `getMetric returns failed reach metric when reach methodology is unspecified`() =
     runBlocking {
       wheneverBlocking {
         permissionsServiceMock.checkPermissions(hasPrincipal(PRINCIPAL.name))
@@ -7209,6 +7209,12 @@ class MetricsServiceTest {
       assertThat(result)
         .isEqualTo(
           SUCCEEDED_INCREMENTAL_REACH_METRIC.copy {
+            state = Metric.State.FAILED
+            failure =
+              MetricKt.failure {
+                reason = Metric.Failure.Reason.MEASUREMENT_RESULT_INVALID
+                message = "Problem with variance calculation"
+              }
             this.result = metricResult {
               reach = MetricResultKt.reachResult { value = INCREMENTAL_REACH_VALUE }
               cmmsMeasurements += PENDING_UNION_ALL_BUT_LAST_PUBLISHER_REACH_MEASUREMENT.name
@@ -8410,7 +8416,7 @@ class MetricsServiceTest {
     }
 
   @Test
-  fun `getMetric returns reach frequency metric without statistics when frequency methodology is unspecified`() =
+  fun `getMetric returns failed rf metric when frequency methodology is unspecified`() =
     runBlocking {
       wheneverBlocking {
         permissionsServiceMock.checkPermissions(hasPrincipal(PRINCIPAL.name))
@@ -8462,6 +8468,12 @@ class MetricsServiceTest {
       assertThat(result)
         .isEqualTo(
           SUCCEEDED_SINGLE_PUBLISHER_REACH_FREQUENCY_METRIC.copy {
+            state = Metric.State.FAILED
+            failure =
+              MetricKt.failure {
+                reason = Metric.Failure.Reason.MEASUREMENT_RESULT_INVALID
+                message = "Problem with variance calculation"
+              }
             this.result =
               this.result.copy {
                 reachAndFrequency =
@@ -8469,9 +8481,6 @@ class MetricsServiceTest {
                     reach =
                       MetricResultKt.reachResult {
                         value = REACH_FREQUENCY_REACH_VALUE
-                        univariateStatistics = univariateStatistics {
-                          standardDeviation = sqrt(VARIANCE_VALUE)
-                        }
                       }
                     frequencyHistogram =
                       MetricResultKt.histogramResult {
@@ -9416,7 +9425,7 @@ class MetricsServiceTest {
     }
 
   @Test
-  fun `getMetric returns impression metric without statistics when methodology is not set`() =
+  fun `getMetric returns failed impression metric when methodology is not set`() =
     runBlocking {
       wheneverBlocking {
         permissionsServiceMock.checkPermissions(hasPrincipal(PRINCIPAL.name))
@@ -9457,6 +9466,12 @@ class MetricsServiceTest {
       assertThat(result)
         .isEqualTo(
           SUCCEEDED_SINGLE_PUBLISHER_IMPRESSION_METRIC.copy {
+            state = Metric.State.FAILED
+            failure =
+              MetricKt.failure {
+                reason = Metric.Failure.Reason.MEASUREMENT_RESULT_INVALID
+                message = "Problem with variance calculation"
+              }
             this.result =
               this.result.copy {
                 impressionCount = impressionCount.copy { clearUnivariateStatistics() }
@@ -9744,7 +9759,7 @@ class MetricsServiceTest {
     }
 
   @Test
-  fun `getMetric returns duration metric without statistics when methodology is not set`() =
+  fun `getMetric returns failed duration metric when methodology is not set`() =
     runBlocking {
       wheneverBlocking {
         permissionsServiceMock.checkPermissions(hasPrincipal(PRINCIPAL.name))
@@ -9787,6 +9802,12 @@ class MetricsServiceTest {
       assertThat(result)
         .isEqualTo(
           SUCCEEDED_CROSS_PUBLISHER_WATCH_DURATION_METRIC.copy {
+            state = Metric.State.FAILED
+            failure =
+              MetricKt.failure {
+                reason = Metric.Failure.Reason.MEASUREMENT_RESULT_INVALID
+                message = "Problem with variance calculation"
+              }
             this.result =
               this.result.copy {
                 watchDuration = watchDuration.copy { clearUnivariateStatistics() }


### PR DESCRIPTION
A failure reason enum is added to differentiate between a Measurement Result having issues and a Measurement itself in a FAILED state.