### PR TITLE
perf: Reduce heap size of Requisition Fulfillment server

### DIFF
--- a/src/main/k8s/dev/duchy_gke.cue
+++ b/src/main/k8s/dev/duchy_gke.cue
@@ -72,13 +72,13 @@ _duchy_cert_name: "duchies/\(_duchy_name)/certificates/\(_certificateId)"
 #FulfillmentResourceRequirements: ResourceRequirements=#ResourceRequirements & {
 	requests: {
 		cpu:    "200m"
-		memory: "576Mi"
+		memory: "512Mi"
 	}
 	limits: {
 		memory: ResourceRequirements.requests.memory
 	}
 }
-#FulfillmentMaxHeapSize:             "320M"
+#FulfillmentMaxHeapSize:             "128M"
 #ControlServiceResourceRequirements: ResourceRequirements=#ResourceRequirements & {
 	requests: {
 		cpu:    "200m"


### PR DESCRIPTION
This avoids OOMKilled when running K8s tests on Halo-managed environments. Real environments will likely want to use more memory depending on fulfillment volume.