### PR TITLE
feat: Support RPC rate limiting for Kingdom public API services

### DIFF
--- a/src/main/kotlin/org/wfanet/measurement/api/v2alpha/PrincipalServerInterceptor.kt
+++ b/src/main/kotlin/org/wfanet/measurement/api/v2alpha/PrincipalServerInterceptor.kt
@@ -100,7 +100,7 @@ fun BindableService.withPrincipalsFromX509AuthorityKeyIdentifiers(
     AuthorityKeyServerInterceptor(),
     AkidPrincipalServerInterceptor(
       ContextKeys.PRINCIPAL_CONTEXT_KEY,
-      AuthorityKeyServerInterceptor.AUTHORITY_KEY_IDENTIFIERS_CONTEXT_KEY,
+      AuthorityKeyServerInterceptor.CLIENT_AUTHORITY_KEY_IDENTIFIER_CONTEXT_KEY,
       akidPrincipalLookup,
     ),
   )

--- a/src/main/kotlin/org/wfanet/measurement/common/grpc/BUILD.bazel
+++ b/src/main/kotlin/org/wfanet/measurement/common/grpc/BUILD.bazel
@@ -27,3 +27,15 @@ kt_jvm_library(
         "@wfa_common_jvm//imports/java/io/grpc:api",
     ],
 )
+
+kt_jvm_library(
+    name = "principal_rate_limiting_server_interceptor",
+    srcs = ["PrincipalRateLimitingServerInterceptor.kt"],
+    deps = [
+        "//src/main/kotlin/org/wfanet/measurement/common/ratelimit:rate_limiter",
+        "//src/main/kotlin/org/wfanet/measurement/common/ratelimit:token_bucket",
+        "//src/main/proto/wfa/measurement/config:rate_limit_config_kt_jvm_proto",
+        "@wfa_common_jvm//imports/java/io/grpc:api",
+        "@wfa_common_jvm//imports/java/io/grpc:context",
+    ],
+)

--- a/src/main/kotlin/org/wfanet/measurement/common/grpc/Interceptors.kt
+++ b/src/main/kotlin/org/wfanet/measurement/common/grpc/Interceptors.kt
@@ -39,3 +39,15 @@ fun ServerServiceDefinition.withInterceptor(
  */
 fun BindableService.withInterceptor(interceptor: ServerInterceptor): ServerServiceDefinition =
   ServerInterceptors.intercept(this, interceptor)
+
+/**
+ * Creates a new [ServerServiceDefinition] whose [io.grpc.ServerCallHandler]s will call
+ * [interceptors] before calling the pre-existing [io.grpc.ServerCallHandler].
+ *
+ * The last interceptor will have its [ServerInterceptor.interceptCall] called first.
+ *
+ * @see ServerInterceptors.intercept
+ */
+fun BindableService.withInterceptors(
+  vararg interceptors: ServerInterceptor
+): ServerServiceDefinition = ServerInterceptors.intercept(this, *interceptors)

--- a/src/main/kotlin/org/wfanet/measurement/common/grpc/PrincipalRateLimitingServerInterceptor.kt
+++ b/src/main/kotlin/org/wfanet/measurement/common/grpc/PrincipalRateLimitingServerInterceptor.kt
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2025 The Cross-Media Measurement Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wfanet.measurement.common.grpc
+
+import io.grpc.Context
+import io.grpc.ForwardingServerCall.SimpleForwardingServerCall
+import io.grpc.Metadata
+import io.grpc.ServerCall
+import io.grpc.ServerCallHandler
+import io.grpc.ServerInterceptor
+import io.grpc.Status
+import java.util.concurrent.ConcurrentHashMap
+import org.wfanet.measurement.common.ratelimit.RateLimiter
+import org.wfanet.measurement.common.ratelimit.TokenBucket
+import org.wfanet.measurement.config.RateLimitConfig
+
+/**
+ * Server interceptor that applies a per-principal, per-method rate limit.
+ *
+ * The principal can be any value from the current gRPC [Context] which has a unique string
+ * identifier.
+ */
+class PrincipalRateLimitingServerInterceptor(
+  /** Map of full method name to cost for that method. */
+  private val methodCost: Map<String, Int>,
+  /**
+   * Function which returns the principal identifier from the specified gRPC [Context], or `null` if
+   * the principal was not found.
+   */
+  private val getPrincipalIdentifier: (context: Context) -> String?,
+  /** Function which returns a new [RateLimiter] for the specified principal identifier. */
+  private val createRateLimiter: (principalIdentifier: String?) -> RateLimiter,
+) : ServerInterceptor {
+  private val rateLimiterByPrincipal = ConcurrentHashMap<String, RateLimiter>()
+
+  override fun <ReqT : Any, RespT : Any> interceptCall(
+    call: ServerCall<ReqT, RespT>,
+    headers: Metadata,
+    next: ServerCallHandler<ReqT, RespT>,
+  ): ServerCall.Listener<ReqT> {
+    val principalIdentifier = getPrincipalIdentifier(Context.current())
+    val rateLimiter: RateLimiter =
+      if (principalIdentifier == null) {
+        createRateLimiter(null)
+      } else {
+        rateLimiterByPrincipal.getOrPut(principalIdentifier) {
+          createRateLimiter(principalIdentifier)
+        }
+      }
+    val cost = methodCost.getOrDefault(call.methodDescriptor.fullMethodName, DEFAULT_METHOD_COST)
+
+    val permit: RateLimiter.Permit? = rateLimiter.tryAcquire(cost)
+    return if (permit != null) {
+      val interceptedCall =
+        object : SimpleForwardingServerCall<ReqT, RespT>(call) {
+          override fun close(status: Status, trailers: Metadata) {
+            permit.release()
+            super.close(status, trailers)
+          }
+        }
+      next.startCall(interceptedCall, headers)
+    } else {
+      call.close(RATE_LIMIT_EXCEEDED_STATUS, Metadata())
+      object : ServerCall.Listener<ReqT>() {}
+    }
+  }
+
+  companion object {
+    private const val DEFAULT_METHOD_COST = 1
+    private val RATE_LIMIT_EXCEEDED_STATUS =
+      Status.UNAVAILABLE.withDescription("Rate limit exceeded")
+
+    fun fromConfig(
+      config: RateLimitConfig,
+      getPrincipalIdentifier: (context: Context) -> String?,
+    ): PrincipalRateLimitingServerInterceptor {
+      return PrincipalRateLimitingServerInterceptor(config.methodCostMap, getPrincipalIdentifier) {
+        principalIdentifier ->
+        val rateLimit =
+          if (principalIdentifier == null) {
+            config.defaultRateLimit
+          } else {
+            config.perPrincipalRateLimitMap.getOrDefault(
+              principalIdentifier,
+              config.defaultRateLimit,
+            )
+          }
+        when {
+          rateLimit.maximumRequestCount == 0 -> RateLimiter.Blocked
+          rateLimit.maximumRequestCount < 0 -> RateLimiter.Unlimited
+          else -> TokenBucket(rateLimit.maximumRequestCount, rateLimit.averageRequestRate)
+        }
+      }
+    }
+  }
+}

--- a/src/main/kotlin/org/wfanet/measurement/common/ratelimit/BUILD.bazel
+++ b/src/main/kotlin/org/wfanet/measurement/common/ratelimit/BUILD.bazel
@@ -1,0 +1,16 @@
+load("@wfa_rules_kotlin_jvm//kotlin:defs.bzl", "kt_jvm_library")
+
+package(default_visibility = ["//visibility:public"])
+
+kt_jvm_library(
+    name = "rate_limiter",
+    srcs = ["RateLimiter.kt"],
+)
+
+kt_jvm_library(
+    name = "token_bucket",
+    srcs = ["TokenBucket.kt"],
+    deps = [
+        ":rate_limiter",
+    ],
+)

--- a/src/main/kotlin/org/wfanet/measurement/common/ratelimit/RateLimiter.kt
+++ b/src/main/kotlin/org/wfanet/measurement/common/ratelimit/RateLimiter.kt
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2025 The Cross-Media Measurement Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wfanet.measurement.common.ratelimit
+
+/** Rate limiter. */
+interface RateLimiter {
+  interface Permit : AutoCloseable {
+    /** Releases the [Permit]. */
+    fun release()
+
+    override fun close() = release()
+
+    object NoOp : Permit {
+      override fun release() = Unit
+    }
+  }
+
+  /**
+   * Attempts to acquire a permit for execution.
+   *
+   * @return the [Permit], or `null` if none was acquired
+   */
+  fun tryAcquire(cost: Int = 1): Permit?
+
+  companion object {
+    val Unlimited =
+      object : RateLimiter {
+        override fun tryAcquire(cost: Int) = Permit.NoOp
+      }
+    val Blocked =
+      object : RateLimiter {
+        override fun tryAcquire(cost: Int) = null
+      }
+  }
+}

--- a/src/main/kotlin/org/wfanet/measurement/common/ratelimit/TokenBucket.kt
+++ b/src/main/kotlin/org/wfanet/measurement/common/ratelimit/TokenBucket.kt
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2025 The Cross-Media Measurement Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wfanet.measurement.common.ratelimit
+
+import kotlin.math.floor
+import kotlin.time.ComparableTimeMark
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.seconds
+import kotlin.time.TimeSource
+
+/**
+ * Implementation of the token bucket rate limit algorithm.
+ *
+ * @param size size of the bucket
+ * @param fillRate number of tokens filled per second
+ */
+class TokenBucket(
+  private val size: Int,
+  fillRate: Double,
+  private val timeSource: TimeSource.WithComparableMarks = TimeSource.Monotonic,
+) : RateLimiter {
+  init {
+    require(size >= 0)
+    require(fillRate > 0)
+  }
+
+  /** Time it takes to refill one token. */
+  private val refillTime: Duration = (1 / fillRate).seconds
+  @Volatile private var tokenCount: Int = size
+  @Volatile private var lastRefill: ComparableTimeMark = timeSource.markNow()
+
+  @Synchronized
+  override fun tryAcquire(cost: Int): RateLimiter.Permit? {
+    require(cost >= 0)
+
+    if (cost > size) {
+      return null
+    }
+
+    refill()
+    return if (tokenCount >= cost) {
+      tokenCount -= cost
+      RateLimiter.Permit.NoOp // Token bucket algorithm does not track release of permits.
+    } else {
+      null
+    }
+  }
+
+  @Synchronized
+  private fun refill() {
+    val now: ComparableTimeMark = timeSource.markNow()
+
+    val elapsed = now - lastRefill
+    check(!elapsed.isNegative()) { "Time source is non-monotonic" }
+    val tokensToAdd = floor(elapsed / refillTime).toInt()
+    if (tokensToAdd == 0) {
+      return
+    }
+
+    if (tokenCount + tokensToAdd >= size) {
+      tokenCount = size
+    } else {
+      tokenCount += tokensToAdd
+    }
+
+    lastRefill = now
+  }
+}

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/common/server/BUILD.bazel
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/common/server/BUILD.bazel
@@ -44,6 +44,8 @@ kt_jvm_library(
     deps = [
         ":utils",
         "//src/main/kotlin/org/wfanet/measurement/api/v2alpha:akid_principal_lookup",
+        "//src/main/kotlin/org/wfanet/measurement/common/grpc:interceptors",
+        "//src/main/kotlin/org/wfanet/measurement/common/grpc:principal_rate_limiting_server_interceptor",
         "//src/main/kotlin/org/wfanet/measurement/kingdom/service/api/v2alpha:accounts_service",
         "//src/main/kotlin/org/wfanet/measurement/kingdom/service/api/v2alpha:api_key_authentication_server_interceptor",
         "//src/main/kotlin/org/wfanet/measurement/kingdom/service/api/v2alpha:api_keys_service",
@@ -65,6 +67,7 @@ kt_jvm_library(
         "//src/main/kotlin/org/wfanet/measurement/kingdom/service/api/v2alpha:populations_service",
         "//src/main/kotlin/org/wfanet/measurement/kingdom/service/api/v2alpha:public_keys_service",
         "//src/main/kotlin/org/wfanet/measurement/kingdom/service/api/v2alpha:requisitions_service",
+        "//src/main/proto/wfa/measurement/config:rate_limit_config_kt_jvm_proto",
         "@wfa_common_jvm//imports/java/io/grpc:api",
         "@wfa_common_jvm//imports/java/picocli",
         "@wfa_common_jvm//src/main/kotlin/org/wfanet/measurement/common",

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/common/server/V2alphaPublicApiServer.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/common/server/V2alphaPublicApiServer.kt
@@ -12,22 +12,32 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+@file:OptIn(ExperimentalStdlibApi::class) // For `HexFormat`.
+
 package org.wfanet.measurement.kingdom.deploy.common.server
 
 import io.grpc.ServerServiceDefinition
 import java.io.File
 import kotlin.properties.Delegates
 import org.wfanet.measurement.api.v2alpha.AkidPrincipalLookup
+import org.wfanet.measurement.api.v2alpha.ContextKeys
 import org.wfanet.measurement.api.v2alpha.ProtocolConfig.NoiseMechanism
-import org.wfanet.measurement.api.v2alpha.withPrincipalsFromX509AuthorityKeyIdentifiers
+import org.wfanet.measurement.common.api.grpc.AkidPrincipalServerInterceptor
 import org.wfanet.measurement.common.commandLineMain
 import org.wfanet.measurement.common.crypto.SigningCerts
 import org.wfanet.measurement.common.grpc.CommonServer
+import org.wfanet.measurement.common.grpc.PrincipalRateLimitingServerInterceptor
 import org.wfanet.measurement.common.grpc.buildMutualTlsChannel
 import org.wfanet.measurement.common.grpc.withDefaultDeadline
+import org.wfanet.measurement.common.grpc.withInterceptors
 import org.wfanet.measurement.common.grpc.withVerboseLogging
+import org.wfanet.measurement.common.identity.AuthorityKeyServerInterceptor
 import org.wfanet.measurement.common.identity.DuchyInfo
 import org.wfanet.measurement.common.identity.DuchyInfoFlags
+import org.wfanet.measurement.common.parseTextProto
+import org.wfanet.measurement.config.RateLimitConfig
+import org.wfanet.measurement.config.RateLimitConfigKt
+import org.wfanet.measurement.config.rateLimitConfig
 import org.wfanet.measurement.internal.kingdom.AccountsGrpcKt.AccountsCoroutineStub as InternalAccountsCoroutineStub
 import org.wfanet.measurement.internal.kingdom.ApiKeysGrpcKt.ApiKeysCoroutineStub as InternalApiKeysCoroutineStub
 import org.wfanet.measurement.internal.kingdom.CertificatesGrpcKt.CertificatesCoroutineStub as InternalCertificatesCoroutineStub
@@ -55,7 +65,9 @@ import org.wfanet.measurement.kingdom.deploy.common.Llv2ProtocolConfig
 import org.wfanet.measurement.kingdom.deploy.common.Llv2ProtocolConfigFlags
 import org.wfanet.measurement.kingdom.deploy.common.RoLlv2ProtocolConfig
 import org.wfanet.measurement.kingdom.deploy.common.RoLlv2ProtocolConfigFlags
+import org.wfanet.measurement.kingdom.service.api.v2alpha.AccountAuthenticationServerInterceptor
 import org.wfanet.measurement.kingdom.service.api.v2alpha.AccountsService
+import org.wfanet.measurement.kingdom.service.api.v2alpha.ApiKeyAuthenticationServerInterceptor
 import org.wfanet.measurement.kingdom.service.api.v2alpha.ApiKeysService
 import org.wfanet.measurement.kingdom.service.api.v2alpha.CertificatesService
 import org.wfanet.measurement.kingdom.service.api.v2alpha.DataProvidersService
@@ -75,11 +87,14 @@ import org.wfanet.measurement.kingdom.service.api.v2alpha.ModelSuitesService
 import org.wfanet.measurement.kingdom.service.api.v2alpha.PopulationsService
 import org.wfanet.measurement.kingdom.service.api.v2alpha.PublicKeysService
 import org.wfanet.measurement.kingdom.service.api.v2alpha.RequisitionsService
-import org.wfanet.measurement.kingdom.service.api.v2alpha.withAccountAuthenticationServerInterceptor
-import org.wfanet.measurement.kingdom.service.api.v2alpha.withApiKeyAuthenticationServerInterceptor
 import picocli.CommandLine
 
 private const val SERVER_NAME = "V2alphaPublicApiServer"
+
+private val KEY_ID_FORMAT = HexFormat {
+  upperCase = true
+  bytes.byteSeparator = ":"
+}
 
 @CommandLine.Command(
   name = SERVER_NAME,
@@ -116,41 +131,67 @@ private fun run(
       .withVerboseLogging(kingdomApiServerFlags.debugVerboseGrpcClientLogging)
       .withDefaultDeadline(kingdomApiServerFlags.internalApiFlags.defaultDeadlineDuration)
 
-  val principalLookup = AkidPrincipalLookup(v2alphaFlags.authorityKeyIdentifierToPrincipalMapFile)
-
   val internalAccountsCoroutineStub = InternalAccountsCoroutineStub(channel)
   val internalApiKeysCoroutineStub = InternalApiKeysCoroutineStub(channel)
   val internalRecurringExchangesCoroutineStub = InternalRecurringExchangesCoroutineStub(channel)
   val internalExchangeStepsCoroutineStub = InternalExchangeStepsCoroutineStub(channel)
   val internalDataProvidersStub = InternalDataProvidersCoroutineStub(channel)
 
+  val accountInterceptor =
+    AccountAuthenticationServerInterceptor(internalAccountsCoroutineStub, v2alphaFlags.redirectUri)
+  val akidInterceptor = AuthorityKeyServerInterceptor()
+  val akidPrincipalInterceptor =
+    AkidPrincipalServerInterceptor(
+      ContextKeys.PRINCIPAL_CONTEXT_KEY,
+      AuthorityKeyServerInterceptor.CLIENT_AUTHORITY_KEY_IDENTIFIER_CONTEXT_KEY,
+      AkidPrincipalLookup(v2alphaFlags.authorityKeyIdentifierToPrincipalMapFile),
+    )
+  val apiKeyPrincipalInterceptor =
+    ApiKeyAuthenticationServerInterceptor(internalApiKeysCoroutineStub)
+  val rateLimitingInterceptor =
+    PrincipalRateLimitingServerInterceptor.fromConfig(v2alphaFlags.rateLimitConfig) { context ->
+      AuthorityKeyServerInterceptor.CLIENT_AUTHORITY_KEY_IDENTIFIER_CONTEXT_KEY.get(context)
+        ?.toByteArray()
+        ?.toHexString(KEY_ID_FORMAT)
+    }
+
   // TODO: do we need something similar to .withDuchyIdentities() for EDP and MC?
   val services: List<ServerServiceDefinition> =
     listOf(
       AccountsService(internalAccountsCoroutineStub, v2alphaFlags.redirectUri)
-        .withAccountAuthenticationServerInterceptor(
-          internalAccountsCoroutineStub,
-          v2alphaFlags.redirectUri,
-        ),
+        .withInterceptors(accountInterceptor, rateLimitingInterceptor, akidInterceptor),
       ApiKeysService(InternalApiKeysCoroutineStub(channel))
-        .withAccountAuthenticationServerInterceptor(
-          internalAccountsCoroutineStub,
-          v2alphaFlags.redirectUri,
-        ),
+        .withInterceptors(accountInterceptor, rateLimitingInterceptor, akidInterceptor),
       CertificatesService(InternalCertificatesCoroutineStub(channel))
-        .withPrincipalsFromX509AuthorityKeyIdentifiers(principalLookup)
-        .withApiKeyAuthenticationServerInterceptor(internalApiKeysCoroutineStub),
+        .withInterceptors(
+          apiKeyPrincipalInterceptor,
+          akidPrincipalInterceptor,
+          rateLimitingInterceptor,
+          akidInterceptor,
+        ),
       DataProvidersService(internalDataProvidersStub)
-        .withPrincipalsFromX509AuthorityKeyIdentifiers(principalLookup)
-        .withApiKeyAuthenticationServerInterceptor(internalApiKeysCoroutineStub),
+        .withInterceptors(
+          apiKeyPrincipalInterceptor,
+          akidPrincipalInterceptor,
+          rateLimitingInterceptor,
+          akidInterceptor,
+        ),
       EventGroupsService(InternalEventGroupsCoroutineStub(channel))
-        .withPrincipalsFromX509AuthorityKeyIdentifiers(principalLookup)
-        .withApiKeyAuthenticationServerInterceptor(internalApiKeysCoroutineStub),
+        .withInterceptors(
+          apiKeyPrincipalInterceptor,
+          akidPrincipalInterceptor,
+          rateLimitingInterceptor,
+          akidInterceptor,
+        ),
       EventGroupMetadataDescriptorsService(
           InternalEventGroupMetadataDescriptorsCoroutineStub(channel)
         )
-        .withPrincipalsFromX509AuthorityKeyIdentifiers(principalLookup)
-        .withApiKeyAuthenticationServerInterceptor(internalApiKeysCoroutineStub),
+        .withInterceptors(
+          apiKeyPrincipalInterceptor,
+          akidPrincipalInterceptor,
+          rateLimitingInterceptor,
+          akidInterceptor,
+        ),
       MeasurementsService(
           InternalMeasurementsCoroutineStub(channel),
           internalDataProvidersStub,
@@ -159,51 +200,68 @@ private fun run(
           hmssEnabled = v2alphaFlags.hmssEnabled,
           hmssEnabledMeasurementConsumers = v2alphaFlags.hmssEnabledMeasurementConsumers,
         )
-        .withPrincipalsFromX509AuthorityKeyIdentifiers(principalLookup)
-        .withApiKeyAuthenticationServerInterceptor(internalApiKeysCoroutineStub),
+        .withInterceptors(
+          apiKeyPrincipalInterceptor,
+          akidPrincipalInterceptor,
+          rateLimitingInterceptor,
+          akidInterceptor,
+        ),
       MeasurementConsumersService(InternalMeasurementConsumersCoroutineStub(channel))
-        .withPrincipalsFromX509AuthorityKeyIdentifiers(principalLookup)
-        .withAccountAuthenticationServerInterceptor(
-          internalAccountsCoroutineStub,
-          v2alphaFlags.redirectUri,
-        )
-        .withApiKeyAuthenticationServerInterceptor(internalApiKeysCoroutineStub),
+        .withInterceptors(
+          accountInterceptor,
+          apiKeyPrincipalInterceptor,
+          akidPrincipalInterceptor,
+          rateLimitingInterceptor,
+          akidInterceptor,
+        ),
       PublicKeysService(InternalPublicKeysCoroutineStub(channel))
-        .withPrincipalsFromX509AuthorityKeyIdentifiers(principalLookup)
-        .withApiKeyAuthenticationServerInterceptor(internalApiKeysCoroutineStub),
+        .withInterceptors(
+          apiKeyPrincipalInterceptor,
+          akidPrincipalInterceptor,
+          rateLimitingInterceptor,
+          akidInterceptor,
+        ),
       RequisitionsService(InternalRequisitionsCoroutineStub(channel))
-        .withPrincipalsFromX509AuthorityKeyIdentifiers(principalLookup)
-        .withApiKeyAuthenticationServerInterceptor(internalApiKeysCoroutineStub),
+        .withInterceptors(
+          apiKeyPrincipalInterceptor,
+          akidPrincipalInterceptor,
+          rateLimitingInterceptor,
+          akidInterceptor,
+        ),
       ExchangesService(
           internalRecurringExchangesCoroutineStub,
           InternalExchangesCoroutineStub(channel),
         )
-        .withPrincipalsFromX509AuthorityKeyIdentifiers(principalLookup),
+        .withInterceptors(akidPrincipalInterceptor, rateLimitingInterceptor, akidInterceptor),
       ExchangeStepsService(
           internalRecurringExchangesCoroutineStub,
           internalExchangeStepsCoroutineStub,
         )
-        .withPrincipalsFromX509AuthorityKeyIdentifiers(principalLookup),
+        .withInterceptors(akidPrincipalInterceptor, rateLimitingInterceptor, akidInterceptor),
       ExchangeStepAttemptsService(
           InternalExchangeStepAttemptsCoroutineStub(channel),
           internalExchangeStepsCoroutineStub,
         )
-        .withPrincipalsFromX509AuthorityKeyIdentifiers(principalLookup),
+        .withInterceptors(akidPrincipalInterceptor, rateLimitingInterceptor, akidInterceptor),
       ModelLinesService(InternalModelLinesCoroutineStub(channel))
-        .withPrincipalsFromX509AuthorityKeyIdentifiers(principalLookup),
+        .withInterceptors(
+          apiKeyPrincipalInterceptor,
+          akidPrincipalInterceptor,
+          rateLimitingInterceptor,
+          akidInterceptor,
+        ),
       ModelShardsService(InternalModelShardsCoroutineStub(channel))
-        .withPrincipalsFromX509AuthorityKeyIdentifiers(principalLookup),
+        .withInterceptors(akidPrincipalInterceptor, rateLimitingInterceptor, akidInterceptor),
       ModelSuitesService(InternalModelSuitesCoroutineStub(channel))
-        .withPrincipalsFromX509AuthorityKeyIdentifiers(principalLookup)
-        .withApiKeyAuthenticationServerInterceptor(internalApiKeysCoroutineStub),
+        .withInterceptors(akidPrincipalInterceptor, rateLimitingInterceptor, akidInterceptor),
       ModelReleasesService(InternalModelReleasesCoroutineStub(channel))
-        .withPrincipalsFromX509AuthorityKeyIdentifiers(principalLookup),
+        .withInterceptors(akidPrincipalInterceptor, rateLimitingInterceptor, akidInterceptor),
       ModelOutagesService(InternalModelOutagesCoroutineStub(channel))
-        .withPrincipalsFromX509AuthorityKeyIdentifiers(principalLookup),
+        .withInterceptors(akidPrincipalInterceptor, rateLimitingInterceptor, akidInterceptor),
       ModelRolloutsService(InternalModelRolloutsCoroutineStub(channel))
-        .withPrincipalsFromX509AuthorityKeyIdentifiers(principalLookup),
+        .withInterceptors(akidPrincipalInterceptor, rateLimitingInterceptor, akidInterceptor),
       PopulationsService(InternalPopulationsCoroutineStub(channel))
-        .withPrincipalsFromX509AuthorityKeyIdentifiers(principalLookup),
+        .withInterceptors(akidPrincipalInterceptor, rateLimitingInterceptor, akidInterceptor),
     )
   CommonServer.fromFlags(commonServerFlags, SERVER_NAME, services).start().blockUntilShutdown()
 }
@@ -228,6 +286,26 @@ private class V2alphaFlags {
   )
   lateinit var redirectUri: String
     private set
+
+  @CommandLine.Option(
+    names = ["--rate-limit-config-file"],
+    description =
+      [
+        "File path to RateLimitConfig protobuf message in text format.",
+        "The principal identifier is the authority key identifier of the client certificate in " +
+          "the format used by openssl-x509.",
+      ],
+    required = false,
+  )
+  private lateinit var rateLimitConfigFile: File
+
+  val rateLimitConfig: RateLimitConfig by lazy {
+    if (::rateLimitConfigFile.isInitialized) {
+      parseTextProto(rateLimitConfigFile, RateLimitConfig.getDefaultInstance())
+    } else {
+      DEFAULT_RATE_LIMIT_CONFIG
+    }
+  }
 
   lateinit var directNoiseMechanisms: List<NoiseMechanism>
     private set
@@ -307,5 +385,15 @@ private class V2alphaFlags {
       }
     }
     directNoiseMechanisms = noiseMechanisms
+  }
+
+  companion object {
+    private val DEFAULT_RATE_LIMIT_CONFIG = rateLimitConfig {
+      defaultRateLimit =
+        RateLimitConfigKt.rateLimit {
+          maximumRequestCount = -1 // Unlimited.
+          averageRequestRate = 1.0
+        }
+    }
   }
 }

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/service/api/v2alpha/AccountAuthenticationServerInterceptor.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/service/api/v2alpha/AccountAuthenticationServerInterceptor.kt
@@ -52,8 +52,7 @@ class AccountAuthenticationServerInterceptor(
   ): ServerCall.Listener<ReqT> {
     var context = Context.current()
     val idToken =
-      headers.get(AccountConstants.ID_TOKEN_METADATA_KEY)
-        ?: return Contexts.interceptCall(context, call, headers, next)
+      headers.get(AccountConstants.ID_TOKEN_METADATA_KEY) ?: return next.startCall(call, headers)
     context = context.withValue(AccountConstants.CONTEXT_ID_TOKEN_KEY, idToken)
 
     try {

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/service/api/v2alpha/BUILD.bazel
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/service/api/v2alpha/BUILD.bazel
@@ -58,7 +58,7 @@ kt_jvm_library(
         "//src/main/kotlin/org/wfanet/measurement/loadtest/measurementconsumer:__pkg__",
     ],
     deps = [
-        "//src/main/kotlin/org/wfanet/measurement/api:api_key_constants",
+        "//src/main/kotlin/org/wfanet/measurement/api:api_key_credentials",
         "//src/main/kotlin/org/wfanet/measurement/api/v2alpha:principal_server_interceptor",
         "//src/main/kotlin/org/wfanet/measurement/api/v2alpha:resource_key",
         "//src/main/kotlin/org/wfanet/measurement/common/identity",

--- a/src/main/proto/google/longrunning/BUILD.bazel
+++ b/src/main/proto/google/longrunning/BUILD.bazel
@@ -1,0 +1,8 @@
+load("@wfa_rules_kotlin_jvm//kotlin:defs.bzl", "kt_jvm_grpc_proto_library")
+
+package(default_visibility = ["//visibility:public"])
+
+kt_jvm_grpc_proto_library(
+    name = "operations_kt_jvm_grpc_proto",
+    deps = ["@com_google_googleapis//google/longrunning:operations_proto"],
+)

--- a/src/main/proto/wfa/measurement/config/BUILD.bazel
+++ b/src/main/proto/wfa/measurement/config/BUILD.bazel
@@ -26,3 +26,14 @@ kt_jvm_proto_library(
     name = "authority_key_to_principal_map_kt_jvm_proto",
     deps = [":authority_key_to_principal_map_proto"],
 )
+
+proto_library(
+    name = "rate_limit_config_proto",
+    srcs = ["rate_limit_config.proto"],
+    strip_import_prefix = IMPORT_PREFIX,
+)
+
+kt_jvm_proto_library(
+    name = "rate_limit_config_kt_jvm_proto",
+    deps = [":rate_limit_config_proto"],
+)

--- a/src/main/proto/wfa/measurement/config/rate_limit_config.proto
+++ b/src/main/proto/wfa/measurement/config/rate_limit_config.proto
@@ -1,0 +1,41 @@
+// Copyright 2025 The Cross-Media Measurement Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package wfa.measurement.config;
+
+option java_package = "org.wfanet.measurement.config";
+option java_multiple_files = true;
+
+message RateLimitConfig {
+  message RateLimit {
+    // Maximum number of requests at one time. A negative value means there is
+    // no rate limit.
+    int32 maximum_request_count = 1;
+    // Average number of requests per second.
+    double average_request_rate = 2;
+  }
+
+  // Default limit applied when there not a per-principal limit.
+  RateLimit default_rate_limit = 1;
+
+  // Map of full method name to cost of that method.
+  //
+  // If the cost is not specified here, it is assumed to be 1.
+  map<string, int32> method_cost = 2;
+
+  // Map of principal identifier to the rate limit for that principal.
+  map<string, RateLimit> per_principal_rate_limit = 3;
+}

--- a/src/test/kotlin/org/wfanet/measurement/common/grpc/BUILD.bazel
+++ b/src/test/kotlin/org/wfanet/measurement/common/grpc/BUILD.bazel
@@ -1,0 +1,19 @@
+load("@wfa_rules_kotlin_jvm//kotlin:defs.bzl", "kt_jvm_test")
+
+package(default_testonly = True)
+
+kt_jvm_test(
+    name = "PrincipalRateLimitingServerInterceptorTest",
+    srcs = ["PrincipalRateLimitingServerInterceptorTest.kt"],
+    test_class = "org.wfanet.measurement.common.grpc.PrincipalRateLimitingServerInterceptorTest",
+    deps = [
+        "//src/main/kotlin/org/wfanet/measurement/common/grpc:interceptors",
+        "//src/main/kotlin/org/wfanet/measurement/common/grpc:principal_rate_limiting_server_interceptor",
+        "//src/main/proto/google/longrunning:operations_kt_jvm_grpc_proto",
+        "@wfa_common_jvm//imports/java/com/google/common/truth",
+        "@wfa_common_jvm//imports/java/org/junit",
+        "@wfa_common_jvm//imports/kotlin/kotlin/test",
+        "@wfa_common_jvm//imports/kotlin/org/mockito/kotlin",
+        "@wfa_common_jvm//src/main/kotlin/org/wfanet/measurement/common/grpc/testing",
+    ],
+)

--- a/src/test/kotlin/org/wfanet/measurement/common/grpc/PrincipalRateLimitingServerInterceptorTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/common/grpc/PrincipalRateLimitingServerInterceptorTest.kt
@@ -1,0 +1,129 @@
+/*
+ * Copyright 2025 The Cross-Media Measurement Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wfanet.measurement.common.grpc
+
+import com.google.common.truth.Truth.assertThat
+import com.google.longrunning.CancelOperationRequest
+import com.google.longrunning.DeleteOperationRequest
+import com.google.longrunning.OperationsGrpc
+import com.google.longrunning.OperationsGrpcKt
+import com.google.protobuf.Empty
+import io.grpc.Status
+import io.grpc.StatusRuntimeException
+import kotlin.test.assertFailsWith
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.spy
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.verifyBlocking
+import org.mockito.kotlin.whenever
+import org.wfanet.measurement.common.grpc.testing.GrpcTestServerRule
+import org.wfanet.measurement.common.grpc.testing.mockService
+import org.wfanet.measurement.common.ratelimit.RateLimiter
+
+@RunWith(JUnit4::class)
+class PrincipalRateLimitingServerInterceptorTest {
+  private val serviceMock =
+    mockService<OperationsGrpcKt.OperationsCoroutineImplBase> {
+      onBlocking { cancelOperation(any()) } doReturn Empty.getDefaultInstance()
+      onBlocking { deleteOperation(any()) } doReturn Empty.getDefaultInstance()
+    }
+  private val createRateLimiterMock = mock<(principalIdentifier: String?) -> RateLimiter>()
+  private var principalIdentifier: String? = null
+  private val interceptor =
+    PrincipalRateLimitingServerInterceptor(
+      mapOf(OperationsGrpcKt.deleteOperationMethod.fullMethodName to DELETE_OPERATION_COST),
+      { principalIdentifier },
+      createRateLimiterMock,
+    )
+
+  @get:Rule
+  val testServer = GrpcTestServerRule { addService(serviceMock.withInterceptor(interceptor)) }
+
+  private lateinit var stub: OperationsGrpc.OperationsBlockingStub
+
+  @Before
+  fun initStub() {
+    stub = OperationsGrpc.newBlockingStub(testServer.channel)
+  }
+
+  @Test
+  fun `forwards call when not rate limited`() {
+    whenever(createRateLimiterMock.invoke(anyOrNull())).thenReturn(RateLimiter.Unlimited)
+
+    stub.cancelOperation(CancelOperationRequest.getDefaultInstance())
+
+    verifyBlocking(serviceMock, times(1)) {
+      cancelOperation(CancelOperationRequest.getDefaultInstance())
+    }
+  }
+
+  @Test
+  fun `closes call when rate limited`() {
+    whenever(createRateLimiterMock.invoke(anyOrNull())).thenReturn(RateLimiter.Blocked)
+
+    val exception =
+      assertFailsWith<StatusRuntimeException> {
+        stub.cancelOperation(CancelOperationRequest.getDefaultInstance())
+      }
+
+    assertThat(exception.status.code).isEqualTo(Status.Code.UNAVAILABLE)
+    verifyBlocking(serviceMock, never()) { cancelOperation(any()) }
+  }
+
+  @Test
+  fun `applies rate limit per principal`() {
+    whenever(createRateLimiterMock.invoke("alice")).thenReturn(RateLimiter.Unlimited)
+    whenever(createRateLimiterMock.invoke("bob")).thenReturn(RateLimiter.Blocked)
+
+    principalIdentifier = "alice"
+    stub.cancelOperation(CancelOperationRequest.getDefaultInstance())
+    stub.cancelOperation(CancelOperationRequest.getDefaultInstance())
+
+    principalIdentifier = "bob"
+    val exception =
+      assertFailsWith<StatusRuntimeException> {
+        stub.cancelOperation(CancelOperationRequest.getDefaultInstance())
+      }
+
+    assertThat(exception.status.code).isEqualTo(Status.Code.UNAVAILABLE)
+    verifyBlocking(serviceMock, times(2)) { cancelOperation(any()) }
+  }
+
+  @Test
+  fun `applies cost per method`() {
+    val rateLimiterSpy = spy(RateLimiter.Unlimited)
+    whenever(createRateLimiterMock.invoke(anyOrNull())).thenReturn(rateLimiterSpy)
+
+    stub.deleteOperation(DeleteOperationRequest.getDefaultInstance())
+
+    verify(rateLimiterSpy).tryAcquire(DELETE_OPERATION_COST)
+  }
+
+  companion object {
+    private const val DELETE_OPERATION_COST = 3
+  }
+}

--- a/src/test/kotlin/org/wfanet/measurement/common/ratelimit/BUILD.bazel
+++ b/src/test/kotlin/org/wfanet/measurement/common/ratelimit/BUILD.bazel
@@ -1,0 +1,15 @@
+load("@wfa_rules_kotlin_jvm//kotlin:defs.bzl", "kt_jvm_test")
+
+package(default_testonly = True)
+
+kt_jvm_test(
+    name = "TokenBucketTest",
+    srcs = ["TokenBucketTest.kt"],
+    test_class = "org.wfanet.measurement.common.ratelimit.TokenBucketTest",
+    deps = [
+        "//src/main/kotlin/org/wfanet/measurement/common/ratelimit:token_bucket",
+        "@wfa_common_jvm//imports/java/com/google/common/truth",
+        "@wfa_common_jvm//imports/java/org/junit",
+        "@wfa_common_jvm//imports/kotlin/kotlin/test",
+    ],
+)

--- a/src/test/kotlin/org/wfanet/measurement/common/ratelimit/TokenBucketTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/common/ratelimit/TokenBucketTest.kt
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2025 The Cross-Media Measurement Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wfanet.measurement.common.ratelimit
+
+import com.google.common.truth.Truth.assertThat
+import kotlin.test.assertFailsWith
+import kotlin.time.Duration.Companion.seconds
+import kotlin.time.TestTimeSource
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+
+@RunWith(JUnit4::class)
+class TokenBucketTest {
+  private val testTimeSource = TestTimeSource()
+
+  @Test
+  fun `tryAcquire returns permit up to size`() {
+    val size = 5
+    val tokenBucket = TokenBucket(size, 1.0, testTimeSource)
+
+    repeat(size) { assertThat(tokenBucket.tryAcquire()).isNotNull() }
+  }
+
+  @Test
+  fun `tryAcquire returns permit up to size when cost is specified`() {
+    val size = 5
+    val tokenBucket = TokenBucket(size, 1.0, testTimeSource)
+
+    assertThat(tokenBucket.tryAcquire(size)).isNotNull()
+  }
+
+  @Test
+  fun `tryAcquire returns null after tokens exhausted`() {
+    val size = 5
+    val tokenBucket = TokenBucket(size, 1.0, testTimeSource)
+    repeat(size) { tokenBucket.tryAcquire() }
+
+    assertThat(tokenBucket.tryAcquire()).isNull()
+  }
+
+  @Test
+  fun `tryAcquire returns null when cost exceeds token count`() {
+    val size = 5
+    val tokenBucket = TokenBucket(size, 1.0, testTimeSource)
+    tokenBucket.tryAcquire()
+
+    assertThat(tokenBucket.tryAcquire(size)).isNull()
+  }
+
+  @Test
+  fun `tryAcquire returns permit after token refill`() {
+    val size = 5
+    val tokenBucket = TokenBucket(size, 1.0, testTimeSource)
+    tokenBucket.tryAcquire(5)
+    testTimeSource += 1.seconds // Refill one token.
+
+    assertThat(tokenBucket.tryAcquire()).isNotNull()
+  }
+
+  @Test
+  fun `tryAcquire returns null after refilled tokens exhausted`() {
+    val size = 5
+    val tokenBucket = TokenBucket(size, 1.0, testTimeSource)
+    tokenBucket.tryAcquire(size)
+    testTimeSource += 1.seconds
+    tokenBucket.tryAcquire()
+
+    assertThat(tokenBucket.tryAcquire()).isNull()
+  }
+
+  @Test
+  fun `tryAcquire returns null after max refilled tokens exhausted`() {
+    val size = 5
+    val tokenBucket = TokenBucket(size, 1.0, testTimeSource)
+    tokenBucket.tryAcquire(size)
+    testTimeSource += 10.seconds // Refill tokens up to size.
+    repeat(size) {
+      assertThat(tokenBucket.tryAcquire()).isNotNull() // Consume all refilled tokens.
+    }
+
+    assertThat(tokenBucket.tryAcquire()).isNull()
+  }
+
+  @Test
+  fun `tryAcquire throws when cost is negative`() {
+    val tokenBucket = TokenBucket(5, 1.0, testTimeSource)
+
+    assertFailsWith<IllegalArgumentException> { tokenBucket.tryAcquire(-1) }
+  }
+
+  @Test
+  fun `constructor throws when size is negative `() {
+    assertFailsWith<IllegalArgumentException> { TokenBucket(-1, 1.0, testTimeSource) }
+  }
+
+  @Test
+  fun `constructor throws when fill rate is not positive`() {
+    assertFailsWith<IllegalArgumentException> { TokenBucket(5, 0.0, testTimeSource) }
+    assertFailsWith<IllegalArgumentException> { TokenBucket(5, -1.0, testTimeSource) }
+  }
+}


### PR DESCRIPTION
RELNOTES: The Kingdom public API server now supports rate limiting. This can be configured using the `--rate-limit-config-file` option. The rate limit is applied individually for each server instance and each client certificate authority key identifier.

Closes #2312 