### PR TITLE
ci: Fix permissions in the UpdateCMMS workflow

### DIFF
--- a/.github/workflows/update-cmms.yml
+++ b/.github/workflows/update-cmms.yml
@@ -235,6 +235,9 @@ jobs:
     ]
     uses: ./.github/workflows/edpa-cloud-test.yml
     secrets: inherit
+    permissions:
+      contents: read
+      id-token: write
     with:
       environment: ${{ inputs.environment }}
 


### PR DESCRIPTION
PR #3283 broke the UpdateCMMS workflow because of a missing permission: the cloud test workflow requires write permissions on id-token. This PR fixes it.