### PR TITLE
feat: Implement Authorized view workflow Preprocess Events

### DIFF
--- a/src/main/kotlin/org/wfanet/panelmatch/client/authorizedview/BUILD.bazel
+++ b/src/main/kotlin/org/wfanet/panelmatch/client/authorizedview/BUILD.bazel
@@ -1,0 +1,17 @@
+load("@wfa_rules_kotlin_jvm//kotlin:defs.bzl", "kt_jvm_library")
+
+package(default_visibility = [
+    "//src/main/kotlin/org/wfanet/panelmatch:__subpackages__",
+    "//src/test/kotlin/org/wfanet/panelmatch:__subpackages__",
+])
+
+kt_jvm_library(
+    name = "authorizedview",
+    srcs = glob(["*.kt"]),
+    deps = [
+        "//src/main/kotlin/org/wfanet/panelmatch/common",
+        "@wfa_common_jvm//imports/java/com/google/common:guava",
+        "@wfa_common_jvm//imports/java/com/google/crypto/tink",
+        "@wfa_common_jvm//imports/java/com/google/protobuf",
+    ],
+)

--- a/src/main/kotlin/org/wfanet/panelmatch/client/authorizedview/TinkAeadHelper.kt
+++ b/src/main/kotlin/org/wfanet/panelmatch/client/authorizedview/TinkAeadHelper.kt
@@ -1,0 +1,120 @@
+// Copyright 2025 The Cross-Media Measurement Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.wfanet.panelmatch.client.authorizedview
+
+import com.google.crypto.tink.Aead
+import com.google.crypto.tink.BinaryKeysetReader
+import com.google.crypto.tink.CleartextKeysetHandle
+import com.google.crypto.tink.aead.AeadConfig
+import com.google.crypto.tink.proto.AesGcmKey
+import com.google.crypto.tink.proto.KeyData
+import com.google.crypto.tink.proto.KeyStatusType
+import com.google.crypto.tink.proto.Keyset
+import com.google.crypto.tink.proto.OutputPrefixType
+import com.google.protobuf.ByteString
+import com.google.protobuf.kotlin.toByteString
+import java.security.SecureRandom
+import kotlin.math.absoluteValue
+
+/**
+ * Helper object for AES-GCM encryption operations using Tink AEAD primitives.
+ *
+ * This class creates Tink AEAD instances from raw key bytes for use in the authorized view
+ * workflow. The encrypted data format matches standard AES-GCM: IV (12 bytes) || ciphertext || auth
+ * tag (16 bytes).
+ *
+ * Uses [OutputPrefixType.RAW] to ensure compatibility with standard AES-GCM format without Tink's
+ * key ID prefix.
+ *
+ * TODO(world-federation-of-advertisers/common-jvm#365): Move this utility to common-jvm.
+ */
+object TinkAeadHelper {
+  private const val AES_KEY_SIZE = 32 // 256 bits for AES-256
+  private const val AES_GCM_KEY_TYPE_URL = "type.googleapis.com/google.crypto.tink.AesGcmKey"
+  private val NO_ASSOCIATED_DATA = byteArrayOf()
+  private val secureRandom = SecureRandom()
+
+  init {
+    AeadConfig.register()
+  }
+
+  /**
+   * Creates a Tink [Aead] primitive from raw key bytes.
+   *
+   * @param key The raw key bytes (must be at least 32 bytes; only first 32 bytes are used)
+   * @return An [Aead] instance for encryption/decryption
+   * @throws IllegalArgumentException if key has fewer than 32 bytes
+   */
+  fun createAead(key: ByteString): Aead {
+    require(key.size() >= AES_KEY_SIZE) {
+      "Key must be at least $AES_KEY_SIZE bytes, got ${key.size()}"
+    }
+    val truncatedKey = key.substring(0, AES_KEY_SIZE)
+
+    val aesGcmKey = AesGcmKey.newBuilder().setVersion(0).setKeyValue(truncatedKey).build()
+
+    val keyData =
+      KeyData.newBuilder()
+        .setTypeUrl(AES_GCM_KEY_TYPE_URL)
+        .setKeyMaterialType(KeyData.KeyMaterialType.SYMMETRIC)
+        .setValue(aesGcmKey.toByteString())
+        .build()
+
+    val keyId = secureRandom.nextInt().absoluteValue
+
+    val keyset =
+      Keyset.newBuilder()
+        .setPrimaryKeyId(keyId)
+        .addKey(
+          Keyset.Key.newBuilder()
+            .setKeyId(keyId)
+            .setStatus(KeyStatusType.ENABLED)
+            .setOutputPrefixType(OutputPrefixType.RAW)
+            .setKeyData(keyData)
+        )
+        .build()
+
+    val keysetHandle =
+      CleartextKeysetHandle.read(BinaryKeysetReader.withBytes(keyset.toByteArray()))
+    return keysetHandle.getPrimitive(Aead::class.java)
+  }
+
+  /**
+   * Encrypts data using AES-GCM via Tink AEAD.
+   *
+   * @param plaintext The data to encrypt
+   * @param key The raw key bytes (must be at least 32 bytes)
+   * @return Encrypted data in format: IV || ciphertext || auth tag
+   * @throws IllegalArgumentException if key has fewer than 32 bytes
+   */
+  fun encrypt(plaintext: ByteString, key: ByteString): ByteString {
+    val aead = createAead(key)
+    return aead.encrypt(plaintext.toByteArray(), NO_ASSOCIATED_DATA).toByteString()
+  }
+
+  /**
+   * Decrypts data that was encrypted using Tink AEAD.
+   *
+   * @param encryptedData The encrypted data (IV || ciphertext || auth tag)
+   * @param key The raw key bytes (must be at least 32 bytes)
+   * @return Decrypted plaintext
+   * @throws IllegalArgumentException if key has fewer than 32 bytes
+   * @throws java.security.GeneralSecurityException if decryption or authentication fails
+   */
+  fun decrypt(encryptedData: ByteString, key: ByteString): ByteString {
+    val aead = createAead(key)
+    return aead.decrypt(encryptedData.toByteArray(), NO_ASSOCIATED_DATA).toByteString()
+  }
+}

--- a/src/main/kotlin/org/wfanet/panelmatch/client/deploy/ProductionExchangeTaskMapper.kt
+++ b/src/main/kotlin/org/wfanet/panelmatch/client/deploy/ProductionExchangeTaskMapper.kt
@@ -43,6 +43,7 @@ import org.wfanet.panelmatch.client.exchangetasks.HybridEncryptTask
 import org.wfanet.panelmatch.client.exchangetasks.InputTask
 import org.wfanet.panelmatch.client.exchangetasks.IntersectValidateTask
 import org.wfanet.panelmatch.client.exchangetasks.JoinKeyHashingExchangeTask
+import org.wfanet.panelmatch.client.exchangetasks.PreprocessEventsTask
 import org.wfanet.panelmatch.client.exchangetasks.ProducerTask
 import org.wfanet.panelmatch.client.exchangetasks.buildPrivateMembershipQueries
 import org.wfanet.panelmatch.client.exchangetasks.copyFromSharedStorage
@@ -126,7 +127,8 @@ open class ProductionExchangeTaskMapper(
         }
       }
       PreprocessEventsStep.PreprocessProtocol.AUTHORIZED_VIEW -> {
-        throw NotImplementedError("Preprocess for authorized view data - Not Implemented")
+        val cipher = JniDeterministicCommutativeCipher()
+        return PreprocessEventsTask(cipher = cipher)
       }
       PreprocessEventsStep.PreprocessProtocol.UNRECOGNIZED -> {
         error("Unrecognized PreprocessProtocol: $preProcessStep")

--- a/src/main/kotlin/org/wfanet/panelmatch/client/exchangetasks/BUILD.bazel
+++ b/src/main/kotlin/org/wfanet/panelmatch/client/exchangetasks/BUILD.bazel
@@ -13,6 +13,7 @@ kt_jvm_library(
     name = "exchangetasks",
     srcs = glob(["*.kt"]),
     deps = [
+        "//src/main/kotlin/org/wfanet/panelmatch/client/authorizedview",
         "//src/main/kotlin/org/wfanet/panelmatch/client/common",
         "//src/main/kotlin/org/wfanet/panelmatch/client/eventpreprocessing",
         "//src/main/kotlin/org/wfanet/panelmatch/client/logger",
@@ -23,6 +24,7 @@ kt_jvm_library(
         "//src/main/kotlin/org/wfanet/panelmatch/common/certificates",
         "//src/main/kotlin/org/wfanet/panelmatch/common/crypto",
         "//src/main/kotlin/org/wfanet/panelmatch/common/storage",
+        "//src/main/proto/wfa/panelmatch/client/authorizedview:encrypted_event_kt_jvm_proto",
         "//src/main/proto/wfa/panelmatch/client/eventpreprocessing:preprocess_events_kt_jvm_proto",
         "//src/main/proto/wfa/panelmatch/client/exchangetasks:join_key_exchange_kt_jvm_proto",
         "//src/main/proto/wfa/panelmatch/client/internal:exchange_step_attempt_kt_jvm_proto",

--- a/src/main/kotlin/org/wfanet/panelmatch/client/exchangetasks/PreprocessEventsTask.kt
+++ b/src/main/kotlin/org/wfanet/panelmatch/client/exchangetasks/PreprocessEventsTask.kt
@@ -1,0 +1,148 @@
+// Copyright 2025 The Cross-Media Measurement Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.wfanet.panelmatch.client.exchangetasks
+
+import com.google.protobuf.ByteString
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.asFlow
+import kotlinx.coroutines.flow.emitAll
+import kotlinx.coroutines.flow.flow
+import org.wfanet.measurement.storage.StorageClient
+import org.wfanet.panelmatch.client.authorizedview.TinkAeadHelper
+import org.wfanet.panelmatch.client.authorizedview.decryptedEventData
+import org.wfanet.panelmatch.client.authorizedview.encryptedMatchedEvent
+import org.wfanet.panelmatch.client.eventpreprocessing.UnprocessedEvent
+import org.wfanet.panelmatch.common.Fingerprinters.sha256
+import org.wfanet.panelmatch.common.crypto.DeterministicCommutativeCipher
+import org.wfanet.panelmatch.common.loggerFor
+import org.wfanet.panelmatch.common.parseDelimitedMessages
+import org.wfanet.panelmatch.common.storage.toByteString
+import org.wfanet.panelmatch.common.toDelimitedByteString
+
+/**
+ * Preprocesses events for the BigQuery authorized view workflow with streaming output.
+ *
+ * Groups multiple events by their join key and encrypts all events for a key together:
+ * 1. Reads UnprocessedEvent protos (plaintext key + DataProviderEvent data)
+ * 2. Groups events by their plaintext join key (id field)
+ * 3. For each unique key:
+ *     - Encrypts key using EDP's commutative deterministic cipher → G(Key)
+ *     - Hashes the encrypted key for use as join key → H(G(Key))
+ *     - Collects all event data for this key into a DecryptedEventData proto
+ *     - Encrypts the DecryptedEventData using AES-GCM with G(Key)
+ * 4. Outputs one EncryptedMatchedEvent per unique key
+ *
+ * Input format (from storage):
+ * - Length-delimited UnprocessedEvent messages
+ * - Each UnprocessedEvent has:
+ *         - id: plaintext join key (e.g., email address, CPN, or Yumi)
+ *         - data: serialized DataProviderEvent proto
+ * - Multiple events can share the same id (key)
+ *
+ * Output format:
+ * - Flow of length-delimited EncryptedMatchedEvent protos (one per unique key)
+ * - Each proto contains:
+ *         - encrypted_join_key: H(G(Key)) - SHA256 hash of commutative-encrypted key (for joining)
+ *         - encrypted_event_data: AES-GCM encrypted DecryptedEventData proto containing all events
+ *
+ * The design ensures that only parties with access to G(Key) can decrypt the event data.
+ */
+class PreprocessEventsTask(private val cipher: DeterministicCommutativeCipher) : ExchangeTask {
+
+  override suspend fun execute(
+    input: Map<String, StorageClient.Blob>
+  ): Map<String, Flow<ByteString>> {
+    logger.info("Starting PreprocessEventsTask")
+    // Get inputs
+    val commutativeEncryptionKey = input.getValue(ENCRYPTION_KEY_LABEL).toByteString()
+    val rawEventsData =
+      input.getValue(RAW_EVENTS_LABEL).toByteString() // Reads all data into memory
+
+    // Parse all events into a List in memory (single pass with validation)
+    val events: List<UnprocessedEvent> = buildList {
+      rawEventsData.parseDelimitedMessages(UnprocessedEvent.getDefaultInstance()).forEachIndexed {
+        index,
+        event ->
+        require(!event.id.isEmpty) { "Event at index $index has empty id" }
+        require(!event.data.isEmpty) { "Event at index $index has empty data" }
+        add(event)
+      }
+    }
+    // Group events by their plaintext join key (id)
+    val eventsByKey: Map<ByteString, List<UnprocessedEvent>> = events.groupBy { it.id }
+
+    logger.info("Processing ${events.size} events grouped into ${eventsByKey.size} unique keys")
+
+    return mapOf(
+      ENCRYPTED_EVENTS_LABEL to
+        flow {
+          // Process grouped events in batches for cipher efficiency
+          val keyGroups = eventsByKey.entries.toList()
+          for (batch in keyGroups.chunked(CIPHER_BATCH_SIZE)) {
+            val batchResults = processGroupedBatch(batch, commutativeEncryptionKey)
+            emitAll(batchResults.asFlow())
+          }
+        }
+    )
+  }
+
+  /**
+   * Process a batch of grouped events with efficient cipher operations.
+   *
+   * Each entry in the batch is a (plaintextKey -> list of events) mapping. Outputs one
+   * EncryptedMatchedEvent per unique key containing all events for that key.
+   */
+  private suspend fun processGroupedBatch(
+    batch: List<Map.Entry<ByteString, List<UnprocessedEvent>>>,
+    commutativeKey: ByteString,
+  ): List<ByteString> {
+    // Step 1: Collect unique plaintext join keys
+    val plaintextKeys = batch.map { it.key }
+
+    // Step 2: Batch encrypt all keys with commutative cipher
+    val edpEncryptedKeys = cipher.encrypt(commutativeKey, plaintextKeys)
+
+    // Step 3: Process each key group with its EDP encrypted key
+    return batch.zip(edpEncryptedKeys).map { (entry, edpEncryptedKey) ->
+      val eventsForKey = entry.value
+
+      // Hash the encrypted key for use as join key: H(G(Key))
+      val hashedJoinKey = sha256(edpEncryptedKey)
+
+      // Build DecryptedEventData containing all events for this key
+      val eventDataProto = decryptedEventData {
+        eventsForKey.forEach { event -> eventData += event.data }
+      }
+
+      // CRITICAL SECURITY: Use G(Key) directly as AES key material
+      // Encrypt the entire DecryptedEventData proto
+      val encryptedEvent = encryptedMatchedEvent {
+        encryptedJoinKey = hashedJoinKey
+        encryptedEventData = TinkAeadHelper.encrypt(eventDataProto.toByteString(), edpEncryptedKey)
+      }
+      encryptedEvent.toDelimitedByteString()
+    }
+  }
+
+  companion object {
+    private val logger by loggerFor()
+    private const val ENCRYPTION_KEY_LABEL = "encryption-key"
+    private const val RAW_EVENTS_LABEL = "raw-events"
+    private const val ENCRYPTED_EVENTS_LABEL = "encrypted-events"
+
+    // Batch processing parameters
+    private const val CIPHER_BATCH_SIZE = 5000 // Process 5000 keys per JNI call
+  }
+}

--- a/src/main/kotlin/org/wfanet/panelmatch/common/Protos.kt
+++ b/src/main/kotlin/org/wfanet/panelmatch/common/Protos.kt
@@ -20,10 +20,18 @@ import java.io.InputStream
 import java.time.Duration
 
 /** Reads length-delimited [T] messages from a [ByteString]. */
+@Deprecated(
+  message = "Use MesosRecordIoStorageClient for streaming reads",
+  replaceWith = ReplaceWith("MesosRecordIoStorageClient"),
+)
 fun <T : MessageLite> ByteString.parseDelimitedMessages(prototype: T): Iterable<T> =
   newInput().parseDelimitedMessages(prototype)
 
 /** Reads length-delimited [T] messages from an [InputStream]. */
+@Deprecated(
+  message = "Use MesosRecordIoStorageClient for streaming reads",
+  replaceWith = ReplaceWith("MesosRecordIoStorageClient"),
+)
 fun <T : MessageLite> InputStream.parseDelimitedMessages(prototype: T): Iterable<T> = Iterable {
   iterator {
     this@parseDelimitedMessages.use { inputStream ->
@@ -38,6 +46,10 @@ fun <T : MessageLite> InputStream.parseDelimitedMessages(prototype: T): Iterable
 }
 
 /** Serializes a [MessageLite] with its length. */
+@Deprecated(
+  message = "Use MesosRecordIoStorageClient for streaming writes",
+  replaceWith = ReplaceWith("MesosRecordIoStorageClient"),
+)
 fun MessageLite.toDelimitedByteString(): ByteString {
   val outputStream = ByteString.newOutput()
   writeDelimitedTo(outputStream)

--- a/src/main/proto/wfa/panelmatch/client/authorizedview/BUILD.bazel
+++ b/src/main/proto/wfa/panelmatch/client/authorizedview/BUILD.bazel
@@ -1,0 +1,15 @@
+load("@rules_proto//proto:defs.bzl", "proto_library")
+load("@wfa_rules_kotlin_jvm//kotlin:defs.bzl", "kt_jvm_proto_library")
+
+package(default_visibility = ["//visibility:public"])
+
+proto_library(
+    name = "encrypted_event_proto",
+    srcs = ["encrypted_event.proto"],
+    strip_import_prefix = "/src/main/proto",
+)
+
+kt_jvm_proto_library(
+    name = "encrypted_event_kt_jvm_proto",
+    deps = [":encrypted_event_proto"],
+)

--- a/src/main/proto/wfa/panelmatch/client/authorizedview/encrypted_event.proto
+++ b/src/main/proto/wfa/panelmatch/client/authorizedview/encrypted_event.proto
@@ -1,0 +1,38 @@
+// Copyright 2025 The Cross-Media Measurement Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package wfa.panelmatch.client.authorizedview;
+
+option java_package = "org.wfanet.panelmatch.client.authorizedview";
+option java_multiple_files = true;
+option java_outer_classname = "EncryptedEventProto";
+
+// Encrypted matched event from BigQuery authorized view JOIN operation.
+message EncryptedMatchedEvent {
+  // H(G(Key)) - SHA256 hash of EDP-encrypted join key, used for matching.
+  bytes encrypted_join_key = 1;
+
+  // AES-GCM encrypted DecryptedEventData proto. Encryption key is G(Key).
+  bytes encrypted_event_data = 2;
+}
+
+// Container for event data payloads associated with a single key.
+// Serialized and AES-GCM encrypted as
+// EncryptedMatchedEvent.encrypted_event_data.
+message DecryptedEventData {
+  // Serialized event protos (e.g., DataProviderEvent) for this key.
+  repeated bytes event_data = 1;
+}

--- a/src/test/kotlin/org/wfanet/panelmatch/client/authorizedview/BUILD.bazel
+++ b/src/test/kotlin/org/wfanet/panelmatch/client/authorizedview/BUILD.bazel
@@ -1,0 +1,29 @@
+# Copyright 2025 The Cross-Media Measurement Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("@wfa_rules_kotlin_jvm//kotlin:defs.bzl", "kt_jvm_test")
+
+kt_jvm_test(
+    name = "TinkAeadHelperTest",
+    timeout = "short",
+    srcs = ["TinkAeadHelperTest.kt"],
+    test_class = "org.wfanet.panelmatch.client.authorizedview.TinkAeadHelperTest",
+    deps = [
+        "//src/main/kotlin/org/wfanet/panelmatch/client/authorizedview",
+        "@wfa_common_jvm//imports/java/com/google/common/truth",
+        "@wfa_common_jvm//imports/java/org/junit",
+        "@wfa_common_jvm//imports/kotlin/com/google/protobuf/kotlin",
+        "@wfa_common_jvm//imports/kotlin/kotlin/test",
+    ],
+)

--- a/src/test/kotlin/org/wfanet/panelmatch/client/authorizedview/TinkAeadHelperTest.kt
+++ b/src/test/kotlin/org/wfanet/panelmatch/client/authorizedview/TinkAeadHelperTest.kt
@@ -1,0 +1,235 @@
+// Copyright 2025 The Cross-Media Measurement Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.wfanet.panelmatch.client.authorizedview
+
+import com.google.common.truth.Truth.assertThat
+import com.google.protobuf.ByteString
+import com.google.protobuf.kotlin.toByteString
+import com.google.protobuf.kotlin.toByteStringUtf8
+import java.security.GeneralSecurityException
+import kotlin.test.assertFailsWith
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+
+@RunWith(JUnit4::class)
+class TinkAeadHelperTest {
+
+  @Test
+  fun `encrypt then decrypt returns original data`() {
+    val plaintext = "test data for encryption".toByteStringUtf8()
+    val key = "my-key-material-that-is-at-least-32-bytes-long".toByteStringUtf8()
+
+    val encrypted = TinkAeadHelper.encrypt(plaintext, key)
+    val decrypted = TinkAeadHelper.decrypt(encrypted, key)
+
+    assertThat(decrypted).isEqualTo(plaintext)
+  }
+
+  @Test
+  fun `encrypt with empty data works`() {
+    val plaintext = ByteString.EMPTY
+    val key = "a-key-that-is-at-least-32-bytes-long-for-aes".toByteStringUtf8()
+
+    val encrypted = TinkAeadHelper.encrypt(plaintext, key)
+    val decrypted = TinkAeadHelper.decrypt(encrypted, key)
+
+    assertThat(decrypted).isEqualTo(plaintext)
+  }
+
+  @Test
+  fun `encrypt with large data works`() {
+    // Create a large plaintext (1MB)
+    val largeData = ByteArray(1024 * 1024) { it.toByte() }
+    val plaintext = largeData.toByteString()
+    val key = "a-key-that-is-at-least-32-bytes-long-for-aes".toByteStringUtf8()
+
+    val encrypted = TinkAeadHelper.encrypt(plaintext, key)
+    val decrypted = TinkAeadHelper.decrypt(encrypted, key)
+
+    assertThat(decrypted).isEqualTo(plaintext)
+  }
+
+  @Test
+  fun `encrypted data differs from plaintext`() {
+    val plaintext = "test data".toByteStringUtf8()
+    val key = "a-key-that-is-at-least-32-bytes-long-for-aes".toByteStringUtf8()
+
+    val encrypted = TinkAeadHelper.encrypt(plaintext, key)
+
+    assertThat(encrypted).isNotEqualTo(plaintext)
+    // Encrypted data should be longer due to IV and auth tag
+    assertThat(encrypted.size()).isGreaterThan(plaintext.size())
+  }
+
+  @Test
+  fun `encrypt produces different ciphertext each time due to random IV`() {
+    val plaintext = "test data".toByteStringUtf8()
+    val key = "a-key-that-is-at-least-32-bytes-long-for-aes".toByteStringUtf8()
+
+    val encrypted1 = TinkAeadHelper.encrypt(plaintext, key)
+    val encrypted2 = TinkAeadHelper.encrypt(plaintext, key)
+
+    // Ciphertexts should differ due to random IV
+    assertThat(encrypted1).isNotEqualTo(encrypted2)
+
+    // But both should decrypt to the same plaintext
+    assertThat(TinkAeadHelper.decrypt(encrypted1, key)).isEqualTo(plaintext)
+    assertThat(TinkAeadHelper.decrypt(encrypted2, key)).isEqualTo(plaintext)
+  }
+
+  @Test
+  fun `encrypt with different keys produces different ciphertext`() {
+    val plaintext = "test data".toByteStringUtf8()
+    val key1 = "key1-that-is-at-least-32-bytes-long-for-aes-256".toByteStringUtf8()
+    val key2 = "key2-that-is-at-least-32-bytes-long-for-aes-256".toByteStringUtf8()
+
+    val encrypted1 = TinkAeadHelper.encrypt(plaintext, key1)
+    val encrypted2 = TinkAeadHelper.encrypt(plaintext, key2)
+
+    // Both should have same length but different content
+    assertThat(encrypted1.size()).isEqualTo(encrypted2.size())
+    assertThat(encrypted1).isNotEqualTo(encrypted2)
+  }
+
+  @Test
+  fun `decrypt with wrong key fails with GeneralSecurityException`() {
+    val plaintext = "test data".toByteStringUtf8()
+    val encryptionKey = "correct-key-that-is-at-least-32-bytes-long".toByteStringUtf8()
+    val wrongKey = "wrong-key-that-is-also-at-least-32-bytes-long".toByteStringUtf8()
+
+    val encrypted = TinkAeadHelper.encrypt(plaintext, encryptionKey)
+
+    assertFailsWith<GeneralSecurityException> { TinkAeadHelper.decrypt(encrypted, wrongKey) }
+  }
+
+  @Test
+  fun `decrypt with corrupted data fails`() {
+    val plaintext = "test data".toByteStringUtf8()
+    val key = "a-key-that-is-at-least-32-bytes-long-for-aes".toByteStringUtf8()
+
+    val encrypted = TinkAeadHelper.encrypt(plaintext, key)
+
+    // Corrupt the encrypted data
+    val corruptedBytes = encrypted.toByteArray()
+    corruptedBytes[corruptedBytes.size - 1] = (corruptedBytes[corruptedBytes.size - 1] + 1).toByte()
+    val corrupted = corruptedBytes.toByteString()
+
+    assertFailsWith<GeneralSecurityException> { TinkAeadHelper.decrypt(corrupted, key) }
+  }
+
+  @Test
+  fun `decrypt with truncated data fails`() {
+    val plaintext = "test data".toByteStringUtf8()
+    val key = "a-key-that-is-at-least-32-bytes-long-for-aes".toByteStringUtf8()
+
+    val encrypted = TinkAeadHelper.encrypt(plaintext, key)
+    val truncated = encrypted.substring(0, 10) // Too short to be valid
+
+    assertFailsWith<GeneralSecurityException> { TinkAeadHelper.decrypt(truncated, key) }
+  }
+
+  @Test
+  fun `encrypt with key shorter than 32 bytes fails`() {
+    val plaintext = "test".toByteStringUtf8()
+    val invalidKey = "short-key".toByteStringUtf8() // Less than 32 bytes
+
+    val exception =
+      assertFailsWith<IllegalArgumentException> { TinkAeadHelper.encrypt(plaintext, invalidKey) }
+    assertThat(exception.message).contains("Key must be at least")
+  }
+
+  @Test
+  fun `decrypt with key shorter than 32 bytes fails`() {
+    val plaintext = "test".toByteStringUtf8()
+    val validKey = "valid-key-that-is-at-least-32-bytes-long-ok".toByteStringUtf8()
+    val encrypted = TinkAeadHelper.encrypt(plaintext, validKey)
+
+    val invalidKey = "short-key".toByteStringUtf8() // Less than 32 bytes
+
+    val exception =
+      assertFailsWith<IllegalArgumentException> { TinkAeadHelper.decrypt(encrypted, invalidKey) }
+    assertThat(exception.message).contains("Key must be at least")
+  }
+
+  @Test
+  fun `encrypt with exactly 32 byte key works`() {
+    val plaintext = "test data".toByteStringUtf8()
+    // Create exactly 32 bytes
+    val key = "12345678901234567890123456789012".toByteStringUtf8() // Exactly 32 bytes
+
+    val encrypted = TinkAeadHelper.encrypt(plaintext, key)
+    val decrypted = TinkAeadHelper.decrypt(encrypted, key)
+
+    assertThat(decrypted).isEqualTo(plaintext)
+  }
+
+  @Test
+  fun `encrypt with key longer than 32 bytes uses only first 32 bytes`() {
+    val plaintext = "test data".toByteStringUtf8()
+    val longKey =
+      "this-is-a-very-long-key-that-is-much-longer-than-32-bytes-and-will-be-truncated"
+        .toByteStringUtf8()
+    val truncatedKey = longKey.substring(0, 32)
+
+    val encryptedWithLong = TinkAeadHelper.encrypt(plaintext, longKey)
+    val encryptedWithTruncated = TinkAeadHelper.encrypt(plaintext, truncatedKey)
+
+    // Can decrypt with either the long key or the truncated key (since only first 32 bytes are
+    // used)
+    val decryptedWithLong = TinkAeadHelper.decrypt(encryptedWithLong, longKey)
+    val decryptedWithTruncated = TinkAeadHelper.decrypt(encryptedWithLong, truncatedKey)
+
+    assertThat(decryptedWithLong).isEqualTo(plaintext)
+    assertThat(decryptedWithTruncated).isEqualTo(plaintext)
+  }
+
+  @Test
+  fun `encrypted data format contains IV and auth tag`() {
+    val plaintext = "test".toByteStringUtf8()
+    val key = "a-key-that-is-at-least-32-bytes-long-for-aes".toByteStringUtf8()
+
+    val encrypted = TinkAeadHelper.encrypt(plaintext, key)
+
+    // Encrypted format: IV (12 bytes) + ciphertext + auth tag (16 bytes)
+    // So encrypted should be at least 12 + 16 = 28 bytes longer than plaintext
+    assertThat(encrypted.size()).isAtLeast(plaintext.size() + 28)
+  }
+
+  @Test
+  fun `encrypt handles binary data correctly`() {
+    // Create binary data (not UTF-8 text)
+    val binaryData = ByteArray(256) { it.toByte() }
+    val plaintext = binaryData.toByteString()
+    val key = "a-key-that-is-at-least-32-bytes-long-for-aes".toByteStringUtf8()
+
+    val encrypted = TinkAeadHelper.encrypt(plaintext, key)
+    val decrypted = TinkAeadHelper.decrypt(encrypted, key)
+
+    assertThat(decrypted).isEqualTo(plaintext)
+  }
+
+  @Test
+  fun `createAead returns working Aead instance`() {
+    val key = "a-key-that-is-at-least-32-bytes-long-for-aes".toByteStringUtf8()
+    val aead = TinkAeadHelper.createAead(key)
+
+    val plaintext = "test data".toByteArray()
+    val encrypted = aead.encrypt(plaintext, byteArrayOf())
+    val decrypted = aead.decrypt(encrypted, byteArrayOf())
+
+    assertThat(decrypted).isEqualTo(plaintext)
+  }
+}

--- a/src/test/kotlin/org/wfanet/panelmatch/client/exchangetasks/BUILD.bazel
+++ b/src/test/kotlin/org/wfanet/panelmatch/client/exchangetasks/BUILD.bazel
@@ -266,3 +266,27 @@ kt_jvm_test(
         "@wfa_common_jvm//imports/kotlin/kotlinx/coroutines:core",
     ],
 )
+
+kt_jvm_test(
+    name = "PreprocessEventsTaskTest",
+    timeout = "short",
+    srcs = ["PreprocessEventsTaskTest.kt"],
+    test_class = "org.wfanet.panelmatch.client.exchangetasks.PreprocessEventsTaskTest",
+    deps = [
+        "//src/main/kotlin/org/wfanet/panelmatch/client/authorizedview",
+        "//src/main/kotlin/org/wfanet/panelmatch/client/exchangetasks",
+        "//src/main/kotlin/org/wfanet/panelmatch/client/exchangetasks/testing",
+        "//src/main/kotlin/org/wfanet/panelmatch/common",
+        "//src/main/kotlin/org/wfanet/panelmatch/common/crypto/testing",
+        "//src/main/kotlin/org/wfanet/panelmatch/common/storage",
+        "//src/main/kotlin/org/wfanet/panelmatch/common/testing",
+        "//src/main/proto/wfa/panelmatch/client/authorizedview:encrypted_event_kt_jvm_proto",
+        "//src/main/proto/wfa/panelmatch/client/eventpreprocessing:preprocess_events_kt_jvm_proto",
+        "@wfa_common_jvm//imports/java/com/google/common/truth",
+        "@wfa_common_jvm//imports/java/com/google/common/truth/extensions/proto",
+        "@wfa_common_jvm//imports/java/org/junit",
+        "@wfa_common_jvm//imports/kotlin/com/google/protobuf/kotlin",
+        "@wfa_common_jvm//imports/kotlin/kotlin/test",
+        "@wfa_common_jvm//imports/kotlin/kotlinx/coroutines:core",
+    ],
+)

--- a/src/test/kotlin/org/wfanet/panelmatch/client/exchangetasks/PreprocessEventsTaskTest.kt
+++ b/src/test/kotlin/org/wfanet/panelmatch/client/exchangetasks/PreprocessEventsTaskTest.kt
@@ -1,0 +1,429 @@
+// Copyright 2025 The Cross-Media Measurement Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.wfanet.panelmatch.client.exchangetasks
+
+import com.google.common.hash.Hashing
+import com.google.common.truth.Truth.assertThat
+import com.google.common.truth.extensions.proto.ProtoTruth.assertThat
+import com.google.protobuf.ByteString
+import com.google.protobuf.kotlin.toByteString
+import com.google.protobuf.kotlin.toByteStringUtf8
+import java.util.NoSuchElementException
+import kotlin.test.assertFailsWith
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+import org.wfanet.panelmatch.client.authorizedview.DecryptedEventData
+import org.wfanet.panelmatch.client.authorizedview.EncryptedMatchedEvent
+import org.wfanet.panelmatch.client.authorizedview.TinkAeadHelper
+import org.wfanet.panelmatch.client.authorizedview.encryptedMatchedEvent
+import org.wfanet.panelmatch.client.eventpreprocessing.unprocessedEvent
+import org.wfanet.panelmatch.client.exchangetasks.testing.executeToByteStrings
+import org.wfanet.panelmatch.common.crypto.testing.FakeDeterministicCommutativeCipher
+import org.wfanet.panelmatch.common.parseDelimitedMessages
+
+@RunWith(JUnit4::class)
+class PreprocessEventsTaskTest {
+
+  private val cipher = FakeDeterministicCommutativeCipher
+  private val encryptionKey = cipher.generateKey()
+
+  private fun createTestEvents(vararg events: Pair<String, String>): ByteString {
+    val outputStream = ByteString.newOutput()
+    for ((id, data) in events) {
+      val event = unprocessedEvent {
+        this.id = id.toByteStringUtf8()
+        this.data = data.toByteStringUtf8()
+      }
+      event.writeDelimitedTo(outputStream)
+    }
+    return outputStream.toByteString()
+  }
+
+  private fun executePreprocess(
+    events: ByteString,
+    key: ByteString = encryptionKey,
+  ): Map<String, ByteString> {
+    return PreprocessEventsTask(cipher)
+      .executeToByteStrings("encryption-key" to key, "raw-events" to events)
+  }
+
+  private fun parseEncryptedEvents(byteString: ByteString): List<EncryptedMatchedEvent> {
+    return byteString.parseDelimitedMessages(encryptedMatchedEvent {}).toList()
+  }
+
+  private fun hashKey(key: ByteString): ByteString {
+    return ByteString.copyFrom(Hashing.sha256().hashBytes(key.toByteArray()).asBytes())
+  }
+
+  @Test
+  fun `successfully preprocesses single event`() {
+    val events = createTestEvents("user1" to "event-data-1")
+
+    val result = executePreprocess(events)
+
+    assertThat(result).containsKey("encrypted-events")
+    val encryptedEvents = parseEncryptedEvents(result.getValue("encrypted-events"))
+    assertThat(encryptedEvents).hasSize(1)
+
+    val event = encryptedEvents[0]
+    // Verify join key is hashed version of encrypted key: H(G(Key))
+    val expectedEncryptedKey = cipher.encrypt(encryptionKey, listOf("user1".toByteStringUtf8()))[0]
+    val expectedHashedKey = hashKey(expectedEncryptedKey)
+    assertThat(event.encryptedJoinKey).isEqualTo(expectedHashedKey)
+
+    // Verify event data can be decrypted using the raw G(Key) (not derived/hashed)
+    val decryptedBytes = TinkAeadHelper.decrypt(event.encryptedEventData, expectedEncryptedKey)
+    // Parse as DecryptedEventData proto
+    val decryptedEventData = DecryptedEventData.parseFrom(decryptedBytes)
+    assertThat(decryptedEventData.eventDataList).hasSize(1)
+    assertThat(decryptedEventData.eventDataList[0]).isEqualTo("event-data-1".toByteStringUtf8())
+  }
+
+  @Test
+  fun `successfully preprocesses multiple events with different keys`() {
+    val events =
+      createTestEvents(
+        "user1" to "event-data-1",
+        "user2" to "event-data-2",
+        "user3" to "event-data-3",
+      )
+
+    val result = executePreprocess(events)
+
+    val encryptedEvents = parseEncryptedEvents(result.getValue("encrypted-events"))
+    // Each user has their own unique key, so 3 output events
+    assertThat(encryptedEvents).hasSize(3)
+
+    // Build a map from hashed key to decrypted event data for verification
+    val expectedIds = listOf("user1", "user2", "user3")
+    val expectedData = listOf("event-data-1", "event-data-2", "event-data-3")
+
+    for (userId in expectedIds) {
+      val expectedEncryptedKey = cipher.encrypt(encryptionKey, listOf(userId.toByteStringUtf8()))[0]
+      val expectedHashedKey = hashKey(expectedEncryptedKey)
+
+      // Find the event with this hashed key
+      val event = encryptedEvents.find { it.encryptedJoinKey == expectedHashedKey }
+      assertThat(event).isNotNull()
+
+      // Verify data decryption using raw G(Key) (not derived/hashed)
+      val decryptedBytes = TinkAeadHelper.decrypt(event!!.encryptedEventData, expectedEncryptedKey)
+      val decryptedEventData = DecryptedEventData.parseFrom(decryptedBytes)
+      assertThat(decryptedEventData.eventDataList).hasSize(1)
+
+      val expectedIndex = expectedIds.indexOf(userId)
+      assertThat(decryptedEventData.eventDataList[0])
+        .isEqualTo(expectedData[expectedIndex].toByteStringUtf8())
+    }
+  }
+
+  @Test
+  fun `handles empty events list`() {
+    val events = createTestEvents() // No events
+
+    val result = executePreprocess(events)
+
+    assertThat(result).containsKey("encrypted-events")
+    val encryptedEvents = parseEncryptedEvents(result.getValue("encrypted-events"))
+    assertThat(encryptedEvents).isEmpty()
+  }
+
+  @Test
+  fun `fails with missing encryption key`() {
+    val events = createTestEvents("user1" to "event-data")
+
+    val exception =
+      assertFailsWith<NoSuchElementException> {
+        PreprocessEventsTask(cipher)
+          .executeToByteStrings(
+            "raw-events" to events
+            // Missing "encryption-key"
+          )
+      }
+
+    assertThat(exception.message).contains("encryption-key")
+  }
+
+  @Test
+  fun `fails with missing raw events`() {
+    val exception =
+      assertFailsWith<NoSuchElementException> {
+        PreprocessEventsTask(cipher)
+          .executeToByteStrings(
+            "encryption-key" to encryptionKey
+            // Missing "raw-events"
+          )
+      }
+
+    assertThat(exception.message).contains("raw-events")
+  }
+
+  @Test
+  fun `produces valid EncryptedMatchedEvent protos`() {
+    val events = createTestEvents("user1" to "event-data")
+
+    val result = executePreprocess(events)
+
+    val encryptedEvents = parseEncryptedEvents(result.getValue("encrypted-events"))
+    val event = encryptedEvents[0]
+
+    // Verify proto structure
+    assertThat(event.encryptedJoinKey.isEmpty).isFalse()
+    assertThat(event.encryptedEventData.isEmpty).isFalse()
+
+    // Encrypted data should be larger than original due to IV and auth tag
+    assertThat(event.encryptedEventData.size()).isGreaterThan("event-data".length)
+  }
+
+  @Test
+  fun `groups multiple events with same key into single output`() {
+    val events =
+      createTestEvents(
+        "user1" to "event-data-1",
+        "user1" to "event-data-2", // Same user ID
+      )
+
+    val result = executePreprocess(events)
+
+    val encryptedEvents = parseEncryptedEvents(result.getValue("encrypted-events"))
+    // Same key should produce ONE output with grouped events
+    assertThat(encryptedEvents).hasSize(1)
+
+    val event = encryptedEvents[0]
+    val expectedEncryptedKey = cipher.encrypt(encryptionKey, listOf("user1".toByteStringUtf8()))[0]
+
+    // Decrypt and verify both events are grouped together
+    val decryptedBytes = TinkAeadHelper.decrypt(event.encryptedEventData, expectedEncryptedKey)
+    val decryptedEventData = DecryptedEventData.parseFrom(decryptedBytes)
+
+    assertThat(decryptedEventData.eventDataList).hasSize(2)
+    assertThat(decryptedEventData.eventDataList)
+      .containsExactly("event-data-1".toByteStringUtf8(), "event-data-2".toByteStringUtf8())
+  }
+
+  @Test
+  fun `different join keys produce different encrypted keys`() {
+    val events =
+      createTestEvents(
+        "user1" to "event-data",
+        "user2" to "event-data", // Different user ID, same data
+      )
+
+    val result = executePreprocess(events)
+
+    val encryptedEvents = parseEncryptedEvents(result.getValue("encrypted-events"))
+    assertThat(encryptedEvents).hasSize(2)
+
+    // Different join keys should produce different encrypted keys
+    assertThat(encryptedEvents[0].encryptedJoinKey)
+      .isNotEqualTo(encryptedEvents[1].encryptedJoinKey)
+  }
+
+  @Test
+  fun `event data encryption uses G(Key) directly without SHA-256 hashing`() {
+    val userId = "test-user"
+    val eventData = "sensitive-event-data"
+    val events = createTestEvents(userId to eventData)
+
+    val result = executePreprocess(events)
+
+    val encryptedEvents = parseEncryptedEvents(result.getValue("encrypted-events"))
+    val event = encryptedEvents[0]
+
+    // Manually verify the encryption flow
+    val gKey = cipher.encrypt(encryptionKey, listOf(userId.toByteStringUtf8()))[0]
+    val hGKey = hashKey(gKey)
+
+    // Join key should be H(G(Key))
+    assertThat(event.encryptedJoinKey).isEqualTo(hGKey)
+
+    // CRITICAL: Event data should be encrypted with raw G(Key), NOT H(G(Key))
+    // This ensures only parties with G(Key) can decrypt, not those with just H(G(Key))
+
+    // Verify decryption works with raw G(Key)
+    val decryptedBytes = TinkAeadHelper.decrypt(event.encryptedEventData, gKey)
+    val decryptedEventData = DecryptedEventData.parseFrom(decryptedBytes)
+    assertThat(decryptedEventData.eventDataList).hasSize(1)
+    assertThat(decryptedEventData.eventDataList[0]).isEqualTo(eventData.toByteStringUtf8())
+
+    // CRITICAL TEST: Verify H(G(Key)) CANNOT be used to decrypt
+    // This is the key security property - knowing the join key shouldn't allow decryption
+
+    // Also verify using H(G(Key)) directly with raw decryption fails
+    assertFailsWith<java.security.GeneralSecurityException> {
+      TinkAeadHelper.decrypt(event.encryptedEventData, hGKey)
+    }
+
+    // Using a completely different key should also fail
+    val wrongKey = "wrong-key-that-is-at-least-32-bytes-long".toByteStringUtf8()
+    assertFailsWith<java.security.GeneralSecurityException> {
+      TinkAeadHelper.decrypt(event.encryptedEventData, wrongKey)
+    }
+  }
+
+  @Test
+  fun `handles large batch processing with unique keys`() {
+    // Create a request with 1000 events, each with unique key
+    val eventCount = 1000
+    val eventPairs = (1..eventCount).map { i -> "user$i" to "event-data-$i" }.toTypedArray()
+
+    val events = createTestEvents(*eventPairs)
+
+    val result = executePreprocess(events)
+
+    val encryptedEvents = parseEncryptedEvents(result.getValue("encrypted-events"))
+    // Each user has unique key, so 1000 output events
+    assertThat(encryptedEvents).hasSize(eventCount)
+
+    // Verify first user's event
+    val firstExpectedKey = cipher.encrypt(encryptionKey, listOf("user1".toByteStringUtf8()))[0]
+    val firstHashedKey = hashKey(firstExpectedKey)
+    val firstEvent = encryptedEvents.find { it.encryptedJoinKey == firstHashedKey }
+    assertThat(firstEvent).isNotNull()
+
+    // Verify last user's event
+    val lastExpectedKey =
+      cipher.encrypt(encryptionKey, listOf("user$eventCount".toByteStringUtf8()))[0]
+    val lastHashedKey = hashKey(lastExpectedKey)
+    val lastEvent = encryptedEvents.find { it.encryptedJoinKey == lastHashedKey }
+    assertThat(lastEvent).isNotNull()
+  }
+
+  @Test
+  fun `handles large batch with grouped events`() {
+    // Create events where 100 users each have 10 events
+    val userCount = 100
+    val eventsPerUser = 10
+    val eventPairs =
+      (1..userCount)
+        .flatMap { userId ->
+          (1..eventsPerUser).map { eventNum -> "user$userId" to "event-$userId-$eventNum" }
+        }
+        .toTypedArray()
+
+    val events = createTestEvents(*eventPairs)
+
+    val result = executePreprocess(events)
+
+    val encryptedEvents = parseEncryptedEvents(result.getValue("encrypted-events"))
+    // 100 unique users should produce 100 output events
+    assertThat(encryptedEvents).hasSize(userCount)
+
+    // Verify one user's grouped events
+    val user1Key = cipher.encrypt(encryptionKey, listOf("user1".toByteStringUtf8()))[0]
+    val user1HashedKey = hashKey(user1Key)
+    val user1Event = encryptedEvents.find { it.encryptedJoinKey == user1HashedKey }
+    assertThat(user1Event).isNotNull()
+
+    val decryptedBytes = TinkAeadHelper.decrypt(user1Event!!.encryptedEventData, user1Key)
+    val decryptedEventData = DecryptedEventData.parseFrom(decryptedBytes)
+    assertThat(decryptedEventData.eventDataList).hasSize(eventsPerUser)
+  }
+
+  @Test
+  fun `throws exception for events with empty data`() {
+    val events =
+      createTestEvents(
+        "user1" to "" // Empty event data - should throw
+      )
+
+    val exception = assertFailsWith<IllegalArgumentException> { executePreprocess(events) }
+    assertThat(exception.message).contains("empty data")
+  }
+
+  @Test
+  fun `handles events with binary data`() {
+    // Create binary data (not UTF-8 text)
+    val binaryData = ByteArray(256) { it.toByte() }
+    val outputStream = ByteString.newOutput()
+    val unprocessed = unprocessedEvent {
+      id = "binary-user".toByteStringUtf8()
+      data = binaryData.toByteString()
+    }
+    unprocessed.writeDelimitedTo(outputStream)
+    val events = outputStream.toByteString()
+
+    val result = executePreprocess(events)
+
+    val encryptedEvents = parseEncryptedEvents(result.getValue("encrypted-events"))
+    val event = encryptedEvents[0]
+
+    // Verify binary data is preserved
+    val encryptedKey = cipher.encrypt(encryptionKey, listOf("binary-user".toByteStringUtf8()))[0]
+    val hashedKey = hashKey(encryptedKey)
+    assertThat(event.encryptedJoinKey).isEqualTo(hashedKey)
+
+    // Verify decryption with raw G(Key) (not derived/hashed)
+    val decryptedBytes = TinkAeadHelper.decrypt(event.encryptedEventData, encryptedKey)
+    val decryptedEventData = DecryptedEventData.parseFrom(decryptedBytes)
+    assertThat(decryptedEventData.eventDataList).hasSize(1)
+    assertThat(decryptedEventData.eventDataList[0]).isEqualTo(binaryData.toByteString())
+  }
+
+  @Test
+  fun `mixed keys with some having multiple events`() {
+    val events =
+      createTestEvents(
+        "user1" to "event-1a",
+        "user2" to "event-2a",
+        "user1" to "event-1b", // Same key as first event
+        "user3" to "event-3a",
+        "user2" to "event-2b", // Same key as second event
+      )
+
+    val result = executePreprocess(events)
+
+    val encryptedEvents = parseEncryptedEvents(result.getValue("encrypted-events"))
+    // 3 unique users should produce 3 output events
+    assertThat(encryptedEvents).hasSize(3)
+
+    // Verify user1 has 2 events grouped
+    val user1Key = cipher.encrypt(encryptionKey, listOf("user1".toByteStringUtf8()))[0]
+    val user1HashedKey = hashKey(user1Key)
+    val user1Event = encryptedEvents.find { it.encryptedJoinKey == user1HashedKey }
+    assertThat(user1Event).isNotNull()
+    val user1Decrypted =
+      DecryptedEventData.parseFrom(
+        TinkAeadHelper.decrypt(user1Event!!.encryptedEventData, user1Key)
+      )
+    assertThat(user1Decrypted.eventDataList).hasSize(2)
+    assertThat(user1Decrypted.eventDataList)
+      .containsExactly("event-1a".toByteStringUtf8(), "event-1b".toByteStringUtf8())
+
+    // Verify user2 has 2 events grouped
+    val user2Key = cipher.encrypt(encryptionKey, listOf("user2".toByteStringUtf8()))[0]
+    val user2HashedKey = hashKey(user2Key)
+    val user2Event = encryptedEvents.find { it.encryptedJoinKey == user2HashedKey }
+    assertThat(user2Event).isNotNull()
+    val user2Decrypted =
+      DecryptedEventData.parseFrom(
+        TinkAeadHelper.decrypt(user2Event!!.encryptedEventData, user2Key)
+      )
+    assertThat(user2Decrypted.eventDataList).hasSize(2)
+
+    // Verify user3 has 1 event
+    val user3Key = cipher.encrypt(encryptionKey, listOf("user3".toByteStringUtf8()))[0]
+    val user3HashedKey = hashKey(user3Key)
+    val user3Event = encryptedEvents.find { it.encryptedJoinKey == user3HashedKey }
+    assertThat(user3Event).isNotNull()
+    val user3Decrypted =
+      DecryptedEventData.parseFrom(
+        TinkAeadHelper.decrypt(user3Event!!.encryptedEventData, user3Key)
+      )
+    assertThat(user3Decrypted.eventDataList).hasSize(1)
+    assertThat(user3Decrypted.eventDataList[0]).isEqualTo("event-3a".toByteStringUtf8())
+  }
+}


### PR DESCRIPTION
Implement the event preprocessing task for the BigQuery authorized view  workflow. This adds the preprocessor that encrypts events before they're written to BigQuery tables.

Key changes:
- Add PreprocessEventsTask to encrypt join keys and event data
- Implement AesGcmCryptoHelper for AES-GCM encryption/decryption
- Define EncryptedMatchedEvent proto format for encrypted events
- Wire up the preprocessor in ProductionExchangeTaskMapper

The preprocessor:
1. Reads UnprocessedEvent protos (plaintext join key + event data)
2. Encrypts join keys using EDP's commutative deterministic cipher
3. Encrypts event data using AES-GCM with encrypted join key
4. Outputs length-delimited EncryptedMatchedEvent protos


Issue: #3084