### PR TITLE
test: Re-enable SpannerModelRolloutsServiceTest

### DIFF
--- a/src/test/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/BUILD.bazel
+++ b/src/test/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/BUILD.bazel
@@ -257,8 +257,6 @@ spanner_emulator_test(
 spanner_emulator_test(
     name = "SpannerModelRolloutsServiceTest",
     srcs = ["SpannerModelRolloutsServiceTest.kt"],
-    # TODO(world-federation-of-advertisers/cross-media-measurement#1368): Remove when flakiness is resolved.
-    flaky = True,
     test_class = "org.wfanet.measurement.kingdom.deploy.gcloud.spanner.SpannerModelRolloutsServiceTest",
     deps = [
         "//src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner:services",

--- a/src/test/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/SpannerModelRolloutsServiceTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/SpannerModelRolloutsServiceTest.kt
@@ -18,7 +18,6 @@ package org.wfanet.measurement.kingdom.deploy.gcloud.spanner
 
 import java.time.Clock
 import org.junit.ClassRule
-import org.junit.Ignore
 import org.junit.Rule
 import org.wfanet.measurement.common.identity.IdGenerator
 import org.wfanet.measurement.gcloud.spanner.testing.SpannerEmulatorDatabaseRule
@@ -26,7 +25,6 @@ import org.wfanet.measurement.gcloud.spanner.testing.SpannerEmulatorRule
 import org.wfanet.measurement.kingdom.deploy.gcloud.spanner.testing.Schemata
 import org.wfanet.measurement.kingdom.service.internal.testing.ModelRolloutsServiceTest
 
-@Ignore("https://github.com/world-federation-of-advertisers/cross-media-measurement/issues/1368")
 class SpannerModelRolloutsServiceTest : ModelRolloutsServiceTest<SpannerModelRolloutsService>() {
 
   @get:Rule


### PR DESCRIPTION
The performance issue introduced in #1076 was addressed in #2353 by applying a limit to the readLatestModelRolloutData query.

Closes #1368 