### PR TITLE
feat: Implement DecryptAndMatchEventsTask for Authorized View Workflow

### DIFF
--- a/src/main/kotlin/org/wfanet/panelmatch/client/deploy/ProductionExchangeTaskMapper.kt
+++ b/src/main/kotlin/org/wfanet/panelmatch/client/deploy/ProductionExchangeTaskMapper.kt
@@ -34,6 +34,7 @@ import org.wfanet.panelmatch.client.exchangetasks.AssignJoinKeyIdsTask
 import org.wfanet.panelmatch.client.exchangetasks.CopyFromPreviousExchangeTask
 import org.wfanet.panelmatch.client.exchangetasks.CopyFromSharedStorageTask
 import org.wfanet.panelmatch.client.exchangetasks.CopyToSharedStorageTask
+import org.wfanet.panelmatch.client.exchangetasks.DecryptAndMatchEventsTask
 import org.wfanet.panelmatch.client.exchangetasks.DeterministicCommutativeCipherTask
 import org.wfanet.panelmatch.client.exchangetasks.ExchangeTask
 import org.wfanet.panelmatch.client.exchangetasks.ExchangeTaskMapper
@@ -472,6 +473,6 @@ open class ProductionExchangeTaskMapper(
 
   override suspend fun ExchangeContext.decryptAndMatchEvents(): ExchangeTask {
     check(step.stepCase == ExchangeWorkflow.Step.StepCase.DECRYPT_AND_MATCH_EVENTS_STEP)
-    throw NotImplementedError("Decrypt and Match Events task - Not Implemented")
+    return DecryptAndMatchEventsTask()
   }
 }

--- a/src/main/kotlin/org/wfanet/panelmatch/client/exchangetasks/DecryptAndMatchEventsTask.kt
+++ b/src/main/kotlin/org/wfanet/panelmatch/client/exchangetasks/DecryptAndMatchEventsTask.kt
@@ -1,0 +1,130 @@
+// Copyright 2025 The Cross-Media Measurement Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.wfanet.panelmatch.client.exchangetasks
+
+import com.google.protobuf.ByteString
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+import org.wfanet.measurement.storage.StorageClient
+import org.wfanet.panelmatch.client.authorizedview.DecryptedEventData
+import org.wfanet.panelmatch.client.authorizedview.TinkAeadHelper
+import org.wfanet.panelmatch.client.authorizedview.encryptedMatchedEvent
+import org.wfanet.panelmatch.client.privatemembership.keyedDecryptedEventDataSet
+import org.wfanet.panelmatch.client.privatemembership.plaintext
+import org.wfanet.panelmatch.common.Fingerprinters.sha256
+import org.wfanet.panelmatch.common.loggerFor
+import org.wfanet.panelmatch.common.parseDelimitedMessages
+import org.wfanet.panelmatch.common.storage.toByteString
+import org.wfanet.panelmatch.common.toBase64
+import org.wfanet.panelmatch.common.toDelimitedByteString
+
+/**
+ * Decrypts and matches encrypted events from BigQuery authorized view workflow.
+ *
+ * Reads EncryptedMatchedEvents containing H(G(Key)), looks up G(Key) and plaintext keys from
+ * JoinKeyAndIdCollections, decrypts the event data using AES-GCM with G(Key), and outputs
+ * KeyedDecryptedEventDataSet with all extracted event payloads.
+ */
+class DecryptAndMatchEventsTask : ExchangeTask {
+
+  override suspend fun execute(
+    input: Map<String, StorageClient.Blob>
+  ): Map<String, Flow<ByteString>> {
+    logger.info("Starting DecryptAndMatchEventsTask")
+
+    val encryptedEventsBlob =
+      requireNotNull(input[ENCRYPTED_EVENTS_LABEL]) {
+        "Missing required input: $ENCRYPTED_EVENTS_LABEL"
+      }
+
+    val plaintextJoinKeysBlob =
+      requireNotNull(input[PLAINTEXT_JOIN_KEYS_LABEL]) {
+        "Missing required input: $PLAINTEXT_JOIN_KEYS_LABEL"
+      }
+
+    val edpEncryptedKeysBlob =
+      requireNotNull(input[EDP_ENCRYPTED_KEYS_LABEL]) {
+        "Missing required input: $EDP_ENCRYPTED_KEYS_LABEL"
+      }
+
+    val plaintextJoinKeyMap = parseJoinKeyMapping(plaintextJoinKeysBlob)
+    val edpEncryptedKeyMap = parseJoinKeyMapping(edpEncryptedKeysBlob)
+    val keyLookupMap = createKeyLookupMap(plaintextJoinKeyMap, edpEncryptedKeyMap)
+
+    return mapOf(OUTPUT_LABEL to processEncryptedEvents(encryptedEventsBlob, keyLookupMap))
+  }
+
+  private suspend fun parseJoinKeyMapping(blob: StorageClient.Blob): Map<ByteString, JoinKeyAndId> =
+    JoinKeyAndIdCollection.parseFrom(blob.toByteString()).let { collection ->
+      collection.joinKeyAndIdsList.associateBy { it.joinKeyIdentifier.id }
+    }
+
+  private fun createKeyLookupMap(
+    plaintextMap: Map<ByteString, JoinKeyAndId>,
+    edpEncryptedMap: Map<ByteString, JoinKeyAndId>,
+  ): Map<ByteString, KeyLookupEntry> =
+    edpEncryptedMap.entries.associate { (identifier, edpEncryptedJoinKeyAndId) ->
+      val gKey = edpEncryptedJoinKeyAndId.joinKey.key
+      val plaintextJoinKeyAndId =
+        plaintextMap[identifier]
+          ?: throw IllegalStateException(
+            "No plaintext mapping found for identifier: '${identifier.toStringUtf8()}'"
+          )
+      sha256(gKey) to KeyLookupEntry(gKey, plaintextJoinKeyAndId)
+    }
+
+  private suspend fun processEncryptedEvents(
+    encryptedEventsBlob: StorageClient.Blob,
+    keyLookupMap: Map<ByteString, KeyLookupEntry>,
+  ): Flow<ByteString> = flow {
+    val encryptedEvents =
+      encryptedEventsBlob.toByteString().parseDelimitedMessages(encryptedMatchedEvent {})
+
+    var processedCount = 0
+
+    for (encryptedEvent in encryptedEvents) {
+      val hGKey = encryptedEvent.encryptedJoinKey
+
+      val keyEntry =
+        requireNotNull(keyLookupMap[hGKey]) {
+          "No key mapping found for H(G(Key)): ${hGKey.toBase64()}"
+        }
+
+      val decryptedBytes = TinkAeadHelper.decrypt(encryptedEvent.encryptedEventData, keyEntry.gKey)
+      val decryptedEventDataProto = DecryptedEventData.parseFrom(decryptedBytes)
+
+      val output = keyedDecryptedEventDataSet {
+        plaintextJoinKeyAndId = keyEntry.plaintextJoinKeyAndId
+        decryptedEventDataProto.eventDataList.forEach { eventBytes ->
+          decryptedEventData += plaintext { payload = eventBytes }
+        }
+      }
+      emit(output.toDelimitedByteString())
+      processedCount++
+    }
+
+    logger.info("Completed DecryptAndMatchEventsTask - processed: $processedCount")
+  }
+
+  companion object {
+    private val logger by loggerFor()
+    private const val ENCRYPTED_EVENTS_LABEL = "encrypted-events"
+    private const val PLAINTEXT_JOIN_KEYS_LABEL = "plaintext-join-keys"
+    private const val EDP_ENCRYPTED_KEYS_LABEL = "edp-encrypted-keys"
+    private const val OUTPUT_LABEL = "decrypted-event-data"
+  }
+
+  private data class KeyLookupEntry(val gKey: ByteString, val plaintextJoinKeyAndId: JoinKeyAndId)
+}

--- a/src/test/kotlin/org/wfanet/panelmatch/client/exchangetasks/BUILD.bazel
+++ b/src/test/kotlin/org/wfanet/panelmatch/client/exchangetasks/BUILD.bazel
@@ -337,3 +337,27 @@ kt_jvm_test(
         "@wfa_common_jvm//src/main/kotlin/org/wfanet/measurement/storage/testing",
     ],
 )
+
+kt_jvm_test(
+    name = "DecryptAndMatchEventsTaskTest",
+    timeout = "short",
+    srcs = ["DecryptAndMatchEventsTaskTest.kt"],
+    test_class = "org.wfanet.panelmatch.client.exchangetasks.DecryptAndMatchEventsTaskTest",
+    deps = [
+        "//src/main/kotlin/org/wfanet/panelmatch/client/authorizedview",
+        "//src/main/kotlin/org/wfanet/panelmatch/client/exchangetasks",
+        "//src/main/kotlin/org/wfanet/panelmatch/client/exchangetasks/testing",
+        "//src/main/kotlin/org/wfanet/panelmatch/client/privatemembership",
+        "//src/main/kotlin/org/wfanet/panelmatch/common",
+        "//src/main/kotlin/org/wfanet/panelmatch/common/testing",
+        "//src/main/proto/wfa/panelmatch/client/authorizedview:encrypted_event_kt_jvm_proto",
+        "//src/main/proto/wfa/panelmatch/client/privatemembership:decrypt_event_data_kt_jvm_proto",
+        "@wfa_common_jvm//imports/java/com/google/common/truth",
+        "@wfa_common_jvm//imports/java/com/google/common/truth/extensions/proto",
+        "@wfa_common_jvm//imports/java/org/junit",
+        "@wfa_common_jvm//imports/kotlin/com/google/protobuf/kotlin",
+        "@wfa_common_jvm//imports/kotlin/kotlin/test",
+        "@wfa_common_jvm//imports/kotlin/kotlinx/coroutines:core",
+        "@wfa_common_jvm//src/main/kotlin/org/wfanet/measurement/storage/testing",
+    ],
+)

--- a/src/test/kotlin/org/wfanet/panelmatch/client/exchangetasks/DecryptAndMatchEventsTaskTest.kt
+++ b/src/test/kotlin/org/wfanet/panelmatch/client/exchangetasks/DecryptAndMatchEventsTaskTest.kt
@@ -1,0 +1,539 @@
+// Copyright 2025 The Cross-Media Measurement Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.wfanet.panelmatch.client.exchangetasks
+
+import com.google.common.truth.Truth.assertThat
+import com.google.common.truth.extensions.proto.ProtoTruth.assertThat
+import com.google.protobuf.ByteString
+import com.google.protobuf.kotlin.toByteString
+import com.google.protobuf.kotlin.toByteStringUtf8
+import kotlin.test.assertFailsWith
+import kotlinx.coroutines.flow.toList
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+import org.wfanet.panelmatch.client.authorizedview.EncryptedMatchedEvent
+import org.wfanet.panelmatch.client.authorizedview.TinkAeadHelper
+import org.wfanet.panelmatch.client.authorizedview.decryptedEventData
+import org.wfanet.panelmatch.client.authorizedview.encryptedMatchedEvent
+import org.wfanet.panelmatch.client.exchangetasks.testing.executeToByteStrings
+import org.wfanet.panelmatch.client.privatemembership.KeyedDecryptedEventDataSet
+import org.wfanet.panelmatch.client.privatemembership.keyedDecryptedEventDataSet
+import org.wfanet.panelmatch.client.privatemembership.plaintext
+import org.wfanet.panelmatch.common.Fingerprinters.sha256
+import org.wfanet.panelmatch.common.parseDelimitedMessages
+import org.wfanet.panelmatch.common.testing.runBlockingTest
+import org.wfanet.panelmatch.common.toDelimitedByteString
+
+@RunWith(JUnit4::class)
+class DecryptAndMatchEventsTaskTest {
+
+  /** Creates an EncryptedMatchedEvent with a single event payload wrapped in DecryptedEventData. */
+  private fun createTestEncryptedEvent(
+    gKey: ByteString,
+    plaintext: ByteString,
+  ): EncryptedMatchedEvent {
+    return createTestEncryptedEventWithMultiplePayloads(gKey, listOf(plaintext))
+  }
+
+  /**
+   * Creates an EncryptedMatchedEvent with multiple event payloads wrapped in DecryptedEventData.
+   */
+  private fun createTestEncryptedEventWithMultiplePayloads(
+    gKey: ByteString,
+    plaintexts: List<ByteString>,
+  ): EncryptedMatchedEvent {
+    val hGKey = sha256(gKey)
+    // Wrap all plaintexts in DecryptedEventData proto
+    val decryptedEventDataProto = decryptedEventData { plaintexts.forEach { eventData += it } }
+    val encryptedEventData = TinkAeadHelper.encrypt(decryptedEventDataProto.toByteString(), gKey)
+    return encryptedMatchedEvent {
+      encryptedJoinKey = hGKey
+      this.encryptedEventData = encryptedEventData
+    }
+  }
+
+  private fun createTestMappings(
+    plainKey: ByteString,
+    encryptedKey: ByteString,
+    identifier: ByteString,
+  ): Pair<JoinKeyAndIdCollection, JoinKeyAndIdCollection> {
+    val plaintextMapping = joinKeyAndIdCollection {
+      joinKeyAndIds += joinKeyAndId {
+        joinKey = joinKey { key = plainKey }
+        joinKeyIdentifier = joinKeyIdentifier { id = identifier }
+      }
+    }
+
+    val edpEncryptedMapping = joinKeyAndIdCollection {
+      joinKeyAndIds += joinKeyAndId {
+        joinKey = joinKey { key = encryptedKey }
+        joinKeyIdentifier = joinKeyIdentifier { id = identifier }
+      }
+    }
+
+    return plaintextMapping to edpEncryptedMapping
+  }
+
+  private fun parseDecryptedEvents(byteString: ByteString): List<KeyedDecryptedEventDataSet> {
+    return byteString.parseDelimitedMessages(keyedDecryptedEventDataSet {}).toList()
+  }
+
+  private fun createTestInputs(
+    encryptedEvents: ByteString,
+    plaintextMapping: JoinKeyAndIdCollection,
+    edpEncryptedMapping: JoinKeyAndIdCollection,
+  ): Array<Pair<String, ByteString>> {
+    return arrayOf(
+      ENCRYPTED_EVENTS_LABEL to encryptedEvents,
+      PLAINTEXT_JOIN_KEYS_LABEL to plaintextMapping.toByteString(),
+      EDP_ENCRYPTED_KEYS_LABEL to edpEncryptedMapping.toByteString(),
+    )
+  }
+
+  @Test
+  fun `execute successfully decrypts and matches single event`() = runBlockingTest {
+    val plainKey = TEST_PLAIN_KEY_1
+    val identifier = TEST_IDENTIFIER_1
+    val plaintext = TEST_PLAINTEXT_1
+    val gKey = TEST_G_KEY_1
+
+    val encryptedEvent = createTestEncryptedEvent(gKey, plaintext)
+    val (plaintextMapping, edpEncryptedMapping) = createTestMappings(plainKey, gKey, identifier)
+
+    val task = DecryptAndMatchEventsTask()
+    val result =
+      task.executeToByteStrings(
+        *createTestInputs(
+          encryptedEvent.toDelimitedByteString(),
+          plaintextMapping,
+          edpEncryptedMapping,
+        )
+      )
+
+    val outputEvents = parseDecryptedEvents(result.getValue(OUTPUT_LABEL))
+
+    assertThat(outputEvents).hasSize(1)
+    val outputEvent = outputEvents.first()
+    assertThat(outputEvent.plaintextJoinKeyAndId.joinKey.key).isEqualTo(plainKey)
+    assertThat(outputEvent.plaintextJoinKeyAndId.joinKeyIdentifier.id).isEqualTo(identifier)
+    assertThat(outputEvent.decryptedEventDataList).hasSize(1)
+    assertThat(outputEvent.decryptedEventDataList.first().payload).isEqualTo(plaintext)
+  }
+
+  @Test
+  fun `execute successfully decrypts and matches multiple events`() = runBlockingTest {
+    val numEvents = 5
+    val encryptedEventsBuilder = mutableListOf<ByteString>()
+    val plaintextJoinKeyAndIds = mutableListOf<JoinKeyAndId>()
+    val edpEncryptedJoinKeyAndIds = mutableListOf<JoinKeyAndId>()
+
+    for (i in 1..numEvents) {
+      val plainKey = "join-key-$i".toByteStringUtf8()
+      val identifier = "id-$i".toByteStringUtf8()
+      val plaintext = "event-data-$i".toByteStringUtf8()
+      val gKey = "edp-key-$i-padded-to-32-bytes-min".toByteStringUtf8()
+
+      val encryptedEvent = createTestEncryptedEvent(gKey, plaintext)
+      encryptedEventsBuilder.add(encryptedEvent.toDelimitedByteString())
+
+      plaintextJoinKeyAndIds.add(
+        joinKeyAndId {
+          joinKey = joinKey { key = plainKey }
+          joinKeyIdentifier = joinKeyIdentifier { id = identifier }
+        }
+      )
+
+      edpEncryptedJoinKeyAndIds.add(
+        joinKeyAndId {
+          joinKey = joinKey { key = gKey }
+          joinKeyIdentifier = joinKeyIdentifier { id = identifier }
+        }
+      )
+    }
+
+    val plaintextMapping = joinKeyAndIdCollection { joinKeyAndIds += plaintextJoinKeyAndIds }
+    val edpEncryptedMapping = joinKeyAndIdCollection { joinKeyAndIds += edpEncryptedJoinKeyAndIds }
+    val allEncryptedEvents = ByteString.copyFrom(encryptedEventsBuilder)
+
+    val task = DecryptAndMatchEventsTask()
+    val result =
+      task.executeToByteStrings(
+        *createTestInputs(allEncryptedEvents, plaintextMapping, edpEncryptedMapping)
+      )
+
+    val outputEvents = parseDecryptedEvents(result.getValue(OUTPUT_LABEL))
+
+    assertThat(outputEvents).hasSize(numEvents)
+    for (i in 1..numEvents) {
+      val event = outputEvents[i - 1]
+      assertThat(event.plaintextJoinKeyAndId.joinKey.key)
+        .isEqualTo("join-key-$i".toByteStringUtf8())
+      assertThat(event.plaintextJoinKeyAndId.joinKeyIdentifier.id)
+        .isEqualTo("id-$i".toByteStringUtf8())
+      assertThat(event.decryptedEventDataList.first().payload)
+        .isEqualTo("event-data-$i".toByteStringUtf8())
+    }
+  }
+
+  @Test
+  fun `execute handles binary non-UTF8 data correctly`() = runBlockingTest {
+    val binaryPlainKey = BINARY_PLAIN_KEY
+    val binaryIdentifier = BINARY_IDENTIFIER
+    val binaryPlaintext = BINARY_PLAINTEXT
+
+    val gKey = ByteString.copyFrom(ByteArray(32) { it.toByte() })
+
+    // Use helper function which correctly wraps in DecryptedEventData
+    val encryptedEvent = createTestEncryptedEvent(gKey, binaryPlaintext)
+
+    val (plaintextMapping, edpEncryptedMapping) =
+      createTestMappings(binaryPlainKey, gKey, binaryIdentifier)
+
+    val task = DecryptAndMatchEventsTask()
+    val result =
+      task.executeToByteStrings(
+        *createTestInputs(
+          encryptedEvent.toDelimitedByteString(),
+          plaintextMapping,
+          edpEncryptedMapping,
+        )
+      )
+
+    val outputEvents = parseDecryptedEvents(result.getValue(OUTPUT_LABEL))
+
+    assertThat(outputEvents).hasSize(1)
+    val outputEvent = outputEvents.first()
+    assertThat(outputEvent.plaintextJoinKeyAndId.joinKey.key).isEqualTo(binaryPlainKey)
+    assertThat(outputEvent.plaintextJoinKeyAndId.joinKeyIdentifier.id).isEqualTo(binaryIdentifier)
+    assertThat(outputEvent.decryptedEventDataList.first().payload).isEqualTo(binaryPlaintext)
+  }
+
+  @Test
+  fun `execute throws on events with missing key mappings`() {
+    val unmappedGKey = "unmapped-key-padded-to-32-bytes!".toByteStringUtf8()
+    val encryptedEvent = createTestEncryptedEvent(unmappedGKey, "test-data".toByteStringUtf8())
+
+    val plaintextMapping = joinKeyAndIdCollection {}
+    val edpEncryptedMapping = joinKeyAndIdCollection {}
+
+    val task = DecryptAndMatchEventsTask()
+    assertFailsWith<IllegalArgumentException> {
+      task.executeToByteStrings(
+        *createTestInputs(
+          encryptedEvent.toDelimitedByteString(),
+          plaintextMapping,
+          edpEncryptedMapping,
+        )
+      )
+    }
+  }
+
+  @Test
+  fun `execute throws on events with decryption failures`() {
+    val plainKey = TEST_PLAIN_KEY_1
+    val identifier = TEST_IDENTIFIER_1
+    val gKey = TEST_G_KEY_1
+    val hGKey = sha256(gKey)
+
+    // Create event with invalid encrypted data (not valid AES-GCM ciphertext)
+    val encryptedEvent = encryptedMatchedEvent {
+      encryptedJoinKey = hGKey
+      encryptedEventData = "invalid-encrypted-data".toByteStringUtf8()
+    }
+
+    val (plaintextMapping, edpEncryptedMapping) = createTestMappings(plainKey, gKey, identifier)
+
+    val task = DecryptAndMatchEventsTask()
+    // Decryption will fail because data is not valid AES-GCM
+    assertFailsWith<java.security.GeneralSecurityException> {
+      task.executeToByteStrings(
+        *createTestInputs(
+          encryptedEvent.toDelimitedByteString(),
+          plaintextMapping,
+          edpEncryptedMapping,
+        )
+      )
+    }
+  }
+
+  @Test
+  fun `execute handles empty input gracefully`() = runBlockingTest {
+    val plaintextMapping = joinKeyAndIdCollection {}
+    val edpEncryptedMapping = joinKeyAndIdCollection {}
+
+    val task = DecryptAndMatchEventsTask()
+    val result =
+      task.executeToByteStrings(
+        *createTestInputs(ByteString.EMPTY, plaintextMapping, edpEncryptedMapping)
+      )
+
+    val outputEvents = parseDecryptedEvents(result.getValue(OUTPUT_LABEL))
+    assertThat(outputEvents).isEmpty()
+  }
+
+  @Test
+  fun `execute throws on first invalid event in mixed batch`() {
+    val validPlainKey = TEST_PLAIN_KEY_1
+    val validIdentifier = TEST_IDENTIFIER_1
+    val validPlaintext = TEST_PLAINTEXT_1
+    val validGKey = TEST_G_KEY_1
+    val validEvent = createTestEncryptedEvent(validGKey, validPlaintext)
+
+    val unmappedGKey = "unmapped-key-padded-to-32-bytes!".toByteStringUtf8()
+    val unmappedEvent = createTestEncryptedEvent(unmappedGKey, "unmapped-data".toByteStringUtf8())
+
+    val allEvents =
+      ByteString.copyFrom(
+        listOf(validEvent.toDelimitedByteString(), unmappedEvent.toDelimitedByteString())
+      )
+
+    val plaintextMapping = joinKeyAndIdCollection {
+      joinKeyAndIds += joinKeyAndId {
+        joinKey = joinKey { key = validPlainKey }
+        joinKeyIdentifier = joinKeyIdentifier { id = validIdentifier }
+      }
+    }
+
+    val edpEncryptedMapping = joinKeyAndIdCollection {
+      joinKeyAndIds += joinKeyAndId {
+        joinKey = joinKey { key = validGKey }
+        joinKeyIdentifier = joinKeyIdentifier { id = validIdentifier }
+      }
+    }
+
+    val task = DecryptAndMatchEventsTask()
+    assertFailsWith<IllegalArgumentException> {
+      task.executeToByteStrings(*createTestInputs(allEvents, plaintextMapping, edpEncryptedMapping))
+    }
+  }
+
+  @Test
+  fun `execute throws when missing encrypted events input`() {
+    val task = DecryptAndMatchEventsTask()
+
+    assertFailsWith<IllegalArgumentException> {
+      task.executeToByteStrings(
+        PLAINTEXT_JOIN_KEYS_LABEL to joinKeyAndIdCollection {}.toByteString(),
+        EDP_ENCRYPTED_KEYS_LABEL to joinKeyAndIdCollection {}.toByteString(),
+      )
+    }
+  }
+
+  @Test
+  fun `execute throws when missing plaintext join keys input`() {
+    val task = DecryptAndMatchEventsTask()
+
+    assertFailsWith<IllegalArgumentException> {
+      task.executeToByteStrings(
+        ENCRYPTED_EVENTS_LABEL to ByteString.EMPTY,
+        EDP_ENCRYPTED_KEYS_LABEL to joinKeyAndIdCollection {}.toByteString(),
+      )
+    }
+  }
+
+  @Test
+  fun `execute throws when missing EDP encrypted keys input`() {
+    val task = DecryptAndMatchEventsTask()
+
+    assertFailsWith<IllegalArgumentException> {
+      task.executeToByteStrings(
+        ENCRYPTED_EVENTS_LABEL to ByteString.EMPTY,
+        PLAINTEXT_JOIN_KEYS_LABEL to joinKeyAndIdCollection {}.toByteString(),
+      )
+    }
+  }
+
+  @Test
+  fun `execute handles duplicate identifiers in mappings correctly`() = runBlockingTest {
+    val plainKey1 = "key-1".toByteStringUtf8()
+    val plainKey2 = "key-2".toByteStringUtf8()
+    val sharedIdentifier = TEST_IDENTIFIER_1
+    val plaintext = TEST_PLAINTEXT_1
+
+    val gKey = TEST_G_KEY_1
+    val encryptedEvent = createTestEncryptedEvent(gKey, plaintext)
+
+    val plaintextMapping = joinKeyAndIdCollection {
+      joinKeyAndIds += joinKeyAndId {
+        joinKey = joinKey { key = plainKey1 }
+        joinKeyIdentifier = joinKeyIdentifier { id = sharedIdentifier }
+      }
+      joinKeyAndIds += joinKeyAndId {
+        joinKey = joinKey { key = plainKey2 }
+        joinKeyIdentifier = joinKeyIdentifier { id = sharedIdentifier }
+      }
+    }
+
+    val edpEncryptedMapping = joinKeyAndIdCollection {
+      joinKeyAndIds += joinKeyAndId {
+        joinKey = joinKey { key = gKey }
+        joinKeyIdentifier = joinKeyIdentifier { id = sharedIdentifier }
+      }
+    }
+
+    val task = DecryptAndMatchEventsTask()
+    val result =
+      task.executeToByteStrings(
+        *createTestInputs(
+          encryptedEvent.toDelimitedByteString(),
+          plaintextMapping,
+          edpEncryptedMapping,
+        )
+      )
+
+    val outputEvents = parseDecryptedEvents(result.getValue(OUTPUT_LABEL))
+
+    assertThat(outputEvents).hasSize(1)
+    val outputEvent = outputEvents.first()
+    assertThat(outputEvent.plaintextJoinKeyAndId.joinKey.key).isEqualTo(plainKey2)
+  }
+
+  @Test
+  fun `encrypt and decrypt are inverses`() = runBlockingTest {
+    val key = ByteString.copyFrom(ByteArray(32) { i -> i.toByte() })
+    val plaintext = "test plaintext data".toByteStringUtf8()
+
+    val encrypted = TinkAeadHelper.encrypt(plaintext, key)
+    val decrypted = TinkAeadHelper.decrypt(encrypted, key)
+
+    assertThat(decrypted).isEqualTo(plaintext)
+  }
+
+  @Test
+  fun `execute extracts multiple events from single EncryptedMatchedEvent`() = runBlockingTest {
+    val plainKey = TEST_PLAIN_KEY_1
+    val identifier = TEST_IDENTIFIER_1
+    val gKey = TEST_G_KEY_1
+
+    // Create encrypted event with multiple payloads
+    val plaintexts =
+      listOf(
+        "event-data-1".toByteStringUtf8(),
+        "event-data-2".toByteStringUtf8(),
+        "event-data-3".toByteStringUtf8(),
+      )
+    val encryptedEvent = createTestEncryptedEventWithMultiplePayloads(gKey, plaintexts)
+    val (plaintextMapping, edpEncryptedMapping) = createTestMappings(plainKey, gKey, identifier)
+
+    val task = DecryptAndMatchEventsTask()
+    val result =
+      task.executeToByteStrings(
+        *createTestInputs(
+          encryptedEvent.toDelimitedByteString(),
+          plaintextMapping,
+          edpEncryptedMapping,
+        )
+      )
+
+    val outputEvents = parseDecryptedEvents(result.getValue(OUTPUT_LABEL))
+
+    assertThat(outputEvents).hasSize(1)
+    val outputEvent = outputEvents.first()
+    assertThat(outputEvent.plaintextJoinKeyAndId.joinKey.key).isEqualTo(plainKey)
+    assertThat(outputEvent.plaintextJoinKeyAndId.joinKeyIdentifier.id).isEqualTo(identifier)
+
+    // Should have all 3 event payloads extracted
+    assertThat(outputEvent.decryptedEventDataList).hasSize(3)
+    assertThat(outputEvent.decryptedEventDataList[0].payload).isEqualTo(plaintexts[0])
+    assertThat(outputEvent.decryptedEventDataList[1].payload).isEqualTo(plaintexts[1])
+    assertThat(outputEvent.decryptedEventDataList[2].payload).isEqualTo(plaintexts[2])
+  }
+
+  @Test
+  fun `execute handles mixed single and multiple event payloads`() = runBlockingTest {
+    // Create two encrypted events: one with 1 payload, one with 3 payloads
+    val plainKey1 = "key-1".toByteStringUtf8()
+    val plainKey2 = "key-2".toByteStringUtf8()
+    val identifier1 = "id-1".toByteStringUtf8()
+    val identifier2 = "id-2".toByteStringUtf8()
+    val gKey1 = "edp-key-1-padded-to-32-bytes-min".toByteStringUtf8()
+    val gKey2 = "edp-key-2-padded-to-32-bytes-min".toByteStringUtf8()
+
+    val singlePayload = listOf("single-event".toByteStringUtf8())
+    val multiplePayloads =
+      listOf(
+        "multi-event-1".toByteStringUtf8(),
+        "multi-event-2".toByteStringUtf8(),
+        "multi-event-3".toByteStringUtf8(),
+      )
+
+    val encryptedEvent1 = createTestEncryptedEventWithMultiplePayloads(gKey1, singlePayload)
+    val encryptedEvent2 = createTestEncryptedEventWithMultiplePayloads(gKey2, multiplePayloads)
+
+    val plaintextMapping = joinKeyAndIdCollection {
+      joinKeyAndIds += joinKeyAndId {
+        joinKey = joinKey { key = plainKey1 }
+        joinKeyIdentifier = joinKeyIdentifier { id = identifier1 }
+      }
+      joinKeyAndIds += joinKeyAndId {
+        joinKey = joinKey { key = plainKey2 }
+        joinKeyIdentifier = joinKeyIdentifier { id = identifier2 }
+      }
+    }
+
+    val edpEncryptedMapping = joinKeyAndIdCollection {
+      joinKeyAndIds += joinKeyAndId {
+        joinKey = joinKey { key = gKey1 }
+        joinKeyIdentifier = joinKeyIdentifier { id = identifier1 }
+      }
+      joinKeyAndIds += joinKeyAndId {
+        joinKey = joinKey { key = gKey2 }
+        joinKeyIdentifier = joinKeyIdentifier { id = identifier2 }
+      }
+    }
+
+    val allEvents =
+      ByteString.copyFrom(
+        listOf(encryptedEvent1.toDelimitedByteString(), encryptedEvent2.toDelimitedByteString())
+      )
+
+    val task = DecryptAndMatchEventsTask()
+    val result =
+      task.executeToByteStrings(*createTestInputs(allEvents, plaintextMapping, edpEncryptedMapping))
+
+    val outputEvents = parseDecryptedEvents(result.getValue(OUTPUT_LABEL))
+    assertThat(outputEvents).hasSize(2)
+
+    // Find output by key and verify
+    val output1 = outputEvents.find { it.plaintextJoinKeyAndId.joinKey.key == plainKey1 }
+    assertThat(output1).isNotNull()
+    assertThat(output1!!.decryptedEventDataList).hasSize(1)
+    assertThat(output1.decryptedEventDataList[0].payload).isEqualTo(singlePayload[0])
+
+    val output2 = outputEvents.find { it.plaintextJoinKeyAndId.joinKey.key == plainKey2 }
+    assertThat(output2).isNotNull()
+    assertThat(output2!!.decryptedEventDataList).hasSize(3)
+  }
+
+  companion object {
+    private val TEST_PLAIN_KEY_1 = "test-join-key-1".toByteStringUtf8()
+    private val TEST_IDENTIFIER_1 = "identifier-1".toByteStringUtf8()
+    private val TEST_PLAINTEXT_1 = "test-event-data".toByteStringUtf8()
+    private val TEST_G_KEY_1 = "edp-encrypted-key-1-padded-to32!".toByteStringUtf8()
+
+    private val BINARY_PLAIN_KEY =
+      byteArrayOf(0x00, 0x01, 0x02, 0xFF.toByte(), 0xFE.toByte()).toByteString()
+    private val BINARY_IDENTIFIER =
+      byteArrayOf(0xDE.toByte(), 0xAD.toByte(), 0xBE.toByte(), 0xEF.toByte()).toByteString()
+    private val BINARY_PLAINTEXT =
+      byteArrayOf(0xCA.toByte(), 0xFE.toByte(), 0xBA.toByte(), 0xBE.toByte()).toByteString()
+
+    private const val ENCRYPTED_EVENTS_LABEL = "encrypted-events"
+    private const val PLAINTEXT_JOIN_KEYS_LABEL = "plaintext-join-keys"
+    private const val EDP_ENCRYPTED_KEYS_LABEL = "edp-encrypted-keys"
+    private const val OUTPUT_LABEL = "decrypted-event-data"
+  }
+}


### PR DESCRIPTION
This PR implements the DecryptAndMatchEventsTask which completes the core decryption and matching functionality for the Authorized View workflow. This task enables secure processing of encrypted events from BigQuery by mapping encrypted keys back to plaintext identifiers and decrypting event data using AES-GCM encryption.

Issue: #3084
