### PR TITLE
fix: Reduce max heap size of computation control server

### DIFF
--- a/src/main/k8s/dev/duchy_gke.cue
+++ b/src/main/k8s/dev/duchy_gke.cue
@@ -82,13 +82,13 @@ _duchy_cert_name: "duchies/\(_duchy_name)/certificates/\(_certificateId)"
 #ControlServiceResourceRequirements: ResourceRequirements=#ResourceRequirements & {
 	requests: {
 		cpu:    "200m"
-		memory: "576Mi"
+		memory: "512Mi"
 	}
 	limits: {
 		memory: ResourceRequirements.requests.memory
 	}
 }
-#ControlServiceMaxHeapSize: "320M"
+#ControlServiceMaxHeapSize: "192M"
 
 objectSets: [defaultNetworkPolicies] + [ for objectSet in duchy {objectSet}]
 


### PR DESCRIPTION
OOMKilled events were still observed despite the changes in #2558. After reviewing monitoring, it appears that the max heap size is set much higher than necessary. This means that the container memory limit can also be reverted back to 512 MiB.

RELNOTES: Operators will likely want to decrease the max heap size of the Duchy computation control service to 192MiB to accomodate dependency updates.