### PR TITLE
build: Align Spanner emulator version with common-jvm

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -86,6 +86,7 @@ bazel_dep(
     name = "grpc_ecosystem_grpc_gateway",
     version = "2.26.0.bzlmod.1",
 )
+# Must also be updated in src/main/k8s/local/BUILD.bazel
 bazel_dep(
     name = "cloud-spanner-emulator-bin",
     version = "1.5.52",

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -88,7 +88,7 @@ bazel_dep(
 )
 bazel_dep(
     name = "cloud-spanner-emulator-bin",
-    version = "1.5.37.libcxx.1",
+    version = "1.5.52",
     repo_name = "cloud_spanner_emulator",
 )
 bazel_dep(

--- a/src/main/k8s/local/BUILD.bazel
+++ b/src/main/k8s/local/BUILD.bazel
@@ -14,7 +14,7 @@ package(
     ],
 )
 
-SPANNER_EMULATOR_VERSION = "1.5.37"
+SPANNER_EMULATOR_VERSION = "1.5.52"
 
 SECRET_NAME = "certs-and-configs"
 


### PR DESCRIPTION
This PR aligns the Spanner emulator version with the one used in common-jvm. It does not change dependency resolution; it only removes the warning that the root module expects a different version.

Also it updates the Spanner version used in src/main/k8s/local/BUILD.bazel.

This change was made in PR world-federation-of-advertisers/common-jvm#380 but was missed in PR #3723.

Issue: #3720