### PR TITLE
feat: add missing roles to results fulfiller Service Account

### DIFF
--- a/src/main/terraform/gcloud/cmms/edp_aggregator.tf
+++ b/src/main/terraform/gcloud/cmms/edp_aggregator.tf
@@ -152,9 +152,6 @@ locals {
 module "edp_aggregator" {
   source = "../modules/edp-aggregator"
 
-  key_ring_name                             = "securecomputation-key-ring"
-  key_ring_location                         = local.key_ring_location
-  kms_key_name                              = "edpa-secure-computation-kek"
   requisition_fulfiller_config              = local.requisition_fulfiller_config
   pubsub_iam_service_account_member         = module.secure_computation.secure_computation_internal_iam_service_account_member
   edp_aggregator_bucket_name                = var.secure_computation_storage_bucket_name

--- a/src/main/terraform/gcloud/modules/edp-aggregator/main.tf
+++ b/src/main/terraform/gcloud/modules/edp-aggregator/main.tf
@@ -252,22 +252,6 @@ resource "google_pubsub_topic_iam_member" "publisher" {
   member = var.pubsub_iam_service_account_member
 }
 
-resource "google_kms_key_ring" "edp_aggregator_key_ring" {
-
-  name     = var.key_ring_name
-  location = var.key_ring_location
-
-  lifecycle {
-    prevent_destroy = false
-  }
-}
-
-resource "google_kms_crypto_key" "edp_aggregator_kek" {
-  name     = var.kms_key_name
-  key_ring = google_kms_key_ring.edp_aggregator_key_ring.id
-  purpose  = "ENCRYPT_DECRYPT"
-}
-
 module "result_fulfiller_tee_app" {
   source   = "../mig"
 

--- a/src/main/terraform/gcloud/modules/edp-aggregator/main.tf
+++ b/src/main/terraform/gcloud/modules/edp-aggregator/main.tf
@@ -267,7 +267,6 @@ module "result_fulfiller_tee_app" {
   max_replicas                  = var.requisition_fulfiller_config.worker.max_replicas
   app_args                      = var.requisition_fulfiller_config.worker.app_args
   machine_type                  = var.requisition_fulfiller_config.worker.machine_type
-  kms_key_id                    = google_kms_crypto_key.edp_aggregator_kek.id
   docker_image                  = var.requisition_fulfiller_config.worker.docker_image
   mig_distribution_policy_zones = var.requisition_fulfiller_config.worker.mig_distribution_policy_zones
   terraform_service_account     = var.terraform_service_account
@@ -310,7 +309,7 @@ resource "google_storage_bucket_iam_member" "data_watcher_config_storage_viewer"
 resource "google_storage_bucket_iam_member" "results_fulfiller_config_storage_viewer" {
   bucket = module.config_files_bucket.storage_bucket.name
   role   = "roles/storage.objectViewer"
-  member = "serviceAccount:${module.mig.mig_service_account.email}"
+  member = "serviceAccount:${module.result_fulfiller_tee_app.mig_service_account.email}"
 }
 
 resource "google_cloud_run_service_iam_member" "event_group_sync_invoker" {

--- a/src/main/terraform/gcloud/modules/edp-aggregator/variables.tf
+++ b/src/main/terraform/gcloud/modules/edp-aggregator/variables.tf
@@ -12,24 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-variable "key_ring_name" {
-  description = "Name of the KMS key ring."
-  type        = string
-  nullable    = false
-}
-
-variable "key_ring_location" {
-  description = "Location of the KMS key ring."
-  type        = string
-  nullable    = false
-}
-
-variable "kms_key_name" {
-  description = "Name of the KMS KEK."
-  type        = string
-  nullable    = false
-}
-
 variable "requisition_fulfiller_config" {
   description = "Config for a single Pub/Sub queue and its corresponding MIG worker"
   type = object({

--- a/src/main/terraform/gcloud/modules/mig/main.tf
+++ b/src/main/terraform/gcloud/modules/mig/main.tf
@@ -32,18 +32,30 @@ resource "google_pubsub_subscription_iam_member" "mig_subscriber" {
   member        = "serviceAccount:${google_service_account.mig_service_account.email}"
 }
 
-resource "google_kms_crypto_key_iam_member" "mig_kms_user" {
-  crypto_key_id = var.kms_key_id
-  role          = "roles/cloudkms.cryptoKeyDecrypter"
-  member        = "serviceAccount:${google_service_account.mig_service_account.email}"
-}
-
 resource "google_secret_manager_secret_iam_member" "mig_sa_secret_accessor" {
   for_each = { for s in var.secrets_to_mount : s.secret_id => s }
 
   secret_id = each.value.secret_id
   role      = "roles/secretmanager.secretAccessor"
   member    = "serviceAccount:${google_service_account.mig_service_account.email}"
+}
+
+resource "google_project_iam_member" "mig_sa_user" {
+  project = var.project_id
+  role    = "roles/iam.serviceAccountUser"
+  member  = "serviceAccount:${google_service_account.mig_service_account.email}"
+}
+
+resource "google_project_iam_member" "mig_workload_user" {
+  project = var.project_id
+  role    = "roles/confidentialComputing.workloadUser"
+  member  = "serviceAccount:${google_service_account.mig_service_account.email}"
+}
+
+resource "google_project_iam_member" "mig_log_writer" {
+  project = var.project_id
+  role    = "roles/logging.logWriter"
+  member  = "serviceAccount:${google_service_account.mig_service_account.email}"
 }
 
 resource "google_compute_instance_template" "confidential_vm_template" {

--- a/src/main/terraform/gcloud/modules/mig/main.tf
+++ b/src/main/terraform/gcloud/modules/mig/main.tf
@@ -46,10 +46,10 @@ resource "google_project_iam_member" "mig_sa_user" {
   member  = "serviceAccount:${google_service_account.mig_service_account.email}"
 }
 
-resource "google_project_iam_member" "mig_workload_user" {
-  project = data.google_project.project.name
-  role    = "roles/confidentialComputing.workloadUser"
-  member  = "serviceAccount:${google_service_account.mig_service_account.email}"
+resource "google_service_account_iam_member" "confidential_workload_user" {
+  service_account_id = google_service_account.mig_service_account.name
+  role               = "roles/confidentialComputing.workloadUser"
+  member             = "serviceAccount:${google_service_account.mig_service_account.email}"
 }
 
 resource "google_project_iam_member" "mig_log_writer" {

--- a/src/main/terraform/gcloud/modules/mig/main.tf
+++ b/src/main/terraform/gcloud/modules/mig/main.tf
@@ -41,19 +41,19 @@ resource "google_secret_manager_secret_iam_member" "mig_sa_secret_accessor" {
 }
 
 resource "google_project_iam_member" "mig_sa_user" {
-  project = var.project_id
+  project = data.google_project.project.name
   role    = "roles/iam.serviceAccountUser"
   member  = "serviceAccount:${google_service_account.mig_service_account.email}"
 }
 
 resource "google_project_iam_member" "mig_workload_user" {
-  project = var.project_id
+  project = data.google_project.project.name
   role    = "roles/confidentialComputing.workloadUser"
   member  = "serviceAccount:${google_service_account.mig_service_account.email}"
 }
 
 resource "google_project_iam_member" "mig_log_writer" {
-  project = var.project_id
+  project = data.google_project.project.name
   role    = "roles/logging.logWriter"
   member  = "serviceAccount:${google_service_account.mig_service_account.email}"
 }

--- a/src/main/terraform/gcloud/modules/mig/main.tf
+++ b/src/main/terraform/gcloud/modules/mig/main.tf
@@ -46,10 +46,10 @@ resource "google_project_iam_member" "mig_sa_user" {
   member  = "serviceAccount:${google_service_account.mig_service_account.email}"
 }
 
-resource "google_service_account_iam_member" "confidential_workload_user" {
-  project = data.google_project.project.name
-  role               = "roles/confidentialcomputing.workloadUser"
-  member             = "serviceAccount:${google_service_account.mig_service_account.email}"
+resource "google_project_iam_member" "confidential_workload_user" {
+  project  = data.google_project.project.name
+  role     = "roles/confidentialcomputing.workloadUser"
+  member   = "serviceAccount:${google_service_account.mig_service_account.email}"
 }
 
 resource "google_project_iam_member" "mig_log_writer" {

--- a/src/main/terraform/gcloud/modules/mig/main.tf
+++ b/src/main/terraform/gcloud/modules/mig/main.tf
@@ -47,8 +47,8 @@ resource "google_project_iam_member" "mig_sa_user" {
 }
 
 resource "google_service_account_iam_member" "confidential_workload_user" {
-  service_account_id = google_service_account.mig_service_account.name
-  role               = "roles/confidentialComputing.workloadUser"
+  project = data.google_project.project.name
+  role               = "roles/confidentialcomputing.workloadUser"
   member             = "serviceAccount:${google_service_account.mig_service_account.email}"
 }
 

--- a/src/main/terraform/gcloud/modules/mig/variables.tf
+++ b/src/main/terraform/gcloud/modules/mig/variables.tf
@@ -88,12 +88,6 @@ variable "machine_type" {
   nullable    = false
 }
 
-variable "kms_key_id" {
-  description = "The kms key id of the key encryption key to grant access to."
-  type        = string
-  nullable    = false
-}
-
 variable "docker_image" {
   description = "The docker image to be deployed."
   type        = string


### PR DESCRIPTION
- Add role to `ResultsFulfiller` service account to access config bucket
- Add roles to `ResultsFulfiller` service account to run confidential workload
- Delete KMS from `halo-cmm-dev` project