### PR TITLE
ci: Restrict write permissions in workflows

### DIFF
--- a/.github/workflows/api-lint.yml
+++ b/.github/workflows/api-lint.yml
@@ -20,6 +20,9 @@ on:
       - main
       - 'releases/**'
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/attach-clis-to-release.yml
+++ b/.github/workflows/attach-clis-to-release.yml
@@ -18,6 +18,9 @@ on:
   release:
     types: [published]
 
+permissions:
+  contents: read
+
 jobs:
   attach-clis-to-release:
     name: Attach CLIs to release

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -29,6 +29,8 @@ on:
         type: boolean
         default: false
 
+permissions:
+  contents: read
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/check-donotsubmit.yml
+++ b/.github/workflows/check-donotsubmit.yml
@@ -20,6 +20,9 @@ on:
       - main
       - 'releases/**'
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/configure-aws-duchy.yml
+++ b/.github/workflows/configure-aws-duchy.yml
@@ -58,7 +58,7 @@ on:
         default: false
 
 permissions:
-  id-token: write
+  contents: read
 
 env:
   KUSTOMIZATION_PATH: "k8s/cmms"
@@ -68,6 +68,9 @@ env:
 jobs:
   update-duchy:
     runs-on: ubuntu-22.04
+    permissions:
+      contents: read
+      id-token: write
     environment: ${{ inputs.environment }}
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/configure-duchy.yml
+++ b/.github/workflows/configure-duchy.yml
@@ -60,7 +60,7 @@ on:
         default: false
 
 permissions:
-  id-token: write
+  contents: read
 
 env:
   KUSTOMIZATION_PATH: "k8s/cmms"
@@ -70,6 +70,9 @@ env:
 jobs:
   update-duchy:
     runs-on: ubuntu-22.04
+    permissions:
+      contents: read
+      id-token: write
     environment: ${{ inputs.environment }}
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/configure-edp-aggregator.yml
+++ b/.github/workflows/configure-edp-aggregator.yml
@@ -48,7 +48,7 @@ on:
         default: false
 
 permissions:
-  id-token: write
+  contents: read
 
 env:
   KUSTOMIZATION_PATH: "k8s/edp_aggregator"
@@ -56,7 +56,9 @@ env:
 jobs:
   update-edp-aggregator-services:
     runs-on: ubuntu-22.04
-
+    permissions:
+      contents: read
+      id-token: write
     environment: ${{ inputs.environment }}
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/configure-kingdom.yml
+++ b/.github/workflows/configure-kingdom.yml
@@ -48,7 +48,7 @@ on:
         default: false
 
 permissions:
-  id-token: write
+  contents: read
 
 env:
   KUSTOMIZATION_PATH: "k8s/cmms"
@@ -56,6 +56,9 @@ env:
 jobs:
   update-kingdom:
     runs-on: ubuntu-22.04
+    permissions:
+      contents: read
+      id-token: write
     environment: ${{ inputs.environment }}
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/configure-population-fulfiller.yml
+++ b/.github/workflows/configure-population-fulfiller.yml
@@ -48,7 +48,7 @@ on:
         default: false
 
 permissions:
-  id-token: write
+  contents: read
 
 env:
   KUSTOMIZATION_PATH: "k8s/cmms"
@@ -58,6 +58,9 @@ env:
 jobs:
   update-kingdom:
     runs-on: ubuntu-22.04
+    permissions:
+      contents: read
+      id-token: write
     environment: ${{ inputs.environment }}
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/configure-reporting-v2.yml
+++ b/.github/workflows/configure-reporting-v2.yml
@@ -48,7 +48,7 @@ on:
         default: false
 
 permissions:
-  id-token: write
+  contents: read
 
 env:
   KUSTOMIZATION_PATH: "k8s/reporting_v2"
@@ -56,6 +56,9 @@ env:
 jobs:
   update-reporting-v2:
     runs-on: ubuntu-22.04
+    permissions:
+      contents: read
+      id-token: write
     environment: ${{ inputs.environment }}
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/configure-secure-computation-control-plane.yml
+++ b/.github/workflows/configure-secure-computation-control-plane.yml
@@ -48,7 +48,7 @@ on:
         default: false
 
 permissions:
-  id-token: write
+  contents: read
 
 env:
   KUSTOMIZATION_PATH: "k8s/secure_computation"
@@ -56,6 +56,9 @@ env:
 jobs:
   update-secure-computation-control-plane:
     runs-on: ubuntu-22.04
+    permissions:
+      contents: read
+      id-token: write
     environment: ${{ inputs.environment }}
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/configure-simulators.yml
+++ b/.github/workflows/configure-simulators.yml
@@ -48,7 +48,7 @@ on:
         default: false
 
 permissions:
-  id-token: write
+  contents: read
 
 env:
   KUSTOMIZATION_PATH: "k8s/cmms"
@@ -56,6 +56,9 @@ env:
 jobs:
   update-simulators:
     runs-on: ubuntu-22.04
+    permissions:
+      contents: read
+      id-token: write
     environment: ${{ inputs.environment }}
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/deploy-nightly.yml
+++ b/.github/workflows/deploy-nightly.yml
@@ -19,9 +19,15 @@ on:
     - cron: '19 6 * * 1,2,3,4,5'  # Sun-Thu night in America/Los_Angeles.
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   deploy-nightly:
     runs-on: ubuntu-22.04
+    permissions:
+      contents: write
+      actions: write    
     steps:
     - id: compute-next-nightly-tag
       # Computes a monotonically increasing "nightly/YYYYMMDD.N" tag based on existing tags in the repo.

--- a/.github/workflows/deploy-on-release.yml
+++ b/.github/workflows/deploy-on-release.yml
@@ -18,9 +18,17 @@ on:
   release:
     types: [published]
 
+permissions:
+  contents: read
+
 jobs:
   update-cmms:
     uses: ./.github/workflows/update-cmms.yml
+    permissions:
+      contents: read
+      id-token: write
+      packages: write
+      security-events: write
     secrets: inherit
     with:
       environment: qa

--- a/.github/workflows/draft-new-release.yml
+++ b/.github/workflows/draft-new-release.yml
@@ -30,6 +30,9 @@ on:
         type: string
         description: "Start tag / full commit SHA for getting release notes. Default: latest final release (no RC, no draft, no pre-release)."
 
+permissions:
+  contents: read
+
 jobs:
   compute-notes-start-commitish:
     runs-on: ubuntu-22.04
@@ -118,6 +121,10 @@ jobs:
   compute-release-notes:
     needs: [compute-notes-start-commitish, compute-milestone-name, compute-release-target]
     uses: ./.github/workflows/generate-release-notes.yml
+    permissions:
+      contents: read
+      issues: read
+      pull-requests: read
     with:
       notes-start-commitish: ${{ needs.compute-notes-start-commitish.outputs.commitish }}
       notes-end-commitish: ${{ needs.compute-release-target.outputs.sha }}

--- a/.github/workflows/edpa-cloud-test.yml
+++ b/.github/workflows/edpa-cloud-test.yml
@@ -32,11 +32,14 @@ on:
           - head
 
 permissions:
-  id-token: write
+  contents: read
 
 jobs:
   run-tests:
     runs-on: ubuntu-22.04
+    permissions:
+      contents: read
+      id-token: write
     environment: ${{ inputs.environment }}
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/generate-release-notes.yml
+++ b/.github/workflows/generate-release-notes.yml
@@ -46,6 +46,9 @@ on:
         description: "Release notes"
         value: ${{ jobs.generate-release-notes.outputs.summary }}
 
+permissions:
+  contents: read
+
 jobs:
   generate-release-notes:
     name: Generate relnotes

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,6 +6,9 @@ on:
       - main
       - 'releases/**'
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/maybe-push-images.yml
+++ b/.github/workflows/maybe-push-images.yml
@@ -26,6 +26,9 @@ on:
         description: "Tag of container images"
         value: ${{ jobs.get-image-tag.outputs.image-tag }}
 
+permissions:
+  contents: read
+
 jobs:
   get-image-tag:
     runs-on: ubuntu-22.04
@@ -53,6 +56,9 @@ jobs:
     if: inputs.existing-image-tag == ''
     needs: [get-image-tag]
     secrets: inherit
+    permissions:
+      contents: read
+      packages: write
     with:
       image-tag: ${{ needs.get-image-tag.outputs.image-tag }}
 
@@ -61,6 +67,9 @@ jobs:
     if: inputs.existing-image-tag == ''
     needs: [ get-image-tag ]
     secrets: inherit
+    permissions:
+      contents: read
+      packages: write    
     with:
       package-version: ${{ needs.get-image-tag.outputs.image-tag }}
 
@@ -68,6 +77,10 @@ jobs:
     uses: ./.github/workflows/sign-images.yml
     needs: [get-image-tag, push-images]
     secrets: inherit
+    permissions:
+      contents: read
+      id-token: write
+      packages: write    
     with:
       image-tag: ${{ needs.get-image-tag.outputs.image-tag }}
       kms-key-resource-name: "${{ vars.IMAGE_SIGNING_TEST_KEY_RESOURCE_NAME }}"
@@ -79,6 +92,10 @@ jobs:
     needs: [get-image-tag, push-images]
     if: ${{ github.event_name == 'release' }}
     secrets: inherit
+    permissions:
+      contents: read
+      id-token: write
+      packages: write    
     with:
       image-tag: ${{ needs.get-image-tag.outputs.image-tag }}
       kms-key-resource-name: "${{ vars.IMAGE_SIGNING_RELEASE_KEY_RESOURCE_NAME }}"

--- a/.github/workflows/publish-cloud-run-function-uber-jars.yml
+++ b/.github/workflows/publish-cloud-run-function-uber-jars.yml
@@ -28,10 +28,16 @@ on:
         type: string
         required: true
 
+permissions:
+  contents: read
+
 jobs:
   publish-artifacts:
     name: Publish Uber‑JAR to GitHub Packages
     runs-on: ubuntu-22.04
+    permissions:
+      contents: read
+      packages: write
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/publish-maven-artifacts.yml
+++ b/.github/workflows/publish-maven-artifacts.yml
@@ -21,6 +21,9 @@ on:
         description: Base artifact version, which will be suffixed with "-SNAPSHOT"
         required: true
 
+permissions:
+  contents: read
+
 jobs:
   publish-artifacts:
     name: Publish Maven artifacts

--- a/.github/workflows/push-images.yml
+++ b/.github/workflows/push-images.yml
@@ -21,6 +21,10 @@ on:
         description: "Tag of container images"
         type: string
         required: true
+
+permissions:
+  contents: read
+
 jobs:
   push-images:
     runs-on: ubuntu-22.04

--- a/.github/workflows/release-test.yml
+++ b/.github/workflows/release-test.yml
@@ -19,6 +19,9 @@ on:
     types: [published]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   build-test:
     name: Build and test

--- a/.github/workflows/run-k8s-tests.yml
+++ b/.github/workflows/run-k8s-tests.yml
@@ -31,6 +31,9 @@ on:
         - qa
         - head
 
+permissions:
+  contents: read
+
 jobs:
   run-tests:
     runs-on: ubuntu-22.04

--- a/.github/workflows/scan-images.yml
+++ b/.github/workflows/scan-images.yml
@@ -44,9 +44,15 @@ on:
         type: string
         required: true
 
+permissions:
+  contents: read
+
 jobs:
   scan-images:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
     strategy:
       matrix:
         # List of images from https://github.com/orgs/world-federation-of-advertisers/packages?repo_name=cross-media-measurement

--- a/.github/workflows/sign-images.yml
+++ b/.github/workflows/sign-images.yml
@@ -34,10 +34,14 @@ on:
         type: string
         required: true
 
+permissions:
+  contents: read
+
 jobs:
   sign-images:
     runs-on: ubuntu-22.04
     permissions:
+      contents: read
       id-token: write
       packages: write
     env:

--- a/.github/workflows/slack-nightly-build-notification.yml
+++ b/.github/workflows/slack-nightly-build-notification.yml
@@ -26,6 +26,9 @@ on:
         type: boolean
         required: true
 
+permissions:
+  contents: read
+
 jobs:
   send-notification:
     runs-on: ubuntu-22.04

--- a/.github/workflows/terraform-cmms.yml
+++ b/.github/workflows/terraform-cmms.yml
@@ -48,11 +48,14 @@ on:
         required: true
 
 permissions:
-  id-token: write
+  contents: read
 
 jobs:
   terraform:
     runs-on: ubuntu-22.04
+    permissions:
+      contents: read
+      id-token: write
     environment: ${{ inputs.environment }}
     env:
       GCLOUD_MODULE_PATH: src/main/terraform/gcloud/cmms

--- a/.github/workflows/update-cmms.yml
+++ b/.github/workflows/update-cmms.yml
@@ -50,10 +50,17 @@ on:
         description: "Tag of existing published images (skips push)"
         type: string
 
+permissions:
+  contents: read
+
 jobs:
   publish-images:
     uses: ./.github/workflows/maybe-push-images.yml
     secrets: inherit
+    permissions:
+      contents: read
+      id-token: write
+      packages: write
     with:
       existing-image-tag: ${{ inputs.existing-image-tag }}
 
@@ -61,6 +68,9 @@ jobs:
     uses: ./.github/workflows/scan-images.yml
     needs: [publish-images]
     if: inputs.existing-image-tag == ''
+    permissions:
+      contents: read
+      security-events: write
     with:
       container-registry: ghcr.io
       image-repo-prefix: ${{ github.repository_owner }}
@@ -70,6 +80,9 @@ jobs:
     uses: ./.github/workflows/terraform-cmms.yml
     needs: [publish-images]
     secrets: inherit
+    permissions:
+      contents: read
+      id-token: write
     with:
       environment: ${{ inputs.environment }}
       apply: ${{ inputs.apply }}
@@ -79,6 +92,9 @@ jobs:
     uses: ./.github/workflows/configure-kingdom.yml
     needs: [publish-images, terraform]
     secrets: inherit
+    permissions:
+      contents: read
+      id-token: write
     with:
       image-tag: ${{ needs.publish-images.outputs.image-tag }}
       environment: ${{ inputs.environment }}
@@ -88,6 +104,9 @@ jobs:
     uses: ./.github/workflows/configure-population-fulfiller.yml
     needs: [publish-images, update-kingdom]
     secrets: inherit
+    permissions:
+      contents: read
+      id-token: write
     with:
       image-tag: ${{ needs.publish-images.outputs.image-tag }}
       environment: ${{ inputs.environment }}
@@ -97,6 +116,9 @@ jobs:
     uses: ./.github/workflows/configure-secure-computation-control-plane.yml
     needs: [ publish-images, terraform ]
     secrets: inherit
+    permissions:
+      contents: read
+      id-token: write    
     with:
       image-tag: ${{ needs.publish-images.outputs.image-tag }}
       environment: ${{ inputs.environment }}
@@ -106,6 +128,9 @@ jobs:
     uses: ./.github/workflows/configure-duchy.yml
     needs: [publish-images, terraform]
     secrets: inherit
+    permissions:
+      contents: read
+      id-token: write
     with:
       duchy-name: aggregator
       image-tag: ${{ needs.publish-images.outputs.image-tag }}
@@ -116,6 +141,9 @@ jobs:
     uses: ./.github/workflows/configure-duchy.yml
     needs: [publish-images, terraform]
     secrets: inherit
+    permissions:
+      contents: read
+      id-token: write
     with:
       duchy-name: worker1
       image-tag: ${{ needs.publish-images.outputs.image-tag }}
@@ -126,6 +154,9 @@ jobs:
     uses: ./.github/workflows/configure-duchy.yml
     needs: [publish-images, terraform]
     secrets: inherit
+    permissions:
+      contents: read
+      id-token: write
     with:
       duchy-name: worker2
       image-tag: ${{ needs.publish-images.outputs.image-tag }}
@@ -136,6 +167,9 @@ jobs:
     uses: ./.github/workflows/configure-simulators.yml
     needs: [publish-images, terraform]
     secrets: inherit
+    permissions:
+      contents: read
+      id-token: write
     with:
       image-tag: ${{ needs.publish-images.outputs.image-tag }}
       environment: ${{ inputs.environment }}
@@ -145,6 +179,9 @@ jobs:
     uses: ./.github/workflows/configure-edp-aggregator.yml
     needs: [publish-images, terraform]
     secrets: inherit
+    permissions:
+      contents: read
+      id-token: write
     with:
       image-tag: ${{ needs.publish-images.outputs.image-tag }}
       environment: ${{ inputs.environment }}
@@ -157,6 +194,9 @@ jobs:
     uses: ./.github/workflows/configure-reporting-v2.yml
     secrets: inherit
     needs: [ publish-images, terraform ]
+    permissions:
+      contents: read
+      id-token: write
     with:
       image-tag: ${{ needs.publish-images.outputs.image-tag }}
       environment: ${{ inputs.environment }}

--- a/.github/workflows/update-trivy-cache.yml
+++ b/.github/workflows/update-trivy-cache.yml
@@ -19,6 +19,9 @@ on:
     - cron: '0 5 * * *'  # Night in America/Los_Angeles, before deploy-nightly.
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   update-trivy-cache:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This PR applies workflow fixes suggested by Scorecard: https://github.com/ossf/scorecard/blob/c22063e786c11f9dd714d777a687ff7c4599b600/docs/checks.md#token-permissions

All workflows were tested, except for some release-related ones:

- .github/workflows/attach-clis-to-release.yml
- .github/workflows/deploy-on-release.yml
- .github/workflows/publish-maven-artifacts.yml
- .github/workflows/release-test.yml

Issue: #3105