### PR TITLE
refactor: Use UpdateTime only for tracking reads for Operational Metrics

### DIFF
--- a/src/main/proto/wfa/measurement/internal/kingdom/bigquerytables/operational_metrics_dataset.proto
+++ b/src/main/proto/wfa/measurement/internal/kingdom/bigquerytables/operational_metrics_dataset.proto
@@ -99,24 +99,24 @@ message ComputationParticipantStagesTableRow {
 }
 
 message LatestMeasurementReadTableRow {
+  reserved 2, 3;
+
   // Since BigQuery timestamp is microsecond precision, this is in nanoseconds
   // and is stored as an integer.
   int64 update_time = 1;
-  int64 external_measurement_consumer_id = 2;
-  int64 external_measurement_id = 3;
 }
 
 message LatestRequisitionReadTableRow {
+  reserved 2, 3;
+
   // Since BigQuery timestamp is microsecond precision, this is in nanoseconds
   // and is stored as an integer.
   int64 update_time = 1;
-  int64 external_data_provider_id = 2;
-  int64 external_requisition_id = 3;
 }
 
 message LatestComputationReadTableRow {
+  reserved 2;
   // Since BigQuery timestamp is microsecond precision, this is in nanoseconds
   // and is stored as an integer.
   int64 update_time = 1;
-  int64 external_computation_id = 2;
 }

--- a/src/main/terraform/gcloud/modules/kingdom/main.tf
+++ b/src/main/terraform/gcloud/modules/kingdom/main.tf
@@ -292,16 +292,6 @@ resource "google_bigquery_table" "latest_measurement_read" {
     "name": "update_time",
     "type": "INTEGER",
     "mode": "REQUIRED"
-  },
-  {
-    "name": "external_measurement_consumer_id",
-    "type": "INTEGER",
-    "mode": "REQUIRED"
-  },
-  {
-    "name": "external_measurement_id",
-    "type": "INTEGER",
-    "mode": "REQUIRED"
   }
 ]
 EOF
@@ -323,16 +313,6 @@ resource "google_bigquery_table" "latest_requisition_read" {
 [
   {
     "name": "update_time",
-    "type": "INTEGER",
-    "mode": "REQUIRED"
-  },
-  {
-    "name": "external_data_provider_id",
-    "type": "INTEGER",
-    "mode": "REQUIRED"
-  },
-  {
-    "name": "external_requisition_id",
     "type": "INTEGER",
     "mode": "REQUIRED"
   }
@@ -358,12 +338,6 @@ resource "google_bigquery_table" "latest_computation_read" {
     "name": "update_time",
     "type": "INTEGER",
     "mode": "REQUIRED"
-  },
-  {
-    "name": "external_computation_id",
-    "type": "INTEGER",
-    "mode": "REQUIRED",
-    "defaultValueExpression": "0"
   }
 ]
 EOF


### PR DESCRIPTION
Currently, Operational Metrics uses all the page token fields for tracking reads, but that isn't stable.