### PR TITLE
feat: Add CLI tools for manual load testing of EventGroup reads and writes

### DIFF
--- a/src/main/kotlin/org/wfanet/measurement/loadtest/dataprovider/tools/BUILD.bazel
+++ b/src/main/kotlin/org/wfanet/measurement/loadtest/dataprovider/tools/BUILD.bazel
@@ -1,0 +1,52 @@
+load("@rules_java//java:defs.bzl", "java_binary")
+load("@wfa_rules_kotlin_jvm//kotlin:defs.bzl", "kt_jvm_library")
+
+kt_jvm_library(
+    name = "latency_stats",
+    srcs = ["LatencyStats.kt"],
+    visibility = ["//visibility:private"],
+    deps = [
+        "@wfa_common_jvm//imports/java/com/google/common:guava",
+    ],
+)
+
+kt_jvm_library(
+    name = "write_event_groups",
+    srcs = ["WriteEventGroups.kt"],
+    deps = [
+        "//src/main/kotlin/org/wfanet/measurement/common/throttler:maximum_rate_throttler",
+        "//src/main/proto/wfa/measurement/api/v2alpha:event_groups_service_kt_jvm_grpc_proto",
+        "@wfa_common_jvm//imports/java/picocli",
+        "@wfa_common_jvm//imports/kotlin/kotlinx/coroutines:core",
+        "@wfa_common_jvm//src/main/kotlin/org/wfanet/measurement/common",
+        "@wfa_common_jvm//src/main/kotlin/org/wfanet/measurement/common/crypto:signing_certs",
+        "@wfa_common_jvm//src/main/kotlin/org/wfanet/measurement/common/grpc",
+    ],
+)
+
+java_binary(
+    name = "WriteEventGroups",
+    main_class = "org.wfanet.measurement.loadtest.dataprovider.tools.WriteEventGroups",
+    runtime_deps = [":write_event_groups"],
+)
+
+kt_jvm_library(
+    name = "read_event_groups",
+    srcs = ["ReadEventGroups.kt"],
+    deps = [
+        ":latency_stats",
+        "//src/main/kotlin/org/wfanet/measurement/common/throttler:maximum_rate_throttler",
+        "//src/main/proto/wfa/measurement/reporting/v2alpha:event_groups_service_kt_jvm_grpc_proto",
+        "@wfa_common_jvm//imports/java/picocli",
+        "@wfa_common_jvm//imports/kotlin/kotlinx/coroutines:core",
+        "@wfa_common_jvm//src/main/kotlin/org/wfanet/measurement/common",
+        "@wfa_common_jvm//src/main/kotlin/org/wfanet/measurement/common/crypto:signing_certs",
+        "@wfa_common_jvm//src/main/kotlin/org/wfanet/measurement/common/grpc",
+    ],
+)
+
+java_binary(
+    name = "ReadEventGroups",
+    main_class = "org.wfanet.measurement.loadtest.dataprovider.tools.ReadEventGroups",
+    runtime_deps = [":read_event_groups"],
+)

--- a/src/main/kotlin/org/wfanet/measurement/loadtest/dataprovider/tools/LatencyStats.kt
+++ b/src/main/kotlin/org/wfanet/measurement/loadtest/dataprovider/tools/LatencyStats.kt
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2026 The Cross-Media Measurement Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wfanet.measurement.loadtest.dataprovider.tools
+
+import com.google.common.math.Quantiles
+import com.google.common.math.Stats
+import java.io.PrintStream
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.milliseconds
+
+data class LatencyStats(
+  val count: Int,
+  val mean: Duration,
+  val standardDeviation: Duration,
+  val p50: Duration,
+  val p95: Duration,
+) {
+  fun print(printStream: PrintStream) {
+    with(printStream) {
+      println("Latency stats")
+      println("Count: $count")
+      println("Mean: $mean")
+      println("Standard deviation: $standardDeviation")
+      println("50th percentile: $p50")
+      println("95th percentile: $p95")
+    }
+  }
+}
+
+class LatencyStatsAccumulator {
+  private val latenciesMillis = mutableListOf<Double>()
+
+  fun record(value: Duration) {
+    latenciesMillis.add(value.inWholeMilliseconds.toDouble())
+  }
+
+  fun snapshot(): LatencyStats {
+    val latenciesArray = latenciesMillis.toDoubleArray()
+    val stats = Stats.of(*latenciesArray)
+    val mean: Duration = stats.mean().milliseconds
+    val standardDeviation: Duration = stats.populationStandardDeviation().milliseconds
+    val p50: Duration =
+      Quantiles.percentiles().index(50).computeInPlace(*latenciesArray).milliseconds
+    val p95: Duration =
+      Quantiles.percentiles().index(95).computeInPlace(*latenciesArray).milliseconds
+
+    return LatencyStats(latenciesArray.size, mean, standardDeviation, p50, p95)
+  }
+}

--- a/src/main/kotlin/org/wfanet/measurement/loadtest/dataprovider/tools/ReadEventGroups.kt
+++ b/src/main/kotlin/org/wfanet/measurement/loadtest/dataprovider/tools/ReadEventGroups.kt
@@ -1,0 +1,176 @@
+/*
+ * Copyright 2025 The Cross-Media Measurement Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wfanet.measurement.loadtest.dataprovider.tools
+
+import io.grpc.ManagedChannel
+import io.grpc.StatusException
+import io.grpc.serviceconfig.copy
+import java.time.Duration
+import kotlin.properties.Delegates
+import kotlin.system.exitProcess
+import kotlin.time.TimeSource
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.runBlocking
+import org.wfanet.measurement.common.commandLineMain
+import org.wfanet.measurement.common.crypto.SigningCerts
+import org.wfanet.measurement.common.grpc.ProtobufServiceConfig
+import org.wfanet.measurement.common.grpc.TlsFlags
+import org.wfanet.measurement.common.grpc.buildMutualTlsChannel
+import org.wfanet.measurement.common.throttler.MaximumRateThrottler
+import org.wfanet.measurement.common.toProtoDuration
+import org.wfanet.measurement.reporting.v2alpha.EventGroupsGrpcKt
+import org.wfanet.measurement.reporting.v2alpha.ListEventGroupsRequest
+import org.wfanet.measurement.reporting.v2alpha.ListEventGroupsRequestKt
+import org.wfanet.measurement.reporting.v2alpha.ListEventGroupsResponse
+import org.wfanet.measurement.reporting.v2alpha.MediaType
+import org.wfanet.measurement.reporting.v2alpha.listEventGroupsRequest
+import picocli.CommandLine
+
+/**
+ * Tool for load testing by reading [org.wfanet.measurement.reporting.v2alpha.EventGroup] resources.
+ */
+@CommandLine.Command(name = "ReadEventGroups", subcommands = [CommandLine.HelpCommand::class])
+class ReadEventGroups private constructor() : Runnable {
+  @CommandLine.Option(names = ["--reporting-public-api-target"], required = true)
+  private lateinit var reportingPublicApiTarget: String
+
+  @CommandLine.Option(names = ["--reporting-public-api-cert-host"], required = false)
+  private var reportingPublicApiCertHost: String? = null
+
+  @CommandLine.Mixin private lateinit var tlsFlags: TlsFlags
+
+  @set:CommandLine.Option(names = ["--max-qps"], required = false, defaultValue = "10")
+  private var maxQps: Double by Delegates.notNull()
+
+  @CommandLine.Option(names = ["--rpc-timeout"], required = false, defaultValue = "10s")
+  private lateinit var rpcTimeout: Duration
+
+  private lateinit var throttler: MaximumRateThrottler
+  private lateinit var eventGroupsStub: EventGroupsGrpcKt.EventGroupsCoroutineStub
+
+  private fun init() {
+    throttler = MaximumRateThrottler(maxQps)
+
+    val clientCerts =
+      SigningCerts.fromPemFiles(
+        tlsFlags.certFile,
+        tlsFlags.privateKeyFile,
+        tlsFlags.certCollectionFile,
+      )
+    val serviceConfig =
+      ProtobufServiceConfig.DEFAULT.copy {
+        methodConfig[0] = methodConfig[0].copy { timeout = rpcTimeout.toProtoDuration() }
+      }
+    val apiChannel: ManagedChannel =
+      buildMutualTlsChannel(
+        reportingPublicApiTarget,
+        clientCerts,
+        hostName = reportingPublicApiCertHost,
+        defaultServiceConfig = serviceConfig,
+      )
+    eventGroupsStub = EventGroupsGrpcKt.EventGroupsCoroutineStub(apiChannel)
+  }
+
+  override fun run() {
+    CommandLine.usage(this, System.err)
+    exitProcess(1)
+  }
+
+  @CommandLine.Command(name = "list", description = ["Calls ListEventGroups until interrupted"])
+  private fun list(
+    @CommandLine.Option(names = ["--parent"], required = true) parent: String,
+    @CommandLine.Option(names = ["--media-type"]) mediaTypes: Set<MediaType>,
+    @CommandLine.Option(names = ["--metadata-search-query"], defaultValue = "")
+    metadataSearchQuery: String,
+    @CommandLine.Option(names = ["--page-token"], required = false, defaultValue = "")
+    pageToken: String,
+    @CommandLine.Option(names = ["--legacy"], required = false, defaultValue = "false")
+    legacy: Boolean,
+  ) {
+    init()
+
+    runBlocking {
+      val latencies = flow {
+        while (coroutineContext.isActive) {
+          val request = listEventGroupsRequest {
+            this.parent = parent
+            this.pageToken = pageToken
+            if (legacy) {
+              val terms = buildList {
+                if (mediaTypes.isNotEmpty()) {
+                  add(mediaTypes.joinToString(" || ") { "${it.number} in media_types" })
+                }
+                if (metadataSearchQuery.isNotEmpty()) {
+                  add(
+                    "$BRAND_NAME_FIELD.contains(\"$metadataSearchQuery\") || " +
+                      "$CAMPAIGN_NAME_FIELD).contains(\"$metadataSearchQuery\")"
+                  )
+                }
+              }
+              filter = terms.joinToString(" && ") { "($it)" }
+            } else {
+              orderBy =
+                ListEventGroupsRequestKt.orderBy {
+                  field = ListEventGroupsRequest.OrderBy.Field.DATA_AVAILABILITY_START_TIME
+                  descending = true
+                }
+              structuredFilter =
+                ListEventGroupsRequestKt.filter {
+                  mediaTypesIntersect += mediaTypes
+                  this.metadataSearchQuery = metadataSearchQuery
+                }
+            }
+          }
+
+          throttler.acquire()
+          val start = TimeSource.Monotonic.markNow()
+          try {
+            val response: ListEventGroupsResponse = eventGroupsStub.listEventGroups(request)
+            System.err.println(
+              "Received ${response.eventGroupsCount} EventGroups. " +
+                "Next page token: ${response.nextPageToken}"
+            )
+            emit(start.elapsedNow())
+          } catch (e: StatusException) {
+            throw Exception("Error listing EventGroups", e)
+          }
+        }
+      }
+
+      // Print stats even if SIGINT is sent to interrupt the process.
+      val latencyStatsAccumulator = LatencyStatsAccumulator()
+      Runtime.getRuntime()
+        .addShutdownHook(
+          object : Thread() {
+            override fun run() {
+              latencyStatsAccumulator.snapshot().print(System.err)
+            }
+          }
+        )
+      latencies.collect { latencyStatsAccumulator.record(it) }
+    }
+  }
+
+  companion object {
+    private const val CAMPAIGN_METADATA_FIELD = "event_group_metadata.ad_metadata.campaign_metadata"
+    private const val BRAND_NAME_FIELD = "$CAMPAIGN_METADATA_FIELD.brand_name"
+    private const val CAMPAIGN_NAME_FIELD = "$CAMPAIGN_METADATA_FIELD.campaign_name"
+
+    @JvmStatic fun main(args: Array<String>) = commandLineMain(ReadEventGroups(), args)
+  }
+}

--- a/src/main/kotlin/org/wfanet/measurement/loadtest/dataprovider/tools/WriteEventGroups.kt
+++ b/src/main/kotlin/org/wfanet/measurement/loadtest/dataprovider/tools/WriteEventGroups.kt
@@ -1,0 +1,353 @@
+/*
+ * Copyright 2025 The Cross-Media Measurement Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wfanet.measurement.loadtest.dataprovider.tools
+
+import com.google.type.interval
+import io.grpc.ManagedChannel
+import io.grpc.StatusException
+import io.grpc.serviceconfig.copy
+import java.io.PrintStream
+import java.time.Duration
+import java.time.Instant
+import java.time.temporal.ChronoUnit
+import kotlin.properties.Delegates
+import kotlin.system.exitProcess
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.sync.Semaphore
+import org.wfanet.measurement.api.v2alpha.EventGroup
+import org.wfanet.measurement.api.v2alpha.EventGroupKt
+import org.wfanet.measurement.api.v2alpha.EventGroupMetadata
+import org.wfanet.measurement.api.v2alpha.EventGroupMetadataKt
+import org.wfanet.measurement.api.v2alpha.EventGroupsGrpcKt
+import org.wfanet.measurement.api.v2alpha.MediaType
+import org.wfanet.measurement.api.v2alpha.createEventGroupRequest
+import org.wfanet.measurement.api.v2alpha.deleteEventGroupRequest
+import org.wfanet.measurement.api.v2alpha.eventGroup
+import org.wfanet.measurement.api.v2alpha.eventGroupMetadata
+import org.wfanet.measurement.api.v2alpha.updateEventGroupRequest
+import org.wfanet.measurement.common.crypto.SigningCerts
+import org.wfanet.measurement.common.grpc.ProtobufServiceConfig
+import org.wfanet.measurement.common.grpc.TlsFlags
+import org.wfanet.measurement.common.grpc.buildMutualTlsChannel
+import org.wfanet.measurement.common.throttler.MaximumRateThrottler
+import org.wfanet.measurement.common.toDuration
+import org.wfanet.measurement.common.toProtoDuration
+import org.wfanet.measurement.common.toProtoTime
+import picocli.CommandLine
+
+/** Tool for load testing by writing [EventGroup] resources. */
+@CommandLine.Command(name = "WriteEventGroups", subcommands = [CommandLine.HelpCommand::class])
+class WriteEventGroups private constructor() : Runnable {
+  @CommandLine.Option(names = ["--kingdom-public-api-target"], required = true)
+  private lateinit var kingdomPublicApiTarget: String
+
+  @CommandLine.Option(names = ["--kingdom-public-api-cert-host"], required = false)
+  private var kingdomPublicApiCertHost: String? = null
+
+  @CommandLine.Mixin private lateinit var tlsFlags: TlsFlags
+
+  @CommandLine.Option(names = ["--measurement-consumer"], required = true)
+  private lateinit var measurementConsumerName: String
+
+  @set:CommandLine.Option(names = ["--max-qps"], required = false, defaultValue = "10")
+  private var maxQps: Double by Delegates.notNull()
+
+  @set:CommandLine.Option(
+    names = ["--parallelism"],
+    description = ["Maximum number of in-flight requests"],
+    required = false,
+    defaultValue = "10",
+  )
+  private var parallelism: Int by Delegates.notNull()
+
+  @CommandLine.Option(names = ["--rpc-timeout"], required = false, defaultValue = "10s")
+  private lateinit var rpcTimeout: Duration
+
+  @CommandLine.Spec private lateinit var commandSpec: CommandLine.Model.CommandSpec
+
+  private lateinit var throttler: MaximumRateThrottler
+  private lateinit var semaphore: Semaphore
+  private lateinit var dispatcher: CoroutineDispatcher
+  private lateinit var eventGroupsStub: EventGroupsGrpcKt.EventGroupsCoroutineStub
+
+  private fun init() {
+    commandSpec.commandLine().setUseSimplifiedAtFiles(true)
+    throttler = MaximumRateThrottler(maxQps)
+    dispatcher = Dispatchers.IO.limitedParallelism(parallelism)
+    semaphore = Semaphore(parallelism)
+
+    val clientCerts =
+      SigningCerts.fromPemFiles(
+        tlsFlags.certFile,
+        tlsFlags.privateKeyFile,
+        tlsFlags.certCollectionFile,
+      )
+    val serviceConfig =
+      ProtobufServiceConfig.DEFAULT.copy {
+        methodConfig[0] = methodConfig[0].copy { timeout = rpcTimeout.toProtoDuration() }
+      }
+    val apiChannel: ManagedChannel =
+      buildMutualTlsChannel(
+        kingdomPublicApiTarget,
+        clientCerts,
+        hostName = kingdomPublicApiCertHost,
+        defaultServiceConfig = serviceConfig,
+      )
+    eventGroupsStub = EventGroupsGrpcKt.EventGroupsCoroutineStub(apiChannel)
+  }
+
+  override fun run() {
+    CommandLine.usage(this, System.err)
+    exitProcess(1)
+  }
+
+  @CommandLine.Command(name = "create")
+  private fun create(
+    @CommandLine.Option(names = ["--parent"], required = true) parent: String,
+    @CommandLine.Option(names = ["--count"], required = true) count: Int,
+    @CommandLine.ArgGroup(multiplicity = "1..*", exclusive = false)
+    campaignOptions: List<CampaignOptions>,
+  ) {
+    init()
+    // Print the options for an update command so it can be passed in using @file syntax. This is
+    // also useful to keep track of what was created so it can be easily deleted.
+    printUpdateOptions()
+
+    runBlocking {
+      repeat(count) { index ->
+        val request = createEventGroupRequest {
+          this.parent = parent
+          eventGroup = eventGroup {
+            fillEventGroup(index, campaignOptions.flatMap { it.toMetadata() })
+          }
+        }
+
+        semaphore.acquire()
+        throttler.acquire()
+        launch(dispatcher) {
+          try {
+            val response: EventGroup = eventGroupsStub.createEventGroup(request)
+            println("--event-group=${response.name}")
+          } finally {
+            semaphore.release()
+          }
+        }
+      }
+    }
+  }
+
+  private inline fun looping(loop: Boolean, action: () -> Unit) {
+    if (loop) {
+      while (true) {
+        action()
+      }
+    } else {
+      action()
+    }
+  }
+
+  @CommandLine.Command(name = "update")
+  private fun update(
+    @CommandLine.ArgGroup(multiplicity = "1..*", exclusive = false)
+    campaignOptions: List<CampaignOptions>,
+    @CommandLine.Option(names = ["--event-group"], required = true) eventGroupNames: List<String>,
+    @CommandLine.Option(names = ["--loop"], required = false, defaultValue = "false") loop: Boolean,
+  ) {
+    init()
+
+    looping(loop) {
+      runBlocking {
+        eventGroupNames.forEachIndexed { index, eventGroupName ->
+          val request = updateEventGroupRequest {
+            eventGroup = eventGroup {
+              name = eventGroupName
+              fillEventGroup(index, campaignOptions.flatMap { it.toMetadata() })
+            }
+          }
+          val referenceId: String = request.eventGroup.eventGroupReferenceId
+
+          semaphore.acquire()
+          throttler.acquire()
+          launch(dispatcher) {
+            try {
+              eventGroupsStub.updateEventGroup(request)
+              System.err.println("Updated $eventGroupName with reference ID $referenceId")
+            } catch (e: StatusException) {
+              val message = "Error updating $eventGroupName with reference ID $referenceId"
+              if (loop) {
+                System.err.println(message)
+                System.err.println(e)
+              } else {
+                throw Exception(message, e)
+              }
+            } finally {
+              semaphore.release()
+            }
+          }
+        }
+      }
+    }
+  }
+
+  @CommandLine.Command(
+    name = "update-single",
+    description = ["Updates the same event group repeatedly"],
+  )
+  private fun updateSingle(
+    @CommandLine.Option(names = ["--event-group"], required = true) eventGroupName: String,
+    @CommandLine.Option(names = ["--count"], required = true) count: Int,
+    @CommandLine.ArgGroup(multiplicity = "1..*", exclusive = false)
+    campaignOptions: List<CampaignOptions>,
+  ) {
+    init()
+
+    runBlocking {
+      repeat(count) { index ->
+        val request = updateEventGroupRequest {
+          eventGroup = eventGroup {
+            name = eventGroupName
+            fillEventGroup(index, campaignOptions.flatMap { it.toMetadata() })
+          }
+        }
+
+        semaphore.acquire()
+        throttler.acquire()
+        launch(dispatcher) {
+          try {
+            System.err.println("Updating $eventGroupName in thread ${Thread.currentThread().name}")
+            eventGroupsStub.updateEventGroup(request)
+            System.err.println("Updated $eventGroupName")
+          } finally {
+            semaphore.release()
+          }
+        }
+      }
+    }
+  }
+
+  @CommandLine.Command(name = "delete")
+  private fun delete(
+    @CommandLine.Option(names = ["--event-group"], required = true) eventGroupNames: List<String>
+  ) {
+    init()
+
+    runBlocking {
+      for (eventGroupName in eventGroupNames) {
+        val request = deleteEventGroupRequest { name = eventGroupName }
+
+        semaphore.acquire()
+        throttler.acquire()
+        launch(dispatcher) {
+          try {
+            eventGroupsStub.deleteEventGroup(request)
+            System.err.println("Deleted $eventGroupName")
+          } finally {
+            semaphore.release()
+          }
+        }
+      }
+    }
+  }
+
+  private fun PrintStream.printArgs(
+    parseResult: CommandLine.ParseResult,
+    excluded: List<String> = emptyList(),
+    swappedCommands: Map<String, String> = emptyMap(),
+  ) {
+    for (option: CommandLine.Model.OptionSpec in parseResult.matchedOptionsSet()) {
+      for (value: String in option.originalStringValues()) {
+        val name = option.longestName()
+        if (name in excluded) {
+          continue
+        }
+        println("$name=$value")
+      }
+    }
+
+    if (parseResult.hasSubcommand()) {
+      val subcommand: CommandLine.ParseResult = parseResult.subcommand()
+      val name = subcommand.commandSpec().name()
+
+      println(swappedCommands.getOrDefault(name, name))
+      printArgs(subcommand, excluded, swappedCommands)
+    }
+  }
+
+  private fun printUpdateOptions() {
+    System.out.printArgs(
+      commandSpec.commandLine().parseResult,
+      listOf("--count", "--parent"),
+      mapOf("create" to "update"),
+    )
+  }
+
+  private fun EventGroupKt.Dsl.fillEventGroup(index: Int, allMetadata: List<EventGroupMetadata>) {
+    val now = Instant.now()
+
+    measurementConsumer = measurementConsumerName
+    eventGroupReferenceId = "$REFERENCE_ID_PREFIX-$index"
+    mediaTypes += MediaType.VIDEO
+    mediaTypes += MediaType.DISPLAY
+    dataAvailabilityInterval = interval { startTime = now.minus(10, ChronoUnit.DAYS).toProtoTime() }
+    eventGroupMetadata = allMetadata[index % allMetadata.size]
+  }
+
+  private class CampaignOptions {
+    @CommandLine.Option(names = ["--brand-name"], required = true)
+    lateinit var brandName: String
+      private set
+
+    @CommandLine.Option(names = ["--campaign-name"], required = true)
+    lateinit var campaignNames: List<String>
+      private set
+
+    fun toMetadata(): List<EventGroupMetadata> =
+      campaignNames.map { campaignName ->
+        eventGroupMetadata {
+          adMetadata =
+            EventGroupMetadataKt.adMetadata {
+              campaignMetadata =
+                EventGroupMetadataKt.AdMetadataKt.campaignMetadata {
+                  brandName = this@CampaignOptions.brandName
+                  this.campaignName = campaignName
+                }
+            }
+        }
+      }
+  }
+
+  companion object {
+    private const val REFERENCE_ID_PREFIX = "load-test"
+
+    @JvmStatic
+    fun main(args: Array<String>) {
+      val commandLine =
+        CommandLine(WriteEventGroups()).apply {
+          registerConverter(Duration::class.java) { it.toDuration() }
+          setUseSimplifiedAtFiles(true)
+        }
+
+      val status: Int = commandLine.execute(*args)
+      if (status != 0) {
+        exitProcess(status)
+      }
+    }
+  }
+}


### PR DESCRIPTION
This was used for load testing the EventGroup search API using plaintext metadata, and is useful for other manual testing of EventGroups.