### PR TITLE
feat: add entity keys services

### DIFF
--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/spanner/SpannerImpressionMetadataService.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/spanner/SpannerImpressionMetadataService.kt
@@ -57,7 +57,6 @@ import org.wfanet.measurement.internal.edpaggregator.ImpressionMetadataState as 
 import org.wfanet.measurement.internal.edpaggregator.ListImpressionMetadataPageTokenKt
 import org.wfanet.measurement.internal.edpaggregator.ListImpressionMetadataRequest
 import org.wfanet.measurement.internal.edpaggregator.ListImpressionMetadataResponse
-import org.wfanet.measurement.internal.edpaggregator.MetaEntityKey
 import org.wfanet.measurement.internal.edpaggregator.batchCreateImpressionMetadataResponse
 import org.wfanet.measurement.internal.edpaggregator.batchDeleteImpressionMetadataResponse
 import org.wfanet.measurement.internal.edpaggregator.computeModelLineBoundsResponse
@@ -485,27 +484,16 @@ class SpannerImpressionMetadataService(
   }
 
   /**
-   * Checks that the specified [EntityKey] has exactly one variant set and that the inner fields
-   * are populated correctly.
+   * Checks that the specified [EntityKey] has both `entity_type` and `id` set.
    *
-   * @throws RequiredFieldNotSetException if the variant or a required inner field is unset
-   * @throws InvalidFieldValueException if an inner enum is set to its UNSPECIFIED value
+   * @throws RequiredFieldNotSetException if a required field is unset
    */
   private fun validateEntityKey(entityKey: EntityKey, fieldPath: String) {
-    when (entityKey.keyCase) {
-      EntityKey.KeyCase.META -> {
-        if (entityKey.meta.type == MetaEntityKey.Type.TYPE_UNSPECIFIED) {
-          throw InvalidFieldValueException("$fieldPath.meta.type") { fieldName ->
-            "$fieldName must not be TYPE_UNSPECIFIED"
-          }
-        }
-        if (entityKey.meta.id.isEmpty()) {
-          throw RequiredFieldNotSetException("$fieldPath.meta.id")
-        }
-      }
-      EntityKey.KeyCase.KEY_NOT_SET -> {
-        throw RequiredFieldNotSetException("$fieldPath.key")
-      }
+    if (entityKey.entityType.isEmpty()) {
+      throw RequiredFieldNotSetException("$fieldPath.entity_type")
+    }
+    if (entityKey.id.isEmpty()) {
+      throw RequiredFieldNotSetException("$fieldPath.id")
     }
   }
 

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/spanner/SpannerImpressionMetadataService.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/spanner/SpannerImpressionMetadataService.kt
@@ -224,8 +224,6 @@ class SpannerImpressionMetadataService(
         validateEntityKey(entityKey, "filter.entity_keys.$index")
       } catch (e: RequiredFieldNotSetException) {
         throw e.asStatusRuntimeException(Status.Code.INVALID_ARGUMENT)
-      } catch (e: InvalidFieldValueException) {
-        throw e.asStatusRuntimeException(Status.Code.INVALID_ARGUMENT)
       }
     }
 
@@ -492,8 +490,8 @@ class SpannerImpressionMetadataService(
     if (entityKey.entityType.isEmpty()) {
       throw RequiredFieldNotSetException("$fieldPath.entity_type")
     }
-    if (entityKey.id.isEmpty()) {
-      throw RequiredFieldNotSetException("$fieldPath.id")
+    if (entityKey.entityId.isEmpty()) {
+      throw RequiredFieldNotSetException("$fieldPath.entity_id")
     }
   }
 

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/spanner/SpannerImpressionMetadataService.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/spanner/SpannerImpressionMetadataService.kt
@@ -49,6 +49,7 @@ import org.wfanet.measurement.internal.edpaggregator.ComputeModelLineBoundsReque
 import org.wfanet.measurement.internal.edpaggregator.ComputeModelLineBoundsResponse
 import org.wfanet.measurement.internal.edpaggregator.CreateImpressionMetadataRequest
 import org.wfanet.measurement.internal.edpaggregator.DeleteImpressionMetadataRequest
+import org.wfanet.measurement.internal.edpaggregator.EntityKey
 import org.wfanet.measurement.internal.edpaggregator.GetImpressionMetadataRequest
 import org.wfanet.measurement.internal.edpaggregator.ImpressionMetadata
 import org.wfanet.measurement.internal.edpaggregator.ImpressionMetadataServiceGrpcKt.ImpressionMetadataServiceCoroutineImplBase
@@ -56,6 +57,7 @@ import org.wfanet.measurement.internal.edpaggregator.ImpressionMetadataState as 
 import org.wfanet.measurement.internal.edpaggregator.ListImpressionMetadataPageTokenKt
 import org.wfanet.measurement.internal.edpaggregator.ListImpressionMetadataRequest
 import org.wfanet.measurement.internal.edpaggregator.ListImpressionMetadataResponse
+import org.wfanet.measurement.internal.edpaggregator.MetaEntityKey
 import org.wfanet.measurement.internal.edpaggregator.batchCreateImpressionMetadataResponse
 import org.wfanet.measurement.internal.edpaggregator.batchDeleteImpressionMetadataResponse
 import org.wfanet.measurement.internal.edpaggregator.computeModelLineBoundsResponse
@@ -216,6 +218,16 @@ class SpannerImpressionMetadataService(
           "$fieldName must be non-negative"
         }
         .asStatusRuntimeException(Status.Code.INVALID_ARGUMENT)
+    }
+
+    request.filter.entityKeysList.forEachIndexed { index, entityKey ->
+      try {
+        validateEntityKey(entityKey, "filter.entity_keys.$index")
+      } catch (e: RequiredFieldNotSetException) {
+        throw e.asStatusRuntimeException(Status.Code.INVALID_ARGUMENT)
+      } catch (e: InvalidFieldValueException) {
+        throw e.asStatusRuntimeException(Status.Code.INVALID_ARGUMENT)
+      }
     }
 
     val pageSize =
@@ -465,6 +477,35 @@ class SpannerImpressionMetadataService(
 
     if (!request.impressionMetadata.hasInterval()) {
       throw RequiredFieldNotSetException("${fieldPathPrefix}impression_metadata.interval")
+    }
+
+    request.impressionMetadata.entityKeysList.forEachIndexed { index, entityKey ->
+      validateEntityKey(entityKey, "${fieldPathPrefix}impression_metadata.entity_keys.$index")
+    }
+  }
+
+  /**
+   * Checks that the specified [EntityKey] has exactly one variant set and that the inner fields
+   * are populated correctly.
+   *
+   * @throws RequiredFieldNotSetException if the variant or a required inner field is unset
+   * @throws InvalidFieldValueException if an inner enum is set to its UNSPECIFIED value
+   */
+  private fun validateEntityKey(entityKey: EntityKey, fieldPath: String) {
+    when (entityKey.keyCase) {
+      EntityKey.KeyCase.META -> {
+        if (entityKey.meta.type == MetaEntityKey.Type.TYPE_UNSPECIFIED) {
+          throw InvalidFieldValueException("$fieldPath.meta.type") { fieldName ->
+            "$fieldName must not be TYPE_UNSPECIFIED"
+          }
+        }
+        if (entityKey.meta.id.isEmpty()) {
+          throw RequiredFieldNotSetException("$fieldPath.meta.id")
+        }
+      }
+      EntityKey.KeyCase.KEY_NOT_SET -> {
+        throw RequiredFieldNotSetException("$fieldPath.key")
+      }
     }
   }
 

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/spanner/db/ImpressionMetadata.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/spanner/db/ImpressionMetadata.kt
@@ -19,6 +19,7 @@ package org.wfanet.measurement.edpaggregator.deploy.gcloud.spanner.db
 import com.google.cloud.spanner.Key
 import com.google.cloud.spanner.Options
 import com.google.cloud.spanner.Struct
+import com.google.cloud.spanner.Type
 import com.google.cloud.spanner.Value
 import com.google.type.Interval
 import com.google.type.interval
@@ -40,17 +41,29 @@ import org.wfanet.measurement.gcloud.spanner.AsyncDatabaseClient
 import org.wfanet.measurement.gcloud.spanner.bufferInsertMutation
 import org.wfanet.measurement.gcloud.spanner.bufferUpdateMutation
 import org.wfanet.measurement.gcloud.spanner.statement
+import org.wfanet.measurement.gcloud.spanner.struct
 import org.wfanet.measurement.internal.edpaggregator.CreateImpressionMetadataRequest
+import org.wfanet.measurement.internal.edpaggregator.EntityKey
 import org.wfanet.measurement.internal.edpaggregator.ImpressionMetadata
 import org.wfanet.measurement.internal.edpaggregator.ImpressionMetadataState as State
 import org.wfanet.measurement.internal.edpaggregator.ListImpressionMetadataPageToken
 import org.wfanet.measurement.internal.edpaggregator.ListImpressionMetadataRequest
+import org.wfanet.measurement.internal.edpaggregator.MetaEntityKey
 import org.wfanet.measurement.internal.edpaggregator.RawImpressionMetadataKey
 import org.wfanet.measurement.internal.edpaggregator.copy
+import org.wfanet.measurement.internal.edpaggregator.entityKey
 import org.wfanet.measurement.internal.edpaggregator.impressionMetadata
+import org.wfanet.measurement.internal.edpaggregator.metaEntityKey
 import org.wfanet.measurement.internal.edpaggregator.rawImpressionMetadataKey
 
 private const val IMPRESSION_METADATA_RESOURCE_ID_PREFIX = "imp"
+
+// Struct shape for binding the ImpressionMetadataMetaEntityKeys filter as an array parameter.
+private val META_ENTITY_KEY_FILTER_STRUCT: Type =
+  Type.struct(
+    Type.StructField.of("MetaType", Type.int64()),
+    Type.StructField.of("EntityId", Type.string()),
+  )
 
 data class ImpressionMetadataResult(
   val impressionMetadata: ImpressionMetadata,
@@ -287,6 +300,30 @@ fun AsyncDatabaseClient.TransactionContext.insertImpressionMetadata(
     set("CreateTime").to(Value.COMMIT_TIMESTAMP)
     set("UpdateTime").to(Value.COMMIT_TIMESTAMP)
   }
+
+  for (entityKey in impressionMetadata.entityKeysList) {
+    if (entityKey.hasMeta()) {
+      insertImpressionMetadataMetaEntityKey(
+        impressionMetadata.dataProviderResourceId,
+        impressionMetadataId,
+        entityKey.meta,
+      )
+    }
+  }
+}
+
+/** Buffers an insert mutation for a single [ImpressionMetadataMetaEntityKeys] row. */
+private fun AsyncDatabaseClient.TransactionContext.insertImpressionMetadataMetaEntityKey(
+  dataProviderResourceId: String,
+  impressionMetadataId: Long,
+  metaEntityKey: MetaEntityKey,
+) {
+  bufferInsertMutation("ImpressionMetadataMetaEntityKeys") {
+    set("DataProviderResourceId").to(dataProviderResourceId)
+    set("ImpressionMetadataId").to(impressionMetadataId)
+    set("MetaType").to(metaEntityKey.type.number.toLong())
+    set("EntityId").to(metaEntityKey.id)
+  }
 }
 
 /**
@@ -395,6 +432,9 @@ fun AsyncDatabaseClient.ReadContext.readImpressionMetadata(
   limit: Int,
   after: ListImpressionMetadataPageToken.After? = null,
 ): Flow<ImpressionMetadataResult> {
+  val metaEntityKeyFilter: List<MetaEntityKey> =
+    filter.entityKeysList.filter { it.hasMeta() }.map { it.meta }
+
   val sql = buildString {
     appendLine(ImpressionMetadataEntity.BASE_SQL)
 
@@ -421,6 +461,25 @@ fun AsyncDatabaseClient.ReadContext.readImpressionMetadata(
 
     if (filter.blobUriPrefix.isNotEmpty()) {
       conjuncts.add("STARTS_WITH(ImpressionMetadata.BlobUri, @blobUriPrefix)")
+    }
+
+    if (metaEntityKeyFilter.isNotEmpty()) {
+      conjuncts.add(
+        """
+        EXISTS (
+          SELECT 1
+          FROM ImpressionMetadataMetaEntityKeys
+          WHERE ImpressionMetadataMetaEntityKeys.DataProviderResourceId = ImpressionMetadata.DataProviderResourceId
+            AND ImpressionMetadataMetaEntityKeys.ImpressionMetadataId = ImpressionMetadata.ImpressionMetadataId
+            AND EXISTS (
+              SELECT 1 FROM UNNEST(@metaEntityKeyFilter) AS f
+              WHERE f.MetaType = ImpressionMetadataMetaEntityKeys.MetaType
+                AND f.EntityId = ImpressionMetadataMetaEntityKeys.EntityId
+            )
+        )
+        """
+          .trimIndent()
+      )
     }
 
     if (after != null) {
@@ -458,6 +517,19 @@ fun AsyncDatabaseClient.ReadContext.readImpressionMetadata(
 
       if (filter.blobUriPrefix.isNotEmpty()) {
         bind("blobUriPrefix").to(filter.blobUriPrefix)
+      }
+
+      if (metaEntityKeyFilter.isNotEmpty()) {
+        bind("metaEntityKeyFilter")
+          .toStructArray(
+            META_ENTITY_KEY_FILTER_STRUCT,
+            metaEntityKeyFilter.map { meta ->
+              struct {
+                set("MetaType").to(meta.type.number.toLong())
+                set("EntityId").to(meta.id)
+              }
+            },
+          )
       }
 
       if (after != null) {
@@ -527,6 +599,15 @@ private object ImpressionMetadataEntity {
       ImpressionMetadata.UpdateTime,
       RawImpressionMetadataBatch.BatchResourceId AS RawImpressionBatchResourceId,
       RawImpressionMetadataBatchFile.FileResourceId AS RawImpressionFileResourceId,
+      ARRAY(
+        SELECT AS STRUCT
+          ImpressionMetadataMetaEntityKeys.MetaType,
+          ImpressionMetadataMetaEntityKeys.EntityId
+        FROM ImpressionMetadataMetaEntityKeys
+        WHERE ImpressionMetadataMetaEntityKeys.DataProviderResourceId = ImpressionMetadata.DataProviderResourceId
+          AND ImpressionMetadataMetaEntityKeys.ImpressionMetadataId = ImpressionMetadata.ImpressionMetadataId
+        ORDER BY ImpressionMetadataMetaEntityKeys.MetaType, ImpressionMetadataMetaEntityKeys.EntityId
+      ) AS MetaEntityKeys,
     FROM
       ImpressionMetadata
     LEFT JOIN (
@@ -562,6 +643,15 @@ private object ImpressionMetadataEntity {
             fileResourceId = struct.getString("RawImpressionFileResourceId")
           }
         }
+        entityKeys +=
+          struct.getStructList("MetaEntityKeys").map { metaStruct ->
+            entityKey {
+              meta = metaEntityKey {
+                type = MetaEntityKey.Type.forNumber(metaStruct.getLong("MetaType").toInt())
+                id = metaStruct.getString("EntityId")
+              }
+            }
+          }
       },
       struct.getLong("ImpressionMetadataId"),
     )

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/spanner/db/ImpressionMetadata.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/spanner/db/ImpressionMetadata.kt
@@ -48,20 +48,18 @@ import org.wfanet.measurement.internal.edpaggregator.ImpressionMetadata
 import org.wfanet.measurement.internal.edpaggregator.ImpressionMetadataState as State
 import org.wfanet.measurement.internal.edpaggregator.ListImpressionMetadataPageToken
 import org.wfanet.measurement.internal.edpaggregator.ListImpressionMetadataRequest
-import org.wfanet.measurement.internal.edpaggregator.MetaEntityKey
 import org.wfanet.measurement.internal.edpaggregator.RawImpressionMetadataKey
 import org.wfanet.measurement.internal.edpaggregator.copy
 import org.wfanet.measurement.internal.edpaggregator.entityKey
 import org.wfanet.measurement.internal.edpaggregator.impressionMetadata
-import org.wfanet.measurement.internal.edpaggregator.metaEntityKey
 import org.wfanet.measurement.internal.edpaggregator.rawImpressionMetadataKey
 
 private const val IMPRESSION_METADATA_RESOURCE_ID_PREFIX = "imp"
 
-// Struct shape for binding the ImpressionMetadataMetaEntityKeys filter as an array parameter.
-private val META_ENTITY_KEY_FILTER_STRUCT: Type =
+// Struct shape for binding the ImpressionMetadataEntityKeys filter as an array parameter.
+private val ENTITY_KEY_FILTER_STRUCT: Type =
   Type.struct(
-    Type.StructField.of("MetaType", Type.int64()),
+    Type.StructField.of("EntityType", Type.string()),
     Type.StructField.of("EntityId", Type.string()),
   )
 
@@ -302,27 +300,25 @@ fun AsyncDatabaseClient.TransactionContext.insertImpressionMetadata(
   }
 
   for (entityKey in impressionMetadata.entityKeysList) {
-    if (entityKey.hasMeta()) {
-      insertImpressionMetadataMetaEntityKey(
-        impressionMetadata.dataProviderResourceId,
-        impressionMetadataId,
-        entityKey.meta,
-      )
-    }
+    insertImpressionMetadataEntityKey(
+      impressionMetadata.dataProviderResourceId,
+      impressionMetadataId,
+      entityKey,
+    )
   }
 }
 
-/** Buffers an insert mutation for a single [ImpressionMetadataMetaEntityKeys] row. */
-private fun AsyncDatabaseClient.TransactionContext.insertImpressionMetadataMetaEntityKey(
+/** Buffers an insert mutation for a single [ImpressionMetadataEntityKeys] row. */
+private fun AsyncDatabaseClient.TransactionContext.insertImpressionMetadataEntityKey(
   dataProviderResourceId: String,
   impressionMetadataId: Long,
-  metaEntityKey: MetaEntityKey,
+  entityKey: EntityKey,
 ) {
-  bufferInsertMutation("ImpressionMetadataMetaEntityKeys") {
+  bufferInsertMutation("ImpressionMetadataEntityKeys") {
     set("DataProviderResourceId").to(dataProviderResourceId)
     set("ImpressionMetadataId").to(impressionMetadataId)
-    set("MetaType").to(metaEntityKey.type.number.toLong())
-    set("EntityId").to(metaEntityKey.id)
+    set("EntityType").to(entityKey.entityType)
+    set("EntityId").to(entityKey.id)
   }
 }
 
@@ -432,8 +428,7 @@ fun AsyncDatabaseClient.ReadContext.readImpressionMetadata(
   limit: Int,
   after: ListImpressionMetadataPageToken.After? = null,
 ): Flow<ImpressionMetadataResult> {
-  val metaEntityKeyFilter: List<MetaEntityKey> =
-    filter.entityKeysList.filter { it.hasMeta() }.map { it.meta }
+  val entityKeyFilter: List<EntityKey> = filter.entityKeysList
 
   val sql = buildString {
     appendLine(ImpressionMetadataEntity.BASE_SQL)
@@ -463,18 +458,18 @@ fun AsyncDatabaseClient.ReadContext.readImpressionMetadata(
       conjuncts.add("STARTS_WITH(ImpressionMetadata.BlobUri, @blobUriPrefix)")
     }
 
-    if (metaEntityKeyFilter.isNotEmpty()) {
+    if (entityKeyFilter.isNotEmpty()) {
       conjuncts.add(
         """
         EXISTS (
           SELECT 1
-          FROM ImpressionMetadataMetaEntityKeys
-          WHERE ImpressionMetadataMetaEntityKeys.DataProviderResourceId = ImpressionMetadata.DataProviderResourceId
-            AND ImpressionMetadataMetaEntityKeys.ImpressionMetadataId = ImpressionMetadata.ImpressionMetadataId
+          FROM ImpressionMetadataEntityKeys
+          WHERE ImpressionMetadataEntityKeys.DataProviderResourceId = ImpressionMetadata.DataProviderResourceId
+            AND ImpressionMetadataEntityKeys.ImpressionMetadataId = ImpressionMetadata.ImpressionMetadataId
             AND EXISTS (
-              SELECT 1 FROM UNNEST(@metaEntityKeyFilter) AS f
-              WHERE f.MetaType = ImpressionMetadataMetaEntityKeys.MetaType
-                AND f.EntityId = ImpressionMetadataMetaEntityKeys.EntityId
+              SELECT 1 FROM UNNEST(@entityKeyFilter) AS f
+              WHERE f.EntityType = ImpressionMetadataEntityKeys.EntityType
+                AND f.EntityId = ImpressionMetadataEntityKeys.EntityId
             )
         )
         """
@@ -519,14 +514,14 @@ fun AsyncDatabaseClient.ReadContext.readImpressionMetadata(
         bind("blobUriPrefix").to(filter.blobUriPrefix)
       }
 
-      if (metaEntityKeyFilter.isNotEmpty()) {
-        bind("metaEntityKeyFilter")
+      if (entityKeyFilter.isNotEmpty()) {
+        bind("entityKeyFilter")
           .toStructArray(
-            META_ENTITY_KEY_FILTER_STRUCT,
-            metaEntityKeyFilter.map { meta ->
+            ENTITY_KEY_FILTER_STRUCT,
+            entityKeyFilter.map { ek ->
               struct {
-                set("MetaType").to(meta.type.number.toLong())
-                set("EntityId").to(meta.id)
+                set("EntityType").to(ek.entityType)
+                set("EntityId").to(ek.id)
               }
             },
           )
@@ -601,13 +596,13 @@ private object ImpressionMetadataEntity {
       RawImpressionMetadataBatchFile.FileResourceId AS RawImpressionFileResourceId,
       ARRAY(
         SELECT AS STRUCT
-          ImpressionMetadataMetaEntityKeys.MetaType,
-          ImpressionMetadataMetaEntityKeys.EntityId
-        FROM ImpressionMetadataMetaEntityKeys
-        WHERE ImpressionMetadataMetaEntityKeys.DataProviderResourceId = ImpressionMetadata.DataProviderResourceId
-          AND ImpressionMetadataMetaEntityKeys.ImpressionMetadataId = ImpressionMetadata.ImpressionMetadataId
-        ORDER BY ImpressionMetadataMetaEntityKeys.MetaType, ImpressionMetadataMetaEntityKeys.EntityId
-      ) AS MetaEntityKeys,
+          ImpressionMetadataEntityKeys.EntityType,
+          ImpressionMetadataEntityKeys.EntityId
+        FROM ImpressionMetadataEntityKeys
+        WHERE ImpressionMetadataEntityKeys.DataProviderResourceId = ImpressionMetadata.DataProviderResourceId
+          AND ImpressionMetadataEntityKeys.ImpressionMetadataId = ImpressionMetadata.ImpressionMetadataId
+        ORDER BY ImpressionMetadataEntityKeys.EntityType, ImpressionMetadataEntityKeys.EntityId
+      ) AS EntityKeys,
     FROM
       ImpressionMetadata
     LEFT JOIN (
@@ -644,12 +639,10 @@ private object ImpressionMetadataEntity {
           }
         }
         entityKeys +=
-          struct.getStructList("MetaEntityKeys").map { metaStruct ->
+          struct.getStructList("EntityKeys").map { ekStruct ->
             entityKey {
-              meta = metaEntityKey {
-                type = MetaEntityKey.Type.forNumber(metaStruct.getLong("MetaType").toInt())
-                id = metaStruct.getString("EntityId")
-              }
+              entityType = ekStruct.getString("EntityType")
+              id = ekStruct.getString("EntityId")
             }
           }
       },

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/spanner/db/ImpressionMetadata.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/spanner/db/ImpressionMetadata.kt
@@ -318,7 +318,7 @@ private fun AsyncDatabaseClient.TransactionContext.insertImpressionMetadataEntit
     set("DataProviderResourceId").to(dataProviderResourceId)
     set("ImpressionMetadataId").to(impressionMetadataId)
     set("EntityType").to(entityKey.entityType)
-    set("EntityId").to(entityKey.id)
+    set("EntityId").to(entityKey.entityId)
   }
 }
 
@@ -521,7 +521,7 @@ fun AsyncDatabaseClient.ReadContext.readImpressionMetadata(
             entityKeyFilter.map { ek ->
               struct {
                 set("EntityType").to(ek.entityType)
-                set("EntityId").to(ek.id)
+                set("EntityId").to(ek.entityId)
               }
             },
           )
@@ -642,7 +642,7 @@ private object ImpressionMetadataEntity {
           struct.getStructList("EntityKeys").map { ekStruct ->
             entityKey {
               entityType = ekStruct.getString("EntityType")
-              id = ekStruct.getString("EntityId")
+              entityId = ekStruct.getString("EntityId")
             }
           }
       },

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/service/internal/testing/ImpressionMetadataServiceTest.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/service/internal/testing/ImpressionMetadataServiceTest.kt
@@ -46,7 +46,6 @@ import org.wfanet.measurement.internal.edpaggregator.ListImpressionMetadataPageT
 import org.wfanet.measurement.internal.edpaggregator.ListImpressionMetadataRequest
 import org.wfanet.measurement.internal.edpaggregator.ListImpressionMetadataRequestKt
 import org.wfanet.measurement.internal.edpaggregator.ListImpressionMetadataResponse
-import org.wfanet.measurement.internal.edpaggregator.MetaEntityKey
 import org.wfanet.measurement.internal.edpaggregator.batchCreateImpressionMetadataRequest
 import org.wfanet.measurement.internal.edpaggregator.batchCreateImpressionMetadataResponse
 import org.wfanet.measurement.internal.edpaggregator.batchDeleteImpressionMetadataRequest
@@ -62,7 +61,6 @@ import org.wfanet.measurement.internal.edpaggregator.impressionMetadata
 import org.wfanet.measurement.internal.edpaggregator.listImpressionMetadataPageToken
 import org.wfanet.measurement.internal.edpaggregator.listImpressionMetadataRequest
 import org.wfanet.measurement.internal.edpaggregator.listImpressionMetadataResponse
-import org.wfanet.measurement.internal.edpaggregator.metaEntityKey
 
 @RunWith(JUnit4::class)
 abstract class ImpressionMetadataServiceTest {
@@ -1776,7 +1774,7 @@ abstract class ImpressionMetadataServiceTest {
       )
 
     assertThat(response.entityKeysList)
-      .containsExactly(META_ENTITY_KEY_AD_1, META_ENTITY_KEY_CAMPAIGN_1)
+      .containsExactly(ENTITY_KEY_AD_1, ENTITY_KEY_CAMPAIGN_1)
       .inOrder()
   }
 
@@ -1795,14 +1793,14 @@ abstract class ImpressionMetadataServiceTest {
       )
 
     assertThat(result.entityKeysList)
-      .containsExactly(META_ENTITY_KEY_AD_1, META_ENTITY_KEY_CAMPAIGN_1)
+      .containsExactly(ENTITY_KEY_AD_1, ENTITY_KEY_CAMPAIGN_1)
       .inOrder()
   }
 
   @Test
   fun `batchCreateImpressionMetadata preserves entity_keys per row`() = runBlocking {
     val secondImpression =
-      IMPRESSION_METADATA_2.copy { entityKeys += META_ENTITY_KEY_AD_2 }
+      IMPRESSION_METADATA_2.copy { entityKeys += ENTITY_KEY_AD_2 }
 
     val response =
       service.batchCreateImpressionMetadata(
@@ -1816,16 +1814,18 @@ abstract class ImpressionMetadataServiceTest {
 
     assertThat(response.impressionMetadataList).hasSize(2)
     assertThat(response.impressionMetadataList[0].entityKeysList)
-      .containsExactly(META_ENTITY_KEY_AD_1, META_ENTITY_KEY_CAMPAIGN_1)
+      .containsExactly(ENTITY_KEY_AD_1, ENTITY_KEY_CAMPAIGN_1)
     assertThat(response.impressionMetadataList[1].entityKeysList)
-      .containsExactly(META_ENTITY_KEY_AD_2)
+      .containsExactly(ENTITY_KEY_AD_2)
       .inOrder()
   }
-
   @Test
-  fun `createImpressionMetadata throws INVALID_ARGUMENT when entity_key has no variant set`() =
+  fun `createImpressionMetadata throws INVALID_ARGUMENT when entity_key entity_type is empty`() =
     runBlocking {
-      val invalid = IMPRESSION_METADATA.copy { entityKeys += entityKey {} }
+      val invalid =
+        IMPRESSION_METADATA.copy {
+          entityKeys += entityKey { id = "x" }
+        }
 
       val exception =
         assertFailsWith<StatusRuntimeException> {
@@ -1840,42 +1840,16 @@ abstract class ImpressionMetadataServiceTest {
           errorInfo {
             domain = Errors.DOMAIN
             reason = Errors.Reason.REQUIRED_FIELD_NOT_SET.name
-            metadata[Errors.Metadata.FIELD_NAME.key] = "impression_metadata.entity_keys.0.key"
+            metadata[Errors.Metadata.FIELD_NAME.key] = "impression_metadata.entity_keys.0.entity_type"
           }
         )
     }
 
   @Test
-  fun `createImpressionMetadata throws INVALID_ARGUMENT when meta type is unspecified`() =
-    runBlocking {
-      val invalid =
-        IMPRESSION_METADATA.copy {
-          entityKeys += entityKey { meta = metaEntityKey { id = "x" } }
-        }
-
-      val exception =
-        assertFailsWith<StatusRuntimeException> {
-          service.createImpressionMetadata(
-            createImpressionMetadataRequest { impressionMetadata = invalid }
-          )
-        }
-
-      assertThat(exception.status.code).isEqualTo(Status.Code.INVALID_ARGUMENT)
-      assertThat(exception.errorInfo)
-        .isEqualTo(
-          errorInfo {
-            domain = Errors.DOMAIN
-            reason = Errors.Reason.INVALID_FIELD_VALUE.name
-            metadata[Errors.Metadata.FIELD_NAME.key] = "impression_metadata.entity_keys.0.meta.type"
-          }
-        )
-    }
-
-  @Test
-  fun `createImpressionMetadata throws INVALID_ARGUMENT when meta id is empty`() = runBlocking {
+  fun `createImpressionMetadata throws INVALID_ARGUMENT when entity_key id is empty`() = runBlocking {
     val invalid =
       IMPRESSION_METADATA.copy {
-        entityKeys += entityKey { meta = metaEntityKey { type = MetaEntityKey.Type.AD } }
+        entityKeys += entityKey { entityType = "ad" }
       }
 
     val exception =
@@ -1891,7 +1865,7 @@ abstract class ImpressionMetadataServiceTest {
         errorInfo {
           domain = Errors.DOMAIN
           reason = Errors.Reason.REQUIRED_FIELD_NOT_SET.name
-          metadata[Errors.Metadata.FIELD_NAME.key] = "impression_metadata.entity_keys.0.meta.id"
+          metadata[Errors.Metadata.FIELD_NAME.key] = "impression_metadata.entity_keys.0.id"
         }
       )
   }
@@ -1910,7 +1884,7 @@ abstract class ImpressionMetadataServiceTest {
         listImpressionMetadataRequest {
           dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
           filter =
-            ListImpressionMetadataRequestKt.filter { entityKeys += META_ENTITY_KEY_AD_1 }
+            ListImpressionMetadataRequestKt.filter { entityKeys += ENTITY_KEY_AD_1 }
         }
       )
 
@@ -1925,9 +1899,9 @@ abstract class ImpressionMetadataServiceTest {
       service.createImpressionMetadata(
         createImpressionMetadataRequest { impressionMetadata = IMPRESSION_METADATA_WITH_ENTITY_KEYS }
       )
-      val im2 = IMPRESSION_METADATA_2.copy { entityKeys += META_ENTITY_KEY_AD_2 }
+      val im2 = IMPRESSION_METADATA_2.copy { entityKeys += ENTITY_KEY_AD_2 }
       service.createImpressionMetadata(createImpressionMetadataRequest { impressionMetadata = im2 })
-      val im3 = IMPRESSION_METADATA_3.copy { entityKeys += META_ENTITY_KEY_AD_SET_1 }
+      val im3 = IMPRESSION_METADATA_3.copy { entityKeys += ENTITY_KEY_AD_SET_1 }
       service.createImpressionMetadata(createImpressionMetadataRequest { impressionMetadata = im3 })
 
       val response =
@@ -1936,8 +1910,8 @@ abstract class ImpressionMetadataServiceTest {
             dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
             filter =
               ListImpressionMetadataRequestKt.filter {
-                entityKeys += META_ENTITY_KEY_AD_1
-                entityKeys += META_ENTITY_KEY_AD_2
+                entityKeys += ENTITY_KEY_AD_1
+                entityKeys += ENTITY_KEY_AD_2
               }
           }
         )
@@ -1961,10 +1935,8 @@ abstract class ImpressionMetadataServiceTest {
           filter =
             ListImpressionMetadataRequestKt.filter {
               entityKeys += entityKey {
-                meta = metaEntityKey {
-                  type = MetaEntityKey.Type.AD_ACCOUNT
-                  id = "no-such-account"
-                }
+                entityType = "ad_account"
+                id = "no-such-account"
               }
             }
         }
@@ -2009,7 +1981,7 @@ abstract class ImpressionMetadataServiceTest {
           errorInfo {
             domain = Errors.DOMAIN
             reason = Errors.Reason.REQUIRED_FIELD_NOT_SET.name
-            metadata[Errors.Metadata.FIELD_NAME.key] = "filter.entity_keys.0.key"
+            metadata[Errors.Metadata.FIELD_NAME.key] = "filter.entity_keys.0.entity_type"
           }
         )
     }
@@ -2032,13 +2004,13 @@ abstract class ImpressionMetadataServiceTest {
         listImpressionMetadataRequest {
           dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
           filter =
-            ListImpressionMetadataRequestKt.filter { entityKeys += META_ENTITY_KEY_AD_1 }
+            ListImpressionMetadataRequestKt.filter { entityKeys += ENTITY_KEY_AD_1 }
         }
       )
 
     assertThat(response.impressionMetadataList).hasSize(1)
     assertThat(response.impressionMetadataList[0].entityKeysList)
-      .containsExactly(META_ENTITY_KEY_AD_1, META_ENTITY_KEY_CAMPAIGN_1)
+      .containsExactly(ENTITY_KEY_AD_1, ENTITY_KEY_CAMPAIGN_1)
     assertThat(response.impressionMetadataList[0].state)
       .isEqualTo(State.IMPRESSION_METADATA_STATE_DELETED)
   }
@@ -2109,38 +2081,30 @@ abstract class ImpressionMetadataServiceTest {
       }
     }
 
-    private val META_ENTITY_KEY_AD_1 = entityKey {
-      meta = metaEntityKey {
-        type = MetaEntityKey.Type.AD
-        id = "ad-1"
-      }
+    private val ENTITY_KEY_AD_1 = entityKey {
+      entityType = "ad"
+      id = "ad-1"
     }
 
-    private val META_ENTITY_KEY_AD_2 = entityKey {
-      meta = metaEntityKey {
-        type = MetaEntityKey.Type.AD
-        id = "ad-2"
-      }
+    private val ENTITY_KEY_AD_2 = entityKey {
+      entityType = "ad"
+      id = "ad-2"
     }
 
-    private val META_ENTITY_KEY_CAMPAIGN_1 = entityKey {
-      meta = metaEntityKey {
-        type = MetaEntityKey.Type.CAMPAIGN
-        id = "campaign-1"
-      }
+    private val ENTITY_KEY_CAMPAIGN_1 = entityKey {
+      entityType = "campaign"
+      id = "campaign-1"
     }
 
-    private val META_ENTITY_KEY_AD_SET_1 = entityKey {
-      meta = metaEntityKey {
-        type = MetaEntityKey.Type.AD_SET
-        id = "adset-1"
-      }
+    private val ENTITY_KEY_AD_SET_1 = entityKey {
+      entityType = "ad_set"
+      id = "adset-1"
     }
 
     private val IMPRESSION_METADATA_WITH_ENTITY_KEYS =
       IMPRESSION_METADATA.copy {
-        entityKeys += META_ENTITY_KEY_AD_1
-        entityKeys += META_ENTITY_KEY_CAMPAIGN_1
+        entityKeys += ENTITY_KEY_AD_1
+        entityKeys += ENTITY_KEY_CAMPAIGN_1
       }
   }
 }

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/service/internal/testing/ImpressionMetadataServiceTest.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/service/internal/testing/ImpressionMetadataServiceTest.kt
@@ -37,7 +37,6 @@ import org.wfanet.measurement.common.toInstant
 import org.wfanet.measurement.edpaggregator.service.internal.Errors
 import org.wfanet.measurement.internal.edpaggregator.BatchCreateImpressionMetadataResponse
 import org.wfanet.measurement.internal.edpaggregator.ComputeModelLineBoundsResponse
-import org.wfanet.measurement.internal.edpaggregator.EntityKey
 import org.wfanet.measurement.internal.edpaggregator.ImpressionMetadata
 import org.wfanet.measurement.internal.edpaggregator.ImpressionMetadataServiceGrpcKt.ImpressionMetadataServiceCoroutineImplBase
 import org.wfanet.measurement.internal.edpaggregator.ImpressionMetadataState as State
@@ -1765,12 +1764,13 @@ abstract class ImpressionMetadataServiceTest {
       )
   }
 
-
   @Test
   fun `create impression metadata with entity_keys returns them`() = runBlocking {
     val response =
       service.createImpressionMetadata(
-        createImpressionMetadataRequest { impressionMetadata = IMPRESSION_METADATA_WITH_ENTITY_KEYS }
+        createImpressionMetadataRequest {
+          impressionMetadata = IMPRESSION_METADATA_WITH_ENTITY_KEYS
+        }
       )
 
     assertThat(response.entityKeysList)
@@ -1799,15 +1799,15 @@ abstract class ImpressionMetadataServiceTest {
 
   @Test
   fun `batchCreateImpressionMetadata preserves entity_keys per row`() = runBlocking {
-    val secondImpression =
-      IMPRESSION_METADATA_2.copy { entityKeys += ENTITY_KEY_AD_2 }
+    val secondImpression = IMPRESSION_METADATA_2.copy { entityKeys += ENTITY_KEY_AD_2 }
 
     val response =
       service.batchCreateImpressionMetadata(
         batchCreateImpressionMetadataRequest {
           dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
-          requests +=
-            createImpressionMetadataRequest { impressionMetadata = IMPRESSION_METADATA_WITH_ENTITY_KEYS }
+          requests += createImpressionMetadataRequest {
+            impressionMetadata = IMPRESSION_METADATA_WITH_ENTITY_KEYS
+          }
           requests += createImpressionMetadataRequest { impressionMetadata = secondImpression }
         }
       )
@@ -1819,13 +1819,11 @@ abstract class ImpressionMetadataServiceTest {
       .containsExactly(ENTITY_KEY_AD_2)
       .inOrder()
   }
+
   @Test
   fun `createImpressionMetadata throws INVALID_ARGUMENT when entity_key entity_type is empty`() =
     runBlocking {
-      val invalid =
-        IMPRESSION_METADATA.copy {
-          entityKeys += entityKey { entityId = "x" }
-        }
+      val invalid = IMPRESSION_METADATA.copy { entityKeys += entityKey { entityId = "x" } }
 
       val exception =
         assertFailsWith<StatusRuntimeException> {
@@ -1840,35 +1838,34 @@ abstract class ImpressionMetadataServiceTest {
           errorInfo {
             domain = Errors.DOMAIN
             reason = Errors.Reason.REQUIRED_FIELD_NOT_SET.name
-            metadata[Errors.Metadata.FIELD_NAME.key] = "impression_metadata.entity_keys.0.entity_type"
+            metadata[Errors.Metadata.FIELD_NAME.key] =
+              "impression_metadata.entity_keys.0.entity_type"
           }
         )
     }
 
   @Test
-  fun `createImpressionMetadata throws INVALID_ARGUMENT when entity_key id is empty`() = runBlocking {
-    val invalid =
-      IMPRESSION_METADATA.copy {
-        entityKeys += entityKey { entityType = "ad" }
-      }
+  fun `createImpressionMetadata throws INVALID_ARGUMENT when entity_key id is empty`() =
+    runBlocking {
+      val invalid = IMPRESSION_METADATA.copy { entityKeys += entityKey { entityType = "ad" } }
 
-    val exception =
-      assertFailsWith<StatusRuntimeException> {
-        service.createImpressionMetadata(
-          createImpressionMetadataRequest { impressionMetadata = invalid }
-        )
-      }
-
-    assertThat(exception.status.code).isEqualTo(Status.Code.INVALID_ARGUMENT)
-    assertThat(exception.errorInfo)
-      .isEqualTo(
-        errorInfo {
-          domain = Errors.DOMAIN
-          reason = Errors.Reason.REQUIRED_FIELD_NOT_SET.name
-          metadata[Errors.Metadata.FIELD_NAME.key] = "impression_metadata.entity_keys.0.entity_id"
+      val exception =
+        assertFailsWith<StatusRuntimeException> {
+          service.createImpressionMetadata(
+            createImpressionMetadataRequest { impressionMetadata = invalid }
+          )
         }
-      )
-  }
+
+      assertThat(exception.status.code).isEqualTo(Status.Code.INVALID_ARGUMENT)
+      assertThat(exception.errorInfo)
+        .isEqualTo(
+          errorInfo {
+            domain = Errors.DOMAIN
+            reason = Errors.Reason.REQUIRED_FIELD_NOT_SET.name
+            metadata[Errors.Metadata.FIELD_NAME.key] = "impression_metadata.entity_keys.0.entity_id"
+          }
+        )
+    }
 
   @Test
   fun `listImpressionMetadata filters by a single meta entity_key`() = runBlocking {
@@ -1883,8 +1880,7 @@ abstract class ImpressionMetadataServiceTest {
       service.listImpressionMetadata(
         listImpressionMetadataRequest {
           dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
-          filter =
-            ListImpressionMetadataRequestKt.filter { entityKeys += ENTITY_KEY_AD_1 }
+          filter = ListImpressionMetadataRequestKt.filter { entityKeys += ENTITY_KEY_AD_1 }
         }
       )
 
@@ -1897,7 +1893,9 @@ abstract class ImpressionMetadataServiceTest {
   fun `listImpressionMetadata applies OR-semantics across multiple meta entity_keys`() =
     runBlocking {
       service.createImpressionMetadata(
-        createImpressionMetadataRequest { impressionMetadata = IMPRESSION_METADATA_WITH_ENTITY_KEYS }
+        createImpressionMetadataRequest {
+          impressionMetadata = IMPRESSION_METADATA_WITH_ENTITY_KEYS
+        }
       )
       val im2 = IMPRESSION_METADATA_2.copy { entityKeys += ENTITY_KEY_AD_2 }
       service.createImpressionMetadata(createImpressionMetadataRequest { impressionMetadata = im2 })
@@ -2003,8 +2001,7 @@ abstract class ImpressionMetadataServiceTest {
       service.listImpressionMetadata(
         listImpressionMetadataRequest {
           dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
-          filter =
-            ListImpressionMetadataRequestKt.filter { entityKeys += ENTITY_KEY_AD_1 }
+          filter = ListImpressionMetadataRequestKt.filter { entityKeys += ENTITY_KEY_AD_1 }
         }
       )
 

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/service/internal/testing/ImpressionMetadataServiceTest.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/service/internal/testing/ImpressionMetadataServiceTest.kt
@@ -37,6 +37,7 @@ import org.wfanet.measurement.common.toInstant
 import org.wfanet.measurement.edpaggregator.service.internal.Errors
 import org.wfanet.measurement.internal.edpaggregator.BatchCreateImpressionMetadataResponse
 import org.wfanet.measurement.internal.edpaggregator.ComputeModelLineBoundsResponse
+import org.wfanet.measurement.internal.edpaggregator.EntityKey
 import org.wfanet.measurement.internal.edpaggregator.ImpressionMetadata
 import org.wfanet.measurement.internal.edpaggregator.ImpressionMetadataServiceGrpcKt.ImpressionMetadataServiceCoroutineImplBase
 import org.wfanet.measurement.internal.edpaggregator.ImpressionMetadataState as State
@@ -45,6 +46,7 @@ import org.wfanet.measurement.internal.edpaggregator.ListImpressionMetadataPageT
 import org.wfanet.measurement.internal.edpaggregator.ListImpressionMetadataRequest
 import org.wfanet.measurement.internal.edpaggregator.ListImpressionMetadataRequestKt
 import org.wfanet.measurement.internal.edpaggregator.ListImpressionMetadataResponse
+import org.wfanet.measurement.internal.edpaggregator.MetaEntityKey
 import org.wfanet.measurement.internal.edpaggregator.batchCreateImpressionMetadataRequest
 import org.wfanet.measurement.internal.edpaggregator.batchCreateImpressionMetadataResponse
 import org.wfanet.measurement.internal.edpaggregator.batchDeleteImpressionMetadataRequest
@@ -54,11 +56,13 @@ import org.wfanet.measurement.internal.edpaggregator.computeModelLineBoundsRespo
 import org.wfanet.measurement.internal.edpaggregator.copy
 import org.wfanet.measurement.internal.edpaggregator.createImpressionMetadataRequest
 import org.wfanet.measurement.internal.edpaggregator.deleteImpressionMetadataRequest
+import org.wfanet.measurement.internal.edpaggregator.entityKey
 import org.wfanet.measurement.internal.edpaggregator.getImpressionMetadataRequest
 import org.wfanet.measurement.internal.edpaggregator.impressionMetadata
 import org.wfanet.measurement.internal.edpaggregator.listImpressionMetadataPageToken
 import org.wfanet.measurement.internal.edpaggregator.listImpressionMetadataRequest
 import org.wfanet.measurement.internal.edpaggregator.listImpressionMetadataResponse
+import org.wfanet.measurement.internal.edpaggregator.metaEntityKey
 
 @RunWith(JUnit4::class)
 abstract class ImpressionMetadataServiceTest {
@@ -1763,6 +1767,282 @@ abstract class ImpressionMetadataServiceTest {
       )
   }
 
+
+  @Test
+  fun `create impression metadata with entity_keys returns them`() = runBlocking {
+    val response =
+      service.createImpressionMetadata(
+        createImpressionMetadataRequest { impressionMetadata = IMPRESSION_METADATA_WITH_ENTITY_KEYS }
+      )
+
+    assertThat(response.entityKeysList)
+      .containsExactly(META_ENTITY_KEY_AD_1, META_ENTITY_KEY_CAMPAIGN_1)
+      .inOrder()
+  }
+
+  @Test
+  fun `getImpressionMetadata returns entity_keys`() = runBlocking {
+    service.createImpressionMetadata(
+      createImpressionMetadataRequest { impressionMetadata = IMPRESSION_METADATA_WITH_ENTITY_KEYS }
+    )
+
+    val result =
+      service.getImpressionMetadata(
+        getImpressionMetadataRequest {
+          dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
+          impressionMetadataResourceId = IMPRESSION_METADATA_RESOURCE_ID
+        }
+      )
+
+    assertThat(result.entityKeysList)
+      .containsExactly(META_ENTITY_KEY_AD_1, META_ENTITY_KEY_CAMPAIGN_1)
+      .inOrder()
+  }
+
+  @Test
+  fun `batchCreateImpressionMetadata preserves entity_keys per row`() = runBlocking {
+    val secondImpression =
+      IMPRESSION_METADATA_2.copy { entityKeys += META_ENTITY_KEY_AD_2 }
+
+    val response =
+      service.batchCreateImpressionMetadata(
+        batchCreateImpressionMetadataRequest {
+          dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
+          requests +=
+            createImpressionMetadataRequest { impressionMetadata = IMPRESSION_METADATA_WITH_ENTITY_KEYS }
+          requests += createImpressionMetadataRequest { impressionMetadata = secondImpression }
+        }
+      )
+
+    assertThat(response.impressionMetadataList).hasSize(2)
+    assertThat(response.impressionMetadataList[0].entityKeysList)
+      .containsExactly(META_ENTITY_KEY_AD_1, META_ENTITY_KEY_CAMPAIGN_1)
+    assertThat(response.impressionMetadataList[1].entityKeysList)
+      .containsExactly(META_ENTITY_KEY_AD_2)
+      .inOrder()
+  }
+
+  @Test
+  fun `createImpressionMetadata throws INVALID_ARGUMENT when entity_key has no variant set`() =
+    runBlocking {
+      val invalid = IMPRESSION_METADATA.copy { entityKeys += entityKey {} }
+
+      val exception =
+        assertFailsWith<StatusRuntimeException> {
+          service.createImpressionMetadata(
+            createImpressionMetadataRequest { impressionMetadata = invalid }
+          )
+        }
+
+      assertThat(exception.status.code).isEqualTo(Status.Code.INVALID_ARGUMENT)
+      assertThat(exception.errorInfo)
+        .isEqualTo(
+          errorInfo {
+            domain = Errors.DOMAIN
+            reason = Errors.Reason.REQUIRED_FIELD_NOT_SET.name
+            metadata[Errors.Metadata.FIELD_NAME.key] = "impression_metadata.entity_keys.0.key"
+          }
+        )
+    }
+
+  @Test
+  fun `createImpressionMetadata throws INVALID_ARGUMENT when meta type is unspecified`() =
+    runBlocking {
+      val invalid =
+        IMPRESSION_METADATA.copy {
+          entityKeys += entityKey { meta = metaEntityKey { id = "x" } }
+        }
+
+      val exception =
+        assertFailsWith<StatusRuntimeException> {
+          service.createImpressionMetadata(
+            createImpressionMetadataRequest { impressionMetadata = invalid }
+          )
+        }
+
+      assertThat(exception.status.code).isEqualTo(Status.Code.INVALID_ARGUMENT)
+      assertThat(exception.errorInfo)
+        .isEqualTo(
+          errorInfo {
+            domain = Errors.DOMAIN
+            reason = Errors.Reason.INVALID_FIELD_VALUE.name
+            metadata[Errors.Metadata.FIELD_NAME.key] = "impression_metadata.entity_keys.0.meta.type"
+          }
+        )
+    }
+
+  @Test
+  fun `createImpressionMetadata throws INVALID_ARGUMENT when meta id is empty`() = runBlocking {
+    val invalid =
+      IMPRESSION_METADATA.copy {
+        entityKeys += entityKey { meta = metaEntityKey { type = MetaEntityKey.Type.AD } }
+      }
+
+    val exception =
+      assertFailsWith<StatusRuntimeException> {
+        service.createImpressionMetadata(
+          createImpressionMetadataRequest { impressionMetadata = invalid }
+        )
+      }
+
+    assertThat(exception.status.code).isEqualTo(Status.Code.INVALID_ARGUMENT)
+    assertThat(exception.errorInfo)
+      .isEqualTo(
+        errorInfo {
+          domain = Errors.DOMAIN
+          reason = Errors.Reason.REQUIRED_FIELD_NOT_SET.name
+          metadata[Errors.Metadata.FIELD_NAME.key] = "impression_metadata.entity_keys.0.meta.id"
+        }
+      )
+  }
+
+  @Test
+  fun `listImpressionMetadata filters by a single meta entity_key`() = runBlocking {
+    service.createImpressionMetadata(
+      createImpressionMetadataRequest { impressionMetadata = IMPRESSION_METADATA_WITH_ENTITY_KEYS }
+    )
+    service.createImpressionMetadata(
+      createImpressionMetadataRequest { impressionMetadata = IMPRESSION_METADATA_2 }
+    )
+
+    val response =
+      service.listImpressionMetadata(
+        listImpressionMetadataRequest {
+          dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
+          filter =
+            ListImpressionMetadataRequestKt.filter { entityKeys += META_ENTITY_KEY_AD_1 }
+        }
+      )
+
+    assertThat(response.impressionMetadataList.map { it.impressionMetadataResourceId })
+      .containsExactly(IMPRESSION_METADATA_RESOURCE_ID)
+      .inOrder()
+  }
+
+  @Test
+  fun `listImpressionMetadata applies OR-semantics across multiple meta entity_keys`() =
+    runBlocking {
+      service.createImpressionMetadata(
+        createImpressionMetadataRequest { impressionMetadata = IMPRESSION_METADATA_WITH_ENTITY_KEYS }
+      )
+      val im2 = IMPRESSION_METADATA_2.copy { entityKeys += META_ENTITY_KEY_AD_2 }
+      service.createImpressionMetadata(createImpressionMetadataRequest { impressionMetadata = im2 })
+      val im3 = IMPRESSION_METADATA_3.copy { entityKeys += META_ENTITY_KEY_AD_SET_1 }
+      service.createImpressionMetadata(createImpressionMetadataRequest { impressionMetadata = im3 })
+
+      val response =
+        service.listImpressionMetadata(
+          listImpressionMetadataRequest {
+            dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
+            filter =
+              ListImpressionMetadataRequestKt.filter {
+                entityKeys += META_ENTITY_KEY_AD_1
+                entityKeys += META_ENTITY_KEY_AD_2
+              }
+          }
+        )
+
+      // im_1 matches AD_1, im_2 matches AD_2; im_3 (only AD_SET_1) excluded.
+      assertThat(response.impressionMetadataList.map { it.impressionMetadataResourceId })
+        .containsExactly(IMPRESSION_METADATA_RESOURCE_ID, im2.impressionMetadataResourceId)
+        .inOrder()
+    }
+
+  @Test
+  fun `listImpressionMetadata returns empty when no entity_key matches`() = runBlocking {
+    service.createImpressionMetadata(
+      createImpressionMetadataRequest { impressionMetadata = IMPRESSION_METADATA_WITH_ENTITY_KEYS }
+    )
+
+    val response =
+      service.listImpressionMetadata(
+        listImpressionMetadataRequest {
+          dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
+          filter =
+            ListImpressionMetadataRequestKt.filter {
+              entityKeys += entityKey {
+                meta = metaEntityKey {
+                  type = MetaEntityKey.Type.AD_ACCOUNT
+                  id = "no-such-account"
+                }
+              }
+            }
+        }
+      )
+
+    assertThat(response.impressionMetadataList).isEmpty()
+  }
+
+  @Test
+  fun `listImpressionMetadata without entity_key filter returns all rows`() = runBlocking {
+    service.createImpressionMetadata(
+      createImpressionMetadataRequest { impressionMetadata = IMPRESSION_METADATA_WITH_ENTITY_KEYS }
+    )
+    service.createImpressionMetadata(
+      createImpressionMetadataRequest { impressionMetadata = IMPRESSION_METADATA_2 }
+    )
+
+    val response =
+      service.listImpressionMetadata(
+        listImpressionMetadataRequest { dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID }
+      )
+
+    assertThat(response.impressionMetadataList).hasSize(2)
+  }
+
+  @Test
+  fun `listImpressionMetadata throws INVALID_ARGUMENT when filter entity_key is invalid`() =
+    runBlocking {
+      val exception =
+        assertFailsWith<StatusRuntimeException> {
+          service.listImpressionMetadata(
+            listImpressionMetadataRequest {
+              dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
+              filter = ListImpressionMetadataRequestKt.filter { entityKeys += entityKey {} }
+            }
+          )
+        }
+
+      assertThat(exception.status.code).isEqualTo(Status.Code.INVALID_ARGUMENT)
+      assertThat(exception.errorInfo)
+        .isEqualTo(
+          errorInfo {
+            domain = Errors.DOMAIN
+            reason = Errors.Reason.REQUIRED_FIELD_NOT_SET.name
+            metadata[Errors.Metadata.FIELD_NAME.key] = "filter.entity_keys.0.key"
+          }
+        )
+    }
+
+  @Test
+  fun `entity_keys are preserved across soft delete`() = runBlocking {
+    service.createImpressionMetadata(
+      createImpressionMetadataRequest { impressionMetadata = IMPRESSION_METADATA_WITH_ENTITY_KEYS }
+    )
+    service.deleteImpressionMetadata(
+      deleteImpressionMetadataRequest {
+        dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
+        impressionMetadataResourceId = IMPRESSION_METADATA_RESOURCE_ID
+      }
+    )
+
+    // No state filter => soft-deleted records included.
+    val response =
+      service.listImpressionMetadata(
+        listImpressionMetadataRequest {
+          dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
+          filter =
+            ListImpressionMetadataRequestKt.filter { entityKeys += META_ENTITY_KEY_AD_1 }
+        }
+      )
+
+    assertThat(response.impressionMetadataList).hasSize(1)
+    assertThat(response.impressionMetadataList[0].entityKeysList)
+      .containsExactly(META_ENTITY_KEY_AD_1, META_ENTITY_KEY_CAMPAIGN_1)
+    assertThat(response.impressionMetadataList[0].state)
+      .isEqualTo(State.IMPRESSION_METADATA_STATE_DELETED)
+  }
+
   companion object {
     private const val DATA_PROVIDER_RESOURCE_ID = "data-provider-1"
     private const val IMPRESSION_METADATA_RESOURCE_ID = "impression-metadata-1"
@@ -1828,5 +2108,39 @@ abstract class ImpressionMetadataServiceTest {
         endTime = timestamp { seconds = 600 }
       }
     }
+
+    private val META_ENTITY_KEY_AD_1 = entityKey {
+      meta = metaEntityKey {
+        type = MetaEntityKey.Type.AD
+        id = "ad-1"
+      }
+    }
+
+    private val META_ENTITY_KEY_AD_2 = entityKey {
+      meta = metaEntityKey {
+        type = MetaEntityKey.Type.AD
+        id = "ad-2"
+      }
+    }
+
+    private val META_ENTITY_KEY_CAMPAIGN_1 = entityKey {
+      meta = metaEntityKey {
+        type = MetaEntityKey.Type.CAMPAIGN
+        id = "campaign-1"
+      }
+    }
+
+    private val META_ENTITY_KEY_AD_SET_1 = entityKey {
+      meta = metaEntityKey {
+        type = MetaEntityKey.Type.AD_SET
+        id = "adset-1"
+      }
+    }
+
+    private val IMPRESSION_METADATA_WITH_ENTITY_KEYS =
+      IMPRESSION_METADATA.copy {
+        entityKeys += META_ENTITY_KEY_AD_1
+        entityKeys += META_ENTITY_KEY_CAMPAIGN_1
+      }
   }
 }

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/service/internal/testing/ImpressionMetadataServiceTest.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/service/internal/testing/ImpressionMetadataServiceTest.kt
@@ -1824,7 +1824,7 @@ abstract class ImpressionMetadataServiceTest {
     runBlocking {
       val invalid =
         IMPRESSION_METADATA.copy {
-          entityKeys += entityKey { id = "x" }
+          entityKeys += entityKey { entityId = "x" }
         }
 
       val exception =
@@ -1865,7 +1865,7 @@ abstract class ImpressionMetadataServiceTest {
         errorInfo {
           domain = Errors.DOMAIN
           reason = Errors.Reason.REQUIRED_FIELD_NOT_SET.name
-          metadata[Errors.Metadata.FIELD_NAME.key] = "impression_metadata.entity_keys.0.id"
+          metadata[Errors.Metadata.FIELD_NAME.key] = "impression_metadata.entity_keys.0.entity_id"
         }
       )
   }
@@ -1936,7 +1936,7 @@ abstract class ImpressionMetadataServiceTest {
             ListImpressionMetadataRequestKt.filter {
               entityKeys += entityKey {
                 entityType = "ad_account"
-                id = "no-such-account"
+                entityId = "no-such-account"
               }
             }
         }
@@ -2083,22 +2083,22 @@ abstract class ImpressionMetadataServiceTest {
 
     private val ENTITY_KEY_AD_1 = entityKey {
       entityType = "ad"
-      id = "ad-1"
+      entityId = "ad-1"
     }
 
     private val ENTITY_KEY_AD_2 = entityKey {
       entityType = "ad"
-      id = "ad-2"
+      entityId = "ad-2"
     }
 
     private val ENTITY_KEY_CAMPAIGN_1 = entityKey {
       entityType = "campaign"
-      id = "campaign-1"
+      entityId = "campaign-1"
     }
 
     private val ENTITY_KEY_AD_SET_1 = entityKey {
       entityType = "ad_set"
-      id = "adset-1"
+      entityId = "adset-1"
     }
 
     private val IMPRESSION_METADATA_WITH_ENTITY_KEYS =


### PR DESCRIPTION
## Summary                                                                                                                                                                                               
   
  Wires up Meta entity_keys end-to-end in the internal ImpressionMetadata                                                                                                                                  
  service: persists them to the child table introduced in   
  `add-impression-metadata-meta-entity-keys.sql`, returns them on every read,                                                                                                                              
  and supports OR-semantics filtering on `ListImpressionMetadata`.                                                                                                                                         
                                                                                                                                                                                                           
  Builds on the proto + Spanner schema landed in                                                                                                                                                           
  `marcopremier/edpa-impression-metadata-entity-keys`.

Issue: #3727 