### PR TITLE
perf: Switch to C3 machine family for Mills in Halo GCloud projects

### DIFF
--- a/src/main/terraform/gcloud/cmms/duchies.tf
+++ b/src/main/terraform/gcloud/cmms/duchies.tf
@@ -123,7 +123,7 @@ module "highmem_node_pools" {
   cluster         = each.value.cluster
   name            = "highmem"
   service_account = module.common.cluster_service_account
-  machine_type    = "c3d-standard-4"
+  machine_type    = "c3-standard-4"
   max_node_count  = 20
   spot            = true
 }


### PR DESCRIPTION
This PR changes the machine family due to a lack of spot instance availability. See related PR #3219.