### PR TITLE
refactor: increase event groups list page size

### DIFF
--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/eventgroups/EventGroupSync.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/eventgroups/EventGroupSync.kt
@@ -238,6 +238,7 @@ class EventGroupSync(
                 listEventGroupsRequest {
                   parent = edpName
                   this.pageToken = pageToken
+                  pageSize = LIST_EVENT_GROUPS_PAGE_SIZE
                 }
               )
             }
@@ -261,6 +262,8 @@ class EventGroupSync(
 
   companion object {
     private val logger: Logger = Logger.getLogger(this::class.java.name)
+
+    private const val LIST_EVENT_GROUPS_PAGE_SIZE = 500
 
     /*
      * Validates that event groups fields are populated


### PR DESCRIPTION
# SUMMARY

Increase the page size used when fetching CMMS EventGroups from the Public API to reduce the total number of gRPC calls required during synchronization. Previously, the page size was implicitly defaulting to 10, leading to large quantities of paginated requests.

This change explicitly sets pageSize = 500 in the listEventGroupsRequest, and defines LIST_EVENT_GROUPS_PAGE_SIZE as a constant for maintainability.