### PR TITLE
fix: Reactivate deleted ImpressionMetadata on re-upload

### DIFF
--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/spanner/SpannerImpressionMetadataService.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/spanner/SpannerImpressionMetadataService.kt
@@ -117,13 +117,15 @@ class SpannerImpressionMetadataService(
         }
         .single()
 
-    if (result.hasCreateTime()) {
+    if (result.hasCreateTime() && result.hasUpdateTime()) {
       return result
     }
 
     val commitTimestamp: Timestamp = transactionRunner.getCommitTimestamp().toProto()
     return result.copy {
-      createTime = commitTimestamp
+      if (!result.hasCreateTime()) {
+        createTime = commitTimestamp
+      }
       updateTime = commitTimestamp
       etag = ETags.computeETag(commitTimestamp.toInstant())
     }
@@ -190,11 +192,13 @@ class SpannerImpressionMetadataService(
     return batchCreateImpressionMetadataResponse {
       impressionMetadata +=
         results.map { result ->
-          if (result.hasCreateTime()) {
+          if (result.hasCreateTime() && result.hasUpdateTime()) {
             result
           } else {
             result.copy {
-              createTime = commitTimestamp
+              if (!result.hasCreateTime()) {
+                createTime = commitTimestamp
+              }
               updateTime = commitTimestamp
               etag = ETags.computeETag(commitTimestamp.toInstant())
             }

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/spanner/db/ImpressionMetadata.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/spanner/db/ImpressionMetadata.kt
@@ -293,13 +293,17 @@ fun AsyncDatabaseClient.TransactionContext.insertImpressionMetadata(
  * Buffers a batch of [ImpressionMetadata] to be inserted in a single transaction.
  *
  * This will check for existence prior to insertion. If an entity with the same create_request_id
- * already exists, it will be returned instead.
+ * already exists and is ACTIVE, it will be returned as-is. If it exists but is DELETED, it will be
+ * reactivated (state set back to ACTIVE). Similarly, if an entity with the same blob_uri exists and
+ * is DELETED, it will be reactivated. If it exists and is ACTIVE, an ALREADY_EXISTS error is
+ * thrown.
  *
- * For newly-created entities, the `create_time`, `update_time`, and "etag" fields will not be set
- * in the returned [ImpressionMetadata]. The caller is responsible for populating these from the
- * commit timestamp.
+ * For newly-created or reactivated entities, the `update_time` and "etag" fields will not be set in
+ * the returned [ImpressionMetadata]. The caller is responsible for populating these from the commit
+ * timestamp.
  *
- * @return a list of [ImpressionMetadata], containing both the newly created and existing entities.
+ * @return a list of [ImpressionMetadata], containing newly created, reactivated, and existing
+ *   entities.
  */
 suspend fun AsyncDatabaseClient.TransactionContext.batchCreateImpressionMetadata(
   requests: List<CreateImpressionMetadataRequest>
@@ -322,11 +326,49 @@ suspend fun AsyncDatabaseClient.TransactionContext.batchCreateImpressionMetadata
       requests.map { it.impressionMetadata.blobUri },
     )
 
+  // Reactivate DELETED records that were matched by requestId.
+  val reactivatedByRequestId: Map<String, ImpressionMetadata> = buildMap {
+    for ((requestId, result) in existingRequestIdToImpressionMetadata) {
+      if (result.impressionMetadata.state == State.IMPRESSION_METADATA_STATE_DELETED) {
+        updateImpressionMetadataState(
+          dataProviderResourceId,
+          result.impressionMetadataId,
+          State.IMPRESSION_METADATA_STATE_ACTIVE,
+        )
+        put(
+          requestId,
+          result.impressionMetadata.copy {
+            state = State.IMPRESSION_METADATA_STATE_ACTIVE
+            clearUpdateTime()
+            clearEtag()
+          },
+        )
+      }
+    }
+  }
+
   val creations: List<ImpressionMetadata> =
     requests
       .filter { !existingRequestIdToImpressionMetadata.containsKey(it.requestId) }
       .map { request ->
-        if (existingBlobUriToImpressionMetadata.containsKey(request.impressionMetadata.blobUri)) {
+        val existingByBlobUri =
+          existingBlobUriToImpressionMetadata[request.impressionMetadata.blobUri]
+        if (existingByBlobUri != null) {
+          if (
+            existingByBlobUri.impressionMetadata.state == State.IMPRESSION_METADATA_STATE_DELETED
+          ) {
+            // Reactivate the DELETED record found by blobUri.
+            updateImpressionMetadataState(
+              dataProviderResourceId,
+              existingByBlobUri.impressionMetadataId,
+              State.IMPRESSION_METADATA_STATE_ACTIVE,
+            )
+            return@map existingByBlobUri.impressionMetadata.copy {
+              state = State.IMPRESSION_METADATA_STATE_ACTIVE
+              clearUpdateTime()
+              clearEtag()
+            }
+          }
           throw ImpressionMetadataAlreadyExistsException(request.impressionMetadata.blobUri)
             .asStatusRuntimeException(Status.Code.ALREADY_EXISTS)
         }
@@ -369,7 +411,8 @@ suspend fun AsyncDatabaseClient.TransactionContext.batchCreateImpressionMetadata
   val newCreationIterator = creations.iterator()
 
   return requests.map {
-    existingRequestIdToImpressionMetadata[it.requestId]?.impressionMetadata
+    reactivatedByRequestId[it.requestId]
+      ?: existingRequestIdToImpressionMetadata[it.requestId]?.impressionMetadata
       ?: newCreationIterator.next()
   }
 }

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/service/internal/testing/ImpressionMetadataServiceTest.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/service/internal/testing/ImpressionMetadataServiceTest.kt
@@ -687,6 +687,183 @@ abstract class ImpressionMetadataServiceTest {
     }
 
   @Test
+  fun `batchCreateImpressionMetadata reactivates DELETED record matched by requestId`() =
+    runBlocking {
+      val requestId = UUID.randomUUID().toString()
+      val createRequest = createImpressionMetadataRequest {
+        impressionMetadata = IMPRESSION_METADATA
+        this.requestId = requestId
+      }
+
+      // Create the record.
+      val initialResponse =
+        service.batchCreateImpressionMetadata(
+          batchCreateImpressionMetadataRequest {
+            dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
+            requests += createRequest
+          }
+        )
+      val created = initialResponse.impressionMetadataList.single()
+      assertThat(created.state).isEqualTo(State.IMPRESSION_METADATA_STATE_ACTIVE)
+
+      // Delete the record.
+      service.deleteImpressionMetadata(
+        deleteImpressionMetadataRequest {
+          dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
+          impressionMetadataResourceId = created.impressionMetadataResourceId
+        }
+      )
+
+      // Re-create with the same requestId. The DELETED record should be reactivated.
+      val reactivatedResponse =
+        service.batchCreateImpressionMetadata(
+          batchCreateImpressionMetadataRequest {
+            dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
+            requests += createRequest
+          }
+        )
+
+      val reactivated = reactivatedResponse.impressionMetadataList.single()
+      assertThat(reactivated.state).isEqualTo(State.IMPRESSION_METADATA_STATE_ACTIVE)
+      assertThat(reactivated.impressionMetadataResourceId)
+        .isEqualTo(created.impressionMetadataResourceId)
+      assertThat(reactivated.updateTime.toInstant())
+        .isGreaterThan(created.updateTime.toInstant())
+    }
+
+  @Test
+  fun `batchCreateImpressionMetadata reactivates DELETED record matched by blobUri`() =
+    runBlocking {
+      val originalRequestId = UUID.randomUUID().toString()
+      val createRequest = createImpressionMetadataRequest {
+        impressionMetadata = IMPRESSION_METADATA
+        requestId = originalRequestId
+      }
+
+      // Create the record.
+      val initialResponse =
+        service.batchCreateImpressionMetadata(
+          batchCreateImpressionMetadataRequest {
+            dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
+            requests += createRequest
+          }
+        )
+      val created = initialResponse.impressionMetadataList.single()
+      assertThat(created.state).isEqualTo(State.IMPRESSION_METADATA_STATE_ACTIVE)
+
+      // Delete the record.
+      service.deleteImpressionMetadata(
+        deleteImpressionMetadataRequest {
+          dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
+          impressionMetadataResourceId = created.impressionMetadataResourceId
+        }
+      )
+
+      // Re-create with a different requestId but the same blobUri.
+      val newRequestId = UUID.randomUUID().toString()
+      val reactivatedResponse =
+        service.batchCreateImpressionMetadata(
+          batchCreateImpressionMetadataRequest {
+            dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
+            requests += createImpressionMetadataRequest {
+              impressionMetadata = IMPRESSION_METADATA
+              requestId = newRequestId
+            }
+          }
+        )
+
+      val reactivated = reactivatedResponse.impressionMetadataList.single()
+      assertThat(reactivated.state).isEqualTo(State.IMPRESSION_METADATA_STATE_ACTIVE)
+      assertThat(reactivated.impressionMetadataResourceId)
+        .isEqualTo(created.impressionMetadataResourceId)
+    }
+
+  @Test
+  fun `batchCreateImpressionMetadata reactivates DELETED and creates new in same batch`() =
+    runBlocking {
+      val requestId1 = UUID.randomUUID().toString()
+      val createRequest1 = createImpressionMetadataRequest {
+        impressionMetadata = IMPRESSION_METADATA
+        requestId = requestId1
+      }
+
+      // Create the first record.
+      val initialResponse =
+        service.batchCreateImpressionMetadata(
+          batchCreateImpressionMetadataRequest {
+            dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
+            requests += createRequest1
+          }
+        )
+      val created = initialResponse.impressionMetadataList.single()
+
+      // Delete it.
+      service.deleteImpressionMetadata(
+        deleteImpressionMetadataRequest {
+          dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
+          impressionMetadataResourceId = created.impressionMetadataResourceId
+        }
+      )
+
+      // Batch with one DELETED record (same requestId) and one new record.
+      val requestId2 = UUID.randomUUID().toString()
+      val createRequest2 = createImpressionMetadataRequest {
+        impressionMetadata = IMPRESSION_METADATA_2
+        requestId = requestId2
+      }
+
+      val batchResponse =
+        service.batchCreateImpressionMetadata(
+          batchCreateImpressionMetadataRequest {
+            dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
+            requests += createRequest1
+            requests += createRequest2
+          }
+        )
+
+      assertThat(batchResponse.impressionMetadataCount).isEqualTo(2)
+      val reactivated = batchResponse.impressionMetadataList[0]
+      val newRecord = batchResponse.impressionMetadataList[1]
+
+      assertThat(reactivated.state).isEqualTo(State.IMPRESSION_METADATA_STATE_ACTIVE)
+      assertThat(reactivated.impressionMetadataResourceId)
+        .isEqualTo(created.impressionMetadataResourceId)
+      assertThat(newRecord.state).isEqualTo(State.IMPRESSION_METADATA_STATE_ACTIVE)
+      assertThat(newRecord.blobUri).isEqualTo(IMPRESSION_METADATA_2.blobUri)
+    }
+
+  @Test
+  fun `batchCreateImpressionMetadata still throws ALREADY_EXISTS for ACTIVE blobUri`() =
+    runBlocking {
+      val duplicateBlobUri = "active-blob-uri"
+      service.batchCreateImpressionMetadata(
+        batchCreateImpressionMetadataRequest {
+          requests += createImpressionMetadataRequest {
+            impressionMetadata = IMPRESSION_METADATA.copy { blobUri = duplicateBlobUri }
+            requestId = UUID.randomUUID().toString()
+          }
+        }
+      )
+
+      // Try to create a different record with the same blobUri but different requestId.
+      // The existing record is ACTIVE, so this should throw ALREADY_EXISTS.
+      val exception =
+        assertFailsWith<StatusRuntimeException> {
+          service.batchCreateImpressionMetadata(
+            batchCreateImpressionMetadataRequest {
+              dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
+              requests += createImpressionMetadataRequest {
+                impressionMetadata = IMPRESSION_METADATA_2.copy { blobUri = duplicateBlobUri }
+                requestId = UUID.randomUUID().toString()
+              }
+            }
+          )
+        }
+
+      assertThat(exception.status.code).isEqualTo(Status.Code.ALREADY_EXISTS)
+    }
+
+  @Test
   fun `deleteImpressionMetadata soft deletes and returns updated ImpressionMetadata`() =
     runBlocking {
       val created =


### PR DESCRIPTION
PR Description
                                                                                                                                                                                                           
  ## Summary                                                

  - `batchCreateImpressionMetadata` now reactivates soft-deleted (`state=DELETED`) records when matched by `requestId` or `blobUri`, instead of returning the stale DELETED record or throwing `ALREADY_EXISTS`.                                       
  - `SpannerImpressionMetadataService` updated to correctly set `updateTime` from commit timestamp on reactivated records.                                                                                                                                             
  - 4 new tests covering: reactivation by requestId, reactivation by blobUri, mixed batch (DELETED + new), and ACTIVE duplicate guard.                                                                                                                                      
                                                                                                                                                                                                           
  ## Context                                                                                                                                                                                               
                                                                                                                                                                                                           
  When a GCS metadata blob is deleted, `DataAvailabilityCleanup` soft-deletes the corresponding `ImpressionMetadata` record. If the blob is later re-uploaded and DataAvailabilitySync re-triggers, the existing `batchCreateImpressionMetadata` idempotency check found the DELETED record by `CreateRequestId` (no state filter) and returned it as-is.                                                                                                                                     
  This left the record permanently in DELETED state, excluded from `computeModelLineBounds`, and therefore missing from availability intervals — even though the underlying data was present in GCS.                                                                                                                                          
                                                                                                                                                                                                           
  ## Test plan                                                                                                                                                                                             
                                                                                                                                                                                                           
  - [x] batchCreateImpressionMetadata reactivates DELETED record matched by requestId
  - [x] batchCreateImpressionMetadata reactivates DELETED record matched by blobUri                                                                                                                                                                                            
  - [x] batchCreateImpressionMetadata reactivates DELETED and creates new in same batch`                                                                                                                                                                                        
  - [x] batchCreateImpressionMetadata still throws ALREADY_EXISTS for ACTIVE blobUri                                                                                                                                                                                        
  - [x] All 60 existing tests in SpannerImpressionMetadataServiceTest pass 