### PR TITLE
fix: Update reporting internal server image name in scan-images.yml

### DIFF
--- a/.github/workflows/scan-images.yml
+++ b/.github/workflows/scan-images.yml
@@ -71,7 +71,7 @@ jobs:
           - panel-exchange/aws-example-daemon
           - reporting/v2/v2alpha-public-api
           - reporting/v2/gcloud-postgres-update-schema
-          - reporting/v2/postgres-internal-server
+          - reporting/v2/gcloud-internal-server
           - simulator/synthetic-generator-edp
           - duchy/postgres-update-schema
           - duchy/gcloud-postgres-update-schema


### PR DESCRIPTION
This fixes the error of 'unable to find image postgres-internal-server' in scan-images during Update CMMS ([example](https://github.com/world-federation-of-advertisers/cross-media-measurement/actions/runs/14869273851/job/41754019619)), similar to #2208. The image was renamed in #2097.