### PR TITLE
test: Don't allow run ReportProcessorTest to run remotely

### DIFF
--- a/src/test/kotlin/org/wfanet/measurement/reporting/postprocessing/v2alpha/BUILD.bazel
+++ b/src/test/kotlin/org/wfanet/measurement/reporting/postprocessing/v2alpha/BUILD.bazel
@@ -3,7 +3,7 @@ load("@wfa_rules_kotlin_jvm//kotlin:defs.bzl", "kt_jvm_test")
 package(default_testonly = True)
 
 kt_jvm_test(
-    name = "no_op_report_processor_test",
+    name = "NoOpReportProcessorTest",
     srcs = ["NoOpReportProcessorTest.kt"],
     test_class = "org.wfanet.measurement.reporting.postprocessing.v2alpha.NoOpReportProcessorTest",
     deps = [
@@ -16,9 +16,10 @@ kt_jvm_test(
 )
 
 kt_jvm_test(
-    name = "report_processor_test",
+    name = "ReportProcessorTest",
     srcs = ["ReportProcessorTest.kt"],
     data = [":sample_reports"],
+    tags = ["no-remote-exec"],
     test_class = "org.wfanet.measurement.reporting.postprocessing.v2alpha.ReportProcessorTest",
     deps = [
         "//src/main/kotlin/org/wfanet/measurement/reporting/postprocessing/v2alpha:postprocessing",
@@ -37,7 +38,7 @@ kt_jvm_test(
 )
 
 kt_jvm_test(
-    name = "report_conversion_test",
+    name = "ReportConversionTest",
     srcs = ["ReportConversionTest.kt"],
     data = [":sample_reports"],
     test_class = "org.wfanet.measurement.reporting.postprocessing.v2alpha.ReportConversionTest",


### PR DESCRIPTION
ReportProcessor runs a Python executable in a separate process, which may not work as well with remote test execution.