### PR TITLE
feat: Add set-type subcommand to ModelRepository CLI

### DIFF
--- a/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/tools/ModelRepository.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/tools/ModelRepository.kt
@@ -65,6 +65,7 @@ import org.wfanet.measurement.api.v2alpha.modelRollout
 import org.wfanet.measurement.api.v2alpha.modelSuite
 import org.wfanet.measurement.api.v2alpha.population
 import org.wfanet.measurement.api.v2alpha.setModelLineActiveEndTimeRequest
+import org.wfanet.measurement.api.v2alpha.setModelLineTypeRequest
 import org.wfanet.measurement.common.ProtoReflection
 import org.wfanet.measurement.common.ProtobufMessages
 import org.wfanet.measurement.common.commandLineMain
@@ -467,6 +468,7 @@ class ListPopulations : Runnable {
       GetModelLine::class,
       ListModelLines::class,
       SetModelLineActiveEndTime::class,
+      SetModelLineType::class,
     ],
 )
 private class ModelLines {
@@ -677,6 +679,33 @@ class SetModelLineActiveEndTime : Runnable {
         setModelLineActiveEndTimeRequest {
           name = modelLineName
           activeEndTime = Timestamps.parse(endTime)
+        }
+      )
+
+    println(result)
+  }
+}
+
+@Command(
+  name = "set-type",
+  description = ["Set the type of a ModelLine"],
+  subcommands = [CommandLine.HelpCommand::class],
+)
+class SetModelLineType : Runnable {
+  @ParentCommand private lateinit var parentCommand: ModelLines
+
+  @Option(names = ["--name"], description = ["API resource name of the ModelLine"], required = true)
+  private lateinit var modelLineName: String
+
+  @Option(names = ["--type"], description = ["Type of the ModelLine"], required = true)
+  private lateinit var modelLineType: ModelLine.Type
+
+  override fun run() {
+    val result =
+      parentCommand.modelLinesClient.setModelLineType(
+        setModelLineTypeRequest {
+          name = modelLineName
+          type = modelLineType
         }
       )
 

--- a/src/test/kotlin/org/wfanet/measurement/kingdom/deploy/tools/ModelRepositoryTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/kingdom/deploy/tools/ModelRepositoryTest.kt
@@ -598,13 +598,7 @@ class ModelRepositoryTest {
   @Test
   fun `modelLines set-type calls SetModelLineType with valid request`() {
     val args =
-      commonArgs +
-        arrayOf(
-          "model-lines",
-          "set-type",
-          "--name=$MODEL_LINE_NAME",
-          "--type=PROD",
-        )
+      commonArgs + arrayOf("model-lines", "set-type", "--name=$MODEL_LINE_NAME", "--type=PROD")
 
     val output = callCli(args)
 

--- a/src/test/kotlin/org/wfanet/measurement/kingdom/deploy/tools/ModelRepositoryTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/kingdom/deploy/tools/ModelRepositoryTest.kt
@@ -76,6 +76,7 @@ import org.wfanet.measurement.api.v2alpha.PopulationKey
 import org.wfanet.measurement.api.v2alpha.PopulationSpecKt
 import org.wfanet.measurement.api.v2alpha.PopulationsGrpcKt
 import org.wfanet.measurement.api.v2alpha.SetModelLineActiveEndTimeRequest
+import org.wfanet.measurement.api.v2alpha.SetModelLineTypeRequest
 import org.wfanet.measurement.api.v2alpha.copy
 import org.wfanet.measurement.api.v2alpha.createModelLineRequest
 import org.wfanet.measurement.api.v2alpha.createModelSuiteRequest
@@ -99,6 +100,7 @@ import org.wfanet.measurement.api.v2alpha.listPopulationsPageToken
 import org.wfanet.measurement.api.v2alpha.listPopulationsRequest
 import org.wfanet.measurement.api.v2alpha.listPopulationsResponse
 import org.wfanet.measurement.api.v2alpha.modelLine
+import org.wfanet.measurement.api.v2alpha.setModelLineTypeRequest
 import org.wfanet.measurement.api.v2alpha.modelProvider
 import org.wfanet.measurement.api.v2alpha.modelRelease
 import org.wfanet.measurement.api.v2alpha.modelRollout
@@ -175,6 +177,8 @@ class ModelRepositoryTest {
     onBlocking { createModelLine(any()) }.thenReturn(MODEL_LINE)
     onBlocking { setModelLineActiveEndTime(any()) }
       .thenReturn(MODEL_LINE.copy { activeEndTime = Timestamps.parse(ACTIVE_END_TIME_2) })
+    onBlocking { setModelLineType(any()) }
+      .thenReturn(MODEL_LINE.copy { type = ModelLine.Type.PROD })
     onBlocking { getModelLine(any()) }.thenReturn(MODEL_LINE)
     onBlocking { listModelLines(any()) }
       .thenReturn(
@@ -589,6 +593,34 @@ class ModelRepositoryTest {
       )
     assertThat(parseTextProto(output.reader(), ModelLine.getDefaultInstance()))
       .isEqualTo(MODEL_LINE.copy { activeEndTime = Timestamps.parse(ACTIVE_END_TIME_2) })
+  }
+
+  @Test
+  fun `modelLines set-type calls SetModelLineType with valid request`() {
+    val args =
+      commonArgs +
+        arrayOf(
+          "model-lines",
+          "set-type",
+          "--name=$MODEL_LINE_NAME",
+          "--type=PROD",
+        )
+
+    val output = callCli(args)
+
+    val request: SetModelLineTypeRequest = captureFirst {
+      runBlocking { verify(modelLinesServiceMock).setModelLineType(capture()) }
+    }
+
+    assertThat(request)
+      .isEqualTo(
+        setModelLineTypeRequest {
+          name = MODEL_LINE_NAME
+          type = ModelLine.Type.PROD
+        }
+      )
+    assertThat(parseTextProto(output.reader(), ModelLine.getDefaultInstance()))
+      .isEqualTo(MODEL_LINE.copy { type = ModelLine.Type.PROD })
   }
 
   private val commonArgs: Array<String>

--- a/src/test/kotlin/org/wfanet/measurement/kingdom/deploy/tools/ModelRepositoryTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/kingdom/deploy/tools/ModelRepositoryTest.kt
@@ -100,7 +100,6 @@ import org.wfanet.measurement.api.v2alpha.listPopulationsPageToken
 import org.wfanet.measurement.api.v2alpha.listPopulationsRequest
 import org.wfanet.measurement.api.v2alpha.listPopulationsResponse
 import org.wfanet.measurement.api.v2alpha.modelLine
-import org.wfanet.measurement.api.v2alpha.setModelLineTypeRequest
 import org.wfanet.measurement.api.v2alpha.modelProvider
 import org.wfanet.measurement.api.v2alpha.modelRelease
 import org.wfanet.measurement.api.v2alpha.modelRollout
@@ -108,6 +107,7 @@ import org.wfanet.measurement.api.v2alpha.modelSuite
 import org.wfanet.measurement.api.v2alpha.population
 import org.wfanet.measurement.api.v2alpha.populationSpec
 import org.wfanet.measurement.api.v2alpha.setModelLineActiveEndTimeRequest
+import org.wfanet.measurement.api.v2alpha.setModelLineTypeRequest
 import org.wfanet.measurement.common.base64UrlEncode
 import org.wfanet.measurement.common.crypto.SigningCerts
 import org.wfanet.measurement.common.getRuntimePath


### PR DESCRIPTION
This PR adds the `set-type` subcommand to the `ModelRepository` CLI, which allows setting the `type` of a `ModelLine`. It invokes the `SetModelLineType` service method. Tests are updated to cover this new functionality.

---
*PR created automatically by Jules for task [10050381215376980849](https://jules.google.com/task/10050381215376980849) started by @SanjayVas*