### PR TITLE
ci: Use Setup Terraform GHA

### DIFF
--- a/.github/workflows/terraform-cmms-v2.yml
+++ b/.github/workflows/terraform-cmms-v2.yml
@@ -155,6 +155,11 @@ jobs:
         </settings>
         EOF
 
+    - name: Set up terraform
+      uses: hashicorp/setup-terraform@v4
+      with:
+        terraform_version: "1.14.8"
+
     - id: get-artifact-version
       uses: ./.github/actions/get-maven-artifact-version
       with:


### PR DESCRIPTION
Changes:
* The selected Terraform version matches the version [installed in the Ubuntu 22 image ](https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2204-Readme.md)(The one we were using before the upgrade to Ubuntu 24 in #3720):  

Issue: #3756