### PR TITLE
fix: close postgresReadContext in listReportingSetsByCampaignGroup on success path

### DIFF
--- a/src/main/kotlin/org/wfanet/measurement/reporting/deploy/v2/gcloud/spanner/SpannerBasicReportsService.kt
+++ b/src/main/kotlin/org/wfanet/measurement/reporting/deploy/v2/gcloud/spanner/SpannerBasicReportsService.kt
@@ -670,9 +670,8 @@ class SpannerBasicReportsService(
         .withSerializableErrorRetries()
         .map { it.reportingSet }
         .toList()
-    } catch (e: Exception) {
+    } finally {
       postgresReadContext?.close()
-      throw e
     }
   }
 


### PR DESCRIPTION
## Description

Fixes a resource leak in `listReportingSetsByCampaignGroup`. The `postgresReadContext` was only closed in the `catch` block, so it was never closed on the success path. This could exhaust the connection pool under load.

## Changes

- Replaced `catch` block with `finally` block so `postgresReadContext` is always closed
- Aligns with the pattern used in `getReportingSets` in the same file

## Impact

- Prevents connection pool exhaustion
- Used in 3 call sites for Basic Reports reporting flow

## Testing

- `bazel build //src/main/kotlin/org/wfanet/measurement/reporting/deploy/v2/gcloud/spanner:...` — Pass
- Existing tests pass

## Checklist

- [x] I have read the [Contributing](CONTRIBUTING.md) guidelines
- [x] I have signed the Contributor License Agreement (CLA)
- [x] Fix follows existing pattern in `getReportingSets` (lines 625–648)