### PR TITLE
fix: Compare public API MediaType in ListEventGroups page token

### DIFF
--- a/src/main/kotlin/org/wfanet/measurement/kingdom/service/api/v2alpha/EventGroupsService.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/service/api/v2alpha/EventGroupsService.kt
@@ -471,7 +471,7 @@ class EventGroupsService(
                 pageToken.showDeleted != showDeleted ||
                 pageToken.externalDataProviderIdInList != externalDataProviderIdIn ||
                 pageToken.externalMeasurementConsumerIdInList != externalMeasurementConsumerIdIn ||
-                pageToken.mediaTypesIntersectList != mediaTypesIntersect ||
+                pageToken.mediaTypesIntersectList != filter.mediaTypesIntersectList ||
                 pageToken.dataAvailabilityStartTimeOnOrAfter !=
                   dataAvailabilityStartTimeOnOrAfter ||
                 pageToken.dataAvailabilityEndTimeOnOrBefore != dataAvailabilityEndTimeOnOrBefore ||

--- a/src/test/kotlin/org/wfanet/measurement/kingdom/service/api/v2alpha/EventGroupsServiceTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/kingdom/service/api/v2alpha/EventGroupsServiceTest.kt
@@ -1092,20 +1092,24 @@ class EventGroupsServiceTest {
 
   @Test
   fun `listEventGroups with page token gets the next page`() {
+    val pageToken = listEventGroupsPageToken {
+      externalDataProviderId = DATA_PROVIDER_EXTERNAL_ID
+      externalMeasurementConsumerIdIn += MEASUREMENT_CONSUMER_EXTERNAL_ID
+      mediaTypesIntersect += MediaType.VIDEO
+      lastEventGroup = previousPageEnd {
+        externalEventGroupId = EVENT_GROUP_EXTERNAL_ID
+        externalDataProviderId = DATA_PROVIDER_EXTERNAL_ID
+        dataAvailabilityStartTime = EVENT_GROUP.dataAvailabilityInterval.startTime
+      }
+    }
     val request = listEventGroupsRequest {
       parent = DATA_PROVIDER_NAME
       pageSize = 2
-      val listEventGroupsPageToken = listEventGroupsPageToken {
-        externalDataProviderId = DATA_PROVIDER_EXTERNAL_ID
-        externalMeasurementConsumerIdIn += MEASUREMENT_CONSUMER_EXTERNAL_ID
-        lastEventGroup = previousPageEnd {
-          externalEventGroupId = EVENT_GROUP_EXTERNAL_ID
-          externalDataProviderId = DATA_PROVIDER_EXTERNAL_ID
-          dataAvailabilityStartTime = EVENT_GROUP.dataAvailabilityInterval.startTime
-        }
+      filter = filter {
+        measurementConsumerIn += MEASUREMENT_CONSUMER_NAME
+        mediaTypesIntersect += MediaType.VIDEO
       }
-      filter = filter { measurementConsumerIn += MEASUREMENT_CONSUMER_NAME }
-      pageToken = listEventGroupsPageToken.toByteArray().base64UrlEncode()
+      this.pageToken = pageToken.toByteArray().base64UrlEncode()
     }
 
     val result =
@@ -1113,19 +1117,18 @@ class EventGroupsServiceTest {
         runBlocking { service.listEventGroups(request) }
       }
 
-    val expected = listEventGroupsResponse {
-      eventGroups += EVENT_GROUP
-      eventGroups += EVENT_GROUP.copy { name = EVENT_GROUP_NAME_2 }
-      val listEventGroupsPageToken = listEventGroupsPageToken {
-        externalDataProviderId = DATA_PROVIDER_EXTERNAL_ID
-        externalMeasurementConsumerIdIn += MEASUREMENT_CONSUMER_EXTERNAL_ID
+    val nextPageToken =
+      pageToken.copy {
         lastEventGroup = previousPageEnd {
           externalEventGroupId = EVENT_GROUP_EXTERNAL_ID_2
           externalDataProviderId = DATA_PROVIDER_EXTERNAL_ID
           dataAvailabilityStartTime = EVENT_GROUP.dataAvailabilityInterval.startTime
         }
       }
-      nextPageToken = listEventGroupsPageToken.toByteArray().base64UrlEncode()
+    val expected = listEventGroupsResponse {
+      eventGroups += EVENT_GROUP
+      eventGroups += EVENT_GROUP.copy { name = EVENT_GROUP_NAME_2 }
+      this.nextPageToken = nextPageToken.toByteArray().base64UrlEncode()
     }
 
     val streamEventGroupsRequest: StreamEventGroupsRequest = captureFirst {
@@ -1141,6 +1144,7 @@ class EventGroupsServiceTest {
             StreamEventGroupsRequestKt.filter {
               externalDataProviderId = DATA_PROVIDER_EXTERNAL_ID
               externalMeasurementConsumerIdIn += MEASUREMENT_CONSUMER_EXTERNAL_ID
+              mediaTypesIntersect += InternalMediaType.VIDEO
               after =
                 StreamEventGroupsRequestKt.FilterKt.after {
                   eventGroupKey = eventGroupKey {


### PR DESCRIPTION
The comparison was incorrectly trying to compare internal vs. public MediaType.

Issue: #2613