### PR TITLE
perf!: Apply limit before joining Requisitions to Measurements

### DIFF
--- a/src/main/kotlin/org/wfanet/measurement/dataprovider/RequisitionFulfiller.kt
+++ b/src/main/kotlin/org/wfanet/measurement/dataprovider/RequisitionFulfiller.kt
@@ -207,10 +207,7 @@ abstract class RequisitionFulfiller(
   protected suspend fun getRequisitions(): List<Requisition> {
     val request = listRequisitionsRequest {
       parent = dataProviderData.name
-      filter = filter {
-        states += Requisition.State.UNFULFILLED
-        measurementStates += Measurement.State.AWAITING_REQUISITION_FULFILLMENT
-      }
+      filter = filter { states += Requisition.State.UNFULFILLED }
     }
 
     try {

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/common/KingdomInternalException.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/common/KingdomInternalException.kt
@@ -69,8 +69,10 @@ sealed class KingdomInternalException : Exception {
   }
 }
 
-class RequiredFieldNotSetException(val fieldName: String) :
-  KingdomInternalException(ErrorCode.REQUIRED_FIELD_NOT_SET, "Required field $fieldName not set") {
+class RequiredFieldNotSetException(
+  val fieldName: String,
+  provideDescription: (fieldName: String) -> String = { "Required field $fieldName not set" },
+) : KingdomInternalException(ErrorCode.REQUIRED_FIELD_NOT_SET, provideDescription(fieldName)) {
   override val context: Map<String, String>
     get() = mapOf("field_name" to fieldName)
 }

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/readers/BUILD.bazel
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/readers/BUILD.bazel
@@ -11,6 +11,7 @@ kt_jvm_library(
     srcs = glob(["*.kt"]),
     deps = KINGDOM_INTERNAL_PROTOS + [
         "//src/main/kotlin/org/wfanet/measurement/api:public_api_version",
+        "//src/main/kotlin/org/wfanet/measurement/common:fillable_template",
         "//src/main/kotlin/org/wfanet/measurement/common:flows",
         "//src/main/kotlin/org/wfanet/measurement/common/identity",
         "//src/main/kotlin/org/wfanet/measurement/kingdom/deploy/common:duchy_ids",

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/readers/RequisitionReader.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/readers/RequisitionReader.kt
@@ -14,12 +14,14 @@
 
 package org.wfanet.measurement.kingdom.deploy.gcloud.spanner.readers
 
+import com.google.cloud.spanner.Statement
 import com.google.cloud.spanner.Struct
+import com.google.cloud.spanner.ValueBinder
 import kotlinx.coroutines.flow.singleOrNull
+import org.wfanet.measurement.common.FillableTemplate
 import org.wfanet.measurement.common.identity.ExternalId
 import org.wfanet.measurement.common.identity.InternalId
 import org.wfanet.measurement.gcloud.spanner.AsyncDatabaseClient
-import org.wfanet.measurement.gcloud.spanner.appendClause
 import org.wfanet.measurement.gcloud.spanner.to
 import org.wfanet.measurement.internal.kingdom.ComputationParticipantDetails
 import org.wfanet.measurement.internal.kingdom.Measurement
@@ -31,7 +33,8 @@ import org.wfanet.measurement.internal.kingdom.RequisitionKt.parentMeasurement
 import org.wfanet.measurement.internal.kingdom.requisition
 import org.wfanet.measurement.kingdom.deploy.common.DuchyIds
 
-class RequisitionReader(primaryTable: PrimaryTable) : SpannerReader<RequisitionReader.Result>() {
+class RequisitionReader private constructor(override val builder: Statement.Builder) :
+  BaseSpannerReader<RequisitionReader.Result>() {
   data class Result(
     val measurementConsumerId: InternalId,
     val measurementId: InternalId,
@@ -40,58 +43,137 @@ class RequisitionReader(primaryTable: PrimaryTable) : SpannerReader<RequisitionR
     val measurementDetails: MeasurementDetails,
   )
 
-  enum class PrimaryTable(val fromClause: String) {
-    REQUISITIONS(
-      """
-      FROM
-        Requisitions
-        JOIN DataProviders USING (DataProviderId)
-        JOIN Measurements USING (MeasurementConsumerId, MeasurementId)
-        JOIN MeasurementConsumers USING (MeasurementConsumerId)
-        JOIN MeasurementConsumerCertificates USING (MeasurementConsumerId, CertificateId)
-        JOIN DataProviderCertificates ON (
-          DataProviderCertificates.CertificateId = Requisitions.DataProviderCertificateId
-        )
-        JOIN Certificates ON (Certificates.CertificateId = DataProviderCertificates.CertificateId)
-      """
-        .trimIndent()
+  enum class Parent(val sqlTemplate: FillableTemplate) {
+    MEASUREMENT(
+      FillableTemplate(
+        """
+        @{spanner_emulator.disable_query_null_filtered_index_check=TRUE}
+        SELECT
+          $COMMON_COLUMNS
+          $COMPUTATION_PARTICIPANTS_COLUMN
+          $MEASUREMENT_REQUISITIONS_COUNT_COLUMN
+        FROM
+          Measurements
+          JOIN MeasurementConsumers USING (MeasurementConsumerId)
+          JOIN Requisitions USING (MeasurementConsumerId, MeasurementId)
+          JOIN DataProviders USING (DataProviderId)
+          JOIN MeasurementConsumerCertificates USING (MeasurementConsumerId, CertificateId)
+          JOIN DataProviderCertificates ON (
+            DataProviderCertificates.CertificateId = Requisitions.DataProviderCertificateId
+          )
+          JOIN Certificates ON (Certificates.CertificateId = DataProviderCertificates.CertificateId)
+        {{whereClause}}
+        {{orderByClause}}
+        {{limitClause}}
+        """
+          .trimIndent()
+      )
     ),
-    MEASUREMENT_CONSUMERS(
-      """
-      FROM
-        MeasurementConsumers
-        JOIN Measurements USING (MeasurementConsumerId)
-        JOIN Requisitions USING (MeasurementConsumerId, MeasurementId)
-        JOIN DataProviders USING (DataProviderId)
-        JOIN MeasurementConsumerCertificates USING (MeasurementConsumerId, CertificateId)
-        JOIN DataProviderCertificates ON (
-          DataProviderCertificates.CertificateId = Requisitions.DataProviderCertificateId
+    DATA_PROVIDER(
+      FillableTemplate(
+        """
+        @{spanner_emulator.disable_query_null_filtered_index_check=TRUE}
+        WITH FilteredRequisitions AS (
+          SELECT
+            Requisitions.*,
+            ExternalDataProviderId,
+            ExternalMeasurementConsumerId,
+            $COMPUTATION_PARTICIPANTS_COLUMN
+          FROM
+            DataProviders
+            JOIN Requisitions USING (DataProviderId)
+            JOIN MeasurementConsumers USING (MeasurementConsumerId)
+          {{whereClause}}
+          {{orderByClause}}
+          {{limitClause}}
         )
-        JOIN Certificates ON (Certificates.CertificateId = DataProviderCertificates.CertificateId)
-      """
-        .trimIndent()
+        SELECT
+          $COMMON_COLUMNS
+          ComputationParticipants,
+          $MEASUREMENT_REQUISITIONS_COUNT_COLUMN
+        FROM
+          FilteredRequisitions AS Requisitions
+          JOIN Measurements USING (MeasurementConsumerId, MeasurementId)
+          JOIN MeasurementConsumerCertificates USING (MeasurementConsumerId, CertificateId)
+          JOIN DataProviderCertificates ON (
+            DataProviderCertificates.CertificateId = Requisitions.DataProviderCertificateId
+          )
+          JOIN Certificates ON (Certificates.CertificateId = DataProviderCertificates.CertificateId)
+        {{orderByClause}}
+        """
+          .trimIndent()
+      )
     ),
-    MEASUREMENTS(
-      """
-      FROM
-        Measurements
-        JOIN Requisitions USING (MeasurementConsumerId, MeasurementId)
-        JOIN MeasurementConsumers USING (MeasurementConsumerId)
-        JOIN MeasurementConsumerCertificates USING (MeasurementConsumerId, CertificateId)
-        JOIN DataProviders USING (DataProviderId)
-        JOIN DataProviderCertificates ON (
-          DataProviderCertificates.CertificateId = Requisitions.DataProviderCertificateId
-        )
-        JOIN Certificates ON (Certificates.CertificateId = DataProviderCertificates.CertificateId)
-      """
-        .trimIndent()
+    NONE(
+      FillableTemplate(
+        """
+        @{spanner_emulator.disable_query_null_filtered_index_check=TRUE}
+        SELECT
+          $COMMON_COLUMNS
+          $COMPUTATION_PARTICIPANTS_COLUMN
+          $MEASUREMENT_REQUISITIONS_COUNT_COLUMN
+        FROM
+          Requisitions
+          JOIN DataProviders USING (DataProviderId)
+          JOIN MeasurementConsumers USING (MeasurementConsumerId)
+          JOIN Measurements USING (MeasurementConsumerId, MeasurementId)
+          JOIN MeasurementConsumerCertificates USING (MeasurementConsumerId, CertificateId)
+          JOIN DataProviderCertificates ON (
+            DataProviderCertificates.CertificateId = Requisitions.DataProviderCertificateId
+          )
+          JOIN Certificates ON (Certificates.CertificateId = DataProviderCertificates.CertificateId)
+        {{whereClause}}
+        {{orderByClause}}
+        {{limitClause}}
+        """
+          .trimIndent()
+      )
     ),
   }
 
-  override val baseSql: String =
-    """
-    @{spanner_emulator.disable_query_null_filtered_index_check=TRUE}
-    SELECT
+  class Builder(parent: Parent) {
+    private val sqlTemplate: FillableTemplate = parent.sqlTemplate
+    private val statementBuilder = Statement.newBuilder("")
+
+    var whereClause: String = ""
+    var orderByClause: String = ""
+    var limitClause: String = ""
+
+    fun bind(parameter: String): ValueBinder<Statement.Builder> = statementBuilder.bind(parameter)
+
+    fun build(): RequisitionReader {
+      statementBuilder.append(
+        sqlTemplate.fill(
+          mapOf(
+            "whereClause" to whereClause,
+            "orderByClause" to orderByClause,
+            "limitClause" to limitClause,
+          )
+        )
+      )
+      return RequisitionReader(statementBuilder)
+    }
+  }
+
+  override suspend fun translate(struct: Struct): Result {
+    return Result(
+      InternalId(struct.getLong("MeasurementConsumerId")),
+      InternalId(struct.getLong("MeasurementId")),
+      InternalId(struct.getLong("RequisitionId")),
+      buildRequisition(struct),
+      struct.getProtoMessage("MeasurementDetails", MeasurementDetails.getDefaultInstance()),
+    )
+  }
+
+  companion object {
+    private object Params {
+      const val EXTERNAL_COMPUTATION_ID = "externalComputationId"
+      const val EXTERNAL_DATA_PROVIDER_ID = "externalDataProviderId"
+      const val EXTERNAL_REQUISITION_ID = "externalRequisitionId"
+    }
+
+    private val COMMON_COLUMNS =
+      """
       MeasurementConsumerId,
       MeasurementId,
       RequisitionId,
@@ -114,15 +196,11 @@ class RequisitionReader(primaryTable: PrimaryTable) : SpannerReader<RequisitionR
       Measurements.State AS MeasurementState,
       MeasurementDetails,
       Measurements.CreateTime,
-      (
-        SELECT
-          COUNT(DataProviderId),
-        FROM
-          Requisitions
-        WHERE
-          Requisitions.MeasurementConsumerId = Measurements.MeasurementConsumerId
-          AND Requisitions.MeasurementId = Measurements.MeasurementId
-      ) AS MeasurementRequisitionCount,
+      """
+        .trimIndent()
+
+    private val COMPUTATION_PARTICIPANTS_COLUMN =
+      """
       ARRAY(
         SELECT AS STRUCT
           ComputationParticipants.DuchyId,
@@ -134,26 +212,26 @@ class RequisitionReader(primaryTable: PrimaryTable) : SpannerReader<RequisitionR
         WHERE
           ComputationParticipants.MeasurementConsumerId = Requisitions.MeasurementConsumerId
           AND ComputationParticipants.MeasurementId = Requisitions.MeasurementId
-      ) AS ComputationParticipants
-    ${primaryTable.fromClause}
-    """
-      .trimIndent()
+      ) AS ComputationParticipants,
+      """
+        .trimIndent()
 
-  override suspend fun translate(struct: Struct): Result {
-    return Result(
-      InternalId(struct.getLong("MeasurementConsumerId")),
-      InternalId(struct.getLong("MeasurementId")),
-      InternalId(struct.getLong("RequisitionId")),
-      buildRequisition(struct),
-      struct.getProtoMessage("MeasurementDetails", MeasurementDetails.getDefaultInstance()),
-    )
-  }
+    private val MEASUREMENT_REQUISITIONS_COUNT_COLUMN =
+      """
+      (
+        SELECT
+          COUNT(DataProviderId),
+        FROM
+          Requisitions
+        WHERE
+          Requisitions.MeasurementConsumerId = Measurements.MeasurementConsumerId
+          AND Requisitions.MeasurementId = Measurements.MeasurementId
+      ) AS MeasurementRequisitionCount,
+      """
+        .trimIndent()
 
-  companion object {
-    private object Params {
-      const val EXTERNAL_COMPUTATION_ID = "externalComputationId"
-      const val EXTERNAL_DATA_PROVIDER_ID = "externalDataProviderId"
-      const val EXTERNAL_REQUISITION_ID = "externalRequisitionId"
+    fun build(parent: Parent, fillBuilder: Builder.() -> Unit): RequisitionReader {
+      return Builder(parent).apply(fillBuilder).build()
     }
 
     suspend fun readByExternalDataProviderId(
@@ -161,16 +239,15 @@ class RequisitionReader(primaryTable: PrimaryTable) : SpannerReader<RequisitionR
       externalDataProviderId: ExternalId,
       externalRequisitionId: ExternalId,
     ): Result? {
-      return RequisitionReader(PrimaryTable.REQUISITIONS)
-        .fillStatementBuilder {
-          appendClause(
-            """
-            WHERE
-              ExternalRequisitionId = @${Params.EXTERNAL_REQUISITION_ID}
-              AND ExternalDataProviderId = @${Params.EXTERNAL_DATA_PROVIDER_ID}
-            """
-              .trimIndent()
-          )
+      val whereClause =
+        """
+        WHERE
+          ExternalRequisitionId = @${Params.EXTERNAL_REQUISITION_ID}
+          AND ExternalDataProviderId = @${Params.EXTERNAL_DATA_PROVIDER_ID}
+        """
+          .trimIndent()
+      return build(Parent.DATA_PROVIDER) {
+          this.whereClause = whereClause
           bind(Params.EXTERNAL_DATA_PROVIDER_ID).to(externalDataProviderId)
           bind(Params.EXTERNAL_REQUISITION_ID).to(externalRequisitionId)
         }
@@ -183,16 +260,15 @@ class RequisitionReader(primaryTable: PrimaryTable) : SpannerReader<RequisitionR
       externalComputationId: ExternalId,
       externalRequisitionId: ExternalId,
     ): Result? {
-      return RequisitionReader(PrimaryTable.MEASUREMENTS)
-        .fillStatementBuilder {
-          appendClause(
-            """
-            WHERE
-              ExternalComputationId = @${Params.EXTERNAL_COMPUTATION_ID}
-              AND ExternalRequisitionId = @${Params.EXTERNAL_REQUISITION_ID}
-            """
-              .trimIndent()
-          )
+      val whereClause =
+        """
+        WHERE
+          ExternalComputationId = @${Params.EXTERNAL_COMPUTATION_ID}
+          AND ExternalRequisitionId = @${Params.EXTERNAL_REQUISITION_ID}
+        """
+          .trimIndent()
+      return build(Parent.MEASUREMENT) {
+          this.whereClause = whereClause
           bind(Params.EXTERNAL_COMPUTATION_ID).to(externalComputationId)
           bind(Params.EXTERNAL_REQUISITION_ID).to(externalRequisitionId)
         }

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/service/api/v2alpha/RequisitionsService.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/service/api/v2alpha/RequisitionsService.kt
@@ -35,6 +35,7 @@ import org.wfanet.measurement.api.v2alpha.ListRequisitionsPageToken
 import org.wfanet.measurement.api.v2alpha.ListRequisitionsPageTokenKt.previousPageEnd
 import org.wfanet.measurement.api.v2alpha.ListRequisitionsRequest
 import org.wfanet.measurement.api.v2alpha.ListRequisitionsResponse
+import org.wfanet.measurement.api.v2alpha.Measurement
 import org.wfanet.measurement.api.v2alpha.MeasurementConsumerCertificateKey
 import org.wfanet.measurement.api.v2alpha.MeasurementKey
 import org.wfanet.measurement.api.v2alpha.MeasurementPrincipal
@@ -107,10 +108,27 @@ class RequisitionsService(private val internalRequisitionStub: RequisitionsCorou
   ): ListRequisitionsResponse {
     fun permissionDeniedStatus() = Permission.LIST.deniedStatus("${request.parent}/requisitions")
 
+    if (request.parent.isEmpty()) {
+      throw Status.INVALID_ARGUMENT.withDescription("parent not set").asRuntimeException()
+    }
     val parentKey: RequisitionParentKey =
       DataProviderKey.fromName(request.parent)
         ?: MeasurementKey.fromName(request.parent)
-        ?: throw Status.INVALID_ARGUMENT.withDescription("parent is invalid").asRuntimeException()
+        ?: throw Status.INVALID_ARGUMENT.withDescription("parent invalid").asRuntimeException()
+
+    if (request.filter.measurementStatesList.isNotEmpty()) {
+      if (
+        // Avoid breaking known existing callers where the measurement state filter is redundant.
+        !(request.filter.statesList == listOf(State.UNFULFILLED) &&
+          request.filter.measurementStatesList ==
+            listOf(Measurement.State.AWAITING_REQUISITION_FULFILLMENT))
+      ) {
+        throw Status.INVALID_ARGUMENT.withDescription(
+            "filter.measurement_states is no longer supported"
+          )
+          .asRuntimeException()
+      }
+    }
 
     val principal: MeasurementPrincipal = principalFromCurrentContext
     when (parentKey) {
@@ -549,15 +567,12 @@ private fun buildInternalStreamRequisitionsRequest(
           states += requestStates.map { it.toInternal() }
         }
 
-        measurementStates += filter.measurementStatesList.flatMap { it.toInternalState() }
-
         if (pageToken != null) {
           if (
             pageToken.externalDataProviderId != externalDataProviderId ||
               pageToken.externalMeasurementConsumerId != externalMeasurementConsumerId ||
               pageToken.externalMeasurementId != externalMeasurementId ||
-              pageToken.statesList != filter.statesList ||
-              pageToken.measurementStatesList != filter.measurementStatesList
+              pageToken.statesList != filter.statesList
           ) {
             throw Status.INVALID_ARGUMENT.withDescription(
                 "Arguments other than page_size must remain the same for subsequent page requests"
@@ -593,7 +608,6 @@ private fun buildNextPageToken(
       externalMeasurementId = internalFilter.externalMeasurementId
     }
     states += filter.statesList
-    measurementStates += filter.measurementStatesList
     lastRequisition = previousPageEnd {
       updateTime = internalRequisitions[internalRequisitions.lastIndex - 1].updateTime
       externalDataProviderId =

--- a/src/main/proto/wfa/measurement/api/v2alpha/page_token.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/page_token.proto
@@ -99,7 +99,7 @@ message ListMeasurementsPageToken {
 }
 
 message ListRequisitionsPageToken {
-  reserved 1;
+  reserved 1, 7;
 
   fixed64 external_measurement_consumer_id = 2;
   fixed64 external_measurement_id = 3;
@@ -111,7 +111,6 @@ message ListRequisitionsPageToken {
     fixed64 external_requisition_id = 2;
   }
   PreviousPageEnd last_requisition = 6;
-  repeated Measurement.State measurement_states = 7;
 }
 
 message ListExchangeStepsPageToken {

--- a/src/main/proto/wfa/measurement/internal/kingdom/requisitions_service.proto
+++ b/src/main/proto/wfa/measurement/internal/kingdom/requisitions_service.proto
@@ -56,7 +56,7 @@ message StreamRequisitionsRequest {
     int64 external_data_provider_id = 3;
     repeated Requisition.State states = 4;
     google.protobuf.Timestamp updated_after = 5;
-    repeated Measurement.State measurement_states = 8;
+    repeated Measurement.State measurement_states = 8 [deprecated = true];
 
     message After {
       google.protobuf.Timestamp update_time = 1;


### PR DESCRIPTION
This applies when listing by DataProvider parent. It should prevent scanning more rows on the Measurements table than the specified limit.

Closes #2299

BREAKING CHANGE: `measurement_states` is no longer supported in `ListRequisitionsRequest.Filter` except in the case where it's set to `AWAITING_REQUISITION_FULFILLMENT` when `states` is set to `UNFULFILLED`. This is the only observed call pattern, in which case `measurement_states` is actually redundant.
BREAKING CHANGE: `ListRequistions` now depends on Requisitions being in the `WITHDRAWN` state under the appropriate conditions. There must not be any `UNFULFILLED` Requisitions in the system created by versions prior to v0.5.9.