### PR TITLE
perf: Switch to cheaper C3D machine family for Mills in Halo GCloud projects

### DIFF
--- a/src/main/terraform/gcloud/cmms/duchies.tf
+++ b/src/main/terraform/gcloud/cmms/duchies.tf
@@ -41,7 +41,7 @@ module "highmem_node_pools" {
   cluster         = each.value.cluster
   name            = "highmem"
   service_account = module.common.cluster_service_account
-  machine_type    = "c2-standard-4"
+  machine_type    = "c3d-standard-4"
   max_node_count  = 20
   spot            = true
 }


### PR DESCRIPTION
There have been scaling issues due to low resource availability of C2 machines in the zone that Halo-managed environments use. C3D machines currently have lower spot VM pricing and are therefore hopefully more available.