### PR TITLE
fix: Increase memory limit of computation control service deployment

### DIFF
--- a/src/main/k8s/dev/duchy_gke.cue
+++ b/src/main/k8s/dev/duchy_gke.cue
@@ -82,7 +82,7 @@ _duchy_cert_name: "duchies/\(_duchy_name)/certificates/\(_certificateId)"
 #ControlServiceResourceRequirements: ResourceRequirements=#ResourceRequirements & {
 	requests: {
 		cpu:    "200m"
-		memory: "512Mi"
+		memory: "576Mi"
 	}
 	limits: {
 		memory: ResourceRequirements.requests.memory


### PR DESCRIPTION
OOMKilled events were observed when running the correctness test in Halo-managed environments. The increase appears to be from classes, as there's a jump in Metaspace usage starting with nightly/20250626.1.