### PR TITLE
feat: add data availability intersects filter to ListEventGroupsRequest

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -49,7 +49,7 @@ bazel_dep(
 )
 bazel_dep(
     name = "cross-media-measurement-api",
-    version = "0.87.0",
+    version = "0.88.0",
     repo_name = "wfa_measurement_proto",
 )
 bazel_dep(

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -543,8 +543,6 @@
     "https://raw.githubusercontent.com/world-federation-of-advertisers/bazel-registry/main/modules/consent-signaling-client/0.23.0/MODULE.bazel": "5fde5a3f897ec6a39300666bc745cb309b4c12e74ce4fcddef6429e5e4a627a2",
     "https://raw.githubusercontent.com/world-federation-of-advertisers/bazel-registry/main/modules/consent-signaling-client/0.23.0/source.json": "3798af185e6c71cabea6550303035ea4ad325a6d53854ab056ee6c93acf03b89",
     "https://raw.githubusercontent.com/world-federation-of-advertisers/bazel-registry/main/modules/crc32c/1.1.0/MODULE.bazel": "not found",
-    "https://raw.githubusercontent.com/world-federation-of-advertisers/bazel-registry/main/modules/cross-media-measurement-api/0.87.0/MODULE.bazel": "c678b3f46885c8dea8e0de6215dc3b935ff93d632eec5d603e0690ce61571398",
-    "https://raw.githubusercontent.com/world-federation-of-advertisers/bazel-registry/main/modules/cross-media-measurement-api/0.87.0/source.json": "2bc4a06e472991aad6a89c70938cd042379697d7029a54eec3aaf761a54bedb0",
     "https://raw.githubusercontent.com/world-federation-of-advertisers/bazel-registry/main/modules/curl/8.4.0/MODULE.bazel": "not found",
     "https://raw.githubusercontent.com/world-federation-of-advertisers/bazel-registry/main/modules/curl/8.7.1/MODULE.bazel": "not found",
     "https://raw.githubusercontent.com/world-federation-of-advertisers/bazel-registry/main/modules/curl/8.8.0.bcr.3/MODULE.bazel": "not found",

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/queries/StreamEventGroups.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/queries/StreamEventGroups.kt
@@ -114,6 +114,17 @@ class StreamEventGroups(
         bind(DATA_AVAILABILITY_END_TIME_GTE)
           .to(filter.dataAvailabilityEndTimeOnOrAfter.toGcloudTimestamp())
       }
+      if (filter.hasDataAvailabilityIntersects()) {
+        val interval = filter.dataAvailabilityIntersects
+        if (interval.hasStartTime()) {
+          add("IFNULL(DataAvailabilityEndTime, @$TIMESTAMP_MAX) >= @$DATA_AVAILABILITY_INTERSECTS_START")
+          bind(DATA_AVAILABILITY_INTERSECTS_START).to(interval.startTime.toGcloudTimestamp())
+        }
+        if (interval.hasEndTime()) {
+          add("DataAvailabilityStartTime <= @$DATA_AVAILABILITY_INTERSECTS_END")
+          bind(DATA_AVAILABILITY_INTERSECTS_END).to(interval.endTime.toGcloudTimestamp())
+        }
+    }
       if (filter.metadataSearchQuery.isNotEmpty()) {
         add("SEARCH(Metadata_Tokens, @$METADATA_SEARCH_QUERY)")
         bind(METADATA_SEARCH_QUERY).to(filter.metadataSearchQuery)
@@ -192,6 +203,8 @@ class StreamEventGroups(
     const val DATA_AVAILABILITY_END_TIME_GTE = "dataAvailabilityEndTimeGte"
     const val DATA_AVAILABILITY_START_TIME_GTE = "dataAvailabilityStartTimeGte"
     const val DATA_AVAILABILITY_END_TIME_LTE = "dataAvailabilityEndTimeLte"
+    const val DATA_AVAILABILITY_INTERSECTS_START = "dataAvailabilityIntersectsStart"
+    const val DATA_AVAILABILITY_INTERSECTS_END = "dataAvailabilityIntersectsEnd"
     const val METADATA_SEARCH_QUERY = "metadataSearchQuery"
     const val TIMESTAMP_MAX = "timestampMax"
   }

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/service/api/v2alpha/EventGroupsService.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/service/api/v2alpha/EventGroupsService.kt
@@ -543,6 +543,9 @@ class EventGroupsService(
       if (internalFilter.hasDataAvailabilityEndTimeOnOrAfter()) {
         dataAvailabilityEndTimeOnOrAfter = internalFilter.dataAvailabilityEndTimeOnOrAfter
       }
+      if (internalFilter.hasDataAvailabilityIntersects()) {
+        dataAvailabilityIntersects = internalFilter.dataAvailabilityIntersects
+      }
       metadataSearchQuery = internalFilter.metadataSearchQuery
       lastEventGroup = previousPageEnd {
         externalDataProviderId = lastInternalEventGroup.externalDataProviderId
@@ -612,6 +615,9 @@ class EventGroupsService(
           if (filter.hasDataAvailabilityEndTimeOnOrAfter()) {
             dataAvailabilityEndTimeOnOrAfter = filter.dataAvailabilityEndTimeOnOrAfter
           }
+          if (filter.hasDataAvailabilityIntersects()) {
+            dataAvailabilityIntersects = filter.dataAvailabilityIntersects
+          }
           metadataSearchQuery = filter.metadataSearchQuery
           this.showDeleted = showDeleted
           if (pageToken != null) {
@@ -628,6 +634,7 @@ class EventGroupsService(
                 pageToken.dataAvailabilityStartTimeOnOrBefore !=
                   dataAvailabilityStartTimeOnOrBefore ||
                 pageToken.dataAvailabilityEndTimeOnOrAfter != dataAvailabilityEndTimeOnOrAfter ||
+                pageToken.dataAvailabilityIntersects != dataAvailabilityIntersects ||
                 pageToken.metadataSearchQuery != metadataSearchQuery
             ) {
               throw Status.INVALID_ARGUMENT.withDescription(

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/service/internal/testing/EventGroupsServiceTest.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/service/internal/testing/EventGroupsServiceTest.kt
@@ -25,6 +25,8 @@ import io.grpc.Status
 import io.grpc.StatusRuntimeException
 import java.time.Clock
 import java.time.Instant
+import java.time.LocalDate
+import java.time.ZoneOffset
 import java.time.temporal.ChronoUnit
 import kotlin.random.Random
 import kotlin.test.assertFailsWith
@@ -1517,6 +1519,293 @@ abstract class EventGroupsServiceTest<T : EventGroupsCoroutineImplBase> {
               it.dataAvailabilityInterval.endTime.toInstant() in filterRange)
         }
       )
+  }
+
+  @Test
+  fun `streamEventGroups with intersects filter returns correct groups for January search`(): Unit = runBlocking {
+    val measurementConsumer: MeasurementConsumer =
+      population.createMeasurementConsumer(measurementConsumersService, accountsService)
+    val dataProvider: DataProvider = population.createDataProvider(dataProvidersService)
+    
+    val eventGroup1 = eventGroupsService.createEventGroup(
+      createEventGroupRequest {
+        eventGroup = eventGroup {
+          externalDataProviderId = dataProvider.externalDataProviderId
+          externalMeasurementConsumerId = measurementConsumer.externalMeasurementConsumerId
+          dataAvailabilityInterval = interval {
+            startTime = LocalDate.of(2026, 1, 5).atStartOfDay(ZoneOffset.UTC).toInstant().toProtoTime()
+            endTime = LocalDate.of(2026, 1, 10).atStartOfDay(ZoneOffset.UTC).toInstant().toProtoTime()
+          }
+          mediaTypes += MediaType.VIDEO
+        }
+      }
+    )
+    
+    val eventGroup2 = eventGroupsService.createEventGroup(
+      createEventGroupRequest {
+        eventGroup = eventGroup {
+          externalDataProviderId = dataProvider.externalDataProviderId
+          externalMeasurementConsumerId = measurementConsumer.externalMeasurementConsumerId
+          dataAvailabilityInterval = interval {
+            startTime = LocalDate.of(2026, 1, 25).atStartOfDay(ZoneOffset.UTC).toInstant().toProtoTime()
+            endTime = LocalDate.of(2026, 2, 10).atStartOfDay(ZoneOffset.UTC).toInstant().toProtoTime()
+          }
+          mediaTypes += MediaType.DISPLAY
+        }
+      }
+    )
+    
+    val eventGroup3 = eventGroupsService.createEventGroup(
+      createEventGroupRequest {
+        eventGroup = eventGroup {
+          externalDataProviderId = dataProvider.externalDataProviderId
+          externalMeasurementConsumerId = measurementConsumer.externalMeasurementConsumerId
+          dataAvailabilityInterval = interval {
+            startTime = LocalDate.of(2025, 12, 1).atStartOfDay(ZoneOffset.UTC).toInstant().toProtoTime()
+            endTime = LocalDate.of(2026, 1, 3).atStartOfDay(ZoneOffset.UTC).toInstant().toProtoTime()
+          }
+          mediaTypes += MediaType.VIDEO
+        }
+      }
+    )
+    
+    val eventGroup4 = eventGroupsService.createEventGroup(
+      createEventGroupRequest {
+        eventGroup = eventGroup {
+          externalDataProviderId = dataProvider.externalDataProviderId
+          externalMeasurementConsumerId = measurementConsumer.externalMeasurementConsumerId
+          dataAvailabilityInterval = interval {
+            startTime = LocalDate.of(2026, 2, 1).atStartOfDay(ZoneOffset.UTC).toInstant().toProtoTime()
+            endTime = LocalDate.of(2026, 2, 10).atStartOfDay(ZoneOffset.UTC).toInstant().toProtoTime()
+          }
+          mediaTypes += MediaType.OTHER
+        }
+      }
+    )
+    
+    val eventGroup5 = eventGroupsService.createEventGroup(
+      createEventGroupRequest {
+        eventGroup = eventGroup {
+          externalDataProviderId = dataProvider.externalDataProviderId
+          externalMeasurementConsumerId = measurementConsumer.externalMeasurementConsumerId
+          dataAvailabilityInterval = interval {
+            startTime = LocalDate.of(2025, 11, 1).atStartOfDay(ZoneOffset.UTC).toInstant().toProtoTime()
+            endTime = LocalDate.of(2025, 11, 30).atStartOfDay(ZoneOffset.UTC).toInstant().toProtoTime()
+          }
+          mediaTypes += MediaType.VIDEO
+        }
+      }
+    )
+    
+    val searchInterval = interval {
+      startTime = LocalDate.of(2026, 1, 1).atStartOfDay(ZoneOffset.UTC).toInstant().toProtoTime()
+      endTime = LocalDate.of(2026, 1, 31).atStartOfDay(ZoneOffset.UTC).toInstant().toProtoTime()
+    }
+    
+    val response = eventGroupsService
+      .streamEventGroups(
+        streamEventGroupsRequest {
+          filter = filter {
+            externalMeasurementConsumerId = measurementConsumer.externalMeasurementConsumerId
+            dataAvailabilityIntersects = searchInterval
+          }
+        }
+      )
+      .toList()
+    
+    assertThat(response).containsExactly(eventGroup1, eventGroup2, eventGroup3)
+    assertThat(response).doesNotContain(eventGroup4)
+    assertThat(response).doesNotContain(eventGroup5)
+  }
+
+  @Test
+  fun `streamEventGroups with intersects filter containing only start date returns correct groups`(): Unit = runBlocking {
+    val measurementConsumer: MeasurementConsumer =
+      population.createMeasurementConsumer(measurementConsumersService, accountsService)
+    val dataProvider: DataProvider = population.createDataProvider(dataProvidersService)
+    
+    val eventGroup1 = eventGroupsService.createEventGroup(
+      createEventGroupRequest {
+        eventGroup = eventGroup {
+          externalDataProviderId = dataProvider.externalDataProviderId
+          externalMeasurementConsumerId = measurementConsumer.externalMeasurementConsumerId
+          dataAvailabilityInterval = interval {
+            startTime = LocalDate.of(2026, 1, 5).atStartOfDay(ZoneOffset.UTC).toInstant().toProtoTime()
+            endTime = LocalDate.of(2026, 1, 10).atStartOfDay(ZoneOffset.UTC).toInstant().toProtoTime()
+          }
+          mediaTypes += MediaType.VIDEO
+        }
+      }
+    )
+    
+    val eventGroup2 = eventGroupsService.createEventGroup(
+      createEventGroupRequest {
+        eventGroup = eventGroup {
+          externalDataProviderId = dataProvider.externalDataProviderId
+          externalMeasurementConsumerId = measurementConsumer.externalMeasurementConsumerId
+          dataAvailabilityInterval = interval {
+            startTime = LocalDate.of(2026, 1, 25).atStartOfDay(ZoneOffset.UTC).toInstant().toProtoTime()
+            endTime = LocalDate.of(2026, 2, 10).atStartOfDay(ZoneOffset.UTC).toInstant().toProtoTime()
+          }
+          mediaTypes += MediaType.DISPLAY
+        }
+      }
+    )
+    
+    val eventGroup3 = eventGroupsService.createEventGroup(
+      createEventGroupRequest {
+        eventGroup = eventGroup {
+          externalDataProviderId = dataProvider.externalDataProviderId
+          externalMeasurementConsumerId = measurementConsumer.externalMeasurementConsumerId
+          dataAvailabilityInterval = interval {
+            startTime = LocalDate.of(2025, 12, 1).atStartOfDay(ZoneOffset.UTC).toInstant().toProtoTime()
+            endTime = LocalDate.of(2026, 1, 3).atStartOfDay(ZoneOffset.UTC).toInstant().toProtoTime()
+          }
+          mediaTypes += MediaType.VIDEO
+        }
+      }
+    )
+    
+    val eventGroup4 = eventGroupsService.createEventGroup(
+      createEventGroupRequest {
+        eventGroup = eventGroup {
+          externalDataProviderId = dataProvider.externalDataProviderId
+          externalMeasurementConsumerId = measurementConsumer.externalMeasurementConsumerId
+          dataAvailabilityInterval = interval {
+            startTime = LocalDate.of(2026, 2, 1).atStartOfDay(ZoneOffset.UTC).toInstant().toProtoTime()
+            endTime = LocalDate.of(2026, 2, 10).atStartOfDay(ZoneOffset.UTC).toInstant().toProtoTime()
+          }
+          mediaTypes += MediaType.OTHER
+        }
+      }
+    )
+    
+    val eventGroup5 = eventGroupsService.createEventGroup(
+      createEventGroupRequest {
+        eventGroup = eventGroup {
+          externalDataProviderId = dataProvider.externalDataProviderId
+          externalMeasurementConsumerId = measurementConsumer.externalMeasurementConsumerId
+          dataAvailabilityInterval = interval {
+            startTime = LocalDate.of(2025, 11, 1).atStartOfDay(ZoneOffset.UTC).toInstant().toProtoTime()
+            endTime = LocalDate.of(2025, 11, 30).atStartOfDay(ZoneOffset.UTC).toInstant().toProtoTime()
+          }
+          mediaTypes += MediaType.VIDEO
+        }
+      }
+    )
+    
+    val searchInterval = interval {
+      startTime = LocalDate.of(2026, 1, 1).atStartOfDay(ZoneOffset.UTC).toInstant().toProtoTime()
+    }
+    
+    val response = eventGroupsService
+      .streamEventGroups(
+        streamEventGroupsRequest {
+          filter = filter {
+            externalMeasurementConsumerId = measurementConsumer.externalMeasurementConsumerId
+            dataAvailabilityIntersects = searchInterval
+          }
+        }
+      )
+      .toList()
+    
+    assertThat(response).containsExactly(eventGroup1, eventGroup2, eventGroup3, eventGroup4)
+    assertThat(response).doesNotContain(eventGroup5)
+  }
+
+  @Test
+  fun `streamEventGroups with intersects filter containing only end date returns correct groups`(): Unit = runBlocking {
+    val measurementConsumer: MeasurementConsumer =
+      population.createMeasurementConsumer(measurementConsumersService, accountsService)
+    val dataProvider: DataProvider = population.createDataProvider(dataProvidersService)
+    
+    val eventGroup1 = eventGroupsService.createEventGroup(
+      createEventGroupRequest {
+        eventGroup = eventGroup {
+          externalDataProviderId = dataProvider.externalDataProviderId
+          externalMeasurementConsumerId = measurementConsumer.externalMeasurementConsumerId
+          dataAvailabilityInterval = interval {
+            startTime = LocalDate.of(2026, 1, 5).atStartOfDay(ZoneOffset.UTC).toInstant().toProtoTime()
+            endTime = LocalDate.of(2026, 1, 10).atStartOfDay(ZoneOffset.UTC).toInstant().toProtoTime()
+          }
+          mediaTypes += MediaType.VIDEO
+        }
+      }
+    )
+    
+    val eventGroup2 = eventGroupsService.createEventGroup(
+      createEventGroupRequest {
+        eventGroup = eventGroup {
+          externalDataProviderId = dataProvider.externalDataProviderId
+          externalMeasurementConsumerId = measurementConsumer.externalMeasurementConsumerId
+          dataAvailabilityInterval = interval {
+            startTime = LocalDate.of(2026, 1, 25).atStartOfDay(ZoneOffset.UTC).toInstant().toProtoTime()
+            endTime = LocalDate.of(2026, 2, 10).atStartOfDay(ZoneOffset.UTC).toInstant().toProtoTime()
+          }
+          mediaTypes += MediaType.DISPLAY
+        }
+      }
+    )
+    
+    val eventGroup3 = eventGroupsService.createEventGroup(
+      createEventGroupRequest {
+        eventGroup = eventGroup {
+          externalDataProviderId = dataProvider.externalDataProviderId
+          externalMeasurementConsumerId = measurementConsumer.externalMeasurementConsumerId
+          dataAvailabilityInterval = interval {
+            startTime = LocalDate.of(2025, 12, 1).atStartOfDay(ZoneOffset.UTC).toInstant().toProtoTime()
+            endTime = LocalDate.of(2026, 1, 3).atStartOfDay(ZoneOffset.UTC).toInstant().toProtoTime()
+          }
+          mediaTypes += MediaType.VIDEO
+        }
+      }
+    )
+    
+    val eventGroup4 = eventGroupsService.createEventGroup(
+      createEventGroupRequest {
+        eventGroup = eventGroup {
+          externalDataProviderId = dataProvider.externalDataProviderId
+          externalMeasurementConsumerId = measurementConsumer.externalMeasurementConsumerId
+          dataAvailabilityInterval = interval {
+            startTime = LocalDate.of(2026, 2, 1).atStartOfDay(ZoneOffset.UTC).toInstant().toProtoTime()
+            endTime = LocalDate.of(2026, 2, 10).atStartOfDay(ZoneOffset.UTC).toInstant().toProtoTime()
+          }
+          mediaTypes += MediaType.OTHER
+        }
+      }
+    )
+    
+    val eventGroup5 = eventGroupsService.createEventGroup(
+      createEventGroupRequest {
+        eventGroup = eventGroup {
+          externalDataProviderId = dataProvider.externalDataProviderId
+          externalMeasurementConsumerId = measurementConsumer.externalMeasurementConsumerId
+          dataAvailabilityInterval = interval {
+            startTime = LocalDate.of(2025, 11, 1).atStartOfDay(ZoneOffset.UTC).toInstant().toProtoTime()
+            endTime = LocalDate.of(2025, 11, 30).atStartOfDay(ZoneOffset.UTC).toInstant().toProtoTime()
+          }
+          mediaTypes += MediaType.VIDEO
+        }
+      }
+    )
+    
+    val searchInterval = interval {
+      endTime = LocalDate.of(2026, 1, 31).atStartOfDay(ZoneOffset.UTC).toInstant().toProtoTime()
+    }
+    
+    val response = eventGroupsService
+      .streamEventGroups(
+        streamEventGroupsRequest {
+          filter = filter {
+            externalMeasurementConsumerId = measurementConsumer.externalMeasurementConsumerId
+            dataAvailabilityIntersects = searchInterval
+          }
+        }
+      )
+      .toList()
+    
+    assertThat(response).containsExactly(eventGroup1, eventGroup2, eventGroup3, eventGroup5)
+    assertThat(response).doesNotContain(eventGroup4)
   }
 
   @Test

--- a/src/main/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/EventGroupsService.kt
+++ b/src/main/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/EventGroupsService.kt
@@ -397,6 +397,9 @@ private fun ListEventGroupsRequest.Filter.toCmmsFilter(): CmmsListEventGroupsReq
     if (source.hasDataAvailabilityEndTimeOnOrAfter()) {
       dataAvailabilityEndTimeOnOrAfter = source.dataAvailabilityEndTimeOnOrAfter
     }
+    if (source.hasDataAvailabilityIntersects()) {
+      dataAvailabilityIntersects = source.dataAvailabilityIntersects
+    }
     metadataSearchQuery = source.metadataSearchQuery
   }
 }

--- a/src/main/proto/wfa/measurement/api/v2alpha/page_token.proto
+++ b/src/main/proto/wfa/measurement/api/v2alpha/page_token.proto
@@ -64,6 +64,7 @@ message ListEventGroupsPageToken {
   google.protobuf.Timestamp data_availability_end_time_on_or_before = 10;
   google.protobuf.Timestamp data_availability_start_time_on_or_before = 13;
   google.protobuf.Timestamp data_availability_end_time_on_or_after = 14;
+  google.type.Interval data_availability_intersects = 15;
   string metadata_search_query = 11;
   ListEventGroupsRequest.OrderBy order_by = 12;
 

--- a/src/main/proto/wfa/measurement/internal/kingdom/BUILD.bazel
+++ b/src/main/proto/wfa/measurement/internal/kingdom/BUILD.bazel
@@ -334,6 +334,7 @@ proto_library(
         ":event_group_proto",
         ":media_type_proto",
         "@com_google_protobuf//:timestamp_proto",
+        "@com_google_googleapis//google/type:interval_proto",
     ],
 )
 

--- a/src/main/proto/wfa/measurement/internal/kingdom/event_groups_service.proto
+++ b/src/main/proto/wfa/measurement/internal/kingdom/event_groups_service.proto
@@ -17,6 +17,7 @@ syntax = "proto3";
 package wfa.measurement.internal.kingdom;
 
 import "google/protobuf/timestamp.proto";
+import "google/type/interval.proto";
 import "wfa/measurement/internal/kingdom/event_group.proto";
 import "wfa/measurement/internal/kingdom/media_type.proto";
 
@@ -103,6 +104,7 @@ message StreamEventGroupsRequest {
     google.protobuf.Timestamp data_availability_end_time_on_or_before = 11;
     google.protobuf.Timestamp data_availability_start_time_on_or_before = 14;
     google.protobuf.Timestamp data_availability_end_time_on_or_after = 15;
+    google.type.Interval data_availability_intersects = 16;
     string metadata_search_query = 12;
 
     // Specification of where the results should start within the ordering.

--- a/src/main/proto/wfa/measurement/reporting/v2alpha/BUILD.bazel
+++ b/src/main/proto/wfa/measurement/reporting/v2alpha/BUILD.bazel
@@ -309,6 +309,7 @@ proto_library(
         "@com_google_googleapis//google/api:field_behavior_proto",
         "@com_google_googleapis//google/api:resource_proto",
         "@com_google_protobuf//:timestamp_proto",
+        "@com_google_googleapis//google/type:interval_proto",
     ],
 )
 

--- a/src/main/proto/wfa/measurement/reporting/v2alpha/event_groups_service.proto
+++ b/src/main/proto/wfa/measurement/reporting/v2alpha/event_groups_service.proto
@@ -21,6 +21,7 @@ import "google/api/client.proto";
 import "google/api/field_behavior.proto";
 import "google/api/resource.proto";
 import "google/protobuf/timestamp.proto";
+import "google/type/interval.proto";
 import "wfa/measurement/reporting/v2alpha/event_group.proto";
 import "wfa/measurement/reporting/v2alpha/media_type.proto";
 
@@ -99,6 +100,11 @@ message ListEventGroupsRequest {
     // [EventGroup.data_availability_interval.end_time][google.type.Interval.end_time]
     // must be on or after.
     google.protobuf.Timestamp data_availability_end_time_on_or_after = 7
+        [(google.api.field_behavior) = OPTIONAL];
+    // Interval that must be intersected by
+    // [EventGroup.data_availability_interval.start_time][google.type.Interval.start_time]
+    // [EventGroup.data_availability_interval.end_time][google.type.Interval.end_time]
+    google.type.Interval data_availability_intersects = 8
         [(google.api.field_behavior) = OPTIONAL];
     // Query for text search on string fields in
     // [EventGroup.event_group_metadata][].

--- a/src/test/kotlin/org/wfanet/measurement/kingdom/service/api/v2alpha/EventGroupsServiceTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/kingdom/service/api/v2alpha/EventGroupsServiceTest.kt
@@ -1477,6 +1477,60 @@ class EventGroupsServiceTest {
   }
 
   @Test
+  fun `listEventGroups requests EventGroups by MeasurementConsumer with dataAvailabilityIntersects filter`() {
+    val searchInterval = interval {
+      startTime =
+        LocalDate.of(2024, 6, 1).atStartOfDay(ZoneOffset.UTC).toInstant().toProtoTime()
+      endTime = LocalDate.of(2024, 7, 1).atStartOfDay(ZoneOffset.UTC).toInstant().toProtoTime()
+    }
+
+    val request = listEventGroupsRequest {
+      parent = MEASUREMENT_CONSUMER_NAME
+      pageSize = 100
+      filter = filter { dataAvailabilityIntersects = searchInterval }
+      orderBy =
+        ListEventGroupsRequestKt.orderBy {
+          field = ListEventGroupsRequest.OrderBy.Field.DATA_AVAILABILITY_START_TIME
+          descending = true
+        }
+    }
+
+    val response: ListEventGroupsResponse =
+      withMeasurementConsumerPrincipal(MEASUREMENT_CONSUMER_NAME) {
+        runBlocking { service.listEventGroups(request) }
+      }
+
+    assertThat(response)
+      .isEqualTo(
+        listEventGroupsResponse {
+          eventGroups += EVENT_GROUP
+          eventGroups += EVENT_GROUP.copy { name = EVENT_GROUP_NAME_2 }
+          eventGroups += EVENT_GROUP.copy { name = EVENT_GROUP_NAME_3 }
+        }
+      )
+    val internalRequest: StreamEventGroupsRequest = captureFirst {
+      verify(internalEventGroupsMock).streamEventGroups(capture())
+    }
+    assertThat(internalRequest)
+      .isEqualTo(
+        streamEventGroupsRequest {
+          filter =
+            StreamEventGroupsRequestKt.filter {
+              externalMeasurementConsumerId = MEASUREMENT_CONSUMER_EXTERNAL_ID
+              dataAvailabilityIntersects = searchInterval
+            }
+          orderBy =
+            StreamEventGroupsRequestKt.orderBy {
+              field = StreamEventGroupsRequest.OrderBy.Field.DATA_AVAILABILITY_START_TIME
+              descending = true
+            }
+          limit = request.pageSize + 1
+          allowStaleReads = true
+        }
+      )
+  }
+
+  @Test
   fun `listEventGroups throws UNAUTHENTICATED when no principal is found`() {
     val request = listEventGroupsRequest {
       parent = DATA_PROVIDER_NAME


### PR DESCRIPTION
Added data_availability_intersects filter to ListEventGroupsRequest in order to filter for EventGroups whose data availability intersects a given range