### PR TITLE
fix: Pad hex representation of integer ID to 16 hex digits instead of 8

### DIFF
--- a/tools/integer-ids/external-to-api
+++ b/tools/integer-ids/external-to-api
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 shopt -s extglob
 
-padded="$(printf '%08lx' "$1" | xxd -r -p | basenc --base64url)"
+padded="$(printf '%016lx' "$1" | xxd -r -p | basenc --base64url)"
 printf "${padded%%+(=)}"


### PR DESCRIPTION
This prevents getting the wrong number of bytes in the output (e.g. 7 instead of 8).