### PR TITLE
feat: Implement Authorized view workflow API changes

### DIFF
--- a/src/main/kotlin/org/wfanet/panelmatch/client/deploy/ProductionExchangeTaskMapper.kt
+++ b/src/main/kotlin/org/wfanet/panelmatch/client/deploy/ProductionExchangeTaskMapper.kt
@@ -52,6 +52,7 @@ import org.wfanet.panelmatch.client.exchangetasks.executePrivateMembershipQuerie
 import org.wfanet.panelmatch.client.exchangetasks.preprocessEvents
 import org.wfanet.panelmatch.client.internal.ExchangeWorkflow
 import org.wfanet.panelmatch.client.internal.ExchangeWorkflow.Step.CopyOptions
+import org.wfanet.panelmatch.client.internal.ExchangeWorkflow.Step.PreprocessEventsStep
 import org.wfanet.panelmatch.client.privatemembership.CreateQueriesParameters
 import org.wfanet.panelmatch.client.privatemembership.EvaluateQueriesParameters
 import org.wfanet.panelmatch.client.privatemembership.JniPrivateMembershipCryptor
@@ -78,6 +79,7 @@ open class ProductionExchangeTaskMapper(
   private val makePipelineOptions: () -> PipelineOptions,
   private val taskContext: TaskParameters,
 ) : ExchangeTaskMapper() {
+
   override suspend fun ExchangeContext.commutativeDeterministicEncrypt(): ExchangeTask {
     return DeterministicCommutativeCipherTask.forEncryption(JniDeterministicCommutativeCipher())
   }
@@ -98,24 +100,37 @@ open class ProductionExchangeTaskMapper(
 
   override suspend fun ExchangeContext.preprocessEvents(): ExchangeTask {
     check(step.stepCase == ExchangeWorkflow.Step.StepCase.PREPROCESS_EVENTS_STEP)
-    val eventPreprocessor = JniEventPreprocessor()
-    val deterministicCommutativeCipherKeyProvider =
-      ::HardCodedDeterministicCommutativeCipherKeyProvider
-    val hkdfPepperProvider = ::HardCodedHkdfPepperProvider
-    val identifierHashPepperProvider = ::HardCodedIdentifierHashPepperProvider
-    val preprocessingParameters: PreprocessingParameters =
-      requireNotNull(taskContext.get(PreprocessingParameters::class)) {
-        "PreprocessingParameters must be set in taskContext"
+    val preProcessStep = step.preprocessEventsStep
+
+    return when (preProcessStep.protocol) {
+      PreprocessEventsStep.PreprocessProtocol.PREPROCESSOR_PROTOCOL_UNSPECIFIED,
+      PreprocessEventsStep.PreprocessProtocol.PRIVATE_MEMBERSHIP -> {
+        val eventPreprocessor = JniEventPreprocessor()
+        val deterministicCommutativeCipherKeyProvider =
+          ::HardCodedDeterministicCommutativeCipherKeyProvider
+        val hkdfPepperProvider = ::HardCodedHkdfPepperProvider
+        val identifierHashPepperProvider = ::HardCodedIdentifierHashPepperProvider
+        val preprocessingParameters: PreprocessingParameters =
+          requireNotNull(taskContext.get(PreprocessingParameters::class)) {
+            "PreprocessingParameters must be set in taskContext"
+          }
+        val outputsManifests = mapOf("preprocessed-event-data" to preprocessingParameters.fileCount)
+        return apacheBeamTaskFor(outputsManifests, emptyList()) {
+          preprocessEvents(
+            eventPreprocessor = eventPreprocessor,
+            deterministicCommutativeCipherKeyProvider = deterministicCommutativeCipherKeyProvider,
+            identifierPepperProvider = identifierHashPepperProvider,
+            hkdfPepperProvider = hkdfPepperProvider,
+            maxByteSize = preprocessingParameters.maxByteSize,
+          )
+        }
       }
-    val outputsManifests = mapOf("preprocessed-event-data" to preprocessingParameters.fileCount)
-    return apacheBeamTaskFor(outputsManifests, emptyList()) {
-      preprocessEvents(
-        eventPreprocessor = eventPreprocessor,
-        deterministicCommutativeCipherKeyProvider = deterministicCommutativeCipherKeyProvider,
-        identifierPepperProvider = identifierHashPepperProvider,
-        hkdfPepperProvider = hkdfPepperProvider,
-        maxByteSize = preprocessingParameters.maxByteSize,
-      )
+      PreprocessEventsStep.PreprocessProtocol.AUTHORIZED_VIEW -> {
+        throw NotImplementedError("Preprocess for authorized view data - Not Implemented")
+      }
+      PreprocessEventsStep.PreprocessProtocol.UNRECOGNIZED -> {
+        error("Unrecognized PreprocessProtocol: $preProcessStep")
+      }
     }
   }
 
@@ -370,5 +385,25 @@ open class ProductionExchangeTaskMapper(
       skipReadInput,
       execute,
     )
+  }
+
+  override suspend fun ExchangeContext.readEncryptedEventsFromBigQuery(): ExchangeTask {
+    check(step.stepCase == ExchangeWorkflow.Step.StepCase.READ_ENCRYPTED_EVENTS_FROM_BIG_QUERY_STEP)
+    throw NotImplementedError("Read Encrypted Events from Big Query task - Not Implemented")
+  }
+
+  override suspend fun ExchangeContext.writeKeysToBigQuery(): ExchangeTask {
+    check(step.stepCase == ExchangeWorkflow.Step.StepCase.WRITE_KEYS_TO_BIG_QUERY_STEP)
+    throw NotImplementedError("Write Keys to Big Query task - Not Implemented")
+  }
+
+  override suspend fun ExchangeContext.writeEventsToBigQuery(): ExchangeTask {
+    check(step.stepCase == ExchangeWorkflow.Step.StepCase.WRITE_EVENTS_TO_BIG_QUERY_STEP)
+    throw NotImplementedError("Write Events to Big Query task - Not Implemented")
+  }
+
+  override suspend fun ExchangeContext.decryptAndMatchEvents(): ExchangeTask {
+    check(step.stepCase == ExchangeWorkflow.Step.StepCase.DECRYPT_AND_MATCH_EVENTS_STEP)
+    throw NotImplementedError("Decrypt and Match Events task - Not Implemented")
   }
 }

--- a/src/main/kotlin/org/wfanet/panelmatch/client/exchangetasks/ExchangeTaskMapper.kt
+++ b/src/main/kotlin/org/wfanet/panelmatch/client/exchangetasks/ExchangeTaskMapper.kt
@@ -46,6 +46,10 @@ abstract class ExchangeTaskMapper {
         StepCase.GENERATE_HYBRID_ENCRYPTION_KEY_PAIR_STEP -> generateHybridEncryptionKeyPair()
         StepCase.GENERATE_RANDOM_BYTES_STEP -> generateRandomBytes()
         StepCase.ASSIGN_JOIN_KEY_IDS_STEP -> assignJoinKeyIds()
+        StepCase.READ_ENCRYPTED_EVENTS_FROM_BIG_QUERY_STEP -> readEncryptedEventsFromBigQuery()
+        StepCase.WRITE_KEYS_TO_BIG_QUERY_STEP -> writeKeysToBigQuery()
+        StepCase.WRITE_EVENTS_TO_BIG_QUERY_STEP -> writeEventsToBigQuery()
+        StepCase.DECRYPT_AND_MATCH_EVENTS_STEP -> decryptAndMatchEvents()
         StepCase.STEP_NOT_SET ->
           throw IllegalArgumentException("Unsupported step type: ${step.stepCase}")
       }
@@ -114,4 +118,16 @@ abstract class ExchangeTaskMapper {
 
   /** Returns the task that assigns ids to each [JoinKey]. */
   abstract suspend fun ExchangeContext.assignJoinKeyIds(): ExchangeTask
+
+  /** Returns the task that reads encrypted events from BigQuery authorized views. */
+  abstract suspend fun ExchangeContext.readEncryptedEventsFromBigQuery(): ExchangeTask
+
+  /** Returns the task that writes keys to BigQuery. */
+  abstract suspend fun ExchangeContext.writeKeysToBigQuery(): ExchangeTask
+
+  /** Returns the task that writes events to BigQuery. */
+  abstract suspend fun ExchangeContext.writeEventsToBigQuery(): ExchangeTask
+
+  /** Returns the task that decrypts and matches events. */
+  abstract suspend fun ExchangeContext.decryptAndMatchEvents(): ExchangeTask
 }

--- a/src/main/kotlin/org/wfanet/panelmatch/client/exchangetasks/testing/FakeExchangeTaskMapper.kt
+++ b/src/main/kotlin/org/wfanet/panelmatch/client/exchangetasks/testing/FakeExchangeTaskMapper.kt
@@ -79,4 +79,16 @@ class FakeExchangeTaskMapper(
 
   override suspend fun ExchangeContext.assignJoinKeyIds() =
     createExchangeTask("assign-join-key-ids")
+
+  override suspend fun ExchangeContext.readEncryptedEventsFromBigQuery() =
+    createExchangeTask("read-encrypted-events-from-bigquery")
+
+  override suspend fun ExchangeContext.writeKeysToBigQuery() =
+    createExchangeTask("write-keys-to-bigquery")
+
+  override suspend fun ExchangeContext.writeEventsToBigQuery() =
+    createExchangeTask("write-events-to-bigquery")
+
+  override suspend fun ExchangeContext.decryptAndMatchEvents() =
+    createExchangeTask("decrypt-and-match-events")
 }

--- a/src/main/proto/wfa/panelmatch/client/internal/exchange_workflow.proto
+++ b/src/main/proto/wfa/panelmatch/client/internal/exchange_workflow.proto
@@ -164,8 +164,19 @@ message ExchangeWorkflow {
     // serialization of the `Certificate` resource.
     message GenerateCertificateStep {}
 
-    // Preprocesses data for later use by ExecutePrivateMembershipQueriesStep
-    message PreprocessEventsStep {}
+    // Preprocesses events for use in the selected exchange workflow.
+    message PreprocessEventsStep {
+      enum PreprocessProtocol {
+        // Default value used if the preprocessor protocol is omitted.
+        PREPROCESSOR_PROTOCOL_UNSPECIFIED = 0;
+        // Indicates events should be preprocessed for Private Membership.
+        PRIVATE_MEMBERSHIP = 1;
+        // Indicates events should be preprocessed for Authorized View.
+        AUTHORIZED_VIEW = 2;
+      }
+      // Optional, Select the type of preprocessor to use.
+      PreprocessProtocol protocol = 1;
+    }
 
     // Copies a blob from a previous exchange into this one. Requires a single
     // output label "output".
@@ -199,6 +210,75 @@ message ExchangeWorkflow {
     // Assigns JoinKey Ids
     message AssignJoinKeyIdsStep {}
 
+    // Reads encrypted events from BigQuery authorized views
+    message ReadEncryptedEventsFromBigQueryStep {
+      // BigQuery project ID
+      string project_id = 1;
+
+      // BigQuery dataset ID
+      string dataset_id = 2;
+
+      // BigQuery table or view name
+      string table_or_view_id = 3;
+
+      // Optional, column name for encrypted join key (default:
+      // "encrypted_join_key")
+      string key_column_name = 4;
+
+      // Optional, column name for encrypted event data (default:
+      // "encrypted_event_data")
+      string event_data_column_name = 5;
+
+      // Optional, column name for exchange date (default: "exchange_date")
+      string date_column_name = 6;
+    }
+
+    // Decrypts matched events from BigQuery authorized view and outputs
+    // KeyedDecryptedEventDataSet format
+    message DecryptAndMatchEventsStep {}
+
+    // Writes encrypted join keys to BigQuery using streaming API
+    message WriteKeysToBigQueryStep {
+      // BigQuery project ID
+      string project_id = 1;
+
+      // BigQuery dataset ID
+      string dataset_id = 2;
+
+      // BigQuery table name for keys
+      string table_id = 3;
+
+      // Optional, column name for encrypted join key (default:
+      // "encrypted_join_key")
+      string key_column_name = 4;
+
+      // Optional, column name for exchange date (default: "exchange_date")
+      string date_column_name = 5;
+    }
+
+    // Writes encrypted events to BigQuery using streaming API
+    message WriteEventsToBigQueryStep {
+      // BigQuery project ID
+      string project_id = 1;
+
+      // BigQuery dataset ID
+      string dataset_id = 2;
+
+      // BigQuery table name for events
+      string table_id = 3;
+
+      // Optional, column name for encrypted join key (default:
+      // "encrypted_join_key")
+      string key_column_name = 4;
+
+      // Optional, column name for encrypted event data (default:
+      // "encrypted_event_data")
+      string event_data_column_name = 5;
+
+      // Optional, column name for exchange date (default: "exchange_date")
+      string date_column_name = 6;
+    }
+
     oneof step {
       CopyFromSharedStorageStep copy_from_shared_storage_step = 5;
       CopyToSharedStorageStep copy_to_shared_storage_step = 6;
@@ -230,6 +310,11 @@ message ExchangeWorkflow {
           generate_hybrid_encryption_key_pair_step = 23;
       GenerateRandomBytesStep generate_random_bytes_step = 24;
       AssignJoinKeyIdsStep assign_join_key_ids_step = 25;
+      ReadEncryptedEventsFromBigQueryStep
+          read_encrypted_events_from_big_query_step = 26;
+      DecryptAndMatchEventsStep decrypt_and_match_events_step = 27;
+      WriteKeysToBigQueryStep write_keys_to_big_query_step = 28;
+      WriteEventsToBigQueryStep write_events_to_big_query_step = 29;
     }
   }
 


### PR DESCRIPTION
This change introduces the necessary API changes to support the Authorized View workflow. This includes adding new steps to the ExchangeWorkflow proto and updating the ExchangeTaskMapper interface and its implementations.

The new steps are:
   - ReadEncryptedEventsFromBigQueryStep
   - WriteKeysToBigQueryStep
   - WriteEventsToBigQueryStep
   - DecryptAndMatchEventsStep

The ExchangeTaskMapper interface has been updated to include methods for these new steps. The ProductionExchangeTaskMapper and FakeExchangeTaskMapper implementations have been updated to include placeholder implementations for these new methods. 

Issue: #3084
RELNOTES: The Kingdomless ExchangeWorkflow message has new step types to support Authorized View workflows