### PR TITLE
test: Ensure GCloudSpannerInProcessReachMeasurementAccuracyTest runs locally

### DIFF
--- a/src/test/kotlin/org/wfanet/measurement/integration/deploy/gcloud/BUILD.bazel
+++ b/src/test/kotlin/org/wfanet/measurement/integration/deploy/gcloud/BUILD.bazel
@@ -149,6 +149,7 @@ java_test(
     tags = [
         "cpu:2",
         "manual",
+        "no-remote-exec",
     ],
     test_class = "org.wfanet.measurement.integration.deploy.gcloud.GCloudSpannerInProcessReachMeasurementAccuracyTest",
     runtime_deps = [":gcloud_spanner_in_process_reach_measurement_accuracy_test"],


### PR DESCRIPTION
This fixes the libc++ error in the release test workflow. See #2562