### PR TITLE
perf: Un-interleave EventGroups table

### DIFF
--- a/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/testing/BUILD.bazel
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/testing/BUILD.bazel
@@ -13,6 +13,9 @@ kt_jvm_library(
     name = "testing",
     srcs = glob(["*.kt"]),
     resources = ["//src/main/resources/kingdom/spanner"],
+    runtime_deps = [
+        "//src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/tools:copy_event_groups",
+    ],
     deps = [
         "@wfa_common_jvm//src/main/kotlin/org/wfanet/measurement/common",
         "@wfa_common_jvm//src/main/kotlin/org/wfanet/measurement/gcloud/spanner/testing",

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/tools/BUILD.bazel
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/tools/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@rules_java//java:defs.bzl", "java_binary")
+load("@wfa_rules_kotlin_jvm//kotlin:defs.bzl", "kt_jvm_library")
 load("//src/main/docker:macros.bzl", "java_image")
 
 java_binary(
@@ -9,6 +10,7 @@ java_binary(
     main_class = "org.wfanet.measurement.gcloud.spanner.tools.UpdateSchema",
     resources = ["//src/main/resources/kingdom/spanner"],
     runtime_deps = [
+        ":copy_event_groups",
         "@wfa_common_jvm//src/main/kotlin/org/wfanet/measurement/gcloud/logging",
         "@wfa_common_jvm//src/main/kotlin/org/wfanet/measurement/gcloud/spanner/tools:update_schema",
     ],
@@ -24,5 +26,16 @@ java_image(
     visibility = [
         "//src/main/docker:__pkg__",
         "//src/main/k8s:__subpackages__",
+    ],
+)
+
+kt_jvm_library(
+    name = "copy_event_groups",
+    srcs = ["CopyEventGroups.kt"],
+    visibility = ["//src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/testing:__pkg__"],
+    deps = [
+        "@wfa_common_jvm//imports/java/liquibase:core",
+        "@wfa_common_jvm//imports/java/liquibase/ext/spanner",
+        "@wfa_common_jvm//src/main/kotlin/org/wfanet/measurement/gcloud/spanner",
     ],
 )

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/tools/CopyEventGroups.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/tools/CopyEventGroups.kt
@@ -1,0 +1,157 @@
+/*
+ * Copyright 2025 The Cross-Media Measurement Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wfanet.measurement.kingdom.deploy.gcloud.spanner.tools
+
+import com.google.cloud.spanner.Database as SpannerDatabase
+import com.google.cloud.spanner.DatabaseClient
+import com.google.cloud.spanner.TransactionContext
+import com.google.cloud.spanner.jdbc.CloudSpannerJdbcConnection
+import liquibase.change.custom.CustomTaskChange
+import liquibase.database.Database
+import liquibase.exception.ValidationErrors
+import liquibase.resource.ResourceAccessor
+import org.wfanet.measurement.gcloud.spanner.appendClause
+import org.wfanet.measurement.gcloud.spanner.insertOrUpdateMutation
+import org.wfanet.measurement.gcloud.spanner.statement
+
+@Suppress("unused") // Used at runtime by Liquibase.
+class CopyEventGroups : CustomTaskChange {
+  private var rowCount = 0
+
+  override fun getConfirmationMessage(): String {
+    return "Copied $rowCount rows from EventGroups to EventGroupsNew"
+  }
+
+  override fun setUp() {}
+
+  override fun setFileOpener(resourceAccessor: ResourceAccessor) {}
+
+  override fun validate(database: Database): ValidationErrors {
+    return ValidationErrors()
+  }
+
+  override fun execute(database: Database) {
+    val connection =
+      database.connection.underlyingConnection.unwrap(CloudSpannerJdbcConnection::class.java)
+
+    // Work around https://github.com/GoogleCloudPlatform/cloud-spanner-emulator/issues/251
+    dropForeignKeyConstraints(connection)
+
+    val dbClient: DatabaseClient = connection.databaseClient
+    var dataProviderId = INVALID_ID
+    var eventGroupId = INVALID_ID
+    do {
+      dbClient.readWriteTransaction().run { txn: TransactionContext ->
+        val query =
+          statement(BASE_SQL) {
+            if (dataProviderId != INVALID_ID) {
+              appendClause(WHERE_CLAUSE)
+              bind("dataProviderId").to(dataProviderId)
+              bind("eventGroupId").to(eventGroupId)
+            }
+            appendClause(ORDER_BY_CLAUSE)
+            appendClause(LIMIT_CLAUSE)
+          }
+        txn.executeQuery(query).use { resultSet ->
+          dataProviderId = INVALID_ID
+          while (resultSet.next()) {
+            rowCount++
+            dataProviderId = resultSet.getLong("DataProviderId")
+            eventGroupId = resultSet.getLong("EventGroupId")
+
+            txn.buffer(
+              insertOrUpdateMutation("EventGroupsNew") {
+                for (columnName in resultSet.type.structFields.map { it.name }) {
+                  if (columnName == "MediaTypes" || resultSet.isNull(columnName)) {
+                    continue
+                  }
+                  set(columnName).to(resultSet.getValue(columnName))
+                }
+              }
+            )
+            for (mediaType in resultSet.getLongArray("MediaTypes")) {
+              txn.buffer(
+                insertOrUpdateMutation("EventGroupMediaTypesNew") {
+                  set("DataProviderId").to(dataProviderId)
+                  set("EventGroupId").to(eventGroupId)
+                  set("MediaType").to(mediaType)
+                }
+              )
+            }
+          }
+        }
+      }
+    } while (dataProviderId != INVALID_ID)
+  }
+
+  private fun dropForeignKeyConstraints(connection: CloudSpannerJdbcConnection) {
+    val sql =
+      """
+      SELECT CONSTRAINT_NAME
+      FROM INFORMATION_SCHEMA.TABLE_CONSTRAINTS
+      WHERE
+        TABLE_NAME = 'EventGroups'
+        AND CONSTRAINT_TYPE = 'FOREIGN KEY'
+      """
+        .trimIndent()
+    val constraintNames: List<String> =
+      connection.databaseClient.singleUse().executeQuery(statement(sql)).use { resultSet ->
+        buildList {
+          while (resultSet.next()) {
+            add(resultSet.getString(0))
+          }
+        }
+      }
+    val statements = constraintNames.map { "ALTER TABLE EventGroups DROP CONSTRAINT $it" }
+
+    val database: SpannerDatabase =
+      connection.spanner.databaseAdminClient.newDatabaseBuilder(connection.databaseId).build()
+    database.updateDdl(statements, null).get()
+  }
+
+  companion object {
+    private const val BATCH_SIZE = 100
+    private const val INVALID_ID = 0L
+
+    private val BASE_SQL =
+      """
+      SELECT
+        *,
+        ARRAY(
+          SELECT MediaType
+          FROM EventGroupMediaTypes
+          WHERE
+            EventGroupMediaTypes.DataProviderId = EventGroups.DataProviderId
+            AND EventGroupMediaTypes.EventGroupId = EventGroups.EventGroupId
+        ) AS MediaTypes,
+      FROM EventGroups
+      """
+        .trimIndent()
+    private val WHERE_CLAUSE =
+      """
+      WHERE
+        DataProviderId > @dataProviderId
+        OR (
+          DataProviderId = @dataProviderId
+          AND EventGroupId > @eventGroupId
+        )
+      """
+        .trimIndent()
+    private const val ORDER_BY_CLAUSE = "ORDER BY DataProviderId, EventGroupId"
+    private const val LIMIT_CLAUSE = "LIMIT $BATCH_SIZE"
+  }
+}

--- a/src/main/resources/kingdom/spanner/add-event-groups-copy.sql
+++ b/src/main/resources/kingdom/spanner/add-event-groups-copy.sql
@@ -1,0 +1,44 @@
+-- liquibase formatted sql
+
+-- Copyright 2025 The Cross-Media Measurement Authors
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+-- changeset sanjayvas:28 dbms:cloudspanner
+-- comment: Add a copy of the EventGroups table that is not interleaved.
+
+CREATE TABLE EventGroupsNew (
+  DataProviderId INT64 NOT NULL,
+  EventGroupId INT64 NOT NULL,
+  MeasurementConsumerId INT64 NOT NULL,
+  MeasurementConsumerCertificateId INT64,
+  ExternalEventGroupId INT64 NOT NULL,
+  ProvidedEventGroupId STRING(MAX),
+  CreateTime TIMESTAMP NOT NULL OPTIONS (allow_commit_timestamp = true),
+  UpdateTime TIMESTAMP OPTIONS (allow_commit_timestamp = true),
+  EventGroupDetails wfa.measurement.internal.kingdom.EventGroupDetails,
+  State INT64 NOT NULL,
+  CreateRequestId STRING(MAX),
+  DataAvailabilityStartTime TIMESTAMP,
+  DataAvailabilityEndTime TIMESTAMP,
+  BrandName_Tokens TOKENLIST AS (TOKENIZE_FULLTEXT(EventGroupDetails.metadata.ad_metadata.campaign_metadata.brand_name)) HIDDEN,
+  CampaignName_Tokens TOKENLIST AS (TOKENIZE_FULLTEXT(EventGroupDetails.metadata.ad_metadata.campaign_metadata.campaign_name)) HIDDEN,
+  Metadata_Tokens TOKENLIST AS (TOKENLIST_CONCAT([BrandName_Tokens, CampaignName_Tokens])) HIDDEN,
+) PRIMARY KEY(DataProviderId, EventGroupId);
+
+CREATE TABLE EventGroupMediaTypesNew (
+  DataProviderId INT64 NOT NULL,
+  EventGroupId INT64 NOT NULL,
+  MediaType INT64 NOT NULL,
+) PRIMARY KEY(DataProviderId, EventGroupId, MediaType),
+  INTERLEAVE IN PARENT EventGroupsNew ON DELETE CASCADE;

--- a/src/main/resources/kingdom/spanner/changelog.yaml
+++ b/src/main/resources/kingdom/spanner/changelog.yaml
@@ -93,3 +93,17 @@ databaseChangeLog:
 - include:
     file: drop-event-group-default-state.sql
     relativeToChangeLogFile: true
+- include:
+    file: add-event-groups-copy.sql
+    relativeToChangeLogFile: true
+- changeSet:
+    id: 29
+    author: sanjayvas
+    dbms: cloudspanner
+    changes:
+    - customChange: {
+      "class": "org.wfanet.measurement.kingdom.deploy.gcloud.spanner.tools.CopyEventGroups"
+    }
+- include:
+    file: swap-event-groups.sql
+    relativeToChangeLogFile: true

--- a/src/main/resources/kingdom/spanner/swap-event-groups.sql
+++ b/src/main/resources/kingdom/spanner/swap-event-groups.sql
@@ -1,0 +1,46 @@
+-- liquibase formatted sql
+
+-- Copyright 2025 The Cross-Media Measurement Authors
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+-- changeset sanjayvas:30 dbms:cloudspanner
+-- comment: Swap EventGroupsNew in for EventGroups.
+START BATCH DDL;
+
+DROP INDEX EventGroupsByCreateRequestId;
+DROP INDEX EventGroupsByExternalId;
+DROP INDEX EventGroupsByMeasurementConsumer;
+DROP INDEX EventGroupsByMetadata;
+
+RENAME TABLE
+  EventGroups TO EventGroupsOld,
+  EventGroupsNew TO EventGroups,
+  EventGroupMediaTypes TO EventGroupMediaTypesOld,
+  EventGroupMediaTypesNew TO EventGroupMediaTypes;
+
+-- Add foreign keys after rename to work around https://github.com/GoogleCloudPlatform/cloud-spanner-emulator/issues/251
+ALTER TABLE EventGroups
+  ADD CONSTRAINT FKey_EventGroups_MeasurementConsumers
+  FOREIGN KEY (MeasurementConsumerId) REFERENCES MeasurementConsumers(MeasurementConsumerId);
+ALTER TABLE EventGroups
+  ADD CONSTRAINT FKey_EventGroups_MeasurementConsumerCertificates
+  FOREIGN KEY (MeasurementConsumerId, MeasurementConsumerCertificateId)
+  REFERENCES MeasurementConsumerCertificates(MeasurementConsumerId, CertificateId);
+
+CREATE UNIQUE NULL_FILTERED INDEX EventGroupsByCreateRequestId ON EventGroups(DataProviderId, CreateRequestId);
+CREATE UNIQUE INDEX EventGroupsByExternalId ON EventGroups(DataProviderId, ExternalEventGroupId);
+CREATE UNIQUE INDEX EventGroupsByMeasurementConsumer ON EventGroups(MeasurementConsumerId, ExternalEventGroupId);
+CREATE SEARCH INDEX EventGroupsByMetadata ON EventGroups(Metadata_Tokens);
+
+RUN BATCH;


### PR DESCRIPTION
Issue: #2536
RELNOTES: This update includes a data migration of the EventGroups table. The update must be applied while there is no traffic to that table. It is highly recommended to back up the Kingdom database before applying this update.