### PR TITLE
fix: align entity key consistency check with downstream selector logic

### DIFF
--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/requisitionfetcher/RequisitionsValidator.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/requisitionfetcher/RequisitionsValidator.kt
@@ -133,17 +133,25 @@ class RequisitionsValidator(private val privateEncryptionKey: PrivateKeyHandle) 
   /**
    * Validates that event group selectors are consistent across all event groups.
    *
-   * If any event group has an `entity_key`, all must. If none have an `entity_key`, all must have a
-   * non-empty `event_group_reference_id`.
+   * An event group is considered to have a meaningful entity key when it has both `entity_key` set
+   * and a non-empty `entity_id`. The Kingdom defaults `entity_type="campaign"` on all event groups,
+   * so `hasEntityKey()` alone is not sufficient to distinguish legacy (reference-id-only) event
+   * groups from those with explicit entity keys.
+   *
+   * If any event group has a meaningful entity key, all must. If none do, all must have a non-empty
+   * `event_group_reference_id`.
    */
   fun validateEventGroupSelectors(eventGroupMap: Map<String, EventGroupDetails>) {
     require(eventGroupMap.isNotEmpty()) { "eventGroupMap must not be empty" }
 
-    val hasEntityKey = eventGroupMap.values.any { it.hasEntityKey() }
-    if (hasEntityKey) {
-      if (!eventGroupMap.values.all { it.hasEntityKey() }) {
+    val hasMeaningfulEntityKey: (EventGroupDetails) -> Boolean = {
+      it.hasEntityKey() && it.entityKey.entityId.isNotEmpty()
+    }
+    val anyHasEntityKey = eventGroupMap.values.any(hasMeaningfulEntityKey)
+    if (anyHasEntityKey) {
+      if (!eventGroupMap.values.all(hasMeaningfulEntityKey)) {
         throw InconsistentEventGroupSelectorsException(
-          "Inconsistent selectors: if any event group has entity_key, all must"
+          "Inconsistent selectors: if any event group has entity_key with entity_id, all must"
         )
       }
     } else {

--- a/src/main/kotlin/org/wfanet/measurement/integration/common/InProcessEdpAggregatorComponents.kt
+++ b/src/main/kotlin/org/wfanet/measurement/integration/common/InProcessEdpAggregatorComponents.kt
@@ -73,7 +73,7 @@ import org.wfanet.measurement.edpaggregator.eventgroups.v1alpha.EventGroup
 import org.wfanet.measurement.edpaggregator.eventgroups.v1alpha.EventGroup.MediaType
 import org.wfanet.measurement.edpaggregator.eventgroups.v1alpha.EventGroupKt.MetadataKt.AdMetadataKt.campaignMetadata
 import org.wfanet.measurement.edpaggregator.eventgroups.v1alpha.EventGroupKt.MetadataKt.adMetadata
-import org.wfanet.measurement.edpaggregator.eventgroups.v1alpha.EventGroupKt.entityKey
+import org.wfanet.measurement.edpaggregator.eventgroups.v1alpha.EventGroupKt.entityKey as edpaEntityKey
 import org.wfanet.measurement.edpaggregator.eventgroups.v1alpha.EventGroupKt.metadata as eventGroupMetadata
 import org.wfanet.measurement.edpaggregator.eventgroups.v1alpha.MappedEventGroup
 import org.wfanet.measurement.edpaggregator.eventgroups.v1alpha.eventGroup
@@ -123,10 +123,10 @@ import org.wfanet.measurement.storage.filesystem.FileSystemStorageClient
  * field may be left null; null fields fall back to the proto default (no entity_key / no
  * entity_metadata).
  */
-data class EventGroupEntityOverride(
-  val entityKey: EventGroup.EntityKey? = null,
+data class EventGroupConfig(
+  val spec: SyntheticEventGroupSpec,
+  val blobEntityKeys: List<EntityKey> = emptyList(),
   val entityMetadata: Struct? = null,
-  val additionalBlobEntityKeys: List<EntityKey> = emptyList(),
 )
 
 class InProcessEdpAggregatorComponents(
@@ -134,10 +134,9 @@ class InProcessEdpAggregatorComponents(
   private val storagePath: Path,
   private val pubSubClient: GooglePubSubEmulatorClient,
   private val syntheticPopulationSpec: SyntheticPopulationSpec,
-  private val syntheticEventGroupMapByEdp: Map<String, Map<String, SyntheticEventGroupSpec>>,
+  private val eventGroupConfigsByEdp: Map<String, Map<String, EventGroupConfig>>,
   private val modelLineInfoMap: Map<String, ModelLineInfo>,
   private val externalKmsClient: FakeKmsClient,
-  private val entityOverridesByEdp: Map<String, Map<String, EventGroupEntityOverride>> = emptyMap(),
 ) : TestRule {
   private val modelLineName: String by lazy { requireSingleModelLineName(modelLineInfoMap.keys) }
 
@@ -373,13 +372,15 @@ class InProcessEdpAggregatorComponents(
       runBlocking { writeImpressionData(mappedEventGroups, edpAggregatorShortName) }
 
       mappedEventGroups.forEach { mappedEventGroup ->
+        val metaConfig: EventGroupConfig =
+          eventGroupConfigsByEdp
+            .getValue(edpAggregatorShortName)
+            .getValue(mappedEventGroup.eventGroupReferenceId)
         val events =
           SyntheticDataGeneration.generateEvents(
             TestEvent.getDefaultInstance(),
             syntheticPopulationSpec,
-            syntheticEventGroupMapByEdp
-              .getValue(edpAggregatorShortName)
-              .getValue(mappedEventGroup.eventGroupReferenceId),
+            metaConfig.spec,
           )
 
         val allDates: List<LocalDate> = events.map { it.localDate }.toList()
@@ -495,12 +496,9 @@ class InProcessEdpAggregatorComponents(
     measurementConsumerData: MeasurementConsumerData,
     edpAggregatorShortName: String,
   ): List<EventGroup> {
-    val edpOverrides: Map<String, EventGroupEntityOverride> =
-      entityOverridesByEdp[edpAggregatorShortName].orEmpty()
-    return syntheticEventGroupMapByEdp.getValue(edpAggregatorShortName).flatMap {
-      (eventGroupReferenceId, syntheticEventGroupSpec) ->
-      val override: EventGroupEntityOverride? = edpOverrides[eventGroupReferenceId]
-      syntheticEventGroupSpec.dateSpecsList.map { dateSpec ->
+    return eventGroupConfigsByEdp.getValue(edpAggregatorShortName).flatMap {
+      (eventGroupReferenceId, config) ->
+      config.spec.dateSpecsList.map { dateSpec ->
         val dateRange = dateSpec.dateRange
         val startTime =
           LocalDate.of(dateRange.start.year, dateRange.start.month, dateRange.start.day)
@@ -529,12 +527,15 @@ class InProcessEdpAggregatorComponents(
                 campaign = "some-brand"
               }
             }
-            if (override?.entityMetadata != null) {
-              this.entityMetadata = override.entityMetadata
+            if (config.entityMetadata != null) {
+              this.entityMetadata = config.entityMetadata
             }
           }
-          if (override?.entityKey != null) {
-            this.entityKey = override.entityKey
+          if (config.blobEntityKeys.isNotEmpty()) {
+            this.entityKey = edpaEntityKey {
+              entityType = config.blobEntityKeys.first().entityType
+              entityId = config.blobEntityKeys.first().entityId
+            }
           }
           mediaTypes += MediaType.valueOf("VIDEO")
         }
@@ -554,13 +555,15 @@ class InProcessEdpAggregatorComponents(
     }
 
     mappedEventGroups.forEach { mappedEventGroup ->
+      val config: EventGroupConfig =
+        eventGroupConfigsByEdp
+          .getValue(edpAggregatorShortName)
+          .getValue(mappedEventGroup.eventGroupReferenceId)
       val events: Sequence<LabeledEventDateShard<TestEvent>> =
         SyntheticDataGeneration.generateEvents(
           TestEvent.getDefaultInstance(),
           syntheticPopulationSpec,
-          syntheticEventGroupMapByEdp
-            .getValue(edpAggregatorShortName)
-            .getValue(mappedEventGroup.eventGroupReferenceId),
+          config.spec,
         )
       val impressionWriter =
         ImpressionsWriter(
@@ -573,42 +576,26 @@ class InProcessEdpAggregatorComponents(
           storagePath.toFile(),
           "file:///",
         )
-      val override: EventGroupEntityOverride? =
-        entityOverridesByEdp[edpAggregatorShortName]?.get(mappedEventGroup.eventGroupReferenceId)
-      val blobEntityKeys: List<EntityKey> =
-        if (override != null) {
-          listOf(
-            EntityKey(
-              entityType =
-                requireNotNull(override.entityKey?.entityType) {
-                  "Override for ${mappedEventGroup.eventGroupReferenceId} has no entityType"
-                },
-              entityId =
-                requireNotNull(override.entityKey?.entityId) {
-                  "Override for ${mappedEventGroup.eventGroupReferenceId} has no entityId"
-                },
-            )
-          )
-        } else {
-          emptyList()
-        }
+      val blobEntityKeys: List<EntityKey> = config.blobEntityKeys
       val entityKeyedEvents: Sequence<EntityKeyedLabeledEventDateShard<TestEvent>> =
-        if (override != null && override.additionalBlobEntityKeys.isNotEmpty()) {
+        if (blobEntityKeys.size > 1) {
           events.map { shard ->
             val materializedEvents = shard.labeledEvents.toList()
-            val splitPoint = materializedEvents.size / 2
+            val chunkSize = materializedEvents.size / blobEntityKeys.size
             EntityKeyedLabeledEventDateShard(
               shard.localDate,
-              sequenceOf(
-                EntityKeysWithLabeledEvents(
-                  blobEntityKeys,
-                  materializedEvents.take(splitPoint).asSequence(),
-                ),
-                EntityKeysWithLabeledEvents(
-                  override.additionalBlobEntityKeys,
-                  materializedEvents.drop(splitPoint).asSequence(),
-                ),
-              ),
+              blobEntityKeys
+                .mapIndexed { i, entityKey ->
+                  val start = i * chunkSize
+                  val end =
+                    if (i == blobEntityKeys.lastIndex) materializedEvents.size
+                    else start + chunkSize
+                  EntityKeysWithLabeledEvents(
+                    listOf(entityKey),
+                    materializedEvents.subList(start, end).asSequence(),
+                  )
+                }
+                .asSequence(),
             )
           }
         } else {

--- a/src/main/kotlin/org/wfanet/measurement/integration/common/InProcessEdpAggregatorComponents.kt
+++ b/src/main/kotlin/org/wfanet/measurement/integration/common/InProcessEdpAggregatorComponents.kt
@@ -126,6 +126,7 @@ import org.wfanet.measurement.storage.filesystem.FileSystemStorageClient
 data class EventGroupEntityOverride(
   val entityKey: EventGroup.EntityKey? = null,
   val entityMetadata: Struct? = null,
+  val additionalBlobEntityKeys: List<EntityKey> = emptyList(),
 )
 
 class InProcessEdpAggregatorComponents(
@@ -592,11 +593,31 @@ class InProcessEdpAggregatorComponents(
           emptyList()
         }
       val entityKeyedEvents: Sequence<EntityKeyedLabeledEventDateShard<TestEvent>> =
-        events.map {
-          EntityKeyedLabeledEventDateShard(
-            it.localDate,
-            sequenceOf(EntityKeysWithLabeledEvents(blobEntityKeys, it.labeledEvents)),
-          )
+        if (override != null && override.additionalBlobEntityKeys.isNotEmpty()) {
+          events.map { shard ->
+            val materializedEvents = shard.labeledEvents.toList()
+            val splitPoint = materializedEvents.size / 2
+            EntityKeyedLabeledEventDateShard(
+              shard.localDate,
+              sequenceOf(
+                EntityKeysWithLabeledEvents(
+                  blobEntityKeys,
+                  materializedEvents.take(splitPoint).asSequence(),
+                ),
+                EntityKeysWithLabeledEvents(
+                  override.additionalBlobEntityKeys,
+                  materializedEvents.drop(splitPoint).asSequence(),
+                ),
+              ),
+            )
+          }
+        } else {
+          events.map {
+            EntityKeyedLabeledEventDateShard(
+              it.localDate,
+              sequenceOf(EntityKeysWithLabeledEvents(blobEntityKeys, it.labeledEvents)),
+            )
+          }
         }
       impressionWriter.writeLabeledImpressionData(entityKeyedEvents, modelLineName, null)
     }

--- a/src/main/kotlin/org/wfanet/measurement/integration/common/InProcessEdpAggregatorLifeOfAMeasurementIntegrationTest.kt
+++ b/src/main/kotlin/org/wfanet/measurement/integration/common/InProcessEdpAggregatorLifeOfAMeasurementIntegrationTest.kt
@@ -77,547 +77,525 @@ import org.wfanet.measurement.system.v1alpha.ComputationLogEntriesGrpcKt.Computa
  * easily.
  */
 abstract class InProcessEdpAggregatorLifeOfAMeasurementIntegrationTest(
-    kingdomDataServicesRule: ProviderRule<DataServices>,
-    duchyDependenciesRule:
-        ProviderRule<
-            (String, ComputationLogEntriesCoroutineStub) -> InProcessDuchy.DuchyDependencies
-        >,
-    secureComputationDatabaseAdmin: SpannerDatabaseAdmin,
+  kingdomDataServicesRule: ProviderRule<DataServices>,
+  duchyDependenciesRule:
+    ProviderRule<(String, ComputationLogEntriesCoroutineStub) -> InProcessDuchy.DuchyDependencies>,
+  secureComputationDatabaseAdmin: SpannerDatabaseAdmin,
 ) {
 
-    private val pubSubClient: GooglePubSubEmulatorClient by lazy {
-        GooglePubSubEmulatorClient(
-            host = pubSubEmulatorProvider.host,
-            port = pubSubEmulatorProvider.port,
-        )
-    }
+  private val pubSubClient: GooglePubSubEmulatorClient by lazy {
+    GooglePubSubEmulatorClient(
+      host = pubSubEmulatorProvider.host,
+      port = pubSubEmulatorProvider.port,
+    )
+  }
 
-    private val sharedKmsClient: FakeKmsClient by lazy {
-        val kekUri = FakeKmsClient.KEY_URI_PREFIX + "key1"
-        val kmsKeyHandle = KeysetHandle.generateNew(KeyTemplates.get("AES128_GCM"))
-        val kmsClient = FakeKmsClient()
-        kmsClient.setAead(kekUri, kmsKeyHandle.getPrimitive(Aead::class.java))
-        kmsClient
-    }
+  private val sharedKmsClient: FakeKmsClient by lazy {
+    val kekUri = FakeKmsClient.KEY_URI_PREFIX + "key1"
+    val kmsKeyHandle = KeysetHandle.generateNew(KeyTemplates.get("AES128_GCM"))
+    val kmsClient = FakeKmsClient()
+    kmsClient.setAead(kekUri, kmsKeyHandle.getPrimitive(Aead::class.java))
+    kmsClient
+  }
 
-    @get:Rule
-    val inProcessCmmsComponents =
-        InProcessCmmsComponents(
-            kingdomDataServicesRule,
-            duchyDependenciesRule,
-            useEdpSimulators = false,
-            trusTeeKmsClient = sharedKmsClient,
-        )
+  @get:Rule
+  val inProcessCmmsComponents =
+    InProcessCmmsComponents(
+      kingdomDataServicesRule,
+      duchyDependenciesRule,
+      useEdpSimulators = false,
+      trusTeeKmsClient = sharedKmsClient,
+    )
 
-    @JvmField
-    @get:Rule
-    val tempPath: Path = run {
-        val tempDirectory = TemporaryFolder()
-        tempDirectory.create()
-        tempDirectory.root.toPath()
-    }
+  @JvmField
+  @get:Rule
+  val tempPath: Path = run {
+    val tempDirectory = TemporaryFolder()
+    tempDirectory.create()
+    tempDirectory.root.toPath()
+  }
 
-    // edp1 is intentionally created without entity key (legacy path: Kingdom defaults
-    // entity_type="campaign", entity_id and entity_metadata unset). The simulator's
-    // ListEventGroups uses the default filter (entity_type_in defaults to ["campaign"]),
-    // so edp1 stays visible to existing measurement tests.
-    private val eventGroupConfigsByEdp: Map<String, Map<String, EventGroupConfig>> =
+  // edp1 is intentionally created without entity key (legacy path: Kingdom defaults
+  // entity_type="campaign", entity_id and entity_metadata unset). The simulator's
+  // ListEventGroups uses the default filter (entity_type_in defaults to ["campaign"]),
+  // so edp1 stays visible to existing measurement tests.
+  private val eventGroupConfigsByEdp: Map<String, Map<String, EventGroupConfig>> =
+    mapOf(
+      EDP_NO_ENTITY_KEY_DISPLAY_NAME to
+        mapOf(EDP_NO_ENTITY_KEY_EVENT_GROUP_REF_ID to EventGroupConfig(syntheticEventGroupSpec)),
+      "edp2" to
         mapOf(
-            EDP_NO_ENTITY_KEY_DISPLAY_NAME to
-                mapOf(
-                    EDP_NO_ENTITY_KEY_EVENT_GROUP_REF_ID to
-                        EventGroupConfig(syntheticEventGroupSpec)
-                ),
-            "edp2" to
-                mapOf(
-                    "edpa-eg-reference-id-2" to
-                        EventGroupConfig(
-                            syntheticEventGroupSpec,
-                            blobEntityKeys =
-                                listOf(EntityKey("ad_group", "edpa-eg-reference-id-2")),
-                            entityMetadata = ENTITY_METADATA,
-                        )
-                ),
-            "edp3" to
-                mapOf(
-                    "edpa-eg-reference-id-3" to
-                        EventGroupConfig(
-                            syntheticEventGroupSpec,
-                            blobEntityKeys =
-                                listOf(EntityKey("ad_group", "edpa-eg-reference-id-3")),
-                            entityMetadata = ENTITY_METADATA,
-                        )
-                ),
-            "edp4" to
-                mapOf(
-                    "edpa-eg-reference-id-4" to
-                        EventGroupConfig(
-                            syntheticEventGroupSpec,
-                            blobEntityKeys =
-                                listOf(EntityKey("ad_group", "edpa-eg-reference-id-4")),
-                            entityMetadata = ENTITY_METADATA,
-                        )
-                ),
+          "edpa-eg-reference-id-2" to
+            EventGroupConfig(
+              syntheticEventGroupSpec,
+              blobEntityKeys = listOf(EntityKey("ad_group", "edpa-eg-reference-id-2")),
+              entityMetadata = ENTITY_METADATA,
+            )
+        ),
+      "edp3" to
+        mapOf(
+          "edpa-eg-reference-id-3" to
+            EventGroupConfig(
+              syntheticEventGroupSpec,
+              blobEntityKeys = listOf(EntityKey("ad_group", "edpa-eg-reference-id-3")),
+              entityMetadata = ENTITY_METADATA,
+            )
+        ),
+      "edp4" to
+        mapOf(
+          "edpa-eg-reference-id-4" to
+            EventGroupConfig(
+              syntheticEventGroupSpec,
+              blobEntityKeys = listOf(EntityKey("ad_group", "edpa-eg-reference-id-4")),
+              entityMetadata = ENTITY_METADATA,
+            )
+        ),
+    )
+
+  private val syntheticEventGroupMap: Map<String, SyntheticEventGroupSpec> =
+    eventGroupConfigsByEdp.values.flatMap { it.entries }.associate { it.key to it.value.spec }
+
+  @get:Rule
+  val inProcessEdpAggregatorComponents: InProcessEdpAggregatorComponents =
+    InProcessEdpAggregatorComponents(
+      secureComputationDatabaseAdmin = secureComputationDatabaseAdmin,
+      storagePath = tempPath,
+      pubSubClient = pubSubClient,
+      eventGroupConfigsByEdp = eventGroupConfigsByEdp,
+      syntheticPopulationSpec = syntheticPopulationSpec,
+      modelLineInfoMap = modelLineInfoMap,
+      externalKmsClient = sharedKmsClient,
+    )
+
+  @Before
+  fun setup() {
+    runBlocking {
+      pubSubClient.createTopic(PROJECT_ID, FULFILLER_TOPIC_ID)
+      pubSubClient.createSubscription(PROJECT_ID, SUBSCRIPTION_ID, FULFILLER_TOPIC_ID)
+    }
+    inProcessCmmsComponents.startDaemons()
+    val measurementConsumerData = inProcessCmmsComponents.getMeasurementConsumerData()
+    val edpDisplayNameToResourceMap = inProcessCmmsComponents.edpDisplayNameToResourceMap
+    val kingdomChannel = inProcessCmmsComponents.kingdom.publicApiChannel
+    val duchyMap =
+      inProcessCmmsComponents.duchies.map { it.externalDuchyId to it.publicApiChannel }.toMap()
+    inProcessEdpAggregatorComponents.startDaemons(
+      kingdomChannel,
+      measurementConsumerData,
+      edpDisplayNameToResourceMap,
+      mapOf(
+        "edp1" to
+          DataProviderKt.capabilities {
+            honestMajorityShareShuffleSupported = true
+            trusTeeSupported = false
+          },
+        "edp2" to
+          DataProviderKt.capabilities {
+            honestMajorityShareShuffleSupported = true
+            trusTeeSupported = true
+          },
+        "edp3" to
+          DataProviderKt.capabilities {
+            honestMajorityShareShuffleSupported = false
+            trusTeeSupported = true
+          },
+        "edp4" to
+          DataProviderKt.capabilities {
+            honestMajorityShareShuffleSupported = true
+            trusTeeSupported = true
+          },
+      ),
+      duchyMap,
+      edpNoise =
+        mapOf(
+          "edp1" to ResultsFulfillerParams.NoiseParams.NoiseType.CONTINUOUS_GAUSSIAN,
+          "edp2" to ResultsFulfillerParams.NoiseParams.NoiseType.CONTINUOUS_GAUSSIAN,
+          "edp3" to ResultsFulfillerParams.NoiseParams.NoiseType.CONTINUOUS_GAUSSIAN,
+          "edp4" to ResultsFulfillerParams.NoiseParams.NoiseType.CONTINUOUS_GAUSSIAN,
+        ),
+      edpMultiPartyNoiseTypes =
+        mapOf("edp4" to listOf(ResultsFulfillerParams.NoiseParams.NoiseType.NONE)),
+    )
+    initMcSimulator()
+  }
+
+  private lateinit var mcSimulator: EdpAggregatorMeasurementConsumerSimulator
+  private lateinit var mcName: String
+  private lateinit var mcApiKey: String
+
+  private val publicMeasurementsClient by lazy {
+    MeasurementsCoroutineStub(inProcessCmmsComponents.kingdom.publicApiChannel)
+  }
+  private val publicMeasurementConsumersClient by lazy {
+    MeasurementConsumersCoroutineStub(inProcessCmmsComponents.kingdom.publicApiChannel)
+  }
+  private val publicCertificatesClient by lazy {
+    CertificatesCoroutineStub(inProcessCmmsComponents.kingdom.publicApiChannel)
+  }
+  private val publicEventGroupsClient by lazy {
+    EventGroupsCoroutineStub(inProcessCmmsComponents.kingdom.publicApiChannel)
+  }
+  private val publicDataProvidersClient by lazy {
+    DataProvidersCoroutineStub(inProcessCmmsComponents.kingdom.publicApiChannel)
+  }
+
+  private fun initMcSimulator() {
+    val measurementConsumerData = inProcessCmmsComponents.getMeasurementConsumerData()
+    mcName = measurementConsumerData.name
+    mcApiKey = measurementConsumerData.apiAuthenticationKey
+    mcSimulator =
+      EdpAggregatorMeasurementConsumerSimulator(
+        MeasurementConsumerData(
+          measurementConsumerData.name,
+          InProcessCmmsComponents.MC_ENTITY_CONTENT.signingKey,
+          InProcessCmmsComponents.MC_ENCRYPTION_PRIVATE_KEY,
+          measurementConsumerData.apiAuthenticationKey,
+        ),
+        OUTPUT_DP_PARAMS,
+        publicDataProvidersClient,
+        publicEventGroupsClient,
+        publicMeasurementsClient,
+        publicMeasurementConsumersClient,
+        publicCertificatesClient,
+        InProcessCmmsComponents.TRUSTED_CERTIFICATES,
+        TestEvent.getDefaultInstance(),
+        NoiseMechanism.CONTINUOUS_GAUSSIAN,
+        syntheticPopulationSpec,
+        syntheticEventGroupMap,
+        ReportKey(
+            MeasurementConsumerKey.fromName(measurementConsumerData.name)!!.measurementConsumerId,
+            "some-report-id",
+          )
+          .toName(),
+        modelLineName = modelLineName,
+        listEventGroupsEntityTypes = listOf("campaign", "ad_group"),
+      )
+  }
+
+  @After
+  fun tearDown() {
+    inProcessCmmsComponents.stopDuchyDaemons()
+    inProcessCmmsComponents.stopPopulationRequisitionFulfillerDaemon()
+    inProcessEdpAggregatorComponents.stopDaemons()
+    runBlocking {
+      pubSubClient.deleteTopic(PROJECT_ID, FULFILLER_TOPIC_ID)
+      pubSubClient.deleteSubscription(PROJECT_ID, SUBSCRIPTION_ID)
+    }
+  }
+
+  @Test
+  fun `create a direct RF measurement and check the result is equal to the expected result`() =
+    runBlocking {
+      // Use frontend simulator to create a direct reach and frequency measurement and verify
+      // its
+      // result.
+      mcSimulator.testDirectReachAndFrequency(runId = "1234", numMeasurements = 1)
+    }
+
+  @Test
+  fun `create a direct reach only measurement and check the result is equal to the expected result`() =
+    runBlocking {
+      // Use frontend simulator to create a direct reach and frequency measurement and verify
+      // its
+      // result.
+      mcSimulator.testDirectReachOnly(runId = "1234", numMeasurements = 1)
+    }
+
+  @Test
+  fun `create incremental direct reach only measurements in same report and check the result is equal to the expected result`() =
+    runBlocking {
+      // Use frontend simulator to create N incremental direct reach and frequency
+      // measurements and
+      // verify its result.
+      mcSimulator.testDirectReachOnly(runId = "1234", numMeasurements = 3)
+    }
+
+  @Test
+  fun `create an impression measurement and check the result is equal to the expected result`() =
+    runBlocking {
+      // Use frontend simulator to create an impression measurement and verify its result.
+      mcSimulator.testImpression("1234")
+    }
+
+  @Test
+  fun `create a Hmss reach-only measurement and check the result is equal to the expected result`() =
+    runBlocking {
+      // Use frontend simulator to create a reach and frequency measurement and verify its
+      // result.
+      mcSimulator.testReachOnly(
+        "1234",
+        ProtocolConfig.Protocol.ProtocolCase.HONEST_MAJORITY_SHARE_SHUFFLE,
+        eventGroupFilter = {
+          it.eventGroupReferenceId != MULTIPARTY_NO_NOISE_EDP_EVENT_GROUP_REF_ID
+        },
+      )
+    }
+
+  @Test
+  fun `create a Hmss RF measurement and check the result is equal to the expected result`() =
+    runBlocking {
+      // Use frontend simulator to create a reach and frequency measurement and verify its
+      // result.
+      mcSimulator.testReachAndFrequency(
+        "1234",
+        ProtocolConfig.Protocol.ProtocolCase.HONEST_MAJORITY_SHARE_SHUFFLE,
+        eventGroupFilter = {
+          it.eventGroupReferenceId != MULTIPARTY_NO_NOISE_EDP_EVENT_GROUP_REF_ID
+        },
+      )
+    }
+
+  @Test
+  fun `create a TrusTee reach-only measurement and check the result is equal to the expected result`() =
+    runBlocking {
+      // Use frontend simulator to create a TrusTee reach-only measurement and verify its
+      // result.
+      mcSimulator.testReachOnly(
+        "1234",
+        ProtocolConfig.Protocol.ProtocolCase.TRUS_TEE,
+        eventGroupFilter = {
+          it.eventGroupReferenceId != MULTIPARTY_NO_NOISE_EDP_EVENT_GROUP_REF_ID
+        },
+      )
+    }
+
+  @Test
+  fun `create a TrusTee RF measurement and check the result is equal to the expected result`() =
+    runBlocking {
+      // Use frontend simulator to create a TrusTee reach and frequency measurement and verify
+      // its
+      // result.
+      mcSimulator.testReachAndFrequency(
+        "1234",
+        ProtocolConfig.Protocol.ProtocolCase.TRUS_TEE,
+        eventGroupFilter = {
+          it.eventGroupReferenceId != MULTIPARTY_NO_NOISE_EDP_EVENT_GROUP_REF_ID
+        },
+      )
+    }
+
+  @Test
+  fun `HMSS measurement fails when EDP requires no noise`() {
+    assertFailsWith<IllegalStateException>("Expected measurement to fail") {
+      runBlocking {
+        mcSimulator.testReachOnly(
+          "hmss-no-noise-1234",
+          ProtocolConfig.Protocol.ProtocolCase.HONEST_MAJORITY_SHARE_SHUFFLE,
+          eventGroupFilter = { it.eventGroupReferenceId in HMSS_NO_NOISE_EVENT_GROUP_REF_IDS },
         )
+      }
+    }
+  }
 
-    private val syntheticEventGroupMap: Map<String, SyntheticEventGroupSpec> =
-        eventGroupConfigsByEdp.values.flatMap { it.entries }.associate { it.key to it.value.spec }
-
-    @get:Rule
-    val inProcessEdpAggregatorComponents: InProcessEdpAggregatorComponents =
-        InProcessEdpAggregatorComponents(
-            secureComputationDatabaseAdmin = secureComputationDatabaseAdmin,
-            storagePath = tempPath,
-            pubSubClient = pubSubClient,
-            eventGroupConfigsByEdp = eventGroupConfigsByEdp,
-            syntheticPopulationSpec = syntheticPopulationSpec,
-            modelLineInfoMap = modelLineInfoMap,
-            externalKmsClient = sharedKmsClient,
+  @Test
+  fun `TrusTee measurement fails when EDP requires no noise`() {
+    assertFailsWith<IllegalStateException>("Expected measurement to fail") {
+      runBlocking {
+        mcSimulator.testReachOnly(
+          "trustee-no-noise-1234",
+          ProtocolConfig.Protocol.ProtocolCase.TRUS_TEE,
+          eventGroupFilter = { it.eventGroupReferenceId in TRUSTEE_NO_NOISE_EVENT_GROUP_REF_IDS },
         )
-
-    @Before
-    fun setup() {
-        runBlocking {
-            pubSubClient.createTopic(PROJECT_ID, FULFILLER_TOPIC_ID)
-            pubSubClient.createSubscription(PROJECT_ID, SUBSCRIPTION_ID, FULFILLER_TOPIC_ID)
-        }
-        inProcessCmmsComponents.startDaemons()
-        val measurementConsumerData = inProcessCmmsComponents.getMeasurementConsumerData()
-        val edpDisplayNameToResourceMap = inProcessCmmsComponents.edpDisplayNameToResourceMap
-        val kingdomChannel = inProcessCmmsComponents.kingdom.publicApiChannel
-        val duchyMap =
-            inProcessCmmsComponents.duchies
-                .map { it.externalDuchyId to it.publicApiChannel }
-                .toMap()
-        inProcessEdpAggregatorComponents.startDaemons(
-            kingdomChannel,
-            measurementConsumerData,
-            edpDisplayNameToResourceMap,
-            mapOf(
-                "edp1" to
-                    DataProviderKt.capabilities {
-                        honestMajorityShareShuffleSupported = true
-                        trusTeeSupported = false
-                    },
-                "edp2" to
-                    DataProviderKt.capabilities {
-                        honestMajorityShareShuffleSupported = true
-                        trusTeeSupported = true
-                    },
-                "edp3" to
-                    DataProviderKt.capabilities {
-                        honestMajorityShareShuffleSupported = false
-                        trusTeeSupported = true
-                    },
-                "edp4" to
-                    DataProviderKt.capabilities {
-                        honestMajorityShareShuffleSupported = true
-                        trusTeeSupported = true
-                    },
-            ),
-            duchyMap,
-            edpNoise =
-                mapOf(
-                    "edp1" to ResultsFulfillerParams.NoiseParams.NoiseType.CONTINUOUS_GAUSSIAN,
-                    "edp2" to ResultsFulfillerParams.NoiseParams.NoiseType.CONTINUOUS_GAUSSIAN,
-                    "edp3" to ResultsFulfillerParams.NoiseParams.NoiseType.CONTINUOUS_GAUSSIAN,
-                    "edp4" to ResultsFulfillerParams.NoiseParams.NoiseType.CONTINUOUS_GAUSSIAN,
-                ),
-            edpMultiPartyNoiseTypes =
-                mapOf("edp4" to listOf(ResultsFulfillerParams.NoiseParams.NoiseType.NONE)),
-        )
-        initMcSimulator()
+      }
     }
+  }
 
-    private lateinit var mcSimulator: EdpAggregatorMeasurementConsumerSimulator
-    private lateinit var mcName: String
-    private lateinit var mcApiKey: String
+  @Test
+  fun `EDPA-registered EventGroups with entity_key round-trip to the CMMS public API`() =
+    runBlocking {
+      val edpDisplayNameToResourceMap = inProcessCmmsComponents.edpDisplayNameToResourceMap
 
-    private val publicMeasurementsClient by lazy {
-        MeasurementsCoroutineStub(inProcessCmmsComponents.kingdom.publicApiChannel)
-    }
-    private val publicMeasurementConsumersClient by lazy {
-        MeasurementConsumersCoroutineStub(inProcessCmmsComponents.kingdom.publicApiChannel)
-    }
-    private val publicCertificatesClient by lazy {
-        CertificatesCoroutineStub(inProcessCmmsComponents.kingdom.publicApiChannel)
-    }
-    private val publicEventGroupsClient by lazy {
-        EventGroupsCoroutineStub(inProcessCmmsComponents.kingdom.publicApiChannel)
-    }
-    private val publicDataProvidersClient by lazy {
-        DataProvidersCoroutineStub(inProcessCmmsComponents.kingdom.publicApiChannel)
-    }
-
-    private fun initMcSimulator() {
-        val measurementConsumerData = inProcessCmmsComponents.getMeasurementConsumerData()
-        mcName = measurementConsumerData.name
-        mcApiKey = measurementConsumerData.apiAuthenticationKey
-        mcSimulator =
-            EdpAggregatorMeasurementConsumerSimulator(
-                MeasurementConsumerData(
-                    measurementConsumerData.name,
-                    InProcessCmmsComponents.MC_ENTITY_CONTENT.signingKey,
-                    InProcessCmmsComponents.MC_ENCRYPTION_PRIVATE_KEY,
-                    measurementConsumerData.apiAuthenticationKey,
-                ),
-                OUTPUT_DP_PARAMS,
-                publicDataProvidersClient,
-                publicEventGroupsClient,
-                publicMeasurementsClient,
-                publicMeasurementConsumersClient,
-                publicCertificatesClient,
-                InProcessCmmsComponents.TRUSTED_CERTIFICATES,
-                TestEvent.getDefaultInstance(),
-                NoiseMechanism.CONTINUOUS_GAUSSIAN,
-                syntheticPopulationSpec,
-                syntheticEventGroupMap,
-                ReportKey(
-                        MeasurementConsumerKey.fromName(measurementConsumerData.name)!!
-                            .measurementConsumerId,
-                        "some-report-id",
-                    )
-                    .toName(),
-                modelLineName = modelLineName,
-                listEventGroupsEntityTypes = listOf("campaign", "ad_group"),
-            )
-    }
-
-    @After
-    fun tearDown() {
-        inProcessCmmsComponents.stopDuchyDaemons()
-        inProcessCmmsComponents.stopPopulationRequisitionFulfillerDaemon()
-        inProcessEdpAggregatorComponents.stopDaemons()
-        runBlocking {
-            pubSubClient.deleteTopic(PROJECT_ID, FULFILLER_TOPIC_ID)
-            pubSubClient.deleteSubscription(PROJECT_ID, SUBSCRIPTION_ID)
-        }
-    }
-
-    @Test
-    fun `create a direct RF measurement and check the result is equal to the expected result`() =
-        runBlocking {
-            // Use frontend simulator to create a direct reach and frequency measurement and verify
-            // its
-            // result.
-            mcSimulator.testDirectReachAndFrequency(runId = "1234", numMeasurements = 1)
-        }
-
-    @Test
-    fun `create a direct reach only measurement and check the result is equal to the expected result`() =
-        runBlocking {
-            // Use frontend simulator to create a direct reach and frequency measurement and verify
-            // its
-            // result.
-            mcSimulator.testDirectReachOnly(runId = "1234", numMeasurements = 1)
-        }
-
-    @Test
-    fun `create incremental direct reach only measurements in same report and check the result is equal to the expected result`() =
-        runBlocking {
-            // Use frontend simulator to create N incremental direct reach and frequency
-            // measurements and
-            // verify its result.
-            mcSimulator.testDirectReachOnly(runId = "1234", numMeasurements = 3)
-        }
-
-    @Test
-    fun `create an impression measurement and check the result is equal to the expected result`() =
-        runBlocking {
-            // Use frontend simulator to create an impression measurement and verify its result.
-            mcSimulator.testImpression("1234")
-        }
-
-    @Test
-    fun `create a Hmss reach-only measurement and check the result is equal to the expected result`() =
-        runBlocking {
-            // Use frontend simulator to create a reach and frequency measurement and verify its
-            // result.
-            mcSimulator.testReachOnly(
-                "1234",
-                ProtocolConfig.Protocol.ProtocolCase.HONEST_MAJORITY_SHARE_SHUFFLE,
-                eventGroupFilter = {
-                    it.eventGroupReferenceId != MULTIPARTY_NO_NOISE_EDP_EVENT_GROUP_REF_ID
-                },
-            )
-        }
-
-    @Test
-    fun `create a Hmss RF measurement and check the result is equal to the expected result`() =
-        runBlocking {
-            // Use frontend simulator to create a reach and frequency measurement and verify its
-            // result.
-            mcSimulator.testReachAndFrequency(
-                "1234",
-                ProtocolConfig.Protocol.ProtocolCase.HONEST_MAJORITY_SHARE_SHUFFLE,
-                eventGroupFilter = {
-                    it.eventGroupReferenceId != MULTIPARTY_NO_NOISE_EDP_EVENT_GROUP_REF_ID
-                },
-            )
-        }
-
-    @Test
-    fun `create a TrusTee reach-only measurement and check the result is equal to the expected result`() =
-        runBlocking {
-            // Use frontend simulator to create a TrusTee reach-only measurement and verify its
-            // result.
-            mcSimulator.testReachOnly(
-                "1234",
-                ProtocolConfig.Protocol.ProtocolCase.TRUS_TEE,
-                eventGroupFilter = {
-                    it.eventGroupReferenceId != MULTIPARTY_NO_NOISE_EDP_EVENT_GROUP_REF_ID
-                },
-            )
-        }
-
-    @Test
-    fun `create a TrusTee RF measurement and check the result is equal to the expected result`() =
-        runBlocking {
-            // Use frontend simulator to create a TrusTee reach and frequency measurement and verify
-            // its
-            // result.
-            mcSimulator.testReachAndFrequency(
-                "1234",
-                ProtocolConfig.Protocol.ProtocolCase.TRUS_TEE,
-                eventGroupFilter = {
-                    it.eventGroupReferenceId != MULTIPARTY_NO_NOISE_EDP_EVENT_GROUP_REF_ID
-                },
-            )
-        }
-
-    @Test
-    fun `HMSS measurement fails when EDP requires no noise`() {
-        assertFailsWith<IllegalStateException>("Expected measurement to fail") {
-            runBlocking {
-                mcSimulator.testReachOnly(
-                    "hmss-no-noise-1234",
-                    ProtocolConfig.Protocol.ProtocolCase.HONEST_MAJORITY_SHARE_SHUFFLE,
-                    eventGroupFilter = {
-                        it.eventGroupReferenceId in HMSS_NO_NOISE_EVENT_GROUP_REF_IDS
-                    },
-                )
-            }
-        }
-    }
-
-    @Test
-    fun `TrusTee measurement fails when EDP requires no noise`() {
-        assertFailsWith<IllegalStateException>("Expected measurement to fail") {
-            runBlocking {
-                mcSimulator.testReachOnly(
-                    "trustee-no-noise-1234",
-                    ProtocolConfig.Protocol.ProtocolCase.TRUS_TEE,
-                    eventGroupFilter = {
-                        it.eventGroupReferenceId in TRUSTEE_NO_NOISE_EVENT_GROUP_REF_IDS
-                    },
-                )
-            }
-        }
-    }
-
-    @Test
-    fun `EDPA-registered EventGroups with entity_key round-trip to the CMMS public API`() =
-        runBlocking {
-            val edpDisplayNameToResourceMap = inProcessCmmsComponents.edpDisplayNameToResourceMap
-
-            for ((edpDisplayName, refConfigs) in eventGroupConfigsByEdp) {
-                val edpResourceName = edpDisplayNameToResourceMap.getValue(edpDisplayName).name
-                val response =
-                    publicEventGroupsClient
-                        .withPrincipalName(edpResourceName)
-                        .listEventGroups(
-                            listEventGroupsRequest {
-                                parent = edpResourceName
-                                pageSize = 1000
-                                filter =
-                                    ListEventGroupsRequestKt.filter {
-                                        entityTypeIn += "campaign"
-                                        entityTypeIn += "ad_group"
-                                    }
-                            }
-                        )
-
-                val byRefId = response.eventGroupsList.associateBy { it.eventGroupReferenceId }
-                assertWithMessage("EventGroups for $edpDisplayName")
-                    .that(byRefId.keys)
-                    .containsAtLeastElementsIn(refConfigs.keys)
-
-                for ((refId, config) in refConfigs) {
-                    if (config.blobEntityKeys.isEmpty()) continue
-                    val eventGroup = byRefId.getValue(refId)
-                    val expectedEntityKey = config.blobEntityKeys.first()
-                    assertWithMessage("entity_key.entity_type for $refId")
-                        .that(eventGroup.entityKey.entityType)
-                        .isEqualTo(expectedEntityKey.entityType)
-                    assertWithMessage("entity_key.entity_id for $refId")
-                        .that(eventGroup.entityKey.entityId)
-                        .isEqualTo(expectedEntityKey.entityId)
-                    assertWithMessage("entity_metadata for $refId")
-                        .that(eventGroup.eventGroupMetadata.entityMetadata)
-                        .isEqualTo(config.entityMetadata)
-                }
-            }
-        }
-
-    @Test
-    fun `EDPA EventGroups without entity_key default to campaign with no entity_id or metadata`() =
-        runBlocking {
-            val edpDisplayNameToResourceMap = inProcessCmmsComponents.edpDisplayNameToResourceMap
-            val edpResourceName =
-                edpDisplayNameToResourceMap.getValue(EDP_NO_ENTITY_KEY_DISPLAY_NAME).name
-
-            val response =
-                publicEventGroupsClient
-                    .withPrincipalName(edpResourceName)
-                    .listEventGroups(
-                        listEventGroupsRequest {
-                            parent = edpResourceName
-                            pageSize = 1000
-                        }
-                    )
-
-            val legacy: EventGroup =
-                response.eventGroupsList.single {
-                    it.eventGroupReferenceId == EDP_NO_ENTITY_KEY_EVENT_GROUP_REF_ID
-                }
-            assertThat(legacy.entityKey.entityType).isEqualTo("campaign")
-            assertThat(legacy.entityKey.entityId).isEmpty()
-            assertThat(legacy.eventGroupMetadata.hasEntityMetadata()).isFalse()
-        }
-
-    @Test
-    fun `default ListEventGroups filter hides non-campaign EventGroups`() = runBlocking {
+      for ((edpDisplayName, refConfigs) in eventGroupConfigsByEdp) {
+        val edpResourceName = edpDisplayNameToResourceMap.getValue(edpDisplayName).name
         val response =
-            publicEventGroupsClient
-                .withAuthenticationKey(mcApiKey)
-                .listEventGroups(
-                    listEventGroupsRequest {
-                        parent = mcName
-                        pageSize = 1000
-                    }
-                )
+          publicEventGroupsClient
+            .withPrincipalName(edpResourceName)
+            .listEventGroups(
+              listEventGroupsRequest {
+                parent = edpResourceName
+                pageSize = 1000
+                filter =
+                  ListEventGroupsRequestKt.filter {
+                    entityTypeIn += "campaign"
+                    entityTypeIn += "ad_group"
+                  }
+              }
+            )
 
-        val refIds = response.eventGroupsList.map { it.eventGroupReferenceId }.toSet()
-        assertThat(refIds).contains(EDP_NO_ENTITY_KEY_EVENT_GROUP_REF_ID)
-        for ((_, refConfigs) in eventGroupConfigsByEdp) {
-            for ((refId, config) in refConfigs) {
-                if (config.blobEntityKeys.isNotEmpty()) {
-                    assertThat(refIds).doesNotContain(refId)
-                }
+        val byRefId = response.eventGroupsList.associateBy { it.eventGroupReferenceId }
+        assertWithMessage("EventGroups for $edpDisplayName")
+          .that(byRefId.keys)
+          .containsAtLeastElementsIn(refConfigs.keys)
+
+        for ((refId, config) in refConfigs) {
+          if (config.blobEntityKeys.isEmpty()) continue
+          val eventGroup = byRefId.getValue(refId)
+          val expectedEntityKey = config.blobEntityKeys.first()
+          assertWithMessage("entity_key.entity_type for $refId")
+            .that(eventGroup.entityKey.entityType)
+            .isEqualTo(expectedEntityKey.entityType)
+          assertWithMessage("entity_key.entity_id for $refId")
+            .that(eventGroup.entityKey.entityId)
+            .isEqualTo(expectedEntityKey.entityId)
+          assertWithMessage("entity_metadata for $refId")
+            .that(eventGroup.eventGroupMetadata.entityMetadata)
+            .isEqualTo(config.entityMetadata)
+        }
+      }
+    }
+
+  @Test
+  fun `EDPA EventGroups without entity_key default to campaign with no entity_id or metadata`() =
+    runBlocking {
+      val edpDisplayNameToResourceMap = inProcessCmmsComponents.edpDisplayNameToResourceMap
+      val edpResourceName =
+        edpDisplayNameToResourceMap.getValue(EDP_NO_ENTITY_KEY_DISPLAY_NAME).name
+
+      val response =
+        publicEventGroupsClient
+          .withPrincipalName(edpResourceName)
+          .listEventGroups(
+            listEventGroupsRequest {
+              parent = edpResourceName
+              pageSize = 1000
             }
+          )
+
+      val legacy: EventGroup =
+        response.eventGroupsList.single {
+          it.eventGroupReferenceId == EDP_NO_ENTITY_KEY_EVENT_GROUP_REF_ID
         }
+      assertThat(legacy.entityKey.entityType).isEqualTo("campaign")
+      assertThat(legacy.entityKey.entityId).isEmpty()
+      assertThat(legacy.eventGroupMetadata.hasEntityMetadata()).isFalse()
     }
 
-    companion object {
-        // edp1 deliberately has no entity_key/entity_metadata override (legacy path); it also
-        // happens
-        // to be the EDP that requires no measurement noise on the HMSS protocol, used by the
-        // HMSS-failure path test.
-        private const val EDP_NO_ENTITY_KEY_DISPLAY_NAME = "edp1"
-        private const val EDP_NO_ENTITY_KEY_EVENT_GROUP_REF_ID = "edpa-eg-reference-id-1"
-        private const val HMSS_NO_NOISE_EDP_EVENT_GROUP_REF_ID =
-            EDP_NO_ENTITY_KEY_EVENT_GROUP_REF_ID
-        private const val TRUSTEE_NO_NOISE_EDP_EVENT_GROUP_REF_ID = "edpa-eg-reference-id-3"
-        private const val MULTIPARTY_NO_NOISE_EDP_EVENT_GROUP_REF_ID = "edpa-eg-reference-id-4"
+  @Test
+  fun `default ListEventGroups filter hides non-campaign EventGroups`() = runBlocking {
+    val response =
+      publicEventGroupsClient
+        .withAuthenticationKey(mcApiKey)
+        .listEventGroups(
+          listEventGroupsRequest {
+            parent = mcName
+            pageSize = 1000
+          }
+        )
 
-        /**
-         * EventGroups whose EDPs cannot satisfy a single-party HMSS measurement's noise contract.
-         */
-        private val HMSS_NO_NOISE_EVENT_GROUP_REF_IDS =
-            setOf(HMSS_NO_NOISE_EDP_EVENT_GROUP_REF_ID, MULTIPARTY_NO_NOISE_EDP_EVENT_GROUP_REF_ID)
-
-        /**
-         * EventGroups whose EDPs cannot satisfy a single-party TrusTee measurement's noise
-         * contract.
-         */
-        private val TRUSTEE_NO_NOISE_EVENT_GROUP_REF_IDS =
-            setOf(
-                TRUSTEE_NO_NOISE_EDP_EVENT_GROUP_REF_ID,
-                MULTIPARTY_NO_NOISE_EDP_EVENT_GROUP_REF_ID,
-            )
-
-        private val logger: Logger = Logger.getLogger(this::class.java.name)
-        private val modelLineName =
-            "modelProviders/AAAAAAAAAHs/modelSuites/AAAAAAAAAHs/modelLines/AAAAAAAAAHs"
-        // Epsilon can vary from 0.0001 to 1.0, delta = 1e-15 is a realistic value.
-        // Set epsilon higher without exceeding privacy budget so the noise is smaller in the
-        // integration test. Check sample values in CompositionTest.kt.
-        private val OUTPUT_DP_PARAMS = differentialPrivacyParams {
-            epsilon = 1.0
-            delta = 1e-15
+    val refIds = response.eventGroupsList.map { it.eventGroupReferenceId }.toSet()
+    assertThat(refIds).contains(EDP_NO_ENTITY_KEY_EVENT_GROUP_REF_ID)
+    for ((_, refConfigs) in eventGroupConfigsByEdp) {
+      for ((refId, config) in refConfigs) {
+        if (config.blobEntityKeys.isNotEmpty()) {
+          assertThat(refIds).doesNotContain(refId)
         }
-
-        // This is the relative location from which population and data spec textprotos are read.
-        private val TEST_DATA_PATH =
-            Paths.get(
-                "wfa_measurement_system",
-                "src",
-                "main",
-                "proto",
-                "wfa",
-                "measurement",
-                "loadtest",
-                "dataprovider",
-            )
-        private val TEST_DATA_RUNTIME_PATH = getRuntimePath(TEST_DATA_PATH)!!
-
-        private val TEST_RESULTS_FULFILLER_DATA_PATH =
-            Paths.get(
-                "wfa_measurement_system",
-                "src",
-                "main",
-                "kotlin",
-                "org",
-                "wfanet",
-                "measurement",
-                "edpaggregator",
-                "resultsfulfiller",
-                "testing",
-            )
-        private val TEST_RESULTS_FULFILLER_DATA_RUNTIME_PATH =
-            getRuntimePath(TEST_RESULTS_FULFILLER_DATA_PATH)!!
-
-        val syntheticPopulationSpec: SyntheticPopulationSpec =
-            parseTextProto(
-                TEST_DATA_RUNTIME_PATH.resolve("small_population_spec.textproto").toFile(),
-                SyntheticPopulationSpec.getDefaultInstance(),
-            )
-        val syntheticEventGroupSpec: SyntheticEventGroupSpec =
-            parseTextProto(
-                TEST_DATA_RUNTIME_PATH.resolve("small_data_spec.textproto").toFile(),
-                SyntheticEventGroupSpec.getDefaultInstance(),
-            )
-        val populationSpec =
-            parseTextProto(
-                TEST_RESULTS_FULFILLER_DATA_RUNTIME_PATH.resolve("small_population_spec.textproto")
-                    .toFile(),
-                PopulationSpec.getDefaultInstance(),
-            )
-        val modelLineInfoMap =
-            mapOf(
-                modelLineName to
-                    ModelLineInfo(
-                        populationSpec = populationSpec,
-                        vidIndexMap = InMemoryVidIndexMap.build(populationSpec),
-                        eventDescriptor = TestEvent.getDescriptor(),
-                        localAlias = null,
-                    )
-            )
-
-        @BeforeClass
-        @JvmStatic
-        fun initConfig() {
-            InProcessCmmsComponents.initConfig(
-                trusTeeProtocolConfigConfig = TRUSTEE_PROTOCOL_CONFIG_CONFIG,
-                hmssProtocolConfigConfig = HMSS_PROTOCOL_CONFIG_CONFIG,
-            )
-        }
-
-        @get:ClassRule @JvmStatic val pubSubEmulatorProvider = GooglePubSubEmulatorProvider()
-
-        private val ENTITY_METADATA = struct {
-            fields["placement"] = value { stringValue = "homepage_top" }
-            fields["objective"] = value { stringValue = "awareness" }
-        }
+      }
     }
+  }
+
+  companion object {
+    // edp1 deliberately has no entity_key/entity_metadata override (legacy path); it also
+    // happens
+    // to be the EDP that requires no measurement noise on the HMSS protocol, used by the
+    // HMSS-failure path test.
+    private const val EDP_NO_ENTITY_KEY_DISPLAY_NAME = "edp1"
+    private const val EDP_NO_ENTITY_KEY_EVENT_GROUP_REF_ID = "edpa-eg-reference-id-1"
+    private const val HMSS_NO_NOISE_EDP_EVENT_GROUP_REF_ID = EDP_NO_ENTITY_KEY_EVENT_GROUP_REF_ID
+    private const val TRUSTEE_NO_NOISE_EDP_EVENT_GROUP_REF_ID = "edpa-eg-reference-id-3"
+    private const val MULTIPARTY_NO_NOISE_EDP_EVENT_GROUP_REF_ID = "edpa-eg-reference-id-4"
+
+    /** EventGroups whose EDPs cannot satisfy a single-party HMSS measurement's noise contract. */
+    private val HMSS_NO_NOISE_EVENT_GROUP_REF_IDS =
+      setOf(HMSS_NO_NOISE_EDP_EVENT_GROUP_REF_ID, MULTIPARTY_NO_NOISE_EDP_EVENT_GROUP_REF_ID)
+
+    /**
+     * EventGroups whose EDPs cannot satisfy a single-party TrusTee measurement's noise contract.
+     */
+    private val TRUSTEE_NO_NOISE_EVENT_GROUP_REF_IDS =
+      setOf(TRUSTEE_NO_NOISE_EDP_EVENT_GROUP_REF_ID, MULTIPARTY_NO_NOISE_EDP_EVENT_GROUP_REF_ID)
+
+    private val logger: Logger = Logger.getLogger(this::class.java.name)
+    private val modelLineName =
+      "modelProviders/AAAAAAAAAHs/modelSuites/AAAAAAAAAHs/modelLines/AAAAAAAAAHs"
+    // Epsilon can vary from 0.0001 to 1.0, delta = 1e-15 is a realistic value.
+    // Set epsilon higher without exceeding privacy budget so the noise is smaller in the
+    // integration test. Check sample values in CompositionTest.kt.
+    private val OUTPUT_DP_PARAMS = differentialPrivacyParams {
+      epsilon = 1.0
+      delta = 1e-15
+    }
+
+    // This is the relative location from which population and data spec textprotos are read.
+    private val TEST_DATA_PATH =
+      Paths.get(
+        "wfa_measurement_system",
+        "src",
+        "main",
+        "proto",
+        "wfa",
+        "measurement",
+        "loadtest",
+        "dataprovider",
+      )
+    private val TEST_DATA_RUNTIME_PATH = getRuntimePath(TEST_DATA_PATH)!!
+
+    private val TEST_RESULTS_FULFILLER_DATA_PATH =
+      Paths.get(
+        "wfa_measurement_system",
+        "src",
+        "main",
+        "kotlin",
+        "org",
+        "wfanet",
+        "measurement",
+        "edpaggregator",
+        "resultsfulfiller",
+        "testing",
+      )
+    private val TEST_RESULTS_FULFILLER_DATA_RUNTIME_PATH =
+      getRuntimePath(TEST_RESULTS_FULFILLER_DATA_PATH)!!
+
+    val syntheticPopulationSpec: SyntheticPopulationSpec =
+      parseTextProto(
+        TEST_DATA_RUNTIME_PATH.resolve("small_population_spec.textproto").toFile(),
+        SyntheticPopulationSpec.getDefaultInstance(),
+      )
+    val syntheticEventGroupSpec: SyntheticEventGroupSpec =
+      parseTextProto(
+        TEST_DATA_RUNTIME_PATH.resolve("small_data_spec.textproto").toFile(),
+        SyntheticEventGroupSpec.getDefaultInstance(),
+      )
+    val populationSpec =
+      parseTextProto(
+        TEST_RESULTS_FULFILLER_DATA_RUNTIME_PATH.resolve("small_population_spec.textproto")
+          .toFile(),
+        PopulationSpec.getDefaultInstance(),
+      )
+    val modelLineInfoMap =
+      mapOf(
+        modelLineName to
+          ModelLineInfo(
+            populationSpec = populationSpec,
+            vidIndexMap = InMemoryVidIndexMap.build(populationSpec),
+            eventDescriptor = TestEvent.getDescriptor(),
+            localAlias = null,
+          )
+      )
+
+    @BeforeClass
+    @JvmStatic
+    fun initConfig() {
+      InProcessCmmsComponents.initConfig(
+        trusTeeProtocolConfigConfig = TRUSTEE_PROTOCOL_CONFIG_CONFIG,
+        hmssProtocolConfigConfig = HMSS_PROTOCOL_CONFIG_CONFIG,
+      )
+    }
+
+    @get:ClassRule @JvmStatic val pubSubEmulatorProvider = GooglePubSubEmulatorProvider()
+
+    private val ENTITY_METADATA = struct {
+      fields["placement"] = value { stringValue = "homepage_top" }
+      fields["objective"] = value { stringValue = "awareness" }
+    }
+  }
 }

--- a/src/main/kotlin/org/wfanet/measurement/integration/common/InProcessEdpAggregatorLifeOfAMeasurementIntegrationTest.kt
+++ b/src/main/kotlin/org/wfanet/measurement/integration/common/InProcessEdpAggregatorLifeOfAMeasurementIntegrationTest.kt
@@ -57,7 +57,6 @@ import org.wfanet.measurement.common.getRuntimePath
 import org.wfanet.measurement.common.identity.withPrincipalName
 import org.wfanet.measurement.common.parseTextProto
 import org.wfanet.measurement.common.testing.ProviderRule
-import org.wfanet.measurement.edpaggregator.eventgroups.v1alpha.EventGroupKt.entityKey as edpaEntityKey
 import org.wfanet.measurement.edpaggregator.resultsfulfiller.ModelLineInfo
 import org.wfanet.measurement.edpaggregator.v1alpha.ResultsFulfillerParams
 import org.wfanet.measurement.eventdataprovider.requisition.v2alpha.common.InMemoryVidIndexMap
@@ -65,6 +64,7 @@ import org.wfanet.measurement.gcloud.pubsub.testing.GooglePubSubEmulatorClient
 import org.wfanet.measurement.gcloud.pubsub.testing.GooglePubSubEmulatorProvider
 import org.wfanet.measurement.gcloud.spanner.testing.SpannerDatabaseAdmin
 import org.wfanet.measurement.kingdom.deploy.common.service.DataServices
+import org.wfanet.measurement.loadtest.dataprovider.EntityKey
 import org.wfanet.measurement.loadtest.measurementconsumer.EdpAggregatorMeasurementConsumerSimulator
 import org.wfanet.measurement.loadtest.measurementconsumer.MeasurementConsumerData
 import org.wfanet.measurement.reporting.service.api.v2alpha.ReportKey
@@ -77,506 +77,547 @@ import org.wfanet.measurement.system.v1alpha.ComputationLogEntriesGrpcKt.Computa
  * easily.
  */
 abstract class InProcessEdpAggregatorLifeOfAMeasurementIntegrationTest(
-  kingdomDataServicesRule: ProviderRule<DataServices>,
-  duchyDependenciesRule:
-    ProviderRule<(String, ComputationLogEntriesCoroutineStub) -> InProcessDuchy.DuchyDependencies>,
-  secureComputationDatabaseAdmin: SpannerDatabaseAdmin,
+    kingdomDataServicesRule: ProviderRule<DataServices>,
+    duchyDependenciesRule:
+        ProviderRule<
+            (String, ComputationLogEntriesCoroutineStub) -> InProcessDuchy.DuchyDependencies
+        >,
+    secureComputationDatabaseAdmin: SpannerDatabaseAdmin,
 ) {
 
-  private val pubSubClient: GooglePubSubEmulatorClient by lazy {
-    GooglePubSubEmulatorClient(
-      host = pubSubEmulatorProvider.host,
-      port = pubSubEmulatorProvider.port,
-    )
-  }
-
-  private val sharedKmsClient: FakeKmsClient by lazy {
-    val kekUri = FakeKmsClient.KEY_URI_PREFIX + "key1"
-    val kmsKeyHandle = KeysetHandle.generateNew(KeyTemplates.get("AES128_GCM"))
-    val kmsClient = FakeKmsClient()
-    kmsClient.setAead(kekUri, kmsKeyHandle.getPrimitive(Aead::class.java))
-    kmsClient
-  }
-
-  @get:Rule
-  val inProcessCmmsComponents =
-    InProcessCmmsComponents(
-      kingdomDataServicesRule,
-      duchyDependenciesRule,
-      useEdpSimulators = false,
-      trusTeeKmsClient = sharedKmsClient,
-    )
-
-  @JvmField
-  @get:Rule
-  val tempPath: Path = run {
-    val tempDirectory = TemporaryFolder()
-    tempDirectory.create()
-    tempDirectory.root.toPath()
-  }
-
-  private val syntheticEventGroupMapByEdp =
-    mapOf(
-      "edp1" to mapOf("edpa-eg-reference-id-1" to syntheticEventGroupSpec),
-      "edp2" to mapOf("edpa-eg-reference-id-2" to syntheticEventGroupSpec),
-      "edp3" to mapOf("edpa-eg-reference-id-3" to syntheticEventGroupSpec),
-      "edp4" to mapOf("edpa-eg-reference-id-4" to syntheticEventGroupSpec),
-    )
-
-  private val syntheticEventGroupMap: Map<String, SyntheticEventGroupSpec> =
-    syntheticEventGroupMapByEdp.values.flatMap { it.entries }.associate { it.key to it.value }
-
-  // edp1 is intentionally absent from this map so its EventGroup is created without entity_key
-  // and entity_metadata, exercising the legacy path: Kingdom's schema default sets entity_type to
-  // "campaign" and leaves entity_id and entity_metadata unset. The simulator's ListEventGroups
-  // uses the default filter (entity_type_in defaults to ["campaign"]), so edp1 stays visible to
-  // existing measurement tests.
-  private val entityOverridesByEdp: Map<String, Map<String, EventGroupEntityOverride>> =
-    syntheticEventGroupMapByEdp
-      .filterKeys { it != EDP_NO_ENTITY_KEY_DISPLAY_NAME }
-      .mapValues { (_, edpRefs) ->
-        edpRefs.keys.associateWith { refId ->
-          EventGroupEntityOverride(
-            entityKey =
-              edpaEntityKey {
-                entityType = "ad_group"
-                entityId = refId
-              },
-            entityMetadata = ENTITY_METADATA,
-          )
-        }
-      }
-
-  @get:Rule
-  val inProcessEdpAggregatorComponents: InProcessEdpAggregatorComponents =
-    InProcessEdpAggregatorComponents(
-      secureComputationDatabaseAdmin = secureComputationDatabaseAdmin,
-      storagePath = tempPath,
-      pubSubClient = pubSubClient,
-      syntheticEventGroupMapByEdp = syntheticEventGroupMapByEdp,
-      syntheticPopulationSpec = syntheticPopulationSpec,
-      modelLineInfoMap = modelLineInfoMap,
-      externalKmsClient = sharedKmsClient,
-      entityOverridesByEdp = entityOverridesByEdp,
-    )
-
-  @Before
-  fun setup() {
-    runBlocking {
-      pubSubClient.createTopic(PROJECT_ID, FULFILLER_TOPIC_ID)
-      pubSubClient.createSubscription(PROJECT_ID, SUBSCRIPTION_ID, FULFILLER_TOPIC_ID)
+    private val pubSubClient: GooglePubSubEmulatorClient by lazy {
+        GooglePubSubEmulatorClient(
+            host = pubSubEmulatorProvider.host,
+            port = pubSubEmulatorProvider.port,
+        )
     }
-    inProcessCmmsComponents.startDaemons()
-    val measurementConsumerData = inProcessCmmsComponents.getMeasurementConsumerData()
-    val edpDisplayNameToResourceMap = inProcessCmmsComponents.edpDisplayNameToResourceMap
-    val kingdomChannel = inProcessCmmsComponents.kingdom.publicApiChannel
-    val duchyMap =
-      inProcessCmmsComponents.duchies.map { it.externalDuchyId to it.publicApiChannel }.toMap()
-    inProcessEdpAggregatorComponents.startDaemons(
-      kingdomChannel,
-      measurementConsumerData,
-      edpDisplayNameToResourceMap,
-      mapOf(
-        "edp1" to
-          DataProviderKt.capabilities {
-            honestMajorityShareShuffleSupported = true
-            trusTeeSupported = false
-          },
-        "edp2" to
-          DataProviderKt.capabilities {
-            honestMajorityShareShuffleSupported = true
-            trusTeeSupported = true
-          },
-        "edp3" to
-          DataProviderKt.capabilities {
-            honestMajorityShareShuffleSupported = false
-            trusTeeSupported = true
-          },
-        "edp4" to
-          DataProviderKt.capabilities {
-            honestMajorityShareShuffleSupported = true
-            trusTeeSupported = true
-          },
-      ),
-      duchyMap,
-      edpNoise =
+
+    private val sharedKmsClient: FakeKmsClient by lazy {
+        val kekUri = FakeKmsClient.KEY_URI_PREFIX + "key1"
+        val kmsKeyHandle = KeysetHandle.generateNew(KeyTemplates.get("AES128_GCM"))
+        val kmsClient = FakeKmsClient()
+        kmsClient.setAead(kekUri, kmsKeyHandle.getPrimitive(Aead::class.java))
+        kmsClient
+    }
+
+    @get:Rule
+    val inProcessCmmsComponents =
+        InProcessCmmsComponents(
+            kingdomDataServicesRule,
+            duchyDependenciesRule,
+            useEdpSimulators = false,
+            trusTeeKmsClient = sharedKmsClient,
+        )
+
+    @JvmField
+    @get:Rule
+    val tempPath: Path = run {
+        val tempDirectory = TemporaryFolder()
+        tempDirectory.create()
+        tempDirectory.root.toPath()
+    }
+
+    // edp1 is intentionally created without entity key (legacy path: Kingdom defaults
+    // entity_type="campaign", entity_id and entity_metadata unset). The simulator's
+    // ListEventGroups uses the default filter (entity_type_in defaults to ["campaign"]),
+    // so edp1 stays visible to existing measurement tests.
+    private val eventGroupConfigsByEdp: Map<String, Map<String, EventGroupConfig>> =
         mapOf(
-          "edp1" to ResultsFulfillerParams.NoiseParams.NoiseType.CONTINUOUS_GAUSSIAN,
-          "edp2" to ResultsFulfillerParams.NoiseParams.NoiseType.CONTINUOUS_GAUSSIAN,
-          "edp3" to ResultsFulfillerParams.NoiseParams.NoiseType.CONTINUOUS_GAUSSIAN,
-          "edp4" to ResultsFulfillerParams.NoiseParams.NoiseType.CONTINUOUS_GAUSSIAN,
-        ),
-      edpMultiPartyNoiseTypes =
-        mapOf("edp4" to listOf(ResultsFulfillerParams.NoiseParams.NoiseType.NONE)),
-    )
-    initMcSimulator()
-  }
-
-  private lateinit var mcSimulator: EdpAggregatorMeasurementConsumerSimulator
-  private lateinit var mcName: String
-  private lateinit var mcApiKey: String
-
-  private val publicMeasurementsClient by lazy {
-    MeasurementsCoroutineStub(inProcessCmmsComponents.kingdom.publicApiChannel)
-  }
-  private val publicMeasurementConsumersClient by lazy {
-    MeasurementConsumersCoroutineStub(inProcessCmmsComponents.kingdom.publicApiChannel)
-  }
-  private val publicCertificatesClient by lazy {
-    CertificatesCoroutineStub(inProcessCmmsComponents.kingdom.publicApiChannel)
-  }
-  private val publicEventGroupsClient by lazy {
-    EventGroupsCoroutineStub(inProcessCmmsComponents.kingdom.publicApiChannel)
-  }
-  private val publicDataProvidersClient by lazy {
-    DataProvidersCoroutineStub(inProcessCmmsComponents.kingdom.publicApiChannel)
-  }
-
-  private fun initMcSimulator() {
-    val measurementConsumerData = inProcessCmmsComponents.getMeasurementConsumerData()
-    mcName = measurementConsumerData.name
-    mcApiKey = measurementConsumerData.apiAuthenticationKey
-    mcSimulator =
-      EdpAggregatorMeasurementConsumerSimulator(
-        MeasurementConsumerData(
-          measurementConsumerData.name,
-          InProcessCmmsComponents.MC_ENTITY_CONTENT.signingKey,
-          InProcessCmmsComponents.MC_ENCRYPTION_PRIVATE_KEY,
-          measurementConsumerData.apiAuthenticationKey,
-        ),
-        OUTPUT_DP_PARAMS,
-        publicDataProvidersClient,
-        publicEventGroupsClient,
-        publicMeasurementsClient,
-        publicMeasurementConsumersClient,
-        publicCertificatesClient,
-        InProcessCmmsComponents.TRUSTED_CERTIFICATES,
-        TestEvent.getDefaultInstance(),
-        NoiseMechanism.CONTINUOUS_GAUSSIAN,
-        syntheticPopulationSpec,
-        syntheticEventGroupMap,
-        ReportKey(
-            MeasurementConsumerKey.fromName(measurementConsumerData.name)!!.measurementConsumerId,
-            "some-report-id",
-          )
-          .toName(),
-        modelLineName = modelLineName,
-        listEventGroupsEntityTypes = listOf("campaign", "ad_group"),
-      )
-  }
-
-  @After
-  fun tearDown() {
-    inProcessCmmsComponents.stopDuchyDaemons()
-    inProcessCmmsComponents.stopPopulationRequisitionFulfillerDaemon()
-    inProcessEdpAggregatorComponents.stopDaemons()
-    runBlocking {
-      pubSubClient.deleteTopic(PROJECT_ID, FULFILLER_TOPIC_ID)
-      pubSubClient.deleteSubscription(PROJECT_ID, SUBSCRIPTION_ID)
-    }
-  }
-
-  @Test
-  fun `create a direct RF measurement and check the result is equal to the expected result`() =
-    runBlocking {
-      // Use frontend simulator to create a direct reach and frequency measurement and verify its
-      // result.
-      mcSimulator.testDirectReachAndFrequency(runId = "1234", numMeasurements = 1)
-    }
-
-  @Test
-  fun `create a direct reach only measurement and check the result is equal to the expected result`() =
-    runBlocking {
-      // Use frontend simulator to create a direct reach and frequency measurement and verify its
-      // result.
-      mcSimulator.testDirectReachOnly(runId = "1234", numMeasurements = 1)
-    }
-
-  @Test
-  fun `create incremental direct reach only measurements in same report and check the result is equal to the expected result`() =
-    runBlocking {
-      // Use frontend simulator to create N incremental direct reach and frequency measurements and
-      // verify its result.
-      mcSimulator.testDirectReachOnly(runId = "1234", numMeasurements = 3)
-    }
-
-  @Test
-  fun `create an impression measurement and check the result is equal to the expected result`() =
-    runBlocking {
-      // Use frontend simulator to create an impression measurement and verify its result.
-      mcSimulator.testImpression("1234")
-    }
-
-  @Test
-  fun `create a Hmss reach-only measurement and check the result is equal to the expected result`() =
-    runBlocking {
-      // Use frontend simulator to create a reach and frequency measurement and verify its result.
-      mcSimulator.testReachOnly(
-        "1234",
-        ProtocolConfig.Protocol.ProtocolCase.HONEST_MAJORITY_SHARE_SHUFFLE,
-        eventGroupFilter = {
-          it.eventGroupReferenceId != MULTIPARTY_NO_NOISE_EDP_EVENT_GROUP_REF_ID
-        },
-      )
-    }
-
-  @Test
-  fun `create a Hmss RF measurement and check the result is equal to the expected result`() =
-    runBlocking {
-      // Use frontend simulator to create a reach and frequency measurement and verify its result.
-      mcSimulator.testReachAndFrequency(
-        "1234",
-        ProtocolConfig.Protocol.ProtocolCase.HONEST_MAJORITY_SHARE_SHUFFLE,
-        eventGroupFilter = {
-          it.eventGroupReferenceId != MULTIPARTY_NO_NOISE_EDP_EVENT_GROUP_REF_ID
-        },
-      )
-    }
-
-  @Test
-  fun `create a TrusTee reach-only measurement and check the result is equal to the expected result`() =
-    runBlocking {
-      // Use frontend simulator to create a TrusTee reach-only measurement and verify its result.
-      mcSimulator.testReachOnly(
-        "1234",
-        ProtocolConfig.Protocol.ProtocolCase.TRUS_TEE,
-        eventGroupFilter = {
-          it.eventGroupReferenceId != MULTIPARTY_NO_NOISE_EDP_EVENT_GROUP_REF_ID
-        },
-      )
-    }
-
-  @Test
-  fun `create a TrusTee RF measurement and check the result is equal to the expected result`() =
-    runBlocking {
-      // Use frontend simulator to create a TrusTee reach and frequency measurement and verify its
-      // result.
-      mcSimulator.testReachAndFrequency(
-        "1234",
-        ProtocolConfig.Protocol.ProtocolCase.TRUS_TEE,
-        eventGroupFilter = {
-          it.eventGroupReferenceId != MULTIPARTY_NO_NOISE_EDP_EVENT_GROUP_REF_ID
-        },
-      )
-    }
-
-  @Test
-  fun `HMSS measurement fails when EDP requires no noise`() {
-    assertFailsWith<IllegalStateException>("Expected measurement to fail") {
-      runBlocking {
-        mcSimulator.testReachOnly(
-          "hmss-no-noise-1234",
-          ProtocolConfig.Protocol.ProtocolCase.HONEST_MAJORITY_SHARE_SHUFFLE,
-          eventGroupFilter = { it.eventGroupReferenceId in HMSS_NO_NOISE_EVENT_GROUP_REF_IDS },
+            EDP_NO_ENTITY_KEY_DISPLAY_NAME to
+                mapOf(
+                    EDP_NO_ENTITY_KEY_EVENT_GROUP_REF_ID to
+                        EventGroupConfig(syntheticEventGroupSpec)
+                ),
+            "edp2" to
+                mapOf(
+                    "edpa-eg-reference-id-2" to
+                        EventGroupConfig(
+                            syntheticEventGroupSpec,
+                            blobEntityKeys =
+                                listOf(EntityKey("ad_group", "edpa-eg-reference-id-2")),
+                            entityMetadata = ENTITY_METADATA,
+                        )
+                ),
+            "edp3" to
+                mapOf(
+                    "edpa-eg-reference-id-3" to
+                        EventGroupConfig(
+                            syntheticEventGroupSpec,
+                            blobEntityKeys =
+                                listOf(EntityKey("ad_group", "edpa-eg-reference-id-3")),
+                            entityMetadata = ENTITY_METADATA,
+                        )
+                ),
+            "edp4" to
+                mapOf(
+                    "edpa-eg-reference-id-4" to
+                        EventGroupConfig(
+                            syntheticEventGroupSpec,
+                            blobEntityKeys =
+                                listOf(EntityKey("ad_group", "edpa-eg-reference-id-4")),
+                            entityMetadata = ENTITY_METADATA,
+                        )
+                ),
         )
-      }
-    }
-  }
 
-  @Test
-  fun `TrusTee measurement fails when EDP requires no noise`() {
-    assertFailsWith<IllegalStateException>("Expected measurement to fail") {
-      runBlocking {
-        mcSimulator.testReachOnly(
-          "trustee-no-noise-1234",
-          ProtocolConfig.Protocol.ProtocolCase.TRUS_TEE,
-          eventGroupFilter = { it.eventGroupReferenceId in TRUSTEE_NO_NOISE_EVENT_GROUP_REF_IDS },
+    private val syntheticEventGroupMap: Map<String, SyntheticEventGroupSpec> =
+        eventGroupConfigsByEdp.values.flatMap { it.entries }.associate { it.key to it.value.spec }
+
+    @get:Rule
+    val inProcessEdpAggregatorComponents: InProcessEdpAggregatorComponents =
+        InProcessEdpAggregatorComponents(
+            secureComputationDatabaseAdmin = secureComputationDatabaseAdmin,
+            storagePath = tempPath,
+            pubSubClient = pubSubClient,
+            eventGroupConfigsByEdp = eventGroupConfigsByEdp,
+            syntheticPopulationSpec = syntheticPopulationSpec,
+            modelLineInfoMap = modelLineInfoMap,
+            externalKmsClient = sharedKmsClient,
         )
-      }
+
+    @Before
+    fun setup() {
+        runBlocking {
+            pubSubClient.createTopic(PROJECT_ID, FULFILLER_TOPIC_ID)
+            pubSubClient.createSubscription(PROJECT_ID, SUBSCRIPTION_ID, FULFILLER_TOPIC_ID)
+        }
+        inProcessCmmsComponents.startDaemons()
+        val measurementConsumerData = inProcessCmmsComponents.getMeasurementConsumerData()
+        val edpDisplayNameToResourceMap = inProcessCmmsComponents.edpDisplayNameToResourceMap
+        val kingdomChannel = inProcessCmmsComponents.kingdom.publicApiChannel
+        val duchyMap =
+            inProcessCmmsComponents.duchies
+                .map { it.externalDuchyId to it.publicApiChannel }
+                .toMap()
+        inProcessEdpAggregatorComponents.startDaemons(
+            kingdomChannel,
+            measurementConsumerData,
+            edpDisplayNameToResourceMap,
+            mapOf(
+                "edp1" to
+                    DataProviderKt.capabilities {
+                        honestMajorityShareShuffleSupported = true
+                        trusTeeSupported = false
+                    },
+                "edp2" to
+                    DataProviderKt.capabilities {
+                        honestMajorityShareShuffleSupported = true
+                        trusTeeSupported = true
+                    },
+                "edp3" to
+                    DataProviderKt.capabilities {
+                        honestMajorityShareShuffleSupported = false
+                        trusTeeSupported = true
+                    },
+                "edp4" to
+                    DataProviderKt.capabilities {
+                        honestMajorityShareShuffleSupported = true
+                        trusTeeSupported = true
+                    },
+            ),
+            duchyMap,
+            edpNoise =
+                mapOf(
+                    "edp1" to ResultsFulfillerParams.NoiseParams.NoiseType.CONTINUOUS_GAUSSIAN,
+                    "edp2" to ResultsFulfillerParams.NoiseParams.NoiseType.CONTINUOUS_GAUSSIAN,
+                    "edp3" to ResultsFulfillerParams.NoiseParams.NoiseType.CONTINUOUS_GAUSSIAN,
+                    "edp4" to ResultsFulfillerParams.NoiseParams.NoiseType.CONTINUOUS_GAUSSIAN,
+                ),
+            edpMultiPartyNoiseTypes =
+                mapOf("edp4" to listOf(ResultsFulfillerParams.NoiseParams.NoiseType.NONE)),
+        )
+        initMcSimulator()
     }
-  }
 
-  @Test
-  fun `EDPA-registered EventGroups with entity_key round-trip to the CMMS public API`() =
-    runBlocking {
-      val edpDisplayNameToResourceMap = inProcessCmmsComponents.edpDisplayNameToResourceMap
+    private lateinit var mcSimulator: EdpAggregatorMeasurementConsumerSimulator
+    private lateinit var mcName: String
+    private lateinit var mcApiKey: String
 
-      for ((edpDisplayName, refOverrides) in entityOverridesByEdp) {
-        val edpResourceName = edpDisplayNameToResourceMap.getValue(edpDisplayName).name
+    private val publicMeasurementsClient by lazy {
+        MeasurementsCoroutineStub(inProcessCmmsComponents.kingdom.publicApiChannel)
+    }
+    private val publicMeasurementConsumersClient by lazy {
+        MeasurementConsumersCoroutineStub(inProcessCmmsComponents.kingdom.publicApiChannel)
+    }
+    private val publicCertificatesClient by lazy {
+        CertificatesCoroutineStub(inProcessCmmsComponents.kingdom.publicApiChannel)
+    }
+    private val publicEventGroupsClient by lazy {
+        EventGroupsCoroutineStub(inProcessCmmsComponents.kingdom.publicApiChannel)
+    }
+    private val publicDataProvidersClient by lazy {
+        DataProvidersCoroutineStub(inProcessCmmsComponents.kingdom.publicApiChannel)
+    }
+
+    private fun initMcSimulator() {
+        val measurementConsumerData = inProcessCmmsComponents.getMeasurementConsumerData()
+        mcName = measurementConsumerData.name
+        mcApiKey = measurementConsumerData.apiAuthenticationKey
+        mcSimulator =
+            EdpAggregatorMeasurementConsumerSimulator(
+                MeasurementConsumerData(
+                    measurementConsumerData.name,
+                    InProcessCmmsComponents.MC_ENTITY_CONTENT.signingKey,
+                    InProcessCmmsComponents.MC_ENCRYPTION_PRIVATE_KEY,
+                    measurementConsumerData.apiAuthenticationKey,
+                ),
+                OUTPUT_DP_PARAMS,
+                publicDataProvidersClient,
+                publicEventGroupsClient,
+                publicMeasurementsClient,
+                publicMeasurementConsumersClient,
+                publicCertificatesClient,
+                InProcessCmmsComponents.TRUSTED_CERTIFICATES,
+                TestEvent.getDefaultInstance(),
+                NoiseMechanism.CONTINUOUS_GAUSSIAN,
+                syntheticPopulationSpec,
+                syntheticEventGroupMap,
+                ReportKey(
+                        MeasurementConsumerKey.fromName(measurementConsumerData.name)!!
+                            .measurementConsumerId,
+                        "some-report-id",
+                    )
+                    .toName(),
+                modelLineName = modelLineName,
+                listEventGroupsEntityTypes = listOf("campaign", "ad_group"),
+            )
+    }
+
+    @After
+    fun tearDown() {
+        inProcessCmmsComponents.stopDuchyDaemons()
+        inProcessCmmsComponents.stopPopulationRequisitionFulfillerDaemon()
+        inProcessEdpAggregatorComponents.stopDaemons()
+        runBlocking {
+            pubSubClient.deleteTopic(PROJECT_ID, FULFILLER_TOPIC_ID)
+            pubSubClient.deleteSubscription(PROJECT_ID, SUBSCRIPTION_ID)
+        }
+    }
+
+    @Test
+    fun `create a direct RF measurement and check the result is equal to the expected result`() =
+        runBlocking {
+            // Use frontend simulator to create a direct reach and frequency measurement and verify
+            // its
+            // result.
+            mcSimulator.testDirectReachAndFrequency(runId = "1234", numMeasurements = 1)
+        }
+
+    @Test
+    fun `create a direct reach only measurement and check the result is equal to the expected result`() =
+        runBlocking {
+            // Use frontend simulator to create a direct reach and frequency measurement and verify
+            // its
+            // result.
+            mcSimulator.testDirectReachOnly(runId = "1234", numMeasurements = 1)
+        }
+
+    @Test
+    fun `create incremental direct reach only measurements in same report and check the result is equal to the expected result`() =
+        runBlocking {
+            // Use frontend simulator to create N incremental direct reach and frequency
+            // measurements and
+            // verify its result.
+            mcSimulator.testDirectReachOnly(runId = "1234", numMeasurements = 3)
+        }
+
+    @Test
+    fun `create an impression measurement and check the result is equal to the expected result`() =
+        runBlocking {
+            // Use frontend simulator to create an impression measurement and verify its result.
+            mcSimulator.testImpression("1234")
+        }
+
+    @Test
+    fun `create a Hmss reach-only measurement and check the result is equal to the expected result`() =
+        runBlocking {
+            // Use frontend simulator to create a reach and frequency measurement and verify its
+            // result.
+            mcSimulator.testReachOnly(
+                "1234",
+                ProtocolConfig.Protocol.ProtocolCase.HONEST_MAJORITY_SHARE_SHUFFLE,
+                eventGroupFilter = {
+                    it.eventGroupReferenceId != MULTIPARTY_NO_NOISE_EDP_EVENT_GROUP_REF_ID
+                },
+            )
+        }
+
+    @Test
+    fun `create a Hmss RF measurement and check the result is equal to the expected result`() =
+        runBlocking {
+            // Use frontend simulator to create a reach and frequency measurement and verify its
+            // result.
+            mcSimulator.testReachAndFrequency(
+                "1234",
+                ProtocolConfig.Protocol.ProtocolCase.HONEST_MAJORITY_SHARE_SHUFFLE,
+                eventGroupFilter = {
+                    it.eventGroupReferenceId != MULTIPARTY_NO_NOISE_EDP_EVENT_GROUP_REF_ID
+                },
+            )
+        }
+
+    @Test
+    fun `create a TrusTee reach-only measurement and check the result is equal to the expected result`() =
+        runBlocking {
+            // Use frontend simulator to create a TrusTee reach-only measurement and verify its
+            // result.
+            mcSimulator.testReachOnly(
+                "1234",
+                ProtocolConfig.Protocol.ProtocolCase.TRUS_TEE,
+                eventGroupFilter = {
+                    it.eventGroupReferenceId != MULTIPARTY_NO_NOISE_EDP_EVENT_GROUP_REF_ID
+                },
+            )
+        }
+
+    @Test
+    fun `create a TrusTee RF measurement and check the result is equal to the expected result`() =
+        runBlocking {
+            // Use frontend simulator to create a TrusTee reach and frequency measurement and verify
+            // its
+            // result.
+            mcSimulator.testReachAndFrequency(
+                "1234",
+                ProtocolConfig.Protocol.ProtocolCase.TRUS_TEE,
+                eventGroupFilter = {
+                    it.eventGroupReferenceId != MULTIPARTY_NO_NOISE_EDP_EVENT_GROUP_REF_ID
+                },
+            )
+        }
+
+    @Test
+    fun `HMSS measurement fails when EDP requires no noise`() {
+        assertFailsWith<IllegalStateException>("Expected measurement to fail") {
+            runBlocking {
+                mcSimulator.testReachOnly(
+                    "hmss-no-noise-1234",
+                    ProtocolConfig.Protocol.ProtocolCase.HONEST_MAJORITY_SHARE_SHUFFLE,
+                    eventGroupFilter = {
+                        it.eventGroupReferenceId in HMSS_NO_NOISE_EVENT_GROUP_REF_IDS
+                    },
+                )
+            }
+        }
+    }
+
+    @Test
+    fun `TrusTee measurement fails when EDP requires no noise`() {
+        assertFailsWith<IllegalStateException>("Expected measurement to fail") {
+            runBlocking {
+                mcSimulator.testReachOnly(
+                    "trustee-no-noise-1234",
+                    ProtocolConfig.Protocol.ProtocolCase.TRUS_TEE,
+                    eventGroupFilter = {
+                        it.eventGroupReferenceId in TRUSTEE_NO_NOISE_EVENT_GROUP_REF_IDS
+                    },
+                )
+            }
+        }
+    }
+
+    @Test
+    fun `EDPA-registered EventGroups with entity_key round-trip to the CMMS public API`() =
+        runBlocking {
+            val edpDisplayNameToResourceMap = inProcessCmmsComponents.edpDisplayNameToResourceMap
+
+            for ((edpDisplayName, refConfigs) in eventGroupConfigsByEdp) {
+                val edpResourceName = edpDisplayNameToResourceMap.getValue(edpDisplayName).name
+                val response =
+                    publicEventGroupsClient
+                        .withPrincipalName(edpResourceName)
+                        .listEventGroups(
+                            listEventGroupsRequest {
+                                parent = edpResourceName
+                                pageSize = 1000
+                                filter =
+                                    ListEventGroupsRequestKt.filter {
+                                        entityTypeIn += "campaign"
+                                        entityTypeIn += "ad_group"
+                                    }
+                            }
+                        )
+
+                val byRefId = response.eventGroupsList.associateBy { it.eventGroupReferenceId }
+                assertWithMessage("EventGroups for $edpDisplayName")
+                    .that(byRefId.keys)
+                    .containsAtLeastElementsIn(refConfigs.keys)
+
+                for ((refId, config) in refConfigs) {
+                    if (config.blobEntityKeys.isEmpty()) continue
+                    val eventGroup = byRefId.getValue(refId)
+                    val expectedEntityKey = config.blobEntityKeys.first()
+                    assertWithMessage("entity_key.entity_type for $refId")
+                        .that(eventGroup.entityKey.entityType)
+                        .isEqualTo(expectedEntityKey.entityType)
+                    assertWithMessage("entity_key.entity_id for $refId")
+                        .that(eventGroup.entityKey.entityId)
+                        .isEqualTo(expectedEntityKey.entityId)
+                    assertWithMessage("entity_metadata for $refId")
+                        .that(eventGroup.eventGroupMetadata.entityMetadata)
+                        .isEqualTo(config.entityMetadata)
+                }
+            }
+        }
+
+    @Test
+    fun `EDPA EventGroups without entity_key default to campaign with no entity_id or metadata`() =
+        runBlocking {
+            val edpDisplayNameToResourceMap = inProcessCmmsComponents.edpDisplayNameToResourceMap
+            val edpResourceName =
+                edpDisplayNameToResourceMap.getValue(EDP_NO_ENTITY_KEY_DISPLAY_NAME).name
+
+            val response =
+                publicEventGroupsClient
+                    .withPrincipalName(edpResourceName)
+                    .listEventGroups(
+                        listEventGroupsRequest {
+                            parent = edpResourceName
+                            pageSize = 1000
+                        }
+                    )
+
+            val legacy: EventGroup =
+                response.eventGroupsList.single {
+                    it.eventGroupReferenceId == EDP_NO_ENTITY_KEY_EVENT_GROUP_REF_ID
+                }
+            assertThat(legacy.entityKey.entityType).isEqualTo("campaign")
+            assertThat(legacy.entityKey.entityId).isEmpty()
+            assertThat(legacy.eventGroupMetadata.hasEntityMetadata()).isFalse()
+        }
+
+    @Test
+    fun `default ListEventGroups filter hides non-campaign EventGroups`() = runBlocking {
         val response =
-          publicEventGroupsClient
-            .withPrincipalName(edpResourceName)
-            .listEventGroups(
-              listEventGroupsRequest {
-                parent = edpResourceName
-                pageSize = 1000
-                filter =
-                  ListEventGroupsRequestKt.filter {
-                    entityTypeIn += "campaign"
-                    entityTypeIn += "ad_group"
-                  }
-              }
+            publicEventGroupsClient
+                .withAuthenticationKey(mcApiKey)
+                .listEventGroups(
+                    listEventGroupsRequest {
+                        parent = mcName
+                        pageSize = 1000
+                    }
+                )
+
+        val refIds = response.eventGroupsList.map { it.eventGroupReferenceId }.toSet()
+        assertThat(refIds).contains(EDP_NO_ENTITY_KEY_EVENT_GROUP_REF_ID)
+        for ((_, refConfigs) in eventGroupConfigsByEdp) {
+            for ((refId, config) in refConfigs) {
+                if (config.blobEntityKeys.isNotEmpty()) {
+                    assertThat(refIds).doesNotContain(refId)
+                }
+            }
+        }
+    }
+
+    companion object {
+        // edp1 deliberately has no entity_key/entity_metadata override (legacy path); it also
+        // happens
+        // to be the EDP that requires no measurement noise on the HMSS protocol, used by the
+        // HMSS-failure path test.
+        private const val EDP_NO_ENTITY_KEY_DISPLAY_NAME = "edp1"
+        private const val EDP_NO_ENTITY_KEY_EVENT_GROUP_REF_ID = "edpa-eg-reference-id-1"
+        private const val HMSS_NO_NOISE_EDP_EVENT_GROUP_REF_ID =
+            EDP_NO_ENTITY_KEY_EVENT_GROUP_REF_ID
+        private const val TRUSTEE_NO_NOISE_EDP_EVENT_GROUP_REF_ID = "edpa-eg-reference-id-3"
+        private const val MULTIPARTY_NO_NOISE_EDP_EVENT_GROUP_REF_ID = "edpa-eg-reference-id-4"
+
+        /**
+         * EventGroups whose EDPs cannot satisfy a single-party HMSS measurement's noise contract.
+         */
+        private val HMSS_NO_NOISE_EVENT_GROUP_REF_IDS =
+            setOf(HMSS_NO_NOISE_EDP_EVENT_GROUP_REF_ID, MULTIPARTY_NO_NOISE_EDP_EVENT_GROUP_REF_ID)
+
+        /**
+         * EventGroups whose EDPs cannot satisfy a single-party TrusTee measurement's noise
+         * contract.
+         */
+        private val TRUSTEE_NO_NOISE_EVENT_GROUP_REF_IDS =
+            setOf(
+                TRUSTEE_NO_NOISE_EDP_EVENT_GROUP_REF_ID,
+                MULTIPARTY_NO_NOISE_EDP_EVENT_GROUP_REF_ID,
             )
 
-        val byRefId = response.eventGroupsList.associateBy { it.eventGroupReferenceId }
-        assertWithMessage("EventGroups for $edpDisplayName")
-          .that(byRefId.keys)
-          .containsAtLeastElementsIn(refOverrides.keys)
-
-        for ((refId, override) in refOverrides) {
-          val eventGroup = byRefId.getValue(refId)
-          assertWithMessage("entity_key.entity_type for $refId")
-            .that(eventGroup.entityKey.entityType)
-            .isEqualTo(override.entityKey!!.entityType)
-          assertWithMessage("entity_key.entity_id for $refId")
-            .that(eventGroup.entityKey.entityId)
-            .isEqualTo(override.entityKey!!.entityId)
-          assertWithMessage("entity_metadata for $refId")
-            .that(eventGroup.eventGroupMetadata.entityMetadata)
-            .isEqualTo(override.entityMetadata)
+        private val logger: Logger = Logger.getLogger(this::class.java.name)
+        private val modelLineName =
+            "modelProviders/AAAAAAAAAHs/modelSuites/AAAAAAAAAHs/modelLines/AAAAAAAAAHs"
+        // Epsilon can vary from 0.0001 to 1.0, delta = 1e-15 is a realistic value.
+        // Set epsilon higher without exceeding privacy budget so the noise is smaller in the
+        // integration test. Check sample values in CompositionTest.kt.
+        private val OUTPUT_DP_PARAMS = differentialPrivacyParams {
+            epsilon = 1.0
+            delta = 1e-15
         }
-      }
-    }
 
-  @Test
-  fun `EDPA EventGroups without entity_key default to campaign with no entity_id or metadata`() =
-    runBlocking {
-      val edpDisplayNameToResourceMap = inProcessCmmsComponents.edpDisplayNameToResourceMap
-      val edpResourceName =
-        edpDisplayNameToResourceMap.getValue(EDP_NO_ENTITY_KEY_DISPLAY_NAME).name
+        // This is the relative location from which population and data spec textprotos are read.
+        private val TEST_DATA_PATH =
+            Paths.get(
+                "wfa_measurement_system",
+                "src",
+                "main",
+                "proto",
+                "wfa",
+                "measurement",
+                "loadtest",
+                "dataprovider",
+            )
+        private val TEST_DATA_RUNTIME_PATH = getRuntimePath(TEST_DATA_PATH)!!
 
-      val response =
-        publicEventGroupsClient
-          .withPrincipalName(edpResourceName)
-          .listEventGroups(
-            listEventGroupsRequest {
-              parent = edpResourceName
-              pageSize = 1000
-            }
-          )
+        private val TEST_RESULTS_FULFILLER_DATA_PATH =
+            Paths.get(
+                "wfa_measurement_system",
+                "src",
+                "main",
+                "kotlin",
+                "org",
+                "wfanet",
+                "measurement",
+                "edpaggregator",
+                "resultsfulfiller",
+                "testing",
+            )
+        private val TEST_RESULTS_FULFILLER_DATA_RUNTIME_PATH =
+            getRuntimePath(TEST_RESULTS_FULFILLER_DATA_PATH)!!
 
-      val legacy: EventGroup =
-        response.eventGroupsList.single {
-          it.eventGroupReferenceId == EDP_NO_ENTITY_KEY_EVENT_GROUP_REF_ID
+        val syntheticPopulationSpec: SyntheticPopulationSpec =
+            parseTextProto(
+                TEST_DATA_RUNTIME_PATH.resolve("small_population_spec.textproto").toFile(),
+                SyntheticPopulationSpec.getDefaultInstance(),
+            )
+        val syntheticEventGroupSpec: SyntheticEventGroupSpec =
+            parseTextProto(
+                TEST_DATA_RUNTIME_PATH.resolve("small_data_spec.textproto").toFile(),
+                SyntheticEventGroupSpec.getDefaultInstance(),
+            )
+        val populationSpec =
+            parseTextProto(
+                TEST_RESULTS_FULFILLER_DATA_RUNTIME_PATH.resolve("small_population_spec.textproto")
+                    .toFile(),
+                PopulationSpec.getDefaultInstance(),
+            )
+        val modelLineInfoMap =
+            mapOf(
+                modelLineName to
+                    ModelLineInfo(
+                        populationSpec = populationSpec,
+                        vidIndexMap = InMemoryVidIndexMap.build(populationSpec),
+                        eventDescriptor = TestEvent.getDescriptor(),
+                        localAlias = null,
+                    )
+            )
+
+        @BeforeClass
+        @JvmStatic
+        fun initConfig() {
+            InProcessCmmsComponents.initConfig(
+                trusTeeProtocolConfigConfig = TRUSTEE_PROTOCOL_CONFIG_CONFIG,
+                hmssProtocolConfigConfig = HMSS_PROTOCOL_CONFIG_CONFIG,
+            )
         }
-      assertThat(legacy.entityKey.entityType).isEqualTo("campaign")
-      assertThat(legacy.entityKey.entityId).isEmpty()
-      assertThat(legacy.eventGroupMetadata.hasEntityMetadata()).isFalse()
+
+        @get:ClassRule @JvmStatic val pubSubEmulatorProvider = GooglePubSubEmulatorProvider()
+
+        private val ENTITY_METADATA = struct {
+            fields["placement"] = value { stringValue = "homepage_top" }
+            fields["objective"] = value { stringValue = "awareness" }
+        }
     }
-
-  @Test
-  fun `default ListEventGroups filter hides non-campaign EventGroups`() = runBlocking {
-    val response =
-      publicEventGroupsClient
-        .withAuthenticationKey(mcApiKey)
-        .listEventGroups(
-          listEventGroupsRequest {
-            parent = mcName
-            pageSize = 1000
-          }
-        )
-
-    val refIds = response.eventGroupsList.map { it.eventGroupReferenceId }.toSet()
-    assertThat(refIds).contains(EDP_NO_ENTITY_KEY_EVENT_GROUP_REF_ID)
-    for ((_, refOverrides) in entityOverridesByEdp) {
-      for (refId in refOverrides.keys) {
-        assertThat(refIds).doesNotContain(refId)
-      }
-    }
-  }
-
-  companion object {
-    // edp1 deliberately has no entity_key/entity_metadata override (legacy path); it also happens
-    // to be the EDP that requires no measurement noise on the HMSS protocol, used by the
-    // HMSS-failure path test.
-    private const val EDP_NO_ENTITY_KEY_DISPLAY_NAME = "edp1"
-    private const val EDP_NO_ENTITY_KEY_EVENT_GROUP_REF_ID = "edpa-eg-reference-id-1"
-    private const val HMSS_NO_NOISE_EDP_EVENT_GROUP_REF_ID = EDP_NO_ENTITY_KEY_EVENT_GROUP_REF_ID
-    private const val TRUSTEE_NO_NOISE_EDP_EVENT_GROUP_REF_ID = "edpa-eg-reference-id-3"
-    private const val MULTIPARTY_NO_NOISE_EDP_EVENT_GROUP_REF_ID = "edpa-eg-reference-id-4"
-
-    /** EventGroups whose EDPs cannot satisfy a single-party HMSS measurement's noise contract. */
-    private val HMSS_NO_NOISE_EVENT_GROUP_REF_IDS =
-      setOf(HMSS_NO_NOISE_EDP_EVENT_GROUP_REF_ID, MULTIPARTY_NO_NOISE_EDP_EVENT_GROUP_REF_ID)
-
-    /**
-     * EventGroups whose EDPs cannot satisfy a single-party TrusTee measurement's noise contract.
-     */
-    private val TRUSTEE_NO_NOISE_EVENT_GROUP_REF_IDS =
-      setOf(TRUSTEE_NO_NOISE_EDP_EVENT_GROUP_REF_ID, MULTIPARTY_NO_NOISE_EDP_EVENT_GROUP_REF_ID)
-
-    private val logger: Logger = Logger.getLogger(this::class.java.name)
-    private val modelLineName =
-      "modelProviders/AAAAAAAAAHs/modelSuites/AAAAAAAAAHs/modelLines/AAAAAAAAAHs"
-    // Epsilon can vary from 0.0001 to 1.0, delta = 1e-15 is a realistic value.
-    // Set epsilon higher without exceeding privacy budget so the noise is smaller in the
-    // integration test. Check sample values in CompositionTest.kt.
-    private val OUTPUT_DP_PARAMS = differentialPrivacyParams {
-      epsilon = 1.0
-      delta = 1e-15
-    }
-
-    // This is the relative location from which population and data spec textprotos are read.
-    private val TEST_DATA_PATH =
-      Paths.get(
-        "wfa_measurement_system",
-        "src",
-        "main",
-        "proto",
-        "wfa",
-        "measurement",
-        "loadtest",
-        "dataprovider",
-      )
-    private val TEST_DATA_RUNTIME_PATH = getRuntimePath(TEST_DATA_PATH)!!
-
-    private val TEST_RESULTS_FULFILLER_DATA_PATH =
-      Paths.get(
-        "wfa_measurement_system",
-        "src",
-        "main",
-        "kotlin",
-        "org",
-        "wfanet",
-        "measurement",
-        "edpaggregator",
-        "resultsfulfiller",
-        "testing",
-      )
-    private val TEST_RESULTS_FULFILLER_DATA_RUNTIME_PATH =
-      getRuntimePath(TEST_RESULTS_FULFILLER_DATA_PATH)!!
-
-    val syntheticPopulationSpec: SyntheticPopulationSpec =
-      parseTextProto(
-        TEST_DATA_RUNTIME_PATH.resolve("small_population_spec.textproto").toFile(),
-        SyntheticPopulationSpec.getDefaultInstance(),
-      )
-    val syntheticEventGroupSpec: SyntheticEventGroupSpec =
-      parseTextProto(
-        TEST_DATA_RUNTIME_PATH.resolve("small_data_spec.textproto").toFile(),
-        SyntheticEventGroupSpec.getDefaultInstance(),
-      )
-    val populationSpec =
-      parseTextProto(
-        TEST_RESULTS_FULFILLER_DATA_RUNTIME_PATH.resolve("small_population_spec.textproto")
-          .toFile(),
-        PopulationSpec.getDefaultInstance(),
-      )
-    val modelLineInfoMap =
-      mapOf(
-        modelLineName to
-          ModelLineInfo(
-            populationSpec = populationSpec,
-            vidIndexMap = InMemoryVidIndexMap.build(populationSpec),
-            eventDescriptor = TestEvent.getDescriptor(),
-            localAlias = null,
-          )
-      )
-
-    @BeforeClass
-    @JvmStatic
-    fun initConfig() {
-      InProcessCmmsComponents.initConfig(
-        trusTeeProtocolConfigConfig = TRUSTEE_PROTOCOL_CONFIG_CONFIG,
-        hmssProtocolConfigConfig = HMSS_PROTOCOL_CONFIG_CONFIG,
-      )
-    }
-
-    @get:ClassRule @JvmStatic val pubSubEmulatorProvider = GooglePubSubEmulatorProvider()
-
-    private val ENTITY_METADATA = struct {
-      fields["placement"] = value { stringValue = "homepage_top" }
-      fields["objective"] = value { stringValue = "awareness" }
-    }
-  }
 }

--- a/src/main/kotlin/org/wfanet/measurement/integration/common/reporting/v2/InProcessEdpAggregatorLifeOfAReportTest.kt
+++ b/src/main/kotlin/org/wfanet/measurement/integration/common/reporting/v2/InProcessEdpAggregatorLifeOfAReportTest.kt
@@ -114,6 +114,7 @@ import org.wfanet.measurement.internal.kingdom.hmssProtocolConfigConfig
 import org.wfanet.measurement.internal.kingdom.trusTeeProtocolConfigConfig
 import org.wfanet.measurement.internal.reporting.v2.getBasicReportRequest as internalGetBasicReportRequest
 import org.wfanet.measurement.kingdom.deploy.common.service.DataServices
+import org.wfanet.measurement.loadtest.dataprovider.EntityKey
 import org.wfanet.measurement.loadtest.measurementconsumer.MeasurementConsumerData
 import org.wfanet.measurement.reporting.deploy.v2.common.service.Services
 import org.wfanet.measurement.reporting.job.BasicReportsReportsJob
@@ -201,6 +202,7 @@ abstract class InProcessEdpAggregatorLifeOfAReportTest(
         mapOf(
           "edp1-eg-ref-1" to syntheticEventGroupSpec2,
           "edp1-eg-creative-1" to syntheticEventGroupSpec2,
+          EDP1_MULTI_ENTITY_KEY_EVENT_GROUP_REF_ID to syntheticEventGroupSpec2,
         ),
       "edp2" to
         mapOf(
@@ -241,11 +243,23 @@ abstract class InProcessEdpAggregatorLifeOfAReportTest(
         entityMetadata = ENTITY_METADATA,
       )
 
-    // edp1: edp1-eg-ref-1 has NO override (legacy); edp1-eg-creative-1 has creative-id.
+    // edp1: edp1-eg-ref-1 has NO override (legacy); edp1-eg-creative-1 has creative-id;
+    //       edp1-eg-multi-creative has two creative-id entity keys in the same blob.
     put(
       EDP_NO_ENTITY_KEY_DISPLAY_NAME,
       mapOf(
-        EDP1_CREATIVE_EVENT_GROUP_REF_ID to creativeIdOverride(EDP1_CREATIVE_EVENT_GROUP_REF_ID)
+        EDP1_CREATIVE_EVENT_GROUP_REF_ID to creativeIdOverride(EDP1_CREATIVE_EVENT_GROUP_REF_ID),
+        EDP1_MULTI_ENTITY_KEY_EVENT_GROUP_REF_ID to
+          EventGroupEntityOverride(
+            entityKey =
+              edpaEntityKey {
+                entityType = CREATIVE_ID_ENTITY_TYPE
+                entityId = EDP1_MULTI_CREATIVE_A_ID
+              },
+            entityMetadata = ENTITY_METADATA,
+            additionalBlobEntityKeys =
+              listOf(EntityKey(CREATIVE_ID_ENTITY_TYPE, EDP1_MULTI_CREATIVE_B_ID)),
+          ),
       ),
     )
     // edp2: edp2-eg-ref-1 has campaign; edp2-eg-creative-1 has creative-id.
@@ -1182,7 +1196,10 @@ abstract class InProcessEdpAggregatorLifeOfAReportTest(
   ): List<EventGroup> {
     return buildList {
       val includedDataProviders = mutableSetOf<String>()
-      val eventGroups = listReportingEventGroups()
+      val eventGroups =
+        listReportingEventGroups().filter {
+          it.eventGroupReferenceId != EDP1_MULTI_ENTITY_KEY_EVENT_GROUP_REF_ID
+        }
       eventGroups.forEach { eventGroup ->
         val dataProvider =
           reportingDataProvidersClient
@@ -1253,7 +1270,10 @@ abstract class InProcessEdpAggregatorLifeOfAReportTest(
     }
 
   private suspend fun getCreativeIdOnlyEventGroups(): List<EventGroup> {
-    return listReportingEventGroups().filter { it.entityKey.entityType == CREATIVE_ID_ENTITY_TYPE }
+    return listReportingEventGroups().filter {
+      it.entityKey.entityType == CREATIVE_ID_ENTITY_TYPE &&
+        it.eventGroupReferenceId != EDP1_MULTI_ENTITY_KEY_EVENT_GROUP_REF_ID
+    }
   }
 
   private suspend fun getReferenceIdOnlyEventGroups(): List<EventGroup> {
@@ -1356,6 +1376,39 @@ abstract class InProcessEdpAggregatorLifeOfAReportTest(
     assertThat(completedBasicReport.state).isEqualTo(BasicReport.State.FAILED)
   }
 
+  @Test
+  fun `basic report with multi-entity-key blob filtering to one entity key succeeds`() =
+    runBlocking {
+      val multiEntityKeyEventGroups =
+        listReportingEventGroups().filter {
+          it.eventGroupReferenceId == EDP1_MULTI_ENTITY_KEY_EVENT_GROUP_REF_ID
+        }
+      check(multiEntityKeyEventGroups.isNotEmpty()) { "No multi-entity-key event group found" }
+
+      val createBasicReportRequest =
+        buildCreateBasicReportRequest(
+          multiEntityKeyEventGroups,
+          "multi-entity-key-campaign",
+          "multi-entity-key-basicreport",
+          includeIqfFilter = false,
+        )
+
+      val createdBasicReport =
+        reportingBasicReportsClient
+          .withCallCredentials(credentials)
+          .createBasicReport(createBasicReportRequest)
+
+      executeBasicReportsReportsJob(createdBasicReport.name)
+      executeReportProcessorJob()
+
+      val completedBasicReport =
+        reportingBasicReportsClient
+          .withCallCredentials(credentials)
+          .getBasicReport(getBasicReportRequest { name = createdBasicReport.name })
+
+      assertThat(completedBasicReport.state).isEqualTo(BasicReport.State.SUCCEEDED)
+    }
+
   companion object {
     // edp1 has no entity_key/entity_metadata override (legacy path).
     // edp4 is configured with multi-party noise CONTINUOUS_GAUSSIAN, so it's the "restricted"
@@ -1367,6 +1420,9 @@ abstract class InProcessEdpAggregatorLifeOfAReportTest(
     private const val AD_GROUP_EDP_EVENT_GROUP_REF_ID = "edp4-eg-ref-1"
     private const val RESTRICTED_EDP_DISPLAY_NAME = AD_GROUP_EDP_DISPLAY_NAME
     private const val CREATIVE_ID_ENTITY_TYPE = "creative-id"
+    private const val EDP1_MULTI_ENTITY_KEY_EVENT_GROUP_REF_ID = "edp1-eg-multi-creative"
+    private const val EDP1_MULTI_CREATIVE_A_ID = "multi-creative-A"
+    private const val EDP1_MULTI_CREATIVE_B_ID = "multi-creative-B"
     private const val EDP1_CREATIVE_EVENT_GROUP_REF_ID = "edp1-eg-creative-1"
     private const val EDP2_CREATIVE_EVENT_GROUP_REF_ID = "edp2-eg-creative-1"
     private val logger: Logger = Logger.getLogger(this::class.java.name)

--- a/src/main/kotlin/org/wfanet/measurement/integration/common/reporting/v2/InProcessEdpAggregatorLifeOfAReportTest.kt
+++ b/src/main/kotlin/org/wfanet/measurement/integration/common/reporting/v2/InProcessEdpAggregatorLifeOfAReportTest.kt
@@ -957,9 +957,7 @@ abstract class InProcessEdpAggregatorLifeOfAReportTest(
 
     assertWithMessage("population size").that(result.metricSet.populationSize).isGreaterThan(0)
 
-    assertWithMessage("reach")
-      .that(reportingUnitCumulative.reach)
-      .isEqualTo(expectedReach)
+    assertWithMessage("reach").that(reportingUnitCumulative.reach).isEqualTo(expectedReach)
 
     assertWithMessage("impressions")
       .that(reportingUnitCumulative.impressions)
@@ -975,9 +973,7 @@ abstract class InProcessEdpAggregatorLifeOfAReportTest(
     val component = result.metricSet.componentsList.single()
     val componentCumulative = component.value.cumulative
 
-    assertWithMessage("component reach")
-      .that(componentCumulative.reach)
-      .isEqualTo(expectedReach)
+    assertWithMessage("component reach").that(componentCumulative.reach).isEqualTo(expectedReach)
 
     assertWithMessage("component impressions")
       .that(componentCumulative.impressions)
@@ -1416,9 +1412,7 @@ abstract class InProcessEdpAggregatorLifeOfAReportTest(
   fun `basic report with single-edp creative-id event group succeeds`() = runBlocking {
     val allEventGroups = listReportingEventGroups()
     val singleCreativeIdEventGroup =
-      allEventGroups.filter {
-        it.eventGroupReferenceId == EDP1_CREATIVE_EVENT_GROUP_REF_ID
-      }
+      allEventGroups.filter { it.eventGroupReferenceId == EDP1_CREATIVE_EVENT_GROUP_REF_ID }
     check(singleCreativeIdEventGroup.isNotEmpty()) {
       "No single creative-id event group found for edp1"
     }

--- a/src/main/kotlin/org/wfanet/measurement/integration/common/reporting/v2/InProcessEdpAggregatorLifeOfAReportTest.kt
+++ b/src/main/kotlin/org/wfanet/measurement/integration/common/reporting/v2/InProcessEdpAggregatorLifeOfAReportTest.kt
@@ -197,35 +197,83 @@ abstract class InProcessEdpAggregatorLifeOfAReportTest(
 
   private val syntheticEventGroupMapByEdp =
     mapOf(
-      "edp1" to mapOf("edp1-eg-ref-1" to syntheticEventGroupSpec2),
-      "edp2" to mapOf("edp2-eg-ref-1" to syntheticEventGroupSpec1),
+      "edp1" to
+        mapOf(
+          "edp1-eg-ref-1" to syntheticEventGroupSpec2,
+          "edp1-eg-creative-1" to syntheticEventGroupSpec2,
+        ),
+      "edp2" to
+        mapOf(
+          "edp2-eg-ref-1" to syntheticEventGroupSpec1,
+          "edp2-eg-creative-1" to syntheticEventGroupSpec1,
+        ),
       "edp3" to mapOf("edp3-eg-ref-1" to syntheticEventGroupSpec2),
       "edp4" to mapOf("edp4-eg-ref-1" to syntheticEventGroupSpec1),
     )
 
   // Mix of entity_key shapes so the test exercises every path the workstream cares about:
-  //   - edp1: no override (legacy path; Kingdom defaults entity_type="campaign", entity_id NULL).
-  //   - edp2, edp3: overridden with entity_type="campaign" + entity_id + metadata.
-  //   - edp4: overridden with entity_type="ad_group" (non-default type round-trip).
-  // listReportingEventGroups() filters entity_type_in=["campaign", "ad_group"] so edp4 stays
-  // visible to the HMSS/TrusTee correctness tests despite its non-default entity_type.
-  private val entityOverridesByEdp: Map<String, Map<String, EventGroupEntityOverride>> =
-    syntheticEventGroupMapByEdp
-      .filterKeys { it != EDP_NO_ENTITY_KEY_DISPLAY_NAME }
-      .mapValues { (edpDisplayName, edpRefs) ->
-        edpRefs.keys.associateWith { refId ->
-          val entityType =
-            if (edpDisplayName == AD_GROUP_EDP_DISPLAY_NAME) "ad_group" else "campaign"
+  //   - edp1-eg-ref-1: no override (legacy path; Kingdom defaults entity_type="campaign",
+  //     entity_id NULL).
+  //   - edp1-eg-creative-1: overridden with entity_type="creative-id".
+  //   - edp2-eg-ref-1, edp3-eg-ref-1: overridden with entity_type="campaign" + entity_id.
+  //   - edp2-eg-creative-1: overridden with entity_type="creative-id".
+  //   - edp4-eg-ref-1: overridden with entity_type="ad_group" (non-default type round-trip).
+  // listReportingEventGroups() filters entity_type_in=["campaign", "ad_group", "creative-id"]
+  // so all event groups are visible.
+  private val entityOverridesByEdp: Map<String, Map<String, EventGroupEntityOverride>> = buildMap {
+    fun creativeIdOverride(refId: String) =
+      EventGroupEntityOverride(
+        entityKey =
+          edpaEntityKey {
+            entityType = CREATIVE_ID_ENTITY_TYPE
+            entityId = refId
+          },
+        entityMetadata = ENTITY_METADATA,
+      )
+
+    fun campaignOverride(refId: String) =
+      EventGroupEntityOverride(
+        entityKey =
+          edpaEntityKey {
+            entityType = "campaign"
+            entityId = refId
+          },
+        entityMetadata = ENTITY_METADATA,
+      )
+
+    // edp1: edp1-eg-ref-1 has NO override (legacy); edp1-eg-creative-1 has creative-id.
+    put(
+      EDP_NO_ENTITY_KEY_DISPLAY_NAME,
+      mapOf(
+        EDP1_CREATIVE_EVENT_GROUP_REF_ID to creativeIdOverride(EDP1_CREATIVE_EVENT_GROUP_REF_ID)
+      ),
+    )
+    // edp2: edp2-eg-ref-1 has campaign; edp2-eg-creative-1 has creative-id.
+    put(
+      "edp2",
+      mapOf(
+        "edp2-eg-ref-1" to campaignOverride("edp2-eg-ref-1"),
+        EDP2_CREATIVE_EVENT_GROUP_REF_ID to creativeIdOverride(EDP2_CREATIVE_EVENT_GROUP_REF_ID),
+      ),
+    )
+    // edp3: campaign.
+    put("edp3", mapOf("edp3-eg-ref-1" to campaignOverride("edp3-eg-ref-1")))
+    // edp4: ad_group.
+    put(
+      AD_GROUP_EDP_DISPLAY_NAME,
+      mapOf(
+        AD_GROUP_EDP_EVENT_GROUP_REF_ID to
           EventGroupEntityOverride(
             entityKey =
               edpaEntityKey {
-                this.entityType = entityType
-                this.entityId = refId
+                entityType = "ad_group"
+                entityId = AD_GROUP_EDP_EVENT_GROUP_REF_ID
               },
             entityMetadata = ENTITY_METADATA,
           )
-        }
-      }
+      ),
+    )
+  }
 
   private val inProcessEdpAggregatorComponents: InProcessEdpAggregatorComponents =
     InProcessEdpAggregatorComponents(
@@ -1022,6 +1070,7 @@ abstract class InProcessEdpAggregatorLifeOfAReportTest(
             ListEventGroupsRequestKt.filter {
               entityTypeIn += "campaign"
               entityTypeIn += "ad_group"
+              entityTypeIn += CREATIVE_ID_ENTITY_TYPE
             }
         }
       )
@@ -1203,6 +1252,110 @@ abstract class InProcessEdpAggregatorLifeOfAReportTest(
       it.trusTeeSupported
     }
 
+  private suspend fun getCreativeIdOnlyEventGroups(): List<EventGroup> {
+    return listReportingEventGroups().filter { it.entityKey.entityType == CREATIVE_ID_ENTITY_TYPE }
+  }
+
+  private suspend fun getReferenceIdOnlyEventGroups(): List<EventGroup> {
+    return listReportingEventGroups().filter { it.entityKey.entityId.isEmpty() }
+  }
+
+  private suspend fun getMixedEntityKeyEventGroups(): List<EventGroup> {
+    val allEventGroups = listReportingEventGroups()
+    val edp1RefIdOnly =
+      allEventGroups.first { it.eventGroupReferenceId == EDP_NO_ENTITY_KEY_EVENT_GROUP_REF_ID }
+    val edp1CreativeId =
+      allEventGroups.first { it.eventGroupReferenceId == EDP1_CREATIVE_EVENT_GROUP_REF_ID }
+    return listOf(edp1RefIdOnly, edp1CreativeId)
+  }
+
+  @Test
+  fun `basic report with reference-id-only event groups succeeds`() = runBlocking {
+    val refIdOnlyEventGroups = getReferenceIdOnlyEventGroups()
+    check(refIdOnlyEventGroups.isNotEmpty()) { "No reference-ID-only event groups found" }
+
+    val createBasicReportRequest =
+      buildCreateBasicReportRequest(
+        refIdOnlyEventGroups,
+        "ref-id-only-campaign",
+        "ref-id-only-basicreport",
+        includeIqfFilter = false,
+      )
+
+    val createdBasicReport =
+      reportingBasicReportsClient
+        .withCallCredentials(credentials)
+        .createBasicReport(createBasicReportRequest)
+
+    executeBasicReportsReportsJob(createdBasicReport.name)
+    executeReportProcessorJob()
+
+    val completedBasicReport =
+      reportingBasicReportsClient
+        .withCallCredentials(credentials)
+        .getBasicReport(getBasicReportRequest { name = createdBasicReport.name })
+
+    assertThat(completedBasicReport.state).isEqualTo(BasicReport.State.SUCCEEDED)
+  }
+
+  @Test
+  fun `basic report with creative-id entity-key-only event groups succeeds`() = runBlocking {
+    val creativeIdEventGroups = getCreativeIdOnlyEventGroups()
+    check(creativeIdEventGroups.size >= 2) {
+      "Expected at least 2 creative-id event groups, got ${creativeIdEventGroups.size}"
+    }
+
+    val createBasicReportRequest =
+      buildCreateBasicReportRequest(
+        creativeIdEventGroups,
+        "creative-id-only-campaign",
+        "creative-id-only-basicreport",
+        includeIqfFilter = false,
+      )
+
+    val createdBasicReport =
+      reportingBasicReportsClient
+        .withCallCredentials(credentials)
+        .createBasicReport(createBasicReportRequest)
+
+    executeBasicReportsReportsJob(createdBasicReport.name)
+    executeReportProcessorJob()
+
+    val completedBasicReport =
+      reportingBasicReportsClient
+        .withCallCredentials(credentials)
+        .getBasicReport(getBasicReportRequest { name = createdBasicReport.name })
+
+    assertThat(completedBasicReport.state).isEqualTo(BasicReport.State.SUCCEEDED)
+  }
+
+  @Test
+  fun `basic report with mixed reference-id and entity-key event groups fails`() = runBlocking {
+    val mixedEventGroups = getMixedEntityKeyEventGroups()
+
+    val createBasicReportRequest =
+      buildCreateBasicReportRequest(
+        mixedEventGroups,
+        "mixed-selectors-campaign",
+        "mixed-selectors-basicreport",
+        includeIqfFilter = false,
+      )
+
+    val createdBasicReport =
+      reportingBasicReportsClient
+        .withCallCredentials(credentials)
+        .createBasicReport(createBasicReportRequest)
+
+    executeBasicReportsReportsJob(createdBasicReport.name)
+
+    val completedBasicReport =
+      reportingBasicReportsClient
+        .withCallCredentials(credentials)
+        .getBasicReport(getBasicReportRequest { name = createdBasicReport.name })
+
+    assertThat(completedBasicReport.state).isEqualTo(BasicReport.State.FAILED)
+  }
+
   companion object {
     // edp1 has no entity_key/entity_metadata override (legacy path).
     // edp4 is configured with multi-party noise CONTINUOUS_GAUSSIAN, so it's the "restricted"
@@ -1213,6 +1366,9 @@ abstract class InProcessEdpAggregatorLifeOfAReportTest(
     private const val AD_GROUP_EDP_DISPLAY_NAME = "edp4"
     private const val AD_GROUP_EDP_EVENT_GROUP_REF_ID = "edp4-eg-ref-1"
     private const val RESTRICTED_EDP_DISPLAY_NAME = AD_GROUP_EDP_DISPLAY_NAME
+    private const val CREATIVE_ID_ENTITY_TYPE = "creative-id"
+    private const val EDP1_CREATIVE_EVENT_GROUP_REF_ID = "edp1-eg-creative-1"
+    private const val EDP2_CREATIVE_EVENT_GROUP_REF_ID = "edp2-eg-creative-1"
     private val logger: Logger = Logger.getLogger(this::class.java.name)
     private val SECRETS_DIR: File =
       getRuntimePath(

--- a/src/main/kotlin/org/wfanet/measurement/integration/common/reporting/v2/InProcessEdpAggregatorLifeOfAReportTest.kt
+++ b/src/main/kotlin/org/wfanet/measurement/integration/common/reporting/v2/InProcessEdpAggregatorLifeOfAReportTest.kt
@@ -90,7 +90,6 @@ import org.wfanet.measurement.config.reporting.encryptionKeyPairConfig
 import org.wfanet.measurement.config.reporting.measurementConsumerConfig
 import org.wfanet.measurement.config.reporting.measurementConsumerConfigs
 import org.wfanet.measurement.config.reporting.metricSpecConfig
-import org.wfanet.measurement.edpaggregator.eventgroups.v1alpha.EventGroupKt.entityKey as edpaEntityKey
 import org.wfanet.measurement.edpaggregator.resultsfulfiller.ModelLineInfo
 import org.wfanet.measurement.edpaggregator.v1alpha.ResultsFulfillerParams
 import org.wfanet.measurement.eventdataprovider.requisition.v2alpha.common.InMemoryVidIndexMap
@@ -98,7 +97,7 @@ import org.wfanet.measurement.gcloud.pubsub.testing.GooglePubSubEmulatorClient
 import org.wfanet.measurement.gcloud.pubsub.testing.GooglePubSubEmulatorProvider
 import org.wfanet.measurement.gcloud.spanner.testing.SpannerDatabaseAdmin
 import org.wfanet.measurement.integration.common.AccessServicesFactory
-import org.wfanet.measurement.integration.common.EventGroupEntityOverride
+import org.wfanet.measurement.integration.common.EventGroupConfig
 import org.wfanet.measurement.integration.common.FULFILLER_TOPIC_ID
 import org.wfanet.measurement.integration.common.InProcessCmmsComponents
 import org.wfanet.measurement.integration.common.InProcessDuchy
@@ -196,109 +195,83 @@ abstract class InProcessEdpAggregatorLifeOfAReportTest(
     tempDirectory.root.toPath()
   }
 
-  private val syntheticEventGroupMapByEdp =
+  // Each event group config combines the synthetic data spec with entity key configuration.
+  //   - edp1-eg-ref-1: no entity key (legacy; Kingdom defaults entity_type="campaign").
+  //   - edp1-eg-creative-1: entity_type="creative-id".
+  //   - edp1-eg-multi-creative: two creative-id entity keys in the same blob.
+  //   - edp2-eg-ref-1, edp3-eg-ref-1: entity_type="campaign" + entity_id.
+  //   - edp2-eg-creative-1: entity_type="creative-id".
+  //   - edp4-eg-ref-1: entity_type="ad_group" (non-default type round-trip).
+  // listReportingEventGroups() filters entity_type_in=["campaign", "ad_group", "creative-id"]
+  // so all event groups are visible.
+  private val eventGroupConfigsByEdp: Map<String, Map<String, EventGroupConfig>> =
     mapOf(
-      "edp1" to
+      EDP_NO_ENTITY_KEY_DISPLAY_NAME to
         mapOf(
-          "edp1-eg-ref-1" to syntheticEventGroupSpec2,
-          "edp1-eg-creative-1" to syntheticEventGroupSpec2,
-          EDP1_MULTI_ENTITY_KEY_EVENT_GROUP_REF_ID to syntheticEventGroupSpec2,
+          "edp1-eg-ref-1" to EventGroupConfig(syntheticEventGroupSpec2),
+          EDP1_CREATIVE_EVENT_GROUP_REF_ID to
+            EventGroupConfig(
+              syntheticEventGroupSpec2,
+              blobEntityKeys =
+                listOf(EntityKey(CREATIVE_ID_ENTITY_TYPE, EDP1_CREATIVE_EVENT_GROUP_REF_ID)),
+              entityMetadata = ENTITY_METADATA,
+            ),
+          EDP1_MULTI_ENTITY_KEY_EVENT_GROUP_REF_ID to
+            EventGroupConfig(
+              syntheticEventGroupSpec2,
+              blobEntityKeys =
+                listOf(
+                  EntityKey(CREATIVE_ID_ENTITY_TYPE, EDP1_MULTI_CREATIVE_A_ID),
+                  EntityKey(CREATIVE_ID_ENTITY_TYPE, EDP1_MULTI_CREATIVE_B_ID),
+                ),
+              entityMetadata = ENTITY_METADATA,
+            ),
         ),
       "edp2" to
         mapOf(
-          "edp2-eg-ref-1" to syntheticEventGroupSpec1,
-          "edp2-eg-creative-1" to syntheticEventGroupSpec1,
+          "edp2-eg-ref-1" to
+            EventGroupConfig(
+              syntheticEventGroupSpec1,
+              blobEntityKeys = listOf(EntityKey("campaign", "edp2-eg-ref-1")),
+              entityMetadata = ENTITY_METADATA,
+            ),
+          EDP2_CREATIVE_EVENT_GROUP_REF_ID to
+            EventGroupConfig(
+              syntheticEventGroupSpec1,
+              blobEntityKeys =
+                listOf(EntityKey(CREATIVE_ID_ENTITY_TYPE, EDP2_CREATIVE_EVENT_GROUP_REF_ID)),
+              entityMetadata = ENTITY_METADATA,
+            ),
         ),
-      "edp3" to mapOf("edp3-eg-ref-1" to syntheticEventGroupSpec2),
-      "edp4" to mapOf("edp4-eg-ref-1" to syntheticEventGroupSpec1),
+      "edp3" to
+        mapOf(
+          "edp3-eg-ref-1" to
+            EventGroupConfig(
+              syntheticEventGroupSpec2,
+              blobEntityKeys = listOf(EntityKey("campaign", "edp3-eg-ref-1")),
+              entityMetadata = ENTITY_METADATA,
+            )
+        ),
+      AD_GROUP_EDP_DISPLAY_NAME to
+        mapOf(
+          AD_GROUP_EDP_EVENT_GROUP_REF_ID to
+            EventGroupConfig(
+              syntheticEventGroupSpec1,
+              blobEntityKeys = listOf(EntityKey("ad_group", AD_GROUP_EDP_EVENT_GROUP_REF_ID)),
+              entityMetadata = ENTITY_METADATA,
+            )
+        ),
     )
-
-  // Mix of entity_key shapes so the test exercises every path the workstream cares about:
-  //   - edp1-eg-ref-1: no override (legacy path; Kingdom defaults entity_type="campaign",
-  //     entity_id NULL).
-  //   - edp1-eg-creative-1: overridden with entity_type="creative-id".
-  //   - edp2-eg-ref-1, edp3-eg-ref-1: overridden with entity_type="campaign" + entity_id.
-  //   - edp2-eg-creative-1: overridden with entity_type="creative-id".
-  //   - edp4-eg-ref-1: overridden with entity_type="ad_group" (non-default type round-trip).
-  // listReportingEventGroups() filters entity_type_in=["campaign", "ad_group", "creative-id"]
-  // so all event groups are visible.
-  private val entityOverridesByEdp: Map<String, Map<String, EventGroupEntityOverride>> = buildMap {
-    fun creativeIdOverride(refId: String) =
-      EventGroupEntityOverride(
-        entityKey =
-          edpaEntityKey {
-            entityType = CREATIVE_ID_ENTITY_TYPE
-            entityId = refId
-          },
-        entityMetadata = ENTITY_METADATA,
-      )
-
-    fun campaignOverride(refId: String) =
-      EventGroupEntityOverride(
-        entityKey =
-          edpaEntityKey {
-            entityType = "campaign"
-            entityId = refId
-          },
-        entityMetadata = ENTITY_METADATA,
-      )
-
-    // edp1: edp1-eg-ref-1 has NO override (legacy); edp1-eg-creative-1 has creative-id;
-    //       edp1-eg-multi-creative has two creative-id entity keys in the same blob.
-    put(
-      EDP_NO_ENTITY_KEY_DISPLAY_NAME,
-      mapOf(
-        EDP1_CREATIVE_EVENT_GROUP_REF_ID to creativeIdOverride(EDP1_CREATIVE_EVENT_GROUP_REF_ID),
-        EDP1_MULTI_ENTITY_KEY_EVENT_GROUP_REF_ID to
-          EventGroupEntityOverride(
-            entityKey =
-              edpaEntityKey {
-                entityType = CREATIVE_ID_ENTITY_TYPE
-                entityId = EDP1_MULTI_CREATIVE_A_ID
-              },
-            entityMetadata = ENTITY_METADATA,
-            additionalBlobEntityKeys =
-              listOf(EntityKey(CREATIVE_ID_ENTITY_TYPE, EDP1_MULTI_CREATIVE_B_ID)),
-          ),
-      ),
-    )
-    // edp2: edp2-eg-ref-1 has campaign; edp2-eg-creative-1 has creative-id.
-    put(
-      "edp2",
-      mapOf(
-        "edp2-eg-ref-1" to campaignOverride("edp2-eg-ref-1"),
-        EDP2_CREATIVE_EVENT_GROUP_REF_ID to creativeIdOverride(EDP2_CREATIVE_EVENT_GROUP_REF_ID),
-      ),
-    )
-    // edp3: campaign.
-    put("edp3", mapOf("edp3-eg-ref-1" to campaignOverride("edp3-eg-ref-1")))
-    // edp4: ad_group.
-    put(
-      AD_GROUP_EDP_DISPLAY_NAME,
-      mapOf(
-        AD_GROUP_EDP_EVENT_GROUP_REF_ID to
-          EventGroupEntityOverride(
-            entityKey =
-              edpaEntityKey {
-                entityType = "ad_group"
-                entityId = AD_GROUP_EDP_EVENT_GROUP_REF_ID
-              },
-            entityMetadata = ENTITY_METADATA,
-          )
-      ),
-    )
-  }
 
   private val inProcessEdpAggregatorComponents: InProcessEdpAggregatorComponents =
     InProcessEdpAggregatorComponents(
       secureComputationDatabaseAdmin = secureComputationDatabaseAdmin,
       storagePath = tempPath,
       pubSubClient = pubSubClient,
-      syntheticEventGroupMapByEdp = syntheticEventGroupMapByEdp,
+      eventGroupConfigsByEdp = eventGroupConfigsByEdp,
       syntheticPopulationSpec = syntheticPopulationSpec,
       modelLineInfoMap = modelLineInfoMap,
       externalKmsClient = sharedKmsClient,
-      entityOverridesByEdp = entityOverridesByEdp,
     )
 
   private val daemonsStartup = TestRule { base, _ ->
@@ -723,18 +696,20 @@ abstract class InProcessEdpAggregatorLifeOfAReportTest(
     val byRefId: Map<String, EventGroup> =
       listReportingEventGroups().associateBy { it.eventGroupReferenceId }
 
-    for ((_, refOverrides) in entityOverridesByEdp) {
-      for ((refId, override) in refOverrides) {
+    for ((_, refConfigs) in eventGroupConfigsByEdp) {
+      for ((refId, config) in refConfigs) {
+        if (config.blobEntityKeys.isEmpty()) continue
         val eventGroup = byRefId.getValue(refId)
+        val expectedEntityKey = config.blobEntityKeys.first()
         assertWithMessage("entity_key.entity_type for $refId")
           .that(eventGroup.entityKey.entityType)
-          .isEqualTo(override.entityKey!!.entityType)
+          .isEqualTo(expectedEntityKey.entityType)
         assertWithMessage("entity_key.entity_id for $refId")
           .that(eventGroup.entityKey.entityId)
-          .isEqualTo(override.entityKey!!.entityId)
+          .isEqualTo(expectedEntityKey.entityId)
         assertWithMessage("entity_metadata for $refId")
           .that(eventGroup.eventGroupMetadata.entityMetadata)
-          .isEqualTo(override.entityMetadata)
+          .isEqualTo(config.entityMetadata)
       }
     }
   }

--- a/src/main/kotlin/org/wfanet/measurement/integration/common/reporting/v2/InProcessEdpAggregatorLifeOfAReportTest.kt
+++ b/src/main/kotlin/org/wfanet/measurement/integration/common/reporting/v2/InProcessEdpAggregatorLifeOfAReportTest.kt
@@ -601,7 +601,7 @@ abstract class InProcessEdpAggregatorLifeOfAReportTest(
       completedBasicReport,
       expectedCrossPublisherReach = EXPECTED_CROSS_PUBLISHER_REACH,
       expectedCrossPublisherImpressions = EXPECTED_CROSS_PUBLISHER_IMPRESSIONS,
-      expectedKPlusReach = EXPECTED_K_PLUS_REACH,
+      expectedKPlusReach = EXPECTED_CROSS_PUBLISHER_K_PLUS_REACH,
       expectedEdpSpec1Reach = EXPECTED_EDP_SPEC1_REACH,
       expectedEdpSpec2Reach = EXPECTED_EDP_SPEC2_REACH,
     )
@@ -656,7 +656,7 @@ abstract class InProcessEdpAggregatorLifeOfAReportTest(
       completedBasicReport,
       expectedCrossPublisherReach = EXPECTED_CROSS_PUBLISHER_REACH,
       expectedCrossPublisherImpressions = EXPECTED_CROSS_PUBLISHER_IMPRESSIONS,
-      expectedKPlusReach = EXPECTED_K_PLUS_REACH,
+      expectedKPlusReach = EXPECTED_CROSS_PUBLISHER_K_PLUS_REACH,
       expectedEdpSpec1Reach = EXPECTED_EDP_SPEC1_REACH,
       expectedEdpSpec2Reach = EXPECTED_EDP_SPEC2_REACH,
     )
@@ -935,6 +935,53 @@ abstract class InProcessEdpAggregatorLifeOfAReportTest(
     assertWithMessage("cross-publisher reach < sum of individual EDP reaches")
       .that(reportingUnitCumulative.reach)
       .isLessThan(componentReaches.sum())
+  }
+
+  private fun assertSingleEdpNoNoiseResults(
+    basicReport: BasicReport,
+    expectedReach: Long,
+    expectedImpressions: Long,
+    expectedKPlusReach: List<Long>,
+  ) {
+    assertWithMessage("result groups").that(basicReport.resultGroupsList).hasSize(1)
+
+    val resultGroup = basicReport.resultGroupsList.single()
+    val totalResults =
+      resultGroup.resultsList.filter {
+        it.metadata.metricFrequency.selectorCase == MetricFrequencySpec.SelectorCase.TOTAL
+      }
+    assertWithMessage("total results").that(totalResults).hasSize(1)
+
+    val result = totalResults.single()
+    val reportingUnitCumulative = result.metricSet.reportingUnit.cumulative
+
+    assertWithMessage("population size").that(result.metricSet.populationSize).isGreaterThan(0)
+
+    assertWithMessage("reach")
+      .that(reportingUnitCumulative.reach)
+      .isEqualTo(expectedReach)
+
+    assertWithMessage("impressions")
+      .that(reportingUnitCumulative.impressions)
+      .isEqualTo(expectedImpressions)
+
+    assertWithMessage("k+ reach")
+      .that(reportingUnitCumulative.kPlusReachList)
+      .containsExactlyElementsIn(expectedKPlusReach)
+      .inOrder()
+
+    assertWithMessage("number of components").that(result.metricSet.componentsCount).isEqualTo(1)
+
+    val component = result.metricSet.componentsList.single()
+    val componentCumulative = component.value.cumulative
+
+    assertWithMessage("component reach")
+      .that(componentCumulative.reach)
+      .isEqualTo(expectedReach)
+
+    assertWithMessage("component impressions")
+      .that(componentCumulative.impressions)
+      .isEqualTo(expectedImpressions)
   }
 
   private fun assertRunningBasicReport(
@@ -1316,10 +1363,17 @@ abstract class InProcessEdpAggregatorLifeOfAReportTest(
         .getBasicReport(getBasicReportRequest { name = createdBasicReport.name })
 
     assertThat(completedBasicReport.state).isEqualTo(BasicReport.State.SUCCEEDED)
+    assertStructuralResults(completedBasicReport)
+    assertSingleEdpNoNoiseResults(
+      completedBasicReport,
+      expectedReach = EXPECTED_SINGLE_EDP_SPEC2_REACH,
+      expectedImpressions = EXPECTED_SINGLE_EDP_SPEC2_IMPRESSIONS,
+      expectedKPlusReach = EXPECTED_SINGLE_EDP_SPEC2_K_PLUS_REACH,
+    )
   }
 
   @Test
-  fun `basic report with creative-id entity-key-only event groups succeeds`() = runBlocking {
+  fun `basic report with cross-publisher creative-id event groups succeeds`() = runBlocking {
     val creativeIdEventGroups = getCreativeIdOnlyEventGroups()
     check(creativeIdEventGroups.size >= 2) {
       "Expected at least 2 creative-id event groups, got ${creativeIdEventGroups.size}"
@@ -1328,8 +1382,8 @@ abstract class InProcessEdpAggregatorLifeOfAReportTest(
     val createBasicReportRequest =
       buildCreateBasicReportRequest(
         creativeIdEventGroups,
-        "creative-id-only-campaign",
-        "creative-id-only-basicreport",
+        "creative-id-cross-pub-campaign",
+        "creative-id-cross-pub-basicreport",
         includeIqfFilter = false,
       )
 
@@ -1347,6 +1401,57 @@ abstract class InProcessEdpAggregatorLifeOfAReportTest(
         .getBasicReport(getBasicReportRequest { name = createdBasicReport.name })
 
     assertThat(completedBasicReport.state).isEqualTo(BasicReport.State.SUCCEEDED)
+    assertStructuralResults(completedBasicReport)
+    assertNoNoiseResults(
+      completedBasicReport,
+      expectedCrossPublisherReach = EXPECTED_CROSS_PUBLISHER_REACH,
+      expectedCrossPublisherImpressions = EXPECTED_CROSS_PUBLISHER_IMPRESSIONS,
+      expectedKPlusReach = EXPECTED_CROSS_PUBLISHER_K_PLUS_REACH,
+      expectedEdpSpec1Reach = EXPECTED_EDP_SPEC1_REACH,
+      expectedEdpSpec2Reach = EXPECTED_EDP_SPEC2_REACH,
+    )
+  }
+
+  @Test
+  fun `basic report with single-edp creative-id event group succeeds`() = runBlocking {
+    val allEventGroups = listReportingEventGroups()
+    val singleCreativeIdEventGroup =
+      allEventGroups.filter {
+        it.eventGroupReferenceId == EDP1_CREATIVE_EVENT_GROUP_REF_ID
+      }
+    check(singleCreativeIdEventGroup.isNotEmpty()) {
+      "No single creative-id event group found for edp1"
+    }
+
+    val createBasicReportRequest =
+      buildCreateBasicReportRequest(
+        singleCreativeIdEventGroup,
+        "creative-id-single-edp-campaign",
+        "creative-id-single-edp-basicreport",
+        includeIqfFilter = false,
+      )
+
+    val createdBasicReport =
+      reportingBasicReportsClient
+        .withCallCredentials(credentials)
+        .createBasicReport(createBasicReportRequest)
+
+    executeBasicReportsReportsJob(createdBasicReport.name)
+    executeReportProcessorJob()
+
+    val completedBasicReport =
+      reportingBasicReportsClient
+        .withCallCredentials(credentials)
+        .getBasicReport(getBasicReportRequest { name = createdBasicReport.name })
+
+    assertThat(completedBasicReport.state).isEqualTo(BasicReport.State.SUCCEEDED)
+    assertStructuralResults(completedBasicReport)
+    assertSingleEdpNoNoiseResults(
+      completedBasicReport,
+      expectedReach = EXPECTED_SINGLE_EDP_SPEC2_REACH,
+      expectedImpressions = EXPECTED_SINGLE_EDP_SPEC2_IMPRESSIONS,
+      expectedKPlusReach = EXPECTED_SINGLE_EDP_SPEC2_K_PLUS_REACH,
+    )
   }
 
   @Test
@@ -1407,6 +1512,13 @@ abstract class InProcessEdpAggregatorLifeOfAReportTest(
           .getBasicReport(getBasicReportRequest { name = createdBasicReport.name })
 
       assertThat(completedBasicReport.state).isEqualTo(BasicReport.State.SUCCEEDED)
+      assertStructuralResults(completedBasicReport)
+      assertSingleEdpNoNoiseResults(
+        completedBasicReport,
+        expectedReach = EXPECTED_MULTI_ENTITY_KEY_REACH,
+        expectedImpressions = EXPECTED_MULTI_ENTITY_KEY_IMPRESSIONS,
+        expectedKPlusReach = EXPECTED_MULTI_ENTITY_KEY_K_PLUS_REACH,
+      )
     }
 
   companion object {
@@ -1538,9 +1650,17 @@ abstract class InProcessEdpAggregatorLifeOfAReportTest(
     // results when using the same input data and no noise.
     private const val EXPECTED_CROSS_PUBLISHER_REACH = 5330L
     private const val EXPECTED_CROSS_PUBLISHER_IMPRESSIONS = 8860L
-    private val EXPECTED_K_PLUS_REACH = listOf(5330L, 2572L, 647L, 311L, 0L)
+    private val EXPECTED_CROSS_PUBLISHER_K_PLUS_REACH = listOf(5330L, 2572L, 647L, 311L, 0L)
     private const val EXPECTED_EDP_SPEC1_REACH = 3937L
     private const val EXPECTED_EDP_SPEC2_REACH = 3638L
+
+    private const val EXPECTED_SINGLE_EDP_SPEC2_REACH = 3638L
+    private const val EXPECTED_SINGLE_EDP_SPEC2_IMPRESSIONS = 4276L
+    private val EXPECTED_SINGLE_EDP_SPEC2_K_PLUS_REACH = listOf(3638L, 638L, 0L, 0L, 0L)
+
+    private const val EXPECTED_MULTI_ENTITY_KEY_REACH = 1811L
+    private const val EXPECTED_MULTI_ENTITY_KEY_IMPRESSIONS = 2137L
+    private val EXPECTED_MULTI_ENTITY_KEY_K_PLUS_REACH = listOf(1811L, 326L, 0L, 0L, 0L)
 
     // Placeholder values required by the MeasurementSpec. Unused since NoiseMechanism is NONE.
     private val NO_NOISE_PRIVACY_PARAMS =

--- a/src/test/kotlin/org/wfanet/measurement/edpaggregator/requisitionfetcher/RequisitionsValidatorTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/edpaggregator/requisitionfetcher/RequisitionsValidatorTest.kt
@@ -79,6 +79,8 @@ import org.wfanet.measurement.consent.client.measurementconsumer.signMeasurement
 import org.wfanet.measurement.consent.client.measurementconsumer.signRequisitionSpec
 import org.wfanet.measurement.edpaggregator.requisitionfetcher.testing.TestRequisitionData
 import org.wfanet.measurement.edpaggregator.v1alpha.GroupedRequisitionsKt
+import org.wfanet.measurement.edpaggregator.v1alpha.GroupedRequisitionsKt.EventGroupDetailsKt.entityKey
+import org.wfanet.measurement.edpaggregator.v1alpha.GroupedRequisitionsKt.eventGroupDetails
 import org.wfanet.measurement.edpaggregator.v1alpha.groupedRequisitions
 
 @RunWith(JUnit4::class)
@@ -154,6 +156,121 @@ class RequisitionsValidatorTest {
       )
     assertFailsWith<InvalidRequisitionException> {
       requisitionValidator.validateModelLines(groupedRequisitionsList, "some-report-id")
+    }
+  }
+
+  @Test
+  fun `validateEventGroupSelectors passes when all event groups have meaningful entity keys`() {
+    val eventGroupMap =
+      mapOf(
+        "eg1" to
+          eventGroupDetails {
+            eventGroupReferenceId = "ref-1"
+            entityKey = entityKey {
+              entityType = "creative-id"
+              entityId = "creative-123"
+            }
+          },
+        "eg2" to
+          eventGroupDetails {
+            eventGroupReferenceId = "ref-2"
+            entityKey = entityKey {
+              entityType = "creative-id"
+              entityId = "creative-456"
+            }
+          },
+      )
+    requisitionValidator.validateEventGroupSelectors(eventGroupMap)
+  }
+
+  @Test
+  fun `validateEventGroupSelectors passes when no event groups have meaningful entity keys`() {
+    val eventGroupMap =
+      mapOf(
+        "eg1" to eventGroupDetails { eventGroupReferenceId = "ref-1" },
+        "eg2" to eventGroupDetails { eventGroupReferenceId = "ref-2" },
+      )
+    requisitionValidator.validateEventGroupSelectors(eventGroupMap)
+  }
+
+  @Test
+  fun `validateEventGroupSelectors passes when all have default entity key with empty entity id`() {
+    val eventGroupMap =
+      mapOf(
+        "eg1" to
+          eventGroupDetails {
+            eventGroupReferenceId = "ref-1"
+            entityKey = entityKey {
+              entityType = "campaign"
+              entityId = ""
+            }
+          },
+        "eg2" to
+          eventGroupDetails {
+            eventGroupReferenceId = "ref-2"
+            entityKey = entityKey {
+              entityType = "campaign"
+              entityId = ""
+            }
+          },
+      )
+    requisitionValidator.validateEventGroupSelectors(eventGroupMap)
+  }
+
+  @Test
+  fun `validateEventGroupSelectors throws when mixing meaningful entity keys with empty entity id`() {
+    val eventGroupMap =
+      mapOf(
+        "eg1" to
+          eventGroupDetails {
+            eventGroupReferenceId = "ref-1"
+            entityKey = entityKey {
+              entityType = "campaign"
+              entityId = ""
+            }
+          },
+        "eg2" to
+          eventGroupDetails {
+            eventGroupReferenceId = "ref-2"
+            entityKey = entityKey {
+              entityType = "creative-id"
+              entityId = "creative-123"
+            }
+          },
+      )
+    assertFailsWith<InconsistentEventGroupSelectorsException> {
+      requisitionValidator.validateEventGroupSelectors(eventGroupMap)
+    }
+  }
+
+  @Test
+  fun `validateEventGroupSelectors throws when mixing entity key present with entity key absent`() {
+    val eventGroupMap =
+      mapOf(
+        "eg1" to eventGroupDetails { eventGroupReferenceId = "ref-1" },
+        "eg2" to
+          eventGroupDetails {
+            eventGroupReferenceId = "ref-2"
+            entityKey = entityKey {
+              entityType = "creative-id"
+              entityId = "creative-456"
+            }
+          },
+      )
+    assertFailsWith<InconsistentEventGroupSelectorsException> {
+      requisitionValidator.validateEventGroupSelectors(eventGroupMap)
+    }
+  }
+
+  @Test
+  fun `validateEventGroupSelectors throws when event group missing reference id and no entity key`() {
+    val eventGroupMap =
+      mapOf(
+        "eg1" to eventGroupDetails { eventGroupReferenceId = "ref-1" },
+        "eg2" to eventGroupDetails { eventGroupReferenceId = "" },
+      )
+    assertFailsWith<InconsistentEventGroupSelectorsException> {
+      requisitionValidator.validateEventGroupSelectors(eventGroupMap)
     }
   }
 


### PR DESCRIPTION
Fixes #3782

## Summary
- Fix `RequisitionsValidator.validateEventGroupSelectors()` to check `entityId.isNotEmpty()` in addition to `hasEntityKey()`, aligning with the downstream `buildEventGroupEntityKeyMap()` filter logic in `ResultsFulfiller`
- The Kingdom defaults `entity_type="campaign"` on all event groups, so `hasEntityKey()` alone cannot distinguish legacy reference-id-only event groups from those with explicit entity keys. This caused mixed selectors to bypass validation and crash with an unhandled `IllegalArgumentException` in `FilterSpecIndex.create()`, killing the work item without properly refusing the requisition
- Add integration tests for three entity key scenarios: ref-id-only succeeds, creative-id-only succeeds, mixed ref-id and entity-key from the same EDP fails with `BasicReport.State.FAILED`
- Add unit tests for `validateEventGroupSelectors` covering all meaningful entity key combinations

## Test plan
- [x] Unit tests for `RequisitionsValidator.validateEventGroupSelectors()` covering:
  - All event groups with meaningful entity keys (passes)
  - No event groups with meaningful entity keys (passes)
  - All with Kingdom-default entity key (empty entity_id) (passes)
  - Mix of meaningful entity key and empty entity_id (throws `InconsistentEventGroupSelectorsException`)
  - Mix of entity key present/absent (throws)
  - Missing reference ID without entity key (throws)
- [x] Integration tests (`GCloudEdpAggregatorLifeOfAReportTest`):
  - `basic report with reference-id-only event groups succeeds`
  - `basic report with creative-id entity-key-only event groups succeeds`
  - `basic report with mixed reference-id and entity-key event groups fails`
- [x] All 10 existing integration tests continue to pass
- Tested locally with:
  ```
  bazel test //src/test/kotlin/org/wfanet/measurement/edpaggregator/requisitionfetcher:RequisitionsValidatorTest
  bazel test //src/test/kotlin/org/wfanet/measurement/integration/common/reporting/v2:GCloudEdpAggregatorLifeOfAReportTest
  ```
  
Issue: #3782