### PR TITLE
fix: update secure-computation image names

### DIFF
--- a/.github/workflows/scan-images.yml
+++ b/.github/workflows/scan-images.yml
@@ -83,9 +83,9 @@ jobs:
           - duchy/aws-postgres-internal-server
           - panel-exchange/forwarded-storage-daemon
           - prober/measurement-system-prober
-          - secure-computation/control-plane-public-api
-          - secure-computation/control-plane-internal-server
-          - secure-computation/control-plane-update-schema
+          - secure-computation/public-api
+          - secure-computation/internal-server
+          - secure-computation/update-schema
     steps:
       - name: Get SARIF file path
         id: get-sarif-file-path


### PR DESCRIPTION
This fixes the error of 'no such image' in scan-images during nightly build's Update CMMS ([example](https://github.com/world-federation-of-advertisers/cross-media-measurement/actions/runs/14900351812/job/41850981649)), similar to https://github.com/world-federation-of-advertisers/cross-media-measurement/pull/2208 and https://github.com/world-federation-of-advertisers/cross-media-measurement/pull/2277. The image was added in https://github.com/world-federation-of-advertisers/cross-media-measurement/pull/2144.