### PR TITLE
feat: add check to skip empty file processing in DataWatcher

### DIFF
--- a/src/main/kotlin/org/wfanet/measurement/securecomputation/deploy/gcloud/datawatcher/DataWatcherFunction.kt
+++ b/src/main/kotlin/org/wfanet/measurement/securecomputation/deploy/gcloud/datawatcher/DataWatcherFunction.kt
@@ -50,10 +50,16 @@ class DataWatcherFunction : CloudEventsFunction {
       StorageObjectData.newBuilder()
         .apply { JsonFormat.parser().merge(cloudEventData, this) }
         .build()
+
     val blobKey: String = data.getName()
     val bucket: String = data.getBucket()
     val path = "$scheme://$bucket/$blobKey"
     logger.info("Receiving path $path")
+    val size = data.size
+    if (size == 0L) {
+      logger.info("Skipping processing: file '${path}' is empty")
+      return
+    }
     runBlocking { dataWatcher.receivePath(path) }
   }
 


### PR DESCRIPTION
Prevent DataWatcher from being triggered multiple times for the same file.