### PR TITLE
bug: set model line in grouped requisitions by report id

### DIFF
--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/requisitionfetcher/RequisitionGrouperByReportId.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/requisitionfetcher/RequisitionGrouperByReportId.kt
@@ -95,7 +95,7 @@ class RequisitionGrouperByReportId(
               }
             }
         groupedRequisitions {
-          this.modelLine = modelLine
+          this.modelLine = groups.firstOrNull()?.modelLine ?: ""
           this.eventGroupMap += entries
           this.requisitions += groups.flatMap { it.requisitionsList }
         }

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/requisitionfetcher/testing/TestRequisitionData.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/requisitionfetcher/testing/TestRequisitionData.kt
@@ -162,6 +162,7 @@ object TestRequisitionData {
       }
     nonceHashes += Hashing.hashSha256(REQUISITION_SPEC.nonce)
     reportingMetadata = MeasurementSpecKt.reportingMetadata { report = "some-report" }
+    modelLine = "some-model-line"
   }
 
   val REQUISITION = requisition {

--- a/src/test/kotlin/org/wfanet/measurement/edpaggregator/requisitionfetcher/RequisitionGrouperByReportIdTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/edpaggregator/requisitionfetcher/RequisitionGrouperByReportIdTest.kt
@@ -141,29 +141,30 @@ class RequisitionGrouperByReportIdTest : AbstractRequisitionGrouperTest() {
       requisitionGrouper.groupRequisitions(listOf(TestRequisitionData.REQUISITION, requisition2))
     }
     assertThat(groupedRequisitions).hasSize(1)
-    groupedRequisitions.forEach { groupedRequisition: GroupedRequisitions ->
-      assertThat(groupedRequisition.eventGroupMapList.single())
-        .isEqualTo(
-          eventGroupMapEntry {
-            eventGroup = "dataProviders/someDataProvider/eventGroups/name"
-            details = eventGroupDetails {
-              eventGroupReferenceId = "some-event-group-reference-id"
-              collectionIntervals +=
-                listOf(
-                  interval {
-                    startTime = TestRequisitionData.TIME_RANGE.start.toProtoTime()
-                    endTime =
-                      TestRequisitionData.TIME_RANGE.endExclusive.plusSeconds(3600).toProtoTime()
-                  }
-                )
-            }
+    val groupedRequisition = groupedRequisitions.single()
+    assertThat(groupedRequisition.eventGroupMapList.single())
+      .isEqualTo(
+        eventGroupMapEntry {
+          eventGroup = "dataProviders/someDataProvider/eventGroups/name"
+          details = eventGroupDetails {
+            eventGroupReferenceId = "some-event-group-reference-id"
+            collectionIntervals +=
+              listOf(
+                interval {
+                  startTime = TestRequisitionData.TIME_RANGE.start.toProtoTime()
+                  endTime =
+                    TestRequisitionData.TIME_RANGE.endExclusive.plusSeconds(3600).toProtoTime()
+                }
+              )
           }
-        )
-      assertThat(
-          groupedRequisition.requisitionsList.map { it.requisition.unpack(Requisition::class.java) }
-        )
-        .isEqualTo(listOf(TestRequisitionData.REQUISITION, requisition2))
-    }
+        }
+      )
+    assertThat(
+        groupedRequisition.requisitionsList.map { it.requisition.unpack(Requisition::class.java) }
+      )
+      .isEqualTo(listOf(TestRequisitionData.REQUISITION, requisition2))
+
+    assertThat(groupedRequisition.modelLine).isEqualTo("some-model-line")
   }
 
   @Test


### PR DESCRIPTION
This fixes a bug where the model line was not properly set by GroupRequistionByReportId.