### PR TITLE
feat: entity keys public api

### DIFF
--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/service/v1alpha/ImpressionMetadataService.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/service/v1alpha/ImpressionMetadataService.kt
@@ -48,14 +48,12 @@ import org.wfanet.measurement.edpaggregator.v1alpha.ImpressionMetadata
 import org.wfanet.measurement.edpaggregator.v1alpha.ImpressionMetadataServiceGrpcKt.ImpressionMetadataServiceCoroutineImplBase
 import org.wfanet.measurement.edpaggregator.v1alpha.ListImpressionMetadataRequest
 import org.wfanet.measurement.edpaggregator.v1alpha.ListImpressionMetadataResponse
-import org.wfanet.measurement.edpaggregator.v1alpha.MetaEntityKey
 import org.wfanet.measurement.edpaggregator.v1alpha.batchCreateImpressionMetadataResponse
 import org.wfanet.measurement.edpaggregator.v1alpha.batchDeleteImpressionMetadataResponse
 import org.wfanet.measurement.edpaggregator.v1alpha.computeModelLineBoundsResponse
 import org.wfanet.measurement.edpaggregator.v1alpha.entityKey
 import org.wfanet.measurement.edpaggregator.v1alpha.impressionMetadata
 import org.wfanet.measurement.edpaggregator.v1alpha.listImpressionMetadataResponse
-import org.wfanet.measurement.edpaggregator.v1alpha.metaEntityKey
 import org.wfanet.measurement.internal.edpaggregator.BatchCreateImpressionMetadataResponse as InternalBatchCreateImpressionMetadataResponse
 import org.wfanet.measurement.internal.edpaggregator.BatchDeleteImpressionMetadataResponse as InternalBatchDeleteImpressionMetadataResponse
 import org.wfanet.measurement.internal.edpaggregator.ComputeModelLineBoundsResponse as InternalComputeModelLineBoundsResponse
@@ -69,7 +67,6 @@ import org.wfanet.measurement.internal.edpaggregator.ListImpressionMetadataPageT
 import org.wfanet.measurement.internal.edpaggregator.ListImpressionMetadataRequest as InternalListImpressionMetadataRequest
 import org.wfanet.measurement.internal.edpaggregator.ListImpressionMetadataRequestKt.filter as internalListImpressionMetadataRequestFilter
 import org.wfanet.measurement.internal.edpaggregator.ListImpressionMetadataResponse as InternalListImpressionMetadataResponse
-import org.wfanet.measurement.internal.edpaggregator.MetaEntityKey as InternalMetaEntityKey
 import org.wfanet.measurement.internal.edpaggregator.batchCreateImpressionMetadataRequest as internalBatchCreateImpressionMetadataRequest
 import org.wfanet.measurement.internal.edpaggregator.batchDeleteImpressionMetadataRequest as internalBatchDeleteImpressionMetadataRequest
 import org.wfanet.measurement.internal.edpaggregator.computeModelLineBoundsRequest as internalComputeModelLineBoundsRequest
@@ -79,7 +76,6 @@ import org.wfanet.measurement.internal.edpaggregator.entityKey as internalEntity
 import org.wfanet.measurement.internal.edpaggregator.getImpressionMetadataRequest as internalGetImpressionMetadataRequest
 import org.wfanet.measurement.internal.edpaggregator.impressionMetadata as internalImpressionMetadata
 import org.wfanet.measurement.internal.edpaggregator.listImpressionMetadataRequest as internalListImpressionMetadataRequest
-import org.wfanet.measurement.internal.edpaggregator.metaEntityKey as internalMetaEntityKey
 
 class ImpressionMetadataService(
   private val internalImpressionMetadataStub: InternalImpressionMetadataServiceCoroutineStub,
@@ -644,27 +640,16 @@ class ImpressionMetadataService(
   }
 
   /**
-   * Checks that the specified [EntityKey] has exactly one variant set and that the inner fields
-   * are populated correctly.
+   * Checks that the specified [EntityKey] has both `entity_type` and `id` set.
    *
-   * @throws RequiredFieldNotSetException if the variant or a required inner field is unset
-   * @throws InvalidFieldValueException if an inner enum is set to its UNSPECIFIED value
+   * @throws RequiredFieldNotSetException if a required field is unset
    */
   private fun validateEntityKey(entityKey: EntityKey, fieldPath: String) {
-    when (entityKey.keyCase) {
-      EntityKey.KeyCase.META -> {
-        if (entityKey.meta.type == MetaEntityKey.Type.TYPE_UNSPECIFIED) {
-          throw InvalidFieldValueException("$fieldPath.meta.type") { fieldName ->
-            "$fieldName must not be TYPE_UNSPECIFIED"
-          }
-        }
-        if (entityKey.meta.id.isEmpty()) {
-          throw RequiredFieldNotSetException("$fieldPath.meta.id")
-        }
-      }
-      EntityKey.KeyCase.KEY_NOT_SET -> {
-        throw RequiredFieldNotSetException("$fieldPath.key")
-      }
+    if (entityKey.entityType.isEmpty()) {
+      throw RequiredFieldNotSetException("$fieldPath.entity_type")
+    }
+    if (entityKey.id.isEmpty()) {
+      throw RequiredFieldNotSetException("$fieldPath.id")
     }
   }
 
@@ -748,14 +733,8 @@ internal fun ImpressionMetadata.State.toInternal(): InternalImpressionMetadataSt
 internal fun InternalEntityKey.toPublic(): EntityKey {
   val source = this
   return entityKey {
-    when (source.keyCase) {
-      InternalEntityKey.KeyCase.META ->
-        meta = metaEntityKey {
-          type = source.meta.type.toPublic()
-          id = source.meta.id
-        }
-      InternalEntityKey.KeyCase.KEY_NOT_SET -> error("EntityKey.key not set")
-    }
+    entityType = source.entityType
+    id = source.id
   }
 }
 
@@ -763,37 +742,7 @@ internal fun InternalEntityKey.toPublic(): EntityKey {
 internal fun EntityKey.toInternal(): InternalEntityKey {
   val source = this
   return internalEntityKey {
-    when (source.keyCase) {
-      EntityKey.KeyCase.META ->
-        meta = internalMetaEntityKey {
-          type = source.meta.type.toInternal()
-          id = source.meta.id
-        }
-      EntityKey.KeyCase.KEY_NOT_SET -> error("EntityKey.key not set")
-    }
-  }
-}
-
-/** Converts an internal [InternalMetaEntityKey.Type] to a public [MetaEntityKey.Type]. */
-internal fun InternalMetaEntityKey.Type.toPublic(): MetaEntityKey.Type {
-  return when (this) {
-    InternalMetaEntityKey.Type.AD -> MetaEntityKey.Type.AD
-    InternalMetaEntityKey.Type.AD_SET -> MetaEntityKey.Type.AD_SET
-    InternalMetaEntityKey.Type.CAMPAIGN -> MetaEntityKey.Type.CAMPAIGN
-    InternalMetaEntityKey.Type.AD_ACCOUNT -> MetaEntityKey.Type.AD_ACCOUNT
-    InternalMetaEntityKey.Type.UNRECOGNIZED,
-    InternalMetaEntityKey.Type.TYPE_UNSPECIFIED -> error("Unrecognized MetaEntityKey.Type")
-  }
-}
-
-/** Converts a public [MetaEntityKey.Type] to an internal [InternalMetaEntityKey.Type]. */
-internal fun MetaEntityKey.Type.toInternal(): InternalMetaEntityKey.Type {
-  return when (this) {
-    MetaEntityKey.Type.AD -> InternalMetaEntityKey.Type.AD
-    MetaEntityKey.Type.AD_SET -> InternalMetaEntityKey.Type.AD_SET
-    MetaEntityKey.Type.CAMPAIGN -> InternalMetaEntityKey.Type.CAMPAIGN
-    MetaEntityKey.Type.AD_ACCOUNT -> InternalMetaEntityKey.Type.AD_ACCOUNT
-    MetaEntityKey.Type.UNRECOGNIZED,
-    MetaEntityKey.Type.TYPE_UNSPECIFIED -> error("Unrecognized MetaEntityKey.Type")
+    entityType = source.entityType
+    id = source.id
   }
 }

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/service/v1alpha/ImpressionMetadataService.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/service/v1alpha/ImpressionMetadataService.kt
@@ -433,8 +433,6 @@ class ImpressionMetadataService(
         validateEntityKey(entityKey, "filter.entity_keys.$index")
       } catch (e: RequiredFieldNotSetException) {
         throw e.asStatusRuntimeException(Status.Code.INVALID_ARGUMENT)
-      } catch (e: InvalidFieldValueException) {
-        throw e.asStatusRuntimeException(Status.Code.INVALID_ARGUMENT)
       }
     }
 

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/service/v1alpha/ImpressionMetadataService.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/service/v1alpha/ImpressionMetadataService.kt
@@ -1,16 +1,18 @@
-// Copyright 2025 The Cross-Media Measurement Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//      http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+/*
+ * Copyright 2025 The Cross-Media Measurement Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package org.wfanet.measurement.edpaggregator.service.v1alpha
 
@@ -40,21 +42,26 @@ import org.wfanet.measurement.edpaggregator.v1alpha.ComputeModelLineBoundsRespon
 import org.wfanet.measurement.edpaggregator.v1alpha.ComputeModelLineBoundsResponseKt.modelLineBoundMapEntry
 import org.wfanet.measurement.edpaggregator.v1alpha.CreateImpressionMetadataRequest
 import org.wfanet.measurement.edpaggregator.v1alpha.DeleteImpressionMetadataRequest
+import org.wfanet.measurement.edpaggregator.v1alpha.EntityKey
 import org.wfanet.measurement.edpaggregator.v1alpha.GetImpressionMetadataRequest
 import org.wfanet.measurement.edpaggregator.v1alpha.ImpressionMetadata
 import org.wfanet.measurement.edpaggregator.v1alpha.ImpressionMetadataServiceGrpcKt.ImpressionMetadataServiceCoroutineImplBase
 import org.wfanet.measurement.edpaggregator.v1alpha.ListImpressionMetadataRequest
 import org.wfanet.measurement.edpaggregator.v1alpha.ListImpressionMetadataResponse
+import org.wfanet.measurement.edpaggregator.v1alpha.MetaEntityKey
 import org.wfanet.measurement.edpaggregator.v1alpha.batchCreateImpressionMetadataResponse
 import org.wfanet.measurement.edpaggregator.v1alpha.batchDeleteImpressionMetadataResponse
 import org.wfanet.measurement.edpaggregator.v1alpha.computeModelLineBoundsResponse
+import org.wfanet.measurement.edpaggregator.v1alpha.entityKey
 import org.wfanet.measurement.edpaggregator.v1alpha.impressionMetadata
 import org.wfanet.measurement.edpaggregator.v1alpha.listImpressionMetadataResponse
+import org.wfanet.measurement.edpaggregator.v1alpha.metaEntityKey
 import org.wfanet.measurement.internal.edpaggregator.BatchCreateImpressionMetadataResponse as InternalBatchCreateImpressionMetadataResponse
 import org.wfanet.measurement.internal.edpaggregator.BatchDeleteImpressionMetadataResponse as InternalBatchDeleteImpressionMetadataResponse
 import org.wfanet.measurement.internal.edpaggregator.ComputeModelLineBoundsResponse as InternalComputeModelLineBoundsResponse
 import org.wfanet.measurement.internal.edpaggregator.CreateImpressionMetadataRequest as InternalCreateImpressionMetadataRequest
 import org.wfanet.measurement.internal.edpaggregator.DeleteImpressionMetadataRequest as InternalDeleteImpressionMetadataRequest
+import org.wfanet.measurement.internal.edpaggregator.EntityKey as InternalEntityKey
 import org.wfanet.measurement.internal.edpaggregator.ImpressionMetadata as InternalImpressionMetadata
 import org.wfanet.measurement.internal.edpaggregator.ImpressionMetadataServiceGrpcKt.ImpressionMetadataServiceCoroutineStub as InternalImpressionMetadataServiceCoroutineStub
 import org.wfanet.measurement.internal.edpaggregator.ImpressionMetadataState as InternalImpressionMetadataState
@@ -62,14 +69,17 @@ import org.wfanet.measurement.internal.edpaggregator.ListImpressionMetadataPageT
 import org.wfanet.measurement.internal.edpaggregator.ListImpressionMetadataRequest as InternalListImpressionMetadataRequest
 import org.wfanet.measurement.internal.edpaggregator.ListImpressionMetadataRequestKt.filter as internalListImpressionMetadataRequestFilter
 import org.wfanet.measurement.internal.edpaggregator.ListImpressionMetadataResponse as InternalListImpressionMetadataResponse
+import org.wfanet.measurement.internal.edpaggregator.MetaEntityKey as InternalMetaEntityKey
 import org.wfanet.measurement.internal.edpaggregator.batchCreateImpressionMetadataRequest as internalBatchCreateImpressionMetadataRequest
 import org.wfanet.measurement.internal.edpaggregator.batchDeleteImpressionMetadataRequest as internalBatchDeleteImpressionMetadataRequest
 import org.wfanet.measurement.internal.edpaggregator.computeModelLineBoundsRequest as internalComputeModelLineBoundsRequest
 import org.wfanet.measurement.internal.edpaggregator.createImpressionMetadataRequest as internalCreateImpressionMetadataRequest
 import org.wfanet.measurement.internal.edpaggregator.deleteImpressionMetadataRequest as internalDeleteImpressionMetadataRequest
+import org.wfanet.measurement.internal.edpaggregator.entityKey as internalEntityKey
 import org.wfanet.measurement.internal.edpaggregator.getImpressionMetadataRequest as internalGetImpressionMetadataRequest
 import org.wfanet.measurement.internal.edpaggregator.impressionMetadata as internalImpressionMetadata
 import org.wfanet.measurement.internal.edpaggregator.listImpressionMetadataRequest as internalListImpressionMetadataRequest
+import org.wfanet.measurement.internal.edpaggregator.metaEntityKey as internalMetaEntityKey
 
 class ImpressionMetadataService(
   private val internalImpressionMetadataStub: InternalImpressionMetadataServiceCoroutineStub,
@@ -422,6 +432,16 @@ class ImpressionMetadataService(
         .asStatusRuntimeException(Status.Code.INVALID_ARGUMENT)
     }
 
+    request.filter.entityKeysList.forEachIndexed { index, entityKey ->
+      try {
+        validateEntityKey(entityKey, "filter.entity_keys.$index")
+      } catch (e: RequiredFieldNotSetException) {
+        throw e.asStatusRuntimeException(Status.Code.INVALID_ARGUMENT)
+      } catch (e: InvalidFieldValueException) {
+        throw e.asStatusRuntimeException(Status.Code.INVALID_ARGUMENT)
+      }
+    }
+
     val pageSize =
       if (request.pageSize == 0) {
         DEFAULT_PAGE_SIZE
@@ -455,6 +475,7 @@ class ImpressionMetadataService(
         if (request.filter.blobUriPrefix.isNotEmpty()) {
           blobUriPrefix = request.filter.blobUriPrefix
         }
+        entityKeys += request.filter.entityKeysList.map { it.toInternal() }
 
         state =
           if (!request.showDeleted) {
@@ -616,6 +637,35 @@ class ImpressionMetadataService(
     if (!request.impressionMetadata.hasInterval()) {
       throw RequiredFieldNotSetException("${fieldPathPrefix}impression_metadata.interval")
     }
+
+    request.impressionMetadata.entityKeysList.forEachIndexed { index, entityKey ->
+      validateEntityKey(entityKey, "${fieldPathPrefix}impression_metadata.entity_keys.$index")
+    }
+  }
+
+  /**
+   * Checks that the specified [EntityKey] has exactly one variant set and that the inner fields
+   * are populated correctly.
+   *
+   * @throws RequiredFieldNotSetException if the variant or a required inner field is unset
+   * @throws InvalidFieldValueException if an inner enum is set to its UNSPECIFIED value
+   */
+  private fun validateEntityKey(entityKey: EntityKey, fieldPath: String) {
+    when (entityKey.keyCase) {
+      EntityKey.KeyCase.META -> {
+        if (entityKey.meta.type == MetaEntityKey.Type.TYPE_UNSPECIFIED) {
+          throw InvalidFieldValueException("$fieldPath.meta.type") { fieldName ->
+            "$fieldName must not be TYPE_UNSPECIFIED"
+          }
+        }
+        if (entityKey.meta.id.isEmpty()) {
+          throw RequiredFieldNotSetException("$fieldPath.meta.id")
+        }
+      }
+      EntityKey.KeyCase.KEY_NOT_SET -> {
+        throw RequiredFieldNotSetException("$fieldPath.key")
+      }
+    }
   }
 
   companion object {
@@ -639,6 +689,7 @@ fun InternalImpressionMetadata.toImpressionMetadata(): ImpressionMetadata {
     state = source.state.toState()
     createTime = source.createTime
     updateTime = source.updateTime
+    entityKeys += source.entityKeysList.map { it.toPublic() }
   }
 }
 
@@ -660,6 +711,7 @@ fun ImpressionMetadata.toInternal(
     eventGroupReferenceId = source.eventGroupReferenceId
     cmmsModelLine = source.modelLine
     interval = source.interval
+    entityKeys += source.entityKeysList.map { it.toInternal() }
   }
 }
 
@@ -689,5 +741,59 @@ internal fun ImpressionMetadata.State.toInternal(): InternalImpressionMetadataSt
       InternalImpressionMetadataState.IMPRESSION_METADATA_STATE_DELETED
     ImpressionMetadata.State.UNRECOGNIZED,
     ImpressionMetadata.State.STATE_UNSPECIFIED -> error("Unrecognized state")
+  }
+}
+
+/** Converts an internal [InternalEntityKey] to a public [EntityKey]. */
+internal fun InternalEntityKey.toPublic(): EntityKey {
+  val source = this
+  return entityKey {
+    when (source.keyCase) {
+      InternalEntityKey.KeyCase.META ->
+        meta = metaEntityKey {
+          type = source.meta.type.toPublic()
+          id = source.meta.id
+        }
+      InternalEntityKey.KeyCase.KEY_NOT_SET -> error("EntityKey.key not set")
+    }
+  }
+}
+
+/** Converts a public [EntityKey] to an internal [InternalEntityKey]. */
+internal fun EntityKey.toInternal(): InternalEntityKey {
+  val source = this
+  return internalEntityKey {
+    when (source.keyCase) {
+      EntityKey.KeyCase.META ->
+        meta = internalMetaEntityKey {
+          type = source.meta.type.toInternal()
+          id = source.meta.id
+        }
+      EntityKey.KeyCase.KEY_NOT_SET -> error("EntityKey.key not set")
+    }
+  }
+}
+
+/** Converts an internal [InternalMetaEntityKey.Type] to a public [MetaEntityKey.Type]. */
+internal fun InternalMetaEntityKey.Type.toPublic(): MetaEntityKey.Type {
+  return when (this) {
+    InternalMetaEntityKey.Type.AD -> MetaEntityKey.Type.AD
+    InternalMetaEntityKey.Type.AD_SET -> MetaEntityKey.Type.AD_SET
+    InternalMetaEntityKey.Type.CAMPAIGN -> MetaEntityKey.Type.CAMPAIGN
+    InternalMetaEntityKey.Type.AD_ACCOUNT -> MetaEntityKey.Type.AD_ACCOUNT
+    InternalMetaEntityKey.Type.UNRECOGNIZED,
+    InternalMetaEntityKey.Type.TYPE_UNSPECIFIED -> error("Unrecognized MetaEntityKey.Type")
+  }
+}
+
+/** Converts a public [MetaEntityKey.Type] to an internal [InternalMetaEntityKey.Type]. */
+internal fun MetaEntityKey.Type.toInternal(): InternalMetaEntityKey.Type {
+  return when (this) {
+    MetaEntityKey.Type.AD -> InternalMetaEntityKey.Type.AD
+    MetaEntityKey.Type.AD_SET -> InternalMetaEntityKey.Type.AD_SET
+    MetaEntityKey.Type.CAMPAIGN -> InternalMetaEntityKey.Type.CAMPAIGN
+    MetaEntityKey.Type.AD_ACCOUNT -> InternalMetaEntityKey.Type.AD_ACCOUNT
+    MetaEntityKey.Type.UNRECOGNIZED,
+    MetaEntityKey.Type.TYPE_UNSPECIFIED -> error("Unrecognized MetaEntityKey.Type")
   }
 }

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/service/v1alpha/ImpressionMetadataService.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/service/v1alpha/ImpressionMetadataService.kt
@@ -646,8 +646,8 @@ class ImpressionMetadataService(
     if (entityKey.entityType.isEmpty()) {
       throw RequiredFieldNotSetException("$fieldPath.entity_type")
     }
-    if (entityKey.id.isEmpty()) {
-      throw RequiredFieldNotSetException("$fieldPath.id")
+    if (entityKey.entityId.isEmpty()) {
+      throw RequiredFieldNotSetException("$fieldPath.entity_id")
     }
   }
 
@@ -732,7 +732,7 @@ internal fun InternalEntityKey.toPublic(): EntityKey {
   val source = this
   return entityKey {
     entityType = source.entityType
-    id = source.id
+    entityId = source.entityId
   }
 }
 
@@ -741,6 +741,6 @@ internal fun EntityKey.toInternal(): InternalEntityKey {
   val source = this
   return internalEntityKey {
     entityType = source.entityType
-    id = source.id
+    entityId = source.entityId
   }
 }

--- a/src/main/proto/wfa/measurement/edpaggregator/v1alpha/impression_metadata.proto
+++ b/src/main/proto/wfa/measurement/edpaggregator/v1alpha/impression_metadata.proto
@@ -28,36 +28,22 @@ option java_outer_classname = "ImpressionMetadataProto";
 // Key of an entity in a DataProvider's system that an ImpressionMetadata
 // blob is associated with.
 //
-// The variant inside `key` identifies which DataProvider's taxonomy the
-// entity belongs to. Each variant carries a per-EDP enum of valid entity
-// types plus the entity's ID. Adding a new EDP means adding a new variant
-// to the `key` oneof and a new corresponding message type.
+// `entity_type` is interpreted per-EDP via configuration (no proto change is
+// required to onboard a new EDP or to add new entity types to an existing
+// EDP's taxonomy).
 message EntityKey {
-  // Exactly one variant must be set.
-  oneof key {
-    MetaEntityKey meta = 1;
-  }
-}
-
-// Entity key for entities in Meta's system (Facebook / Instagram).
-message MetaEntityKey {
-  // Taxonomy of entities in Meta's system that an ImpressionMetadata blob
-  // may be associated with.
-  enum Type {
-    TYPE_UNSPECIFIED = 0;
-    AD = 1;
-    AD_SET = 2;
-    CAMPAIGN = 3;
-    AD_ACCOUNT = 4;
-  }
-
-  Type type = 1 [(google.api.field_behavior) = REQUIRED];
-
-  // ID of the entity in Meta's system.
+  // ID of the entity in the DataProvider's system.
   //
   // Must be a URL-safe string, such that URL-encoding or -decoding results
   // in the same string.
-  string id = 2 [(google.api.field_behavior) = REQUIRED];
+  string id = 1 [(google.api.field_behavior) = REQUIRED];
+
+  // Type of the entity in the DataProvider's system. Interpreted per-EDP
+  // via configuration.
+  //
+  // Must be a URL-safe string, such that URL-encoding or -decoding results
+  // in the same string.
+  string entity_type = 2 [(google.api.field_behavior) = REQUIRED];
 }
 
 // Metadata for a blob of labeled impressions.

--- a/src/main/proto/wfa/measurement/edpaggregator/v1alpha/impression_metadata.proto
+++ b/src/main/proto/wfa/measurement/edpaggregator/v1alpha/impression_metadata.proto
@@ -32,18 +32,18 @@ option java_outer_classname = "ImpressionMetadataProto";
 // required to onboard a new EDP or to add new entity types to an existing
 // EDP's taxonomy).
 message EntityKey {
-  // ID of the entity in the DataProvider's system.
-  //
-  // Must be a URL-safe string, such that URL-encoding or -decoding results
-  // in the same string.
-  string id = 1 [(google.api.field_behavior) = REQUIRED];
-
   // Type of the entity in the DataProvider's system. Interpreted per-EDP
   // via configuration.
   //
   // Must be a URL-safe string, such that URL-encoding or -decoding results
   // in the same string.
-  string entity_type = 2 [(google.api.field_behavior) = REQUIRED];
+  string entity_type = 1 [(google.api.field_behavior) = REQUIRED];
+
+  // ID of the entity in the DataProvider's system, scoped to entity_type.
+  //
+  // Must be a URL-safe string, such that URL-encoding or -decoding results
+  // in the same string.
+  string entity_id = 2 [(google.api.field_behavior) = REQUIRED];
 }
 
 // Metadata for a blob of labeled impressions.

--- a/src/main/proto/wfa/measurement/edpaggregator/v1alpha/impression_metadata.proto
+++ b/src/main/proto/wfa/measurement/edpaggregator/v1alpha/impression_metadata.proto
@@ -25,6 +25,41 @@ option java_package = "org.wfanet.measurement.edpaggregator.v1alpha";
 option java_multiple_files = true;
 option java_outer_classname = "ImpressionMetadataProto";
 
+// Key of an entity in a DataProvider's system that an ImpressionMetadata
+// blob is associated with.
+//
+// The variant inside `key` identifies which DataProvider's taxonomy the
+// entity belongs to. Each variant carries a per-EDP enum of valid entity
+// types plus the entity's ID. Adding a new EDP means adding a new variant
+// to the `key` oneof and a new corresponding message type.
+message EntityKey {
+  // Exactly one variant must be set.
+  oneof key {
+    MetaEntityKey meta = 1;
+  }
+}
+
+// Entity key for entities in Meta's system (Facebook / Instagram).
+message MetaEntityKey {
+  // Taxonomy of entities in Meta's system that an ImpressionMetadata blob
+  // may be associated with.
+  enum Type {
+    TYPE_UNSPECIFIED = 0;
+    AD = 1;
+    AD_SET = 2;
+    CAMPAIGN = 3;
+    AD_ACCOUNT = 4;
+  }
+
+  Type type = 1 [(google.api.field_behavior) = REQUIRED];
+
+  // ID of the entity in Meta's system.
+  //
+  // Must be a URL-safe string, such that URL-encoding or -decoding results
+  // in the same string.
+  string id = 2 [(google.api.field_behavior) = REQUIRED];
+}
+
 // Metadata for a blob of labeled impressions.
 // This resource tracks the location and context of raw data files uploaded by
 // an EDP.
@@ -86,4 +121,12 @@ message ImpressionMetadata {
   // The timestamp when this metadata entry was last updated (e.g., deleted).
   google.protobuf.Timestamp update_time = 9
       [(google.api.field_behavior) = OUTPUT_ONLY];
+
+  // Entities in the DataProvider's system that the impressions in this blob
+  // are associated with.
+  //
+  // A single blob may be tagged with multiple entities. Consumers may use
+  // this field to filter blobs to a subset of entities without joining
+  // against EventGroup metadata.
+  repeated EntityKey entity_keys = 10 [(google.api.field_behavior) = OPTIONAL];
 }

--- a/src/main/proto/wfa/measurement/edpaggregator/v1alpha/impression_metadata_service.proto
+++ b/src/main/proto/wfa/measurement/edpaggregator/v1alpha/impression_metadata_service.proto
@@ -178,6 +178,10 @@ message ListImpressionMetadataRequest {
 
     // The blob URI prefix to filter by.
     string blob_uri_prefix = 4 [(google.api.field_behavior) = OPTIONAL];
+
+    // Filter by entity keys. OR-semantics: a metadata entry matches if its
+    // `entity_keys` set contains at least one of the entries listed here.
+    repeated EntityKey entity_keys = 5 [(google.api.field_behavior) = OPTIONAL];
   }
 
   // A flag indicating whether to include soft DELETED entries.

--- a/src/test/kotlin/org/wfanet/measurement/edpaggregator/service/v1alpha/ImpressionMetadataServiceTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/edpaggregator/service/v1alpha/ImpressionMetadataServiceTest.kt
@@ -52,7 +52,6 @@ import org.wfanet.measurement.edpaggregator.v1alpha.GetImpressionMetadataRequest
 import org.wfanet.measurement.edpaggregator.v1alpha.ImpressionMetadata
 import org.wfanet.measurement.edpaggregator.v1alpha.ListImpressionMetadataRequest
 import org.wfanet.measurement.edpaggregator.v1alpha.ListImpressionMetadataRequestKt
-import org.wfanet.measurement.edpaggregator.v1alpha.MetaEntityKey
 import org.wfanet.measurement.edpaggregator.v1alpha.batchCreateImpressionMetadataRequest
 import org.wfanet.measurement.edpaggregator.v1alpha.batchCreateImpressionMetadataResponse
 import org.wfanet.measurement.edpaggregator.v1alpha.batchDeleteImpressionMetadataRequest
@@ -67,7 +66,6 @@ import org.wfanet.measurement.edpaggregator.v1alpha.getImpressionMetadataRequest
 import org.wfanet.measurement.edpaggregator.v1alpha.impressionMetadata
 import org.wfanet.measurement.edpaggregator.v1alpha.listImpressionMetadataRequest
 import org.wfanet.measurement.edpaggregator.v1alpha.listImpressionMetadataResponse
-import org.wfanet.measurement.edpaggregator.v1alpha.metaEntityKey
 import org.wfanet.measurement.gcloud.spanner.testing.SpannerEmulatorDatabaseRule
 import org.wfanet.measurement.gcloud.spanner.testing.SpannerEmulatorRule
 import org.wfanet.measurement.internal.edpaggregator.ImpressionMetadataServiceGrpcKt.ImpressionMetadataServiceCoroutineImplBase as InternalImpressionMetadataServiceCoroutineImplBase
@@ -1482,7 +1480,7 @@ class ImpressionMetadataServiceTest {
       )
 
     assertThat(response.entityKeysList)
-      .containsExactly(META_ENTITY_KEY_AD_1, META_ENTITY_KEY_CAMPAIGN_1)
+      .containsExactly(ENTITY_KEY_AD_1, ENTITY_KEY_CAMPAIGN_1)
       .inOrder()
   }
 
@@ -1500,7 +1498,7 @@ class ImpressionMetadataServiceTest {
       service.getImpressionMetadata(getImpressionMetadataRequest { name = created.name })
 
     assertThat(fetched.entityKeysList)
-      .containsExactly(META_ENTITY_KEY_AD_1, META_ENTITY_KEY_CAMPAIGN_1)
+      .containsExactly(ENTITY_KEY_AD_1, ENTITY_KEY_CAMPAIGN_1)
       .inOrder()
   }
 
@@ -1518,26 +1516,26 @@ class ImpressionMetadataServiceTest {
           requests +=
             createImpressionMetadataRequest {
               parent = DATA_PROVIDER_KEY.toName()
-              impressionMetadata = IMPRESSION_METADATA_2.copy { entityKeys += META_ENTITY_KEY_AD_2 }
+              impressionMetadata = IMPRESSION_METADATA_2.copy { entityKeys += ENTITY_KEY_AD_2 }
             }
         }
       )
 
     assertThat(response.impressionMetadataList).hasSize(2)
     assertThat(response.impressionMetadataList[0].entityKeysList)
-      .containsExactly(META_ENTITY_KEY_AD_1, META_ENTITY_KEY_CAMPAIGN_1)
+      .containsExactly(ENTITY_KEY_AD_1, ENTITY_KEY_CAMPAIGN_1)
       .inOrder()
     assertThat(response.impressionMetadataList[1].entityKeysList)
-      .containsExactly(META_ENTITY_KEY_AD_2)
+      .containsExactly(ENTITY_KEY_AD_2)
       .inOrder()
   }
-
   @Test
-  fun `createImpressionMetadata throws INVALID_ARGUMENT when entity_key has no variant set`() =
+  fun `createImpressionMetadata throws INVALID_ARGUMENT when entity_key entity_type is empty`() =
     runBlocking {
       val request = createImpressionMetadataRequest {
         parent = DATA_PROVIDER_KEY.toName()
-        impressionMetadata = IMPRESSION_METADATA.copy { entityKeys += entityKey {} }
+        impressionMetadata =
+          IMPRESSION_METADATA.copy { entityKeys += entityKey { id = "x" } }
       }
 
       val exception =
@@ -1548,43 +1546,17 @@ class ImpressionMetadataServiceTest {
           errorInfo {
             domain = Errors.DOMAIN
             reason = Errors.Reason.REQUIRED_FIELD_NOT_SET.name
-            metadata[Errors.Metadata.FIELD_NAME.key] = "impression_metadata.entity_keys.0.key"
+            metadata[Errors.Metadata.FIELD_NAME.key] = "impression_metadata.entity_keys.0.entity_type"
           }
         )
     }
 
   @Test
-  fun `createImpressionMetadata throws INVALID_ARGUMENT when meta type is unspecified`() =
-    runBlocking {
-      val request = createImpressionMetadataRequest {
-        parent = DATA_PROVIDER_KEY.toName()
-        impressionMetadata =
-          IMPRESSION_METADATA.copy {
-            entityKeys += entityKey { meta = metaEntityKey { id = "x" } }
-          }
-      }
-
-      val exception =
-        assertFailsWith<StatusRuntimeException> { service.createImpressionMetadata(request) }
-      assertThat(exception.status.code).isEqualTo(Status.Code.INVALID_ARGUMENT)
-      assertThat(exception.errorInfo)
-        .isEqualTo(
-          errorInfo {
-            domain = Errors.DOMAIN
-            reason = Errors.Reason.INVALID_FIELD_VALUE.name
-            metadata[Errors.Metadata.FIELD_NAME.key] = "impression_metadata.entity_keys.0.meta.type"
-          }
-        )
-    }
-
-  @Test
-  fun `createImpressionMetadata throws INVALID_ARGUMENT when meta id is empty`() = runBlocking {
+  fun `createImpressionMetadata throws INVALID_ARGUMENT when entity_key id is empty`() = runBlocking {
     val request = createImpressionMetadataRequest {
       parent = DATA_PROVIDER_KEY.toName()
       impressionMetadata =
-        IMPRESSION_METADATA.copy {
-          entityKeys += entityKey { meta = metaEntityKey { type = MetaEntityKey.Type.AD } }
-        }
+        IMPRESSION_METADATA.copy { entityKeys += entityKey { entityType = "ad" } }
     }
 
     val exception =
@@ -1595,7 +1567,7 @@ class ImpressionMetadataServiceTest {
         errorInfo {
           domain = Errors.DOMAIN
           reason = Errors.Reason.REQUIRED_FIELD_NOT_SET.name
-          metadata[Errors.Metadata.FIELD_NAME.key] = "impression_metadata.entity_keys.0.meta.id"
+          metadata[Errors.Metadata.FIELD_NAME.key] = "impression_metadata.entity_keys.0.id"
         }
       )
   }
@@ -1619,13 +1591,13 @@ class ImpressionMetadataServiceTest {
       service.listImpressionMetadata(
         listImpressionMetadataRequest {
           parent = DATA_PROVIDER_KEY.toName()
-          filter = ListImpressionMetadataRequestKt.filter { entityKeys += META_ENTITY_KEY_AD_1 }
+          filter = ListImpressionMetadataRequestKt.filter { entityKeys += ENTITY_KEY_AD_1 }
         }
       )
 
     assertThat(response.impressionMetadataList).hasSize(1)
     assertThat(response.impressionMetadataList[0].entityKeysList)
-      .containsExactly(META_ENTITY_KEY_AD_1, META_ENTITY_KEY_CAMPAIGN_1)
+      .containsExactly(ENTITY_KEY_AD_1, ENTITY_KEY_CAMPAIGN_1)
       .inOrder()
   }
 
@@ -1638,7 +1610,7 @@ class ImpressionMetadataServiceTest {
           impressionMetadata = IMPRESSION_METADATA_WITH_ENTITY_KEYS
         }
       )
-      val secondImpression = IMPRESSION_METADATA_2.copy { entityKeys += META_ENTITY_KEY_AD_2 }
+      val secondImpression = IMPRESSION_METADATA_2.copy { entityKeys += ENTITY_KEY_AD_2 }
       service.createImpressionMetadata(
         createImpressionMetadataRequest {
           parent = DATA_PROVIDER_KEY.toName()
@@ -1652,8 +1624,8 @@ class ImpressionMetadataServiceTest {
             parent = DATA_PROVIDER_KEY.toName()
             filter =
               ListImpressionMetadataRequestKt.filter {
-                entityKeys += META_ENTITY_KEY_AD_1
-                entityKeys += META_ENTITY_KEY_AD_2
+                entityKeys += ENTITY_KEY_AD_1
+                entityKeys += ENTITY_KEY_AD_2
               }
           }
         )
@@ -1677,10 +1649,8 @@ class ImpressionMetadataServiceTest {
           filter =
             ListImpressionMetadataRequestKt.filter {
               entityKeys += entityKey {
-                meta = metaEntityKey {
-                  type = MetaEntityKey.Type.AD_ACCOUNT
-                  id = "no-such-account"
-                }
+                entityType = "ad_account"
+                id = "no-such-account"
               }
             }
         }
@@ -1708,7 +1678,7 @@ class ImpressionMetadataServiceTest {
           errorInfo {
             domain = Errors.DOMAIN
             reason = Errors.Reason.REQUIRED_FIELD_NOT_SET.name
-            metadata[Errors.Metadata.FIELD_NAME.key] = "filter.entity_keys.0.key"
+            metadata[Errors.Metadata.FIELD_NAME.key] = "filter.entity_keys.0.entity_type"
           }
         )
     }
@@ -1754,31 +1724,25 @@ class ImpressionMetadataServiceTest {
       // state not set
     }
 
-    private val META_ENTITY_KEY_AD_1 = entityKey {
-      meta = metaEntityKey {
-        type = MetaEntityKey.Type.AD
-        id = "ad-1"
-      }
+    private val ENTITY_KEY_AD_1 = entityKey {
+      entityType = "ad"
+      id = "ad-1"
     }
 
-    private val META_ENTITY_KEY_AD_2 = entityKey {
-      meta = metaEntityKey {
-        type = MetaEntityKey.Type.AD
-        id = "ad-2"
-      }
+    private val ENTITY_KEY_AD_2 = entityKey {
+      entityType = "ad"
+      id = "ad-2"
     }
 
-    private val META_ENTITY_KEY_CAMPAIGN_1 = entityKey {
-      meta = metaEntityKey {
-        type = MetaEntityKey.Type.CAMPAIGN
-        id = "campaign-1"
-      }
+    private val ENTITY_KEY_CAMPAIGN_1 = entityKey {
+      entityType = "campaign"
+      id = "campaign-1"
     }
 
     private val IMPRESSION_METADATA_WITH_ENTITY_KEYS =
       IMPRESSION_METADATA.copy {
-        entityKeys += META_ENTITY_KEY_AD_1
-        entityKeys += META_ENTITY_KEY_CAMPAIGN_1
+        entityKeys += ENTITY_KEY_AD_1
+        entityKeys += ENTITY_KEY_CAMPAIGN_1
       }
   }
 }

--- a/src/test/kotlin/org/wfanet/measurement/edpaggregator/service/v1alpha/ImpressionMetadataServiceTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/edpaggregator/service/v1alpha/ImpressionMetadataServiceTest.kt
@@ -1535,7 +1535,7 @@ class ImpressionMetadataServiceTest {
       val request = createImpressionMetadataRequest {
         parent = DATA_PROVIDER_KEY.toName()
         impressionMetadata =
-          IMPRESSION_METADATA.copy { entityKeys += entityKey { id = "x" } }
+          IMPRESSION_METADATA.copy { entityKeys += entityKey { entityId = "x" } }
       }
 
       val exception =
@@ -1567,7 +1567,7 @@ class ImpressionMetadataServiceTest {
         errorInfo {
           domain = Errors.DOMAIN
           reason = Errors.Reason.REQUIRED_FIELD_NOT_SET.name
-          metadata[Errors.Metadata.FIELD_NAME.key] = "impression_metadata.entity_keys.0.id"
+          metadata[Errors.Metadata.FIELD_NAME.key] = "impression_metadata.entity_keys.0.entity_id"
         }
       )
   }
@@ -1650,7 +1650,7 @@ class ImpressionMetadataServiceTest {
             ListImpressionMetadataRequestKt.filter {
               entityKeys += entityKey {
                 entityType = "ad_account"
-                id = "no-such-account"
+                entityId = "no-such-account"
               }
             }
         }
@@ -1726,17 +1726,17 @@ class ImpressionMetadataServiceTest {
 
     private val ENTITY_KEY_AD_1 = entityKey {
       entityType = "ad"
-      id = "ad-1"
+      entityId = "ad-1"
     }
 
     private val ENTITY_KEY_AD_2 = entityKey {
       entityType = "ad"
-      id = "ad-2"
+      entityId = "ad-2"
     }
 
     private val ENTITY_KEY_CAMPAIGN_1 = entityKey {
       entityType = "campaign"
-      id = "campaign-1"
+      entityId = "campaign-1"
     }
 
     private val IMPRESSION_METADATA_WITH_ENTITY_KEYS =

--- a/src/test/kotlin/org/wfanet/measurement/edpaggregator/service/v1alpha/ImpressionMetadataServiceTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/edpaggregator/service/v1alpha/ImpressionMetadataServiceTest.kt
@@ -47,10 +47,12 @@ import org.wfanet.measurement.edpaggregator.service.Errors
 import org.wfanet.measurement.edpaggregator.service.ImpressionMetadataKey
 import org.wfanet.measurement.edpaggregator.v1alpha.ComputeModelLineBoundsResponseKt.modelLineBoundMapEntry
 import org.wfanet.measurement.edpaggregator.v1alpha.DeleteImpressionMetadataRequest
+import org.wfanet.measurement.edpaggregator.v1alpha.EntityKey
 import org.wfanet.measurement.edpaggregator.v1alpha.GetImpressionMetadataRequest
 import org.wfanet.measurement.edpaggregator.v1alpha.ImpressionMetadata
 import org.wfanet.measurement.edpaggregator.v1alpha.ListImpressionMetadataRequest
 import org.wfanet.measurement.edpaggregator.v1alpha.ListImpressionMetadataRequestKt
+import org.wfanet.measurement.edpaggregator.v1alpha.MetaEntityKey
 import org.wfanet.measurement.edpaggregator.v1alpha.batchCreateImpressionMetadataRequest
 import org.wfanet.measurement.edpaggregator.v1alpha.batchCreateImpressionMetadataResponse
 import org.wfanet.measurement.edpaggregator.v1alpha.batchDeleteImpressionMetadataRequest
@@ -60,10 +62,12 @@ import org.wfanet.measurement.edpaggregator.v1alpha.computeModelLineBoundsRespon
 import org.wfanet.measurement.edpaggregator.v1alpha.copy
 import org.wfanet.measurement.edpaggregator.v1alpha.createImpressionMetadataRequest
 import org.wfanet.measurement.edpaggregator.v1alpha.deleteImpressionMetadataRequest
+import org.wfanet.measurement.edpaggregator.v1alpha.entityKey
 import org.wfanet.measurement.edpaggregator.v1alpha.getImpressionMetadataRequest
 import org.wfanet.measurement.edpaggregator.v1alpha.impressionMetadata
 import org.wfanet.measurement.edpaggregator.v1alpha.listImpressionMetadataRequest
 import org.wfanet.measurement.edpaggregator.v1alpha.listImpressionMetadataResponse
+import org.wfanet.measurement.edpaggregator.v1alpha.metaEntityKey
 import org.wfanet.measurement.gcloud.spanner.testing.SpannerEmulatorDatabaseRule
 import org.wfanet.measurement.gcloud.spanner.testing.SpannerEmulatorRule
 import org.wfanet.measurement.internal.edpaggregator.ImpressionMetadataServiceGrpcKt.ImpressionMetadataServiceCoroutineImplBase as InternalImpressionMetadataServiceCoroutineImplBase
@@ -1466,6 +1470,249 @@ class ImpressionMetadataServiceTest {
     }
   }
 
+
+  @Test
+  fun `createImpressionMetadata returns entity_keys`() = runBlocking {
+    val response =
+      service.createImpressionMetadata(
+        createImpressionMetadataRequest {
+          parent = DATA_PROVIDER_KEY.toName()
+          impressionMetadata = IMPRESSION_METADATA_WITH_ENTITY_KEYS
+        }
+      )
+
+    assertThat(response.entityKeysList)
+      .containsExactly(META_ENTITY_KEY_AD_1, META_ENTITY_KEY_CAMPAIGN_1)
+      .inOrder()
+  }
+
+  @Test
+  fun `getImpressionMetadata returns entity_keys`() = runBlocking {
+    val created =
+      service.createImpressionMetadata(
+        createImpressionMetadataRequest {
+          parent = DATA_PROVIDER_KEY.toName()
+          impressionMetadata = IMPRESSION_METADATA_WITH_ENTITY_KEYS
+        }
+      )
+
+    val fetched =
+      service.getImpressionMetadata(getImpressionMetadataRequest { name = created.name })
+
+    assertThat(fetched.entityKeysList)
+      .containsExactly(META_ENTITY_KEY_AD_1, META_ENTITY_KEY_CAMPAIGN_1)
+      .inOrder()
+  }
+
+  @Test
+  fun `batchCreateImpressionMetadata preserves entity_keys per row`() = runBlocking {
+    val response =
+      service.batchCreateImpressionMetadata(
+        batchCreateImpressionMetadataRequest {
+          parent = DATA_PROVIDER_KEY.toName()
+          requests +=
+            createImpressionMetadataRequest {
+              parent = DATA_PROVIDER_KEY.toName()
+              impressionMetadata = IMPRESSION_METADATA_WITH_ENTITY_KEYS
+            }
+          requests +=
+            createImpressionMetadataRequest {
+              parent = DATA_PROVIDER_KEY.toName()
+              impressionMetadata = IMPRESSION_METADATA_2.copy { entityKeys += META_ENTITY_KEY_AD_2 }
+            }
+        }
+      )
+
+    assertThat(response.impressionMetadataList).hasSize(2)
+    assertThat(response.impressionMetadataList[0].entityKeysList)
+      .containsExactly(META_ENTITY_KEY_AD_1, META_ENTITY_KEY_CAMPAIGN_1)
+      .inOrder()
+    assertThat(response.impressionMetadataList[1].entityKeysList)
+      .containsExactly(META_ENTITY_KEY_AD_2)
+      .inOrder()
+  }
+
+  @Test
+  fun `createImpressionMetadata throws INVALID_ARGUMENT when entity_key has no variant set`() =
+    runBlocking {
+      val request = createImpressionMetadataRequest {
+        parent = DATA_PROVIDER_KEY.toName()
+        impressionMetadata = IMPRESSION_METADATA.copy { entityKeys += entityKey {} }
+      }
+
+      val exception =
+        assertFailsWith<StatusRuntimeException> { service.createImpressionMetadata(request) }
+      assertThat(exception.status.code).isEqualTo(Status.Code.INVALID_ARGUMENT)
+      assertThat(exception.errorInfo)
+        .isEqualTo(
+          errorInfo {
+            domain = Errors.DOMAIN
+            reason = Errors.Reason.REQUIRED_FIELD_NOT_SET.name
+            metadata[Errors.Metadata.FIELD_NAME.key] = "impression_metadata.entity_keys.0.key"
+          }
+        )
+    }
+
+  @Test
+  fun `createImpressionMetadata throws INVALID_ARGUMENT when meta type is unspecified`() =
+    runBlocking {
+      val request = createImpressionMetadataRequest {
+        parent = DATA_PROVIDER_KEY.toName()
+        impressionMetadata =
+          IMPRESSION_METADATA.copy {
+            entityKeys += entityKey { meta = metaEntityKey { id = "x" } }
+          }
+      }
+
+      val exception =
+        assertFailsWith<StatusRuntimeException> { service.createImpressionMetadata(request) }
+      assertThat(exception.status.code).isEqualTo(Status.Code.INVALID_ARGUMENT)
+      assertThat(exception.errorInfo)
+        .isEqualTo(
+          errorInfo {
+            domain = Errors.DOMAIN
+            reason = Errors.Reason.INVALID_FIELD_VALUE.name
+            metadata[Errors.Metadata.FIELD_NAME.key] = "impression_metadata.entity_keys.0.meta.type"
+          }
+        )
+    }
+
+  @Test
+  fun `createImpressionMetadata throws INVALID_ARGUMENT when meta id is empty`() = runBlocking {
+    val request = createImpressionMetadataRequest {
+      parent = DATA_PROVIDER_KEY.toName()
+      impressionMetadata =
+        IMPRESSION_METADATA.copy {
+          entityKeys += entityKey { meta = metaEntityKey { type = MetaEntityKey.Type.AD } }
+        }
+    }
+
+    val exception =
+      assertFailsWith<StatusRuntimeException> { service.createImpressionMetadata(request) }
+    assertThat(exception.status.code).isEqualTo(Status.Code.INVALID_ARGUMENT)
+    assertThat(exception.errorInfo)
+      .isEqualTo(
+        errorInfo {
+          domain = Errors.DOMAIN
+          reason = Errors.Reason.REQUIRED_FIELD_NOT_SET.name
+          metadata[Errors.Metadata.FIELD_NAME.key] = "impression_metadata.entity_keys.0.meta.id"
+        }
+      )
+  }
+
+  @Test
+  fun `listImpressionMetadata filters by single meta entity_key`() = runBlocking {
+    service.createImpressionMetadata(
+      createImpressionMetadataRequest {
+        parent = DATA_PROVIDER_KEY.toName()
+        impressionMetadata = IMPRESSION_METADATA_WITH_ENTITY_KEYS
+      }
+    )
+    service.createImpressionMetadata(
+      createImpressionMetadataRequest {
+        parent = DATA_PROVIDER_KEY.toName()
+        impressionMetadata = IMPRESSION_METADATA_2
+      }
+    )
+
+    val response =
+      service.listImpressionMetadata(
+        listImpressionMetadataRequest {
+          parent = DATA_PROVIDER_KEY.toName()
+          filter = ListImpressionMetadataRequestKt.filter { entityKeys += META_ENTITY_KEY_AD_1 }
+        }
+      )
+
+    assertThat(response.impressionMetadataList).hasSize(1)
+    assertThat(response.impressionMetadataList[0].entityKeysList)
+      .containsExactly(META_ENTITY_KEY_AD_1, META_ENTITY_KEY_CAMPAIGN_1)
+      .inOrder()
+  }
+
+  @Test
+  fun `listImpressionMetadata applies OR-semantics across multiple meta entity_keys`() =
+    runBlocking {
+      service.createImpressionMetadata(
+        createImpressionMetadataRequest {
+          parent = DATA_PROVIDER_KEY.toName()
+          impressionMetadata = IMPRESSION_METADATA_WITH_ENTITY_KEYS
+        }
+      )
+      val secondImpression = IMPRESSION_METADATA_2.copy { entityKeys += META_ENTITY_KEY_AD_2 }
+      service.createImpressionMetadata(
+        createImpressionMetadataRequest {
+          parent = DATA_PROVIDER_KEY.toName()
+          impressionMetadata = secondImpression
+        }
+      )
+
+      val response =
+        service.listImpressionMetadata(
+          listImpressionMetadataRequest {
+            parent = DATA_PROVIDER_KEY.toName()
+            filter =
+              ListImpressionMetadataRequestKt.filter {
+                entityKeys += META_ENTITY_KEY_AD_1
+                entityKeys += META_ENTITY_KEY_AD_2
+              }
+          }
+        )
+
+      assertThat(response.impressionMetadataList).hasSize(2)
+    }
+
+  @Test
+  fun `listImpressionMetadata returns empty when no entity_key matches`() = runBlocking {
+    service.createImpressionMetadata(
+      createImpressionMetadataRequest {
+        parent = DATA_PROVIDER_KEY.toName()
+        impressionMetadata = IMPRESSION_METADATA_WITH_ENTITY_KEYS
+      }
+    )
+
+    val response =
+      service.listImpressionMetadata(
+        listImpressionMetadataRequest {
+          parent = DATA_PROVIDER_KEY.toName()
+          filter =
+            ListImpressionMetadataRequestKt.filter {
+              entityKeys += entityKey {
+                meta = metaEntityKey {
+                  type = MetaEntityKey.Type.AD_ACCOUNT
+                  id = "no-such-account"
+                }
+              }
+            }
+        }
+      )
+
+    assertThat(response.impressionMetadataList).isEmpty()
+  }
+
+  @Test
+  fun `listImpressionMetadata throws INVALID_ARGUMENT when filter entity_key is invalid`() =
+    runBlocking {
+      val exception =
+        assertFailsWith<StatusRuntimeException> {
+          service.listImpressionMetadata(
+            listImpressionMetadataRequest {
+              parent = DATA_PROVIDER_KEY.toName()
+              filter = ListImpressionMetadataRequestKt.filter { entityKeys += entityKey {} }
+            }
+          )
+        }
+
+      assertThat(exception.status.code).isEqualTo(Status.Code.INVALID_ARGUMENT)
+      assertThat(exception.errorInfo)
+        .isEqualTo(
+          errorInfo {
+            domain = Errors.DOMAIN
+            reason = Errors.Reason.REQUIRED_FIELD_NOT_SET.name
+            metadata[Errors.Metadata.FIELD_NAME.key] = "filter.entity_keys.0.key"
+          }
+        )
+    }
+
   companion object {
     @get:ClassRule @JvmStatic val spannerEmulator = SpannerEmulatorRule()
 
@@ -1506,5 +1753,32 @@ class ImpressionMetadataServiceTest {
       }
       // state not set
     }
+
+    private val META_ENTITY_KEY_AD_1 = entityKey {
+      meta = metaEntityKey {
+        type = MetaEntityKey.Type.AD
+        id = "ad-1"
+      }
+    }
+
+    private val META_ENTITY_KEY_AD_2 = entityKey {
+      meta = metaEntityKey {
+        type = MetaEntityKey.Type.AD
+        id = "ad-2"
+      }
+    }
+
+    private val META_ENTITY_KEY_CAMPAIGN_1 = entityKey {
+      meta = metaEntityKey {
+        type = MetaEntityKey.Type.CAMPAIGN
+        id = "campaign-1"
+      }
+    }
+
+    private val IMPRESSION_METADATA_WITH_ENTITY_KEYS =
+      IMPRESSION_METADATA.copy {
+        entityKeys += META_ENTITY_KEY_AD_1
+        entityKeys += META_ENTITY_KEY_CAMPAIGN_1
+      }
   }
 }

--- a/src/test/kotlin/org/wfanet/measurement/edpaggregator/service/v1alpha/ImpressionMetadataServiceTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/edpaggregator/service/v1alpha/ImpressionMetadataServiceTest.kt
@@ -47,7 +47,6 @@ import org.wfanet.measurement.edpaggregator.service.Errors
 import org.wfanet.measurement.edpaggregator.service.ImpressionMetadataKey
 import org.wfanet.measurement.edpaggregator.v1alpha.ComputeModelLineBoundsResponseKt.modelLineBoundMapEntry
 import org.wfanet.measurement.edpaggregator.v1alpha.DeleteImpressionMetadataRequest
-import org.wfanet.measurement.edpaggregator.v1alpha.EntityKey
 import org.wfanet.measurement.edpaggregator.v1alpha.GetImpressionMetadataRequest
 import org.wfanet.measurement.edpaggregator.v1alpha.ImpressionMetadata
 import org.wfanet.measurement.edpaggregator.v1alpha.ListImpressionMetadataRequest
@@ -1468,7 +1467,6 @@ class ImpressionMetadataServiceTest {
     }
   }
 
-
   @Test
   fun `createImpressionMetadata returns entity_keys`() = runBlocking {
     val response =
@@ -1508,16 +1506,14 @@ class ImpressionMetadataServiceTest {
       service.batchCreateImpressionMetadata(
         batchCreateImpressionMetadataRequest {
           parent = DATA_PROVIDER_KEY.toName()
-          requests +=
-            createImpressionMetadataRequest {
-              parent = DATA_PROVIDER_KEY.toName()
-              impressionMetadata = IMPRESSION_METADATA_WITH_ENTITY_KEYS
-            }
-          requests +=
-            createImpressionMetadataRequest {
-              parent = DATA_PROVIDER_KEY.toName()
-              impressionMetadata = IMPRESSION_METADATA_2.copy { entityKeys += ENTITY_KEY_AD_2 }
-            }
+          requests += createImpressionMetadataRequest {
+            parent = DATA_PROVIDER_KEY.toName()
+            impressionMetadata = IMPRESSION_METADATA_WITH_ENTITY_KEYS
+          }
+          requests += createImpressionMetadataRequest {
+            parent = DATA_PROVIDER_KEY.toName()
+            impressionMetadata = IMPRESSION_METADATA_2.copy { entityKeys += ENTITY_KEY_AD_2 }
+          }
         }
       )
 
@@ -1529,13 +1525,13 @@ class ImpressionMetadataServiceTest {
       .containsExactly(ENTITY_KEY_AD_2)
       .inOrder()
   }
+
   @Test
   fun `createImpressionMetadata throws INVALID_ARGUMENT when entity_key entity_type is empty`() =
     runBlocking {
       val request = createImpressionMetadataRequest {
         parent = DATA_PROVIDER_KEY.toName()
-        impressionMetadata =
-          IMPRESSION_METADATA.copy { entityKeys += entityKey { entityId = "x" } }
+        impressionMetadata = IMPRESSION_METADATA.copy { entityKeys += entityKey { entityId = "x" } }
       }
 
       val exception =
@@ -1546,31 +1542,33 @@ class ImpressionMetadataServiceTest {
           errorInfo {
             domain = Errors.DOMAIN
             reason = Errors.Reason.REQUIRED_FIELD_NOT_SET.name
-            metadata[Errors.Metadata.FIELD_NAME.key] = "impression_metadata.entity_keys.0.entity_type"
+            metadata[Errors.Metadata.FIELD_NAME.key] =
+              "impression_metadata.entity_keys.0.entity_type"
           }
         )
     }
 
   @Test
-  fun `createImpressionMetadata throws INVALID_ARGUMENT when entity_key id is empty`() = runBlocking {
-    val request = createImpressionMetadataRequest {
-      parent = DATA_PROVIDER_KEY.toName()
-      impressionMetadata =
-        IMPRESSION_METADATA.copy { entityKeys += entityKey { entityType = "ad" } }
-    }
+  fun `createImpressionMetadata throws INVALID_ARGUMENT when entity_key id is empty`() =
+    runBlocking {
+      val request = createImpressionMetadataRequest {
+        parent = DATA_PROVIDER_KEY.toName()
+        impressionMetadata =
+          IMPRESSION_METADATA.copy { entityKeys += entityKey { entityType = "ad" } }
+      }
 
-    val exception =
-      assertFailsWith<StatusRuntimeException> { service.createImpressionMetadata(request) }
-    assertThat(exception.status.code).isEqualTo(Status.Code.INVALID_ARGUMENT)
-    assertThat(exception.errorInfo)
-      .isEqualTo(
-        errorInfo {
-          domain = Errors.DOMAIN
-          reason = Errors.Reason.REQUIRED_FIELD_NOT_SET.name
-          metadata[Errors.Metadata.FIELD_NAME.key] = "impression_metadata.entity_keys.0.entity_id"
-        }
-      )
-  }
+      val exception =
+        assertFailsWith<StatusRuntimeException> { service.createImpressionMetadata(request) }
+      assertThat(exception.status.code).isEqualTo(Status.Code.INVALID_ARGUMENT)
+      assertThat(exception.errorInfo)
+        .isEqualTo(
+          errorInfo {
+            domain = Errors.DOMAIN
+            reason = Errors.Reason.REQUIRED_FIELD_NOT_SET.name
+            metadata[Errors.Metadata.FIELD_NAME.key] = "impression_metadata.entity_keys.0.entity_id"
+          }
+        )
+    }
 
   @Test
   fun `listImpressionMetadata filters by single meta entity_key`() = runBlocking {


### PR DESCRIPTION
## Summary                                                                                                                                                                                               
   
  Surfaces `entity_keys` on the public v1alpha API: adds the field to                                                                                                                                      
  `ImpressionMetadata` and to `ListImpressionMetadataRequest.Filter`, and
  maps it both directions through the internal service.                                                                                                                                                    
                                                                                                      
Issue: #3727                                                                                                      