### PR TITLE
feat: Improve accuracy of CreateBasicReportRequest validation errors

### DIFF
--- a/src/main/kotlin/org/wfanet/measurement/common/grpc/testing/BUILD.bazel
+++ b/src/main/kotlin/org/wfanet/measurement/common/grpc/testing/BUILD.bazel
@@ -1,0 +1,17 @@
+load("@wfa_rules_kotlin_jvm//kotlin:defs.bzl", "kt_jvm_library")
+
+package(
+    default_testonly = True,
+    default_visibility = ["//visibility:public"],
+)
+
+kt_jvm_library(
+    name = "status_exception_subject",
+    srcs = ["StatusExceptionSubject.kt"],
+    deps = [
+        "//src/main/kotlin/org/wfanet/measurement/common/grpc:error_info",
+        "@wfa_common_jvm//imports/java/com/google/common/truth",
+        "@wfa_common_jvm//imports/java/com/google/common/truth/extensions/proto",
+        "@wfa_common_jvm//imports/java/io/grpc:api",
+    ],
+)

--- a/src/main/kotlin/org/wfanet/measurement/common/grpc/testing/StatusExceptionSubject.kt
+++ b/src/main/kotlin/org/wfanet/measurement/common/grpc/testing/StatusExceptionSubject.kt
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2025 The Cross-Media Measurement Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wfanet.measurement.common.grpc.testing
+
+import com.google.common.truth.ComparableSubject
+import com.google.common.truth.FailureMetadata
+import com.google.common.truth.Subject
+import com.google.common.truth.ThrowableSubject
+import com.google.common.truth.Truth
+import com.google.common.truth.extensions.proto.ProtoSubject
+import com.google.common.truth.extensions.proto.ProtoTruth
+import com.google.rpc.ErrorInfo
+import io.grpc.Status
+import io.grpc.StatusException
+import io.grpc.StatusRuntimeException
+import org.wfanet.measurement.common.grpc.errorInfo
+
+/**
+ * Truth [Subject] for [StatusException] or [StatusRuntimeException].
+ *
+ * This includes more context in failure messages than less-specific subjects.
+ */
+class StatusExceptionSubject
+private constructor(metadata: FailureMetadata, private val actual: StatusExceptionAdapter?) :
+  ThrowableSubject(metadata, actual?.delegate) {
+  constructor(
+    metadata: FailureMetadata,
+    actual: StatusException?,
+  ) : this(metadata, actual?.let { StatusExceptionAdapter(actual) })
+
+  constructor(
+    metadata: FailureMetadata,
+    actual: StatusRuntimeException?,
+  ) : this(metadata, actual?.let { StatusExceptionAdapter(actual) })
+
+  fun status(): StatusSubject {
+    val status = checkNotNull(actual).status
+    return check("status")
+      .withMessage("errorInfo: ${actual.errorInfo}")
+      .about(StatusSubject.Factory)
+      .that(status)
+  }
+
+  fun errorInfo(): ProtoSubject {
+    return check("errorInfo").about(ProtoTruth.protos()).that(checkNotNull(actual).errorInfo)
+  }
+
+  private class StatusExceptionAdapter
+  private constructor(val delegate: Exception, val status: Status, val errorInfo: ErrorInfo?) {
+    constructor(e: StatusException) : this(e, e.status, e.errorInfo)
+
+    constructor(e: StatusRuntimeException) : this(e, e.status, e.errorInfo)
+  }
+
+  object Factory : Subject.Factory<StatusExceptionSubject, StatusException> {
+    override fun createSubject(
+      metadata: FailureMetadata,
+      actual: StatusException?,
+    ): StatusExceptionSubject = StatusExceptionSubject(metadata, actual)
+  }
+
+  object RuntimeFactory : Subject.Factory<StatusExceptionSubject, StatusRuntimeException> {
+    override fun createSubject(
+      metadata: FailureMetadata,
+      actual: StatusRuntimeException?,
+    ): StatusExceptionSubject = StatusExceptionSubject(metadata, actual)
+  }
+
+  companion object {
+    fun assertThat(actual: StatusException?) = Truth.assertAbout(Factory).that(actual)
+
+    fun assertThat(actual: StatusRuntimeException?) = Truth.assertAbout(RuntimeFactory).that(actual)
+  }
+}
+
+class StatusSubject(metadata: FailureMetadata, private val actual: Status?) :
+  Subject(metadata, actual) {
+  fun code(): ComparableSubject<Status.Code> {
+    checkNotNull(actual)
+    return check("code").withMessage("status: $actual").that(actual.code)
+  }
+
+  companion object Factory : Subject.Factory<StatusSubject, Status> {
+    override fun createSubject(metadata: FailureMetadata, actual: Status?): StatusSubject =
+      StatusSubject(metadata, actual)
+
+    fun assertThat(actual: Status?) = Truth.assertAbout(this)
+  }
+}

--- a/src/main/kotlin/org/wfanet/measurement/reporting/service/api/Errors.kt
+++ b/src/main/kotlin/org/wfanet/measurement/reporting/service/api/Errors.kt
@@ -40,6 +40,11 @@ object Errors {
     INVALID_METRIC_STATE_TRANSITION,
     ARGUMENT_CHANGED_IN_REQUEST_FOR_NEXT_PAGE,
     IMPRESSION_QUALIFICATION_FILTER_NOT_FOUND,
+    MODEL_LINE_NOT_FOUND,
+    MODEL_LINE_NOT_ACTIVE,
+    DATA_PROVIDER_NOT_FOUND_FOR_CAMPAIGN_GROUP,
+    /** A reference to a field in an event template is invalid for the Event message type. */
+    EVENT_TEMPLATE_FIELD_INVALID,
   }
 
   enum class Metadata(val key: String) {
@@ -49,7 +54,10 @@ object Errors {
     NEW_METRIC_STATE("newMetricState"),
     REPORTING_SET("reportingSet"),
     FIELD_NAME("fieldName"),
-    IMPRESSION_QUALIFICATION_FILTER("impressionQualificationFilter");
+    IMPRESSION_QUALIFICATION_FILTER("impressionQualificationFilter"),
+    MODEL_LINE("modelLine"),
+    DATA_PROVIDER("dataProvider"),
+    EVENT_TEMPLATE_FIELD_PATH("eventTemplateFieldPath");
 
     companion object {
       private val METADATA_BY_KEY by lazy { entries.associateBy { it.key } }
@@ -135,10 +143,14 @@ class CampaignGroupInvalidException(reportingSet: String, cause: Throwable? = nu
     cause,
   )
 
-class RequiredFieldNotSetException(fieldName: String, cause: Throwable? = null) :
+class RequiredFieldNotSetException(
+  fieldName: String,
+  cause: Throwable? = null,
+  buildMessage: (fieldName: String) -> String = { "$fieldName not set" },
+) :
   ServiceException(
     Errors.Reason.REQUIRED_FIELD_NOT_SET,
-    "$fieldName not set",
+    buildMessage(fieldName),
     mapOf(Errors.Metadata.FIELD_NAME to fieldName),
     cause,
   )
@@ -204,4 +216,49 @@ class ImpressionQualificationFilterNotFoundException(name: String, cause: Throwa
     "ImpressionQualificationFilter $name not found",
     mapOf(Errors.Metadata.IMPRESSION_QUALIFICATION_FILTER to name),
     cause,
-  ) {}
+  )
+
+class ModelLineNotFoundException(name: String, cause: Throwable? = null) :
+  ServiceException(
+    Errors.Reason.MODEL_LINE_NOT_FOUND,
+    "ModelLine $name not found",
+    mapOf(Errors.Metadata.MODEL_LINE to name),
+    cause,
+  )
+
+class ModelLineNotActiveException(name: String, cause: Throwable? = null) :
+  ServiceException(
+    Errors.Reason.MODEL_LINE_NOT_ACTIVE,
+    "ModelLine $name not active for the DataProviders within the interval",
+    mapOf(Errors.Metadata.MODEL_LINE to name),
+    cause,
+  )
+
+class DataProviderNotFoundForCampaignGroupException(
+  dataProviderName: String,
+  reportingSetName: String,
+  cause: Throwable? = null,
+) :
+  ServiceException(
+    Errors.Reason.DATA_PROVIDER_NOT_FOUND_FOR_CAMPAIGN_GROUP,
+    "$dataProviderName has no EventGroups in Campaign Group $reportingSetName",
+    mapOf(
+      Errors.Metadata.DATA_PROVIDER to dataProviderName,
+      Errors.Metadata.REPORTING_SET to reportingSetName,
+    ),
+    cause,
+  )
+
+class EventTemplateFieldInvalidException(
+  eventTemplateFieldPath: String,
+  cause: Throwable? = null,
+  buildMessage: (eventTemplateFieldPath: String) -> String = {
+    "Reference to field $eventTemplateFieldPath is invalid for the event message type"
+  },
+) :
+  ServiceException(
+    Errors.Reason.EVENT_TEMPLATE_FIELD_INVALID,
+    buildMessage(eventTemplateFieldPath),
+    mapOf(Errors.Metadata.EVENT_TEMPLATE_FIELD_PATH to eventTemplateFieldPath),
+    cause,
+  )

--- a/src/main/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/BasicReportsService.kt
+++ b/src/main/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/BasicReportsService.kt
@@ -46,7 +46,7 @@ import org.wfanet.measurement.config.reporting.MetricSpecConfig
 import org.wfanet.measurement.internal.reporting.ErrorCode
 import org.wfanet.measurement.internal.reporting.v2.BasicReport as InternalBasicReport
 import org.wfanet.measurement.internal.reporting.v2.BasicReportsGrpcKt.BasicReportsCoroutineStub
-import org.wfanet.measurement.internal.reporting.v2.ImpressionQualificationFilter as ImpressionQualificationFilter
+import org.wfanet.measurement.internal.reporting.v2.ImpressionQualificationFilter as InternalImpressionQualificationFilter
 import org.wfanet.measurement.internal.reporting.v2.ImpressionQualificationFiltersGrpcKt.ImpressionQualificationFiltersCoroutineStub
 import org.wfanet.measurement.internal.reporting.v2.ListBasicReportsPageToken
 import org.wfanet.measurement.internal.reporting.v2.ListBasicReportsPageTokenKt
@@ -58,7 +58,6 @@ import org.wfanet.measurement.internal.reporting.v2.MetricCalculationSpec
 import org.wfanet.measurement.internal.reporting.v2.MetricCalculationSpecsGrpcKt.MetricCalculationSpecsCoroutineStub as InternalMetricCalculationSpecsCoroutineStub
 import org.wfanet.measurement.internal.reporting.v2.MetricSpec
 import org.wfanet.measurement.internal.reporting.v2.MetricSpecKt
-import org.wfanet.measurement.internal.reporting.v2.ReportingImpressionQualificationFilter as InternalReportingImpressionQualificationFilter
 import org.wfanet.measurement.internal.reporting.v2.ReportingSet as InternalReportingSet
 import org.wfanet.measurement.internal.reporting.v2.ReportingSetsGrpcKt.ReportingSetsCoroutineStub as InternalReportingSetsCoroutineStub
 import org.wfanet.measurement.internal.reporting.v2.StreamReportingSetsRequestKt
@@ -74,18 +73,19 @@ import org.wfanet.measurement.internal.reporting.v2.listBasicReportsRequest as i
 import org.wfanet.measurement.internal.reporting.v2.listMetricCalculationSpecsRequest
 import org.wfanet.measurement.internal.reporting.v2.metricCalculationSpec
 import org.wfanet.measurement.internal.reporting.v2.metricSpec
-import org.wfanet.measurement.internal.reporting.v2.reportingImpressionQualificationFilter
 import org.wfanet.measurement.internal.reporting.v2.setExternalReportIdRequest
 import org.wfanet.measurement.internal.reporting.v2.streamReportingSetsRequest
 import org.wfanet.measurement.reporting.service.api.ArgumentChangedInRequestForNextPageException
 import org.wfanet.measurement.reporting.service.api.BasicReportAlreadyExistsException
 import org.wfanet.measurement.reporting.service.api.BasicReportNotFoundException
-import org.wfanet.measurement.reporting.service.api.Errors
+import org.wfanet.measurement.reporting.service.api.CampaignGroupInvalidException
+import org.wfanet.measurement.reporting.service.api.DataProviderNotFoundForCampaignGroupException
+import org.wfanet.measurement.reporting.service.api.EventTemplateFieldInvalidException
+import org.wfanet.measurement.reporting.service.api.FieldUnimplementedException
 import org.wfanet.measurement.reporting.service.api.ImpressionQualificationFilterNotFoundException
 import org.wfanet.measurement.reporting.service.api.InvalidFieldValueException
 import org.wfanet.measurement.reporting.service.api.ReportingSetNotFoundException
 import org.wfanet.measurement.reporting.service.api.RequiredFieldNotSetException
-import org.wfanet.measurement.reporting.service.api.ServiceException
 import org.wfanet.measurement.reporting.service.internal.Errors as InternalErrors
 import org.wfanet.measurement.reporting.service.internal.ReportingInternalException
 import org.wfanet.measurement.reporting.v2alpha.BasicReport
@@ -97,12 +97,14 @@ import org.wfanet.measurement.reporting.v2alpha.ListBasicReportsRequest
 import org.wfanet.measurement.reporting.v2alpha.ListBasicReportsResponse
 import org.wfanet.measurement.reporting.v2alpha.Report
 import org.wfanet.measurement.reporting.v2alpha.ReportKt
+import org.wfanet.measurement.reporting.v2alpha.ReportingImpressionQualificationFilter
 import org.wfanet.measurement.reporting.v2alpha.ReportingSet
 import org.wfanet.measurement.reporting.v2alpha.ReportingSetKt
 import org.wfanet.measurement.reporting.v2alpha.ReportsGrpcKt.ReportsCoroutineStub
 import org.wfanet.measurement.reporting.v2alpha.createReportRequest
 import org.wfanet.measurement.reporting.v2alpha.listBasicReportsResponse
 import org.wfanet.measurement.reporting.v2alpha.report
+import org.wfanet.measurement.reporting.v2alpha.reportingImpressionQualificationFilter
 import org.wfanet.measurement.reporting.v2alpha.reportingSet
 
 class BasicReportsService(
@@ -118,7 +120,7 @@ class BasicReportsService(
   private val secureRandom: Random,
   private val authorization: Authorization,
   private val measurementConsumerConfigs: MeasurementConsumerConfigs,
-  private val baseImpressionQualificationFilters: List<ImpressionQualificationFilter>,
+  baseImpressionQualificationFilters: Iterable<InternalImpressionQualificationFilter>,
   coroutineContext: CoroutineContext = EmptyCoroutineContext,
 ) : BasicReportsCoroutineImplBase(coroutineContext) {
   private sealed class ReportingSetMapKey {
@@ -127,25 +129,13 @@ class BasicReportsService(
     data class Primitive(val cmmsEventGroups: Set<String>) : ReportingSetMapKey()
   }
 
-  private val baseInternalReportingQualificationFilterByImpressionQualificationFilterName:
-    Map<String, InternalReportingImpressionQualificationFilter> =
-    buildMap {
-      for (baseImpressionQualificationFilter in baseImpressionQualificationFilters) {
-        val key =
-          ImpressionQualificationFilterKey(
-            baseImpressionQualificationFilter.externalImpressionQualificationFilterId
-          )
-
-        put(
-          key.toName(),
-          reportingImpressionQualificationFilter {
-            externalImpressionQualificationFilterId =
-              baseImpressionQualificationFilter.externalImpressionQualificationFilterId
-            filterSpecs += baseImpressionQualificationFilter.filterSpecsList
-          },
-        )
-      }
+  private val baseInternalImpressionQualificationFilterByKey:
+    Map<ImpressionQualificationFilterKey, InternalImpressionQualificationFilter> =
+    baseImpressionQualificationFilters.associateBy {
+      ImpressionQualificationFilterKey(it.externalImpressionQualificationFilterId)
     }
+  private val baseImpressionQualificationFilterNames =
+    baseInternalImpressionQualificationFilterByKey.keys.map { it.toName() }
 
   private data class ReportingSetMaps(
     // Map of DataProvider resource name to Primitive ReportingSet
@@ -155,57 +145,49 @@ class BasicReportsService(
   )
 
   override suspend fun createBasicReport(request: CreateBasicReportRequest): BasicReport {
-    if (request.parent.isEmpty()) {
-      throw RequiredFieldNotSetException("parent")
-        .asStatusRuntimeException(Status.Code.INVALID_ARGUMENT)
-    }
-
-    val measurementConsumerKey =
-      MeasurementConsumerKey.fromName(request.parent)
-        ?: throw InvalidFieldValueException("parent")
-          .asStatusRuntimeException(Status.Code.INVALID_ARGUMENT)
-
-    authorization.check(listOf(request.parent, measurementConsumerKey.toName()), Permission.CREATE)
+    val eventTemplateFieldsByPath = eventMessageDescriptor?.eventTemplateFieldsByPath ?: emptyMap()
 
     if (request.basicReport.campaignGroup.isEmpty()) {
       throw RequiredFieldNotSetException("basic_report.campaign_group")
         .asStatusRuntimeException(Status.Code.INVALID_ARGUMENT)
     }
-
     val campaignGroupKey =
       ReportingSetKey.fromName(request.basicReport.campaignGroup)
-        ?: throw InvalidFieldValueException("basic_report.campaign_group")
+        ?: throw InvalidFieldValueException("basic_report.campaign_group") { fieldPath ->
+            "$fieldPath is not a valid ReportingSet resource name"
+          }
           .asStatusRuntimeException(Status.Code.INVALID_ARGUMENT)
-
-    // Required for creating Report
-    val campaignGroup: ReportingSet = getReportingSet(request.basicReport.campaignGroup)
-
-    val eventTemplateFieldsByPath = eventMessageDescriptor?.eventTemplateFieldsByPath ?: emptyMap()
-
-    try {
-      validateCreateBasicReportRequest(
-        request,
-        campaignGroup,
-        eventTemplateFieldsByPath,
-        baseImpressionQualificationFilters.isEmpty(),
-      )
-    } catch (e: ServiceException) {
-      throw when (e.reason) {
-        Errors.Reason.REQUIRED_FIELD_NOT_SET,
-        Errors.Reason.INVALID_FIELD_VALUE ->
-          e.asStatusRuntimeException(Status.Code.INVALID_ARGUMENT)
-        Errors.Reason.FIELD_UNIMPLEMENTED -> e.asStatusRuntimeException(Status.Code.UNIMPLEMENTED)
-        Errors.Reason.BASIC_REPORT_NOT_FOUND,
-        Errors.Reason.BASIC_REPORT_ALREADY_EXISTS,
-        Errors.Reason.REPORTING_SET_NOT_FOUND,
-        Errors.Reason.METRIC_NOT_FOUND,
-        Errors.Reason.CAMPAIGN_GROUP_INVALID,
-        Errors.Reason.INVALID_METRIC_STATE_TRANSITION,
-        Errors.Reason.ARGUMENT_CHANGED_IN_REQUEST_FOR_NEXT_PAGE,
-        Errors.Reason.IMPRESSION_QUALIFICATION_FILTER_NOT_FOUND ->
-          e.asStatusRuntimeException(Status.Code.INTERNAL) // Shouldn't be reached
+    val campaignGroup: ReportingSet =
+      try {
+        getReportingSet(campaignGroupKey)
+      } catch (e: ReportingSetNotFoundException) {
+        throw e.asStatusRuntimeException(Status.Code.FAILED_PRECONDITION)
       }
+    if (campaignGroup.campaignGroup != campaignGroup.name) {
+      throw CampaignGroupInvalidException(request.basicReport.campaignGroup)
+        .asStatusRuntimeException(Status.Code.FAILED_PRECONDITION)
     }
+
+    val (parentKey: MeasurementConsumerKey, requestImpressionQualificationFilterKeys) =
+      try {
+        CreateBasicReportRequestValidation.validateRequest(
+          request,
+          campaignGroup,
+          eventTemplateFieldsByPath,
+        )
+      } catch (e: RequiredFieldNotSetException) {
+        throw e.asStatusRuntimeException(Status.Code.INVALID_ARGUMENT)
+      } catch (e: InvalidFieldValueException) {
+        throw e.asStatusRuntimeException(Status.Code.INVALID_ARGUMENT)
+      } catch (e: FieldUnimplementedException) {
+        throw e.asStatusRuntimeException(Status.Code.UNIMPLEMENTED)
+      } catch (e: DataProviderNotFoundForCampaignGroupException) {
+        throw e.asStatusRuntimeException(Status.Code.FAILED_PRECONDITION)
+      } catch (e: EventTemplateFieldInvalidException) {
+        throw e.asStatusRuntimeException(Status.Code.INVALID_ARGUMENT)
+      }
+
+    authorization.check(request.parent, Permission.CREATE)
 
     val reportingSetMaps: ReportingSetMaps = buildReportingSetMaps(campaignGroup, campaignGroupKey)
 
@@ -215,7 +197,7 @@ class BasicReportsService(
           .asRuntimeException()
 
     val measurementConsumerCredentials =
-      MeasurementConsumerCredentials.fromConfig(measurementConsumerKey, measurementConsumerConfig)
+      MeasurementConsumerCredentials.fromConfig(parentKey, measurementConsumerConfig)
 
     val validModelLines =
       kingdomModelLinesStub
@@ -254,98 +236,46 @@ class BasicReportsService(
         ""
       }
 
-    // Validates that IQFs exist, but also constructs a List required for creating Report
-    val impressionQualificationFilterSpecsLists:
-      MutableList<List<ImpressionQualificationFilterSpec>> =
-      mutableListOf()
-
-    impressionQualificationFilterSpecsLists.addAll(
-      baseImpressionQualificationFilters.map { baseImpressionQualificationFilter ->
-        baseImpressionQualificationFilter.filterSpecsList.map {
-          it.toImpressionQualificationFilterSpec()
+    val impressionQualificationFilterKeyByName: Map<String, ImpressionQualificationFilterKey> =
+      (baseInternalImpressionQualificationFilterByKey.keys +
+          requestImpressionQualificationFilterKeys)
+        .associateBy { it.toName() }
+    val effectiveReportingImpressionQualificationFilters:
+      List<ReportingImpressionQualificationFilter> =
+      baseImpressionQualificationFilterNames.map {
+        reportingImpressionQualificationFilter { impressionQualificationFilter = it }
+      } +
+        request.basicReport.impressionQualificationFiltersList.filter {
+          it.impressionQualificationFilter !in baseImpressionQualificationFilterNames
         }
-      }
-    )
-
-    val internalReportingImpressionQualificationFilters:
-      List<InternalReportingImpressionQualificationFilter> =
-      buildList {
-        for (impressionQualificationFilter in
-          request.basicReport.impressionQualificationFiltersList) {
-          if (impressionQualificationFilter.hasImpressionQualificationFilter()) {
-            if (
-              baseInternalReportingQualificationFilterByImpressionQualificationFilterName.contains(
-                impressionQualificationFilter.impressionQualificationFilter
-              )
-            ) {
-              add(
-                baseInternalReportingQualificationFilterByImpressionQualificationFilterName
-                  .getValue(impressionQualificationFilter.impressionQualificationFilter)
-              )
-              continue
-            }
-
-            val key =
-              ImpressionQualificationFilterKey.fromName(
-                impressionQualificationFilter.impressionQualificationFilter
-              )
+    if (effectiveReportingImpressionQualificationFilters.isEmpty()) {
+      throw RequiredFieldNotSetException("basic_report.impression_qualification_filters") {
+          fieldPath ->
+          "$fieldPath must be set when there are no base ImpressionQualificationFilters configured"
+        }
+        .asStatusRuntimeException(Status.Code.INVALID_ARGUMENT)
+    }
+    // Validates that IQFs exist, but also constructs a List required for creating Report
+    val impressionQualificationFilterSpecLists: List<List<ImpressionQualificationFilterSpec>> =
+      effectiveReportingImpressionQualificationFilters.map {
+        if (it.hasImpressionQualificationFilter()) {
+          val impressionQualificationFilterKey =
+            impressionQualificationFilterKeyByName.getValue(it.impressionQualificationFilter)
+          val internalImpressionQualificationFilter: InternalImpressionQualificationFilter =
             try {
-              val internalImpressionQualificationFilter =
-                internalImpressionQualificationFiltersStub.getImpressionQualificationFilter(
-                  getImpressionQualificationFilterRequest {
-                    externalImpressionQualificationFilterId = key!!.impressionQualificationFilterId
-                  }
-                )
-
-              add(
-                reportingImpressionQualificationFilter {
-                  externalImpressionQualificationFilterId =
-                    internalImpressionQualificationFilter.externalImpressionQualificationFilterId
-                  filterSpecs += internalImpressionQualificationFilter.filterSpecsList
-                }
-              )
-
-              impressionQualificationFilterSpecsLists.add(
-                internalImpressionQualificationFilter
-                  .toImpressionQualificationFilter()
-                  .filterSpecsList
-              )
-            } catch (e: StatusException) {
-              throw when (InternalErrors.getReason(e)) {
-                InternalErrors.Reason.IMPRESSION_QUALIFICATION_FILTER_NOT_FOUND ->
-                  ImpressionQualificationFilterNotFoundException(
-                      impressionQualificationFilter.impressionQualificationFilter
-                    )
-                    .asStatusRuntimeException(Status.Code.FAILED_PRECONDITION)
-                InternalErrors.Reason.BASIC_REPORT_NOT_FOUND,
-                InternalErrors.Reason.MEASUREMENT_CONSUMER_NOT_FOUND,
-                InternalErrors.Reason.BASIC_REPORT_ALREADY_EXISTS,
-                InternalErrors.Reason.REQUIRED_FIELD_NOT_SET,
-                InternalErrors.Reason.INVALID_FIELD_VALUE,
-                InternalErrors.Reason.METRIC_NOT_FOUND,
-                InternalErrors.Reason.INVALID_METRIC_STATE_TRANSITION,
-                InternalErrors.Reason.REPORT_RESULT_NOT_FOUND,
-                InternalErrors.Reason.REPORTING_SET_RESULT_NOT_FOUND,
-                InternalErrors.Reason.REPORTING_WINDOW_RESULT_NOT_FOUND,
-                InternalErrors.Reason.BASIC_REPORT_STATE_INVALID,
-                null -> Status.INTERNAL.withCause(e).asRuntimeException()
-              }
+              getInternalImpressionQualificationFilter(impressionQualificationFilterKey)
+            } catch (e: ImpressionQualificationFilterNotFoundException) {
+              throw e.asStatusRuntimeException(Status.Code.FAILED_PRECONDITION)
             }
-          } else if (impressionQualificationFilter.hasCustom()) {
-            add(impressionQualificationFilter.toInternal())
-            impressionQualificationFilterSpecsLists.add(
-              impressionQualificationFilter.custom.filterSpecList
-            )
+          internalImpressionQualificationFilter.filterSpecsList.map { internalFilterSpec ->
+            internalFilterSpec.toImpressionQualificationFilterSpec()
           }
+        } else {
+          it.custom.filterSpecList
         }
       }
 
     val createReportRequestId = UUID.randomUUID().toString()
-
-    val basicReportImpressionQualificationFilterNames: List<String> =
-      request.basicReport.impressionQualificationFiltersList
-        .filter { it.hasImpressionQualificationFilter() }
-        .map { it.impressionQualificationFilter }
 
     val createdInternalBasicReport =
       try {
@@ -353,17 +283,14 @@ class BasicReportsService(
           createBasicReportRequest {
             basicReport =
               request.basicReport.toInternal(
-                cmmsMeasurementConsumerId = measurementConsumerKey.measurementConsumerId,
+                cmmsMeasurementConsumerId = parentKey.measurementConsumerId,
                 basicReportId = request.basicReportId,
                 campaignGroupId = campaignGroupKey.reportingSetId,
                 createReportRequestId = createReportRequestId,
                 internalReportingImpressionQualificationFilters =
-                  internalReportingImpressionQualificationFilters,
+                  request.basicReport.impressionQualificationFiltersList.map { it.toInternal() },
                 internalEffectiveReportingImpressionQualificationFilters =
-                  baseInternalReportingQualificationFilterByImpressionQualificationFilterName
-                    .entries
-                    .filterNot { it.key in basicReportImpressionQualificationFilterNames }
-                    .map { it.value } + internalReportingImpressionQualificationFilters,
+                  effectiveReportingImpressionQualificationFilters.map { it.toInternal() },
                 effectiveModelLine = modelLine,
               )
             requestId = request.requestId
@@ -374,7 +301,7 @@ class BasicReportsService(
           InternalErrors.Reason.BASIC_REPORT_ALREADY_EXISTS ->
             BasicReportAlreadyExistsException(
                 BasicReportKey(
-                    cmmsMeasurementConsumerId = measurementConsumerKey.measurementConsumerId,
+                    cmmsMeasurementConsumerId = parentKey.measurementConsumerId,
                     basicReportId = request.basicReportId,
                   )
                   .toName()
@@ -399,7 +326,7 @@ class BasicReportsService(
       Map<ReportingSet, List<InternalMetricCalculationSpec.Details>> =
       buildReportingSetMetricCalculationSpecDetailsMap(
         campaignGroupName = request.basicReport.campaignGroup,
-        impressionQualificationFilterSpecsLists = impressionQualificationFilterSpecsLists,
+        impressionQualificationFilterSpecsLists = impressionQualificationFilterSpecLists,
         dataProviderPrimitiveReportingSetMap =
           reportingSetMaps.primitiveReportingSetsByDataProvider,
         resultGroupSpecs = request.basicReport.resultGroupSpecsList,
@@ -426,13 +353,52 @@ class BasicReportsService(
 
     internalBasicReportsStub.setExternalReportId(
       setExternalReportIdRequest {
-        cmmsMeasurementConsumerId = measurementConsumerKey.measurementConsumerId
+        cmmsMeasurementConsumerId = parentKey.measurementConsumerId
         externalBasicReportId = request.basicReportId
         externalReportId = createReportRequest.reportId
       }
     )
 
     return createdInternalBasicReport.toBasicReport()
+  }
+
+  /**
+   * Gets an [InternalImpressionQualificationFilter].
+   *
+   * @throws ImpressionQualificationFilterNotFoundException
+   */
+  private suspend fun getInternalImpressionQualificationFilter(
+    key: ImpressionQualificationFilterKey
+  ): InternalImpressionQualificationFilter {
+    val baseInternalIqf = baseInternalImpressionQualificationFilterByKey[key]
+    if (baseInternalIqf != null) {
+      return baseInternalIqf
+    }
+
+    return try {
+      internalImpressionQualificationFiltersStub.getImpressionQualificationFilter(
+        getImpressionQualificationFilterRequest {
+          externalImpressionQualificationFilterId = key.impressionQualificationFilterId
+        }
+      )
+    } catch (e: StatusException) {
+      throw when (InternalErrors.getReason(e)) {
+        InternalErrors.Reason.IMPRESSION_QUALIFICATION_FILTER_NOT_FOUND ->
+          ImpressionQualificationFilterNotFoundException(key.toName())
+        InternalErrors.Reason.BASIC_REPORT_NOT_FOUND,
+        InternalErrors.Reason.MEASUREMENT_CONSUMER_NOT_FOUND,
+        InternalErrors.Reason.BASIC_REPORT_ALREADY_EXISTS,
+        InternalErrors.Reason.REQUIRED_FIELD_NOT_SET,
+        InternalErrors.Reason.INVALID_FIELD_VALUE,
+        InternalErrors.Reason.METRIC_NOT_FOUND,
+        InternalErrors.Reason.INVALID_METRIC_STATE_TRANSITION,
+        InternalErrors.Reason.REPORT_RESULT_NOT_FOUND,
+        InternalErrors.Reason.REPORTING_SET_RESULT_NOT_FOUND,
+        InternalErrors.Reason.REPORTING_WINDOW_RESULT_NOT_FOUND,
+        InternalErrors.Reason.BASIC_REPORT_STATE_INVALID,
+        null -> Exception("Error retrieving internal ImpressionQualificationFilter", e)
+      }
+    }
   }
 
   override suspend fun getBasicReport(request: GetBasicReportRequest): BasicReport {
@@ -534,15 +500,18 @@ class BasicReportsService(
     }
   }
 
-  /** Get a single [ReportingSet] */
-  private suspend fun getReportingSet(name: String): ReportingSet {
-    val reportingSetKey = ReportingSetKey.fromName(name)!!
+  /**
+   * Gets a single [ReportingSet].
+   *
+   * @throws ReportingSetNotFoundException
+   */
+  private suspend fun getReportingSet(key: ReportingSetKey): ReportingSet {
     return try {
       internalReportingSetsStub
         .batchGetReportingSets(
           batchGetReportingSetsRequest {
-            cmmsMeasurementConsumerId = reportingSetKey.cmmsMeasurementConsumerId
-            externalReportingSetIds += reportingSetKey.reportingSetId
+            cmmsMeasurementConsumerId = key.cmmsMeasurementConsumerId
+            externalReportingSetIds += key.reportingSetId
           }
         )
         .reportingSetsList
@@ -550,9 +519,7 @@ class BasicReportsService(
         .toReportingSet()
     } catch (e: StatusException) {
       throw when (ReportingInternalException.getErrorCode(e)) {
-        ErrorCode.REPORTING_SET_NOT_FOUND ->
-          throw ReportingSetNotFoundException(name)
-            .asStatusRuntimeException(Status.Code.FAILED_PRECONDITION)
+        ErrorCode.REPORTING_SET_NOT_FOUND -> ReportingSetNotFoundException(key.toName())
         ErrorCode.MEASUREMENT_CONSUMER_NOT_FOUND,
         ErrorCode.REPORTING_SET_ALREADY_EXISTS,
         ErrorCode.CAMPAIGN_GROUP_INVALID,
@@ -573,7 +540,7 @@ class BasicReportsService(
         ErrorCode.METRIC_CALCULATION_SPEC_NOT_FOUND,
         ErrorCode.METRIC_CALCULATION_SPEC_ALREADY_EXISTS,
         ErrorCode.UNRECOGNIZED,
-        null -> Status.INTERNAL.withCause(e).asRuntimeException()
+        null -> Exception("Internal error retrieving ReportingSet", e)
       }
     }
   }

--- a/src/main/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/CreateBasicReportRequestValidation.kt
+++ b/src/main/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/CreateBasicReportRequestValidation.kt
@@ -19,15 +19,16 @@ package org.wfanet.measurement.reporting.service.api.v2alpha
 import com.google.protobuf.Descriptors
 import io.grpc.Status
 import java.util.UUID
-import kotlin.collections.List
 import kotlin.collections.Set
-import org.wfanet.measurement.api.v2alpha.DataProvider
 import org.wfanet.measurement.api.v2alpha.DataProviderKey
 import org.wfanet.measurement.api.v2alpha.EventGroupKey
 import org.wfanet.measurement.api.v2alpha.EventMessageDescriptor
+import org.wfanet.measurement.api.v2alpha.MeasurementConsumerKey
 import org.wfanet.measurement.api.v2alpha.ModelLineKey
 import org.wfanet.measurement.common.api.ResourceIds
 import org.wfanet.measurement.common.mediatype.toEventAnnotationMediaType
+import org.wfanet.measurement.reporting.service.api.DataProviderNotFoundForCampaignGroupException
+import org.wfanet.measurement.reporting.service.api.EventTemplateFieldInvalidException
 import org.wfanet.measurement.reporting.service.api.FieldUnimplementedException
 import org.wfanet.measurement.reporting.service.api.InvalidFieldValueException
 import org.wfanet.measurement.reporting.service.api.RequiredFieldNotSetException
@@ -44,679 +45,663 @@ import org.wfanet.measurement.reporting.v2alpha.ReportingUnit
 import org.wfanet.measurement.reporting.v2alpha.ResultGroupMetricSpec
 import org.wfanet.measurement.reporting.v2alpha.ResultGroupSpec
 
-private val RESOURCE_ID_REGEX = ResourceIds.AIP_122_REGEX
+object CreateBasicReportRequestValidation {
+  private val RESOURCE_ID_REGEX = ResourceIds.AIP_122_REGEX
 
-/**
- * Validates a [CreateBasicReportRequest]. Only supports validation that does not requires gRPC
- * calls
- *
- * @param request
- * @param campaignGroup
- * @param eventTemplateFieldsByPath Map of EventTemplate field path with respect to Event message to
- *   info for the field. Used for validating [EventTemplateField]
- * @param requireImpressionQualificationFilters Whether impression_qualification_filters field is
- *   required or not
- * @throws [RequiredFieldNotSetException] when validation fails
- * @throws [InvalidFieldValueException] when validation fails
- */
-fun validateCreateBasicReportRequest(
-  request: CreateBasicReportRequest,
-  campaignGroup: ReportingSet,
-  eventTemplateFieldsByPath: Map<String, EventMessageDescriptor.EventTemplateFieldInfo>,
-  requireImpressionQualificationFilters: Boolean,
-) {
-  if (request.basicReportId.isEmpty()) {
-    throw RequiredFieldNotSetException("basic_report_id")
+  data class ParsedFields(
+    val parentKey: MeasurementConsumerKey,
+    val impressionQualificationFilterKeys: Set<ImpressionQualificationFilterKey>,
+  )
+
+  private data class CampaignGroupInfo(val name: String, val dataProviderNames: Set<String>) {
+    constructor(
+      campaignGroup: ReportingSet
+    ) : this(
+      campaignGroup.name,
+      buildSet {
+        for (eventGroupName in campaignGroup.primitive.cmmsEventGroupsList) {
+          val eventGroupKey = requireNotNull(EventGroupKey.fromName(eventGroupName))
+          add(eventGroupKey.parentKey.toName())
+        }
+      },
+    )
   }
 
-  if (!request.basicReportId.matches(RESOURCE_ID_REGEX)) {
-    throw InvalidFieldValueException("basic_report_id")
-  }
-
-  if (request.requestId.isNotEmpty()) {
-    try {
-      UUID.fromString(request.requestId)
-    } catch (e: IllegalArgumentException) {
-      throw InvalidFieldValueException("request_id") { "Not a UUID" }
+  /**
+   * Validates [request].
+   *
+   * This does not validate the
+   * [request.basicReport.campaignGroup][org.wfanet.measurement.reporting.v2alpha.BasicReport.campaignGroup]
+   * field.
+   *
+   * @throws InvalidFieldValueException
+   * @throws RequiredFieldNotSetException
+   * @throws DataProviderNotFoundForCampaignGroupException
+   * @throws EventTemplateFieldInvalidException
+   * @throws FieldUnimplementedException
+   */
+  fun validateRequest(
+    request: CreateBasicReportRequest,
+    campaignGroup: ReportingSet,
+    eventTemplateFieldsByPath: Map<String, EventMessageDescriptor.EventTemplateFieldInfo>,
+  ): ParsedFields {
+    if (request.basicReportId.isEmpty()) {
+      throw RequiredFieldNotSetException("basic_report_id")
     }
-  }
 
-  if (campaignGroup.campaignGroup != campaignGroup.name) {
-    throw InvalidFieldValueException("basic_report.campaign_group") { "Not a Campaign Group" }
-  }
+    if (!request.basicReportId.matches(RESOURCE_ID_REGEX)) {
+      throw InvalidFieldValueException("basic_report_id")
+    }
 
-  if (request.basicReport.hasReportingInterval()) {
-    validateReportingInterval(request.basicReport.reportingInterval)
-  } else {
-    throw RequiredFieldNotSetException("basic_report.reporting_interval")
-  }
+    if (request.requestId.isNotEmpty()) {
+      try {
+        UUID.fromString(request.requestId)
+      } catch (e: IllegalArgumentException) {
+        throw InvalidFieldValueException("request_id", e) { fieldPath ->
+          "$fieldPath is not a valid UUID"
+        }
+      }
+    }
 
-  if (request.basicReport.modelLine.isNotEmpty()) {
-    ModelLineKey.fromName(request.basicReport.modelLine)
-      ?: throw InvalidFieldValueException("basic_report.model_line")
+    if (request.parent.isEmpty()) {
+      throw RequiredFieldNotSetException("parent")
         .asStatusRuntimeException(Status.Code.INVALID_ARGUMENT)
-  }
-
-  validateReportingImpressionQualificationFilters(
-    request.basicReport.impressionQualificationFiltersList,
-    eventTemplateFieldsByPath,
-    requireImpressionQualificationFilters,
-  )
-  validateResultGroupSpecs(
-    request.basicReport.resultGroupSpecsList,
-    campaignGroup,
-    eventTemplateFieldsByPath,
-  )
-}
-
-/**
- * Validates a [List] of [ResultGroupSpec]
- *
- * @param resultGroupSpecs [List] of [ResultGroupSpec] to validate
- * @param campaignGroup [ReportingSet] to validate against
- * @param eventTemplateFieldsByPath Map of EventTemplate field path with respect to Event message to
- *   info for the field. Used for validating [EventTemplateField]
- * @throws [RequiredFieldNotSetException] when validation fails
- * @throws [InvalidFieldValueException] when validation fails
- */
-fun validateResultGroupSpecs(
-  resultGroupSpecs: List<ResultGroupSpec>,
-  campaignGroup: ReportingSet,
-  eventTemplateFieldsByPath: Map<String, EventMessageDescriptor.EventTemplateFieldInfo>,
-) {
-  if (resultGroupSpecs.isEmpty()) {
-    throw RequiredFieldNotSetException("basic_report.result_group_specs")
-  }
-
-  val dataProviderNameSet: Set<String> = buildSet {
-    for (cmmsEventGroup in campaignGroup.primitive.cmmsEventGroupsList) {
-      val eventGroupKey = EventGroupKey.fromName(cmmsEventGroup)
-      add(eventGroupKey!!.parentKey.toName())
     }
-  }
+    val parentKey =
+      MeasurementConsumerKey.fromName(request.parent)
+        ?: throw InvalidFieldValueException("parent") { fieldPath ->
+          "$fieldPath is not a valid MeasurmentConsumer resource name"
+        }
 
-  for (resultGroupSpec in resultGroupSpecs) {
-    if (
-      resultGroupSpec.metricFrequency.selectorCase ==
-        MetricFrequencySpec.SelectorCase.SELECTOR_NOT_SET
-    ) {
-      throw RequiredFieldNotSetException("basic_report.result_group_specs.metric_frequency")
+    if (!request.hasBasicReport()) {
+      throw RequiredFieldNotSetException("basic_report")
     }
-
-    if (resultGroupSpec.hasReportingUnit()) {
-      validateReportingUnit(resultGroupSpec.reportingUnit, dataProviderNameSet)
+    if (request.basicReport.hasReportingInterval()) {
+      validateReportingInterval(request.basicReport.reportingInterval)
     } else {
-      throw RequiredFieldNotSetException("basic_report.result_group_specs.reporting_unit")
+      throw RequiredFieldNotSetException("basic_report.reporting_interval")
     }
-
-    if (resultGroupSpec.hasDimensionSpec()) {
-      validateDimensionSpec(resultGroupSpec.dimensionSpec, eventTemplateFieldsByPath)
-    } else {
-      throw RequiredFieldNotSetException("basic_report.result_group_specs.dimension_spec")
+    if (request.basicReport.modelLine.isNotEmpty()) {
+      ModelLineKey.fromName(request.basicReport.modelLine)
+        ?: throw InvalidFieldValueException("basic_report.model_line")
     }
-
-    if (resultGroupSpec.hasResultGroupMetricSpec()) {
-      validateResultGroupMetricSpec(
-        resultGroupSpec.resultGroupMetricSpec,
-        resultGroupSpec.metricFrequency.selectorCase,
+    val impressionQualificationFilterKeyByName =
+      validateReportingImpressionQualificationFilters(
+        request.basicReport.impressionQualificationFiltersList,
+        eventTemplateFieldsByPath,
       )
-    } else {
-      throw RequiredFieldNotSetException("basic_report.result_group_specs.result_group_metric_spec")
-    }
-  }
-}
 
-/**
- * Validates a [ReportingUnit]
- *
- * @param reportingUnit [ReportingUnit] to validate
- * @param dataProviderNameSet [Set] of [DataProvider] names that CampaignGroup is associated with
- * @throws [InvalidFieldValueException] when validation fails
- */
-fun validateReportingUnit(reportingUnit: ReportingUnit, dataProviderNameSet: Set<String>) {
-  if (reportingUnit.componentsList.isEmpty()) {
-    throw InvalidFieldValueException("basic_report.result_group_specs.reporting_unit.components")
+    validateResultGroupSpecs(
+      request.basicReport.resultGroupSpecsList,
+      eventTemplateFieldsByPath,
+      CampaignGroupInfo(campaignGroup),
+    )
+
+    return ParsedFields(parentKey, impressionQualificationFilterKeyByName)
   }
 
-  for (component in reportingUnit.componentsList) {
-    DataProviderKey.fromName(component)
-      ?: throw InvalidFieldValueException(
-        "basic_report.result_group_specs.reporting_unit.components"
-      ) { fieldName ->
-        "$component in $fieldName is not a valid data provider name"
+  /**
+   * Validates [resultGroupSpecs] within the context of a [CreateBasicReportRequest].
+   *
+   * @param resultGroupSpecs [List] of [ResultGroupSpec] to validate
+   * @param eventTemplateFieldsByPath Map of EventTemplate field path with respect to Event message
+   *   to info for the field. Used for validating [EventTemplateField]
+   * @throws [RequiredFieldNotSetException] when validation fails
+   * @throws [InvalidFieldValueException] when validation fails
+   * @throws FieldUnimplementedException
+   */
+  private fun validateResultGroupSpecs(
+    resultGroupSpecs: List<ResultGroupSpec>,
+    eventTemplateFieldsByPath: Map<String, EventMessageDescriptor.EventTemplateFieldInfo>,
+    campaignGroupInfo: CampaignGroupInfo,
+  ) {
+    val fieldPath = "basic_report.result_group_specs"
+    if (resultGroupSpecs.isEmpty()) {
+      throw RequiredFieldNotSetException(fieldPath)
+    }
+
+    resultGroupSpecs.forEachIndexed { index, resultGroupSpec ->
+      val resultGroupSpecFieldPath = "$fieldPath[$index]"
+      if (
+        resultGroupSpec.metricFrequency.selectorCase ==
+          MetricFrequencySpec.SelectorCase.SELECTOR_NOT_SET
+      ) {
+        throw RequiredFieldNotSetException("$resultGroupSpecFieldPath.metric_frequency")
       }
 
-    if (!dataProviderNameSet.contains(component)) {
-      throw InvalidFieldValueException(
-        "basic_report.result_group_specs.reporting_unit.components"
-      ) { fieldName ->
-        "$component in $fieldName does not have any cmms_event_groups in campaign_group"
+      if (resultGroupSpec.hasReportingUnit()) {
+        validateReportingUnit(
+          resultGroupSpec.reportingUnit,
+          "$resultGroupSpecFieldPath.reporting_unit",
+          campaignGroupInfo,
+        )
+      } else {
+        throw RequiredFieldNotSetException("$resultGroupSpecFieldPath.reporting_unit")
+      }
+
+      if (resultGroupSpec.hasDimensionSpec()) {
+        validateDimensionSpec(
+          resultGroupSpec.dimensionSpec,
+          "$resultGroupSpecFieldPath.dimension_spec",
+          eventTemplateFieldsByPath,
+        )
+      } else {
+        throw RequiredFieldNotSetException("$resultGroupSpecFieldPath.dimension_spec")
+      }
+
+      if (resultGroupSpec.hasResultGroupMetricSpec()) {
+        validateResultGroupMetricSpec(
+          resultGroupSpec.resultGroupMetricSpec,
+          "$resultGroupSpecFieldPath.result_group_metric_spec",
+          resultGroupSpec.metricFrequency.selectorCase,
+        )
+      } else {
+        throw RequiredFieldNotSetException("$resultGroupSpecFieldPath.result_group_metric_spec")
       }
     }
   }
-}
 
-/**
- * Validates a [DimensionSpec]
- *
- * @param dimensionSpec [DimensionSpec] to validate
- * @param eventTemplateFieldsByPath Map of EventTemplate field path with respect to Event message to
- *   info for the field. Used for validating [EventTemplateField]
- * @throws [RequiredFieldNotSetException] when validation fails
- * @throws [InvalidFieldValueException] when validation fails
- */
-fun validateDimensionSpec(
-  dimensionSpec: DimensionSpec,
-  eventTemplateFieldsByPath: Map<String, EventMessageDescriptor.EventTemplateFieldInfo>,
-) {
-  val groupingEventTemplateFieldsSet: Set<String> = buildSet {
-    if (dimensionSpec.hasGrouping()) {
-      validateDimensionSpecGrouping(dimensionSpec.grouping, eventTemplateFieldsByPath)
-      for (eventTemplateFieldPath in dimensionSpec.grouping.eventTemplateFieldsList) {
-        add(eventTemplateFieldPath)
+  /**
+   * Validates [reportingUnit] within the context of a [CreateBasicReportRequest].
+   *
+   * @param fieldPath Path of [reportingUnit] relative to the request message
+   * @param campaignGroupInfo Information about the Campaign Group for the BasicReport
+   */
+  private fun validateReportingUnit(
+    reportingUnit: ReportingUnit,
+    fieldPath: String,
+    campaignGroupInfo: CampaignGroupInfo,
+  ) {
+    if (reportingUnit.componentsList.isEmpty()) {
+      throw InvalidFieldValueException("$fieldPath.components")
+    }
+
+    reportingUnit.componentsList.forEachIndexed { index, component ->
+      DataProviderKey.fromName(component)
+        ?: throw InvalidFieldValueException("$fieldPath.components[$index]") { fieldPath ->
+          "$fieldPath is not a valid data provider name"
+        }
+
+      if (!campaignGroupInfo.dataProviderNames.contains(component)) {
+        throw DataProviderNotFoundForCampaignGroupException(component, campaignGroupInfo.name)
       }
     }
   }
 
-  for (eventFilter in dimensionSpec.filtersList) {
-    if (eventFilter.termsList.isEmpty()) {
-      throw RequiredFieldNotSetException(
-        "basic_report.result_group_specs.dimension_spec.filters.terms"
-      )
-    }
-    if (eventFilter.termsList.size > 1) {
-      throw InvalidFieldValueException(
-        "basic_report.result_group_specs.dimension_spec.filters.terms"
-      ) { fieldName ->
-        "$fieldName can only have a size of 1"
+  /**
+   * Validates [dimensionSpec] within the context of a [CreateBasicReportRequest].
+   *
+   * @param dimensionSpec [DimensionSpec] to validate
+   * @param fieldPath Path of [dimensionSpec] relative to the request
+   * @param eventTemplateFieldsByPath Map of EventTemplate field path with respect to Event message
+   *   to info for the field. Used for validating [EventTemplateField]
+   * @throws RequiredFieldNotSetException
+   * @throws InvalidFieldValueException
+   * @throws EventTemplateFieldInvalidException
+   */
+  private fun validateDimensionSpec(
+    dimensionSpec: DimensionSpec,
+    fieldPath: String,
+    eventTemplateFieldsByPath: Map<String, EventMessageDescriptor.EventTemplateFieldInfo>,
+  ) {
+    val groupingEventTemplateFieldsSet: Set<String> = buildSet {
+      if (dimensionSpec.hasGrouping()) {
+        validateDimensionSpecGrouping(
+          dimensionSpec.grouping,
+          "$fieldPath.grouping",
+          eventTemplateFieldsByPath,
+        )
+        for (eventTemplateFieldPath in dimensionSpec.grouping.eventTemplateFieldsList) {
+          add(eventTemplateFieldPath)
+        }
       }
     }
 
-    for (eventTemplateField in eventFilter.termsList) {
-      validateDimensionSpecEventTemplateField(eventTemplateField, eventTemplateFieldsByPath)
-      if (groupingEventTemplateFieldsSet.contains(eventTemplateField.path)) {
-        throw InvalidFieldValueException(
-          "basic_report.result_group_specs.dimension_spec.filters.terms.path"
-        ) { fieldName ->
-          "$fieldName is already in basic_report.result_group_specs.dimension_spec.grouping.event_template_fields for the same dimension_spec"
+    dimensionSpec.filtersList.forEachIndexed { index, eventFilter ->
+      val filterFieldPath = "$fieldPath.filters[$index]"
+      if (eventFilter.termsList.isEmpty()) {
+        throw RequiredFieldNotSetException("$filterFieldPath.terms")
+      }
+      if (eventFilter.termsList.size > 1) {
+        throw InvalidFieldValueException("$filterFieldPath.terms") { fieldName ->
+          "$fieldName can only have a size of 1"
+        }
+      }
+
+      eventFilter.termsList.forEachIndexed { index, term ->
+        val termFieldPath = "$filterFieldPath.terms[$index]"
+        validateDimensionSpecEventTemplateField(term, termFieldPath, eventTemplateFieldsByPath)
+        if (groupingEventTemplateFieldsSet.contains(term.path)) {
+          throw InvalidFieldValueException(termFieldPath) { fieldName ->
+            "$fieldName is already in $fieldPath.grouping.event_template_fields for the same dimension_spec"
+          }
         }
       }
     }
   }
-}
 
-/**
- * Validates a [DimensionSpec.Grouping]
- *
- * @param grouping [DimensionSpec.Grouping] to validate
- * @param eventTemplateFieldsByPath Map of EventTemplate field path with respect to Event message to
- *   info for the field. Used for validating [EventTemplateField]
- * @throws [RequiredFieldNotSetException] when validation fails
- * @throws [InvalidFieldValueException] when validation fails
- */
-fun validateDimensionSpecGrouping(
-  grouping: DimensionSpec.Grouping,
-  eventTemplateFieldsByPath: Map<String, EventMessageDescriptor.EventTemplateFieldInfo>,
-) {
-  if (grouping.eventTemplateFieldsList.isEmpty()) {
-    throw RequiredFieldNotSetException(
-      "basic_report.result_group_specs.dimension_spec.grouping.event_template_fields"
-    )
-  }
+  /**
+   * Validates [grouping] within the context of a [CreateBasicReportRequest].
+   *
+   * @param grouping [DimensionSpec.Grouping] to validate
+   * @param fieldPath Path of [grouping] relative to the request
+   * @param eventTemplateFieldsByPath Map of EventTemplate field path with respect to Event message
+   *   to info for the field. Used for validating [EventTemplateField]
+   * @throws RequiredFieldNotSetException
+   * @throws EventTemplateFieldInvalidException
+   */
+  private fun validateDimensionSpecGrouping(
+    grouping: DimensionSpec.Grouping,
+    fieldPath: String,
+    eventTemplateFieldsByPath: Map<String, EventMessageDescriptor.EventTemplateFieldInfo>,
+  ) {
+    if (grouping.eventTemplateFieldsList.isEmpty()) {
+      throw RequiredFieldNotSetException("$fieldPath.event_template_fields")
+    }
 
-  for (eventTemplateFieldPath in grouping.eventTemplateFieldsList) {
-    val eventTemplateFieldInfo =
-      eventTemplateFieldsByPath[eventTemplateFieldPath]
-        ?: throw InvalidFieldValueException(
-          "basic_report.result_group_specs.dimension_spec.grouping.event_template_fields"
-        ) { fieldName ->
-          "$fieldName contains event template field that doesn't exist"
+    for (eventTemplateFieldPath in grouping.eventTemplateFieldsList) {
+      val eventTemplateFieldInfo =
+        eventTemplateFieldsByPath[eventTemplateFieldPath]
+          ?: throw EventTemplateFieldInvalidException(eventTemplateFieldPath) {
+            eventTemplateFieldPath ->
+            "$eventTemplateFieldPath does not exist in event message"
+          }
+
+      if (!eventTemplateFieldInfo.supportedReportingFeatures.groupable) {
+        throw EventTemplateFieldInvalidException(eventTemplateFieldPath) { eventTemplateFieldPath ->
+          "$eventTemplateFieldPath is not groupable"
         }
-
-    if (!eventTemplateFieldInfo.supportedReportingFeatures.groupable) {
-      throw InvalidFieldValueException(
-        "basic_report.result_group_specs.dimension_spec.grouping.event_template_fields"
-      ) { fieldName ->
-        "$fieldName contains event template field that is not groupable"
       }
-    }
 
-    if (!eventTemplateFieldInfo.isPopulationAttribute) {
-      throw InvalidFieldValueException(
-        "basic_report.result_group_specs.dimension_spec.grouping.event_template_fields"
-      ) { fieldName ->
-        "$fieldName contains event template field that is not a population attribute"
+      if (!eventTemplateFieldInfo.isPopulationAttribute) {
+        throw EventTemplateFieldInvalidException(eventTemplateFieldPath) { eventTemplateFieldPath ->
+          "$eventTemplateFieldPath is not a population attribute"
+        }
       }
     }
   }
-}
 
-/**
- * Validates an [EventTemplateField] for a [DimensionSpec]
- *
- * @param eventTemplateField [EventTemplateField] to validate
- * @param eventTemplateFieldsByPath Map of EventTemplate field path with respect to Event message to
- *   info for the field. Used for validating [EventTemplateField]
- * @throws [RequiredFieldNotSetException] when validation fails
- * @throws [InvalidFieldValueException] when validation fails
- */
-fun validateDimensionSpecEventTemplateField(
-  eventTemplateField: EventTemplateField,
-  eventTemplateFieldsByPath: Map<String, EventMessageDescriptor.EventTemplateFieldInfo>,
-) {
-  if (eventTemplateField.path.isEmpty()) {
-    throw RequiredFieldNotSetException(
-      "basic_report.result_group_specs.dimension_spec.filters.terms.path"
-    )
-  } else {
+  /**
+   * Validates [eventTemplateField] within the context of a [CreateBasicReportRequest].
+   *
+   * @param eventTemplateField [EventTemplateField] to validate
+   * @param fieldPath Path of [eventTemplateField] relative to the request
+   * @param eventTemplateFieldsByPath Map of EventTemplate field path with respect to Event message
+   *   to info for the field. Used for validating [EventTemplateField]
+   * @throws EventTemplateFieldInvalidException
+   * @throws RequiredFieldNotSetException
+   * @throws InvalidFieldValueException
+   */
+  private fun validateDimensionSpecEventTemplateField(
+    eventTemplateField: EventTemplateField,
+    fieldPath: String,
+    eventTemplateFieldsByPath: Map<String, EventMessageDescriptor.EventTemplateFieldInfo>,
+  ) {
+    if (eventTemplateField.path.isEmpty()) {
+      throw RequiredFieldNotSetException("$fieldPath.path")
+    }
+    if (!eventTemplateField.hasValue()) {
+      throw RequiredFieldNotSetException("$fieldPath.value")
+    }
+
     val eventTemplateFieldInfo =
       eventTemplateFieldsByPath[eventTemplateField.path]
-        ?: throw InvalidFieldValueException(
-          "basic_report.result_group_specs.dimension_spec.filters.terms.path"
-        ) { fieldName ->
-          "$fieldName doesn't exist"
-        }
+        ?: throw EventTemplateFieldInvalidException(eventTemplateField.path)
 
     if (!eventTemplateFieldInfo.supportedReportingFeatures.filterable) {
-      throw InvalidFieldValueException(
-        "basic_report.result_group_specs.dimension_spec.filters.terms.path"
-      ) { fieldName ->
-        "$fieldName is not filterable"
+      throw EventTemplateFieldInvalidException(eventTemplateField.path) { eventTemplateFieldPath ->
+        "$eventTemplateFieldPath is not filterable"
+      }
+    }
+    if (!eventTemplateFieldInfo.isPopulationAttribute) {
+      throw EventTemplateFieldInvalidException(eventTemplateField.path) { eventTemplateFieldPath ->
+        "$eventTemplateFieldPath is not a population attribute"
       }
     }
 
-    @Suppress("WHEN_ENUM_CAN_BE_NULL_IN_JAVA") // Protobuf enum fields cannot be null.
+    validateEventTemplateFieldValue(eventTemplateField, fieldPath, eventTemplateFieldInfo)
+  }
+
+  /**
+   * Validates [eventTemplateField] in the context of a [CreateBasicReportRequest].
+   *
+   * @param fieldPath Path of [eventTemplateField] relative to the request
+   * @throws EventTemplateFieldInvalidException
+   * @throws RequiredFieldNotSetException
+   */
+  private fun validateEventTemplateFieldValue(
+    eventTemplateField: EventTemplateField,
+    fieldPath: String,
+    eventTemplateFieldInfo: EventMessageDescriptor.EventTemplateFieldInfo,
+  ) {
     when (eventTemplateField.value.selectorCase) {
       EventTemplateField.FieldValue.SelectorCase.STRING_VALUE -> {
         if (eventTemplateFieldInfo.type != Descriptors.FieldDescriptor.Type.STRING) {
-          throw InvalidFieldValueException(
-            "basic_report.result_group_specs.dimension_spec.filters.terms.value.string_value"
-          ) { fieldName ->
-            "$fieldName is invalid for ${eventTemplateField.path}"
+          throw EventTemplateFieldInvalidException(eventTemplateField.path) { eventTemplateFieldPath
+            ->
+            "Incorrect value type specified for template field $eventTemplateFieldPath"
           }
         }
       }
+
       EventTemplateField.FieldValue.SelectorCase.ENUM_VALUE -> {
+        if (eventTemplateFieldInfo.type != Descriptors.FieldDescriptor.Type.ENUM) {
+          throw EventTemplateFieldInvalidException(eventTemplateField.path) { eventTemplateFieldPath
+            ->
+            "Incorrect value type specified for template field $eventTemplateFieldPath"
+          }
+        }
         if (
-          eventTemplateFieldInfo.type != Descriptors.FieldDescriptor.Type.ENUM ||
-            eventTemplateFieldInfo.enumType?.findValueByName(eventTemplateField.value.enumValue) ==
-              null
+          eventTemplateFieldInfo.enumType!!.findValueByName(eventTemplateField.value.enumValue) ==
+            null
         ) {
-          throw InvalidFieldValueException(
-            "basic_report.result_group_specs.dimension_spec.filters.terms.value.enum_value"
-          ) { fieldName ->
-            "$fieldName is invalid for for ${eventTemplateField.path}"
+          throw EventTemplateFieldInvalidException(eventTemplateField.path) { eventTemplateFieldPath
+            ->
+            "Invalid enum value specified for template field $eventTemplateFieldPath"
           }
         }
       }
+
       EventTemplateField.FieldValue.SelectorCase.BOOL_VALUE ->
         if (eventTemplateFieldInfo.type != Descriptors.FieldDescriptor.Type.BOOL) {
-          throw InvalidFieldValueException(
-            "basic_report.result_group_specs.dimension_spec.filters.terms.value.bool_value"
-          ) { fieldName ->
-            "$fieldName is invalid for ${eventTemplateField.path}"
+          throw EventTemplateFieldInvalidException(eventTemplateField.path) { eventTemplateFieldPath
+            ->
+            "Incorrect value type specified for template field $eventTemplateFieldPath"
           }
         }
-      EventTemplateField.FieldValue.SelectorCase.FLOAT_VALUE -> {
-        if (eventTemplateFieldInfo.type != Descriptors.FieldDescriptor.Type.FLOAT) {
-          throw InvalidFieldValueException(
-            "basic_report.result_group_specs.dimension_spec.filters.terms.value.float_value"
-          ) { fieldName ->
-            "$fieldName is invalid for ${eventTemplateField.path}"
-          }
-        }
-      }
-      EventTemplateField.FieldValue.SelectorCase.SELECTOR_NOT_SET -> {
-        throw RequiredFieldNotSetException(
-          "basic_report.result_group_specs.dimension_spec.filters.terms.value"
-        )
-      }
-    }
 
-    if (!eventTemplateFieldInfo.isPopulationAttribute) {
-      throw InvalidFieldValueException(
-        "basic_report.result_group_specs.dimension_spec.filters.terms.path"
-      ) { fieldName ->
-        "$fieldName is not a population attribute"
+      EventTemplateField.FieldValue.SelectorCase.FLOAT_VALUE -> {
+        throw EventTemplateFieldInvalidException(eventTemplateField.path) { eventTemplateFieldPath
+          ->
+          "Incorrect value type specified for template field $eventTemplateFieldPath"
+        }
+      }
+
+      EventTemplateField.FieldValue.SelectorCase.SELECTOR_NOT_SET -> {
+        throw RequiredFieldNotSetException("$fieldPath.value.selector")
       }
     }
   }
-}
 
-/**
- * Validates an [EventTemplateField] for an [CustomImpressionQualificationFilterSpec]
- *
- * @param eventTemplateField [EventTemplateField] to validate
- * @param eventTemplateFieldsByPath Map of EventTemplate field path with respect to Event message to
- *   info for the field. Used for validating [EventTemplateField]
- * @param mediaType [MediaType] to check against if set
- * @throws [RequiredFieldNotSetException] when validation fails
- * @throws [InvalidFieldValueException] when validation fails
- */
-fun validateCustomImpressionQualificationFilterSpecEventTemplateField(
-  eventTemplateField: EventTemplateField,
-  eventTemplateFieldsByPath: Map<String, EventMessageDescriptor.EventTemplateFieldInfo>,
-  mediaType: MediaType,
-) {
-  if (eventTemplateField.path.isEmpty()) {
-    throw RequiredFieldNotSetException(
-      "basic_report.impression_qualification_filters.custom.filter_spec.filters.terms.path"
-    )
-  } else {
+  /**
+   * Validates [term] of an Impression Qualification Filter (IQF) spec in the context of a
+   * [CreateBasicReportRequest].
+   *
+   * @param term [EventTemplateField] to validate
+   * @param fieldPath Path of [term] relative to the request
+   * @param eventTemplateFieldsByPath Map of EventTemplate field path with respect to Event message
+   *   to info for the field. Used for validating [EventTemplateField]
+   * @param mediaType [MediaType] to check against if set
+   * @throws EventTemplateFieldInvalidException
+   */
+  private fun validateIqfTerm(
+    term: EventTemplateField,
+    fieldPath: String,
+    eventTemplateFieldsByPath: Map<String, EventMessageDescriptor.EventTemplateFieldInfo>,
+    mediaType: MediaType,
+  ) {
+    if (term.path.isEmpty()) {
+      throw RequiredFieldNotSetException("$fieldPath.path")
+    }
+    if (!term.hasValue()) {
+      throw RequiredFieldNotSetException("$fieldPath.value")
+    }
+
     val eventTemplateFieldInfo =
-      eventTemplateFieldsByPath[eventTemplateField.path]
-        ?: throw InvalidFieldValueException(
-          "basic_report.impression_qualification_filters.custom.filter_spec.filters.terms.path"
-        ) { fieldName ->
-          "$fieldName doesn't exist"
+      eventTemplateFieldsByPath[term.path]
+        ?: throw EventTemplateFieldInvalidException(term.path) { eventTemplateFieldPath ->
+          "$eventTemplateFieldPath does not exist in event message"
         }
 
     if (!eventTemplateFieldInfo.supportedReportingFeatures.impressionQualification) {
-      throw InvalidFieldValueException(
-        "basic_report.impression_qualification_filters.custom.filter_spec.filters.terms.path"
-      ) { fieldName ->
-        "$fieldName cannot be used for impression qualification"
+      throw EventTemplateFieldInvalidException(term.path) { eventTemplateFieldPath ->
+        "$eventTemplateFieldPath cannot be used for impression qualification"
       }
     }
 
     if (eventTemplateFieldInfo.mediaType != mediaType.toEventAnnotationMediaType()) {
-      throw InvalidFieldValueException(
-        "basic_report.impression_qualification_filters.custom.filter_spec.filters.terms.path"
-      ) { fieldName ->
+      throw InvalidFieldValueException("$fieldPath.path") { fieldName ->
         "$fieldName does not have same media_type as parent ImpressionQualificationFilterSpec"
       }
     }
 
-    @Suppress("WHEN_ENUM_CAN_BE_NULL_IN_JAVA") // Protobuf enum fields cannot be null.
-    when (eventTemplateField.value.selectorCase) {
-      EventTemplateField.FieldValue.SelectorCase.STRING_VALUE -> {
-        if (eventTemplateFieldInfo.type != Descriptors.FieldDescriptor.Type.STRING) {
-          throw InvalidFieldValueException(
-            "basic_report.impression_qualification_filters.custom.filter_spec.filters.terms.value.string_value"
-          ) { fieldName ->
-            "$fieldName is invalid for ${eventTemplateField.path}"
-          }
+    validateEventTemplateFieldValue(term, fieldPath, eventTemplateFieldInfo)
+  }
+
+  /**
+   * Validates a [ResultGroupMetricSpec]
+   *
+   * @param resultGroupMetricSpec [ResultGroupMetricSpec] to validate
+   * @param metricFrequencySelectorCase [MetricFrequencySpec.SelectorCase] to validate against
+   * @throws [RequiredFieldNotSetException] when validation fails
+   * @throws [InvalidFieldValueException] when validation fails
+   * @throws [FieldUnimplementedException] when validation fails
+   */
+  private fun validateResultGroupMetricSpec(
+    resultGroupMetricSpec: ResultGroupMetricSpec,
+    fieldPath: String,
+    metricFrequencySelectorCase: MetricFrequencySpec.SelectorCase,
+  ) {
+    if (resultGroupMetricSpec.hasComponentIntersection()) {
+      throw FieldUnimplementedException("$fieldPath.component_intersection")
+    }
+
+    if (metricFrequencySelectorCase == MetricFrequencySpec.SelectorCase.TOTAL) {
+      if (resultGroupMetricSpec.reportingUnit.hasNonCumulative()) {
+        throw InvalidFieldValueException("$fieldPath.reporting_unit.non_cumulative") { fieldName ->
+          "$fieldName cannot be specified when metric_frequency is total"
         }
       }
-      EventTemplateField.FieldValue.SelectorCase.ENUM_VALUE -> {
-        if (
-          eventTemplateFieldInfo.type != Descriptors.FieldDescriptor.Type.ENUM ||
-            eventTemplateFieldInfo.enumType?.findValueByName(eventTemplateField.value.enumValue) ==
-              null
-        ) {
-          throw InvalidFieldValueException(
-            "basic_report.impression_qualification_filters.custom.filter_spec.filters.terms.value.enum_value"
-          ) { fieldName ->
-            "$fieldName is invalid for for ${eventTemplateField.path}"
-          }
+
+      if (resultGroupMetricSpec.component.hasNonCumulative()) {
+        throw InvalidFieldValueException("$fieldPath.component.non_cumulative") { fieldName ->
+          "$fieldName cannot be specified when metric_frequency is total"
         }
       }
-      EventTemplateField.FieldValue.SelectorCase.BOOL_VALUE ->
-        if (eventTemplateFieldInfo.type != Descriptors.FieldDescriptor.Type.BOOL) {
-          throw InvalidFieldValueException(
-            "basic_report.impression_qualification_filters.custom.filter_spec.filters.terms.value.bool_value"
-          ) { fieldName ->
-            "$fieldName is invalid for ${eventTemplateField.path}"
-          }
+
+      if (resultGroupMetricSpec.component.hasNonCumulativeUnique()) {
+        throw InvalidFieldValueException("$fieldPath.component.non_cumulative_unique") { fieldName
+          ->
+          "$fieldName cannot be specified when metric_frequency is total"
         }
-      EventTemplateField.FieldValue.SelectorCase.FLOAT_VALUE -> {
-        if (eventTemplateFieldInfo.type != Descriptors.FieldDescriptor.Type.FLOAT) {
-          throw InvalidFieldValueException(
-            "basic_report.impression_qualification_filters.custom.filter_spec.filters.terms.value.float_value"
-          ) { fieldName ->
-            "$fieldName is invalid for ${eventTemplateField.path}"
-          }
-        }
-      }
-      EventTemplateField.FieldValue.SelectorCase.SELECTOR_NOT_SET -> {
-        throw RequiredFieldNotSetException(
-          "basic_report.impression_qualification_filters.custom.filter_spec.filters.terms.value"
-        )
       }
     }
-  }
-}
 
-/**
- * Validates a [ResultGroupMetricSpec]
- *
- * @param resultGroupMetricSpec [ResultGroupMetricSpec] to validate
- * @param metricFrequencySelectorCase [MetricFrequencySpec.SelectorCase] to validate against
- * @throws [RequiredFieldNotSetException] when validation fails
- * @throws [InvalidFieldValueException] when validation fails
- * @throws [FieldUnimplementedException] when validation fails
- */
-fun validateResultGroupMetricSpec(
-  resultGroupMetricSpec: ResultGroupMetricSpec,
-  metricFrequencySelectorCase: MetricFrequencySpec.SelectorCase,
-) {
-  if (resultGroupMetricSpec.hasComponentIntersection()) {
-    throw FieldUnimplementedException(
-      "basic_report.result_group_specs.result_group_metric_spec.component_intersection"
+    validateBasicMetricSetSpec(
+      resultGroupMetricSpec.reportingUnit.cumulative,
+      "$fieldPath.reporting_unit.cumulative",
     )
-  }
-
-  if (metricFrequencySelectorCase == MetricFrequencySpec.SelectorCase.TOTAL) {
-    if (resultGroupMetricSpec.reportingUnit.hasNonCumulative()) {
-      throw InvalidFieldValueException(
-        "basic_report.result_group_specs.result_group_metric_spec.reporting_unit.non_cumulative"
-      ) { fieldName ->
-        "$fieldName cannot be specified when metric_frequency is total"
-      }
-    }
-
-    if (resultGroupMetricSpec.component.hasNonCumulative()) {
-      throw InvalidFieldValueException(
-        "basic_report.result_group_specs.result_group_metric_spec.component.non_cumulative"
-      ) { fieldName ->
-        "$fieldName cannot be specified when metric_frequency is total"
-      }
-    }
-
-    if (resultGroupMetricSpec.component.hasNonCumulativeUnique()) {
-      throw InvalidFieldValueException(
-        "basic_report.result_group_specs.result_group_metric_spec.component.non_cumulative_unique"
-      ) { fieldName ->
-        "$fieldName cannot be specified when metric_frequency is total"
-      }
-    }
-  }
-
-  validateBasicMetricSetSpec(
-    resultGroupMetricSpec.reportingUnit.cumulative,
-    "basic_report.result_group_specs.result_group_metric_spec.reporting_unit.cumulative.k_plus_reach",
-  )
-  validateBasicMetricSetSpec(
-    resultGroupMetricSpec.reportingUnit.nonCumulative,
-    "basic_report.result_group_specs.result_group_metric_spec.reporting_unit.non_cumulative.k_plus_reach",
-  )
-  validateBasicMetricSetSpec(
-    resultGroupMetricSpec.component.nonCumulative,
-    "basic_report.result_group_specs.result_group_metric_spec.component.non_cumulative.k_plus_reach",
-  )
-  validateBasicMetricSetSpec(
-    resultGroupMetricSpec.component.cumulative,
-    "basic_report.result_group_specs.result_group_metric_spec.component.cumulative.k_plus_reach",
-  )
-
-  if (
-    resultGroupMetricSpec.reportingUnit.stackedIncrementalReach &&
-      metricFrequencySelectorCase != MetricFrequencySpec.SelectorCase.TOTAL
-  ) {
-    throw InvalidFieldValueException(
-      "basic_report.result_group_specs.result_group_metric_spec.reporting_unit.stacked_incremental_reach"
-    ) { fieldName ->
-      "$fieldName requires metric_frequency to be total"
-    }
-  }
-}
-
-/**
- * Validates a [ReportingInterval]
- *
- * @param reportingInterval [ReportingInterval] to validate
- * @throws [RequiredFieldNotSetException] when validation fails
- * @throws [InvalidFieldValueException] when validation fails
- */
-fun validateReportingInterval(reportingInterval: ReportingInterval) {
-  if (!reportingInterval.hasReportStart()) {
-    throw RequiredFieldNotSetException("basic_report.reporting_interval.report_start")
-  }
-
-  if (!reportingInterval.hasReportEnd()) {
-    throw RequiredFieldNotSetException("basic_report.reporting_interval.report_end")
-  }
-
-  if (
-    reportingInterval.reportStart.year == 0 ||
-      reportingInterval.reportStart.month == 0 ||
-      reportingInterval.reportStart.day == 0 ||
-      !(reportingInterval.reportStart.hasTimeZone() || reportingInterval.reportStart.hasUtcOffset())
-  ) {
-    throw InvalidFieldValueException("basic_report.reporting_interval.report_start") { fieldName ->
-      "$fieldName requires year, month, and day to all be set, as well as either time_zone or utc_offset"
-    }
-  }
-
-  if (
-    reportingInterval.reportEnd.year == 0 ||
-      reportingInterval.reportEnd.month == 0 ||
-      reportingInterval.reportEnd.day == 0
-  ) {
-    throw InvalidFieldValueException("basic_report.reporting_interval.report_end") { fieldName ->
-      "$fieldName requires year, month, and day to be set"
-    }
-  }
-}
-
-/**
- * Validates a [List] of [ReportingImpressionQualificationFilter]
- *
- * @param reportingImpressionQualificationFilters [List] of [ReportingImpressionQualificationFilter]
- *   to validate
- * @param eventTemplateFieldsByPath Map of EventTemplate field path with respect to Event message to
- *   info for the field. Used for validating [EventTemplateField]
- * @param requireImpressionQualificationFilters Whether impression_qualification_filters field is
- *   required or not
- * @throws [RequiredFieldNotSetException] when validation fails
- * @throws [InvalidFieldValueException] when validation fails
- */
-fun validateReportingImpressionQualificationFilters(
-  reportingImpressionQualificationFilters: List<ReportingImpressionQualificationFilter>,
-  eventTemplateFieldsByPath: Map<String, EventMessageDescriptor.EventTemplateFieldInfo>,
-  requireImpressionQualificationFilters: Boolean,
-) {
-  if (reportingImpressionQualificationFilters.isEmpty() && requireImpressionQualificationFilters) {
-    throw RequiredFieldNotSetException("basic_report.impression_qualification_filters")
-  }
-
-  var customImpressionQualificationFilterUsed = false
-  for (impressionQualificationFilter in reportingImpressionQualificationFilters) {
-    if (impressionQualificationFilter.hasImpressionQualificationFilter()) {
-      ImpressionQualificationFilterKey.fromName(
-        impressionQualificationFilter.impressionQualificationFilter
-      )
-        ?: throw InvalidFieldValueException(
-          "basic_report.impression_qualification_filters.impression_qualification_filter"
-        )
-    } else if (impressionQualificationFilter.hasCustom()) {
-      if (customImpressionQualificationFilterUsed) {
-        throw InvalidFieldValueException("basic_report.impression_qualification_filters") {
-          fieldName ->
-          "$fieldName can only have one custom filter"
-        }
-      }
-
-      customImpressionQualificationFilterUsed = true
-      validateCustomImpressionQualificationFilterSpec(
-        impressionQualificationFilter.custom,
-        eventTemplateFieldsByPath,
-      )
-    } else {
-      throw InvalidFieldValueException("basic_report.impression_qualification_filters.selector")
-    }
-  }
-}
-
-/**
- * Validates a [CustomImpressionQualificationFilterSpec]
- *
- * @param customImpressionQualificationFilterSpec [CustomImpressionQualificationFilterSpec] to
- *   validate
- * @param eventTemplateFieldsByPath Map of EventTemplate field path with respect to Event message to
- *   info for the field. Used for validating [EventTemplateField]
- * @throws [RequiredFieldNotSetException] when validation fails
- * @throws [InvalidFieldValueException] when validation fails
- */
-fun validateCustomImpressionQualificationFilterSpec(
-  customImpressionQualificationFilterSpec: CustomImpressionQualificationFilterSpec,
-  eventTemplateFieldsByPath: Map<String, EventMessageDescriptor.EventTemplateFieldInfo>,
-) {
-  if (customImpressionQualificationFilterSpec.filterSpecList.isEmpty()) {
-    throw RequiredFieldNotSetException(
-      "basic_report.impression_qualification_filters.custom.filter_spec"
+    validateBasicMetricSetSpec(
+      resultGroupMetricSpec.reportingUnit.nonCumulative,
+      "$fieldPath.reporting_unit.non_cumulative",
     )
+    validateBasicMetricSetSpec(
+      resultGroupMetricSpec.component.nonCumulative,
+      "$fieldPath.component.non_cumulative",
+    )
+    validateBasicMetricSetSpec(
+      resultGroupMetricSpec.component.cumulative,
+      "$fieldPath.component.cumulative",
+    )
+
+    if (
+      resultGroupMetricSpec.reportingUnit.stackedIncrementalReach &&
+        metricFrequencySelectorCase != MetricFrequencySpec.SelectorCase.TOTAL
+    ) {
+      throw InvalidFieldValueException("$fieldPath.reporting_unit.stacked_incremental_reach") {
+        fieldName ->
+        "$fieldName requires metric_frequency to be total"
+      }
+    }
   }
 
-  // No more than 1 filter_spec per MediaType
-  buildSet<MediaType> {
-    for (filterSpec in customImpressionQualificationFilterSpec.filterSpecList) {
-      if (this.contains(filterSpec.mediaType)) {
-        throw InvalidFieldValueException(
-          "basic_report.impression_qualification_filters.custom.filter_spec"
-        ) { fieldName ->
-          "$fieldName cannot have more than 1 filter_spec for MediaType ${filterSpec.mediaType}. Only 1 filter_spec per MediaType allowed"
+  /**
+   * Validates [reportingInterval] within the context of a [CreateBasicReportRequest].
+   *
+   * @param reportingInterval [ReportingInterval] to validate
+   * @throws RequiredFieldNotSetException when validation fails
+   * @throws InvalidFieldValueException when validation fails
+   */
+  private fun validateReportingInterval(reportingInterval: ReportingInterval) {
+    val fieldPath = "basic_report.reporting_interval"
+    if (!reportingInterval.hasReportStart()) {
+      throw RequiredFieldNotSetException("$fieldPath.report_start")
+    }
+
+    if (!reportingInterval.hasReportEnd()) {
+      throw RequiredFieldNotSetException("$fieldPath.report_end")
+    }
+
+    if (
+      reportingInterval.reportStart.year == 0 ||
+        reportingInterval.reportStart.month == 0 ||
+        reportingInterval.reportStart.day == 0 ||
+        !(reportingInterval.reportStart.hasTimeZone() ||
+          reportingInterval.reportStart.hasUtcOffset())
+    ) {
+      throw InvalidFieldValueException("$fieldPath.report_start") { fieldName ->
+        "$fieldName requires year, month, and day to all be set, as well as either time_zone or utc_offset"
+      }
+    }
+
+    if (
+      reportingInterval.reportEnd.year == 0 ||
+        reportingInterval.reportEnd.month == 0 ||
+        reportingInterval.reportEnd.day == 0
+    ) {
+      throw InvalidFieldValueException("$fieldPath.report_end") { fieldName ->
+        "$fieldName requires year, month, and day to be set"
+      }
+    }
+  }
+
+  /**
+   * Validates [reportingImpressionQualificationFilters] within the context of a
+   * [CreateBasicReportRequest].
+   *
+   * @param reportingImpressionQualificationFilters [List] of
+   *   [ReportingImpressionQualificationFilter] to validate
+   * @param eventTemplateFieldsByPath Map of EventTemplate field path with respect to Event message
+   *   to info for the field. Used for validating [EventTemplateField]
+   * @throws [RequiredFieldNotSetException] when validation fails
+   * @throws [InvalidFieldValueException] when validation fails
+   */
+  private fun validateReportingImpressionQualificationFilters(
+    reportingImpressionQualificationFilters: List<ReportingImpressionQualificationFilter>,
+    eventTemplateFieldsByPath: Map<String, EventMessageDescriptor.EventTemplateFieldInfo>,
+  ): Set<ImpressionQualificationFilterKey> {
+    val fieldPath = "basic_report.impression_qualification_filters"
+
+    return buildSet {
+      var customImpressionQualificationFilterUsed = false
+      reportingImpressionQualificationFilters.forEachIndexed { index, reportingIqf ->
+        val reportingIqfFieldPath = "$fieldPath[$index]"
+        when (reportingIqf.selectorCase) {
+          ReportingImpressionQualificationFilter.SelectorCase.IMPRESSION_QUALIFICATION_FILTER -> {
+            val key =
+              ImpressionQualificationFilterKey.fromName(reportingIqf.impressionQualificationFilter)
+                ?: throw InvalidFieldValueException(
+                  "$reportingIqfFieldPath.impression_qualification_filter"
+                )
+            add(key)
+          }
+
+          ReportingImpressionQualificationFilter.SelectorCase.CUSTOM -> {
+            if (customImpressionQualificationFilterUsed) {
+              throw InvalidFieldValueException(fieldPath) { fieldPath ->
+                "$fieldPath may have at most one entry with a custom filter"
+              }
+            }
+            validateCustomImpressionQualificationFilterSpec(
+              reportingIqf.custom,
+              "$reportingIqfFieldPath.custom",
+              eventTemplateFieldsByPath,
+            )
+
+            customImpressionQualificationFilterUsed = true
+          }
+
+          ReportingImpressionQualificationFilter.SelectorCase.SELECTOR_NOT_SET ->
+            throw RequiredFieldNotSetException("$reportingIqfFieldPath.selector")
         }
       }
-      add(filterSpec.mediaType)
+    }
+  }
 
-      if (filterSpec.filtersList.isEmpty()) {
-        throw RequiredFieldNotSetException(
-          "basic_report.impression_qualification_filters.custom.filter_spec.filters"
-        )
-      }
+  /**
+   * Validates a [CustomImpressionQualificationFilterSpec]
+   *
+   * @param customImpressionQualificationFilterSpec [CustomImpressionQualificationFilterSpec] to
+   *   validate
+   * @param eventTemplateFieldsByPath Map of EventTemplate field path with respect to Event message
+   *   to info for the field. Used for validating [EventTemplateField]
+   * @throws [RequiredFieldNotSetException] when validation fails
+   * @throws [InvalidFieldValueException] when validation fails
+   */
+  private fun validateCustomImpressionQualificationFilterSpec(
+    customImpressionQualificationFilterSpec: CustomImpressionQualificationFilterSpec,
+    fieldPath: String,
+    eventTemplateFieldsByPath: Map<String, EventMessageDescriptor.EventTemplateFieldInfo>,
+  ) {
+    if (customImpressionQualificationFilterSpec.filterSpecList.isEmpty()) {
+      throw RequiredFieldNotSetException("$fieldPath.filter_spec")
+    }
 
-      for (eventFilter in filterSpec.filtersList) {
-        if (eventFilter.termsList.isEmpty()) {
-          throw RequiredFieldNotSetException(
-            "basic_report.impression_qualification_filters.custom.filter_spec.filters.terms"
-          )
-        }
-        if (eventFilter.termsList.size > 1) {
-          throw InvalidFieldValueException(
-            "basic_report.impression_qualification_filters.custom.filter_spec.filters.terms"
-          ) { fieldName ->
-            "$fieldName can only have a size of 1"
+    // No more than 1 filter_spec per MediaType
+    buildSet<MediaType> {
+      customImpressionQualificationFilterSpec.filterSpecList.forEachIndexed { index, filterSpec ->
+        if (this.contains(filterSpec.mediaType)) {
+          throw InvalidFieldValueException("$fieldPath.filter_specs") { fieldName ->
+            "$fieldName cannot have more than 1 filter_spec for MediaType ${filterSpec.mediaType}. Only 1 filter_spec per MediaType allowed"
           }
         }
+        add(filterSpec.mediaType)
 
-        for (eventTemplateField in eventFilter.termsList) {
-          validateCustomImpressionQualificationFilterSpecEventTemplateField(
-            eventTemplateField,
-            eventTemplateFieldsByPath,
-            filterSpec.mediaType,
-          )
+        val filterSpecFieldPath = "$fieldPath.filter_specs[$index]"
+        if (filterSpec.filtersList.isEmpty()) {
+          throw RequiredFieldNotSetException("$filterSpecFieldPath.filters")
+        }
+
+        filterSpec.filtersList.forEachIndexed { filterIndex, filter ->
+          val filterFieldPath = "$filterSpecFieldPath.filters[$filterIndex]"
+          if (filter.termsList.isEmpty()) {
+            throw RequiredFieldNotSetException("$filterFieldPath.terms")
+          }
+          if (filter.termsList.size > 1) {
+            throw InvalidFieldValueException("$filterFieldPath.terms") { fieldName ->
+              "$fieldName can only have a size of 1"
+            }
+          }
+
+          filter.termsList.forEachIndexed { termIndex, term ->
+            validateIqfTerm(
+              term,
+              "$filterFieldPath.terms[$termIndex]",
+              eventTemplateFieldsByPath,
+              filterSpec.mediaType,
+            )
+          }
         }
       }
     }
   }
-}
 
-/**
- * Validates a [ResultGroupMetricSpec.BasicMetricSetSpec]
- *
- * @param basicMetricSetSpec [ResultGroupMetricSpec.BasicMetricSetSpec] to validate
- * @param kPlusReachFieldName field name to use in error
- * @throws [InvalidFieldValueException] when validation fails
- */
-fun validateBasicMetricSetSpec(
-  basicMetricSetSpec: ResultGroupMetricSpec.BasicMetricSetSpec,
-  kPlusReachFieldName: String,
-) {
-  if (basicMetricSetSpec.percentKPlusReach) {
-    if (basicMetricSetSpec.kPlusReach <= 0) {
-      throw InvalidFieldValueException(kPlusReachFieldName) { fieldName ->
-        "$fieldName must have a positive value"
+  /**
+   * Validates [basicMetricSetSpec] within the context of a [CreateBasicReportRequest],
+   *
+   * @param basicMetricSetSpec [ResultGroupMetricSpec.BasicMetricSetSpec] to validate
+   * @param fieldPath Path of [basicMetricSetSpec] relative to the request
+   * @throws InvalidFieldValueException
+   */
+  private fun validateBasicMetricSetSpec(
+    basicMetricSetSpec: ResultGroupMetricSpec.BasicMetricSetSpec,
+    fieldPath: String,
+  ) {
+    if (basicMetricSetSpec.percentKPlusReach) {
+      if (basicMetricSetSpec.kPlusReach <= 0) {
+        throw InvalidFieldValueException("$fieldPath.k_plus_reach") { fieldName ->
+          "$fieldName must have a positive value"
+        }
       }
     }
   }

--- a/src/test/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/BUILD.bazel
+++ b/src/test/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/BUILD.bazel
@@ -342,6 +342,7 @@ spanner_emulator_test(
         "//src/main/kotlin/org/wfanet/measurement/access/client/v1alpha/testing:authentication",
         "//src/main/kotlin/org/wfanet/measurement/access/client/v1alpha/testing:principal_matcher",
         "//src/main/kotlin/org/wfanet/measurement/api/v2alpha:event_message_descriptor",
+        "//src/main/kotlin/org/wfanet/measurement/common/grpc/testing:status_exception_subject",
         "//src/main/kotlin/org/wfanet/measurement/reporting/deploy/v2/common/service:impression_qualification_filters_service",
         "//src/main/kotlin/org/wfanet/measurement/reporting/deploy/v2/gcloud/spanner:basic_reports_service",
         "//src/main/kotlin/org/wfanet/measurement/reporting/deploy/v2/gcloud/spanner/testing",

--- a/src/test/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/BasicReportsServiceTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/BasicReportsServiceTest.kt
@@ -75,6 +75,7 @@ import org.wfanet.measurement.common.db.r2dbc.postgres.testing.PostgresDatabaseP
 import org.wfanet.measurement.common.getRuntimePath
 import org.wfanet.measurement.common.grpc.errorInfo
 import org.wfanet.measurement.common.grpc.testing.GrpcTestServerRule
+import org.wfanet.measurement.common.grpc.testing.StatusExceptionSubject.Companion.assertThat
 import org.wfanet.measurement.common.grpc.testing.mockService
 import org.wfanet.measurement.common.identity.RandomIdGenerator
 import org.wfanet.measurement.common.parseTextProto
@@ -2839,8 +2840,9 @@ class BasicReportsServiceTest {
         withPrincipalAndScopes(PRINCIPAL, SCOPES) { service.createBasicReport(request) }
       }
 
-    assertThat(exception.status.code).isEqualTo(Status.Code.INVALID_ARGUMENT)
-    assertThat(exception.errorInfo)
+    assertThat(exception).status().code().isEqualTo(Status.Code.INVALID_ARGUMENT)
+    assertThat(exception)
+      .errorInfo()
       .isEqualTo(
         errorInfo {
           domain = Errors.DOMAIN
@@ -2882,8 +2884,9 @@ class BasicReportsServiceTest {
         withPrincipalAndScopes(PRINCIPAL, SCOPES) { service.createBasicReport(request) }
       }
 
-    assertThat(exception.status.code).isEqualTo(Status.Code.INVALID_ARGUMENT)
-    assertThat(exception.errorInfo)
+    assertThat(exception).status().code().isEqualTo(Status.Code.INVALID_ARGUMENT)
+    assertThat(exception)
+      .errorInfo()
       .isEqualTo(
         errorInfo {
           domain = Errors.DOMAIN
@@ -2928,7 +2931,7 @@ class BasicReportsServiceTest {
           }
         }
 
-      assertThat(exception.status.code).isEqualTo(Status.Code.PERMISSION_DENIED)
+      assertThat(exception).status().code().isEqualTo(Status.Code.PERMISSION_DENIED)
       assertThat(exception).hasMessageThat().contains(BasicReportsService.Permission.CREATE)
     }
 
@@ -2963,8 +2966,9 @@ class BasicReportsServiceTest {
         withPrincipalAndScopes(PRINCIPAL, SCOPES) { service.createBasicReport(request) }
       }
 
-    assertThat(exception.status.code).isEqualTo(Status.Code.INVALID_ARGUMENT)
-    assertThat(exception.errorInfo)
+    assertThat(exception).status().code().isEqualTo(Status.Code.INVALID_ARGUMENT)
+    assertThat(exception)
+      .errorInfo()
       .isEqualTo(
         errorInfo {
           domain = Errors.DOMAIN
@@ -3006,8 +3010,9 @@ class BasicReportsServiceTest {
         withPrincipalAndScopes(PRINCIPAL, SCOPES) { service.createBasicReport(request) }
       }
 
-    assertThat(exception.status.code).isEqualTo(Status.Code.INVALID_ARGUMENT)
-    assertThat(exception.errorInfo)
+    assertThat(exception).status().code().isEqualTo(Status.Code.INVALID_ARGUMENT)
+    assertThat(exception)
+      .errorInfo()
       .isEqualTo(
         errorInfo {
           domain = Errors.DOMAIN
@@ -3053,8 +3058,9 @@ class BasicReportsServiceTest {
         withPrincipalAndScopes(PRINCIPAL, SCOPES) { service.createBasicReport(request) }
       }
 
-    assertThat(exception.status.code).isEqualTo(Status.Code.ALREADY_EXISTS)
-    assertThat(exception.errorInfo)
+    assertThat(exception).status().code().isEqualTo(Status.Code.ALREADY_EXISTS)
+    assertThat(exception)
+      .errorInfo()
       .isEqualTo(
         errorInfo {
           domain = Errors.DOMAIN
@@ -3097,8 +3103,9 @@ class BasicReportsServiceTest {
         withPrincipalAndScopes(PRINCIPAL, SCOPES) { service.createBasicReport(request) }
       }
 
-    assertThat(exception.status.code).isEqualTo(Status.Code.INVALID_ARGUMENT)
-    assertThat(exception.errorInfo)
+    assertThat(exception).status().code().isEqualTo(Status.Code.INVALID_ARGUMENT)
+    assertThat(exception)
+      .errorInfo()
       .isEqualTo(
         errorInfo {
           domain = Errors.DOMAIN
@@ -3140,8 +3147,9 @@ class BasicReportsServiceTest {
         withPrincipalAndScopes(PRINCIPAL, SCOPES) { service.createBasicReport(request) }
       }
 
-    assertThat(exception.status.code).isEqualTo(Status.Code.INVALID_ARGUMENT)
-    assertThat(exception.errorInfo)
+    assertThat(exception).status().code().isEqualTo(Status.Code.INVALID_ARGUMENT)
+    assertThat(exception)
+      .errorInfo()
       .isEqualTo(
         errorInfo {
           domain = Errors.DOMAIN
@@ -3171,8 +3179,9 @@ class BasicReportsServiceTest {
         withPrincipalAndScopes(PRINCIPAL, SCOPES) { service.createBasicReport(request) }
       }
 
-    assertThat(exception.status.code).isEqualTo(Status.Code.INVALID_ARGUMENT)
-    assertThat(exception.errorInfo)
+    assertThat(exception).status().code().isEqualTo(Status.Code.INVALID_ARGUMENT)
+    assertThat(exception)
+      .errorInfo()
       .isEqualTo(
         errorInfo {
           domain = Errors.DOMAIN
@@ -3203,8 +3212,9 @@ class BasicReportsServiceTest {
         withPrincipalAndScopes(PRINCIPAL, SCOPES) { service.createBasicReport(request) }
       }
 
-    assertThat(exception.status.code).isEqualTo(Status.Code.FAILED_PRECONDITION)
-    assertThat(exception.errorInfo)
+    assertThat(exception).status().code().isEqualTo(Status.Code.FAILED_PRECONDITION)
+    assertThat(exception)
+      .errorInfo()
       .isEqualTo(
         errorInfo {
           domain = Errors.DOMAIN
@@ -3215,7 +3225,7 @@ class BasicReportsServiceTest {
   }
 
   @Test
-  fun `createBasicReport throws INVALID_ARGUMENT when campaignGroup not campaignGroup`() =
+  fun `createBasicReport throws FAILED_PRECONDITION when campaignGroup not campaignGroup`() =
     runBlocking {
       val measurementConsumerKey = MeasurementConsumerKey(CMMS_MEASUREMENT_CONSUMER_ID)
       val campaignGroupKey = ReportingSetKey(measurementConsumerKey, "1234")
@@ -3236,24 +3246,25 @@ class BasicReportsServiceTest {
           externalReportingSetId = campaignGroupKey.reportingSetId
         }
       )
-
       val request = createBasicReportRequest {
         parent = measurementConsumerKey.toName()
         basicReport = BASIC_REPORT.copy { campaignGroup = campaignGroupKey.toName() }
         basicReportId = "a1234"
       }
+
       val exception =
         assertFailsWith<StatusRuntimeException> {
           withPrincipalAndScopes(PRINCIPAL, SCOPES) { service.createBasicReport(request) }
         }
 
-      assertThat(exception.status.code).isEqualTo(Status.Code.INVALID_ARGUMENT)
-      assertThat(exception.errorInfo)
+      assertThat(exception).status().code().isEqualTo(Status.Code.FAILED_PRECONDITION)
+      assertThat(exception)
+        .errorInfo()
         .isEqualTo(
           errorInfo {
             domain = Errors.DOMAIN
-            reason = Errors.Reason.INVALID_FIELD_VALUE.name
-            metadata[Errors.Metadata.FIELD_NAME.key] = "basic_report.campaign_group"
+            reason = Errors.Reason.CAMPAIGN_GROUP_INVALID.name
+            metadata[Errors.Metadata.REPORTING_SET.key] = request.basicReport.campaignGroup
           }
         )
     }
@@ -3294,8 +3305,9 @@ class BasicReportsServiceTest {
         withPrincipalAndScopes(PRINCIPAL, SCOPES) { service.createBasicReport(request) }
       }
 
-    assertThat(exception.status.code).isEqualTo(Status.Code.INVALID_ARGUMENT)
-    assertThat(exception.errorInfo)
+    assertThat(exception).status().code().isEqualTo(Status.Code.INVALID_ARGUMENT)
+    assertThat(exception)
+      .errorInfo()
       .isEqualTo(
         errorInfo {
           domain = Errors.DOMAIN
@@ -3373,8 +3385,9 @@ class BasicReportsServiceTest {
           withPrincipalAndScopes(PRINCIPAL, SCOPES) { service.createBasicReport(request) }
         }
 
-      assertThat(exception.status.code).isEqualTo(Status.Code.FAILED_PRECONDITION)
-      assertThat(exception.errorInfo)
+      assertThat(exception).status().code().isEqualTo(Status.Code.FAILED_PRECONDITION)
+      assertThat(exception)
+        .errorInfo()
         .isEqualTo(
           errorInfo {
             domain = Errors.DOMAIN
@@ -3420,8 +3433,9 @@ class BasicReportsServiceTest {
         withPrincipalAndScopes(PRINCIPAL, SCOPES) { service.createBasicReport(request) }
       }
 
-    assertThat(exception.status.code).isEqualTo(Status.Code.INVALID_ARGUMENT)
-    assertThat(exception.errorInfo)
+    assertThat(exception).status().code().isEqualTo(Status.Code.INVALID_ARGUMENT)
+    assertThat(exception)
+      .errorInfo()
       .isEqualTo(
         errorInfo {
           domain = Errors.DOMAIN
@@ -3468,8 +3482,9 @@ class BasicReportsServiceTest {
           withPrincipalAndScopes(PRINCIPAL, SCOPES) { service.createBasicReport(request) }
         }
 
-      assertThat(exception.status.code).isEqualTo(Status.Code.INVALID_ARGUMENT)
-      assertThat(exception.errorInfo)
+      assertThat(exception).status().code().isEqualTo(Status.Code.INVALID_ARGUMENT)
+      assertThat(exception)
+        .errorInfo()
         .isEqualTo(
           errorInfo {
             domain = Errors.DOMAIN
@@ -3517,8 +3532,9 @@ class BasicReportsServiceTest {
           withPrincipalAndScopes(PRINCIPAL, SCOPES) { service.createBasicReport(request) }
         }
 
-      assertThat(exception.status.code).isEqualTo(Status.Code.INVALID_ARGUMENT)
-      assertThat(exception.errorInfo)
+      assertThat(exception).status().code().isEqualTo(Status.Code.INVALID_ARGUMENT)
+      assertThat(exception)
+        .errorInfo()
         .isEqualTo(
           errorInfo {
             domain = Errors.DOMAIN
@@ -3565,8 +3581,9 @@ class BasicReportsServiceTest {
         withPrincipalAndScopes(PRINCIPAL, SCOPES) { service.createBasicReport(request) }
       }
 
-    assertThat(exception.status.code).isEqualTo(Status.Code.INVALID_ARGUMENT)
-    assertThat(exception.errorInfo)
+    assertThat(exception).status().code().isEqualTo(Status.Code.INVALID_ARGUMENT)
+    assertThat(exception)
+      .errorInfo()
       .isEqualTo(
         errorInfo {
           domain = Errors.DOMAIN
@@ -3613,8 +3630,9 @@ class BasicReportsServiceTest {
         withPrincipalAndScopes(PRINCIPAL, SCOPES) { service.createBasicReport(request) }
       }
 
-    assertThat(exception.status.code).isEqualTo(Status.Code.INVALID_ARGUMENT)
-    assertThat(exception.errorInfo)
+    assertThat(exception).status().code().isEqualTo(Status.Code.INVALID_ARGUMENT)
+    assertThat(exception)
+      .errorInfo()
       .isEqualTo(
         errorInfo {
           domain = Errors.DOMAIN
@@ -3661,8 +3679,9 @@ class BasicReportsServiceTest {
         withPrincipalAndScopes(PRINCIPAL, SCOPES) { service.createBasicReport(request) }
       }
 
-    assertThat(exception.status.code).isEqualTo(Status.Code.INVALID_ARGUMENT)
-    assertThat(exception.errorInfo)
+    assertThat(exception).status().code().isEqualTo(Status.Code.INVALID_ARGUMENT)
+    assertThat(exception)
+      .errorInfo()
       .isEqualTo(
         errorInfo {
           domain = Errors.DOMAIN
@@ -3712,8 +3731,9 @@ class BasicReportsServiceTest {
           withPrincipalAndScopes(PRINCIPAL, SCOPES) { service.createBasicReport(request) }
         }
 
-      assertThat(exception.status.code).isEqualTo(Status.Code.INVALID_ARGUMENT)
-      assertThat(exception.errorInfo)
+      assertThat(exception).status().code().isEqualTo(Status.Code.INVALID_ARGUMENT)
+      assertThat(exception)
+        .errorInfo()
         .isEqualTo(
           errorInfo {
             domain = Errors.DOMAIN
@@ -3761,8 +3781,9 @@ class BasicReportsServiceTest {
         withPrincipalAndScopes(PRINCIPAL, SCOPES) { service.createBasicReport(request) }
       }
 
-    assertThat(exception.status.code).isEqualTo(Status.Code.INVALID_ARGUMENT)
-    assertThat(exception.errorInfo)
+    assertThat(exception).status().code().isEqualTo(Status.Code.INVALID_ARGUMENT)
+    assertThat(exception)
+      .errorInfo()
       .isEqualTo(
         errorInfo {
           domain = Errors.DOMAIN
@@ -3809,8 +3830,9 @@ class BasicReportsServiceTest {
         withPrincipalAndScopes(PRINCIPAL, SCOPES) { service.createBasicReport(request) }
       }
 
-    assertThat(exception.status.code).isEqualTo(Status.Code.INVALID_ARGUMENT)
-    assertThat(exception.errorInfo)
+    assertThat(exception).status().code().isEqualTo(Status.Code.INVALID_ARGUMENT)
+    assertThat(exception)
+      .errorInfo()
       .isEqualTo(
         errorInfo {
           domain = Errors.DOMAIN
@@ -3857,8 +3879,9 @@ class BasicReportsServiceTest {
         withPrincipalAndScopes(PRINCIPAL, SCOPES) { service.createBasicReport(request) }
       }
 
-    assertThat(exception.status.code).isEqualTo(Status.Code.INVALID_ARGUMENT)
-    assertThat(exception.errorInfo)
+    assertThat(exception).status().code().isEqualTo(Status.Code.INVALID_ARGUMENT)
+    assertThat(exception)
+      .errorInfo()
       .isEqualTo(
         errorInfo {
           domain = Errors.DOMAIN
@@ -3904,8 +3927,9 @@ class BasicReportsServiceTest {
         withPrincipalAndScopes(PRINCIPAL, SCOPES) { service.createBasicReport(request) }
       }
 
-    assertThat(exception.status.code).isEqualTo(Status.Code.INVALID_ARGUMENT)
-    assertThat(exception.errorInfo)
+    assertThat(exception).status().code().isEqualTo(Status.Code.INVALID_ARGUMENT)
+    assertThat(exception)
+      .errorInfo()
       .isEqualTo(
         errorInfo {
           domain = Errors.DOMAIN
@@ -3955,14 +3979,15 @@ class BasicReportsServiceTest {
           withPrincipalAndScopes(PRINCIPAL, SCOPES) { service.createBasicReport(request) }
         }
 
-      assertThat(exception.status.code).isEqualTo(Status.Code.INVALID_ARGUMENT)
-      assertThat(exception.errorInfo)
+      assertThat(exception).status().code().isEqualTo(Status.Code.INVALID_ARGUMENT)
+      assertThat(exception)
+        .errorInfo()
         .isEqualTo(
           errorInfo {
             domain = Errors.DOMAIN
             reason = Errors.Reason.INVALID_FIELD_VALUE.name
             metadata[Errors.Metadata.FIELD_NAME.key] =
-              "basic_report.impression_qualification_filters.impression_qualification_filter"
+              "basic_report.impression_qualification_filters[0].impression_qualification_filter"
           }
         )
     }
@@ -4031,8 +4056,9 @@ class BasicReportsServiceTest {
         withPrincipalAndScopes(PRINCIPAL, SCOPES) { service.createBasicReport(request) }
       }
 
-    assertThat(exception.status.code).isEqualTo(Status.Code.INVALID_ARGUMENT)
-    assertThat(exception.errorInfo)
+    assertThat(exception).status().code().isEqualTo(Status.Code.INVALID_ARGUMENT)
+    assertThat(exception)
+      .errorInfo()
       .isEqualTo(
         errorInfo {
           domain = Errors.DOMAIN
@@ -4083,14 +4109,15 @@ class BasicReportsServiceTest {
           withPrincipalAndScopes(PRINCIPAL, SCOPES) { service.createBasicReport(request) }
         }
 
-      assertThat(exception.status.code).isEqualTo(Status.Code.INVALID_ARGUMENT)
-      assertThat(exception.errorInfo)
+      assertThat(exception).status().code().isEqualTo(Status.Code.INVALID_ARGUMENT)
+      assertThat(exception)
+        .errorInfo()
         .isEqualTo(
           errorInfo {
             domain = Errors.DOMAIN
             reason = Errors.Reason.REQUIRED_FIELD_NOT_SET.name
             metadata[Errors.Metadata.FIELD_NAME.key] =
-              "basic_report.impression_qualification_filters.custom.filter_spec"
+              "basic_report.impression_qualification_filters[0].custom.filter_spec"
           }
         )
     }
@@ -4155,14 +4182,15 @@ class BasicReportsServiceTest {
           withPrincipalAndScopes(PRINCIPAL, SCOPES) { service.createBasicReport(request) }
         }
 
-      assertThat(exception.status.code).isEqualTo(Status.Code.INVALID_ARGUMENT)
-      assertThat(exception.errorInfo)
+      assertThat(exception).status().code().isEqualTo(Status.Code.INVALID_ARGUMENT)
+      assertThat(exception)
+        .errorInfo()
         .isEqualTo(
           errorInfo {
             domain = Errors.DOMAIN
             reason = Errors.Reason.INVALID_FIELD_VALUE.name
             metadata[Errors.Metadata.FIELD_NAME.key] =
-              "basic_report.impression_qualification_filters.custom.filter_spec"
+              "basic_report.impression_qualification_filters[0].custom.filter_specs"
           }
         )
     }
@@ -4210,14 +4238,15 @@ class BasicReportsServiceTest {
           withPrincipalAndScopes(PRINCIPAL, SCOPES) { service.createBasicReport(request) }
         }
 
-      assertThat(exception.status.code).isEqualTo(Status.Code.INVALID_ARGUMENT)
-      assertThat(exception.errorInfo)
+      assertThat(exception).status().code().isEqualTo(Status.Code.INVALID_ARGUMENT)
+      assertThat(exception)
+        .errorInfo()
         .isEqualTo(
           errorInfo {
             domain = Errors.DOMAIN
             reason = Errors.Reason.REQUIRED_FIELD_NOT_SET.name
             metadata[Errors.Metadata.FIELD_NAME.key] =
-              "basic_report.impression_qualification_filters.custom.filter_spec.filters"
+              "basic_report.impression_qualification_filters[0].custom.filter_specs[0].filters"
           }
         )
     }
@@ -4268,14 +4297,15 @@ class BasicReportsServiceTest {
           withPrincipalAndScopes(PRINCIPAL, SCOPES) { service.createBasicReport(request) }
         }
 
-      assertThat(exception.status.code).isEqualTo(Status.Code.INVALID_ARGUMENT)
-      assertThat(exception.errorInfo)
+      assertThat(exception).status().code().isEqualTo(Status.Code.INVALID_ARGUMENT)
+      assertThat(exception)
+        .errorInfo()
         .isEqualTo(
           errorInfo {
             domain = Errors.DOMAIN
             reason = Errors.Reason.REQUIRED_FIELD_NOT_SET.name
             metadata[Errors.Metadata.FIELD_NAME.key] =
-              "basic_report.impression_qualification_filters.custom.filter_spec.filters.terms"
+              "basic_report.impression_qualification_filters[0].custom.filter_specs[0].filters[0].terms"
           }
         )
     }
@@ -4330,14 +4360,15 @@ class BasicReportsServiceTest {
           withPrincipalAndScopes(PRINCIPAL, SCOPES) { service.createBasicReport(request) }
         }
 
-      assertThat(exception.status.code).isEqualTo(Status.Code.INVALID_ARGUMENT)
-      assertThat(exception.errorInfo)
+      assertThat(exception).status().code().isEqualTo(Status.Code.INVALID_ARGUMENT)
+      assertThat(exception)
+        .errorInfo()
         .isEqualTo(
           errorInfo {
             domain = Errors.DOMAIN
             reason = Errors.Reason.REQUIRED_FIELD_NOT_SET.name
             metadata[Errors.Metadata.FIELD_NAME.key] =
-              "basic_report.impression_qualification_filters.custom.filter_spec.filters.terms.path"
+              "basic_report.impression_qualification_filters[0].custom.filter_specs[0].filters[0].terms[0].path"
           }
         )
     }
@@ -4390,14 +4421,15 @@ class BasicReportsServiceTest {
           withPrincipalAndScopes(PRINCIPAL, SCOPES) { service.createBasicReport(request) }
         }
 
-      assertThat(exception.status.code).isEqualTo(Status.Code.INVALID_ARGUMENT)
-      assertThat(exception.errorInfo)
+      assertThat(exception).status().code().isEqualTo(Status.Code.INVALID_ARGUMENT)
+      assertThat(exception)
+        .errorInfo()
         .isEqualTo(
           errorInfo {
             domain = Errors.DOMAIN
             reason = Errors.Reason.REQUIRED_FIELD_NOT_SET.name
             metadata[Errors.Metadata.FIELD_NAME.key] =
-              "basic_report.impression_qualification_filters.custom.filter_spec.filters.terms.value"
+              "basic_report.impression_qualification_filters[0].custom.filter_specs[0].filters[0].terms[0].value"
           }
         )
     }
@@ -4440,14 +4472,15 @@ class BasicReportsServiceTest {
           withPrincipalAndScopes(PRINCIPAL, SCOPES) { service.createBasicReport(request) }
         }
 
-      assertThat(exception.status.code).isEqualTo(Status.Code.INVALID_ARGUMENT)
-      assertThat(exception.errorInfo)
+      assertThat(exception).status().code().isEqualTo(Status.Code.INVALID_ARGUMENT)
+      assertThat(exception)
+        .errorInfo()
         .isEqualTo(
           errorInfo {
             domain = Errors.DOMAIN
-            reason = Errors.Reason.INVALID_FIELD_VALUE.name
+            reason = Errors.Reason.REQUIRED_FIELD_NOT_SET.name
             metadata[Errors.Metadata.FIELD_NAME.key] =
-              "basic_report.impression_qualification_filters.selector"
+              "basic_report.impression_qualification_filters[0].selector"
           }
         )
     }
@@ -4488,8 +4521,9 @@ class BasicReportsServiceTest {
         withPrincipalAndScopes(PRINCIPAL, SCOPES) { service.createBasicReport(request) }
       }
 
-    assertThat(exception.status.code).isEqualTo(Status.Code.INVALID_ARGUMENT)
-    assertThat(exception.errorInfo)
+    assertThat(exception).status().code().isEqualTo(Status.Code.INVALID_ARGUMENT)
+    assertThat(exception)
+      .errorInfo()
       .isEqualTo(
         errorInfo {
           domain = Errors.DOMAIN
@@ -4536,14 +4570,15 @@ class BasicReportsServiceTest {
           withPrincipalAndScopes(PRINCIPAL, SCOPES) { service.createBasicReport(request) }
         }
 
-      assertThat(exception.status.code).isEqualTo(Status.Code.INVALID_ARGUMENT)
-      assertThat(exception.errorInfo)
+      assertThat(exception).status().code().isEqualTo(Status.Code.INVALID_ARGUMENT)
+      assertThat(exception)
+        .errorInfo()
         .isEqualTo(
           errorInfo {
             domain = Errors.DOMAIN
             reason = Errors.Reason.REQUIRED_FIELD_NOT_SET.name
             metadata[Errors.Metadata.FIELD_NAME.key] =
-              "basic_report.result_group_specs.reporting_unit"
+              "basic_report.result_group_specs[0].reporting_unit"
           }
         )
     }
@@ -4585,14 +4620,15 @@ class BasicReportsServiceTest {
           withPrincipalAndScopes(PRINCIPAL, SCOPES) { service.createBasicReport(request) }
         }
 
-      assertThat(exception.status.code).isEqualTo(Status.Code.INVALID_ARGUMENT)
-      assertThat(exception.errorInfo)
+      assertThat(exception).status().code().isEqualTo(Status.Code.INVALID_ARGUMENT)
+      assertThat(exception)
+        .errorInfo()
         .isEqualTo(
           errorInfo {
             domain = Errors.DOMAIN
             reason = Errors.Reason.INVALID_FIELD_VALUE.name
             metadata[Errors.Metadata.FIELD_NAME.key] =
-              "basic_report.result_group_specs.reporting_unit.components"
+              "basic_report.result_group_specs[0].reporting_unit.components"
           }
         )
     }
@@ -4635,20 +4671,21 @@ class BasicReportsServiceTest {
           withPrincipalAndScopes(PRINCIPAL, SCOPES) { service.createBasicReport(request) }
         }
 
-      assertThat(exception.status.code).isEqualTo(Status.Code.INVALID_ARGUMENT)
-      assertThat(exception.errorInfo)
+      assertThat(exception).status().code().isEqualTo(Status.Code.INVALID_ARGUMENT)
+      assertThat(exception)
+        .errorInfo()
         .isEqualTo(
           errorInfo {
             domain = Errors.DOMAIN
             reason = Errors.Reason.INVALID_FIELD_VALUE.name
             metadata[Errors.Metadata.FIELD_NAME.key] =
-              "basic_report.result_group_specs.reporting_unit.components"
+              "basic_report.result_group_specs[0].reporting_unit.components[0]"
           }
         )
     }
 
   @Test
-  fun `createBasicReport throws INVALID_ARGUMENT when component not in campaign group`() =
+  fun `createBasicReport throws FAILED_PRECONDITION when component not in campaign group`() =
     runBlocking {
       val measurementConsumerKey = MeasurementConsumerKey(CMMS_MEASUREMENT_CONSUMER_ID)
       val campaignGroupKey = ReportingSetKey(measurementConsumerKey, "1234")
@@ -4687,14 +4724,16 @@ class BasicReportsServiceTest {
           withPrincipalAndScopes(PRINCIPAL, SCOPES) { service.createBasicReport(request) }
         }
 
-      assertThat(exception.status.code).isEqualTo(Status.Code.INVALID_ARGUMENT)
-      assertThat(exception.errorInfo)
+      assertThat(exception).status().code().isEqualTo(Status.Code.FAILED_PRECONDITION)
+      assertThat(exception)
+        .errorInfo()
         .isEqualTo(
           errorInfo {
             domain = Errors.DOMAIN
-            reason = Errors.Reason.INVALID_FIELD_VALUE.name
-            metadata[Errors.Metadata.FIELD_NAME.key] =
-              "basic_report.result_group_specs.reporting_unit.components"
+            reason = Errors.Reason.DATA_PROVIDER_NOT_FOUND_FOR_CAMPAIGN_GROUP.name
+            metadata[Errors.Metadata.REPORTING_SET.key] =
+              "measurementConsumers/1234/reportingSets/1234"
+            metadata[Errors.Metadata.DATA_PROVIDER.key] = "dataProviders/4321"
           }
         )
     }
@@ -4735,14 +4774,15 @@ class BasicReportsServiceTest {
         withPrincipalAndScopes(PRINCIPAL, SCOPES) { service.createBasicReport(request) }
       }
 
-    assertThat(exception.status.code).isEqualTo(Status.Code.INVALID_ARGUMENT)
-    assertThat(exception.errorInfo)
+    assertThat(exception).status().code().isEqualTo(Status.Code.INVALID_ARGUMENT)
+    assertThat(exception)
+      .errorInfo()
       .isEqualTo(
         errorInfo {
           domain = Errors.DOMAIN
           reason = Errors.Reason.REQUIRED_FIELD_NOT_SET.name
           metadata[Errors.Metadata.FIELD_NAME.key] =
-            "basic_report.result_group_specs.dimension_spec"
+            "basic_report.result_group_specs[0].dimension_spec"
         }
       )
   }
@@ -4790,14 +4830,15 @@ class BasicReportsServiceTest {
           withPrincipalAndScopes(PRINCIPAL, SCOPES) { service.createBasicReport(request) }
         }
 
-      assertThat(exception.status.code).isEqualTo(Status.Code.INVALID_ARGUMENT)
-      assertThat(exception.errorInfo)
+      assertThat(exception).status().code().isEqualTo(Status.Code.INVALID_ARGUMENT)
+      assertThat(exception)
+        .errorInfo()
         .isEqualTo(
           errorInfo {
             domain = Errors.DOMAIN
             reason = Errors.Reason.REQUIRED_FIELD_NOT_SET.name
             metadata[Errors.Metadata.FIELD_NAME.key] =
-              "basic_report.result_group_specs.dimension_spec.grouping.event_template_fields"
+              "basic_report.result_group_specs[0].dimension_spec.grouping.event_template_fields"
           }
         )
     }
@@ -4845,15 +4886,15 @@ class BasicReportsServiceTest {
           withPrincipalAndScopes(PRINCIPAL, SCOPES) { service.createBasicReport(request) }
         }
 
-      assertThat(exception.status.code).isEqualTo(Status.Code.INVALID_ARGUMENT)
-      assertThat(exception.message).contains("exist")
-      assertThat(exception.errorInfo)
+      assertThat(exception).status().code().isEqualTo(Status.Code.INVALID_ARGUMENT)
+      assertThat(exception).hasMessageThat().contains("exist")
+      assertThat(exception)
+        .errorInfo()
         .isEqualTo(
           errorInfo {
             domain = Errors.DOMAIN
-            reason = Errors.Reason.INVALID_FIELD_VALUE.name
-            metadata[Errors.Metadata.FIELD_NAME.key] =
-              "basic_report.result_group_specs.dimension_spec.grouping.event_template_fields"
+            reason = Errors.Reason.EVENT_TEMPLATE_FIELD_INVALID.name
+            metadata[Errors.Metadata.EVENT_TEMPLATE_FIELD_PATH.key] = "person.height"
           }
         )
     }
@@ -4902,15 +4943,15 @@ class BasicReportsServiceTest {
           withPrincipalAndScopes(PRINCIPAL, SCOPES) { service.createBasicReport(request) }
         }
 
-      assertThat(exception.status.code).isEqualTo(Status.Code.INVALID_ARGUMENT)
-      assertThat(exception.message).contains("groupable")
-      assertThat(exception.errorInfo)
+      assertThat(exception).status().code().isEqualTo(Status.Code.INVALID_ARGUMENT)
+      assertThat(exception).hasMessageThat().contains("groupable")
+      assertThat(exception)
+        .errorInfo()
         .isEqualTo(
           errorInfo {
             domain = Errors.DOMAIN
-            reason = Errors.Reason.INVALID_FIELD_VALUE.name
-            metadata[Errors.Metadata.FIELD_NAME.key] =
-              "basic_report.result_group_specs.dimension_spec.grouping.event_template_fields"
+            reason = Errors.Reason.EVENT_TEMPLATE_FIELD_INVALID.name
+            metadata[Errors.Metadata.EVENT_TEMPLATE_FIELD_PATH.key] = "banner_ad.viewable"
           }
         )
     }
@@ -4958,14 +4999,15 @@ class BasicReportsServiceTest {
           withPrincipalAndScopes(PRINCIPAL, SCOPES) { service.createBasicReport(request) }
         }
 
-      assertThat(exception.status.code).isEqualTo(Status.Code.INVALID_ARGUMENT)
-      assertThat(exception.errorInfo)
+      assertThat(exception).status().code().isEqualTo(Status.Code.INVALID_ARGUMENT)
+      assertThat(exception)
+        .errorInfo()
         .isEqualTo(
           errorInfo {
             domain = Errors.DOMAIN
             reason = Errors.Reason.REQUIRED_FIELD_NOT_SET.name
             metadata[Errors.Metadata.FIELD_NAME.key] =
-              "basic_report.result_group_specs.dimension_spec.filters.terms"
+              "basic_report.result_group_specs[0].dimension_spec.filters[2].terms"
           }
         )
     }
@@ -5022,14 +5064,15 @@ class BasicReportsServiceTest {
           withPrincipalAndScopes(PRINCIPAL, SCOPES) { service.createBasicReport(request) }
         }
 
-      assertThat(exception.status.code).isEqualTo(Status.Code.INVALID_ARGUMENT)
-      assertThat(exception.errorInfo)
+      assertThat(exception).status().code().isEqualTo(Status.Code.INVALID_ARGUMENT)
+      assertThat(exception)
+        .errorInfo()
         .isEqualTo(
           errorInfo {
             domain = Errors.DOMAIN
             reason = Errors.Reason.INVALID_FIELD_VALUE.name
             metadata[Errors.Metadata.FIELD_NAME.key] =
-              "basic_report.result_group_specs.dimension_spec.filters.terms"
+              "basic_report.result_group_specs[0].dimension_spec.filters[2].terms"
           }
         )
     }
@@ -5081,14 +5124,15 @@ class BasicReportsServiceTest {
           withPrincipalAndScopes(PRINCIPAL, SCOPES) { service.createBasicReport(request) }
         }
 
-      assertThat(exception.status.code).isEqualTo(Status.Code.INVALID_ARGUMENT)
-      assertThat(exception.errorInfo)
+      assertThat(exception).status().code().isEqualTo(Status.Code.INVALID_ARGUMENT)
+      assertThat(exception)
+        .errorInfo()
         .isEqualTo(
           errorInfo {
             domain = Errors.DOMAIN
             reason = Errors.Reason.REQUIRED_FIELD_NOT_SET.name
             metadata[Errors.Metadata.FIELD_NAME.key] =
-              "basic_report.result_group_specs.dimension_spec.filters.terms.path"
+              "basic_report.result_group_specs[0].dimension_spec.filters[2].terms[0].path"
           }
         )
     }
@@ -5141,15 +5185,14 @@ class BasicReportsServiceTest {
           withPrincipalAndScopes(PRINCIPAL, SCOPES) { service.createBasicReport(request) }
         }
 
-      assertThat(exception.status.code).isEqualTo(Status.Code.INVALID_ARGUMENT)
-      assertThat(exception.message).contains("exist")
-      assertThat(exception.errorInfo)
+      assertThat(exception).status().code().isEqualTo(Status.Code.INVALID_ARGUMENT)
+      assertThat(exception)
+        .errorInfo()
         .isEqualTo(
           errorInfo {
             domain = Errors.DOMAIN
-            reason = Errors.Reason.INVALID_FIELD_VALUE.name
-            metadata[Errors.Metadata.FIELD_NAME.key] =
-              "basic_report.result_group_specs.dimension_spec.filters.terms.path"
+            reason = Errors.Reason.EVENT_TEMPLATE_FIELD_INVALID.name
+            metadata[Errors.Metadata.EVENT_TEMPLATE_FIELD_PATH.key] = "person.height"
           }
         )
     }
@@ -5202,15 +5245,15 @@ class BasicReportsServiceTest {
           withPrincipalAndScopes(PRINCIPAL, SCOPES) { service.createBasicReport(request) }
         }
 
-      assertThat(exception.status.code).isEqualTo(Status.Code.INVALID_ARGUMENT)
-      assertThat(exception.message).contains("filterable")
-      assertThat(exception.errorInfo)
+      assertThat(exception).status().code().isEqualTo(Status.Code.INVALID_ARGUMENT)
+      assertThat(exception).hasMessageThat().contains("filterable")
+      assertThat(exception)
+        .errorInfo()
         .isEqualTo(
           errorInfo {
             domain = Errors.DOMAIN
-            reason = Errors.Reason.INVALID_FIELD_VALUE.name
-            metadata[Errors.Metadata.FIELD_NAME.key] =
-              "basic_report.result_group_specs.dimension_spec.filters.terms.path"
+            reason = Errors.Reason.EVENT_TEMPLATE_FIELD_INVALID.name
+            metadata[Errors.Metadata.EVENT_TEMPLATE_FIELD_PATH.key] = "banner_ad.viewable"
           }
         )
     }
@@ -5265,14 +5308,15 @@ class BasicReportsServiceTest {
           withPrincipalAndScopes(PRINCIPAL, SCOPES) { service.createBasicReport(request) }
         }
 
-      assertThat(exception.status.code).isEqualTo(Status.Code.INVALID_ARGUMENT)
-      assertThat(exception.errorInfo)
+      assertThat(exception).status().code().isEqualTo(Status.Code.INVALID_ARGUMENT)
+      assertThat(exception)
+        .errorInfo()
         .isEqualTo(
           errorInfo {
             domain = Errors.DOMAIN
             reason = Errors.Reason.INVALID_FIELD_VALUE.name
             metadata[Errors.Metadata.FIELD_NAME.key] =
-              "basic_report.result_group_specs.dimension_spec.filters.terms.path"
+              "basic_report.result_group_specs[0].dimension_spec.filters[0].terms[0]"
           }
         )
     }
@@ -5322,14 +5366,15 @@ class BasicReportsServiceTest {
           withPrincipalAndScopes(PRINCIPAL, SCOPES) { service.createBasicReport(request) }
         }
 
-      assertThat(exception.status.code).isEqualTo(Status.Code.INVALID_ARGUMENT)
-      assertThat(exception.errorInfo)
+      assertThat(exception).status().code().isEqualTo(Status.Code.INVALID_ARGUMENT)
+      assertThat(exception)
+        .errorInfo()
         .isEqualTo(
           errorInfo {
             domain = Errors.DOMAIN
             reason = Errors.Reason.REQUIRED_FIELD_NOT_SET.name
             metadata[Errors.Metadata.FIELD_NAME.key] =
-              "basic_report.result_group_specs.dimension_spec.filters.terms.value"
+              "basic_report.result_group_specs[0].dimension_spec.filters[2].terms[0].value"
           }
         )
     }
@@ -5382,14 +5427,14 @@ class BasicReportsServiceTest {
           withPrincipalAndScopes(PRINCIPAL, SCOPES) { service.createBasicReport(request) }
         }
 
-      assertThat(exception.status.code).isEqualTo(Status.Code.INVALID_ARGUMENT)
-      assertThat(exception.errorInfo)
+      assertThat(exception).status().code().isEqualTo(Status.Code.INVALID_ARGUMENT)
+      assertThat(exception)
+        .errorInfo()
         .isEqualTo(
           errorInfo {
             domain = Errors.DOMAIN
-            reason = Errors.Reason.INVALID_FIELD_VALUE.name
-            metadata[Errors.Metadata.FIELD_NAME.key] =
-              "basic_report.result_group_specs.dimension_spec.filters.terms.value.string_value"
+            reason = Errors.Reason.EVENT_TEMPLATE_FIELD_INVALID.name
+            metadata[Errors.Metadata.EVENT_TEMPLATE_FIELD_PATH.key] = "video_ad.length"
           }
         )
     }
@@ -5442,14 +5487,14 @@ class BasicReportsServiceTest {
           withPrincipalAndScopes(PRINCIPAL, SCOPES) { service.createBasicReport(request) }
         }
 
-      assertThat(exception.status.code).isEqualTo(Status.Code.INVALID_ARGUMENT)
-      assertThat(exception.errorInfo)
+      assertThat(exception).status().code().isEqualTo(Status.Code.INVALID_ARGUMENT)
+      assertThat(exception)
+        .errorInfo()
         .isEqualTo(
           errorInfo {
             domain = Errors.DOMAIN
-            reason = Errors.Reason.INVALID_FIELD_VALUE.name
-            metadata[Errors.Metadata.FIELD_NAME.key] =
-              "basic_report.result_group_specs.dimension_spec.filters.terms.value.enum_value"
+            reason = Errors.Reason.EVENT_TEMPLATE_FIELD_INVALID.name
+            metadata[Errors.Metadata.EVENT_TEMPLATE_FIELD_PATH.key] = "video_ad.length"
           }
         )
     }
@@ -5502,14 +5547,14 @@ class BasicReportsServiceTest {
           withPrincipalAndScopes(PRINCIPAL, SCOPES) { service.createBasicReport(request) }
         }
 
-      assertThat(exception.status.code).isEqualTo(Status.Code.INVALID_ARGUMENT)
-      assertThat(exception.errorInfo)
+      assertThat(exception).status().code().isEqualTo(Status.Code.INVALID_ARGUMENT)
+      assertThat(exception)
+        .errorInfo()
         .isEqualTo(
           errorInfo {
             domain = Errors.DOMAIN
-            reason = Errors.Reason.INVALID_FIELD_VALUE.name
-            metadata[Errors.Metadata.FIELD_NAME.key] =
-              "basic_report.result_group_specs.dimension_spec.filters.terms.value.bool_value"
+            reason = Errors.Reason.EVENT_TEMPLATE_FIELD_INVALID.name
+            metadata[Errors.Metadata.EVENT_TEMPLATE_FIELD_PATH.key] = "video_ad.length"
           }
         )
     }
@@ -5562,14 +5607,14 @@ class BasicReportsServiceTest {
           withPrincipalAndScopes(PRINCIPAL, SCOPES) { service.createBasicReport(request) }
         }
 
-      assertThat(exception.status.code).isEqualTo(Status.Code.INVALID_ARGUMENT)
-      assertThat(exception.errorInfo)
+      assertThat(exception).status().code().isEqualTo(Status.Code.INVALID_ARGUMENT)
+      assertThat(exception)
+        .errorInfo()
         .isEqualTo(
           errorInfo {
             domain = Errors.DOMAIN
-            reason = Errors.Reason.INVALID_FIELD_VALUE.name
-            metadata[Errors.Metadata.FIELD_NAME.key] =
-              "basic_report.result_group_specs.dimension_spec.filters.terms.value.float_value"
+            reason = Errors.Reason.EVENT_TEMPLATE_FIELD_INVALID.name
+            metadata[Errors.Metadata.EVENT_TEMPLATE_FIELD_PATH.key] = "video_ad.length"
           }
         )
     }
@@ -5622,14 +5667,14 @@ class BasicReportsServiceTest {
           withPrincipalAndScopes(PRINCIPAL, SCOPES) { service.createBasicReport(request) }
         }
 
-      assertThat(exception.status.code).isEqualTo(Status.Code.INVALID_ARGUMENT)
-      assertThat(exception.errorInfo)
+      assertThat(exception).status().code().isEqualTo(Status.Code.INVALID_ARGUMENT)
+      assertThat(exception)
+        .errorInfo()
         .isEqualTo(
           errorInfo {
             domain = Errors.DOMAIN
-            reason = Errors.Reason.INVALID_FIELD_VALUE.name
-            metadata[Errors.Metadata.FIELD_NAME.key] =
-              "basic_report.result_group_specs.dimension_spec.filters.terms.value.string_value"
+            reason = Errors.Reason.EVENT_TEMPLATE_FIELD_INVALID.name
+            metadata[Errors.Metadata.EVENT_TEMPLATE_FIELD_PATH.key] = "person.gender"
           }
         )
     }
@@ -5682,14 +5727,14 @@ class BasicReportsServiceTest {
           withPrincipalAndScopes(PRINCIPAL, SCOPES) { service.createBasicReport(request) }
         }
 
-      assertThat(exception.status.code).isEqualTo(Status.Code.INVALID_ARGUMENT)
-      assertThat(exception.errorInfo)
+      assertThat(exception).status().code().isEqualTo(Status.Code.INVALID_ARGUMENT)
+      assertThat(exception)
+        .errorInfo()
         .isEqualTo(
           errorInfo {
             domain = Errors.DOMAIN
-            reason = Errors.Reason.INVALID_FIELD_VALUE.name
-            metadata[Errors.Metadata.FIELD_NAME.key] =
-              "basic_report.result_group_specs.dimension_spec.filters.terms.value.enum_value"
+            reason = Errors.Reason.EVENT_TEMPLATE_FIELD_INVALID.name
+            metadata[Errors.Metadata.EVENT_TEMPLATE_FIELD_PATH.key] = "person.gender"
           }
         )
     }
@@ -5742,14 +5787,14 @@ class BasicReportsServiceTest {
           withPrincipalAndScopes(PRINCIPAL, SCOPES) { service.createBasicReport(request) }
         }
 
-      assertThat(exception.status.code).isEqualTo(Status.Code.INVALID_ARGUMENT)
-      assertThat(exception.errorInfo)
+      assertThat(exception).status().code().isEqualTo(Status.Code.INVALID_ARGUMENT)
+      assertThat(exception)
+        .errorInfo()
         .isEqualTo(
           errorInfo {
             domain = Errors.DOMAIN
-            reason = Errors.Reason.INVALID_FIELD_VALUE.name
-            metadata[Errors.Metadata.FIELD_NAME.key] =
-              "basic_report.result_group_specs.dimension_spec.filters.terms.value.bool_value"
+            reason = Errors.Reason.EVENT_TEMPLATE_FIELD_INVALID.name
+            metadata[Errors.Metadata.EVENT_TEMPLATE_FIELD_PATH.key] = "person.gender"
           }
         )
     }
@@ -5802,14 +5847,14 @@ class BasicReportsServiceTest {
           withPrincipalAndScopes(PRINCIPAL, SCOPES) { service.createBasicReport(request) }
         }
 
-      assertThat(exception.status.code).isEqualTo(Status.Code.INVALID_ARGUMENT)
-      assertThat(exception.errorInfo)
+      assertThat(exception).status().code().isEqualTo(Status.Code.INVALID_ARGUMENT)
+      assertThat(exception)
+        .errorInfo()
         .isEqualTo(
           errorInfo {
             domain = Errors.DOMAIN
-            reason = Errors.Reason.INVALID_FIELD_VALUE.name
-            metadata[Errors.Metadata.FIELD_NAME.key] =
-              "basic_report.result_group_specs.dimension_spec.filters.terms.value.float_value"
+            reason = Errors.Reason.EVENT_TEMPLATE_FIELD_INVALID.name
+            metadata[Errors.Metadata.EVENT_TEMPLATE_FIELD_PATH.key] = "person.gender"
           }
         )
     }
@@ -5859,14 +5904,15 @@ class BasicReportsServiceTest {
         withPrincipalAndScopes(PRINCIPAL, SCOPES) { service.createBasicReport(request) }
       }
 
-    assertThat(exception.status.code).isEqualTo(Status.Code.INVALID_ARGUMENT)
-    assertThat(exception.errorInfo)
+    assertThat(exception).status().code().isEqualTo(Status.Code.INVALID_ARGUMENT)
+    assertThat(exception)
+      .errorInfo()
       .isEqualTo(
         errorInfo {
           domain = Errors.DOMAIN
           reason = Errors.Reason.REQUIRED_FIELD_NOT_SET.name
           metadata[Errors.Metadata.FIELD_NAME.key] =
-            "basic_report.impression_qualification_filters.custom.filter_spec.filters.terms"
+            "basic_report.impression_qualification_filters[0].custom.filter_specs[0].filters[0].terms"
         }
       )
   }
@@ -5925,14 +5971,15 @@ class BasicReportsServiceTest {
         withPrincipalAndScopes(PRINCIPAL, SCOPES) { service.createBasicReport(request) }
       }
 
-    assertThat(exception.status.code).isEqualTo(Status.Code.INVALID_ARGUMENT)
-    assertThat(exception.errorInfo)
+    assertThat(exception).status().code().isEqualTo(Status.Code.INVALID_ARGUMENT)
+    assertThat(exception)
+      .errorInfo()
       .isEqualTo(
         errorInfo {
           domain = Errors.DOMAIN
           reason = Errors.Reason.INVALID_FIELD_VALUE.name
           metadata[Errors.Metadata.FIELD_NAME.key] =
-            "basic_report.impression_qualification_filters.custom.filter_spec.filters.terms"
+            "basic_report.impression_qualification_filters[0].custom.filter_specs[0].filters[0].terms"
         }
       )
   }
@@ -5988,15 +6035,15 @@ class BasicReportsServiceTest {
           withPrincipalAndScopes(PRINCIPAL, SCOPES) { service.createBasicReport(request) }
         }
 
-      assertThat(exception.status.code).isEqualTo(Status.Code.INVALID_ARGUMENT)
-      assertThat(exception.message).contains("exist")
-      assertThat(exception.errorInfo)
+      assertThat(exception).status().code().isEqualTo(Status.Code.INVALID_ARGUMENT)
+      assertThat(exception).hasMessageThat().contains("exist")
+      assertThat(exception)
+        .errorInfo()
         .isEqualTo(
           errorInfo {
             domain = Errors.DOMAIN
-            reason = Errors.Reason.INVALID_FIELD_VALUE.name
-            metadata[Errors.Metadata.FIELD_NAME.key] =
-              "basic_report.impression_qualification_filters.custom.filter_spec.filters.terms.path"
+            reason = Errors.Reason.EVENT_TEMPLATE_FIELD_INVALID.name
+            metadata[Errors.Metadata.EVENT_TEMPLATE_FIELD_PATH.key] = "banner_ad.height"
           }
         )
     }
@@ -6052,15 +6099,15 @@ class BasicReportsServiceTest {
           withPrincipalAndScopes(PRINCIPAL, SCOPES) { service.createBasicReport(request) }
         }
 
-      assertThat(exception.status.code).isEqualTo(Status.Code.INVALID_ARGUMENT)
-      assertThat(exception.message).contains("impression qualification")
-      assertThat(exception.errorInfo)
+      assertThat(exception).status().code().isEqualTo(Status.Code.INVALID_ARGUMENT)
+      assertThat(exception).hasMessageThat().contains("impression qualification")
+      assertThat(exception)
+        .errorInfo()
         .isEqualTo(
           errorInfo {
             domain = Errors.DOMAIN
-            reason = Errors.Reason.INVALID_FIELD_VALUE.name
-            metadata[Errors.Metadata.FIELD_NAME.key] =
-              "basic_report.impression_qualification_filters.custom.filter_spec.filters.terms.path"
+            reason = Errors.Reason.EVENT_TEMPLATE_FIELD_INVALID.name
+            metadata[Errors.Metadata.EVENT_TEMPLATE_FIELD_PATH.key] = "person.gender"
           }
         )
     }
@@ -6116,15 +6163,16 @@ class BasicReportsServiceTest {
           withPrincipalAndScopes(PRINCIPAL, SCOPES) { service.createBasicReport(request) }
         }
 
-      assertThat(exception.status.code).isEqualTo(Status.Code.INVALID_ARGUMENT)
-      assertThat(exception.message).contains("media_type")
-      assertThat(exception.errorInfo)
+      assertThat(exception).status().code().isEqualTo(Status.Code.INVALID_ARGUMENT)
+      assertThat(exception).hasMessageThat().contains("media_type")
+      assertThat(exception)
+        .errorInfo()
         .isEqualTo(
           errorInfo {
             domain = Errors.DOMAIN
             reason = Errors.Reason.INVALID_FIELD_VALUE.name
             metadata[Errors.Metadata.FIELD_NAME.key] =
-              "basic_report.impression_qualification_filters.custom.filter_spec.filters.terms.path"
+              "basic_report.impression_qualification_filters[0].custom.filter_specs[0].filters[0].terms[0].path"
           }
         )
     }
@@ -6180,14 +6228,14 @@ class BasicReportsServiceTest {
           withPrincipalAndScopes(PRINCIPAL, SCOPES) { service.createBasicReport(request) }
         }
 
-      assertThat(exception.status.code).isEqualTo(Status.Code.INVALID_ARGUMENT)
-      assertThat(exception.errorInfo)
+      assertThat(exception).status().code().isEqualTo(Status.Code.INVALID_ARGUMENT)
+      assertThat(exception)
+        .errorInfo()
         .isEqualTo(
           errorInfo {
             domain = Errors.DOMAIN
-            reason = Errors.Reason.INVALID_FIELD_VALUE.name
-            metadata[Errors.Metadata.FIELD_NAME.key] =
-              "basic_report.impression_qualification_filters.custom.filter_spec.filters.terms.value.string_value"
+            reason = Errors.Reason.EVENT_TEMPLATE_FIELD_INVALID.name
+            metadata[Errors.Metadata.EVENT_TEMPLATE_FIELD_PATH.key] = "banner_ad.viewable"
           }
         )
     }
@@ -6243,14 +6291,14 @@ class BasicReportsServiceTest {
           withPrincipalAndScopes(PRINCIPAL, SCOPES) { service.createBasicReport(request) }
         }
 
-      assertThat(exception.status.code).isEqualTo(Status.Code.INVALID_ARGUMENT)
-      assertThat(exception.errorInfo)
+      assertThat(exception).status().code().isEqualTo(Status.Code.INVALID_ARGUMENT)
+      assertThat(exception)
+        .errorInfo()
         .isEqualTo(
           errorInfo {
             domain = Errors.DOMAIN
-            reason = Errors.Reason.INVALID_FIELD_VALUE.name
-            metadata[Errors.Metadata.FIELD_NAME.key] =
-              "basic_report.impression_qualification_filters.custom.filter_spec.filters.terms.value.enum_value"
+            reason = Errors.Reason.EVENT_TEMPLATE_FIELD_INVALID.name
+            metadata[Errors.Metadata.EVENT_TEMPLATE_FIELD_PATH.key] = "banner_ad.viewable"
           }
         )
     }
@@ -6306,14 +6354,14 @@ class BasicReportsServiceTest {
           withPrincipalAndScopes(PRINCIPAL, SCOPES) { service.createBasicReport(request) }
         }
 
-      assertThat(exception.status.code).isEqualTo(Status.Code.INVALID_ARGUMENT)
-      assertThat(exception.errorInfo)
+      assertThat(exception).status().code().isEqualTo(Status.Code.INVALID_ARGUMENT)
+      assertThat(exception)
+        .errorInfo()
         .isEqualTo(
           errorInfo {
             domain = Errors.DOMAIN
-            reason = Errors.Reason.INVALID_FIELD_VALUE.name
-            metadata[Errors.Metadata.FIELD_NAME.key] =
-              "basic_report.impression_qualification_filters.custom.filter_spec.filters.terms.value.float_value"
+            reason = Errors.Reason.EVENT_TEMPLATE_FIELD_INVALID.name
+            metadata[Errors.Metadata.EVENT_TEMPLATE_FIELD_PATH.key] = "banner_ad.viewable"
           }
         )
     }
@@ -6369,14 +6417,14 @@ class BasicReportsServiceTest {
           withPrincipalAndScopes(PRINCIPAL, SCOPES) { service.createBasicReport(request) }
         }
 
-      assertThat(exception.status.code).isEqualTo(Status.Code.INVALID_ARGUMENT)
-      assertThat(exception.errorInfo)
+      assertThat(exception).status().code().isEqualTo(Status.Code.INVALID_ARGUMENT)
+      assertThat(exception)
+        .errorInfo()
         .isEqualTo(
           errorInfo {
             domain = Errors.DOMAIN
-            reason = Errors.Reason.INVALID_FIELD_VALUE.name
-            metadata[Errors.Metadata.FIELD_NAME.key] =
-              "basic_report.impression_qualification_filters.custom.filter_spec.filters.terms.value.bool_value"
+            reason = Errors.Reason.EVENT_TEMPLATE_FIELD_INVALID.name
+            metadata[Errors.Metadata.EVENT_TEMPLATE_FIELD_PATH.key] = "video_ad.viewed_fraction"
           }
         )
     }
@@ -6432,14 +6480,14 @@ class BasicReportsServiceTest {
           withPrincipalAndScopes(PRINCIPAL, SCOPES) { service.createBasicReport(request) }
         }
 
-      assertThat(exception.status.code).isEqualTo(Status.Code.INVALID_ARGUMENT)
-      assertThat(exception.errorInfo)
+      assertThat(exception).status().code().isEqualTo(Status.Code.INVALID_ARGUMENT)
+      assertThat(exception)
+        .errorInfo()
         .isEqualTo(
           errorInfo {
             domain = Errors.DOMAIN
-            reason = Errors.Reason.INVALID_FIELD_VALUE.name
-            metadata[Errors.Metadata.FIELD_NAME.key] =
-              "basic_report.impression_qualification_filters.custom.filter_spec.filters.terms.value.float_value"
+            reason = Errors.Reason.EVENT_TEMPLATE_FIELD_INVALID.name
+            metadata[Errors.Metadata.EVENT_TEMPLATE_FIELD_PATH.key] = "video_ad.viewed_fraction"
           }
         )
     }
@@ -6481,14 +6529,15 @@ class BasicReportsServiceTest {
           withPrincipalAndScopes(PRINCIPAL, SCOPES) { service.createBasicReport(request) }
         }
 
-      assertThat(exception.status.code).isEqualTo(Status.Code.INVALID_ARGUMENT)
-      assertThat(exception.errorInfo)
+      assertThat(exception).status().code().isEqualTo(Status.Code.INVALID_ARGUMENT)
+      assertThat(exception)
+        .errorInfo()
         .isEqualTo(
           errorInfo {
             domain = Errors.DOMAIN
             reason = Errors.Reason.REQUIRED_FIELD_NOT_SET.name
             metadata[Errors.Metadata.FIELD_NAME.key] =
-              "basic_report.result_group_specs.result_group_metric_spec"
+              "basic_report.result_group_specs[0].result_group_metric_spec"
           }
         )
     }
@@ -6535,14 +6584,15 @@ class BasicReportsServiceTest {
         withPrincipalAndScopes(PRINCIPAL, SCOPES) { service.createBasicReport(request) }
       }
 
-    assertThat(exception.status.code).isEqualTo(Status.Code.UNIMPLEMENTED)
-    assertThat(exception.errorInfo)
+    assertThat(exception).status().code().isEqualTo(Status.Code.UNIMPLEMENTED)
+    assertThat(exception)
+      .errorInfo()
       .isEqualTo(
         errorInfo {
           domain = Errors.DOMAIN
           reason = Errors.Reason.FIELD_UNIMPLEMENTED.name
           metadata[Errors.Metadata.FIELD_NAME.key] =
-            "basic_report.result_group_specs.result_group_metric_spec.component_intersection"
+            "basic_report.result_group_specs[0].result_group_metric_spec.component_intersection"
         }
       )
   }
@@ -6583,14 +6633,15 @@ class BasicReportsServiceTest {
         withPrincipalAndScopes(PRINCIPAL, SCOPES) { service.createBasicReport(request) }
       }
 
-    assertThat(exception.status.code).isEqualTo(Status.Code.INVALID_ARGUMENT)
-    assertThat(exception.errorInfo)
+    assertThat(exception).status().code().isEqualTo(Status.Code.INVALID_ARGUMENT)
+    assertThat(exception)
+      .errorInfo()
       .isEqualTo(
         errorInfo {
           domain = Errors.DOMAIN
           reason = Errors.Reason.REQUIRED_FIELD_NOT_SET.name
           metadata[Errors.Metadata.FIELD_NAME.key] =
-            "basic_report.result_group_specs.metric_frequency"
+            "basic_report.result_group_specs[0].metric_frequency"
         }
       )
   }
@@ -6641,14 +6692,15 @@ class BasicReportsServiceTest {
           withPrincipalAndScopes(PRINCIPAL, SCOPES) { service.createBasicReport(request) }
         }
 
-      assertThat(exception.status.code).isEqualTo(Status.Code.INVALID_ARGUMENT)
-      assertThat(exception.errorInfo)
+      assertThat(exception).status().code().isEqualTo(Status.Code.INVALID_ARGUMENT)
+      assertThat(exception)
+        .errorInfo()
         .isEqualTo(
           errorInfo {
             domain = Errors.DOMAIN
             reason = Errors.Reason.INVALID_FIELD_VALUE.name
             metadata[Errors.Metadata.FIELD_NAME.key] =
-              "basic_report.result_group_specs.result_group_metric_spec.reporting_unit.non_cumulative"
+              "basic_report.result_group_specs[0].result_group_metric_spec.reporting_unit.non_cumulative"
           }
         )
     }
@@ -6699,14 +6751,15 @@ class BasicReportsServiceTest {
           withPrincipalAndScopes(PRINCIPAL, SCOPES) { service.createBasicReport(request) }
         }
 
-      assertThat(exception.status.code).isEqualTo(Status.Code.INVALID_ARGUMENT)
-      assertThat(exception.errorInfo)
+      assertThat(exception).status().code().isEqualTo(Status.Code.INVALID_ARGUMENT)
+      assertThat(exception)
+        .errorInfo()
         .isEqualTo(
           errorInfo {
             domain = Errors.DOMAIN
             reason = Errors.Reason.INVALID_FIELD_VALUE.name
             metadata[Errors.Metadata.FIELD_NAME.key] =
-              "basic_report.result_group_specs.result_group_metric_spec.component.non_cumulative"
+              "basic_report.result_group_specs[0].result_group_metric_spec.component.non_cumulative"
           }
         )
     }
@@ -6758,14 +6811,15 @@ class BasicReportsServiceTest {
           withPrincipalAndScopes(PRINCIPAL, SCOPES) { service.createBasicReport(request) }
         }
 
-      assertThat(exception.status.code).isEqualTo(Status.Code.INVALID_ARGUMENT)
-      assertThat(exception.errorInfo)
+      assertThat(exception).status().code().isEqualTo(Status.Code.INVALID_ARGUMENT)
+      assertThat(exception)
+        .errorInfo()
         .isEqualTo(
           errorInfo {
             domain = Errors.DOMAIN
             reason = Errors.Reason.INVALID_FIELD_VALUE.name
             metadata[Errors.Metadata.FIELD_NAME.key] =
-              "basic_report.result_group_specs.result_group_metric_spec.component.non_cumulative_unique"
+              "basic_report.result_group_specs[0].result_group_metric_spec.component.non_cumulative_unique"
           }
         )
     }
@@ -6820,14 +6874,15 @@ class BasicReportsServiceTest {
           withPrincipalAndScopes(PRINCIPAL, SCOPES) { service.createBasicReport(request) }
         }
 
-      assertThat(exception.status.code).isEqualTo(Status.Code.INVALID_ARGUMENT)
-      assertThat(exception.errorInfo)
+      assertThat(exception).status().code().isEqualTo(Status.Code.INVALID_ARGUMENT)
+      assertThat(exception)
+        .errorInfo()
         .isEqualTo(
           errorInfo {
             domain = Errors.DOMAIN
             reason = Errors.Reason.INVALID_FIELD_VALUE.name
             metadata[Errors.Metadata.FIELD_NAME.key] =
-              "basic_report.result_group_specs.result_group_metric_spec.reporting_unit.non_cumulative.k_plus_reach"
+              "basic_report.result_group_specs[0].result_group_metric_spec.reporting_unit.non_cumulative.k_plus_reach"
           }
         )
     }
@@ -6882,14 +6937,15 @@ class BasicReportsServiceTest {
           withPrincipalAndScopes(PRINCIPAL, SCOPES) { service.createBasicReport(request) }
         }
 
-      assertThat(exception.status.code).isEqualTo(Status.Code.INVALID_ARGUMENT)
-      assertThat(exception.errorInfo)
+      assertThat(exception).status().code().isEqualTo(Status.Code.INVALID_ARGUMENT)
+      assertThat(exception)
+        .errorInfo()
         .isEqualTo(
           errorInfo {
             domain = Errors.DOMAIN
             reason = Errors.Reason.INVALID_FIELD_VALUE.name
             metadata[Errors.Metadata.FIELD_NAME.key] =
-              "basic_report.result_group_specs.result_group_metric_spec.reporting_unit.cumulative.k_plus_reach"
+              "basic_report.result_group_specs[0].result_group_metric_spec.reporting_unit.cumulative.k_plus_reach"
           }
         )
     }
@@ -6940,14 +6996,15 @@ class BasicReportsServiceTest {
           withPrincipalAndScopes(PRINCIPAL, SCOPES) { service.createBasicReport(request) }
         }
 
-      assertThat(exception.status.code).isEqualTo(Status.Code.INVALID_ARGUMENT)
-      assertThat(exception.errorInfo)
+      assertThat(exception).status().code().isEqualTo(Status.Code.INVALID_ARGUMENT)
+      assertThat(exception)
+        .errorInfo()
         .isEqualTo(
           errorInfo {
             domain = Errors.DOMAIN
             reason = Errors.Reason.INVALID_FIELD_VALUE.name
             metadata[Errors.Metadata.FIELD_NAME.key] =
-              "basic_report.result_group_specs.result_group_metric_spec.reporting_unit.stacked_incremental_reach"
+              "basic_report.result_group_specs[0].result_group_metric_spec.reporting_unit.stacked_incremental_reach"
           }
         )
     }
@@ -7002,14 +7059,15 @@ class BasicReportsServiceTest {
           withPrincipalAndScopes(PRINCIPAL, SCOPES) { service.createBasicReport(request) }
         }
 
-      assertThat(exception.status.code).isEqualTo(Status.Code.INVALID_ARGUMENT)
-      assertThat(exception.errorInfo)
+      assertThat(exception).status().code().isEqualTo(Status.Code.INVALID_ARGUMENT)
+      assertThat(exception)
+        .errorInfo()
         .isEqualTo(
           errorInfo {
             domain = Errors.DOMAIN
             reason = Errors.Reason.INVALID_FIELD_VALUE.name
             metadata[Errors.Metadata.FIELD_NAME.key] =
-              "basic_report.result_group_specs.result_group_metric_spec.component.non_cumulative.k_plus_reach"
+              "basic_report.result_group_specs[0].result_group_metric_spec.component.non_cumulative.k_plus_reach"
           }
         )
     }
@@ -7064,14 +7122,15 @@ class BasicReportsServiceTest {
           withPrincipalAndScopes(PRINCIPAL, SCOPES) { service.createBasicReport(request) }
         }
 
-      assertThat(exception.status.code).isEqualTo(Status.Code.INVALID_ARGUMENT)
-      assertThat(exception.errorInfo)
+      assertThat(exception).status().code().isEqualTo(Status.Code.INVALID_ARGUMENT)
+      assertThat(exception)
+        .errorInfo()
         .isEqualTo(
           errorInfo {
             domain = Errors.DOMAIN
             reason = Errors.Reason.INVALID_FIELD_VALUE.name
             metadata[Errors.Metadata.FIELD_NAME.key] =
-              "basic_report.result_group_specs.result_group_metric_spec.component.cumulative.k_plus_reach"
+              "basic_report.result_group_specs[0].result_group_metric_spec.component.cumulative.k_plus_reach"
           }
         )
     }
@@ -7118,8 +7177,9 @@ class BasicReportsServiceTest {
           withPrincipalAndScopes(PRINCIPAL, SCOPES) { service.createBasicReport(request) }
         }
 
-      assertThat(exception.status.code).isEqualTo(Status.Code.FAILED_PRECONDITION)
-      assertThat(exception.errorInfo)
+      assertThat(exception).status().code().isEqualTo(Status.Code.FAILED_PRECONDITION)
+      assertThat(exception)
+        .errorInfo()
         .isEqualTo(
           errorInfo {
             domain = Errors.DOMAIN
@@ -8650,8 +8710,9 @@ class BasicReportsServiceTest {
     val request = getBasicReportRequest {}
     val exception = assertFailsWith<StatusRuntimeException> { service.getBasicReport(request) }
 
-    assertThat(exception.status.code).isEqualTo(Status.Code.INVALID_ARGUMENT)
-    assertThat(exception.errorInfo)
+    assertThat(exception).status().code().isEqualTo(Status.Code.INVALID_ARGUMENT)
+    assertThat(exception)
+      .errorInfo()
       .isEqualTo(
         errorInfo {
           domain = Errors.DOMAIN
@@ -8666,8 +8727,9 @@ class BasicReportsServiceTest {
     val request = getBasicReportRequest { name = "/basicReports/def" }
     val exception = assertFailsWith<StatusRuntimeException> { service.getBasicReport(request) }
 
-    assertThat(exception.status.code).isEqualTo(Status.Code.INVALID_ARGUMENT)
-    assertThat(exception.errorInfo)
+    assertThat(exception).status().code().isEqualTo(Status.Code.INVALID_ARGUMENT)
+    assertThat(exception)
+      .errorInfo()
       .isEqualTo(
         errorInfo {
           domain = Errors.DOMAIN
@@ -8685,8 +8747,9 @@ class BasicReportsServiceTest {
         withPrincipalAndScopes(PRINCIPAL, SCOPES) { service.getBasicReport(request) }
       }
 
-    assertThat(exception.status.code).isEqualTo(Status.Code.NOT_FOUND)
-    assertThat(exception.errorInfo)
+    assertThat(exception).status().code().isEqualTo(Status.Code.NOT_FOUND)
+    assertThat(exception)
+      .errorInfo()
       .isEqualTo(
         errorInfo {
           domain = Errors.DOMAIN
@@ -8707,7 +8770,7 @@ class BasicReportsServiceTest {
           }
         }
 
-      assertThat(exception.status.code).isEqualTo(Status.Code.PERMISSION_DENIED)
+      assertThat(exception).status().code().isEqualTo(Status.Code.PERMISSION_DENIED)
       assertThat(exception).hasMessageThat().contains(BasicReportsService.Permission.GET)
     }
 
@@ -9295,7 +9358,7 @@ class BasicReportsServiceTest {
         }
       }
 
-    assertThat(exception.status.code).isEqualTo(Status.Code.PERMISSION_DENIED)
+    assertThat(exception).status().code().isEqualTo(Status.Code.PERMISSION_DENIED)
     assertThat(exception).hasMessageThat().contains(BasicReportsService.Permission.LIST)
   }
 
@@ -9304,8 +9367,9 @@ class BasicReportsServiceTest {
     val request = listBasicReportsRequest { pageSize = 5 }
     val exception = assertFailsWith<StatusRuntimeException> { service.listBasicReports(request) }
 
-    assertThat(exception.status.code).isEqualTo(Status.Code.INVALID_ARGUMENT)
-    assertThat(exception.errorInfo)
+    assertThat(exception).status().code().isEqualTo(Status.Code.INVALID_ARGUMENT)
+    assertThat(exception)
+      .errorInfo()
       .isEqualTo(
         errorInfo {
           domain = Errors.DOMAIN
@@ -9323,8 +9387,9 @@ class BasicReportsServiceTest {
         withPrincipalAndScopes(PRINCIPAL, SCOPES) { service.listBasicReports(request) }
       }
 
-    assertThat(exception.status.code).isEqualTo(Status.Code.INVALID_ARGUMENT)
-    assertThat(exception.errorInfo)
+    assertThat(exception).status().code().isEqualTo(Status.Code.INVALID_ARGUMENT)
+    assertThat(exception)
+      .errorInfo()
       .isEqualTo(
         errorInfo {
           domain = Errors.DOMAIN
@@ -9342,8 +9407,9 @@ class BasicReportsServiceTest {
     }
     val exception = assertFailsWith<StatusRuntimeException> { service.listBasicReports(request) }
 
-    assertThat(exception.status.code).isEqualTo(Status.Code.INVALID_ARGUMENT)
-    assertThat(exception.errorInfo)
+    assertThat(exception).status().code().isEqualTo(Status.Code.INVALID_ARGUMENT)
+    assertThat(exception)
+      .errorInfo()
       .isEqualTo(
         errorInfo {
           domain = Errors.DOMAIN
@@ -9365,8 +9431,9 @@ class BasicReportsServiceTest {
         withPrincipalAndScopes(PRINCIPAL, SCOPES) { service.listBasicReports(request) }
       }
 
-    assertThat(exception.status.code).isEqualTo(Status.Code.INVALID_ARGUMENT)
-    assertThat(exception.errorInfo)
+    assertThat(exception).status().code().isEqualTo(Status.Code.INVALID_ARGUMENT)
+    assertThat(exception)
+      .errorInfo()
       .isEqualTo(
         errorInfo {
           domain = Errors.DOMAIN
@@ -9396,8 +9463,9 @@ class BasicReportsServiceTest {
           withPrincipalAndScopes(PRINCIPAL, SCOPES) { service.listBasicReports(request) }
         }
 
-      assertThat(exception.status.code).isEqualTo(Status.Code.INVALID_ARGUMENT)
-      assertThat(exception.errorInfo)
+      assertThat(exception).status().code().isEqualTo(Status.Code.INVALID_ARGUMENT)
+      assertThat(exception)
+        .errorInfo()
         .isEqualTo(
           errorInfo {
             domain = Errors.DOMAIN


### PR DESCRIPTION
* Specify indexes for repeated fields.
* Use FAILED_PRECONDITION instead of INVALID_ARGUMENT where appropriate
* Use more specific error reasons DATA_PROVIDER_NOT_FOUND_FOR_CAMPAIGN_GROUP and EVENT_TEMPLATE_FIELD_INVALID.

This is pre-factoring for #3221