### PR TITLE
perf: Use stale reads for ListEventGroups

### DIFF
--- a/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/SpannerDataServices.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/SpannerDataServices.kt
@@ -16,6 +16,7 @@ package org.wfanet.measurement.kingdom.deploy.gcloud.spanner
 
 import com.google.protobuf.Descriptors
 import java.time.Clock
+import java.time.Duration
 import kotlin.coroutines.CoroutineContext
 import org.wfanet.measurement.common.identity.IdGenerator
 import org.wfanet.measurement.gcloud.spanner.AsyncDatabaseClient
@@ -27,6 +28,7 @@ class SpannerDataServices(
   private val idGenerator: IdGenerator,
   private val client: AsyncDatabaseClient,
   override val knownEventGroupMetadataTypes: Iterable<Descriptors.FileDescriptor> = emptyList(),
+  private val maxEventGroupReadStaleness: Duration = Duration.ofSeconds(1L),
 ) : DataServices {
   override fun buildDataServices(coroutineContext: CoroutineContext): KingdomDataServices {
     return KingdomDataServices(
@@ -41,7 +43,7 @@ class SpannerDataServices(
         knownEventGroupMetadataTypes,
         coroutineContext,
       ),
-      SpannerEventGroupsService(idGenerator, client, coroutineContext),
+      SpannerEventGroupsService(idGenerator, client, maxEventGroupReadStaleness, coroutineContext),
       SpannerMeasurementConsumersService(idGenerator, client, coroutineContext),
       SpannerMeasurementsService(idGenerator, client, coroutineContext),
       SpannerPublicKeysService(idGenerator, client, coroutineContext),

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/service/api/v2alpha/EventGroupsService.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/service/api/v2alpha/EventGroupsService.kt
@@ -424,6 +424,7 @@ class EventGroupsService(
     pageToken: ListEventGroupsPageToken?,
   ): StreamEventGroupsRequest {
     return streamEventGroupsRequest {
+      allowStaleReads = true
       this.filter =
         InternalStreamEventGroupsRequests.filter {
           if (parentKey is DataProviderKey) {

--- a/src/main/proto/wfa/measurement/internal/kingdom/event_groups_service.proto
+++ b/src/main/proto/wfa/measurement/internal/kingdom/event_groups_service.proto
@@ -115,6 +115,9 @@ message StreamEventGroupsRequest {
   }
   // How results should be ordered.
   OrderBy order_by = 3;
+
+  // Whether to allow stale rather than strong reads.
+  bool allow_stale_reads = 4;
 }
 
 message EventGroupKey {

--- a/src/test/kotlin/org/wfanet/measurement/kingdom/service/api/v2alpha/EventGroupsServiceTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/kingdom/service/api/v2alpha/EventGroupsServiceTest.kt
@@ -974,6 +974,7 @@ class EventGroupsServiceTest {
           filter =
             StreamEventGroupsRequestKt.filter { externalDataProviderId = DATA_PROVIDER_EXTERNAL_ID }
           limit = request.pageSize + 1
+          allowStaleReads = true
         }
       )
   }
@@ -1019,6 +1020,7 @@ class EventGroupsServiceTest {
               descending = true
             }
           limit = request.pageSize + 1
+          allowStaleReads = true
         }
       )
   }
@@ -1066,6 +1068,7 @@ class EventGroupsServiceTest {
               metadataSearchQuery = request.filter.metadataSearchQuery
             }
           limit = request.pageSize + 1
+          allowStaleReads = true
         }
       )
     val nextPageToken = ListEventGroupsPageToken.parseFrom(response.nextPageToken.base64UrlDecode())
@@ -1150,6 +1153,7 @@ class EventGroupsServiceTest {
               // available for at least one release.
               eventGroupKeyAfter = after.eventGroupKey
             }
+          allowStaleReads = true
         }
       )
 


### PR DESCRIPTION
RELNOTES: The Kingdom internal API server has a new `--max-event-group-read-staleness` option that can be used to configure the maximum staleness for stale reads of EventGroups.