### PR TITLE
ci: Use applysets for remaining K8s workflows

### DIFF
--- a/.github/workflows/configure-edp-aggregator.yml
+++ b/.github/workflows/configure-edp-aggregator.yml
@@ -138,7 +138,7 @@ jobs:
 
     - name: kubectl apply
       if: ${{ inputs.apply }}
-      run: kubectl apply -k "$KUSTOMIZE_PATH"
+      run: kubectl apply -k "$KUSTOMIZE_PATH" --namespace=default --prune --applyset=configmaps/kubectl-edpa
 
     - name: Wait for rollout
       if: ${{ inputs.apply }}

--- a/.github/workflows/configure-kingdom.yml
+++ b/.github/workflows/configure-kingdom.yml
@@ -144,7 +144,7 @@ jobs:
 
       - name: kubectl apply
         if: ${{ inputs.apply }}
-        run: kubectl apply -k "$KUSTOMIZATION_PATH/src/main/k8s/dev/kingdom"
+        run: kubectl apply -k "$KUSTOMIZATION_PATH/src/main/k8s/dev/kingdom" --namespace=default --prune --applyset=configmaps/kubectl-kingdom
 
       - name: Wait for rollout
         if: ${{ inputs.apply }}

--- a/.github/workflows/configure-reporting-v2.yml
+++ b/.github/workflows/configure-reporting-v2.yml
@@ -214,7 +214,7 @@ jobs:
 
     - name: kubectl apply
       if: ${{ inputs.apply }}
-      run: kubectl apply -k "$KUSTOMIZE_PATH"
+      run: kubectl apply -k "$KUSTOMIZE_PATH" --namespace=default --prune --applyset=configmaps/kubectl-reporting
 
     - name: Wait for rollout
       if: ${{ inputs.apply }}

--- a/.github/workflows/configure-secure-computation-control-plane.yml
+++ b/.github/workflows/configure-secure-computation-control-plane.yml
@@ -134,7 +134,7 @@ jobs:
 
     - name: kubectl apply
       if: ${{ inputs.apply }}
-      run: kubectl apply -k "$KUSTOMIZE_PATH"
+      run: kubectl apply -k "$KUSTOMIZE_PATH" --namespace=default --prune --applyset=configmaps/kubectl-secure-comp
 
     - name: Wait for rollout
       if: ${{ inputs.apply }}

--- a/.github/workflows/configure-simulators.yml
+++ b/.github/workflows/configure-simulators.yml
@@ -167,7 +167,7 @@ jobs:
 
     - name: kubectl apply
       if: ${{ inputs.apply }}
-      run: kubectl apply -k "$KUSTOMIZE_PATH"
+      run: kubectl apply -k "$KUSTOMIZE_PATH" --namespace=default --prune --applyset=configmaps/kubectl-edp-sims
 
     - name: Wait for rollout
       if: ${{ inputs.apply }}


### PR DESCRIPTION
This is already done for some workflows. It ensures that removed/renamed resources are pruned.