### PR TITLE
feat: Add --default-service-config option to Duchy internal API server

### DIFF
--- a/src/main/k8s/duchy.cue
+++ b/src/main/k8s/duchy.cue
@@ -214,7 +214,6 @@ import ("strings")
 			_container: args: [
 						_debug_verbose_grpc_server_logging_flag,
 						_duchy_name_flag,
-						_duchy_info_config_flag,
 						_duchy_tls_cert_file_flag,
 						_duchy_tls_key_file_flag,
 						_duchy_cert_collection_file_flag,


### PR DESCRIPTION
This also sets the default timeout for CreateComputationLogEntry to be significantly shorter that the overall default timeout.

Closes #2955

Issue: #2955