### PR TITLE
perf: Increase container memory for Reporting internal API server

### DIFF
--- a/src/main/k8s/dev/reporting_v2_gke.cue
+++ b/src/main/k8s/dev/reporting_v2_gke.cue
@@ -30,9 +30,13 @@ _accessPublicApiAddressName:   "access-public"
 // Name of K8s service account for the Access internal API server.
 #InternalAccessServerServiceAccount: "internal-access-server"
 
-#InternalServerResourceRequirements: #ResourceRequirements & {
+#InternalServerResourceRequirements: ResourceRequirements=#ResourceRequirements & {
 	requests: {
-		cpu: "100m"
+		cpu:    "100m"
+		memory: "384Mi"
+	}
+	limits: {
+		memory: ResourceRequirements.requests.memory
 	}
 }
 #PublicServerResourceRequirements: ResourceRequirements=#ResourceRequirements & {


### PR DESCRIPTION
Seeing restarts that look like OOMKilled even at only 35MiB of heap usage.