### PR TITLE
test: add entity key consistency tests to cloud EdpAggregatorCorrectness

### DIFF
--- a/src/main/kotlin/org/wfanet/measurement/integration/common/InProcessEdpAggregatorLifeOfAMeasurementIntegrationTest.kt
+++ b/src/main/kotlin/org/wfanet/measurement/integration/common/InProcessEdpAggregatorLifeOfAMeasurementIntegrationTest.kt
@@ -130,7 +130,17 @@ abstract class InProcessEdpAggregatorLifeOfAMeasurementIntegrationTest(
               syntheticEventGroupSpec,
               blobEntityKeys = listOf(EntityKey("ad_group", "edpa-eg-reference-id-2")),
               entityMetadata = ENTITY_METADATA,
-            )
+            ),
+          MULTI_ENTITY_KEY_EVENT_GROUP_REF_ID to
+            EventGroupConfig(
+              syntheticEventGroupSpec,
+              blobEntityKeys =
+                listOf(
+                  EntityKey(CREATIVE_ID_ENTITY_TYPE, MULTI_CREATIVE_A_ID),
+                  EntityKey(CREATIVE_ID_ENTITY_TYPE, MULTI_CREATIVE_B_ID),
+                ),
+              entityMetadata = ENTITY_METADATA,
+            ),
         ),
       "edp3" to
         mapOf(
@@ -154,6 +164,12 @@ abstract class InProcessEdpAggregatorLifeOfAMeasurementIntegrationTest(
 
   private val syntheticEventGroupMap: Map<String, SyntheticEventGroupSpec> =
     eventGroupConfigsByEdp.values.flatMap { it.entries }.associate { it.key to it.value.spec }
+
+  private val entityKeyCountByRefId: Map<String, Int> =
+    eventGroupConfigsByEdp.values
+      .flatMap { it.entries }
+      .filter { it.value.blobEntityKeys.size > 1 }
+      .associate { it.key to it.value.blobEntityKeys.size }
 
   @get:Rule
   val inProcessEdpAggregatorComponents: InProcessEdpAggregatorComponents =
@@ -268,7 +284,8 @@ abstract class InProcessEdpAggregatorLifeOfAMeasurementIntegrationTest(
           )
           .toName(),
         modelLineName = modelLineName,
-        listEventGroupsEntityTypes = listOf("campaign", "ad_group"),
+        listEventGroupsEntityTypes = listOf("campaign", "ad_group", "creative-id"),
+        entityKeyCountByRefId = entityKeyCountByRefId,
       )
   }
 
@@ -314,7 +331,10 @@ abstract class InProcessEdpAggregatorLifeOfAMeasurementIntegrationTest(
   fun `create an impression measurement and check the result is equal to the expected result`() =
     runBlocking {
       // Use frontend simulator to create an impression measurement and verify its result.
-      mcSimulator.testImpression("1234")
+      mcSimulator.testImpression(
+        "1234",
+        eventGroupFilter = { it.eventGroupReferenceId != MULTI_ENTITY_KEY_EVENT_GROUP_REF_ID },
+      )
     }
 
   @Test
@@ -326,7 +346,8 @@ abstract class InProcessEdpAggregatorLifeOfAMeasurementIntegrationTest(
         "1234",
         ProtocolConfig.Protocol.ProtocolCase.HONEST_MAJORITY_SHARE_SHUFFLE,
         eventGroupFilter = {
-          it.eventGroupReferenceId != MULTIPARTY_NO_NOISE_EDP_EVENT_GROUP_REF_ID
+          it.eventGroupReferenceId != MULTIPARTY_NO_NOISE_EDP_EVENT_GROUP_REF_ID &&
+            it.eventGroupReferenceId != MULTI_ENTITY_KEY_EVENT_GROUP_REF_ID
         },
       )
     }
@@ -340,7 +361,8 @@ abstract class InProcessEdpAggregatorLifeOfAMeasurementIntegrationTest(
         "1234",
         ProtocolConfig.Protocol.ProtocolCase.HONEST_MAJORITY_SHARE_SHUFFLE,
         eventGroupFilter = {
-          it.eventGroupReferenceId != MULTIPARTY_NO_NOISE_EDP_EVENT_GROUP_REF_ID
+          it.eventGroupReferenceId != MULTIPARTY_NO_NOISE_EDP_EVENT_GROUP_REF_ID &&
+            it.eventGroupReferenceId != MULTI_ENTITY_KEY_EVENT_GROUP_REF_ID
         },
       )
     }
@@ -354,7 +376,8 @@ abstract class InProcessEdpAggregatorLifeOfAMeasurementIntegrationTest(
         "1234",
         ProtocolConfig.Protocol.ProtocolCase.TRUS_TEE,
         eventGroupFilter = {
-          it.eventGroupReferenceId != MULTIPARTY_NO_NOISE_EDP_EVENT_GROUP_REF_ID
+          it.eventGroupReferenceId != MULTIPARTY_NO_NOISE_EDP_EVENT_GROUP_REF_ID &&
+            it.eventGroupReferenceId != MULTI_ENTITY_KEY_EVENT_GROUP_REF_ID
         },
       )
     }
@@ -369,7 +392,8 @@ abstract class InProcessEdpAggregatorLifeOfAMeasurementIntegrationTest(
         "1234",
         ProtocolConfig.Protocol.ProtocolCase.TRUS_TEE,
         eventGroupFilter = {
-          it.eventGroupReferenceId != MULTIPARTY_NO_NOISE_EDP_EVENT_GROUP_REF_ID
+          it.eventGroupReferenceId != MULTIPARTY_NO_NOISE_EDP_EVENT_GROUP_REF_ID &&
+            it.eventGroupReferenceId != MULTI_ENTITY_KEY_EVENT_GROUP_REF_ID
         },
       )
     }
@@ -418,6 +442,7 @@ abstract class InProcessEdpAggregatorLifeOfAMeasurementIntegrationTest(
                   ListEventGroupsRequestKt.filter {
                     entityTypeIn += "campaign"
                     entityTypeIn += "ad_group"
+                    entityTypeIn += "creative-id"
                   }
               }
             )
@@ -471,6 +496,15 @@ abstract class InProcessEdpAggregatorLifeOfAMeasurementIntegrationTest(
     }
 
   @Test
+  fun `direct measurement with multi-entity-key filtering returns correct subset`() = runBlocking {
+    mcSimulator.testDirectReachAndFrequency(
+      runId = "1235",
+      numMeasurements = 1,
+      eventGroupFilter = { it.eventGroupReferenceId == MULTI_ENTITY_KEY_EVENT_GROUP_REF_ID },
+    )
+  }
+
+  @Test
   fun `default ListEventGroups filter hides non-campaign EventGroups`() = runBlocking {
     val response =
       publicEventGroupsClient
@@ -503,6 +537,11 @@ abstract class InProcessEdpAggregatorLifeOfAMeasurementIntegrationTest(
     private const val HMSS_NO_NOISE_EDP_EVENT_GROUP_REF_ID = EDP_NO_ENTITY_KEY_EVENT_GROUP_REF_ID
     private const val TRUSTEE_NO_NOISE_EDP_EVENT_GROUP_REF_ID = "edpa-eg-reference-id-3"
     private const val MULTIPARTY_NO_NOISE_EDP_EVENT_GROUP_REF_ID = "edpa-eg-reference-id-4"
+
+    private const val MULTI_ENTITY_KEY_EVENT_GROUP_REF_ID = "edpa-eg-multi-creative"
+    private const val MULTI_CREATIVE_A_ID = "creative-a"
+    private const val MULTI_CREATIVE_B_ID = "creative-b"
+    private const val CREATIVE_ID_ENTITY_TYPE = "creative-id"
 
     /** EventGroups whose EDPs cannot satisfy a single-party HMSS measurement's noise contract. */
     private val HMSS_NO_NOISE_EVENT_GROUP_REF_IDS =

--- a/src/main/kotlin/org/wfanet/measurement/loadtest/measurementconsumer/EdpAggregatorMeasurementConsumerSimulator.kt
+++ b/src/main/kotlin/org/wfanet/measurement/loadtest/measurementconsumer/EdpAggregatorMeasurementConsumerSimulator.kt
@@ -69,6 +69,7 @@ class EdpAggregatorMeasurementConsumerSimulator(
   maximumResultPollingDelay: Duration = Duration.ofMinutes(1),
   listEventGroupsEntityTypes: List<String>,
   onMeasurementsCreated: (() -> Unit)? = null,
+  private val entityKeyCountByRefId: Map<String, Int> = emptyMap(),
 ) :
   MeasurementConsumerSimulator(
     measurementConsumerData,
@@ -100,7 +101,14 @@ class EdpAggregatorMeasurementConsumerSimulator(
     measurementInfo: MeasurementInfo,
     targetDataProviderId: String? = null,
   ): Sequence<Long> {
-    val eventGroupSpecs: Sequence<Triple<SyntheticEventGroupSpec, String, Interval>> =
+    data class EventGroupSpecInfo(
+      val spec: SyntheticEventGroupSpec,
+      val expression: String,
+      val collectionInterval: Interval,
+      val refId: String,
+    )
+
+    val eventGroupSpecs: Sequence<EventGroupSpecInfo> =
       measurementInfo.requisitions.asSequence().flatMap { requisitionInfo ->
         requisitionInfo.eventGroups
           .zip(requisitionInfo.requisitionSpec.events.eventGroupsList)
@@ -110,23 +118,33 @@ class EdpAggregatorMeasurementConsumerSimulator(
                 requireNotNull(EventGroupKey.fromName(eventGroup.name)).dataProviderId
           }
           .map { (eventGroup, eventGroupEntry) ->
-            Triple(
+            EventGroupSpecInfo(
               syntheticEventGroupMap.getValue(eventGroup.eventGroupReferenceId),
               eventGroupEntry.value.filter.expression,
               eventGroupEntry.value.collectionInterval,
+              eventGroup.eventGroupReferenceId,
             )
           }
       }
     return eventGroupSpecs
-      .flatMap { (syntheticEventGroupSpec, expression, collectionInterval) ->
+      .flatMap { (syntheticEventGroupSpec, expression, collectionInterval, refId) ->
         val program: Program =
           EventFilters.compileProgram(messageInstance.descriptorForType, expression)
+        val totalEntityKeys = entityKeyCountByRefId.getOrDefault(refId, 1)
         SyntheticDataGeneration.generateEvents(
             messageInstance,
             syntheticPopulationSpec,
             syntheticEventGroupSpec,
           )
-          .flatMap { it.labeledEvents }
+          .flatMap { shard ->
+            val allEvents = shard.labeledEvents.toList()
+            if (totalEntityKeys > 1) {
+              val chunkSize = allEvents.size / totalEntityKeys
+              allEvents.subList(0, chunkSize).asSequence()
+            } else {
+              allEvents.asSequence()
+            }
+          }
           .filter { impression -> EventFilters.matches(impression.message, program) }
           .filter { impression ->
             targetDataProviderId != null ||

--- a/src/test/kotlin/org/wfanet/measurement/integration/k8s/AbstractEdpAggregatorCorrectnessTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/integration/k8s/AbstractEdpAggregatorCorrectnessTest.kt
@@ -200,6 +200,16 @@ abstract class AbstractEdpAggregatorCorrectnessTest(
     )
   }
 
+  @Test
+  fun `direct measurement with multi-entity-key blob filtering to one entity key succeeds`() =
+    runBlocking {
+      mcSimulator.testDirectReachAndFrequency(
+        "1242",
+        1,
+        eventGroupFilter = { it.eventGroupReferenceId == MULTI_CREATIVE_EVENT_GROUP_REF_ID },
+      )
+    }
+
   interface MeasurementSystem {
     val runId: String
     val mcSimulator: MeasurementConsumerSimulator
@@ -215,6 +225,7 @@ abstract class AbstractEdpAggregatorCorrectnessTest(
 
     const val EDP_NO_ENTITY_KEY_EVENT_GROUP_REF_ID = "edpa-eg-reference-id-1"
     const val CREATIVE_ID_EVENT_GROUP_REF_ID = "edpa-eg-creative-id-1"
+    const val MULTI_CREATIVE_EVENT_GROUP_REF_ID = "edpa-eg-multi-creative-1"
     const val EDPA_META_EVENT_GROUP_REF_ID = "edpa-eg-reference-id-2"
 
     val OUTPUT_DP_PARAMS = differentialPrivacyParams {

--- a/src/test/kotlin/org/wfanet/measurement/integration/k8s/AbstractEdpAggregatorCorrectnessTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/integration/k8s/AbstractEdpAggregatorCorrectnessTest.kt
@@ -125,20 +125,19 @@ abstract class AbstractEdpAggregatorCorrectnessTest(
             listEventGroupsRequest {
               parent = measurementSystem.measurementConsumerName
               pageSize = 100
-              // Default entity_type_in is ["campaign"], which would hide the ad_group EventGroup.
               filter =
                 ListEventGroupsRequestKt.filter {
                   entityTypeIn += "campaign"
-                  entityTypeIn += "ad_group"
+                  entityTypeIn += "creative-id"
                 }
             }
           )
 
       val byRefId = response.eventGroupsList.associateBy { it.eventGroupReferenceId }
-      val adGroup: EventGroup = byRefId.getValue(AD_GROUP_EDP_EVENT_GROUP_REF_ID)
-      assertThat(adGroup.entityKey.entityType).isEqualTo("ad_group")
-      assertThat(adGroup.entityKey.entityId).isEqualTo(AD_GROUP_EDP_EVENT_GROUP_REF_ID)
-      assertThat(adGroup.eventGroupMetadata.entityMetadata.fieldsMap).containsKey("placement")
+      val creativeId: EventGroup = byRefId.getValue(CREATIVE_ID_EVENT_GROUP_REF_ID)
+      assertThat(creativeId.entityKey.entityType).isEqualTo("creative-id")
+      assertThat(creativeId.entityKey.entityId).isEqualTo(CREATIVE_ID_EVENT_GROUP_REF_ID)
+      assertThat(creativeId.eventGroupMetadata.entityMetadata.fieldsMap).containsKey("placement")
     }
 
   @Test
@@ -180,7 +179,25 @@ abstract class AbstractEdpAggregatorCorrectnessTest(
 
     val refIds = response.eventGroupsList.map { it.eventGroupReferenceId }.toSet()
     assertThat(refIds).contains(EDP_NO_ENTITY_KEY_EVENT_GROUP_REF_ID)
-    assertThat(refIds).doesNotContain(AD_GROUP_EDP_EVENT_GROUP_REF_ID)
+    assertThat(refIds).doesNotContain(CREATIVE_ID_EVENT_GROUP_REF_ID)
+  }
+
+  @Test
+  fun `direct measurement with reference-id-only event groups succeeds`() = runBlocking {
+    mcSimulator.testDirectReachAndFrequency(
+      "1240",
+      1,
+      eventGroupFilter = { it.eventGroupReferenceId == EDP_NO_ENTITY_KEY_EVENT_GROUP_REF_ID },
+    )
+  }
+
+  @Test
+  fun `direct measurement with creative-id entity-key-only event groups succeeds`() = runBlocking {
+    mcSimulator.testDirectReachAndFrequency(
+      "1241",
+      1,
+      eventGroupFilter = { it.eventGroupReferenceId == CREATIVE_ID_EVENT_GROUP_REF_ID },
+    )
   }
 
   interface MeasurementSystem {
@@ -197,7 +214,8 @@ abstract class AbstractEdpAggregatorCorrectnessTest(
     private const val MC_CS_PRIVATE_KEY_DER_NAME = "mc_cs_private.der"
 
     const val EDP_NO_ENTITY_KEY_EVENT_GROUP_REF_ID = "edpa-eg-reference-id-1"
-    const val AD_GROUP_EDP_EVENT_GROUP_REF_ID = "edpa-eg-reference-id-2"
+    const val CREATIVE_ID_EVENT_GROUP_REF_ID = "edpa-eg-creative-id-1"
+    const val EDPA_META_EVENT_GROUP_REF_ID = "edpa-eg-reference-id-2"
 
     val OUTPUT_DP_PARAMS = differentialPrivacyParams {
       epsilon = 0.1

--- a/src/test/kotlin/org/wfanet/measurement/integration/k8s/EdpAggregatorCorrectnessTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/integration/k8s/EdpAggregatorCorrectnessTest.kt
@@ -405,6 +405,7 @@ class EdpAggregatorCorrectnessTest : AbstractEdpAggregatorCorrectnessTest(measur
         TEST_CONFIG.modelLine,
         listEventGroupsEntityTypes = listOf("campaign", "creative-id"),
         onMeasurementsCreated = ::triggerRequisitionFetcher,
+        entityKeyCountByRefId = mapOf(MULTI_CREATIVE_EVENT_GROUP_REF_ID to 2),
       )
     }
 

--- a/src/test/kotlin/org/wfanet/measurement/integration/k8s/EdpAggregatorCorrectnessTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/integration/k8s/EdpAggregatorCorrectnessTest.kt
@@ -83,7 +83,7 @@ class EdpAggregatorCorrectnessTest : AbstractEdpAggregatorCorrectnessTest(measur
 
   override val EVENT_GROUP_FILTERING_LAMBDA_CROSS_PUB: (CmmsEventGroup) -> Boolean = {
     it.eventGroupReferenceId in
-      setOf(EDP_NO_ENTITY_KEY_EVENT_GROUP_REF_ID, AD_GROUP_EDP_EVENT_GROUP_REF_ID)
+      setOf(EDP_NO_ENTITY_KEY_EVENT_GROUP_REF_ID, EDPA_META_EVENT_GROUP_REF_ID)
   }
 
   private class UploadEventGroup : TestRule {
@@ -93,27 +93,29 @@ class EdpAggregatorCorrectnessTest : AbstractEdpAggregatorCorrectnessTest(measur
       System.getenv("GOOGLE_CLOUD_PROJECT") ?: error("GOOGLE_CLOUD_PROJECT must be set")
     private val storageClient = StorageOptions.getDefaultInstance().service
 
-    /** Per-eventGroupReferenceId storage config so each provider writes to its own directory. */
-    private data class EventGroupStorage(
+    /** Per-EDP storage config. Multiple event groups for the same EDP share one blob. */
+    private data class EdpStorage(
       val objectMapKey: String,
       val objectKey: String,
       val blobUri: String,
+      val eventGroupReferenceIds: Set<String>,
     )
 
-    private val eventGroupStorageMap: Map<String, EventGroupStorage> =
-      mapOf(
-        EDP_NO_ENTITY_KEY_EVENT_GROUP_REF_ID to
-          EventGroupStorage(
-            objectMapKey = "edp7/event-groups-map/edp7-event-group.binpb",
-            objectKey = "edp7/event-groups/edp7-event-group.binpb",
-            blobUri = "gs://$bucket/edp7/event-groups/edp7-event-group.binpb",
-          ),
-        AD_GROUP_EDP_EVENT_GROUP_REF_ID to
-          EventGroupStorage(
-            objectMapKey = "edpa_meta/event-groups-map/edpa_meta-event-group.binpb",
-            objectKey = "edpa_meta/event-groups/edpa_meta-event-group.binpb",
-            blobUri = "gs://$bucket/edpa_meta/event-groups/edpa_meta-event-group.binpb",
-          ),
+    private val edpStorageList: List<EdpStorage> =
+      listOf(
+        EdpStorage(
+          objectMapKey = "edp7/event-groups-map/edp7-event-group.binpb",
+          objectKey = "edp7/event-groups/edp7-event-group.binpb",
+          blobUri = "gs://$bucket/edp7/event-groups/edp7-event-group.binpb",
+          eventGroupReferenceIds =
+            setOf(EDP_NO_ENTITY_KEY_EVENT_GROUP_REF_ID, CREATIVE_ID_EVENT_GROUP_REF_ID),
+        ),
+        EdpStorage(
+          objectMapKey = "edpa_meta/event-groups-map/edpa_meta-event-group.binpb",
+          objectKey = "edpa_meta/event-groups/edpa_meta-event-group.binpb",
+          blobUri = "gs://$bucket/edpa_meta/event-groups/edpa_meta-event-group.binpb",
+          eventGroupReferenceIds = setOf(EDPA_META_EVENT_GROUP_REF_ID),
+        ),
       )
 
     override fun apply(base: Statement, description: Description): Statement {
@@ -122,17 +124,15 @@ class EdpAggregatorCorrectnessTest : AbstractEdpAggregatorCorrectnessTest(measur
           runBlocking {
             deleteExistingEventGroupsMaps()
             val allEventGroups = createEventGroups()
-            val eventGroupsByReferenceId: Map<String, List<EventGroup>> =
-              allEventGroups.groupBy { it.eventGroupReferenceId }
 
-            for ((refId, groups) in eventGroupsByReferenceId) {
-              val storage =
-                eventGroupStorageMap[refId]
-                  ?: error("Missing storage mapping for eventGroupReferenceId=$refId")
-
-              uploadEventGroups(storage, groups)
-              waitForEventGroupSyncToComplete(storage)
-              logger.info("Event Group Sync completed for $refId.")
+            for (edpStorage in edpStorageList) {
+              val groups =
+                allEventGroups.filter {
+                  it.eventGroupReferenceId in edpStorage.eventGroupReferenceIds
+                }
+              uploadEventGroups(edpStorage, groups)
+              waitForEventGroupSyncToComplete(edpStorage)
+              logger.info("Event Group Sync completed for ${edpStorage.eventGroupReferenceIds}.")
             }
 
             logger.info("Event Group Sync completed.")
@@ -142,7 +142,7 @@ class EdpAggregatorCorrectnessTest : AbstractEdpAggregatorCorrectnessTest(measur
       }
     }
 
-    private suspend fun waitForEventGroupSyncToComplete(storage: EventGroupStorage) {
+    private suspend fun waitForEventGroupSyncToComplete(storage: EdpStorage) {
       withTimeout(EVENT_GROUP_SYNC_TIMEOUT) {
         while (!isEventGroupSyncDone(storage)) {
           logger.info("Waiting on Event Group Sync to complete...")
@@ -151,20 +151,15 @@ class EdpAggregatorCorrectnessTest : AbstractEdpAggregatorCorrectnessTest(measur
       }
     }
 
-    private fun isEventGroupSyncDone(storage: EventGroupStorage): Boolean {
+    private fun isEventGroupSyncDone(storage: EdpStorage): Boolean {
       return storageClient.get(bucket, storage.objectMapKey) != null
     }
 
     private fun deleteExistingEventGroupsMaps() {
-      eventGroupStorageMap.values.forEach { storage ->
-        storageClient.delete(bucket, storage.objectMapKey)
-      }
+      edpStorageList.forEach { storage -> storageClient.delete(bucket, storage.objectMapKey) }
     }
 
-    private suspend fun uploadEventGroups(
-      storage: EventGroupStorage,
-      eventGroups: List<EventGroup>,
-    ) {
+    private suspend fun uploadEventGroups(storage: EdpStorage, eventGroups: List<EventGroup>) {
       val eventGroupsBlobUri = SelectedStorageClient.parseBlobUri(storage.blobUri)
       MesosRecordIoStorageClient(
           SelectedStorageClient(
@@ -193,11 +188,7 @@ class EdpAggregatorCorrectnessTest : AbstractEdpAggregatorCorrectnessTest(measur
               .atTime(23, 59, 59)
               .atZone(ZONE_ID)
               .toInstant()
-          // EDP1 is the legacy path: no entity_key supplied → Kingdom schema defaults
-          // entity_type="campaign", leaves entity_id NULL, no entity_metadata.
-          // EDP2 carries a non-default entity_type ("ad_group") so the deployed Kingdom +
-          // Reporting stack exercises both paths end-to-end on cluster.
-          val isLegacyEdp = eventGroupReferenceId == EDP_NO_ENTITY_KEY_EVENT_GROUP_REF_ID
+          val hasCreativeIdEntityKey = eventGroupReferenceId == CREATIVE_ID_EVENT_GROUP_REF_ID
           eventGroup {
             this.eventGroupReferenceId = eventGroupReferenceId
             measurementConsumer = TEST_CONFIG.measurementConsumer
@@ -212,16 +203,16 @@ class EdpAggregatorCorrectnessTest : AbstractEdpAggregatorCorrectnessTest(measur
                   campaign = "some-campaign"
                 }
               }
-              if (!isLegacyEdp) {
+              if (hasCreativeIdEntityKey) {
                 this.entityMetadata = struct {
                   fields["placement"] = value { stringValue = "homepage_top" }
                   fields["objective"] = value { stringValue = "awareness" }
                 }
               }
             }
-            if (!isLegacyEdp) {
+            if (hasCreativeIdEntityKey) {
               this.entityKey = entityKey {
-                entityType = "ad_group"
+                entityType = "creative-id"
                 entityId = eventGroupReferenceId
               }
             }
@@ -406,7 +397,7 @@ class EdpAggregatorCorrectnessTest : AbstractEdpAggregatorCorrectnessTest(measur
         syntheticEventGroupMap,
         reportName,
         TEST_CONFIG.modelLine,
-        listEventGroupsEntityTypes = listOf("campaign", "ad_group"),
+        listEventGroupsEntityTypes = listOf("campaign", "creative-id"),
         onMeasurementsCreated = ::triggerRequisitionFetcher,
       )
     }
@@ -482,7 +473,8 @@ class EdpAggregatorCorrectnessTest : AbstractEdpAggregatorCorrectnessTest(measur
     val syntheticEventGroupMap =
       mapOf(
         EDP_NO_ENTITY_KEY_EVENT_GROUP_REF_ID to syntheticEventGroupSpec,
-        AD_GROUP_EDP_EVENT_GROUP_REF_ID to syntheticEventGroupSpec,
+        CREATIVE_ID_EVENT_GROUP_REF_ID to syntheticEventGroupSpec,
+        EDPA_META_EVENT_GROUP_REF_ID to syntheticEventGroupSpec,
       )
 
     private val ZONE_ID = ZoneId.of("UTC")

--- a/src/test/kotlin/org/wfanet/measurement/integration/k8s/EdpAggregatorCorrectnessTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/integration/k8s/EdpAggregatorCorrectnessTest.kt
@@ -219,12 +219,7 @@ class EdpAggregatorCorrectnessTest : AbstractEdpAggregatorCorrectnessTest(measur
             if (hasCreativeIdEntityKey) {
               this.entityKey = entityKey {
                 entityType = "creative-id"
-                entityId =
-                  if (eventGroupReferenceId == MULTI_CREATIVE_EVENT_GROUP_REF_ID) {
-                    "multi-creative-A"
-                  } else {
-                    eventGroupReferenceId
-                  }
+                entityId = eventGroupReferenceId
               }
             }
             mediaTypes += MediaType.valueOf("VIDEO")

--- a/src/test/kotlin/org/wfanet/measurement/integration/k8s/EdpAggregatorCorrectnessTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/integration/k8s/EdpAggregatorCorrectnessTest.kt
@@ -410,7 +410,6 @@ class EdpAggregatorCorrectnessTest : AbstractEdpAggregatorCorrectnessTest(measur
         TEST_CONFIG.modelLine,
         listEventGroupsEntityTypes = listOf("campaign", "creative-id"),
         onMeasurementsCreated = ::triggerRequisitionFetcher,
-        entityKeyCountByRefId = mapOf(MULTI_CREATIVE_EVENT_GROUP_REF_ID to 2),
       )
     }
 

--- a/src/test/kotlin/org/wfanet/measurement/integration/k8s/EdpAggregatorCorrectnessTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/integration/k8s/EdpAggregatorCorrectnessTest.kt
@@ -219,7 +219,12 @@ class EdpAggregatorCorrectnessTest : AbstractEdpAggregatorCorrectnessTest(measur
             if (hasCreativeIdEntityKey) {
               this.entityKey = entityKey {
                 entityType = "creative-id"
-                entityId = eventGroupReferenceId
+                entityId =
+                  if (eventGroupReferenceId == MULTI_CREATIVE_EVENT_GROUP_REF_ID) {
+                    "multi-creative-A"
+                  } else {
+                    eventGroupReferenceId
+                  }
               }
             }
             mediaTypes += MediaType.valueOf("VIDEO")

--- a/src/test/kotlin/org/wfanet/measurement/integration/k8s/EdpAggregatorCorrectnessTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/integration/k8s/EdpAggregatorCorrectnessTest.kt
@@ -108,7 +108,11 @@ class EdpAggregatorCorrectnessTest : AbstractEdpAggregatorCorrectnessTest(measur
           objectKey = "edp7/event-groups/edp7-event-group.binpb",
           blobUri = "gs://$bucket/edp7/event-groups/edp7-event-group.binpb",
           eventGroupReferenceIds =
-            setOf(EDP_NO_ENTITY_KEY_EVENT_GROUP_REF_ID, CREATIVE_ID_EVENT_GROUP_REF_ID),
+            setOf(
+              EDP_NO_ENTITY_KEY_EVENT_GROUP_REF_ID,
+              CREATIVE_ID_EVENT_GROUP_REF_ID,
+              MULTI_CREATIVE_EVENT_GROUP_REF_ID,
+            ),
         ),
         EdpStorage(
           objectMapKey = "edpa_meta/event-groups-map/edpa_meta-event-group.binpb",
@@ -188,7 +192,9 @@ class EdpAggregatorCorrectnessTest : AbstractEdpAggregatorCorrectnessTest(measur
               .atTime(23, 59, 59)
               .atZone(ZONE_ID)
               .toInstant()
-          val hasCreativeIdEntityKey = eventGroupReferenceId == CREATIVE_ID_EVENT_GROUP_REF_ID
+          val hasCreativeIdEntityKey =
+            eventGroupReferenceId in
+              setOf(CREATIVE_ID_EVENT_GROUP_REF_ID, MULTI_CREATIVE_EVENT_GROUP_REF_ID)
           eventGroup {
             this.eventGroupReferenceId = eventGroupReferenceId
             measurementConsumer = TEST_CONFIG.measurementConsumer
@@ -474,6 +480,7 @@ class EdpAggregatorCorrectnessTest : AbstractEdpAggregatorCorrectnessTest(measur
       mapOf(
         EDP_NO_ENTITY_KEY_EVENT_GROUP_REF_ID to syntheticEventGroupSpec,
         CREATIVE_ID_EVENT_GROUP_REF_ID to syntheticEventGroupSpec,
+        MULTI_CREATIVE_EVENT_GROUP_REF_ID to syntheticEventGroupSpec,
         EDPA_META_EVENT_GROUP_REF_ID to syntheticEventGroupSpec,
       )
 


### PR DESCRIPTION
Fixes #3787

## Summary
- Add entity key consistency tests to cloud EdpAggregatorCorrectnessTest: direct measurements with creative-id entity-key-only event groups and multi-entity-key blob filtering
- Extend EdpAggregatorMeasurementConsumerSimulator with entityKeyCountByRefId so getMeasurementFilteredVids computes expected VIDs using per-shard entity key chunking for multi-entity-key blobs
- Add in-process measurement integration test validating entity key filtering returns the correct subset
- Fix cross-publisher filter to not mix legacy and entity-key-aware event groups

## Test plan
- [x] In-process measurement integration test: all 14 tests pass including new direct measurement with multi-entity-key filtering returns correct subset
- [x] Cloud test: Update CMMS workflow on branch (run pending)

Issue: #3787