### PR TITLE
fix(report-processor): add threshold for large correction.

### DIFF
--- a/src/main/python/wfa/measurement/reporting/postprocessing/report/report.py
+++ b/src/main/python/wfa/measurement/reporting/postprocessing/report/report.py
@@ -51,6 +51,8 @@ STANDARD_DEVIATION_TEST_THRESHOLD = 7.0
 
 CONSISTENCY_TEST_TOLERANCE = 1.0
 
+LARGE_CORRECTION_THRESHOLD = 1.0
+
 
 def fuzzy_equal(val: float, target: float, tolerance: float) -> bool:
   """Checks if two float values are approximately equal within an absolute tolerance."""
@@ -788,7 +790,15 @@ class Report:
           continue
 
         difference = abs(corrected_measurement.value - measurement.value)
-        if difference > STANDARD_DEVIATION_TEST_THRESHOLD*measurement.sigma:
+
+        # LARGE_CORRECTION_THRESHOLD is used to prevent the false positive cases
+        # where sigma is zero. For metric with zero standard deviation, its
+        # corrected value must be far enough from the original value to be
+        # considered a large correction.
+        if difference > max(
+          STANDARD_DEVIATION_TEST_THRESHOLD*measurement.sigma,
+          LARGE_CORRECTION_THRESHOLD
+        ):
           logging.warning(
             f"Measurement {measurement.name} has a large correction: original="
             f"{measurement.value}, corrected={corrected_measurement.value}, "

--- a/src/test/python/wfa/measurement/reporting/postprocessing/report/report_test.py
+++ b/src/test/python/wfa/measurement/reporting/postprocessing/report/report_test.py
@@ -3054,6 +3054,58 @@ class TestReport(unittest.TestCase):
         ]
     )
 
+  def test_small_correction_for_unnoised_edp_does_not_log_large_correction(
+      self
+  ):
+      report = Report(
+          metric_reports={
+              "ami": MetricReport(
+                  weekly_cumulative_reaches={
+                      frozenset({EDP_ONE}): [
+                          Measurement(48, 0, "measurement_02")
+                      ],
+                  },
+                  whole_campaign_measurements=build_measurement_set(
+                      reach={
+                          frozenset({EDP_ONE}): Measurement(48.01, 0, "measurement_04"),
+                      },
+                      k_reach={},
+                      impression={}),
+                  weekly_non_cumulative_measurements={},
+              )
+          },
+          metric_subsets_by_parent={},
+          cumulative_inconsistency_allowed_edp_combinations={},
+      )
+
+      corrected, report_post_processor_result = report.get_corrected_report()
+
+      expected = Report(
+          metric_reports={
+              "ami": MetricReport(
+                  weekly_cumulative_reaches={
+                      frozenset({EDP_ONE}): [
+                          Measurement(48.0033325, 0, "measurement_02")
+                      ],
+                  },
+                  whole_campaign_measurements=build_measurement_set(
+                      reach={
+                          frozenset({EDP_ONE}): Measurement(48.00666747, 0, "measurement_04"),
+                      },
+                      k_reach={},
+                      impression={}),
+                  weekly_non_cumulative_measurements={},
+              )
+          },
+          metric_subsets_by_parent={},
+          cumulative_inconsistency_allowed_edp_combinations={},
+      )
+
+      self.assertEqual(report_post_processor_result.status.status_code,
+                       StatusCode.SOLUTION_FOUND_WITH_OSQP)
+      self._assertReportsAlmostEqual(expected, corrected, corrected.to_array())
+      self.assertEqual(len(report_post_processor_result.large_corrections), 0)
+
 
   def test_get_corrected_reach_only_report_single_metric_multiple_edps(self):
     report = Report(


### PR DESCRIPTION
Noise correction may modify the unnoised metrics a bit (e.g. 1e-9). However, this is enough to flag these updates as `large correction` as the check (abs(updated value - original value) > 7*standard_deviation) where standard_deviation = 0.

In order to avoid these false positives, we update the check for a large correction to (abs(updated value - original value) > max(7*standard_deviation, 1.0).