### PR TITLE
refactor: update cloud function deployment

### DIFF
--- a/src/main/terraform/gcloud/modules/edp-aggregator/main.tf
+++ b/src/main/terraform/gcloud/modules/edp-aggregator/main.tf
@@ -196,6 +196,7 @@ resource "google_storage_bucket_object" "upload_data_watcher_config" {
   name   = var.data_watcher_config.destination
   bucket = module.config_files_bucket.storage_bucket.name
   source = var.data_watcher_config.local_path
+  source_md5hash = filemd5(var.data_watcher_config.local_path)
 }
 
 resource "google_storage_bucket_object" "upload_data_watcher_delete_config" {
@@ -208,6 +209,7 @@ resource "google_storage_bucket_object" "upload_requisition_fetcher_config" {
   name   = var.requisition_fetcher_config.destination
   bucket = module.config_files_bucket.storage_bucket.name
   source = var.requisition_fetcher_config.local_path
+  source_md5hash = filemd5(var.requisition_fetcher_config.local_path)
 }
 
 resource "google_storage_bucket_object" "upload_edps_config" {
@@ -276,6 +278,7 @@ module "data_watcher_cloud_function" {
   uber_jar_path                               = var.cloud_function_configs.data_watcher.uber_jar_path
   secrets_to_access                           = [for key in local.data_watcher_secrets_access : local.all_secrets[key].secret_id]
   trigger_event_type                          = "finalized"
+  uploaded_config_generation                  = google_storage_bucket_object.upload_data_watcher_config.generation
 }
 
 module "data_watcher_delete_cloud_function" {
@@ -309,6 +312,7 @@ module "requisition_fetcher_cloud_function" {
   secret_mappings                          = var.cloud_function_configs.requisition_fetcher.secret_mappings
   uber_jar_path                            = var.cloud_function_configs.requisition_fetcher.uber_jar_path
   secrets_to_access                        = [for key in local.requisition_fetcher_secrets_access : local.all_secrets[key].secret_id]
+  config_path                               = var.requisition_fetcher_config.local_path
 }
 
 module "requisition_fetcher_cloud_scheduler" {

--- a/src/main/terraform/gcloud/modules/gcs-bucket-cloud-function/main.tf
+++ b/src/main/terraform/gcloud/modules/gcs-bucket-cloud-function/main.tf
@@ -82,7 +82,12 @@ resource "terraform_data" "deploy_gcs_cloud_function" {
     google_secret_manager_secret_iam_member.secret_accessor,
   ]
 
-  triggers_replace = [var.uber_jar_path]
+  triggers_replace = [
+    var.uber_jar_path,
+    var.extra_env_vars,
+    var.secret_mappings,
+    var.uploaded_config_generation,
+  ]
 
   provisioner "local-exec" {
     interpreter = ["/bin/bash", "-c"]

--- a/src/main/terraform/gcloud/modules/gcs-bucket-cloud-function/variable.tf
+++ b/src/main/terraform/gcloud/modules/gcs-bucket-cloud-function/variable.tf
@@ -82,3 +82,9 @@ variable "trigger_event_type" {
     error_message = "trigger_event_type must be either 'finalized' or 'deleted'."
   }
 }
+variable "uploaded_config_generation" {
+  description = "The GCS generation of the uploaded config file. Changes only when file is re-uploaded."
+  type        = string
+  nullable    = true
+  default     = null
+}

--- a/src/main/terraform/gcloud/modules/http-cloud-function/main.tf
+++ b/src/main/terraform/gcloud/modules/http-cloud-function/main.tf
@@ -41,7 +41,12 @@ resource "terraform_data" "deploy_http_cloud_function" {
     google_secret_manager_secret_iam_member.secret_accessor,
   ]
 
-  triggers_replace = [var.uber_jar_path]
+  triggers_replace = [
+    var.uber_jar_path,
+    var.extra_env_vars,
+    var.secret_mappings,
+    var.config_path != null ? filesha256(var.config_path) : "",
+  ]
 
   provisioner "local-exec" {
     interpreter = ["/bin/bash", "-c"]

--- a/src/main/terraform/gcloud/modules/http-cloud-function/variables.tf
+++ b/src/main/terraform/gcloud/modules/http-cloud-function/variables.tf
@@ -59,3 +59,10 @@ variable "secrets_to_access" {
   type        = list(string)
   default     = []
 }
+
+variable "config_path" {
+  description = "The path to the config file the Cloud Function uses."
+  type        = string
+  nullable    = true
+  default     = null
+}


### PR DESCRIPTION
Cloud Functions not redeployed when config or env vars change. Expand triggers_replace to include env vars, secrets, and config file generation.

Fixes #3986

Issue: #3986