### PR TITLE
Fix: Secure Computation Work Item Attempts Service

### DIFF
--- a/src/main/kotlin/org/wfanet/measurement/securecomputation/controlplane/v1alpha/WorkItemAttemptsService.kt
+++ b/src/main/kotlin/org/wfanet/measurement/securecomputation/controlplane/v1alpha/WorkItemAttemptsService.kt
@@ -72,7 +72,7 @@ class WorkItemAttemptsService(
       try {
         internalWorkItemAttemptsStub.createWorkItemAttempt(
           internalCreateWorkItemAttemptRequest {
-            internalWorkItemAttempt {
+            this.workItemAttempt = internalWorkItemAttempt {
               workItemResourceId = parentKey.workItemId
               workItemAttemptResourceId = request.workItemAttemptId
             }

--- a/src/main/kotlin/org/wfanet/measurement/securecomputation/deploy/gcloud/spanner/SpannerWorkItemService.kt
+++ b/src/main/kotlin/org/wfanet/measurement/securecomputation/deploy/gcloud/spanner/SpannerWorkItemService.kt
@@ -62,7 +62,6 @@ class SpannerWorkItemsService(
 ) : WorkItemsCoroutineImplBase() {
 
   override suspend fun createWorkItem(request: CreateWorkItemRequest): WorkItem {
-
     if (request.workItem.queueResourceId.isEmpty()) {
       throw RequiredFieldNotSetException("queue_resource_id")
         .asStatusRuntimeException(Status.Code.INVALID_ARGUMENT)
@@ -122,7 +121,7 @@ class SpannerWorkItemsService(
     try {
       workItemPublisher.publishMessage(
         request.workItem.queueResourceId,
-        request.workItem.workItemParams,
+        request.workItem
       )
     } catch (e: Exception) {
       throw Status.INTERNAL.withCause(e).asRuntimeException()

--- a/src/main/kotlin/org/wfanet/measurement/securecomputation/deploy/gcloud/spanner/SpannerWorkItemService.kt
+++ b/src/main/kotlin/org/wfanet/measurement/securecomputation/deploy/gcloud/spanner/SpannerWorkItemService.kt
@@ -119,10 +119,7 @@ class SpannerWorkItemsService(
       }
 
     try {
-      workItemPublisher.publishMessage(
-        request.workItem.queueResourceId,
-        request.workItem
-      )
+      workItemPublisher.publishMessage(request.workItem.queueResourceId, request.workItem)
     } catch (e: Exception) {
       throw Status.INTERNAL.withCause(e).asRuntimeException()
     }

--- a/src/test/kotlin/org/wfanet/measurement/securecomputation/controlplane/v1alpha/WorkItemAttemptsServiceTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/securecomputation/controlplane/v1alpha/WorkItemAttemptsServiceTest.kt
@@ -98,8 +98,8 @@ class WorkItemAttemptsServiceTest {
       )
       .isEqualTo(
         internalCreateWorkItemAttemptRequest {
-          internalWorkItemAttempt {
-            workItemResourceId = request.parent
+          this.workItemAttempt = internalWorkItemAttempt {
+            workItemResourceId = internalWorkItemAttempt.workItemResourceId
             workItemAttemptResourceId = request.workItemAttemptId
           }
         }


### PR DESCRIPTION
Fixes two issues:
1. Creation of internal work item attempts from public api
2. Publishes messages of type WorkItem, not WorkItemParams on internal api