### PR TITLE
perf: Drop CTE for EventGroupMediaTypes

### DIFF
--- a/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/queries/StreamEventGroups.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/queries/StreamEventGroups.kt
@@ -78,9 +78,14 @@ class StreamEventGroups(
         add(
           """
           EXISTS(
-            SELECT MediaType
-            FROM UNNEST(EventGroups.MediaTypes) AS MediaType
-            WHERE MediaType IN UNNEST(@$MEDIA_TYPES)
+            SELECT
+              MediaType
+            FROM
+              EventGroupMediaTypes
+            WHERE
+              EventGroupMediaTypes.DataProviderId = EventGroups.DataProviderId
+              AND EventGroupMediaTypes.EventGroupId = EventGroups.EventGroupId
+              AND MediaType IN UNNEST(@$MEDIA_TYPES)
           )
           """
             .trimIndent()

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/readers/EventGroupReader.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/readers/EventGroupReader.kt
@@ -152,20 +152,6 @@ class EventGroupReader : BaseSpannerReader<EventGroupReader.Result>() {
   companion object {
     private val BASE_SQL =
       """
-      WITH EventGroups AS (
-        SELECT
-          *,
-          Metadata_Tokens,
-          ARRAY(
-            SELECT MediaType
-            FROM EventGroupMediaTypes
-            WHERE
-              EventGroupMediaTypes.DataProviderId = EventGroups.DataProviderId
-              AND EventGroupMediaTypes.EventGroupId = EventGroups.EventGroupId
-          ) AS MediaTypes,
-        FROM
-          EventGroups
-      )
       SELECT
         EventGroups.EventGroupId,
         EventGroups.ExternalEventGroupId,
@@ -180,7 +166,13 @@ class EventGroupReader : BaseSpannerReader<EventGroupReader.Result>() {
         MeasurementConsumers.ExternalMeasurementConsumerId,
         DataProviders.ExternalDataProviderId,
         EventGroups.State,
-        EventGroups.MediaTypes,
+        ARRAY(
+          SELECT MediaType
+          FROM EventGroupMediaTypes
+          WHERE
+            EventGroupMediaTypes.DataProviderId = EventGroups.DataProviderId
+            AND EventGroupMediaTypes.EventGroupId = EventGroups.EventGroupId
+        ) AS MediaTypes,
       FROM
         EventGroups
         JOIN DataProviders USING (DataProviderId)


### PR DESCRIPTION
This reduces the chance of a full table scan and allows indexing.

Issue: #2536