### PR TITLE
fix: wrong replacement trigger to mig module

### DIFF
--- a/src/main/terraform/gcloud/modules/mig/main.tf
+++ b/src/main/terraform/gcloud/modules/mig/main.tf
@@ -132,7 +132,6 @@ resource "google_compute_region_instance_group_manager" "mig" {
   distribution_policy_zones = var.mig_distribution_policy_zones
   lifecycle {
     create_before_destroy = true
-    replace_triggered_by  = [google_compute_instance_template.confidential_vm_template]
   }
 }
 


### PR DESCRIPTION
Prevent unnecessary MIG replacement caused by instance template name suffixes.