### PR TITLE
ci: Add TCP keepalive to Accuracy test to reduce the chance of disconnection from BES

### DIFF
--- a/.github/workflows/accuracy-test.yml
+++ b/.github/workflows/accuracy-test.yml
@@ -50,6 +50,10 @@ jobs:
         common --config=ci
         EOF
 
+    # Reduce chance of disconnection from the Build Event Service.
+    - name: Set TCP keepalive
+      run: sudo sysctl -w net.ipv4.tcp_keepalive_time=60
+        
     - name: Run tests
       id: run-tests
       run: >


### PR DESCRIPTION
Issue: #3736