### PR TITLE
fix: increase duchy memory and nodes

### DIFF
--- a/src/main/k8s/dev/duchy_gke.cue
+++ b/src/main/k8s/dev/duchy_gke.cue
@@ -72,13 +72,13 @@ _duchy_cert_name: "duchies/\(_duchy_name)/certificates/\(_certificateId)"
 #FulfillmentResourceRequirements: ResourceRequirements=#ResourceRequirements & {
 	requests: {
 		cpu:    "200m"
-		memory: "512Mi"
+		memory: "1Gi"
 	}
 	limits: {
 		memory: ResourceRequirements.requests.memory
 	}
 }
-#FulfillmentMaxHeapSize:             "192M"
+#FulfillmentMaxHeapSize:             "640M"
 #ControlServiceResourceRequirements: ResourceRequirements=#ResourceRequirements & {
 	requests: {
 		cpu:    "200m"

--- a/src/main/terraform/gcloud/cmms/duchies.tf
+++ b/src/main/terraform/gcloud/cmms/duchies.tf
@@ -31,7 +31,7 @@ module "default_node_pools" {
   name            = "default"
   service_account = module.common.cluster_service_account
   machine_type    = "e2-standard-2"
-  max_node_count  = 2
+  max_node_count  = 3
 }
 
 module "highmem_node_pools" {


### PR DESCRIPTION
RELNOTES: Operators may wish to increase the max heap size and container memory of the Duchy Requisition fulfillment server to handle a larger number of simultaneous fulfillments.