### PR TITLE
fix: report_result and corresponding service

### DIFF
--- a/src/main/proto/wfa/measurement/internal/reporting/v2/report_result.proto
+++ b/src/main/proto/wfa/measurement/internal/reporting/v2/report_result.proto
@@ -40,7 +40,7 @@ message ReportResult {
     // Indicates that the metrics for a ReportingSet are for the
     // primitive Venn diagram region entailed by sub-ReportingSets
     PRIMITIVE = 2;
-  }  // `MeasurementConsumer` ID from the CMMS public API.
+  }
 
   // The CMMS Measurement Consumer ID
   string cmms_measurement_consumer_id = 1;
@@ -64,14 +64,15 @@ message ReportResult {
     // The event template dimensions the result is grouped by
     // Each event template field path may exist at most once in this list.
     repeated EventTemplateField groupings = 6;
-    // The filter, sans the IQF criteria, that was applied to these results.
-    EventFilter event_filter = 7;
+    // The filters, sans the IQF criteria, that were applied to these results.
+    repeated EventFilter event_filters = 7;
     int32 population_size = 8;
     // Represents the results for a reporting window with respect to a
     // ReportingSetResult.
     message ReportingWindowResult {
       google.type.Date window_start_date = 1;
       google.type.Date window_end_date = 2;
+
       // Represents result values with respect to a ReportingWindowResult.
       //
       // The combination of (cmms_measurement_consumer_id,
@@ -89,8 +90,9 @@ message ReportResult {
         ResultGroup.MetricSet.BasicMetricSet cumulative_results = 3;
         ResultGroup.MetricSet.BasicMetricSet non_cumulative_results = 4;
       }
+      ReportResultValues report_result_values = 3;
     }
-    repeated ReportingWindowResult reporting_window_result = 9;
+    repeated ReportingWindowResult reporting_window_results = 9;
   }
-  repeated ReportingSetResult reporting_set_result = 4;
+  repeated ReportingSetResult reporting_set_results = 4;
 }

--- a/src/main/proto/wfa/measurement/internal/reporting/v2/report_results_service.proto
+++ b/src/main/proto/wfa/measurement/internal/reporting/v2/report_results_service.proto
@@ -24,15 +24,13 @@ option java_multiple_files = true;
 
 // Internal service for persistence of Metric entities.
 service ReportResults {
-  // Add a batch of non-cumulative noisy result values to a ReportResult.
+  // Add a batch of noisy result values to a ReportResult.
+  //
   // This method will create the hierarchy of rows as necessary. If they
   // already exist existing rows will be reused. This method will only add
-  // non-cumulative noisy results. If non-cumulative noisy results already exist
-  // for the NoisyReportResultValue indicate then an error will be thrown.
-  rpc AddNonCumulativeNoisyResultValues(AddNoisyResultValuesRequest)
-      returns (google.protobuf.Empty);
-  // Same as AddNonCumulativeNoisyResults but applies to cumulative results.
-  rpc AddCumulativeNoisyResultValues(AddNoisyResultValuesRequest)
+  // noisy results. If noisy results already exist for the
+  // NoisyReportResultValue indicate then an error will be thrown.
+  rpc AddNoisyResultValues(AddNoisyResultValuesRequest)
       returns (google.protobuf.Empty);
   // Add a batch of denoised result to a ReportResult. This method should not
   // need to create any intermediate artifacts as noisy result values should

--- a/src/main/resources/reporting/spanner/create-report-results-schema.sql
+++ b/src/main/resources/reporting/spanner/create-report-results-schema.sql
@@ -88,8 +88,8 @@ CREATE TABLE ReportingSetResults(
  -- prior to fingerprinting. It does not include any filters implied by the IQF.
  -- This field is NULL if no filters were applied.
  FilterFingerprint INT64,
- -- The actual filter used
- EventFilter `wfa.measurement.internal.reporting.v2.EventFilter`,
+ -- The actual filters used
+ EventFilters ARRAY<`wfa.measurement.internal.reporting.v2.EventFilter`>,
  -- The population size associated with the results
  PopulationSize INT64 NOT NULL,
  -- The creation time of this row.


### PR DESCRIPTION
The filter component, without the IQF, is a list of EventFilter so event_filter is changed to a repeated event_filters. ReportResultValues is unused so report_result_values is added. reporting_window_result and reporting_set_result are renamed to be plural. It seems like it would be complicated to add cumulative and noncumulative noisy results separately in Spanner and it is fairly doable in code so the methods are merged back into one.

Issue: #2972 