### PR TITLE
feat: Update CreateBasicReportRequestValidation to validate DimensionSpec EventTemplateFields

### DIFF
--- a/src/main/kotlin/org/wfanet/measurement/integration/common/reporting/v2/BUILD.bazel
+++ b/src/main/kotlin/org/wfanet/measurement/integration/common/reporting/v2/BUILD.bazel
@@ -77,6 +77,7 @@ kt_jvm_library(
         "//src/main/proto/wfa/measurement/api/v2alpha:measurement_consumers_service_kt_jvm_grpc_proto",
         "//src/main/proto/wfa/measurement/api/v2alpha:measurements_service_kt_jvm_grpc_proto",
         "//src/main/proto/wfa/measurement/api/v2alpha:model_lines_service_kt_jvm_grpc_proto",
+        "//src/main/proto/wfa/measurement/api/v2alpha/event_templates/testing:test_event_kt_jvm_proto",
         "//src/main/proto/wfa/measurement/config/reporting:encryption_key_pair_config_kt_jvm_proto",
         "//src/main/proto/wfa/measurement/reporting/v2alpha:basic_reports_service_kt_jvm_grpc_proto",
         "//src/main/proto/wfa/measurement/reporting/v2alpha:event_groups_service_kt_jvm_grpc_proto",

--- a/src/main/kotlin/org/wfanet/measurement/integration/common/reporting/v2/InProcessReportingServer.kt
+++ b/src/main/kotlin/org/wfanet/measurement/integration/common/reporting/v2/InProcessReportingServer.kt
@@ -90,6 +90,7 @@ import org.wfanet.measurement.reporting.service.api.v2alpha.ReportsService
 import org.wfanet.measurement.reporting.service.api.v2alpha.validate
 import org.wfanet.measurement.reporting.v2alpha.EventGroup
 import org.wfanet.measurement.reporting.v2alpha.MetricsGrpcKt.MetricsCoroutineStub as PublicMetricsCoroutineStub
+import org.wfanet.measurement.api.v2alpha.event_templates.testing.TestEvent
 
 /** TestRule that starts and stops all Reporting Server gRPC services. */
 class InProcessReportingServer(
@@ -299,6 +300,7 @@ class InProcessReportingServer(
                 internalBasicReportsClient,
                 internalImpressionQualificationFiltersClient,
                 internalReportingSetsClient,
+                BasicReportsService.buildEventTemplateFieldsMap(TestEvent.getDescriptor()),
                 authorization,
               )
               .withTrustedPrincipalAuthentication(),

--- a/src/main/kotlin/org/wfanet/measurement/reporting/deploy/v2/common/server/V2AlphaPublicApiServer.kt
+++ b/src/main/kotlin/org/wfanet/measurement/reporting/deploy/v2/common/server/V2AlphaPublicApiServer.kt
@@ -329,11 +329,13 @@ private object V2AlphaPublicApiServer {
           )
           .withInterceptor(principalAuthInterceptor),
         BasicReportsService(
-            InternalBasicReportsCoroutineStub(channel),
-            InternalImpressionQualificationFiltersCoroutineStub(channel),
-            InternalReportingSetsCoroutineStub(channel),
-            authorization,
-            serviceDispatcher,
+          InternalBasicReportsCoroutineStub(channel),
+          InternalImpressionQualificationFiltersCoroutineStub(channel),
+          InternalReportingSetsCoroutineStub(channel),
+          // TODO(@tristanvuong2021): Switch to non-empty map when ready to deploy
+          emptyMap(),
+          authorization,
+          serviceDispatcher,
           )
           .withInterceptor(principalAuthInterceptor),
         ModelLinesService(

--- a/src/main/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/BUILD.bazel
+++ b/src/main/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/BUILD.bazel
@@ -315,6 +315,7 @@ kt_jvm_library(
     deps = [
         ":basic_report_proto_conversions",
         ":create_basic_report_request_validation",
+        ":event_template_field_info",
         ":proto_conversions",
         ":resource_key",
         "//src/main/kotlin/org/wfanet/measurement/access/client/v1alpha:authorization",
@@ -322,6 +323,7 @@ kt_jvm_library(
         "//src/main/kotlin/org/wfanet/measurement/reporting/service/api:errors",
         "//src/main/kotlin/org/wfanet/measurement/reporting/service/internal:errors",
         "//src/main/kotlin/org/wfanet/measurement/reporting/service/internal:internal_exception",
+        "//src/main/proto/wfa/measurement/api/v2alpha:event_annotations_kt_jvm_proto",
         "//src/main/proto/wfa/measurement/internal/reporting/v2:basic_reports_service_kt_jvm_grpc_proto",
         "//src/main/proto/wfa/measurement/internal/reporting/v2:impression_qualification_filters_service_kt_jvm_grpc_proto",
         "//src/main/proto/wfa/measurement/internal/reporting/v2:reporting_sets_service_kt_jvm_grpc_proto",
@@ -333,9 +335,19 @@ kt_jvm_library(
 )
 
 kt_jvm_library(
+    name = "event_template_field_info",
+    srcs = ["EventTemplateFieldInfo.kt"],
+    deps = [
+        "//src/main/proto/wfa/measurement/api/v2alpha:media_type_kt_jvm_proto",
+        "@wfa_common_jvm//imports/java/com/google/protobuf",
+    ],
+)
+
+kt_jvm_library(
     name = "create_basic_report_request_validation",
     srcs = ["CreateBasicReportRequestValidation.kt"],
     deps = [
+        ":event_template_field_info",
         ":resource_key",
         "//src/main/kotlin/org/wfanet/measurement/api/v2alpha:resource_key",
         "//src/main/kotlin/org/wfanet/measurement/common/api:resource_ids",

--- a/src/main/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/EventTemplateFieldInfo.kt
+++ b/src/main/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/EventTemplateFieldInfo.kt
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2025 The Cross-Media Measurement Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wfanet.measurement.reporting.service.api.v2alpha
+
+import com.google.protobuf.Descriptors
+import org.wfanet.measurement.api.v2alpha.MediaType
+
+object EventTemplateFieldInfo {
+  data class SupportedReportingFeatures(
+    var groupable: Boolean = false,
+    var filterable: Boolean = false,
+    var impressionQualification: Boolean = false,
+  )
+  data class EventTemplateFieldInfo(
+    val mediaType: MediaType,
+    val isPopulationAttribute: Boolean,
+    val supportedReportingFeatures: SupportedReportingFeatures,
+    val type: Descriptors.FieldDescriptor.Type,
+    val groupingValuesMap: Map<String, Int>,
+  )
+}

--- a/src/test/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/BUILD.bazel
+++ b/src/test/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/BUILD.bazel
@@ -344,6 +344,7 @@ spanner_emulator_test(
         "//src/main/kotlin/org/wfanet/measurement/reporting/service/api:errors",
         "//src/main/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha:basic_reports_service",
         "//src/main/proto/wfa/measurement/access/v1alpha:permissions_service_kt_jvm_grpc_proto",
+        "//src/main/proto/wfa/measurement/api/v2alpha/event_templates/testing:test_event_kt_jvm_proto",
         "//src/main/proto/wfa/measurement/config/reporting:impression_qualification_filter_config_kt_jvm_proto",
         "//src/main/proto/wfa/measurement/internal/reporting/v2:basic_reports_service_kt_jvm_grpc_proto",
         "//src/main/proto/wfa/measurement/internal/reporting/v2:impression_qualification_filters_service_kt_jvm_grpc_proto",


### PR DESCRIPTION
Issue: #2608 

The relevant Descriptor sets are processed once into a Map, which is used to quickly lookup the relevant information afterwards.