### PR TITLE
fix: remove event group sync iam binding

### DIFF
--- a/src/main/terraform/gcloud/cmms/edp_aggregator.tf
+++ b/src/main/terraform/gcloud/cmms/edp_aggregator.tf
@@ -125,6 +125,7 @@ module "edp_aggregator" {
   requisition_fetcher_service_account_name  = "edpa-requisition-fetcher"
   event_group_sync_service_account_name     = "edpa-event-group-sync"
   event_group_sync_function_name            = "event-group-sync"
+  event_group_sync_function_location        = data.google_client_config.default.region
   edpa_tee_app_tls_key                      = local.edpa_tee_app_tls_key
   edpa_tee_app_tls_pem                      = local.edpa_tee_app_tls_pem
   data_watcher_tls_key                      = local.data_watcher_tls_key

--- a/src/main/terraform/gcloud/modules/edp-aggregator/main.tf
+++ b/src/main/terraform/gcloud/modules/edp-aggregator/main.tf
@@ -253,17 +253,3 @@ resource "google_storage_bucket_iam_binding" "aggregator_storage_admin" {
     "serviceAccount:${module.event_group_sync_function_service_account.cloud_function_service_account.email}",
   ]
 }
-
-resource "google_cloudfunctions2_function" "event_group_sync" {
-  name        = var.event_group_sync_function_name
-  location    = var.event_group_sync_function_location
-  build_config {
-    runtime     = "java17"
-  }
- }
-
-resource "google_cloud_run_service_iam_member" "event_group_sync_invoker" {
-  service  = var.event_group_sync_function_name
-  role     = "roles/run.invoker"
-  member   = "serviceAccount:${module.data_watcher_function_service_accounts.cloud_function_service_account.email}"
-}

--- a/src/main/terraform/gcloud/modules/edp-aggregator/main.tf
+++ b/src/main/terraform/gcloud/modules/edp-aggregator/main.tf
@@ -254,6 +254,11 @@ resource "google_storage_bucket_iam_binding" "aggregator_storage_admin" {
   ]
 }
 
+resource "google_cloudfunctions2_function" "event_group_sync" {
+  name        = var.event_group_sync_function_name
+  location    = var.event_group_sync_function_location
+ }
+
 resource "google_cloud_run_service_iam_member" "event_group_sync_invoker" {
   service  = var.event_group_sync_function_name
   role     = "roles/run.invoker"

--- a/src/main/terraform/gcloud/modules/edp-aggregator/main.tf
+++ b/src/main/terraform/gcloud/modules/edp-aggregator/main.tf
@@ -257,6 +257,9 @@ resource "google_storage_bucket_iam_binding" "aggregator_storage_admin" {
 resource "google_cloudfunctions2_function" "event_group_sync" {
   name        = var.event_group_sync_function_name
   location    = var.event_group_sync_function_location
+  build_config {
+    runtime     = "java17"
+  }
  }
 
 resource "google_cloud_run_service_iam_member" "event_group_sync_invoker" {

--- a/src/main/terraform/gcloud/modules/edp-aggregator/variables.tf
+++ b/src/main/terraform/gcloud/modules/edp-aggregator/variables.tf
@@ -193,3 +193,9 @@ variable "event_group_sync_function_name" {
   type        = string
   nullable    = false
 }
+
+variable "event_group_sync_function_location" {
+  description = "The location of the EventGroupSync cloud function."
+  type        = string
+  nullable    = false
+}


### PR DESCRIPTION
The Event Group Sync Cloud Function is deployed via the `deploy_edp_aggregator_cloud_functions` workflow using a gcloud command.

Terraform was previously attempting to assign the `roles/run.invoker `permission to the Data Watcher service account for this function, but failed because the function does not yet exist at the time of the Terraform run.

This PR removes the IAM binding from Terraform to prevent the failure. The binding will be applied separately using a gcloud command in a follow-up PR.