### PR TITLE
fix: Ensure thread safety of SetExpressionCompiler caches

### DIFF
--- a/src/main/kotlin/org/wfanet/measurement/integration/common/reporting/v2/InProcessLifeOfAReportIntegrationTest.kt
+++ b/src/main/kotlin/org/wfanet/measurement/integration/common/reporting/v2/InProcessLifeOfAReportIntegrationTest.kt
@@ -17,6 +17,7 @@
 package org.wfanet.measurement.integration.common.reporting.v2
 
 import com.google.common.truth.Truth.assertThat
+import com.google.common.truth.Truth.assertWithMessage
 import com.google.common.truth.extensions.proto.ProtoTruth.assertThat
 import com.google.protobuf.timestamp
 import com.google.type.DayOfWeek
@@ -63,6 +64,7 @@ import org.wfanet.measurement.api.v2alpha.Measurement
 import org.wfanet.measurement.api.v2alpha.MeasurementConsumerKey
 import org.wfanet.measurement.api.v2alpha.MeasurementConsumersGrpcKt.MeasurementConsumersCoroutineStub
 import org.wfanet.measurement.api.v2alpha.MeasurementKt
+import org.wfanet.measurement.api.v2alpha.MeasurementSpec
 import org.wfanet.measurement.api.v2alpha.MeasurementsGrpcKt.MeasurementsCoroutineStub
 import org.wfanet.measurement.api.v2alpha.RequisitionSpecKt
 import org.wfanet.measurement.api.v2alpha.eventGroup as cmmsEventGroup
@@ -72,6 +74,7 @@ import org.wfanet.measurement.api.v2alpha.getDataProviderRequest
 import org.wfanet.measurement.api.v2alpha.getMeasurementConsumerRequest
 import org.wfanet.measurement.api.v2alpha.listMeasurementsRequest
 import org.wfanet.measurement.api.v2alpha.testing.MeasurementResultSubject.Companion.assertThat
+import org.wfanet.measurement.api.v2alpha.unpack
 import org.wfanet.measurement.api.withAuthenticationKey
 import org.wfanet.measurement.common.OpenEndTimeRange
 import org.wfanet.measurement.common.base64UrlEncode
@@ -119,6 +122,7 @@ import org.wfanet.measurement.reporting.v2alpha.MetricCalculationSpec
 import org.wfanet.measurement.reporting.v2alpha.MetricCalculationSpecKt
 import org.wfanet.measurement.reporting.v2alpha.MetricCalculationSpecsGrpcKt.MetricCalculationSpecsCoroutineStub
 import org.wfanet.measurement.reporting.v2alpha.MetricFrequencySpec
+import org.wfanet.measurement.reporting.v2alpha.MetricResult
 import org.wfanet.measurement.reporting.v2alpha.MetricSpec
 import org.wfanet.measurement.reporting.v2alpha.MetricSpecKt
 import org.wfanet.measurement.reporting.v2alpha.MetricsGrpcKt.MetricsCoroutineStub
@@ -637,53 +641,49 @@ abstract class InProcessLifeOfAReportIntegrationTest(
   fun `report with HMSS union reach across 2 edps has the expected result`() = runBlocking {
     val measurementConsumerData = inProcessCmmsComponents.getMeasurementConsumerData()
     val edpDisplayNames = ALL_EDP_DISPLAY_NAMES.take(2)
-    val eventGroups: List<EventGroup> =
-      listEventGroups().filter {
+    val eventGroupsByEdpDisplayName: Map<String, List<EventGroup>> =
+      listEventGroups().groupBy {
         inProcessCmmsComponents.getDataProviderDisplayNameFromDataProviderName(
           it.cmmsDataProvider
-        )!! in edpDisplayNames
+        )!!
       }
-
     val eventGroupEntries: List<Pair<EventGroup, String>> =
       listOf(
-        eventGroups[0] to "person.age_group == ${Person.AgeGroup.YEARS_18_TO_34_VALUE}",
-        eventGroups[1] to "person.age_group == ${Person.AgeGroup.YEARS_55_PLUS_VALUE}",
+        eventGroupsByEdpDisplayName.getValue(edpDisplayNames[0]).first() to
+          "person.age_group == ${Person.AgeGroup.YEARS_18_TO_34_VALUE}",
+        eventGroupsByEdpDisplayName.getValue(edpDisplayNames[1]).first() to
+          "person.age_group == ${Person.AgeGroup.YEARS_55_PLUS_VALUE}",
       )
-
-    val createdPrimitiveReportingSets: List<ReportingSet> =
+    val primitiveReportingSets: List<ReportingSet> =
       createPrimitiveReportingSets(eventGroupEntries, measurementConsumerData.name)
-
-    val compositeReportingSet = reportingSet {
-      displayName = "composite"
-      composite =
-        ReportingSetKt.composite {
-          expression =
-            ReportingSetKt.setExpression {
-              operation = ReportingSet.SetExpression.Operation.UNION
-              lhs =
-                ReportingSetKt.SetExpressionKt.operand {
-                  reportingSet = createdPrimitiveReportingSets[0].name
-                }
-              rhs =
-                ReportingSetKt.SetExpressionKt.operand {
-                  reportingSet = createdPrimitiveReportingSets[1].name
-                }
-            }
-        }
-    }
-
-    val createdCompositeReportingSet =
+    val compositeReportingSet =
       publicReportingSetsClient
         .withCallCredentials(credentials)
         .createReportingSet(
           createReportingSetRequest {
             parent = measurementConsumerData.name
-            reportingSet = compositeReportingSet
+            reportingSet = reportingSet {
+              displayName = "composite"
+              composite =
+                ReportingSetKt.composite {
+                  expression =
+                    ReportingSetKt.setExpression {
+                      operation = ReportingSet.SetExpression.Operation.UNION
+                      lhs =
+                        ReportingSetKt.SetExpressionKt.operand {
+                          reportingSet = primitiveReportingSets[0].name
+                        }
+                      rhs =
+                        ReportingSetKt.SetExpressionKt.operand {
+                          reportingSet = primitiveReportingSets[1].name
+                        }
+                    }
+                }
+            }
             reportingSetId = "def"
           }
         )
-
-    val createdMetricCalculationSpec =
+    val metricCalculationSpec =
       publicMetricCalculationSpecsClient
         .withCallCredentials(credentials)
         .createMetricCalculationSpec(
@@ -700,56 +700,58 @@ abstract class InProcessLifeOfAReportIntegrationTest(
           }
         )
 
-    val report = report {
-      reportingMetricEntries +=
-        ReportKt.reportingMetricEntry {
-          key = createdCompositeReportingSet.name
-          value =
-            ReportKt.reportingMetricCalculationSpec {
-              metricCalculationSpecs += createdMetricCalculationSpec.name
-            }
-        }
-      timeIntervals = timeIntervals { timeIntervals += EVENT_RANGE.toInterval() }
-    }
-
-    val createdReport =
+    val reportName: String =
       publicReportsClient
         .withCallCredentials(credentials)
         .createReport(
           createReportRequest {
             parent = measurementConsumerData.name
-            this.report = report
+            this.report = report {
+              reportingMetricEntries +=
+                ReportKt.reportingMetricEntry {
+                  key = compositeReportingSet.name
+                  value =
+                    ReportKt.reportingMetricCalculationSpec {
+                      metricCalculationSpecs += metricCalculationSpec.name
+                    }
+                }
+              timeIntervals = timeIntervals { timeIntervals += EVENT_RANGE.toInterval() }
+            }
             reportId = "report"
           }
         )
+        .name
 
-    val retrievedReport = pollForCompletedReport(createdReport.name)
-    assertThat(retrievedReport.state).isEqualTo(Report.State.SUCCEEDED)
+    val report: Report = pollForCompletedReport(reportName)
+    assertThat(report.state).isEqualTo(Report.State.SUCCEEDED)
 
-    val eventGroupSpecs: Iterable<EventQuery.EventGroupSpec> =
+    val measurements: List<Measurement> =
+      listMeasurements().filter {
+        it.measurementSpec.unpack<MeasurementSpec>().reportingMetadata.report == reportName
+      }
+    assertThat(measurements).hasSize(1)
+    assertWithMessage("protocol is HMSS")
+      .that(
+        measurements.single().protocolConfig.protocolsList.single().hasHonestMajorityShareShuffle()
+      )
+      .isTrue()
+
+    val eventGroupSpecs: List<EventQuery.EventGroupSpec> =
       eventGroupEntries.map { (eventGroup, filter) ->
         buildEventGroupSpec(eventGroup, filter, EVENT_RANGE.toInterval())
       }
-    val expectedResult = calculateExpectedReachMeasurementResult(eventGroupSpecs)
+    val expectedResult: Measurement.Result =
+      calculateExpectedReachMeasurementResult(eventGroupSpecs)
 
-    val reachResult =
-      retrievedReport.metricCalculationResultsList
-        .single()
-        .resultAttributesList
-        .single()
-        .metricResult
-        .reach
-    val actualResult =
-      MeasurementKt.result { reach = MeasurementKt.ResultKt.reach { value = reachResult.value } }
+    val reachResult: MetricResult.ReachResult =
+      report.metricCalculationResultsList.single().resultAttributesList.single().metricResult.reach
     val tolerance = computeErrorMargin(reachResult.univariateStatistics.standardDeviation)
-
-    assertThat(actualResult).reachValue().isWithin(tolerance).of(expectedResult.reach.value)
-
-    val measurements: List<Measurement> = listMeasurements()
-    assertThat(measurements).hasSize(1)
-    assertThat(measurements[0].protocolConfig.protocolsList).hasSize(1)
-    assertThat(measurements[0].protocolConfig.protocolsList[0].hasHonestMajorityShareShuffle())
-      .isTrue()
+    assertThat(
+        MeasurementKt.result { reach = MeasurementKt.ResultKt.reach { value = reachResult.value } }
+      )
+      .reachValue()
+      .isWithin(tolerance)
+      .of(expectedResult.reach.value)
   }
 
   @Test
@@ -1355,7 +1357,7 @@ abstract class InProcessLifeOfAReportIntegrationTest(
                 MetricCalculationSpecKt.metricFrequencySpec {
                   weekly =
                     MetricCalculationSpecKt.MetricFrequencySpecKt.weekly {
-                      dayOfWeek = com.google.type.DayOfWeek.WEDNESDAY
+                      dayOfWeek = DayOfWeek.WEDNESDAY
                     }
                 }
               trailingWindow =

--- a/src/main/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/BUILD.bazel
+++ b/src/main/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/BUILD.bazel
@@ -173,9 +173,6 @@ kt_jvm_library(
 kt_jvm_library(
     name = "set_expression_compiler",
     srcs = ["SetExpressionCompiler.kt"],
-    deps = [
-        "@wfa_common_jvm//imports/kotlin/kotlinx/coroutines:core",
-    ],
 )
 
 kt_jvm_library(

--- a/src/main/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/SetExpressionCompiler.kt
+++ b/src/main/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/SetExpressionCompiler.kt
@@ -16,9 +16,9 @@
 
 package org.wfanet.measurement.reporting.service.api.v2alpha
 
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.ConcurrentMap
 import kotlin.math.pow
-import kotlinx.coroutines.coroutineScope
-import kotlinx.coroutines.launch
 
 /**
  * A primitive region of a Venn diagram is the intersection of a set of reporting sets, and it is
@@ -42,28 +42,8 @@ private typealias PrimitiveRegion = ULong
  */
 private typealias UnionSet = ULong
 
-private typealias NumberReportingSets = Int
-
 /** A mapping from a [UnionSet] to its coefficient in the Venn diagram region decomposition. */
 private typealias UnionSetCoefficientMap = Map<UnionSet, Int>
-
-/**
- * A mapping for cardinality computation from a [PrimitiveRegion] to its decomposition in terms of
- * union-sets represented by [UnionSetCoefficientMap]. Take a case of 3 reporting sets (rs0, rs1,
- * rs2) as an example. A primitive region with its value equal to 3 (b'011') means rs0 INTERSECT rs1
- * INTERSECT COMPLEMENT(rs2). The decomposition of the cardinality of the region =
- * PrimitiveRegionToUnionSetCoefficientMap\[region\] = {4: -1, 5: 1, 6: 1, 7: -1}, i.e. |union-set5|
- * + |union-set6| - |union-set4| - |union-set7|.
- */
-private typealias PrimitiveRegionToUnionSetCoefficientMap =
-  MutableMap<PrimitiveRegion, UnionSetCoefficientMap>
-
-/**
- * A memory cache that stores the Venn diagram region cardinality decompositions for different
- * numbers of reporting sets.
- */
-private typealias PrimitiveRegionCache =
-  MutableMap<NumberReportingSets, PrimitiveRegionToUnionSetCoefficientMap>
 
 /**
  * A list of sets of primitive regions, where the index of the list represents the reporting set ID,
@@ -74,32 +54,45 @@ private typealias PrimitiveRegionCache =
  */
 private typealias VennDiagramDecomposition = List<Set<PrimitiveRegion>>
 
-/**
- * A memory cache that stores the decompositions of Venn Diagrams given different number of
- * reporting sets.
- */
-private typealias VennDiagramDecompositionCache =
-  MutableMap<NumberReportingSets, VennDiagramDecomposition>
-
-enum class Operator {
-  UNION,
-  INTERSECT,
-  DIFFERENCE,
-}
-
-interface Operand
-
-data class ReportingSet(val id: Int) : Operand
-
-data class SetOperationExpression(val setOperator: Operator, val lhs: Operand, val rhs: Operand?) :
-  Operand
-
-data class WeightedSubsetUnion(val reportingSetIds: List<Int>, val coefficient: Int)
-
 class SetExpressionCompiler {
+  enum class Operator {
+    UNION,
+    INTERSECT,
+    DIFFERENCE,
+  }
 
-  private val primitiveRegionCache: PrimitiveRegionCache = mutableMapOf()
-  private val vennDiagramDecompositionCache: VennDiagramDecompositionCache = mutableMapOf()
+  sealed interface Operand
+
+  data class ReportingSet(val id: Int) : Operand
+
+  data class SetOperationExpression(
+    val setOperator: Operator,
+    val lhs: Operand,
+    val rhs: Operand?,
+  ) : Operand
+
+  data class WeightedSubsetUnion(val reportingSets: List<ReportingSet>, val coefficient: Int) {
+    val binaryRepresentation: Int
+      get() = reportingSets.sumOf { 1 shl it.id }
+  }
+
+  private data class PrimitiveRegionKey(val reportingSetCount: Int, val region: PrimitiveRegion)
+
+  /**
+   * A mapping for cardinality computation from a [PrimitiveRegionKey] to its decomposition in terms
+   * of union-sets represented by [UnionSetCoefficientMap]. Take a case of 3 reporting sets (rs0,
+   * rs1, rs2) as an example. A primitive region with its value equal to `3` (`0b011`) means rs0
+   * INTERSECT rs1 INTERSECT COMPLEMENT(rs2). The decomposition of the cardinality of the region is
+   * `{4: -1, 5: 1, 6: 1, 7: -1}`, i.e. `|union-set5| + |union-set6| - |union-set4| - |union-set7|`.
+   */
+  private val primitiveRegionCache: ConcurrentMap<PrimitiveRegionKey, UnionSetCoefficientMap> =
+    ConcurrentHashMap()
+  /**
+   * A memory cache that stores the decompositions of Venn Diagrams given different number of
+   * reporting sets.
+   */
+  private val vennDiagramDecompositionCache: ConcurrentMap<Int, VennDiagramDecomposition> =
+    ConcurrentHashMap()
 
   /**
    * Compiles a set expression to a list of [WeightedSubsetUnion]s which will be used for the
@@ -112,38 +105,38 @@ class SetExpressionCompiler {
    *
    * @param [setOperationExpression] is a binary tree structure representing the expression of
    *   binary set operations. The reporting set IDs in [setOperationExpression] should be indexed
-   *   from 0 to [numReportingSets] - 1.
-   * @param [numReportingSets] total number of reporting sets used in [setOperationExpression].
+   *   from 0 to [reportingSetCount] - 1.
+   * @param [reportingSetCount] total number of reporting sets used in [setOperationExpression].
    */
-  suspend fun compileSetExpression(
+  fun compileSetExpression(
     setOperationExpression: SetOperationExpression,
-    numReportingSets: Int,
+    reportingSetCount: Int,
   ): List<WeightedSubsetUnion> {
     // Step 1 - Gets the primitive regions that form the set expression
     val primitiveRegions =
-      setOperationExpressionToPrimitiveRegions(numReportingSets, setOperationExpression)
+      setOperationExpressionToPrimitiveRegions(reportingSetCount, setOperationExpression)
 
     // Step 2 - Converts a set of primitive regions to a map of union-set to its coefficients for
     // cardinality computation.
     val unionSetCoefficientMap =
-      convertPrimitiveRegionsToUnionSetCoefficientMap(numReportingSets, primitiveRegions)
+      convertPrimitiveRegionsToUnionSetCoefficientMap(reportingSetCount, primitiveRegions)
 
-    return convertUnionSetToWeightedSubsetUnions(unionSetCoefficientMap, numReportingSets)
+    return convertUnionSetToWeightedSubsetUnions(unionSetCoefficientMap, reportingSetCount)
   }
 
   /** Converts a [UnionSetCoefficientMap] to [WeightedSubsetUnion]s. */
   private fun convertUnionSetToWeightedSubsetUnions(
     unionSetCoefficientMap: UnionSetCoefficientMap,
-    numReportingSets: Int,
+    reportingSetCount: Int,
   ): List<WeightedSubsetUnion> {
     return unionSetCoefficientMap.map { (unionSet, coefficient) ->
       // Find the reporting sets in the union-set.
-      val reportingSetNames =
-        (0 until numReportingSets).mapNotNull { bitPosition ->
-          if (isBitSet(unionSet, bitPosition)) bitPosition else null
+      val reportingSets =
+        (0 until reportingSetCount).mapNotNull { bitPosition ->
+          if (isBitSet(unionSet, bitPosition)) ReportingSet(bitPosition) else null
         }
 
-      WeightedSubsetUnion(reportingSetNames, coefficient)
+      WeightedSubsetUnion(reportingSets, coefficient)
     }
   }
 
@@ -151,57 +144,48 @@ class SetExpressionCompiler {
    * Converts a set of primitive regions to a map of union-set to its coefficients for cardinality
    * computation
    */
-  private suspend fun convertPrimitiveRegionsToUnionSetCoefficientMap(
-    numReportingSets: Int,
+  private fun convertPrimitiveRegionsToUnionSetCoefficientMap(
+    reportingSetCount: Int,
     primitiveRegions: Set<PrimitiveRegion>,
   ): UnionSetCoefficientMap {
-
-    val primitiveRegionsToUnionSetCoefficients: PrimitiveRegionToUnionSetCoefficientMap =
-      mutableMapOf()
-
-    coroutineScope {
-      for (region in primitiveRegions) {
-        // Reuse previous computation if available
-        if (
-          reusePreviousComputation(numReportingSets, region, primitiveRegionsToUnionSetCoefficients)
-        ) {
-          continue
-        }
-
-        launch {
-          convertSinglePrimitiveRegionToUnionSetCoefficientMap(
-            numReportingSets,
-            region,
-            primitiveRegionsToUnionSetCoefficients,
-          )
+    val primitiveRegionsToUnionSetCoefficients: Map<PrimitiveRegion, UnionSetCoefficientMap> =
+      buildMap {
+        for (region in primitiveRegions) {
+          val primitiveRegionKey = PrimitiveRegionKey(reportingSetCount, region)
+          val unionSetCoefficientMap =
+            primitiveRegionCache.compute(primitiveRegionKey) { _, previousValue ->
+              previousValue
+                ?: convertSinglePrimitiveRegionToUnionSetCoefficientMap(reportingSetCount, region)
+            }
+          if (unionSetCoefficientMap != null) {
+            put(region, unionSetCoefficientMap)
+          }
         }
       }
-    }
-
-    // Updates the memory cache with new computation result.
-    primitiveRegionCache.getOrPut(numReportingSets, ::mutableMapOf) +=
-      primitiveRegionsToUnionSetCoefficients
 
     return aggregateCoefficientsByUnionSets(primitiveRegionsToUnionSetCoefficients)
   }
 
   /** Aggregates the coefficients by union-sets. */
   private fun aggregateCoefficientsByUnionSets(
-    primitiveRegionsToUnionSetCoefficients: PrimitiveRegionToUnionSetCoefficientMap
+    primitiveRegionsToUnionSetCoefficients: Map<PrimitiveRegion, UnionSetCoefficientMap>
   ): UnionSetCoefficientMap {
-    val aggregatedResult = mutableMapOf<UnionSet, Int>()
-    for ((_, unionSetCoefficients) in primitiveRegionsToUnionSetCoefficients) {
-      for ((unionSet, coefficient) in unionSetCoefficients) {
-        aggregatedResult[unionSet] = aggregatedResult.getOrDefault(unionSet, 0) + coefficient
+    return buildMap {
+        for ((_, unionSetCoefficients) in primitiveRegionsToUnionSetCoefficients) {
+          for ((unionSet, coefficient) in unionSetCoefficients) {
+            val aggregateCoefficient = getOrDefault(unionSet, 0) + coefficient
 
-        // Remove the entry if its coefficient is zero.
-        if (aggregatedResult[unionSet] == 0) {
-          aggregatedResult.remove(unionSet)
+            // Remove the entry if its coefficient is zero.
+            if (aggregateCoefficient == 0) {
+              remove(unionSet)
+            } else {
+              put(unionSet, aggregateCoefficient)
+            }
+          }
         }
       }
-    }
-    // Sort the aggregatedResult to make sure the result is consistent every time.
-    return aggregatedResult.toSortedMap().toMap()
+      .toSortedMap() // Sort the aggregatedResult to make sure the result is consistent every time.
+      .toMap()
   }
 
   /**
@@ -217,17 +201,19 @@ class SetExpressionCompiler {
    *     B     -1         0       1
    *   A U B    1         1      -1
    * ```
+   *
+   * @return the converted map of union-set to its coefficients, or `null` if there are no
+   *   coefficients
    */
   private fun convertSinglePrimitiveRegionToUnionSetCoefficientMap(
-    numReportingSets: Int,
+    reportingSetCount: Int,
     region: PrimitiveRegion,
-    primitiveRegionsToUnionSetCoefficients: PrimitiveRegionToUnionSetCoefficientMap,
-  ) {
+  ): UnionSetCoefficientMap? {
     // For a given region, we first find which bit positions are set and which are not.
     val setBitPositions = mutableListOf<Int>()
     val unsetBitPositions = mutableListOf<Int>()
 
-    for (bitPosition in 0 until numReportingSets) {
+    for (bitPosition in 0 until reportingSetCount) {
       if (isBitSet(region, bitPosition)) {
         setBitPositions.add(bitPosition)
       } else {
@@ -236,15 +222,15 @@ class SetExpressionCompiler {
     }
     val primitiveRegionWeight = setBitPositions.size
 
-    // Always starts from -1 unless the primitive region = (2^numReportingSets - 1) = b'11...1'.
-    val baseSign = if (primitiveRegionWeight != numReportingSets) -1 else 1
+    // Always starts from -1 unless the primitive region = (2^reportingSetCount - 1) = b'11...1'.
+    val baseSign = if (primitiveRegionWeight != reportingSetCount) -1 else 1
     var count = 0
 
     val unionSetCoefficients = mutableMapOf<UnionSet, Int>()
 
-    for (size in 1..numReportingSets) {
+    for (size in 1..reportingSetCount) {
       // Skips it if the union-only set is too light
-      if (size + primitiveRegionWeight < numReportingSets) {
+      if (size + primitiveRegionWeight < reportingSetCount) {
         continue
       }
 
@@ -256,26 +242,11 @@ class SetExpressionCompiler {
       unionSetCoefficients += composingUnionSets.associateWith { sign }
     }
 
-    if (unionSetCoefficients.isNotEmpty()) {
-      primitiveRegionsToUnionSetCoefficients[region] = unionSetCoefficients.toMap()
+    return if (unionSetCoefficients.isEmpty()) {
+      null
+    } else {
+      unionSetCoefficients.toMap()
     }
-  }
-
-  /** Reuses previous result in the memory cache if there is any. */
-  private fun reusePreviousComputation(
-    numReportingSets: Int,
-    region: PrimitiveRegion,
-    primitiveRegionsToUnionSetCoefficients: PrimitiveRegionToUnionSetCoefficientMap,
-  ): Boolean {
-    // If the compiler has already run the case where the number of reporting sets equal to
-    // `numReportingSets`.
-    primitiveRegionCache[numReportingSets]?.also { cachedPrimitiveRegionsToUnionSetCoefficients ->
-      // If the compiler has calculated this region before.
-      cachedPrimitiveRegionsToUnionSetCoefficients[region]?.also { cachedUnionSetCoefficientMap ->
-        primitiveRegionsToUnionSetCoefficients[region] = cachedUnionSetCoefficientMap
-      }
-    }
-    return primitiveRegionsToUnionSetCoefficients.containsKey(region)
   }
 
   /**
@@ -325,10 +296,10 @@ class SetExpressionCompiler {
 
   /** Gets the set of the primitive regions that form the set from the set operation expression. */
   private fun setOperationExpressionToPrimitiveRegions(
-    numReportingSets: Int,
+    reportingSetCount: Int,
     setOperationExpression: SetOperationExpression,
   ): Set<PrimitiveRegion> {
-    val allPrimitiveRegionSetsList = buildAllPrimitiveRegions(numReportingSets)
+    val allPrimitiveRegionSetsList = buildAllPrimitiveRegions(reportingSetCount)
     return setOperationExpression.decompose(allPrimitiveRegionSetsList)
   }
 
@@ -340,73 +311,70 @@ class SetExpressionCompiler {
    * allPrimitiveRegionSetsList\[reportingSetId\] = setOf(1(=b’001’), 3(=b’011’), 5(=b’101’),
    * 7(=b’111’)).
    */
-  private fun buildAllPrimitiveRegions(numReportingSets: Int): VennDiagramDecomposition {
-    if (vennDiagramDecompositionCache.contains(numReportingSets)) {
-      return vennDiagramDecompositionCache.getValue(numReportingSets)
-    }
+  private fun buildAllPrimitiveRegions(reportingSetCount: Int): VennDiagramDecomposition {
+    return vennDiagramDecompositionCache.computeIfAbsent(reportingSetCount) {
+      val numPrimitiveRegions =
+        2.0.pow(reportingSetCount).toPrimitiveRegion() - 1.toPrimitiveRegion()
+      val allPrimitiveRegionSetsList: List<MutableSet<PrimitiveRegion>> =
+        List(reportingSetCount) { mutableSetOf() }
 
-    val numPrimitiveRegions = 2.0.pow(numReportingSets).toPrimitiveRegion() - 1.toPrimitiveRegion()
-    val allPrimitiveRegionSetsList: List<MutableSet<PrimitiveRegion>> =
-      List(numReportingSets) { mutableSetOf() }
-
-    // A region is in the set of reportingSet when its bit at bit position == reportingSetId is set.
-    for (region in 1.toPrimitiveRegion()..numPrimitiveRegions) {
-      for (reportingSetId in 0 until numReportingSets) {
-        if (isBitSet(region, reportingSetId)) {
-          allPrimitiveRegionSetsList[reportingSetId].add(region)
+      // A region is in the set of reportingSet when its bit at bit position == reportingSetId is
+      // set.
+      for (region in 1.toPrimitiveRegion()..numPrimitiveRegions) {
+        for (reportingSetId in 0 until reportingSetCount) {
+          if (isBitSet(region, reportingSetId)) {
+            allPrimitiveRegionSetsList[reportingSetId].add(region)
+          }
         }
       }
+
+      allPrimitiveRegionSetsList
     }
-
-    vennDiagramDecompositionCache[numReportingSets] = allPrimitiveRegionSetsList
-
-    return allPrimitiveRegionSetsList
   }
-}
 
-/**
- * Decomposes the set operation expression to a set of primitive regions by calculating the set
- * expression between each two operands.
- */
-private fun SetOperationExpression.decompose(
-  allPrimitiveRegionSetsList: List<Set<PrimitiveRegion>>
-): Set<PrimitiveRegion> {
-  val source = this
-  val lhsPrimitiveRegions = source.lhs.decompose(allPrimitiveRegionSetsList)
-  val rhsPrimitiveRegions = source.rhs.decompose(allPrimitiveRegionSetsList)
-  return calculateBinarySetExpression(lhsPrimitiveRegions, rhsPrimitiveRegions, source.setOperator)
-}
-
-/** Decomposes the operand to a set of primitive regions. */
-private fun Operand?.decompose(
-  allPrimitiveRegionSetsList: List<Set<PrimitiveRegion>>
-): Set<PrimitiveRegion> {
-  return when (val operand = this) {
-    is SetOperationExpression -> {
-      operand.decompose(allPrimitiveRegionSetsList)
+  /** Calculates the binary set expression. */
+  private fun calculateBinarySetExpression(
+    lhs: Set<PrimitiveRegion>,
+    rhs: Set<PrimitiveRegion>,
+    operator: Operator,
+  ): Set<PrimitiveRegion> {
+    return when (operator) {
+      Operator.UNION -> lhs union rhs
+      Operator.INTERSECT -> lhs intersect rhs
+      Operator.DIFFERENCE -> lhs subtract rhs
     }
-    is ReportingSet -> {
-      if (operand.id >= allPrimitiveRegionSetsList.size) {
-        throw IllegalArgumentException(
-          "ReportingSet's ID must be less than the number of total reporting sets."
-        )
+  }
+
+  /**
+   * Decomposes the set operation expression to a set of primitive regions by calculating the set
+   * expression between each two operands.
+   */
+  private fun SetOperationExpression.decompose(
+    allPrimitiveRegionSetsList: List<Set<PrimitiveRegion>>
+  ): Set<PrimitiveRegion> {
+    val lhsPrimitiveRegions = lhs.decompose(allPrimitiveRegionSetsList)
+    val rhsPrimitiveRegions = rhs.decompose(allPrimitiveRegionSetsList)
+    return calculateBinarySetExpression(lhsPrimitiveRegions, rhsPrimitiveRegions, setOperator)
+  }
+
+  /** Decomposes the operand to a set of primitive regions. */
+  private fun Operand?.decompose(
+    allPrimitiveRegionSetsList: List<Set<PrimitiveRegion>>
+  ): Set<PrimitiveRegion> {
+    return when (val operand = this) {
+      is SetOperationExpression -> {
+        operand.decompose(allPrimitiveRegionSetsList)
       }
-      allPrimitiveRegionSetsList[operand.id]
+      is ReportingSet -> {
+        if (operand.id >= allPrimitiveRegionSetsList.size) {
+          throw IllegalArgumentException(
+            "ReportingSet's ID must be less than the number of total reporting sets."
+          )
+        }
+        allPrimitiveRegionSetsList[operand.id]
+      }
+      else -> setOf()
     }
-    else -> setOf()
-  }
-}
-
-/** Calculates the binary set expression. */
-private fun calculateBinarySetExpression(
-  lhs: Set<PrimitiveRegion>,
-  rhs: Set<PrimitiveRegion>,
-  operator: Operator,
-): Set<PrimitiveRegion> {
-  return when (operator) {
-    Operator.UNION -> lhs union rhs
-    Operator.INTERSECT -> lhs intersect rhs
-    Operator.DIFFERENCE -> lhs subtract rhs
   }
 }
 

--- a/src/test/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/BUILD.bazel
+++ b/src/test/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/BUILD.bazel
@@ -155,16 +155,12 @@ kt_jvm_test(
 kt_jvm_test(
     name = "SetExpressionCompilerTest",
     srcs = ["SetExpressionCompilerTest.kt"],
-    associates = [
-        "//src/main/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha:set_expression_compiler",
-    ],
     test_class = "org.wfanet.measurement.reporting.service.api.v2alpha.SetExpressionCompilerTest",
     deps = [
+        "//src/main/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha:set_expression_compiler",
         "@wfa_common_jvm//imports/java/com/google/common/truth",
-        "@wfa_common_jvm//imports/java/com/google/common/truth/extensions/proto",
+        "@wfa_common_jvm//imports/java/org/junit",
         "@wfa_common_jvm//imports/kotlin/kotlin/test",
-        "@wfa_common_jvm//imports/kotlin/kotlinx/coroutines:core",
-        "@wfa_common_jvm//src/main/kotlin/org/wfanet/measurement/common/testing",
     ],
 )
 

--- a/src/test/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/SetExpressionCompilerTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/SetExpressionCompilerTest.kt
@@ -17,46 +17,56 @@
 package org.wfanet.measurement.reporting.service.api.v2alpha
 
 import com.google.common.truth.Truth.assertThat
-import kotlinx.coroutines.runBlocking
-import org.junit.Assert.assertThrows
+import kotlin.test.assertFailsWith
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 
 // Reporting set IDs and names
-private val REPORTING_SETS = (0..2).map { ReportingSet(it) }
+private val REPORTING_SETS = (0..2).map { SetExpressionCompiler.ReportingSet(it) }
 
 private val EXPECTED_REPORTING_SETS_LIST_ALL_UNION = REPORTING_SETS.sortedBy { it.id }
 
 private val SET_EXPRESSION =
-  SetOperationExpression(
-    setOperator = Operator.UNION,
+  SetExpressionCompiler.SetOperationExpression(
+    setOperator = SetExpressionCompiler.Operator.UNION,
     lhs = REPORTING_SETS[0],
     rhs = REPORTING_SETS[1],
   )
 private val SET_EXPRESSION_ALL_UNION =
-  SetOperationExpression(
-    setOperator = Operator.UNION,
+  SetExpressionCompiler.SetOperationExpression(
+    setOperator = SetExpressionCompiler.Operator.UNION,
     lhs = SET_EXPRESSION,
     rhs = REPORTING_SETS[2],
   )
 // SetExpression = A + B + C - B
 
 private val SET_EXPRESSION_ALL_UNION_BUT_ONE =
-  SetOperationExpression(
-    setOperator = Operator.DIFFERENCE,
+  SetExpressionCompiler.SetOperationExpression(
+    setOperator = SetExpressionCompiler.Operator.DIFFERENCE,
     lhs = SET_EXPRESSION_ALL_UNION,
     rhs = EXPECTED_REPORTING_SETS_LIST_ALL_UNION[1],
   )
 
 private val EXPECTED_RESULT_FOR_ALL_UNION_SET_EXPRESSION =
-  listOf(WeightedSubsetUnion(EXPECTED_REPORTING_SETS_LIST_ALL_UNION.map { it.id }, coefficient = 1))
+  listOf(
+    SetExpressionCompiler.WeightedSubsetUnion(
+      EXPECTED_REPORTING_SETS_LIST_ALL_UNION,
+      coefficient = 1,
+    )
+  )
 
 private val EXPECTED_RESULT_FOR_ALL_UNION_BUT_ONE_SET_EXPRESSION =
   listOf(
-    WeightedSubsetUnion(EXPECTED_REPORTING_SETS_LIST_ALL_UNION.map { it.id }, coefficient = 1),
-    WeightedSubsetUnion(listOf(EXPECTED_REPORTING_SETS_LIST_ALL_UNION[1].id), coefficient = -1),
+    SetExpressionCompiler.WeightedSubsetUnion(
+      EXPECTED_REPORTING_SETS_LIST_ALL_UNION,
+      coefficient = 1,
+    ),
+    SetExpressionCompiler.WeightedSubsetUnion(
+      listOf(EXPECTED_REPORTING_SETS_LIST_ALL_UNION[1]),
+      coefficient = -1,
+    ),
   )
 
 @RunWith(JUnit4::class)
@@ -70,22 +80,36 @@ class SetExpressionCompilerTest {
 
   @Test
   fun `compileSetExpression returns a list of weightedSubsetUnions for union all`() {
-    val resultAllUnion = runBlocking {
+    val resultAllUnion =
       reportResultCompiler.compileSetExpression(SET_EXPRESSION_ALL_UNION, REPORTING_SETS.size)
-    }
     assertThat(resultAllUnion)
       .containsExactlyElementsIn(EXPECTED_RESULT_FOR_ALL_UNION_SET_EXPRESSION)
   }
 
   @Test
   fun `compileSetExpression returns a list of weightedSubsetUnions for union all but one`() {
-    val resultAllUnionButOne = runBlocking {
+    val resultAllUnionButOne =
       reportResultCompiler.compileSetExpression(
         SET_EXPRESSION_ALL_UNION_BUT_ONE,
         REPORTING_SETS.size,
       )
-    }
     assertThat(resultAllUnionButOne)
+      .containsExactlyElementsIn(EXPECTED_RESULT_FOR_ALL_UNION_BUT_ONE_SET_EXPRESSION)
+  }
+
+  @Test
+  fun `compileSetExpression returns consistent results over multiple calls`() {
+    assertThat(
+        reportResultCompiler.compileSetExpression(SET_EXPRESSION_ALL_UNION, REPORTING_SETS.size)
+      )
+      .containsExactlyElementsIn(EXPECTED_RESULT_FOR_ALL_UNION_SET_EXPRESSION)
+
+    assertThat(
+        reportResultCompiler.compileSetExpression(
+          SET_EXPRESSION_ALL_UNION_BUT_ONE,
+          REPORTING_SETS.size,
+        )
+      )
       .containsExactlyElementsIn(EXPECTED_RESULT_FOR_ALL_UNION_BUT_ONE_SET_EXPRESSION)
   }
 
@@ -94,13 +118,11 @@ class SetExpressionCompilerTest {
     val setOperationWithSetOperatorTypeNotSet =
       SET_EXPRESSION_ALL_UNION.copy(rhs = REPORTING_SETS[2].copy(id = REPORTING_SETS.size))
 
-    assertThrows(IllegalArgumentException::class.java) {
-      runBlocking {
-        reportResultCompiler.compileSetExpression(
-          setOperationWithSetOperatorTypeNotSet,
-          REPORTING_SETS.size,
-        )
-      }
+    assertFailsWith<IllegalArgumentException> {
+      reportResultCompiler.compileSetExpression(
+        setOperationWithSetOperatorTypeNotSet,
+        REPORTING_SETS.size,
+      )
     }
   }
 }


### PR DESCRIPTION
In addition to using safe operations for cache updates, this removes the attempted parallelism in set expression compilation which is likely what caused the observed concurrent writes. This also improves test failure messages for GCloudInProcessLifeOfAReportV2IntegrationTest.

Closes #3555

Issue: #3555