### PR TITLE
fix: Ensure error info and messages are set for ReportingSets service

### DIFF
--- a/src/main/kotlin/org/wfanet/measurement/reporting/service/api/BUILD.bazel
+++ b/src/main/kotlin/org/wfanet/measurement/reporting/service/api/BUILD.bazel
@@ -25,7 +25,9 @@ kt_jvm_library(
     srcs = ["Errors.kt"],
     deps = [
         "//src/main/kotlin/org/wfanet/measurement/common/grpc:error_info",
+        "//src/main/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha:resource_key",
         "//src/main/kotlin/org/wfanet/measurement/reporting/service/internal:errors",
+        "//src/main/kotlin/org/wfanet/measurement/reporting/service/internal:internal_exception",
         "//src/main/proto/google/rpc:error_details_kt_jvm_proto",
         "//src/main/proto/wfa/measurement/reporting/v2alpha:metric_kt_jvm_proto",
         "@wfa_common_jvm//imports/java/io/grpc:api",

--- a/src/main/proto/wfa/measurement/reporting/README.md
+++ b/src/main/proto/wfa/measurement/reporting/README.md
@@ -1,0 +1,32 @@
+# Reporting API Definition
+
+This API definition attempts to follow the
+[API Improvement Proposals (AIPs)](https://google.aip.dev/) with the following
+notable exceptions:
+
+*   List methods which provide filtering use a structured message rather than
+    the filtering language defined in
+    [AIP-160: Filtering](https://google.aip.dev/160)
+*   List methods which provide ordering use a structured message rather than the
+    language defined in
+    [AIP-132: Standard methods: List](https://google.aip.dev/132#ordering)
+
+## Resource IDs
+
+The format of a resource ID is documented either on the `name` field of the
+resource type or on the `{resource}_id` field of the corresponding Create
+request.
+
+## Errors
+
+Following [AIP-193](https://google.aip.dev/193), methods result in a gRPC Status
+when an API error occurs. In addition to the canonical status code, there may be
+an `ErrorInfo` with a reason within the `reporting.halo-cmm.org` domain.
+
+### General Reasons
+
+Any method may return an error with one of the following reasons even if not
+listed in the specific method documentation:
+
+*   `REQUIRED_FIELD_NOT_SET`
+*   `INVALID_FIELD_VALUE`

--- a/src/main/proto/wfa/measurement/reporting/v2alpha/reporting_sets_service.proto
+++ b/src/main/proto/wfa/measurement/reporting/v2alpha/reporting_sets_service.proto
@@ -30,6 +30,9 @@ option go_package = "github.com/world-federation-of-advertisers/cross-media-meas
 // Service for interacting with `ReportingSet` resources.
 service ReportingSets {
   // Lists `ReportingSet`s.
+  //
+  // Error reasons:
+  // * `ARGUMENT_CHANGED_IN_REQUEST_FOR_NEXT_PAGE`
   rpc ListReportingSets(ListReportingSetsRequest)
       returns (ListReportingSetsResponse) {
     option (google.api.http) = {
@@ -39,6 +42,9 @@ service ReportingSets {
   }
 
   // Returns the `ReportingSet` with the specified resource key.
+  //
+  // Error reasons:
+  // * `REPORTING_SET_NOT_FOUND`
   rpc GetReportingSet(GetReportingSetRequest) returns (ReportingSet) {
     option (google.api.http) = {
       get: "/v2alpha/{name=measurementConsumers/*/reportingSets/*}"
@@ -47,6 +53,12 @@ service ReportingSets {
   }
 
   // Creates a `ReportingSet`.
+  //
+  // Error reasons:
+  // * `CAMPAIGN_GROUP_INVALID`
+  // * `MEASUREMENT_CONSUMER_NOT_FOUND`
+  // * `REPORTING_SET_ALREADY_EXISTS`
+  // * `REPORTING_SET_NOT_FOUND`
   rpc CreateReportingSet(CreateReportingSetRequest) returns (ReportingSet) {
     option (google.api.http) = {
       post: "/v2alpha/{parent=measurementConsumers/*}/reportingSets"

--- a/src/test/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/ReportingSetsServiceTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/ReportingSetsServiceTest.kt
@@ -471,13 +471,24 @@ class ReportingSetsServiceTest {
       reportingSet = ROOT_COMPOSITE_REPORTING_SET.copy { clearName() }
       reportingSetId = "reporting-set-id"
     }
+
     val exception =
       assertFailsWith<StatusRuntimeException> {
         withPrincipalAndScopes(PRINCIPAL, SCOPES) {
           runBlocking { service.createReportingSet(request) }
         }
       }
-    assertThat(exception.status.code).isEqualTo(Status.Code.INVALID_ARGUMENT)
+
+    assertThat(exception).status().code().isEqualTo(Status.Code.INVALID_ARGUMENT)
+    assertThat(exception)
+      .errorInfo()
+      .isEqualTo(
+        errorInfo {
+          domain = Errors.DOMAIN
+          reason = Errors.Reason.REQUIRED_FIELD_NOT_SET.name
+          metadata[Errors.Metadata.FIELD_NAME.key] = "parent"
+        }
+      )
   }
 
   @Test
@@ -486,13 +497,24 @@ class ReportingSetsServiceTest {
       parent = MEASUREMENT_CONSUMER_KEYS.first().toName()
       reportingSet = ROOT_COMPOSITE_REPORTING_SET.copy { clearName() }
     }
+
     val exception =
       assertFailsWith<StatusRuntimeException> {
         withPrincipalAndScopes(PRINCIPAL, SCOPES) {
           runBlocking { service.createReportingSet(request) }
         }
       }
-    assertThat(exception.status.code).isEqualTo(Status.Code.INVALID_ARGUMENT)
+
+    assertThat(exception).status().code().isEqualTo(Status.Code.INVALID_ARGUMENT)
+    assertThat(exception)
+      .errorInfo()
+      .isEqualTo(
+        errorInfo {
+          domain = Errors.DOMAIN
+          reason = Errors.Reason.REQUIRED_FIELD_NOT_SET.name
+          metadata[Errors.Metadata.FIELD_NAME.key] = "reporting_set_id"
+        }
+      )
   }
 
   @Test
@@ -502,13 +524,24 @@ class ReportingSetsServiceTest {
       reportingSet = ROOT_COMPOSITE_REPORTING_SET.copy { clearName() }
       reportingSetId = "1s"
     }
+
     val exception =
       assertFailsWith<StatusRuntimeException> {
         withPrincipalAndScopes(PRINCIPAL, SCOPES) {
           runBlocking { service.createReportingSet(request) }
         }
       }
-    assertThat(exception.status.code).isEqualTo(Status.Code.INVALID_ARGUMENT)
+
+    assertThat(exception).status().code().isEqualTo(Status.Code.INVALID_ARGUMENT)
+    assertThat(exception)
+      .errorInfo()
+      .isEqualTo(
+        errorInfo {
+          domain = Errors.DOMAIN
+          reason = Errors.Reason.INVALID_FIELD_VALUE.name
+          metadata[Errors.Metadata.FIELD_NAME.key] = "reporting_set_id"
+        }
+      )
   }
 
   @Test
@@ -518,13 +551,24 @@ class ReportingSetsServiceTest {
       reportingSet = ROOT_COMPOSITE_REPORTING_SET.copy { clearName() }
       reportingSetId = "s".repeat(100)
     }
+
     val exception =
       assertFailsWith<StatusRuntimeException> {
         withPrincipalAndScopes(PRINCIPAL, SCOPES) {
           runBlocking { service.createReportingSet(request) }
         }
       }
-    assertThat(exception.status.code).isEqualTo(Status.Code.INVALID_ARGUMENT)
+
+    assertThat(exception).status().code().isEqualTo(Status.Code.INVALID_ARGUMENT)
+    assertThat(exception)
+      .errorInfo()
+      .isEqualTo(
+        errorInfo {
+          domain = Errors.DOMAIN
+          reason = Errors.Reason.INVALID_FIELD_VALUE.name
+          metadata[Errors.Metadata.FIELD_NAME.key] = "reporting_set_id"
+        }
+      )
   }
 
   @Test
@@ -534,13 +578,24 @@ class ReportingSetsServiceTest {
       reportingSet = ROOT_COMPOSITE_REPORTING_SET.copy { clearName() }
       reportingSetId = "contain_invalid_char"
     }
+
     val exception =
       assertFailsWith<StatusRuntimeException> {
         withPrincipalAndScopes(PRINCIPAL, SCOPES) {
           runBlocking { service.createReportingSet(request) }
         }
       }
-    assertThat(exception.status.code).isEqualTo(Status.Code.INVALID_ARGUMENT)
+
+    assertThat(exception).status().code().isEqualTo(Status.Code.INVALID_ARGUMENT)
+    assertThat(exception)
+      .errorInfo()
+      .isEqualTo(
+        errorInfo {
+          domain = Errors.DOMAIN
+          reason = Errors.Reason.INVALID_FIELD_VALUE.name
+          metadata[Errors.Metadata.FIELD_NAME.key] = "reporting_set_id"
+        }
+      )
   }
 
   @Test
@@ -549,13 +604,24 @@ class ReportingSetsServiceTest {
       parent = MEASUREMENT_CONSUMER_KEYS.first().toName()
       reportingSetId = "reporting-set-id"
     }
+
     val exception =
       assertFailsWith<StatusRuntimeException> {
         withPrincipalAndScopes(PRINCIPAL, SCOPES) {
           runBlocking { service.createReportingSet(request) }
         }
       }
-    assertThat(exception.status.code).isEqualTo(Status.Code.INVALID_ARGUMENT)
+
+    assertThat(exception).status().code().isEqualTo(Status.Code.INVALID_ARGUMENT)
+    assertThat(exception)
+      .errorInfo()
+      .isEqualTo(
+        errorInfo {
+          domain = Errors.DOMAIN
+          reason = Errors.Reason.REQUIRED_FIELD_NOT_SET.name
+          metadata[Errors.Metadata.FIELD_NAME.key] = "reporting_set"
+        }
+      )
   }
 
   @Test
@@ -569,13 +635,24 @@ class ReportingSetsServiceTest {
         }
       reportingSetId = "reporting-set-id"
     }
+
     val exception =
       assertFailsWith<StatusRuntimeException> {
         withPrincipalAndScopes(PRINCIPAL, SCOPES) {
           runBlocking { service.createReportingSet(request) }
         }
       }
-    assertThat(exception.status.code).isEqualTo(Status.Code.INVALID_ARGUMENT)
+
+    assertThat(exception).status().code().isEqualTo(Status.Code.INVALID_ARGUMENT)
+    assertThat(exception)
+      .errorInfo()
+      .isEqualTo(
+        errorInfo {
+          domain = Errors.DOMAIN
+          reason = Errors.Reason.REQUIRED_FIELD_NOT_SET.name
+          metadata[Errors.Metadata.FIELD_NAME.key] = "reporting_set.value"
+        }
+      )
   }
 
   @Test
@@ -589,13 +666,24 @@ class ReportingSetsServiceTest {
         }
       reportingSetId = "reporting-set-id"
     }
+
     val exception =
       assertFailsWith<StatusRuntimeException> {
         withPrincipalAndScopes(PRINCIPAL, SCOPES) {
           runBlocking { service.createReportingSet(request) }
         }
       }
-    assertThat(exception.status.code).isEqualTo(Status.Code.INVALID_ARGUMENT)
+
+    assertThat(exception).status().code().isEqualTo(Status.Code.INVALID_ARGUMENT)
+    assertThat(exception)
+      .errorInfo()
+      .isEqualTo(
+        errorInfo {
+          domain = Errors.DOMAIN
+          reason = Errors.Reason.REQUIRED_FIELD_NOT_SET.name
+          metadata[Errors.Metadata.FIELD_NAME.key] = "reporting_set.composite.expression"
+        }
+      )
   }
 
   @Test
@@ -609,13 +697,24 @@ class ReportingSetsServiceTest {
         }
       reportingSetId = "reporting-set-id"
     }
+
     val exception =
       assertFailsWith<StatusRuntimeException> {
         withPrincipalAndScopes(PRINCIPAL, SCOPES) {
           runBlocking { service.createReportingSet(request) }
         }
       }
-    assertThat(exception.status.code).isEqualTo(Status.Code.INVALID_ARGUMENT)
+
+    assertThat(exception).status().code().isEqualTo(Status.Code.INVALID_ARGUMENT)
+    assertThat(exception)
+      .errorInfo()
+      .isEqualTo(
+        errorInfo {
+          domain = Errors.DOMAIN
+          reason = Errors.Reason.REQUIRED_FIELD_NOT_SET.name
+          metadata[Errors.Metadata.FIELD_NAME.key] = "reporting_set.composite.expression.operation"
+        }
+      )
   }
 
   @Test
@@ -629,13 +728,24 @@ class ReportingSetsServiceTest {
         }
       reportingSetId = "reporting-set-id"
     }
+
     val exception =
       assertFailsWith<StatusRuntimeException> {
         withPrincipalAndScopes(PRINCIPAL, SCOPES) {
           runBlocking { service.createReportingSet(request) }
         }
       }
-    assertThat(exception.status.code).isEqualTo(Status.Code.INVALID_ARGUMENT)
+
+    assertThat(exception).status().code().isEqualTo(Status.Code.INVALID_ARGUMENT)
+    assertThat(exception)
+      .errorInfo()
+      .isEqualTo(
+        errorInfo {
+          domain = Errors.DOMAIN
+          reason = Errors.Reason.REQUIRED_FIELD_NOT_SET.name
+          metadata[Errors.Metadata.FIELD_NAME.key] = "reporting_set.composite.expression.lhs"
+        }
+      )
   }
 
   @Test
@@ -659,12 +769,14 @@ class ReportingSetsServiceTest {
         }
       reportingSetId = "reporting-set-id"
     }
+
     val exception =
       assertFailsWith<StatusRuntimeException> {
         withPrincipalAndScopes(PRINCIPAL, SCOPES) {
           runBlocking { service.createReportingSet(request) }
         }
       }
+
     assertThat(exception).status().code().isEqualTo(Status.Code.INVALID_ARGUMENT)
     assertThat(exception)
       .errorInfo()
@@ -704,17 +816,29 @@ class ReportingSetsServiceTest {
         }
       reportingSetId = "reporting-set-id"
     }
+
     val exception =
       assertFailsWith<StatusRuntimeException> {
         withPrincipalAndScopes(PRINCIPAL, SCOPES) {
           runBlocking { service.createReportingSet(request) }
         }
       }
-    assertThat(exception.status.code).isEqualTo(Status.Code.INVALID_ARGUMENT)
+
+    assertThat(exception).status().code().isEqualTo(Status.Code.INVALID_ARGUMENT)
+    assertThat(exception)
+      .errorInfo()
+      .isEqualTo(
+        errorInfo {
+          domain = Errors.DOMAIN
+          reason = Errors.Reason.INVALID_FIELD_VALUE.name
+          metadata[Errors.Metadata.FIELD_NAME.key] =
+            "reporting_set.composite.expression.lhs.reporting_set"
+        }
+      )
   }
 
   @Test
-  fun `createReportingSet throws FAILED_PRECONDITION when child ReportingSet cannot be found`() =
+  fun `createReportingSet throws FAILED_PRECONDITION when referenced ReportingSet cannot be found`() =
     runBlocking {
       permissionsServiceMock.stub {
         onBlocking { checkPermissions(hasPrincipal(PRINCIPAL.name)) } doReturn
@@ -733,10 +857,12 @@ class ReportingSetsServiceTest {
         reportingSet = ROOT_COMPOSITE_REPORTING_SET.copy { clearName() }
         reportingSetId = "reporting-set-id"
       }
+
       val exception =
         assertFailsWith<StatusRuntimeException> {
           withPrincipalAndScopes(PRINCIPAL, SCOPES) { service.createReportingSet(request) }
         }
+
       assertThat(exception).status().code().isEqualTo(Status.Code.FAILED_PRECONDITION)
       assertThat(exception)
         .errorInfo()
@@ -755,7 +881,7 @@ class ReportingSetsServiceTest {
     }
 
   @Test
-  fun `createReportingSet throws FAILED_PRECONDITION when child reporting cannot be found during creation`() =
+  fun `createReportingSet throws FAILED_PRECONDITION when referenced ReportingSet cannot be found during internal Create`() =
     runBlocking {
       val cmmsMeasurementConsumerId = MEASUREMENT_CONSUMER_KEYS.first().toName()
       permissionsServiceMock.stub {
@@ -767,20 +893,27 @@ class ReportingSetsServiceTest {
           ReportingSetNotFoundException(cmmsMeasurementConsumerId, "absent")
             .asStatusRuntimeException(Status.Code.FAILED_PRECONDITION)
         )
-
       val request = createReportingSetRequest {
         parent = cmmsMeasurementConsumerId
-        reportingSet =
-          ROOT_COMPOSITE_REPORTING_SET.copy {
-            name = "$cmmsMeasurementConsumerId/reportingSets/absent"
-          }
+        reportingSet = ROOT_COMPOSITE_REPORTING_SET.copy { clearName() }
         reportingSetId = "reporting-set-id"
       }
+
       val exception =
         assertFailsWith<StatusRuntimeException> {
           withPrincipalAndScopes(PRINCIPAL, SCOPES) { service.createReportingSet(request) }
         }
-      assertThat(exception.status.code).isEqualTo(Status.Code.FAILED_PRECONDITION)
+
+      assertThat(exception)
+        .errorInfo()
+        .isEqualTo(
+          errorInfo {
+            domain = Errors.DOMAIN
+            reason = Errors.Reason.REPORTING_SET_NOT_FOUND.name
+            metadata[Errors.Metadata.REPORTING_SET.key] =
+              ReportingSetKey(cmmsMeasurementConsumerId, "absent").toName()
+          }
+        )
     }
 
   @Test
@@ -794,13 +927,24 @@ class ReportingSetsServiceTest {
         }
       reportingSetId = "reporting-set-id"
     }
+
     val exception =
       assertFailsWith<StatusRuntimeException> {
         withPrincipalAndScopes(PRINCIPAL, SCOPES) {
           runBlocking { service.createReportingSet(request) }
         }
       }
-    assertThat(exception.status.code).isEqualTo(Status.Code.INVALID_ARGUMENT)
+
+    assertThat(exception).status().code().isEqualTo(Status.Code.INVALID_ARGUMENT)
+    assertThat(exception)
+      .errorInfo()
+      .isEqualTo(
+        errorInfo {
+          domain = Errors.DOMAIN
+          reason = Errors.Reason.REQUIRED_FIELD_NOT_SET.name
+          metadata[Errors.Metadata.FIELD_NAME.key] = "reporting_set.primitive.cmms_event_groups"
+        }
+      )
   }
 
   @Test
@@ -815,12 +959,14 @@ class ReportingSetsServiceTest {
         }
       reportingSetId = "reporting-set-id"
     }
+
     val exception =
       assertFailsWith<StatusRuntimeException> {
         withPrincipalAndScopes(PRINCIPAL, SCOPES) {
           runBlocking { service.createReportingSet(request) }
         }
       }
+
     assertThat(exception).status().code().isEqualTo(Status.Code.INVALID_ARGUMENT)
     assertThat(exception)
       .errorInfo()
@@ -897,8 +1043,15 @@ class ReportingSetsServiceTest {
       onBlocking { checkPermissions(hasPrincipal(PRINCIPAL.name)) } doReturn
         checkPermissionsResponse { permissions += PermissionName.GET }
     }
+    val internalReportingSet = INTERNAL_PRIMITIVE_REPORTING_SETS.first()
     whenever(internalReportingSetsMock.batchGetReportingSets(any()))
-      .thenThrow(Status.NOT_FOUND.asRuntimeException())
+      .thenThrow(
+        ReportingSetNotFoundException(
+            internalReportingSet.cmmsMeasurementConsumerId,
+            internalReportingSet.externalReportingSetId,
+          )
+          .asStatusRuntimeException(Status.Code.NOT_FOUND)
+      )
     val request = getReportingSetRequest { name = PRIMITIVE_REPORTING_SETS.first().name }
 
     val exception =
@@ -908,7 +1061,16 @@ class ReportingSetsServiceTest {
         }
       }
 
-    assertThat(exception.status.code).isEqualTo(Status.Code.NOT_FOUND)
+    assertThat(exception).status().code().isEqualTo(Status.Code.NOT_FOUND)
+    assertThat(exception)
+      .errorInfo()
+      .isEqualTo(
+        errorInfo {
+          domain = Errors.DOMAIN
+          reason = Errors.Reason.REPORTING_SET_NOT_FOUND.name
+          metadata[Errors.Metadata.REPORTING_SET.key] = request.name
+        }
+      )
   }
 
   @Test
@@ -944,7 +1106,17 @@ class ReportingSetsServiceTest {
           runBlocking { service.getReportingSet(GetReportingSetRequest.getDefaultInstance()) }
         }
       }
-    assertThat(exception.status.code).isEqualTo(Status.Code.INVALID_ARGUMENT)
+
+    assertThat(exception).status().code().isEqualTo(Status.Code.INVALID_ARGUMENT)
+    assertThat(exception)
+      .errorInfo()
+      .isEqualTo(
+        errorInfo {
+          domain = Errors.DOMAIN
+          reason = Errors.Reason.REQUIRED_FIELD_NOT_SET.name
+          metadata[Errors.Metadata.FIELD_NAME.key] = "name"
+        }
+      )
   }
 
   @Test
@@ -1241,14 +1413,24 @@ class ReportingSetsServiceTest {
       parent = MEASUREMENT_CONSUMER_KEYS.first().toName()
       pageSize = -1
     }
+
     val exception =
       assertFailsWith<StatusRuntimeException> {
         withPrincipalAndScopes(PRINCIPAL, SCOPES) {
           runBlocking { service.listReportingSets(request) }
         }
       }
-    assertThat(exception.status.code).isEqualTo(Status.Code.INVALID_ARGUMENT)
-    assertThat(exception.status.description).isEqualTo("Page size cannot be less than 0")
+
+    assertThat(exception).status().code().isEqualTo(Status.Code.INVALID_ARGUMENT)
+    assertThat(exception)
+      .errorInfo()
+      .isEqualTo(
+        errorInfo {
+          domain = Errors.DOMAIN
+          reason = Errors.Reason.INVALID_FIELD_VALUE.name
+          metadata[Errors.Metadata.FIELD_NAME.key] = "page_size"
+        }
+      )
   }
 
   @Test
@@ -1259,7 +1441,17 @@ class ReportingSetsServiceTest {
           runBlocking { service.listReportingSets(ListReportingSetsRequest.getDefaultInstance()) }
         }
       }
-    assertThat(exception.status.code).isEqualTo(Status.Code.INVALID_ARGUMENT)
+
+    assertThat(exception).status().code().isEqualTo(Status.Code.INVALID_ARGUMENT)
+    assertThat(exception)
+      .errorInfo()
+      .isEqualTo(
+        errorInfo {
+          domain = Errors.DOMAIN
+          reason = Errors.Reason.REQUIRED_FIELD_NOT_SET.name
+          metadata[Errors.Metadata.FIELD_NAME.key] = "parent"
+        }
+      )
   }
 
   @Test
@@ -1285,7 +1477,17 @@ class ReportingSetsServiceTest {
           runBlocking { service.listReportingSets(request) }
         }
       }
-    assertThat(exception.status.code).isEqualTo(Status.Code.INVALID_ARGUMENT)
+
+    assertThat(exception).status().code().isEqualTo(Status.Code.INVALID_ARGUMENT)
+    assertThat(exception)
+      .errorInfo()
+      .isEqualTo(
+        errorInfo {
+          domain = Errors.DOMAIN
+          reason = Errors.Reason.ARGUMENT_CHANGED_IN_REQUEST_FOR_NEXT_PAGE.name
+          metadata[Errors.Metadata.FIELD_NAME.key] = "parent"
+        }
+      )
   }
 
   object PermissionName {


### PR DESCRIPTION
This builds on the work done in #3559.

Closes #3571

Issue: #3571