### PR TITLE
ci: Use rsync to speed up large directory deletion

### DIFF
--- a/.github/actions/free-disk-space/action.yml
+++ b/.github/actions/free-disk-space/action.yml
@@ -27,19 +27,19 @@ runs:
 
     - name: Remove Android toolkit
       shell: bash
-      run: sudo rm -rf /usr/local/lib/android
+      run: sudo ${{ github.action_path }}/rdelete /usr/local/lib/android
 
     - name: Remove dotnet
       shell: bash
-      run: sudo rm -rf /usr/share/dotnet
-    
+      run: sudo ${{ github.action_path }}/rdelete /usr/share/dotnet
+
     - name: Remove CodeQL
       shell: bash
-      run: sudo rm -rf /opt/hostedtoolcache/CodeQL
+      run: sudo ${{ github.action_path }}/rdelete /opt/hostedtoolcache/CodeQL
 
     - name: Remove GHC (Haskell)
       shell: bash
-      run: sudo rm -rf /opt/ghc
+      run: sudo ${{ github.action_path }}/rdelete /opt/ghc
 
     - shell: bash
       run: df -h

--- a/.github/actions/free-disk-space/rdelete
+++ b/.github/actions/free-disk-space/rdelete
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+# Recursively delete a directory and its contents
+
+target_dir="$1"
+shift 1
+empty_dir="$(mktemp -d)"
+rsync --archive --delete "${empty_dir}/" "${target_dir}" "$@"
+rmdir "${target_dir}"
+rmdir "${empty_dir}"


### PR DESCRIPTION
`rsync --delete` tends to be faster than `rm -r` for large directory trees

Issue: #3075