### PR TITLE
ci: Change the milestone link in release notes to point to closed issues

### DIFF
--- a/.github/workflows/generate-release-notes.yml
+++ b/.github/workflows/generate-release-notes.yml
@@ -154,7 +154,7 @@ jobs:
           }
 
           print_summary() {
-            echo "See the [corresponding milestone](${MILESTONE_URL}) for this release."
+            echo "See the [corresponding milestone](${MILESTONE_URL}?closed=1) for this release."
             print_section "Highlights" "${HIGHLIGHTS}"
             print_section "Issues Addressed" "${ISSUES_ADDRESSED}"
             print_section "Potentially Requiring Action" "${POTENTIALLY_REQUIRING_ACTION}"


### PR DESCRIPTION
Tested in workflow run:
https://github.com/world-federation-of-advertisers/cross-media-measurement/actions/runs/25690666585
