### PR TITLE
refactor: Refer to unprocessed/processed instead of noisy/de-noised

### DIFF
--- a/src/main/kotlin/org/wfanet/measurement/reporting/deploy/v2/gcloud/spanner/BUILD.bazel
+++ b/src/main/kotlin/org/wfanet/measurement/reporting/deploy/v2/gcloud/spanner/BUILD.bazel
@@ -12,7 +12,7 @@ kt_jvm_library(
     name = "basic_reports_service",
     srcs = ["SpannerBasicReportsService.kt"],
     deps = [
-        ":basic_report_noise_corrected_results_transformation",
+        ":basic_report_processed_results_transformation",
         "//src/main/kotlin/org/wfanet/measurement/common:id_generator",
         "//src/main/kotlin/org/wfanet/measurement/reporting/deploy/v2/gcloud/spanner/db:basic_reports",
         "//src/main/kotlin/org/wfanet/measurement/reporting/deploy/v2/gcloud/spanner/db:measurement_consumers",
@@ -57,8 +57,8 @@ kt_jvm_library(
 )
 
 kt_jvm_library(
-    name = "basic_report_noise_corrected_results_transformation",
-    srcs = ["BasicReportNoiseCorrectedResultsTransformation.kt"],
+    name = "basic_report_processed_results_transformation",
+    srcs = ["BasicReportProcessedResultsTransformation.kt"],
     visibility = [
         "//src/main/kotlin/org/wfanet/measurement/reporting/deploy/v2/gcloud/spanner:__pkg__",
         "//src/test/kotlin/org/wfanet/measurement/reporting/deploy/v2/gcloud/spanner:__pkg__",

--- a/src/main/kotlin/org/wfanet/measurement/reporting/deploy/v2/gcloud/spanner/SpannerBasicReportsService.kt
+++ b/src/main/kotlin/org/wfanet/measurement/reporting/deploy/v2/gcloud/spanner/SpannerBasicReportsService.kt
@@ -51,7 +51,7 @@ import org.wfanet.measurement.internal.reporting.v2.listBasicReportsPageToken
 import org.wfanet.measurement.internal.reporting.v2.listBasicReportsResponse
 import org.wfanet.measurement.internal.reporting.v2.measurementConsumer
 import org.wfanet.measurement.internal.reporting.v2.streamReportingSetsRequest
-import org.wfanet.measurement.reporting.deploy.v2.gcloud.spanner.BasicReportNoiseCorrectedResultsTransformation.buildResultGroups
+import org.wfanet.measurement.reporting.deploy.v2.gcloud.spanner.BasicReportProcessedResultsTransformation.buildResultGroups
 import org.wfanet.measurement.reporting.deploy.v2.gcloud.spanner.db.BasicReportResult
 import org.wfanet.measurement.reporting.deploy.v2.gcloud.spanner.db.MeasurementConsumerResult
 import org.wfanet.measurement.reporting.deploy.v2.gcloud.spanner.db.basicReportExists
@@ -636,7 +636,7 @@ class SpannerBasicReportsService(
       campaignGroup.primitive.eventGroupKeysList.groupBy { it.cmmsDataProviderId }
 
     val primitiveInfoByDataProviderId:
-      Map<String, BasicReportNoiseCorrectedResultsTransformation.PrimitiveInfo> =
+      Map<String, BasicReportProcessedResultsTransformation.PrimitiveInfo> =
       buildMap {
         for (dataProviderId in eventGroupKeysByDataProviderId.keys) {
           val primitiveEventGroupKeys =
@@ -646,7 +646,7 @@ class SpannerBasicReportsService(
           if (campaignGroupReportingSetIdByReportingSetKey.containsKey(reportingSetKey)) {
             put(
               dataProviderId,
-              BasicReportNoiseCorrectedResultsTransformation.PrimitiveInfo(
+              BasicReportProcessedResultsTransformation.PrimitiveInfo(
                 eventGroupKeys = primitiveEventGroupKeys,
                 externalReportingSetId =
                   campaignGroupReportingSetIdByReportingSetKey.getValue(reportingSetKey),

--- a/src/main/kotlin/org/wfanet/measurement/reporting/deploy/v2/gcloud/spanner/db/BasicReports.kt
+++ b/src/main/kotlin/org/wfanet/measurement/reporting/deploy/v2/gcloud/spanner/db/BasicReports.kt
@@ -259,9 +259,9 @@ fun AsyncDatabaseClient.TransactionContext.setBasicReportStateToFailed(
 
 /**
  * Buffers an update mutation to set the State of a BasicReports row to
- * [BasicReport.State.NOISY_RESULTS_READY].
+ * [BasicReport.State.UNPROCESSED_RESULTS_READY].
  */
-fun AsyncDatabaseClient.TransactionContext.setBasicReportStateToNoisyResultsReady(
+fun AsyncDatabaseClient.TransactionContext.setBasicReportStateToUnprocessedResultsReady(
   measurementConsumerId: Long,
   basicReportId: Long,
   reportResultId: Long,
@@ -270,7 +270,7 @@ fun AsyncDatabaseClient.TransactionContext.setBasicReportStateToNoisyResultsRead
     set("MeasurementConsumerId").to(measurementConsumerId)
     set("BasicReportId").to(basicReportId)
     set("ReportResultId").to(reportResultId)
-    set("State").to(BasicReport.State.NOISY_RESULTS_READY)
+    set("State").to(BasicReport.State.UNPROCESSED_RESULTS_READY)
   }
 }
 

--- a/src/main/kotlin/org/wfanet/measurement/reporting/deploy/v2/gcloud/spanner/db/ReportingSetResults.kt
+++ b/src/main/kotlin/org/wfanet/measurement/reporting/deploy/v2/gcloud/spanner/db/ReportingSetResults.kt
@@ -165,7 +165,7 @@ private data class MutableReportingSetResultResult(
     )
 }
 
-fun AsyncDatabaseClient.ReadContext.readNoisyReportingSetResults(
+fun AsyncDatabaseClient.ReadContext.readUnprocessedReportingSetResults(
   impressionQualificationFilterMapping: ImpressionQualificationFilterMapping,
   groupingDimensions: GroupingDimensions,
   measurementConsumerId: Long,
@@ -206,7 +206,7 @@ private fun AsyncDatabaseClient.ReadContext.readReportingSetResults(
     if (fullView) {
       ReportingSetResultsInternal.FULL_SQL
     } else {
-      ReportingSetResultsInternal.NOISY_SQL
+      ReportingSetResultsInternal.UNPROCESSED_SQL
     }
   val query =
     statement(sql) {
@@ -217,7 +217,7 @@ private fun AsyncDatabaseClient.ReadContext.readReportingSetResults(
   return flow {
     var current: MutableReportingSetResultResult? = null
     // One row per ReportingWindowResult.
-    executeQuery(query, Options.tag("action=readNoisyReportingSetResults")).collect { row ->
+    executeQuery(query, Options.tag("action=readReportingSetResults")).collect { row ->
       val pKey =
         ReportingSetResultPKey(
           measurementConsumerId,
@@ -296,20 +296,20 @@ private fun AsyncDatabaseClient.ReadContext.readReportingSetResults(
               }
             value =
               ReportingSetResultKt.reportingWindowResult {
-                noisyReportResultValues = noisyReportResultValues {
-                  if (!row.isNull("NoisyCumulativeResults")) {
+                unprocessedReportResultValues = noisyReportResultValues {
+                  if (!row.isNull("UnprocessedCumulativeResults")) {
                     cumulativeResults =
                       row.getProtoMessage(
-                        "NoisyCumulativeResults",
+                        "UnprocessedCumulativeResults",
                         ReportingSetResult.ReportingWindowResult.NoisyReportResultValues
                           .NoisyMetricSet
                           .getDefaultInstance(),
                       )
                   }
-                  if (!row.isNull("NoisyNonCumulativeResults")) {
+                  if (!row.isNull("UnprocessedNonCumulativeResults")) {
                     nonCumulativeResults =
                       row.getProtoMessage(
-                        "NoisyNonCumulativeResults",
+                        "UnprocessedNonCumulativeResults",
                         ReportingSetResult.ReportingWindowResult.NoisyReportResultValues
                           .NoisyMetricSet
                           .getDefaultInstance(),
@@ -320,7 +320,7 @@ private fun AsyncDatabaseClient.ReadContext.readReportingSetResults(
                   val hasCumulativeResults = !row.isNull("CumulativeResults")
                   val hasNonCumulativeResults = !row.isNull("NonCumulativeResults")
                   if (hasCumulativeResults || hasNonCumulativeResults) {
-                    denoisedReportResultValues = reportResultValues {
+                    processedReportResultValues = reportResultValues {
                       if (hasCumulativeResults) {
                         cumulativeResults =
                           row.getProtoMessage(
@@ -372,8 +372,8 @@ private object ReportingSetResultsInternal {
     ReportingWindowResultId,
     ReportingWindowStartDate,
     ReportingWindowEndDate,
-    NoisyReportResultValues.CumulativeResults AS NoisyCumulativeResults,
-    NoisyReportResultValues.NonCumulativeResults AS NoisyNonCumulativeResults,
+    NoisyReportResultValues.CumulativeResults AS UnprocessedCumulativeResults,
+    NoisyReportResultValues.NonCumulativeResults AS UnprocessedNonCumulativeResults,
     """
       .trimIndent()
 
@@ -397,7 +397,7 @@ private object ReportingSetResultsInternal {
     """
       .trimIndent()
 
-  val NOISY_SQL =
+  val UNPROCESSED_SQL =
     """
     SELECT
       $COMMON_COLUMNS

--- a/src/main/kotlin/org/wfanet/measurement/reporting/job/BasicReportsReportsJob.kt
+++ b/src/main/kotlin/org/wfanet/measurement/reporting/job/BasicReportsReportsJob.kt
@@ -284,7 +284,7 @@ class BasicReportsReportsJob(
                 this.key = window
                 value =
                   ReportingSetResultKt.reportingWindowResult {
-                    noisyReportResultValues =
+                    unprocessedReportResultValues =
                       ReportingSetResultKt.ReportingWindowResultKt.noisyReportResultValues {
                         val cumulativeResults: MetricResults? =
                           reportingWindowResultInfoEntry.value.cumulativeResults

--- a/src/main/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/BasicReportProtoConversions.kt
+++ b/src/main/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/BasicReportProtoConversions.kt
@@ -404,7 +404,7 @@ fun InternalBasicReport.toBasicReport(): BasicReport {
       when (source.state) {
         InternalBasicReport.State.CREATED,
         InternalBasicReport.State.REPORT_CREATED,
-        InternalBasicReport.State.NOISY_RESULTS_READY -> BasicReport.State.RUNNING
+        InternalBasicReport.State.UNPROCESSED_RESULTS_READY -> BasicReport.State.RUNNING
         InternalBasicReport.State.SUCCEEDED -> BasicReport.State.SUCCEEDED
         InternalBasicReport.State.FAILED -> BasicReport.State.FAILED
         InternalBasicReport.State.INVALID -> BasicReport.State.INVALID

--- a/src/main/proto/wfa/measurement/internal/reporting/v2/basic_report.proto
+++ b/src/main/proto/wfa/measurement/internal/reporting/v2/basic_report.proto
@@ -59,9 +59,9 @@ message BasicReport {
     // `Report` created.
     REPORT_CREATED = 2;
     // `Report` is in SUCCEEDED state, and its results are persisted with the
-    // `BasicReport`, but not yet processed by the noise corrector.
-    NOISY_RESULTS_READY = 3;
-    // Results have been noise-corrected. Available in the `BasicReport` as
+    // `BasicReport`, but not yet processed by the Report Processor.
+    UNPROCESSED_RESULTS_READY = 3;
+    // Results have been processed. Available in the `BasicReport` as
     // `result_details`.
     SUCCEEDED = 4;
     // Completed with failure. Terminal state.
@@ -93,7 +93,7 @@ message BasicReport {
   // External ID of the `ReportResult` associated with this `BasicReport.
   // Output-only.
   //
-  // Set when `state` has been `NOISY_RESULTS_READY`.
+  // Set when `state` has been `UNPROCESSED_RESULTS_READY`.
   fixed64 external_report_result_id = 13;
 
   bool model_line_system_specified = 14;

--- a/src/main/proto/wfa/measurement/internal/reporting/v2/report_result.proto
+++ b/src/main/proto/wfa/measurement/internal/reporting/v2/report_result.proto
@@ -163,13 +163,13 @@ message ReportingSetResult {
       ResultGroup.MetricSet.BasicMetricSet non_cumulative_results = 2;
     }
 
-    // Noisy report result values. Required. Immutable.
-    NoisyReportResultValues noisy_report_result_values = 1;
+    // Unprocessed report result values. Required. Immutable.
+    NoisyReportResultValues unprocessed_report_result_values = 1;
 
-    // Denoised report result values. Output-only.
+    // Processed report result values. Output-only.
     //
     // In responses, only set when view is `REPORTING_SET_RESULT_VIEW_FULL`.
-    ReportResultValues denoised_report_result_values = 2;
+    ReportResultValues processed_report_result_values = 2;
   }
   message ReportingWindowEntry {
     ReportingWindow key = 1;
@@ -190,10 +190,10 @@ message ReportingSetResult {
 }
 
 enum ReportingSetResultView {
-  // Default value. The API will default to the NOISY view.
+  // Default value. The API will default to the UNPROCESSED view.
   REPORTING_SET_RESULT_VIEW_UNSPECIFIED = 0;
-  // View which includes noisy values only.
-  REPORTING_SET_RESULT_VIEW_NOISY = 1;
-  // View which includes all values (noisy and de-noised).
+  // View which includes unprocessed values only.
+  REPORTING_SET_RESULT_VIEW_UNPROCESSED = 1;
+  // View which includes all values (unprocessed and processed).
   REPORTING_SET_RESULT_VIEW_FULL = 2;
 }

--- a/src/main/proto/wfa/measurement/internal/reporting/v2/report_results_service.proto
+++ b/src/main/proto/wfa/measurement/internal/reporting/v2/report_results_service.proto
@@ -35,11 +35,11 @@ service ReportResults {
   rpc ListReportingSetResults(ListReportingSetResultsRequest)
       returns (ListReportingSetResultsResponse);
 
-  // Adds denoised result values to a `ReportResult`.
+  // Adds processed result values to a `ReportResult`.
   //
   // Any `BasicReport` associated with this `ReportResult` will be transitioned
   // to the `SUCCEEDED` state.
-  rpc AddDenoisedResultValues(AddDenoisedResultValuesRequest)
+  rpc AddProcessedResultValues(AddProcessedResultValuesRequest)
       returns (google.protobuf.Empty);
 
   // Gets a `ReportResult`.
@@ -104,15 +104,15 @@ message ListReportingSetResultsResponse {
 // For future backwards-compatible support of pagination.
 message ListReportingSetResultsPageToken {}
 
-// Request message for the `AddDenoisedResultValues` method.
-message AddDenoisedResultValuesRequest {
+// Request message for the `AddProcessedResultValues` method.
+message AddProcessedResultValuesRequest {
   // The CMMS MeasurementConsumer ID. Required.
   string cmms_measurement_consumer_id = 1;
 
   // The external ID of the ReportResult. Required.
   fixed64 external_report_result_id = 2;
 
-  message DenoisedReportingSetResult {
+  message ProcessedReportingSetResult {
     message ReportingWindowEntry {
       ReportingSetResult.ReportingWindow key = 1;
       ReportingSetResult.ReportingWindowResult.ReportResultValues value = 2;
@@ -121,8 +121,8 @@ message AddDenoisedResultValuesRequest {
     repeated ReportingWindowEntry reporting_window_results = 1;
   }
 
-  // Map of external ReportingSetResult ID to `DenoisedReportingSetResult`.
-  map<fixed64, DenoisedReportingSetResult> reporting_set_results = 4;
+  // Map of external ReportingSetResult ID to `ProcessedReportingSetResult`.
+  map<fixed64, ProcessedReportingSetResult> reporting_set_results = 4;
 
   // TODO(@SanjayVas): Support including log entry for processor once the format
   // is defined.

--- a/src/main/python/wfa/measurement/reporting/postprocessing/tools/report_conversion.py
+++ b/src/main/python/wfa/measurement/reporting/postprocessing/tools/report_conversion.py
@@ -155,9 +155,13 @@ def _validate_report_result(
 
         # Validates that each reporting window result has the required fields.
         for window_entry in reporting_set_result.reporting_window_results:
-            if not window_entry.value.HasField("noisy_report_result_values"):
-                raise ValueError("Missing noisy_report_result_values field.")
-            if window_entry.value.noisy_report_result_values.HasField(
+            if not window_entry.value.HasField(
+                "unprocessed_report_result_values"
+            ):
+                raise ValueError(
+                    "Missing unprocessed_report_result_values field."
+                )
+            if window_entry.value.unprocessed_report_result_values.HasField(
                 "non_cumulative_results"
             ) and not window_entry.key.HasField("non_cumulative_start"):
                 raise ValueError(
@@ -168,7 +172,7 @@ def _validate_report_result(
                 raise ValueError("ReportingWindow must have an end date.")
             if dimension.metric_frequency_spec.WhichOneof(
                 "selector"
-            ) == "total" and window_entry.value.noisy_report_result_values.HasField(
+            ) == "total" and window_entry.value.unprocessed_report_result_values.HasField(
                 "non_cumulative_results"
             ):
                 raise ValueError(
@@ -383,7 +387,7 @@ def _process_reporting_windows(
     )
 
     for window_entry in sorted_windows:
-        noisy_values = window_entry.value.noisy_report_result_values
+        noisy_values = window_entry.value.unprocessed_report_result_values
 
         # Processes cumulative results. The whole campaign result has the
         # metric_frequency_spec_type of TOTAL.

--- a/src/test/kotlin/org/wfanet/measurement/reporting/deploy/v2/gcloud/spanner/BUILD.bazel
+++ b/src/test/kotlin/org/wfanet/measurement/reporting/deploy/v2/gcloud/spanner/BUILD.bazel
@@ -63,11 +63,11 @@ spanner_emulator_test(
 )
 
 kt_jvm_test(
-    name = "BasicReportNoiseCorrectedResultsTransformationTest",
-    srcs = ["BasicReportNoiseCorrectedResultsTransformationTest.kt"],
-    test_class = "org.wfanet.measurement.reporting.deploy.v2.gcloud.spanner.BasicReportNoiseCorrectedResultsTransformationTest",
+    name = "BasicReportProcessedResultsTransformationTest",
+    srcs = ["BasicReportProcessedResultsTransformationTest.kt"],
+    test_class = "org.wfanet.measurement.reporting.deploy.v2.gcloud.spanner.BasicReportProcessedResultsTransformationTest",
     deps = [
-        "//src/main/kotlin/org/wfanet/measurement/reporting/deploy/v2/gcloud/spanner:basic_report_noise_corrected_results_transformation",
+        "//src/main/kotlin/org/wfanet/measurement/reporting/deploy/v2/gcloud/spanner:basic_report_processed_results_transformation",
         "//src/main/proto/wfa/measurement/internal/reporting/v2:basic_report_kt_jvm_proto",
         "//src/main/proto/wfa/measurement/internal/reporting/v2:event_filter_kt_jvm_proto",
         "//src/main/proto/wfa/measurement/internal/reporting/v2:event_template_field_kt_jvm_proto",

--- a/src/test/kotlin/org/wfanet/measurement/reporting/deploy/v2/gcloud/spanner/BasicReportProcessedResultsTransformationTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/reporting/deploy/v2/gcloud/spanner/BasicReportProcessedResultsTransformationTest.kt
@@ -50,10 +50,10 @@ import org.wfanet.measurement.internal.reporting.v2.reportingUnit
 import org.wfanet.measurement.internal.reporting.v2.resultGroup
 import org.wfanet.measurement.internal.reporting.v2.resultGroupMetricSpec
 import org.wfanet.measurement.internal.reporting.v2.resultGroupSpec
-import org.wfanet.measurement.reporting.deploy.v2.gcloud.spanner.BasicReportNoiseCorrectedResultsTransformation.buildResultGroups
+import org.wfanet.measurement.reporting.deploy.v2.gcloud.spanner.BasicReportProcessedResultsTransformation.buildResultGroups
 
 @RunWith(JUnit4::class)
-class BasicReportNoiseCorrectedResultsTransformationTest {
+class BasicReportProcessedResultsTransformationTest {
   @Test
   fun `buildResultGroups creates result groups correctly`() {
     val basicReport = basicReport {
@@ -116,7 +116,7 @@ class BasicReportNoiseCorrectedResultsTransformationTest {
               key = ReportingSetResultKt.reportingWindow { end = REPORTING_INTERVAL.reportEnd }
               value =
                 ReportingSetResultKt.reportingWindowResult {
-                  denoisedReportResultValues =
+                  processedReportResultValues =
                     ReportingSetResultKt.ReportingWindowResultKt.reportResultValues {
                       cumulativeResults =
                         ResultGroupKt.MetricSetKt.basicMetricSet {
@@ -150,7 +150,7 @@ class BasicReportNoiseCorrectedResultsTransformationTest {
               key = ReportingSetResultKt.reportingWindow { end = REPORTING_INTERVAL.reportEnd }
               value =
                 ReportingSetResultKt.reportingWindowResult {
-                  denoisedReportResultValues =
+                  processedReportResultValues =
                     ReportingSetResultKt.ReportingWindowResultKt.reportResultValues {
                       cumulativeResults =
                         ResultGroupKt.MetricSetKt.basicMetricSet {
@@ -184,7 +184,7 @@ class BasicReportNoiseCorrectedResultsTransformationTest {
               key = ReportingSetResultKt.reportingWindow { end = REPORTING_INTERVAL.reportEnd }
               value =
                 ReportingSetResultKt.reportingWindowResult {
-                  denoisedReportResultValues =
+                  processedReportResultValues =
                     ReportingSetResultKt.ReportingWindowResultKt.reportResultValues {
                       cumulativeResults = ResultGroupKt.MetricSetKt.basicMetricSet { reach = 25 }
                     }
@@ -196,12 +196,12 @@ class BasicReportNoiseCorrectedResultsTransformationTest {
     val primitiveInfoByDataProviderId =
       mapOf(
         DATA_PROVIDER_1_ID to
-          BasicReportNoiseCorrectedResultsTransformation.PrimitiveInfo(
+          BasicReportProcessedResultsTransformation.PrimitiveInfo(
             eventGroupKeys = PRIMITIVE_REPORTING_SET_1.primitive.eventGroupKeysList.toSet(),
             externalReportingSetId = PRIMITIVE_REPORTING_SET_1_ID,
           ),
         DATA_PROVIDER_2_ID to
-          BasicReportNoiseCorrectedResultsTransformation.PrimitiveInfo(
+          BasicReportProcessedResultsTransformation.PrimitiveInfo(
             eventGroupKeys = PRIMITIVE_REPORTING_SET_2.primitive.eventGroupKeysList.toSet(),
             externalReportingSetId = PRIMITIVE_REPORTING_SET_2_ID,
           ),
@@ -405,7 +405,7 @@ class BasicReportNoiseCorrectedResultsTransformationTest {
               key = ReportingSetResultKt.reportingWindow { end = REPORTING_INTERVAL.reportEnd }
               value =
                 ReportingSetResultKt.reportingWindowResult {
-                  denoisedReportResultValues =
+                  processedReportResultValues =
                     ReportingSetResultKt.ReportingWindowResultKt.reportResultValues {
                       cumulativeResults =
                         ResultGroupKt.MetricSetKt.basicMetricSet {
@@ -439,7 +439,7 @@ class BasicReportNoiseCorrectedResultsTransformationTest {
               key = ReportingSetResultKt.reportingWindow { end = REPORTING_INTERVAL.reportEnd }
               value =
                 ReportingSetResultKt.reportingWindowResult {
-                  denoisedReportResultValues =
+                  processedReportResultValues =
                     ReportingSetResultKt.ReportingWindowResultKt.reportResultValues {
                       cumulativeResults =
                         ResultGroupKt.MetricSetKt.basicMetricSet {
@@ -473,7 +473,7 @@ class BasicReportNoiseCorrectedResultsTransformationTest {
               key = ReportingSetResultKt.reportingWindow { end = REPORTING_INTERVAL.reportEnd }
               value =
                 ReportingSetResultKt.reportingWindowResult {
-                  denoisedReportResultValues =
+                  processedReportResultValues =
                     ReportingSetResultKt.ReportingWindowResultKt.reportResultValues {
                       cumulativeResults = ResultGroupKt.MetricSetKt.basicMetricSet { reach = 25 }
                     }
@@ -485,12 +485,12 @@ class BasicReportNoiseCorrectedResultsTransformationTest {
     val primitiveInfoByDataProviderId =
       mapOf(
         DATA_PROVIDER_1_ID to
-          BasicReportNoiseCorrectedResultsTransformation.PrimitiveInfo(
+          BasicReportProcessedResultsTransformation.PrimitiveInfo(
             eventGroupKeys = PRIMITIVE_REPORTING_SET_1.primitive.eventGroupKeysList.toSet(),
             externalReportingSetId = PRIMITIVE_REPORTING_SET_1_ID,
           ),
         DATA_PROVIDER_2_ID to
-          BasicReportNoiseCorrectedResultsTransformation.PrimitiveInfo(
+          BasicReportProcessedResultsTransformation.PrimitiveInfo(
             eventGroupKeys = PRIMITIVE_REPORTING_SET_2.primitive.eventGroupKeysList.toSet(),
             externalReportingSetId = PRIMITIVE_REPORTING_SET_2_ID,
           ),
@@ -729,7 +729,7 @@ class BasicReportNoiseCorrectedResultsTransformationTest {
                 }
               value =
                 ReportingSetResultKt.reportingWindowResult {
-                  denoisedReportResultValues =
+                  processedReportResultValues =
                     ReportingSetResultKt.ReportingWindowResultKt.reportResultValues {
                       cumulativeResults = ResultGroupKt.MetricSetKt.basicMetricSet { reach = 25 }
                     }
@@ -741,12 +741,12 @@ class BasicReportNoiseCorrectedResultsTransformationTest {
     val primitiveInfoByDataProviderId =
       mapOf(
         DATA_PROVIDER_1_ID to
-          BasicReportNoiseCorrectedResultsTransformation.PrimitiveInfo(
+          BasicReportProcessedResultsTransformation.PrimitiveInfo(
             eventGroupKeys = PRIMITIVE_REPORTING_SET_1.primitive.eventGroupKeysList.toSet(),
             externalReportingSetId = PRIMITIVE_REPORTING_SET_1_ID,
           ),
         DATA_PROVIDER_2_ID to
-          BasicReportNoiseCorrectedResultsTransformation.PrimitiveInfo(
+          BasicReportProcessedResultsTransformation.PrimitiveInfo(
             eventGroupKeys = PRIMITIVE_REPORTING_SET_2.primitive.eventGroupKeysList.toSet(),
             externalReportingSetId = PRIMITIVE_REPORTING_SET_2_ID,
           ),
@@ -893,7 +893,7 @@ class BasicReportNoiseCorrectedResultsTransformationTest {
               key = ReportingSetResultKt.reportingWindow { end = REPORTING_INTERVAL.reportEnd }
               value =
                 ReportingSetResultKt.reportingWindowResult {
-                  denoisedReportResultValues =
+                  processedReportResultValues =
                     ReportingSetResultKt.ReportingWindowResultKt.reportResultValues {
                       cumulativeResults =
                         ResultGroupKt.MetricSetKt.basicMetricSet {
@@ -909,12 +909,12 @@ class BasicReportNoiseCorrectedResultsTransformationTest {
     val primitiveInfoByDataProviderId =
       mapOf(
         DATA_PROVIDER_1_ID to
-          BasicReportNoiseCorrectedResultsTransformation.PrimitiveInfo(
+          BasicReportProcessedResultsTransformation.PrimitiveInfo(
             eventGroupKeys = PRIMITIVE_REPORTING_SET_1.primitive.eventGroupKeysList.toSet(),
             externalReportingSetId = PRIMITIVE_REPORTING_SET_1_ID,
           ),
         DATA_PROVIDER_2_ID to
-          BasicReportNoiseCorrectedResultsTransformation.PrimitiveInfo(
+          BasicReportProcessedResultsTransformation.PrimitiveInfo(
             eventGroupKeys = PRIMITIVE_REPORTING_SET_2.primitive.eventGroupKeysList.toSet(),
             externalReportingSetId = PRIMITIVE_REPORTING_SET_2_ID,
           ),
@@ -1044,7 +1044,7 @@ class BasicReportNoiseCorrectedResultsTransformationTest {
                 }
               value =
                 ReportingSetResultKt.reportingWindowResult {
-                  denoisedReportResultValues =
+                  processedReportResultValues =
                     ReportingSetResultKt.ReportingWindowResultKt.reportResultValues {
                       nonCumulativeResults =
                         ResultGroupKt.MetricSetKt.basicMetricSet {
@@ -1082,7 +1082,7 @@ class BasicReportNoiseCorrectedResultsTransformationTest {
                 }
               value =
                 ReportingSetResultKt.reportingWindowResult {
-                  denoisedReportResultValues =
+                  processedReportResultValues =
                     ReportingSetResultKt.ReportingWindowResultKt.reportResultValues {
                       nonCumulativeResults =
                         ResultGroupKt.MetricSetKt.basicMetricSet {
@@ -1120,7 +1120,7 @@ class BasicReportNoiseCorrectedResultsTransformationTest {
                 }
               value =
                 ReportingSetResultKt.reportingWindowResult {
-                  denoisedReportResultValues =
+                  processedReportResultValues =
                     ReportingSetResultKt.ReportingWindowResultKt.reportResultValues {
                       nonCumulativeResults = ResultGroupKt.MetricSetKt.basicMetricSet { reach = 25 }
                     }
@@ -1132,17 +1132,17 @@ class BasicReportNoiseCorrectedResultsTransformationTest {
     val primitiveInfoByDataProviderId =
       mapOf(
         DATA_PROVIDER_1_ID to
-          BasicReportNoiseCorrectedResultsTransformation.PrimitiveInfo(
+          BasicReportProcessedResultsTransformation.PrimitiveInfo(
             eventGroupKeys = PRIMITIVE_REPORTING_SET_1.primitive.eventGroupKeysList.toSet(),
             externalReportingSetId = PRIMITIVE_REPORTING_SET_1_ID,
           ),
         DATA_PROVIDER_2_ID to
-          BasicReportNoiseCorrectedResultsTransformation.PrimitiveInfo(
+          BasicReportProcessedResultsTransformation.PrimitiveInfo(
             eventGroupKeys = PRIMITIVE_REPORTING_SET_2.primitive.eventGroupKeysList.toSet(),
             externalReportingSetId = PRIMITIVE_REPORTING_SET_2_ID,
           ),
         DATA_PROVIDER_3_ID to
-          BasicReportNoiseCorrectedResultsTransformation.PrimitiveInfo(
+          BasicReportProcessedResultsTransformation.PrimitiveInfo(
             eventGroupKeys = PRIMITIVE_REPORTING_SET_3.primitive.eventGroupKeysList.toSet(),
             externalReportingSetId = PRIMITIVE_REPORTING_SET_3_ID,
           ),
@@ -1330,7 +1330,7 @@ class BasicReportNoiseCorrectedResultsTransformationTest {
                 }
               value =
                 ReportingSetResultKt.reportingWindowResult {
-                  denoisedReportResultValues =
+                  processedReportResultValues =
                     ReportingSetResultKt.ReportingWindowResultKt.reportResultValues {
                       nonCumulativeResults =
                         ResultGroupKt.MetricSetKt.basicMetricSet {
@@ -1368,7 +1368,7 @@ class BasicReportNoiseCorrectedResultsTransformationTest {
                 }
               value =
                 ReportingSetResultKt.reportingWindowResult {
-                  denoisedReportResultValues =
+                  processedReportResultValues =
                     ReportingSetResultKt.ReportingWindowResultKt.reportResultValues {
                       nonCumulativeResults =
                         ResultGroupKt.MetricSetKt.basicMetricSet {
@@ -1406,7 +1406,7 @@ class BasicReportNoiseCorrectedResultsTransformationTest {
                 }
               value =
                 ReportingSetResultKt.reportingWindowResult {
-                  denoisedReportResultValues =
+                  processedReportResultValues =
                     ReportingSetResultKt.ReportingWindowResultKt.reportResultValues {
                       nonCumulativeResults =
                         ResultGroupKt.MetricSetKt.basicMetricSet {
@@ -1444,7 +1444,7 @@ class BasicReportNoiseCorrectedResultsTransformationTest {
                 }
               value =
                 ReportingSetResultKt.reportingWindowResult {
-                  denoisedReportResultValues =
+                  processedReportResultValues =
                     ReportingSetResultKt.ReportingWindowResultKt.reportResultValues {
                       nonCumulativeResults = ResultGroupKt.MetricSetKt.basicMetricSet { reach = 25 }
                     }
@@ -1478,7 +1478,7 @@ class BasicReportNoiseCorrectedResultsTransformationTest {
                 }
               value =
                 ReportingSetResultKt.reportingWindowResult {
-                  denoisedReportResultValues =
+                  processedReportResultValues =
                     ReportingSetResultKt.ReportingWindowResultKt.reportResultValues {
                       nonCumulativeResults = ResultGroupKt.MetricSetKt.basicMetricSet { reach = 30 }
                     }
@@ -1512,7 +1512,7 @@ class BasicReportNoiseCorrectedResultsTransformationTest {
                 }
               value =
                 ReportingSetResultKt.reportingWindowResult {
-                  denoisedReportResultValues =
+                  processedReportResultValues =
                     ReportingSetResultKt.ReportingWindowResultKt.reportResultValues {
                       nonCumulativeResults = ResultGroupKt.MetricSetKt.basicMetricSet { reach = 45 }
                     }
@@ -1546,7 +1546,7 @@ class BasicReportNoiseCorrectedResultsTransformationTest {
                 }
               value =
                 ReportingSetResultKt.reportingWindowResult {
-                  denoisedReportResultValues =
+                  processedReportResultValues =
                     ReportingSetResultKt.ReportingWindowResultKt.reportResultValues {
                       nonCumulativeResults = ResultGroupKt.MetricSetKt.basicMetricSet { reach = 55 }
                     }
@@ -1558,17 +1558,17 @@ class BasicReportNoiseCorrectedResultsTransformationTest {
     val primitiveInfoByDataProviderId =
       mapOf(
         DATA_PROVIDER_1_ID to
-          BasicReportNoiseCorrectedResultsTransformation.PrimitiveInfo(
+          BasicReportProcessedResultsTransformation.PrimitiveInfo(
             eventGroupKeys = PRIMITIVE_REPORTING_SET_1.primitive.eventGroupKeysList.toSet(),
             externalReportingSetId = PRIMITIVE_REPORTING_SET_1_ID,
           ),
         DATA_PROVIDER_2_ID to
-          BasicReportNoiseCorrectedResultsTransformation.PrimitiveInfo(
+          BasicReportProcessedResultsTransformation.PrimitiveInfo(
             eventGroupKeys = PRIMITIVE_REPORTING_SET_2.primitive.eventGroupKeysList.toSet(),
             externalReportingSetId = PRIMITIVE_REPORTING_SET_2_ID,
           ),
         DATA_PROVIDER_3_ID to
-          BasicReportNoiseCorrectedResultsTransformation.PrimitiveInfo(
+          BasicReportProcessedResultsTransformation.PrimitiveInfo(
             eventGroupKeys = PRIMITIVE_REPORTING_SET_3.primitive.eventGroupKeysList.toSet(),
             externalReportingSetId = PRIMITIVE_REPORTING_SET_3_ID,
           ),
@@ -1786,7 +1786,7 @@ class BasicReportNoiseCorrectedResultsTransformationTest {
               key = ReportingSetResultKt.reportingWindow { end = REPORTING_INTERVAL.reportEnd }
               value =
                 ReportingSetResultKt.reportingWindowResult {
-                  denoisedReportResultValues =
+                  processedReportResultValues =
                     ReportingSetResultKt.ReportingWindowResultKt.reportResultValues {
                       cumulativeResults =
                         ResultGroupKt.MetricSetKt.basicMetricSet {
@@ -1816,7 +1816,7 @@ class BasicReportNoiseCorrectedResultsTransformationTest {
               key = ReportingSetResultKt.reportingWindow { end = REPORTING_INTERVAL.reportEnd }
               value =
                 ReportingSetResultKt.reportingWindowResult {
-                  denoisedReportResultValues =
+                  processedReportResultValues =
                     ReportingSetResultKt.ReportingWindowResultKt.reportResultValues {
                       cumulativeResults =
                         ResultGroupKt.MetricSetKt.basicMetricSet {
@@ -1847,7 +1847,7 @@ class BasicReportNoiseCorrectedResultsTransformationTest {
               key = ReportingSetResultKt.reportingWindow { end = REPORTING_INTERVAL.reportEnd }
               value =
                 ReportingSetResultKt.reportingWindowResult {
-                  denoisedReportResultValues =
+                  processedReportResultValues =
                     ReportingSetResultKt.ReportingWindowResultKt.reportResultValues {
                       cumulativeResults =
                         ResultGroupKt.MetricSetKt.basicMetricSet {
@@ -1877,7 +1877,7 @@ class BasicReportNoiseCorrectedResultsTransformationTest {
               key = ReportingSetResultKt.reportingWindow { end = REPORTING_INTERVAL.reportEnd }
               value =
                 ReportingSetResultKt.reportingWindowResult {
-                  denoisedReportResultValues =
+                  processedReportResultValues =
                     ReportingSetResultKt.ReportingWindowResultKt.reportResultValues {
                       cumulativeResults =
                         ResultGroupKt.MetricSetKt.basicMetricSet {
@@ -1893,12 +1893,12 @@ class BasicReportNoiseCorrectedResultsTransformationTest {
     val primitiveInfoByDataProviderId =
       mapOf(
         DATA_PROVIDER_1_ID to
-          BasicReportNoiseCorrectedResultsTransformation.PrimitiveInfo(
+          BasicReportProcessedResultsTransformation.PrimitiveInfo(
             eventGroupKeys = PRIMITIVE_REPORTING_SET_1.primitive.eventGroupKeysList.toSet(),
             externalReportingSetId = PRIMITIVE_REPORTING_SET_1_ID,
           ),
         DATA_PROVIDER_2_ID to
-          BasicReportNoiseCorrectedResultsTransformation.PrimitiveInfo(
+          BasicReportProcessedResultsTransformation.PrimitiveInfo(
             eventGroupKeys = PRIMITIVE_REPORTING_SET_2.primitive.eventGroupKeysList.toSet(),
             externalReportingSetId = PRIMITIVE_REPORTING_SET_2_ID,
           ),
@@ -2127,7 +2127,7 @@ class BasicReportNoiseCorrectedResultsTransformationTest {
                 }
               value =
                 ReportingSetResultKt.reportingWindowResult {
-                  denoisedReportResultValues =
+                  processedReportResultValues =
                     ReportingSetResultKt.ReportingWindowResultKt.reportResultValues {
                       cumulativeResults =
                         ResultGroupKt.MetricSetKt.basicMetricSet {
@@ -2170,7 +2170,7 @@ class BasicReportNoiseCorrectedResultsTransformationTest {
                 }
               value =
                 ReportingSetResultKt.reportingWindowResult {
-                  denoisedReportResultValues =
+                  processedReportResultValues =
                     ReportingSetResultKt.ReportingWindowResultKt.reportResultValues {
                       cumulativeResults =
                         ResultGroupKt.MetricSetKt.basicMetricSet {
@@ -2218,7 +2218,7 @@ class BasicReportNoiseCorrectedResultsTransformationTest {
                 }
               value =
                 ReportingSetResultKt.reportingWindowResult {
-                  denoisedReportResultValues =
+                  processedReportResultValues =
                     ReportingSetResultKt.ReportingWindowResultKt.reportResultValues {
                       cumulativeResults =
                         ResultGroupKt.MetricSetKt.basicMetricSet {
@@ -2261,7 +2261,7 @@ class BasicReportNoiseCorrectedResultsTransformationTest {
                 }
               value =
                 ReportingSetResultKt.reportingWindowResult {
-                  denoisedReportResultValues =
+                  processedReportResultValues =
                     ReportingSetResultKt.ReportingWindowResultKt.reportResultValues {
                       cumulativeResults =
                         ResultGroupKt.MetricSetKt.basicMetricSet {
@@ -2277,12 +2277,12 @@ class BasicReportNoiseCorrectedResultsTransformationTest {
     val primitiveInfoByDataProviderId =
       mapOf(
         DATA_PROVIDER_1_ID to
-          BasicReportNoiseCorrectedResultsTransformation.PrimitiveInfo(
+          BasicReportProcessedResultsTransformation.PrimitiveInfo(
             eventGroupKeys = PRIMITIVE_REPORTING_SET_1.primitive.eventGroupKeysList.toSet(),
             externalReportingSetId = PRIMITIVE_REPORTING_SET_1_ID,
           ),
         DATA_PROVIDER_2_ID to
-          BasicReportNoiseCorrectedResultsTransformation.PrimitiveInfo(
+          BasicReportProcessedResultsTransformation.PrimitiveInfo(
             eventGroupKeys = PRIMITIVE_REPORTING_SET_2.primitive.eventGroupKeysList.toSet(),
             externalReportingSetId = PRIMITIVE_REPORTING_SET_2_ID,
           ),

--- a/src/test/kotlin/org/wfanet/measurement/reporting/job/BasicReportsReportsJobTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/reporting/job/BasicReportsReportsJobTest.kt
@@ -525,7 +525,7 @@ class BasicReportsReportsJobTest {
 
                     value =
                       ReportingSetResultKt.reportingWindowResult {
-                        noisyReportResultValues =
+                        unprocessedReportResultValues =
                           ReportingSetResultKt.ReportingWindowResultKt.noisyReportResultValues {
                             cumulativeResults =
                               ReportingSetResultKt.ReportingWindowResultKt.NoisyReportResultValuesKt
@@ -575,7 +575,7 @@ class BasicReportsReportsJobTest {
                       }
                     value =
                       ReportingSetResultKt.reportingWindowResult {
-                        noisyReportResultValues =
+                        unprocessedReportResultValues =
                           ReportingSetResultKt.ReportingWindowResultKt.noisyReportResultValues {
                             nonCumulativeResults =
                               ReportingSetResultKt.ReportingWindowResultKt.NoisyReportResultValuesKt
@@ -633,7 +633,7 @@ class BasicReportsReportsJobTest {
                       }
                     value =
                       ReportingSetResultKt.reportingWindowResult {
-                        noisyReportResultValues =
+                        unprocessedReportResultValues =
                           ReportingSetResultKt.ReportingWindowResultKt.noisyReportResultValues {
                             nonCumulativeResults =
                               ReportingSetResultKt.ReportingWindowResultKt.NoisyReportResultValuesKt
@@ -685,7 +685,7 @@ class BasicReportsReportsJobTest {
                       }
                     value =
                       ReportingSetResultKt.reportingWindowResult {
-                        noisyReportResultValues =
+                        unprocessedReportResultValues =
                           ReportingSetResultKt.ReportingWindowResultKt.noisyReportResultValues {
                             cumulativeResults =
                               ReportingSetResultKt.ReportingWindowResultKt.NoisyReportResultValuesKt
@@ -1712,7 +1712,7 @@ class BasicReportsReportsJobTest {
             }
           value =
             ReportingSetResultKt.reportingWindowResult {
-              noisyReportResultValues =
+              unprocessedReportResultValues =
                 ReportingSetResultKt.ReportingWindowResultKt.noisyReportResultValues {
                   cumulativeResults =
                     ReportingSetResultKt.ReportingWindowResultKt.NoisyReportResultValuesKt
@@ -1898,7 +1898,7 @@ class BasicReportsReportsJobTest {
               }
             value =
               ReportingSetResultKt.reportingWindowResult {
-                noisyReportResultValues =
+                unprocessedReportResultValues =
                   ReportingSetResultKt.ReportingWindowResultKt.noisyReportResultValues {
                     cumulativeResults =
                       ReportingSetResultKt.ReportingWindowResultKt.NoisyReportResultValuesKt
@@ -1981,7 +1981,7 @@ class BasicReportsReportsJobTest {
             }
           value =
             ReportingSetResultKt.reportingWindowResult {
-              noisyReportResultValues =
+              unprocessedReportResultValues =
                 ReportingSetResultKt.ReportingWindowResultKt.noisyReportResultValues {
                   cumulativeResults =
                     ReportingSetResultKt.ReportingWindowResultKt.NoisyReportResultValuesKt
@@ -2071,7 +2071,7 @@ class BasicReportsReportsJobTest {
               }
             value =
               ReportingSetResultKt.reportingWindowResult {
-                noisyReportResultValues =
+                unprocessedReportResultValues =
                   ReportingSetResultKt.ReportingWindowResultKt.noisyReportResultValues {
                     cumulativeResults =
                       ReportingSetResultKt.ReportingWindowResultKt.NoisyReportResultValuesKt
@@ -2095,7 +2095,7 @@ class BasicReportsReportsJobTest {
               }
             value =
               ReportingSetResultKt.reportingWindowResult {
-                noisyReportResultValues =
+                unprocessedReportResultValues =
                   ReportingSetResultKt.ReportingWindowResultKt.noisyReportResultValues {
                     cumulativeResults =
                       ReportingSetResultKt.ReportingWindowResultKt.NoisyReportResultValuesKt

--- a/src/test/python/wfa/measurement/reporting/postprocessing/tools/report_conversion_test.py
+++ b/src/test/python/wfa/measurement/reporting/postprocessing/tools/report_conversion_test.py
@@ -173,13 +173,15 @@ class ReportConversionTest(unittest.TestCase):
                 self.reporting_set_results, self.edp_combinations
             )
 
-    def test_report_result_missing_noisy_report_result_values_raises_error(
-            self):
+    def test_report_result_missing_unprocessed_report_result_values_raises_error(
+        self,
+    ):
         self.reporting_set_results[0].reporting_window_results[
             0
-        ].value.ClearField('noisy_report_result_values')
-        with self.assertRaisesRegex(ValueError,
-                                    'Missing noisy_report_result_values'):
+        ].value.ClearField('unprocessed_report_result_values')
+        with self.assertRaisesRegex(
+            ValueError, 'Missing unprocessed_report_result_values'
+        ):
             report_summaries_from_reporting_set_results(
                 self.reporting_set_results, self.edp_combinations
             )
@@ -208,7 +210,7 @@ class ReportConversionTest(unittest.TestCase):
               grouping_dimension_fingerprint: 2
               reporting_window_results {
                 key { end { year: 2025 month: 10 day: 15 } }
-                value { noisy_report_result_values { cumulative_results { reach { value: 1 } } } }
+                value { unprocessed_report_result_values { cumulative_results { reach { value: 1 } } } }
               }
             }
             reporting_set_results {
@@ -232,7 +234,7 @@ class ReportConversionTest(unittest.TestCase):
               grouping_dimension_fingerprint: 2
               reporting_window_results {
                 key { end { year: 2025 month: 10 day: 15 } }
-                value { noisy_report_result_values { cumulative_results { reach { value: 1 } } } }
+                value { unprocessed_report_result_values { cumulative_results { reach { value: 1 } } } }
               }
             }
         """
@@ -292,7 +294,7 @@ class ReportConversionTest(unittest.TestCase):
                   end { year: 2025 month: 10 day: 15 }
                 }
                 value {
-                  noisy_report_result_values {
+                  unprocessed_report_result_values {
                     non_cumulative_results {
                       reach {
                         value: 5000
@@ -357,7 +359,7 @@ class ReportConversionTest(unittest.TestCase):
                   end { year: 2025 month: 10 day: 15 }
                 }
                 value {
-                  noisy_report_result_values {
+                  unprocessed_report_result_values {
                     cumulative_results {
                       reach {
                         value: 5000
@@ -451,7 +453,7 @@ class ReportConversionTest(unittest.TestCase):
                   end { year: 2025 month: 10 day: 15 }
                 }
                 value {
-                  noisy_report_result_values {
+                  unprocessed_report_result_values {
                     cumulative_results {
                       reach {
                         value: 5000
@@ -532,7 +534,7 @@ class ReportConversionTest(unittest.TestCase):
                   end { year: 2025 month: 10 day: 8 }
                 }
                 value {
-                  noisy_report_result_values {
+                  unprocessed_report_result_values {
                     non_cumulative_results {
                       reach { value: 2000 }
                       impression_count { value: 20000 }
@@ -549,7 +551,7 @@ class ReportConversionTest(unittest.TestCase):
                   end { year: 2025 month: 10 day: 15 }
                 }
                 value {
-                  noisy_report_result_values {
+                  unprocessed_report_result_values {
                     non_cumulative_results {
                       reach {
                         value: 3000
@@ -665,7 +667,7 @@ class ReportConversionTest(unittest.TestCase):
                     end { year: 2025 month: 10 day: 8 }
                   }
                   value {
-                    noisy_report_result_values {
+                    unprocessed_report_result_values {
                       non_cumulative_results {
                         reach { value: 2000 }
                         impression_count { value: 20000 }
@@ -682,7 +684,7 @@ class ReportConversionTest(unittest.TestCase):
                     end { year: 2025 month: 10 day: 15 }
                   }
                   value {
-                    noisy_report_result_values {
+                    unprocessed_report_result_values {
                       non_cumulative_results {
                         reach {
                           value: 3000
@@ -794,7 +796,7 @@ class ReportConversionTest(unittest.TestCase):
                   end { year: 2025 month: 10 day: 8 }
                 }
                 value {
-                  noisy_report_result_values {
+                  unprocessed_report_result_values {
                     cumulative_results {
                       reach { value: 2000 }
                     }
@@ -807,7 +809,7 @@ class ReportConversionTest(unittest.TestCase):
                   end { year: 2025 month: 10 day: 15 }
                 }
                 value {
-                  noisy_report_result_values {
+                  unprocessed_report_result_values {
                     cumulative_results {
                       reach {
                         value: 3000
@@ -878,7 +880,7 @@ class ReportConversionTest(unittest.TestCase):
                   end { year: 2025 month: 10 day: 8 }
                 }
                 value {
-                  noisy_report_result_values {
+                  unprocessed_report_result_values {
                     cumulative_results {
                       reach { value: 2000 }
                     }
@@ -891,7 +893,7 @@ class ReportConversionTest(unittest.TestCase):
                   end { year: 2025 month: 10 day: 15 }
                 }
                 value {
-                  noisy_report_result_values {
+                  unprocessed_report_result_values {
                     cumulative_results {
                       reach {
                         value: 3000

--- a/src/test/python/wfa/measurement/reporting/postprocessing/tools/sample_report_result.textproto
+++ b/src/test/python/wfa/measurement/reporting/postprocessing/tools/sample_report_result.textproto
@@ -44,7 +44,7 @@ reporting_set_results {
       }
     }
     value {
-      noisy_report_result_values {
+      unprocessed_report_result_values {
         cumulative_results {
           reach {
             value: 9992500
@@ -115,7 +115,7 @@ reporting_set_results {
       }
     }
     value {
-      noisy_report_result_values {
+      unprocessed_report_result_values {
         cumulative_results {
           reach {
             value: 11998422
@@ -217,7 +217,7 @@ reporting_set_results {
       }
     }
     value {
-      noisy_report_result_values {
+      unprocessed_report_result_values {
         cumulative_results {
           reach {
             value: 11978894
@@ -314,7 +314,7 @@ reporting_set_results {
       }
     }
     value {
-      noisy_report_result_values {
+      unprocessed_report_result_values {
         cumulative_results {
           reach { value: 5000000 }
         }
@@ -361,7 +361,7 @@ reporting_set_results {
       }
     }
     value {
-      noisy_report_result_values {
+      unprocessed_report_result_values {
         cumulative_results {
           reach { value: 6000000 }
         }
@@ -439,7 +439,7 @@ reporting_set_results {
       }
     }
     value {
-      noisy_report_result_values {
+      unprocessed_report_result_values {
         cumulative_results {
           reach { value: 6000000 }
           impression_count { value: 11216125 }
@@ -514,7 +514,7 @@ reporting_set_results {
       }
     }
     value {
-      noisy_report_result_values {
+      unprocessed_report_result_values {
         cumulative_results {
           reach { value: 800000 }
         }
@@ -561,7 +561,7 @@ reporting_set_results {
       }
     }
     value {
-      noisy_report_result_values {
+      unprocessed_report_result_values {
         cumulative_results {
           reach { value: 1000000 }
         }
@@ -639,7 +639,7 @@ reporting_set_results {
       }
     }
     value {
-      noisy_report_result_values {
+      unprocessed_report_result_values {
         cumulative_results {
           reach { value: 1000000 }
           impression_count { value: 1844136 }
@@ -714,7 +714,7 @@ reporting_set_results {
       }
     }
     value {
-      noisy_report_result_values {
+      unprocessed_report_result_values {
         cumulative_results {
           reach {
             value: 15830545
@@ -785,7 +785,7 @@ reporting_set_results {
       }
     }
     value {
-      noisy_report_result_values {
+      unprocessed_report_result_values {
         cumulative_results {
           reach {
             value: 19010669
@@ -887,7 +887,7 @@ reporting_set_results {
       }
     }
     value {
-      noisy_report_result_values {
+      unprocessed_report_result_values {
         cumulative_results {
           reach {
             value: 19021738
@@ -983,7 +983,7 @@ reporting_set_results {
       }
     }
     value {
-      noisy_report_result_values {
+      unprocessed_report_result_values {
         cumulative_results {
           reach {
             value: 16686873
@@ -1042,7 +1042,7 @@ reporting_set_results {
       }
     }
     value {
-      noisy_report_result_values {
+      unprocessed_report_result_values {
         cumulative_results {
           reach {
             value: 9501618
@@ -1113,7 +1113,7 @@ reporting_set_results {
       }
     }
     value {
-      noisy_report_result_values {
+      unprocessed_report_result_values {
         cumulative_results {
           reach {
             value: 11389309
@@ -1215,7 +1215,7 @@ reporting_set_results {
       }
     }
     value {
-      noisy_report_result_values {
+      unprocessed_report_result_values {
         cumulative_results {
           reach {
             value: 11382243
@@ -1311,7 +1311,7 @@ reporting_set_results {
       }
     }
     value {
-      noisy_report_result_values {
+      unprocessed_report_result_values {
         cumulative_results {
           reach { value: 4750000 }
         }
@@ -1358,7 +1358,7 @@ reporting_set_results {
       }
     }
     value {
-      noisy_report_result_values {
+      unprocessed_report_result_values {
         cumulative_results {
           reach { value: 5700000 }
         }
@@ -1436,7 +1436,7 @@ reporting_set_results {
       }
     }
     value {
-      noisy_report_result_values {
+      unprocessed_report_result_values {
         cumulative_results {
           reach { value: 5700000 }
           impression_count { value: 10645760 }
@@ -1511,7 +1511,7 @@ reporting_set_results {
       }
     }
     value {
-      noisy_report_result_values {
+      unprocessed_report_result_values {
         cumulative_results {
           reach { value: 760000 }
         }
@@ -1558,7 +1558,7 @@ reporting_set_results {
       }
     }
     value {
-      noisy_report_result_values {
+      unprocessed_report_result_values {
         cumulative_results {
           reach { value: 950000 }
         }
@@ -1636,7 +1636,7 @@ reporting_set_results {
       }
     }
     value {
-      noisy_report_result_values {
+      unprocessed_report_result_values {
         cumulative_results {
           reach { value: 950000 }
           impression_count { value: 1751669 }
@@ -1711,7 +1711,7 @@ reporting_set_results {
       }
     }
     value {
-      noisy_report_result_values {
+      unprocessed_report_result_values {
         cumulative_results {
           reach {
             value: 13427250
@@ -1782,7 +1782,7 @@ reporting_set_results {
       }
     }
     value {
-      noisy_report_result_values {
+      unprocessed_report_result_values {
         cumulative_results {
           reach {
             value: 15920317
@@ -1884,7 +1884,7 @@ reporting_set_results {
       }
     }
     value {
-      noisy_report_result_values {
+      unprocessed_report_result_values {
         cumulative_results {
           reach {
             value: 15908881
@@ -1981,7 +1981,7 @@ reporting_set_results {
       }
     }
     value {
-      noisy_report_result_values {
+      unprocessed_report_result_values {
         cumulative_results {
           reach {
             value: 9984642
@@ -2052,7 +2052,7 @@ reporting_set_results {
       }
     }
     value {
-      noisy_report_result_values {
+      unprocessed_report_result_values {
         cumulative_results {
           reach {
             value: 12020226
@@ -2155,7 +2155,7 @@ reporting_set_results {
       }
     }
     value {
-      noisy_report_result_values {
+      unprocessed_report_result_values {
         cumulative_results {
           reach {
             value: 12017026
@@ -2252,7 +2252,7 @@ reporting_set_results {
       }
     }
     value {
-      noisy_report_result_values {
+      unprocessed_report_result_values {
         cumulative_results {
           reach { value: 5000000 }
         }
@@ -2299,7 +2299,7 @@ reporting_set_results {
       }
     }
     value {
-      noisy_report_result_values {
+      unprocessed_report_result_values {
         cumulative_results {
           reach { value: 6000000 }
         }
@@ -2378,7 +2378,7 @@ reporting_set_results {
       }
     }
     value {
-      noisy_report_result_values {
+      unprocessed_report_result_values {
         cumulative_results {
           reach { value: 6000000 }
           impression_count { value: 11216125 }
@@ -2454,7 +2454,7 @@ reporting_set_results {
       }
     }
     value {
-      noisy_report_result_values {
+      unprocessed_report_result_values {
         cumulative_results {
           reach { value: 800000 }
         }
@@ -2501,7 +2501,7 @@ reporting_set_results {
       }
     }
     value {
-      noisy_report_result_values {
+      unprocessed_report_result_values {
         cumulative_results {
           reach { value: 1000000 }
         }
@@ -2580,7 +2580,7 @@ reporting_set_results {
       }
     }
     value {
-      noisy_report_result_values {
+      unprocessed_report_result_values {
         cumulative_results {
           reach { value: 1000000 }
           impression_count { value: 1844136 }
@@ -2656,7 +2656,7 @@ reporting_set_results {
       }
     }
     value {
-      noisy_report_result_values {
+      unprocessed_report_result_values {
         cumulative_results {
           reach {
             value: 15799013
@@ -2727,7 +2727,7 @@ reporting_set_results {
       }
     }
     value {
-      noisy_report_result_values {
+      unprocessed_report_result_values {
         cumulative_results {
           reach {
             value: 19015392
@@ -2830,7 +2830,7 @@ reporting_set_results {
       }
     }
     value {
-      noisy_report_result_values {
+      unprocessed_report_result_values {
         cumulative_results {
           reach {
             value: 19030737


### PR DESCRIPTION
In the Reporting internal API, the terms "noisy" and "de-noised" have been used incorrectly. The Report Processor does not de-noise, but rather processes Report results to add derived metrics and ensure constraints are met. Similarly in the case where differential privacy is not used, the unprocessed results aren't technically "noisy".

This updates references within that API. To avoid churn, it avoids any cases that would require a database schema update.

Issue: #3096