### PR TITLE
feat!: Require new permission to create Metrics and BasicReports with DEV ModelLine

### DIFF
--- a/src/main/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/MetricsService.kt
+++ b/src/main/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/MetricsService.kt
@@ -27,7 +27,6 @@ import io.grpc.Status
 import io.grpc.StatusException
 import io.grpc.StatusRuntimeException
 import java.io.File
-import java.lang.IllegalStateException
 import java.security.PrivateKey
 import java.security.SignatureException
 import java.security.cert.CertPathValidatorException
@@ -87,6 +86,7 @@ import org.wfanet.measurement.api.v2alpha.MeasurementKt.dataProviderEntry
 import org.wfanet.measurement.api.v2alpha.MeasurementSpec
 import org.wfanet.measurement.api.v2alpha.MeasurementSpecKt.reportingMetadata
 import org.wfanet.measurement.api.v2alpha.MeasurementsGrpcKt.MeasurementsCoroutineStub
+import org.wfanet.measurement.api.v2alpha.ModelLine
 import org.wfanet.measurement.api.v2alpha.ModelLineKey
 import org.wfanet.measurement.api.v2alpha.ModelLinesGrpcKt.ModelLinesCoroutineStub
 import org.wfanet.measurement.api.v2alpha.RequisitionSpec.EventGroupEntry
@@ -187,6 +187,7 @@ import org.wfanet.measurement.reporting.service.api.EncryptionKeyPairStore
 import org.wfanet.measurement.reporting.service.api.InvalidFieldValueException
 import org.wfanet.measurement.reporting.service.api.InvalidMetricStateTransitionException
 import org.wfanet.measurement.reporting.service.api.MetricNotFoundException
+import org.wfanet.measurement.reporting.service.api.ModelLineNotFoundException
 import org.wfanet.measurement.reporting.service.api.RequiredFieldNotSetException
 import org.wfanet.measurement.reporting.service.api.submitBatchRequests
 import org.wfanet.measurement.reporting.service.internal.Errors as InternalErrors
@@ -250,8 +251,8 @@ class MetricsService(
   private val secureRandom: Random,
   signingPrivateKeyDir: File,
   trustedCertificates: Map<ByteString, X509Certificate>,
-  defaultVidModelLine: String,
-  measurementConsumerModelLines: Map<String, String>,
+  private val defaultVidModelLine: String,
+  private val measurementConsumerModelLines: Map<String, String>,
   populationDataProvider: String,
   certificateCacheExpirationDuration: Duration = Duration.ofMinutes(60),
   dataProviderCacheExpirationDuration: Duration = Duration.ofMinutes(60),
@@ -280,8 +281,6 @@ class MetricsService(
       dataProviderCacheExpirationDuration = dataProviderCacheExpirationDuration,
       keyReaderContext,
       cacheLoaderContext,
-      defaultVidModelLine,
-      measurementConsumerModelLines,
       populationDataProvider,
     )
 
@@ -299,10 +298,17 @@ class MetricsService(
     dataProviderCacheExpirationDuration: Duration,
     private val keyReaderContext: @BlockingExecutor CoroutineContext = Dispatchers.IO,
     cacheLoaderContext: @NonBlockingExecutor CoroutineContext = Dispatchers.Default,
-    private val defaultModelLine: String,
-    private val measurementConsumerModelLines: Map<String, String>,
     private val populationDataProvider: String,
   ) {
+    data class RunningMetric(
+      val internalMetric: InternalMetric,
+      val effectiveModelLineName: String,
+    ) {
+      init {
+        require(internalMetric.state == InternalMetric.State.RUNNING)
+      }
+    }
+
     private data class ResourceNameApiAuthenticationKey(
       val name: String,
       val apiAuthenticationKey: String,
@@ -334,7 +340,7 @@ class MetricsService(
 
     /** Creates CMM public [Measurement]s from a list of [InternalMetric]. */
     suspend fun createCmmsMeasurements(
-      internalMetricsList: List<InternalMetric>,
+      runningMetrics: Iterable<RunningMetric>,
       internalPrimitiveReportingSetMap: Map<String, InternalReportingSet>,
       measurementConsumerCreds: MeasurementConsumerCredentials,
     ) {
@@ -353,13 +359,13 @@ class MetricsService(
       val measurementConsumerSigningKey = getMeasurementConsumerSigningKey(measurementConsumerCreds)
 
       val cmmsCreateMeasurementRequests: Flow<CreateMeasurementRequest> = flow {
-        for (internalMetric in internalMetricsList) {
-          for (weightedMeasurement in internalMetric.weightedMeasurementsList) {
+        for (runningMetric in runningMetrics) {
+          for (weightedMeasurement in runningMetric.internalMetric.weightedMeasurementsList) {
             if (weightedMeasurement.measurement.cmmsMeasurementId.isBlank()) {
               emit(
                 buildCreateMeasurementRequest(
                   weightedMeasurement.measurement,
-                  internalMetric,
+                  runningMetric,
                   internalPrimitiveReportingSetMap,
                   measurementConsumer,
                   measurementConsumerCreds,
@@ -469,13 +475,14 @@ class MetricsService(
     /** Builds a CMMS [CreateMeasurementRequest]. */
     private suspend fun buildCreateMeasurementRequest(
       internalMeasurement: InternalMeasurement,
-      metric: InternalMetric,
+      runningMetric: RunningMetric,
       internalPrimitiveReportingSetMap: Map<String, InternalReportingSet>,
       measurementConsumer: MeasurementConsumer,
       measurementConsumerCreds: MeasurementConsumerCredentials,
       dataProviderInfoMap: Map<String, DataProviderInfo>,
       measurementConsumerSigningKey: SigningKeyHandle,
     ): CreateMeasurementRequest {
+      val internalMetric: InternalMetric = runningMetric.internalMetric
       val packedMeasurementEncryptionPublicKey = measurementConsumer.publicKey.message
 
       return createMeasurementRequest {
@@ -483,14 +490,14 @@ class MetricsService(
         measurement = measurement {
           measurementConsumerCertificate = measurementConsumerCreds.signingCertificateKey.toName()
 
-          if (metric.metricSpec.hasPopulationCount()) {
+          if (internalMetric.metricSpec.hasPopulationCount()) {
             dataProviders +=
               buildPopulationDataProviderEntry(
                 packedMeasurementEncryptionPublicKey,
                 measurementConsumerSigningKey,
                 internalMeasurement,
                 measurementConsumerCreds,
-                metric,
+                internalMetric,
               )
           } else {
             val eventGroupEntriesByDataProvider =
@@ -510,10 +517,9 @@ class MetricsService(
 
           val unsignedMeasurementSpec: MeasurementSpec =
             buildUnsignedMeasurementSpec(
-              measurementConsumer.name,
               packedMeasurementEncryptionPublicKey,
               dataProviders.map { it.value.nonceHash },
-              metric,
+              runningMetric,
             )
 
           measurementSpec =
@@ -546,12 +552,12 @@ class MetricsService(
 
     /** Builds an unsigned [MeasurementSpec]. */
     private fun buildUnsignedMeasurementSpec(
-      measurementConsumerName: String,
       packedMeasurementEncryptionPublicKey: ProtoAny,
       nonceHashes: List<ByteString>,
-      metric: InternalMetric,
+      runningMetric: RunningMetric,
     ): MeasurementSpec {
       val isSingleDataProvider: Boolean = nonceHashes.size == 1
+      val metric = runningMetric.internalMetric
       val metricSpec = metric.metricSpec
 
       return measurementSpec {
@@ -589,10 +595,7 @@ class MetricsService(
               "Unset metric type should've already raised error."
             }
         }
-        modelLine =
-          metric.cmmsModelLine.ifEmpty {
-            measurementConsumerModelLines.getOrDefault(measurementConsumerName, defaultModelLine)
-          }
+        modelLine = runningMetric.effectiveModelLineName
 
         // Add reporting metadata
         reportingMetadata = reportingMetadata {
@@ -1433,14 +1436,44 @@ class MetricsService(
         .asRuntimeException()
     }
 
-    authorization.check(measurementConsumerName, Permission.CREATE)
-
     val measurementConsumerConfig =
       measurementConsumerConfigs.configsMap[measurementConsumerName]
         ?: throw Status.INTERNAL.withDescription("Config not found for $measurementConsumerName")
           .asRuntimeException()
     val measurementConsumerCreds =
       MeasurementConsumerCredentials.fromConfig(parentKey, measurementConsumerConfig)
+    val effectiveModelLineName =
+      try {
+        getEffectiveModelLine(
+          request.metric.modelLine,
+          "metric.model_line",
+          measurementConsumerName,
+        )
+      } catch (e: InvalidFieldValueException) {
+        throw e.asStatusRuntimeException(Status.Code.INVALID_ARGUMENT)
+      }
+    val requiredPermissionIds = buildSet {
+      add(Permission.CREATE)
+      if (effectiveModelLineName.isNotEmpty()) {
+        val modelLine =
+          try {
+            kingdomModelLinesStub
+              .withAuthenticationKey(measurementConsumerCreds.callCredentials.apiAuthenticationKey)
+              .getModelLine(getModelLineRequest { name = effectiveModelLineName })
+          } catch (e: StatusException) {
+            throw when (e.status.code) {
+              Status.Code.NOT_FOUND ->
+                ModelLineNotFoundException(effectiveModelLineName, e)
+                  .asStatusRuntimeException(Status.Code.FAILED_PRECONDITION)
+              else -> Status.INTERNAL.withCause(e).asRuntimeException()
+            }
+          }
+        if (modelLine.type == ModelLine.Type.DEV) {
+          add(Permission.CREATE_WITH_DEV_MODEL_LINE)
+        }
+      }
+    }
+    authorization.check(measurementConsumerName, requiredPermissionIds)
 
     val batchGetReportingSetsResponse =
       batchGetInternalReportingSets(
@@ -1460,7 +1493,6 @@ class MetricsService(
         request,
         batchGetReportingSetsResponse.reportingSetsList.single(),
         internalPrimitiveReportingSetMap,
-        measurementConsumerCreds,
       )
 
     val internalMetric =
@@ -1486,7 +1518,7 @@ class MetricsService(
 
     if (internalMetric.state == InternalMetric.State.RUNNING) {
       measurementSupplier.createCmmsMeasurements(
-        listOf(internalMetric),
+        listOf(MeasurementSupplier.RunningMetric(internalMetric, effectiveModelLineName)),
         internalPrimitiveReportingSetMap,
         measurementConsumerCreds,
       )
@@ -1505,14 +1537,50 @@ class MetricsService(
       }
 
     val measurementConsumerName: String = parentKey.toName()
-    authorization.check(measurementConsumerName, Permission.CREATE)
-
     val measurementConsumerConfig =
       measurementConsumerConfigs.configsMap[measurementConsumerName]
         ?: throw Status.INTERNAL.withDescription("Config not found for $measurementConsumerName")
           .asRuntimeException()
     val measurementConsumerCreds =
       MeasurementConsumerCredentials.fromConfig(parentKey, measurementConsumerConfig)
+    val effectiveModelLineNames =
+      request.requestsList.mapIndexed { index, subRequest ->
+        try {
+          getEffectiveModelLine(
+            subRequest.metric.modelLine,
+            "requests[$index].metric.model_line",
+            measurementConsumerName,
+          )
+        } catch (e: InvalidFieldValueException) {
+          throw e.asStatusRuntimeException(Status.Code.INVALID_ARGUMENT)
+        }
+      }
+
+    val requiredPermissionIds = buildSet {
+      add(Permission.CREATE)
+      for (effectiveModelLineName in effectiveModelLineNames) {
+        if (effectiveModelLineName.isEmpty()) {
+          continue
+        }
+        val modelLine =
+          try {
+            kingdomModelLinesStub
+              .withAuthenticationKey(measurementConsumerCreds.callCredentials.apiAuthenticationKey)
+              .getModelLine(getModelLineRequest { name = effectiveModelLineName })
+          } catch (e: StatusException) {
+            throw when (e.status.code) {
+              Status.Code.NOT_FOUND ->
+                ModelLineNotFoundException(effectiveModelLineName, e)
+                  .asStatusRuntimeException(Status.Code.FAILED_PRECONDITION)
+              else -> StatusRuntimeException(Status.INTERNAL)
+            }
+          }
+        if (modelLine.type == ModelLine.Type.DEV) {
+          add(Permission.CREATE_WITH_DEV_MODEL_LINE)
+        }
+      }
+    }
+    authorization.check(measurementConsumerName, requiredPermissionIds)
 
     grpcRequire(request.requestsList.isNotEmpty()) { "Requests is empty." }
     grpcRequire(request.requestsList.size <= MAX_BATCH_SIZE) {
@@ -1570,22 +1638,22 @@ class MetricsService(
         reportingSetNameToInternalReportingSetMap.values,
       )
 
-    val internalCreateMetricRequestsList: List<Deferred<InternalCreateMetricRequest>> =
+    val internalCreateMetricRequests: List<InternalCreateMetricRequest> =
       coroutineScope {
-        request.requestsList.map { createMetricRequest ->
-          async {
-            buildInternalCreateMetricRequest(
-              parentKey.measurementConsumerId,
-              createMetricRequest,
-              reportingSetNameToInternalReportingSetMap.getValue(
-                createMetricRequest.metric.reportingSet
-              ),
-              internalPrimitiveReportingSetMap,
-              measurementConsumerCreds,
-            )
+          request.requestsList.map { createMetricRequest ->
+            async {
+              buildInternalCreateMetricRequest(
+                parentKey.measurementConsumerId,
+                createMetricRequest,
+                reportingSetNameToInternalReportingSetMap.getValue(
+                  createMetricRequest.metric.reportingSet
+                ),
+                internalPrimitiveReportingSetMap,
+              )
+            }
           }
         }
-      }
+        .awaitAll()
 
     val internalMetrics =
       try {
@@ -1593,7 +1661,7 @@ class MetricsService(
           .batchCreateMetrics(
             internalBatchCreateMetricsRequest {
               cmmsMeasurementConsumerId = parentKey.measurementConsumerId
-              requests += internalCreateMetricRequestsList.awaitAll()
+              requests += internalCreateMetricRequests
             }
           )
           .metricsList
@@ -1611,10 +1679,13 @@ class MetricsService(
           .asRuntimeException()
       }
 
-    val internalRunningMetrics =
-      internalMetrics.filter { internalMetric ->
-        internalMetric.state == InternalMetric.State.RUNNING
-      }
+    val internalRunningMetrics: List<MeasurementSupplier.RunningMetric> =
+      internalMetrics
+        .zip(effectiveModelLineNames)
+        .filter { (internalMetric, _) -> internalMetric.state == InternalMetric.State.RUNNING }
+        .map { (internalMetric, effectiveModelLineName) ->
+          MeasurementSupplier.RunningMetric(internalMetric, effectiveModelLineName)
+        }
     if (internalRunningMetrics.isNotEmpty()) {
       measurementSupplier.createCmmsMeasurements(
         internalRunningMetrics,
@@ -1627,13 +1698,43 @@ class MetricsService(
     return batchCreateMetricsResponse { metrics += internalMetrics.map { it.toMetric(variances) } }
   }
 
+  /**
+   * Returns the resource name of the effective [ModelLine], or empty string if there is none.
+   *
+   * @param requestModelLine resource name of the [ModelLine] from a request, which may be empty
+   * @param fieldPath field path of [requestModelLine] relative to the request
+   * @param measurementConsumer resource name of the [MeasurementConsumer]
+   * @throws InvalidFieldValueException if [requestModelLine] is specified and invalid
+   */
+  private fun getEffectiveModelLine(
+    requestModelLine: String,
+    fieldPath: String,
+    measurementConsumer: String,
+  ): String {
+    val key: ModelLineKey? =
+      if (requestModelLine.isEmpty()) {
+        val effectiveModelLine =
+          measurementConsumerModelLines[measurementConsumer] ?: defaultVidModelLine.ifEmpty { null }
+        if (effectiveModelLine == null) {
+          null
+        } else {
+          checkNotNull(ModelLineKey.fromName(effectiveModelLine)) {
+            "Invalid ModelLine $effectiveModelLine for $measurementConsumer in config"
+          }
+        }
+      } else {
+        ModelLineKey.fromName(requestModelLine) ?: throw InvalidFieldValueException(fieldPath)
+      }
+
+    return key?.toName() ?: ""
+  }
+
   /** Builds an [InternalCreateMetricRequest]. */
-  private suspend fun buildInternalCreateMetricRequest(
+  private fun buildInternalCreateMetricRequest(
     cmmsMeasurementConsumerId: String,
     request: CreateMetricRequest,
     internalReportingSet: InternalReportingSet,
     internalPrimitiveReportingSetMap: Map<String, InternalReportingSet>,
-    measurementConsumerCreds: MeasurementConsumerCredentials,
   ): InternalCreateMetricRequest {
     grpcRequire(request.metricId.matches(RESOURCE_ID_REGEX)) { "Metric ID is invalid." }
     grpcRequire(request.metric.reportingSet.isNotEmpty()) {
@@ -1668,25 +1769,6 @@ class MetricsService(
     ) {
       failGrpc(Status.INVALID_ARGUMENT) {
         "Reach-and-frequency metrics can only be computed on union-only set expressions."
-      }
-    }
-
-    if (request.metric.modelLine.isNotEmpty()) {
-      ModelLineKey.fromName(request.metric.modelLine)
-        ?: throw InvalidFieldValueException("request.metric.model_line")
-          .asStatusRuntimeException(Status.Code.INVALID_ARGUMENT)
-
-      try {
-        kingdomModelLinesStub
-          .withAuthenticationKey(measurementConsumerCreds.callCredentials.apiAuthenticationKey)
-          .getModelLine(getModelLineRequest { name = request.metric.modelLine })
-      } catch (e: StatusException) {
-        throw when (e.status.code) {
-          Status.Code.NOT_FOUND ->
-            InvalidFieldValueException("request.metric.model_line")
-              .asStatusRuntimeException(Status.Code.NOT_FOUND)
-          else -> StatusRuntimeException(Status.INTERNAL)
-        }
       }
     }
 
@@ -1984,6 +2066,7 @@ class MetricsService(
     const val GET = "reporting.metrics.get"
     const val LIST = "reporting.metrics.list"
     const val CREATE = "reporting.metrics.create"
+    const val CREATE_WITH_DEV_MODEL_LINE = "reporting.metrics.createWithDevModelLine"
     const val INVALIDATE = "reporting.metrics.invalidate"
   }
 

--- a/src/main/proto/wfa/measurement/config/access/permissions_config.proto
+++ b/src/main/proto/wfa/measurement/config/access/permissions_config.proto
@@ -31,6 +31,9 @@ message PermissionsConfig {
     // resource type `example.com/Shelf` to grant reading all books on the
     // shelf.
     repeated string protected_resource_types = 1;
+
+    // Optional description of what the Permission allows the Principal to do.
+    string description = 2;
   }
 
   // Map of permission resource ID to `Permission`.

--- a/src/main/proto/wfa/measurement/internal/reporting/v2/metrics_service.proto
+++ b/src/main/proto/wfa/measurement/internal/reporting/v2/metrics_service.proto
@@ -51,6 +51,8 @@ message BatchCreateMetricsRequest {
 }
 
 message BatchCreateMetricsResponse {
+  // Created `Metric` entities in the same order as
+  // `BatchCreateMetricsRequest.requests`.
   repeated Metric metrics = 1;
 }
 

--- a/src/main/proto/wfa/measurement/reporting/v2alpha/permissions_config.textproto
+++ b/src/main/proto/wfa/measurement/reporting/v2alpha/permissions_config.textproto
@@ -47,16 +47,16 @@ permissions {
   }
 }
 permissions {
-  # Allow creation of primitive ReportingSets.
   key: "reporting.reportingSets.createPrimitive"
   value {
+    description: "Create a primitive ReportingSet resource"
     protected_resource_types: "halo.wfanet.org/MeasurementConsumer"
   }
 }
 permissions {
-  # Allow creation of composite ReportingSets.
   key: "reporting.reportingSets.createComposite"
   value {
+    description: "Create a composite ReportingSet resource"
     protected_resource_types: "halo.wfanet.org/MeasurementConsumer"
   }
 }
@@ -79,6 +79,14 @@ permissions {
   key: "reporting.metrics.create"
   value {
     protected_resource_types: "halo.wfanet.org/MeasurementConsumer"
+    description: "Create a Metric resource."
+  }
+}
+permissions {
+  key: "reporting.metrics.createWithDevModelLine"
+  value {
+    protected_resource_types: "halo.wfanet.org/MeasurementConsumer"
+    description: "When creating a Metric resource, use a ModelLine of type DEV."
   }
 }
 permissions {
@@ -163,6 +171,14 @@ permissions {
 permissions {
   key: "reporting.basicReports.create"
   value {
+    description: "Create a BasicReport resource"
+    protected_resource_types: "halo.wfanet.org/MeasurementConsumer"
+  }
+}
+permissions {
+  key: "reporting.basicReports.createWithDevModelLine"
+  value {
+    description: "When creating a BasicReport resource, use a ModelLine of type DEV"
     protected_resource_types: "halo.wfanet.org/MeasurementConsumer"
   }
 }

--- a/src/test/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/BasicReportsServiceTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/BasicReportsServiceTest.kt
@@ -49,6 +49,7 @@ import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.doAnswer
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
+import org.mockito.kotlin.wheneverBlocking
 import org.wfanet.measurement.access.client.v1alpha.Authorization
 import org.wfanet.measurement.access.client.v1alpha.testing.Authentication.withPrincipalAndScopes
 import org.wfanet.measurement.access.client.v1alpha.testing.PrincipalMatcher.Companion.hasPrincipal
@@ -73,7 +74,6 @@ import org.wfanet.measurement.api.v2alpha.modelLine
 import org.wfanet.measurement.common.base64UrlEncode
 import org.wfanet.measurement.common.db.r2dbc.postgres.testing.PostgresDatabaseProviderRule
 import org.wfanet.measurement.common.getRuntimePath
-import org.wfanet.measurement.common.grpc.errorInfo
 import org.wfanet.measurement.common.grpc.testing.GrpcTestServerRule
 import org.wfanet.measurement.common.grpc.testing.StatusExceptionSubject.Companion.assertThat
 import org.wfanet.measurement.common.grpc.testing.mockService
@@ -2936,6 +2936,170 @@ class BasicReportsServiceTest {
     }
 
   @Test
+  fun `createBasicReport throws PERMISSION_DENIED when caller does not have permission for DEV ModelLine`() =
+    runBlocking {
+      wheneverBlocking { permissionsServiceMock.checkPermissions(any()) } doAnswer
+        { invocation ->
+          val request: CheckPermissionsRequest = invocation.getArgument(0)
+          checkPermissionsResponse {
+            permissions +=
+              request.permissionsList.intersect(
+                listOf("permissions/${BasicReportsService.Permission.CREATE}")
+              )
+          }
+        }
+      val modelLine = modelLine {
+        name = ModelLineKey("1234", "1234", "1234").toName()
+        type = ModelLine.Type.DEV
+      }
+      whenever(modelLinesServiceMock.enumerateValidModelLines(any()))
+        .thenReturn(enumerateValidModelLinesResponse { modelLines += modelLine })
+      val measurementConsumerKey = MeasurementConsumerKey(CMMS_MEASUREMENT_CONSUMER_ID)
+      val campaignGroupKey = ReportingSetKey(measurementConsumerKey, "1234")
+      measurementConsumersService.createMeasurementConsumer(
+        measurementConsumer {
+          cmmsMeasurementConsumerId = measurementConsumerKey.measurementConsumerId
+        }
+      )
+      internalReportingSetsService.createReportingSet(
+        createReportingSetRequest {
+          reportingSet = internalReportingSet {
+            cmmsMeasurementConsumerId = measurementConsumerKey.measurementConsumerId
+            externalCampaignGroupId = campaignGroupKey.reportingSetId
+            displayName = "displayName"
+            primitive =
+              ReportingSetKt.primitive {
+                eventGroupKeys +=
+                  ReportingSetKt.PrimitiveKt.eventGroupKey {
+                    cmmsDataProviderId = DATA_PROVIDER_KEY.dataProviderId
+                    cmmsEventGroupId = "1235"
+                  }
+              }
+          }
+          externalReportingSetId = campaignGroupKey.reportingSetId
+        }
+      )
+      val request = createBasicReportRequest {
+        parent = measurementConsumerKey.toName()
+        basicReport = basicReport {
+          title = "title"
+          campaignGroup = campaignGroupKey.toName()
+          this.modelLine = modelLine.name
+          reportingInterval = reportingInterval {
+            reportStart = dateTime {
+              year = 2025
+              month = 7
+              day = 3
+              timeZone = timeZone { id = "America/Los_Angeles" }
+            }
+            reportEnd = date {
+              year = 2026
+              month = 1
+              day = 5
+            }
+          }
+          impressionQualificationFilters += reportingImpressionQualificationFilter {
+            impressionQualificationFilter =
+              ImpressionQualificationFilterKey(AMI_IQF.externalImpressionQualificationFilterId)
+                .toName()
+          }
+          impressionQualificationFilters += reportingImpressionQualificationFilter {
+            custom =
+              ReportingImpressionQualificationFilterKt.customImpressionQualificationFilterSpec {
+                filterSpec += impressionQualificationFilterSpec {
+                  mediaType = MediaType.DISPLAY
+                  filters += eventFilter {
+                    terms += eventTemplateField {
+                      path = "banner_ad.viewable"
+                      value = EventTemplateFieldKt.fieldValue { boolValue = true }
+                    }
+                  }
+                }
+              }
+          }
+          resultGroupSpecs += resultGroupSpec {
+            title = "title"
+            reportingUnit = reportingUnit { components += DATA_PROVIDER_KEY.toName() }
+            metricFrequency = metricFrequencySpec { weekly = DayOfWeek.MONDAY }
+            dimensionSpec = dimensionSpec {
+              grouping =
+                DimensionSpecKt.grouping { eventTemplateFields += "person.social_grade_group" }
+              filters += eventFilter {
+                terms += eventTemplateField {
+                  path = "person.age_group"
+                  value = EventTemplateFieldKt.fieldValue { enumValue = "YEARS_18_TO_34" }
+                }
+              }
+            }
+            resultGroupMetricSpec = resultGroupMetricSpec {
+              populationSize = true
+              reportingUnit =
+                ResultGroupMetricSpecKt.reportingUnitMetricSetSpec {
+                  nonCumulative =
+                    ResultGroupMetricSpecKt.basicMetricSetSpec {
+                      reach = true
+                      percentReach = true
+                      kPlusReach = 5
+                      percentKPlusReach = true
+                      averageFrequency = true
+                      impressions = true
+                      grps = true
+                    }
+                  cumulative =
+                    ResultGroupMetricSpecKt.basicMetricSetSpec {
+                      reach = true
+                      percentReach = true
+                      kPlusReach = 5
+                      percentKPlusReach = true
+                      averageFrequency = true
+                      impressions = true
+                      grps = true
+                    }
+                  stackedIncrementalReach = false
+                }
+              component =
+                ResultGroupMetricSpecKt.componentMetricSetSpec {
+                  nonCumulative =
+                    ResultGroupMetricSpecKt.basicMetricSetSpec {
+                      reach = true
+                      percentReach = true
+                      kPlusReach = 5
+                      percentKPlusReach = true
+                      averageFrequency = true
+                      impressions = true
+                      grps = true
+                    }
+                  cumulative =
+                    ResultGroupMetricSpecKt.basicMetricSetSpec {
+                      reach = true
+                      percentReach = true
+                      kPlusReach = 5
+                      percentKPlusReach = true
+                      averageFrequency = true
+                      impressions = true
+                      grps = true
+                    }
+                  nonCumulativeUnique = ResultGroupMetricSpecKt.uniqueMetricSetSpec { reach = true }
+                  cumulativeUnique = ResultGroupMetricSpecKt.uniqueMetricSetSpec { reach = true }
+                }
+            }
+          }
+        }
+        basicReportId = "a1234"
+      }
+
+      val exception =
+        assertFailsWith<StatusRuntimeException> {
+          withPrincipalAndScopes(PRINCIPAL, SCOPES) { service.createBasicReport(request) }
+        }
+
+      assertThat(exception).status().code().isEqualTo(Status.Code.PERMISSION_DENIED)
+      assertThat(exception)
+        .hasMessageThat()
+        .contains(BasicReportsService.Permission.CREATE_WITH_DEV_MODEL_LINE)
+    }
+
+  @Test
   fun `createBasicReport throws INVALID_ARGUMENT when basicReportId is missing`() = runBlocking {
     val measurementConsumerKey = MeasurementConsumerKey(CMMS_MEASUREMENT_CONSUMER_ID)
     val campaignGroupKey = ReportingSetKey(measurementConsumerKey, "1234")
@@ -3318,7 +3482,7 @@ class BasicReportsServiceTest {
   }
 
   @Test
-  fun `createBasicReport throws INVALID_ARGUMENT when modelLine not part of valid list`(): Unit =
+  fun `createBasicReport throws FAILED_PRECONDITION when modelLine not part of valid list`(): Unit =
     runBlocking {
       val measurementConsumerKey = MeasurementConsumerKey(CMMS_MEASUREMENT_CONSUMER_ID)
       val campaignGroupKey = ReportingSetKey(measurementConsumerKey, "1234")
@@ -3391,8 +3555,8 @@ class BasicReportsServiceTest {
         .isEqualTo(
           errorInfo {
             domain = Errors.DOMAIN
-            reason = Errors.Reason.INVALID_FIELD_VALUE.name
-            metadata[Errors.Metadata.FIELD_NAME.key] = "basic_report.model_line"
+            reason = Errors.Reason.MODEL_LINE_NOT_ACTIVE.name
+            metadata[Errors.Metadata.MODEL_LINE.key] = request.basicReport.modelLine
           }
         )
     }
@@ -9518,6 +9682,7 @@ class BasicReportsServiceTest {
         BasicReportsService.Permission.GET,
         BasicReportsService.Permission.LIST,
         BasicReportsService.Permission.CREATE,
+        BasicReportsService.Permission.CREATE_WITH_DEV_MODEL_LINE,
       )
     private val SCOPES = ALL_PERMISSIONS
     private val PRINCIPAL = principal { name = "principals/mc-user" }

--- a/src/test/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/MetricsServiceTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/MetricsServiceTest.kt
@@ -98,6 +98,7 @@ import org.wfanet.measurement.api.v2alpha.MeasurementSpecKt
 import org.wfanet.measurement.api.v2alpha.MeasurementSpecKt.reportingMetadata
 import org.wfanet.measurement.api.v2alpha.MeasurementsGrpcKt
 import org.wfanet.measurement.api.v2alpha.MeasurementsGrpcKt.MeasurementsCoroutineImplBase
+import org.wfanet.measurement.api.v2alpha.ModelLine
 import org.wfanet.measurement.api.v2alpha.ModelLineKey
 import org.wfanet.measurement.api.v2alpha.ModelLinesGrpcKt.ModelLinesCoroutineImplBase
 import org.wfanet.measurement.api.v2alpha.ModelLinesGrpcKt.ModelLinesCoroutineStub
@@ -517,9 +518,10 @@ private val ENCRYPTION_KEY_PAIR_STORE =
     )
   )
 
-private const val DEFAULT_VID_MODEL_LINE = "the-model-line"
+private const val DEFAULT_VID_MODEL_LINE = "modelProviders/mp-1/modelSuites/ms-1/modelLines/default"
+private const val MC_MODEL_LINE = "modelProviders/mp-1/modelSuites/ms-1/modelLines/mc-model-line"
 private val MEASUREMENT_CONSUMER_MODEL_LINES: Map<String, String> =
-  mapOf(MEASUREMENT_CONSUMERS.values.first().name to "mc-model-line")
+  mapOf(MEASUREMENT_CONSUMERS.values.first().name to MC_MODEL_LINE)
 
 private val DATA_PROVIDER_PUBLIC_KEY = encryptionPublicKey {
   format = EncryptionPublicKey.Format.TINK_KEYSET
@@ -2702,7 +2704,7 @@ class MetricsServiceTest {
     // Verify proto argument of internal MeasurementsCoroutineImplBase::batchSetCmmsMeasurementId
     verifyProtoArgument(
         internalMeasurementsMock,
-        InternalMeasurementsGrpcKt.MeasurementsCoroutineImplBase::batchSetCmmsMeasurementIds,
+        InternalMeasurementsCoroutineImplBase::batchSetCmmsMeasurementIds,
       )
       .ignoringRepeatedFieldOrder()
       .isEqualTo(
@@ -2989,7 +2991,7 @@ class MetricsServiceTest {
     // Verify proto argument of internal MeasurementsCoroutineImplBase::batchSetCmmsMeasurementIds
     verifyProtoArgument(
         internalMeasurementsMock,
-        InternalMeasurementsGrpcKt.MeasurementsCoroutineImplBase::batchSetCmmsMeasurementIds,
+        InternalMeasurementsCoroutineImplBase::batchSetCmmsMeasurementIds,
       )
       .ignoringRepeatedFieldOrder()
       .isEqualTo(
@@ -3231,7 +3233,7 @@ class MetricsServiceTest {
     // Verify proto argument of internal MeasurementsCoroutineImplBase::batchSetCmmsMeasurementIds
     verifyProtoArgument(
         internalMeasurementsMock,
-        InternalMeasurementsGrpcKt.MeasurementsCoroutineImplBase::batchSetCmmsMeasurementIds,
+        InternalMeasurementsCoroutineImplBase::batchSetCmmsMeasurementIds,
       )
       .ignoringRepeatedFieldOrder()
       .isEqualTo(
@@ -3534,7 +3536,7 @@ class MetricsServiceTest {
     // Verify proto argument of internal MeasurementsCoroutineImplBase::batchSetCmmsMeasurementIds
     verifyProtoArgument(
         internalMeasurementsMock,
-        InternalMeasurementsGrpcKt.MeasurementsCoroutineImplBase::batchSetCmmsMeasurementIds,
+        InternalMeasurementsCoroutineImplBase::batchSetCmmsMeasurementIds,
       )
       .ignoringRepeatedFieldOrder()
       .isEqualTo(
@@ -3653,7 +3655,7 @@ class MetricsServiceTest {
     // Verify proto argument of internal MeasurementsCoroutineImplBase::batchSetCmmsMeasurementIds
     verifyProtoArgument(
         internalMeasurementsMock,
-        InternalMeasurementsGrpcKt.MeasurementsCoroutineImplBase::batchSetCmmsMeasurementIds,
+        InternalMeasurementsCoroutineImplBase::batchSetCmmsMeasurementIds,
       )
       .ignoringRepeatedFieldOrder()
       .isEqualTo(
@@ -3777,7 +3779,7 @@ class MetricsServiceTest {
     // Verify proto argument of internal MeasurementsCoroutineImplBase::batchSetCmmsMeasurementIds
     verifyProtoArgument(
         internalMeasurementsMock,
-        InternalMeasurementsGrpcKt.MeasurementsCoroutineImplBase::batchSetCmmsMeasurementIds,
+        InternalMeasurementsCoroutineImplBase::batchSetCmmsMeasurementIds,
       )
       .ignoringRepeatedFieldOrder()
       .isEqualTo(
@@ -4006,7 +4008,7 @@ class MetricsServiceTest {
     // Verify proto argument of internal MeasurementsCoroutineImplBase::batchSetCmmsMeasurementIds
     verifyProtoArgument(
         internalMeasurementsMock,
-        InternalMeasurementsGrpcKt.MeasurementsCoroutineImplBase::batchSetCmmsMeasurementIds,
+        InternalMeasurementsCoroutineImplBase::batchSetCmmsMeasurementIds,
       )
       .ignoringRepeatedFieldOrder()
       .isEqualTo(
@@ -4129,7 +4131,7 @@ class MetricsServiceTest {
     // Verify proto argument of internal MeasurementsCoroutineImplBase::batchSetCmmsMeasurementIds
     verifyProtoArgument(
         internalMeasurementsMock,
-        InternalMeasurementsGrpcKt.MeasurementsCoroutineImplBase::batchSetCmmsMeasurementIds,
+        InternalMeasurementsCoroutineImplBase::batchSetCmmsMeasurementIds,
       )
       .ignoringRepeatedFieldOrder()
       .isEqualTo(
@@ -5396,7 +5398,7 @@ class MetricsServiceTest {
     // Verify proto argument of internal MeasurementsCoroutineImplBase::batchSetCmmsMeasurementId
     verifyProtoArgument(
         internalMeasurementsMock,
-        InternalMeasurementsGrpcKt.MeasurementsCoroutineImplBase::batchSetCmmsMeasurementIds,
+        InternalMeasurementsCoroutineImplBase::batchSetCmmsMeasurementIds,
       )
       .ignoringRepeatedFieldOrder()
       .isEqualTo(
@@ -5726,6 +5728,83 @@ class MetricsServiceTest {
   }
 
   @Test
+  fun `batchCreateMetrics passes DEV ModelLine in CMMS Measurement requests`() {
+    val devModelLine = "modelProviders/mp-1/modelSuites/ms-1/modelLines/dev"
+    wheneverBlocking {
+      permissionsServiceMock.checkPermissions(hasPrincipal(PRINCIPAL.name))
+    } doReturn
+      checkPermissionsResponse {
+        permissions += PermissionName.CREATE
+        permissions += PermissionName.CREATE_WITH_DEV_MODEL_LINE
+      }
+    wheneverBlocking { modelLinesMock.getModelLine(any()) } doReturn
+      modelLine { type = ModelLine.Type.DEV }
+    val request = batchCreateMetricsRequest {
+      parent = MEASUREMENT_CONSUMERS.values.first().name
+      requests += createMetricRequest {
+        parent = MEASUREMENT_CONSUMERS.values.first().name
+        metric = REQUESTING_INCREMENTAL_REACH_METRIC.copy { modelLine = devModelLine }
+        metricId = "metric-id1"
+      }
+      requests += createMetricRequest {
+        parent = MEASUREMENT_CONSUMERS.values.first().name
+        metric = REQUESTING_SINGLE_PUBLISHER_IMPRESSION_METRIC
+        metricId = "metric-id2"
+      }
+    }
+
+    withPrincipalAndScopes(PRINCIPAL, SCOPES) {
+      runBlocking { service.batchCreateMetrics(request) }
+    }
+
+    val measurementsRequestCaptor = argumentCaptor<BatchCreateMeasurementsRequest>()
+    verifyBlocking(measurementsMock) {
+      batchCreateMeasurements(measurementsRequestCaptor.capture())
+    }
+    val batchCreateMeasurementsRequest = measurementsRequestCaptor.allValues.single()
+    val modelLines =
+      batchCreateMeasurementsRequest.requestsList.map {
+        it.measurement.measurementSpec.unpack<MeasurementSpec>().modelLine
+      }
+    assertThat(modelLines).contains(devModelLine)
+  }
+
+  @Test
+  fun `batchCreateMetrics throws PERMISSION_DENIED for DEV ModelLine`() {
+    val devModelLine = "modelProviders/mp-1/modelSuites/ms-1/modelLines/dev"
+    wheneverBlocking {
+      permissionsServiceMock.checkPermissions(hasPrincipal(PRINCIPAL.name))
+    } doReturn checkPermissionsResponse { permissions += PermissionName.CREATE }
+    wheneverBlocking { modelLinesMock.getModelLine(any()) } doReturn
+      modelLine { type = ModelLine.Type.DEV }
+    val request = batchCreateMetricsRequest {
+      parent = MEASUREMENT_CONSUMERS.values.first().name
+      requests += createMetricRequest {
+        parent = MEASUREMENT_CONSUMERS.values.first().name
+        metric = REQUESTING_INCREMENTAL_REACH_METRIC.copy { modelLine = devModelLine }
+        metricId = "metric-id1"
+      }
+      requests += createMetricRequest {
+        parent = MEASUREMENT_CONSUMERS.values.first().name
+        metric = REQUESTING_SINGLE_PUBLISHER_IMPRESSION_METRIC
+        metricId = "metric-id2"
+      }
+    }
+
+    val exception =
+      assertFailsWith<StatusRuntimeException> {
+        withPrincipalAndScopes(PRINCIPAL, SCOPES) {
+          runBlocking { service.batchCreateMetrics(request) }
+        }
+      }
+
+    assertThat(exception.status.code).isEqualTo(Status.Code.PERMISSION_DENIED)
+    assertThat(exception)
+      .hasMessageThat()
+      .contains(MetricsService.Permission.CREATE_WITH_DEV_MODEL_LINE)
+  }
+
+  @Test
   fun `batchCreateMetrics creates CMMS measurements with default model_line`() = runBlocking {
     service =
       MetricsService(
@@ -5865,7 +5944,7 @@ class MetricsServiceTest {
     // Verify proto argument of internal MeasurementsCoroutineImplBase::batchSetCmmsMeasurementId
     verifyProtoArgument(
         internalMeasurementsMock,
-        InternalMeasurementsGrpcKt.MeasurementsCoroutineImplBase::batchSetCmmsMeasurementIds,
+        InternalMeasurementsCoroutineImplBase::batchSetCmmsMeasurementIds,
       )
       .ignoringRepeatedFieldOrder()
       .isEqualTo(
@@ -6007,7 +6086,7 @@ class MetricsServiceTest {
     // Verify proto argument of internal MeasurementsCoroutineImplBase::batchSetCmmsMeasurementId
     verifyProtoArgument(
         internalMeasurementsMock,
-        InternalMeasurementsGrpcKt.MeasurementsCoroutineImplBase::batchSetCmmsMeasurementIds,
+        InternalMeasurementsCoroutineImplBase::batchSetCmmsMeasurementIds,
       )
       .ignoringRepeatedFieldOrder()
       .isEqualTo(
@@ -6133,17 +6212,17 @@ class MetricsServiceTest {
         errorInfo {
           domain = Errors.DOMAIN
           reason = Errors.Reason.INVALID_FIELD_VALUE.name
-          metadata[Errors.Metadata.FIELD_NAME.key] = "request.metric.model_line"
+          metadata[Errors.Metadata.FIELD_NAME.key] = "requests[0].metric.model_line"
         }
       )
   }
 
   @Test
-  fun `batchCreateMetrics throws NOT_FOUND when model_line not found`() {
+  fun `batchCreateMetrics throws FAILED_PRECONDITION when model_line not found`() {
     wheneverBlocking { modelLinesMock.getModelLine(any()) }
       .thenThrow(StatusRuntimeException(Status.NOT_FOUND))
 
-    val modelLineKey = ModelLineKey("123", "124", "125")
+    val modelLineName = "modelProviders/mp-1/modelSuites/ms-1/modelLines/absent"
     wheneverBlocking {
       permissionsServiceMock.checkPermissions(hasPrincipal(PRINCIPAL.name))
     } doReturn checkPermissionsResponse { permissions += PermissionName.CREATE }
@@ -6152,7 +6231,7 @@ class MetricsServiceTest {
 
       requests += createMetricRequest {
         parent = MEASUREMENT_CONSUMERS.values.first().name
-        metric = REQUESTING_INCREMENTAL_REACH_METRIC.copy { modelLine = modelLineKey.toName() }
+        metric = REQUESTING_INCREMENTAL_REACH_METRIC.copy { modelLine = modelLineName }
         metricId = "metric-id"
       }
     }
@@ -6164,13 +6243,13 @@ class MetricsServiceTest {
         }
       }
 
-    assertThat(exception.status.code).isEqualTo(Status.NOT_FOUND.code)
+    assertThat(exception.status.code).isEqualTo(Status.FAILED_PRECONDITION.code)
     assertThat(exception.errorInfo)
       .isEqualTo(
         errorInfo {
           domain = Errors.DOMAIN
-          reason = Errors.Reason.INVALID_FIELD_VALUE.name
-          metadata[Errors.Metadata.FIELD_NAME.key] = "request.metric.model_line"
+          reason = Errors.Reason.MODEL_LINE_NOT_FOUND.name
+          metadata[Errors.Metadata.MODEL_LINE.key] = modelLineName
         }
       )
   }
@@ -11491,7 +11570,7 @@ class MetricsServiceTest {
     // Verify proto argument of internal MeasurementsCoroutineImplBase::batchSetCmmsMeasurementId
     verifyProtoArgument(
         internalMeasurementsMock,
-        InternalMeasurementsGrpcKt.MeasurementsCoroutineImplBase::batchSetCmmsMeasurementIds,
+        InternalMeasurementsCoroutineImplBase::batchSetCmmsMeasurementIds,
       )
       .ignoringRepeatedFieldOrder()
       .isEqualTo(
@@ -11711,6 +11790,8 @@ class MetricsServiceTest {
     const val GET = "permissions/${MetricsService.Permission.GET}"
     const val LIST = "permissions/${MetricsService.Permission.LIST}"
     const val CREATE = "permissions/${MetricsService.Permission.CREATE}"
+    const val CREATE_WITH_DEV_MODEL_LINE =
+      "permissions/${MetricsService.Permission.CREATE_WITH_DEV_MODEL_LINE}"
     const val INVALIDATE = "permissions/${MetricsService.Permission.INVALIDATE}"
   }
 
@@ -11721,6 +11802,7 @@ class MetricsServiceTest {
         MetricsService.Permission.GET,
         MetricsService.Permission.LIST,
         MetricsService.Permission.CREATE,
+        MetricsService.Permission.CREATE_WITH_DEV_MODEL_LINE,
         MetricsService.Permission.INVALIDATE,
       )
     private val SCOPES = ALL_PERMISSIONS


### PR DESCRIPTION
Closes #3221

Issue: #3221
BREAKING-CHANGE: Creating a Metric (and therefore a Report or BasicReport) using a ModelLine of type DEV requires the Principal to have the `reporting.metrics.createWithDevModelLine` permission.
BREAKING-CHANGE: Creating a BasicReport using a ModelLine of type DEV requires the Principal to have the `reporting.basicReports.createWithDevModelLine` permission.