### PR TITLE
fix: Use correct status codes for internal CreateModelLine errors

### DIFF
--- a/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/SpannerModelLinesService.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/SpannerModelLinesService.kt
@@ -26,6 +26,7 @@ import org.wfanet.measurement.common.grpc.failGrpc
 import org.wfanet.measurement.common.grpc.grpcRequire
 import org.wfanet.measurement.common.identity.ExternalId
 import org.wfanet.measurement.common.identity.IdGenerator
+import org.wfanet.measurement.common.toInstant
 import org.wfanet.measurement.gcloud.spanner.AsyncDatabaseClient
 import org.wfanet.measurement.internal.kingdom.EnumerateValidModelLinesRequest
 import org.wfanet.measurement.internal.kingdom.EnumerateValidModelLinesResponse
@@ -35,10 +36,12 @@ import org.wfanet.measurement.internal.kingdom.SetActiveEndTimeRequest
 import org.wfanet.measurement.internal.kingdom.SetModelLineHoldbackModelLineRequest
 import org.wfanet.measurement.internal.kingdom.StreamModelLinesRequest
 import org.wfanet.measurement.internal.kingdom.enumerateValidModelLinesResponse
+import org.wfanet.measurement.kingdom.deploy.gcloud.spanner.common.InvalidFieldValueException
 import org.wfanet.measurement.kingdom.deploy.gcloud.spanner.common.ModelLineInvalidArgsException
 import org.wfanet.measurement.kingdom.deploy.gcloud.spanner.common.ModelLineNotFoundException
 import org.wfanet.measurement.kingdom.deploy.gcloud.spanner.common.ModelLineTypeIllegalException
 import org.wfanet.measurement.kingdom.deploy.gcloud.spanner.common.ModelSuiteNotFoundException
+import org.wfanet.measurement.kingdom.deploy.gcloud.spanner.common.RequiredFieldNotSetException
 import org.wfanet.measurement.kingdom.deploy.gcloud.spanner.queries.StreamModelLines
 import org.wfanet.measurement.kingdom.deploy.gcloud.spanner.readers.ModelLineReader
 import org.wfanet.measurement.kingdom.deploy.gcloud.spanner.writers.CreateModelLine
@@ -52,25 +55,56 @@ class SpannerModelLinesService(
 ) : ModelLinesCoroutineImplBase() {
 
   override suspend fun createModelLine(request: ModelLine): ModelLine {
-    grpcRequire(request.hasActiveStartTime()) { "ActiveStartTime is missing." }
-    grpcRequire(request.type != ModelLine.Type.TYPE_UNSPECIFIED) {
-      "Unrecognized ModelLine's type ${request.type}"
+    val now = clock.instant()
+    if (!request.hasActiveStartTime()) {
+      throw RequiredFieldNotSetException("active_start_time")
+        .asStatusRuntimeException(Status.Code.INVALID_ARGUMENT)
     }
+    val activeStartTime = request.activeStartTime.toInstant()
+    if (activeStartTime <= now) {
+      throw InvalidFieldValueException("active_start_time") { fieldName ->
+          "$fieldName must be in the future"
+        }
+        .asStatusRuntimeException(Status.Code.INVALID_ARGUMENT)
+    }
+    if (request.hasActiveEndTime()) {
+      val activeEndTime = request.activeEndTime.toInstant()
+      if (activeEndTime < activeStartTime) {
+        throw InvalidFieldValueException("active_end_time") { fieldName ->
+            "$fieldName must be at least active_start_time"
+          }
+          .asStatusRuntimeException(Status.Code.INVALID_ARGUMENT)
+      }
+    }
+    if (request.externalHoldbackModelLineId != 0L && request.type != ModelLine.Type.PROD) {
+      throw InvalidFieldValueException("external_holdback_model_line_id") { fieldName ->
+          "$fieldName may only be specified when type is PROD"
+        }
+        .asStatusRuntimeException(Status.Code.INVALID_ARGUMENT)
+    }
+    @Suppress("WHEN_ENUM_CAN_BE_NULL_IN_JAVA") // Protobuf enum accessors cannot return null.
+    when (request.type) {
+      ModelLine.Type.DEV,
+      ModelLine.Type.HOLDBACK,
+      ModelLine.Type.PROD -> {}
+      ModelLine.Type.TYPE_UNSPECIFIED ->
+        throw RequiredFieldNotSetException("type")
+          .asStatusRuntimeException(Status.Code.INVALID_ARGUMENT)
+      ModelLine.Type.UNRECOGNIZED ->
+        throw InvalidFieldValueException("type") { fieldName ->
+            "Unrecognized value for $fieldName"
+          }
+          .asStatusRuntimeException(Status.Code.INVALID_ARGUMENT)
+    }
+
     try {
-      return CreateModelLine(request, clock).execute(client, idGenerator)
+      return CreateModelLine(request).execute(client, idGenerator)
     } catch (e: ModelSuiteNotFoundException) {
-      throw e.asStatusRuntimeException(Status.Code.NOT_FOUND, "ModelSuite not found.")
+      throw e.asStatusRuntimeException(Status.Code.NOT_FOUND)
+    } catch (e: ModelLineNotFoundException) {
+      throw e.asStatusRuntimeException(Status.Code.FAILED_PRECONDITION)
     } catch (e: ModelLineTypeIllegalException) {
-      throw e.asStatusRuntimeException(
-        Status.Code.INVALID_ARGUMENT,
-        e.message
-          ?: "Only ModelLines with type equal to 'PROD' can have a HoldbackModelLine having type equal to 'HOLDBACK'.",
-      )
-    } catch (e: ModelLineInvalidArgsException) {
-      throw e.asStatusRuntimeException(
-        Status.Code.INVALID_ARGUMENT,
-        e.message ?: "ActiveStartTime and/or ActiveEndTime is invalid.",
-      )
+      throw e.asStatusRuntimeException(Status.Code.FAILED_PRECONDITION)
     }
   }
 

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/common/KingdomInternalException.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/common/KingdomInternalException.kt
@@ -77,6 +77,14 @@ class RequiredFieldNotSetException(
     get() = mapOf("field_name" to fieldName)
 }
 
+class InvalidFieldValueException(
+  val fieldName: String,
+  provideDescription: (fieldName: String) -> String = { "Value of $fieldName is invalid" },
+) : KingdomInternalException(ErrorCode.INVALID_FIELD_VALUE, provideDescription(fieldName)) {
+  override val context: Map<String, String>
+    get() = mapOf("field_name" to fieldName)
+}
+
 class MeasurementConsumerNotFoundException(
   val externalMeasurementConsumerId: ExternalId,
   provideDescription: () -> String = { "MeasurementConsumer not found" },

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/service/api/v2alpha/InternalStatusConversion.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/service/api/v2alpha/InternalStatusConversion.kt
@@ -77,6 +77,10 @@ fun Status.toExternalStatusRuntimeException(
         put("fieldName", errorInfo.metadataMap.getValue("field_name"))
         Unit
       }
+      ErrorCode.INVALID_FIELD_VALUE -> {
+        put("fieldName", errorInfo.metadataMap.getValue("field_name"))
+        Unit
+      }
       ErrorCode.MEASUREMENT_NOT_FOUND -> {
         val measurementName =
           MeasurementKey(

--- a/src/main/proto/wfa/measurement/internal/kingdom/error_code.proto
+++ b/src/main/proto/wfa/measurement/internal/kingdom/error_code.proto
@@ -24,6 +24,8 @@ enum ErrorCode {
 
   /** A required field was not set. */
   REQUIRED_FIELD_NOT_SET = 45;
+  /** Field has invalid value. */
+  INVALID_FIELD_VALUE = 46;
   /** MeasurementConsumer resource queried could not be found. */
   MEASUREMENT_CONSUMER_NOT_FOUND = 1;
   /** DataProvider resource queried could not be found. */

--- a/src/test/kotlin/org/wfanet/measurement/kingdom/service/api/v2alpha/ModelLinesServiceTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/kingdom/service/api/v2alpha/ModelLinesServiceTest.kt
@@ -20,6 +20,7 @@ import com.google.common.truth.Truth.assertThat
 import com.google.common.truth.extensions.proto.ProtoTruth.assertThat
 import com.google.protobuf.Timestamp
 import com.google.protobuf.timestamp
+import com.google.rpc.errorInfo
 import com.google.type.interval
 import io.grpc.Status
 import io.grpc.StatusRuntimeException
@@ -70,6 +71,7 @@ import org.wfanet.measurement.common.identity.externalIdToApiId
 import org.wfanet.measurement.common.testing.captureFirst
 import org.wfanet.measurement.common.testing.verifyProtoArgument
 import org.wfanet.measurement.common.toProtoTime
+import org.wfanet.measurement.internal.kingdom.ErrorCode
 import org.wfanet.measurement.internal.kingdom.ModelLine as InternalModelLine
 import org.wfanet.measurement.internal.kingdom.ModelLine.Type as InternalType
 import org.wfanet.measurement.internal.kingdom.ModelLinesGrpcKt.ModelLinesCoroutineImplBase
@@ -84,6 +86,7 @@ import org.wfanet.measurement.internal.kingdom.modelLine as internalModelLine
 import org.wfanet.measurement.internal.kingdom.setActiveEndTimeRequest as internalsetActiveEndTimeRequest
 import org.wfanet.measurement.internal.kingdom.setModelLineHoldbackModelLineRequest as internalSetModelLineHoldbackModelLineRequest
 import org.wfanet.measurement.internal.kingdom.streamModelLinesRequest as internalStreamModelLinesRequest
+import org.wfanet.measurement.kingdom.deploy.gcloud.spanner.common.InvalidFieldValueException
 import org.wfanet.measurement.kingdom.deploy.gcloud.spanner.common.ModelLineInvalidArgsException
 import org.wfanet.measurement.kingdom.deploy.gcloud.spanner.common.ModelLineNotFoundException
 import org.wfanet.measurement.kingdom.deploy.gcloud.spanner.common.ModelLineTypeIllegalException
@@ -1055,16 +1058,13 @@ class ModelLinesServiceTest {
   }
 
   @Test
-  fun `createModelLine throws INVALID_ARGUMENT with model line name when model line args invalid`() {
+  fun `createModelLine throws INVALID_ARGUMENT when field has invalid value`() {
+    val fieldName = "active_start_time"
     internalModelLinesMock.stub {
       onBlocking { createModelLine(any()) }
         .thenThrow(
-          ModelLineInvalidArgsException(
-              ExternalId(EXTERNAL_MODEL_PROVIDER_ID),
-              ExternalId(EXTERNAL_MODEL_SUITE_ID),
-              ExternalId(EXTERNAL_MODEL_LINE_ID),
-            )
-            .asStatusRuntimeException(Status.Code.INVALID_ARGUMENT, "ModelLine args invalid")
+          InvalidFieldValueException(fieldName)
+            .asStatusRuntimeException(Status.Code.INVALID_ARGUMENT)
         )
     }
     val exception =
@@ -1081,7 +1081,14 @@ class ModelLinesServiceTest {
         }
       }
     assertThat(exception.status.code).isEqualTo(Status.Code.INVALID_ARGUMENT)
-    assertThat(exception.errorInfo?.metadataMap).containsEntry("modelLine", MODEL_LINE_NAME)
+    assertThat(exception.errorInfo)
+      .isEqualTo(
+        errorInfo {
+          domain = "halo.wfanet.org"
+          reason = ErrorCode.INVALID_FIELD_VALUE.name
+          metadata["fieldName"] = fieldName
+        }
+      )
   }
 
   @Test


### PR DESCRIPTION
This also moves request validation out of the DB writer and into the service implementation where it belongs.