### PR TITLE
refactor: Restrict visibility of requisitions common library

### DIFF
--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/resultsfulfiller/BUILD.bazel
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/resultsfulfiller/BUILD.bazel
@@ -160,7 +160,7 @@ kt_jvm_library(
     name = "model_line_info",
     srcs = ["ModelLineInfo.kt"],
     deps = [
-        "//src/main/kotlin/org/wfanet/measurement/eventdataprovider/requisition/v2alpha/common",
+        "//src/main/kotlin/org/wfanet/measurement/eventdataprovider/requisition/v2alpha:requisition",
         "//src/main/proto/wfa/measurement/api/v2alpha:population_spec_kt_jvm_proto",
     ],
 )

--- a/src/main/kotlin/org/wfanet/measurement/eventdataprovider/requisition/v2alpha/common/BUILD.bazel
+++ b/src/main/kotlin/org/wfanet/measurement/eventdataprovider/requisition/v2alpha/common/BUILD.bazel
@@ -1,11 +1,8 @@
 load("@rules_jvm_external//:defs.bzl", "maven_export")
-load("@wfa_common_jvm//build:defs.bzl", "test_target")
 load("@wfa_common_jvm//build/maven:defs.bzl", "artifact_version")
 load("@wfa_rules_kotlin_jvm//kotlin:defs.bzl", "kt_jvm_library")
 
 package(default_visibility = [
-    test_target(":__pkg__"),
-    "//src/main/kotlin/org/wfanet/measurement/edpaggregator/resultsfulfiller:__subpackages__",
     "//src/main/kotlin/org/wfanet/measurement/eventdataprovider/requisition/v2alpha:__subpackages__",
     "//src/test/kotlin/org/wfanet/measurement/eventdataprovider/requisition/v2alpha:__subpackages__",
 ])


### PR DESCRIPTION
Visibility of all subpackages of the EDP requisition library is intentionally restricted to force usage of the top-level library target.