### PR TITLE
feat(report-processor): Log when a Measurement has a large correction

### DIFF
--- a/src/main/proto/wfa/measurement/reporting/postprocessing/v2alpha/report_post_processor_result.proto
+++ b/src/main/proto/wfa/measurement/reporting/postprocessing/v2alpha/report_post_processor_result.proto
@@ -162,7 +162,7 @@ message ReportPostProcessorResult {
   // statistically out of bound (e.g. |corrected_value - value| > 7*sigma).
   message LargeCorrection {
     // The unique name of the measurement.
-    string measurement_name = 1;
+    string measurement_id = 1;
 
     // The original value of the measurement before correction.
     int64 original_value = 2;

--- a/src/main/proto/wfa/measurement/reporting/postprocessing/v2alpha/report_post_processor_result.proto
+++ b/src/main/proto/wfa/measurement/reporting/postprocessing/v2alpha/report_post_processor_result.proto
@@ -158,11 +158,11 @@ message ReportPostProcessorResult {
   // the error message.
   string error_message = 7;
 
-  // Contains details about a measurement where the correction applied was
+  // Contains details about a metric where the correction applied was
   // statistically out of bound (e.g. |corrected_value - value| > 7*sigma).
   message LargeCorrection {
-    // The unique name of the measurement that was corrected.
-    string name = 1;
+    // The unique name of the metric title that was corrected.
+    string metric_title = 1;
 
     // The original value of the measurement before correction.
     int64 original_value = 2;
@@ -174,6 +174,6 @@ message ReportPostProcessorResult {
     double sigma = 4;
   }
 
-  // Contains details about all large measurements.
+  // Contains details about all metric with large correction.
   repeated LargeCorrection large_corrections = 8;
 }

--- a/src/main/proto/wfa/measurement/reporting/postprocessing/v2alpha/report_post_processor_result.proto
+++ b/src/main/proto/wfa/measurement/reporting/postprocessing/v2alpha/report_post_processor_result.proto
@@ -157,4 +157,23 @@ message ReportPostProcessorResult {
   // If an unhandled exception occurred during processing, this field contains
   // the error message.
   string error_message = 7;
+
+  // Contains details about a measurement where the correction applied was
+  // statistically out of bound (e.g. |corrected_value - value| > 7*sigma).
+  message LargeCorrection {
+    // The unique name of the measurement.
+    string measurement_name = 1;
+
+    // The original value of the measurement before correction.
+    int64 original_value = 2;
+
+    // The new value of the measurement after correction.
+    int64 corrected_value = 3;
+
+    // The standard deviation of the measurement.
+    double sigma = 4;
+  }
+
+  // Contains details about all large measurements.
+  repeated LargeCorrection large_corrections = 8;
 }

--- a/src/main/proto/wfa/measurement/reporting/postprocessing/v2alpha/report_post_processor_result.proto
+++ b/src/main/proto/wfa/measurement/reporting/postprocessing/v2alpha/report_post_processor_result.proto
@@ -164,16 +164,16 @@ message ReportPostProcessorResult {
     // The unique name of the metric title that was corrected.
     string metric_title = 1;
 
-    // The original value of the measurement before correction.
+    // The original value of the metric before correction.
     int64 original_value = 2;
 
-    // The new value of the measurement after correction.
+    // The new value of the metric after correction.
     int64 corrected_value = 3;
 
-    // The standard deviation of the measurement.
+    // The standard deviation of the metric.
     double sigma = 4;
   }
 
-  // Contains details about all metric with large correction.
+  // Contains details about all metrics with large correction.
   repeated LargeCorrection large_corrections = 8;
 }

--- a/src/main/proto/wfa/measurement/reporting/postprocessing/v2alpha/report_post_processor_result.proto
+++ b/src/main/proto/wfa/measurement/reporting/postprocessing/v2alpha/report_post_processor_result.proto
@@ -161,8 +161,8 @@ message ReportPostProcessorResult {
   // Contains details about a measurement where the correction applied was
   // statistically out of bound (e.g. |corrected_value - value| > 7*sigma).
   message LargeCorrection {
-    // The unique name of the measurement.
-    string measurement_id = 1;
+    // The unique name of the measurement that was corrected.
+    string name = 1;
 
     // The original value of the measurement before correction.
     int64 original_value = 2;

--- a/src/main/python/wfa/measurement/reporting/postprocessing/report/report.py
+++ b/src/main/python/wfa/measurement/reporting/postprocessing/report/report.py
@@ -620,7 +620,7 @@ class Report:
             f"sigma={measurement.sigma}."
           )
           report_post_processor_result.large_corrections.add(
-            name=measurement_name,
+            metric_title=measurement_name,
             original_value=round(measurement.value),
             corrected_value=round(corrected_measurement.value),
             sigma=measurement.sigma,

--- a/src/main/python/wfa/measurement/reporting/postprocessing/report/report.py
+++ b/src/main/python/wfa/measurement/reporting/postprocessing/report/report.py
@@ -604,10 +604,10 @@ class Report:
     )
 
     if corrected_report:
-      for measurement_id in self._measurement_name_to_measurement.keys():
-        measurement = self.get_measurement_from_name(measurement_id)
+      for measurement_name in self._measurement_name_to_measurement.keys():
+        measurement = self.get_measurement_from_name(measurement_name)
         corrected_measurement = corrected_report.get_measurement_from_name(
-            measurement_id
+            measurement_name
         )
         if measurement is None or corrected_measurement is None:
           continue
@@ -620,7 +620,7 @@ class Report:
             f"sigma={measurement.sigma}."
           )
           report_post_processor_result.large_corrections.add(
-            measurement_id=measurement_id,
+            name=measurement_name,
             original_value=round(measurement.value),
             corrected_value=round(corrected_measurement.value),
             sigma=measurement.sigma,

--- a/src/main/python/wfa/measurement/reporting/postprocessing/report/report.py
+++ b/src/main/python/wfa/measurement/reporting/postprocessing/report/report.py
@@ -604,10 +604,10 @@ class Report:
     )
 
     if corrected_report:
-      for measurement_name in self._measurement_name_to_measurement.keys():
-        measurement = self.get_measurement_from_name(measurement_name)
+      for measurement_id in self._measurement_name_to_measurement.keys():
+        measurement = self.get_measurement_from_name(measurement_id)
         corrected_measurement = corrected_report.get_measurement_from_name(
-            measurement_name
+            measurement_id
         )
         if measurement is None or corrected_measurement is None:
           continue
@@ -620,7 +620,7 @@ class Report:
             f"sigma={measurement.sigma}."
           )
           report_post_processor_result.large_corrections.add(
-            measurement_name=measurement_name,
+            measurement_id=measurement_id,
             original_value=round(measurement.value),
             corrected_value=round(corrected_measurement.value),
             sigma=measurement.sigma,

--- a/src/main/python/wfa/measurement/reporting/postprocessing/report/report.py
+++ b/src/main/python/wfa/measurement/reporting/postprocessing/report/report.py
@@ -515,6 +515,7 @@ class Report:
     # standard deviation of the measurements when the report is corrected.
     measurement_index = 0
     self._measurement_name_to_index = {}
+    self._measurement_name_to_measurement = {}
     self._max_standard_deviation = UNIT_SCALING_FACTOR
     for metric in metric_reports.keys():
       # Assigns an index for whole campaign reaches.
@@ -523,6 +524,7 @@ class Report:
         measurement = metric_reports[
             metric].get_whole_campaign_reach_measurement(edp_combination)
         self._measurement_name_to_index[measurement.name] = measurement_index
+        self._measurement_name_to_measurement[measurement.name] = measurement
         self._max_standard_deviation = max(self._max_standard_deviation,
                                            measurement.sigma)
         measurement_index += 1
@@ -535,6 +537,7 @@ class Report:
               metric].get_weekly_cumulative_reach_measurement(
                   edp_combination, period)
           self._measurement_name_to_index[measurement.name] = measurement_index
+          self._measurement_name_to_measurement[measurement.name] = measurement
           self._max_standard_deviation = max(self._max_standard_deviation,
                                              measurement.sigma)
           measurement_index += 1
@@ -547,6 +550,7 @@ class Report:
               metric].get_whole_campaign_k_reach_measurement(
                   edp_combination, frequency)
           self._measurement_name_to_index[measurement.name] = measurement_index
+          self._measurement_name_to_measurement[measurement.name] = measurement
           self._max_standard_deviation = max(self._max_standard_deviation,
                                              measurement.sigma)
           measurement_index += 1
@@ -557,11 +561,17 @@ class Report:
         measurement = metric_reports[
             metric].get_whole_campaign_impression_measurement(edp_combination)
         self._measurement_name_to_index[measurement.name] = measurement_index
+        self._measurement_name_to_measurement[measurement.name] = measurement
         self._max_standard_deviation = max(self._max_standard_deviation,
                                            measurement.sigma)
         measurement_index += 1
 
     self._num_vars = measurement_index
+
+  def get_measurement_from_name(self, measurement_name: str) -> Measurement:
+    if measurement_name not in self._measurement_name_to_measurement:
+      return None
+    return self._measurement_name_to_measurement[measurement_name]
 
   def get_metric_report(self, metric: str) -> "MetricReport":
     return self._metric_reports[metric]
@@ -586,13 +596,37 @@ class Report:
         else ReportQuality()
     )
 
-    return corrected_report, \
-      ReportPostProcessorResult(
-          updated_measurements={},
-          status=report_post_processor_status,
-          pre_correction_quality=pre_correction_quality,
-          post_correction_quality=post_correction_quality,
-      )
+    report_post_processor_result = ReportPostProcessorResult(
+        updated_measurements={},
+        status=report_post_processor_status,
+        pre_correction_quality=pre_correction_quality,
+        post_correction_quality=post_correction_quality,
+    )
+
+    if corrected_report:
+      for measurement_name in self._measurement_name_to_measurement.keys():
+        measurement = self.get_measurement_from_name(measurement_name)
+        corrected_measurement = corrected_report.get_measurement_from_name(
+            measurement_name
+        )
+        if measurement is None or corrected_measurement is None:
+          continue
+
+        difference = abs(corrected_measurement.value - measurement.value)
+        if difference > STANDARD_DEVIATION_TEST_THRESHOLD*measurement.sigma:
+          logging.warning(
+            f"Measurement {measurement.name} has a large correction: original="
+            f"{measurement.value}, corrected={corrected_measurement.value}, "
+            f"sigma={measurement.sigma}."
+          )
+          report_post_processor_result.large_corrections.add(
+            measurement_name=measurement_name,
+            original_value=round(measurement.value),
+            corrected_value=round(corrected_measurement.value),
+            sigma=measurement.sigma,
+          )
+
+    return corrected_report, report_post_processor_result
 
   def report_from_solution(self, solution: Solution) -> Optional["Report"]:
     logging.info("Generating the adjusted report from the solution.")

--- a/src/test/python/wfa/measurement/reporting/postprocessing/report/report_test.py
+++ b/src/test/python/wfa/measurement/reporting/postprocessing/report/report_test.py
@@ -3056,13 +3056,13 @@ class TestReport(unittest.TestCase):
         report_post_processor_result.large_corrections,
         [
             LargeCorrection(
-                measurement_id="measurement_04",
+                name="measurement_04",
                 original_value=2,
                 corrected_value=25,
                 sigma=1.0
             ),
             LargeCorrection(
-                measurement_id="measurement_02",
+                name="measurement_02",
                 original_value=48,
                 corrected_value=25,
                 sigma=1.0

--- a/src/test/python/wfa/measurement/reporting/postprocessing/report/report_test.py
+++ b/src/test/python/wfa/measurement/reporting/postprocessing/report/report_test.py
@@ -3056,13 +3056,13 @@ class TestReport(unittest.TestCase):
         report_post_processor_result.large_corrections,
         [
             LargeCorrection(
-                name="measurement_04",
+                metric_title="measurement_04",
                 original_value=2,
                 corrected_value=25,
                 sigma=1.0
             ),
             LargeCorrection(
-                name="measurement_02",
+                metric_title="measurement_02",
                 original_value=48,
                 corrected_value=25,
                 sigma=1.0

--- a/src/test/python/wfa/measurement/reporting/postprocessing/report/report_test.py
+++ b/src/test/python/wfa/measurement/reporting/postprocessing/report/report_test.py
@@ -3056,13 +3056,13 @@ class TestReport(unittest.TestCase):
         report_post_processor_result.large_corrections,
         [
             LargeCorrection(
-                measurement_name="measurement_04",
+                measurement_id="measurement_04",
                 original_value=2,
                 corrected_value=25,
                 sigma=1.0
             ),
             LargeCorrection(
-                measurement_name="measurement_02",
+                measurement_id="measurement_02",
                 original_value=48,
                 corrected_value=25,
                 sigma=1.0


### PR DESCRIPTION
Sometimes, noise correction makes large adjustments to the measurement values. This PR adds these measurements with relevant information to the ReportPostProcessorResult, which is included in ReportPostProcessorLog. The additional information will help users identify potential issues, either with the input report, or with the noise correction result.