### PR TITLE
test: Add tests for Computing Metric Results when Measurement Results are 0

### DIFF
--- a/src/main/kotlin/org/wfanet/measurement/integration/common/reporting/v2/InProcessLifeOfAReportIntegrationTest.kt
+++ b/src/main/kotlin/org/wfanet/measurement/integration/common/reporting/v2/InProcessLifeOfAReportIntegrationTest.kt
@@ -107,6 +107,9 @@ import org.wfanet.measurement.internal.reporting.v2.metricFrequencySpec as inter
 import org.wfanet.measurement.internal.reporting.v2.reportingImpressionQualificationFilter as internalReportingImpressionQualificationFilter
 import org.wfanet.measurement.internal.reporting.v2.reportingInterval as internalReportingInterval
 import org.wfanet.measurement.internal.reporting.v2.resultGroup as internalResultGroup
+import com.google.protobuf.duration
+import java.lang.Math.pow
+import kotlin.time.toDuration
 import org.wfanet.measurement.kingdom.deploy.common.service.DataServices
 import org.wfanet.measurement.loadtest.dataprovider.EventQuery
 import org.wfanet.measurement.loadtest.dataprovider.SyntheticGeneratorEventQuery
@@ -1714,6 +1717,86 @@ abstract class InProcessLifeOfAReportIntegrationTest(
   }
 
   @Test
+  fun `reach-and-frequency metric with no data has a result of 0`() = runBlocking {
+    val measurementConsumerData = inProcessCmmsComponents.getMeasurementConsumerData()
+    val eventGroups = listEventGroups()
+    val eventGroup = eventGroups.first()
+    val eventGroupEntries: List<Pair<EventGroup, String>> =
+      listOf(eventGroup to "person.age_group == ${Person.AgeGroup.YEARS_18_TO_34_VALUE}")
+    val createdPrimitiveReportingSet: ReportingSet =
+      createPrimitiveReportingSets(eventGroupEntries, measurementConsumerData.name).single()
+
+    val metric = metric {
+      reportingSet = createdPrimitiveReportingSet.name
+      timeInterval = interval {
+        startTime = timestamp { seconds = 1 }
+        endTime = timestamp { seconds = 2 }
+      }
+      metricSpec = metricSpec {
+        reachAndFrequency =
+          MetricSpecKt.reachAndFrequencyParams {
+            reachPrivacyParams = DP_PARAMS
+            frequencyPrivacyParams = DP_PARAMS
+            maximumFrequency = 5
+          }
+        vidSamplingInterval = VID_SAMPLING_INTERVAL
+      }
+    }
+
+    val createdMetric =
+      publicMetricsClient
+        .withCallCredentials(credentials)
+        .createMetric(
+          createMetricRequest {
+            parent = measurementConsumerData.name
+            this.metric = metric
+            metricId = "abc"
+          }
+        )
+
+    val retrievedMetric = pollForCompletedMetric(createdMetric.name)
+    assertThat(retrievedMetric.state).isEqualTo(Metric.State.SUCCEEDED)
+
+    val reachAndFrequencyResult = retrievedMetric.result.reachAndFrequency
+    val actualResult =
+      MeasurementKt.result {
+        reach = MeasurementKt.ResultKt.reach { value = reachAndFrequencyResult.reach.value }
+        frequency =
+          MeasurementKt.ResultKt.frequency {
+            relativeFrequencyDistribution.putAll(
+              reachAndFrequencyResult.frequencyHistogram.binsList.associate {
+                Pair(it.label.toLong(),
+                     if (reachAndFrequencyResult.reach.value == 0L) {
+                       0.0
+                     } else {
+                      it.binResult.value / reachAndFrequencyResult.reach.value
+                     }
+                )
+              }
+            )
+          }
+      }
+    val reachTolerance =
+      computeErrorMargin(reachAndFrequencyResult.reach.univariateStatistics.standardDeviation)
+    val frequencyToleranceMap: Map<Long, Double> =
+      reachAndFrequencyResult.frequencyHistogram.binsList.associate { bin ->
+        bin.label.toLong() to computeErrorMargin(bin.relativeUnivariateStatistics.standardDeviation)
+      }
+
+    val mapWithAllZeroFrequency = buildMap {
+      reachAndFrequencyResult.frequencyHistogram.binsList.forEach { bin ->
+        put(bin.label.toLong(), 0.0)
+      }
+    }
+
+    assertThat(actualResult).reachValue().isWithin(reachTolerance).of(0)
+    assertThat(actualResult)
+      .frequencyDistribution()
+      .isWithin(frequencyToleranceMap)
+      .of(mapWithAllZeroFrequency)
+  }
+
+  @Test
   fun `impression count metric has the expected result`() = runBlocking {
     val measurementConsumerData = inProcessCmmsComponents.getMeasurementConsumerData()
     val eventGroups = listEventGroups()
@@ -1767,6 +1850,55 @@ abstract class InProcessLifeOfAReportIntegrationTest(
       .impressionValue()
       .isWithin(tolerance)
       .of(expectedResult.impression.value)
+  }
+
+  @Test
+  fun `impression count metric with no data has a result of 0`() = runBlocking {
+    val measurementConsumerData = inProcessCmmsComponents.getMeasurementConsumerData()
+    val eventGroups = listEventGroups()
+    val eventGroup = eventGroups.first()
+    val eventGroupEntries: List<Pair<EventGroup, String>> =
+      listOf(eventGroup to "person.age_group == ${Person.AgeGroup.YEARS_18_TO_34_VALUE}")
+    val createdPrimitiveReportingSet: ReportingSet =
+      createPrimitiveReportingSets(eventGroupEntries, measurementConsumerData.name).single()
+
+    val metric = metric {
+      reportingSet = createdPrimitiveReportingSet.name
+      timeInterval = interval {
+        startTime = timestamp { seconds = 1 }
+        endTime = timestamp { seconds = 2 }
+      }
+      metricSpec = metricSpec {
+        impressionCount = MetricSpecKt.impressionCountParams { privacyParams = DP_PARAMS }
+        vidSamplingInterval = VID_SAMPLING_INTERVAL
+      }
+    }
+
+    val createdMetric =
+      publicMetricsClient
+        .withCallCredentials(credentials)
+        .createMetric(
+          createMetricRequest {
+            parent = measurementConsumerData.name
+            this.metric = metric
+            metricId = "abc"
+          }
+        )
+
+    val retrievedMetric = pollForCompletedMetric(createdMetric.name)
+    assertThat(retrievedMetric.state).isEqualTo(Metric.State.SUCCEEDED)
+
+    val impressionResult = retrievedMetric.result.impressionCount
+    val actualResult =
+      MeasurementKt.result {
+        impression = MeasurementKt.ResultKt.impression { value = impressionResult.value }
+      }
+    val tolerance = computeErrorMargin(impressionResult.univariateStatistics.standardDeviation)
+
+    assertThat(actualResult)
+      .impressionValue()
+      .isWithin(tolerance)
+      .of(0)
   }
 
   @Test
@@ -1852,6 +1984,50 @@ abstract class InProcessLifeOfAReportIntegrationTest(
       MeasurementKt.result { reach = MeasurementKt.ResultKt.reach { value = reachResult.value } }
     val tolerance = computeErrorMargin(reachResult.univariateStatistics.standardDeviation)
     assertThat(actualResult).reachValue().isWithin(tolerance).of(expectedResult.reach.value)
+  }
+
+  @Test
+  fun `reach metric with no data has a result of 0`() = runBlocking {
+    val measurementConsumerData = inProcessCmmsComponents.getMeasurementConsumerData()
+    val eventGroups = listEventGroups()
+    val eventGroup = eventGroups.first()
+    val eventGroupEntries: List<Pair<EventGroup, String>> =
+      listOf(eventGroup to "person.age_group == ${Person.AgeGroup.YEARS_18_TO_34_VALUE}")
+    val createdPrimitiveReportingSet: ReportingSet =
+      createPrimitiveReportingSets(eventGroupEntries, measurementConsumerData.name).single()
+
+    val metric = metric {
+      reportingSet = createdPrimitiveReportingSet.name
+      timeInterval = interval {
+        startTime = timestamp { seconds = 1 }
+        endTime = timestamp { seconds = 2 }
+      }
+      metricSpec = metricSpec {
+        reach = MetricSpecKt.reachParams { privacyParams = DP_PARAMS }
+        vidSamplingInterval = VID_SAMPLING_INTERVAL
+      }
+      filters += "person.gender == ${Person.Gender.MALE_VALUE}"
+    }
+
+    val createdMetric =
+      publicMetricsClient
+        .withCallCredentials(credentials)
+        .createMetric(
+          createMetricRequest {
+            parent = measurementConsumerData.name
+            this.metric = metric
+            metricId = "abc"
+          }
+        )
+
+    val retrievedMetric = pollForCompletedMetric(createdMetric.name)
+    assertThat(retrievedMetric.state).isEqualTo(Metric.State.SUCCEEDED)
+
+    val reachResult = retrievedMetric.result.reach
+    val actualResult =
+      MeasurementKt.result { reach = MeasurementKt.ResultKt.reach { value = reachResult.value } }
+    val tolerance = computeErrorMargin(reachResult.univariateStatistics.standardDeviation)
+    assertThat(actualResult).reachValue().isWithin(tolerance).of(0)
   }
 
   @Test

--- a/src/test/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/MetricsServiceTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/MetricsServiceTest.kt
@@ -9202,6 +9202,239 @@ class MetricsServiceTest {
     }
 
   @Test
+  fun `getMetric returns impression metric with 0 result when measurement results are 0`(): Unit =
+    runBlocking {
+      wheneverBlocking {
+        permissionsServiceMock.checkPermissions(hasPrincipal(PRINCIPAL.name))
+      } doReturn checkPermissionsResponse { permissions += PermissionName.GET }
+
+      whenever(internalMetricsMock.batchGetMetrics(any()))
+        .thenReturn(
+          internalBatchGetMetricsResponse {
+            metrics +=
+              INTERNAL_SUCCEEDED_SINGLE_PUBLISHER_IMPRESSION_METRIC.copy {
+                weightedMeasurements.clear()
+                weightedMeasurements += weightedMeasurement {
+                  weight = 1
+                  binaryRepresentation = 1
+                  measurement =
+                    INTERNAL_PENDING_SINGLE_PUBLISHER_IMPRESSION_MEASUREMENT.copy {
+                      state = InternalMeasurement.State.SUCCEEDED
+                      details =
+                        details.copy {
+                          results +=
+                            InternalMeasurementKt.result {
+                              impression =
+                                InternalMeasurementKt.ResultKt.impression {
+                                  value = 0
+                                }
+                            }
+                        }
+                    }
+                }
+                weightedMeasurements += weightedMeasurement {
+                  weight = 1
+                  binaryRepresentation = 1
+                  measurement =
+                    INTERNAL_PENDING_SINGLE_PUBLISHER_IMPRESSION_MEASUREMENT.copy {
+                      state = InternalMeasurement.State.SUCCEEDED
+                      details =
+                        details.copy {
+                          results +=
+                            InternalMeasurementKt.result {
+                              impression =
+                                InternalMeasurementKt.ResultKt.impression {
+                                  value = 0
+                                }
+                            }
+                        }
+                    }
+                }
+              }
+          }
+        )
+
+      val request = getMetricRequest {
+        name = SUCCEEDED_SINGLE_PUBLISHER_IMPRESSION_METRIC.name
+      }
+
+      val result =
+        withPrincipalAndScopes(PRINCIPAL, SCOPES) { runBlocking { service.getMetric(request) } }
+
+      assertThat(result)
+        .isEqualTo(
+          PENDING_SINGLE_PUBLISHER_IMPRESSION_METRIC.copy {
+            state = Metric.State.SUCCEEDED
+            this.result = metricResult {
+              cmmsMeasurements += PENDING_SINGLE_PUBLISHER_IMPRESSION_MEASUREMENT.name
+              cmmsMeasurements += PENDING_SINGLE_PUBLISHER_IMPRESSION_MEASUREMENT.name
+              impressionCount =
+                MetricResultKt.impressionCountResult {
+                  value = 0L
+                }
+            }
+          }
+        )
+    }
+
+  @Test
+  fun `getMetric returns reach metric with 0 result when measurement results are 0`(): Unit =
+    runBlocking {
+      wheneverBlocking {
+        permissionsServiceMock.checkPermissions(hasPrincipal(PRINCIPAL.name))
+      } doReturn checkPermissionsResponse { permissions += PermissionName.GET }
+
+      whenever(internalMetricsMock.batchGetMetrics(any()))
+        .thenReturn(
+          internalBatchGetMetricsResponse {
+            metrics +=
+              INTERNAL_SUCCEEDED_INCREMENTAL_REACH_METRIC.copy {
+                weightedMeasurements.clear()
+                weightedMeasurements += weightedMeasurement {
+                  weight = 1
+                  binaryRepresentation = 1
+                  measurement =
+                    INTERNAL_PENDING_UNION_ALL_REACH_MEASUREMENT.copy {
+                      state = InternalMeasurement.State.SUCCEEDED
+                      details =
+                        details.copy {
+                          results +=
+                            InternalMeasurementKt.result {
+                              reach =
+                                InternalMeasurementKt.ResultKt.reach {
+                                  value = 0
+                                }
+                            }
+                        }
+                    }
+                }
+                weightedMeasurements += weightedMeasurement {
+                  weight = 1
+                  binaryRepresentation = 1
+                  measurement =
+                    INTERNAL_PENDING_UNION_ALL_BUT_LAST_PUBLISHER_REACH_MEASUREMENT.copy {
+                      state = InternalMeasurement.State.SUCCEEDED
+                      details =
+                        details.copy {
+                          results +=
+                            InternalMeasurementKt.result {
+                              reach =
+                                InternalMeasurementKt.ResultKt.reach {
+                                  value = 0
+                                }
+                            }
+                        }
+                    }
+                }
+              }
+          }
+        )
+
+      val request = getMetricRequest {
+        name = SUCCEEDED_INCREMENTAL_REACH_METRIC.name
+      }
+
+      val result =
+        withPrincipalAndScopes(PRINCIPAL, SCOPES) { runBlocking { service.getMetric(request) } }
+
+      assertThat(result)
+        .isEqualTo(
+          PENDING_INCREMENTAL_REACH_METRIC.copy {
+            state = Metric.State.SUCCEEDED
+            this.result = metricResult {
+              cmmsMeasurements += PENDING_UNION_ALL_REACH_MEASUREMENT.name
+              cmmsMeasurements += PENDING_UNION_ALL_BUT_LAST_PUBLISHER_REACH_MEASUREMENT.name
+              reach =
+                MetricResultKt.reachResult {
+                  value = 0L
+                }
+            }
+          }
+        )
+    }
+
+  @Test
+  fun `getMetric returns duration metric with 0 result when measurement results are 0`(): Unit =
+    runBlocking {
+      wheneverBlocking {
+        permissionsServiceMock.checkPermissions(hasPrincipal(PRINCIPAL.name))
+      } doReturn checkPermissionsResponse { permissions += PermissionName.GET }
+
+      whenever(internalMetricsMock.batchGetMetrics(any()))
+        .thenReturn(
+          internalBatchGetMetricsResponse {
+            metrics +=
+              INTERNAL_SUCCEEDED_CROSS_PUBLISHER_WATCH_DURATION_METRIC.copy {
+                weightedMeasurements.clear()
+                weightedMeasurements += weightedMeasurement {
+                  weight = 1
+                  binaryRepresentation = 1
+                  measurement =
+                    INTERNAL_PENDING_UNION_ALL_WATCH_DURATION_MEASUREMENT.copy {
+                      state = InternalMeasurement.State.SUCCEEDED
+                      details =
+                        details.copy {
+                          results +=
+                            InternalMeasurementKt.result {
+                              watchDuration =
+                                InternalMeasurementKt.ResultKt.watchDuration {
+                                  value = duration {
+                                    seconds = 0
+                                    nanos = 0
+                                  }
+                                }
+                            }
+                        }
+                    }
+                }
+                weightedMeasurements += weightedMeasurement {
+                  weight = 1
+                  binaryRepresentation = 1
+                  measurement =
+                    INTERNAL_PENDING_UNION_ALL_WATCH_DURATION_MEASUREMENT.copy {
+                      state = InternalMeasurement.State.SUCCEEDED
+                      details =
+                        details.copy {
+                          results +=
+                            InternalMeasurementKt.result {
+                              watchDuration =
+                                InternalMeasurementKt.ResultKt.watchDuration {
+                                  value = duration {
+                                    seconds = 0
+                                    nanos = 0
+                                  }                                }
+                            }
+                        }
+                    }
+                }
+              }
+          }
+        )
+
+      val request = getMetricRequest {
+        name = SUCCEEDED_CROSS_PUBLISHER_WATCH_DURATION_METRIC.name
+      }
+
+      val result =
+        withPrincipalAndScopes(PRINCIPAL, SCOPES) { runBlocking { service.getMetric(request) } }
+
+      assertThat(result)
+        .isEqualTo(
+          PENDING_CROSS_PUBLISHER_WATCH_DURATION_METRIC.copy {
+            state = Metric.State.SUCCEEDED
+            this.result = metricResult {
+              cmmsMeasurements += PENDING_UNION_ALL_WATCH_DURATION_MEASUREMENT.name
+              cmmsMeasurements += PENDING_UNION_ALL_WATCH_DURATION_MEASUREMENT.name
+              watchDuration =
+                MetricResultKt.watchDurationResult {
+                  value = 0.0
+                }
+            }
+          }
+        )
+    }
+
+  @Test
   fun `getMetric returns duration metric with SUCCEEDED when measurements are updated to SUCCEEDED`() =
     runBlocking {
       wheneverBlocking {


### PR DESCRIPTION
Add tests for Computing Metric Results when Measurement Results are 0. Add new unit tests for Reach, Impression, and Duration. Add new In-Process tests for Reach, ReachAndFrequency, and Impression.