### PR TITLE
fix: Only use documented attributes of google_project TF data source

### DIFF
--- a/src/main/terraform/gcloud/modules/access/main.tf
+++ b/src/main/terraform/gcloud/modules/access/main.tf
@@ -23,7 +23,7 @@ module "access_internal" {
 }
 
 resource "google_project_iam_member" "access_internal_metric_writer" {
-  project = data.google_project.project.name
+  project = data.google_project.project.id
   role    = "roles/monitoring.metricWriter"
   member  = module.access_internal.iam_service_account.member
 }

--- a/src/main/terraform/gcloud/modules/cluster/main.tf
+++ b/src/main/terraform/gcloud/modules/cluster/main.tf
@@ -14,12 +14,16 @@
 
 data "google_project" "project" {}
 
+locals {
+  google_project_id = trimprefix(data.google_project.project.id, "projects/")
+}
+
 resource "google_container_cluster" "cluster" {
   name     = var.name
   location = var.location
 
   workload_identity_config {
-    workload_pool = "${data.google_project.project.project_id}.svc.id.goog"
+    workload_pool = "${local.google_project_id}.svc.id.goog"
   }
 
   database_encryption {

--- a/src/main/terraform/gcloud/modules/common/main.tf
+++ b/src/main/terraform/gcloud/modules/common/main.tf
@@ -44,7 +44,7 @@ resource "google_service_account" "gke_cluster" {
 }
 
 resource "google_project_iam_member" "node_service_account" {
-  project = data.google_project.project.name
+  project = data.google_project.project.id
   role    = "roles/container.nodeServiceAccount"
   member  = google_service_account.gke_cluster.member
 }

--- a/src/main/terraform/gcloud/modules/duchy/main.tf
+++ b/src/main/terraform/gcloud/modules/duchy/main.tf
@@ -20,24 +20,24 @@ locals {
 
   trustee_secrets_to_access = var.trustee_config != null ? [
     {
-      secret_id  = var.trustee_config.aggregator_tls_cert.secret_id
-      version    = "latest"
+      secret_id = var.trustee_config.aggregator_tls_cert.secret_id
+      version   = "latest"
     },
     {
-      secret_id  = var.trustee_config.aggregator_tls_key.secret_id
-      version    = "latest"
+      secret_id = var.trustee_config.aggregator_tls_key.secret_id
+      version   = "latest"
     },
     {
-      secret_id  = var.trustee_config.aggregator_cert_collection.secret_id
-      version    = "latest"
+      secret_id = var.trustee_config.aggregator_cert_collection.secret_id
+      version   = "latest"
     },
     {
-      secret_id  = var.trustee_config.aggregator_cs_cert.secret_id
-      version    = "latest"
+      secret_id = var.trustee_config.aggregator_cs_cert.secret_id
+      version   = "latest"
     },
     {
-      secret_id  = var.trustee_config.aggregator_cs_private.secret_id
-      version    = "latest"
+      secret_id = var.trustee_config.aggregator_cs_private.secret_id
+      version   = "latest"
     },
   ] : []
 
@@ -59,7 +59,7 @@ module "storage_user" {
 }
 
 resource "google_project_iam_member" "storage_metric_writer" {
-  project = data.google_project.project.name
+  project = data.google_project.project.id
   role    = "roles/monitoring.metricWriter"
   member  = module.storage_user.iam_service_account.member
 }
@@ -73,7 +73,7 @@ module "internal_server_user" {
 }
 
 resource "google_project_iam_member" "internal_server_metric_writer" {
-  project = data.google_project.project.name
+  project = data.google_project.project.id
   role    = "roles/monitoring.metricWriter"
   member  = module.internal_server_user.iam_service_account.member
 }
@@ -108,7 +108,7 @@ resource "google_storage_bucket_iam_member" "storage" {
 }
 
 resource "google_storage_bucket_iam_member" "trustee_mill" {
-  count  = var.trustee_config != null ? 1 : 0
+  count = var.trustee_config != null ? 1 : 0
 
   bucket = var.storage_bucket.name
   role   = "roles/storage.objectAdmin"
@@ -126,8 +126,8 @@ resource "google_compute_address" "system_v1alpha" {
 }
 
 resource "google_compute_address" "internal" {
-  name    = "${var.name}-duchy-internal"
-  address = var.internal_ip_address
+  name         = "${var.name}-duchy-internal"
+  address      = var.internal_ip_address
   address_type = "INTERNAL"
 }
 
@@ -142,16 +142,16 @@ resource "google_monitoring_dashboard" "dashboards" {
 resource "google_compute_subnetwork" "trustee_mill_subnetwork" {
   count = var.trustee_config != null ? 1 : 0
 
-  name          = "${var.name}-trustee-mill-compute-subnetwork"
-  region        = data.google_client_config.default.region
-  network       = var.trustee_mill_subnetwork_network
-  ip_cidr_range = var.trustee_mill_subnetwork_cidr_range
+  name                     = "${var.name}-trustee-mill-compute-subnetwork"
+  region                   = data.google_client_config.default.region
+  network                  = var.trustee_mill_subnetwork_network
+  ip_cidr_range            = var.trustee_mill_subnetwork_cidr_range
   private_ip_google_access = true
 }
 
 # Cloud Router for NAT gateway
 resource "google_compute_router" "trustee_mill_router" {
-  count   = var.trustee_config != null ? 1 : 0
+  count = var.trustee_config != null ? 1 : 0
 
   name    = "${var.name}-trustee-mill-compute-router"
   region  = data.google_client_config.default.region
@@ -184,7 +184,7 @@ resource "google_compute_router_nat" "trustee_mill_nat" {
 module "trustee_mill" {
   count = var.trustee_config != null ? 1 : 0
 
-  source   = "../mig"
+  source = "../mig"
 
   depends_on = [module.secrets]
 
@@ -206,11 +206,11 @@ module "trustee_mill" {
 }
 
 module "secrets" {
-  source            = "../secret"
+  source = "../secret"
 
-  for_each          = local.all_secrets
-  secret_id         = each.value.secret_id
-  secret_path       = each.value.secret_local_path
-  is_binary_format  = each.value.is_binary_format
+  for_each         = local.all_secrets
+  secret_id        = each.value.secret_id
+  secret_path      = each.value.secret_local_path
+  is_binary_format = each.value.is_binary_format
 }
 

--- a/src/main/terraform/gcloud/modules/edp-aggregator-edp-deployment/main.tf
+++ b/src/main/terraform/gcloud/modules/edp-aggregator-edp-deployment/main.tf
@@ -15,7 +15,6 @@
 data "google_project" "project" {}
 
 resource "google_kms_key_ring" "edp_key_ring" {
-  project  = data.google_project.project.name
   name     = var.kms_keyring
   location = var.location
 }
@@ -40,16 +39,15 @@ resource "google_kms_crypto_key_iam_member" "edp_sa_decrypter" {
 }
 
 resource "google_iam_workload_identity_pool" "edp_workload_identity_pool" {
-  project                           = data.google_project.project.name
-  location                          = var.location
-  workload_identity_pool_id         = var.workload_identity_pool_id
-  display_name                      = var.wip_display_name
-  description                       = "EDP workload identity pool."
-  disabled                          = false
+  location                  = var.location
+  workload_identity_pool_id = var.workload_identity_pool_id
+  display_name              = var.wip_display_name
+  description               = "EDP workload identity pool."
+  disabled                  = false
 }
 
 resource "google_service_account_iam_member" "edp_sa_workload_identity_user" {
   service_account_id = google_service_account.edp_service_account.name
-  role = "roles/iam.workloadIdentityUser"
-  member = "principalSet://iam.googleapis.com/projects/${data.google_project.project.number}/locations/global/workloadIdentityPools/${google_iam_workload_identity_pool.edp_workload_identity_pool.workload_identity_pool_id}/*"
+  role               = "roles/iam.workloadIdentityUser"
+  member             = "principalSet://iam.googleapis.com/projects/${data.google_project.project.number}/locations/global/workloadIdentityPools/${google_iam_workload_identity_pool.edp_workload_identity_pool.workload_identity_pool_id}/*"
 }

--- a/src/main/terraform/gcloud/modules/edp-aggregator/main.tf
+++ b/src/main/terraform/gcloud/modules/edp-aggregator/main.tf
@@ -16,55 +16,56 @@ data "google_client_config" "default" {}
 data "google_project" "project" {}
 
 locals {
+  google_project_id = trimprefix(data.google_project.project.id, "projects/")
 
   # IP addresses for private.googleapis.com (Private Google Access default VIPs)
   # Reference: https://cloud.google.com/vpc/docs/configure-private-google-access#ip-addr-defaults
-  private_googleapis_ipv4 = ["199.36.153.8","199.36.153.9","199.36.153.10","199.36.153.11"]
+  private_googleapis_ipv4 = ["199.36.153.8", "199.36.153.9", "199.36.153.10", "199.36.153.11"]
 
   common_secrets_to_access = [
     {
-      secret_id  = var.edpa_tee_app_tls_key.secret_id
-      version    = "latest"
+      secret_id = var.edpa_tee_app_tls_key.secret_id
+      version   = "latest"
     },
     {
-      secret_id  = var.edpa_tee_app_tls_pem.secret_id
-      version    = "latest"
+      secret_id = var.edpa_tee_app_tls_pem.secret_id
+      version   = "latest"
     },
     {
-      secret_id  = var.secure_computation_root_ca.secret_id
-      version    = "latest"
+      secret_id = var.secure_computation_root_ca.secret_id
+      version   = "latest"
     },
     {
-      secret_id  = var.trusted_root_ca_collection.secret_id
-      version    = "latest"
+      secret_id = var.trusted_root_ca_collection.secret_id
+      version   = "latest"
     },
     {
-      secret_id  = var.metadata_storage_root_ca.secret_id
-      version    = "latest"
+      secret_id = var.metadata_storage_root_ca.secret_id
+      version   = "latest"
     },
   ]
 
   edp_secrets_to_access = flatten([
     for edp_name, certs in var.edps_certs : [
       {
-        secret_id  = certs.cert_der.secret_id
-        version    = "latest"
+        secret_id = certs.cert_der.secret_id
+        version   = "latest"
       },
       {
-        secret_id  = certs.private_der.secret_id
-        version    = "latest"
+        secret_id = certs.private_der.secret_id
+        version   = "latest"
       },
       {
-        secret_id  = certs.enc_private.secret_id
-        version    = "latest"
+        secret_id = certs.enc_private.secret_id
+        version   = "latest"
       },
       {
-        secret_id  = certs.tls_key.secret_id
-        version    = "latest"
+        secret_id = certs.tls_key.secret_id
+        version   = "latest"
       },
       {
-        secret_id  = certs.tls_pem.secret_id
-        version    = "latest"
+        secret_id = certs.tls_pem.secret_id
+        version   = "latest"
       },
     ]
   ])
@@ -81,17 +82,17 @@ locals {
   ]...)
 
   all_secrets = merge(
-    { edpa_tee_app_tls_key                          = var.edpa_tee_app_tls_key },
-    { edpa_tee_app_tls_pem                          = var.edpa_tee_app_tls_pem },
-    { data_watcher_tls_key                          = var.data_watcher_tls_key },
-    { data_watcher_tls_pem                          = var.data_watcher_tls_pem },
-    { data_availability_tls_key                     = var.data_availability_tls_key },
-    { data_availability_tls_pem                     = var.data_availability_tls_pem },
-    { requisition_fetcher_tls_pem                   = var.requisition_fetcher_tls_pem },
-    { requisition_fetcher_tls_key                   = var.requisition_fetcher_tls_key },
-    { secure_computation_root_ca                    = var.secure_computation_root_ca },
-    { metadata_storage_root_ca                      = var.metadata_storage_root_ca },
-    { trusted_root_ca_collection                    = var.trusted_root_ca_collection },
+    { edpa_tee_app_tls_key = var.edpa_tee_app_tls_key },
+    { edpa_tee_app_tls_pem = var.edpa_tee_app_tls_pem },
+    { data_watcher_tls_key = var.data_watcher_tls_key },
+    { data_watcher_tls_pem = var.data_watcher_tls_pem },
+    { data_availability_tls_key = var.data_availability_tls_key },
+    { data_availability_tls_pem = var.data_availability_tls_pem },
+    { requisition_fetcher_tls_pem = var.requisition_fetcher_tls_pem },
+    { requisition_fetcher_tls_key = var.requisition_fetcher_tls_key },
+    { secure_computation_root_ca = var.secure_computation_root_ca },
+    { metadata_storage_root_ca = var.metadata_storage_root_ca },
+    { trusted_root_ca_collection = var.trusted_root_ca_collection },
     local.edps_secrets
   )
 
@@ -155,13 +156,13 @@ locals {
     "tee-env-OTEL_TRACES_EXPORTER"                  = "google_cloud_trace",
     "tee-env-OTEL_LOGS_EXPORTER"                    = "logging",
     "tee-env-OTEL_SERVICE_NAME"                     = "edpa.results_fulfiller",
-    "tee-env-OTEL_EXPORTER_GOOGLE_CLOUD_PROJECT_ID" = data.google_project.project.project_id
+    "tee-env-OTEL_EXPORTER_GOOGLE_CLOUD_PROJECT_ID" = local.google_project_id
     "tee-env-OTEL_METRIC_EXPORT_INTERVAL"           = "60000"
   }
 }
 
 module "edp_aggregator_bucket" {
-  source   = "../storage-bucket"
+  source = "../storage-bucket"
 
   name     = var.edp_aggregator_bucket_name
   location = var.edp_aggregator_buckets_location
@@ -171,18 +172,18 @@ module "edp_aggregator_bucket" {
     {
       name           = "edp7"
       prefix         = "edp/edp7/"
-      retention_days = 3650  # 10 years
+      retention_days = 3650 # 10 years
     },
     {
       name           = "edp_meta"
       prefix         = "edp/edp_meta/"
-      retention_days = 3650  # 10 years
+      retention_days = 3650 # 10 years
     },
   ]
 }
 
 module "config_files_bucket" {
-  source   = "../storage-bucket"
+  source = "../storage-bucket"
 
   name     = var.config_files_bucket_name
   location = var.edp_aggregator_buckets_location
@@ -225,134 +226,134 @@ resource "google_storage_bucket_object" "upload_results_fulfiller_population_spe
 }
 
 resource "google_project_iam_member" "eventarc_service_agent" {
-  project = data.google_project.project.project_id
+  project = data.google_project.project.id
   role    = "roles/eventarc.serviceAgent"
   member  = "serviceAccount:service-${data.google_project.project.number}@gcp-sa-eventarc.iam.gserviceaccount.com"
 }
 
 resource "google_project_iam_member" "storage_service_agent" {
-  project = data.google_project.project.project_id
+  project = data.google_project.project.id
   role    = "roles/pubsub.publisher"
   member  = "serviceAccount:service-${data.google_project.project.number}@gs-project-accounts.iam.gserviceaccount.com"
 }
 
 module "secrets" {
-  source            = "../secret"
-  for_each          = local.all_secrets
-  secret_id         = each.value.secret_id
-  secret_path       = each.value.secret_local_path
-  is_binary_format  = each.value.is_binary_format
+  source           = "../secret"
+  for_each         = local.all_secrets
+  secret_id        = each.value.secret_id
+  secret_path      = each.value.secret_local_path
+  is_binary_format = each.value.is_binary_format
 }
 
 module "data_watcher_cloud_function" {
-  source    = "../gcs-bucket-cloud-function"
+  source = "../gcs-bucket-cloud-function"
 
   depends_on = [module.secrets]
 
-  cloud_function_service_account_name           = var.data_watcher_service_account_name
-  cloud_function_trigger_service_account_name   = var.data_watcher_trigger_service_account_name
-  trigger_bucket_name                           = module.edp_aggregator_bucket.storage_bucket.name
-  terraform_service_account                     = var.terraform_service_account
-  function_name                                 = var.cloud_function_configs.data_watcher.function_name
-  entry_point                                   = var.cloud_function_configs.data_watcher.entry_point
-  extra_env_vars                                = var.cloud_function_configs.data_watcher.extra_env_vars
-  secret_mappings                               = var.cloud_function_configs.data_watcher.secret_mappings
-  uber_jar_path                                 = var.cloud_function_configs.data_watcher.uber_jar_path
-  secrets_to_access                             = [for key in local.data_watcher_secrets_access : local.all_secrets[key].secret_id]
-  trigger_event_type                            = "finalized"
+  cloud_function_service_account_name         = var.data_watcher_service_account_name
+  cloud_function_trigger_service_account_name = var.data_watcher_trigger_service_account_name
+  trigger_bucket_name                         = module.edp_aggregator_bucket.storage_bucket.name
+  terraform_service_account                   = var.terraform_service_account
+  function_name                               = var.cloud_function_configs.data_watcher.function_name
+  entry_point                                 = var.cloud_function_configs.data_watcher.entry_point
+  extra_env_vars                              = var.cloud_function_configs.data_watcher.extra_env_vars
+  secret_mappings                             = var.cloud_function_configs.data_watcher.secret_mappings
+  uber_jar_path                               = var.cloud_function_configs.data_watcher.uber_jar_path
+  secrets_to_access                           = [for key in local.data_watcher_secrets_access : local.all_secrets[key].secret_id]
+  trigger_event_type                          = "finalized"
 }
 
 module "data_watcher_delete_cloud_function" {
-  source    = "../gcs-bucket-cloud-function"
+  source = "../gcs-bucket-cloud-function"
 
   depends_on = [module.secrets]
 
-  cloud_function_service_account_name           = var.data_watcher_delete_service_account_name
-  cloud_function_trigger_service_account_name   = var.data_watcher_delete_trigger_service_account_name
-  trigger_bucket_name                           = module.edp_aggregator_bucket.storage_bucket.name
-  terraform_service_account                     = var.terraform_service_account
-  function_name                                 = var.cloud_function_configs.data_watcher_delete.function_name
-  entry_point                                   = var.cloud_function_configs.data_watcher_delete.entry_point
-  extra_env_vars                                = var.cloud_function_configs.data_watcher_delete.extra_env_vars
-  secret_mappings                               = var.cloud_function_configs.data_watcher_delete.secret_mappings
-  uber_jar_path                                 = var.cloud_function_configs.data_watcher_delete.uber_jar_path
-  secrets_to_access                             = [for key in local.data_watcher_delete_secrets_access : local.all_secrets[key].secret_id]
-  trigger_event_type                            = "deleted"
+  cloud_function_service_account_name         = var.data_watcher_delete_service_account_name
+  cloud_function_trigger_service_account_name = var.data_watcher_delete_trigger_service_account_name
+  trigger_bucket_name                         = module.edp_aggregator_bucket.storage_bucket.name
+  terraform_service_account                   = var.terraform_service_account
+  function_name                               = var.cloud_function_configs.data_watcher_delete.function_name
+  entry_point                                 = var.cloud_function_configs.data_watcher_delete.entry_point
+  extra_env_vars                              = var.cloud_function_configs.data_watcher_delete.extra_env_vars
+  secret_mappings                             = var.cloud_function_configs.data_watcher_delete.secret_mappings
+  uber_jar_path                               = var.cloud_function_configs.data_watcher_delete.uber_jar_path
+  secrets_to_access                           = [for key in local.data_watcher_delete_secrets_access : local.all_secrets[key].secret_id]
+  trigger_event_type                          = "deleted"
 }
 
 module "requisition_fetcher_cloud_function" {
-  source    = "../http-cloud-function"
+  source = "../http-cloud-function"
 
   depends_on = [module.secrets]
 
-  http_cloud_function_service_account_name  = var.requisition_fetcher_service_account_name
-  terraform_service_account                 = var.terraform_service_account
-  function_name                             = var.cloud_function_configs.requisition_fetcher.function_name
-  entry_point                               = var.cloud_function_configs.requisition_fetcher.entry_point
-  extra_env_vars                            = var.cloud_function_configs.requisition_fetcher.extra_env_vars
-  secret_mappings                           = var.cloud_function_configs.requisition_fetcher.secret_mappings
-  uber_jar_path                             = var.cloud_function_configs.requisition_fetcher.uber_jar_path
-  secrets_to_access                         = [for key in local.requisition_fetcher_secrets_access : local.all_secrets[key].secret_id]
+  http_cloud_function_service_account_name = var.requisition_fetcher_service_account_name
+  terraform_service_account                = var.terraform_service_account
+  function_name                            = var.cloud_function_configs.requisition_fetcher.function_name
+  entry_point                              = var.cloud_function_configs.requisition_fetcher.entry_point
+  extra_env_vars                           = var.cloud_function_configs.requisition_fetcher.extra_env_vars
+  secret_mappings                          = var.cloud_function_configs.requisition_fetcher.secret_mappings
+  uber_jar_path                            = var.cloud_function_configs.requisition_fetcher.uber_jar_path
+  secrets_to_access                        = [for key in local.requisition_fetcher_secrets_access : local.all_secrets[key].secret_id]
 }
 
 module "requisition_fetcher_cloud_scheduler" {
-  source                        = "../cloud-scheduler"
-  terraform_service_account     = var.terraform_service_account
-  scheduler_config              = var.requisition_fetcher_scheduler_config
-  depends_on                    = [module.requisition_fetcher_cloud_function]
+  source                    = "../cloud-scheduler"
+  terraform_service_account = var.terraform_service_account
+  scheduler_config          = var.requisition_fetcher_scheduler_config
+  depends_on                = [module.requisition_fetcher_cloud_function]
 }
 
 module "event_group_sync_cloud_function" {
-  source    = "../http-cloud-function"
+  source = "../http-cloud-function"
 
   depends_on = [module.secrets]
 
-  http_cloud_function_service_account_name  = var.event_group_sync_service_account_name
-  terraform_service_account                 = var.terraform_service_account
-  function_name                             = var.cloud_function_configs.event_group_sync.function_name
-  entry_point                               = var.cloud_function_configs.event_group_sync.entry_point
-  extra_env_vars                            = var.cloud_function_configs.event_group_sync.extra_env_vars
-  secret_mappings                           = var.cloud_function_configs.event_group_sync.secret_mappings
-  uber_jar_path                             = var.cloud_function_configs.event_group_sync.uber_jar_path
-  secrets_to_access                         = [for key in local.event_group_sync_secrets_access : local.all_secrets[key].secret_id]
+  http_cloud_function_service_account_name = var.event_group_sync_service_account_name
+  terraform_service_account                = var.terraform_service_account
+  function_name                            = var.cloud_function_configs.event_group_sync.function_name
+  entry_point                              = var.cloud_function_configs.event_group_sync.entry_point
+  extra_env_vars                           = var.cloud_function_configs.event_group_sync.extra_env_vars
+  secret_mappings                          = var.cloud_function_configs.event_group_sync.secret_mappings
+  uber_jar_path                            = var.cloud_function_configs.event_group_sync.uber_jar_path
+  secrets_to_access                        = [for key in local.event_group_sync_secrets_access : local.all_secrets[key].secret_id]
 }
 
 module "data_availability_sync_cloud_function" {
-  source    = "../http-cloud-function"
+  source = "../http-cloud-function"
 
   depends_on = [module.secrets]
 
-  http_cloud_function_service_account_name  = var.data_availability_sync_service_account_name
-  terraform_service_account                 = var.terraform_service_account
-  function_name                             = var.cloud_function_configs.data_availability_sync.function_name
-  entry_point                               = var.cloud_function_configs.data_availability_sync.entry_point
-  extra_env_vars                            = var.cloud_function_configs.data_availability_sync.extra_env_vars
-  secret_mappings                           = var.cloud_function_configs.data_availability_sync.secret_mappings
-  uber_jar_path                             = var.cloud_function_configs.data_availability_sync.uber_jar_path
-  secrets_to_access                         = [for key in local.data_availability_sync_secrets_access : local.all_secrets[key].secret_id]
+  http_cloud_function_service_account_name = var.data_availability_sync_service_account_name
+  terraform_service_account                = var.terraform_service_account
+  function_name                            = var.cloud_function_configs.data_availability_sync.function_name
+  entry_point                              = var.cloud_function_configs.data_availability_sync.entry_point
+  extra_env_vars                           = var.cloud_function_configs.data_availability_sync.extra_env_vars
+  secret_mappings                          = var.cloud_function_configs.data_availability_sync.secret_mappings
+  uber_jar_path                            = var.cloud_function_configs.data_availability_sync.uber_jar_path
+  secrets_to_access                        = [for key in local.data_availability_sync_secrets_access : local.all_secrets[key].secret_id]
 }
 
 module "data_availability_cleanup_cloud_function" {
-  source    = "../http-cloud-function"
+  source = "../http-cloud-function"
 
   depends_on = [module.secrets]
 
-  http_cloud_function_service_account_name  = var.data_availability_cleanup_service_account_name
-  terraform_service_account                 = var.terraform_service_account
-  function_name                             = var.cloud_function_configs.data_availability_cleanup.function_name
-  entry_point                               = var.cloud_function_configs.data_availability_cleanup.entry_point
-  extra_env_vars                            = var.cloud_function_configs.data_availability_cleanup.extra_env_vars
-  secret_mappings                           = var.cloud_function_configs.data_availability_cleanup.secret_mappings
-  uber_jar_path                             = var.cloud_function_configs.data_availability_cleanup.uber_jar_path
-  secrets_to_access                         = [for key in local.data_availability_cleanup_secrets_access : local.all_secrets[key].secret_id]
+  http_cloud_function_service_account_name = var.data_availability_cleanup_service_account_name
+  terraform_service_account                = var.terraform_service_account
+  function_name                            = var.cloud_function_configs.data_availability_cleanup.function_name
+  entry_point                              = var.cloud_function_configs.data_availability_cleanup.entry_point
+  extra_env_vars                           = var.cloud_function_configs.data_availability_cleanup.extra_env_vars
+  secret_mappings                          = var.cloud_function_configs.data_availability_cleanup.secret_mappings
+  uber_jar_path                            = var.cloud_function_configs.data_availability_cleanup.uber_jar_path
+  secrets_to_access                        = [for key in local.data_availability_cleanup_secrets_access : local.all_secrets[key].secret_id]
 }
 
 module "result_fulfiller_queue" {
-  source   = "../pubsub"
+  source = "../pubsub"
 
-  topic_name              = var.requisition_fulfiller_config.queue.topic_name
-  subscription_name       = var.requisition_fulfiller_config.queue.subscription_name
-  ack_deadline_seconds    = var.requisition_fulfiller_config.queue.ack_deadline_seconds
+  topic_name           = var.requisition_fulfiller_config.queue.topic_name
+  subscription_name    = var.requisition_fulfiller_config.queue.subscription_name
+  ack_deadline_seconds = var.requisition_fulfiller_config.queue.ack_deadline_seconds
 }
 
 resource "google_pubsub_topic_iam_member" "publisher" {
@@ -362,7 +363,7 @@ resource "google_pubsub_topic_iam_member" "publisher" {
 }
 
 module "result_fulfiller_tee_app" {
-  source   = "../mig"
+  source = "../mig"
 
   depends_on = [module.secrets]
 
@@ -385,8 +386,8 @@ module "result_fulfiller_tee_app" {
   config_storage_bucket         = module.config_files_bucket.storage_bucket.name
   subnetwork_name               = google_compute_subnetwork.private_subnetwork.name
   # TODO(world-federation-of-advertisers/cross-media-measurement#2924): Rename `results_fulfiller` into `results-fulfiller`
-  tee_signed_image_repo         = "ghcr.io/world-federation-of-advertisers/edp-aggregator/results_fulfiller"
-  extra_metadata                = local.otel_metadata
+  tee_signed_image_repo = "ghcr.io/world-federation-of-advertisers/edp-aggregator/results_fulfiller"
+  extra_metadata        = local.otel_metadata
 }
 
 resource "google_storage_bucket_iam_member" "result_fulfiller_storage_viewer" {
@@ -403,16 +404,16 @@ resource "google_storage_bucket_iam_member" "result_fulfiller_storage_creator" {
 
 resource "google_storage_bucket_iam_member" "data_availability_storage_object_user" {
   depends_on = [module.data_availability_sync_cloud_function]
-  bucket = module.edp_aggregator_bucket.storage_bucket.name
-  role   = "roles/storage.objectUser"
-  member = "serviceAccount:${module.data_availability_sync_cloud_function.cloud_function_service_account.email}"
+  bucket     = module.edp_aggregator_bucket.storage_bucket.name
+  role       = "roles/storage.objectUser"
+  member     = "serviceAccount:${module.data_availability_sync_cloud_function.cloud_function_service_account.email}"
 }
 
 resource "google_storage_bucket_iam_member" "data_availability_cleanup_storage_viewer" {
   depends_on = [module.data_availability_cleanup_cloud_function]
-  bucket = module.edp_aggregator_bucket.storage_bucket.name
-  role   = "roles/storage.objectViewer"
-  member = "serviceAccount:${module.data_availability_cleanup_cloud_function.cloud_function_service_account.email}"
+  bucket     = module.edp_aggregator_bucket.storage_bucket.name
+  role       = "roles/storage.objectViewer"
+  member     = "serviceAccount:${module.data_availability_cleanup_cloud_function.cloud_function_service_account.email}"
 }
 
 resource "google_storage_bucket_iam_binding" "aggregator_storage_admin" {
@@ -450,16 +451,16 @@ resource "google_storage_bucket_iam_member" "results_fulfiller_config_storage_vi
 
 resource "google_cloud_run_service_iam_member" "event_group_sync_invoker" {
   depends_on = [module.event_group_sync_cloud_function]
-  service  = var.event_group_sync_function_name
-  role     = "roles/run.invoker"
-  member   = "serviceAccount:${module.data_watcher_cloud_function.cloud_function_service_account.email}"
+  service    = var.event_group_sync_function_name
+  role       = "roles/run.invoker"
+  member     = "serviceAccount:${module.data_watcher_cloud_function.cloud_function_service_account.email}"
 }
 
 resource "google_cloud_run_service_iam_member" "data_availability_sync_invoker" {
   depends_on = [module.data_availability_sync_cloud_function]
-  service  = var.data_availability_sync_function_name
-  role     = "roles/run.invoker"
-  member   = "serviceAccount:${module.data_watcher_cloud_function.cloud_function_service_account.email}"
+  service    = var.data_availability_sync_function_name
+  role       = "roles/run.invoker"
+  member     = "serviceAccount:${module.data_watcher_cloud_function.cloud_function_service_account.email}"
 }
 
 resource "google_cloud_run_service_iam_member" "data_availability_cleanup_invoker" {
@@ -518,7 +519,7 @@ resource "google_dns_managed_zone" "private_gcs" {
 
   private_visibility_config {
     networks {
-      network_url = "projects/${data.google_project.project.project_id}/global/networks/default"
+      network_url = "${data.google_project.project.id}/global/networks/default"
     }
   }
 }
@@ -551,7 +552,7 @@ module "edp_aggregator_internal" {
 }
 
 resource "google_project_iam_member" "edp_aggregator_internal_metric_writer" {
-  project = data.google_project.project.name
+  project = data.google_project.project.id
   role    = "roles/monitoring.metricWriter"
   member  = module.edp_aggregator_internal.iam_service_account.member
 }
@@ -580,21 +581,21 @@ resource "google_compute_address" "edp_aggregator_api_server" {
 
 resource "google_project_iam_member" "telemetry_log_writer" {
   for_each = local.service_accounts
-  project  = data.google_project.project.project_id
+  project  = data.google_project.project.id
   role     = "roles/logging.logWriter"
   member   = "serviceAccount:${each.value}"
 }
 
 resource "google_project_iam_member" "telemetry_metric_writer" {
   for_each = local.service_accounts
-  project  = data.google_project.project.project_id
+  project  = data.google_project.project.id
   role     = "roles/monitoring.metricWriter"
   member   = "serviceAccount:${each.value}"
 }
 
 resource "google_project_iam_member" "telemetry_trace_agent" {
   for_each = local.service_accounts
-  project  = data.google_project.project.project_id
+  project  = data.google_project.project.id
   role     = "roles/cloudtrace.agent"
   member   = "serviceAccount:${each.value}"
 }

--- a/src/main/terraform/gcloud/modules/gcs-bucket-cloud-function/main.tf
+++ b/src/main/terraform/gcloud/modules/gcs-bucket-cloud-function/main.tf
@@ -50,13 +50,13 @@ resource "google_storage_bucket_iam_member" "cloud_function_object_creator" {
 }
 
 resource "google_project_iam_member" "trigger_event_receiver" {
-  project = data.google_project.project.project_id
+  project = data.google_project.project.id
   role    = "roles/eventarc.eventReceiver"
   member  = "serviceAccount:${google_service_account.cloud_function_trigger_service_account.email}"
 }
 
 resource "google_project_iam_member" "trigger_run_invoker" {
-  project = data.google_project.project.project_id
+  project = data.google_project.project.id
   role    = "roles/run.invoker"
   member  = "serviceAccount:${google_service_account.cloud_function_trigger_service_account.email}"
 }

--- a/src/main/terraform/gcloud/modules/kingdom/main.tf
+++ b/src/main/terraform/gcloud/modules/kingdom/main.tf
@@ -23,7 +23,7 @@ module "kingdom_internal" {
 }
 
 resource "google_project_iam_member" "kingdom_internal_metric_writer" {
-  project = data.google_project.project.name
+  project = data.google_project.project.id
   role    = "roles/monitoring.metricWriter"
   member  = module.kingdom_internal.iam_service_account.member
 }
@@ -401,7 +401,7 @@ resource "google_bigquery_dataset_iam_member" "bigquery_writer" {
 }
 
 resource "google_project_iam_member" "bigquery_job_user" {
-  project = data.google_project.project.project_id
+  project = data.google_project.project.id
   role    = "roles/bigquery.jobUser"
   member  = module.kingdom_operational_metrics.iam_service_account.member
 }
@@ -411,5 +411,4 @@ resource "google_monitoring_dashboard" "dashboards" {
   for_each = toset(var.dashboard_json_files)
 
   dashboard_json = file("${path.module}/${each.value}")
-  project        = data.google_project.project.project_id
 }

--- a/src/main/terraform/gcloud/modules/mig/main.tf
+++ b/src/main/terraform/gcloud/modules/mig/main.tf
@@ -18,13 +18,13 @@ locals {
 
   metadata_map = merge(
     {
-      "tee-signed-image-repos"                        = var.tee_signed_image_repo
-      "tee-image-reference"                           = var.docker_image
-      "tee-cmd"                                       = jsonencode(var.tee_cmd)
+      "tee-signed-image-repos" = var.tee_signed_image_repo
+      "tee-image-reference"    = var.docker_image
+      "tee-cmd"                = jsonencode(var.tee_cmd)
 
-      "google-logging-enabled"                        = "true"
-      "google-monitoring-enabled"                     = "true"
-      "tee-container-log-redirect"                    = "true"
+      "google-logging-enabled"     = "true"
+      "google-monitoring-enabled"  = "true"
+      "tee-container-log-redirect" = "true"
     },
     var.config_storage_bucket == null ? {} : {
       "tee-env-EDPA_CONFIG_STORAGE_BUCKET" = "gs://${var.config_storage_bucket}"
@@ -51,9 +51,9 @@ resource "google_service_account_iam_member" "allow_terraform_to_use_mig_sa" {
 resource "google_pubsub_subscription_iam_member" "mig_subscriber" {
   count = var.subscription_id != null ? 1 : 0
 
-  subscription  = var.subscription_id
-  role          = "roles/pubsub.subscriber"
-  member        = "serviceAccount:${google_service_account.mig_service_account.email}"
+  subscription = var.subscription_id
+  role         = "roles/pubsub.subscriber"
+  member       = "serviceAccount:${google_service_account.mig_service_account.email}"
 }
 
 resource "google_secret_manager_secret_iam_member" "mig_sa_secret_accessor" {
@@ -65,31 +65,31 @@ resource "google_secret_manager_secret_iam_member" "mig_sa_secret_accessor" {
 }
 
 resource "google_project_iam_member" "mig_sa_user" {
-  project = data.google_project.project.name
+  project = data.google_project.project.id
   role    = "roles/iam.serviceAccountUser"
   member  = "serviceAccount:${google_service_account.mig_service_account.email}"
 }
 
 resource "google_project_iam_member" "confidential_workload_user" {
-  project  = data.google_project.project.name
-  role     = "roles/confidentialcomputing.workloadUser"
-  member   = "serviceAccount:${google_service_account.mig_service_account.email}"
+  project = data.google_project.project.id
+  role    = "roles/confidentialcomputing.workloadUser"
+  member  = "serviceAccount:${google_service_account.mig_service_account.email}"
 }
 
 resource "google_project_iam_member" "mig_log_writer" {
-  project = data.google_project.project.name
+  project = data.google_project.project.id
   role    = "roles/logging.logWriter"
   member  = "serviceAccount:${google_service_account.mig_service_account.email}"
 }
 
 resource "google_project_iam_member" "mig_metric_writer" {
-  project = data.google_project.project.name
+  project = data.google_project.project.id
   role    = "roles/monitoring.metricWriter"
   member  = "serviceAccount:${google_service_account.mig_service_account.email}"
 }
 
 resource "google_project_iam_member" "mig_trace_agent" {
-  project = data.google_project.project.name
+  project = data.google_project.project.id
   role    = "roles/cloudtrace.agent"
   member  = "serviceAccount:${google_service_account.mig_service_account.email}"
 }
@@ -137,15 +137,15 @@ resource "google_compute_instance_template" "confidential_vm_template" {
   service_account {
     email = google_service_account.mig_service_account.email
     scopes = [
-        "https://www.googleapis.com/auth/cloud-platform",
-        "https://www.googleapis.com/auth/pubsub"
+      "https://www.googleapis.com/auth/cloud-platform",
+      "https://www.googleapis.com/auth/pubsub"
     ]
   }
 }
 
 resource "google_compute_region_instance_group_manager" "mig" {
-  name                    = var.managed_instance_group_name
-  base_instance_name      = var.base_instance_name
+  name               = var.managed_instance_group_name
+  base_instance_name = var.base_instance_name
   version {
     instance_template = google_compute_instance_template.confidential_vm_template.id
   }

--- a/src/main/terraform/gcloud/modules/pubsub/main.tf
+++ b/src/main/terraform/gcloud/modules/pubsub/main.tf
@@ -15,12 +15,10 @@
 data "google_project" "project" {}
 
 resource "google_pubsub_topic" "topic" {
-  project = data.google_project.project.name
-  name    = var.topic_name
+  name = var.topic_name
 }
 
 resource "google_pubsub_topic" "dead_letter_topic" {
-  project = data.google_project.project.name
   name = "${var.topic_name}-dlq"
 }
 
@@ -41,8 +39,8 @@ resource "google_pubsub_subscription" "subscription" {
 }
 
 resource "google_pubsub_topic_iam_member" "dead_letter_writer" {
-  topic = google_pubsub_topic.dead_letter_topic.name
-  role  = "roles/pubsub.publisher"
+  topic  = google_pubsub_topic.dead_letter_topic.name
+  role   = "roles/pubsub.publisher"
   member = "serviceAccount:service-${data.google_project.project.number}@gcp-sa-pubsub.iam.gserviceaccount.com"
 }
 

--- a/src/main/terraform/gcloud/modules/reporting/main.tf
+++ b/src/main/terraform/gcloud/modules/reporting/main.tf
@@ -30,7 +30,7 @@ module "reporting_internal" {
 }
 
 resource "google_project_iam_member" "reporting_internal_metric_writer" {
-  project = data.google_project.project.name
+  project = data.google_project.project.id
   role    = "roles/monitoring.metricWriter"
   member  = module.reporting_internal.iam_service_account.member
 }
@@ -42,13 +42,13 @@ resource "google_sql_user" "reporting_internal" {
 }
 
 resource "google_project_iam_member" "sql_user" {
-  project = data.google_project.project.name
+  project = data.google_project.project.id
   role    = "roles/cloudsql.instanceUser"
   member  = module.reporting_internal.iam_service_account.member
 }
 
 resource "google_project_iam_member" "sql_client" {
-  project = data.google_project.project.name
+  project = data.google_project.project.id
   role    = "roles/cloudsql.client"
   member  = module.reporting_internal.iam_service_account.member
 }
@@ -97,6 +97,5 @@ resource "google_monitoring_dashboard" "dashboards" {
   for_each = toset(var.dashboard_json_files)
 
   dashboard_json = file("${path.module}/${each.value}")
-  project        = data.google_project.project.project_id
 }
 

--- a/src/main/terraform/gcloud/modules/secure-computation/main.tf
+++ b/src/main/terraform/gcloud/modules/secure-computation/main.tf
@@ -23,7 +23,7 @@ module "secure_computation_internal" {
 }
 
 resource "google_project_iam_member" "secure_computation_internal_metric_writer" {
-  project = data.google_project.project.name
+  project = data.google_project.project.id
   role    = "roles/monitoring.metricWriter"
   member  = module.secure_computation_internal.iam_service_account.member
 }

--- a/src/main/terraform/gcloud/modules/simulator/main.tf
+++ b/src/main/terraform/gcloud/modules/simulator/main.tf
@@ -17,7 +17,7 @@ data "google_project" "project" {}
 locals {
   kms_keyring_name                = "${var.simulator_name}-key-ring"
   kms_key_name                    = "${var.simulator_name}-kek"
-  edp_service_account_name        = "${var.simulator_name}"
+  edp_service_account_name        = var.simulator_name
   tee_decrypter_account_name      = "${var.simulator_name}-kms-decrypt"
   workload_identity_pool_id       = "${var.simulator_name}-wip"
   workload_identity_pool_name     = "${var.simulator_name}-wip"
@@ -45,7 +45,6 @@ module "workload_identity_binding" {
 }
 
 resource "google_kms_key_ring" "edp_key_ring" {
-  project  = data.google_project.project.name
   name     = local.kms_keyring_name
   location = var.key_ring_location
 }
@@ -70,11 +69,10 @@ resource "google_kms_crypto_key_iam_member" "tee_sa_decrypter" {
 }
 
 resource "google_iam_workload_identity_pool" "edp_workload_identity_pool" {
-  project                           = data.google_project.project.name
-  workload_identity_pool_id         = local.workload_identity_pool_id
-  display_name                      = local.workload_identity_pool_name
-  description                       = "EDP workload identity pool for ${var.simulator_name}"
-  disabled                          = false
+  workload_identity_pool_id = local.workload_identity_pool_id
+  display_name              = local.workload_identity_pool_name
+  description               = "EDP workload identity pool for ${var.simulator_name}"
+  disabled                  = false
 }
 
 resource "google_iam_workload_identity_pool_provider" "oidc_provider" {

--- a/src/main/terraform/gcloud/modules/workload-identity-user/main.tf
+++ b/src/main/terraform/gcloud/modules/workload-identity-user/main.tf
@@ -12,13 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+data "google_project" "project" {}
+
 locals {
-  workload_pool       = "${data.google_project.project.name}.svc.id.goog"
+  google_project_id   = trimprefix(data.google_project.project.id, "projects/")
+  workload_pool       = "${local.google_project_id}.svc.id.goog"
   member              = "serviceAccount:${local.workload_pool}[${var.cluster_namespace}/${var.k8s_service_account_name}]"
   iam_service_account = try(google_service_account.iam[0], var.iam_service_account)
 }
-
-data "google_project" "project" {}
 
 resource "google_service_account" "iam" {
   count = var.iam_service_account == null ? 1 : 0


### PR DESCRIPTION
`project_id` and `name` are documented as arguments on the resource but not as attributes. Therefore they are not guaranteed to be available on the data source.