### PR TITLE
fix: Add reporting.metrics.invalidate permission for invalidateMetric

### DIFF
--- a/src/main/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/MetricsService.kt
+++ b/src/main/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/MetricsService.kt
@@ -1295,7 +1295,7 @@ class MetricsService(
           .asStatusRuntimeException(Status.Code.INVALID_ARGUMENT)
 
     val measurementConsumerName: String = metricKey.parentKey.toName()
-    authorization.check(measurementConsumerName, Permission.CREATE)
+    authorization.check(measurementConsumerName, Permission.INVALIDATE)
 
     try {
       return internalMetricsStub
@@ -1888,6 +1888,7 @@ class MetricsService(
     const val GET = "reporting.metrics.get"
     const val LIST = "reporting.metrics.list"
     const val CREATE = "reporting.metrics.create"
+    const val INVALIDATE = "reporting.metrics.invalidate"
   }
 
   companion object {

--- a/src/main/proto/wfa/measurement/reporting/v2alpha/permissions_config.textproto
+++ b/src/main/proto/wfa/measurement/reporting/v2alpha/permissions_config.textproto
@@ -81,6 +81,13 @@ permissions {
     protected_resource_types: "halo.wfanet.org/MeasurementConsumer"
   }
 }
+permissions {
+  key: "reporting.metrics.invalidate"
+  value {
+    protected_resource_types: "halo.wfanet.org/MeasurementConsumer"
+    protected_resource_types: "reporting.halo-cmm.org/Metric"
+  }
+}
 
 # metricCalculationSpecs
 permissions {

--- a/src/test/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/MetricsServiceTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/MetricsServiceTest.kt
@@ -10568,7 +10568,7 @@ class MetricsServiceTest {
   fun `invalidateMetric returns Metric with state INVALID`() = runBlocking {
     wheneverBlocking {
       permissionsServiceMock.checkPermissions(hasPrincipal(PRINCIPAL.name))
-    } doReturn checkPermissionsResponse { permissions += PermissionName.CREATE }
+    } doReturn checkPermissionsResponse { permissions += PermissionName.INVALIDATE }
 
     whenever(internalMetricsMock.invalidateMetric(any()))
       .thenReturn(
@@ -10603,7 +10603,7 @@ class MetricsServiceTest {
   fun `invalidateMetric throws FAILED_PRECONDITION when metric FAILED`() = runBlocking {
     wheneverBlocking {
       permissionsServiceMock.checkPermissions(hasPrincipal(PRINCIPAL.name))
-    } doReturn checkPermissionsResponse { permissions += PermissionName.CREATE }
+    } doReturn checkPermissionsResponse { permissions += PermissionName.INVALIDATE }
 
     val measurementConsumerKey =
       MeasurementConsumerKey.fromName(MEASUREMENT_CONSUMERS.values.first().name)
@@ -10640,7 +10640,7 @@ class MetricsServiceTest {
   fun `invalidateMetric throws NOT_FOUND when metric not found`() = runBlocking {
     wheneverBlocking {
       permissionsServiceMock.checkPermissions(hasPrincipal(PRINCIPAL.name))
-    } doReturn checkPermissionsResponse { permissions += PermissionName.CREATE }
+    } doReturn checkPermissionsResponse { permissions += PermissionName.INVALIDATE }
 
     val measurementConsumerKey =
       MeasurementConsumerKey.fromName(MEASUREMENT_CONSUMERS.values.first().name)
@@ -10720,6 +10720,7 @@ class MetricsServiceTest {
     const val GET = "permissions/${MetricsService.Permission.GET}"
     const val LIST = "permissions/${MetricsService.Permission.LIST}"
     const val CREATE = "permissions/${MetricsService.Permission.CREATE}"
+    const val INVALIDATE = "permissions/${MetricsService.Permission.INVALIDATE}"
   }
 
   companion object {
@@ -10729,6 +10730,7 @@ class MetricsServiceTest {
         MetricsService.Permission.GET,
         MetricsService.Permission.LIST,
         MetricsService.Permission.CREATE,
+        MetricsService.Permission.INVALIDATE,
       )
     private val SCOPES = ALL_PERMISSIONS
 


### PR DESCRIPTION
invalidateMetric was looking for the reporting.metrics.create permission.