### PR TITLE
perf: Attempt to reduce contention on FulfillRequisition by reading in a separate transaction

### DIFF
--- a/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/writers/RefuseRequisition.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/writers/RefuseRequisition.kt
@@ -47,8 +47,8 @@ class RefuseRequisition(private val request: RefuseRequisitionRequest) :
   SpannerWriter<Requisition, Requisition>() {
   override suspend fun TransactionScope.runTransaction(): Requisition {
     val readResult: RequisitionReader.Result = readRequisition()
-    val (measurementConsumerId, measurementId, requisitionId, requisition, measurementDetails) =
-      readResult
+    val (requisitionKey, requisition, measurementDetails) = readResult
+    val (measurementConsumerId, measurementId, requisitionId) = requisitionKey
 
     val state = requisition.state
     if (state != Requisition.State.UNFULFILLED) {


### PR DESCRIPTION
This should hopefully resolve flakiness in `//src/test/kotlin/org/wfanet/measurement/integration/k8s:EmptyClusterCorrectnessTest` related to timeouts on impression and duration Measurements.