### PR TITLE
chore: Update OpenTelemetry Operator to 0.129.1

### DIFF
--- a/.github/actions/install-otel-operator/action.yml
+++ b/.github/actions/install-otel-operator/action.yml
@@ -25,7 +25,7 @@ runs:
   - name: Install cert-manager
     shell: bash
     run: |
-      kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.14.5/cert-manager.yaml
+      kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.18.2/cert-manager.yaml
       for deployment in $(kubectl --namespace=cert-manager get deployments -o name); do
         kubectl --namespace=cert-manager rollout status "$deployment" --timeout=5m
       done
@@ -33,7 +33,7 @@ runs:
   - name: Install OpenTelemetry operator
     shell: bash
     run: |
-      kubectl apply -f https://github.com/open-telemetry/opentelemetry-operator/releases/download/v0.99.0/opentelemetry-operator.yaml
+      kubectl apply -f https://github.com/open-telemetry/opentelemetry-operator/releases/download/v0.129.1/opentelemetry-operator.yaml
       for deployment in $(kubectl --namespace=opentelemetry-operator-system get deployments -o name); do
         kubectl --namespace=opentelemetry-operator-system rollout status "$deployment" --timeout=5m
       done

--- a/docs/gke/metrics-deployment.md
+++ b/docs/gke/metrics-deployment.md
@@ -77,13 +77,13 @@ and the collector image specified in
 [`open_telemetry.cue`](../../src/main/k8s/open_telemetry.cue).
 
 ```shell
-kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.14.5/cert-manager.yaml
+kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.18.2/cert-manager.yaml
 ```
 
 ### Install OpenTelemetry Operator
 
 ```shell
-kubectl apply -f https://github.com/open-telemetry/opentelemetry-operator/releases/download/v0.99.0/opentelemetry-operator.yaml
+kubectl apply -f https://github.com/open-telemetry/opentelemetry-operator/releases/download/v0.129.1/opentelemetry-operator.yaml
 ```
 
 ### Apply OpenTelemetry Configurations

--- a/src/main/k8s/open_telemetry.cue
+++ b/src/main/k8s/open_telemetry.cue
@@ -135,7 +135,7 @@ package k8s
 					name:  k
 					value: v
 				}]
-				java: image: "ghcr.io/open-telemetry/opentelemetry-operator/autoinstrumentation-java:2.3.0"
+				java: image: "ghcr.io/open-telemetry/opentelemetry-operator/autoinstrumentation-java:2.18.1"
 			}
 		}
 	}


### PR DESCRIPTION
Issue: #2701
RELNOTES: Operators may want to update their OpenTelemetry Operator to at least v0.129.1 with CertManager v1.18.2 and Auto Instrumentation Java v2.18.1.