### PR TITLE
feat!: integrate requisition metadata storage in results fulfiller

### DIFF
--- a/.github/workflows/terraform-cmms.yml
+++ b/.github/workflows/terraform-cmms.yml
@@ -200,6 +200,7 @@ jobs:
         CONFIG_DIR: ${{ runner.temp }}/configs
         KINGDOM_PUBLIC_API_TARGET: ${{ vars.KINGDOM_PUBLIC_API_TARGET }}
         SECURE_COMPUTATION_PUBLIC_API_TARGET: ${{ vars.SECURE_COMPUTATION_PUBLIC_API_TARGET }}
+        EDP_AGGREGATOR_PUBLIC_API_TARGET: ${{ vars.EDP_AGGREGATOR_PUBLIC_API_TARGET }}
         IMAGE_TAG: ${{ inputs.image-tag }}
         DATA_WATCHER_FUNCTION_NAME: ${{ vars.DATA_WATCHER_FUNCTION_NAME }}
         REQUISITION_FETCHER_FUNCTION_NAME: ${{ vars.REQUISITION_FETCHER_FUNCTION_NAME }}
@@ -238,6 +239,7 @@ jobs:
         -var="event_data_provider_configs_file_path=$CONFIG_DIR/event-data-provider-configs.textproto"
         -var="kingdom_public_api_target=$KINGDOM_PUBLIC_API_TARGET"
         -var="secure_computation_public_api_target=$SECURE_COMPUTATION_PUBLIC_API_TARGET"
+        -var="edp_aggregator_public_api_target=$EDP_AGGREGATOR_PUBLIC_API_TARGET"
         -var="data_watcher_function_name=$DATA_WATCHER_FUNCTION_NAME"
         -var="requisition_fetcher_function_name=$REQUISITION_FETCHER_FUNCTION_NAME"
         -var="event_group_sync_function_name=$EVENT_GROUP_FUNCTION_NAME"

--- a/src/main/k8s/testing/secretfiles/BUILD.bazel
+++ b/src/main/k8s/testing/secretfiles/BUILD.bazel
@@ -98,6 +98,7 @@ filegroup(
     name = "edp_aggregator_trusted_certs",
     srcs = [
         "edp_aggregator_root.pem",
+        "secure_computation_root.pem",
     ],
 )
 

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/resultsfulfiller/BUILD.bazel
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/resultsfulfiller/BUILD.bazel
@@ -46,6 +46,7 @@ kt_jvm_library(
         "//src/main/proto/wfa/measurement/api/v2alpha:requisitions_service_kt_jvm_grpc_proto",
         "//src/main/proto/wfa/measurement/edpaggregator/v1alpha:grouped_requisitions_kt_jvm_proto",
         "//src/main/proto/wfa/measurement/edpaggregator/v1alpha:labeled_impression_kt_jvm_proto",
+        "//src/main/proto/wfa/measurement/edpaggregator/v1alpha:requisition_metadata_service_kt_jvm_grpc_proto",
         "@wfa_common_jvm//imports/java/com/google/protobuf",
         "@wfa_common_jvm//imports/kotlin/kotlinx/coroutines:core",
         "@wfa_common_jvm//src/main/kotlin/org/wfanet/measurement/storage:selected_storage_client",

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/resultsfulfiller/ResultsFulfillerApp.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/resultsfulfiller/ResultsFulfillerApp.kt
@@ -44,6 +44,7 @@ import org.wfanet.measurement.securecomputation.controlplane.v1alpha.WorkItemAtt
 import org.wfanet.measurement.securecomputation.controlplane.v1alpha.WorkItemsGrpcKt
 import org.wfanet.measurement.securecomputation.teesdk.BaseTeeApplication
 import org.wfanet.measurement.storage.SelectedStorageClient
+import org.wfanet.measurement.edpaggregator.v1alpha.RequisitionMetadataServiceGrpcKt.RequisitionMetadataServiceCoroutineStub
 
 /**
  * Application for fulfilling results in the CMMS.
@@ -58,6 +59,7 @@ import org.wfanet.measurement.storage.SelectedStorageClient
  * @param workItemsClient gRPC client stub for [WorkItemsGrpcKt.WorkItemsCoroutineStub].
  * @param workItemAttemptsClient gRPC client stub for
  *   [WorkItemAttemptsGrpcKt.WorkItemAttemptsCoroutineStub].
+ * @param requisitionMetadataStub used to sync [Requisition]s with RequisitionMetadataStorage
  * @param requisitionStubFactory Factory for creating requisition stubs.
  * @param kmsClient The Tink [KmsClient] for key management.
  * @param getImpressionsMetadataStorageConfig Lambda to obtain [StorageConfig] for impressions
@@ -74,6 +76,7 @@ class ResultsFulfillerApp(
   parser: Parser<WorkItem>,
   workItemsClient: WorkItemsGrpcKt.WorkItemsCoroutineStub,
   workItemAttemptsClient: WorkItemAttemptsGrpcKt.WorkItemAttemptsCoroutineStub,
+  private val requisitionMetadataStub: RequisitionMetadataServiceCoroutineStub,
   private val requisitionStubFactory: RequisitionStubFactory,
   private val kmsClients: MutableMap<String, KmsClient>,
   private val getImpressionsMetadataStorageConfig: (StorageParams) -> StorageConfig,
@@ -182,6 +185,8 @@ class ResultsFulfillerApp(
       )
 
     ResultsFulfiller(
+        dataProvider = fulfillerParams.dataProvider,
+        requisitionMetadataStub = requisitionMetadataStub,
         privateEncryptionKey = loadPrivateKey(encryptionPrivateKeyFile),
         groupedRequisitions = groupedRequisitions,
         modelLineInfoMap = modelLineInfoMap,

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/resultsfulfiller/ResultsFulfillerAppRunner.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/resultsfulfiller/ResultsFulfillerAppRunner.kt
@@ -48,6 +48,7 @@ import org.wfanet.measurement.queue.QueueSubscriber
 import org.wfanet.measurement.securecomputation.controlplane.v1alpha.WorkItem
 import org.wfanet.measurement.securecomputation.controlplane.v1alpha.WorkItemAttemptsGrpcKt
 import org.wfanet.measurement.securecomputation.controlplane.v1alpha.WorkItemsGrpcKt
+import org.wfanet.measurement.edpaggregator.v1alpha.RequisitionMetadataServiceGrpcKt.RequisitionMetadataServiceCoroutineStub
 import picocli.CommandLine
 
 @CommandLine.Command(name = "results_fulfiller_app_runner")
@@ -228,6 +229,8 @@ class ResultsFulfillerAppRunner : Runnable {
         secureComputationPublicApiCertHost,
       )
     val workItemsClient = WorkItemsGrpcKt.WorkItemsCoroutineStub(publicChannel)
+    // DO_NOT_SUBMIT (Replace with correct channel once deployed)
+    val requisitionMetadataStub by lazy { RequisitionMetadataServiceCoroutineStub(publicChannel) }
     val workItemAttemptsClient = WorkItemAttemptsGrpcKt.WorkItemAttemptsCoroutineStub(publicChannel)
     val trustedRootCaCollectionFile = File(TRUSTED_ROOT_CA_COLLECTION_FILE_PATH)
 
@@ -249,6 +252,7 @@ class ResultsFulfillerAppRunner : Runnable {
         queueSubscriber = queueSubscriber,
         parser = parser,
         workItemsClient = workItemsClient,
+        requisitionMetadataStub = requisitionMetadataStub,
         workItemAttemptsClient = workItemAttemptsClient,
         requisitionStubFactory = requisitionStubFactory,
         kmsClients = kmsClientsMap,

--- a/src/main/terraform/gcloud/cmms/edp_aggregator.tf
+++ b/src/main/terraform/gcloud/cmms/edp_aggregator.tf
@@ -46,6 +46,12 @@ locals {
     is_binary_format  = false
   }
 
+  edp_aggregator_root_ca = {
+      secret_id         = "edpaggregator-root-ca"
+      secret_local_path = abspath("${path.root}/../../../k8s/testing/secretfiles/edp_aggregator_root.pem"),
+      is_binary_format  = false
+    }
+
   trusted_root_ca_collection = {
     secret_id         = "trusted-root-ca"
     secret_local_path = var.results_fulfiller_trusted_root_ca_collection_file_path
@@ -103,9 +109,11 @@ locals {
                                           "--edpa-tls-cert-secret-id", "edpa-tee-app-tls-pem",
                                           "--edpa-tls-key-secret-id", "edpa-tee-app-tls-key",
                                           "--secure-computation-cert-collection-secret-id", "securecomputation-root-ca",
+                                          "--edp-aggregator-cert-collection-secret-id", "edpaggregator-root-ca",
                                           "--trusted-cert-collection-secret-id", "trusted-root-ca",
                                           "--kingdom-public-api-target", var.kingdom_public_api_target,
                                           "--secure-computation-public-api-target", var.secure_computation_public_api_target,
+                                          "--edp-aggregator-public-api-target", var.edp_aggregator_public_api_target,
                                           "--subscription-id", "results-fulfiller-subscription",
                                           "--google-project-id", data.google_client_config.default.project,
                                           "--model-line", "some-model-line",

--- a/src/main/terraform/gcloud/cmms/variables.tf
+++ b/src/main/terraform/gcloud/cmms/variables.tf
@@ -142,6 +142,11 @@ variable "secure_computation_public_api_target" {
   type        = string
 }
 
+variable "edp_aggregator_public_api_target" {
+  description = "EDP Aggregator public api target"
+  type        = string
+}
+
 variable "image_tag" {
   description = "Tag of container images"
   type        = string


### PR DESCRIPTION
BREAKING-CHANGE: ResultsFulfiller has new required flags to support the RequisitionMetadataStorage: `--edpa-aggregator-public-api-target`. ResultsFulfiller has a new required terraform variable: `edp_aggregator_public_api_target`.

Issue: #2983 