### PR TITLE
feat: Add Terraform infrastructure for DataAvailabilityMonitor cloud function

### DIFF
--- a/.github/workflows/publish-cloud-run-function-uber-jars.yml
+++ b/.github/workflows/publish-cloud-run-function-uber-jars.yml
@@ -129,3 +129,13 @@ jobs:
           artifact-group-id: org.wfanet.measurement.edpaggregator.deploy.gcloud.dataavailability
           bazel_target_label: //src/main/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/dataavailability:DataAvailabilityCleanupFunction_deploy.jar
 
+      - name: Build and Deploy Data Availability Monitor
+        env:
+          MAVEN_USERNAME: ${{ github.actor }}
+          MAVEN_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+        uses: ./.github/actions/build-and-push-uber-jar
+        with:
+          package-version: ${{ steps.get-artifact-version.outputs.artifact-version }}
+          artifact-id: data-availability-monitor
+          artifact-group-id: org.wfanet.measurement.edpaggregator.deploy.gcloud.dataavailability
+          bazel_target_label: //src/main/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/dataavailability:DataAvailabilityMonitorFunction_deploy.jar

--- a/.github/workflows/terraform-cmms-v2.yml
+++ b/.github/workflows/terraform-cmms-v2.yml
@@ -67,6 +67,7 @@ jobs:
       EDPA_EDPS_CONFIG: ${{ vars.EDPA_EDPS_CONFIG }}
       EVENT_GROUP_SYNC_CONFIG_CONTENT: ${{ vars.EVENT_GROUP_SYNC_CONFIG_CONTENT }}
       DATA_AVAILABILITY_SYNC_CONFIG_CONTENT: ${{ vars.DATA_AVAILABILITY_SYNC_CONFIG_CONTENT }}
+      DATA_AVAILABILITY_MONITOR_CONFIG_CONTENT: ${{ vars.DATA_AVAILABILITY_MONITOR_CONFIG_CONTENT }}
       RESULTS_FULFILLER_POPULATION_SPEC_CONTENT: ${{ vars.RESULTS_FULFILLER_POPULATION_SPEC_CONTENT }}
       RESULTS_FULFILLER_TRUSTED_CA_CONTENT: ${{ secrets.RESULTS_FULFILLER_TRUSTED_CA_CONTENT }}
       EDP_SIMULATOR_NAMES: '["edp1-simulator", "edp2-simulator", "edp3-simulator", "edp4-simulator", "edp5-simulator", "edp6-simulator"]'
@@ -135,6 +136,7 @@ jobs:
         echo "$EDPA_EDPS_CONFIG" > "$CONFIG_DIR/event-data-provider-configs.textproto"
         echo "$EVENT_GROUP_SYNC_CONFIG_CONTENT" > "$CONFIG_DIR/event-group-sync-config.textproto"
         echo "$DATA_AVAILABILITY_SYNC_CONFIG_CONTENT" > "$CONFIG_DIR/data-availability-sync-config.textproto"
+        echo "$DATA_AVAILABILITY_MONITOR_CONFIG_CONTENT" > "$CONFIG_DIR/data-availability-monitor-config.textproto"
         echo "$RESULTS_FULFILLER_POPULATION_SPEC_CONTENT" > "$CONFIG_DIR/results-fulfiller-population-spec.textproto"
         echo "$RESULTS_FULFILLER_TRUSTED_CA_CONTENT" > "$CONFIG_DIR/results-fulfiller-trusted-root-ca.pem"
         
@@ -174,6 +176,7 @@ jobs:
         coords[event-group-sync]="org.wfanet.measurement.edpaggregator.deploy.gcloud.eventgroups:event-group-sync:$ARTIFACT_VERSION:jar"
         coords[data-availability-sync]="org.wfanet.measurement.edpaggregator.deploy.gcloud.dataavailability:data-availability-sync:$ARTIFACT_VERSION:jar"
         coords[data-availability-cleanup]="org.wfanet.measurement.edpaggregator.deploy.gcloud.dataavailability:data-availability-cleanup:$ARTIFACT_VERSION:jar"
+        coords[data-availability-monitor]="org.wfanet.measurement.edpaggregator.deploy.gcloud.dataavailability:data-availability-monitor:$ARTIFACT_VERSION:jar"
         
         LOCAL_REPO=$(mvn help:evaluate -Dexpression=settings.localRepository -q -DforceStdout)
 
@@ -258,6 +261,7 @@ jobs:
         DATA_AVAILABILITY_SECRET_MAPPING: ${{ vars.DATA_AVAILABILITY_SECRET_MAPPING }}
         DATA_AVAILABILITY_CLEANUP_ENV_VAR: ${{ vars.DATA_AVAILABILITY_CLEANUP_ENV_VAR }}
         DATA_AVAILABILITY_CLEANUP_SECRET_MAPPING: ${{ vars.DATA_AVAILABILITY_CLEANUP_SECRET_MAPPING }}
+        DATA_AVAILABILITY_MONITOR_ENV_VAR: ${{ vars.DATA_AVAILABILITY_MONITOR_ENV_VAR }}
         RESULTS_FULFILLER_EVENT_DESCRIPTOR_BLOB_URI: ${{ vars.RESULTS_FULFILLER_EVENT_DESCRIPTOR_BLOB_URI }}
         RESULTS_FULFILLER_EVENT_TEMPLATE_TYPE_NAME: ${{ vars.RESULTS_FULFILLER_EVENT_TEMPLATE_TYPE_NAME }}
         RESULTS_FULFILLER_POPULATION_SPEC_BLOB_URI: ${{ vars.RESULTS_FULFILLER_POPULATION_SPEC_BLOB_URI }}
@@ -311,6 +315,9 @@ jobs:
         -var="data_availability_cleanup_env_var=$DATA_AVAILABILITY_CLEANUP_ENV_VAR"
         -var="data_availability_cleanup_secret_mapping=$DATA_AVAILABILITY_CLEANUP_SECRET_MAPPING"
         -var="data_availability_cleanup_uber_jar_path=${{ steps.download-uber-jars.outputs.data_availability_cleanup_source_path }}"
+        -var="data_availability_monitor_config_file_path=$CONFIG_DIR/data-availability-monitor-config.textproto"
+        -var="data_availability_monitor_env_var=$DATA_AVAILABILITY_MONITOR_ENV_VAR"
+        -var="data_availability_monitor_uber_jar_path=${{ steps.download-uber-jars.outputs.data_availability_monitor_source_path }}"
         -var="image_tag=$IMAGE_TAG"
         -var="results_fulfiller_event_proto_descriptor_path=${{ steps.build-test-event-descriptors.outputs.event_proto_descriptors_path }}"
         -var="results_fulfiller_event_proto_descriptor_blob_uri=$RESULTS_FULFILLER_EVENT_DESCRIPTOR_BLOB_URI"

--- a/src/main/terraform/gcloud/cmms/edp_aggregator.tf
+++ b/src/main/terraform/gcloud/cmms/edp_aggregator.tf
@@ -175,7 +175,7 @@ locals {
   data_availability_monitor_scheduler_config = {
     schedule                  = "0 6 * * *"
     time_zone                 = "UTC"
-    name                      = "data-availability-monitor-scheduler"
+    name                      = "da-monitor-scheduler"
     function_url              = "https://${data.google_client_config.default.region}-${data.google_client_config.default.project}.cloudfunctions.net/data-availability-monitor"
     scheduler_sa_display_name = "Data Availability Monitor Scheduler"
     scheduler_sa_description  = "Service account for Cloud Scheduler to trigger data availability monitor"

--- a/src/main/terraform/gcloud/cmms/edp_aggregator.tf
+++ b/src/main/terraform/gcloud/cmms/edp_aggregator.tf
@@ -330,7 +330,6 @@ module "edp_aggregator" {
   edp_aggregator_service_account_name           = "edp-aggregator-internal"
   data_availability_monitor_service_account_name = "edpa-data-avail-monitor"
   data_availability_monitor_config                = local.data_availability_monitor_config
-  data_availability_monitor_function_name         = "data-availability-monitor"
   data_availability_monitor_scheduler_config      = local.data_availability_monitor_scheduler_config
   spanner_instance                              = google_spanner_instance.spanner_instance
 }

--- a/src/main/terraform/gcloud/cmms/edp_aggregator.tf
+++ b/src/main/terraform/gcloud/cmms/edp_aggregator.tf
@@ -172,6 +172,17 @@ locals {
     scheduler_sa_description    = "Service account for Cloud Scheduler to trigger requisition fetcher"
     scheduler_job_description   = "Scheduled job to fetch unfulfilled requisitions from the Kingdom"
   }
+  data_availability_monitor_scheduler_config = {
+    schedule                  = "0 6 * * *"
+    time_zone                 = "UTC"
+    name                      = "data-availability-monitor-scheduler"
+    function_url              = "https://${data.google_client_config.default.region}-${data.google_client_config.default.project}.cloudfunctions.net/data-availability-monitor"
+    scheduler_sa_display_name = "Data Availability Monitor Scheduler"
+    scheduler_sa_description  = "Service account for Cloud Scheduler to trigger data availability monitor"
+    scheduler_job_description = "Scheduled job to monitor data availability for staleness and gaps"
+    scheduler_job_name        = "data-availability-monitor"
+  }
+
 
   data_watcher_config = {
     local_path  = var.data_watcher_config_file_path
@@ -201,6 +212,11 @@ locals {
   data_availability_sync_config = {
     local_path  = var.data_availability_sync_config_file_path
     destination = "data-availability-sync-config.textproto"
+  }
+
+  data_availability_monitor_config = {
+    local_path  = var.data_availability_monitor_config_file_path
+    destination = "data-availability-monitor-config.textproto"
   }
 
   results_fulfiller_event_descriptor = {
@@ -256,6 +272,13 @@ locals {
       secret_mappings     = var.data_availability_cleanup_secret_mapping
       uber_jar_path       = var.data_availability_cleanup_uber_jar_path
     }
+    data_availability_monitor = {
+      function_name       = "data-availability-monitor"
+      entry_point         = "org.wfanet.measurement.edpaggregator.deploy.gcloud.dataavailability.DataAvailabilityMonitorFunction"
+      extra_env_vars      = "${var.data_availability_monitor_env_var},CONFIG_BLOB_KEY=${local.data_availability_monitor_config.destination},EDPA_CONFIG_STORAGE_BUCKET=gs://${var.edpa_config_files_bucket_name}"
+      secret_mappings     = ""
+      uber_jar_path       = var.data_availability_monitor_uber_jar_path
+    }
   }
 
 }
@@ -305,5 +328,9 @@ module "edp_aggregator" {
   results_fulfiller_disk_image_family           = "confidential-space"
   dns_managed_zone_name                         = "googleapis-private"
   edp_aggregator_service_account_name           = "edp-aggregator-internal"
+  data_availability_monitor_service_account_name = "edpa-data-avail-monitor"
+  data_availability_monitor_config                = local.data_availability_monitor_config
+  data_availability_monitor_function_name         = "data-availability-monitor"
+  data_availability_monitor_scheduler_config      = local.data_availability_monitor_scheduler_config
   spanner_instance                              = google_spanner_instance.spanner_instance
 }

--- a/src/main/terraform/gcloud/cmms/variables.tf
+++ b/src/main/terraform/gcloud/cmms/variables.tf
@@ -340,3 +340,18 @@ variable "data_availability_sync_config_file_path" {
   description = "Path to DataAvailabilitySync config file."
   type        = string
 }
+
+variable "data_availability_monitor_config_file_path" {
+  description = "Path to DataAvailabilityMonitor config file."
+  type        = string
+}
+
+variable "data_availability_monitor_env_var" {
+  description = "DataAvailabilityMonitor extra env variables"
+  type        = string
+}
+
+variable "data_availability_monitor_uber_jar_path" {
+  description = "Path to DataAvailabilityMonitor uber jar."
+  type        = string
+}

--- a/src/main/terraform/gcloud/modules/cloud-scheduler/main.tf
+++ b/src/main/terraform/gcloud/modules/cloud-scheduler/main.tf
@@ -33,7 +33,7 @@ resource "google_project_iam_member" "scheduler_function_invoker" {
 }
 
 resource "google_cloud_scheduler_job" "scheduler_job" {
-  name        = "${var.scheduler_config.name}-requisition-fetcher"
+  name        = coalesce(var.scheduler_config.scheduler_job_name, "${var.scheduler_config.name}-requisition-fetcher")
   description = var.scheduler_config.scheduler_job_description
   schedule    = var.scheduler_config.schedule
   time_zone   = var.scheduler_config.time_zone

--- a/src/main/terraform/gcloud/modules/cloud-scheduler/variables.tf
+++ b/src/main/terraform/gcloud/modules/cloud-scheduler/variables.tf
@@ -22,6 +22,7 @@ variable "scheduler_config" {
     scheduler_sa_display_name   = string
     scheduler_sa_description    = string
     scheduler_job_description   = string
+    scheduler_job_name          = optional(string)
   })
   nullable = false
 }

--- a/src/main/terraform/gcloud/modules/edp-aggregator/main.tf
+++ b/src/main/terraform/gcloud/modules/edp-aggregator/main.tf
@@ -148,6 +148,7 @@ locals {
     "data_availability_sync"    = module.data_availability_sync_cloud_function.cloud_function_service_account.email
     "data_watcher_delete"       = module.data_watcher_delete_cloud_function.cloud_function_service_account.email
     "data_availability_cleanup" = module.data_availability_cleanup_cloud_function.cloud_function_service_account.email
+    "data_availability_monitor" = module.data_availability_monitor_cloud_function.cloud_function_service_account.email
   }
 
   otel_metadata = {
@@ -630,4 +631,44 @@ resource "google_project_iam_member" "telemetry_trace_agent" {
   project  = data.google_project.project.id
   role     = "roles/cloudtrace.agent"
   member   = "serviceAccount:${each.value}"
+}
+
+resource "google_storage_bucket_object" "upload_data_availability_monitor_config" {
+  name   = var.data_availability_monitor_config.destination
+  bucket = module.config_files_bucket.storage_bucket.name
+  source = var.data_availability_monitor_config.local_path
+}
+
+module "data_availability_monitor_cloud_function" {
+  source = "../http-cloud-function"
+
+  depends_on = [module.secrets]
+
+  http_cloud_function_service_account_name = var.data_availability_monitor_service_account_name
+  terraform_service_account                = var.terraform_service_account
+  function_name                            = var.cloud_function_configs.data_availability_monitor.function_name
+  entry_point                              = var.cloud_function_configs.data_availability_monitor.entry_point
+  extra_env_vars                           = var.cloud_function_configs.data_availability_monitor.extra_env_vars
+  secret_mappings                          = var.cloud_function_configs.data_availability_monitor.secret_mappings
+  uber_jar_path                            = var.cloud_function_configs.data_availability_monitor.uber_jar_path
+}
+
+module "data_availability_monitor_cloud_scheduler" {
+  source                    = "../cloud-scheduler"
+  terraform_service_account = var.terraform_service_account
+  scheduler_config          = var.data_availability_monitor_scheduler_config
+  depends_on                = [module.data_availability_monitor_cloud_function]
+}
+
+resource "google_storage_bucket_iam_member" "data_availability_monitor_storage_viewer" {
+  depends_on = [module.data_availability_monitor_cloud_function]
+  bucket     = module.edp_aggregator_bucket.storage_bucket.name
+  role       = "roles/storage.objectViewer"
+  member     = "serviceAccount:${module.data_availability_monitor_cloud_function.cloud_function_service_account.email}"
+}
+
+resource "google_storage_bucket_iam_member" "data_availability_monitor_config_storage_viewer" {
+  bucket = module.config_files_bucket.storage_bucket.name
+  role   = "roles/storage.objectViewer"
+  member = "serviceAccount:${module.data_availability_monitor_cloud_function.cloud_function_service_account.email}"
 }

--- a/src/main/terraform/gcloud/modules/edp-aggregator/main.tf
+++ b/src/main/terraform/gcloud/modules/edp-aggregator/main.tf
@@ -645,8 +645,6 @@ module "data_availability_monitor_cloud_function" {
   depends_on = [
     module.secrets,
     google_storage_bucket_object.upload_data_availability_monitor_config,
-    google_storage_bucket_iam_member.data_availability_monitor_config_storage_viewer,
-    google_storage_bucket_iam_member.data_availability_monitor_storage_viewer,
   ]
 
   http_cloud_function_service_account_name = var.data_availability_monitor_service_account_name

--- a/src/main/terraform/gcloud/modules/edp-aggregator/main.tf
+++ b/src/main/terraform/gcloud/modules/edp-aggregator/main.tf
@@ -642,7 +642,12 @@ resource "google_storage_bucket_object" "upload_data_availability_monitor_config
 module "data_availability_monitor_cloud_function" {
   source = "../http-cloud-function"
 
-  depends_on = [module.secrets]
+  depends_on = [
+    module.secrets,
+    google_storage_bucket_object.upload_data_availability_monitor_config,
+    google_storage_bucket_iam_member.data_availability_monitor_config_storage_viewer,
+    google_storage_bucket_iam_member.data_availability_monitor_storage_viewer,
+  ]
 
   http_cloud_function_service_account_name = var.data_availability_monitor_service_account_name
   terraform_service_account                = var.terraform_service_account

--- a/src/main/terraform/gcloud/modules/edp-aggregator/variables.tf
+++ b/src/main/terraform/gcloud/modules/edp-aggregator/variables.tf
@@ -422,3 +422,38 @@ variable "edp_aggregator_api_server_ip_address" {
   default     = null
 }
 
+
+variable "data_availability_monitor_service_account_name" {
+  description = "Name of the DataAvailabilityMonitor service account."
+  type        = string
+  nullable    = false
+}
+
+variable "data_availability_monitor_config" {
+  description = "An object containing the local path of the DataAvailabilityMonitor config file and its destination path in Cloud Storage."
+  type = object({
+    local_path  = string
+    destination = string
+  })
+}
+
+variable "data_availability_monitor_function_name" {
+  description = "Name of the DataAvailabilityMonitor cloud function."
+  type        = string
+  nullable    = false
+}
+
+variable "data_availability_monitor_scheduler_config" {
+  description = "Configuration for Google Cloud Scheduler to trigger the DataAvailabilityMonitor"
+  type = object({
+    schedule                  = string
+    time_zone                 = string
+    name                      = string
+    function_url              = string
+    scheduler_sa_display_name = string
+    scheduler_sa_description  = string
+    scheduler_job_description = string
+    scheduler_job_name        = optional(string)
+  })
+  nullable = false
+}

--- a/src/main/terraform/gcloud/modules/edp-aggregator/variables.tf
+++ b/src/main/terraform/gcloud/modules/edp-aggregator/variables.tf
@@ -437,12 +437,6 @@ variable "data_availability_monitor_config" {
   })
 }
 
-variable "data_availability_monitor_function_name" {
-  description = "Name of the DataAvailabilityMonitor cloud function."
-  type        = string
-  nullable    = false
-}
-
 variable "data_availability_monitor_scheduler_config" {
   description = "Configuration for Google Cloud Scheduler to trigger the DataAvailabilityMonitor"
   type = object({


### PR DESCRIPTION
## Summary                                                                                                                                                                                               
                                                                                                                                                                                                           
  The DataAvailabilityMonitorFunction Kotlin code and Bazel BUILD target already exist                                                                                                                     
  but had no Terraform infrastructure to deploy it. This PR adds the full deployment
  pipeline: cloud function, Cloud Scheduler (daily at 6 AM UTC), IAM grants, config                                                                                                                        
  upload, Maven artifact publishing, and CI integration.                                                                                                                                                   
   
  Changes                                                                                                                                                                                                  
                                                            
  Terraform modules (modules/)
  - cloud-scheduler: Add optional scheduler_job_name field so the module can be
  reused beyond requisition-fetcher (backward compatible via coalesce()).      
  - edp-aggregator: Add HTTP cloud function + Cloud Scheduler for the monitor,
  storage.objectViewer IAM on both the impression and config buckets, config blob                                                                                                                          
  upload with depends_on to ensure it exists before the function deploys, and    
  telemetry IAM (logging/monitoring/tracing via the service_accounts local).                                                                                                                               
                                                                                                                                                                                                           
  Root module (cmms/)
  - edp_aggregator.tf: Add monitor locals (config path, scheduler config with                                                                                                                              
  shortened SA name to fit 30-char limit, cloud_function_configs entry with  
  secret_mappings = ""), wire new variables into the module call.          
  - variables.tf: Add data_availability_monitor_config_file_path,                                                                                                                                          
  data_availability_monitor_env_var, data_availability_monitor_uber_jar_path.                                                                                                                              
                                                                                                                                                                                                           
  CI workflows                                                                                                                                                                                             
  - terraform-cmms-v2.yml: Add DATA_AVAILABILITY_MONITOR_CONFIG_CONTENT env var,                                                                                                                           
  config file write, Maven JAR download, and terraform plan -var flags.         
  - publish-cloud-run-function-uber-jars.yml: Add build-and-push step for the                                                                                                                              
  data-availability-monitor uber JAR.

Test plan                                                                                                                                                                                                
                                                                                                                                                                                                           
  - Verify terraform plan succeeds with all new variables populated                                                                                                                                        
  - Deploy to dev environment and confirm the cloud function is created
  - Confirm Cloud Scheduler job triggers the function successfully
  - Verify the function can read its config from the config bucket at startup                                                                                                                              
  - Verify the function can scan the impression bucket for staleness/gaps
  - Check Cloud Logging 


Issue: #3672 