### PR TITLE
feat: add VidLabelerAppRunner and KMS config

### DIFF
--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/vidlabeler/BUILD.bazel
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/vidlabeler/BUILD.bazel
@@ -1,4 +1,6 @@
+load("@rules_java//java:defs.bzl", "java_binary")
 load("@wfa_rules_kotlin_jvm//kotlin:defs.bzl", "kt_jvm_library")
+load("//src/main/docker:macros.bzl", "java_image")
 
 package(default_visibility = [
     "//src/main/kotlin/org/wfanet/measurement/edpaggregator:__subpackages__",
@@ -43,6 +45,55 @@ kt_jvm_library(
         "@wfa_common_jvm//imports/java/com/google/protobuf",
         "@wfa_common_jvm//src/main/kotlin/org/wfanet/measurement/queue:queue_subscriber",
     ],
+)
+
+kt_jvm_library(
+    name = "vid_labeler_app_runner",
+    srcs = ["VidLabelerAppRunner.kt"],
+    deps = [
+        ":vid_labeler_app",
+        "//imports/java/com/google/cloud/logging",
+        "//imports/java/com/google/cloud/secretmanager",
+        "//imports/java/io/opentelemetry/instrumentation/grpc",
+        "//src/main/kotlin/org/wfanet/measurement/common/edpaggregator:edp_aggregator_config",
+        "//src/main/kotlin/org/wfanet/measurement/edpaggregator:storage_config",
+        "//src/main/kotlin/org/wfanet/measurement/edpaggregator/telemetry",
+        "//src/main/proto/wfa/measurement/config/edpaggregator:vid_labeling_config_kt_jvm_proto",
+        "//src/main/proto/wfa/measurement/edpaggregator/v1alpha:vid_labeler_params_kt_jvm_proto",
+        "//src/main/proto/wfa/measurement/securecomputation/controlplane/v1alpha:work_item_attempts_service_kt_jvm_grpc_proto",
+        "//src/main/proto/wfa/measurement/securecomputation/controlplane/v1alpha:work_item_kt_jvm_proto",
+        "//src/main/proto/wfa/measurement/securecomputation/controlplane/v1alpha:work_items_service_kt_jvm_grpc_proto",
+        "@wfa_common_jvm//imports/java/com/google/crypto/tink",
+        "@wfa_common_jvm//src/main/kotlin/org/wfanet/measurement/common",
+        "@wfa_common_jvm//src/main/kotlin/org/wfanet/measurement/common/crypto:signing_certs",
+        "@wfa_common_jvm//src/main/kotlin/org/wfanet/measurement/common/crypto/tink",
+        "@wfa_common_jvm//src/main/kotlin/org/wfanet/measurement/common/grpc",
+        "@wfa_common_jvm//src/main/kotlin/org/wfanet/measurement/gcloud/kms:gcloud_to_aws_kms_client_factory",
+        "@wfa_common_jvm//src/main/kotlin/org/wfanet/measurement/gcloud/kms:gcp_kms_client_factory",
+        "@wfa_common_jvm//src/main/kotlin/org/wfanet/measurement/gcloud/pubsub:google_pub_sub_client",
+        "@wfa_common_jvm//src/main/kotlin/org/wfanet/measurement/gcloud/pubsub:subscriber",
+        "@wfa_common_jvm//src/main/kotlin/org/wfanet/measurement/queue:queue_subscriber",
+    ],
+)
+
+java_binary(
+    name = "VidLabeler",
+    main_class = "org.wfanet.measurement.edpaggregator.vidlabeler.VidLabelerAppRunner",
+    runtime_deps = [
+        ":vid_labeler_app_runner",
+    ],
+)
+
+java_image(
+    name = "vid_labeler_image",
+    base = "@java_image_base_root",
+    binary = ":VidLabeler",
+    labels = {
+        "tee.launch_policy.allow_env_override": "EDPA_CONFIG_STORAGE_BUCKET,JAVA_TOOL_OPTIONS,OTEL_SERVICE_NAME,OTEL_METRICS_EXPORTER,OTEL_TRACES_EXPORTER,OTEL_LOGS_EXPORTER,OTEL_EXPORTER_GOOGLE_CLOUD_PROJECT_ID,OTEL_METRIC_EXPORT_INTERVAL",
+        "tee.launch_policy.log_redirect": "always",
+    },
+    main_class = "org.wfanet.measurement.edpaggregator.vidlabeler.VidLabelerAppRunner",
+    visibility = ["//src:docker_image_deployment"],
 )
 
 kt_jvm_library(

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/vidlabeler/VidLabelerAppRunner.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/vidlabeler/VidLabelerAppRunner.kt
@@ -229,8 +229,8 @@ class VidLabelerAppRunner : Runnable {
   }
 
   private fun buildKmsClient(kmsConfig: VidLabelingConfig.KmsConfig): KmsClient {
-    return when (kmsConfig.providerCase) {
-      VidLabelingConfig.KmsConfig.ProviderCase.GCP -> {
+    return when (kmsConfig.providerConfigCase) {
+      VidLabelingConfig.KmsConfig.ProviderConfigCase.GCP -> {
         val gcp = kmsConfig.gcp
         val credentials =
           GCloudWifCredentials(
@@ -243,7 +243,7 @@ class VidLabelerAppRunner : Runnable {
           )
         GCloudKmsClientFactory().getKmsClient(credentials)
       }
-      VidLabelingConfig.KmsConfig.ProviderCase.AWS -> {
+      VidLabelingConfig.KmsConfig.ProviderConfigCase.AWS -> {
         val aws = kmsConfig.aws
         val credentials =
           GCloudToAwsWifCredentials(
@@ -260,7 +260,7 @@ class VidLabelerAppRunner : Runnable {
           )
         GCloudToAwsKmsClientFactory().getKmsClient(credentials)
       }
-      VidLabelingConfig.KmsConfig.ProviderCase.PROVIDER_NOT_SET,
+      VidLabelingConfig.KmsConfig.ProviderConfigCase.PROVIDERCONFIG_NOT_SET,
       null ->
         error("KmsConfig provider must be set")
     }

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/vidlabeler/VidLabelerAppRunner.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/vidlabeler/VidLabelerAppRunner.kt
@@ -1,0 +1,355 @@
+/*
+ * Copyright 2026 The Cross-Media Measurement Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wfanet.measurement.edpaggregator.vidlabeler
+
+import com.google.cloud.logging.LoggingHandler
+import com.google.cloud.secretmanager.v1.AccessSecretVersionRequest
+import com.google.cloud.secretmanager.v1.SecretManagerServiceClient
+import com.google.cloud.secretmanager.v1.SecretVersionName
+import com.google.crypto.tink.KmsClient
+import io.grpc.ClientInterceptors
+import io.opentelemetry.context.Context
+import io.opentelemetry.extension.kotlin.asContextElement
+import io.opentelemetry.instrumentation.grpc.v1_6.GrpcTelemetry
+import java.io.File
+import java.util.logging.Level
+import java.util.logging.LogManager
+import java.util.logging.Logger
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.runBlocking
+import org.wfanet.measurement.common.Instrumentation
+import org.wfanet.measurement.common.commandLineMain
+import org.wfanet.measurement.common.crypto.SigningCerts
+import org.wfanet.measurement.common.crypto.tink.GCloudToAwsWifCredentials
+import org.wfanet.measurement.common.crypto.tink.GCloudWifCredentials
+import org.wfanet.measurement.common.edpaggregator.EdpAggregatorConfig
+import org.wfanet.measurement.common.grpc.buildMutualTlsChannel
+import org.wfanet.measurement.config.edpaggregator.VidLabelingConfig
+import org.wfanet.measurement.config.edpaggregator.VidLabelingConfigs
+import org.wfanet.measurement.edpaggregator.StorageConfig
+import org.wfanet.measurement.edpaggregator.telemetry.EdpaTelemetry
+import org.wfanet.measurement.edpaggregator.v1alpha.VidLabelerParams.StorageParams
+import org.wfanet.measurement.gcloud.kms.GCloudKmsClientFactory
+import org.wfanet.measurement.gcloud.kms.GCloudToAwsKmsClientFactory
+import org.wfanet.measurement.gcloud.pubsub.DefaultGooglePubSubClient
+import org.wfanet.measurement.gcloud.pubsub.GooglePubSubClient
+import org.wfanet.measurement.gcloud.pubsub.Subscriber
+import org.wfanet.measurement.queue.QueueSubscriber
+import org.wfanet.measurement.securecomputation.controlplane.v1alpha.WorkItem
+import org.wfanet.measurement.securecomputation.controlplane.v1alpha.WorkItemAttemptsGrpcKt
+import org.wfanet.measurement.securecomputation.controlplane.v1alpha.WorkItemsGrpcKt
+import picocli.CommandLine
+
+@CommandLine.Command(name = "vid_labeler_app_runner")
+class VidLabelerAppRunner : Runnable {
+  private val grpcTelemetry by lazy { GrpcTelemetry.create(Instrumentation.openTelemetry) }
+
+  @CommandLine.Option(
+    names = ["--edpa-tls-cert-secret-id"],
+    description = ["Secret ID of EDPA TLS cert file."],
+    required = true,
+  )
+  private lateinit var edpaCertSecretId: String
+
+  @CommandLine.Option(
+    names = ["--edpa-tls-cert-file-path"],
+    description = ["Local path where the --edpa-tls-cert-secret-id secret is stored."],
+    required = true,
+  )
+  private lateinit var edpaCertFilePath: String
+
+  @CommandLine.Option(
+    names = ["--edpa-tls-key-secret-id"],
+    description = ["Secret ID of EDPA TLS key file."],
+    required = true,
+  )
+  private lateinit var edpaPrivateKeySecretId: String
+
+  @CommandLine.Option(
+    names = ["--edpa-tls-key-file-path"],
+    description = ["Local path where the --edpa-tls-key-secret-id secret is stored."],
+    required = true,
+  )
+  private lateinit var edpaPrivateKeyFilePath: String
+
+  @CommandLine.Option(
+    names = ["--secure-computation-cert-collection-secret-id"],
+    description = ["Secret ID of SecureComputation Trusted root Cert collection file."],
+    required = true,
+  )
+  private lateinit var secureComputationCertCollectionSecretId: String
+
+  @CommandLine.Option(
+    names = ["--secure-computation-cert-collection-file-path"],
+    description =
+      ["Local path where the --secure-computation-cert-collection-secret-id secret is stored."],
+    required = true,
+  )
+  private lateinit var secureComputationCertCollectionFilePath: String
+
+  @CommandLine.Option(
+    names = ["--metadata-storage-cert-collection-secret-id"],
+    description = ["Secret ID of Metadata Storage Trusted root Cert collection file."],
+    required = true,
+  )
+  private lateinit var metadataStorageCertCollectionSecretId: String
+
+  @CommandLine.Option(
+    names = ["--metadata-storage-cert-collection-file-path"],
+    description =
+      ["Local path where the --metadata-storage-cert-collection-secret-id secret is stored."],
+    required = true,
+  )
+  private lateinit var metadataStorageCertCollectionFilePath: String
+
+  @CommandLine.Option(
+    names = ["--secure-computation-public-api-target"],
+    description = ["gRPC target of the Secure Computation public API server"],
+    required = true,
+  )
+  private lateinit var secureComputationPublicApiTarget: String
+
+  @CommandLine.Option(
+    names = ["--secure-computation-public-api-cert-host"],
+    description =
+      [
+        "Expected hostname (DNS-ID) in the SecureComputation public API server's TLS certificate.",
+        "This overrides derivation of the TLS DNS-ID from --secure-computation-public-api-target.",
+      ],
+    required = false,
+  )
+  private var secureComputationPublicApiCertHost: String? = null
+
+  @CommandLine.Option(
+    names = ["--metadata-storage-public-api-target"],
+    description = ["gRPC target of the Metadata Storage public API server"],
+    required = true,
+  )
+  private lateinit var metadataStoragePublicApiTarget: String
+
+  @CommandLine.Option(
+    names = ["--metadata-storage-public-api-cert-host"],
+    description =
+      [
+        "Expected hostname (DNS-ID) in the Metadata Storage public API server's TLS certificate.",
+        "This overrides derivation of the TLS DNS-ID from --metadata-storage-public-api-target.",
+      ],
+    required = false,
+  )
+  private var metadataStoragePublicApiCertHost: String? = null
+
+  @CommandLine.Option(
+    names = ["--subscription-id"],
+    description = ["Subscription ID for the queue"],
+    required = true,
+  )
+  private lateinit var subscriptionId: String
+
+  @CommandLine.Option(
+    names = ["--google-project-id"],
+    description = ["Project ID of EDP Aggregator."],
+    required = true,
+  )
+  private lateinit var googleProjectId: String
+
+  private lateinit var rawImpressionsKmsClients: MutableMap<String, KmsClient>
+  private lateinit var vidLabeledImpressionsKmsClients: MutableMap<String, KmsClient>
+
+  private val getStorageConfig: (StorageParams) -> StorageConfig = { storageParams ->
+    StorageConfig(projectId = storageParams.gcsProjectId)
+  }
+
+  override fun run() {
+    saveCerts()
+    createKmsClients()
+
+    val pubSubClient = DefaultGooglePubSubClient()
+    val queueSubscriber = createQueueSubscriber(pubSubClient)
+
+    // Build the mutual TLS channel for Secure Computation API.
+    val secureComputationClientCerts =
+      SigningCerts.fromPemFiles(
+        certificateFile = File(edpaCertFilePath),
+        privateKeyFile = File(edpaPrivateKeyFilePath),
+        trustedCertCollectionFile = File(secureComputationCertCollectionFilePath),
+      )
+    val secureComputationPublicChannel =
+      ClientInterceptors.intercept(
+        buildMutualTlsChannel(
+          secureComputationPublicApiTarget,
+          secureComputationClientCerts,
+          secureComputationPublicApiCertHost,
+        ),
+        grpcTelemetry.newClientInterceptor(),
+      )
+    val workItemsClient = WorkItemsGrpcKt.WorkItemsCoroutineStub(secureComputationPublicChannel)
+    val workItemAttemptsClient =
+      WorkItemAttemptsGrpcKt.WorkItemAttemptsCoroutineStub(secureComputationPublicChannel)
+
+    val vidLabelerApp =
+      VidLabelerApp(
+        subscriptionId = subscriptionId,
+        queueSubscriber = queueSubscriber,
+        parser = WorkItem.parser(),
+        workItemsClient = workItemsClient,
+        workItemAttemptsClient = workItemAttemptsClient,
+        rawImpressionsKmsClient = rawImpressionsKmsClients,
+        vidLabeledImpressionsKmsClient = vidLabeledImpressionsKmsClients,
+        getStorageConfig = getStorageConfig,
+      )
+
+    runBlockingWithTelemetry { vidLabelerApp.run() }
+  }
+
+  /** Creates KMS clients for each EDP from [VidLabelingConfigs]. */
+  fun createKmsClients() {
+    rawImpressionsKmsClients = mutableMapOf()
+    vidLabeledImpressionsKmsClients = mutableMapOf()
+
+    for (config in vidLabelingConfigs.configsList) {
+      rawImpressionsKmsClients[config.dataProvider] =
+        buildKmsClient(config.rawImpressionsKmsConfig)
+      vidLabeledImpressionsKmsClients[config.dataProvider] =
+        buildKmsClient(config.vidLabeledImpressionsKmsConfig)
+    }
+  }
+
+  private fun buildKmsClient(kmsConfig: VidLabelingConfig.KmsConfig): KmsClient {
+    return when (kmsConfig.kmsType) {
+      VidLabelingConfig.KmsConfig.KmsType.AWS -> {
+        val credentials =
+          GCloudToAwsWifCredentials(
+            gcloudAudience = kmsConfig.kmsAudience,
+            subjectTokenType = SUBJECT_TOKEN_TYPE,
+            tokenUrl = TOKEN_URL,
+            credentialSourceFilePath = CREDENTIAL_SOURCE_FILE_PATH,
+            serviceAccountImpersonationUrl =
+              EDP_TARGET_SERVICE_ACCOUNT_FORMAT.format(kmsConfig.serviceAccount),
+            roleArn = kmsConfig.awsRoleArn,
+            roleSessionName = kmsConfig.awsRoleSessionName,
+            region = kmsConfig.awsRegion,
+            awsAudience = kmsConfig.awsAudience,
+          )
+        GCloudToAwsKmsClientFactory().getKmsClient(credentials)
+      }
+      VidLabelingConfig.KmsConfig.KmsType.GCP -> {
+        val credentials =
+          GCloudWifCredentials(
+            audience = kmsConfig.kmsAudience,
+            subjectTokenType = SUBJECT_TOKEN_TYPE,
+            tokenUrl = TOKEN_URL,
+            credentialSourceFilePath = CREDENTIAL_SOURCE_FILE_PATH,
+            serviceAccountImpersonationUrl =
+              EDP_TARGET_SERVICE_ACCOUNT_FORMAT.format(kmsConfig.serviceAccount),
+          )
+        GCloudKmsClientFactory().getKmsClient(credentials)
+      }
+      VidLabelingConfig.KmsConfig.KmsType.KMS_TYPE_UNSPECIFIED,
+      VidLabelingConfig.KmsConfig.KmsType.UNRECOGNIZED ->
+        error("Unsupported KMS type: ${kmsConfig.kmsType}")
+    }
+  }
+
+  /** Pulls EDPA certificates from Google Secret Manager and saves them to local files. */
+  fun saveCerts() {
+    saveSecret(edpaCertSecretId, edpaCertFilePath)
+    saveSecret(edpaPrivateKeySecretId, edpaPrivateKeyFilePath)
+    saveSecret(secureComputationCertCollectionSecretId, secureComputationCertCollectionFilePath)
+    saveSecret(metadataStorageCertCollectionSecretId, metadataStorageCertCollectionFilePath)
+  }
+
+  private fun saveSecret(secretId: String, filePath: String) {
+    val bytes = accessSecretBytes(googleProjectId, secretId)
+    val file = File(filePath)
+    file.parentFile?.mkdirs()
+    file.writeBytes(bytes)
+  }
+
+  private fun accessSecretBytes(projectId: String, secretId: String): ByteArray {
+    return SecretManagerServiceClient.create().use { client ->
+      val secretVersionName = SecretVersionName.of(projectId, secretId, SECRET_VERSION)
+      val request =
+        AccessSecretVersionRequest.newBuilder().setName(secretVersionName.toString()).build()
+      client.accessSecretVersion(request).payload.data.toByteArray()
+    }
+  }
+
+  private fun createQueueSubscriber(pubSubClient: GooglePubSubClient): QueueSubscriber {
+    logger.info("Creating Subscriber for project: $googleProjectId, subscription: $subscriptionId")
+    return Subscriber(
+      projectId = googleProjectId,
+      googlePubSubClient = pubSubClient,
+      maxMessages = 1,
+      pullIntervalMillis = 100,
+      ackDeadlineExtensionIntervalSeconds = 60,
+      ackDeadlineExtensionSeconds = 600,
+      blockingContext = Dispatchers.IO,
+    )
+  }
+
+  companion object {
+    private val logger = Logger.getLogger(this::class.java.name)
+
+    private const val SECRET_VERSION = "latest"
+    private const val SUBJECT_TOKEN_TYPE = "urn:ietf:params:oauth:token-type:jwt"
+    private const val TOKEN_URL = "https://sts.googleapis.com/v1/token"
+    private const val CREDENTIAL_SOURCE_FILE_PATH =
+      "/run/container_launcher/attestation_verifier_claims_token"
+    private const val EDP_TARGET_SERVICE_ACCOUNT_FORMAT =
+      "https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/%s:generateAccessToken"
+
+    private const val VID_LABELING_CONFIGS_BLOB_KEY = "vid-labeling-configs.textproto"
+    private val vidLabelingConfigs: VidLabelingConfigs by lazy {
+      runBlockingWithTelemetry {
+        EdpAggregatorConfig.getConfigAsProtoMessage(
+          VID_LABELING_CONFIGS_BLOB_KEY,
+          VidLabelingConfigs.getDefaultInstance(),
+        )
+      }
+    }
+
+    init {
+      configureCloudLoggingHandler()
+      EdpaTelemetry.ensureInitialized()
+    }
+
+    private fun configureCloudLoggingHandler() {
+      try {
+        val rootLogger = LogManager.getLogManager().getLogger("")
+        if (rootLogger.handlers.none { it is LoggingHandler }) {
+          val otelServiceName = System.getenv("OTEL_SERVICE_NAME")
+          val handler =
+            if (otelServiceName.isNullOrBlank()) {
+              LoggingHandler()
+            } else {
+              LoggingHandler(otelServiceName)
+            }
+          rootLogger.addHandler(handler)
+          logger.info("Configured Google Cloud Logging handler for java.util.logging")
+        }
+      } catch (e: Exception) {
+        logger.log(Level.WARNING, "Failed to configure Google Cloud Logging handler", e)
+      }
+    }
+
+    @JvmStatic fun main(args: Array<String>) = commandLineMain(VidLabelerAppRunner(), args)
+  }
+}
+
+private fun <T> runBlockingWithTelemetry(block: suspend () -> T): T {
+  return runBlocking(Context.current().asContextElement()) { block() }
+}

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/vidlabeler/VidLabelerAppRunner.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/vidlabeler/VidLabelerAppRunner.kt
@@ -229,24 +229,9 @@ class VidLabelerAppRunner : Runnable {
   }
 
   private fun buildKmsClient(kmsConfig: VidLabelingConfig.KmsConfig): KmsClient {
-    return when (kmsConfig.kmsType) {
-      VidLabelingConfig.KmsConfig.KmsType.AWS -> {
-        val credentials =
-          GCloudToAwsWifCredentials(
-            gcloudAudience = kmsConfig.kmsAudience,
-            subjectTokenType = SUBJECT_TOKEN_TYPE,
-            tokenUrl = TOKEN_URL,
-            credentialSourceFilePath = CREDENTIAL_SOURCE_FILE_PATH,
-            serviceAccountImpersonationUrl =
-              EDP_TARGET_SERVICE_ACCOUNT_FORMAT.format(kmsConfig.serviceAccount),
-            roleArn = kmsConfig.awsRoleArn,
-            roleSessionName = kmsConfig.awsRoleSessionName,
-            region = kmsConfig.awsRegion,
-            awsAudience = kmsConfig.awsAudience,
-          )
-        GCloudToAwsKmsClientFactory().getKmsClient(credentials)
-      }
-      VidLabelingConfig.KmsConfig.KmsType.GCP -> {
+    return when (kmsConfig.providerCase) {
+      VidLabelingConfig.KmsConfig.ProviderCase.GCP -> {
+        val gcp = kmsConfig.gcp
         val credentials =
           GCloudWifCredentials(
             audience = kmsConfig.kmsAudience,
@@ -254,13 +239,30 @@ class VidLabelerAppRunner : Runnable {
             tokenUrl = TOKEN_URL,
             credentialSourceFilePath = CREDENTIAL_SOURCE_FILE_PATH,
             serviceAccountImpersonationUrl =
-              EDP_TARGET_SERVICE_ACCOUNT_FORMAT.format(kmsConfig.serviceAccount),
+              EDP_TARGET_SERVICE_ACCOUNT_FORMAT.format(gcp.serviceAccount),
           )
         GCloudKmsClientFactory().getKmsClient(credentials)
       }
-      VidLabelingConfig.KmsConfig.KmsType.KMS_TYPE_UNSPECIFIED,
-      VidLabelingConfig.KmsConfig.KmsType.UNRECOGNIZED ->
-        error("Unsupported KMS type: ${kmsConfig.kmsType}")
+      VidLabelingConfig.KmsConfig.ProviderCase.AWS -> {
+        val aws = kmsConfig.aws
+        val credentials =
+          GCloudToAwsWifCredentials(
+            gcloudAudience = kmsConfig.kmsAudience,
+            subjectTokenType = SUBJECT_TOKEN_TYPE,
+            tokenUrl = TOKEN_URL,
+            credentialSourceFilePath = CREDENTIAL_SOURCE_FILE_PATH,
+            serviceAccountImpersonationUrl =
+              EDP_TARGET_SERVICE_ACCOUNT_FORMAT.format(aws.serviceAccount),
+            roleArn = aws.roleArn,
+            roleSessionName = aws.roleSessionName,
+            region = aws.region,
+            awsAudience = aws.audience,
+          )
+        GCloudToAwsKmsClientFactory().getKmsClient(credentials)
+      }
+      VidLabelingConfig.KmsConfig.ProviderCase.PROVIDER_NOT_SET,
+      null ->
+        error("KmsConfig provider must be set")
     }
   }
 

--- a/src/main/proto/wfa/measurement/config/edpaggregator/vid_labeling_config.proto
+++ b/src/main/proto/wfa/measurement/config/edpaggregator/vid_labeling_config.proto
@@ -73,6 +73,47 @@ message VidLabelingConfig {
   // Maximum batch size in bytes for partitioning raw impression files.
   // If unset, defaults to 10 GB (10000000000 bytes).
   int64 max_batch_size_bytes = 8 [(google.api.field_behavior) = OPTIONAL];
+
+  // KMS configuration for a specific cloud provider.
+  message KmsConfig {
+    enum KmsType {
+      KMS_TYPE_UNSPECIFIED = 0;
+      GCP = 1;
+      AWS = 2;
+    }
+
+    // Type of KMS provider.
+    KmsType kms_type = 1 [(google.api.field_behavior) = REQUIRED];
+
+    // GCP: WIF credential audience as workload identity pool provider.
+    string kms_audience = 2 [(google.api.field_behavior) = REQUIRED];
+
+    // GCP: Service account with KMS access.
+    string service_account = 3 [(google.api.field_behavior) = REQUIRED];
+
+    // AWS IAM role ARN to assume via GCP identity federation.
+    // Required when kms_type is AWS.
+    string aws_role_arn = 4 [(google.api.field_behavior) = OPTIONAL];
+
+    // Identifier for the assumed AWS role session.
+    // Required when kms_type is AWS.
+    string aws_role_session_name = 5 [(google.api.field_behavior) = OPTIONAL];
+
+    // AWS region for STS and KMS endpoints.
+    // Required when kms_type is AWS.
+    string aws_region = 6 [(google.api.field_behavior) = OPTIONAL];
+
+    // OIDC audience for the GCP ID token presented to AWS IAM.
+    // Required when kms_type is AWS.
+    string aws_audience = 7 [(google.api.field_behavior) = OPTIONAL];
+  }
+
+  // KMS config for decrypting raw impression data.
+  KmsConfig raw_impressions_kms_config = 9 [(google.api.field_behavior) = REQUIRED];
+
+  // KMS config for encrypting VID-labeled impression output.
+  KmsConfig vid_labeled_impressions_kms_config = 10
+      [(google.api.field_behavior) = REQUIRED];
 }
 
 // Wrapper containing VID Labeling configurations for all EDPs.

--- a/src/main/proto/wfa/measurement/config/edpaggregator/vid_labeling_config.proto
+++ b/src/main/proto/wfa/measurement/config/edpaggregator/vid_labeling_config.proto
@@ -103,7 +103,7 @@ message VidLabelingConfig {
       string audience = 5 [(google.api.field_behavior) = REQUIRED];
     }
 
-    oneof provider {
+    oneof provider_config {
       GcpKmsConfig gcp = 2;
       AwsKmsConfig aws = 3;
     }

--- a/src/main/proto/wfa/measurement/config/edpaggregator/vid_labeling_config.proto
+++ b/src/main/proto/wfa/measurement/config/edpaggregator/vid_labeling_config.proto
@@ -76,36 +76,37 @@ message VidLabelingConfig {
 
   // KMS configuration for a specific cloud provider.
   message KmsConfig {
-    enum KmsType {
-      KMS_TYPE_UNSPECIFIED = 0;
-      GCP = 1;
-      AWS = 2;
+    // WIF credential audience as workload identity pool provider.
+    string kms_audience = 1 [(google.api.field_behavior) = REQUIRED];
+
+    // GCP-specific KMS configuration.
+    message GcpKmsConfig {
+      // Service account with KMS access.
+      string service_account = 1 [(google.api.field_behavior) = REQUIRED];
     }
 
-    // Type of KMS provider.
-    KmsType kms_type = 1 [(google.api.field_behavior) = REQUIRED];
+    // AWS-specific KMS configuration, federated through GCP.
+    message AwsKmsConfig {
+      // GCP service account used for identity federation to AWS.
+      string service_account = 1 [(google.api.field_behavior) = REQUIRED];
 
-    // GCP: WIF credential audience as workload identity pool provider.
-    string kms_audience = 2 [(google.api.field_behavior) = REQUIRED];
+      // AWS IAM role ARN to assume via GCP identity federation.
+      string role_arn = 2 [(google.api.field_behavior) = REQUIRED];
 
-    // GCP: Service account with KMS access.
-    string service_account = 3 [(google.api.field_behavior) = REQUIRED];
+      // Identifier for the assumed AWS role session.
+      string role_session_name = 3 [(google.api.field_behavior) = REQUIRED];
 
-    // AWS IAM role ARN to assume via GCP identity federation.
-    // Required when kms_type is AWS.
-    string aws_role_arn = 4 [(google.api.field_behavior) = OPTIONAL];
+      // AWS region for STS and KMS endpoints.
+      string region = 4 [(google.api.field_behavior) = REQUIRED];
 
-    // Identifier for the assumed AWS role session.
-    // Required when kms_type is AWS.
-    string aws_role_session_name = 5 [(google.api.field_behavior) = OPTIONAL];
+      // OIDC audience for the GCP ID token presented to AWS IAM.
+      string audience = 5 [(google.api.field_behavior) = REQUIRED];
+    }
 
-    // AWS region for STS and KMS endpoints.
-    // Required when kms_type is AWS.
-    string aws_region = 6 [(google.api.field_behavior) = OPTIONAL];
-
-    // OIDC audience for the GCP ID token presented to AWS IAM.
-    // Required when kms_type is AWS.
-    string aws_audience = 7 [(google.api.field_behavior) = OPTIONAL];
+    oneof provider {
+      GcpKmsConfig gcp = 2;
+      AwsKmsConfig aws = 3;
+    }
   }
 
   // KMS config for decrypting raw impression data.


### PR DESCRIPTION
## Summary

Adds the `main()` entry point for the VID labeler TEE app plus its KMS configuration.

- **`VidLabelerAppRunner`** — Picocli `Runnable` entry point (`commandLineMain`), following the `ResultsFulfillerAppRunner` pattern. Builds a `KmsClient` for each KMS config and wires OpenTelemetry.
- **`KmsConfig`** (nested in `VidLabelingConfig`) — a `provider_config` oneof over `GcpKmsConfig` / `AwsKmsConfig` plus a shared `kms_audience`, used in two places on `VidLabelingConfig`:
  - `raw_impressions_kms_config` (REQUIRED) — decrypts the raw-impression input
  - `vid_labeled_impressions_kms_config` (REQUIRED) — encrypts the VID-labeled output
- **BUILD** — `java_binary` (`VidLabeler`) + `java_image` (`vid_labeler_image`) targets.

## Design decision

The VID labeler reads from one encrypted store and writes to another, potentially under different KMS keys or cloud providers, so it gets its own `KmsConfig` (GCP + AWS providers) nested in `VidLabelingConfig` rather than reusing `EventDataProviderConfig.KmsConfig` (shared with the Results Fulfiller). This scopes the config to VID labeling and avoids modifying a shared proto.

Stacked on the VID labeler scaffolding (base `jojijacob-vid-labeler-scaffolding`).


## Test plan

Verified on the dev server:
- [x] `vid_labeling_config_kt_jvm_proto` compiles with the new `KmsConfig` message and the `raw_impressions_kms_config` / `vid_labeled_impressions_kms_config` fields
- [x] `//src/main/kotlin/org/wfanet/measurement/edpaggregator/vidlabeler:vid_labeler_app_runner` library builds
- [x] `//src/main/kotlin/org/wfanet/measurement/edpaggregator/vidlabeler:VidLabeler` `java_binary` resolves all dependencies and builds

No unit test — this is a thin Picocli entry point, so the binary build is the contract.

Issue: #3578
