### PR TITLE
fix: map INVALID_ARGUMENT from internal service in ClientAccountsService

### DIFF
--- a/src/main/kotlin/org/wfanet/measurement/kingdom/service/api/v2alpha/ClientAccountsService.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/service/api/v2alpha/ClientAccountsService.kt
@@ -136,6 +136,7 @@ class ClientAccountsService(
       throw when (e.status.code) {
         Status.Code.NOT_FOUND -> Status.NOT_FOUND
         Status.Code.ALREADY_EXISTS -> Status.ALREADY_EXISTS
+        Status.Code.INVALID_ARGUMENT -> Status.INVALID_ARGUMENT
         Status.Code.DEADLINE_EXCEEDED -> Status.DEADLINE_EXCEEDED
         else -> Status.UNKNOWN
       }.toExternalStatusRuntimeException(e)
@@ -259,6 +260,7 @@ class ClientAccountsService(
     } catch (e: StatusException) {
       throw when (e.status.code) {
         Status.Code.NOT_FOUND -> permissionDeniedStatus()
+        Status.Code.INVALID_ARGUMENT -> Status.INVALID_ARGUMENT
         Status.Code.DEADLINE_EXCEEDED -> Status.DEADLINE_EXCEEDED
         else -> Status.UNKNOWN
       }.toExternalStatusRuntimeException(e)
@@ -301,6 +303,7 @@ class ClientAccountsService(
         internalClientAccountsStub.listClientAccounts(internalRequest)
       } catch (e: StatusException) {
         throw when (e.status.code) {
+          Status.Code.INVALID_ARGUMENT -> Status.INVALID_ARGUMENT
           Status.Code.DEADLINE_EXCEEDED -> Status.DEADLINE_EXCEEDED
           else -> Status.UNKNOWN
         }.toExternalStatusRuntimeException(e)
@@ -357,6 +360,7 @@ class ClientAccountsService(
     } catch (e: StatusException) {
       throw when (e.status.code) {
         Status.Code.NOT_FOUND -> permissionDeniedStatus()
+        Status.Code.INVALID_ARGUMENT -> Status.INVALID_ARGUMENT
         Status.Code.DEADLINE_EXCEEDED -> Status.DEADLINE_EXCEEDED
         else -> Status.UNKNOWN
       }.toExternalStatusRuntimeException(e)
@@ -410,6 +414,7 @@ class ClientAccountsService(
     } catch (e: StatusException) {
       throw when (e.status.code) {
         Status.Code.NOT_FOUND -> permissionDeniedStatus()
+        Status.Code.INVALID_ARGUMENT -> Status.INVALID_ARGUMENT
         Status.Code.DEADLINE_EXCEEDED -> Status.DEADLINE_EXCEEDED
         else -> Status.UNKNOWN
       }.toExternalStatusRuntimeException(e)


### PR DESCRIPTION
## Summary

- Add `Status.Code.INVALID_ARGUMENT -> Status.INVALID_ARGUMENT` mapping to all catch blocks in `ClientAccountsService`
- Previously, `INVALID_ARGUMENT` from the internal service fell through to `else -> Status.UNKNOWN`, returning uninformative errors to clients

Issue: #3746

## Affected methods

- `createClientAccount`
- `batchCreateClientAccounts`
- `getClientAccount`
- `listClientAccounts`
- `deleteClientAccount`
- `batchDeleteClientAccounts`

## Test plan

- [x] Existing `ClientAccountsServiceTest` passes
- [x] Build passes
