### PR TITLE
combine DirectReachResultBuilder maxFrequency with KAnonymity.reachMaxFrequencyPerUser

### DIFF
--- a/src/main/kotlin/org/wfanet/measurement/computation/KAnonymityParams.kt
+++ b/src/main/kotlin/org/wfanet/measurement/computation/KAnonymityParams.kt
@@ -22,11 +22,11 @@ package org.wfanet.measurement.computation
  * @property minUsers The minimum number of unique users required for the data to be considered
  *   k-anonymous.
  * @property minImpressions The minimum number of impressions required to satisfy k-anonymity.
- * @property maxFrequencyPerUser The max frequency per user if differential privacy is needed for
- *   reach use cases. Required if differential privacy is applied in addition to k-anonymity.
+ * @property reachMaxFrequencyPerUser The max frequency per user for reach use cases. Required if
+ *   differential privacy is applied in addition to k-anonymity. The default is Byte.MAX_VALUE.
  */
 data class KAnonymityParams(
   val minUsers: Int,
   val minImpressions: Int,
-  val maxFrequencyPerUser: Int? = null,
+  val reachMaxFrequencyPerUser: Int = Byte.MAX_VALUE.toInt(),
 )

--- a/src/main/kotlin/org/wfanet/measurement/computation/ReachAndFrequencyComputations.kt
+++ b/src/main/kotlin/org/wfanet/measurement/computation/ReachAndFrequencyComputations.kt
@@ -89,12 +89,9 @@ object ReachAndFrequencyComputations {
           minScaledNoisedReach
         }
       } else {
-        checkNotNull(kAnonymityParams.maxFrequencyPerUser) {
-          "frequencyPerUser cannot be null if dpParams and kAnonymityParams are set"
-        }
         val rawImpressionCount =
           rawHistogram.withIndex().sumOf { (index, count) ->
-            val frequency = min(kAnonymityParams.maxFrequencyPerUser!!, index + 1)
+            val frequency = min(kAnonymityParams.reachMaxFrequencyPerUser, index + 1)
             frequency * count
           }
 
@@ -103,7 +100,7 @@ object ReachAndFrequencyComputations {
           noise.addNoise(
             rawImpressionCount,
             1,
-            kAnonymityParams.maxFrequencyPerUser!!.toLong(),
+            kAnonymityParams.reachMaxFrequencyPerUser.toLong(),
             dpParams.epsilon,
             dpParams.delta,
           )

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/resultsfulfiller/compute/protocols/direct/DirectReachResultBuilder.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/resultsfulfiller/compute/protocols/direct/DirectReachResultBuilder.kt
@@ -41,8 +41,8 @@ import org.wfanet.measurement.eventdataprovider.noiser.DirectNoiseMechanism
  * @param reachPrivacyParams The differential privacy parameters for reach.
  * @param samplingRate The sampling rate used to sample the events.
  * @param directNoiseMechanism The direct noise mechanism to use.
- * @param maxPopulation The max Population that can be returned.
- * @param maxFrequency Optional. Used for k-anonymity.
+ * @param maxPopulation The max Population that can be returned. Optional.
+ * @param kAnonymityParams The k-anonymity params. Optional.
  */
 class DirectReachResultBuilder(
   private val directProtocolConfig: ProtocolConfig.Direct,
@@ -51,7 +51,6 @@ class DirectReachResultBuilder(
   private val samplingRate: Float,
   private val directNoiseMechanism: DirectNoiseMechanism,
   private val maxPopulation: Int?,
-  private val maxFrequency: Int = Byte.MAX_VALUE.toInt(),
   private val kAnonymityParams: KAnonymityParams?,
 ) : MeasurementResultBuilder {
 
@@ -65,7 +64,7 @@ class DirectReachResultBuilder(
     val histogram: LongArray =
       HistogramComputations.buildHistogram(
         frequencyVector = frequencyData,
-        maxFrequency = maxFrequency,
+        maxFrequency = kAnonymityParams?.reachMaxFrequencyPerUser ?: 1,
       )
 
     val reachValue = getReachValue(histogram)

--- a/src/main/kotlin/org/wfanet/measurement/eventdataprovider/requisition/v2alpha/common/FrequencyVectorBuilder.kt
+++ b/src/main/kotlin/org/wfanet/measurement/eventdataprovider/requisition/v2alpha/common/FrequencyVectorBuilder.kt
@@ -82,7 +82,7 @@ class FrequencyVectorBuilder(
     }
 
     if (measurementSpec.hasReach() && kAnonymityParams != null) {
-      require(kAnonymityParams.reachMaxFrequencyPerUser!! >= 1) {
+      require(kAnonymityParams.reachMaxFrequencyPerUser >= 1) {
         "kAnonymityParams.maxFrequencyPerUser must be >= 1 for reach measurements with kAnonymity"
       }
     }

--- a/src/main/kotlin/org/wfanet/measurement/eventdataprovider/requisition/v2alpha/common/FrequencyVectorBuilder.kt
+++ b/src/main/kotlin/org/wfanet/measurement/eventdataprovider/requisition/v2alpha/common/FrequencyVectorBuilder.kt
@@ -81,12 +81,8 @@ class FrequencyVectorBuilder(
       }
     }
 
-    if (
-      measurementSpec.hasReach() &&
-        kAnonymityParams != null &&
-        kAnonymityParams.maxFrequencyPerUser != null
-    ) {
-      require(kAnonymityParams.maxFrequencyPerUser!! >= 1) {
+    if (measurementSpec.hasReach() && kAnonymityParams != null) {
+      require(kAnonymityParams.reachMaxFrequencyPerUser!! >= 1) {
         "kAnonymityParams.maxFrequencyPerUser must be >= 1 for reach measurements with kAnonymity"
       }
     }
@@ -97,7 +93,7 @@ class FrequencyVectorBuilder(
       } else if (measurementSpec.hasImpression()) {
         measurementSpec.impression.maximumFrequencyPerUser
       } else if (measurementSpec.hasReach()) {
-        kAnonymityParams?.maxFrequencyPerUser ?: 1
+        kAnonymityParams?.reachMaxFrequencyPerUser ?: 1
       } else {
         1
       }

--- a/src/test/kotlin/org/wfanet/measurement/computation/ReachAndFrequencyComputationsTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/computation/ReachAndFrequencyComputationsTest.kt
@@ -93,7 +93,7 @@ class ReachAndFrequencyComputationsTest {
         vectorSize = 40,
         dpParams = null,
         kAnonymityParams =
-          KAnonymityParams(minUsers = 30, minImpressions = 50, maxFrequencyPerUser = 3),
+          KAnonymityParams(minUsers = 30, minImpressions = 50, reachMaxFrequencyPerUser = 3),
       )
     assertThat(reach).isEqualTo(0)
   }
@@ -125,25 +125,10 @@ class ReachAndFrequencyComputationsTest {
         vectorSize = 200,
         dpParams = DP_PARAMS,
         kAnonymityParams =
-          KAnonymityParams(minUsers = 30, minImpressions = 50, maxFrequencyPerUser = 3),
+          KAnonymityParams(minUsers = 30, minImpressions = 50, reachMaxFrequencyPerUser = 3),
       )
     assertThat(reach).isAtMost(min(200, 170 + tolerance))
     assertThat(reach).isAtLeast(max(0L, 170 - tolerance))
-  }
-
-  @Test
-  fun `computeReach with noise and k-anonymity fails if maxFrequencyPerUser not set`() {
-    val rawHistogram = longArrayOf(100, 50, 20) // Reach in sample = 170
-    val tolerance = getNoiseTolerance(DP_PARAMS)
-    assertFailsWith<IllegalStateException> {
-      ReachAndFrequencyComputations.computeReach(
-        rawHistogram,
-        vidSamplingIntervalWidth = 1.0f,
-        vectorSize = 200,
-        dpParams = DP_PARAMS,
-        kAnonymityParams = KAnonymityParams(minUsers = 30, minImpressions = 50),
-      )
-    }
   }
 
   @Test
@@ -156,7 +141,7 @@ class ReachAndFrequencyComputationsTest {
         vectorSize = 200,
         dpParams = DP_PARAMS,
         kAnonymityParams =
-          KAnonymityParams(minUsers = 200, minImpressions = 200, maxFrequencyPerUser = 3),
+          KAnonymityParams(minUsers = 200, minImpressions = 200, reachMaxFrequencyPerUser = 3),
       )
     assertThat(reach).isEqualTo(0)
   }

--- a/src/test/kotlin/org/wfanet/measurement/edpaggregator/resultsfulfiller/compute/protocols/direct/DirectReachResultBuilderTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/edpaggregator/resultsfulfiller/compute/protocols/direct/DirectReachResultBuilderTest.kt
@@ -41,7 +41,6 @@ class DirectReachResultBuilderTest {
       val directReachResultBuilder =
         DirectReachResultBuilder(
           directProtocolConfig = DIRECT_PROTOCOL,
-          maxFrequency = MAX_FREQUENCY,
           reachPrivacyParams = REACH_PRIVACY_PARAMS,
           samplingRate = SAMPLING_RATE,
           directNoiseMechanism = DirectNoiseMechanism.NONE,
@@ -67,7 +66,6 @@ class DirectReachResultBuilderTest {
       val directReachResultBuilder =
         DirectReachResultBuilder(
           directProtocolConfig = DIRECT_PROTOCOL,
-          maxFrequency = MAX_FREQUENCY,
           reachPrivacyParams = REACH_PRIVACY_PARAMS,
           samplingRate = SAMPLING_RATE,
           directNoiseMechanism = DirectNoiseMechanism.CONTINUOUS_GAUSSIAN,


### PR DESCRIPTION
Two variables were being used to track max frequency for reach calculation use cases with k-anonymity is applied. This PR makes reachMaxFrequencyPerUser a required k-anonymity param and replaces the existing maxFrequency param in the DirectReachResultBuilder.