### PR TITLE
fix: ignore unknown fields for cloud events in data watcher

### DIFF
--- a/src/main/kotlin/org/wfanet/measurement/securecomputation/deploy/gcloud/datawatcher/DataWatcherFunction.kt
+++ b/src/main/kotlin/org/wfanet/measurement/securecomputation/deploy/gcloud/datawatcher/DataWatcherFunction.kt
@@ -66,7 +66,7 @@ class DataWatcherFunction(
         requireNotNull(event.getData()) { "event must have data" }.toBytes().decodeToString()
       val data =
         StorageObjectData.newBuilder()
-          .apply { JsonFormat.parser().merge(cloudEventData, this) }
+          .apply { JsonFormat.parser().ignoringUnknownFields().merge(cloudEventData, this) }
           .build()
 
       val blobKey: String = data.getName()


### PR DESCRIPTION
The DataWatcherFunction fails when a Cloud Event contains fields not defined in the StorageObjectData proto (e.g., customTime). The JsonFormat parser throws an exception on unknown fields, causing the function to crash. This fix adds ignoringUnknownFields() to the JSON parser so that unrecognized fields in the Cloud Event data payload are silently skipped instead of causing a failure.

- Updated JsonFormat.parser() in DataWatcherFunction to call ignoringUnknownFields() before merging the Cloud Event JSON data
- Added a test case that verifies the function correctly handles Cloud Events containing unknown fields like customTime

Exception:
Failed to execute org.wfanet.measurement.securecomputation.deploy.gcloud.datawatcher.DataWatcherFunction
com.google.protobuf.InvalidProtocolBufferException: Cannot find field: customTime in message google.events.cloud.storage.v1.StorageObjectData
 