### PR TITLE
fix: Include media type predicates in MetricCalculationSpec filters from IQFs

### DIFF
--- a/src/main/kotlin/org/wfanet/measurement/eventdataprovider/eventfiltration/validation/EventFilterValidationException.kt
+++ b/src/main/kotlin/org/wfanet/measurement/eventdataprovider/eventfiltration/validation/EventFilterValidationException.kt
@@ -14,7 +14,8 @@
 
 package org.wfanet.measurement.eventdataprovider.eventfiltration.validation
 
-class EventFilterValidationException(val code: Code, message: String) : Exception(message) {
+class EventFilterValidationException(val code: Code, message: String, cause: Throwable? = null) :
+  Exception(message, cause) {
 
   enum class Code(val description: String) {
     INVALID_CEL_EXPRESSION(

--- a/src/main/kotlin/org/wfanet/measurement/eventdataprovider/eventfiltration/validation/EventFilterValidator.kt
+++ b/src/main/kotlin/org/wfanet/measurement/eventdataprovider/eventfiltration/validation/EventFilterValidator.kt
@@ -220,7 +220,8 @@ object EventFilterValidator {
       } catch (e: Exception) {
         throw EventFilterValidationException(
           EventFilterValidationException.Code.INVALID_CEL_EXPRESSION,
-          e.message ?: "Compiling expression threw an unexpected exception",
+          "Failed to compile CEL expression $celExpression",
+          e,
         )
       }
     failOnInvalidExpression(astAndIssues.issues)

--- a/src/main/kotlin/org/wfanet/measurement/reporting/job/BasicReportsReportsJob.kt
+++ b/src/main/kotlin/org/wfanet/measurement/reporting/job/BasicReportsReportsJob.kt
@@ -64,9 +64,8 @@ import org.wfanet.measurement.reporting.service.api.v2alpha.BasicReportKey
 import org.wfanet.measurement.reporting.service.api.v2alpha.MetricCalculationSpecKey
 import org.wfanet.measurement.reporting.service.api.v2alpha.ReportKey
 import org.wfanet.measurement.reporting.service.api.v2alpha.ReportingSetKey
-import org.wfanet.measurement.reporting.service.api.v2alpha.createDimensionSpecFilter
-import org.wfanet.measurement.reporting.service.api.v2alpha.createImpressionQualificationFilterSpecsFilter
-import org.wfanet.measurement.reporting.service.api.v2alpha.createMetricCalculationSpecFilters
+import org.wfanet.measurement.reporting.service.api.v2alpha.buildCelExpression
+import org.wfanet.measurement.reporting.service.api.v2alpha.buildCelExpressions
 import org.wfanet.measurement.reporting.service.api.v2alpha.toEventFilter
 import org.wfanet.measurement.reporting.service.api.v2alpha.toImpressionQualificationFilterSpec
 import org.wfanet.measurement.reporting.service.internal.InvalidBasicReportException
@@ -625,7 +624,7 @@ class BasicReportsReportsJob(
       for (reportingImpressionQualificationFilter in
         basicReport.details.effectiveImpressionQualificationFiltersList) {
         val impressionQualificationFilterString =
-          createImpressionQualificationFilterSpecsFilter(
+          buildCelExpression(
             reportingImpressionQualificationFilter.filterSpecsList.map {
               it.toImpressionQualificationFilterSpec()
             },
@@ -635,15 +634,12 @@ class BasicReportsReportsJob(
         for (resultGroupSpec in basicReport.details.resultGroupSpecsList) {
           val dimensionSpecFilters = resultGroupSpec.dimensionSpec.filtersList
           val dimensionSpecFilter: String =
-            createDimensionSpecFilter(
+            buildCelExpression(
               dimensionSpecFilters.map { it.toEventFilter() },
               eventTemplateFieldsByPath,
             )
           val filter =
-            createMetricCalculationSpecFilters(
-                listOf(impressionQualificationFilterString),
-                dimensionSpecFilter,
-              )
+            buildCelExpressions(listOf(impressionQualificationFilterString), dimensionSpecFilter)
               .first()
 
           val externalImpressionQualificationFilterId: String? =

--- a/src/main/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/BUILD.bazel
+++ b/src/main/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/BUILD.bazel
@@ -348,7 +348,9 @@ kt_jvm_library(
     srcs = ["BasicReportTransformations.kt"],
     deps = [
         "//src/main/kotlin/org/wfanet/measurement/api/v2alpha:event_message_descriptor",
+        "//src/main/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha:basic_report_proto_conversions",
         "//src/main/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha:resource_key",
+        "//src/main/kotlin/org/wfanet/measurement/reporting/service/internal:normalization",
         "//src/main/proto/wfa/measurement/api/v2alpha:data_provider_kt_jvm_proto",
         "//src/main/proto/wfa/measurement/api/v2alpha:event_group_kt_jvm_proto",
         "//src/main/proto/wfa/measurement/internal/reporting/v2:metric_calculation_spec_kt_jvm_proto",

--- a/src/test/kotlin/org/wfanet/measurement/reporting/job/BasicReportsReportsJobTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/reporting/job/BasicReportsReportsJobTest.kt
@@ -187,7 +187,7 @@ class BasicReportsReportsJobTest {
               groupingPredicates += "person.gender == 1"
               groupingPredicates += "person.age_group == 1"
               filter =
-                "((has(banner_ad.viewable) && banner_ad.viewable == true) || (has(video_ad.viewed_fraction) && video_ad.viewed_fraction == 1.0)) && (person.age_group == 1)"
+                "((banner_ad != null && banner_ad.viewable == true) || (video_ad != null && video_ad.viewed_fraction == 1.0)) && (person.age_group == 1)"
             }
 
           metricCalculationResults +=
@@ -249,7 +249,7 @@ class BasicReportsReportsJobTest {
                   groupingPredicates += "person.gender == 1"
                   groupingPredicates += "person.age_group == 2"
                   filter =
-                    "((has(banner_ad.viewable) && banner_ad.viewable == true) || (has(video_ad.viewed_fraction) && video_ad.viewed_fraction == 1.0)) && (person.age_group == 1)"
+                    "((banner_ad != null && banner_ad.viewable == true) || (video_ad != null && video_ad.viewed_fraction == 1.0)) && (person.age_group == 1)"
                   metricSpec = metricSpec {
                     impressionCount = MetricSpecKt.impressionCountParams {}
                   }
@@ -286,7 +286,7 @@ class BasicReportsReportsJobTest {
                   metricSpec = metricSpec {
                     populationCount = MetricSpecKt.populationCountParams {}
                   }
-                  filter = "(person.age_group == 1)"
+                  filter = "person.age_group == 1"
                   timeInterval = interval {
                     startTime = timestamp { seconds = 1736150400 }
                     endTime = timestamp { seconds = 1736755200 }
@@ -303,7 +303,7 @@ class BasicReportsReportsJobTest {
                   metricSpec = metricSpec {
                     populationCount = MetricSpecKt.populationCountParams {}
                   }
-                  filter = "(person.age_group == 1)"
+                  filter = "person.age_group == 1"
                   timeInterval = interval {
                     startTime = timestamp { seconds = 1736150400 }
                     endTime = timestamp { seconds = 1736755200 }
@@ -391,7 +391,7 @@ class BasicReportsReportsJobTest {
                   groupingPredicates += "person.age_group == 1"
                   metricSpec = metricSpec { reach = MetricSpecKt.reachParams {} }
                   filter =
-                    "((has(banner_ad.viewable) && banner_ad.viewable == true) || (has(video_ad.viewed_fraction) && video_ad.viewed_fraction == 1.0)) && (person.age_group == 2)"
+                    "((banner_ad != null && banner_ad.viewable == true) || (video_ad != null && video_ad.viewed_fraction == 1.0)) && (person.age_group == 2)"
                   timeInterval = interval {
                     startTime = timestamp { seconds = 1736150400 }
                     endTime = timestamp { seconds = 1736755200 }
@@ -423,7 +423,7 @@ class BasicReportsReportsJobTest {
                   metricSpec = metricSpec {
                     populationCount = MetricSpecKt.populationCountParams {}
                   }
-                  filter = "(person.age_group == 2)"
+                  filter = "person.age_group == 2"
                   timeInterval = interval {
                     startTime = timestamp { seconds = 1736150400 }
                     endTime = timestamp { seconds = 1736755200 }
@@ -826,7 +826,7 @@ class BasicReportsReportsJobTest {
 
               resultAttributes +=
                 ReportKt.MetricCalculationResultKt.resultAttribute {
-                  filter = "((has(banner_ad.viewable) && banner_ad.viewable == true))"
+                  filter = "banner_ad != null && banner_ad.viewable == true"
                   metricSpec = metricSpec { reach = MetricSpecKt.reachParams {} }
                   timeInterval = interval {
                     startTime = timestamp { seconds = 1736150400 }
@@ -1022,7 +1022,7 @@ class BasicReportsReportsJobTest {
 
               resultAttributes +=
                 ReportKt.MetricCalculationResultKt.resultAttribute {
-                  filter = "((has(banner_ad.viewable) && banner_ad.viewable == true))"
+                  filter = "banner_ad != null && banner_ad.viewable == true"
                   metricSpec = metricSpec { reach = MetricSpecKt.reachParams {} }
                   timeInterval = interval {
                     startTime = timestamp { seconds = 1736150400 }
@@ -1049,7 +1049,7 @@ class BasicReportsReportsJobTest {
 
               resultAttributes +=
                 ReportKt.MetricCalculationResultKt.resultAttribute {
-                  filter = "((has(banner_ad.viewable) && banner_ad.viewable == true))"
+                  filter = "banner_ad != null && banner_ad.viewable == true"
                   metricSpec = metricSpec { reach = MetricSpecKt.reachParams {} }
                   timeInterval = interval {
                     startTime = timestamp { seconds = 1736150400 }
@@ -1117,7 +1117,7 @@ class BasicReportsReportsJobTest {
 
             resultAttributes +=
               ReportKt.MetricCalculationResultKt.resultAttribute {
-                filter = "((has(banner_ad.viewable) && banner_ad.viewable == true))"
+                filter = "banner_ad != null && banner_ad.viewable == true"
                 metricSpec = metricSpec { reach = MetricSpecKt.reachParams {} }
                 timeInterval = interval {
                   startTime = timestamp { seconds = 1736150400 }
@@ -1188,7 +1188,7 @@ class BasicReportsReportsJobTest {
 
             resultAttributes +=
               ReportKt.MetricCalculationResultKt.resultAttribute {
-                filter = "((has(banner_ad.viewable) && banner_ad.viewable == true))"
+                filter = "banner_ad != null && banner_ad.viewable == true"
                 metricSpec = metricSpec { reach = MetricSpecKt.reachParams {} }
                 timeInterval = interval {
                   startTime = timestamp { seconds = 1736150400 }
@@ -1239,7 +1239,7 @@ class BasicReportsReportsJobTest {
             }
             effectiveImpressionQualificationFilters += reportingImpressionQualificationFilter {
               filterSpecs += impressionQualificationFilterSpec {
-                mediaType = MediaType.DISPLAY
+                mediaType = MediaType.VIDEO
                 filters += eventFilter {
                   terms += eventTemplateField {
                     path = "video_ad.viewed_fraction"
@@ -1276,7 +1276,7 @@ class BasicReportsReportsJobTest {
 
             resultAttributes +=
               ReportKt.MetricCalculationResultKt.resultAttribute {
-                filter = "((has(banner_ad.viewable) && banner_ad.viewable == true))"
+                filter = "banner_ad != null && banner_ad.viewable == true"
                 metricSpec = metricSpec { reach = MetricSpecKt.reachParams {} }
                 timeInterval = interval {
                   startTime = timestamp { seconds = 1736150400 }
@@ -1303,7 +1303,7 @@ class BasicReportsReportsJobTest {
 
             resultAttributes +=
               ReportKt.MetricCalculationResultKt.resultAttribute {
-                filter = "((has(video_ad.viewed_fraction) && video_ad.viewed_fraction == 1.0))"
+                filter = "video_ad != null && video_ad.viewed_fraction == 1.0"
                 metricSpec = metricSpec { reach = MetricSpecKt.reachParams {} }
                 timeInterval = interval {
                   startTime = timestamp { seconds = 1736150400 }
@@ -1350,7 +1350,7 @@ class BasicReportsReportsJobTest {
 
               resultAttributes +=
                 ReportKt.MetricCalculationResultKt.resultAttribute {
-                  filter = "((has(banner_ad.viewable) && banner_ad.viewable == true))"
+                  filter = "banner_ad != null && banner_ad.viewable == true"
                   metricSpec = metricSpec { reach = MetricSpecKt.reachParams {} }
                   timeInterval = interval {
                     startTime = timestamp { seconds = 1736150400 }
@@ -1404,7 +1404,7 @@ class BasicReportsReportsJobTest {
 
             resultAttributes +=
               ReportKt.MetricCalculationResultKt.resultAttribute {
-                filter = "((has(banner_ad.viewable) && banner_ad.viewable == true))"
+                filter = "banner_ad != null && banner_ad.viewable == true"
                 metricSpec = metricSpec { reach = MetricSpecKt.reachParams {} }
                 timeInterval = interval {
                   startTime = timestamp { seconds = 1736150400 }
@@ -1461,7 +1461,7 @@ class BasicReportsReportsJobTest {
                 groupingPredicates += "person.gender == 1"
                 groupingPredicates += "person.age_group == 1"
                 groupingPredicates += "person.social_grade_group == 1"
-                filter = "((has(banner_ad.viewable) && banner_ad.viewable == true))"
+                filter = "banner_ad != null && banner_ad.viewable == true"
                 metricSpec = metricSpec { reach = MetricSpecKt.reachParams {} }
                 timeInterval = interval {
                   startTime = timestamp { seconds = 1736150400 }
@@ -1523,7 +1523,7 @@ class BasicReportsReportsJobTest {
 
             resultAttributes +=
               ReportKt.MetricCalculationResultKt.resultAttribute {
-                filter = "((has(banner_ad.viewable) && banner_ad.viewable == true))"
+                filter = "banner_ad != null && banner_ad.viewable == true"
                 metricSpec = metricSpec { reach = MetricSpecKt.reachParams {} }
                 timeInterval = interval {
                   startTime = timestamp { seconds = 1736150400 }
@@ -1564,7 +1564,7 @@ class BasicReportsReportsJobTest {
               effectiveImpressionQualificationFilters.clear()
               effectiveImpressionQualificationFilters += reportingImpressionQualificationFilter {
                 filterSpecs += impressionQualificationFilterSpec {
-                  mediaType = MediaType.VIDEO
+                  mediaType = MediaType.DISPLAY
                   filters += eventFilter {
                     terms += eventTemplateField {
                       path = "banner_ad.viewable"
@@ -1613,7 +1613,7 @@ class BasicReportsReportsJobTest {
               resultAttributes +=
                 ReportKt.MetricCalculationResultKt.resultAttribute {
                   filter =
-                    "((has(banner_ad.viewable) && banner_ad.viewable == true)) && (person.age_group == 1)"
+                    "(banner_ad != null && banner_ad.viewable == true) && (person.age_group == 1)"
                   metricSpec = metricSpec { reach = MetricSpecKt.reachParams {} }
                   timeInterval = interval {
                     startTime = timestamp { seconds = 1736150400 }
@@ -1661,7 +1661,7 @@ class BasicReportsReportsJobTest {
               effectiveImpressionQualificationFilters.clear()
               effectiveImpressionQualificationFilters += reportingImpressionQualificationFilter {
                 filterSpecs += impressionQualificationFilterSpec {
-                  mediaType = MediaType.VIDEO
+                  mediaType = MediaType.DISPLAY
                   filters += eventFilter {
                     terms += eventTemplateField {
                       path = "banner_ad.viewable"
@@ -1700,7 +1700,7 @@ class BasicReportsReportsJobTest {
 
               resultAttributes +=
                 ReportKt.MetricCalculationResultKt.resultAttribute {
-                  filter = "((has(banner_ad.viewable) && banner_ad.viewable == true))"
+                  filter = "banner_ad != null && banner_ad.viewable == true"
                   metricSpec = metricSpec { reach = MetricSpecKt.reachParams {} }
                   timeInterval = interval {
                     startTime = timestamp { seconds = 1736150400 }
@@ -1754,7 +1754,7 @@ class BasicReportsReportsJobTest {
 
             resultAttributes +=
               ReportKt.MetricCalculationResultKt.resultAttribute {
-                filter = "((has(banner_ad.viewable) && banner_ad.viewable == true))"
+                filter = "banner_ad != null && banner_ad.viewable == true"
                 metricSpec = metricSpec { impressionCount = MetricSpecKt.impressionCountParams {} }
                 timeInterval = interval {
                   startTime = timestamp { seconds = 1736150400 }
@@ -1788,7 +1788,7 @@ class BasicReportsReportsJobTest {
 
             resultAttributes +=
               ReportKt.MetricCalculationResultKt.resultAttribute {
-                filter = "((has(banner_ad.viewable) && banner_ad.viewable == true))"
+                filter = "banner_ad != null && banner_ad.viewable == true"
                 metricSpec = metricSpec { reach = MetricSpecKt.reachParams {} }
                 timeInterval = interval {
                   startTime = timestamp { seconds = 1736150400 }
@@ -1822,7 +1822,7 @@ class BasicReportsReportsJobTest {
 
             resultAttributes +=
               ReportKt.MetricCalculationResultKt.resultAttribute {
-                filter = "((has(banner_ad.viewable) && banner_ad.viewable == true))"
+                filter = "banner_ad != null && banner_ad.viewable == true"
                 metricSpec = metricSpec { impressionCount = MetricSpecKt.impressionCountParams {} }
                 timeInterval = interval {
                   startTime = timestamp { seconds = 1736150400 }
@@ -1838,7 +1838,7 @@ class BasicReportsReportsJobTest {
               }
             resultAttributes +=
               ReportKt.MetricCalculationResultKt.resultAttribute {
-                filter = "((has(banner_ad.viewable) && banner_ad.viewable == true))"
+                filter = "banner_ad != null && banner_ad.viewable == true"
                 metricSpec = metricSpec {
                   reachAndFrequency = MetricSpecKt.reachAndFrequencyParams {}
                 }
@@ -2115,7 +2115,7 @@ class BasicReportsReportsJobTest {
 
               resultAttributes +=
                 ReportKt.MetricCalculationResultKt.resultAttribute {
-                  filter = "((has(banner_ad.viewable) && banner_ad.viewable == true))"
+                  filter = "banner_ad != null && banner_ad.viewable == true"
                   metricSpec = metricSpec { reach = MetricSpecKt.reachParams {} }
                   timeInterval = interval {
                     startTime = timestamp { seconds = 1736150400 }
@@ -2142,7 +2142,7 @@ class BasicReportsReportsJobTest {
 
               resultAttributes +=
                 ReportKt.MetricCalculationResultKt.resultAttribute {
-                  filter = "((has(banner_ad.viewable) && banner_ad.viewable == true))"
+                  filter = "banner_ad != null && banner_ad.viewable == true"
                   metricSpec = metricSpec { reach = MetricSpecKt.reachParams {} }
                   timeInterval = interval {
                     startTime = timestamp { seconds = 1736150400 }
@@ -2231,7 +2231,7 @@ class BasicReportsReportsJobTest {
 
             resultAttributes +=
               ReportKt.MetricCalculationResultKt.resultAttribute {
-                filter = "((has(banner_ad.viewable) && banner_ad.viewable == true))"
+                filter = "banner_ad != null && banner_ad.viewable == true"
                 metricSpec = metricSpec { reach = MetricSpecKt.reachParams {} }
                 timeInterval = interval {
                   startTime = timestamp { seconds = 1736150400 }
@@ -2307,7 +2307,7 @@ class BasicReportsReportsJobTest {
 
               resultAttributes +=
                 ReportKt.MetricCalculationResultKt.resultAttribute {
-                  filter = "((has(banner_ad.viewable) && banner_ad.viewable == true))"
+                  filter = "banner_ad != null && banner_ad.viewable == true"
                   metricSpec = metricSpec { reach = MetricSpecKt.reachParams {} }
                   timeInterval = interval {
                     startTime = timestamp { seconds = 1736150400 }
@@ -2318,7 +2318,7 @@ class BasicReportsReportsJobTest {
 
               resultAttributes +=
                 ReportKt.MetricCalculationResultKt.resultAttribute {
-                  filter = "((has(banner_ad.viewable) && banner_ad.viewable == true))"
+                  filter = "banner_ad != null && banner_ad.viewable == true"
                   metricSpec = metricSpec { reach = MetricSpecKt.reachParams {} }
                   timeInterval = interval {
                     startTime = timestamp { seconds = 1736755200 }

--- a/src/test/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/BUILD.bazel
+++ b/src/test/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/BUILD.bazel
@@ -420,6 +420,7 @@ kt_jvm_test(
         "//src/main/proto/wfa/measurement/reporting/v2alpha:reporting_unit_kt_jvm_proto",
         "//src/main/proto/wfa/measurement/reporting/v2alpha:result_group_kt_jvm_proto",
         "@wfa_common_jvm//imports/java/com/google/common/truth",
+        "@wfa_common_jvm//imports/java/com/google/common/truth/extensions/proto",
         "@wfa_common_jvm//imports/kotlin/kotlin/test",
     ],
 )

--- a/src/test/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/BasicReportTransformationsTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/BasicReportTransformationsTest.kt
@@ -17,6 +17,7 @@
 package org.wfanet.measurement.reporting.service.api.v2alpha
 
 import com.google.common.truth.Truth.assertThat
+import com.google.common.truth.extensions.proto.ProtoTruth.assertThat
 import com.google.type.DayOfWeek
 import kotlin.test.assertFailsWith
 import org.junit.Test
@@ -30,6 +31,7 @@ import org.wfanet.measurement.internal.reporting.v2.MetricSpecKt
 import org.wfanet.measurement.internal.reporting.v2.metricSpec
 import org.wfanet.measurement.reporting.v2alpha.DimensionSpecKt
 import org.wfanet.measurement.reporting.v2alpha.EventTemplateFieldKt
+import org.wfanet.measurement.reporting.v2alpha.ImpressionQualificationFilterSpec
 import org.wfanet.measurement.reporting.v2alpha.MediaType
 import org.wfanet.measurement.reporting.v2alpha.ReportingSet
 import org.wfanet.measurement.reporting.v2alpha.ReportingSetKt
@@ -107,7 +109,7 @@ class BasicReportTransformationsTest {
         PRIMITIVE_REPORTING_SET_1,
         listOf(
           MetricCalculationSpecKt.details {
-            filter = "(person.age_group == 1 && person.gender == 1)"
+            filter = "person.age_group == 1 && person.gender == 1"
             metricSpecs += metricSpec { populationCount = MetricSpecKt.populationCountParams {} }
           }
         ),
@@ -143,7 +145,7 @@ class BasicReportTransformationsTest {
           add(
             MetricCalculationSpecKt.details {
               filter =
-                "((has(banner_ad.viewable) && banner_ad.viewable == true) || (has(video_ad.viewed_fraction) && video_ad.viewed_fraction == 1.0)) && (person.age_group == 1 && person.gender == 1)"
+                "((banner_ad != null && banner_ad.viewable == true) || (video_ad != null && video_ad.viewed_fraction == 1.0)) && (person.age_group == 1 && person.gender == 1)"
               metricFrequencySpec =
                 MetricCalculationSpecKt.metricFrequencySpec {
                   weekly =
@@ -164,7 +166,7 @@ class BasicReportTransformationsTest {
           add(
             MetricCalculationSpecKt.details {
               filter =
-                "((has(banner_ad.viewable) && banner_ad.viewable == true) || (has(video_ad.viewed_fraction) && video_ad.viewed_fraction == 1.0)) && (person.age_group == 1 && person.gender == 1)"
+                "((banner_ad != null && banner_ad.viewable == true) || (video_ad != null && video_ad.viewed_fraction == 1.0)) && (person.age_group == 1 && person.gender == 1)"
               metricFrequencySpec =
                 MetricCalculationSpecKt.metricFrequencySpec {
                   weekly =
@@ -238,14 +240,14 @@ class BasicReportTransformationsTest {
         buildList {
           add(
             MetricCalculationSpecKt.details {
-              filter = "(person.age_group == 1 && person.gender == 1)"
+              filter = "person.age_group == 1 && person.gender == 1"
               metricSpecs += metricSpec { populationCount = MetricSpecKt.populationCountParams {} }
             }
           )
           add(
             MetricCalculationSpecKt.details {
               filter =
-                "((has(banner_ad.viewable) && banner_ad.viewable == true) || (has(video_ad.viewed_fraction) && video_ad.viewed_fraction == 1.0)) && (person.age_group == 1 && person.gender == 1)"
+                "((banner_ad != null && banner_ad.viewable == true) || (video_ad != null && video_ad.viewed_fraction == 1.0)) && (person.age_group == 1 && person.gender == 1)"
               metricSpecs += metricSpec { reach = MetricSpecKt.reachParams {} }
             }
           )
@@ -283,7 +285,7 @@ class BasicReportTransformationsTest {
           add(
             MetricCalculationSpecKt.details {
               filter =
-                "((has(banner_ad.viewable) && banner_ad.viewable == true) || (has(video_ad.viewed_fraction) && video_ad.viewed_fraction == 1.0)) && (person.age_group == 1 && person.gender == 1)"
+                "((banner_ad != null && banner_ad.viewable == true) || (video_ad != null && video_ad.viewed_fraction == 1.0)) && (person.age_group == 1 && person.gender == 1)"
               metricSpecs += metricSpec { reach = MetricSpecKt.reachParams {} }
               metricSpecs += metricSpec { impressionCount = MetricSpecKt.impressionCountParams {} }
             }
@@ -356,14 +358,14 @@ class BasicReportTransformationsTest {
         buildList {
           add(
             MetricCalculationSpecKt.details {
-              filter = "(person.age_group == 1 && person.gender == 1)"
+              filter = "person.age_group == 1 && person.gender == 1"
               metricSpecs += metricSpec { populationCount = MetricSpecKt.populationCountParams {} }
             }
           )
           add(
             MetricCalculationSpecKt.details {
               filter =
-                "((has(banner_ad.viewable) && banner_ad.viewable == true) || (has(video_ad.viewed_fraction) && video_ad.viewed_fraction == 1.0)) && (person.age_group == 1 && person.gender == 1)"
+                "((banner_ad != null && banner_ad.viewable == true) || (video_ad != null && video_ad.viewed_fraction == 1.0)) && (person.age_group == 1 && person.gender == 1)"
               metricFrequencySpec =
                 MetricCalculationSpecKt.metricFrequencySpec {
                   weekly =
@@ -384,7 +386,7 @@ class BasicReportTransformationsTest {
           add(
             MetricCalculationSpecKt.details {
               filter =
-                "((has(banner_ad.viewable) && banner_ad.viewable == true) || (has(video_ad.viewed_fraction) && video_ad.viewed_fraction == 1.0)) && (person.age_group == 1 && person.gender == 1)"
+                "((banner_ad != null && banner_ad.viewable == true) || (video_ad != null && video_ad.viewed_fraction == 1.0)) && (person.age_group == 1 && person.gender == 1)"
               metricFrequencySpec =
                 MetricCalculationSpecKt.metricFrequencySpec {
                   weekly =
@@ -406,7 +408,7 @@ class BasicReportTransformationsTest {
           add(
             MetricCalculationSpecKt.details {
               filter =
-                "((has(banner_ad.viewable) && banner_ad.viewable == true) || (has(video_ad.viewed_fraction) && video_ad.viewed_fraction == 1.0)) && (person.age_group == 1 && person.gender == 1)"
+                "((banner_ad != null && banner_ad.viewable == true) || (video_ad != null && video_ad.viewed_fraction == 1.0)) && (person.age_group == 1 && person.gender == 1)"
               metricFrequencySpec =
                 MetricCalculationSpecKt.metricFrequencySpec {
                   weekly =
@@ -427,7 +429,7 @@ class BasicReportTransformationsTest {
           add(
             MetricCalculationSpecKt.details {
               filter =
-                "((has(banner_ad.viewable) && banner_ad.viewable == true) || (has(video_ad.viewed_fraction) && video_ad.viewed_fraction == 1.0)) && (person.age_group == 1 && person.gender == 1)"
+                "((banner_ad != null && banner_ad.viewable == true) || (video_ad != null && video_ad.viewed_fraction == 1.0)) && (person.age_group == 1 && person.gender == 1)"
               metricFrequencySpec =
                 MetricCalculationSpecKt.metricFrequencySpec {
                   weekly =
@@ -473,7 +475,7 @@ class BasicReportTransformationsTest {
           add(
             MetricCalculationSpecKt.details {
               filter =
-                "((has(banner_ad.viewable) && banner_ad.viewable == true) || (has(video_ad.viewed_fraction) && video_ad.viewed_fraction == 1.0)) && (person.age_group == 1 && person.gender == 1)"
+                "((banner_ad != null && banner_ad.viewable == true) || (video_ad != null && video_ad.viewed_fraction == 1.0)) && (person.age_group == 1 && person.gender == 1)"
               metricFrequencySpec =
                 MetricCalculationSpecKt.metricFrequencySpec {
                   weekly =
@@ -493,7 +495,7 @@ class BasicReportTransformationsTest {
           add(
             MetricCalculationSpecKt.details {
               filter =
-                "((has(banner_ad.viewable) && banner_ad.viewable == true) || (has(video_ad.viewed_fraction) && video_ad.viewed_fraction == 1.0)) && (person.age_group == 1 && person.gender == 1)"
+                "((banner_ad != null && banner_ad.viewable == true) || (video_ad != null && video_ad.viewed_fraction == 1.0)) && (person.age_group == 1 && person.gender == 1)"
               metricFrequencySpec =
                 MetricCalculationSpecKt.metricFrequencySpec {
                   weekly =
@@ -566,14 +568,14 @@ class BasicReportTransformationsTest {
         buildList {
           add(
             MetricCalculationSpecKt.details {
-              filter = "(person.age_group == 1 && person.gender == 1)"
+              filter = "person.age_group == 1 && person.gender == 1"
               metricSpecs += metricSpec { populationCount = MetricSpecKt.populationCountParams {} }
             }
           )
           add(
             MetricCalculationSpecKt.details {
               filter =
-                "((has(banner_ad.viewable) && banner_ad.viewable == true) || (has(video_ad.viewed_fraction) && video_ad.viewed_fraction == 1.0)) && (person.age_group == 1 && person.gender == 1)"
+                "((banner_ad != null && banner_ad.viewable == true) || (video_ad != null && video_ad.viewed_fraction == 1.0)) && (person.age_group == 1 && person.gender == 1)"
               metricSpecs += metricSpec { reach = MetricSpecKt.reachParams {} }
               metricSpecs += metricSpec { impressionCount = MetricSpecKt.impressionCountParams {} }
             }
@@ -588,7 +590,7 @@ class BasicReportTransformationsTest {
           add(
             MetricCalculationSpecKt.details {
               filter =
-                "((has(banner_ad.viewable) && banner_ad.viewable == true) || (has(video_ad.viewed_fraction) && video_ad.viewed_fraction == 1.0)) && (person.age_group == 1 && person.gender == 1)"
+                "((banner_ad != null && banner_ad.viewable == true) || (video_ad != null && video_ad.viewed_fraction == 1.0)) && (person.age_group == 1 && person.gender == 1)"
               metricSpecs += metricSpec { reach = MetricSpecKt.reachParams {} }
               metricSpecs += metricSpec { impressionCount = MetricSpecKt.impressionCountParams {} }
             }
@@ -627,7 +629,7 @@ class BasicReportTransformationsTest {
           add(
             MetricCalculationSpecKt.details {
               filter =
-                "((has(banner_ad.viewable) && banner_ad.viewable == true) || (has(video_ad.viewed_fraction) && video_ad.viewed_fraction == 1.0)) && (person.age_group == 1 && person.gender == 1)"
+                "((banner_ad != null && banner_ad.viewable == true) || (video_ad != null && video_ad.viewed_fraction == 1.0)) && (person.age_group == 1 && person.gender == 1)"
               metricSpecs += metricSpec { reach = MetricSpecKt.reachParams {} }
             }
           )
@@ -692,14 +694,14 @@ class BasicReportTransformationsTest {
         buildList {
           add(
             MetricCalculationSpecKt.details {
-              filter = "(person.age_group == 1 && person.gender == 1)"
+              filter = "person.age_group == 1 && person.gender == 1"
               metricSpecs += metricSpec { populationCount = MetricSpecKt.populationCountParams {} }
             }
           )
           add(
             MetricCalculationSpecKt.details {
               filter =
-                "((has(banner_ad.viewable) && banner_ad.viewable == true) || (has(video_ad.viewed_fraction) && video_ad.viewed_fraction == 1.0)) && (person.age_group == 1 && person.gender == 1)"
+                "((banner_ad != null && banner_ad.viewable == true) || (video_ad != null && video_ad.viewed_fraction == 1.0)) && (person.age_group == 1 && person.gender == 1)"
               metricSpecs += metricSpec { reach = MetricSpecKt.reachParams {} }
               metricSpecs += metricSpec { impressionCount = MetricSpecKt.impressionCountParams {} }
             }
@@ -714,7 +716,7 @@ class BasicReportTransformationsTest {
           add(
             MetricCalculationSpecKt.details {
               filter =
-                "((has(banner_ad.viewable) && banner_ad.viewable == true) || (has(video_ad.viewed_fraction) && video_ad.viewed_fraction == 1.0)) && (person.age_group == 1 && person.gender == 1)"
+                "((banner_ad != null && banner_ad.viewable == true) || (video_ad != null && video_ad.viewed_fraction == 1.0)) && (person.age_group == 1 && person.gender == 1)"
               metricSpecs += metricSpec { reach = MetricSpecKt.reachParams {} }
               metricSpecs += metricSpec { impressionCount = MetricSpecKt.impressionCountParams {} }
             }
@@ -776,14 +778,14 @@ class BasicReportTransformationsTest {
         buildList {
           add(
             MetricCalculationSpecKt.details {
-              filter = "(person.age_group == 1 && person.gender == 1)"
+              filter = "person.age_group == 1 && person.gender == 1"
               metricSpecs += metricSpec { populationCount = MetricSpecKt.populationCountParams {} }
             }
           )
           add(
             MetricCalculationSpecKt.details {
               filter =
-                "((has(banner_ad.viewable) && banner_ad.viewable == true) || (has(video_ad.viewed_fraction) && video_ad.viewed_fraction == 1.0)) && (person.age_group == 1 && person.gender == 1)"
+                "((banner_ad != null && banner_ad.viewable == true) || (video_ad != null && video_ad.viewed_fraction == 1.0)) && (person.age_group == 1 && person.gender == 1)"
               metricFrequencySpec =
                 MetricCalculationSpecKt.metricFrequencySpec {
                   weekly =
@@ -809,7 +811,7 @@ class BasicReportTransformationsTest {
           add(
             MetricCalculationSpecKt.details {
               filter =
-                "((has(banner_ad.viewable) && banner_ad.viewable == true) || (has(video_ad.viewed_fraction) && video_ad.viewed_fraction == 1.0)) && (person.age_group == 1 && person.gender == 1)"
+                "((banner_ad != null && banner_ad.viewable == true) || (video_ad != null && video_ad.viewed_fraction == 1.0)) && (person.age_group == 1 && person.gender == 1)"
               metricFrequencySpec =
                 MetricCalculationSpecKt.metricFrequencySpec {
                   weekly =
@@ -859,7 +861,7 @@ class BasicReportTransformationsTest {
           add(
             MetricCalculationSpecKt.details {
               filter =
-                "((has(banner_ad.viewable) && banner_ad.viewable == true) || (has(video_ad.viewed_fraction) && video_ad.viewed_fraction == 1.0)) && (person.age_group == 1 && person.gender == 1)"
+                "((banner_ad != null && banner_ad.viewable == true) || (video_ad != null && video_ad.viewed_fraction == 1.0)) && (person.age_group == 1 && person.gender == 1)"
               metricFrequencySpec =
                 MetricCalculationSpecKt.metricFrequencySpec {
                   weekly =
@@ -928,7 +930,7 @@ class BasicReportTransformationsTest {
         PRIMITIVE_REPORTING_SET_1,
         listOf(
           MetricCalculationSpecKt.details {
-            filter = "(person.age_group == 1 && person.gender == 1)"
+            filter = "person.age_group == 1 && person.gender == 1"
             metricSpecs += metricSpec { populationCount = MetricSpecKt.populationCountParams {} }
           }
         ),
@@ -989,7 +991,7 @@ class BasicReportTransformationsTest {
         PRIMITIVE_REPORTING_SET_1,
         listOf(
           MetricCalculationSpecKt.details {
-            filter = "(person.age_group == 1 && person.gender == 1)"
+            filter = "person.age_group == 1 && person.gender == 1"
             metricSpecs += metricSpec { populationCount = MetricSpecKt.populationCountParams {} }
           }
         ),
@@ -1038,7 +1040,7 @@ class BasicReportTransformationsTest {
                   increment = MetricCalculationSpec.TrailingWindow.Increment.WEEK
                 }
               filter =
-                "((has(banner_ad.viewable) && banner_ad.viewable == true) || (has(video_ad.viewed_fraction) && video_ad.viewed_fraction == 1.0)) && (person.age_group == 1 && person.gender == 1)"
+                "((banner_ad != null && banner_ad.viewable == true) || (video_ad != null && video_ad.viewed_fraction == 1.0)) && (person.age_group == 1 && person.gender == 1)"
               metricSpecs += metricSpec { reach = MetricSpecKt.reachParams {} }
             }
           )
@@ -1088,7 +1090,7 @@ class BasicReportTransformationsTest {
                   increment = MetricCalculationSpec.TrailingWindow.Increment.WEEK
                 }
               filter =
-                "((has(banner_ad.viewable) && banner_ad.viewable == true) || (has(video_ad.viewed_fraction) && video_ad.viewed_fraction == 1.0)) && (person.age_group == 1 && person.gender == 1)"
+                "((banner_ad != null && banner_ad.viewable == true) || (video_ad != null && video_ad.viewed_fraction == 1.0)) && (person.age_group == 1 && person.gender == 1)"
               metricSpecs += metricSpec { reach = MetricSpecKt.reachParams {} }
             }
           )
@@ -1138,7 +1140,7 @@ class BasicReportTransformationsTest {
                   increment = MetricCalculationSpec.TrailingWindow.Increment.WEEK
                 }
               filter =
-                "((has(banner_ad.viewable) && banner_ad.viewable == true) || (has(video_ad.viewed_fraction) && video_ad.viewed_fraction == 1.0)) && (person.age_group == 1 && person.gender == 1)"
+                "((banner_ad != null && banner_ad.viewable == true) || (video_ad != null && video_ad.viewed_fraction == 1.0)) && (person.age_group == 1 && person.gender == 1)"
               metricSpecs += metricSpec { reach = MetricSpecKt.reachParams {} }
             }
           )
@@ -1199,7 +1201,7 @@ class BasicReportTransformationsTest {
                   increment = MetricCalculationSpec.TrailingWindow.Increment.WEEK
                 }
               filter =
-                "((has(banner_ad.viewable) && banner_ad.viewable == true) || (has(video_ad.viewed_fraction) && video_ad.viewed_fraction == 1.0)) && (person.age_group == 1 && person.gender == 1)"
+                "((banner_ad != null && banner_ad.viewable == true) || (video_ad != null && video_ad.viewed_fraction == 1.0)) && (person.age_group == 1 && person.gender == 1)"
               metricSpecs += metricSpec { reach = MetricSpecKt.reachParams {} }
             }
           )
@@ -1261,7 +1263,7 @@ class BasicReportTransformationsTest {
         PRIMITIVE_REPORTING_SET_1,
         listOf(
           MetricCalculationSpecKt.details {
-            filter = "(person.age_group == 1 && person.gender == 1)"
+            filter = "person.age_group == 1 && person.gender == 1"
             metricSpecs += metricSpec { populationCount = MetricSpecKt.populationCountParams {} }
           }
         ),
@@ -1298,7 +1300,7 @@ class BasicReportTransformationsTest {
           add(
             MetricCalculationSpecKt.details {
               filter =
-                "((has(banner_ad.viewable) && banner_ad.viewable == true) || (has(video_ad.viewed_fraction) && video_ad.viewed_fraction == 1.0)) && (person.age_group == 1 && person.gender == 1)"
+                "((banner_ad != null && banner_ad.viewable == true) || (video_ad != null && video_ad.viewed_fraction == 1.0)) && (person.age_group == 1 && person.gender == 1)"
               metricSpecs += metricSpec { reach = MetricSpecKt.reachParams {} }
             }
           )
@@ -1336,7 +1338,7 @@ class BasicReportTransformationsTest {
           add(
             MetricCalculationSpecKt.details {
               filter =
-                "((has(banner_ad.viewable) && banner_ad.viewable == true) || (has(video_ad.viewed_fraction) && video_ad.viewed_fraction == 1.0)) && (person.age_group == 1 && person.gender == 1)"
+                "((banner_ad != null && banner_ad.viewable == true) || (video_ad != null && video_ad.viewed_fraction == 1.0)) && (person.age_group == 1 && person.gender == 1)"
               metricSpecs += metricSpec { reach = MetricSpecKt.reachParams {} }
             }
           )
@@ -1374,7 +1376,7 @@ class BasicReportTransformationsTest {
           add(
             MetricCalculationSpecKt.details {
               filter =
-                "((has(banner_ad.viewable) && banner_ad.viewable == true) || (has(video_ad.viewed_fraction) && video_ad.viewed_fraction == 1.0)) && (person.age_group == 1 && person.gender == 1)"
+                "((banner_ad != null && banner_ad.viewable == true) || (video_ad != null && video_ad.viewed_fraction == 1.0)) && (person.age_group == 1 && person.gender == 1)"
               metricSpecs += metricSpec { reach = MetricSpecKt.reachParams {} }
             }
           )
@@ -1423,7 +1425,7 @@ class BasicReportTransformationsTest {
           add(
             MetricCalculationSpecKt.details {
               filter =
-                "((has(banner_ad.viewable) && banner_ad.viewable == true) || (has(video_ad.viewed_fraction) && video_ad.viewed_fraction == 1.0)) && (person.age_group == 1 && person.gender == 1)"
+                "((banner_ad != null && banner_ad.viewable == true) || (video_ad != null && video_ad.viewed_fraction == 1.0)) && (person.age_group == 1 && person.gender == 1)"
               metricSpecs += metricSpec { reach = MetricSpecKt.reachParams {} }
             }
           )
@@ -1481,7 +1483,7 @@ class BasicReportTransformationsTest {
         buildList {
           add(
             MetricCalculationSpecKt.details {
-              filter = "(person.age_group == 1 && person.gender == 1)"
+              filter = "person.age_group == 1 && person.gender == 1"
               metricSpecs += metricSpec { populationCount = MetricSpecKt.populationCountParams {} }
             }
           )
@@ -1489,7 +1491,7 @@ class BasicReportTransformationsTest {
           add(
             MetricCalculationSpecKt.details {
               filter =
-                "((has(banner_ad.viewable) && banner_ad.viewable == true) || (has(video_ad.viewed_fraction) && video_ad.viewed_fraction == 1.0)) && (person.age_group == 1 && person.gender == 1)"
+                "((banner_ad != null && banner_ad.viewable == true) || (video_ad != null && video_ad.viewed_fraction == 1.0)) && (person.age_group == 1 && person.gender == 1)"
               metricSpecs += metricSpec { reach = MetricSpecKt.reachParams {} }
               metricSpecs += metricSpec { impressionCount = MetricSpecKt.impressionCountParams {} }
             }
@@ -1546,7 +1548,7 @@ class BasicReportTransformationsTest {
         buildList {
           add(
             MetricCalculationSpecKt.details {
-              filter = "(person.age_group == 1 && person.gender == 1)"
+              filter = "person.age_group == 1 && person.gender == 1"
               metricSpecs += metricSpec { populationCount = MetricSpecKt.populationCountParams {} }
             }
           )
@@ -1554,7 +1556,7 @@ class BasicReportTransformationsTest {
           add(
             MetricCalculationSpecKt.details {
               filter =
-                "((has(banner_ad.viewable) && banner_ad.viewable == true) || (has(video_ad.viewed_fraction) && video_ad.viewed_fraction == 1.0)) && (person.age_group == 1 && person.gender == 1)"
+                "((banner_ad != null && banner_ad.viewable == true) || (video_ad != null && video_ad.viewed_fraction == 1.0)) && (person.age_group == 1 && person.gender == 1)"
               metricSpecs += metricSpec { reach = MetricSpecKt.reachParams {} }
             }
           )
@@ -1615,7 +1617,7 @@ class BasicReportTransformationsTest {
         buildList {
           add(
             MetricCalculationSpecKt.details {
-              filter = "(person.age_group == 1 && person.gender == 1)"
+              filter = "person.age_group == 1 && person.gender == 1"
               metricSpecs += metricSpec { populationCount = MetricSpecKt.populationCountParams {} }
             }
           )
@@ -1623,7 +1625,7 @@ class BasicReportTransformationsTest {
           add(
             MetricCalculationSpecKt.details {
               filter =
-                "((has(banner_ad.viewable) && banner_ad.viewable == true) || (has(video_ad.viewed_fraction) && video_ad.viewed_fraction == 1.0)) && (person.age_group == 1 && person.gender == 1)"
+                "((banner_ad != null && banner_ad.viewable == true) || (video_ad != null && video_ad.viewed_fraction == 1.0)) && (person.age_group == 1 && person.gender == 1)"
               metricSpecs += metricSpec { reach = MetricSpecKt.reachParams {} }
             }
           )
@@ -1661,7 +1663,7 @@ class BasicReportTransformationsTest {
           add(
             MetricCalculationSpecKt.details {
               filter =
-                "((has(banner_ad.viewable) && banner_ad.viewable == true) || (has(video_ad.viewed_fraction) && video_ad.viewed_fraction == 1.0)) && (person.age_group == 1 && person.gender == 1)"
+                "((banner_ad != null && banner_ad.viewable == true) || (video_ad != null && video_ad.viewed_fraction == 1.0)) && (person.age_group == 1 && person.gender == 1)"
               metricSpecs += metricSpec { reach = MetricSpecKt.reachParams {} }
             }
           )
@@ -1710,7 +1712,7 @@ class BasicReportTransformationsTest {
           add(
             MetricCalculationSpecKt.details {
               filter =
-                "((has(banner_ad.viewable) && banner_ad.viewable == true) || (has(video_ad.viewed_fraction) && video_ad.viewed_fraction == 1.0)) && (person.age_group == 1 && person.gender == 1)"
+                "((banner_ad != null && banner_ad.viewable == true) || (video_ad != null && video_ad.viewed_fraction == 1.0)) && (person.age_group == 1 && person.gender == 1)"
               metricSpecs += metricSpec { reach = MetricSpecKt.reachParams {} }
             }
           )
@@ -1719,7 +1721,7 @@ class BasicReportTransformationsTest {
   }
 
   @Test
-  fun `differnt values in dimensionSpec filter can be processed and sorted`() {
+  fun `different values in dimensionSpec filter can be processed and sorted`() {
     val dataProviderPrimitiveReportingSetMap = buildMap {
       put(DATA_PROVIDER_NAME_1, PRIMITIVE_REPORTING_SET_1)
       put(DATA_PROVIDER_NAME_2, PRIMITIVE_REPORTING_SET_2)
@@ -1765,26 +1767,19 @@ class BasicReportTransformationsTest {
         eventTemplateFieldsByPath = TEST_EVENT_DESCRIPTOR.eventTemplateFieldsByPath,
       )
 
-    assertThat(reportingSetMetricCalculationSpecDetailsMap).hasSize(1)
-    assertThat(reportingSetMetricCalculationSpecDetailsMap)
-      .containsEntry(
-        PRIMITIVE_REPORTING_SET_1,
-        buildList {
-          add(
-            MetricCalculationSpecKt.details {
-              filter =
-                "(banner_ad.viewable == true && person.age_group == 1 && video_ad.viewed_fraction == 0.5)"
-              metricSpecs += metricSpec { populationCount = MetricSpecKt.populationCountParams {} }
-            }
-          )
-
-          add(
-            MetricCalculationSpecKt.details {
-              filter =
-                "((has(banner_ad.viewable) && banner_ad.viewable == true) || (has(video_ad.viewed_fraction) && video_ad.viewed_fraction == 1.0)) && (banner_ad.viewable == true && person.age_group == 1 && video_ad.viewed_fraction == 0.5)"
-              metricSpecs += metricSpec { reach = MetricSpecKt.reachParams {} }
-            }
-          )
+    assertThat(reportingSetMetricCalculationSpecDetailsMap.keys)
+      .containsExactly(PRIMITIVE_REPORTING_SET_1)
+    assertThat(reportingSetMetricCalculationSpecDetailsMap[PRIMITIVE_REPORTING_SET_1])
+      .containsExactly(
+        MetricCalculationSpecKt.details {
+          filter =
+            "banner_ad.viewable == true && person.age_group == 1 && video_ad.viewed_fraction == 0.5"
+          metricSpecs += metricSpec { populationCount = MetricSpecKt.populationCountParams {} }
+        },
+        MetricCalculationSpecKt.details {
+          filter =
+            "((banner_ad != null && banner_ad.viewable == true) || (video_ad != null && video_ad.viewed_fraction == 1.0)) && (banner_ad.viewable == true && person.age_group == 1 && video_ad.viewed_fraction == 0.5)"
+          metricSpecs += metricSpec { reach = MetricSpecKt.reachParams {} }
         },
       )
   }
@@ -1940,7 +1935,7 @@ class BasicReportTransformationsTest {
         buildList {
           add(
             MetricCalculationSpecKt.details {
-              filter = "(person.age_group == 1 && person.gender == 1)"
+              filter = "person.age_group == 1 && person.gender == 1"
               metricSpecs += metricSpec { populationCount = MetricSpecKt.populationCountParams {} }
             }
           )
@@ -1948,7 +1943,7 @@ class BasicReportTransformationsTest {
           add(
             MetricCalculationSpecKt.details {
               filter =
-                "((has(banner_ad.viewable) && banner_ad.viewable == true) || (has(video_ad.viewed_fraction) && video_ad.viewed_fraction == 1.0)) && (person.age_group == 1 && person.gender == 1)"
+                "((banner_ad != null && banner_ad.viewable == true) || (video_ad != null && video_ad.viewed_fraction == 1.0)) && (person.age_group == 1 && person.gender == 1)"
               metricSpecs += metricSpec { reach = MetricSpecKt.reachParams {} }
             }
           )
@@ -2006,7 +2001,7 @@ class BasicReportTransformationsTest {
         buildList {
           add(
             MetricCalculationSpecKt.details {
-              filter = "(person.age_group == 1 && person.gender == 1)"
+              filter = "person.age_group == 1 && person.gender == 1"
               metricSpecs += metricSpec { populationCount = MetricSpecKt.populationCountParams {} }
             }
           )
@@ -2014,7 +2009,7 @@ class BasicReportTransformationsTest {
           add(
             MetricCalculationSpecKt.details {
               filter =
-                "((has(banner_ad.viewable) && banner_ad.viewable == true) || (has(video_ad.viewed_fraction) && video_ad.viewed_fraction == 1.0)) && (person.age_group == 1 && person.gender == 1)"
+                "((banner_ad != null && banner_ad.viewable == true) || (video_ad != null && video_ad.viewed_fraction == 1.0)) && (person.age_group == 1 && person.gender == 1)"
               metricSpecs += metricSpec { reach = MetricSpecKt.reachParams {} }
             }
           )
@@ -2072,7 +2067,7 @@ class BasicReportTransformationsTest {
         buildList {
           add(
             MetricCalculationSpecKt.details {
-              filter = "(person.age_group == 1 && person.gender == 1)"
+              filter = "person.age_group == 1 && person.gender == 1"
               metricSpecs += metricSpec { populationCount = MetricSpecKt.populationCountParams {} }
             }
           )
@@ -2080,7 +2075,7 @@ class BasicReportTransformationsTest {
           add(
             MetricCalculationSpecKt.details {
               filter =
-                "((has(banner_ad.viewable) && banner_ad.viewable == true) || (has(video_ad.viewed_fraction) && video_ad.viewed_fraction == 1.0)) && (person.age_group == 1 && person.gender == 1)"
+                "((banner_ad != null && banner_ad.viewable == true) || (video_ad != null && video_ad.viewed_fraction == 1.0)) && (person.age_group == 1 && person.gender == 1)"
               metricSpecs += metricSpec {
                 reachAndFrequency = MetricSpecKt.reachAndFrequencyParams {}
               }
@@ -2140,7 +2135,7 @@ class BasicReportTransformationsTest {
         buildList {
           add(
             MetricCalculationSpecKt.details {
-              filter = "(person.age_group == 1 && person.gender == 1)"
+              filter = "person.age_group == 1 && person.gender == 1"
               metricSpecs += metricSpec { populationCount = MetricSpecKt.populationCountParams {} }
             }
           )
@@ -2148,7 +2143,7 @@ class BasicReportTransformationsTest {
           add(
             MetricCalculationSpecKt.details {
               filter =
-                "((has(banner_ad.viewable) && banner_ad.viewable == true) || (has(video_ad.viewed_fraction) && video_ad.viewed_fraction == 1.0)) && (person.age_group == 1 && person.gender == 1)"
+                "((banner_ad != null && banner_ad.viewable == true) || (video_ad != null && video_ad.viewed_fraction == 1.0)) && (person.age_group == 1 && person.gender == 1)"
               metricSpecs += metricSpec {
                 reachAndFrequency = MetricSpecKt.reachAndFrequencyParams {}
               }
@@ -2208,7 +2203,7 @@ class BasicReportTransformationsTest {
         buildList {
           add(
             MetricCalculationSpecKt.details {
-              filter = "(person.age_group == 1 && person.gender == 1)"
+              filter = "person.age_group == 1 && person.gender == 1"
               metricSpecs += metricSpec { populationCount = MetricSpecKt.populationCountParams {} }
             }
           )
@@ -2216,7 +2211,7 @@ class BasicReportTransformationsTest {
           add(
             MetricCalculationSpecKt.details {
               filter =
-                "((has(banner_ad.viewable) && banner_ad.viewable == true) || (has(video_ad.viewed_fraction) && video_ad.viewed_fraction == 1.0)) && (person.age_group == 1 && person.gender == 1)"
+                "((banner_ad != null && banner_ad.viewable == true) || (video_ad != null && video_ad.viewed_fraction == 1.0)) && (person.age_group == 1 && person.gender == 1)"
               metricSpecs += metricSpec { reach = MetricSpecKt.reachParams {} }
               metricSpecs += metricSpec { impressionCount = MetricSpecKt.impressionCountParams {} }
             }
@@ -2275,7 +2270,7 @@ class BasicReportTransformationsTest {
         buildList {
           add(
             MetricCalculationSpecKt.details {
-              filter = "(person.age_group == 1 && person.gender == 1)"
+              filter = "person.age_group == 1 && person.gender == 1"
               metricSpecs += metricSpec { populationCount = MetricSpecKt.populationCountParams {} }
             }
           )
@@ -2283,7 +2278,7 @@ class BasicReportTransformationsTest {
           add(
             MetricCalculationSpecKt.details {
               filter =
-                "((has(banner_ad.viewable) && banner_ad.viewable == true) || (has(video_ad.viewed_fraction) && video_ad.viewed_fraction == 1.0)) && (person.age_group == 1 && person.gender == 1)"
+                "((banner_ad != null && banner_ad.viewable == true) || (video_ad != null && video_ad.viewed_fraction == 1.0)) && (person.age_group == 1 && person.gender == 1)"
               metricSpecs += metricSpec { impressionCount = MetricSpecKt.impressionCountParams {} }
             }
           )
@@ -2341,7 +2336,7 @@ class BasicReportTransformationsTest {
         buildList {
           add(
             MetricCalculationSpecKt.details {
-              filter = "(person.age_group == 1 && person.gender == 1)"
+              filter = "person.age_group == 1 && person.gender == 1"
               metricSpecs += metricSpec { populationCount = MetricSpecKt.populationCountParams {} }
             }
           )
@@ -2349,7 +2344,7 @@ class BasicReportTransformationsTest {
           add(
             MetricCalculationSpecKt.details {
               filter =
-                "((has(banner_ad.viewable) && banner_ad.viewable == true) || (has(video_ad.viewed_fraction) && video_ad.viewed_fraction == 1.0)) && (person.age_group == 1 && person.gender == 1)"
+                "((banner_ad != null && banner_ad.viewable == true) || (video_ad != null && video_ad.viewed_fraction == 1.0)) && (person.age_group == 1 && person.gender == 1)"
               metricSpecs += metricSpec { impressionCount = MetricSpecKt.impressionCountParams {} }
             }
           )
@@ -2407,7 +2402,7 @@ class BasicReportTransformationsTest {
                   predicates += "person.gender == 1"
                   predicates += "person.gender == 2"
                 }
-              filter = "(person.age_group == 1)"
+              filter = "person.age_group == 1"
               metricSpecs += metricSpec { impressionCount = MetricSpecKt.impressionCountParams {} }
               metricSpecs += metricSpec { populationCount = MetricSpecKt.populationCountParams {} }
             }
@@ -2476,7 +2471,7 @@ class BasicReportTransformationsTest {
                   predicates += "person.age_group == 2"
                   predicates += "person.age_group == 3"
                 }
-              filter = "(person.age_group == 1)"
+              filter = "person.age_group == 1"
               metricSpecs += metricSpec { impressionCount = MetricSpecKt.impressionCountParams {} }
               metricSpecs += metricSpec { populationCount = MetricSpecKt.populationCountParams {} }
             }
@@ -2534,7 +2529,7 @@ class BasicReportTransformationsTest {
         buildList {
           add(
             MetricCalculationSpecKt.details {
-              filter = "(person.age_group == 1 && person.gender == 1)"
+              filter = "person.age_group == 1 && person.gender == 1"
               metricSpecs += metricSpec { reach = MetricSpecKt.reachParams {} }
               metricSpecs += metricSpec { populationCount = MetricSpecKt.populationCountParams {} }
             }
@@ -2580,6 +2575,7 @@ class BasicReportTransformationsTest {
       add(
         listOf(
           impressionQualificationFilterSpec {
+            mediaType = MediaType.VIDEO
             filters += eventFilter {
               terms += eventTemplateField {
                 path = "video_ad.viewed_fraction"
@@ -2592,6 +2588,7 @@ class BasicReportTransformationsTest {
       add(
         listOf(
           impressionQualificationFilterSpec {
+            mediaType = MediaType.DISPLAY
             filters += eventFilter {
               terms += eventTemplateField {
                 path = "banner_ad.viewable"
@@ -2619,21 +2616,21 @@ class BasicReportTransformationsTest {
         buildList {
           add(
             MetricCalculationSpecKt.details {
-              filter = "(person.age_group == 1 && person.gender == 1)"
+              filter = "person.age_group == 1 && person.gender == 1"
               metricSpecs += metricSpec { populationCount = MetricSpecKt.populationCountParams {} }
             }
           )
           add(
             MetricCalculationSpecKt.details {
               filter =
-                "((has(video_ad.viewed_fraction) && video_ad.viewed_fraction == 1.0)) && (person.age_group == 1 && person.gender == 1)"
+                "(video_ad != null && video_ad.viewed_fraction == 1.0) && (person.age_group == 1 && person.gender == 1)"
               metricSpecs += metricSpec { reach = MetricSpecKt.reachParams {} }
             }
           )
           add(
             MetricCalculationSpecKt.details {
               filter =
-                "((has(banner_ad.viewable) && banner_ad.viewable == true)) && (person.age_group == 1 && person.gender == 1)"
+                "(banner_ad != null && banner_ad.viewable == true) && (person.age_group == 1 && person.gender == 1)"
               metricSpecs += metricSpec { reach = MetricSpecKt.reachParams {} }
             }
           )
@@ -2678,19 +2675,23 @@ class BasicReportTransformationsTest {
       add(
         listOf(
           impressionQualificationFilterSpec {
+            mediaType = MediaType.DISPLAY
             filters += eventFilter {
               terms += eventTemplateField {
                 path = "banner_ad.viewable"
                 value = EventTemplateFieldKt.fieldValue { boolValue = true }
               }
             }
+          },
+          impressionQualificationFilterSpec {
+            mediaType = MediaType.VIDEO
             filters += eventFilter {
               terms += eventTemplateField {
-                path = "banner_ad.viewable"
-                value = EventTemplateFieldKt.fieldValue { boolValue = true }
+                path = "video_ad.viewed_fraction"
+                value = EventTemplateFieldKt.fieldValue { floatValue = 0.5f }
               }
             }
-          }
+          },
         )
       )
     }
@@ -2711,7 +2712,7 @@ class BasicReportTransformationsTest {
         buildList {
           add(
             MetricCalculationSpecKt.details {
-              filter = "(person.age_group == 1 && person.gender == 1)"
+              filter = "person.age_group == 1 && person.gender == 1"
               metricSpecs += metricSpec { populationCount = MetricSpecKt.populationCountParams {} }
             }
           )
@@ -2719,7 +2720,7 @@ class BasicReportTransformationsTest {
           add(
             MetricCalculationSpecKt.details {
               filter =
-                "((has(banner_ad.viewable) && banner_ad.viewable == true && has(banner_ad.viewable) && banner_ad.viewable == true)) && (person.age_group == 1 && person.gender == 1)"
+                "((banner_ad != null && banner_ad.viewable == true) || (video_ad != null && video_ad.viewed_fraction == 0.5)) && (person.age_group == 1 && person.gender == 1)"
               metricSpecs += metricSpec { reach = MetricSpecKt.reachParams {} }
             }
           )
@@ -2769,7 +2770,7 @@ class BasicReportTransformationsTest {
           add(
             MetricCalculationSpecKt.details {
               filter =
-                "((has(banner_ad.viewable) && banner_ad.viewable == true) || (has(video_ad.viewed_fraction) && video_ad.viewed_fraction == 1.0))"
+                "(banner_ad != null && banner_ad.viewable == true) || (video_ad != null && video_ad.viewed_fraction == 1.0)"
               metricSpecs += metricSpec { reach = MetricSpecKt.reachParams {} }
             }
           )
@@ -2816,6 +2817,74 @@ class BasicReportTransformationsTest {
               metricSpecs += metricSpec { populationCount = MetricSpecKt.populationCountParams {} }
             }
           )
+        },
+      )
+  }
+
+  @Test
+  fun `resultGroupSpec with IQF with no filters transforms into correct map`() {
+    val dataProviderPrimitiveReportingSetMap = buildMap {
+      put(DATA_PROVIDER_NAME_1, PRIMITIVE_REPORTING_SET_1)
+    }
+    val resultGroupSpecs =
+      listOf(
+        resultGroupSpec {
+          reportingUnit = reportingUnit { components += DATA_PROVIDER_NAME_1 }
+          metricFrequency = metricFrequencySpec { total = true }
+          dimensionSpec = dimensionSpec {
+            filters += eventFilter {
+              terms += eventTemplateField {
+                path = "person.age_group"
+                value = EventTemplateFieldKt.fieldValue { enumValue = "YEARS_18_TO_34" }
+              }
+            }
+            filters += eventFilter {
+              terms += eventTemplateField {
+                path = "person.gender"
+                value = EventTemplateFieldKt.fieldValue { enumValue = "MALE" }
+              }
+            }
+          }
+          resultGroupMetricSpec = resultGroupMetricSpec {
+            reportingUnit =
+              ResultGroupMetricSpecKt.reportingUnitMetricSetSpec {
+                cumulative = ResultGroupMetricSpecKt.basicMetricSetSpec { reach = true }
+              }
+          }
+        }
+      )
+
+    val impressionQualificationFilterSpecList: List<List<ImpressionQualificationFilterSpec>> =
+      buildList {
+        add(
+          listOf(
+            impressionQualificationFilterSpec { mediaType = MediaType.VIDEO },
+            impressionQualificationFilterSpec { mediaType = MediaType.DISPLAY },
+          )
+        )
+      }
+
+    val reportingSetMetricCalculationSpecDetailsMap =
+      buildReportingSetMetricCalculationSpecDetailsMap(
+        campaignGroupName = CAMPAIGN_GROUP_NAME,
+        impressionQualificationFilterSpecsLists = impressionQualificationFilterSpecList,
+        dataProviderPrimitiveReportingSetMap = dataProviderPrimitiveReportingSetMap,
+        resultGroupSpecs = resultGroupSpecs,
+        eventTemplateFieldsByPath = TEST_EVENT_DESCRIPTOR.eventTemplateFieldsByPath,
+      )
+
+    assertThat(reportingSetMetricCalculationSpecDetailsMap.keys)
+      .containsExactly(PRIMITIVE_REPORTING_SET_1)
+    assertThat(reportingSetMetricCalculationSpecDetailsMap[PRIMITIVE_REPORTING_SET_1])
+      .containsExactly(
+        MetricCalculationSpecKt.details {
+          filter = "person.age_group == 1 && person.gender == 1"
+          metricSpecs += metricSpec { populationCount = MetricSpecKt.populationCountParams {} }
+        },
+        MetricCalculationSpecKt.details {
+          filter =
+            "((banner_ad != null) || (video_ad != null)) && (person.age_group == 1 && person.gender == 1)"
+          metricSpecs += metricSpec { reach = MetricSpecKt.reachParams {} }
         },
       )
   }

--- a/src/test/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/BasicReportsServiceTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/BasicReportsServiceTest.kt
@@ -1916,7 +1916,7 @@ class BasicReportsServiceTest {
                     predicates += "person.social_grade_group == 1"
                     predicates += "person.social_grade_group == 2"
                   }
-                filter = "((has(banner_ad.viewable) && banner_ad.viewable == true))"
+                filter = "banner_ad != null && banner_ad.viewable == true"
                 metricFrequencySpec =
                   MetricCalculationSpecKt.metricFrequencySpec {
                     weekly =
@@ -2012,7 +2012,7 @@ class BasicReportsServiceTest {
                     predicates += "person.social_grade_group == 1"
                     predicates += "person.social_grade_group == 2"
                   }
-                filter = "((has(banner_ad.viewable) && banner_ad.viewable == true))"
+                filter = "banner_ad != null && banner_ad.viewable == true"
                 metricFrequencySpec =
                   MetricCalculationSpecKt.metricFrequencySpec {
                     weekly =
@@ -2151,7 +2151,7 @@ class BasicReportsServiceTest {
             details =
               MetricCalculationSpecKt.details {
                 filter =
-                  "((has(banner_ad.viewable) && banner_ad.viewable == true)) && (person.age_group == 1)"
+                  "(banner_ad != null && banner_ad.viewable == true) && (person.age_group == 1)"
                 metricFrequencySpec =
                   MetricCalculationSpecKt.metricFrequencySpec {
                     weekly =
@@ -2226,7 +2226,7 @@ class BasicReportsServiceTest {
             cmmsModelLine = specifiedModelLine.name
             details =
               MetricCalculationSpecKt.details {
-                filter = "(person.age_group == 1)"
+                filter = "person.age_group == 1"
                 metricSpecs += metricSpec {
                   populationCount = MetricSpecKt.populationCountParams {}
                 }
@@ -2239,7 +2239,7 @@ class BasicReportsServiceTest {
             details =
               MetricCalculationSpecKt.details {
                 filter =
-                  "((has(banner_ad.viewable) && banner_ad.viewable == true)) && (person.age_group == 1)"
+                  "(banner_ad != null && banner_ad.viewable == true) && (person.age_group == 1)"
                 metricFrequencySpec =
                   MetricCalculationSpecKt.metricFrequencySpec {
                     weekly =


### PR DESCRIPTION
This also removes unnecessary empty terms and parentheses from the resulting CEL expression in MetricCalculationSpec.

Closes #3417

Issue: #3417