### PR TITLE
fix: Specify ENTERPRISE edition for Spanner instance

### DIFF
--- a/src/main/terraform/gcloud/cmms/main.tf
+++ b/src/main/terraform/gcloud/cmms/main.tf
@@ -46,6 +46,7 @@ resource "google_spanner_instance" "spanner_instance" {
   config           = var.spanner_instance_config
   display_name     = "Halo CMMS"
   processing_units = var.spanner_processing_units
+  edition          = "ENTERPRISE"
 }
 
 resource "google_sql_database_instance" "postgres" {

--- a/src/main/terraform/gcloud/examples/kingdom/main.tf
+++ b/src/main/terraform/gcloud/examples/kingdom/main.tf
@@ -33,6 +33,7 @@ resource "google_spanner_instance" "spanner_instance" {
   config           = var.spanner_instance_config
   display_name     = "Halo CMMS"
   processing_units = 1000
+  edition          = "ENTERPRISE"
 }
 
 module "kingdom_cluster" {


### PR DESCRIPTION
The schema updates in #2278 require this edition as they use the full-text search feature.