### PR TITLE
test: Ensure all tests which use Spanner emulator execute locally

### DIFF
--- a/src/test/kotlin/org/wfanet/measurement/integration/deploy/gcloud/BUILD.bazel
+++ b/src/test/kotlin/org/wfanet/measurement/integration/deploy/gcloud/BUILD.bazel
@@ -168,6 +168,10 @@ kt_jvm_library(
 java_test(
     name = "GCloudSpannerInProcessMeasurementSystemProberIntegrationTest",
     size = "large",
+    tags = [
+        "cpu:2",
+        "no-remote-exec",
+    ],
     test_class = "org.wfanet.measurement.integration.deploy.gcloud.GCloudSpannerInProcessMeasurementSystemProberIntegrationTest",
     runtime_deps = [":gcloud_spanner_in_process_measurement_system_prober_integration_test"],
 )
@@ -189,6 +193,10 @@ kt_jvm_library(
 java_test(
     name = "GCloudInProcessAccessCliIntegrationTest",
     size = "large",
+    tags = [
+        "cpu:2",
+        "no-remote-exec",
+    ],
     # TODO(world-federation-of-advertisers/cross-media-measurement#827): Remove when flakiness is resolved.
     test_class = "org.wfanet.measurement.integration.deploy.gcloud.GCloudInProcessAccessCliIntegrationTest",
     runtime_deps = [":gcloud_in_process_access_cli_integration_test"],
@@ -207,6 +215,10 @@ kt_jvm_library(
 java_test(
     name = "GCloudInProcessModelRepositoryCliIntegrationTest",
     size = "large",
+    tags = [
+        "cpu:2",
+        "no-remote-exec",
+    ],
     test_class = "org.wfanet.measurement.integration.deploy.gcloud.GCloudInProcessModelRepositoryCliIntegrationTest",
     runtime_deps = [":gcloud_in_process_model_repository_cli_integration_test"],
 )


### PR DESCRIPTION
This fixes a small subset of test targets that were missing the appropriate tags.