### PR TITLE
ci: Disable Codecov comment in PRs

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+comment: false
 coverage:
   status:
     patch:


### PR DESCRIPTION
Disable the posting of Codecov comments on the PRs to reduce the noise caused by not having Kotlin test coverage yet.

It only disables the posting of the comment; the calculation, upload, and integration of the coverage reports still work.