### PR TITLE
feat: Specify low value of --max-event-group-read-staleness for testing

### DIFF
--- a/docs/gke/kingdom-deployment.md
+++ b/docs/gke/kingdom-deployment.md
@@ -134,6 +134,10 @@ You can customize this generated object configuration with your own settings
 such as the number of replicas per deployment, the memory and CPU requirements
 of each container, and the JVM options of each container.
 
+Note that the `dev` configuration uses a very low value for the
+`--max-event-group-read-staleness` option on the Kingdom internal API server to
+reduce test flakiness. You will likely want to adjust this.
+
 ## Customize the K8s secret
 
 We use a K8s secret to hold sensitive information, such as private keys.

--- a/src/main/k8s/kingdom.cue
+++ b/src/main/k8s/kingdom.cue
@@ -134,6 +134,7 @@ import ("strings")
 					_kingdom_root_cert_file_flag,
 					_knownEventGroupMetadataTypeFlag,
 					_debug_verbose_grpc_server_logging_flag,
+					"--max-event-group-read-staleness=100ms",
 				] + Container._commonServerFlags + _spannerConfig.flags
 			}
 			_updateSchemaContainer: Container=#Container & {

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/SpannerEventGroupsService.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/SpannerEventGroupsService.kt
@@ -55,7 +55,11 @@ class SpannerEventGroupsService(
   coroutineContext: CoroutineContext = EmptyCoroutineContext,
 ) : EventGroupsCoroutineImplBase(coroutineContext) {
   private val staleReadTimestampBound =
-    TimestampBound.ofMaxStaleness(maxReadStaleness.toMillis(), TimeUnit.MILLISECONDS)
+    if (maxReadStaleness == Duration.ZERO) {
+      TimestampBound.strong()
+    } else {
+      TimestampBound.ofMaxStaleness(maxReadStaleness.toMillis(), TimeUnit.MILLISECONDS)
+    }
 
   override suspend fun createEventGroup(request: CreateEventGroupRequest): EventGroup {
     try {


### PR DESCRIPTION
Tests are more likely to read EventGroups shortly after writing them.