### PR TITLE
feat: enable telemetry for data watcher

### DIFF
--- a/src/main/kotlin/org/wfanet/measurement/securecomputation/deploy/gcloud/datawatcher/BUILD.bazel
+++ b/src/main/kotlin/org/wfanet/measurement/securecomputation/deploy/gcloud/datawatcher/BUILD.bazel
@@ -11,6 +11,7 @@ kt_jvm_library(
     srcs = ["DataWatcherFunction.kt"],
     deps = [
         "//imports/java/com/google/cloud/functions/invoker:java_function_invoker",
+        "//imports/java/io/opentelemetry/instrumentation/grpc",
         "//src/main/kotlin/org/wfanet/measurement/common/edpaggregator:edp_aggregator_config",
         "//src/main/kotlin/org/wfanet/measurement/edpaggregator/telemetry",
         "//src/main/kotlin/org/wfanet/measurement/securecomputation/controlplane/v1alpha:work_items_service",
@@ -22,6 +23,7 @@ kt_jvm_library(
         "@wfa_common_jvm//imports/java/com/google/cloud/storage",
         "@wfa_common_jvm//imports/java/com/google/events",
         "@wfa_common_jvm//imports/java/com/google/protobuf",
+        "@wfa_common_jvm//imports/java/io/grpc:api",
         "@wfa_common_jvm//imports/kotlin/kotlinx/coroutines:core",
         "@wfa_common_jvm//src/main/kotlin/org/wfanet/measurement/common",
     ],

--- a/src/test/kotlin/org/wfanet/measurement/securecomputation/deploy/gcloud/datawatcher/InvokeDataWatcherFunctionTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/securecomputation/deploy/gcloud/datawatcher/InvokeDataWatcherFunctionTest.kt
@@ -132,6 +132,9 @@ class InvokeDataWatcherFunctionTest() {
             "PRIVATE_KEY_FILE_PATH" to SECRETS_DIR.resolve("edp7_tls.key").toString(),
             "CERT_COLLECTION_FILE_PATH" to SECRETS_DIR.resolve("kingdom_root.pem").toString(),
             "EDPA_CONFIG_STORAGE_BUCKET" to DATA_WATCHER_CONFIG_FILE_SYSTEM_PATH,
+            "OTEL_METRICS_EXPORTER" to "none",
+            "OTEL_TRACES_EXPORTER" to "none",
+            "OTEL_LOGS_EXPORTER" to "none",
           ) + additionalFlags
         )
       logger.info("Started DataWatcher process on port $port")


### PR DESCRIPTION
RELNOTES: The `data-watcher` Cloud Run Function now supports exporting metrics and traces to Google Cloud Monitoring and Google Cloud Trace, respectively. This should be enabled by including the following in the `extra_env_vars` field of the appropriate entry in the `cloud_function_configs` variable of the `edp-aggregator` Terraform module: `OTEL_SERVICE_NAME=edpa.data_watcher,OTEL_METRICS_EXPORTER=google_cloud_monitoring,OTEL_TRACES_EXPORTER=google_cloud_trace,OTEL_LOGS_EXPORTER=logging,OTEL_METRIC_EXPORT_INTERVAL=60000`