### PR TITLE
perf: Increase heap size of Requisition Fulfillment server

### DIFF
--- a/src/main/k8s/dev/duchy_gke.cue
+++ b/src/main/k8s/dev/duchy_gke.cue
@@ -78,7 +78,7 @@ _duchy_cert_name: "duchies/\(_duchy_name)/certificates/\(_certificateId)"
 		memory: ResourceRequirements.requests.memory
 	}
 }
-#FulfillmentMaxHeapSize:             "128M"
+#FulfillmentMaxHeapSize:             "192M"
 #ControlServiceResourceRequirements: ResourceRequirements=#ResourceRequirements & {
 	requests: {
 		cpu:    "200m"


### PR DESCRIPTION
The value specified in #2951 was slightly too low for our K8s test.