### PR TITLE
ci: Avoid triggering code-based workflows when PR description is edited

### DIFF
--- a/.github/workflows/api-lint.yml
+++ b/.github/workflows/api-lint.yml
@@ -19,7 +19,6 @@ on:
     branches:
       - main
       - 'releases/**'
-    types: [opened, synchronize, edited]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -23,7 +23,6 @@ on:
     branches:
       - main
       - 'releases/**'
-    types: [opened, synchronize, edited]
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -5,7 +5,6 @@ on:
     branches:
       - main
       - 'releases/**'
-    types: [opened, synchronize, edited]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
This relies on the default types for the `pull_request` event (`opened`, `synchronize`, `reopened`). See https://docs.github.com/en/actions/reference/events-that-trigger-workflows#pull_request