### PR TITLE
feat: Implement Write To Big Query Task

### DIFF
--- a/src/main/kotlin/org/wfanet/panelmatch/client/deploy/ProductionExchangeTaskMapper.kt
+++ b/src/main/kotlin/org/wfanet/panelmatch/client/deploy/ProductionExchangeTaskMapper.kt
@@ -47,6 +47,7 @@ import org.wfanet.panelmatch.client.exchangetasks.JoinKeyHashingExchangeTask
 import org.wfanet.panelmatch.client.exchangetasks.PreprocessEventsTask
 import org.wfanet.panelmatch.client.exchangetasks.ProducerTask
 import org.wfanet.panelmatch.client.exchangetasks.ReadEncryptedEventsFromBigQueryTask
+import org.wfanet.panelmatch.client.exchangetasks.WriteToBigQueryTask
 import org.wfanet.panelmatch.client.exchangetasks.buildPrivateMembershipQueries
 import org.wfanet.panelmatch.client.exchangetasks.copyFromSharedStorage
 import org.wfanet.panelmatch.client.exchangetasks.copyToSharedStorage
@@ -421,12 +422,52 @@ open class ProductionExchangeTaskMapper(
 
   override suspend fun ExchangeContext.writeKeysToBigQuery(): ExchangeTask {
     check(step.stepCase == ExchangeWorkflow.Step.StepCase.WRITE_KEYS_TO_BIG_QUERY_STEP)
-    throw NotImplementedError("Write Keys to Big Query task - Not Implemented")
+    requireNotNull(bigQueryServiceFactory) {
+      "bigQueryServiceFactory must be set for BigQuery tasks"
+    }
+    val writeStep = step.writeKeysToBigQueryStep
+    return WriteToBigQueryTask.forJoinKeys(
+      projectId = writeStep.projectId,
+      datasetId = writeStep.datasetId,
+      tableId = writeStep.tableId,
+      exchangeDate = exchangeDateKey.date,
+      bigQueryServiceFactory = bigQueryServiceFactory,
+      keyColumnName =
+        writeStep.keyColumnName.ifEmpty {
+          WriteToBigQueryTask.DEFAULT_ENCRYPTED_JOIN_KEY_COLUMN_NAME
+        },
+      dateColumnName =
+        writeStep.dateColumnName.ifEmpty {
+          WriteToBigQueryTask.DEFAULT_ENCRYPTED_EXCHANGE_DATE_COLUMN_NAME
+        },
+    )
   }
 
   override suspend fun ExchangeContext.writeEventsToBigQuery(): ExchangeTask {
     check(step.stepCase == ExchangeWorkflow.Step.StepCase.WRITE_EVENTS_TO_BIG_QUERY_STEP)
-    throw NotImplementedError("Write Events to Big Query task - Not Implemented")
+    requireNotNull(bigQueryServiceFactory) {
+      "bigQueryServiceFactory must be set for BigQuery tasks"
+    }
+    val writeStep = step.writeEventsToBigQueryStep
+    return WriteToBigQueryTask.forEncryptedEvents(
+      projectId = writeStep.projectId,
+      datasetId = writeStep.datasetId,
+      tableId = writeStep.tableId,
+      exchangeDate = exchangeDateKey.date,
+      bigQueryServiceFactory = bigQueryServiceFactory,
+      keyColumnName =
+        writeStep.keyColumnName.ifEmpty {
+          WriteToBigQueryTask.DEFAULT_ENCRYPTED_JOIN_KEY_COLUMN_NAME
+        },
+      dataColumnName =
+        writeStep.eventDataColumnName.ifEmpty {
+          WriteToBigQueryTask.DEFAULT_ENCRYPTED_EVENT_DATA_COLUMN_NAME
+        },
+      dateColumnName =
+        writeStep.dateColumnName.ifEmpty {
+          WriteToBigQueryTask.DEFAULT_ENCRYPTED_EXCHANGE_DATE_COLUMN_NAME
+        },
+    )
   }
 
   override suspend fun ExchangeContext.decryptAndMatchEvents(): ExchangeTask {

--- a/src/main/kotlin/org/wfanet/panelmatch/client/exchangetasks/BUILD.bazel
+++ b/src/main/kotlin/org/wfanet/panelmatch/client/exchangetasks/BUILD.bazel
@@ -25,6 +25,7 @@ kt_jvm_library(
         "//src/main/kotlin/org/wfanet/panelmatch/common/certificates",
         "//src/main/kotlin/org/wfanet/panelmatch/common/crypto",
         "//src/main/kotlin/org/wfanet/panelmatch/common/storage",
+        "//src/main/proto/wfa/panelmatch/client/authorizedview:bigquery_streaming_status_kt_jvm_proto",
         "//src/main/proto/wfa/panelmatch/client/authorizedview:encrypted_event_kt_jvm_proto",
         "//src/main/proto/wfa/panelmatch/client/eventpreprocessing:preprocess_events_kt_jvm_proto",
         "//src/main/proto/wfa/panelmatch/client/exchangetasks:join_key_exchange_kt_jvm_proto",

--- a/src/main/kotlin/org/wfanet/panelmatch/client/exchangetasks/WriteToBigQueryTask.kt
+++ b/src/main/kotlin/org/wfanet/panelmatch/client/exchangetasks/WriteToBigQueryTask.kt
@@ -1,0 +1,320 @@
+// Copyright 2025 The Cross-Media Measurement Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.wfanet.panelmatch.client.exchangetasks
+
+import com.google.cloud.bigquery.BigQuery
+import com.google.cloud.bigquery.InsertAllRequest
+import com.google.cloud.bigquery.QueryJobConfiguration
+import com.google.cloud.bigquery.TableId
+import com.google.protobuf.ByteString
+import java.time.LocalDate
+import java.time.format.DateTimeFormatter
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
+import org.wfanet.measurement.common.toProtoDate
+import org.wfanet.measurement.storage.StorageClient
+import org.wfanet.panelmatch.client.authorizedview.BigQueryServiceFactory
+import org.wfanet.panelmatch.client.authorizedview.BigQueryStreamingStatus
+import org.wfanet.panelmatch.client.authorizedview.BigQueryStreamingStatus.DataType
+import org.wfanet.panelmatch.client.authorizedview.bigQueryStreamingStatus
+import org.wfanet.panelmatch.client.authorizedview.encryptedMatchedEvent
+import org.wfanet.panelmatch.common.Fingerprinters.sha256
+import org.wfanet.panelmatch.common.loggerFor
+import org.wfanet.panelmatch.common.parseDelimitedMessages
+import org.wfanet.panelmatch.common.storage.toByteString
+import org.wfanet.panelmatch.common.toBase64
+
+/**
+ * Writes JoinKeyAndId or EncryptedMatchedEvent protos to BigQuery using the streaming API.
+ *
+ * Use [forJoinKeys] or [forEncryptedEvents] to create instances.
+ */
+class WriteToBigQueryTask
+internal constructor(
+  private val projectId: String,
+  private val datasetId: String,
+  private val tableId: String,
+  private val exchangeDate: LocalDate,
+  private val keyColumnName: String,
+  private val dataColumnName: String? = null,
+  private val dateColumnName: String,
+  private val bigQueryServiceFactory: BigQueryServiceFactory,
+  private val process: suspend WriteToBigQueryTask.(StorageClient.Blob) -> BigQueryStreamingStatus,
+) : ExchangeTask {
+
+  private val bigQueryTableId: TableId by lazy { TableId.of(projectId, datasetId, tableId) }
+
+  private val bigquery: BigQuery by lazy { bigQueryServiceFactory.getService(projectId) }
+
+  override suspend fun execute(
+    input: Map<String, StorageClient.Blob>
+  ): Map<String, Flow<ByteString>> {
+    logger.info("Starting WriteToBigQueryTask for $projectId.$datasetId.$tableId")
+
+    deleteExistingRowsForDate()
+
+    val inputBlob = requireNotNull(input[INPUT_LABEL]) { "Missing required input: $INPUT_LABEL" }
+
+    val statusProto = process(inputBlob)
+
+    logger.info(
+      "BigQuery Streaming Complete: ${statusProto.status}, " +
+        "Rows written: ${statusProto.statistics.rowsWritten}, " +
+        "Rows failed: ${statusProto.statistics.rowsFailed}"
+    )
+
+    if (statusProto.statistics.rowsFailed > 0) {
+      throw IllegalStateException(
+        "Failed to stream ${statusProto.statistics.rowsFailed} rows " +
+          "out of ${statusProto.statistics.rowsWritten + statusProto.statistics.rowsFailed} total"
+      )
+    }
+
+    return mapOf(OUTPUT_LABEL to flowOf(statusProto.toByteString()))
+  }
+
+  private fun deleteExistingRowsForDate() {
+    val fullTableName = "`$projectId.$datasetId.$tableId`"
+    val deleteQuery =
+      "DELETE FROM $fullTableName WHERE `$dateColumnName` = DATE('${exchangeDate.toIsoDateString()}')"
+
+    logger.info("Deleting existing rows for exchange date $exchangeDate")
+
+    val queryConfig = QueryJobConfiguration.newBuilder(deleteQuery).setUseLegacySql(false).build()
+    bigquery.query(queryConfig)
+
+    logger.info("Deleted existing rows for exchange date $exchangeDate")
+  }
+
+  /**
+   * Hashes G(Key) to H(G(Key)) and writes to BigQuery to match EDP's PreprocessEventsTask format.
+   */
+  private suspend fun processJoinKeys(blob: StorageClient.Blob): BigQueryStreamingStatus {
+    val stats = StreamingStats()
+    val collection = JoinKeyAndIdCollection.parseFrom(blob.toByteString())
+
+    val validJoinKeyAndIds =
+      collection.joinKeyAndIdsList.filter {
+        it.joinKey.key != ByteString.EMPTY && it.joinKeyIdentifier.id != ByteString.EMPTY
+      }
+
+    if (validJoinKeyAndIds.isEmpty()) {
+      logger.warning("JoinKeyAndIdCollection is empty after filtering.")
+      return stats.toStatusProto(bigQueryTableId, exchangeDate, DataType.JOIN_KEYS)
+    }
+
+    val joinKeys = validJoinKeyAndIds.map { it.joinKey.key }
+    require(joinKeys.toSet().size == joinKeys.size) { "JoinKeys are not distinct after filtering" }
+
+    logger.info("Processing ${validJoinKeyAndIds.size} valid keys from JoinKeyAndIdCollection")
+
+    for (batch in validJoinKeyAndIds.chunked(BATCH_SIZE)) {
+      val bigQueryRows =
+        batch.map { joinKeyAndId ->
+          val key = sha256(joinKeyAndId.joinKey.key).toBase64()
+          val row = mapOf(keyColumnName to key, dateColumnName to exchangeDate.toIsoDateString())
+          key to row
+        }
+      streamBatch(bigQueryRows, stats)
+    }
+
+    logger.info("Successfully hashed and wrote join keys as H(G(Key)) for authorized view")
+    return stats.toStatusProto(bigQueryTableId, exchangeDate, DataType.JOIN_KEYS)
+  }
+
+  private suspend fun processEncryptedEvents(blob: StorageClient.Blob): BigQueryStreamingStatus {
+    requireNotNull(dataColumnName) { "dataColumnName must be set for encrypted events" }
+
+    val stats = StreamingStats()
+
+    val encryptedEventsSequence =
+      blob.toByteString().parseDelimitedMessages(encryptedMatchedEvent {}).asSequence().filter {
+        event ->
+        event.encryptedJoinKey != ByteString.EMPTY && event.encryptedEventData != ByteString.EMPTY
+      }
+
+    var eventCount = 0
+    for (batch in encryptedEventsSequence.chunked(BATCH_SIZE)) {
+      eventCount += batch.size
+      val bigQueryRows =
+        batch.map { encryptedEvent ->
+          val key = encryptedEvent.encryptedJoinKey.toBase64()
+          val row =
+            mapOf(
+              keyColumnName to key,
+              dataColumnName to encryptedEvent.encryptedEventData.toBase64(),
+              dateColumnName to exchangeDate.toIsoDateString(),
+            )
+          key to row
+        }
+      streamBatch(bigQueryRows, stats)
+    }
+
+    if (eventCount == 0) {
+      logger.warning("No valid encrypted events found in input blob after filtering.")
+    } else {
+      logger.info("Processed $eventCount valid encrypted events")
+    }
+    return stats.toStatusProto(bigQueryTableId, exchangeDate, DataType.ENCRYPTED_EVENTS)
+  }
+
+  private suspend fun streamBatch(
+    batch: List<Pair<String, Map<String, Any>>>,
+    stats: StreamingStats,
+  ) {
+    val request =
+      InsertAllRequest.newBuilder(bigQueryTableId)
+        .apply { batch.forEach { (insertId, row) -> addRow(insertId, row) } }
+        .build()
+
+    val response = bigquery.insertAll(request)
+
+    if (response.hasErrors()) {
+      val errorCount = response.insertErrors.size
+      stats.failureCount += errorCount
+      stats.successCount += batch.size - errorCount
+      logger.warning("$errorCount rows failed in batch of ${batch.size}")
+      response.insertErrors.forEach { (index, errorList) ->
+        logger.fine("Row at index $index failed: $errorList")
+      }
+    } else {
+      stats.successCount += batch.size
+      logger.fine("Successfully inserted ${batch.size} rows")
+    }
+    stats.batchCount++
+  }
+
+  companion object {
+    private const val INPUT_LABEL = "input"
+    private const val OUTPUT_LABEL = "status"
+
+    private const val BATCH_SIZE = 5000
+
+    private val logger by loggerFor()
+
+    const val DEFAULT_ENCRYPTED_JOIN_KEY_COLUMN_NAME = "encrypted_join_key"
+    const val DEFAULT_ENCRYPTED_EVENT_DATA_COLUMN_NAME = "encrypted_event_data"
+    const val DEFAULT_ENCRYPTED_EXCHANGE_DATE_COLUMN_NAME = "exchange_date"
+
+    @JvmStatic
+    fun forJoinKeys(
+      projectId: String,
+      datasetId: String,
+      tableId: String,
+      exchangeDate: LocalDate,
+      bigQueryServiceFactory: BigQueryServiceFactory,
+      keyColumnName: String = DEFAULT_ENCRYPTED_JOIN_KEY_COLUMN_NAME,
+      dateColumnName: String = DEFAULT_ENCRYPTED_EXCHANGE_DATE_COLUMN_NAME,
+    ): ExchangeTask {
+      return WriteToBigQueryTask(
+        projectId = projectId,
+        datasetId = datasetId,
+        tableId = tableId,
+        exchangeDate = exchangeDate,
+        keyColumnName = keyColumnName,
+        dataColumnName = null,
+        dateColumnName = dateColumnName,
+        bigQueryServiceFactory = bigQueryServiceFactory,
+        process = WriteToBigQueryTask::processJoinKeys,
+      )
+    }
+
+    @JvmStatic
+    fun forEncryptedEvents(
+      projectId: String,
+      datasetId: String,
+      tableId: String,
+      exchangeDate: LocalDate,
+      bigQueryServiceFactory: BigQueryServiceFactory,
+      keyColumnName: String = DEFAULT_ENCRYPTED_JOIN_KEY_COLUMN_NAME,
+      dataColumnName: String = DEFAULT_ENCRYPTED_EVENT_DATA_COLUMN_NAME,
+      dateColumnName: String = DEFAULT_ENCRYPTED_EXCHANGE_DATE_COLUMN_NAME,
+    ): ExchangeTask {
+      return WriteToBigQueryTask(
+        projectId = projectId,
+        datasetId = datasetId,
+        tableId = tableId,
+        exchangeDate = exchangeDate,
+        keyColumnName = keyColumnName,
+        dataColumnName = dataColumnName,
+        dateColumnName = dateColumnName,
+        bigQueryServiceFactory = bigQueryServiceFactory,
+        process = WriteToBigQueryTask::processEncryptedEvents,
+      )
+    }
+
+    private fun LocalDate.toIsoDateString(): String {
+      return this.format(DateTimeFormatter.ISO_DATE)
+    }
+  }
+
+  private data class StreamingStats(
+    var successCount: Int = 0,
+    var failureCount: Int = 0,
+    var batchCount: Int = 0,
+  ) {
+    fun toProto(): BigQueryStreamingStatus.StreamingStatistics {
+      return BigQueryStreamingStatus.StreamingStatistics.newBuilder()
+        .apply {
+          rowsWritten = this@StreamingStats.successCount.toLong()
+          rowsFailed = this@StreamingStats.failureCount.toLong()
+          batchesSent = this@StreamingStats.batchCount
+        }
+        .build()
+    }
+
+    fun toStatus(): BigQueryStreamingStatus.Status {
+      return when {
+        failureCount == 0 && successCount > 0 -> BigQueryStreamingStatus.Status.SUCCESS
+        failureCount > 0 && successCount > 0 -> BigQueryStreamingStatus.Status.PARTIAL_SUCCESS
+        successCount == 0 && failureCount > 0 -> BigQueryStreamingStatus.Status.FAILURE
+        else -> BigQueryStreamingStatus.Status.STATUS_UNSPECIFIED
+      }
+    }
+
+    fun toErrorMessage(): String? {
+      return if (failureCount > 0) {
+        "Failed to stream $failureCount rows out of ${successCount + failureCount} total rows"
+      } else null
+    }
+
+    fun toStatusProto(
+      tableId: TableId,
+      exchangeDate: LocalDate,
+      dataType: DataType,
+    ): BigQueryStreamingStatus {
+      return bigQueryStreamingStatus {
+        tableInfo = tableId.toProtoTableInfo()
+        this.exchangeDate = exchangeDate.toProtoDate()
+        this.dataType = dataType
+        statistics = this@StreamingStats.toProto()
+        status = this@StreamingStats.toStatus()
+        this@StreamingStats.toErrorMessage()?.let { errorMessage = it }
+      }
+    }
+
+    companion object {
+      private fun TableId.toProtoTableInfo(): BigQueryStreamingStatus.TableInfo {
+        return BigQueryStreamingStatus.TableInfo.newBuilder()
+          .apply {
+            projectId = this@toProtoTableInfo.project
+            datasetId = this@toProtoTableInfo.dataset
+            tableId = this@toProtoTableInfo.table
+          }
+          .build()
+      }
+    }
+  }
+}

--- a/src/main/proto/wfa/panelmatch/client/authorizedview/BUILD.bazel
+++ b/src/main/proto/wfa/panelmatch/client/authorizedview/BUILD.bazel
@@ -13,3 +13,17 @@ kt_jvm_proto_library(
     name = "encrypted_event_kt_jvm_proto",
     deps = [":encrypted_event_proto"],
 )
+
+proto_library(
+    name = "bigquery_streaming_status_proto",
+    srcs = ["bigquery_streaming_status.proto"],
+    strip_import_prefix = "/src/main/proto",
+    deps = [
+        "@com_google_googleapis//google/type:date_proto",
+    ],
+)
+
+kt_jvm_proto_library(
+    name = "bigquery_streaming_status_kt_jvm_proto",
+    deps = [":bigquery_streaming_status_proto"],
+)

--- a/src/main/proto/wfa/panelmatch/client/authorizedview/bigquery_streaming_status.proto
+++ b/src/main/proto/wfa/panelmatch/client/authorizedview/bigquery_streaming_status.proto
@@ -1,0 +1,74 @@
+// Copyright 2025 The Cross-Media Measurement Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package wfa.panelmatch.client.authorizedview;
+
+import "google/type/date.proto";
+
+option java_package = "org.wfanet.panelmatch.client.authorizedview";
+option java_multiple_files = true;
+option java_outer_classname = "BigQueryStreamingStatusProto";
+
+// Status information for BigQuery streaming operations in the authorized view
+// workflow.
+message BigQueryStreamingStatus {
+  // BigQuery table information
+  message TableInfo {
+    string project_id = 1;
+    string dataset_id = 2;
+    string table_id = 3;
+  }
+  TableInfo table_info = 1;
+
+  // Date of the exchange this streaming operation is for
+  google.type.Date exchange_date = 2;
+
+  // Type of data being streamed
+  enum DataType {
+    DATA_TYPE_UNSPECIFIED = 0;
+    // JoinKeyAndId data (keys only)
+    JOIN_KEYS = 1;
+    // EncryptedMatchedEvent data (keys and encrypted events)
+    ENCRYPTED_EVENTS = 2;
+  }
+  DataType data_type = 3;
+
+  // Statistics from the streaming operation
+  message StreamingStatistics {
+    // Number of rows successfully written to BigQuery
+    int64 rows_written = 1;
+    // Number of rows that failed to write
+    int64 rows_failed = 2;
+    // Number of batches sent to BigQuery streaming API
+    int32 batches_sent = 3;
+  }
+  StreamingStatistics statistics = 4;
+
+  // Overall status of the streaming operation
+  enum Status {
+    STATUS_UNSPECIFIED = 0;
+    // All rows were successfully written
+    SUCCESS = 1;
+    // Some rows were written but some failed
+    PARTIAL_SUCCESS = 2;
+    // No rows were written (complete failure)
+    FAILURE = 3;
+  }
+  Status status = 5;
+
+  // Optional error message if status is not SUCCESS
+  string error_message = 6;
+}

--- a/src/test/kotlin/org/wfanet/panelmatch/client/deploy/ProductionExchangeTaskMapperTest.kt
+++ b/src/test/kotlin/org/wfanet/panelmatch/client/deploy/ProductionExchangeTaskMapperTest.kt
@@ -27,12 +27,15 @@ import org.wfanet.panelmatch.client.deploy.testing.TestProductionExchangeTaskMap
 import org.wfanet.panelmatch.client.exchangetasks.CopyToSharedStorageTask
 import org.wfanet.panelmatch.client.exchangetasks.PreprocessEventsTask
 import org.wfanet.panelmatch.client.exchangetasks.ReadEncryptedEventsFromBigQueryTask
+import org.wfanet.panelmatch.client.exchangetasks.WriteToBigQueryTask
 import org.wfanet.panelmatch.client.internal.ExchangeWorkflow
 import org.wfanet.panelmatch.client.internal.ExchangeWorkflowKt.StepKt.commutativeDeterministicEncryptStep
 import org.wfanet.panelmatch.client.internal.ExchangeWorkflowKt.StepKt.copyOptions
 import org.wfanet.panelmatch.client.internal.ExchangeWorkflowKt.StepKt.copyToSharedStorageStep
 import org.wfanet.panelmatch.client.internal.ExchangeWorkflowKt.StepKt.preprocessEventsStep
 import org.wfanet.panelmatch.client.internal.ExchangeWorkflowKt.StepKt.readEncryptedEventsFromBigQueryStep
+import org.wfanet.panelmatch.client.internal.ExchangeWorkflowKt.StepKt.writeEventsToBigQueryStep
+import org.wfanet.panelmatch.client.internal.ExchangeWorkflowKt.StepKt.writeKeysToBigQueryStep
 import org.wfanet.panelmatch.client.internal.ExchangeWorkflowKt.step
 import org.wfanet.panelmatch.client.internal.exchangeWorkflow
 import org.wfanet.panelmatch.client.launcher.testing.inputStep
@@ -125,6 +128,48 @@ class ProductionExchangeTaskMapperTest {
 
     // Verify that the correct task type is created for the readEncryptedEventsFromBigQuery step
     assertThat(exchangeTask).isInstanceOf(ReadEncryptedEventsFromBigQueryTask::class.java)
+  }
+
+  @Test
+  fun `map writeKeysToBigQuery task`() = runBlockingTest {
+    val workflow = exchangeWorkflow {
+      steps += inputStep("input" to "data")
+      steps += step {
+        this.writeKeysToBigQueryStep = writeKeysToBigQueryStep {
+          projectId = "test-project"
+          datasetId = "test-dataset"
+          tableId = "test-table"
+        }
+        inputLabels.put("join-key-and-ids", "join-key-and-ids")
+        outputLabels.put("status", "streaming-status")
+      }
+    }
+    val context = ExchangeContext(ATTEMPT_KEY, DATE, workflow, workflow.getSteps(1))
+    val exchangeTask = exchangeTaskMapper.getExchangeTaskForStep(context)
+
+    // Verify that the correct task type is created for the writeKeysToBigQuery step
+    assertThat(exchangeTask).isInstanceOf(WriteToBigQueryTask::class.java)
+  }
+
+  @Test
+  fun `map writeEventsToBigQuery task`() = runBlockingTest {
+    val workflow = exchangeWorkflow {
+      steps += inputStep("input" to "data")
+      steps += step {
+        this.writeEventsToBigQueryStep = writeEventsToBigQueryStep {
+          projectId = "test-project"
+          datasetId = "test-dataset"
+          tableId = "test-table"
+        }
+        inputLabels.put("encrypted-events", "encrypted-events")
+        outputLabels.put("status", "streaming-status")
+      }
+    }
+    val context = ExchangeContext(ATTEMPT_KEY, DATE, workflow, workflow.getSteps(1))
+    val exchangeTask = exchangeTaskMapper.getExchangeTaskForStep(context)
+
+    // Verify that the correct task type is created for the writeEventsToBigQuery step
+    assertThat(exchangeTask).isInstanceOf(WriteToBigQueryTask::class.java)
   }
 
   companion object {

--- a/src/test/kotlin/org/wfanet/panelmatch/client/exchangetasks/BUILD.bazel
+++ b/src/test/kotlin/org/wfanet/panelmatch/client/exchangetasks/BUILD.bazel
@@ -312,3 +312,28 @@ kt_jvm_test(
         "@wfa_common_jvm//src/main/kotlin/org/wfanet/measurement/storage/testing",
     ],
 )
+
+kt_jvm_test(
+    name = "WriteToBigQueryTaskTest",
+    timeout = "short",
+    srcs = ["WriteToBigQueryTaskTest.kt"],
+    test_class = "org.wfanet.panelmatch.client.exchangetasks.WriteToBigQueryTaskTest",
+    deps = [
+        "//imports/java/com/google/cloud/bigquery",
+        "//src/main/kotlin/org/wfanet/panelmatch/client/authorizedview",
+        "//src/main/kotlin/org/wfanet/panelmatch/client/exchangetasks",
+        "//src/main/kotlin/org/wfanet/panelmatch/common/storage",
+        "//src/main/kotlin/org/wfanet/panelmatch/common/testing",
+        "//src/main/proto/wfa/panelmatch/client/authorizedview:bigquery_streaming_status_kt_jvm_proto",
+        "//src/main/proto/wfa/panelmatch/client/authorizedview:encrypted_event_kt_jvm_proto",
+        "@wfa_common_jvm//imports/java/com/google/common/truth",
+        "@wfa_common_jvm//imports/java/com/google/common/truth/extensions/proto",
+        "@wfa_common_jvm//imports/java/org/junit",
+        "@wfa_common_jvm//imports/kotlin/com/google/protobuf/kotlin",
+        "@wfa_common_jvm//imports/kotlin/kotlin/test",
+        "@wfa_common_jvm//imports/kotlin/kotlinx/coroutines:core",
+        "@wfa_common_jvm//imports/kotlin/org/mockito/kotlin",
+        "@wfa_common_jvm//src/main/kotlin/org/wfanet/measurement/storage:client",
+        "@wfa_common_jvm//src/main/kotlin/org/wfanet/measurement/storage/testing",
+    ],
+)

--- a/src/test/kotlin/org/wfanet/panelmatch/client/exchangetasks/WriteToBigQueryTaskTest.kt
+++ b/src/test/kotlin/org/wfanet/panelmatch/client/exchangetasks/WriteToBigQueryTaskTest.kt
@@ -1,0 +1,1041 @@
+// Copyright 2025 The Cross-Media Measurement Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.wfanet.panelmatch.client.exchangetasks
+
+import com.google.cloud.bigquery.BigQuery
+import com.google.cloud.bigquery.BigQueryError
+import com.google.cloud.bigquery.BigQueryException
+import com.google.cloud.bigquery.InsertAllRequest
+import com.google.cloud.bigquery.InsertAllResponse
+import com.google.cloud.bigquery.QueryJobConfiguration
+import com.google.cloud.bigquery.TableResult
+import com.google.common.truth.Truth.assertThat
+import com.google.common.truth.extensions.proto.ProtoTruth.assertThat
+import com.google.protobuf.ByteString
+import com.google.protobuf.kotlin.toByteStringUtf8
+import java.time.LocalDate
+import java.util.Base64
+import kotlin.test.assertFailsWith
+import kotlinx.coroutines.flow.single
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.inOrder
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.wfanet.measurement.storage.StorageClient
+import org.wfanet.measurement.storage.testing.InMemoryStorageClient
+import org.wfanet.panelmatch.client.authorizedview.BigQueryServiceFactory
+import org.wfanet.panelmatch.client.authorizedview.BigQueryStreamingStatus
+import org.wfanet.panelmatch.client.authorizedview.encryptedMatchedEvent
+import org.wfanet.panelmatch.common.Fingerprinters.sha256
+import org.wfanet.panelmatch.common.storage.toByteString
+import org.wfanet.panelmatch.common.testing.runBlockingTest
+
+private const val PROJECT_ID = "test-project"
+private const val DATASET_ID = "test-dataset"
+private const val TABLE_ID = "test-table"
+private val EXCHANGE_DATE = LocalDate.of(2025, 1, 15)
+
+@RunWith(JUnit4::class)
+class WriteToBigQueryTaskTest {
+  private val mockBigQuery: BigQuery = mock()
+  private val mockBigQueryServiceFactory: BigQueryServiceFactory = mock()
+  private val mockInsertAllResponse: InsertAllResponse = mock()
+  private val mockTableResult: TableResult = mock()
+  private val storageClient = InMemoryStorageClient()
+
+  @Before
+  fun setUp() {
+    whenever(mockBigQueryServiceFactory.getService(any())).thenReturn(mockBigQuery)
+    whenever(mockBigQuery.query(any<QueryJobConfiguration>())).thenReturn(mockTableResult)
+  }
+
+  @Test
+  fun `forJoinKeys creates task with correct configuration`() = runBlockingTest {
+    // Given
+    val task =
+      WriteToBigQueryTask.forJoinKeys(
+        projectId = PROJECT_ID,
+        datasetId = DATASET_ID,
+        tableId = TABLE_ID,
+        exchangeDate = EXCHANGE_DATE,
+        bigQueryServiceFactory = mockBigQueryServiceFactory,
+      )
+
+    val joinKeyAndIdCollection = joinKeyAndIdCollection {
+      joinKeyAndIds += joinKeyAndId {
+        joinKey = joinKey { key = "test-key".toByteStringUtf8() }
+        joinKeyIdentifier = joinKeyIdentifier { id = ByteString.copyFromUtf8("1") }
+      }
+    }
+    val inputBlob = createTestBlob("input", joinKeyAndIdCollection.toByteString())
+
+    setupMockBigQueryResponse(hasErrors = false)
+
+    // When
+    val result = task.execute(mapOf("input" to inputBlob))
+
+    // Then - verify task executes successfully
+    assertThat(result).containsKey("status")
+    val status = BigQueryStreamingStatus.parseFrom(result["status"]!!.single().toByteArray())
+    assertThat(status.dataType).isEqualTo(BigQueryStreamingStatus.DataType.JOIN_KEYS)
+  }
+
+  @Test
+  fun `forEncryptedEvents creates task with correct configuration`() = runBlockingTest {
+    // Given
+    val task =
+      WriteToBigQueryTask.forEncryptedEvents(
+        projectId = PROJECT_ID,
+        datasetId = DATASET_ID,
+        tableId = TABLE_ID,
+        exchangeDate = EXCHANGE_DATE,
+        bigQueryServiceFactory = mockBigQueryServiceFactory,
+      )
+
+    val encryptedEvent = encryptedMatchedEvent {
+      encryptedJoinKey = ByteString.copyFromUtf8("encrypted-key")
+      encryptedEventData = ByteString.copyFromUtf8("encrypted-data")
+    }
+
+    val delimitedBytes =
+      ByteString.newOutput().use { output ->
+        encryptedEvent.writeDelimitedTo(output)
+        output.toByteString()
+      }
+
+    val inputBlob = createTestBlob("input", delimitedBytes)
+
+    setupMockBigQueryResponse(hasErrors = false)
+
+    // When
+    val result = task.execute(mapOf("input" to inputBlob))
+
+    // Then - verify task executes successfully
+    assertThat(result).containsKey("status")
+    val status = BigQueryStreamingStatus.parseFrom(result["status"]!!.single().toByteArray())
+    assertThat(status.dataType).isEqualTo(BigQueryStreamingStatus.DataType.ENCRYPTED_EVENTS)
+  }
+
+  @Test
+  fun `task uses custom column names when specified`() = runBlockingTest {
+    // Given
+    val customKeyColumn = "custom_key"
+    val customDataColumn = "custom_data"
+    val customDateColumn = "custom_date"
+
+    val task =
+      WriteToBigQueryTask.forEncryptedEvents(
+        projectId = PROJECT_ID,
+        datasetId = DATASET_ID,
+        tableId = TABLE_ID,
+        exchangeDate = EXCHANGE_DATE,
+        bigQueryServiceFactory = mockBigQueryServiceFactory,
+        keyColumnName = customKeyColumn,
+        dataColumnName = customDataColumn,
+        dateColumnName = customDateColumn,
+      )
+
+    val encryptedEvent = encryptedMatchedEvent {
+      encryptedJoinKey = ByteString.copyFromUtf8("key")
+      encryptedEventData = ByteString.copyFromUtf8("data")
+    }
+
+    val delimitedBytes =
+      ByteString.newOutput().use { output ->
+        encryptedEvent.writeDelimitedTo(output)
+        output.toByteString()
+      }
+
+    val inputBlob = createTestBlob("input", delimitedBytes)
+    setupMockBigQueryResponse(hasErrors = false)
+
+    // When
+    task.execute(mapOf("input" to inputBlob))
+
+    // Then - verify insert request uses custom column names
+    val requestCaptor = argumentCaptor<InsertAllRequest>()
+    verify(mockBigQuery).insertAll(requestCaptor.capture())
+
+    val insertedRows = requestCaptor.firstValue.rows
+    assertThat(insertedRows).isNotEmpty()
+    val firstRowContent = insertedRows.first().content
+    assertThat(firstRowContent).containsKey(customKeyColumn)
+    assertThat(firstRowContent).containsKey(customDataColumn)
+    assertThat(firstRowContent).containsKey(customDateColumn)
+  }
+
+  @Test
+  fun `processJoinKeys handles valid collection`() = runBlockingTest {
+    // Given
+    val task =
+      WriteToBigQueryTask.forJoinKeys(
+        projectId = PROJECT_ID,
+        datasetId = DATASET_ID,
+        tableId = TABLE_ID,
+        exchangeDate = EXCHANGE_DATE,
+        bigQueryServiceFactory = mockBigQueryServiceFactory,
+      )
+
+    val joinKeyAndIdCollection = joinKeyAndIdCollection {
+      joinKeyAndIds +=
+        (1..10).map { i ->
+          joinKeyAndId {
+            joinKey = joinKey { key = "key-$i".toByteStringUtf8() }
+            joinKeyIdentifier = joinKeyIdentifier { id = ByteString.copyFromUtf8("$i") }
+          }
+        }
+    }
+
+    val inputBlob = createTestBlob("input", joinKeyAndIdCollection.toByteString())
+    setupMockBigQueryResponse(hasErrors = false)
+
+    // When
+    val result = task.execute(mapOf("input" to inputBlob))
+
+    // Then
+    val status = BigQueryStreamingStatus.parseFrom(result["status"]!!.single().toByteArray())
+    assertThat(status.status).isEqualTo(BigQueryStreamingStatus.Status.SUCCESS)
+    assertThat(status.statistics.rowsWritten).isEqualTo(10)
+    assertThat(status.statistics.rowsFailed).isEqualTo(0)
+  }
+
+  @Test
+  fun `processJoinKeys handles empty collection gracefully`() = runBlockingTest {
+    // Given
+    val task =
+      WriteToBigQueryTask.forJoinKeys(
+        projectId = PROJECT_ID,
+        datasetId = DATASET_ID,
+        tableId = TABLE_ID,
+        exchangeDate = EXCHANGE_DATE,
+        bigQueryServiceFactory = mockBigQueryServiceFactory,
+      )
+
+    val emptyCollection = joinKeyAndIdCollection {}
+    val inputBlob = createTestBlob("input", emptyCollection.toByteString())
+    setupMockBigQueryResponse(hasErrors = false)
+
+    // When
+    val result = task.execute(mapOf("input" to inputBlob))
+
+    // Then - should complete successfully with empty result
+    assertThat(result).containsKey("status")
+    val status = BigQueryStreamingStatus.parseFrom(result["status"]!!.single().toByteArray())
+    assertThat(status.status).isEqualTo(BigQueryStreamingStatus.Status.STATUS_UNSPECIFIED)
+    assertThat(status.statistics.rowsWritten).isEqualTo(0)
+    assertThat(status.statistics.rowsFailed).isEqualTo(0)
+  }
+
+  @Test
+  fun `processJoinKeys fails on duplicate keys`() = runBlockingTest {
+    // Given
+    val task =
+      WriteToBigQueryTask.forJoinKeys(
+        projectId = PROJECT_ID,
+        datasetId = DATASET_ID,
+        tableId = TABLE_ID,
+        exchangeDate = EXCHANGE_DATE,
+        bigQueryServiceFactory = mockBigQueryServiceFactory,
+      )
+
+    val collectionWithDuplicateKeys = joinKeyAndIdCollection {
+      joinKeyAndIds += joinKeyAndId {
+        joinKey = joinKey { key = "duplicate-key".toByteStringUtf8() }
+        joinKeyIdentifier = joinKeyIdentifier { id = ByteString.copyFromUtf8("1") }
+      }
+      joinKeyAndIds += joinKeyAndId {
+        joinKey = joinKey { key = "duplicate-key".toByteStringUtf8() } // Duplicate key
+        joinKeyIdentifier = joinKeyIdentifier { id = ByteString.copyFromUtf8("2") }
+      }
+    }
+
+    val inputBlob = createTestBlob("input", collectionWithDuplicateKeys.toByteString())
+
+    // When/Then
+    val exception =
+      assertFailsWith<IllegalArgumentException> { task.execute(mapOf("input" to inputBlob)) }
+    assertThat(exception.message).contains("JoinKeys are not distinct")
+  }
+
+  @Test
+  fun `processJoinKeys handles duplicate identifiers`() = runBlockingTest {
+    // Given
+    val task =
+      WriteToBigQueryTask.forJoinKeys(
+        projectId = PROJECT_ID,
+        datasetId = DATASET_ID,
+        tableId = TABLE_ID,
+        exchangeDate = EXCHANGE_DATE,
+        bigQueryServiceFactory = mockBigQueryServiceFactory,
+      )
+
+    val collectionWithDuplicateIds = joinKeyAndIdCollection {
+      joinKeyAndIds += joinKeyAndId {
+        joinKey = joinKey { key = "key-1".toByteStringUtf8() }
+        joinKeyIdentifier = joinKeyIdentifier { id = ByteString.copyFromUtf8("1") }
+      }
+      joinKeyAndIds += joinKeyAndId {
+        joinKey = joinKey { key = "key-2".toByteStringUtf8() }
+        joinKeyIdentifier = joinKeyIdentifier { id = ByteString.copyFromUtf8("1") } // Duplicate ID
+      }
+    }
+
+    val inputBlob = createTestBlob("input", collectionWithDuplicateIds.toByteString())
+    setupMockBigQueryResponse(hasErrors = false)
+
+    // When
+    val result = task.execute(mapOf("input" to inputBlob))
+
+    // Then - should succeed despite duplicate identifiers (no validation for duplicate IDs)
+    assertThat(result).containsKey("status")
+    val status = BigQueryStreamingStatus.parseFrom(result["status"]!!.single().toByteArray())
+    assertThat(status.status).isEqualTo(BigQueryStreamingStatus.Status.SUCCESS)
+    assertThat(status.statistics.rowsWritten).isEqualTo(2)
+  }
+
+  @Test
+  fun `processEncryptedEvents handles valid stream`() = runBlockingTest {
+    // Given
+    val task =
+      WriteToBigQueryTask.forEncryptedEvents(
+        projectId = PROJECT_ID,
+        datasetId = DATASET_ID,
+        tableId = TABLE_ID,
+        exchangeDate = EXCHANGE_DATE,
+        bigQueryServiceFactory = mockBigQueryServiceFactory,
+      )
+
+    // Create a stream of delimited encrypted events
+    val events =
+      (1..10).map { i ->
+        encryptedMatchedEvent {
+          encryptedJoinKey = ByteString.copyFromUtf8("key-$i")
+          encryptedEventData = ByteString.copyFromUtf8("data-$i")
+        }
+      }
+
+    val delimitedBytes =
+      ByteString.newOutput().use { output ->
+        events.forEach { it.writeDelimitedTo(output) }
+        output.toByteString()
+      }
+
+    val inputBlob = createTestBlob("input", delimitedBytes)
+    setupMockBigQueryResponse(hasErrors = false)
+
+    // When
+    val result = task.execute(mapOf("input" to inputBlob))
+
+    // Then
+    val status = BigQueryStreamingStatus.parseFrom(result["status"]!!.single().toByteArray())
+    assertThat(status.status).isEqualTo(BigQueryStreamingStatus.Status.SUCCESS)
+    assertThat(status.statistics.rowsWritten).isEqualTo(10)
+    assertThat(status.statistics.rowsFailed).isEqualTo(0)
+  }
+
+  @Test
+  fun `processEncryptedEvents handles empty stream gracefully`() = runBlockingTest {
+    // Given
+    val task =
+      WriteToBigQueryTask.forEncryptedEvents(
+        projectId = PROJECT_ID,
+        datasetId = DATASET_ID,
+        tableId = TABLE_ID,
+        exchangeDate = EXCHANGE_DATE,
+        bigQueryServiceFactory = mockBigQueryServiceFactory,
+      )
+
+    val emptyBlob = createTestBlob("input", ByteString.EMPTY)
+    setupMockBigQueryResponse(hasErrors = false)
+
+    // When
+    val result = task.execute(mapOf("input" to emptyBlob))
+
+    // Then - should complete successfully with empty result
+    assertThat(result).containsKey("status")
+    val status = BigQueryStreamingStatus.parseFrom(result["status"]!!.single().toByteArray())
+    assertThat(status.status).isEqualTo(BigQueryStreamingStatus.Status.STATUS_UNSPECIFIED)
+    assertThat(status.statistics.rowsWritten).isEqualTo(0)
+    assertThat(status.statistics.rowsFailed).isEqualTo(0)
+  }
+
+  @Test
+  fun `processEncryptedEvents filters out empty join key`() = runBlockingTest {
+    // Given
+    val task =
+      WriteToBigQueryTask.forEncryptedEvents(
+        projectId = PROJECT_ID,
+        datasetId = DATASET_ID,
+        tableId = TABLE_ID,
+        exchangeDate = EXCHANGE_DATE,
+        bigQueryServiceFactory = mockBigQueryServiceFactory,
+      )
+
+    val eventWithEmptyKey = encryptedMatchedEvent {
+      encryptedJoinKey = ByteString.EMPTY // Empty key
+      encryptedEventData = ByteString.copyFromUtf8("data")
+    }
+
+    val delimitedBytes =
+      ByteString.newOutput().use { output ->
+        eventWithEmptyKey.writeDelimitedTo(output)
+        output.toByteString()
+      }
+
+    val inputBlob = createTestBlob("input", delimitedBytes)
+    setupMockBigQueryResponse(hasErrors = false)
+
+    // When
+    val result = task.execute(mapOf("input" to inputBlob))
+
+    // Then - should complete successfully but with no events (filtered out)
+    assertThat(result).containsKey("status")
+    val status = BigQueryStreamingStatus.parseFrom(result["status"]!!.single().toByteArray())
+    assertThat(status.status).isEqualTo(BigQueryStreamingStatus.Status.STATUS_UNSPECIFIED)
+    assertThat(status.statistics.rowsWritten).isEqualTo(0)
+  }
+
+  @Test
+  fun `processEncryptedEvents filters out empty event data`() = runBlockingTest {
+    // Given
+    val task =
+      WriteToBigQueryTask.forEncryptedEvents(
+        projectId = PROJECT_ID,
+        datasetId = DATASET_ID,
+        tableId = TABLE_ID,
+        exchangeDate = EXCHANGE_DATE,
+        bigQueryServiceFactory = mockBigQueryServiceFactory,
+      )
+
+    val eventWithEmptyData = encryptedMatchedEvent {
+      encryptedJoinKey = ByteString.copyFromUtf8("key")
+      encryptedEventData = ByteString.EMPTY // Empty data
+    }
+
+    val delimitedBytes =
+      ByteString.newOutput().use { output ->
+        eventWithEmptyData.writeDelimitedTo(output)
+        output.toByteString()
+      }
+
+    val inputBlob = createTestBlob("input", delimitedBytes)
+    setupMockBigQueryResponse(hasErrors = false)
+
+    // When
+    val result = task.execute(mapOf("input" to inputBlob))
+
+    // Then - should complete successfully but with no events (filtered out)
+    assertThat(result).containsKey("status")
+    val status = BigQueryStreamingStatus.parseFrom(result["status"]!!.single().toByteArray())
+    assertThat(status.status).isEqualTo(BigQueryStreamingStatus.Status.STATUS_UNSPECIFIED)
+    assertThat(status.statistics.rowsWritten).isEqualTo(0)
+  }
+
+  @Test
+  fun `streamBatch handles successful insert`() = runBlockingTest {
+    // Given
+    val task =
+      WriteToBigQueryTask.forJoinKeys(
+        projectId = PROJECT_ID,
+        datasetId = DATASET_ID,
+        tableId = TABLE_ID,
+        exchangeDate = EXCHANGE_DATE,
+        bigQueryServiceFactory = mockBigQueryServiceFactory,
+      )
+
+    val joinKeyAndIdCollection = joinKeyAndIdCollection {
+      joinKeyAndIds +=
+        (1..100).map { i ->
+          joinKeyAndId {
+            joinKey = joinKey { key = "key-$i".toByteStringUtf8() }
+            joinKeyIdentifier = joinKeyIdentifier { id = ByteString.copyFromUtf8("$i") }
+          }
+        }
+    }
+
+    val inputBlob = createTestBlob("input", joinKeyAndIdCollection.toByteString())
+    setupMockBigQueryResponse(hasErrors = false)
+
+    // When
+    val result = task.execute(mapOf("input" to inputBlob))
+
+    // Then - verify insertAll was called
+    verify(mockBigQuery, times(1)).insertAll(any())
+
+    val status = BigQueryStreamingStatus.parseFrom(result["status"]!!.single().toByteArray())
+    assertThat(status.status).isEqualTo(BigQueryStreamingStatus.Status.SUCCESS)
+    assertThat(status.statistics.rowsWritten).isEqualTo(100)
+    assertThat(status.statistics.batchesSent).isEqualTo(1)
+  }
+
+  @Test
+  fun `streamBatch handles large datasets with multiple batches`() = runBlockingTest {
+    // Given
+    val task =
+      WriteToBigQueryTask.forJoinKeys(
+        projectId = PROJECT_ID,
+        datasetId = DATASET_ID,
+        tableId = TABLE_ID,
+        exchangeDate = EXCHANGE_DATE,
+        bigQueryServiceFactory = mockBigQueryServiceFactory,
+      )
+
+    // Create 10,000 keys to trigger multiple batches (batch size is 5000)
+    val joinKeyAndIdCollection = joinKeyAndIdCollection {
+      joinKeyAndIds +=
+        (1..10000).map { i ->
+          joinKeyAndId {
+            joinKey = joinKey { key = "key-$i".toByteStringUtf8() }
+            joinKeyIdentifier = joinKeyIdentifier { id = ByteString.copyFromUtf8("$i") }
+          }
+        }
+    }
+
+    val inputBlob = createTestBlob("input", joinKeyAndIdCollection.toByteString())
+    setupMockBigQueryResponse(hasErrors = false)
+
+    // When
+    val result = task.execute(mapOf("input" to inputBlob))
+
+    // Then - verify multiple batches were sent
+    verify(mockBigQuery, times(2)).insertAll(any()) // 10,000 / 5,000 = 2 batches
+
+    val status = BigQueryStreamingStatus.parseFrom(result["status"]!!.single().toByteArray())
+    assertThat(status.statistics.batchesSent).isEqualTo(2)
+  }
+
+  @Test
+  fun `streamBatch handles partial failures by throwing exception`() = runBlockingTest {
+    // Given
+    val task =
+      WriteToBigQueryTask.forJoinKeys(
+        projectId = PROJECT_ID,
+        datasetId = DATASET_ID,
+        tableId = TABLE_ID,
+        exchangeDate = EXCHANGE_DATE,
+        bigQueryServiceFactory = mockBigQueryServiceFactory,
+      )
+
+    val joinKeyAndIdCollection = joinKeyAndIdCollection {
+      joinKeyAndIds +=
+        (1..10).map { i ->
+          joinKeyAndId {
+            joinKey = joinKey { key = "key-$i".toByteStringUtf8() }
+            joinKeyIdentifier = joinKeyIdentifier { id = ByteString.copyFromUtf8("$i") }
+          }
+        }
+    }
+
+    val inputBlob = createTestBlob("input", joinKeyAndIdCollection.toByteString())
+
+    // Setup mock to simulate partial failure
+    val errorMap = mapOf(0L to listOf(mock<BigQueryError>()), 2L to listOf(mock<BigQueryError>()))
+    whenever(mockInsertAllResponse.hasErrors()).thenReturn(true)
+    whenever(mockInsertAllResponse.insertErrors).thenReturn(errorMap)
+    whenever(mockBigQuery.insertAll(any())).thenReturn(mockInsertAllResponse)
+
+    // When/Then - task should throw on any failure
+    val exception =
+      assertFailsWith<IllegalStateException> { task.execute(mapOf("input" to inputBlob)) }
+    assertThat(exception.message).contains("Failed to stream 2 rows")
+  }
+
+  @Test
+  fun `streamBatch handles complete failure by throwing exception`() = runBlockingTest {
+    // Given
+    val task =
+      WriteToBigQueryTask.forJoinKeys(
+        projectId = PROJECT_ID,
+        datasetId = DATASET_ID,
+        tableId = TABLE_ID,
+        exchangeDate = EXCHANGE_DATE,
+        bigQueryServiceFactory = mockBigQueryServiceFactory,
+      )
+
+    val joinKeyAndIdCollection = joinKeyAndIdCollection {
+      joinKeyAndIds +=
+        (1..5).map { i ->
+          joinKeyAndId {
+            joinKey = joinKey { key = "key-$i".toByteStringUtf8() }
+            joinKeyIdentifier = joinKeyIdentifier { id = ByteString.copyFromUtf8("$i") }
+          }
+        }
+    }
+
+    val inputBlob = createTestBlob("input", joinKeyAndIdCollection.toByteString())
+
+    // Setup mock to simulate complete failure
+    val errorMap = (0..4).associateBy({ it.toLong() }, { listOf(mock<BigQueryError>()) })
+    whenever(mockInsertAllResponse.hasErrors()).thenReturn(true)
+    whenever(mockInsertAllResponse.insertErrors).thenReturn(errorMap)
+    whenever(mockBigQuery.insertAll(any())).thenReturn(mockInsertAllResponse)
+
+    // When/Then - task should throw on complete failure
+    val exception =
+      assertFailsWith<IllegalStateException> { task.execute(mapOf("input" to inputBlob)) }
+    assertThat(exception.message).contains("Failed to stream 5 rows")
+  }
+
+  @Test
+  fun `execute handles BigQuery exceptions gracefully`() = runBlockingTest {
+    // Given
+    val task =
+      WriteToBigQueryTask.forJoinKeys(
+        projectId = PROJECT_ID,
+        datasetId = DATASET_ID,
+        tableId = TABLE_ID,
+        exchangeDate = EXCHANGE_DATE,
+        bigQueryServiceFactory = mockBigQueryServiceFactory,
+      )
+
+    val joinKeyAndIdCollection = joinKeyAndIdCollection {
+      joinKeyAndIds += joinKeyAndId {
+        joinKey = joinKey { key = "key".toByteStringUtf8() }
+        joinKeyIdentifier = joinKeyIdentifier { id = ByteString.copyFromUtf8("1") }
+      }
+    }
+
+    val inputBlob = createTestBlob("input", joinKeyAndIdCollection.toByteString())
+
+    // Setup mock to throw BigQuery exception
+    whenever(mockBigQuery.insertAll(any())).thenThrow(BigQueryException(500, "Internal error"))
+
+    // When/Then - should propagate the exception
+    assertFailsWith<BigQueryException> { task.execute(mapOf("input" to inputBlob)) }
+  }
+
+  @Test
+  fun `execute requires input blob`() = runBlockingTest {
+    // Given
+    val task =
+      WriteToBigQueryTask.forJoinKeys(
+        projectId = PROJECT_ID,
+        datasetId = DATASET_ID,
+        tableId = TABLE_ID,
+        exchangeDate = EXCHANGE_DATE,
+        bigQueryServiceFactory = mockBigQueryServiceFactory,
+      )
+
+    // When/Then
+    val exception = assertFailsWith<IllegalArgumentException> { task.execute(emptyMap()) }
+    assertThat(exception.message).contains("Missing required input")
+  }
+
+  @Test
+  fun `data is correctly Base64 encoded for BigQuery`() = runBlockingTest {
+    // Given
+    val task =
+      WriteToBigQueryTask.forJoinKeys(
+        projectId = PROJECT_ID,
+        datasetId = DATASET_ID,
+        tableId = TABLE_ID,
+        exchangeDate = EXCHANGE_DATE,
+        bigQueryServiceFactory = mockBigQueryServiceFactory,
+      )
+
+    val testKey = ByteString.copyFromUtf8("test-key-data")
+    val joinKeyAndIdCollection = joinKeyAndIdCollection {
+      joinKeyAndIds += joinKeyAndId {
+        joinKey = joinKey { key = testKey }
+        joinKeyIdentifier = joinKeyIdentifier { id = ByteString.copyFromUtf8("1") }
+      }
+    }
+
+    val inputBlob = createTestBlob("input", joinKeyAndIdCollection.toByteString())
+    setupMockBigQueryResponse(hasErrors = false)
+
+    // When
+    task.execute(mapOf("input" to inputBlob))
+
+    // Then - verify data is Base64 encoded
+    val requestCaptor = argumentCaptor<InsertAllRequest>()
+    verify(mockBigQuery).insertAll(requestCaptor.capture())
+
+    val insertedRows = requestCaptor.firstValue.rows
+    assertThat(insertedRows).hasSize(1)
+    val rowContent = insertedRows.first().content
+
+    val encodedKey = rowContent["encrypted_join_key"] as String
+    // forJoinKeys hashes the key with SHA256 before encoding (H(G(Key)))
+    val expectedHash = sha256(testKey)
+    assertThat(encodedKey).isEqualTo(Base64.getEncoder().encodeToString(expectedHash.toByteArray()))
+  }
+
+  @Test
+  fun `date is correctly formatted for BigQuery`() = runBlockingTest {
+    // Given
+    val specificDate = LocalDate.of(2025, 12, 31)
+    val task =
+      WriteToBigQueryTask.forJoinKeys(
+        projectId = PROJECT_ID,
+        datasetId = DATASET_ID,
+        tableId = TABLE_ID,
+        exchangeDate = specificDate,
+        bigQueryServiceFactory = mockBigQueryServiceFactory,
+      )
+
+    val joinKeyAndIdCollection = joinKeyAndIdCollection {
+      joinKeyAndIds += joinKeyAndId {
+        joinKey = joinKey { key = "key".toByteStringUtf8() }
+        joinKeyIdentifier = joinKeyIdentifier { id = ByteString.copyFromUtf8("1") }
+      }
+    }
+
+    val inputBlob = createTestBlob("input", joinKeyAndIdCollection.toByteString())
+    setupMockBigQueryResponse(hasErrors = false)
+
+    // When
+    task.execute(mapOf("input" to inputBlob))
+
+    // Then - verify date format
+    val requestCaptor = argumentCaptor<InsertAllRequest>()
+    verify(mockBigQuery).insertAll(requestCaptor.capture())
+
+    val rowContent = requestCaptor.firstValue.rows.first().content
+    assertThat(rowContent["exchange_date"]).isEqualTo("2025-12-31")
+  }
+
+  @Test
+  fun `status proto contains correct table information`() = runBlockingTest {
+    // Given
+    val task =
+      WriteToBigQueryTask.forJoinKeys(
+        projectId = PROJECT_ID,
+        datasetId = DATASET_ID,
+        tableId = TABLE_ID,
+        exchangeDate = EXCHANGE_DATE,
+        bigQueryServiceFactory = mockBigQueryServiceFactory,
+      )
+
+    val joinKeyAndIdCollection = joinKeyAndIdCollection {
+      joinKeyAndIds += joinKeyAndId {
+        joinKey = joinKey { key = "key".toByteStringUtf8() }
+        joinKeyIdentifier = joinKeyIdentifier { id = ByteString.copyFromUtf8("1") }
+      }
+    }
+
+    val inputBlob = createTestBlob("input", joinKeyAndIdCollection.toByteString())
+    setupMockBigQueryResponse(hasErrors = false)
+
+    // When
+    val result = task.execute(mapOf("input" to inputBlob))
+
+    // Then
+    val status = BigQueryStreamingStatus.parseFrom(result["status"]!!.single().toByteArray())
+    assertThat(status.tableInfo.projectId).isEqualTo(PROJECT_ID)
+    assertThat(status.tableInfo.datasetId).isEqualTo(DATASET_ID)
+    assertThat(status.tableInfo.tableId).isEqualTo(TABLE_ID)
+  }
+
+  @Test
+  fun `status proto contains correct exchange date`() = runBlockingTest {
+    // Given
+    val specificDate = LocalDate.of(2025, 3, 15)
+    val task =
+      WriteToBigQueryTask.forJoinKeys(
+        projectId = PROJECT_ID,
+        datasetId = DATASET_ID,
+        tableId = TABLE_ID,
+        exchangeDate = specificDate,
+        bigQueryServiceFactory = mockBigQueryServiceFactory,
+      )
+
+    val joinKeyAndIdCollection = joinKeyAndIdCollection {
+      joinKeyAndIds += joinKeyAndId {
+        joinKey = joinKey { key = "key".toByteStringUtf8() }
+        joinKeyIdentifier = joinKeyIdentifier { id = ByteString.copyFromUtf8("1") }
+      }
+    }
+
+    val inputBlob = createTestBlob("input", joinKeyAndIdCollection.toByteString())
+    setupMockBigQueryResponse(hasErrors = false)
+
+    // When
+    val result = task.execute(mapOf("input" to inputBlob))
+
+    // Then
+    val status = BigQueryStreamingStatus.parseFrom(result["status"]!!.single().toByteArray())
+    assertThat(status.exchangeDate.year).isEqualTo(2025)
+    assertThat(status.exchangeDate.month).isEqualTo(3)
+    assertThat(status.exchangeDate.day).isEqualTo(15)
+  }
+
+  @Test
+  fun `bigQueryServiceFactory is called with correct project ID`() = runBlockingTest {
+    // Given
+    val task =
+      WriteToBigQueryTask.forJoinKeys(
+        projectId = PROJECT_ID,
+        datasetId = DATASET_ID,
+        tableId = TABLE_ID,
+        exchangeDate = EXCHANGE_DATE,
+        bigQueryServiceFactory = mockBigQueryServiceFactory,
+      )
+
+    val joinKeyAndIdCollection = joinKeyAndIdCollection {
+      joinKeyAndIds += joinKeyAndId {
+        joinKey = joinKey { key = "key".toByteStringUtf8() }
+        joinKeyIdentifier = joinKeyIdentifier { id = ByteString.copyFromUtf8("1") }
+      }
+    }
+
+    val inputBlob = createTestBlob("input", joinKeyAndIdCollection.toByteString())
+    setupMockBigQueryResponse(hasErrors = false)
+
+    // When
+    task.execute(mapOf("input" to inputBlob))
+
+    // Then
+    verify(mockBigQueryServiceFactory).getService(PROJECT_ID)
+  }
+
+  @Test
+  fun `BigQuery service obtained lazily`() {
+    // Given
+    val task =
+      WriteToBigQueryTask.forJoinKeys(
+        projectId = PROJECT_ID,
+        datasetId = DATASET_ID,
+        tableId = TABLE_ID,
+        exchangeDate = EXCHANGE_DATE,
+        bigQueryServiceFactory = mockBigQueryServiceFactory,
+      )
+
+    // Then - service should not be created in constructor
+    verify(mockBigQueryServiceFactory, never()).getService(any())
+  }
+
+  @Test
+  fun `insert ID generation uses unique hashed keys`() = runBlockingTest {
+    // Given
+    val task =
+      WriteToBigQueryTask.forJoinKeys(
+        projectId = PROJECT_ID,
+        datasetId = DATASET_ID,
+        tableId = TABLE_ID,
+        exchangeDate = EXCHANGE_DATE,
+        bigQueryServiceFactory = mockBigQueryServiceFactory,
+      )
+
+    val joinKeyAndIdCollection = joinKeyAndIdCollection {
+      joinKeyAndIds +=
+        (1..3).map { i ->
+          joinKeyAndId {
+            joinKey = joinKey { key = "key-$i".toByteStringUtf8() }
+            joinKeyIdentifier = joinKeyIdentifier { id = ByteString.copyFromUtf8("$i") }
+          }
+        }
+    }
+
+    val inputBlob = createTestBlob("input", joinKeyAndIdCollection.toByteString())
+    setupMockBigQueryResponse(hasErrors = false)
+
+    // When
+    task.execute(mapOf("input" to inputBlob))
+
+    // Then - verify all insert IDs are unique (they are H(G(Key)) in Base64 format)
+    val requestCaptor = argumentCaptor<InsertAllRequest>()
+    verify(mockBigQuery).insertAll(requestCaptor.capture())
+
+    val insertIds = requestCaptor.firstValue.rows.map { it.id }
+    assertThat(insertIds).containsNoDuplicates()
+    assertThat(insertIds).hasSize(3)
+  }
+
+  @Test
+  fun `deleteExistingRowsForDate is called before streaming`() = runBlockingTest {
+    // Given
+    val task =
+      WriteToBigQueryTask.forJoinKeys(
+        projectId = PROJECT_ID,
+        datasetId = DATASET_ID,
+        tableId = TABLE_ID,
+        exchangeDate = EXCHANGE_DATE,
+        bigQueryServiceFactory = mockBigQueryServiceFactory,
+      )
+
+    val joinKeyAndIdCollection = joinKeyAndIdCollection {
+      joinKeyAndIds += joinKeyAndId {
+        joinKey = joinKey { key = "key".toByteStringUtf8() }
+        joinKeyIdentifier = joinKeyIdentifier { id = ByteString.copyFromUtf8("1") }
+      }
+    }
+
+    val inputBlob = createTestBlob("input", joinKeyAndIdCollection.toByteString())
+    setupMockBigQueryResponse(hasErrors = false)
+
+    // When
+    task.execute(mapOf("input" to inputBlob))
+
+    // Then - verify query (delete) was called before insertAll
+    val orderVerifier = inOrder(mockBigQuery)
+    orderVerifier.verify(mockBigQuery).query(any<QueryJobConfiguration>())
+    orderVerifier.verify(mockBigQuery).insertAll(any())
+  }
+
+  @Test
+  fun `deleteExistingRowsForDate uses correct date format`() = runBlockingTest {
+    // Given
+    val specificDate = LocalDate.of(2025, 3, 15)
+    val task =
+      WriteToBigQueryTask.forJoinKeys(
+        projectId = PROJECT_ID,
+        datasetId = DATASET_ID,
+        tableId = TABLE_ID,
+        exchangeDate = specificDate,
+        bigQueryServiceFactory = mockBigQueryServiceFactory,
+      )
+
+    val joinKeyAndIdCollection = joinKeyAndIdCollection {
+      joinKeyAndIds += joinKeyAndId {
+        joinKey = joinKey { key = "key".toByteStringUtf8() }
+        joinKeyIdentifier = joinKeyIdentifier { id = ByteString.copyFromUtf8("1") }
+      }
+    }
+
+    val inputBlob = createTestBlob("input", joinKeyAndIdCollection.toByteString())
+    setupMockBigQueryResponse(hasErrors = false)
+
+    // When
+    task.execute(mapOf("input" to inputBlob))
+
+    // Then - verify delete query uses correct ISO date format
+    val queryCaptor = argumentCaptor<QueryJobConfiguration>()
+    verify(mockBigQuery).query(queryCaptor.capture())
+
+    val deleteQuery = queryCaptor.firstValue.query
+    assertThat(deleteQuery).contains("DATE('2025-03-15')")
+    assertThat(deleteQuery).contains("`$PROJECT_ID.$DATASET_ID.$TABLE_ID`")
+  }
+
+  @Test
+  fun `deleteExistingRowsForDate uses custom date column name`() = runBlockingTest {
+    // Given
+    val customDateColumn = "custom_date_column"
+    val task =
+      WriteToBigQueryTask.forJoinKeys(
+        projectId = PROJECT_ID,
+        datasetId = DATASET_ID,
+        tableId = TABLE_ID,
+        exchangeDate = EXCHANGE_DATE,
+        bigQueryServiceFactory = mockBigQueryServiceFactory,
+        dateColumnName = customDateColumn,
+      )
+
+    val joinKeyAndIdCollection = joinKeyAndIdCollection {
+      joinKeyAndIds += joinKeyAndId {
+        joinKey = joinKey { key = "key".toByteStringUtf8() }
+        joinKeyIdentifier = joinKeyIdentifier { id = ByteString.copyFromUtf8("1") }
+      }
+    }
+
+    val inputBlob = createTestBlob("input", joinKeyAndIdCollection.toByteString())
+    setupMockBigQueryResponse(hasErrors = false)
+
+    // When
+    task.execute(mapOf("input" to inputBlob))
+
+    // Then - verify delete query uses custom date column name
+    val queryCaptor = argumentCaptor<QueryJobConfiguration>()
+    verify(mockBigQuery).query(queryCaptor.capture())
+
+    val deleteQuery = queryCaptor.firstValue.query
+    assertThat(deleteQuery).contains("`$customDateColumn`")
+  }
+
+  @Test
+  fun `deleteExistingRowsForDate failure causes task to fail`() = runBlockingTest {
+    // Given
+    val task =
+      WriteToBigQueryTask.forJoinKeys(
+        projectId = PROJECT_ID,
+        datasetId = DATASET_ID,
+        tableId = TABLE_ID,
+        exchangeDate = EXCHANGE_DATE,
+        bigQueryServiceFactory = mockBigQueryServiceFactory,
+      )
+
+    val joinKeyAndIdCollection = joinKeyAndIdCollection {
+      joinKeyAndIds += joinKeyAndId {
+        joinKey = joinKey { key = "key".toByteStringUtf8() }
+        joinKeyIdentifier = joinKeyIdentifier { id = ByteString.copyFromUtf8("1") }
+      }
+    }
+
+    val inputBlob = createTestBlob("input", joinKeyAndIdCollection.toByteString())
+
+    // Setup mock to throw exception on delete query
+    whenever(mockBigQuery.query(any<QueryJobConfiguration>()))
+      .thenThrow(BigQueryException(500, "Delete failed"))
+
+    // When/Then - should propagate the exception
+    assertFailsWith<BigQueryException> { task.execute(mapOf("input" to inputBlob)) }
+
+    // Verify insertAll was never called since delete failed
+    verify(mockBigQuery, never()).insertAll(any())
+  }
+
+  @Test
+  fun `deleteExistingRowsForDate uses standard SQL`() = runBlockingTest {
+    // Given
+    val task =
+      WriteToBigQueryTask.forJoinKeys(
+        projectId = PROJECT_ID,
+        datasetId = DATASET_ID,
+        tableId = TABLE_ID,
+        exchangeDate = EXCHANGE_DATE,
+        bigQueryServiceFactory = mockBigQueryServiceFactory,
+      )
+
+    val joinKeyAndIdCollection = joinKeyAndIdCollection {
+      joinKeyAndIds += joinKeyAndId {
+        joinKey = joinKey { key = "key".toByteStringUtf8() }
+        joinKeyIdentifier = joinKeyIdentifier { id = ByteString.copyFromUtf8("1") }
+      }
+    }
+
+    val inputBlob = createTestBlob("input", joinKeyAndIdCollection.toByteString())
+    setupMockBigQueryResponse(hasErrors = false)
+
+    // When
+    task.execute(mapOf("input" to inputBlob))
+
+    // Then - verify query configuration uses standard SQL (not legacy)
+    val queryCaptor = argumentCaptor<QueryJobConfiguration>()
+    verify(mockBigQuery).query(queryCaptor.capture())
+
+    assertThat(queryCaptor.firstValue.useLegacySql()).isFalse()
+  }
+
+  private fun setupMockBigQueryResponse(hasErrors: Boolean) {
+    whenever(mockInsertAllResponse.hasErrors()).thenReturn(hasErrors)
+    if (!hasErrors) {
+      whenever(mockInsertAllResponse.insertErrors).thenReturn(emptyMap())
+    }
+    whenever(mockBigQuery.insertAll(any())).thenReturn(mockInsertAllResponse)
+  }
+
+  private suspend fun createTestBlob(path: String, data: ByteString): StorageClient.Blob {
+    return storageClient.writeBlob(path, data)
+  }
+}


### PR DESCRIPTION
Adds BigQuery streaming support for writing encrypted data to BigQuery tables as part of the Authorized View workflow.
- WriteToBigQueryTask - Streams JoinKeyAndId collections and EncryptedMatchedEvent data to BigQuery
- bigquery_streaming_status.proto - Tracks streaming operation status
- ProductionExchangeTaskMapper - Implements writeKeysToBigQuery() and writeEventsToBigQuery() methods
- Supports both join keys and encrypted events data types
- Efficient batching (5000 records per batch)
- Configurable column names
- Detailed error reporting with partial failure handling
- Base64 encoding for binary data
- 24 unit tests in WriteToBigQueryTaskTest covering all scenarios
- 2 mapper tests in ProductionExchangeTaskMapperTest

Issue: #3084