### PR TITLE
refactor: Remove useEdpSimulator param from InProcessCmmsComponents

### DIFF
--- a/src/main/kotlin/org/wfanet/measurement/integration/common/InProcessCmmsComponents.kt
+++ b/src/main/kotlin/org/wfanet/measurement/integration/common/InProcessCmmsComponents.kt
@@ -71,7 +71,6 @@ class InProcessCmmsComponents(
     SyntheticGenerationSpecs.SYNTHETIC_POPULATION_SPEC_SMALL,
   private val syntheticEventGroupSpecs: List<SyntheticEventGroupSpec> =
     SyntheticGenerationSpecs.SYNTHETIC_DATA_SPECS_SMALL,
-  private val useEdpSimulators: Boolean,
 ) : TestRule {
   private val kingdomDataServices: DataServices
     get() = kingdomDataServicesRule.value
@@ -292,8 +291,8 @@ class InProcessCmmsComponents(
    */
   fun getDataProviderDisplayNameFromDataProviderName(dataProviderName: String): String? {
     return edpDisplayNameToResourceMap.entries
-      .find { entry -> dataProviderName.equals(entry.value.name) }
-      ?.key ?: null
+      .find { entry -> dataProviderName == entry.value.name }
+      ?.key
   }
 
   fun getDataProviderResourceNames(): List<String> {
@@ -305,12 +304,9 @@ class InProcessCmmsComponents(
     createAllResources()
     // Start daemons. Mills and EDP simulators can only be started after resources have been
     // created.
-    if (useEdpSimulators) {
-      eventGroups = edpSimulators.map { it.ensureEventGroup() }
-      edpSimulators.forEach { it.start() }
-      edpSimulators.forEach { it.waitUntilHealthy() }
-    }
-
+    eventGroups = edpSimulators.map { it.ensureEventGroup() }
+    edpSimulators.forEach { it.start() }
+    edpSimulators.forEach { it.waitUntilHealthy() }
     duchies.forEach {
       it.startHerald()
       it.startMill(duchyCertMap)
@@ -332,9 +328,7 @@ class InProcessCmmsComponents(
   }
 
   fun stopDaemons() {
-    if (useEdpSimulators) {
-      stopEdpSimulators()
-    }
+    stopEdpSimulators()
     stopDuchyDaemons()
     stopPopulationRequisitionFulfillerDaemon()
   }

--- a/src/main/kotlin/org/wfanet/measurement/integration/common/InProcessLifeOfAMeasurementIntegrationTest.kt
+++ b/src/main/kotlin/org/wfanet/measurement/integration/common/InProcessLifeOfAMeasurementIntegrationTest.kt
@@ -71,7 +71,7 @@ abstract class InProcessLifeOfAMeasurementIntegrationTest(
 
   @get:Rule
   val inProcessCmmsComponents =
-    InProcessCmmsComponents(kingdomDataServicesRule, duchyDependenciesRule, useEdpSimulators = true)
+    InProcessCmmsComponents(kingdomDataServicesRule, duchyDependenciesRule)
 
   private lateinit var mcSimulator: EventQueryMeasurementConsumerSimulator
 

--- a/src/main/kotlin/org/wfanet/measurement/integration/common/InProcessMeasurementSystemProberIntegrationTest.kt
+++ b/src/main/kotlin/org/wfanet/measurement/integration/common/InProcessMeasurementSystemProberIntegrationTest.kt
@@ -59,7 +59,7 @@ abstract class InProcessMeasurementSystemProberIntegrationTest(
 
   @get:Rule
   val inProcessCmmsComponents =
-    InProcessCmmsComponents(kingdomDataServicesRule, duchyDependenciesRule, useEdpSimulators = true)
+    InProcessCmmsComponents(kingdomDataServicesRule, duchyDependenciesRule)
 
   private val publicMeasurementsClient by lazy {
     MeasurementsCoroutineStub(inProcessCmmsComponents.kingdom.publicApiChannel)

--- a/src/main/kotlin/org/wfanet/measurement/integration/common/InProcessReachMeasurementAccuracyTest.kt
+++ b/src/main/kotlin/org/wfanet/measurement/integration/common/InProcessReachMeasurementAccuracyTest.kt
@@ -76,7 +76,6 @@ abstract class InProcessReachMeasurementAccuracyTest(
       duchyDependenciesRule,
       SYNTHETIC_POPULATION_SPEC,
       SYNTHETIC_EVENT_GROUP_SPECS,
-      useEdpSimulators = true,
     )
 
   private lateinit var mcSimulator: EventQueryMeasurementConsumerSimulator

--- a/src/main/kotlin/org/wfanet/measurement/integration/common/reporting/v2/InProcessLifeOfAReportIntegrationTest.kt
+++ b/src/main/kotlin/org/wfanet/measurement/integration/common/reporting/v2/InProcessLifeOfAReportIntegrationTest.kt
@@ -189,7 +189,7 @@ abstract class InProcessLifeOfAReportIntegrationTest(
   reportingDataServicesProviderRule: ProviderRule<Services>,
 ) {
   private val inProcessCmmsComponents: InProcessCmmsComponents =
-    InProcessCmmsComponents(kingdomDataServicesRule, duchyDependenciesRule, useEdpSimulators = true)
+    InProcessCmmsComponents(kingdomDataServicesRule, duchyDependenciesRule)
 
   private val inProcessCmmsComponentsStartup = TestRule { base, _ ->
     object : Statement() {


### PR DESCRIPTION
This appears to have been incorrectly added in #2322.

The class is supposed to provide all CMMS components needed to run Measurements. EDP simulators are required for that.