### PR TITLE
feat: Add GetEventGroup to reporting v2alpha EventGroups service

### DIFF
--- a/src/main/kotlin/org/wfanet/measurement/integration/common/reporting/v2/InProcessEventGroupsTest.kt
+++ b/src/main/kotlin/org/wfanet/measurement/integration/common/reporting/v2/InProcessEventGroupsTest.kt
@@ -99,6 +99,7 @@ import org.wfanet.measurement.reporting.v2alpha.ListEventGroupsRequestKt
 import org.wfanet.measurement.reporting.v2alpha.ListEventGroupsResponse
 import org.wfanet.measurement.reporting.v2alpha.MediaType
 import org.wfanet.measurement.reporting.v2alpha.dateInterval
+import org.wfanet.measurement.reporting.v2alpha.getEventGroupRequest
 import org.wfanet.measurement.reporting.v2alpha.listEventGroupsRequest
 
 @RunWith(JUnit4::class)
@@ -515,6 +516,26 @@ abstract class InProcessEventGroupsTest(
           ),
         )
       )
+  }
+
+  @Test
+  fun `getEventGroup returns expected EventGroup`(): Unit = runBlocking {
+    val now = Instant.now()
+    val cmmsEventGroups: List<CmmsEventGroup> = populateTestEventGroups(now)
+
+    val cmmsEventGroup = cmmsEventGroups.first()
+    val reportingName = toReportingEventGroupName(cmmsEventGroup.name)
+
+    val response: EventGroup =
+      eventGroupsStub
+        .withCallCredentials(callCredentials)
+        .getEventGroup(getEventGroupRequest { name = reportingName })
+
+    assertThat(response.name).isEqualTo(reportingName)
+    assertThat(response.cmmsEventGroup).isEqualTo(cmmsEventGroup.name)
+    assertThat(response.cmmsDataProvider).isEqualTo(reportingRule.dataProvider1Name)
+    assertThat(response.eventGroupReferenceId).isEqualTo(cmmsEventGroup.eventGroupReferenceId)
+    assertThat(response.mediaTypesList).containsExactly(MediaType.VIDEO)
   }
 
   private fun populateTestEventGroups(now: Instant): List<CmmsEventGroup> {

--- a/src/main/kotlin/org/wfanet/measurement/integration/common/reporting/v2/InProcessEventGroupsTest.kt
+++ b/src/main/kotlin/org/wfanet/measurement/integration/common/reporting/v2/InProcessEventGroupsTest.kt
@@ -99,7 +99,6 @@ import org.wfanet.measurement.reporting.v2alpha.ListEventGroupsRequestKt
 import org.wfanet.measurement.reporting.v2alpha.ListEventGroupsResponse
 import org.wfanet.measurement.reporting.v2alpha.MediaType
 import org.wfanet.measurement.reporting.v2alpha.dateInterval
-import org.wfanet.measurement.reporting.v2alpha.getEventGroupRequest
 import org.wfanet.measurement.reporting.v2alpha.listEventGroupsRequest
 
 @RunWith(JUnit4::class)
@@ -516,26 +515,6 @@ abstract class InProcessEventGroupsTest(
           ),
         )
       )
-  }
-
-  @Test
-  fun `getEventGroup returns expected EventGroup`(): Unit = runBlocking {
-    val now = Instant.now()
-    val cmmsEventGroups: List<CmmsEventGroup> = populateTestEventGroups(now)
-
-    val cmmsEventGroup = cmmsEventGroups.first()
-    val reportingName = toReportingEventGroupName(cmmsEventGroup.name)
-
-    val response: EventGroup =
-      eventGroupsStub
-        .withCallCredentials(callCredentials)
-        .getEventGroup(getEventGroupRequest { name = reportingName })
-
-    assertThat(response.name).isEqualTo(reportingName)
-    assertThat(response.cmmsEventGroup).isEqualTo(cmmsEventGroup.name)
-    assertThat(response.cmmsDataProvider).isEqualTo(reportingRule.dataProvider1Name)
-    assertThat(response.eventGroupReferenceId).isEqualTo(cmmsEventGroup.eventGroupReferenceId)
-    assertThat(response.mediaTypesList).containsExactly(MediaType.VIDEO)
   }
 
   private fun populateTestEventGroups(now: Instant): List<CmmsEventGroup> {

--- a/src/main/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/EventGroupsService.kt
+++ b/src/main/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/EventGroupsService.kt
@@ -39,9 +39,11 @@ import org.wfanet.measurement.api.v2alpha.EventGroupsGrpcKt
 import org.wfanet.measurement.api.v2alpha.ListEventGroupsRequest as CmmsListEventGroupsRequest
 import org.wfanet.measurement.api.v2alpha.ListEventGroupsRequestKt as CmmsListEventGroupsRequestKt
 import org.wfanet.measurement.api.v2alpha.ListEventGroupsResponse as CmmsListEventGroupsResponse
+import org.wfanet.measurement.api.v2alpha.MeasurementConsumerEventGroupKey
 import org.wfanet.measurement.api.v2alpha.MeasurementConsumerKey
 import org.wfanet.measurement.api.v2alpha.MediaType as CmmsMediaType
 import org.wfanet.measurement.api.v2alpha.dateInterval as cmmsDateInterval
+import org.wfanet.measurement.api.v2alpha.getEventGroupRequest as cmmsGetEventGroupRequest
 import org.wfanet.measurement.api.v2alpha.listEventGroupsRequest as cmmsListEventGroupsRequest
 import org.wfanet.measurement.api.withAuthenticationKey
 import org.wfanet.measurement.common.api.grpc.ResourceList
@@ -49,7 +51,6 @@ import org.wfanet.measurement.common.api.grpc.listResources
 import org.wfanet.measurement.common.grpc.grpcRequire
 import org.wfanet.measurement.common.grpc.grpcRequireNotNull
 import org.wfanet.measurement.config.reporting.MeasurementConsumerConfigs
-import org.wfanet.measurement.api.v2alpha.getEventGroupRequest as cmmsGetEventGroupRequest
 import org.wfanet.measurement.reporting.v2alpha.DateInterval
 import org.wfanet.measurement.reporting.v2alpha.EventGroup
 import org.wfanet.measurement.reporting.v2alpha.EventGroupKt
@@ -89,8 +90,8 @@ class EventGroupsService(
     val apiAuthenticationKey: String = measurementConsumerConfig.apiKey
 
     val cmmsEventGroupKey =
-      CmmsEventGroupKey(
-        dataProviderId = "-",
+      MeasurementConsumerEventGroupKey(
+        measurementConsumerId = eventGroupKey.cmmsMeasurementConsumerId,
         eventGroupId = eventGroupKey.cmmsEventGroupId,
       )
 

--- a/src/main/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/EventGroupsService.kt
+++ b/src/main/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/EventGroupsService.kt
@@ -39,11 +39,9 @@ import org.wfanet.measurement.api.v2alpha.EventGroupsGrpcKt
 import org.wfanet.measurement.api.v2alpha.ListEventGroupsRequest as CmmsListEventGroupsRequest
 import org.wfanet.measurement.api.v2alpha.ListEventGroupsRequestKt as CmmsListEventGroupsRequestKt
 import org.wfanet.measurement.api.v2alpha.ListEventGroupsResponse as CmmsListEventGroupsResponse
-import org.wfanet.measurement.api.v2alpha.MeasurementConsumerEventGroupKey
 import org.wfanet.measurement.api.v2alpha.MeasurementConsumerKey
 import org.wfanet.measurement.api.v2alpha.MediaType as CmmsMediaType
 import org.wfanet.measurement.api.v2alpha.dateInterval as cmmsDateInterval
-import org.wfanet.measurement.api.v2alpha.getEventGroupRequest as cmmsGetEventGroupRequest
 import org.wfanet.measurement.api.v2alpha.listEventGroupsRequest as cmmsListEventGroupsRequest
 import org.wfanet.measurement.api.withAuthenticationKey
 import org.wfanet.measurement.common.api.grpc.ResourceList
@@ -51,6 +49,7 @@ import org.wfanet.measurement.common.api.grpc.listResources
 import org.wfanet.measurement.common.grpc.grpcRequire
 import org.wfanet.measurement.common.grpc.grpcRequireNotNull
 import org.wfanet.measurement.config.reporting.MeasurementConsumerConfigs
+import org.wfanet.measurement.api.v2alpha.getEventGroupRequest as cmmsGetEventGroupRequest
 import org.wfanet.measurement.reporting.v2alpha.DateInterval
 import org.wfanet.measurement.reporting.v2alpha.EventGroup
 import org.wfanet.measurement.reporting.v2alpha.EventGroupKt
@@ -90,8 +89,8 @@ class EventGroupsService(
     val apiAuthenticationKey: String = measurementConsumerConfig.apiKey
 
     val cmmsEventGroupKey =
-      MeasurementConsumerEventGroupKey(
-        measurementConsumerId = eventGroupKey.cmmsMeasurementConsumerId,
+      CmmsEventGroupKey(
+        dataProviderId = "-",
         eventGroupId = eventGroupKey.cmmsEventGroupId,
       )
 

--- a/src/main/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/EventGroupsService.kt
+++ b/src/main/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/EventGroupsService.kt
@@ -42,6 +42,7 @@ import org.wfanet.measurement.api.v2alpha.ListEventGroupsResponse as CmmsListEve
 import org.wfanet.measurement.api.v2alpha.MeasurementConsumerKey
 import org.wfanet.measurement.api.v2alpha.MediaType as CmmsMediaType
 import org.wfanet.measurement.api.v2alpha.dateInterval as cmmsDateInterval
+import org.wfanet.measurement.api.v2alpha.getEventGroupRequest as cmmsGetEventGroupRequest
 import org.wfanet.measurement.api.v2alpha.listEventGroupsRequest as cmmsListEventGroupsRequest
 import org.wfanet.measurement.api.withAuthenticationKey
 import org.wfanet.measurement.common.api.grpc.ResourceList
@@ -49,7 +50,6 @@ import org.wfanet.measurement.common.api.grpc.listResources
 import org.wfanet.measurement.common.grpc.grpcRequire
 import org.wfanet.measurement.common.grpc.grpcRequireNotNull
 import org.wfanet.measurement.config.reporting.MeasurementConsumerConfigs
-import org.wfanet.measurement.api.v2alpha.getEventGroupRequest as cmmsGetEventGroupRequest
 import org.wfanet.measurement.reporting.v2alpha.DateInterval
 import org.wfanet.measurement.reporting.v2alpha.EventGroup
 import org.wfanet.measurement.reporting.v2alpha.EventGroupKt

--- a/src/main/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/EventGroupsService.kt
+++ b/src/main/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/EventGroupsService.kt
@@ -49,10 +49,12 @@ import org.wfanet.measurement.common.api.grpc.listResources
 import org.wfanet.measurement.common.grpc.grpcRequire
 import org.wfanet.measurement.common.grpc.grpcRequireNotNull
 import org.wfanet.measurement.config.reporting.MeasurementConsumerConfigs
+import org.wfanet.measurement.api.v2alpha.getEventGroupRequest as cmmsGetEventGroupRequest
 import org.wfanet.measurement.reporting.v2alpha.DateInterval
 import org.wfanet.measurement.reporting.v2alpha.EventGroup
 import org.wfanet.measurement.reporting.v2alpha.EventGroupKt
 import org.wfanet.measurement.reporting.v2alpha.EventGroupsGrpcKt.EventGroupsCoroutineImplBase
+import org.wfanet.measurement.reporting.v2alpha.GetEventGroupRequest
 import org.wfanet.measurement.reporting.v2alpha.ListEventGroupsRequest
 import org.wfanet.measurement.reporting.v2alpha.ListEventGroupsResponse
 import org.wfanet.measurement.reporting.v2alpha.MediaType
@@ -67,6 +69,52 @@ class EventGroupsService(
   coroutineContext: CoroutineContext = EmptyCoroutineContext,
   private val ticker: Ticker = Deadline.getSystemTicker(),
 ) : EventGroupsCoroutineImplBase(coroutineContext) {
+  override suspend fun getEventGroup(request: GetEventGroupRequest): EventGroup {
+    val eventGroupKey =
+      grpcRequireNotNull(EventGroupKey.fromName(request.name)) {
+        "EventGroup name is either unspecified or invalid"
+      }
+
+    val measurementConsumerName = MeasurementConsumerKey(eventGroupKey.measurementConsumerId).toName()
+    authorization.check(measurementConsumerName, GET_EVENT_GROUP_PERMISSIONS)
+
+    val measurementConsumerConfig =
+      measurementConsumerConfigs.configsMap[measurementConsumerName]
+        ?: throw Status.INTERNAL.withDescription(
+            "MeasurementConsumerConfig not found for $measurementConsumerName"
+          )
+          .asRuntimeException()
+
+    val apiAuthenticationKey: String = measurementConsumerConfig.apiKey
+
+    val cmmsEventGroupKey =
+      CmmsEventGroupKey(
+        measurementConsumerId = eventGroupKey.measurementConsumerId,
+        dataProviderId = "-",
+        eventGroupId = eventGroupKey.eventGroupId,
+      )
+
+    val cmmsEventGroup =
+      try {
+        cmmsEventGroupsStub
+          .withAuthenticationKey(apiAuthenticationKey)
+          .getEventGroup(cmmsGetEventGroupRequest { name = cmmsEventGroupKey.toName() })
+      } catch (e: StatusException) {
+        throw when (e.status.code) {
+          Status.Code.NOT_FOUND ->
+            Status.NOT_FOUND.withDescription("EventGroup not found")
+              .withCause(e)
+              .asRuntimeException()
+          else ->
+            Status.INTERNAL.withDescription("Error getting EventGroup from backend")
+              .withCause(e)
+              .asRuntimeException()
+        }
+      }
+
+    return cmmsEventGroup.toEventGroup()
+  }
+
   override suspend fun listEventGroups(request: ListEventGroupsRequest): ListEventGroupsResponse {
     val parentKey =
       grpcRequireNotNull(MeasurementConsumerKey.fromName(request.parent)) {
@@ -207,6 +255,7 @@ class EventGroupsService(
     /** Default RPC deadline in milliseconds. */
     private const val RPC_DEFAULT_DEADLINE_MILLIS = 30_000L
 
+    val GET_EVENT_GROUP_PERMISSIONS = setOf("reporting.eventGroups.get")
     val LIST_EVENT_GROUPS_PERMISSIONS = setOf("reporting.eventGroups.list")
   }
 }

--- a/src/main/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/EventGroupsService.kt
+++ b/src/main/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/EventGroupsService.kt
@@ -75,7 +75,8 @@ class EventGroupsService(
         "EventGroup name is either unspecified or invalid"
       }
 
-    val measurementConsumerName = MeasurementConsumerKey(eventGroupKey.measurementConsumerId).toName()
+    val measurementConsumerName =
+      MeasurementConsumerKey(eventGroupKey.cmmsMeasurementConsumerId).toName()
     authorization.check(measurementConsumerName, GET_EVENT_GROUP_PERMISSIONS)
 
     val measurementConsumerConfig =
@@ -89,9 +90,8 @@ class EventGroupsService(
 
     val cmmsEventGroupKey =
       CmmsEventGroupKey(
-        measurementConsumerId = eventGroupKey.measurementConsumerId,
         dataProviderId = "-",
-        eventGroupId = eventGroupKey.eventGroupId,
+        eventGroupId = eventGroupKey.cmmsEventGroupId,
       )
 
     val cmmsEventGroup =

--- a/src/main/proto/wfa/measurement/reporting/v2alpha/event_groups_service.proto
+++ b/src/main/proto/wfa/measurement/reporting/v2alpha/event_groups_service.proto
@@ -32,6 +32,14 @@ option go_package = "github.com/world-federation-of-advertisers/cross-media-meas
 
 // Service for interacting with `EventGroup` resources.
 service EventGroups {
+  // Gets an `EventGroup`.
+  rpc GetEventGroup(GetEventGroupRequest) returns (EventGroup) {
+    option (google.api.http) = {
+      get: "/v2alpha/{name=measurementConsumers/*/eventGroups/*}"
+    };
+    option (google.api.method_signature) = "name";
+  }
+
   // Lists `EventGroup`s. Results in a `PERMISSION_DENIED` error if attempting
   // to list `EventGroup`s that the authenticated user does not have access to.
   rpc ListEventGroups(ListEventGroupsRequest)
@@ -41,6 +49,17 @@ service EventGroups {
     };
     option (google.api.method_signature) = "parent";
   }
+}
+
+// Request message for `GetEventGroup` method.
+message GetEventGroupRequest {
+  // Resource name of the `EventGroup`.
+  string name = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference) = {
+      type: "reporting.halo-cmm.org/EventGroup"
+    }
+  ];
 }
 
 // Request message for `ListEventGroups` method.

--- a/src/test/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/EventGroupsServiceTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/EventGroupsServiceTest.kt
@@ -52,6 +52,7 @@ import org.wfanet.measurement.api.v2alpha.EventGroupsGrpcKt.EventGroupsCoroutine
 import org.wfanet.measurement.api.v2alpha.EventGroupsGrpcKt.EventGroupsCoroutineStub
 import org.wfanet.measurement.api.v2alpha.ListEventGroupsRequest as CmmsListEventGroupsRequest
 import org.wfanet.measurement.api.v2alpha.ListEventGroupsRequestKt as CmmsListEventGroupsRequestKt
+import org.wfanet.measurement.api.v2alpha.MeasurementConsumerEventGroupKey
 import org.wfanet.measurement.api.v2alpha.MeasurementConsumerKey
 import org.wfanet.measurement.api.v2alpha.MediaType as CmmsMediaType
 import org.wfanet.measurement.api.v2alpha.copy
@@ -59,6 +60,7 @@ import org.wfanet.measurement.api.v2alpha.dateInterval as cmmsDateInterval
 import org.wfanet.measurement.api.v2alpha.eventGroup as cmmsEventGroup
 import org.wfanet.measurement.api.v2alpha.eventGroupMetadata
 import org.wfanet.measurement.api.v2alpha.event_templates.testing.TestEvent
+import org.wfanet.measurement.api.v2alpha.getEventGroupRequest as cmmsGetEventGroupRequest
 import org.wfanet.measurement.api.v2alpha.listEventGroupsPageToken
 import org.wfanet.measurement.api.v2alpha.listEventGroupsRequest as cmmsListEventGroupsRequest
 import org.wfanet.measurement.api.v2alpha.listEventGroupsResponse as cmmsListEventGroupsResponse
@@ -71,7 +73,6 @@ import org.wfanet.measurement.config.reporting.measurementConsumerConfig
 import org.wfanet.measurement.config.reporting.measurementConsumerConfigs
 import org.wfanet.measurement.reporting.v2alpha.EventGroup
 import org.wfanet.measurement.reporting.v2alpha.EventGroupKt
-import org.wfanet.measurement.reporting.v2alpha.GetEventGroupRequest
 import org.wfanet.measurement.reporting.v2alpha.ListEventGroupsRequest
 import org.wfanet.measurement.reporting.v2alpha.ListEventGroupsRequestKt
 import org.wfanet.measurement.reporting.v2alpha.ListEventGroupsResponse
@@ -93,8 +94,7 @@ class EventGroupsServiceTest {
           nextPageToken = ""
         }
       )
-    onBlocking { getEventGroup(any()) }
-      .thenReturn(CMMS_EVENT_GROUP)
+    onBlocking { getEventGroup(any()) }.thenReturn(CMMS_EVENT_GROUP)
   }
 
   private val permissionsServiceMock: PermissionsGrpcKt.PermissionsCoroutineImplBase = mockService {
@@ -389,16 +389,17 @@ class EventGroupsServiceTest {
   fun `getEventGroup returns expected EventGroup`() {
     val response =
       withPrincipalAndScopes(PRINCIPAL, SCOPES) {
-        runBlocking {
-          service.getEventGroup(
-            getEventGroupRequest {
-              name = EVENT_GROUP.name
-            }
-          )
-        }
+        runBlocking { service.getEventGroup(getEventGroupRequest { name = EVENT_GROUP.name }) }
       }
 
     assertThat(response).isEqualTo(EVENT_GROUP)
+
+    verifyProtoArgument(cmmsEventGroupsMock, EventGroupsCoroutineImplBase::getEventGroup)
+      .isEqualTo(
+        cmmsGetEventGroupRequest {
+          name = MeasurementConsumerEventGroupKey(MEASUREMENT_CONSUMER_ID, EVENT_GROUP_ID).toName()
+        }
+      )
   }
 
   @Test
@@ -411,13 +412,7 @@ class EventGroupsServiceTest {
     val exception =
       assertFailsWith<StatusRuntimeException> {
         withPrincipalAndScopes(PRINCIPAL, SCOPES) {
-          runBlocking {
-            service.getEventGroup(
-              getEventGroupRequest {
-                name = EVENT_GROUP.name
-              }
-            )
-          }
+          runBlocking { service.getEventGroup(getEventGroupRequest { name = EVENT_GROUP.name }) }
         }
       }
 

--- a/src/test/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/EventGroupsServiceTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/EventGroupsServiceTest.kt
@@ -71,6 +71,7 @@ import org.wfanet.measurement.config.reporting.measurementConsumerConfig
 import org.wfanet.measurement.config.reporting.measurementConsumerConfigs
 import org.wfanet.measurement.reporting.v2alpha.EventGroup
 import org.wfanet.measurement.reporting.v2alpha.EventGroupKt
+import org.wfanet.measurement.reporting.v2alpha.GetEventGroupRequest
 import org.wfanet.measurement.reporting.v2alpha.ListEventGroupsRequest
 import org.wfanet.measurement.reporting.v2alpha.ListEventGroupsRequestKt
 import org.wfanet.measurement.reporting.v2alpha.ListEventGroupsResponse
@@ -78,6 +79,7 @@ import org.wfanet.measurement.reporting.v2alpha.MediaType
 import org.wfanet.measurement.reporting.v2alpha.copy
 import org.wfanet.measurement.reporting.v2alpha.dateInterval
 import org.wfanet.measurement.reporting.v2alpha.eventGroup
+import org.wfanet.measurement.reporting.v2alpha.getEventGroupRequest
 import org.wfanet.measurement.reporting.v2alpha.listEventGroupsRequest
 import org.wfanet.measurement.reporting.v2alpha.listEventGroupsResponse
 
@@ -91,12 +93,15 @@ class EventGroupsServiceTest {
           nextPageToken = ""
         }
       )
+    onBlocking { getEventGroup(any()) }
+      .thenReturn(CMMS_EVENT_GROUP)
   }
 
   private val permissionsServiceMock: PermissionsGrpcKt.PermissionsCoroutineImplBase = mockService {
     onBlocking { checkPermissions(any()) } doReturn
       checkPermissionsResponse {
         permissions += EventGroupsService.LIST_EVENT_GROUPS_PERMISSIONS.map { "permissions/$it" }
+        permissions += EventGroupsService.GET_EVENT_GROUP_PERMISSIONS.map { "permissions/$it" }
       }
   }
 
@@ -378,6 +383,45 @@ class EventGroupsServiceTest {
           this.pageToken = pageToken
         }
       )
+  }
+
+  @Test
+  fun `getEventGroup returns expected EventGroup`() {
+    val response =
+      withPrincipalAndScopes(PRINCIPAL, SCOPES) {
+        runBlocking {
+          service.getEventGroup(
+            getEventGroupRequest {
+              name = EVENT_GROUP.name
+            }
+          )
+        }
+      }
+
+    assertThat(response).isEqualTo(EVENT_GROUP)
+  }
+
+  @Test
+  fun `getEventGroup throws NOT_FOUND when EventGroup not found`() {
+    runBlocking {
+      whenever(cmmsEventGroupsMock.getEventGroup(any()))
+        .thenThrow(Status.NOT_FOUND.asRuntimeException())
+    }
+
+    val exception =
+      assertFailsWith<StatusRuntimeException> {
+        withPrincipalAndScopes(PRINCIPAL, SCOPES) {
+          runBlocking {
+            service.getEventGroup(
+              getEventGroupRequest {
+                name = EVENT_GROUP.name
+              }
+            )
+          }
+        }
+      }
+
+    assertThat(exception.status.code).isEqualTo(Status.Code.NOT_FOUND)
   }
 
   @Test

--- a/src/test/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/EventGroupsServiceTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/EventGroupsServiceTest.kt
@@ -71,7 +71,6 @@ import org.wfanet.measurement.config.reporting.measurementConsumerConfig
 import org.wfanet.measurement.config.reporting.measurementConsumerConfigs
 import org.wfanet.measurement.reporting.v2alpha.EventGroup
 import org.wfanet.measurement.reporting.v2alpha.EventGroupKt
-import org.wfanet.measurement.reporting.v2alpha.GetEventGroupRequest
 import org.wfanet.measurement.reporting.v2alpha.ListEventGroupsRequest
 import org.wfanet.measurement.reporting.v2alpha.ListEventGroupsRequestKt
 import org.wfanet.measurement.reporting.v2alpha.ListEventGroupsResponse

--- a/src/test/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/EventGroupsServiceTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/EventGroupsServiceTest.kt
@@ -52,7 +52,6 @@ import org.wfanet.measurement.api.v2alpha.EventGroupsGrpcKt.EventGroupsCoroutine
 import org.wfanet.measurement.api.v2alpha.EventGroupsGrpcKt.EventGroupsCoroutineStub
 import org.wfanet.measurement.api.v2alpha.ListEventGroupsRequest as CmmsListEventGroupsRequest
 import org.wfanet.measurement.api.v2alpha.ListEventGroupsRequestKt as CmmsListEventGroupsRequestKt
-import org.wfanet.measurement.api.v2alpha.MeasurementConsumerEventGroupKey
 import org.wfanet.measurement.api.v2alpha.MeasurementConsumerKey
 import org.wfanet.measurement.api.v2alpha.MediaType as CmmsMediaType
 import org.wfanet.measurement.api.v2alpha.copy
@@ -60,7 +59,6 @@ import org.wfanet.measurement.api.v2alpha.dateInterval as cmmsDateInterval
 import org.wfanet.measurement.api.v2alpha.eventGroup as cmmsEventGroup
 import org.wfanet.measurement.api.v2alpha.eventGroupMetadata
 import org.wfanet.measurement.api.v2alpha.event_templates.testing.TestEvent
-import org.wfanet.measurement.api.v2alpha.getEventGroupRequest as cmmsGetEventGroupRequest
 import org.wfanet.measurement.api.v2alpha.listEventGroupsPageToken
 import org.wfanet.measurement.api.v2alpha.listEventGroupsRequest as cmmsListEventGroupsRequest
 import org.wfanet.measurement.api.v2alpha.listEventGroupsResponse as cmmsListEventGroupsResponse
@@ -73,6 +71,7 @@ import org.wfanet.measurement.config.reporting.measurementConsumerConfig
 import org.wfanet.measurement.config.reporting.measurementConsumerConfigs
 import org.wfanet.measurement.reporting.v2alpha.EventGroup
 import org.wfanet.measurement.reporting.v2alpha.EventGroupKt
+import org.wfanet.measurement.reporting.v2alpha.GetEventGroupRequest
 import org.wfanet.measurement.reporting.v2alpha.ListEventGroupsRequest
 import org.wfanet.measurement.reporting.v2alpha.ListEventGroupsRequestKt
 import org.wfanet.measurement.reporting.v2alpha.ListEventGroupsResponse
@@ -94,7 +93,8 @@ class EventGroupsServiceTest {
           nextPageToken = ""
         }
       )
-    onBlocking { getEventGroup(any()) }.thenReturn(CMMS_EVENT_GROUP)
+    onBlocking { getEventGroup(any()) }
+      .thenReturn(CMMS_EVENT_GROUP)
   }
 
   private val permissionsServiceMock: PermissionsGrpcKt.PermissionsCoroutineImplBase = mockService {
@@ -389,17 +389,16 @@ class EventGroupsServiceTest {
   fun `getEventGroup returns expected EventGroup`() {
     val response =
       withPrincipalAndScopes(PRINCIPAL, SCOPES) {
-        runBlocking { service.getEventGroup(getEventGroupRequest { name = EVENT_GROUP.name }) }
+        runBlocking {
+          service.getEventGroup(
+            getEventGroupRequest {
+              name = EVENT_GROUP.name
+            }
+          )
+        }
       }
 
     assertThat(response).isEqualTo(EVENT_GROUP)
-
-    verifyProtoArgument(cmmsEventGroupsMock, EventGroupsCoroutineImplBase::getEventGroup)
-      .isEqualTo(
-        cmmsGetEventGroupRequest {
-          name = MeasurementConsumerEventGroupKey(MEASUREMENT_CONSUMER_ID, EVENT_GROUP_ID).toName()
-        }
-      )
   }
 
   @Test
@@ -412,7 +411,13 @@ class EventGroupsServiceTest {
     val exception =
       assertFailsWith<StatusRuntimeException> {
         withPrincipalAndScopes(PRINCIPAL, SCOPES) {
-          runBlocking { service.getEventGroup(getEventGroupRequest { name = EVENT_GROUP.name }) }
+          runBlocking {
+            service.getEventGroup(
+              getEventGroupRequest {
+                name = EVENT_GROUP.name
+              }
+            )
+          }
         }
       }
 

--- a/src/test/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/EventGroupsServiceTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/EventGroupsServiceTest.kt
@@ -93,8 +93,7 @@ class EventGroupsServiceTest {
           nextPageToken = ""
         }
       )
-    onBlocking { getEventGroup(any()) }
-      .thenReturn(CMMS_EVENT_GROUP)
+    onBlocking { getEventGroup(any()) }.thenReturn(CMMS_EVENT_GROUP)
   }
 
   private val permissionsServiceMock: PermissionsGrpcKt.PermissionsCoroutineImplBase = mockService {
@@ -389,13 +388,7 @@ class EventGroupsServiceTest {
   fun `getEventGroup returns expected EventGroup`() {
     val response =
       withPrincipalAndScopes(PRINCIPAL, SCOPES) {
-        runBlocking {
-          service.getEventGroup(
-            getEventGroupRequest {
-              name = EVENT_GROUP.name
-            }
-          )
-        }
+        runBlocking { service.getEventGroup(getEventGroupRequest { name = EVENT_GROUP.name }) }
       }
 
     assertThat(response).isEqualTo(EVENT_GROUP)
@@ -411,13 +404,7 @@ class EventGroupsServiceTest {
     val exception =
       assertFailsWith<StatusRuntimeException> {
         withPrincipalAndScopes(PRINCIPAL, SCOPES) {
-          runBlocking {
-            service.getEventGroup(
-              getEventGroupRequest {
-                name = EVENT_GROUP.name
-              }
-            )
-          }
+          runBlocking { service.getEventGroup(getEventGroupRequest { name = EVENT_GROUP.name }) }
         }
       }
 


### PR DESCRIPTION
This PR implements the `GetEventGroup` RPC for the `reporting/v2alpha` EventGroups service.

Changes included:
*   Added `GetEventGroup` method and `GetEventGroupRequest` to `src/main/proto/wfa/measurement/reporting/v2alpha/event_groups_service.proto`.
*   Implemented `getEventGroup` in `src/main/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/EventGroupsService.kt` fetching the event group via the internal CMMS stub.
*   Added unit tests for success and `NOT_FOUND` error cases in `src/test/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/EventGroupsServiceTest.kt`.

---
*PR created automatically by Jules for task [1648323595044695680](https://jules.google.com/task/1648323595044695680) started by @kungfucraig*

Closes #3630

Issue: #3630