### PR TITLE
fix: Correctly propagate errors from internal ReportingSets service

### DIFF
--- a/src/main/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/BUILD.bazel
+++ b/src/main/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/BUILD.bazel
@@ -31,13 +31,28 @@ kt_jvm_library(
 )
 
 kt_jvm_library(
+    name = "reporting_sets",
+    srcs = ["ReportingSets.kt"],
+    deps = [
+        ":proto_conversions",
+        ":reporting_exceptions",
+        ":set_expression_compiler",
+        "//src/main/kotlin/org/wfanet/measurement/reporting/service/api:errors",
+        "//src/main/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha:resource_key",
+        "//src/main/kotlin/org/wfanet/measurement/reporting/service/internal:internal_exception",
+        "//src/main/proto/wfa/measurement/internal/reporting/v2:reporting_set_kt_jvm_proto",
+        "//src/main/proto/wfa/measurement/internal/reporting/v2:reporting_sets_service_kt_jvm_grpc_proto",
+        "//src/main/proto/wfa/measurement/reporting/v2alpha:reporting_set_kt_jvm_proto",
+        "//src/main/proto/wfa/measurement/reporting/v2alpha:reporting_sets_service_kt_jvm_grpc_proto",
+    ],
+)
+
+kt_jvm_library(
     name = "proto_conversions",
     srcs = ["ProtoConversions.kt"],
     deps = [
         ":reporting_exceptions",
-        ":set_expression_compiler",
         "//src/main/kotlin/org/wfanet/measurement/measurementconsumer/stats:measurement_statistics",
-        "//src/main/kotlin/org/wfanet/measurement/reporting/service/api:errors",
         "//src/main/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha:metric_spec_defaults",
         "//src/main/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha:resource_key",
         "//src/main/proto/wfa/measurement/api/v2alpha:measurement_consumers_service_kt_jvm_grpc_proto",
@@ -194,6 +209,7 @@ kt_jvm_library(
         "//src/main/kotlin/org/wfanet/measurement/common/api:resource_ids",
         "//src/main/kotlin/org/wfanet/measurement/reporting/service/api:errors",
         "//src/main/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha:proto_conversions",
+        "//src/main/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha:reporting_sets",
         "//src/main/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha:resource_key",
         "//src/main/kotlin/org/wfanet/measurement/reporting/service/internal:internal_exception",
         "//src/main/proto/wfa/measurement/internal/reporting:error_code_kt_jvm_proto",
@@ -323,6 +339,7 @@ kt_jvm_library(
         "//src/main/kotlin/org/wfanet/measurement/common:timestamps",
         "//src/main/kotlin/org/wfanet/measurement/reporting/service/api:errors",
         "//src/main/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha:measurement_consumer_credentials",
+        "//src/main/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha:reporting_sets",
         "//src/main/kotlin/org/wfanet/measurement/reporting/service/internal:errors",
         "//src/main/kotlin/org/wfanet/measurement/reporting/service/internal:internal_exception",
         "//src/main/kotlin/org/wfanet/measurement/reporting/service/internal:normalization",

--- a/src/main/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/ProtoConversions.kt
+++ b/src/main/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/ProtoConversions.kt
@@ -19,8 +19,6 @@ package org.wfanet.measurement.reporting.service.api.v2alpha
 import com.google.protobuf.Timestamp
 import com.google.type.DateTime
 import io.grpc.Status
-import io.grpc.StatusException
-import io.grpc.StatusRuntimeException
 import java.time.DateTimeException
 import java.time.OffsetDateTime
 import java.time.ZoneId
@@ -66,7 +64,6 @@ import org.wfanet.measurement.internal.reporting.v2.ReportKt as InternalReportKt
 import org.wfanet.measurement.internal.reporting.v2.ReportSchedule as InternalReportSchedule
 import org.wfanet.measurement.internal.reporting.v2.ReportingSet as InternalReportingSet
 import org.wfanet.measurement.internal.reporting.v2.ReportingSetKt as InternalReportingSetKt
-import org.wfanet.measurement.internal.reporting.v2.ReportingSetsGrpcKt.ReportingSetsCoroutineStub as InternalReportingSetsCoroutineStub
 import org.wfanet.measurement.internal.reporting.v2.StreamMetricsRequest
 import org.wfanet.measurement.internal.reporting.v2.StreamMetricsRequestKt
 import org.wfanet.measurement.internal.reporting.v2.StreamReportingSetsRequest
@@ -74,7 +71,6 @@ import org.wfanet.measurement.internal.reporting.v2.StreamReportingSetsRequestKt
 import org.wfanet.measurement.internal.reporting.v2.StreamReportsRequest
 import org.wfanet.measurement.internal.reporting.v2.StreamReportsRequestKt
 import org.wfanet.measurement.internal.reporting.v2.TimeIntervals as InternalTimeIntervals
-import org.wfanet.measurement.internal.reporting.v2.batchGetReportingSetsRequest
 import org.wfanet.measurement.internal.reporting.v2.customDirectMethodology
 import org.wfanet.measurement.internal.reporting.v2.deterministicCount
 import org.wfanet.measurement.internal.reporting.v2.honestMajorityShareShuffle
@@ -85,16 +81,12 @@ import org.wfanet.measurement.internal.reporting.v2.liquidLegionsV2
 import org.wfanet.measurement.internal.reporting.v2.metricSpec as internalMetricSpec
 import org.wfanet.measurement.internal.reporting.v2.reachOnlyLiquidLegionsSketchParams
 import org.wfanet.measurement.internal.reporting.v2.reachOnlyLiquidLegionsV2
-import org.wfanet.measurement.internal.reporting.v2.reportingSet as internalReportingSet
 import org.wfanet.measurement.internal.reporting.v2.streamMetricsRequest
 import org.wfanet.measurement.internal.reporting.v2.streamReportingSetsRequest
 import org.wfanet.measurement.internal.reporting.v2.streamReportsRequest
 import org.wfanet.measurement.internal.reporting.v2.timeIntervals as internalTimeIntervals
 import org.wfanet.measurement.measurementconsumer.stats.NoiseMechanism as StatsNoiseMechanism
 import org.wfanet.measurement.measurementconsumer.stats.VidSamplingInterval as StatsVidSamplingInterval
-import org.wfanet.measurement.reporting.service.api.CampaignGroupInvalidException
-import org.wfanet.measurement.reporting.service.api.InvalidFieldValueException
-import org.wfanet.measurement.reporting.service.api.RequiredFieldNotSetException
 import org.wfanet.measurement.reporting.v2alpha.CreateMetricRequest
 import org.wfanet.measurement.reporting.v2alpha.ListMetricsPageToken
 import org.wfanet.measurement.reporting.v2alpha.ListReportingSetsPageToken
@@ -1356,345 +1348,8 @@ fun Temporal.toTimestamp(): Timestamp {
   }
 }
 
-suspend fun ReportingSet.toInternal(
-  reportingSetId: String,
-  cmmsMeasurementConsumerId: String,
-  internalReportingSetsStub: InternalReportingSetsCoroutineStub,
-): InternalReportingSet {
-  val source = this
-  return internalReportingSet {
-    this.cmmsMeasurementConsumerId = cmmsMeasurementConsumerId
-    if (source.campaignGroup.isNotEmpty()) {
-      val campaignGroupKey =
-        ReportingSetKey.fromName(source.campaignGroup)
-          ?: throw InvalidFieldValueException("reporting_set.campaign_group")
-      if (campaignGroupKey.cmmsMeasurementConsumerId != cmmsMeasurementConsumerId) {
-        throw InvalidFieldValueException("reporting_set.campaign_group") { fieldName ->
-          "$fieldName must belong to the same MeasurementConsumer"
-        }
-      }
-      if (campaignGroupKey.reportingSetId == reportingSetId && !source.hasPrimitive()) {
-        throw CampaignGroupInvalidException(source.campaignGroup)
-      }
-      this.externalCampaignGroupId = campaignGroupKey.reportingSetId
-    }
-    displayName = source.displayName
-    if (!source.filter.isNullOrBlank()) {
-      filter = source.filter
-    }
-
-    details = InternalReportingSetKt.details { tags.putAll(source.tagsMap) }
-
-    @Suppress("WHEN_ENUM_CAN_BE_NULL_IN_JAVA")
-    when (source.valueCase) {
-      ReportingSet.ValueCase.PRIMITIVE -> {
-        primitive = source.primitive.toInternal()
-      }
-      ReportingSet.ValueCase.COMPOSITE -> {
-        composite = source.composite.expression.toInternal()
-        weightedSubsetUnions +=
-          compileCompositeReportingSet(source, cmmsMeasurementConsumerId, internalReportingSetsStub)
-      }
-      ReportingSet.ValueCase.VALUE_NOT_SET ->
-        throw RequiredFieldNotSetException("reporting_set.value")
-    }
-  }
-}
-
-/**
- * Compiles a public composite [ReportingSet] to a list of
- * [InternalReportingSet.WeightedSubsetUnion]s.
- */
-private suspend fun compileCompositeReportingSet(
-  rootReportingSet: ReportingSet,
-  cmmsMeasurementConsumerId: String,
-  internalReportingsetsStub: InternalReportingSetsCoroutineStub,
-): List<InternalReportingSet.WeightedSubsetUnion> {
-  val primitiveReportingSetBasesMap =
-    mutableMapOf<ProtoConversions.PrimitiveReportingSetBasis, Int>()
-  val initialFiltersStack = mutableListOf<String>()
-
-  if (!rootReportingSet.filter.isNullOrBlank()) {
-    initialFiltersStack += rootReportingSet.filter
-  }
-
-  val setOperationExpression =
-    buildSetOperationExpression(
-      rootReportingSet.composite.expression,
-      initialFiltersStack,
-      primitiveReportingSetBasesMap,
-      cmmsMeasurementConsumerId,
-      internalReportingsetsStub,
-    )
-
-  val idToPrimitiveReportingSetBasis: Map<Int, ProtoConversions.PrimitiveReportingSetBasis> =
-    primitiveReportingSetBasesMap.entries.associateBy({ it.value }) { it.key }
-
-  if (idToPrimitiveReportingSetBasis.size != primitiveReportingSetBasesMap.size) {
-    error("The reporting set ID in the set operation expression should be indexed uniquely.")
-  }
-
-  val weightedSubsetUnions: List<WeightedSubsetUnion> =
-    ProtoConversions.setExpressionCompiler.compileSetExpression(
-      setOperationExpression,
-      idToPrimitiveReportingSetBasis.size,
-    )
-
-  return weightedSubsetUnions.map { weightedSubsetUnion ->
-    buildInternalWeightedSubsetUnion(weightedSubsetUnion, idToPrimitiveReportingSetBasis)
-  }
-}
-
-/**
- * Gets an [InternalReportingSet] given the reporting set resource name.
- *
- * @throw [StatusException] when gRPC call fails.
- * @throw [IllegalArgumentException] when reportingSet is an invalid name.
- */
-suspend fun getInternalReportingSet(
-  reportingSet: String,
-  cmmsMeasurementConsumerId: String,
-  internalReportingSetsStub: InternalReportingSetsCoroutineStub,
-): InternalReportingSet {
-  val reportingSetKey =
-    ReportingSetKey.fromName(reportingSet)
-      ?: throw IllegalArgumentException("Invalid reporting set name: $reportingSet")
-
-  return internalReportingSetsStub
-    .batchGetReportingSets(
-      batchGetReportingSetsRequest {
-        this.cmmsMeasurementConsumerId = cmmsMeasurementConsumerId
-        externalReportingSetIds += reportingSetKey.reportingSetId
-      }
-    )
-    .reportingSetsList
-    .single()
-}
-
-/**
- * Builds a [SetOperationExpression] by expanding the given [ReportingSet.SetExpression].
- *
- * @throws [StatusRuntimeException] when gRPC call fails
- * @throws [InvalidFieldValueException] when lhs is missing
- * @throws [InvalidFieldValueException] when ReportingSet name in lhs is invalid
- * @throws [InvalidFieldValueException] when ReportingSet name in rhs is invalid
- */
-private suspend fun buildSetOperationExpression(
-  expression: ReportingSet.SetExpression,
-  filters: MutableList<String>,
-  primitiveReportingSetBasesMap: MutableMap<ProtoConversions.PrimitiveReportingSetBasis, Int>,
-  cmmsMeasurementConsumerId: String,
-  internalReportingSetsStub: InternalReportingSetsCoroutineStub,
-): SetOperationExpression {
-  val lhs =
-    try {
-      buildSetOperationExpressionOperand(
-        expression.lhs,
-        filters,
-        primitiveReportingSetBasesMap,
-        cmmsMeasurementConsumerId,
-        internalReportingSetsStub,
-      )
-    } catch (_: IllegalArgumentException) {
-      throw InvalidFieldValueException("reporting_set.composite.expression.lhs")
-    }
-
-  if (lhs == null) {
-    throw RequiredFieldNotSetException("reporting_set.composite.expression.lhs")
-  }
-
-  val rhs =
-    try {
-      buildSetOperationExpressionOperand(
-        expression.rhs,
-        filters,
-        primitiveReportingSetBasesMap,
-        cmmsMeasurementConsumerId,
-        internalReportingSetsStub,
-      )
-    } catch (_: IllegalArgumentException) {
-      throw InvalidFieldValueException("reporting_set.composite.expression.rhs")
-    }
-
-  return SetOperationExpression(
-    setOperator = expression.operation.toSetOperator(),
-    lhs = lhs,
-    rhs = rhs,
-  )
-}
-
-/**
- * Builds a nullable [Operand] from a [ReportingSet.SetExpression.Operand].
- *
- * @throws [StatusRuntimeException] when ReprtingSet in expression not found
- * @throws [IllegalArgumentException] when ReportingSet resource name invalid
- */
-private suspend fun buildSetOperationExpressionOperand(
-  operand: ReportingSet.SetExpression.Operand,
-  filters: MutableList<String>,
-  primitiveReportingSetBasesMap: MutableMap<ProtoConversions.PrimitiveReportingSetBasis, Int>,
-  cmmsMeasurementConsumerId: String,
-  internalReportingSetsStub: InternalReportingSetsCoroutineStub,
-): Operand? {
-  @Suppress("WHEN_ENUM_CAN_BE_NULL_IN_JAVA")
-  return when (operand.operandCase) {
-    ReportingSet.SetExpression.Operand.OperandCase.REPORTING_SET -> {
-      val internalReportingSet =
-        try {
-          getInternalReportingSet(
-            operand.reportingSet,
-            cmmsMeasurementConsumerId,
-            internalReportingSetsStub,
-          )
-        } catch (e: StatusException) {
-          throw when (e.status.code) {
-              Status.Code.NOT_FOUND ->
-                Status.FAILED_PRECONDITION.withDescription("${operand.reportingSet} not found")
-              else -> Status.INTERNAL
-            }
-            .withCause(e)
-            .asRuntimeException()
-        }
-
-      when (internalReportingSet.valueCase) {
-        // Reach the leaf node
-        InternalReportingSet.ValueCase.PRIMITIVE -> {
-          val primitiveReportingSetBasis =
-            ProtoConversions.PrimitiveReportingSetBasis(
-              externalReportingSetId = internalReportingSet.externalReportingSetId,
-              filters =
-                (filters + internalReportingSet.filter).filter { !it.isNullOrBlank() }.toSet(),
-            )
-
-          // Avoid duplicates
-          if (!primitiveReportingSetBasesMap.contains(primitiveReportingSetBasis)) {
-            // New ID == current size of the map
-            primitiveReportingSetBasesMap[primitiveReportingSetBasis] =
-              primitiveReportingSetBasesMap.size
-          }
-
-          // Return the leaf reporting set
-          ReportingSet(primitiveReportingSetBasesMap.getValue(primitiveReportingSetBasis))
-        }
-        InternalReportingSet.ValueCase.COMPOSITE -> {
-          // Add the reporting set's filter to the stack.
-          if (!internalReportingSet.filter.isNullOrBlank()) {
-            filters += internalReportingSet.filter
-          }
-
-          // Return the set operation expression
-          buildSetOperationExpression(
-              internalReportingSet.composite.toExpression(cmmsMeasurementConsumerId),
-              filters,
-              primitiveReportingSetBasesMap,
-              cmmsMeasurementConsumerId,
-              internalReportingSetsStub,
-            )
-            .also {
-              // Remove the reporting set's filter from the stack if there is any.
-              if (!internalReportingSet.filter.isNullOrBlank()) {
-                filters.removeLast()
-              }
-            }
-        }
-        InternalReportingSet.ValueCase.VALUE_NOT_SET -> {
-          error("The reporting set [${operand.reportingSet}] value type should've been set. ")
-        }
-      }
-    }
-    ReportingSet.SetExpression.Operand.OperandCase.EXPRESSION -> {
-      buildSetOperationExpression(
-        operand.expression,
-        filters,
-        primitiveReportingSetBasesMap,
-        cmmsMeasurementConsumerId,
-        internalReportingSetsStub,
-      )
-    }
-    ReportingSet.SetExpression.Operand.OperandCase.OPERAND_NOT_SET -> {
-      null
-    }
-  }
-}
-
-/** Builds an [InternalReportingSet.WeightedSubsetUnion] from a [WeightedSubsetUnion]. */
-private fun buildInternalWeightedSubsetUnion(
-  weightedSubsetUnion: WeightedSubsetUnion,
-  idToPrimitiveReportingSetBasis: Map<Int, ProtoConversions.PrimitiveReportingSetBasis>,
-): InternalReportingSet.WeightedSubsetUnion {
-  return InternalReportingSetKt.weightedSubsetUnion {
-    primitiveReportingSetBases +=
-      weightedSubsetUnion.reportingSetIds.map { reportingSetId ->
-        InternalReportingSetKt.primitiveReportingSetBasis {
-          val primitiveReportingSetBasis = idToPrimitiveReportingSetBasis.getValue(reportingSetId)
-          externalReportingSetId = primitiveReportingSetBasis.externalReportingSetId
-          filters += primitiveReportingSetBasis.filters.toList()
-        }
-      }
-    weight = weightedSubsetUnion.coefficient
-    binaryRepresentation = weightedSubsetUnion.reportingSetIds.sumOf { 1 shl it }
-  }
-}
-
-/** Converts a [ReportingSet.SetExpression] to an [InternalReportingSet.SetExpression]. */
-private fun ReportingSet.SetExpression.toInternal(): InternalReportingSet.SetExpression {
-  val source = this
-
-  return InternalReportingSetKt.setExpression {
-    operation = source.operation.toInternal()
-
-    lhs = source.lhs.toInternal()
-    if (source.hasRhs()) {
-      rhs = source.rhs.toInternal()
-    }
-  }
-}
-
-/**
- * Converts a [ReportingSet.SetExpression.Operation] to an
- * [InternalReportingSet.SetExpression.Operation].
- */
-private fun ReportingSet.SetExpression.Operation.toInternal():
-  InternalReportingSet.SetExpression.Operation {
-  return when (this) {
-    ReportingSet.SetExpression.Operation.UNION -> {
-      InternalReportingSet.SetExpression.Operation.UNION
-    }
-    ReportingSet.SetExpression.Operation.DIFFERENCE -> {
-      InternalReportingSet.SetExpression.Operation.DIFFERENCE
-    }
-    ReportingSet.SetExpression.Operation.INTERSECTION -> {
-      InternalReportingSet.SetExpression.Operation.INTERSECTION
-    }
-    ReportingSet.SetExpression.Operation.OPERATION_UNSPECIFIED,
-    ReportingSet.SetExpression.Operation.UNRECOGNIZED -> error("operation not set or invalid")
-  }
-}
-
-/**
- * Converts a [ReportingSet.SetExpression.Operand] to an
- * [InternalReportingSet.SetExpression.Operand].
- */
-private fun ReportingSet.SetExpression.Operand.toInternal():
-  InternalReportingSet.SetExpression.Operand {
-  val source = this
-  return InternalReportingSetKt.SetExpressionKt.operand {
-    @Suppress("WHEN_ENUM_CAN_BE_NULL_IN_JAVA")
-    when (source.operandCase) {
-      ReportingSet.SetExpression.Operand.OperandCase.REPORTING_SET -> {
-        val reportingSetKey = ReportingSetKey.fromName(source.reportingSet)
-        externalReportingSetId = reportingSetKey!!.reportingSetId
-      }
-      ReportingSet.SetExpression.Operand.OperandCase.EXPRESSION -> {
-        expression = source.expression.toInternal()
-      }
-      ReportingSet.SetExpression.Operand.OperandCase.OPERAND_NOT_SET -> {}
-    }
-  }
-}
-
 /** Converts a [ReportingSet.Primitive] to an [InternalReportingSet.Primitive]. */
-private fun ReportingSet.Primitive.toInternal(): InternalReportingSet.Primitive {
+fun ReportingSet.Primitive.toInternal(): InternalReportingSet.Primitive {
   val source = this
 
   return InternalReportingSetKt.primitive {
@@ -1711,39 +1366,4 @@ private fun ReportingSet.Primitive.toInternal(): InternalReportingSet.Primitive 
         }
       }
   }
-}
-
-/**
- * Converts a [ReportingSet.SetExpression.Operation] to an [Operator].
- *
- * @throws [RequiredFieldNotSetException] when operation is unspecified
- * @throws [InvalidFieldValueException] when operation is invalid
- */
-private fun ReportingSet.SetExpression.Operation.toSetOperator(): Operator {
-  return when (this) {
-    ReportingSet.SetExpression.Operation.UNION -> {
-      Operator.UNION
-    }
-    ReportingSet.SetExpression.Operation.DIFFERENCE -> {
-      Operator.DIFFERENCE
-    }
-    ReportingSet.SetExpression.Operation.INTERSECTION -> {
-      Operator.INTERSECT
-    }
-    ReportingSet.SetExpression.Operation.OPERATION_UNSPECIFIED -> {
-      throw RequiredFieldNotSetException("reporting_set.composite.expression.operation")
-    }
-    ReportingSet.SetExpression.Operation.UNRECOGNIZED -> {
-      throw InvalidFieldValueException("reporting_set.composite.expression.operation")
-    }
-  }
-}
-
-private object ProtoConversions {
-  val setExpressionCompiler = SetExpressionCompiler()
-
-  data class PrimitiveReportingSetBasis(
-    val externalReportingSetId: String,
-    val filters: Set<String>,
-  )
 }

--- a/src/main/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/ReportingExceptions.kt
+++ b/src/main/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/ReportingExceptions.kt
@@ -31,3 +31,7 @@ class MeasurementVarianceNotComputableException(message: String? = null, cause: 
 /** [Exception] which indicates an error that metric result is not computable. */
 class MetricResultNotComputableException(message: String? = null, cause: Throwable? = null) :
   Exception(message, cause)
+
+/** Unspecified error from the internal ReportingSets service. */
+class InternalReportingSetsException(override val message: String, cause: Throwable? = null) :
+  Exception(message, cause)

--- a/src/main/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/ReportingSets.kt
+++ b/src/main/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/ReportingSets.kt
@@ -1,0 +1,458 @@
+/*
+ * Copyright 2026 The Cross-Media Measurement Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wfanet.measurement.reporting.service.api.v2alpha
+
+import io.grpc.StatusException
+import org.wfanet.measurement.api.v2alpha.MeasurementConsumerKey as CmmsMeasurementConsumerKey
+import org.wfanet.measurement.common.grpc.errorInfo
+import org.wfanet.measurement.internal.reporting.ErrorCode
+import org.wfanet.measurement.internal.reporting.v2.CreateReportingSetRequest as InternalCreateReportingSetRequest
+import org.wfanet.measurement.internal.reporting.v2.ReportingSet as InternalReportingSet
+import org.wfanet.measurement.internal.reporting.v2.ReportingSetKt as InternalReportingSetKt
+import org.wfanet.measurement.internal.reporting.v2.ReportingSetsGrpcKt.ReportingSetsCoroutineStub as InternalReportingSetsCoroutineStub
+import org.wfanet.measurement.internal.reporting.v2.batchGetReportingSetsRequest
+import org.wfanet.measurement.internal.reporting.v2.createReportingSetRequest as internalCreateReportingSetRequest
+import org.wfanet.measurement.internal.reporting.v2.reportingSet as internalReportingSet
+import org.wfanet.measurement.reporting.service.api.ReportingSetNotFoundException
+import org.wfanet.measurement.reporting.service.api.RequiredFieldNotSetException
+import org.wfanet.measurement.reporting.service.internal.ReportingInternalException
+import org.wfanet.measurement.reporting.v2alpha.CreateReportingSetRequest
+import org.wfanet.measurement.reporting.v2alpha.ReportingSet
+
+/** Utilities for [ReportingSet]s. */
+object ReportingSets {
+  private data class PrimitiveReportingSetBasis(
+    val externalReportingSetId: String,
+    val filters: Set<String>,
+  )
+
+  private val setExpressionCompiler = SetExpressionCompiler()
+
+  /**
+   * Retrieves the [InternalReportingSet]s directly and transitively referenced by
+   * [reportingSetKeys].
+   *
+   * @throws ReportingSetNotFoundException if any referenced [ReportingSet] could not be found
+   * @throws InternalReportingSetsException if there was some other error retrieving
+   *   [InternalReportingSet]s
+   */
+  suspend fun getReferencedReportingSets(
+    internalReportingSetsStub: InternalReportingSetsCoroutineStub,
+    reportingSetKeys: Set<ReportingSetKey>,
+  ): Map<ReportingSetKey, InternalReportingSet> {
+    var keysToFetch: Set<ReportingSetKey> = reportingSetKeys
+    return buildMap {
+      while (keysToFetch.isNotEmpty()) {
+        val internalReportingSets: Map<ReportingSetKey, InternalReportingSet> =
+          batchGetInternalReportingSets(internalReportingSetsStub, keysToFetch)
+        putAll(internalReportingSets)
+
+        // Process the ReportingSets that were just fetched to determine the next batch of keys.
+        keysToFetch = buildSet {
+          for (value: InternalReportingSet in internalReportingSets.values) {
+            if (value.hasComposite()) {
+              for (referencedKey in
+                getReferencedReportingSetKeys(value.toReportingSet().composite.expression)) {
+                if (referencedKey in this) {
+                  // Skip any that have already been fetched.
+                  continue
+                }
+                add(referencedKey)
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
+  /**
+   * Returns [InternalReportingSet]s for the specified keys.
+   *
+   * @param reportingSetKeys keys of [InternalReportingSet]s to retrieve belonging to the same
+   *   parent
+   * @throws ReportingSetNotFoundException if an [InternalReportingSet] is not found for any of the
+   *   specified keys
+   * @throws InternalReportingSetsException if there was some other error retrieving
+   *   [InternalReportingSet]s
+   */
+  private suspend fun batchGetInternalReportingSets(
+    internalReportingSetsStub: InternalReportingSetsCoroutineStub,
+    reportingSetKeys: Set<ReportingSetKey>,
+  ): Map<ReportingSetKey, InternalReportingSet> {
+    if (reportingSetKeys.isEmpty()) {
+      return mutableMapOf()
+    }
+
+    val parentKey = reportingSetKeys.first().parentKey
+    val internalReportingSetsResponse =
+      try {
+        internalReportingSetsStub.batchGetReportingSets(
+          batchGetReportingSetsRequest {
+            cmmsMeasurementConsumerId = parentKey.measurementConsumerId
+            for (reportingSetKey in reportingSetKeys) {
+              require(reportingSetKey.parentKey == parentKey)
+              externalReportingSetIds += reportingSetKey.reportingSetId
+            }
+          }
+        )
+      } catch (e: StatusException) {
+        throw when (ReportingInternalException.getErrorCode(e)) {
+          ErrorCode.REPORTING_SET_NOT_FOUND -> {
+            val reportingSetId = e.errorInfo!!.metadataMap.getValue("externalReportingSetId")
+            ReportingSetNotFoundException(ReportingSetKey(parentKey, reportingSetId).toName(), e)
+          }
+          ErrorCode.REPORTING_SET_ALREADY_EXISTS,
+          ErrorCode.MEASUREMENT_ALREADY_EXISTS,
+          ErrorCode.MEASUREMENT_NOT_FOUND,
+          ErrorCode.MEASUREMENT_CALCULATION_TIME_INTERVAL_NOT_FOUND,
+          ErrorCode.REPORT_NOT_FOUND,
+          ErrorCode.MEASUREMENT_STATE_INVALID,
+          ErrorCode.MEASUREMENT_CONSUMER_NOT_FOUND,
+          ErrorCode.MEASUREMENT_CONSUMER_ALREADY_EXISTS,
+          ErrorCode.METRIC_ALREADY_EXISTS,
+          ErrorCode.REPORT_ALREADY_EXISTS,
+          ErrorCode.REPORT_SCHEDULE_ALREADY_EXISTS,
+          ErrorCode.REPORT_SCHEDULE_NOT_FOUND,
+          ErrorCode.REPORT_SCHEDULE_STATE_INVALID,
+          ErrorCode.REPORT_SCHEDULE_ITERATION_NOT_FOUND,
+          ErrorCode.REPORT_SCHEDULE_ITERATION_STATE_INVALID,
+          ErrorCode.METRIC_CALCULATION_SPEC_NOT_FOUND,
+          ErrorCode.METRIC_CALCULATION_SPEC_ALREADY_EXISTS,
+          ErrorCode.CAMPAIGN_GROUP_INVALID,
+          ErrorCode.UNKNOWN_ERROR,
+          ErrorCode.UNRECOGNIZED,
+          null -> InternalReportingSetsException("Error retrieving ReportingSets", e)
+        }
+      }
+    return internalReportingSetsResponse.reportingSetsList.associateBy {
+      ReportingSetKey(it.cmmsMeasurementConsumerId, it.externalReportingSetId)
+    }
+  }
+
+  /**
+   * Returns the keys of the [ReportingSet]s directly referenced by [setExpression], i.e. those that
+   * do not require dereferencing a [ReportingSet].
+   */
+  fun getReferencedReportingSetKeys(
+    setExpression: ReportingSet.SetExpression
+  ): Set<ReportingSetKey> {
+    return buildSet {
+      addAll(getReferencedReportingSetKeys(setExpression.lhs))
+      if (setExpression.hasRhs()) {
+        addAll(getReferencedReportingSetKeys(setExpression.rhs))
+      }
+    }
+  }
+
+  /**
+   * Returns the keys of the [ReportingSet]s directly referenced by [operand], i.e. those that do
+   * not require dereferencing a [ReportingSet].
+   */
+  private fun getReferencedReportingSetKeys(
+    operand: ReportingSet.SetExpression.Operand
+  ): Set<ReportingSetKey> {
+    return when (operand.operandCase) {
+      ReportingSet.SetExpression.Operand.OperandCase.REPORTING_SET ->
+        setOf(checkNotNull(ReportingSetKey.fromName(operand.reportingSet)))
+      ReportingSet.SetExpression.Operand.OperandCase.EXPRESSION ->
+        getReferencedReportingSetKeys(operand.expression)
+      ReportingSet.SetExpression.Operand.OperandCase.OPERAND_NOT_SET -> error("Operand not set")
+    }
+  }
+
+  /**
+   * Builds an [InternalCreateReportingSetRequest] from a parsed, validated
+   * [CreateReportingSetRequest].
+   *
+   * This performs set expression compilation as-needed for composite ReportingSets.
+   */
+  suspend fun buildInternalCreateReportingSetRequest(
+    request: CreateReportingSetRequest,
+    parentKey: CmmsMeasurementConsumerKey,
+    campaignGroupKey: ReportingSetKey?,
+    referencedReportingSets: Map<ReportingSetKey, InternalReportingSet>,
+  ): InternalCreateReportingSetRequest {
+    val internalReportingSetsByName = referencedReportingSets.mapKeys { it.key.toName() }
+    return internalCreateReportingSetRequest {
+      externalReportingSetId = request.reportingSetId
+      reportingSet = internalReportingSet {
+        cmmsMeasurementConsumerId = parentKey.measurementConsumerId
+        if (campaignGroupKey != null) {
+          externalCampaignGroupId = campaignGroupKey.reportingSetId
+        }
+        displayName = request.reportingSet.displayName
+        filter = request.reportingSet.filter
+
+        details = InternalReportingSetKt.details { tags.putAll(request.reportingSet.tagsMap) }
+
+        when (request.reportingSet.valueCase) {
+          ReportingSet.ValueCase.PRIMITIVE -> {
+            primitive = request.reportingSet.primitive.toInternal()
+          }
+          ReportingSet.ValueCase.COMPOSITE -> {
+            composite = request.reportingSet.composite.expression.toInternal()
+            weightedSubsetUnions +=
+              compileWeightedSubsetUnions(
+                request.reportingSet.filter,
+                request.reportingSet.composite.expression,
+                cmmsMeasurementConsumerId,
+                internalReportingSetsByName,
+              )
+          }
+          ReportingSet.ValueCase.VALUE_NOT_SET ->
+            throw RequiredFieldNotSetException("reporting_set.value")
+        }
+      }
+    }
+  }
+
+  /** Compiles [InternalReportingSet.WeightedSubsetUnion]s for a composite [ReportingSet]. */
+  private suspend fun compileWeightedSubsetUnions(
+    filter: String,
+    setExpression: ReportingSet.SetExpression,
+    cmmsMeasurementConsumerId: String,
+    internalReportingSetsByName: Map<String, InternalReportingSet>,
+  ): List<InternalReportingSet.WeightedSubsetUnion> {
+    val primitiveReportingSetBasesMap = mutableMapOf<PrimitiveReportingSetBasis, Int>()
+    val initialFiltersStack = mutableListOf<String>()
+
+    if (filter.isNotEmpty()) {
+      initialFiltersStack += filter
+    }
+
+    val setOperationExpression: SetOperationExpression =
+      buildSetOperationExpression(
+        setExpression,
+        initialFiltersStack,
+        primitiveReportingSetBasesMap,
+        cmmsMeasurementConsumerId,
+        internalReportingSetsByName,
+      )
+
+    val idToPrimitiveReportingSetBasis: Map<Int, PrimitiveReportingSetBasis> =
+      primitiveReportingSetBasesMap.entries.associateBy({ it.value }) { it.key }
+
+    if (idToPrimitiveReportingSetBasis.size != primitiveReportingSetBasesMap.size) {
+      error("The reporting set ID in the set operation expression should be indexed uniquely.")
+    }
+
+    val weightedSubsetUnions: List<WeightedSubsetUnion> =
+      setExpressionCompiler.compileSetExpression(
+        setOperationExpression,
+        idToPrimitiveReportingSetBasis.size,
+      )
+
+    return weightedSubsetUnions.map { weightedSubsetUnion ->
+      buildInternalWeightedSubsetUnion(weightedSubsetUnion, idToPrimitiveReportingSetBasis)
+    }
+  }
+
+  /** Builds an [InternalReportingSet.WeightedSubsetUnion] from a [WeightedSubsetUnion]. */
+  private fun buildInternalWeightedSubsetUnion(
+    weightedSubsetUnion: WeightedSubsetUnion,
+    idToPrimitiveReportingSetBasis: Map<Int, PrimitiveReportingSetBasis>,
+  ): InternalReportingSet.WeightedSubsetUnion {
+    return InternalReportingSetKt.weightedSubsetUnion {
+      primitiveReportingSetBases +=
+        weightedSubsetUnion.reportingSetIds.map { reportingSetId ->
+          InternalReportingSetKt.primitiveReportingSetBasis {
+            val primitiveReportingSetBasis = idToPrimitiveReportingSetBasis.getValue(reportingSetId)
+            externalReportingSetId = primitiveReportingSetBasis.externalReportingSetId
+            filters += primitiveReportingSetBasis.filters.toList()
+          }
+        }
+      weight = weightedSubsetUnion.coefficient
+      binaryRepresentation = weightedSubsetUnion.reportingSetIds.sumOf { 1 shl it }
+    }
+  }
+
+  /** Builds a [SetOperationExpression] by expanding the given [ReportingSet.SetExpression]. */
+  private fun buildSetOperationExpression(
+    expression: ReportingSet.SetExpression,
+    filters: MutableList<String>,
+    primitiveReportingSetBasesMap: MutableMap<PrimitiveReportingSetBasis, Int>,
+    cmmsMeasurementConsumerId: String,
+    internalReportingSetsByName: Map<String, InternalReportingSet>,
+  ): SetOperationExpression {
+    val lhs =
+      buildSetOperationExpressionOperand(
+        expression.lhs,
+        filters,
+        primitiveReportingSetBasesMap,
+        cmmsMeasurementConsumerId,
+        internalReportingSetsByName,
+      )
+
+    val rhs =
+      if (expression.hasRhs()) {
+        buildSetOperationExpressionOperand(
+          expression.rhs,
+          filters,
+          primitiveReportingSetBasesMap,
+          cmmsMeasurementConsumerId,
+          internalReportingSetsByName,
+        )
+      } else {
+        null
+      }
+
+    return SetOperationExpression(
+      setOperator = expression.operation.toSetOperator(),
+      lhs = lhs,
+      rhs = rhs,
+    )
+  }
+
+  /** Builds an [Operand] from a [ReportingSet.SetExpression.Operand]. */
+  private fun buildSetOperationExpressionOperand(
+    operand: ReportingSet.SetExpression.Operand,
+    filters: MutableList<String>,
+    primitiveReportingSetBasesMap: MutableMap<PrimitiveReportingSetBasis, Int>,
+    cmmsMeasurementConsumerId: String,
+    internalReportingSetsByName: Map<String, InternalReportingSet>,
+  ): Operand {
+    return when (operand.operandCase) {
+      ReportingSet.SetExpression.Operand.OperandCase.REPORTING_SET -> {
+        val internalReportingSet: InternalReportingSet =
+          internalReportingSetsByName.getValue(operand.reportingSet)
+
+        when (internalReportingSet.valueCase) {
+          // Reach the leaf node
+          InternalReportingSet.ValueCase.PRIMITIVE -> {
+            val primitiveReportingSetBasis =
+              PrimitiveReportingSetBasis(
+                externalReportingSetId = internalReportingSet.externalReportingSetId,
+                filters =
+                  (filters + internalReportingSet.filter).filter { !it.isNullOrBlank() }.toSet(),
+              )
+
+            // Avoid duplicates
+            if (!primitiveReportingSetBasesMap.contains(primitiveReportingSetBasis)) {
+              // New ID == current size of the map
+              primitiveReportingSetBasesMap[primitiveReportingSetBasis] =
+                primitiveReportingSetBasesMap.size
+            }
+
+            // Return the leaf reporting set
+            ReportingSet(primitiveReportingSetBasesMap.getValue(primitiveReportingSetBasis))
+          }
+          InternalReportingSet.ValueCase.COMPOSITE -> {
+            // Add the reporting set's filter to the stack.
+            if (!internalReportingSet.filter.isEmpty()) {
+              filters += internalReportingSet.filter
+            }
+
+            // Return the set operation expression
+            buildSetOperationExpression(
+                internalReportingSet.composite.toExpression(cmmsMeasurementConsumerId),
+                filters,
+                primitiveReportingSetBasesMap,
+                cmmsMeasurementConsumerId,
+                internalReportingSetsByName,
+              )
+              .also {
+                // Remove the reporting set's filter from the stack if there is any.
+                if (!internalReportingSet.filter.isEmpty()) {
+                  filters.removeLast()
+                }
+              }
+          }
+          InternalReportingSet.ValueCase.VALUE_NOT_SET -> error("Value not set")
+        }
+      }
+      ReportingSet.SetExpression.Operand.OperandCase.EXPRESSION -> {
+        buildSetOperationExpression(
+          operand.expression,
+          filters,
+          primitiveReportingSetBasesMap,
+          cmmsMeasurementConsumerId,
+          internalReportingSetsByName,
+        )
+      }
+      ReportingSet.SetExpression.Operand.OperandCase.OPERAND_NOT_SET -> error("Operand not set")
+    }
+  }
+
+  /** Converts a [ReportingSet.SetExpression] to an [InternalReportingSet.SetExpression]. */
+  private fun ReportingSet.SetExpression.toInternal(): InternalReportingSet.SetExpression {
+    val source = this
+
+    return InternalReportingSetKt.setExpression {
+      operation = source.operation.toInternal()
+
+      lhs = source.lhs.toInternal()
+      if (source.hasRhs()) {
+        rhs = source.rhs.toInternal()
+      }
+    }
+  }
+
+  /**
+   * Converts a [ReportingSet.SetExpression.Operand] to an
+   * [InternalReportingSet.SetExpression.Operand].
+   */
+  private fun ReportingSet.SetExpression.Operand.toInternal():
+    InternalReportingSet.SetExpression.Operand {
+    val source = this
+    return InternalReportingSetKt.SetExpressionKt.operand {
+      @Suppress("WHEN_ENUM_CAN_BE_NULL_IN_JAVA")
+      when (source.operandCase) {
+        ReportingSet.SetExpression.Operand.OperandCase.REPORTING_SET -> {
+          val reportingSetKey = ReportingSetKey.fromName(source.reportingSet)
+          externalReportingSetId = reportingSetKey!!.reportingSetId
+        }
+        ReportingSet.SetExpression.Operand.OperandCase.EXPRESSION -> {
+          expression = source.expression.toInternal()
+        }
+        ReportingSet.SetExpression.Operand.OperandCase.OPERAND_NOT_SET -> {}
+      }
+    }
+  }
+
+  /**
+   * Converts a [ReportingSet.SetExpression.Operation] to an
+   * [InternalReportingSet.SetExpression.Operation].
+   */
+  private fun ReportingSet.SetExpression.Operation.toInternal():
+    InternalReportingSet.SetExpression.Operation {
+    return when (this) {
+      ReportingSet.SetExpression.Operation.UNION -> {
+        InternalReportingSet.SetExpression.Operation.UNION
+      }
+      ReportingSet.SetExpression.Operation.DIFFERENCE -> {
+        InternalReportingSet.SetExpression.Operation.DIFFERENCE
+      }
+      ReportingSet.SetExpression.Operation.INTERSECTION -> {
+        InternalReportingSet.SetExpression.Operation.INTERSECTION
+      }
+      ReportingSet.SetExpression.Operation.OPERATION_UNSPECIFIED,
+      ReportingSet.SetExpression.Operation.UNRECOGNIZED -> error("operation not set or invalid")
+    }
+  }
+
+  /** Converts a [ReportingSet.SetExpression.Operation] to an [Operator]. */
+  private fun ReportingSet.SetExpression.Operation.toSetOperator(): Operator {
+    return when (this) {
+      ReportingSet.SetExpression.Operation.UNION -> Operator.UNION
+      ReportingSet.SetExpression.Operation.DIFFERENCE -> Operator.DIFFERENCE
+      ReportingSet.SetExpression.Operation.INTERSECTION -> Operator.INTERSECT
+      ReportingSet.SetExpression.Operation.OPERATION_UNSPECIFIED -> error("Operation unspecified")
+      ReportingSet.SetExpression.Operation.UNRECOGNIZED -> error("Operation unrecognized")
+    }
+  }
+}

--- a/src/main/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/ReportingSetsService.kt
+++ b/src/main/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/ReportingSetsService.kt
@@ -25,7 +25,7 @@ import kotlinx.coroutines.flow.toList
 import org.wfanet.measurement.access.client.v1alpha.Authorization
 import org.wfanet.measurement.access.client.v1alpha.check
 import org.wfanet.measurement.api.v2alpha.EventGroupKey as CmmsEventGroupKey
-import org.wfanet.measurement.api.v2alpha.MeasurementConsumerKey
+import org.wfanet.measurement.api.v2alpha.MeasurementConsumerKey as CmmsMeasurementConsumerKey
 import org.wfanet.measurement.common.api.ResourceIds
 import org.wfanet.measurement.common.base64UrlDecode
 import org.wfanet.measurement.common.base64UrlEncode
@@ -35,11 +35,11 @@ import org.wfanet.measurement.internal.reporting.ErrorCode
 import org.wfanet.measurement.internal.reporting.v2.CreateReportingSetRequest as InternalCreateReportingSetRequest
 import org.wfanet.measurement.internal.reporting.v2.ReportingSet as InternalReportingSet
 import org.wfanet.measurement.internal.reporting.v2.ReportingSetsGrpcKt.ReportingSetsCoroutineStub
-import org.wfanet.measurement.internal.reporting.v2.createReportingSetRequest as internalCreateReportingSetRequest
+import org.wfanet.measurement.internal.reporting.v2.batchGetReportingSetsRequest
 import org.wfanet.measurement.reporting.service.api.CampaignGroupInvalidException
 import org.wfanet.measurement.reporting.service.api.InvalidFieldValueException
+import org.wfanet.measurement.reporting.service.api.ReportingSetNotFoundException
 import org.wfanet.measurement.reporting.service.api.RequiredFieldNotSetException
-import org.wfanet.measurement.reporting.service.api.ServiceException
 import org.wfanet.measurement.reporting.service.internal.ReportingInternalException
 import org.wfanet.measurement.reporting.v2alpha.CreateReportingSetRequest
 import org.wfanet.measurement.reporting.v2alpha.GetReportingSetRequest
@@ -63,43 +63,53 @@ class ReportingSetsService(
   coroutineContext: CoroutineContext = EmptyCoroutineContext,
 ) : ReportingSetsCoroutineImplBase(coroutineContext) {
   override suspend fun createReportingSet(request: CreateReportingSetRequest): ReportingSet {
-    val parentKey =
-      grpcRequireNotNull(MeasurementConsumerKey.fromName(request.parent)) {
-        "Parent is either unspecified or invalid."
+    val parsedRequest: ParsedCreateReportingSetRequest =
+      try {
+        validate(request)
+      } catch (e: InvalidFieldValueException) {
+        throw e.asStatusRuntimeException(Status.Code.INVALID_ARGUMENT)
+      } catch (e: RequiredFieldNotSetException) {
+        throw e.asStatusRuntimeException(Status.Code.INVALID_ARGUMENT)
+      } catch (e: CampaignGroupInvalidException) {
+        throw e.asStatusRuntimeException(Status.Code.INVALID_ARGUMENT)
       }
-    grpcRequire(request.hasReportingSet()) { "ReportingSet is not specified." }
-    grpcRequire(request.reportingSetId.matches(RESOURCE_ID_REGEX)) {
-      "Reporting set ID is invalid."
-    }
 
     @Suppress("WHEN_ENUM_CAN_BE_NULL_IN_JAVA") // Protobuf enum accessors cannot return null.
     val requiredPermissions: Set<String> =
       when (request.reportingSet.valueCase) {
         ReportingSet.ValueCase.PRIMITIVE -> {
-          validateEventGroups(request.reportingSet.primitive)
           setOf(Permission.CREATE_PRIMITIVE)
         }
         ReportingSet.ValueCase.COMPOSITE -> {
-          validateSetExpression(parentKey, request.reportingSet.composite.expression)
           setOf(Permission.CREATE_COMPOSITE)
         }
         ReportingSet.ValueCase.VALUE_NOT_SET ->
-          throw Status.INVALID_ARGUMENT.withDescription("reporting_set.value not set")
-            .asRuntimeException()
+          error("reporting_set not specified") // Already validated.
       }
     authorization.check(request.parent, requiredPermissions)
 
-    val internalCreateReportingSetRequest: InternalCreateReportingSetRequest =
+    val referencedReportingSets =
       try {
-        request.toInternal()
-      } catch (e: ServiceException) {
-        throw e.asStatusRuntimeException(Status.Code.INVALID_ARGUMENT)
+        ReportingSets.getReferencedReportingSets(
+          internalReportingSetsStub,
+          parsedRequest.referencedReportingSetKeys,
+        )
+      } catch (e: ReportingSetNotFoundException) {
+        throw e.asStatusRuntimeException(Status.Code.FAILED_PRECONDITION)
+      } catch (e: InternalReportingSetsException) {
+        throw Status.INTERNAL.withDescription(e.message).withCause(e).asRuntimeException()
       }
 
+    val internalRequest: InternalCreateReportingSetRequest =
+      ReportingSets.buildInternalCreateReportingSetRequest(
+        request,
+        parsedRequest.parentKey,
+        parsedRequest.campaignGroupKey,
+        referencedReportingSets,
+      )
+
     return try {
-      internalReportingSetsStub
-        .createReportingSet(internalCreateReportingSetRequest)
-        .toReportingSet()
+      internalReportingSetsStub.createReportingSet(internalRequest).toReportingSet()
     } catch (e: StatusException) {
       throw when (ReportingInternalException.getErrorCode(e)) {
         ErrorCode.MEASUREMENT_CONSUMER_NOT_FOUND ->
@@ -133,96 +143,163 @@ class ReportingSetsService(
     }
   }
 
+  private data class ParsedCreateReportingSetRequest(
+    val request: CreateReportingSetRequest,
+    val parentKey: CmmsMeasurementConsumerKey,
+    val campaignGroupKey: ReportingSetKey?,
+    val referencedReportingSetKeys: Set<ReportingSetKey>,
+  )
+
   /**
-   * Validates EventGroups in request [primitive].
+   * Validates [request].
    *
-   * @throws io.grpc.StatusRuntimeException
+   * @throws InvalidFieldValueException
+   * @throws RequiredFieldNotSetException
+   * @throws CampaignGroupInvalidException
    */
-  private fun validateEventGroups(primitive: ReportingSet.Primitive) {
-    if (primitive.cmmsEventGroupsList.isEmpty()) {
-      throw Status.INVALID_ARGUMENT.withDescription("cmms_event_groups is not set")
-        .asRuntimeException()
+  private fun validate(request: CreateReportingSetRequest): ParsedCreateReportingSetRequest {
+    val parentKey =
+      CmmsMeasurementConsumerKey.fromName(request.parent)
+        ?: throw InvalidFieldValueException("parent")
+    if (!request.hasReportingSet()) {
+      throw RequiredFieldNotSetException("reporting_set")
     }
-    for (eventGroupName in primitive.cmmsEventGroupsList) {
-      if (CmmsEventGroupKey.fromName(eventGroupName) == null) {
-        throw Status.INVALID_ARGUMENT.withDescription(
-            "$eventGroupName is not a valid EventGroup resource name"
+    if (!request.reportingSetId.matches(RESOURCE_ID_REGEX)) {
+      throw InvalidFieldValueException("reporting_set_id")
+    }
+
+    val referencedReportingSetKeys: Set<ReportingSetKey> =
+      when (request.reportingSet.valueCase) {
+        ReportingSet.ValueCase.PRIMITIVE -> {
+          if (request.reportingSet.primitive.cmmsEventGroupsList.isEmpty()) {
+            throw RequiredFieldNotSetException("reporting_set.primitive.cmms_event_groups")
+          }
+          request.reportingSet.primitive.cmmsEventGroupsList.forEachIndexed {
+            index,
+            cmmsEventGroupName ->
+            if (CmmsEventGroupKey.fromName(cmmsEventGroupName) == null) {
+              throw InvalidFieldValueException("reporting_set.primitive.cmms_event_groups[$index]")
+            }
+          }
+          emptySet()
+        }
+        ReportingSet.ValueCase.COMPOSITE -> {
+          validateSetExpression(
+            parentKey,
+            request.reportingSet.composite.expression,
+            "reporting_set.composite.expression",
           )
-          .asRuntimeException()
+        }
+        ReportingSet.ValueCase.VALUE_NOT_SET ->
+          throw RequiredFieldNotSetException("reporting_set.value")
+      }
+
+    val campaignGroupKey: ReportingSetKey? =
+      if (request.reportingSet.campaignGroup.isEmpty()) {
+        null
+      } else {
+        ReportingSetKey.fromName(request.reportingSet.campaignGroup)
+          ?: throw InvalidFieldValueException("reporting_set.campaign_group")
+      }
+    if (campaignGroupKey != null) {
+      if (campaignGroupKey.parentKey != parentKey) {
+        throw InvalidFieldValueException("reporting_set.campaign_group") { fieldPath ->
+          "$fieldPath belongs to a different MeasurementConsumer"
+        }
+      }
+      if (
+        campaignGroupKey.reportingSetId == request.reportingSetId &&
+          !request.reportingSet.hasPrimitive()
+      ) {
+        throw CampaignGroupInvalidException(request.reportingSet.campaignGroup)
       }
     }
+
+    return ParsedCreateReportingSetRequest(
+      request,
+      parentKey,
+      campaignGroupKey,
+      referencedReportingSetKeys,
+    )
   }
 
   /**
    * Validates a request [setExpression].
    *
-   * @throws io.grpc.StatusRuntimeException
+   * @return the set of keys of the referenced ReportingSets
+   * @throws RequiredFieldNotSetException
+   * @throws InvalidFieldValueException
    */
   private fun validateSetExpression(
-    parentKey: MeasurementConsumerKey,
+    parentKey: CmmsMeasurementConsumerKey,
     setExpression: ReportingSet.SetExpression,
-  ) {
-    @Suppress("WHEN_ENUM_CAN_BE_NULL_IN_JAVA") // Protobuf enum accessors cannot return null.
+    fieldPath: String,
+  ): Set<ReportingSetKey> {
     when (setExpression.operation) {
       ReportingSet.SetExpression.Operation.UNION,
       ReportingSet.SetExpression.Operation.DIFFERENCE,
       ReportingSet.SetExpression.Operation.INTERSECTION -> {}
-      ReportingSet.SetExpression.Operation.OPERATION_UNSPECIFIED,
+      ReportingSet.SetExpression.Operation.OPERATION_UNSPECIFIED ->
+        throw RequiredFieldNotSetException("$fieldPath.operation")
       ReportingSet.SetExpression.Operation.UNRECOGNIZED ->
-        throw Status.INVALID_ARGUMENT.withDescription("operation not set or invalid")
-          .asRuntimeException()
+        throw InvalidFieldValueException("$fieldPath.operation")
     }
 
-    validateOperand(parentKey, setExpression.lhs)
-    if (setExpression.hasRhs()) {
-      validateOperand(parentKey, setExpression.rhs)
+    return buildSet {
+      addAll(validateOperand(parentKey, setExpression.lhs, "$fieldPath.lhs"))
+      if (setExpression.hasRhs()) {
+        addAll(validateOperand(parentKey, setExpression.rhs, "$fieldPath.rhs"))
+      }
     }
   }
 
   /**
    * Validates a request [operand].
    *
-   * @throws io.grpc.StatusRuntimeException
+   * @return the set of keys of the referenced ReportingSets
+   * @throws InvalidFieldValueException
+   * @throws RequiredFieldNotSetException
    */
   private fun validateOperand(
-    parentKey: MeasurementConsumerKey,
+    parentKey: CmmsMeasurementConsumerKey,
     operand: ReportingSet.SetExpression.Operand,
-  ) {
-    @Suppress("WHEN_ENUM_CAN_BE_NULL_IN_JAVA") // Protobuf enum accessors cannot return null.
-    when (operand.operandCase) {
+    fieldPath: String,
+  ): Set<ReportingSetKey> {
+    return when (operand.operandCase) {
       ReportingSet.SetExpression.Operand.OperandCase.REPORTING_SET -> {
         val reportingSetKey =
           ReportingSetKey.fromName(operand.reportingSet)
-            ?: throw Status.INVALID_ARGUMENT.withDescription(
-                "${operand.reportingSet} is not a valid ReportingSet resource name"
-              )
-              .asRuntimeException()
+            ?: throw InvalidFieldValueException("$fieldPath.reporting_set")
         if (reportingSetKey.parentKey != parentKey) {
-          throw Status.INVALID_ARGUMENT.withDescription("ReportingSet has incorrect parent")
-            .asRuntimeException()
+          throw InvalidFieldValueException("$fieldPath.reporting_set") { invalidFieldPath ->
+            "$invalidFieldPath does not belong to the same MeasurementConsumer"
+          }
         }
+        setOf(reportingSetKey)
       }
       ReportingSet.SetExpression.Operand.OperandCase.EXPRESSION -> {
-        validateSetExpression(parentKey, operand.expression)
+        validateSetExpression(parentKey, operand.expression, "$fieldPath.expression")
       }
       ReportingSet.SetExpression.Operand.OperandCase.OPERAND_NOT_SET ->
-        throw Status.INVALID_ARGUMENT.withDescription("operand not set").asRuntimeException()
+        throw RequiredFieldNotSetException("$fieldPath.operand")
     }
   }
 
   override suspend fun getReportingSet(request: GetReportingSetRequest): ReportingSet {
     val reportingSetKey =
-      grpcRequireNotNull(ReportingSetKey.fromName(request.name)) {
-        "ReportingSet name is either unspecified or invalid."
-      }
+      ReportingSetKey.fromName(request.name)
+        ?: throw InvalidFieldValueException("name")
+          .asStatusRuntimeException(Status.Code.INVALID_ARGUMENT)
+
     authorization.check(listOf(request.name, reportingSetKey.parentKey.toName()), Permission.GET)
 
     val internalResponse =
       try {
-        getInternalReportingSet(
-          reportingSetKey.toName(),
-          reportingSetKey.cmmsMeasurementConsumerId,
-          internalReportingSetsStub,
+        internalReportingSetsStub.batchGetReportingSets(
+          batchGetReportingSetsRequest {
+            this.cmmsMeasurementConsumerId = reportingSetKey.parentKey.measurementConsumerId
+            externalReportingSetIds += reportingSetKey.reportingSetId
+          }
         )
       } catch (e: StatusException) {
         throw when (e.status.code) {
@@ -233,13 +310,13 @@ class ReportingSetsService(
           .asRuntimeException()
       }
 
-    return internalResponse.toReportingSet()
+    return internalResponse.reportingSetsList.single().toReportingSet()
   }
 
   override suspend fun listReportingSets(
     request: ListReportingSetsRequest
   ): ListReportingSetsResponse {
-    grpcRequireNotNull(MeasurementConsumerKey.fromName(request.parent)) {
+    grpcRequireNotNull(CmmsMeasurementConsumerKey.fromName(request.parent)) {
       "Parent is either unspecified or invalid."
     }
     val listReportingSetsPageToken = request.toListReportingSetsPageToken()
@@ -274,31 +351,6 @@ class ReportingSetsService(
     }
   }
 
-  /**
-   * Converts a [CreateReportingSetRequest] to an [InternalCreateReportingSetRequest].
-   *
-   * @throws InvalidFieldValueException
-   * @throws RequiredFieldNotSetException
-   * @throws CampaignGroupInvalidException
-   */
-  private suspend fun CreateReportingSetRequest.toInternal(): InternalCreateReportingSetRequest {
-    val source = this
-    val cmmsMeasurementConsumerId =
-      checkNotNull(MeasurementConsumerKey.fromName(source.parent)).measurementConsumerId
-
-    val internalReportingSet =
-      source.reportingSet.toInternal(
-        source.reportingSetId,
-        cmmsMeasurementConsumerId,
-        internalReportingSetsStub,
-      )
-
-    return internalCreateReportingSetRequest {
-      this.reportingSet = internalReportingSet
-      this.externalReportingSetId = source.reportingSetId
-    }
-  }
-
   object Permission {
     private const val TYPE = "reporting.reportingSets"
     const val CREATE_PRIMITIVE = "$TYPE.createPrimitive"
@@ -317,8 +369,8 @@ private fun ListReportingSetsRequest.toListReportingSetsPageToken(): ListReporti
   grpcRequire(pageSize >= 0) { "Page size cannot be less than 0" }
 
   val source = this
-  val parentKey: MeasurementConsumerKey =
-    grpcRequireNotNull(MeasurementConsumerKey.fromName(parent)) {
+  val parentKey =
+    grpcRequireNotNull(CmmsMeasurementConsumerKey.fromName(parent)) {
       "Parent is either unspecified or invalid."
     }
 

--- a/src/test/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/BUILD.bazel
+++ b/src/test/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/BUILD.bazel
@@ -178,6 +178,7 @@ kt_jvm_test(
     deps = [
         "//src/main/kotlin/org/wfanet/measurement/access/client/v1alpha/testing:authentication",
         "//src/main/kotlin/org/wfanet/measurement/access/client/v1alpha/testing:principal_matcher",
+        "//src/main/kotlin/org/wfanet/measurement/common/grpc/testing:status_exception_subject",
         "@wfa_common_jvm//imports/java/com/google/common/truth",
         "@wfa_common_jvm//imports/java/com/google/common/truth/extensions/proto",
         "@wfa_common_jvm//imports/java/com/google/protobuf",

--- a/src/test/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/ReportingSetsServiceTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/ReportingSetsServiceTest.kt
@@ -17,6 +17,7 @@ package org.wfanet.measurement.reporting.service.api.v2alpha
 
 import com.google.common.truth.Truth.assertThat
 import com.google.common.truth.extensions.proto.ProtoTruth.assertThat
+import com.google.rpc.errorInfo
 import io.grpc.Status
 import io.grpc.StatusRuntimeException
 import kotlin.test.assertFailsWith
@@ -45,6 +46,7 @@ import org.wfanet.measurement.api.v2alpha.EventGroupKey as CmmsEventGroupKey
 import org.wfanet.measurement.api.v2alpha.MeasurementConsumerKey
 import org.wfanet.measurement.common.base64UrlEncode
 import org.wfanet.measurement.common.grpc.testing.GrpcTestServerRule
+import org.wfanet.measurement.common.grpc.testing.StatusExceptionSubject.Companion.assertThat
 import org.wfanet.measurement.common.grpc.testing.mockService
 import org.wfanet.measurement.common.identity.ExternalId
 import org.wfanet.measurement.common.testing.verifyProtoArgument
@@ -55,11 +57,13 @@ import org.wfanet.measurement.internal.reporting.v2.ReportingSetsGrpcKt.Reportin
 import org.wfanet.measurement.internal.reporting.v2.ReportingSetsGrpcKt.ReportingSetsCoroutineStub
 import org.wfanet.measurement.internal.reporting.v2.StreamReportingSetsRequest
 import org.wfanet.measurement.internal.reporting.v2.StreamReportingSetsRequestKt
+import org.wfanet.measurement.internal.reporting.v2.batchGetReportingSetsRequest
 import org.wfanet.measurement.internal.reporting.v2.batchGetReportingSetsResponse
 import org.wfanet.measurement.internal.reporting.v2.copy
 import org.wfanet.measurement.internal.reporting.v2.createReportingSetRequest as internalCreateReportingSetRequest
 import org.wfanet.measurement.internal.reporting.v2.reportingSet as internalReportingSet
 import org.wfanet.measurement.internal.reporting.v2.streamReportingSetsRequest
+import org.wfanet.measurement.reporting.service.api.Errors
 import org.wfanet.measurement.reporting.service.internal.ReportingSetNotFoundException
 import org.wfanet.measurement.reporting.v2alpha.GetReportingSetRequest
 import org.wfanet.measurement.reporting.v2alpha.ListReportingSetsPageTokenKt.previousPageEnd
@@ -87,15 +91,9 @@ class ReportingSetsServiceTest {
       .thenAnswer {
         val request = it.arguments[0] as BatchGetReportingSetsRequest
         val internalReportingSetsMap =
-          mapOf(
-            INTERNAL_COMPOSITE_REPORTING_SET.externalReportingSetId to
-              INTERNAL_COMPOSITE_REPORTING_SET,
-            INTERNAL_COMPOSITE_REPORTING_SET2.externalReportingSetId to
-              INTERNAL_COMPOSITE_REPORTING_SET2,
-          ) +
-            INTERNAL_PRIMITIVE_REPORTING_SETS.associateBy { internalReportingSet ->
-              internalReportingSet.externalReportingSetId
-            }
+          INTERNAL_REPORTING_SETS.associateBy { internalReportingSet ->
+            internalReportingSet.externalReportingSetId
+          }
         batchGetReportingSetsResponse {
           reportingSets +=
             request.externalReportingSetIdsList.map { externalReportingSetId ->
@@ -667,8 +665,17 @@ class ReportingSetsServiceTest {
           runBlocking { service.createReportingSet(request) }
         }
       }
-    assertThat(exception.status.code).isEqualTo(Status.Code.INVALID_ARGUMENT)
-    assertThat(exception.status.description).contains(invalidReportingSetName)
+    assertThat(exception).status().code().isEqualTo(Status.Code.INVALID_ARGUMENT)
+    assertThat(exception)
+      .errorInfo()
+      .isEqualTo(
+        errorInfo {
+          domain = Errors.DOMAIN
+          reason = Errors.Reason.INVALID_FIELD_VALUE.name
+          metadata[Errors.Metadata.FIELD_NAME.key] =
+            "reporting_set.composite.expression.lhs.reporting_set"
+        }
+      )
   }
 
   @Test
@@ -714,7 +721,13 @@ class ReportingSetsServiceTest {
           checkPermissionsResponse { permissions += PermissionName.CREATE_COMPOSITE }
       }
       whenever(internalReportingSetsMock.batchGetReportingSets(any()))
-        .thenThrow(StatusRuntimeException(Status.NOT_FOUND))
+        .thenThrow(
+          ReportingSetNotFoundException(
+              INTERNAL_COMPOSITE_REPORTING_SET.cmmsMeasurementConsumerId,
+              INTERNAL_COMPOSITE_REPORTING_SET.externalReportingSetId,
+            )
+            .asStatusRuntimeException(Status.Code.NOT_FOUND)
+        )
       val request = createReportingSetRequest {
         parent = MEASUREMENT_CONSUMER_KEYS.first().toName()
         reportingSet = ROOT_COMPOSITE_REPORTING_SET.copy { clearName() }
@@ -724,7 +737,21 @@ class ReportingSetsServiceTest {
         assertFailsWith<StatusRuntimeException> {
           withPrincipalAndScopes(PRINCIPAL, SCOPES) { service.createReportingSet(request) }
         }
-      assertThat(exception.status.code).isEqualTo(Status.Code.FAILED_PRECONDITION)
+      assertThat(exception).status().code().isEqualTo(Status.Code.FAILED_PRECONDITION)
+      assertThat(exception)
+        .errorInfo()
+        .isEqualTo(
+          errorInfo {
+            domain = Errors.DOMAIN
+            reason = Errors.Reason.REPORTING_SET_NOT_FOUND.name
+            metadata[Errors.Metadata.REPORTING_SET.key] =
+              ReportingSetKey(
+                  INTERNAL_COMPOSITE_REPORTING_SET.cmmsMeasurementConsumerId,
+                  INTERNAL_COMPOSITE_REPORTING_SET.externalReportingSetId,
+                )
+                .toName()
+          }
+        )
     }
 
   @Test
@@ -794,8 +821,16 @@ class ReportingSetsServiceTest {
           runBlocking { service.createReportingSet(request) }
         }
       }
-    assertThat(exception.status.code).isEqualTo(Status.Code.INVALID_ARGUMENT)
-    assertThat(exception.status.description).contains(invalidEventGroupName)
+    assertThat(exception).status().code().isEqualTo(Status.Code.INVALID_ARGUMENT)
+    assertThat(exception)
+      .errorInfo()
+      .isEqualTo(
+        errorInfo {
+          domain = Errors.DOMAIN
+          reason = Errors.Reason.INVALID_FIELD_VALUE.name
+          metadata[Errors.Metadata.FIELD_NAME.key] = "reporting_set.primitive.cmms_event_groups[0]"
+        }
+      )
   }
 
   @Test
@@ -810,6 +845,18 @@ class ReportingSetsServiceTest {
       withPrincipalAndScopes(PRINCIPAL, SCOPES) { runBlocking { service.getReportingSet(request) } }
 
     assertThat(reportingSet).isEqualTo(PRIMITIVE_REPORTING_SETS.first())
+    verifyProtoArgument(
+        internalReportingSetsMock,
+        ReportingSetsCoroutineImplBase::batchGetReportingSets,
+      )
+      .isEqualTo(
+        batchGetReportingSetsRequest {
+          cmmsMeasurementConsumerId =
+            INTERNAL_PRIMITIVE_REPORTING_SETS.first().cmmsMeasurementConsumerId
+          externalReportingSetIds +=
+            INTERNAL_PRIMITIVE_REPORTING_SETS.first().externalReportingSetId
+        }
+      )
   }
 
   @Test
@@ -1278,7 +1325,7 @@ class ReportingSetsServiceTest {
       (0L..2L).map {
         internalReportingSet {
           cmmsMeasurementConsumerId = MEASUREMENT_CONSUMER_KEYS.first().measurementConsumerId
-          externalReportingSetId = (it + 440L).toString()
+          externalReportingSetId = "primitive-$it"
           filter = "AGE>18"
           displayName = "primitive_reporting_set_display_name$it"
           primitive =
@@ -1302,7 +1349,7 @@ class ReportingSetsServiceTest {
 
     private val INTERNAL_COMPOSITE_REPORTING_SET: InternalReportingSet = internalReportingSet {
       cmmsMeasurementConsumerId = MEASUREMENT_CONSUMER_KEYS.first().measurementConsumerId
-      externalReportingSetId = "450"
+      externalReportingSetId = "composite"
       filter = "GENDER==MALE"
       displayName = "composite_reporting_set_display_name"
       composite =
@@ -1412,6 +1459,11 @@ class ReportingSetsServiceTest {
         }
       details = InternalReportingSetKt.details { tags.put("name", "ROOT_COMPOSITE_REPORTING_SET") }
     }
+
+    private val INTERNAL_REPORTING_SETS =
+      INTERNAL_PRIMITIVE_REPORTING_SETS +
+        INTERNAL_COMPOSITE_REPORTING_SET +
+        INTERNAL_COMPOSITE_REPORTING_SET2
 
     // Reporting sets
     private val PRIMITIVE_REPORTING_SETS: List<ReportingSet> =


### PR DESCRIPTION
This extracts validation of ReportingSets requests and fetching of internal ReportingSets from ProtoConversion.kt into a `ReportingSets` utility object.

This was part of the investigation for #3555.

Issue: #3555