### PR TITLE
fix: synchronous flush and batch getBlob for BufferedDataAvailabilityCleanup

### DIFF
--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/dataavailability/BUILD.bazel
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/dataavailability/BUILD.bazel
@@ -9,6 +9,7 @@ package(default_visibility = [
 kt_jvm_library(
     name = "data_availability_sync",
     srcs = [
+        "BufferedDataAvailabilityCleanup.kt",
         "DataAvailabilityCleanup.kt",
         "DataAvailabilityCleanupMetrics.kt",
         "DataAvailabilitySync.kt",
@@ -26,6 +27,7 @@ kt_jvm_library(
         "//src/main/proto/wfa/measurement/edpaggregator/v1alpha:blob_details_kt_jvm_proto",
         "//src/main/proto/wfa/measurement/edpaggregator/v1alpha:impression_metadata_service_kt_jvm_grpc_proto",
         "@wfa_common_jvm//imports/java/io/opentelemetry/api",
+        "@wfa_common_jvm//imports/kotlin/kotlinx/coroutines:core",
         "@wfa_common_jvm//src/main/kotlin/org/wfanet/measurement/common",
         "@wfa_common_jvm//src/main/kotlin/org/wfanet/measurement/common/grpc",
         "@wfa_common_jvm//src/main/kotlin/org/wfanet/measurement/gcloud/common",

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/dataavailability/BufferedDataAvailabilityCleanup.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/dataavailability/BufferedDataAvailabilityCleanup.kt
@@ -18,10 +18,8 @@ package org.wfanet.measurement.edpaggregator.dataavailability
 
 import io.opentelemetry.api.common.Attributes
 import java.util.concurrent.ConcurrentLinkedQueue
-import java.util.concurrent.Executors
-import java.util.concurrent.ScheduledExecutorService
-import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicLong
 import java.util.logging.Level
 import java.util.logging.Logger
 import kotlin.time.TimeSource
@@ -46,15 +44,20 @@ data class DeleteEvent(
  * instance reuse to accumulate delete events across invocations and process them together,
  * rather than N individual RPCs.
  *
+ * Flushing is always done synchronously within the calling thread (the HTTP request handler
+ * thread), avoiding CPU throttling issues with background threads on Cloud Functions Gen2
+ * where CPU is throttled between invocations.
+ *
  * Events are flushed when:
- * - The buffer reaches [batchSize] events, OR
- * - A periodic timer fires every [flushIntervalSeconds] seconds.
+ * - The buffer reaches [batchSize] events (flushed by the enqueuing thread), OR
+ * - The buffer has events older than [flushIntervalSeconds] (flushed by the next enqueuing
+ *   thread).
  *
  * During flush:
  * 1. Events whose blobs still have a live version in storage are skipped (noncurrent version
  *    deletion).
  * 2. Events without a resource ID are batch-resolved via a single `ListImpressionMetadata` RPC
- *    using the `blob_uris` filter, instead of N individual lookups.
+ *    using the `blob_uris` filter.
  * 3. Resolved resource names are chunked into groups of [MAX_BATCH_DELETE_SIZE] and each chunk
  *    is deleted via a single `BatchDeleteImpressionMetadata` RPC.
  * 4. Events that fail resolution are re-queued.
@@ -68,14 +71,12 @@ class BufferedDataAvailabilityCleanup(
   private val metrics: DataAvailabilityCleanupMetrics = DataAvailabilityCleanupMetrics(),
 ) {
   private val queue = ConcurrentLinkedQueue<DeleteEvent>()
-  private val scheduler: ScheduledExecutorService =
-    Executors.newSingleThreadScheduledExecutor { r ->
-      Thread(r, "cleanup-buffer-flush").apply { isDaemon = true }
-    }
-  private val flushScheduled = AtomicBoolean(false)
+  private val firstEnqueueTimeMs = AtomicLong(0)
+  private val flushing = AtomicBoolean(false)
 
   fun enqueue(event: DeleteEvent) {
     queue.add(event)
+    firstEnqueueTimeMs.compareAndSet(0, System.currentTimeMillis())
     val size = queue.size
     if (size % LOG_INTERVAL == 0 || size <= 10) {
       logger.info(
@@ -83,30 +84,37 @@ class BufferedDataAvailabilityCleanup(
       )
     }
 
-    ensureFlushScheduled()
-
     if (size >= batchSize) {
       logger.info("Batch size threshold ($batchSize) reached, flushing immediately")
+      flush()
+    } else if (isStale()) {
+      logger.info("Buffer age exceeded ${flushIntervalSeconds}s, flushing")
       flush()
     }
   }
 
-  private fun ensureFlushScheduled() {
-    if (flushScheduled.compareAndSet(false, true)) {
-      scheduler.scheduleAtFixedRate(
-        { flush() },
-        flushIntervalSeconds,
-        flushIntervalSeconds,
-        TimeUnit.SECONDS,
-      )
-      logger.info("Scheduled periodic flush every ${flushIntervalSeconds}s")
-    }
+  private fun isStale(): Boolean {
+    val first = firstEnqueueTimeMs.get()
+    if (first == 0L) return false
+    return System.currentTimeMillis() - first >= flushIntervalSeconds * 1000
   }
 
   fun flush() {
+    if (!flushing.compareAndSet(false, true)) {
+      return
+    }
+    try {
+      doFlush()
+    } finally {
+      flushing.set(false)
+    }
+  }
+
+  private fun doFlush() {
     val batch = drain()
     if (batch.isEmpty()) return
 
+    firstEnqueueTimeMs.set(if (queue.isEmpty()) 0 else System.currentTimeMillis())
     val flushStart = TimeSource.Monotonic.markNow()
     logger.info("Flushing ${batch.size} buffered delete events")
 
@@ -216,12 +224,6 @@ class BufferedDataAvailabilityCleanup(
     }
   }
 
-  /**
-   * Batch-resolves resource names for events that need blob URI lookup.
-   *
-   * Uses the `blob_uris` filter on `ListImpressionMetadata` to resolve all blob URIs in a single
-   * RPC, instead of N individual lookups.
-   */
   private suspend fun batchResolveResourceNames(
     events: List<DeleteEvent>,
   ): List<String> {
@@ -279,15 +281,6 @@ class BufferedDataAvailabilityCleanup(
   fun shutdown() {
     logger.info("Shutting down buffered cleanup, flushing remaining events")
     flush()
-    scheduler.shutdown()
-    try {
-      if (!scheduler.awaitTermination(SHUTDOWN_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
-        scheduler.shutdownNow()
-      }
-    } catch (e: InterruptedException) {
-      scheduler.shutdownNow()
-      Thread.currentThread().interrupt()
-    }
   }
 
   fun pendingCount(): Int = queue.size
@@ -299,7 +292,6 @@ class BufferedDataAvailabilityCleanup(
     const val DEFAULT_FLUSH_INTERVAL_SECONDS = 30L
     const val MAX_BATCH_DELETE_SIZE = 100
     const val MAX_BATCH_RESOLVE_SIZE = 100
-    private const val SHUTDOWN_TIMEOUT_SECONDS = 10L
     private const val BATCH_FLUSH_STATUS = "batch_flush"
     private const val LOG_INTERVAL = 50
   }

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/dataavailability/BufferedDataAvailabilityCleanup.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/dataavailability/BufferedDataAvailabilityCleanup.kt
@@ -50,11 +50,14 @@ data class DeleteEvent(
  * - The buffer reaches [batchSize] events, OR
  * - A periodic timer fires every [flushIntervalSeconds] seconds.
  *
- * During flush, events without a resource ID are resolved by looking up the blob URI in the
- * ImpressionMetadata service. Events whose blobs still have a live version in storage are skipped
- * (noncurrent version deletion). Resolved resource names are chunked into groups of
- * [MAX_BATCH_DELETE_SIZE] and each chunk is deleted via a single batch RPC. Events that fail
- * resolution are re-queued.
+ * During flush:
+ * 1. Events whose blobs still have a live version in storage are skipped (noncurrent version
+ *    deletion).
+ * 2. Events without a resource ID are batch-resolved via a single `ListImpressionMetadata` RPC
+ *    using the `blob_uris` filter, instead of N individual lookups.
+ * 3. Resolved resource names are chunked into groups of [MAX_BATCH_DELETE_SIZE] and each chunk
+ *    is deleted via a single `BatchDeleteImpressionMetadata` RPC.
+ * 4. Events that fail resolution are re-queued.
  */
 class BufferedDataAvailabilityCleanup(
   private val impressionMetadataServiceStub: ImpressionMetadataServiceCoroutineStub,
@@ -111,10 +114,16 @@ class BufferedDataAvailabilityCleanup(
       val resourceNames = mutableListOf<String>()
       var skippedCount = 0
       var resolveFailCount = 0
+      val eventsNeedingResolution = mutableListOf<DeleteEvent>()
 
-      val resolveStart = TimeSource.Monotonic.markNow()
+      val checkStart = TimeSource.Monotonic.markNow()
       for (event in batch) {
         try {
+          if (!event.impressionMetadataResourceId.isNullOrEmpty()) {
+            resourceNames.add(event.impressionMetadataResourceId)
+            continue
+          }
+
           val blobUri = SelectedStorageClient.parseBlobUri(event.deletedBlobPath)
           val liveBlob = storageClient.getBlob(blobUri.key)
           if (liveBlob != null) {
@@ -122,27 +131,35 @@ class BufferedDataAvailabilityCleanup(
             continue
           }
 
-          val resourceName = resolveResourceName(event)
-          if (resourceName != null) {
-            resourceNames.add(resourceName)
-          } else {
-            skippedCount++
-          }
+          eventsNeedingResolution.add(event)
         } catch (e: Exception) {
           logger.log(
             Level.WARNING,
-            "Failed to resolve ${event.deletedBlobPath}, re-queuing",
+            "Failed to check ${event.deletedBlobPath}, re-queuing",
             e,
           )
           resolveFailCount++
           queue.add(event)
         }
       }
-      val resolveMs = resolveStart.elapsedNow().inWholeMilliseconds
+      val checkMs = checkStart.elapsedNow().inWholeMilliseconds
       logger.info(
-        "Resolved ${resourceNames.size} names, skipped $skippedCount, " +
-          "re-queued $resolveFailCount in ${resolveMs}ms"
+        "Live-version check: ${resourceNames.size} pre-resolved, " +
+          "${eventsNeedingResolution.size} need lookup, " +
+          "$skippedCount skipped (live), $resolveFailCount failed [${checkMs}ms]"
       )
+
+      if (eventsNeedingResolution.isNotEmpty()) {
+        val resolveStart = TimeSource.Monotonic.markNow()
+        val resolved = batchResolveResourceNames(eventsNeedingResolution)
+        val resolveMs = resolveStart.elapsedNow().inWholeMilliseconds
+        logger.info(
+          "Batch-resolved ${resolved.size}/${eventsNeedingResolution.size} " +
+            "blob URIs in ${resolveMs}ms"
+        )
+        resourceNames.addAll(resolved)
+        skippedCount += eventsNeedingResolution.size - resolved.size
+      }
 
       if (resourceNames.isNotEmpty()) {
         val chunks = resourceNames.chunked(MAX_BATCH_DELETE_SIZE)
@@ -168,7 +185,8 @@ class BufferedDataAvailabilityCleanup(
           } catch (e: Exception) {
             logger.log(
               Level.SEVERE,
-              "Batch RPC ${index + 1}/${chunks.size} failed for ${chunk.size} records, re-queuing",
+              "Batch RPC ${index + 1}/${chunks.size} failed for ${chunk.size} records, " +
+                "re-queuing",
               e,
             )
             chunk.forEach { name -> queue.add(DeleteEvent(name, name)) }
@@ -180,7 +198,7 @@ class BufferedDataAvailabilityCleanup(
         logger.info(
           "Flush complete: $totalDeleted deleted, $skippedCount skipped, " +
             "$resolveFailCount re-queued, ${queue.size} remaining " +
-            "[resolve=${resolveMs}ms, delete=${deleteMs}ms, total=${totalMs}ms]"
+            "[check=${checkMs}ms, delete=${deleteMs}ms, total=${totalMs}ms]"
         )
         metrics.recordsDeletedCounter.add(
           totalDeleted.toLong(),
@@ -198,38 +216,56 @@ class BufferedDataAvailabilityCleanup(
     }
   }
 
-  private suspend fun resolveResourceName(event: DeleteEvent): String? {
-    if (!event.impressionMetadataResourceId.isNullOrEmpty()) {
-      return event.impressionMetadataResourceId
-    }
+  /**
+   * Batch-resolves resource names for events that need blob URI lookup.
+   *
+   * Uses the `blob_uris` filter on `ListImpressionMetadata` to resolve all blob URIs in a single
+   * RPC, instead of N individual lookups.
+   */
+  private suspend fun batchResolveResourceNames(
+    events: List<DeleteEvent>,
+  ): List<String> {
+    val blobUris = events.map { it.deletedBlobPath }
 
-    val listResponse =
-      impressionMetadataServiceStub.listImpressionMetadata(
-        listImpressionMetadataRequest {
-          parent = dataProviderName
-          filter = ListImpressionMetadataRequestKt.filter {
-            blobUriPrefix = event.deletedBlobPath
+    val resolvedNames = mutableListOf<String>()
+    for (chunk in blobUris.chunked(MAX_BATCH_RESOLVE_SIZE)) {
+      try {
+        val listResponse =
+          impressionMetadataServiceStub.listImpressionMetadata(
+            listImpressionMetadataRequest {
+              parent = dataProviderName
+              filter = ListImpressionMetadataRequestKt.filter {
+                this.blobUris += chunk
+              }
+            }
+          )
+
+        val resultsByUri = listResponse.impressionMetadataList.groupBy { it.blobUri }
+        for (uri in chunk) {
+          val matches = resultsByUri[uri]
+          when {
+            matches == null || matches.isEmpty() -> {
+              logger.warning("No ImpressionMetadata found for blob URI: $uri. Skipping.")
+            }
+            matches.size > 1 -> {
+              logger.warning(
+                "Multiple ImpressionMetadata records (${matches.size}) for $uri. Skipping."
+              )
+            }
+            else -> resolvedNames.add(matches.single().name)
           }
         }
-      )
-
-    val results = listResponse.impressionMetadataList
-    return when {
-      results.isEmpty() -> {
-        logger.warning(
-          "No ImpressionMetadata found for blob URI: ${event.deletedBlobPath}. Skipping."
+      } catch (e: Exception) {
+        logger.log(
+          Level.WARNING,
+          "Batch resolve failed for ${chunk.size} URIs, re-queuing",
+          e,
         )
-        null
+        chunk.forEach { uri -> queue.add(DeleteEvent(uri, null)) }
       }
-      results.size > 1 -> {
-        logger.warning(
-          "Multiple ImpressionMetadata records (${results.size}) found for " +
-            "blob URI: ${event.deletedBlobPath}. Skipping."
-        )
-        null
-      }
-      else -> results.single().name
     }
+
+    return resolvedNames
   }
 
   private fun drain(): List<DeleteEvent> {
@@ -262,6 +298,7 @@ class BufferedDataAvailabilityCleanup(
     const val DEFAULT_BATCH_SIZE = 100
     const val DEFAULT_FLUSH_INTERVAL_SECONDS = 30L
     const val MAX_BATCH_DELETE_SIZE = 100
+    const val MAX_BATCH_RESOLVE_SIZE = 100
     private const val SHUTDOWN_TIMEOUT_SECONDS = 10L
     private const val BATCH_FLUSH_STATUS = "batch_flush"
     private const val LOG_INTERVAL = 50

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/dataavailability/BufferedDataAvailabilityCleanup.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/dataavailability/BufferedDataAvailabilityCleanup.kt
@@ -24,6 +24,7 @@ import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.logging.Level
 import java.util.logging.Logger
+import kotlin.time.TimeSource
 import kotlinx.coroutines.runBlocking
 import org.wfanet.measurement.edpaggregator.v1alpha.ImpressionMetadataServiceGrpcKt.ImpressionMetadataServiceCoroutineStub
 import org.wfanet.measurement.edpaggregator.v1alpha.ListImpressionMetadataRequestKt
@@ -38,12 +39,12 @@ data class DeleteEvent(
 )
 
 /**
- * Buffers delete events in memory and flushes them via a single
- * `BatchDeleteImpressionMetadata` RPC.
+ * Buffers delete events in memory and flushes them via `BatchDeleteImpressionMetadata` RPCs,
+ * each capped at [MAX_BATCH_DELETE_SIZE] records.
  *
  * On Cloud Functions Gen2, a single instance can handle concurrent requests. This class exploits
- * instance reuse to accumulate delete events across invocations and process them together in one
- * Spanner transaction, rather than N individual RPCs.
+ * instance reuse to accumulate delete events across invocations and process them together,
+ * rather than N individual RPCs.
  *
  * Events are flushed when:
  * - The buffer reaches [batchSize] events, OR
@@ -51,8 +52,9 @@ data class DeleteEvent(
  *
  * During flush, events without a resource ID are resolved by looking up the blob URI in the
  * ImpressionMetadata service. Events whose blobs still have a live version in storage are skipped
- * (noncurrent version deletion). All resolved resource names are then deleted in a single batch
- * RPC. Events that fail resolution are re-queued.
+ * (noncurrent version deletion). Resolved resource names are chunked into groups of
+ * [MAX_BATCH_DELETE_SIZE] and each chunk is deleted via a single batch RPC. Events that fail
+ * resolution are re-queued.
  */
 class BufferedDataAvailabilityCleanup(
   private val impressionMetadataServiceStub: ImpressionMetadataServiceCoroutineStub,
@@ -71,11 +73,16 @@ class BufferedDataAvailabilityCleanup(
 
   fun enqueue(event: DeleteEvent) {
     queue.add(event)
-    logger.info("Buffered delete event for: ${event.deletedBlobPath} (queue size: ${queue.size})")
+    val size = queue.size
+    if (size % LOG_INTERVAL == 0 || size <= 10) {
+      logger.info(
+        "Buffered delete event for: ${event.deletedBlobPath} (queue size: $size)"
+      )
+    }
 
     ensureFlushScheduled()
 
-    if (queue.size >= batchSize) {
+    if (size >= batchSize) {
       logger.info("Batch size threshold ($batchSize) reached, flushing immediately")
       flush()
     }
@@ -97,21 +104,20 @@ class BufferedDataAvailabilityCleanup(
     val batch = drain()
     if (batch.isEmpty()) return
 
+    val flushStart = TimeSource.Monotonic.markNow()
     logger.info("Flushing ${batch.size} buffered delete events")
 
     runBlocking {
       val resourceNames = mutableListOf<String>()
       var skippedCount = 0
+      var resolveFailCount = 0
 
+      val resolveStart = TimeSource.Monotonic.markNow()
       for (event in batch) {
         try {
           val blobUri = SelectedStorageClient.parseBlobUri(event.deletedBlobPath)
           val liveBlob = storageClient.getBlob(blobUri.key)
           if (liveBlob != null) {
-            logger.info(
-              "Live version still exists for ${event.deletedBlobPath}. " +
-                "Skipping (noncurrent version deletion)."
-            )
             skippedCount++
             continue
           }
@@ -128,40 +134,66 @@ class BufferedDataAvailabilityCleanup(
             "Failed to resolve ${event.deletedBlobPath}, re-queuing",
             e,
           )
+          resolveFailCount++
           queue.add(event)
         }
       }
+      val resolveMs = resolveStart.elapsedNow().inWholeMilliseconds
+      logger.info(
+        "Resolved ${resourceNames.size} names, skipped $skippedCount, " +
+          "re-queued $resolveFailCount in ${resolveMs}ms"
+      )
 
       if (resourceNames.isNotEmpty()) {
-        try {
-          logger.info(
-            "Calling BatchDeleteImpressionMetadata with ${resourceNames.size} resource names"
-          )
-          impressionMetadataServiceStub.batchDeleteImpressionMetadata(
-            batchDeleteImpressionMetadataRequest {
-              parent = dataProviderName
-              names += resourceNames
-            }
-          )
-          logger.info(
-            "Batch delete succeeded: ${resourceNames.size} deleted, " +
-              "$skippedCount skipped, ${queue.size} remaining in buffer"
-          )
-          metrics.recordsDeletedCounter.add(
-            resourceNames.size.toLong(),
-            Attributes.of(
-              DataAvailabilityCleanupMetrics.CLEANUP_STATUS_ATTR,
-              BATCH_FLUSH_STATUS,
-            ),
-          )
-        } catch (e: Exception) {
-          logger.log(Level.SEVERE, "Batch delete RPC failed, re-queuing all ${resourceNames.size} events", e)
-          resourceNames.forEach { name ->
-            queue.add(DeleteEvent(name, name))
+        val chunks = resourceNames.chunked(MAX_BATCH_DELETE_SIZE)
+        logger.info(
+          "Deleting ${resourceNames.size} records in ${chunks.size} batch RPC(s) " +
+            "(max $MAX_BATCH_DELETE_SIZE per RPC)"
+        )
+        val deleteStart = TimeSource.Monotonic.markNow()
+        var totalDeleted = 0
+
+        for ((index, chunk) in chunks.withIndex()) {
+          try {
+            impressionMetadataServiceStub.batchDeleteImpressionMetadata(
+              batchDeleteImpressionMetadataRequest {
+                parent = dataProviderName
+                names += chunk
+              }
+            )
+            totalDeleted += chunk.size
+            logger.info(
+              "Batch RPC ${index + 1}/${chunks.size}: deleted ${chunk.size} records"
+            )
+          } catch (e: Exception) {
+            logger.log(
+              Level.SEVERE,
+              "Batch RPC ${index + 1}/${chunks.size} failed for ${chunk.size} records, re-queuing",
+              e,
+            )
+            chunk.forEach { name -> queue.add(DeleteEvent(name, name)) }
           }
         }
+
+        val deleteMs = deleteStart.elapsedNow().inWholeMilliseconds
+        val totalMs = flushStart.elapsedNow().inWholeMilliseconds
+        logger.info(
+          "Flush complete: $totalDeleted deleted, $skippedCount skipped, " +
+            "$resolveFailCount re-queued, ${queue.size} remaining " +
+            "[resolve=${resolveMs}ms, delete=${deleteMs}ms, total=${totalMs}ms]"
+        )
+        metrics.recordsDeletedCounter.add(
+          totalDeleted.toLong(),
+          Attributes.of(
+            DataAvailabilityCleanupMetrics.CLEANUP_STATUS_ATTR,
+            BATCH_FLUSH_STATUS,
+          ),
+        )
       } else {
-        logger.info("No events to batch-delete ($skippedCount skipped)")
+        val totalMs = flushStart.elapsedNow().inWholeMilliseconds
+        logger.info(
+          "No events to batch-delete ($skippedCount skipped) [total=${totalMs}ms]"
+        )
       }
     }
   }
@@ -229,7 +261,9 @@ class BufferedDataAvailabilityCleanup(
       Logger.getLogger(BufferedDataAvailabilityCleanup::class.java.name)
     const val DEFAULT_BATCH_SIZE = 100
     const val DEFAULT_FLUSH_INTERVAL_SECONDS = 30L
+    const val MAX_BATCH_DELETE_SIZE = 100
     private const val SHUTDOWN_TIMEOUT_SECONDS = 10L
     private const val BATCH_FLUSH_STATUS = "batch_flush"
+    private const val LOG_INTERVAL = 50
   }
 }

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/dataavailability/BufferedDataAvailabilityCleanup.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/dataavailability/BufferedDataAvailabilityCleanup.kt
@@ -33,33 +33,30 @@ import org.wfanet.measurement.edpaggregator.v1alpha.listImpressionMetadataReques
 import org.wfanet.measurement.storage.SelectedStorageClient
 import org.wfanet.measurement.storage.StorageClient
 
-data class DeleteEvent(
-  val deletedBlobPath: String,
-  val impressionMetadataResourceId: String?,
-)
+data class DeleteEvent(val deletedBlobPath: String, val impressionMetadataResourceId: String?)
 
 /**
- * Buffers delete events in memory and flushes them via `BatchDeleteImpressionMetadata` RPCs,
- * each capped at [MAX_BATCH_DELETE_SIZE] records.
+ * Buffers delete events in memory and flushes them via `BatchDeleteImpressionMetadata` RPCs, each
+ * capped at [MAX_BATCH_DELETE_SIZE] records.
  *
  * On Cloud Functions Gen2, a single instance can handle concurrent requests. This class exploits
- * instance reuse to accumulate delete events across invocations and process them together,
- * rather than N individual RPCs.
+ * instance reuse to accumulate delete events across invocations and process them together, rather
+ * than N individual RPCs.
  *
  * Events are flushed when:
  * - The buffer reaches [batchSize] events (flushed synchronously by the enqueuing thread), OR
  * - A periodic background timer fires every [flushIntervalSeconds] seconds as a fallback.
  *
- * NOTE: The background timer requires CPU >= 1 with concurrency > 1 to function reliably.
- * With fractional CPU, Cloud Run throttles background threads between requests.
+ * NOTE: The background timer requires CPU >= 1 with concurrency > 1 to function reliably. With
+ * fractional CPU, Cloud Run throttles background threads between requests.
  *
  * During flush:
  * 1. Events whose blobs still have a live version in storage are skipped (noncurrent version
  *    deletion).
  * 2. Events without a resource ID are batch-resolved via a single `ListImpressionMetadata` RPC
  *    using the `blob_uris` filter.
- * 3. Resolved resource names are chunked into groups of [MAX_BATCH_DELETE_SIZE] and each chunk
- *    is deleted via a single `BatchDeleteImpressionMetadata` RPC.
+ * 3. Resolved resource names are chunked into groups of [MAX_BATCH_DELETE_SIZE] and each chunk is
+ *    deleted via a single `BatchDeleteImpressionMetadata` RPC.
  * 4. Events that fail resolution are re-queued.
  */
 class BufferedDataAvailabilityCleanup(
@@ -75,16 +72,20 @@ class BufferedDataAvailabilityCleanup(
   private val timerScheduled = AtomicBoolean(false)
   private val scheduler: ScheduledExecutorService =
     Executors.newSingleThreadScheduledExecutor { r ->
-      Thread(r, "cleanup-buffer-flush").apply { isDaemon = true }
+      Thread(r, "cleanup-buffer-flush").apply {
+        isDaemon = true
+        uncaughtExceptionHandler =
+          Thread.UncaughtExceptionHandler { t, e ->
+            logger.log(Level.SEVERE, "Uncaught exception in timer thread ${t.name}", e)
+          }
+      }
     }
 
   fun enqueue(event: DeleteEvent) {
     queue.add(event)
     val size = queue.size
     if (size % LOG_INTERVAL == 0 || size <= 10) {
-      logger.info(
-        "Buffered delete event for: ${event.deletedBlobPath} (queue size: $size)"
-      )
+      logger.info("Buffered delete event for: ${event.deletedBlobPath} (queue size: $size)")
     }
 
     ensureTimerScheduled()
@@ -97,23 +98,39 @@ class BufferedDataAvailabilityCleanup(
 
   private fun ensureTimerScheduled() {
     if (timerScheduled.compareAndSet(false, true)) {
-      scheduler.scheduleAtFixedRate(
-        {
-          if (!queue.isEmpty()) {
-            logger.info("Periodic flush timer fired (${queue.size} events pending)")
-            flush()
-          }
-        },
-        flushIntervalSeconds,
-        flushIntervalSeconds,
-        TimeUnit.SECONDS,
-      )
-      logger.info("Scheduled periodic flush every ${flushIntervalSeconds}s")
+      try {
+        scheduler.scheduleAtFixedRate(
+          {
+            try {
+              if (!queue.isEmpty()) {
+                logger.info("Periodic flush timer fired (${queue.size} events pending)")
+                flush()
+              } else {
+                logger.fine("Periodic flush timer fired (queue empty, skipping)")
+              }
+            } catch (e: Exception) {
+              logger.log(
+                Level.SEVERE,
+                "Timer flush failed, re-queuing will happen on next flush",
+                e,
+              )
+            }
+          },
+          flushIntervalSeconds,
+          flushIntervalSeconds,
+          TimeUnit.SECONDS,
+        )
+        logger.info("Scheduled periodic flush every ${flushIntervalSeconds}s")
+      } catch (e: Exception) {
+        logger.log(Level.SEVERE, "Failed to schedule periodic flush timer", e)
+        timerScheduled.set(false)
+      }
     }
   }
 
   fun flush() {
     if (!flushing.compareAndSet(false, true)) {
+      logger.info("Flush already in progress, skipping")
       return
     }
     try {
@@ -153,11 +170,7 @@ class BufferedDataAvailabilityCleanup(
 
           eventsNeedingResolution.add(event)
         } catch (e: Exception) {
-          logger.log(
-            Level.WARNING,
-            "Failed to check ${event.deletedBlobPath}, re-queuing",
-            e,
-          )
+          logger.log(Level.WARNING, "Failed to check ${event.deletedBlobPath}, re-queuing", e)
           resolveFailCount++
           queue.add(event)
         }
@@ -199,9 +212,7 @@ class BufferedDataAvailabilityCleanup(
               }
             )
             totalDeleted += chunk.size
-            logger.info(
-              "Batch RPC ${index + 1}/${chunks.size}: deleted ${chunk.size} records"
-            )
+            logger.info("Batch RPC ${index + 1}/${chunks.size}: deleted ${chunk.size} records")
           } catch (e: Exception) {
             logger.log(
               Level.SEVERE,
@@ -222,23 +233,16 @@ class BufferedDataAvailabilityCleanup(
         )
         metrics.recordsDeletedCounter.add(
           totalDeleted.toLong(),
-          Attributes.of(
-            DataAvailabilityCleanupMetrics.CLEANUP_STATUS_ATTR,
-            BATCH_FLUSH_STATUS,
-          ),
+          Attributes.of(DataAvailabilityCleanupMetrics.CLEANUP_STATUS_ATTR, BATCH_FLUSH_STATUS),
         )
       } else {
         val totalMs = flushStart.elapsedNow().inWholeMilliseconds
-        logger.info(
-          "No events to batch-delete ($skippedCount skipped) [total=${totalMs}ms]"
-        )
+        logger.info("No events to batch-delete ($skippedCount skipped) [total=${totalMs}ms]")
       }
     }
   }
 
-  private suspend fun batchResolveResourceNames(
-    events: List<DeleteEvent>,
-  ): List<String> {
+  private suspend fun batchResolveResourceNames(events: List<DeleteEvent>): List<String> {
     val blobUris = events.map { it.deletedBlobPath }
 
     val resolvedNames = mutableListOf<String>()
@@ -248,9 +252,7 @@ class BufferedDataAvailabilityCleanup(
           impressionMetadataServiceStub.listImpressionMetadata(
             listImpressionMetadataRequest {
               parent = dataProviderName
-              filter = ListImpressionMetadataRequestKt.filter {
-                this.blobUris += chunk
-              }
+              filter = ListImpressionMetadataRequestKt.filter { this.blobUris += chunk }
             }
           )
 
@@ -270,11 +272,7 @@ class BufferedDataAvailabilityCleanup(
           }
         }
       } catch (e: Exception) {
-        logger.log(
-          Level.WARNING,
-          "Batch resolve failed for ${chunk.size} URIs, re-queuing",
-          e,
-        )
+        logger.log(Level.WARNING, "Batch resolve failed for ${chunk.size} URIs, re-queuing", e)
         chunk.forEach { uri -> queue.add(DeleteEvent(uri, null)) }
       }
     }
@@ -307,8 +305,7 @@ class BufferedDataAvailabilityCleanup(
   fun pendingCount(): Int = queue.size
 
   companion object {
-    private val logger: Logger =
-      Logger.getLogger(BufferedDataAvailabilityCleanup::class.java.name)
+    private val logger: Logger = Logger.getLogger(BufferedDataAvailabilityCleanup::class.java.name)
     const val DEFAULT_BATCH_SIZE = 100
     const val DEFAULT_FLUSH_INTERVAL_SECONDS = 30L
     const val MAX_BATCH_DELETE_SIZE = 100

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/dataavailability/BufferedDataAvailabilityCleanup.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/dataavailability/BufferedDataAvailabilityCleanup.kt
@@ -150,10 +150,10 @@ class BufferedDataAvailabilityCleanup(
       }
 
       if (resolvedEvents.isNotEmpty()) {
-        val chunks = resolvedEvents.chunked(MAX_BATCH_DELETE_SIZE)
+        val chunks = resolvedEvents.chunked(batchSize)
         logger.info(
           "Deleting ${resolvedEvents.size} records in ${chunks.size} batch RPC(s) " +
-            "(max $MAX_BATCH_DELETE_SIZE per RPC)"
+            "(max $batchSize per RPC)"
         )
         val deleteStart = TimeSource.Monotonic.markNow()
         var totalDeleted = 0

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/dataavailability/BufferedDataAvailabilityCleanup.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/dataavailability/BufferedDataAvailabilityCleanup.kt
@@ -1,0 +1,178 @@
+/*
+ * Copyright 2025 The Cross-Media Measurement Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wfanet.measurement.edpaggregator.dataavailability
+
+import io.opentelemetry.api.common.Attributes
+import java.util.concurrent.ConcurrentLinkedQueue
+import java.util.concurrent.Executors
+import java.util.concurrent.ScheduledExecutorService
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.logging.Level
+import java.util.logging.Logger
+import kotlinx.coroutines.runBlocking
+
+/**
+ * A delete event to be buffered for batch processing.
+ *
+ * @property deletedBlobPath The GCS path of the deleted blob.
+ * @property impressionMetadataResourceId Optional resource ID for direct deletion.
+ */
+data class DeleteEvent(
+  val deletedBlobPath: String,
+  val impressionMetadataResourceId: String?,
+)
+
+/**
+ * Buffers delete events in memory and flushes them in batches.
+ *
+ * On Cloud Functions Gen2, a single instance can handle concurrent requests. This class exploits
+ * instance reuse to accumulate delete events across invocations and process them together, reducing
+ * per-event overhead (gRPC channel setup, Spanner round-trips) when lifecycle rules delete many
+ * files in a short window.
+ *
+ * Events are flushed when:
+ * - The buffer reaches [batchSize] events, OR
+ * - A periodic timer fires every [flushIntervalSeconds] seconds.
+ *
+ * Failed events are re-queued for the next flush cycle. A shutdown hook should call [shutdown] to
+ * drain remaining events before the instance is terminated.
+ *
+ * @property cleanupDelegate The underlying cleanup logic that processes individual events.
+ * @property batchSize Flush immediately when this many events are buffered.
+ * @property flushIntervalSeconds Periodic flush interval in seconds.
+ * @property metrics Metrics recorder for telemetry.
+ */
+class BufferedDataAvailabilityCleanup(
+  private val cleanupDelegate: DataAvailabilityCleanup,
+  private val batchSize: Int = DEFAULT_BATCH_SIZE,
+  private val flushIntervalSeconds: Long = DEFAULT_FLUSH_INTERVAL_SECONDS,
+  private val metrics: DataAvailabilityCleanupMetrics = DataAvailabilityCleanupMetrics(),
+) {
+  private val queue = ConcurrentLinkedQueue<DeleteEvent>()
+  private val scheduler: ScheduledExecutorService =
+    Executors.newSingleThreadScheduledExecutor { r ->
+      Thread(r, "cleanup-buffer-flush").apply { isDaemon = true }
+    }
+  private val flushScheduled = AtomicBoolean(false)
+
+  /**
+   * Adds a delete event to the buffer.
+   *
+   * If the buffer reaches [batchSize], triggers an immediate flush.
+   */
+  fun enqueue(event: DeleteEvent) {
+    queue.add(event)
+    logger.info("Buffered delete event for: ${event.deletedBlobPath} (queue size: ${queue.size})")
+
+    ensureFlushScheduled()
+
+    if (queue.size >= batchSize) {
+      logger.info("Batch size threshold ($batchSize) reached, flushing immediately")
+      flush()
+    }
+  }
+
+  private fun ensureFlushScheduled() {
+    if (flushScheduled.compareAndSet(false, true)) {
+      scheduler.scheduleAtFixedRate(
+        { flush() },
+        flushIntervalSeconds,
+        flushIntervalSeconds,
+        TimeUnit.SECONDS,
+      )
+      logger.info("Scheduled periodic flush every ${flushIntervalSeconds}s")
+    }
+  }
+
+  /** Drains all buffered events and processes them sequentially. Failed events are re-queued. */
+  fun flush() {
+    val batch = drain()
+    if (batch.isEmpty()) return
+
+    logger.info("Flushing ${batch.size} buffered delete events")
+    var successCount = 0
+    var failedCount = 0
+
+    for (event in batch) {
+      try {
+        runBlocking {
+          cleanupDelegate.cleanup(event.deletedBlobPath, event.impressionMetadataResourceId)
+        }
+        successCount++
+      } catch (e: Exception) {
+        failedCount++
+        logger.log(
+          Level.WARNING,
+          "Failed to clean up ${event.deletedBlobPath}, re-queuing",
+          e,
+        )
+        queue.add(event)
+      }
+    }
+
+    logger.info(
+      "Flush complete: $successCount succeeded, $failedCount failed (re-queued), " +
+        "${queue.size} remaining in buffer"
+    )
+
+    if (successCount > 0) {
+      metrics.recordsDeletedCounter.add(
+        successCount.toLong(),
+        Attributes.of(
+          DataAvailabilityCleanupMetrics.CLEANUP_STATUS_ATTR,
+          BATCH_FLUSH_STATUS,
+        ),
+      )
+    }
+  }
+
+  private fun drain(): List<DeleteEvent> {
+    val batch = mutableListOf<DeleteEvent>()
+    while (true) {
+      queue.poll()?.let { batch.add(it) } ?: break
+    }
+    return batch
+  }
+
+  /** Flushes remaining events and shuts down the periodic scheduler. */
+  fun shutdown() {
+    logger.info("Shutting down buffered cleanup, flushing remaining events")
+    flush()
+    scheduler.shutdown()
+    try {
+      if (!scheduler.awaitTermination(SHUTDOWN_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
+        scheduler.shutdownNow()
+      }
+    } catch (e: InterruptedException) {
+      scheduler.shutdownNow()
+      Thread.currentThread().interrupt()
+    }
+  }
+
+  /** Returns the number of events currently buffered. */
+  fun pendingCount(): Int = queue.size
+
+  companion object {
+    private val logger: Logger =
+      Logger.getLogger(BufferedDataAvailabilityCleanup::class.java.name)
+    const val DEFAULT_BATCH_SIZE = 100
+    const val DEFAULT_FLUSH_INTERVAL_SECONDS = 30L
+    private const val SHUTDOWN_TIMEOUT_SECONDS = 10L
+    private const val BATCH_FLUSH_STATUS = "batch_flush"
+  }
+}

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/dataavailability/BufferedDataAvailabilityCleanup.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/dataavailability/BufferedDataAvailabilityCleanup.kt
@@ -18,8 +18,10 @@ package org.wfanet.measurement.edpaggregator.dataavailability
 
 import io.opentelemetry.api.common.Attributes
 import java.util.concurrent.ConcurrentLinkedQueue
+import java.util.concurrent.Executors
+import java.util.concurrent.ScheduledExecutorService
+import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicBoolean
-import java.util.concurrent.atomic.AtomicLong
 import java.util.logging.Level
 import java.util.logging.Logger
 import kotlin.time.TimeSource
@@ -44,14 +46,12 @@ data class DeleteEvent(
  * instance reuse to accumulate delete events across invocations and process them together,
  * rather than N individual RPCs.
  *
- * Flushing is always done synchronously within the calling thread (the HTTP request handler
- * thread), avoiding CPU throttling issues with background threads on Cloud Functions Gen2
- * where CPU is throttled between invocations.
- *
  * Events are flushed when:
- * - The buffer reaches [batchSize] events (flushed by the enqueuing thread), OR
- * - The buffer has events older than [flushIntervalSeconds] (flushed by the next enqueuing
- *   thread).
+ * - The buffer reaches [batchSize] events (flushed synchronously by the enqueuing thread), OR
+ * - A periodic background timer fires every [flushIntervalSeconds] seconds as a fallback.
+ *
+ * NOTE: The background timer requires CPU >= 1 with concurrency > 1 to function reliably.
+ * With fractional CPU, Cloud Run throttles background threads between requests.
  *
  * During flush:
  * 1. Events whose blobs still have a live version in storage are skipped (noncurrent version
@@ -71,12 +71,15 @@ class BufferedDataAvailabilityCleanup(
   private val metrics: DataAvailabilityCleanupMetrics = DataAvailabilityCleanupMetrics(),
 ) {
   private val queue = ConcurrentLinkedQueue<DeleteEvent>()
-  private val firstEnqueueTimeMs = AtomicLong(0)
   private val flushing = AtomicBoolean(false)
+  private val timerScheduled = AtomicBoolean(false)
+  private val scheduler: ScheduledExecutorService =
+    Executors.newSingleThreadScheduledExecutor { r ->
+      Thread(r, "cleanup-buffer-flush").apply { isDaemon = true }
+    }
 
   fun enqueue(event: DeleteEvent) {
     queue.add(event)
-    firstEnqueueTimeMs.compareAndSet(0, System.currentTimeMillis())
     val size = queue.size
     if (size % LOG_INTERVAL == 0 || size <= 10) {
       logger.info(
@@ -84,19 +87,29 @@ class BufferedDataAvailabilityCleanup(
       )
     }
 
+    ensureTimerScheduled()
+
     if (size >= batchSize) {
       logger.info("Batch size threshold ($batchSize) reached, flushing immediately")
-      flush()
-    } else if (isStale()) {
-      logger.info("Buffer age exceeded ${flushIntervalSeconds}s, flushing")
       flush()
     }
   }
 
-  private fun isStale(): Boolean {
-    val first = firstEnqueueTimeMs.get()
-    if (first == 0L) return false
-    return System.currentTimeMillis() - first >= flushIntervalSeconds * 1000
+  private fun ensureTimerScheduled() {
+    if (timerScheduled.compareAndSet(false, true)) {
+      scheduler.scheduleAtFixedRate(
+        {
+          if (!queue.isEmpty()) {
+            logger.info("Periodic flush timer fired (${queue.size} events pending)")
+            flush()
+          }
+        },
+        flushIntervalSeconds,
+        flushIntervalSeconds,
+        TimeUnit.SECONDS,
+      )
+      logger.info("Scheduled periodic flush every ${flushIntervalSeconds}s")
+    }
   }
 
   fun flush() {
@@ -114,7 +127,6 @@ class BufferedDataAvailabilityCleanup(
     val batch = drain()
     if (batch.isEmpty()) return
 
-    firstEnqueueTimeMs.set(if (queue.isEmpty()) 0 else System.currentTimeMillis())
     val flushStart = TimeSource.Monotonic.markNow()
     logger.info("Flushing ${batch.size} buffered delete events")
 
@@ -281,6 +293,15 @@ class BufferedDataAvailabilityCleanup(
   fun shutdown() {
     logger.info("Shutting down buffered cleanup, flushing remaining events")
     flush()
+    scheduler.shutdown()
+    try {
+      if (!scheduler.awaitTermination(SHUTDOWN_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
+        scheduler.shutdownNow()
+      }
+    } catch (e: InterruptedException) {
+      scheduler.shutdownNow()
+      Thread.currentThread().interrupt()
+    }
   }
 
   fun pendingCount(): Int = queue.size
@@ -292,6 +313,7 @@ class BufferedDataAvailabilityCleanup(
     const val DEFAULT_FLUSH_INTERVAL_SECONDS = 30L
     const val MAX_BATCH_DELETE_SIZE = 100
     const val MAX_BATCH_RESOLVE_SIZE = 100
+    private const val SHUTDOWN_TIMEOUT_SECONDS = 10L
     private const val BATCH_FLUSH_STATUS = "batch_flush"
     private const val LOG_INTERVAL = 50
   }

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/dataavailability/BufferedDataAvailabilityCleanup.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/dataavailability/BufferedDataAvailabilityCleanup.kt
@@ -21,12 +21,10 @@ import io.grpc.StatusException
 import io.grpc.StatusRuntimeException
 import io.opentelemetry.api.common.Attributes
 import java.util.concurrent.ConcurrentLinkedQueue
-import java.util.concurrent.Executors
-import java.util.concurrent.ScheduledExecutorService
-import java.util.concurrent.TimeUnit
-import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.locks.ReentrantLock
 import java.util.logging.Level
 import java.util.logging.Logger
+import kotlin.concurrent.withLock
 import kotlin.time.TimeSource
 import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.runBlocking
@@ -44,18 +42,24 @@ data class DeleteEvent(val deletedBlobPath: String, val impressionMetadataResour
  * Buffers delete events in memory and flushes them via `BatchDeleteImpressionMetadata` RPCs, each
  * capped at [MAX_BATCH_DELETE_SIZE] records.
  *
- * On Cloud Functions Gen2, a single instance can handle concurrent requests. This class exploits
- * instance reuse to accumulate delete events across invocations and process them together, rather
- * than N individual RPCs.
+ * On Cloud Run (Gen2 Cloud Functions), a single instance handles concurrent requests. When GCS
+ * lifecycle rules delete many objects in a short window, the resulting OBJECT_DELETE events arrive
+ * as concurrent HTTP requests to the same instance. This class accumulates those events and
+ * processes them in batches, replacing N individual RPCs with ceil(N/100) batch RPCs.
  *
- * Events are flushed when:
- * - The buffer reaches [batchSize] events (flushed synchronously by the enqueuing thread), OR
- * - A periodic background timer fires every [flushIntervalSeconds] seconds as a fallback.
+ * ## Flush strategy
  *
- * NOTE: The background timer requires CPU >= 1 with concurrency > 1 to function reliably. With
- * fractional CPU, Cloud Run throttles background threads between requests.
+ * Every [enqueue] call attempts a synchronous flush. The flush lock serializes concurrent flushes:
+ * the first thread to acquire the lock drains and processes all queued events; concurrent threads
+ * block on the lock and then find the queue empty (their events were already flushed). This
+ * naturally coalesces concurrent events into batches without any background timer.
  *
- * During flush:
+ * This design is critical on Cloud Run: background timer threads cannot reliably flush because
+ * Cloud Run may scale down an instance as soon as all HTTP requests complete, killing background
+ * threads before they fire. By flushing synchronously within the request, the HTTP connection stays
+ * alive during the flush, keeping the instance active.
+ *
+ * ## Flush pipeline
  * 1. All blob paths are grouped by directory prefix and bulk-checked via `listBlobs` to find which
  *    blobs still have a live (current) version. Events whose blobs are still live are skipped — the
  *    delete event was for a noncurrent version and the object is still in use.
@@ -63,29 +67,18 @@ data class DeleteEvent(val deletedBlobPath: String, val impressionMetadataResour
  *    using the `blob_uris` filter.
  * 3. Resolved resource names are chunked into groups of [MAX_BATCH_DELETE_SIZE] and each chunk is
  *    deleted via a single `BatchDeleteImpressionMetadata` RPC.
- * 4. Events that fail resolution are re-queued.
+ * 4. Events that fail resolution are re-queued for the next flush.
  */
 class BufferedDataAvailabilityCleanup(
   private val impressionMetadataServiceStub: ImpressionMetadataServiceCoroutineStub,
   private val dataProviderName: String,
   private val storageClient: StorageClient,
   private val batchSize: Int = DEFAULT_BATCH_SIZE,
-  private val flushIntervalSeconds: Long = DEFAULT_FLUSH_INTERVAL_SECONDS,
+  @Suppress("UNUSED_PARAMETER") flushIntervalSeconds: Long = DEFAULT_FLUSH_INTERVAL_SECONDS,
   private val metrics: DataAvailabilityCleanupMetrics = DataAvailabilityCleanupMetrics(),
 ) {
   private val queue = ConcurrentLinkedQueue<DeleteEvent>()
-  private val flushing = AtomicBoolean(false)
-  private val timerScheduled = AtomicBoolean(false)
-  private val scheduler: ScheduledExecutorService =
-    Executors.newSingleThreadScheduledExecutor { r ->
-      Thread(r, "cleanup-buffer-flush").apply {
-        isDaemon = true
-        uncaughtExceptionHandler =
-          Thread.UncaughtExceptionHandler { t, e ->
-            logger.log(Level.SEVERE, "Uncaught exception in timer thread ${t.name}", e)
-          }
-      }
-    }
+  private val flushLock = ReentrantLock()
 
   fun enqueue(event: DeleteEvent) {
     queue.add(event)
@@ -94,56 +87,11 @@ class BufferedDataAvailabilityCleanup(
       logger.info("Buffered delete event for: ${event.deletedBlobPath} (queue size: $size)")
     }
 
-    ensureTimerScheduled()
-
-    if (size >= batchSize) {
-      logger.info("Batch size threshold ($batchSize) reached, flushing immediately")
-      flush()
-    }
-  }
-
-  private fun ensureTimerScheduled() {
-    if (timerScheduled.compareAndSet(false, true)) {
-      try {
-        scheduler.scheduleAtFixedRate(
-          {
-            try {
-              if (!queue.isEmpty()) {
-                logger.info("Periodic flush timer fired (${queue.size} events pending)")
-                flush()
-              } else {
-                logger.fine("Periodic flush timer fired (queue empty, skipping)")
-              }
-            } catch (e: Exception) {
-              logger.log(
-                Level.SEVERE,
-                "Timer flush failed, re-queuing will happen on next flush",
-                e,
-              )
-            }
-          },
-          flushIntervalSeconds,
-          flushIntervalSeconds,
-          TimeUnit.SECONDS,
-        )
-        logger.info("Scheduled periodic flush every ${flushIntervalSeconds}s")
-      } catch (e: Exception) {
-        logger.log(Level.SEVERE, "Failed to schedule periodic flush timer", e)
-        timerScheduled.set(false)
-      }
-    }
+    flush()
   }
 
   fun flush() {
-    if (!flushing.compareAndSet(false, true)) {
-      logger.info("Flush already in progress, skipping")
-      return
-    }
-    try {
-      doFlush()
-    } finally {
-      flushing.set(false)
-    }
+    flushLock.withLock { doFlush() }
   }
 
   private fun doFlush() {
@@ -158,7 +106,7 @@ class BufferedDataAvailabilityCleanup(
       val liveBlobKeys = findLiveBlobKeys(batch)
       val checkMs = checkStart.elapsedNow().inWholeMilliseconds
 
-      val resourceNames = mutableListOf<String>()
+      val resolvedEvents = mutableListOf<DeleteEvent>()
       var skippedCount = 0
       var resolveFailCount = 0
       val eventsNeedingResolution = mutableListOf<DeleteEvent>()
@@ -172,7 +120,7 @@ class BufferedDataAvailabilityCleanup(
           }
 
           if (!event.impressionMetadataResourceId.isNullOrEmpty()) {
-            resourceNames.add(event.impressionMetadataResourceId)
+            resolvedEvents.add(event)
           } else {
             eventsNeedingResolution.add(event)
           }
@@ -183,7 +131,7 @@ class BufferedDataAvailabilityCleanup(
         }
       }
       logger.info(
-        "Live-version check: ${resourceNames.size} pre-resolved, " +
+        "Live-version check: ${resolvedEvents.size} pre-resolved, " +
           "${eventsNeedingResolution.size} need lookup, " +
           "$skippedCount skipped (live), $resolveFailCount failed " +
           "[${liveBlobKeys.size} live keys from ${batch.size} events, ${checkMs}ms]"
@@ -197,25 +145,26 @@ class BufferedDataAvailabilityCleanup(
           "Batch-resolved ${resolved.size}/${eventsNeedingResolution.size} " +
             "blob URIs in ${resolveMs}ms"
         )
-        resourceNames.addAll(resolved)
+        resolvedEvents.addAll(resolved)
         skippedCount += eventsNeedingResolution.size - resolved.size
       }
 
-      if (resourceNames.isNotEmpty()) {
-        val chunks = resourceNames.chunked(MAX_BATCH_DELETE_SIZE)
+      if (resolvedEvents.isNotEmpty()) {
+        val chunks = resolvedEvents.chunked(MAX_BATCH_DELETE_SIZE)
         logger.info(
-          "Deleting ${resourceNames.size} records in ${chunks.size} batch RPC(s) " +
+          "Deleting ${resolvedEvents.size} records in ${chunks.size} batch RPC(s) " +
             "(max $MAX_BATCH_DELETE_SIZE per RPC)"
         )
         val deleteStart = TimeSource.Monotonic.markNow()
         var totalDeleted = 0
 
         for ((index, chunk) in chunks.withIndex()) {
+          val chunkNames = chunk.map { it.impressionMetadataResourceId!! }
           try {
             impressionMetadataServiceStub.batchDeleteImpressionMetadata(
               batchDeleteImpressionMetadataRequest {
                 parent = dataProviderName
-                names += chunk
+                names += chunkNames
               }
             )
             totalDeleted += chunk.size
@@ -268,14 +217,14 @@ class BufferedDataAvailabilityCleanup(
     val liveBlobKeys = mutableSetOf<String>()
     for (prefix in prefixes) {
       try {
-        storageClient.listBlobs(prefix).toList().forEach { blob ->
-          liveBlobKeys.add(blob.blobKey)
-        }
+        storageClient.listBlobs(prefix).toList().forEach { blob -> liveBlobKeys.add(blob.blobKey) }
       } catch (e: Exception) {
         logger.log(Level.WARNING, "Failed to list blobs with prefix $prefix", e)
       }
     }
-    logger.info("Bulk live-version check: ${prefixes.size} prefixes, ${liveBlobKeys.size} live blobs")
+    logger.info(
+      "Bulk live-version check: ${prefixes.size} prefixes, ${liveBlobKeys.size} live blobs"
+    )
     return liveBlobKeys
   }
 
@@ -283,23 +232,15 @@ class BufferedDataAvailabilityCleanup(
    * Handles a failed `BatchDeleteImpressionMetadata` RPC.
    *
    * `BatchDeleteImpressionMetadata` is atomic — if ANY record in the batch returns NOT_FOUND, the
-   * entire RPC fails with NOT_FOUND. This can happen when:
-   * - A record was already cleaned up by a previous flush cycle or duplicate event.
-   * - On a versioned GCS bucket, multiple noncurrent version deletions for the same object each
-   *   trigger an OBJECT_DELETE event, but only the first cleanup call will find the metadata.
+   * entire RPC fails with NOT_FOUND. When NOT_FOUND, falls back to individual deletes where
+   * NOT_FOUND is treated as idempotent success. For other errors, re-queues the entire chunk using
+   * the original [DeleteEvent] (preserving the blob path for the next flush cycle).
    *
-   * When the batch fails with NOT_FOUND, this method falls back to individual
-   * `DeleteImpressionMetadata` RPCs for each record in the chunk. Individual NOT_FOUND errors are
-   * treated as successful (idempotent delete) since the record is already gone.
-   *
-   * For non-NOT_FOUND errors, all records in the chunk are re-queued for retry on the next flush.
-   *
-   * @return the number of records successfully deleted (including NOT_FOUND, which counts as
-   *   already-deleted)
+   * @return the number of records successfully deleted (including NOT_FOUND as already-deleted)
    */
   private suspend fun handleBatchDeleteFailure(
     error: Exception,
-    chunk: List<String>,
+    chunk: List<DeleteEvent>,
     rpcIndex: Int,
     totalRpcs: Int,
   ): Int {
@@ -311,7 +252,7 @@ class BufferedDataAvailabilityCleanup(
         "Batch RPC $rpcIndex/$totalRpcs failed for ${chunk.size} records, re-queuing",
         error,
       )
-      chunk.forEach { name -> queue.add(DeleteEvent(name, name)) }
+      chunk.forEach { event -> queue.add(event) }
       return 0
     }
 
@@ -324,10 +265,10 @@ class BufferedDataAvailabilityCleanup(
     var alreadyGone = 0
     var failed = 0
 
-    for (name in chunk) {
+    for (event in chunk) {
       try {
         impressionMetadataServiceStub.deleteImpressionMetadata(
-          deleteImpressionMetadataRequest { this.name = name }
+          deleteImpressionMetadataRequest { name = event.impressionMetadataResourceId!! }
         )
         deleted++
       } catch (e: Exception) {
@@ -336,8 +277,12 @@ class BufferedDataAvailabilityCleanup(
           alreadyGone++
         } else {
           failed++
-          logger.log(Level.WARNING, "Individual delete failed for $name, re-queuing", e)
-          queue.add(DeleteEvent(name, name))
+          logger.log(
+            Level.WARNING,
+            "Individual delete failed for ${event.impressionMetadataResourceId}, re-queuing",
+            e,
+          )
+          queue.add(event)
         }
       }
     }
@@ -357,42 +302,45 @@ class BufferedDataAvailabilityCleanup(
     }
   }
 
-  private suspend fun batchResolveResourceNames(events: List<DeleteEvent>): List<String> {
-    val blobUris = events.map { it.deletedBlobPath }
+  private suspend fun batchResolveResourceNames(events: List<DeleteEvent>): List<DeleteEvent> {
+    val resolvedEvents = mutableListOf<DeleteEvent>()
 
-    val resolvedNames = mutableListOf<String>()
-    for (chunk in blobUris.chunked(MAX_BATCH_RESOLVE_SIZE)) {
+    for (chunk in events.chunked(MAX_BATCH_RESOLVE_SIZE)) {
+      val blobUris = chunk.map { it.deletedBlobPath }
       try {
         val listResponse =
           impressionMetadataServiceStub.listImpressionMetadata(
             listImpressionMetadataRequest {
               parent = dataProviderName
-              filter = ListImpressionMetadataRequestKt.filter { this.blobUris += chunk }
+              filter = ListImpressionMetadataRequestKt.filter { this.blobUris += blobUris }
             }
           )
 
         val resultsByUri = listResponse.impressionMetadataList.groupBy { it.blobUri }
-        for (uri in chunk) {
-          val matches = resultsByUri[uri]
+        for (event in chunk) {
+          val matches = resultsByUri[event.deletedBlobPath]
           when {
             matches == null || matches.isEmpty() -> {
-              logger.warning("No ImpressionMetadata found for blob URI: $uri. Skipping.")
+              logger.warning(
+                "No ImpressionMetadata found for blob URI: ${event.deletedBlobPath}. Skipping."
+              )
             }
             matches.size > 1 -> {
               logger.warning(
-                "Multiple ImpressionMetadata records (${matches.size}) for $uri. Skipping."
+                "Multiple ImpressionMetadata records (${matches.size}) for " +
+                  "${event.deletedBlobPath}. Skipping."
               )
             }
-            else -> resolvedNames.add(matches.single().name)
+            else -> resolvedEvents.add(DeleteEvent(event.deletedBlobPath, matches.single().name))
           }
         }
       } catch (e: Exception) {
         logger.log(Level.WARNING, "Batch resolve failed for ${chunk.size} URIs, re-queuing", e)
-        chunk.forEach { uri -> queue.add(DeleteEvent(uri, null)) }
+        chunk.forEach { event -> queue.add(event) }
       }
     }
 
-    return resolvedNames
+    return resolvedEvents
   }
 
   private fun drain(): List<DeleteEvent> {
@@ -406,15 +354,6 @@ class BufferedDataAvailabilityCleanup(
   fun shutdown() {
     logger.info("Shutting down buffered cleanup, flushing remaining events")
     flush()
-    scheduler.shutdown()
-    try {
-      if (!scheduler.awaitTermination(SHUTDOWN_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
-        scheduler.shutdownNow()
-      }
-    } catch (e: InterruptedException) {
-      scheduler.shutdownNow()
-      Thread.currentThread().interrupt()
-    }
   }
 
   fun pendingCount(): Int = queue.size
@@ -425,7 +364,6 @@ class BufferedDataAvailabilityCleanup(
     const val DEFAULT_FLUSH_INTERVAL_SECONDS = 30L
     const val MAX_BATCH_DELETE_SIZE = 100
     const val MAX_BATCH_RESOLVE_SIZE = 100
-    private const val SHUTDOWN_TIMEOUT_SECONDS = 10L
     private const val BATCH_FLUSH_STATUS = "batch_flush"
     private const val LOG_INTERVAL = 50
   }

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/dataavailability/BufferedDataAvailabilityCleanup.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/dataavailability/BufferedDataAvailabilityCleanup.kt
@@ -25,40 +25,39 @@ import java.util.concurrent.atomic.AtomicBoolean
 import java.util.logging.Level
 import java.util.logging.Logger
 import kotlinx.coroutines.runBlocking
+import org.wfanet.measurement.edpaggregator.v1alpha.ImpressionMetadataServiceGrpcKt.ImpressionMetadataServiceCoroutineStub
+import org.wfanet.measurement.edpaggregator.v1alpha.ListImpressionMetadataRequestKt
+import org.wfanet.measurement.edpaggregator.v1alpha.batchDeleteImpressionMetadataRequest
+import org.wfanet.measurement.edpaggregator.v1alpha.listImpressionMetadataRequest
+import org.wfanet.measurement.storage.SelectedStorageClient
+import org.wfanet.measurement.storage.StorageClient
 
-/**
- * A delete event to be buffered for batch processing.
- *
- * @property deletedBlobPath The GCS path of the deleted blob.
- * @property impressionMetadataResourceId Optional resource ID for direct deletion.
- */
 data class DeleteEvent(
   val deletedBlobPath: String,
   val impressionMetadataResourceId: String?,
 )
 
 /**
- * Buffers delete events in memory and flushes them in batches.
+ * Buffers delete events in memory and flushes them via a single
+ * `BatchDeleteImpressionMetadata` RPC.
  *
  * On Cloud Functions Gen2, a single instance can handle concurrent requests. This class exploits
- * instance reuse to accumulate delete events across invocations and process them together, reducing
- * per-event overhead (gRPC channel setup, Spanner round-trips) when lifecycle rules delete many
- * files in a short window.
+ * instance reuse to accumulate delete events across invocations and process them together in one
+ * Spanner transaction, rather than N individual RPCs.
  *
  * Events are flushed when:
  * - The buffer reaches [batchSize] events, OR
  * - A periodic timer fires every [flushIntervalSeconds] seconds.
  *
- * Failed events are re-queued for the next flush cycle. A shutdown hook should call [shutdown] to
- * drain remaining events before the instance is terminated.
- *
- * @property cleanupDelegate The underlying cleanup logic that processes individual events.
- * @property batchSize Flush immediately when this many events are buffered.
- * @property flushIntervalSeconds Periodic flush interval in seconds.
- * @property metrics Metrics recorder for telemetry.
+ * During flush, events without a resource ID are resolved by looking up the blob URI in the
+ * ImpressionMetadata service. Events whose blobs still have a live version in storage are skipped
+ * (noncurrent version deletion). All resolved resource names are then deleted in a single batch
+ * RPC. Events that fail resolution are re-queued.
  */
 class BufferedDataAvailabilityCleanup(
-  private val cleanupDelegate: DataAvailabilityCleanup,
+  private val impressionMetadataServiceStub: ImpressionMetadataServiceCoroutineStub,
+  private val dataProviderName: String,
+  private val storageClient: StorageClient,
   private val batchSize: Int = DEFAULT_BATCH_SIZE,
   private val flushIntervalSeconds: Long = DEFAULT_FLUSH_INTERVAL_SECONDS,
   private val metrics: DataAvailabilityCleanupMetrics = DataAvailabilityCleanupMetrics(),
@@ -70,11 +69,6 @@ class BufferedDataAvailabilityCleanup(
     }
   private val flushScheduled = AtomicBoolean(false)
 
-  /**
-   * Adds a delete event to the buffer.
-   *
-   * If the buffer reaches [batchSize], triggers an immediate flush.
-   */
   fun enqueue(event: DeleteEvent) {
     queue.add(event)
     logger.info("Buffered delete event for: ${event.deletedBlobPath} (queue size: ${queue.size})")
@@ -99,45 +93,110 @@ class BufferedDataAvailabilityCleanup(
     }
   }
 
-  /** Drains all buffered events and processes them sequentially. Failed events are re-queued. */
   fun flush() {
     val batch = drain()
     if (batch.isEmpty()) return
 
     logger.info("Flushing ${batch.size} buffered delete events")
-    var successCount = 0
-    var failedCount = 0
 
-    for (event in batch) {
-      try {
-        runBlocking {
-          cleanupDelegate.cleanup(event.deletedBlobPath, event.impressionMetadataResourceId)
+    runBlocking {
+      val resourceNames = mutableListOf<String>()
+      var skippedCount = 0
+
+      for (event in batch) {
+        try {
+          val blobUri = SelectedStorageClient.parseBlobUri(event.deletedBlobPath)
+          val liveBlob = storageClient.getBlob(blobUri.key)
+          if (liveBlob != null) {
+            logger.info(
+              "Live version still exists for ${event.deletedBlobPath}. " +
+                "Skipping (noncurrent version deletion)."
+            )
+            skippedCount++
+            continue
+          }
+
+          val resourceName = resolveResourceName(event)
+          if (resourceName != null) {
+            resourceNames.add(resourceName)
+          } else {
+            skippedCount++
+          }
+        } catch (e: Exception) {
+          logger.log(
+            Level.WARNING,
+            "Failed to resolve ${event.deletedBlobPath}, re-queuing",
+            e,
+          )
+          queue.add(event)
         }
-        successCount++
-      } catch (e: Exception) {
-        failedCount++
-        logger.log(
-          Level.WARNING,
-          "Failed to clean up ${event.deletedBlobPath}, re-queuing",
-          e,
-        )
-        queue.add(event)
+      }
+
+      if (resourceNames.isNotEmpty()) {
+        try {
+          logger.info(
+            "Calling BatchDeleteImpressionMetadata with ${resourceNames.size} resource names"
+          )
+          impressionMetadataServiceStub.batchDeleteImpressionMetadata(
+            batchDeleteImpressionMetadataRequest {
+              parent = dataProviderName
+              names += resourceNames
+            }
+          )
+          logger.info(
+            "Batch delete succeeded: ${resourceNames.size} deleted, " +
+              "$skippedCount skipped, ${queue.size} remaining in buffer"
+          )
+          metrics.recordsDeletedCounter.add(
+            resourceNames.size.toLong(),
+            Attributes.of(
+              DataAvailabilityCleanupMetrics.CLEANUP_STATUS_ATTR,
+              BATCH_FLUSH_STATUS,
+            ),
+          )
+        } catch (e: Exception) {
+          logger.log(Level.SEVERE, "Batch delete RPC failed, re-queuing all ${resourceNames.size} events", e)
+          resourceNames.forEach { name ->
+            queue.add(DeleteEvent(name, name))
+          }
+        }
+      } else {
+        logger.info("No events to batch-delete ($skippedCount skipped)")
       }
     }
+  }
 
-    logger.info(
-      "Flush complete: $successCount succeeded, $failedCount failed (re-queued), " +
-        "${queue.size} remaining in buffer"
-    )
+  private suspend fun resolveResourceName(event: DeleteEvent): String? {
+    if (!event.impressionMetadataResourceId.isNullOrEmpty()) {
+      return event.impressionMetadataResourceId
+    }
 
-    if (successCount > 0) {
-      metrics.recordsDeletedCounter.add(
-        successCount.toLong(),
-        Attributes.of(
-          DataAvailabilityCleanupMetrics.CLEANUP_STATUS_ATTR,
-          BATCH_FLUSH_STATUS,
-        ),
+    val listResponse =
+      impressionMetadataServiceStub.listImpressionMetadata(
+        listImpressionMetadataRequest {
+          parent = dataProviderName
+          filter = ListImpressionMetadataRequestKt.filter {
+            blobUriPrefix = event.deletedBlobPath
+          }
+        }
       )
+
+    val results = listResponse.impressionMetadataList
+    return when {
+      results.isEmpty() -> {
+        logger.warning(
+          "No ImpressionMetadata found for blob URI: ${event.deletedBlobPath}. Skipping."
+        )
+        null
+      }
+      results.size > 1 -> {
+        logger.warning(
+          "Multiple ImpressionMetadata records (${results.size}) found for " +
+            "blob URI: ${event.deletedBlobPath}. Skipping."
+        )
+        null
+      }
+      else -> results.single().name
     }
   }
 
@@ -149,7 +208,6 @@ class BufferedDataAvailabilityCleanup(
     return batch
   }
 
-  /** Flushes remaining events and shuts down the periodic scheduler. */
   fun shutdown() {
     logger.info("Shutting down buffered cleanup, flushing remaining events")
     flush()
@@ -164,7 +222,6 @@ class BufferedDataAvailabilityCleanup(
     }
   }
 
-  /** Returns the number of events currently buffered. */
   fun pendingCount(): Int = queue.size
 
   companion object {

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/dataavailability/BufferedDataAvailabilityCleanup.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/dataavailability/BufferedDataAvailabilityCleanup.kt
@@ -16,6 +16,9 @@
 
 package org.wfanet.measurement.edpaggregator.dataavailability
 
+import io.grpc.Status
+import io.grpc.StatusException
+import io.grpc.StatusRuntimeException
 import io.opentelemetry.api.common.Attributes
 import java.util.concurrent.ConcurrentLinkedQueue
 import java.util.concurrent.Executors
@@ -29,6 +32,7 @@ import kotlinx.coroutines.runBlocking
 import org.wfanet.measurement.edpaggregator.v1alpha.ImpressionMetadataServiceGrpcKt.ImpressionMetadataServiceCoroutineStub
 import org.wfanet.measurement.edpaggregator.v1alpha.ListImpressionMetadataRequestKt
 import org.wfanet.measurement.edpaggregator.v1alpha.batchDeleteImpressionMetadataRequest
+import org.wfanet.measurement.edpaggregator.v1alpha.deleteImpressionMetadataRequest
 import org.wfanet.measurement.edpaggregator.v1alpha.listImpressionMetadataRequest
 import org.wfanet.measurement.storage.SelectedStorageClient
 import org.wfanet.measurement.storage.StorageClient
@@ -214,13 +218,7 @@ class BufferedDataAvailabilityCleanup(
             totalDeleted += chunk.size
             logger.info("Batch RPC ${index + 1}/${chunks.size}: deleted ${chunk.size} records")
           } catch (e: Exception) {
-            logger.log(
-              Level.SEVERE,
-              "Batch RPC ${index + 1}/${chunks.size} failed for ${chunk.size} records, " +
-                "re-queuing",
-              e,
-            )
-            chunk.forEach { name -> queue.add(DeleteEvent(name, name)) }
+            totalDeleted += handleBatchDeleteFailure(e, chunk, index + 1, chunks.size)
           }
         }
 
@@ -239,6 +237,84 @@ class BufferedDataAvailabilityCleanup(
         val totalMs = flushStart.elapsedNow().inWholeMilliseconds
         logger.info("No events to batch-delete ($skippedCount skipped) [total=${totalMs}ms]")
       }
+    }
+  }
+
+  /**
+   * Handles a failed `BatchDeleteImpressionMetadata` RPC.
+   *
+   * `BatchDeleteImpressionMetadata` is atomic — if ANY record in the batch returns NOT_FOUND, the
+   * entire RPC fails with NOT_FOUND. This can happen when:
+   * - A record was already cleaned up by a previous flush cycle or duplicate event.
+   * - On a versioned GCS bucket, multiple noncurrent version deletions for the same object each
+   *   trigger an OBJECT_DELETE event, but only the first cleanup call will find the metadata.
+   *
+   * When the batch fails with NOT_FOUND, this method falls back to individual
+   * `DeleteImpressionMetadata` RPCs for each record in the chunk. Individual NOT_FOUND errors are
+   * treated as successful (idempotent delete) since the record is already gone.
+   *
+   * For non-NOT_FOUND errors, all records in the chunk are re-queued for retry on the next flush.
+   *
+   * @return the number of records successfully deleted (including NOT_FOUND, which counts as
+   *   already-deleted)
+   */
+  private suspend fun handleBatchDeleteFailure(
+    error: Exception,
+    chunk: List<String>,
+    rpcIndex: Int,
+    totalRpcs: Int,
+  ): Int {
+    val statusCode = extractStatusCode(error)
+
+    if (statusCode != Status.Code.NOT_FOUND) {
+      logger.log(
+        Level.SEVERE,
+        "Batch RPC $rpcIndex/$totalRpcs failed for ${chunk.size} records, re-queuing",
+        error,
+      )
+      chunk.forEach { name -> queue.add(DeleteEvent(name, name)) }
+      return 0
+    }
+
+    logger.warning(
+      "Batch RPC $rpcIndex/$totalRpcs failed with NOT_FOUND for ${chunk.size} records. " +
+        "Falling back to individual deletes."
+    )
+
+    var deleted = 0
+    var alreadyGone = 0
+    var failed = 0
+
+    for (name in chunk) {
+      try {
+        impressionMetadataServiceStub.deleteImpressionMetadata(
+          deleteImpressionMetadataRequest { this.name = name }
+        )
+        deleted++
+      } catch (e: Exception) {
+        val individualStatusCode = extractStatusCode(e)
+        if (individualStatusCode == Status.Code.NOT_FOUND) {
+          alreadyGone++
+        } else {
+          failed++
+          logger.log(Level.WARNING, "Individual delete failed for $name, re-queuing", e)
+          queue.add(DeleteEvent(name, name))
+        }
+      }
+    }
+
+    logger.info(
+      "Individual delete fallback: $deleted deleted, $alreadyGone already gone (NOT_FOUND), " +
+        "$failed failed and re-queued"
+    )
+    return deleted + alreadyGone
+  }
+
+  private fun extractStatusCode(error: Exception): Status.Code? {
+    return when (error) {
+      is StatusRuntimeException -> error.status.code
+      is StatusException -> error.status.code
+      else -> null
     }
   }
 

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/dataavailability/BufferedDataAvailabilityCleanup.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/dataavailability/BufferedDataAvailabilityCleanup.kt
@@ -28,6 +28,7 @@ import java.util.concurrent.atomic.AtomicBoolean
 import java.util.logging.Level
 import java.util.logging.Logger
 import kotlin.time.TimeSource
+import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.runBlocking
 import org.wfanet.measurement.edpaggregator.v1alpha.ImpressionMetadataServiceGrpcKt.ImpressionMetadataServiceCoroutineStub
 import org.wfanet.measurement.edpaggregator.v1alpha.ListImpressionMetadataRequestKt
@@ -55,8 +56,9 @@ data class DeleteEvent(val deletedBlobPath: String, val impressionMetadataResour
  * fractional CPU, Cloud Run throttles background threads between requests.
  *
  * During flush:
- * 1. Events whose blobs still have a live version in storage are skipped (noncurrent version
- *    deletion).
+ * 1. All blob paths are grouped by directory prefix and bulk-checked via `listBlobs` to find which
+ *    blobs still have a live (current) version. Events whose blobs are still live are skipped — the
+ *    delete event was for a noncurrent version and the object is still in use.
  * 2. Events without a resource ID are batch-resolved via a single `ListImpressionMetadata` RPC
  *    using the `blob_uris` filter.
  * 3. Resolved resource names are chunked into groups of [MAX_BATCH_DELETE_SIZE] and each chunk is
@@ -152,38 +154,39 @@ class BufferedDataAvailabilityCleanup(
     logger.info("Flushing ${batch.size} buffered delete events")
 
     runBlocking {
+      val checkStart = TimeSource.Monotonic.markNow()
+      val liveBlobKeys = findLiveBlobKeys(batch)
+      val checkMs = checkStart.elapsedNow().inWholeMilliseconds
+
       val resourceNames = mutableListOf<String>()
       var skippedCount = 0
       var resolveFailCount = 0
       val eventsNeedingResolution = mutableListOf<DeleteEvent>()
 
-      val checkStart = TimeSource.Monotonic.markNow()
       for (event in batch) {
         try {
-          if (!event.impressionMetadataResourceId.isNullOrEmpty()) {
-            resourceNames.add(event.impressionMetadataResourceId)
-            continue
-          }
-
           val blobUri = SelectedStorageClient.parseBlobUri(event.deletedBlobPath)
-          val liveBlob = storageClient.getBlob(blobUri.key)
-          if (liveBlob != null) {
+          if (blobUri.key in liveBlobKeys) {
             skippedCount++
             continue
           }
 
-          eventsNeedingResolution.add(event)
+          if (!event.impressionMetadataResourceId.isNullOrEmpty()) {
+            resourceNames.add(event.impressionMetadataResourceId)
+          } else {
+            eventsNeedingResolution.add(event)
+          }
         } catch (e: Exception) {
           logger.log(Level.WARNING, "Failed to check ${event.deletedBlobPath}, re-queuing", e)
           resolveFailCount++
           queue.add(event)
         }
       }
-      val checkMs = checkStart.elapsedNow().inWholeMilliseconds
       logger.info(
         "Live-version check: ${resourceNames.size} pre-resolved, " +
           "${eventsNeedingResolution.size} need lookup, " +
-          "$skippedCount skipped (live), $resolveFailCount failed [${checkMs}ms]"
+          "$skippedCount skipped (live), $resolveFailCount failed " +
+          "[${liveBlobKeys.size} live keys from ${batch.size} events, ${checkMs}ms]"
       )
 
       if (eventsNeedingResolution.isNotEmpty()) {
@@ -238,6 +241,42 @@ class BufferedDataAvailabilityCleanup(
         logger.info("No events to batch-delete ($skippedCount skipped) [total=${totalMs}ms]")
       }
     }
+  }
+
+  /**
+   * Bulk-checks which blobs in [batch] still have a live (current) version in storage.
+   *
+   * Instead of N individual `getBlob` calls, this groups blob paths by their directory prefix and
+   * issues one `listBlobs` per unique prefix. On a versioned GCS bucket, a delete event fires for
+   * both noncurrent version deletions (where a newer current version may still exist) and final
+   * deletions (no current version remains). Only the latter should trigger metadata cleanup.
+   *
+   * @return set of blob keys that still have a live version (should be skipped)
+   */
+  private suspend fun findLiveBlobKeys(batch: List<DeleteEvent>): Set<String> {
+    val prefixes = mutableSetOf<String>()
+    for (event in batch) {
+      try {
+        val blobUri = SelectedStorageClient.parseBlobUri(event.deletedBlobPath)
+        val lastSlash = blobUri.key.lastIndexOf('/')
+        if (lastSlash > 0) {
+          prefixes.add(blobUri.key.substring(0, lastSlash + 1))
+        }
+      } catch (_: Exception) {}
+    }
+
+    val liveBlobKeys = mutableSetOf<String>()
+    for (prefix in prefixes) {
+      try {
+        storageClient.listBlobs(prefix).toList().forEach { blob ->
+          liveBlobKeys.add(blob.blobKey)
+        }
+      } catch (e: Exception) {
+        logger.log(Level.WARNING, "Failed to list blobs with prefix $prefix", e)
+      }
+    }
+    logger.info("Bulk live-version check: ${prefixes.size} prefixes, ${liveBlobKeys.size} live blobs")
+    return liveBlobKeys
   }
 
   /**

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/dataavailability/DataAvailabilitySync.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/dataavailability/DataAvailabilitySync.kt
@@ -29,8 +29,6 @@ import java.util.logging.Logger
 import kotlin.text.Charsets.UTF_8
 import kotlin.time.TimeSource
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.toList
 import org.wfanet.measurement.api.v2alpha.DataProviderKt.dataAvailabilityMapEntry
 import org.wfanet.measurement.api.v2alpha.DataProvidersGrpcKt
@@ -160,8 +158,8 @@ class DataAvailabilitySync(
       }
 
       val doneBlobFolderPath = doneBlobUri.key.substringBeforeLast("/")
-      val impressionMetadataBlobs: Flow<StorageClient.Blob> =
-        storageClient.listBlobs(doneBlobFolderPath)
+      val impressionMetadataBlobs: List<StorageClient.Blob> =
+        storageClient.listBlobs(doneBlobFolderPath).toList()
 
       // 1. Retrieve blob details from storage and build a map and validate them
       val impressionMetadataMap: Map<ModelLineKey, List<ImpressionMetadataWithBlobKey>> =
@@ -459,103 +457,113 @@ class DataAvailabilitySync(
    * @throws IllegalArgumentException if a blob has an unsupported file extension.
    */
   private suspend fun createModelLineToImpressionMetadataMap(
-    impressionMetadataBlobs: Flow<StorageClient.Blob>,
+    impressionMetadataBlobs: List<StorageClient.Blob>,
     doneBlobUri: BlobUri,
   ): Map<ModelLineKey, List<ImpressionMetadataWithBlobKey>> {
-    val impressionMetadataMap =
-      mutableMapOf<ModelLineKey, MutableList<ImpressionMetadataWithBlobKey>>()
-    impressionMetadataBlobs
-      .filter { impressionMetadataBlob ->
-        val fileName = impressionMetadataBlob.blobKey.substringAfterLast("/").lowercase()
-        METADATA_FILE_NAME in fileName
-      }
-      .collect { impressionMetadataBlob ->
-        val fileName = impressionMetadataBlob.blobKey.substringAfterLast("/").lowercase()
-        val bytes: ByteString = impressionMetadataBlob.read().flatten()
+    data class ParsedMetadata(
+      val metadataBlob: StorageClient.Blob,
+      val blobDetails: BlobDetails,
+      val impressionBlobUri: BlobUri,
+    )
 
-        // Build the blob details object
-        val blobDetails =
-          if (fileName.endsWith(PROTO_FILE_SUFFIX)) {
-            BlobDetails.parseFrom(bytes)
-          } else if (fileName.endsWith(JSON_FILE_SUFFIX)) {
-            val builder = BlobDetails.newBuilder()
-            JsonFormat.parser().ignoringUnknownFields().merge(bytes.toString(UTF_8), builder)
-            builder.build()
-          } else {
-            throw IllegalArgumentException("Unsupported file extension for metadata: $fileName")
-          }
+    val parsed = mutableListOf<ParsedMetadata>()
+    val impressionBlobPrefixes = mutableSetOf<String>()
 
-        // Validate intervals
-        require(blobDetails.interval.hasStartTime() && blobDetails.interval.hasEndTime()) {
-          "Found interval without start or end time for blob detail with blob_uri = ${blobDetails.blobUri}"
+    for (metadataBlob in impressionMetadataBlobs) {
+      val fileName = metadataBlob.blobKey.substringAfterLast("/").lowercase()
+      if (METADATA_FILE_NAME !in fileName) continue
+
+      val bytes: ByteString = metadataBlob.read().flatten()
+      val blobDetails =
+        if (fileName.endsWith(PROTO_FILE_SUFFIX)) {
+          BlobDetails.parseFrom(bytes)
+        } else if (fileName.endsWith(JSON_FILE_SUFFIX)) {
+          val builder = BlobDetails.newBuilder()
+          JsonFormat.parser().ignoringUnknownFields().merge(bytes.toString(UTF_8), builder)
+          builder.build()
+        } else {
+          throw IllegalArgumentException("Unsupported file extension for metadata: $fileName")
         }
-        // At least one of event_group_reference_id or entity_keys must identify the
-        // EventGroup that produced this blob. Both empty means the metadata cannot be
-        // associated with any EventGroup downstream.
-        require(
-          blobDetails.eventGroupReferenceId.isNotEmpty() || blobDetails.entityKeysList.isNotEmpty()
-        ) {
-          "BlobDetails must have either event_group_reference_id or entity_keys populated " +
+
+      require(blobDetails.interval.hasStartTime() && blobDetails.interval.hasEndTime()) {
+        "Found interval without start or end time for blob detail with blob_uri = ${blobDetails.blobUri}"
+      }
+      require(
+        blobDetails.eventGroupReferenceId.isNotEmpty() || blobDetails.entityKeysList.isNotEmpty()
+      ) {
+        "BlobDetails must have either event_group_reference_id or entity_keys populated " +
+          "for blob_uri = ${blobDetails.blobUri}"
+      }
+      blobDetails.entityKeysList.forEachIndexed { groupIndex, group ->
+        require(group.entityType.isNotEmpty()) {
+          "BlobDetails entity_keys[$groupIndex].entity_type is empty " +
             "for blob_uri = ${blobDetails.blobUri}"
         }
-        // Every EntityKeyGroup must be well-formed: a non-empty entity_type and at least
-        // one non-empty entity_id. Malformed groups would create unusable EntityKey entries
-        // on the resulting ImpressionMetadata.
-        blobDetails.entityKeysList.forEachIndexed { groupIndex, group ->
-          require(group.entityType.isNotEmpty()) {
-            "BlobDetails entity_keys[$groupIndex].entity_type is empty " +
-              "for blob_uri = ${blobDetails.blobUri}"
-          }
-          require(group.entityIdsList.isNotEmpty()) {
-            "BlobDetails entity_keys[$groupIndex].entity_ids is empty " +
-              "for blob_uri = ${blobDetails.blobUri}"
-          }
-          group.entityIdsList.forEachIndexed { idIndex, entityId ->
-            require(entityId.isNotEmpty()) {
-              "BlobDetails entity_keys[$groupIndex].entity_ids[$idIndex] is empty " +
-                "for blob_uri = ${blobDetails.blobUri}"
-            }
-          }
+        require(group.entityIdsList.isNotEmpty()) {
+          "BlobDetails entity_keys[$groupIndex].entity_ids is empty " +
+            "for blob_uri = ${blobDetails.blobUri}"
         }
-        val impressionBlobUri: BlobUri = SelectedStorageClient.parseBlobUri(blobDetails.blobUri)
-        val metadataBlobUri =
-          when (doneBlobUri.scheme) {
-            "gs" ->
-              "${doneBlobUri.scheme}://${doneBlobUri.bucket}/${impressionMetadataBlob.blobKey}"
-            "file" ->
-              "${doneBlobUri.scheme}:///${doneBlobUri.bucket}/${impressionMetadataBlob.blobKey}"
-            else -> throw IllegalArgumentException("Unsupported scheme: ${doneBlobUri.scheme}")
+        group.entityIdsList.forEachIndexed { idIndex, entityId ->
+          require(entityId.isNotEmpty()) {
+            "BlobDetails entity_keys[$groupIndex].entity_ids[$idIndex] is empty " +
+              "for blob_uri = ${blobDetails.blobUri}"
           }
-        logger.info("Checking impression blob presence: ${impressionBlobUri.key}")
-        val impressionBlob = storageClient.getBlob(impressionBlobUri.key)
-        if (impressionBlob == null) {
-          logger.info(
-            "Encrypted impressions blob non found for metadata: ${impressionMetadataBlob.blobKey}."
-          )
-        } else {
-          logger.info("MetadataBlobUri is: $metadataBlobUri")
-          val impressionMetadata = impressionMetadata {
-            this.blobUri = metadataBlobUri
-            blobTypeUrl = BLOB_TYPE_URL
-            eventGroupReferenceId = blobDetails.eventGroupReferenceId
-            modelLine = blobDetails.modelLine
-            interval = blobDetails.interval
-            entityKeys += blobDetails.entityKeysList.flatMap { it.toEntityKeys() }
-          }
-          val modelLineKey =
-            requireNotNull(ModelLineKey.fromName(blobDetails.modelLine)) {
-              "Invalid model line resource name: ${blobDetails.modelLine}"
-            }
-          impressionMetadataMap
-            .getOrPut(modelLineKey) { mutableListOf() }
-            .add(
-              ImpressionMetadataWithBlobKey(
-                impressionMetadata = impressionMetadata,
-                impressionsBlobKey = impressionBlobUri.key,
-              )
-            )
         }
       }
+
+      val impressionBlobUri = SelectedStorageClient.parseBlobUri(blobDetails.blobUri)
+      parsed.add(ParsedMetadata(metadataBlob, blobDetails, impressionBlobUri))
+      val lastSlash = impressionBlobUri.key.lastIndexOf('/')
+      if (lastSlash > 0) {
+        impressionBlobPrefixes.add(impressionBlobUri.key.substring(0, lastSlash + 1))
+      }
+    }
+
+    val existingBlobKeys = mutableSetOf<String>()
+    for (prefix in impressionBlobPrefixes) {
+      storageClient.listBlobs(prefix).toList().forEach { existingBlobKeys.add(it.blobKey) }
+    }
+
+    val impressionMetadataMap =
+      mutableMapOf<ModelLineKey, MutableList<ImpressionMetadataWithBlobKey>>()
+
+    for ((impressionMetadataBlob, blobDetails, impressionBlobUri) in parsed) {
+      val metadataBlobUri =
+        when (doneBlobUri.scheme) {
+          "gs" -> "${doneBlobUri.scheme}://${doneBlobUri.bucket}/${impressionMetadataBlob.blobKey}"
+          "file" ->
+            "${doneBlobUri.scheme}:///${doneBlobUri.bucket}/${impressionMetadataBlob.blobKey}"
+          else -> throw IllegalArgumentException("Unsupported scheme: ${doneBlobUri.scheme}")
+        }
+      logger.info("Checking impression blob presence: ${impressionBlobUri.key}")
+      if (impressionBlobUri.key !in existingBlobKeys) {
+        logger.info(
+          "Encrypted impressions blob non found for metadata: ${impressionMetadataBlob.blobKey}."
+        )
+      } else {
+        logger.info("MetadataBlobUri is: $metadataBlobUri")
+        val impressionMetadata = impressionMetadata {
+          this.blobUri = metadataBlobUri
+          blobTypeUrl = BLOB_TYPE_URL
+          eventGroupReferenceId = blobDetails.eventGroupReferenceId
+          modelLine = blobDetails.modelLine
+          interval = blobDetails.interval
+          entityKeys += blobDetails.entityKeysList.flatMap { it.toEntityKeys() }
+        }
+        val modelLineKey =
+          requireNotNull(ModelLineKey.fromName(blobDetails.modelLine)) {
+            "Invalid model line resource name: ${blobDetails.modelLine}"
+          }
+        impressionMetadataMap
+          .getOrPut(modelLineKey) { mutableListOf() }
+          .add(
+            ImpressionMetadataWithBlobKey(
+              impressionMetadata = impressionMetadata,
+              impressionsBlobKey = impressionBlobUri.key,
+            )
+          )
+      }
+    }
     return impressionMetadataMap
   }
 

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/dataavailability/DataAvailabilitySync.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/dataavailability/DataAvailabilitySync.kt
@@ -29,6 +29,8 @@ import java.util.logging.Logger
 import kotlin.text.Charsets.UTF_8
 import kotlin.time.TimeSource
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.toList
 import org.wfanet.measurement.api.v2alpha.DataProviderKt.dataAvailabilityMapEntry
 import org.wfanet.measurement.api.v2alpha.DataProvidersGrpcKt
@@ -158,8 +160,8 @@ class DataAvailabilitySync(
       }
 
       val doneBlobFolderPath = doneBlobUri.key.substringBeforeLast("/")
-      val impressionMetadataBlobs: List<StorageClient.Blob> =
-        storageClient.listBlobs(doneBlobFolderPath).toList()
+      val impressionMetadataBlobs: Flow<StorageClient.Blob> =
+        storageClient.listBlobs(doneBlobFolderPath)
 
       // 1. Retrieve blob details from storage and build a map and validate them
       val impressionMetadataMap: Map<ModelLineKey, List<ImpressionMetadataWithBlobKey>> =
@@ -457,113 +459,103 @@ class DataAvailabilitySync(
    * @throws IllegalArgumentException if a blob has an unsupported file extension.
    */
   private suspend fun createModelLineToImpressionMetadataMap(
-    impressionMetadataBlobs: List<StorageClient.Blob>,
+    impressionMetadataBlobs: Flow<StorageClient.Blob>,
     doneBlobUri: BlobUri,
   ): Map<ModelLineKey, List<ImpressionMetadataWithBlobKey>> {
-    data class ParsedMetadata(
-      val metadataBlob: StorageClient.Blob,
-      val blobDetails: BlobDetails,
-      val impressionBlobUri: BlobUri,
-    )
-
-    val parsed = mutableListOf<ParsedMetadata>()
-    val impressionBlobPrefixes = mutableSetOf<String>()
-
-    for (metadataBlob in impressionMetadataBlobs) {
-      val fileName = metadataBlob.blobKey.substringAfterLast("/").lowercase()
-      if (METADATA_FILE_NAME !in fileName) continue
-
-      val bytes: ByteString = metadataBlob.read().flatten()
-      val blobDetails =
-        if (fileName.endsWith(PROTO_FILE_SUFFIX)) {
-          BlobDetails.parseFrom(bytes)
-        } else if (fileName.endsWith(JSON_FILE_SUFFIX)) {
-          val builder = BlobDetails.newBuilder()
-          JsonFormat.parser().ignoringUnknownFields().merge(bytes.toString(UTF_8), builder)
-          builder.build()
-        } else {
-          throw IllegalArgumentException("Unsupported file extension for metadata: $fileName")
-        }
-
-      require(blobDetails.interval.hasStartTime() && blobDetails.interval.hasEndTime()) {
-        "Found interval without start or end time for blob detail with blob_uri = ${blobDetails.blobUri}"
-      }
-      require(
-        blobDetails.eventGroupReferenceId.isNotEmpty() || blobDetails.entityKeysList.isNotEmpty()
-      ) {
-        "BlobDetails must have either event_group_reference_id or entity_keys populated " +
-          "for blob_uri = ${blobDetails.blobUri}"
-      }
-      blobDetails.entityKeysList.forEachIndexed { groupIndex, group ->
-        require(group.entityType.isNotEmpty()) {
-          "BlobDetails entity_keys[$groupIndex].entity_type is empty " +
-            "for blob_uri = ${blobDetails.blobUri}"
-        }
-        require(group.entityIdsList.isNotEmpty()) {
-          "BlobDetails entity_keys[$groupIndex].entity_ids is empty " +
-            "for blob_uri = ${blobDetails.blobUri}"
-        }
-        group.entityIdsList.forEachIndexed { idIndex, entityId ->
-          require(entityId.isNotEmpty()) {
-            "BlobDetails entity_keys[$groupIndex].entity_ids[$idIndex] is empty " +
-              "for blob_uri = ${blobDetails.blobUri}"
-          }
-        }
-      }
-
-      val impressionBlobUri = SelectedStorageClient.parseBlobUri(blobDetails.blobUri)
-      parsed.add(ParsedMetadata(metadataBlob, blobDetails, impressionBlobUri))
-      val lastSlash = impressionBlobUri.key.lastIndexOf('/')
-      if (lastSlash > 0) {
-        impressionBlobPrefixes.add(impressionBlobUri.key.substring(0, lastSlash + 1))
-      }
-    }
-
-    val existingBlobKeys = mutableSetOf<String>()
-    for (prefix in impressionBlobPrefixes) {
-      storageClient.listBlobs(prefix).toList().forEach { existingBlobKeys.add(it.blobKey) }
-    }
-
     val impressionMetadataMap =
       mutableMapOf<ModelLineKey, MutableList<ImpressionMetadataWithBlobKey>>()
-
-    for ((impressionMetadataBlob, blobDetails, impressionBlobUri) in parsed) {
-      val metadataBlobUri =
-        when (doneBlobUri.scheme) {
-          "gs" -> "${doneBlobUri.scheme}://${doneBlobUri.bucket}/${impressionMetadataBlob.blobKey}"
-          "file" ->
-            "${doneBlobUri.scheme}:///${doneBlobUri.bucket}/${impressionMetadataBlob.blobKey}"
-          else -> throw IllegalArgumentException("Unsupported scheme: ${doneBlobUri.scheme}")
-        }
-      logger.info("Checking impression blob presence: ${impressionBlobUri.key}")
-      if (impressionBlobUri.key !in existingBlobKeys) {
-        logger.info(
-          "Encrypted impressions blob non found for metadata: ${impressionMetadataBlob.blobKey}."
-        )
-      } else {
-        logger.info("MetadataBlobUri is: $metadataBlobUri")
-        val impressionMetadata = impressionMetadata {
-          this.blobUri = metadataBlobUri
-          blobTypeUrl = BLOB_TYPE_URL
-          eventGroupReferenceId = blobDetails.eventGroupReferenceId
-          modelLine = blobDetails.modelLine
-          interval = blobDetails.interval
-          entityKeys += blobDetails.entityKeysList.flatMap { it.toEntityKeys() }
-        }
-        val modelLineKey =
-          requireNotNull(ModelLineKey.fromName(blobDetails.modelLine)) {
-            "Invalid model line resource name: ${blobDetails.modelLine}"
-          }
-        impressionMetadataMap
-          .getOrPut(modelLineKey) { mutableListOf() }
-          .add(
-            ImpressionMetadataWithBlobKey(
-              impressionMetadata = impressionMetadata,
-              impressionsBlobKey = impressionBlobUri.key,
-            )
-          )
+    impressionMetadataBlobs
+      .filter { impressionMetadataBlob ->
+        val fileName = impressionMetadataBlob.blobKey.substringAfterLast("/").lowercase()
+        METADATA_FILE_NAME in fileName
       }
-    }
+      .collect { impressionMetadataBlob ->
+        val fileName = impressionMetadataBlob.blobKey.substringAfterLast("/").lowercase()
+        val bytes: ByteString = impressionMetadataBlob.read().flatten()
+
+        // Build the blob details object
+        val blobDetails =
+          if (fileName.endsWith(PROTO_FILE_SUFFIX)) {
+            BlobDetails.parseFrom(bytes)
+          } else if (fileName.endsWith(JSON_FILE_SUFFIX)) {
+            val builder = BlobDetails.newBuilder()
+            JsonFormat.parser().ignoringUnknownFields().merge(bytes.toString(UTF_8), builder)
+            builder.build()
+          } else {
+            throw IllegalArgumentException("Unsupported file extension for metadata: $fileName")
+          }
+
+        // Validate intervals
+        require(blobDetails.interval.hasStartTime() && blobDetails.interval.hasEndTime()) {
+          "Found interval without start or end time for blob detail with blob_uri = ${blobDetails.blobUri}"
+        }
+        // At least one of event_group_reference_id or entity_keys must identify the
+        // EventGroup that produced this blob. Both empty means the metadata cannot be
+        // associated with any EventGroup downstream.
+        require(
+          blobDetails.eventGroupReferenceId.isNotEmpty() || blobDetails.entityKeysList.isNotEmpty()
+        ) {
+          "BlobDetails must have either event_group_reference_id or entity_keys populated " +
+            "for blob_uri = ${blobDetails.blobUri}"
+        }
+        // Every EntityKeyGroup must be well-formed: a non-empty entity_type and at least
+        // one non-empty entity_id. Malformed groups would create unusable EntityKey entries
+        // on the resulting ImpressionMetadata.
+        blobDetails.entityKeysList.forEachIndexed { groupIndex, group ->
+          require(group.entityType.isNotEmpty()) {
+            "BlobDetails entity_keys[$groupIndex].entity_type is empty " +
+              "for blob_uri = ${blobDetails.blobUri}"
+          }
+          require(group.entityIdsList.isNotEmpty()) {
+            "BlobDetails entity_keys[$groupIndex].entity_ids is empty " +
+              "for blob_uri = ${blobDetails.blobUri}"
+          }
+          group.entityIdsList.forEachIndexed { idIndex, entityId ->
+            require(entityId.isNotEmpty()) {
+              "BlobDetails entity_keys[$groupIndex].entity_ids[$idIndex] is empty " +
+                "for blob_uri = ${blobDetails.blobUri}"
+            }
+          }
+        }
+        val impressionBlobUri: BlobUri = SelectedStorageClient.parseBlobUri(blobDetails.blobUri)
+        val metadataBlobUri =
+          when (doneBlobUri.scheme) {
+            "gs" ->
+              "${doneBlobUri.scheme}://${doneBlobUri.bucket}/${impressionMetadataBlob.blobKey}"
+            "file" ->
+              "${doneBlobUri.scheme}:///${doneBlobUri.bucket}/${impressionMetadataBlob.blobKey}"
+            else -> throw IllegalArgumentException("Unsupported scheme: ${doneBlobUri.scheme}")
+          }
+        logger.info("Checking impression blob presence: ${impressionBlobUri.key}")
+        val impressionBlob = storageClient.getBlob(impressionBlobUri.key)
+        if (impressionBlob == null) {
+          logger.info(
+            "Encrypted impressions blob non found for metadata: ${impressionMetadataBlob.blobKey}."
+          )
+        } else {
+          logger.info("MetadataBlobUri is: $metadataBlobUri")
+          val impressionMetadata = impressionMetadata {
+            this.blobUri = metadataBlobUri
+            blobTypeUrl = BLOB_TYPE_URL
+            eventGroupReferenceId = blobDetails.eventGroupReferenceId
+            modelLine = blobDetails.modelLine
+            interval = blobDetails.interval
+            entityKeys += blobDetails.entityKeysList.flatMap { it.toEntityKeys() }
+          }
+          val modelLineKey =
+            requireNotNull(ModelLineKey.fromName(blobDetails.modelLine)) {
+              "Invalid model line resource name: ${blobDetails.modelLine}"
+            }
+          impressionMetadataMap
+            .getOrPut(modelLineKey) { mutableListOf() }
+            .add(
+              ImpressionMetadataWithBlobKey(
+                impressionMetadata = impressionMetadata,
+                impressionsBlobKey = impressionBlobUri.key,
+              )
+            )
+        }
+      }
     return impressionMetadataMap
   }
 

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/dataavailability/DataAvailabilityCleanupFunction.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/dataavailability/DataAvailabilityCleanupFunction.kt
@@ -49,13 +49,9 @@ import org.wfanet.measurement.gcloud.gcs.GcsStorageClient
  *
  * ## Buffered Mode
  *
- * When `CLEANUP_BUFFER_ENABLED=true`, delete events are buffered in memory and flushed in batches.
- * This reduces per-event overhead when GCS lifecycle rules delete many files in a short window.
- * Cloud Functions Gen2 supports instance reuse, so the in-memory buffer persists across
- * invocations on the same instance.
- *
- * Buffered mode requires `--no-cpu-throttling` on the Cloud Function so that the background flush
- * thread continues running between invocations.
+ * When `CLEANUP_BUFFER_ENABLED=true`, delete events are buffered in memory and flushed via a
+ * single `BatchDeleteImpressionMetadata` RPC. This reduces N individual Spanner transactions to
+ * one when GCS lifecycle rules delete many files in a short window.
  *
  * ## Headers
  * - `X-DataWatcher-Path`: Required. The GCS object path that was deleted (used as blob URI).
@@ -165,9 +161,9 @@ class DataAvailabilityCleanupFunction : HttpFunction {
       }
     }
 
-    private fun createCleanup(
+    private fun createInstrumentedStub(
       dataAvailabilitySyncConfig: DataAvailabilitySyncConfig
-    ): DataAvailabilityCleanup {
+    ): ImpressionMetadataServiceCoroutineStub {
       val grpcChannels =
         DataAvailabilitySyncFunction.getOrCreateSharedChannels(dataAvailabilitySyncConfig)
 
@@ -178,15 +174,16 @@ class DataAvailabilityCleanupFunction : HttpFunction {
           grpcTelemetry.newClientInterceptor(),
         )
 
-      val impressionMetadataServiceStub =
-        ImpressionMetadataServiceCoroutineStub(instrumentedChannel)
+      return ImpressionMetadataServiceCoroutineStub(instrumentedChannel)
+    }
 
-      val storageClient = createStorageClient(dataAvailabilitySyncConfig)
-
+    private fun createCleanup(
+      dataAvailabilitySyncConfig: DataAvailabilitySyncConfig
+    ): DataAvailabilityCleanup {
       return DataAvailabilityCleanup(
-        impressionMetadataServiceStub,
+        createInstrumentedStub(dataAvailabilitySyncConfig),
         dataAvailabilitySyncConfig.dataProvider,
-        storageClient,
+        createStorageClient(dataAvailabilitySyncConfig),
       )
     }
 
@@ -195,9 +192,11 @@ class DataAvailabilityCleanupFunction : HttpFunction {
     ): BufferedDataAvailabilityCleanup {
       return sharedBuffer ?: synchronized(this) {
         sharedBuffer ?: run {
-          val cleanup = createCleanup(dataAvailabilitySyncConfig)
           BufferedDataAvailabilityCleanup(
-            cleanupDelegate = cleanup,
+            impressionMetadataServiceStub =
+              createInstrumentedStub(dataAvailabilitySyncConfig),
+            dataProviderName = dataAvailabilitySyncConfig.dataProvider,
+            storageClient = createStorageClient(dataAvailabilitySyncConfig),
             batchSize = bufferBatchSize,
             flushIntervalSeconds = bufferFlushIntervalSeconds,
           ).also {

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/dataavailability/DataAvailabilityCleanupFunction.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/dataavailability/DataAvailabilityCleanupFunction.kt
@@ -32,7 +32,9 @@ import org.wfanet.measurement.common.edpaggregator.EdpAggregatorConfig
 import org.wfanet.measurement.config.edpaggregator.DataAvailabilitySyncConfig
 import org.wfanet.measurement.config.edpaggregator.DataAvailabilitySyncConfigs
 import org.wfanet.measurement.edpaggregator.ConfigLoader
+import org.wfanet.measurement.edpaggregator.dataavailability.BufferedDataAvailabilityCleanup
 import org.wfanet.measurement.edpaggregator.dataavailability.DataAvailabilityCleanup
+import org.wfanet.measurement.edpaggregator.dataavailability.DeleteEvent
 import org.wfanet.measurement.edpaggregator.telemetry.EdpaTelemetry
 import org.wfanet.measurement.edpaggregator.telemetry.Tracing
 import org.wfanet.measurement.edpaggregator.v1alpha.ImpressionMetadataServiceGrpcKt.ImpressionMetadataServiceCoroutineStub
@@ -45,6 +47,16 @@ import org.wfanet.measurement.gcloud.gcs.GcsStorageClient
  * the ImpressionMetadata resource name from the request header and calls DeleteImpressionMetadata
  * to soft-delete the corresponding Spanner record.
  *
+ * ## Buffered Mode
+ *
+ * When `CLEANUP_BUFFER_ENABLED=true`, delete events are buffered in memory and flushed in batches.
+ * This reduces per-event overhead when GCS lifecycle rules delete many files in a short window.
+ * Cloud Functions Gen2 supports instance reuse, so the in-memory buffer persists across
+ * invocations on the same instance.
+ *
+ * Buffered mode requires `--no-cpu-throttling` on the Cloud Function so that the background flush
+ * thread continues running between invocations.
+ *
  * ## Headers
  * - `X-DataWatcher-Path`: Required. The GCS object path that was deleted (used as blob URI).
  * - `X-Impression-Metadata-Resource-Id`: Optional. The ImpressionMetadata resource name to delete.
@@ -53,6 +65,9 @@ import org.wfanet.measurement.gcloud.gcs.GcsStorageClient
  * ## Environment Variables
  * - `IMPRESSION_METADATA_TARGET`: Required. Target endpoint for the Impression Metadata service.
  * - `IMPRESSION_METADATA_CERT_HOST`: Optional. Overrides TLS authority for testing.
+ * - `CLEANUP_BUFFER_ENABLED`: Optional. Set to "true" to enable buffered batch processing.
+ * - `CLEANUP_BUFFER_BATCH_SIZE`: Optional. Flush threshold (default: 100).
+ * - `CLEANUP_BUFFER_FLUSH_INTERVAL_SECONDS`: Optional. Periodic flush interval (default: 30).
  *
  * ## Configuration
  * - The request body contains versioned params (as a `google.protobuf.Any`) or a legacy
@@ -71,38 +86,27 @@ class DataAvailabilityCleanupFunction : HttpFunction {
       val dataAvailabilitySyncConfig =
         ConfigLoader.buildDataAvailabilitySyncConfig(requestBody, runtimeConfigs.configsList)
 
-      // Read the path as request header
       val deletedBlobPath =
         request.getFirstHeader(DATA_WATCHER_PATH_HEADER).orElseThrow {
           IllegalArgumentException("Missing required header: $DATA_WATCHER_PATH_HEADER")
         }
 
-      // Read the ImpressionMetadata resource ID from header (optional)
       val impressionMetadataResourceId =
         request.getFirstHeader(IMPRESSION_METADATA_RESOURCE_ID_HEADER).orElse(null)
 
-      val grpcChannels =
-        DataAvailabilitySyncFunction.getOrCreateSharedChannels(dataAvailabilitySyncConfig)
-      val impressionMetadataChannel = grpcChannels.impressionMetadataChannel
-
-      val grpcTelemetry = GrpcTelemetry.create(Instrumentation.openTelemetry)
-      val instrumentedChannel =
-        ClientInterceptors.intercept(
-          impressionMetadataChannel,
-          grpcTelemetry.newClientInterceptor(),
+      if (bufferEnabled) {
+        val buffer = getOrCreateBuffer(dataAvailabilitySyncConfig)
+        buffer.enqueue(DeleteEvent(deletedBlobPath, impressionMetadataResourceId))
+        logger.info(
+          "Buffered delete event for $deletedBlobPath " +
+            "(pending: ${buffer.pendingCount()})"
         )
+        response.setStatusCode(200)
+        response.writer.write("Buffered (pending: ${buffer.pendingCount()})")
+        return
+      }
 
-      val impressionMetadataServiceStub =
-        ImpressionMetadataServiceCoroutineStub(instrumentedChannel)
-
-      val storageClient = createStorageClient(dataAvailabilitySyncConfig)
-
-      val dataAvailabilityCleanup =
-        DataAvailabilityCleanup(
-          impressionMetadataServiceStub,
-          dataAvailabilitySyncConfig.dataProvider,
-          storageClient,
-        )
+      val dataAvailabilityCleanup = createCleanup(dataAvailabilitySyncConfig)
 
       Tracing.withW3CTraceContext(request) {
         runBlocking(Context.current().asContextElement()) {
@@ -116,7 +120,6 @@ class DataAvailabilityCleanupFunction : HttpFunction {
       response.setStatusCode(500)
       response.writer.write("Internal error: ${e.message}")
     } finally {
-      // Critical for Cloud Functions: flush metrics before function freezes
       EdpaTelemetry.flush()
     }
   }
@@ -136,6 +139,76 @@ class DataAvailabilityCleanupFunction : HttpFunction {
         configBlobKey,
         DataAvailabilitySyncConfigs.getDefaultInstance(),
       )
+    }
+
+    val bufferEnabled: Boolean =
+      System.getenv("CLEANUP_BUFFER_ENABLED")?.equals("true", ignoreCase = true) ?: false
+
+    private val bufferBatchSize: Int =
+      System.getenv("CLEANUP_BUFFER_BATCH_SIZE")?.toIntOrNull()
+        ?: BufferedDataAvailabilityCleanup.DEFAULT_BATCH_SIZE
+
+    private val bufferFlushIntervalSeconds: Long =
+      System.getenv("CLEANUP_BUFFER_FLUSH_INTERVAL_SECONDS")?.toLongOrNull()
+        ?: BufferedDataAvailabilityCleanup.DEFAULT_FLUSH_INTERVAL_SECONDS
+
+    @Volatile private var sharedBuffer: BufferedDataAvailabilityCleanup? = null
+
+    init {
+      if (bufferEnabled) {
+        Runtime.getRuntime().addShutdownHook(
+          Thread {
+            logger.info("Shutdown hook: flushing buffered delete events")
+            sharedBuffer?.shutdown()
+          }
+        )
+      }
+    }
+
+    private fun createCleanup(
+      dataAvailabilitySyncConfig: DataAvailabilitySyncConfig
+    ): DataAvailabilityCleanup {
+      val grpcChannels =
+        DataAvailabilitySyncFunction.getOrCreateSharedChannels(dataAvailabilitySyncConfig)
+
+      val grpcTelemetry = GrpcTelemetry.create(Instrumentation.openTelemetry)
+      val instrumentedChannel =
+        ClientInterceptors.intercept(
+          grpcChannels.impressionMetadataChannel,
+          grpcTelemetry.newClientInterceptor(),
+        )
+
+      val impressionMetadataServiceStub =
+        ImpressionMetadataServiceCoroutineStub(instrumentedChannel)
+
+      val storageClient = createStorageClient(dataAvailabilitySyncConfig)
+
+      return DataAvailabilityCleanup(
+        impressionMetadataServiceStub,
+        dataAvailabilitySyncConfig.dataProvider,
+        storageClient,
+      )
+    }
+
+    private fun getOrCreateBuffer(
+      dataAvailabilitySyncConfig: DataAvailabilitySyncConfig
+    ): BufferedDataAvailabilityCleanup {
+      return sharedBuffer ?: synchronized(this) {
+        sharedBuffer ?: run {
+          val cleanup = createCleanup(dataAvailabilitySyncConfig)
+          BufferedDataAvailabilityCleanup(
+            cleanupDelegate = cleanup,
+            batchSize = bufferBatchSize,
+            flushIntervalSeconds = bufferFlushIntervalSeconds,
+          ).also {
+            sharedBuffer = it
+            logger.info(
+              "Created shared buffer (batchSize=$bufferBatchSize, " +
+                "flushInterval=${bufferFlushIntervalSeconds}s)"
+            )
+          }
+        }
+      }
     }
 
     private fun createStorageClient(

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/dataavailability/testing/BUILD.bazel
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/dataavailability/testing/BUILD.bazel
@@ -29,3 +29,16 @@ java_binary(
         "//src/main/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/dataavailability:DataAvailabilityMonitorFunction_deploy.jar",
     ],
 )
+
+java_binary(
+    name = "InvokeDataAvailabilityCleanupFunction",
+    main_class = "com.google.cloud.functions.invoker.runner.Invoker",
+    resources = [
+        "//src/main/k8s/testing/secretfiles:root_certs",
+        "//src/main/k8s/testing/secretfiles:secret_files",
+    ],
+    runtime_deps = [
+        "//imports/java/com/google/cloud/functions/invoker:java_function_invoker",
+        "//src/main/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/dataavailability:DataAvailabilityCleanupFunction_deploy.jar",
+    ],
+)

--- a/src/test/kotlin/org/wfanet/measurement/edpaggregator/dataavailability/BUILD.bazel
+++ b/src/test/kotlin/org/wfanet/measurement/edpaggregator/dataavailability/BUILD.bazel
@@ -79,3 +79,23 @@ kt_jvm_test(
         "@wfa_common_jvm//src/main/kotlin/org/wfanet/measurement/storage/filesystem:client",
     ],
 )
+
+kt_jvm_test(
+    name = "BufferedDataAvailabilityCleanupTest",
+    srcs = ["BufferedDataAvailabilityCleanupTest.kt"],
+    test_class = "org.wfanet.measurement.edpaggregator.dataavailability.BufferedDataAvailabilityCleanupTest",
+    deps = [
+        "//imports/java/io/opentelemetry/api",
+        "//imports/java/io/opentelemetry/sdk",
+        "//imports/java/io/opentelemetry/sdk:sdk_metrics",
+        "//src/main/kotlin/org/wfanet/measurement/edpaggregator/dataavailability:data_availability_sync",
+        "@wfa_common_jvm//imports/java/com/google/common/truth",
+        "@wfa_common_jvm//imports/java/com/google/protobuf",
+        "@wfa_common_jvm//imports/java/io/opentelemetry/sdk/testing",
+        "@wfa_common_jvm//imports/kotlin/kotlin/test",
+        "@wfa_common_jvm//imports/kotlin/kotlinx/coroutines:core",
+        "@wfa_common_jvm//imports/kotlin/org/mockito/kotlin",
+        "@wfa_common_jvm//src/main/kotlin/org/wfanet/measurement/common/grpc/testing",
+        "@wfa_common_jvm//src/main/kotlin/org/wfanet/measurement/storage/filesystem:client",
+    ],
+)

--- a/src/test/kotlin/org/wfanet/measurement/edpaggregator/dataavailability/BufferedDataAvailabilityCleanupTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/edpaggregator/dataavailability/BufferedDataAvailabilityCleanupTest.kt
@@ -20,16 +20,20 @@ import com.google.common.truth.Truth.assertThat
 import com.google.protobuf.timestamp
 import com.google.type.interval
 import io.grpc.Status
-import io.grpc.StatusException
 import io.grpc.StatusRuntimeException
 import java.io.File
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
+import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TemporaryFolder
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
+import org.mockito.Mockito
 import org.mockito.kotlin.any
 import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.atLeast
 import org.mockito.kotlin.never
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verifyBlocking
@@ -126,14 +130,9 @@ class BufferedDataAvailabilityCleanupTest {
 
   @get:Rule val tempFolder = TemporaryFolder()
 
-  /** Storage client with no blobs — simulates all blobs permanently deleted. */
   private fun emptyStorageClient(): FileSystemStorageClient =
     FileSystemStorageClient(tempFolder.newFolder("empty-${System.nanoTime()}"))
 
-  /**
-   * Storage client with specific blob keys present — simulates blobs that still have a live
-   * (current) version in GCS.
-   */
   private fun storageClientWithLiveBlobs(vararg blobKeys: String): FileSystemStorageClient {
     val root = tempFolder.newFolder("storage-${System.nanoTime()}")
     for (key in blobKeys) {
@@ -147,43 +146,24 @@ class BufferedDataAvailabilityCleanupTest {
   @get:Rule
   val grpcTestServerRule = GrpcTestServerRule { addService(impressionMetadataServiceMock) }
 
-  private fun createBuffer(
-    batchSize: Int = 100,
-    flushIntervalSeconds: Long = 300,
-    storageClient: StorageClient? = null,
-  ): BufferedDataAvailabilityCleanup {
+  @Before
+  fun setUp() {
+    Mockito.clearInvocations(impressionMetadataServiceMock)
+  }
+
+  private fun createBuffer(storageClient: StorageClient? = null): BufferedDataAvailabilityCleanup {
     return BufferedDataAvailabilityCleanup(
       impressionMetadataServiceStub = impressionMetadataStub,
       dataProviderName = DATA_PROVIDER_NAME,
       storageClient = storageClient ?: emptyStorageClient(),
-      batchSize = batchSize,
-      flushIntervalSeconds = flushIntervalSeconds,
     )
   }
 
   @Test
-  fun `enqueue buffers events without immediate processing`() {
-    val buffer = createBuffer(batchSize = 10)
+  fun `enqueue flushes synchronously`() {
+    val buffer = createBuffer()
 
     buffer.enqueue(DeleteEvent(blobUri(1), resourceId(1)))
-
-    assertThat(buffer.pendingCount()).isEqualTo(1)
-    verifyBlocking(impressionMetadataServiceMock, never()) { batchDeleteImpressionMetadata(any()) }
-
-    buffer.shutdown()
-  }
-
-  @Test
-  fun `flush calls single batch delete RPC for multiple events with resource IDs`() {
-    val buffer = createBuffer(batchSize = 10)
-
-    for (i in 1..5) {
-      buffer.enqueue(DeleteEvent(blobUri(i), resourceId(i)))
-    }
-
-    assertThat(buffer.pendingCount()).isEqualTo(5)
-
-    buffer.flush()
 
     assertThat(buffer.pendingCount()).isEqualTo(0)
 
@@ -191,111 +171,109 @@ class BufferedDataAvailabilityCleanupTest {
     verifyBlocking(impressionMetadataServiceMock, times(1)) {
       batchDeleteImpressionMetadata(captor.capture())
     }
-    assertThat(captor.firstValue.parent).isEqualTo(DATA_PROVIDER_NAME)
-    assertThat(captor.firstValue.namesList).hasSize(5)
+    assertThat(captor.firstValue.namesList).containsExactly(resourceId(1))
+  }
+
+  @Test
+  fun `enqueue with pre-resolved resource ID uses batch delete`() {
+    val buffer = createBuffer()
+
+    buffer.enqueue(DeleteEvent(blobUri(1), resourceId(1)))
+    buffer.enqueue(DeleteEvent(blobUri(2), resourceId(2)))
+    buffer.enqueue(DeleteEvent(blobUri(3), resourceId(3)))
+
+    assertThat(buffer.pendingCount()).isEqualTo(0)
 
     verifyBlocking(impressionMetadataServiceMock, never()) { deleteImpressionMetadata(any()) }
-
-    buffer.shutdown()
   }
 
   @Test
   fun `flush batch-resolves blob URIs via single list RPC`() {
-    val buffer = createBuffer(batchSize = 10)
+    val buffer = createBuffer()
 
-    for (i in 1..5) {
-      buffer.enqueue(DeleteEvent(blobUri(i), null))
-    }
+    buffer.enqueue(DeleteEvent(blobUri(1), null))
 
-    buffer.flush()
+    assertThat(buffer.pendingCount()).isEqualTo(0)
 
     val listCaptor = argumentCaptor<ListImpressionMetadataRequest>()
     verifyBlocking(impressionMetadataServiceMock, times(1)) {
       listImpressionMetadata(listCaptor.capture())
     }
-    assertThat(listCaptor.firstValue.filter.blobUrisList).hasSize(5)
+    assertThat(listCaptor.firstValue.filter.blobUrisList).containsExactly(blobUri(1))
 
     val deleteCaptor = argumentCaptor<BatchDeleteImpressionMetadataRequest>()
     verifyBlocking(impressionMetadataServiceMock, times(1)) {
       batchDeleteImpressionMetadata(deleteCaptor.capture())
     }
-    assertThat(deleteCaptor.firstValue.namesList).hasSize(5)
-
-    buffer.shutdown()
+    assertThat(deleteCaptor.firstValue.namesList).containsExactly(resourceId(1))
   }
 
   @Test
-  fun `batch size threshold triggers flush with remaining tail via shutdown`() {
-    // batchSize=3 with 5 events: first 3 trigger threshold flush, remaining 2 flushed at shutdown
-    val buffer = createBuffer(batchSize = 3)
+  fun `concurrent enqueues coalesce via flush lock`() {
+    val buffer = createBuffer()
+    val threadCount = 12
+    val latch = CountDownLatch(threadCount)
+    val executor = Executors.newFixedThreadPool(threadCount)
 
-    for (i in 1..5) {
-      buffer.enqueue(DeleteEvent(blobUri(i), resourceId(i)))
+    for (i in 1..threadCount) {
+      executor.submit {
+        latch.countDown()
+        latch.await()
+        buffer.enqueue(DeleteEvent(blobUri(i), resourceId(i)))
+      }
     }
 
-    // After enqueuing 5 with batchSize=3, the first batch of 3 was flushed at threshold.
-    // Remaining 2 are still pending.
-    assertThat(buffer.pendingCount()).isEqualTo(2)
-
-    buffer.shutdown()
+    executor.shutdown()
+    executor.awaitTermination(10, java.util.concurrent.TimeUnit.SECONDS)
 
     assertThat(buffer.pendingCount()).isEqualTo(0)
-
-    val captor = argumentCaptor<BatchDeleteImpressionMetadataRequest>()
-    verifyBlocking(impressionMetadataServiceMock, times(2)) {
-      batchDeleteImpressionMetadata(captor.capture())
-    }
-    assertThat(captor.allValues[0].namesList).hasSize(3)
-    assertThat(captor.allValues[1].namesList).hasSize(2)
-
-    buffer.shutdown()
   }
 
   @Test
   fun `flush chunks large batches into multiple RPCs of MAX_BATCH_DELETE_SIZE`() {
-    // batchSize=250 means threshold flush at 250, which chunks into 3 RPCs (100+100+50)
-    // Use 260 to ensure tail of 10 is flushed at shutdown
-    val buffer = createBuffer(batchSize = 250)
+    val buffer = createBuffer()
+    val count = 260
+    val threadCount = 20
+    val latch = CountDownLatch(threadCount)
+    val executor = Executors.newFixedThreadPool(threadCount)
+    val eventsPerThread = count / threadCount
 
-    for (i in 1..260) {
-      buffer.enqueue(DeleteEvent(blobUri(i), resourceId(i)))
+    for (t in 0 until threadCount) {
+      executor.submit {
+        latch.countDown()
+        latch.await()
+        val start = t * eventsPerThread + 1
+        for (i in start until start + eventsPerThread) {
+          buffer.enqueue(DeleteEvent(blobUri(i), resourceId(i)))
+        }
+      }
     }
 
-    // 250 flushed at threshold (in 3 chunks), 10 remain
-    assertThat(buffer.pendingCount()).isEqualTo(10)
-
-    buffer.shutdown()
+    executor.shutdown()
+    executor.awaitTermination(30, java.util.concurrent.TimeUnit.SECONDS)
 
     assertThat(buffer.pendingCount()).isEqualTo(0)
 
     val captor = argumentCaptor<BatchDeleteImpressionMetadataRequest>()
-    verifyBlocking(impressionMetadataServiceMock, times(4)) {
+    verifyBlocking(impressionMetadataServiceMock, atLeast(1)) {
       batchDeleteImpressionMetadata(captor.capture())
     }
 
-    val allValues = captor.allValues
-    assertThat(allValues[0].namesList).hasSize(100)
-    assertThat(allValues[1].namesList).hasSize(100)
-    assertThat(allValues[2].namesList).hasSize(50)
-    assertThat(allValues[3].namesList).hasSize(10)
+    val totalDeleted = captor.allValues.sumOf { it.namesList.size }
+    assertThat(totalDeleted).isEqualTo(count)
 
-    buffer.shutdown()
+    for (request in captor.allValues) {
+      assertThat(request.namesList.size).isAtMost(100)
+    }
   }
 
   @Test
-  fun `shutdown flushes remaining events via batch RPC`() {
-    val buffer = createBuffer(batchSize = 10)
-
-    for (i in 1..5) {
-      buffer.enqueue(DeleteEvent(blobUri(i), resourceId(i)))
-    }
-
-    assertThat(buffer.pendingCount()).isEqualTo(5)
+  fun `shutdown flushes remaining events`() {
+    val buffer = createBuffer()
 
     buffer.shutdown()
 
     assertThat(buffer.pendingCount()).isEqualTo(0)
-    verifyBlocking(impressionMetadataServiceMock, times(1)) { batchDeleteImpressionMetadata(any()) }
   }
 
   @Test
@@ -306,56 +284,19 @@ class BufferedDataAvailabilityCleanupTest {
     val buffer = createBuffer()
 
     buffer.enqueue(DeleteEvent(blobUri(9999), null))
-    buffer.enqueue(DeleteEvent(blobUri(1), resourceId(1)))
-
-    buffer.flush()
-
-    val captor = argumentCaptor<BatchDeleteImpressionMetadataRequest>()
-    verifyBlocking(impressionMetadataServiceMock, times(1)) {
-      batchDeleteImpressionMetadata(captor.capture())
-    }
-    assertThat(captor.firstValue.namesList).containsExactly(resourceId(1))
-
-    buffer.shutdown()
-  }
-
-  @Test
-  fun `periodic timer flushes remaining events including tail`() {
-    // batchSize=3 with 5 events: 3 flushed at threshold, 2 flushed by timer
-    val buffer = createBuffer(batchSize = 3, flushIntervalSeconds = 1)
-
-    for (i in 1..5) {
-      buffer.enqueue(DeleteEvent(blobUri(i), resourceId(i)))
-    }
-
-    // 3 were flushed at threshold, 2 remain for timer
-    assertThat(buffer.pendingCount()).isEqualTo(2)
-
-    Thread.sleep(2500)
 
     assertThat(buffer.pendingCount()).isEqualTo(0)
 
-    val captor = argumentCaptor<BatchDeleteImpressionMetadataRequest>()
-    verifyBlocking(impressionMetadataServiceMock, times(2)) {
-      batchDeleteImpressionMetadata(captor.capture())
-    }
-    assertThat(captor.allValues[0].namesList).hasSize(3)
-    assertThat(captor.allValues[1].namesList).hasSize(2)
-
-    buffer.shutdown()
+    verifyBlocking(impressionMetadataServiceMock, never()) { batchDeleteImpressionMetadata(any()) }
   }
 
   @Test
   fun `skips events whose blobs still have a live version`() {
-    // blob-1 still has a live version; blob-2 and blob-3 are fully deleted
     val sc = storageClientWithLiveBlobs("path/to/blob-1")
-    val buffer = createBuffer(batchSize = 5, storageClient = sc)
+    val buffer = createBuffer(storageClient = sc)
 
-    for (i in 1..3) {
-      buffer.enqueue(DeleteEvent(blobUri(i), resourceId(i)))
-    }
-
-    buffer.flush()
+    buffer.enqueue(DeleteEvent(blobUri(1), resourceId(1)))
+    buffer.enqueue(DeleteEvent(blobUri(2), resourceId(2)))
 
     assertThat(buffer.pendingCount()).isEqualTo(0)
 
@@ -363,32 +304,27 @@ class BufferedDataAvailabilityCleanupTest {
     verifyBlocking(impressionMetadataServiceMock, times(1)) {
       batchDeleteImpressionMetadata(captor.capture())
     }
-    // blob-1 is skipped (live version exists), blob-2 and blob-3 are deleted
-    assertThat(captor.firstValue.namesList).containsExactly(resourceId(2), resourceId(3))
-
-    buffer.shutdown()
+    assertThat(captor.firstValue.namesList).containsExactly(resourceId(2))
   }
 
   @Test
   fun `bulk live-version check groups by prefix`() {
-    // Both blobs share the same prefix "path/to/" — only one listBlobs call needed
     val sc = storageClientWithLiveBlobs("path/to/blob-1", "path/to/blob-3")
-    val buffer = createBuffer(batchSize = 5, storageClient = sc)
+    val buffer = createBuffer(storageClient = sc)
 
-    for (i in 1..4) {
-      buffer.enqueue(DeleteEvent(blobUri(i), resourceId(i)))
-    }
+    buffer.enqueue(DeleteEvent(blobUri(1), resourceId(1)))
+    buffer.enqueue(DeleteEvent(blobUri(2), resourceId(2)))
+    buffer.enqueue(DeleteEvent(blobUri(3), resourceId(3)))
 
-    buffer.flush()
+    assertThat(buffer.pendingCount()).isEqualTo(0)
 
     val captor = argumentCaptor<BatchDeleteImpressionMetadataRequest>()
-    verifyBlocking(impressionMetadataServiceMock, times(1)) {
+    verifyBlocking(impressionMetadataServiceMock) {
       batchDeleteImpressionMetadata(captor.capture())
     }
-    // blob-1 and blob-3 are live, only blob-2 and blob-4 should be deleted
-    assertThat(captor.firstValue.namesList).containsExactly(resourceId(2), resourceId(4))
 
-    buffer.shutdown()
+    val allDeleted = captor.allValues.flatMap { it.namesList }
+    assertThat(allDeleted).containsExactly(resourceId(2))
   }
 
   @Test
@@ -396,26 +332,19 @@ class BufferedDataAvailabilityCleanupTest {
     wheneverBlocking { impressionMetadataServiceMock.batchDeleteImpressionMetadata(any()) }
       .thenThrow(StatusRuntimeException(Status.NOT_FOUND))
 
-    val buffer = createBuffer(batchSize = 5)
+    val buffer = createBuffer()
 
-    for (i in 1..4) {
-      buffer.enqueue(DeleteEvent(blobUri(i), resourceId(i)))
-    }
-
-    buffer.flush()
+    buffer.enqueue(DeleteEvent(blobUri(1), resourceId(1)))
 
     assertThat(buffer.pendingCount()).isEqualTo(0)
 
     verifyBlocking(impressionMetadataServiceMock, times(1)) { batchDeleteImpressionMetadata(any()) }
 
     val captor = argumentCaptor<DeleteImpressionMetadataRequest>()
-    verifyBlocking(impressionMetadataServiceMock, times(4)) {
+    verifyBlocking(impressionMetadataServiceMock, times(1)) {
       deleteImpressionMetadata(captor.capture())
     }
-    assertThat(captor.allValues.map { it.name })
-      .containsExactly(resourceId(1), resourceId(2), resourceId(3), resourceId(4))
-
-    buffer.shutdown()
+    assertThat(captor.firstValue.name).isEqualTo(resourceId(1))
   }
 
   @Test
@@ -424,22 +353,13 @@ class BufferedDataAvailabilityCleanupTest {
       .thenThrow(StatusRuntimeException(Status.NOT_FOUND))
 
     wheneverBlocking { impressionMetadataServiceMock.deleteImpressionMetadata(any()) }
-      .thenReturn(ImpressionMetadata.getDefaultInstance())
-      .thenThrow(StatusRuntimeException(Status.NOT_FOUND))
-      .thenReturn(ImpressionMetadata.getDefaultInstance())
       .thenThrow(StatusRuntimeException(Status.NOT_FOUND))
 
-    val buffer = createBuffer(batchSize = 5)
+    val buffer = createBuffer()
 
-    for (i in 1..4) {
-      buffer.enqueue(DeleteEvent(blobUri(i), resourceId(i)))
-    }
-
-    buffer.flush()
+    buffer.enqueue(DeleteEvent(blobUri(1), resourceId(1)))
 
     assertThat(buffer.pendingCount()).isEqualTo(0)
-
-    buffer.shutdown()
   }
 
   @Test
@@ -448,41 +368,26 @@ class BufferedDataAvailabilityCleanupTest {
       .thenThrow(StatusRuntimeException(Status.NOT_FOUND))
 
     wheneverBlocking { impressionMetadataServiceMock.deleteImpressionMetadata(any()) }
-      .thenReturn(ImpressionMetadata.getDefaultInstance())
       .thenThrow(StatusRuntimeException(Status.UNAVAILABLE))
-      .thenReturn(ImpressionMetadata.getDefaultInstance())
-      .thenReturn(ImpressionMetadata.getDefaultInstance())
 
-    val buffer = createBuffer(batchSize = 5)
+    val buffer = createBuffer()
 
-    for (i in 1..4) {
-      buffer.enqueue(DeleteEvent(blobUri(i), resourceId(i)))
-    }
-
-    buffer.flush()
+    buffer.enqueue(DeleteEvent(blobUri(1), resourceId(1)))
 
     assertThat(buffer.pendingCount()).isEqualTo(1)
-
-    buffer.shutdown()
   }
 
   @Test
-  fun `non-NOT_FOUND batch error re-queues entire chunk without fallback`() {
+  fun `non-NOT_FOUND batch error re-queues with original blob path`() {
     wheneverBlocking { impressionMetadataServiceMock.batchDeleteImpressionMetadata(any()) }
       .thenThrow(StatusRuntimeException(Status.INTERNAL))
 
-    val buffer = createBuffer(batchSize = 5)
+    val buffer = createBuffer()
 
-    for (i in 1..3) {
-      buffer.enqueue(DeleteEvent(blobUri(i), resourceId(i)))
-    }
+    buffer.enqueue(DeleteEvent(blobUri(1), resourceId(1)))
 
-    buffer.flush()
-
-    assertThat(buffer.pendingCount()).isEqualTo(3)
+    assertThat(buffer.pendingCount()).isEqualTo(1)
 
     verifyBlocking(impressionMetadataServiceMock, never()) { deleteImpressionMetadata(any()) }
-
-    buffer.shutdown()
   }
 }

--- a/src/test/kotlin/org/wfanet/measurement/edpaggregator/dataavailability/BufferedDataAvailabilityCleanupTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/edpaggregator/dataavailability/BufferedDataAvailabilityCleanupTest.kt
@@ -150,7 +150,6 @@ class BufferedDataAvailabilityCleanupTest {
 
     assertThat(buffer.pendingCount()).isEqualTo(0)
 
-    // Verify ONE batch delete RPC was called with all 3 names
     val captor = argumentCaptor<BatchDeleteImpressionMetadataRequest>()
     verifyBlocking(impressionMetadataServiceMock, times(1)) {
       batchDeleteImpressionMetadata(captor.capture())
@@ -160,7 +159,6 @@ class BufferedDataAvailabilityCleanupTest {
       resourceId(1), resourceId(2), resourceId(3)
     )
 
-    // Verify NO individual deletes were called
     verifyBlocking(impressionMetadataServiceMock, never()) {
       deleteImpressionMetadata(any())
     }
@@ -177,12 +175,10 @@ class BufferedDataAvailabilityCleanupTest {
 
     buffer.flush()
 
-    // Verify list was called twice (once per event to resolve resource ID)
     verifyBlocking(impressionMetadataServiceMock, times(2)) {
       listImpressionMetadata(any())
     }
 
-    // Verify ONE batch delete RPC was called
     val captor = argumentCaptor<BatchDeleteImpressionMetadataRequest>()
     verifyBlocking(impressionMetadataServiceMock, times(1)) {
       batchDeleteImpressionMetadata(captor.capture())
@@ -207,6 +203,35 @@ class BufferedDataAvailabilityCleanupTest {
       batchDeleteImpressionMetadata(captor.capture())
     }
     assertThat(captor.firstValue.namesList).hasSize(3)
+
+    buffer.shutdown()
+  }
+
+  @Test
+  fun `flush chunks large batches into multiple RPCs of MAX_BATCH_DELETE_SIZE`() {
+    val buffer = createBuffer(batchSize = 250)
+
+    for (i in 1..250) {
+      buffer.enqueue(DeleteEvent("${BLOB_URI}-$i", resourceId(i)))
+    }
+
+    assertThat(buffer.pendingCount()).isEqualTo(0)
+
+    val captor = argumentCaptor<BatchDeleteImpressionMetadataRequest>()
+    verifyBlocking(impressionMetadataServiceMock, times(3)) {
+      batchDeleteImpressionMetadata(captor.capture())
+    }
+
+    val allValues = captor.allValues
+    assertThat(allValues[0].namesList).hasSize(100)
+    assertThat(allValues[1].namesList).hasSize(100)
+    assertThat(allValues[2].namesList).hasSize(50)
+
+    val allNames = allValues.flatMap { it.namesList }
+    assertThat(allNames).hasSize(250)
+    for (i in 1..250) {
+      assertThat(allNames).contains(resourceId(i))
+    }
 
     buffer.shutdown()
   }
@@ -240,7 +265,6 @@ class BufferedDataAvailabilityCleanupTest {
 
     buffer.flush()
 
-    // Batch delete should only include the one with a resource ID
     val captor = argumentCaptor<BatchDeleteImpressionMetadataRequest>()
     verifyBlocking(impressionMetadataServiceMock, times(1)) {
       batchDeleteImpressionMetadata(captor.capture())

--- a/src/test/kotlin/org/wfanet/measurement/edpaggregator/dataavailability/BufferedDataAvailabilityCleanupTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/edpaggregator/dataavailability/BufferedDataAvailabilityCleanupTest.kt
@@ -62,22 +62,42 @@ class BufferedDataAvailabilityCleanupTest {
       onBlocking { listImpressionMetadata(any<ListImpressionMetadataRequest>()) }
         .thenAnswer { invocation ->
           val request = invocation.getArgument<ListImpressionMetadataRequest>(0)
-          val blobUri = request.filter.blobUriPrefix
-          val index = blobUri.substringAfterLast("-").toIntOrNull() ?: 1
-          listImpressionMetadataResponse {
-            impressionMetadata +=
-              listOf(
-                impressionMetadata {
-                  name = resourceId(index)
-                  modelLine = "modelLine1"
-                  this.blobUri = blobUri
-                  interval = interval {
-                    startTime = timestamp { seconds = 100 }
-                    endTime = timestamp { seconds = 200 }
+          val blobUrisList = request.filter.blobUrisList
+          if (blobUrisList.isNotEmpty()) {
+            listImpressionMetadataResponse {
+              impressionMetadata +=
+                blobUrisList.mapNotNull { uri ->
+                  val index = uri.substringAfterLast("-").toIntOrNull() ?: return@mapNotNull null
+                  impressionMetadata {
+                    name = resourceId(index)
+                    modelLine = "modelLine1"
+                    blobUri = uri
+                    interval = interval {
+                      startTime = timestamp { seconds = 100 }
+                      endTime = timestamp { seconds = 200 }
+                    }
+                    state = ImpressionMetadata.State.ACTIVE
                   }
-                  state = ImpressionMetadata.State.ACTIVE
                 }
-              )
+            }
+          } else {
+            val blobUri = request.filter.blobUriPrefix
+            val index = blobUri.substringAfterLast("-").toIntOrNull() ?: 1
+            listImpressionMetadataResponse {
+              impressionMetadata +=
+                listOf(
+                  impressionMetadata {
+                    name = resourceId(index)
+                    modelLine = "modelLine1"
+                    this.blobUri = blobUri
+                    interval = interval {
+                      startTime = timestamp { seconds = 100 }
+                      endTime = timestamp { seconds = 200 }
+                    }
+                    state = ImpressionMetadata.State.ACTIVE
+                  }
+                )
+            }
           }
         }
       onBlocking { deleteImpressionMetadata(any<DeleteImpressionMetadataRequest>()) }
@@ -137,7 +157,7 @@ class BufferedDataAvailabilityCleanupTest {
   }
 
   @Test
-  fun `flush calls single batch delete RPC for multiple events`() {
+  fun `flush calls single batch delete RPC for multiple events with resource IDs`() {
     val buffer = createBuffer()
 
     buffer.enqueue(DeleteEvent("${BLOB_URI}-1", resourceId(1)))
@@ -167,23 +187,29 @@ class BufferedDataAvailabilityCleanupTest {
   }
 
   @Test
-  fun `flush resolves blob URIs via list when no resource ID provided`() {
+  fun `flush batch-resolves blob URIs via single list RPC`() {
     val buffer = createBuffer()
 
     buffer.enqueue(DeleteEvent("${BLOB_URI}-1", null))
     buffer.enqueue(DeleteEvent("${BLOB_URI}-2", null))
+    buffer.enqueue(DeleteEvent("${BLOB_URI}-3", null))
 
     buffer.flush()
 
-    verifyBlocking(impressionMetadataServiceMock, times(2)) {
-      listImpressionMetadata(any())
-    }
-
-    val captor = argumentCaptor<BatchDeleteImpressionMetadataRequest>()
+    // Verify ONE list RPC was called (batch resolve) instead of 3 individual calls
+    val listCaptor = argumentCaptor<ListImpressionMetadataRequest>()
     verifyBlocking(impressionMetadataServiceMock, times(1)) {
-      batchDeleteImpressionMetadata(captor.capture())
+      listImpressionMetadata(listCaptor.capture())
     }
-    assertThat(captor.firstValue.namesList).hasSize(2)
+    assertThat(listCaptor.firstValue.filter.blobUrisList).containsExactly(
+      "${BLOB_URI}-1", "${BLOB_URI}-2", "${BLOB_URI}-3"
+    )
+
+    val deleteCaptor = argumentCaptor<BatchDeleteImpressionMetadataRequest>()
+    verifyBlocking(impressionMetadataServiceMock, times(1)) {
+      batchDeleteImpressionMetadata(deleteCaptor.capture())
+    }
+    assertThat(deleteCaptor.firstValue.namesList).hasSize(3)
 
     buffer.shutdown()
   }

--- a/src/test/kotlin/org/wfanet/measurement/edpaggregator/dataavailability/BufferedDataAvailabilityCleanupTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/edpaggregator/dataavailability/BufferedDataAvailabilityCleanupTest.kt
@@ -21,6 +21,7 @@ import com.google.protobuf.timestamp
 import com.google.type.interval
 import io.grpc.Status
 import io.grpc.StatusException
+import io.grpc.StatusRuntimeException
 import kotlinx.coroutines.runBlocking
 import org.junit.Rule
 import org.junit.Test
@@ -306,6 +307,103 @@ class BufferedDataAvailabilityCleanupTest {
     assertThat(buffer.pendingCount()).isEqualTo(0)
     verifyBlocking(impressionMetadataServiceMock, times(1)) {
       batchDeleteImpressionMetadata(any())
+    }
+
+    buffer.shutdown()
+  }
+
+  @Test
+  fun `batch NOT_FOUND falls back to individual deletes`() {
+    wheneverBlocking { impressionMetadataServiceMock.batchDeleteImpressionMetadata(any()) }
+      .thenThrow(StatusRuntimeException(Status.NOT_FOUND))
+
+    val buffer = createBuffer()
+
+    buffer.enqueue(DeleteEvent("${BLOB_URI}-1", resourceId(1)))
+    buffer.enqueue(DeleteEvent("${BLOB_URI}-2", resourceId(2)))
+    buffer.enqueue(DeleteEvent("${BLOB_URI}-3", resourceId(3)))
+
+    buffer.flush()
+
+    assertThat(buffer.pendingCount()).isEqualTo(0)
+
+    verifyBlocking(impressionMetadataServiceMock, times(1)) {
+      batchDeleteImpressionMetadata(any())
+    }
+
+    val captor = argumentCaptor<DeleteImpressionMetadataRequest>()
+    verifyBlocking(impressionMetadataServiceMock, times(3)) {
+      deleteImpressionMetadata(captor.capture())
+    }
+    assertThat(captor.allValues.map { it.name }).containsExactly(
+      resourceId(1), resourceId(2), resourceId(3)
+    )
+
+    buffer.shutdown()
+  }
+
+  @Test
+  fun `individual delete treats NOT_FOUND as success`() {
+    wheneverBlocking { impressionMetadataServiceMock.batchDeleteImpressionMetadata(any()) }
+      .thenThrow(StatusRuntimeException(Status.NOT_FOUND))
+
+    wheneverBlocking { impressionMetadataServiceMock.deleteImpressionMetadata(any()) }
+      .thenReturn(ImpressionMetadata.getDefaultInstance())
+      .thenThrow(StatusRuntimeException(Status.NOT_FOUND))
+      .thenReturn(ImpressionMetadata.getDefaultInstance())
+
+    val buffer = createBuffer()
+
+    buffer.enqueue(DeleteEvent("${BLOB_URI}-1", resourceId(1)))
+    buffer.enqueue(DeleteEvent("${BLOB_URI}-2", resourceId(2)))
+    buffer.enqueue(DeleteEvent("${BLOB_URI}-3", resourceId(3)))
+
+    buffer.flush()
+
+    assertThat(buffer.pendingCount()).isEqualTo(0)
+
+    buffer.shutdown()
+  }
+
+  @Test
+  fun `individual delete re-queues on non-NOT_FOUND error`() {
+    wheneverBlocking { impressionMetadataServiceMock.batchDeleteImpressionMetadata(any()) }
+      .thenThrow(StatusRuntimeException(Status.NOT_FOUND))
+
+    wheneverBlocking { impressionMetadataServiceMock.deleteImpressionMetadata(any()) }
+      .thenReturn(ImpressionMetadata.getDefaultInstance())
+      .thenThrow(StatusRuntimeException(Status.UNAVAILABLE))
+      .thenReturn(ImpressionMetadata.getDefaultInstance())
+
+    val buffer = createBuffer()
+
+    buffer.enqueue(DeleteEvent("${BLOB_URI}-1", resourceId(1)))
+    buffer.enqueue(DeleteEvent("${BLOB_URI}-2", resourceId(2)))
+    buffer.enqueue(DeleteEvent("${BLOB_URI}-3", resourceId(3)))
+
+    buffer.flush()
+
+    assertThat(buffer.pendingCount()).isEqualTo(1)
+
+    buffer.shutdown()
+  }
+
+  @Test
+  fun `non-NOT_FOUND batch error re-queues entire chunk without fallback`() {
+    wheneverBlocking { impressionMetadataServiceMock.batchDeleteImpressionMetadata(any()) }
+      .thenThrow(StatusRuntimeException(Status.INTERNAL))
+
+    val buffer = createBuffer()
+
+    buffer.enqueue(DeleteEvent("${BLOB_URI}-1", resourceId(1)))
+    buffer.enqueue(DeleteEvent("${BLOB_URI}-2", resourceId(2)))
+
+    buffer.flush()
+
+    assertThat(buffer.pendingCount()).isEqualTo(2)
+
+    verifyBlocking(impressionMetadataServiceMock, never()) {
+      deleteImpressionMetadata(any())
     }
 
     buffer.shutdown()

--- a/src/test/kotlin/org/wfanet/measurement/edpaggregator/dataavailability/BufferedDataAvailabilityCleanupTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/edpaggregator/dataavailability/BufferedDataAvailabilityCleanupTest.kt
@@ -196,7 +196,6 @@ class BufferedDataAvailabilityCleanupTest {
 
     buffer.flush()
 
-    // Verify ONE list RPC was called (batch resolve) instead of 3 individual calls
     val listCaptor = argumentCaptor<ListImpressionMetadataRequest>()
     verifyBlocking(impressionMetadataServiceMock, times(1)) {
       listImpressionMetadata(listCaptor.capture())
@@ -301,16 +300,17 @@ class BufferedDataAvailabilityCleanupTest {
   }
 
   @Test
-  fun `periodic flush uses batch RPC`() {
-    val buffer = createBuffer(flushIntervalSeconds = 1)
+  fun `stale buffer flushes on next enqueue`() {
+    val buffer = createBuffer(batchSize = 100, flushIntervalSeconds = 1)
 
     buffer.enqueue(DeleteEvent("${BLOB_URI}-1", resourceId(1)))
-
     assertThat(buffer.pendingCount()).isEqualTo(1)
 
-    Thread.sleep(2500)
+    Thread.sleep(1500)
 
-    assertThat(buffer.pendingCount()).isEqualTo(0)
+    buffer.enqueue(DeleteEvent("${BLOB_URI}-2", resourceId(2)))
+
+    assertThat(buffer.pendingCount()).isAtMost(1)
     verifyBlocking(impressionMetadataServiceMock, times(1)) {
       batchDeleteImpressionMetadata(any())
     }

--- a/src/test/kotlin/org/wfanet/measurement/edpaggregator/dataavailability/BufferedDataAvailabilityCleanupTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/edpaggregator/dataavailability/BufferedDataAvailabilityCleanupTest.kt
@@ -23,7 +23,6 @@ import io.grpc.Status
 import io.grpc.StatusException
 import io.grpc.StatusRuntimeException
 import java.io.File
-import kotlinx.coroutines.runBlocking
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TemporaryFolder
@@ -59,8 +58,7 @@ class BufferedDataAvailabilityCleanupTest {
 
   private fun blobUri(index: Int) = "$BLOB_URI_PREFIX/blob-$index"
 
-  private fun resourceId(index: Int) =
-    "$DATA_PROVIDER_NAME/impressionMetadata/im-$index"
+  private fun resourceId(index: Int) = "$DATA_PROVIDER_NAME/impressionMetadata/im-$index"
 
   private val impressionMetadataServiceMock: ImpressionMetadataServiceCoroutineImplBase =
     mockService {
@@ -170,22 +168,20 @@ class BufferedDataAvailabilityCleanupTest {
     buffer.enqueue(DeleteEvent(blobUri(1), resourceId(1)))
 
     assertThat(buffer.pendingCount()).isEqualTo(1)
-    verifyBlocking(impressionMetadataServiceMock, never()) {
-      batchDeleteImpressionMetadata(any())
-    }
+    verifyBlocking(impressionMetadataServiceMock, never()) { batchDeleteImpressionMetadata(any()) }
 
     buffer.shutdown()
   }
 
   @Test
   fun `flush calls single batch delete RPC for multiple events with resource IDs`() {
-    val buffer = createBuffer()
+    val buffer = createBuffer(batchSize = 10)
 
-    buffer.enqueue(DeleteEvent(blobUri(1), resourceId(1)))
-    buffer.enqueue(DeleteEvent(blobUri(2), resourceId(2)))
-    buffer.enqueue(DeleteEvent(blobUri(3), resourceId(3)))
+    for (i in 1..5) {
+      buffer.enqueue(DeleteEvent(blobUri(i), resourceId(i)))
+    }
 
-    assertThat(buffer.pendingCount()).isEqualTo(3)
+    assertThat(buffer.pendingCount()).isEqualTo(5)
 
     buffer.flush()
 
@@ -196,24 +192,20 @@ class BufferedDataAvailabilityCleanupTest {
       batchDeleteImpressionMetadata(captor.capture())
     }
     assertThat(captor.firstValue.parent).isEqualTo(DATA_PROVIDER_NAME)
-    assertThat(captor.firstValue.namesList).containsExactly(
-      resourceId(1), resourceId(2), resourceId(3)
-    )
+    assertThat(captor.firstValue.namesList).hasSize(5)
 
-    verifyBlocking(impressionMetadataServiceMock, never()) {
-      deleteImpressionMetadata(any())
-    }
+    verifyBlocking(impressionMetadataServiceMock, never()) { deleteImpressionMetadata(any()) }
 
     buffer.shutdown()
   }
 
   @Test
   fun `flush batch-resolves blob URIs via single list RPC`() {
-    val buffer = createBuffer()
+    val buffer = createBuffer(batchSize = 10)
 
-    buffer.enqueue(DeleteEvent(blobUri(1), null))
-    buffer.enqueue(DeleteEvent(blobUri(2), null))
-    buffer.enqueue(DeleteEvent(blobUri(3), null))
+    for (i in 1..5) {
+      buffer.enqueue(DeleteEvent(blobUri(i), null))
+    }
 
     buffer.flush()
 
@@ -221,50 +213,63 @@ class BufferedDataAvailabilityCleanupTest {
     verifyBlocking(impressionMetadataServiceMock, times(1)) {
       listImpressionMetadata(listCaptor.capture())
     }
-    assertThat(listCaptor.firstValue.filter.blobUrisList).containsExactly(
-      blobUri(1), blobUri(2), blobUri(3)
-    )
+    assertThat(listCaptor.firstValue.filter.blobUrisList).hasSize(5)
 
     val deleteCaptor = argumentCaptor<BatchDeleteImpressionMetadataRequest>()
     verifyBlocking(impressionMetadataServiceMock, times(1)) {
       batchDeleteImpressionMetadata(deleteCaptor.capture())
     }
-    assertThat(deleteCaptor.firstValue.namesList).hasSize(3)
+    assertThat(deleteCaptor.firstValue.namesList).hasSize(5)
 
     buffer.shutdown()
   }
 
   @Test
-  fun `batch size threshold triggers immediate flush with batch RPC`() {
+  fun `batch size threshold triggers flush with remaining tail via shutdown`() {
+    // batchSize=3 with 5 events: first 3 trigger threshold flush, remaining 2 flushed at shutdown
     val buffer = createBuffer(batchSize = 3)
 
-    buffer.enqueue(DeleteEvent(blobUri(1), resourceId(1)))
-    buffer.enqueue(DeleteEvent(blobUri(2), resourceId(2)))
-    buffer.enqueue(DeleteEvent(blobUri(3), resourceId(3)))
+    for (i in 1..5) {
+      buffer.enqueue(DeleteEvent(blobUri(i), resourceId(i)))
+    }
+
+    // After enqueuing 5 with batchSize=3, the first batch of 3 was flushed at threshold.
+    // Remaining 2 are still pending.
+    assertThat(buffer.pendingCount()).isEqualTo(2)
+
+    buffer.shutdown()
 
     assertThat(buffer.pendingCount()).isEqualTo(0)
 
     val captor = argumentCaptor<BatchDeleteImpressionMetadataRequest>()
-    verifyBlocking(impressionMetadataServiceMock, times(1)) {
+    verifyBlocking(impressionMetadataServiceMock, times(2)) {
       batchDeleteImpressionMetadata(captor.capture())
     }
-    assertThat(captor.firstValue.namesList).hasSize(3)
+    assertThat(captor.allValues[0].namesList).hasSize(3)
+    assertThat(captor.allValues[1].namesList).hasSize(2)
 
     buffer.shutdown()
   }
 
   @Test
   fun `flush chunks large batches into multiple RPCs of MAX_BATCH_DELETE_SIZE`() {
+    // batchSize=250 means threshold flush at 250, which chunks into 3 RPCs (100+100+50)
+    // Use 260 to ensure tail of 10 is flushed at shutdown
     val buffer = createBuffer(batchSize = 250)
 
-    for (i in 1..250) {
+    for (i in 1..260) {
       buffer.enqueue(DeleteEvent(blobUri(i), resourceId(i)))
     }
+
+    // 250 flushed at threshold (in 3 chunks), 10 remain
+    assertThat(buffer.pendingCount()).isEqualTo(10)
+
+    buffer.shutdown()
 
     assertThat(buffer.pendingCount()).isEqualTo(0)
 
     val captor = argumentCaptor<BatchDeleteImpressionMetadataRequest>()
-    verifyBlocking(impressionMetadataServiceMock, times(3)) {
+    verifyBlocking(impressionMetadataServiceMock, times(4)) {
       batchDeleteImpressionMetadata(captor.capture())
     }
 
@@ -272,25 +277,25 @@ class BufferedDataAvailabilityCleanupTest {
     assertThat(allValues[0].namesList).hasSize(100)
     assertThat(allValues[1].namesList).hasSize(100)
     assertThat(allValues[2].namesList).hasSize(50)
+    assertThat(allValues[3].namesList).hasSize(10)
 
     buffer.shutdown()
   }
 
   @Test
   fun `shutdown flushes remaining events via batch RPC`() {
-    val buffer = createBuffer()
+    val buffer = createBuffer(batchSize = 10)
 
-    buffer.enqueue(DeleteEvent(blobUri(1), resourceId(1)))
-    buffer.enqueue(DeleteEvent(blobUri(2), resourceId(2)))
+    for (i in 1..5) {
+      buffer.enqueue(DeleteEvent(blobUri(i), resourceId(i)))
+    }
 
-    assertThat(buffer.pendingCount()).isEqualTo(2)
+    assertThat(buffer.pendingCount()).isEqualTo(5)
 
     buffer.shutdown()
 
     assertThat(buffer.pendingCount()).isEqualTo(0)
-    verifyBlocking(impressionMetadataServiceMock, times(1)) {
-      batchDeleteImpressionMetadata(any())
-    }
+    verifyBlocking(impressionMetadataServiceMock, times(1)) { batchDeleteImpressionMetadata(any()) }
   }
 
   @Test
@@ -315,31 +320,40 @@ class BufferedDataAvailabilityCleanupTest {
   }
 
   @Test
-  fun `periodic timer flushes remaining events`() {
-    val buffer = createBuffer(flushIntervalSeconds = 1)
+  fun `periodic timer flushes remaining events including tail`() {
+    // batchSize=3 with 5 events: 3 flushed at threshold, 2 flushed by timer
+    val buffer = createBuffer(batchSize = 3, flushIntervalSeconds = 1)
 
-    buffer.enqueue(DeleteEvent(blobUri(1), resourceId(1)))
+    for (i in 1..5) {
+      buffer.enqueue(DeleteEvent(blobUri(i), resourceId(i)))
+    }
 
-    assertThat(buffer.pendingCount()).isEqualTo(1)
+    // 3 were flushed at threshold, 2 remain for timer
+    assertThat(buffer.pendingCount()).isEqualTo(2)
 
     Thread.sleep(2500)
 
     assertThat(buffer.pendingCount()).isEqualTo(0)
-    verifyBlocking(impressionMetadataServiceMock, times(1)) {
-      batchDeleteImpressionMetadata(any())
+
+    val captor = argumentCaptor<BatchDeleteImpressionMetadataRequest>()
+    verifyBlocking(impressionMetadataServiceMock, times(2)) {
+      batchDeleteImpressionMetadata(captor.capture())
     }
+    assertThat(captor.allValues[0].namesList).hasSize(3)
+    assertThat(captor.allValues[1].namesList).hasSize(2)
 
     buffer.shutdown()
   }
 
   @Test
   fun `skips events whose blobs still have a live version`() {
-    // blob-1 still has a live version; blob-2 is fully deleted
+    // blob-1 still has a live version; blob-2 and blob-3 are fully deleted
     val sc = storageClientWithLiveBlobs("path/to/blob-1")
-    val buffer = createBuffer(storageClient = sc)
+    val buffer = createBuffer(batchSize = 5, storageClient = sc)
 
-    buffer.enqueue(DeleteEvent(blobUri(1), resourceId(1)))
-    buffer.enqueue(DeleteEvent(blobUri(2), resourceId(2)))
+    for (i in 1..3) {
+      buffer.enqueue(DeleteEvent(blobUri(i), resourceId(i)))
+    }
 
     buffer.flush()
 
@@ -349,8 +363,8 @@ class BufferedDataAvailabilityCleanupTest {
     verifyBlocking(impressionMetadataServiceMock, times(1)) {
       batchDeleteImpressionMetadata(captor.capture())
     }
-    // Only blob-2 should be deleted; blob-1 is skipped (live version exists)
-    assertThat(captor.firstValue.namesList).containsExactly(resourceId(2))
+    // blob-1 is skipped (live version exists), blob-2 and blob-3 are deleted
+    assertThat(captor.firstValue.namesList).containsExactly(resourceId(2), resourceId(3))
 
     buffer.shutdown()
   }
@@ -359,11 +373,11 @@ class BufferedDataAvailabilityCleanupTest {
   fun `bulk live-version check groups by prefix`() {
     // Both blobs share the same prefix "path/to/" — only one listBlobs call needed
     val sc = storageClientWithLiveBlobs("path/to/blob-1", "path/to/blob-3")
-    val buffer = createBuffer(storageClient = sc)
+    val buffer = createBuffer(batchSize = 5, storageClient = sc)
 
-    buffer.enqueue(DeleteEvent(blobUri(1), resourceId(1)))
-    buffer.enqueue(DeleteEvent(blobUri(2), resourceId(2)))
-    buffer.enqueue(DeleteEvent(blobUri(3), resourceId(3)))
+    for (i in 1..4) {
+      buffer.enqueue(DeleteEvent(blobUri(i), resourceId(i)))
+    }
 
     buffer.flush()
 
@@ -371,8 +385,8 @@ class BufferedDataAvailabilityCleanupTest {
     verifyBlocking(impressionMetadataServiceMock, times(1)) {
       batchDeleteImpressionMetadata(captor.capture())
     }
-    // blob-1 and blob-3 are live, only blob-2 should be deleted
-    assertThat(captor.firstValue.namesList).containsExactly(resourceId(2))
+    // blob-1 and blob-3 are live, only blob-2 and blob-4 should be deleted
+    assertThat(captor.firstValue.namesList).containsExactly(resourceId(2), resourceId(4))
 
     buffer.shutdown()
   }
@@ -382,27 +396,24 @@ class BufferedDataAvailabilityCleanupTest {
     wheneverBlocking { impressionMetadataServiceMock.batchDeleteImpressionMetadata(any()) }
       .thenThrow(StatusRuntimeException(Status.NOT_FOUND))
 
-    val buffer = createBuffer()
+    val buffer = createBuffer(batchSize = 5)
 
-    buffer.enqueue(DeleteEvent(blobUri(1), resourceId(1)))
-    buffer.enqueue(DeleteEvent(blobUri(2), resourceId(2)))
-    buffer.enqueue(DeleteEvent(blobUri(3), resourceId(3)))
+    for (i in 1..4) {
+      buffer.enqueue(DeleteEvent(blobUri(i), resourceId(i)))
+    }
 
     buffer.flush()
 
     assertThat(buffer.pendingCount()).isEqualTo(0)
 
-    verifyBlocking(impressionMetadataServiceMock, times(1)) {
-      batchDeleteImpressionMetadata(any())
-    }
+    verifyBlocking(impressionMetadataServiceMock, times(1)) { batchDeleteImpressionMetadata(any()) }
 
     val captor = argumentCaptor<DeleteImpressionMetadataRequest>()
-    verifyBlocking(impressionMetadataServiceMock, times(3)) {
+    verifyBlocking(impressionMetadataServiceMock, times(4)) {
       deleteImpressionMetadata(captor.capture())
     }
-    assertThat(captor.allValues.map { it.name }).containsExactly(
-      resourceId(1), resourceId(2), resourceId(3)
-    )
+    assertThat(captor.allValues.map { it.name })
+      .containsExactly(resourceId(1), resourceId(2), resourceId(3), resourceId(4))
 
     buffer.shutdown()
   }
@@ -416,12 +427,13 @@ class BufferedDataAvailabilityCleanupTest {
       .thenReturn(ImpressionMetadata.getDefaultInstance())
       .thenThrow(StatusRuntimeException(Status.NOT_FOUND))
       .thenReturn(ImpressionMetadata.getDefaultInstance())
+      .thenThrow(StatusRuntimeException(Status.NOT_FOUND))
 
-    val buffer = createBuffer()
+    val buffer = createBuffer(batchSize = 5)
 
-    buffer.enqueue(DeleteEvent(blobUri(1), resourceId(1)))
-    buffer.enqueue(DeleteEvent(blobUri(2), resourceId(2)))
-    buffer.enqueue(DeleteEvent(blobUri(3), resourceId(3)))
+    for (i in 1..4) {
+      buffer.enqueue(DeleteEvent(blobUri(i), resourceId(i)))
+    }
 
     buffer.flush()
 
@@ -439,12 +451,13 @@ class BufferedDataAvailabilityCleanupTest {
       .thenReturn(ImpressionMetadata.getDefaultInstance())
       .thenThrow(StatusRuntimeException(Status.UNAVAILABLE))
       .thenReturn(ImpressionMetadata.getDefaultInstance())
+      .thenReturn(ImpressionMetadata.getDefaultInstance())
 
-    val buffer = createBuffer()
+    val buffer = createBuffer(batchSize = 5)
 
-    buffer.enqueue(DeleteEvent(blobUri(1), resourceId(1)))
-    buffer.enqueue(DeleteEvent(blobUri(2), resourceId(2)))
-    buffer.enqueue(DeleteEvent(blobUri(3), resourceId(3)))
+    for (i in 1..4) {
+      buffer.enqueue(DeleteEvent(blobUri(i), resourceId(i)))
+    }
 
     buffer.flush()
 
@@ -458,18 +471,17 @@ class BufferedDataAvailabilityCleanupTest {
     wheneverBlocking { impressionMetadataServiceMock.batchDeleteImpressionMetadata(any()) }
       .thenThrow(StatusRuntimeException(Status.INTERNAL))
 
-    val buffer = createBuffer()
+    val buffer = createBuffer(batchSize = 5)
 
-    buffer.enqueue(DeleteEvent(blobUri(1), resourceId(1)))
-    buffer.enqueue(DeleteEvent(blobUri(2), resourceId(2)))
+    for (i in 1..3) {
+      buffer.enqueue(DeleteEvent(blobUri(i), resourceId(i)))
+    }
 
     buffer.flush()
 
-    assertThat(buffer.pendingCount()).isEqualTo(2)
+    assertThat(buffer.pendingCount()).isEqualTo(3)
 
-    verifyBlocking(impressionMetadataServiceMock, never()) {
-      deleteImpressionMetadata(any())
-    }
+    verifyBlocking(impressionMetadataServiceMock, never()) { deleteImpressionMetadata(any()) }
 
     buffer.shutdown()
   }

--- a/src/test/kotlin/org/wfanet/measurement/edpaggregator/dataavailability/BufferedDataAvailabilityCleanupTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/edpaggregator/dataavailability/BufferedDataAvailabilityCleanupTest.kt
@@ -1,0 +1,231 @@
+/*
+ * Copyright 2025 The Cross-Media Measurement Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wfanet.measurement.edpaggregator.dataavailability
+
+import com.google.common.truth.Truth.assertThat
+import com.google.protobuf.timestamp
+import com.google.type.interval
+import io.grpc.Status
+import io.grpc.StatusException
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import kotlinx.coroutines.runBlocking
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+import org.mockito.kotlin.any
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verifyBlocking
+import org.mockito.kotlin.wheneverBlocking
+import org.wfanet.measurement.common.grpc.testing.GrpcTestServerRule
+import org.wfanet.measurement.common.grpc.testing.mockService
+import org.wfanet.measurement.edpaggregator.v1alpha.DeleteImpressionMetadataRequest
+import org.wfanet.measurement.edpaggregator.v1alpha.ImpressionMetadata
+import org.wfanet.measurement.edpaggregator.v1alpha.ImpressionMetadataServiceGrpcKt.ImpressionMetadataServiceCoroutineImplBase
+import org.wfanet.measurement.edpaggregator.v1alpha.ImpressionMetadataServiceGrpcKt.ImpressionMetadataServiceCoroutineStub
+import org.wfanet.measurement.edpaggregator.v1alpha.ListImpressionMetadataRequest
+import org.wfanet.measurement.edpaggregator.v1alpha.impressionMetadata
+import org.wfanet.measurement.edpaggregator.v1alpha.listImpressionMetadataResponse
+import org.wfanet.measurement.storage.filesystem.FileSystemStorageClient
+
+@RunWith(JUnit4::class)
+class BufferedDataAvailabilityCleanupTest {
+
+  companion object {
+    private const val DATA_PROVIDER_NAME = "dataProviders/dataProvider123"
+    private const val RESOURCE_ID = "$DATA_PROVIDER_NAME/impressionMetadata/im-123"
+    private const val BLOB_URI = "gs://bucket/path/to/blob"
+  }
+
+  private val impressionMetadataServiceMock: ImpressionMetadataServiceCoroutineImplBase =
+    mockService {
+      onBlocking { listImpressionMetadata(any<ListImpressionMetadataRequest>()) }
+        .thenAnswer { invocation ->
+          val request = invocation.getArgument<ListImpressionMetadataRequest>(0)
+          listImpressionMetadataResponse {
+            impressionMetadata +=
+              listOf(
+                impressionMetadata {
+                  name = RESOURCE_ID
+                  modelLine = "modelLine1"
+                  blobUri = request.filter.blobUriPrefix
+                  interval = interval {
+                    startTime = timestamp { seconds = 100 }
+                    endTime = timestamp { seconds = 200 }
+                  }
+                  state = ImpressionMetadata.State.ACTIVE
+                }
+              )
+          }
+        }
+      onBlocking { deleteImpressionMetadata(any<DeleteImpressionMetadataRequest>()) }
+        .thenAnswer { ImpressionMetadata.getDefaultInstance() }
+    }
+
+  private val impressionMetadataStub: ImpressionMetadataServiceCoroutineStub by lazy {
+    ImpressionMetadataServiceCoroutineStub(grpcTestServerRule.channel)
+  }
+
+  @get:Rule val tempFolder = TemporaryFolder()
+
+  private val emptyStorageClient: FileSystemStorageClient
+    get() = FileSystemStorageClient(tempFolder.newFolder("empty-storage"))
+
+  @get:Rule
+  val grpcTestServerRule = GrpcTestServerRule { addService(impressionMetadataServiceMock) }
+
+  private fun createCleanup(): DataAvailabilityCleanup {
+    return DataAvailabilityCleanup(impressionMetadataStub, DATA_PROVIDER_NAME, emptyStorageClient)
+  }
+
+  @Test
+  fun `enqueue buffers events without immediate processing`() {
+    val buffer =
+      BufferedDataAvailabilityCleanup(
+        cleanupDelegate = createCleanup(),
+        batchSize = 10,
+        flushIntervalSeconds = 300,
+      )
+
+    buffer.enqueue(DeleteEvent(BLOB_URI, RESOURCE_ID))
+
+    assertThat(buffer.pendingCount()).isEqualTo(1)
+
+    verifyBlocking(impressionMetadataServiceMock, times(0)) { deleteImpressionMetadata(any()) }
+
+    buffer.shutdown()
+  }
+
+  @Test
+  fun `flush processes all buffered events`() {
+    val buffer =
+      BufferedDataAvailabilityCleanup(
+        cleanupDelegate = createCleanup(),
+        batchSize = 100,
+        flushIntervalSeconds = 300,
+      )
+
+    buffer.enqueue(DeleteEvent("${BLOB_URI}/1", RESOURCE_ID))
+    buffer.enqueue(DeleteEvent("${BLOB_URI}/2", RESOURCE_ID))
+    buffer.enqueue(DeleteEvent("${BLOB_URI}/3", RESOURCE_ID))
+
+    assertThat(buffer.pendingCount()).isEqualTo(3)
+
+    buffer.flush()
+
+    assertThat(buffer.pendingCount()).isEqualTo(0)
+    verifyBlocking(impressionMetadataServiceMock, times(3)) { deleteImpressionMetadata(any()) }
+
+    buffer.shutdown()
+  }
+
+  @Test
+  fun `batch size threshold triggers immediate flush`() {
+    val buffer =
+      BufferedDataAvailabilityCleanup(
+        cleanupDelegate = createCleanup(),
+        batchSize = 3,
+        flushIntervalSeconds = 300,
+      )
+
+    buffer.enqueue(DeleteEvent("${BLOB_URI}/1", RESOURCE_ID))
+    buffer.enqueue(DeleteEvent("${BLOB_URI}/2", RESOURCE_ID))
+
+    // Not yet at threshold
+    assertThat(buffer.pendingCount()).isEqualTo(2)
+
+    // This triggers the threshold
+    buffer.enqueue(DeleteEvent("${BLOB_URI}/3", RESOURCE_ID))
+
+    // After flush, queue should be empty
+    assertThat(buffer.pendingCount()).isEqualTo(0)
+    verifyBlocking(impressionMetadataServiceMock, times(3)) { deleteImpressionMetadata(any()) }
+
+    buffer.shutdown()
+  }
+
+  @Test
+  fun `failed events are re-queued`() {
+    // First call succeeds, second fails, third succeeds
+    wheneverBlocking { impressionMetadataServiceMock.deleteImpressionMetadata(any()) }
+      .thenAnswer { ImpressionMetadata.getDefaultInstance() }
+      .thenAnswer { throw StatusException(Status.UNAVAILABLE) }
+      .thenAnswer { ImpressionMetadata.getDefaultInstance() }
+
+    val buffer =
+      BufferedDataAvailabilityCleanup(
+        cleanupDelegate = createCleanup(),
+        batchSize = 100,
+        flushIntervalSeconds = 300,
+      )
+
+    buffer.enqueue(DeleteEvent("${BLOB_URI}/1", RESOURCE_ID))
+    buffer.enqueue(DeleteEvent("${BLOB_URI}/2", RESOURCE_ID))
+    buffer.enqueue(DeleteEvent("${BLOB_URI}/3", RESOURCE_ID))
+
+    buffer.flush()
+
+    // One event failed and was re-queued
+    assertThat(buffer.pendingCount()).isEqualTo(1)
+
+    buffer.shutdown()
+  }
+
+  @Test
+  fun `shutdown flushes remaining events`() {
+    val buffer =
+      BufferedDataAvailabilityCleanup(
+        cleanupDelegate = createCleanup(),
+        batchSize = 100,
+        flushIntervalSeconds = 300,
+      )
+
+    buffer.enqueue(DeleteEvent("${BLOB_URI}/1", RESOURCE_ID))
+    buffer.enqueue(DeleteEvent("${BLOB_URI}/2", RESOURCE_ID))
+
+    assertThat(buffer.pendingCount()).isEqualTo(2)
+
+    buffer.shutdown()
+
+    assertThat(buffer.pendingCount()).isEqualTo(0)
+    verifyBlocking(impressionMetadataServiceMock, times(2)) { deleteImpressionMetadata(any()) }
+  }
+
+  @Test
+  fun `periodic flush processes buffered events`() {
+    val buffer =
+      BufferedDataAvailabilityCleanup(
+        cleanupDelegate = createCleanup(),
+        batchSize = 100,
+        flushIntervalSeconds = 1,
+      )
+
+    buffer.enqueue(DeleteEvent(BLOB_URI, RESOURCE_ID))
+
+    assertThat(buffer.pendingCount()).isEqualTo(1)
+
+    // Wait for the periodic flush to fire
+    Thread.sleep(2500)
+
+    assertThat(buffer.pendingCount()).isEqualTo(0)
+    verifyBlocking(impressionMetadataServiceMock, times(1)) { deleteImpressionMetadata(any()) }
+
+    buffer.shutdown()
+  }
+}

--- a/src/test/kotlin/org/wfanet/measurement/edpaggregator/dataavailability/BufferedDataAvailabilityCleanupTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/edpaggregator/dataavailability/BufferedDataAvailabilityCleanupTest.kt
@@ -21,8 +21,6 @@ import com.google.protobuf.timestamp
 import com.google.type.interval
 import io.grpc.Status
 import io.grpc.StatusException
-import java.util.concurrent.CountDownLatch
-import java.util.concurrent.TimeUnit
 import kotlinx.coroutines.runBlocking
 import org.junit.Rule
 import org.junit.Test
@@ -30,16 +28,20 @@ import org.junit.rules.TemporaryFolder
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.never
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verifyBlocking
 import org.mockito.kotlin.wheneverBlocking
 import org.wfanet.measurement.common.grpc.testing.GrpcTestServerRule
 import org.wfanet.measurement.common.grpc.testing.mockService
+import org.wfanet.measurement.edpaggregator.v1alpha.BatchDeleteImpressionMetadataRequest
 import org.wfanet.measurement.edpaggregator.v1alpha.DeleteImpressionMetadataRequest
 import org.wfanet.measurement.edpaggregator.v1alpha.ImpressionMetadata
 import org.wfanet.measurement.edpaggregator.v1alpha.ImpressionMetadataServiceGrpcKt.ImpressionMetadataServiceCoroutineImplBase
 import org.wfanet.measurement.edpaggregator.v1alpha.ImpressionMetadataServiceGrpcKt.ImpressionMetadataServiceCoroutineStub
 import org.wfanet.measurement.edpaggregator.v1alpha.ListImpressionMetadataRequest
+import org.wfanet.measurement.edpaggregator.v1alpha.batchDeleteImpressionMetadataResponse
 import org.wfanet.measurement.edpaggregator.v1alpha.impressionMetadata
 import org.wfanet.measurement.edpaggregator.v1alpha.listImpressionMetadataResponse
 import org.wfanet.measurement.storage.filesystem.FileSystemStorageClient
@@ -49,22 +51,26 @@ class BufferedDataAvailabilityCleanupTest {
 
   companion object {
     private const val DATA_PROVIDER_NAME = "dataProviders/dataProvider123"
-    private const val RESOURCE_ID = "$DATA_PROVIDER_NAME/impressionMetadata/im-123"
     private const val BLOB_URI = "gs://bucket/path/to/blob"
   }
+
+  private fun resourceId(index: Int) =
+    "$DATA_PROVIDER_NAME/impressionMetadata/im-$index"
 
   private val impressionMetadataServiceMock: ImpressionMetadataServiceCoroutineImplBase =
     mockService {
       onBlocking { listImpressionMetadata(any<ListImpressionMetadataRequest>()) }
         .thenAnswer { invocation ->
           val request = invocation.getArgument<ListImpressionMetadataRequest>(0)
+          val blobUri = request.filter.blobUriPrefix
+          val index = blobUri.substringAfterLast("-").toIntOrNull() ?: 1
           listImpressionMetadataResponse {
             impressionMetadata +=
               listOf(
                 impressionMetadata {
-                  name = RESOURCE_ID
+                  name = resourceId(index)
                   modelLine = "modelLine1"
-                  blobUri = request.filter.blobUriPrefix
+                  this.blobUri = blobUri
                   interval = interval {
                     startTime = timestamp { seconds = 100 }
                     endTime = timestamp { seconds = 200 }
@@ -76,6 +82,19 @@ class BufferedDataAvailabilityCleanupTest {
         }
       onBlocking { deleteImpressionMetadata(any<DeleteImpressionMetadataRequest>()) }
         .thenAnswer { ImpressionMetadata.getDefaultInstance() }
+      onBlocking { batchDeleteImpressionMetadata(any<BatchDeleteImpressionMetadataRequest>()) }
+        .thenAnswer { invocation ->
+          val request = invocation.getArgument<BatchDeleteImpressionMetadataRequest>(0)
+          batchDeleteImpressionMetadataResponse {
+            impressionMetadata +=
+              request.namesList.map {
+                impressionMetadata {
+                  name = it
+                  state = ImpressionMetadata.State.DELETED
+                }
+              }
+          }
+        }
     }
 
   private val impressionMetadataStub: ImpressionMetadataServiceCoroutineStub by lazy {
@@ -90,141 +109,161 @@ class BufferedDataAvailabilityCleanupTest {
   @get:Rule
   val grpcTestServerRule = GrpcTestServerRule { addService(impressionMetadataServiceMock) }
 
-  private fun createCleanup(): DataAvailabilityCleanup {
-    return DataAvailabilityCleanup(impressionMetadataStub, DATA_PROVIDER_NAME, emptyStorageClient)
+  private fun createBuffer(
+    batchSize: Int = 100,
+    flushIntervalSeconds: Long = 300,
+  ): BufferedDataAvailabilityCleanup {
+    return BufferedDataAvailabilityCleanup(
+      impressionMetadataServiceStub = impressionMetadataStub,
+      dataProviderName = DATA_PROVIDER_NAME,
+      storageClient = emptyStorageClient,
+      batchSize = batchSize,
+      flushIntervalSeconds = flushIntervalSeconds,
+    )
   }
 
   @Test
   fun `enqueue buffers events without immediate processing`() {
-    val buffer =
-      BufferedDataAvailabilityCleanup(
-        cleanupDelegate = createCleanup(),
-        batchSize = 10,
-        flushIntervalSeconds = 300,
-      )
+    val buffer = createBuffer(batchSize = 10)
 
-    buffer.enqueue(DeleteEvent(BLOB_URI, RESOURCE_ID))
+    buffer.enqueue(DeleteEvent(BLOB_URI, resourceId(1)))
 
     assertThat(buffer.pendingCount()).isEqualTo(1)
-
-    verifyBlocking(impressionMetadataServiceMock, times(0)) { deleteImpressionMetadata(any()) }
+    verifyBlocking(impressionMetadataServiceMock, never()) {
+      batchDeleteImpressionMetadata(any())
+    }
 
     buffer.shutdown()
   }
 
   @Test
-  fun `flush processes all buffered events`() {
-    val buffer =
-      BufferedDataAvailabilityCleanup(
-        cleanupDelegate = createCleanup(),
-        batchSize = 100,
-        flushIntervalSeconds = 300,
-      )
+  fun `flush calls single batch delete RPC for multiple events`() {
+    val buffer = createBuffer()
 
-    buffer.enqueue(DeleteEvent("${BLOB_URI}/1", RESOURCE_ID))
-    buffer.enqueue(DeleteEvent("${BLOB_URI}/2", RESOURCE_ID))
-    buffer.enqueue(DeleteEvent("${BLOB_URI}/3", RESOURCE_ID))
+    buffer.enqueue(DeleteEvent("${BLOB_URI}-1", resourceId(1)))
+    buffer.enqueue(DeleteEvent("${BLOB_URI}-2", resourceId(2)))
+    buffer.enqueue(DeleteEvent("${BLOB_URI}-3", resourceId(3)))
 
     assertThat(buffer.pendingCount()).isEqualTo(3)
 
     buffer.flush()
 
     assertThat(buffer.pendingCount()).isEqualTo(0)
-    verifyBlocking(impressionMetadataServiceMock, times(3)) { deleteImpressionMetadata(any()) }
+
+    // Verify ONE batch delete RPC was called with all 3 names
+    val captor = argumentCaptor<BatchDeleteImpressionMetadataRequest>()
+    verifyBlocking(impressionMetadataServiceMock, times(1)) {
+      batchDeleteImpressionMetadata(captor.capture())
+    }
+    assertThat(captor.firstValue.parent).isEqualTo(DATA_PROVIDER_NAME)
+    assertThat(captor.firstValue.namesList).containsExactly(
+      resourceId(1), resourceId(2), resourceId(3)
+    )
+
+    // Verify NO individual deletes were called
+    verifyBlocking(impressionMetadataServiceMock, never()) {
+      deleteImpressionMetadata(any())
+    }
 
     buffer.shutdown()
   }
 
   @Test
-  fun `batch size threshold triggers immediate flush`() {
-    val buffer =
-      BufferedDataAvailabilityCleanup(
-        cleanupDelegate = createCleanup(),
-        batchSize = 3,
-        flushIntervalSeconds = 300,
-      )
+  fun `flush resolves blob URIs via list when no resource ID provided`() {
+    val buffer = createBuffer()
 
-    buffer.enqueue(DeleteEvent("${BLOB_URI}/1", RESOURCE_ID))
-    buffer.enqueue(DeleteEvent("${BLOB_URI}/2", RESOURCE_ID))
-
-    // Not yet at threshold
-    assertThat(buffer.pendingCount()).isEqualTo(2)
-
-    // This triggers the threshold
-    buffer.enqueue(DeleteEvent("${BLOB_URI}/3", RESOURCE_ID))
-
-    // After flush, queue should be empty
-    assertThat(buffer.pendingCount()).isEqualTo(0)
-    verifyBlocking(impressionMetadataServiceMock, times(3)) { deleteImpressionMetadata(any()) }
-
-    buffer.shutdown()
-  }
-
-  @Test
-  fun `failed events are re-queued`() {
-    // First call succeeds, second fails, third succeeds
-    wheneverBlocking { impressionMetadataServiceMock.deleteImpressionMetadata(any()) }
-      .thenAnswer { ImpressionMetadata.getDefaultInstance() }
-      .thenAnswer { throw StatusException(Status.UNAVAILABLE) }
-      .thenAnswer { ImpressionMetadata.getDefaultInstance() }
-
-    val buffer =
-      BufferedDataAvailabilityCleanup(
-        cleanupDelegate = createCleanup(),
-        batchSize = 100,
-        flushIntervalSeconds = 300,
-      )
-
-    buffer.enqueue(DeleteEvent("${BLOB_URI}/1", RESOURCE_ID))
-    buffer.enqueue(DeleteEvent("${BLOB_URI}/2", RESOURCE_ID))
-    buffer.enqueue(DeleteEvent("${BLOB_URI}/3", RESOURCE_ID))
+    buffer.enqueue(DeleteEvent("${BLOB_URI}-1", null))
+    buffer.enqueue(DeleteEvent("${BLOB_URI}-2", null))
 
     buffer.flush()
 
-    // One event failed and was re-queued
-    assertThat(buffer.pendingCount()).isEqualTo(1)
+    // Verify list was called twice (once per event to resolve resource ID)
+    verifyBlocking(impressionMetadataServiceMock, times(2)) {
+      listImpressionMetadata(any())
+    }
+
+    // Verify ONE batch delete RPC was called
+    val captor = argumentCaptor<BatchDeleteImpressionMetadataRequest>()
+    verifyBlocking(impressionMetadataServiceMock, times(1)) {
+      batchDeleteImpressionMetadata(captor.capture())
+    }
+    assertThat(captor.firstValue.namesList).hasSize(2)
 
     buffer.shutdown()
   }
 
   @Test
-  fun `shutdown flushes remaining events`() {
-    val buffer =
-      BufferedDataAvailabilityCleanup(
-        cleanupDelegate = createCleanup(),
-        batchSize = 100,
-        flushIntervalSeconds = 300,
-      )
+  fun `batch size threshold triggers immediate flush with batch RPC`() {
+    val buffer = createBuffer(batchSize = 3)
 
-    buffer.enqueue(DeleteEvent("${BLOB_URI}/1", RESOURCE_ID))
-    buffer.enqueue(DeleteEvent("${BLOB_URI}/2", RESOURCE_ID))
+    buffer.enqueue(DeleteEvent("${BLOB_URI}-1", resourceId(1)))
+    buffer.enqueue(DeleteEvent("${BLOB_URI}-2", resourceId(2)))
+    buffer.enqueue(DeleteEvent("${BLOB_URI}-3", resourceId(3)))
+
+    assertThat(buffer.pendingCount()).isEqualTo(0)
+
+    val captor = argumentCaptor<BatchDeleteImpressionMetadataRequest>()
+    verifyBlocking(impressionMetadataServiceMock, times(1)) {
+      batchDeleteImpressionMetadata(captor.capture())
+    }
+    assertThat(captor.firstValue.namesList).hasSize(3)
+
+    buffer.shutdown()
+  }
+
+  @Test
+  fun `shutdown flushes remaining events via batch RPC`() {
+    val buffer = createBuffer()
+
+    buffer.enqueue(DeleteEvent("${BLOB_URI}-1", resourceId(1)))
+    buffer.enqueue(DeleteEvent("${BLOB_URI}-2", resourceId(2)))
 
     assertThat(buffer.pendingCount()).isEqualTo(2)
 
     buffer.shutdown()
 
     assertThat(buffer.pendingCount()).isEqualTo(0)
-    verifyBlocking(impressionMetadataServiceMock, times(2)) { deleteImpressionMetadata(any()) }
+    verifyBlocking(impressionMetadataServiceMock, times(1)) {
+      batchDeleteImpressionMetadata(any())
+    }
   }
 
   @Test
-  fun `periodic flush processes buffered events`() {
-    val buffer =
-      BufferedDataAvailabilityCleanup(
-        cleanupDelegate = createCleanup(),
-        batchSize = 100,
-        flushIntervalSeconds = 1,
-      )
+  fun `skips events with no matching impression metadata`() {
+    wheneverBlocking { impressionMetadataServiceMock.listImpressionMetadata(any()) }
+      .thenReturn(listImpressionMetadataResponse {})
 
-    buffer.enqueue(DeleteEvent(BLOB_URI, RESOURCE_ID))
+    val buffer = createBuffer()
+
+    buffer.enqueue(DeleteEvent("${BLOB_URI}-missing", null))
+    buffer.enqueue(DeleteEvent("${BLOB_URI}-1", resourceId(1)))
+
+    buffer.flush()
+
+    // Batch delete should only include the one with a resource ID
+    val captor = argumentCaptor<BatchDeleteImpressionMetadataRequest>()
+    verifyBlocking(impressionMetadataServiceMock, times(1)) {
+      batchDeleteImpressionMetadata(captor.capture())
+    }
+    assertThat(captor.firstValue.namesList).containsExactly(resourceId(1))
+
+    buffer.shutdown()
+  }
+
+  @Test
+  fun `periodic flush uses batch RPC`() {
+    val buffer = createBuffer(flushIntervalSeconds = 1)
+
+    buffer.enqueue(DeleteEvent("${BLOB_URI}-1", resourceId(1)))
 
     assertThat(buffer.pendingCount()).isEqualTo(1)
 
-    // Wait for the periodic flush to fire
     Thread.sleep(2500)
 
     assertThat(buffer.pendingCount()).isEqualTo(0)
-    verifyBlocking(impressionMetadataServiceMock, times(1)) { deleteImpressionMetadata(any()) }
+    verifyBlocking(impressionMetadataServiceMock, times(1)) {
+      batchDeleteImpressionMetadata(any())
+    }
 
     buffer.shutdown()
   }

--- a/src/test/kotlin/org/wfanet/measurement/edpaggregator/dataavailability/BufferedDataAvailabilityCleanupTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/edpaggregator/dataavailability/BufferedDataAvailabilityCleanupTest.kt
@@ -22,6 +22,7 @@ import com.google.type.interval
 import io.grpc.Status
 import io.grpc.StatusException
 import io.grpc.StatusRuntimeException
+import java.io.File
 import kotlinx.coroutines.runBlocking
 import org.junit.Rule
 import org.junit.Test
@@ -45,6 +46,7 @@ import org.wfanet.measurement.edpaggregator.v1alpha.ListImpressionMetadataReques
 import org.wfanet.measurement.edpaggregator.v1alpha.batchDeleteImpressionMetadataResponse
 import org.wfanet.measurement.edpaggregator.v1alpha.impressionMetadata
 import org.wfanet.measurement.edpaggregator.v1alpha.listImpressionMetadataResponse
+import org.wfanet.measurement.storage.StorageClient
 import org.wfanet.measurement.storage.filesystem.FileSystemStorageClient
 
 @RunWith(JUnit4::class)
@@ -52,8 +54,10 @@ class BufferedDataAvailabilityCleanupTest {
 
   companion object {
     private const val DATA_PROVIDER_NAME = "dataProviders/dataProvider123"
-    private const val BLOB_URI = "gs://bucket/path/to/blob"
+    private const val BLOB_URI_PREFIX = "gs://bucket/path/to"
   }
+
+  private fun blobUri(index: Int) = "$BLOB_URI_PREFIX/blob-$index"
 
   private fun resourceId(index: Int) =
     "$DATA_PROVIDER_NAME/impressionMetadata/im-$index"
@@ -124,8 +128,23 @@ class BufferedDataAvailabilityCleanupTest {
 
   @get:Rule val tempFolder = TemporaryFolder()
 
-  private val emptyStorageClient: FileSystemStorageClient
-    get() = FileSystemStorageClient(tempFolder.newFolder("empty-storage"))
+  /** Storage client with no blobs — simulates all blobs permanently deleted. */
+  private fun emptyStorageClient(): FileSystemStorageClient =
+    FileSystemStorageClient(tempFolder.newFolder("empty-${System.nanoTime()}"))
+
+  /**
+   * Storage client with specific blob keys present — simulates blobs that still have a live
+   * (current) version in GCS.
+   */
+  private fun storageClientWithLiveBlobs(vararg blobKeys: String): FileSystemStorageClient {
+    val root = tempFolder.newFolder("storage-${System.nanoTime()}")
+    for (key in blobKeys) {
+      val file = File(root, key)
+      file.parentFile.mkdirs()
+      file.writeText("live-blob")
+    }
+    return FileSystemStorageClient(root)
+  }
 
   @get:Rule
   val grpcTestServerRule = GrpcTestServerRule { addService(impressionMetadataServiceMock) }
@@ -133,11 +152,12 @@ class BufferedDataAvailabilityCleanupTest {
   private fun createBuffer(
     batchSize: Int = 100,
     flushIntervalSeconds: Long = 300,
+    storageClient: StorageClient? = null,
   ): BufferedDataAvailabilityCleanup {
     return BufferedDataAvailabilityCleanup(
       impressionMetadataServiceStub = impressionMetadataStub,
       dataProviderName = DATA_PROVIDER_NAME,
-      storageClient = emptyStorageClient,
+      storageClient = storageClient ?: emptyStorageClient(),
       batchSize = batchSize,
       flushIntervalSeconds = flushIntervalSeconds,
     )
@@ -147,7 +167,7 @@ class BufferedDataAvailabilityCleanupTest {
   fun `enqueue buffers events without immediate processing`() {
     val buffer = createBuffer(batchSize = 10)
 
-    buffer.enqueue(DeleteEvent(BLOB_URI, resourceId(1)))
+    buffer.enqueue(DeleteEvent(blobUri(1), resourceId(1)))
 
     assertThat(buffer.pendingCount()).isEqualTo(1)
     verifyBlocking(impressionMetadataServiceMock, never()) {
@@ -161,9 +181,9 @@ class BufferedDataAvailabilityCleanupTest {
   fun `flush calls single batch delete RPC for multiple events with resource IDs`() {
     val buffer = createBuffer()
 
-    buffer.enqueue(DeleteEvent("${BLOB_URI}-1", resourceId(1)))
-    buffer.enqueue(DeleteEvent("${BLOB_URI}-2", resourceId(2)))
-    buffer.enqueue(DeleteEvent("${BLOB_URI}-3", resourceId(3)))
+    buffer.enqueue(DeleteEvent(blobUri(1), resourceId(1)))
+    buffer.enqueue(DeleteEvent(blobUri(2), resourceId(2)))
+    buffer.enqueue(DeleteEvent(blobUri(3), resourceId(3)))
 
     assertThat(buffer.pendingCount()).isEqualTo(3)
 
@@ -191,9 +211,9 @@ class BufferedDataAvailabilityCleanupTest {
   fun `flush batch-resolves blob URIs via single list RPC`() {
     val buffer = createBuffer()
 
-    buffer.enqueue(DeleteEvent("${BLOB_URI}-1", null))
-    buffer.enqueue(DeleteEvent("${BLOB_URI}-2", null))
-    buffer.enqueue(DeleteEvent("${BLOB_URI}-3", null))
+    buffer.enqueue(DeleteEvent(blobUri(1), null))
+    buffer.enqueue(DeleteEvent(blobUri(2), null))
+    buffer.enqueue(DeleteEvent(blobUri(3), null))
 
     buffer.flush()
 
@@ -202,7 +222,7 @@ class BufferedDataAvailabilityCleanupTest {
       listImpressionMetadata(listCaptor.capture())
     }
     assertThat(listCaptor.firstValue.filter.blobUrisList).containsExactly(
-      "${BLOB_URI}-1", "${BLOB_URI}-2", "${BLOB_URI}-3"
+      blobUri(1), blobUri(2), blobUri(3)
     )
 
     val deleteCaptor = argumentCaptor<BatchDeleteImpressionMetadataRequest>()
@@ -218,9 +238,9 @@ class BufferedDataAvailabilityCleanupTest {
   fun `batch size threshold triggers immediate flush with batch RPC`() {
     val buffer = createBuffer(batchSize = 3)
 
-    buffer.enqueue(DeleteEvent("${BLOB_URI}-1", resourceId(1)))
-    buffer.enqueue(DeleteEvent("${BLOB_URI}-2", resourceId(2)))
-    buffer.enqueue(DeleteEvent("${BLOB_URI}-3", resourceId(3)))
+    buffer.enqueue(DeleteEvent(blobUri(1), resourceId(1)))
+    buffer.enqueue(DeleteEvent(blobUri(2), resourceId(2)))
+    buffer.enqueue(DeleteEvent(blobUri(3), resourceId(3)))
 
     assertThat(buffer.pendingCount()).isEqualTo(0)
 
@@ -238,7 +258,7 @@ class BufferedDataAvailabilityCleanupTest {
     val buffer = createBuffer(batchSize = 250)
 
     for (i in 1..250) {
-      buffer.enqueue(DeleteEvent("${BLOB_URI}-$i", resourceId(i)))
+      buffer.enqueue(DeleteEvent(blobUri(i), resourceId(i)))
     }
 
     assertThat(buffer.pendingCount()).isEqualTo(0)
@@ -260,8 +280,8 @@ class BufferedDataAvailabilityCleanupTest {
   fun `shutdown flushes remaining events via batch RPC`() {
     val buffer = createBuffer()
 
-    buffer.enqueue(DeleteEvent("${BLOB_URI}-1", resourceId(1)))
-    buffer.enqueue(DeleteEvent("${BLOB_URI}-2", resourceId(2)))
+    buffer.enqueue(DeleteEvent(blobUri(1), resourceId(1)))
+    buffer.enqueue(DeleteEvent(blobUri(2), resourceId(2)))
 
     assertThat(buffer.pendingCount()).isEqualTo(2)
 
@@ -280,8 +300,8 @@ class BufferedDataAvailabilityCleanupTest {
 
     val buffer = createBuffer()
 
-    buffer.enqueue(DeleteEvent("${BLOB_URI}-missing", null))
-    buffer.enqueue(DeleteEvent("${BLOB_URI}-1", resourceId(1)))
+    buffer.enqueue(DeleteEvent(blobUri(9999), null))
+    buffer.enqueue(DeleteEvent(blobUri(1), resourceId(1)))
 
     buffer.flush()
 
@@ -298,7 +318,7 @@ class BufferedDataAvailabilityCleanupTest {
   fun `periodic timer flushes remaining events`() {
     val buffer = createBuffer(flushIntervalSeconds = 1)
 
-    buffer.enqueue(DeleteEvent("${BLOB_URI}-1", resourceId(1)))
+    buffer.enqueue(DeleteEvent(blobUri(1), resourceId(1)))
 
     assertThat(buffer.pendingCount()).isEqualTo(1)
 
@@ -313,15 +333,60 @@ class BufferedDataAvailabilityCleanupTest {
   }
 
   @Test
+  fun `skips events whose blobs still have a live version`() {
+    // blob-1 still has a live version; blob-2 is fully deleted
+    val sc = storageClientWithLiveBlobs("path/to/blob-1")
+    val buffer = createBuffer(storageClient = sc)
+
+    buffer.enqueue(DeleteEvent(blobUri(1), resourceId(1)))
+    buffer.enqueue(DeleteEvent(blobUri(2), resourceId(2)))
+
+    buffer.flush()
+
+    assertThat(buffer.pendingCount()).isEqualTo(0)
+
+    val captor = argumentCaptor<BatchDeleteImpressionMetadataRequest>()
+    verifyBlocking(impressionMetadataServiceMock, times(1)) {
+      batchDeleteImpressionMetadata(captor.capture())
+    }
+    // Only blob-2 should be deleted; blob-1 is skipped (live version exists)
+    assertThat(captor.firstValue.namesList).containsExactly(resourceId(2))
+
+    buffer.shutdown()
+  }
+
+  @Test
+  fun `bulk live-version check groups by prefix`() {
+    // Both blobs share the same prefix "path/to/" — only one listBlobs call needed
+    val sc = storageClientWithLiveBlobs("path/to/blob-1", "path/to/blob-3")
+    val buffer = createBuffer(storageClient = sc)
+
+    buffer.enqueue(DeleteEvent(blobUri(1), resourceId(1)))
+    buffer.enqueue(DeleteEvent(blobUri(2), resourceId(2)))
+    buffer.enqueue(DeleteEvent(blobUri(3), resourceId(3)))
+
+    buffer.flush()
+
+    val captor = argumentCaptor<BatchDeleteImpressionMetadataRequest>()
+    verifyBlocking(impressionMetadataServiceMock, times(1)) {
+      batchDeleteImpressionMetadata(captor.capture())
+    }
+    // blob-1 and blob-3 are live, only blob-2 should be deleted
+    assertThat(captor.firstValue.namesList).containsExactly(resourceId(2))
+
+    buffer.shutdown()
+  }
+
+  @Test
   fun `batch NOT_FOUND falls back to individual deletes`() {
     wheneverBlocking { impressionMetadataServiceMock.batchDeleteImpressionMetadata(any()) }
       .thenThrow(StatusRuntimeException(Status.NOT_FOUND))
 
     val buffer = createBuffer()
 
-    buffer.enqueue(DeleteEvent("${BLOB_URI}-1", resourceId(1)))
-    buffer.enqueue(DeleteEvent("${BLOB_URI}-2", resourceId(2)))
-    buffer.enqueue(DeleteEvent("${BLOB_URI}-3", resourceId(3)))
+    buffer.enqueue(DeleteEvent(blobUri(1), resourceId(1)))
+    buffer.enqueue(DeleteEvent(blobUri(2), resourceId(2)))
+    buffer.enqueue(DeleteEvent(blobUri(3), resourceId(3)))
 
     buffer.flush()
 
@@ -354,9 +419,9 @@ class BufferedDataAvailabilityCleanupTest {
 
     val buffer = createBuffer()
 
-    buffer.enqueue(DeleteEvent("${BLOB_URI}-1", resourceId(1)))
-    buffer.enqueue(DeleteEvent("${BLOB_URI}-2", resourceId(2)))
-    buffer.enqueue(DeleteEvent("${BLOB_URI}-3", resourceId(3)))
+    buffer.enqueue(DeleteEvent(blobUri(1), resourceId(1)))
+    buffer.enqueue(DeleteEvent(blobUri(2), resourceId(2)))
+    buffer.enqueue(DeleteEvent(blobUri(3), resourceId(3)))
 
     buffer.flush()
 
@@ -377,9 +442,9 @@ class BufferedDataAvailabilityCleanupTest {
 
     val buffer = createBuffer()
 
-    buffer.enqueue(DeleteEvent("${BLOB_URI}-1", resourceId(1)))
-    buffer.enqueue(DeleteEvent("${BLOB_URI}-2", resourceId(2)))
-    buffer.enqueue(DeleteEvent("${BLOB_URI}-3", resourceId(3)))
+    buffer.enqueue(DeleteEvent(blobUri(1), resourceId(1)))
+    buffer.enqueue(DeleteEvent(blobUri(2), resourceId(2)))
+    buffer.enqueue(DeleteEvent(blobUri(3), resourceId(3)))
 
     buffer.flush()
 
@@ -395,8 +460,8 @@ class BufferedDataAvailabilityCleanupTest {
 
     val buffer = createBuffer()
 
-    buffer.enqueue(DeleteEvent("${BLOB_URI}-1", resourceId(1)))
-    buffer.enqueue(DeleteEvent("${BLOB_URI}-2", resourceId(2)))
+    buffer.enqueue(DeleteEvent(blobUri(1), resourceId(1)))
+    buffer.enqueue(DeleteEvent(blobUri(2), resourceId(2)))
 
     buffer.flush()
 

--- a/src/test/kotlin/org/wfanet/measurement/edpaggregator/dataavailability/BufferedDataAvailabilityCleanupTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/edpaggregator/dataavailability/BufferedDataAvailabilityCleanupTest.kt
@@ -252,12 +252,6 @@ class BufferedDataAvailabilityCleanupTest {
     assertThat(allValues[1].namesList).hasSize(100)
     assertThat(allValues[2].namesList).hasSize(50)
 
-    val allNames = allValues.flatMap { it.namesList }
-    assertThat(allNames).hasSize(250)
-    for (i in 1..250) {
-      assertThat(allNames).contains(resourceId(i))
-    }
-
     buffer.shutdown()
   }
 
@@ -300,17 +294,16 @@ class BufferedDataAvailabilityCleanupTest {
   }
 
   @Test
-  fun `stale buffer flushes on next enqueue`() {
-    val buffer = createBuffer(batchSize = 100, flushIntervalSeconds = 1)
+  fun `periodic timer flushes remaining events`() {
+    val buffer = createBuffer(flushIntervalSeconds = 1)
 
     buffer.enqueue(DeleteEvent("${BLOB_URI}-1", resourceId(1)))
+
     assertThat(buffer.pendingCount()).isEqualTo(1)
 
-    Thread.sleep(1500)
+    Thread.sleep(2500)
 
-    buffer.enqueue(DeleteEvent("${BLOB_URI}-2", resourceId(2)))
-
-    assertThat(buffer.pendingCount()).isAtMost(1)
+    assertThat(buffer.pendingCount()).isEqualTo(0)
     verifyBlocking(impressionMetadataServiceMock, times(1)) {
       batchDeleteImpressionMetadata(any())
     }

--- a/src/test/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/dataavailability/BUILD.bazel
+++ b/src/test/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/dataavailability/BUILD.bazel
@@ -44,3 +44,28 @@ kt_jvm_test(
         "@wfa_common_jvm//src/main/kotlin/org/wfanet/measurement/storage/filesystem:client",
     ],
 )
+
+kt_jvm_test(
+    name = "DataAvailabilityCleanupFunctionTest",
+    srcs = ["DataAvailabilityCleanupFunctionTest.kt"],
+    data = [
+        "//src/main/k8s/testing/secretfiles:root_certs",
+        "//src/main/k8s/testing/secretfiles:secret_files",
+        "//src/main/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/dataavailability/testing:InvokeDataAvailabilityCleanupFunction",
+    ],
+    test_class = "org.wfanet.measurement.edpaggregator.deploy.gcloud.dataavailability.DataAvailabilityCleanupFunctionTest",
+    deps = [
+        "//src/main/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/dataavailability:data_availability_cleanup_function",
+        "//src/main/kotlin/org/wfanet/measurement/gcloud/testing",
+        "//src/main/proto/wfa/measurement/config/edpaggregator:data_availability_sync_configs_kt_jvm_proto",
+        "@wfa_common_jvm//imports/java/com/google/common/truth",
+        "@wfa_common_jvm//imports/java/com/google/protobuf",
+        "@wfa_common_jvm//imports/java/io/grpc:api",
+        "@wfa_common_jvm//imports/kotlin/kotlin/test",
+        "@wfa_common_jvm//imports/kotlin/kotlinx/coroutines:core",
+        "@wfa_common_jvm//imports/kotlin/org/mockito/kotlin",
+        "@wfa_common_jvm//src/main/kotlin/org/wfanet/measurement/common",
+        "@wfa_common_jvm//src/main/kotlin/org/wfanet/measurement/common/grpc/testing",
+        "@wfa_common_jvm//src/main/kotlin/org/wfanet/measurement/storage/filesystem:client",
+    ],
+)

--- a/src/test/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/dataavailability/DataAvailabilityCleanupFunctionTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/dataavailability/DataAvailabilityCleanupFunctionTest.kt
@@ -28,6 +28,8 @@ import java.net.http.HttpRequest
 import java.net.http.HttpResponse
 import java.nio.file.Path
 import java.nio.file.Paths
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
 import java.util.logging.Logger
 import kotlinx.coroutines.runBlocking
 import org.junit.After
@@ -37,7 +39,10 @@ import org.junit.Test
 import org.junit.rules.TemporaryFolder
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
+import org.mockito.Mockito
 import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.atLeast
 import org.mockito.kotlin.never
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verifyBlocking
@@ -204,9 +209,10 @@ class DataAvailabilityCleanupFunctionTest {
   }
 
   @Test
-  fun `buffered cleanup enqueues events and flushes at batch size`() {
-    // batchSize=3 with 4 requests: first 3 trigger batch flush, 4th remains pending
-    val port = startFunction(bufferEnabled = true, bufferBatchSize = 3)
+  fun `buffered cleanup flushes synchronously on each request`() {
+    val port = startFunction(bufferEnabled = true)
+
+    Mockito.clearInvocations(impressionMetadataServiceMock)
 
     val client = HttpClient.newHttpClient()
     val config = fileSystemDataAvailabilitySyncConfig()
@@ -227,10 +233,61 @@ class DataAvailabilityCleanupFunctionTest {
       assertThat(response.statusCode()).isEqualTo(200)
     }
 
-    // Allow async flush to complete
-    Thread.sleep(1000)
+    val captor = argumentCaptor<BatchDeleteImpressionMetadataRequest>()
+    verifyBlocking(impressionMetadataServiceMock, atLeast(1)) {
+      batchDeleteImpressionMetadata(captor.capture())
+    }
+    val totalDeleted = captor.allValues.sumOf { it.namesList.size }
+    assertThat(totalDeleted).isEqualTo(4)
+    verifyBlocking(impressionMetadataServiceMock, never()) { deleteImpressionMetadata(any()) }
+  }
 
-    verifyBlocking(impressionMetadataServiceMock, times(1)) { batchDeleteImpressionMetadata(any()) }
+  @Test
+  fun `concurrent buffered requests coalesce via flush lock`() {
+    val port = startFunction(bufferEnabled = true)
+
+    Mockito.clearInvocations(impressionMetadataServiceMock)
+
+    val client = HttpClient.newHttpClient()
+    val config = fileSystemDataAvailabilitySyncConfig()
+    val requestCount = 12
+    val executor = Executors.newFixedThreadPool(requestCount)
+
+    val futures =
+      (1..requestCount).map { i ->
+        executor.submit<HttpResponse<String>> {
+          val request =
+            HttpRequest.newBuilder()
+              .uri(URI.create("http://localhost:$port"))
+              .header("X-DataWatcher-Path", "file:///edp/edp_name/timestamp/blob-$i")
+              .header(
+                "X-Impression-Metadata-Resource-Id",
+                "dataProviders/edp123/impressionMetadata/im-$i",
+              )
+              .POST(HttpRequest.BodyPublishers.ofString(config.toJson()))
+              .build()
+          client.send(request, HttpResponse.BodyHandlers.ofString())
+        }
+      }
+
+    executor.shutdown()
+    executor.awaitTermination(30, TimeUnit.SECONDS)
+
+    for ((i, future) in futures.withIndex()) {
+      val response = future.get()
+      logger.info("Concurrent request ${i + 1} response: ${response.statusCode()}")
+      assertThat(response.statusCode()).isEqualTo(200)
+    }
+
+    val captor = argumentCaptor<BatchDeleteImpressionMetadataRequest>()
+    verifyBlocking(impressionMetadataServiceMock, atLeast(1)) {
+      batchDeleteImpressionMetadata(captor.capture())
+    }
+    val totalDeleted = captor.allValues.sumOf { it.namesList.size }
+    assertThat(totalDeleted).isEqualTo(requestCount)
+    for (request in captor.allValues) {
+      assertThat(request.namesList.size).isAtMost(100)
+    }
     verifyBlocking(impressionMetadataServiceMock, never()) { deleteImpressionMetadata(any()) }
   }
 

--- a/src/test/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/dataavailability/DataAvailabilityCleanupFunctionTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/dataavailability/DataAvailabilityCleanupFunctionTest.kt
@@ -1,0 +1,290 @@
+/*
+ * Copyright 2025 The Cross-Media Measurement Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wfanet.measurement.edpaggregator.deploy.gcloud.dataavailability
+
+import com.google.common.truth.Truth.assertThat
+import com.google.protobuf.TextFormat
+import com.google.protobuf.timestamp
+import com.google.type.interval
+import io.netty.handler.ssl.ClientAuth
+import java.io.File
+import java.net.URI
+import java.net.http.HttpClient
+import java.net.http.HttpRequest
+import java.net.http.HttpResponse
+import java.nio.file.Path
+import java.nio.file.Paths
+import java.util.logging.Logger
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+import org.mockito.kotlin.any
+import org.mockito.kotlin.never
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verifyBlocking
+import org.wfanet.measurement.common.crypto.SigningCerts
+import org.wfanet.measurement.common.getRuntimePath
+import org.wfanet.measurement.common.grpc.CommonServer
+import org.wfanet.measurement.common.grpc.testing.mockService
+import org.wfanet.measurement.common.toJson
+import org.wfanet.measurement.config.edpaggregator.DataAvailabilitySyncConfig
+import org.wfanet.measurement.config.edpaggregator.DataAvailabilitySyncConfigKt.modelLineList
+import org.wfanet.measurement.config.edpaggregator.StorageParamsKt.fileSystemStorage
+import org.wfanet.measurement.config.edpaggregator.dataAvailabilitySyncConfig
+import org.wfanet.measurement.config.edpaggregator.dataAvailabilitySyncConfigs
+import org.wfanet.measurement.config.edpaggregator.storageParams
+import org.wfanet.measurement.config.edpaggregator.transportLayerSecurityParams
+import org.wfanet.measurement.edpaggregator.v1alpha.BatchDeleteImpressionMetadataRequest
+import org.wfanet.measurement.edpaggregator.v1alpha.DeleteImpressionMetadataRequest
+import org.wfanet.measurement.edpaggregator.v1alpha.ImpressionMetadata
+import org.wfanet.measurement.edpaggregator.v1alpha.ImpressionMetadataServiceGrpcKt.ImpressionMetadataServiceCoroutineImplBase
+import org.wfanet.measurement.edpaggregator.v1alpha.ListImpressionMetadataRequest
+import org.wfanet.measurement.edpaggregator.v1alpha.batchDeleteImpressionMetadataResponse
+import org.wfanet.measurement.edpaggregator.v1alpha.impressionMetadata
+import org.wfanet.measurement.edpaggregator.v1alpha.listImpressionMetadataResponse
+import org.wfanet.measurement.gcloud.testing.FunctionsFrameworkInvokerProcess
+
+@RunWith(JUnit4::class)
+class DataAvailabilityCleanupFunctionTest {
+
+  private lateinit var grpcServer: CommonServer
+  private lateinit var functionProcess: FunctionsFrameworkInvokerProcess
+
+  private val impressionMetadataServiceMock: ImpressionMetadataServiceCoroutineImplBase =
+    mockService {
+      onBlocking { listImpressionMetadata(any<ListImpressionMetadataRequest>()) }
+        .thenAnswer { invocation ->
+          val request = invocation.getArgument<ListImpressionMetadataRequest>(0)
+          val blobUriPrefix = request.filter.blobUriPrefix
+          if (blobUriPrefix.isNotEmpty()) {
+            listImpressionMetadataResponse {
+              impressionMetadata += impressionMetadata {
+                name = "dataProviders/edp123/impressionMetadata/im-1"
+                modelLine = "modelLine1"
+                blobUri = blobUriPrefix
+                interval = interval {
+                  startTime = timestamp { seconds = 100 }
+                  endTime = timestamp { seconds = 200 }
+                }
+                state = ImpressionMetadata.State.ACTIVE
+              }
+            }
+          } else {
+            val blobUrisList = request.filter.blobUrisList
+            listImpressionMetadataResponse {
+              impressionMetadata +=
+                blobUrisList.mapIndexed { index, uri ->
+                  impressionMetadata {
+                    name = "dataProviders/edp123/impressionMetadata/im-${index + 1}"
+                    modelLine = "modelLine1"
+                    blobUri = uri
+                    interval = interval {
+                      startTime = timestamp { seconds = 100 }
+                      endTime = timestamp { seconds = 200 }
+                    }
+                    state = ImpressionMetadata.State.ACTIVE
+                  }
+                }
+            }
+          }
+        }
+      onBlocking { deleteImpressionMetadata(any<DeleteImpressionMetadataRequest>()) }
+        .thenAnswer { ImpressionMetadata.getDefaultInstance() }
+      onBlocking { batchDeleteImpressionMetadata(any<BatchDeleteImpressionMetadataRequest>()) }
+        .thenAnswer { invocation ->
+          val request = invocation.getArgument<BatchDeleteImpressionMetadataRequest>(0)
+          batchDeleteImpressionMetadataResponse {
+            impressionMetadata +=
+              request.namesList.map {
+                impressionMetadata {
+                  name = it
+                  state = ImpressionMetadata.State.DELETED
+                }
+              }
+          }
+        }
+    }
+
+  @get:Rule val tempFolder = TemporaryFolder()
+
+  @Before
+  fun startInfra() {
+    grpcServer =
+      CommonServer.fromParameters(
+          verboseGrpcLogging = true,
+          certs = serverCerts,
+          clientAuth = ClientAuth.REQUIRE,
+          nameForLogging = "CleanupTestServers",
+          services = listOf(impressionMetadataServiceMock.bindService()),
+        )
+        .start()
+    functionProcess =
+      FunctionsFrameworkInvokerProcess(
+        javaBinaryPath = FUNCTION_BINARY_PATH,
+        classTarget = GCF_TARGET,
+      )
+    logger.info("Started gRPC server on port ${grpcServer.port}")
+  }
+
+  @After
+  fun cleanUp() {
+    grpcServer.shutdown()
+  }
+
+  private fun startFunction(bufferEnabled: Boolean = false, bufferBatchSize: Int = 100): Int {
+    val configBucketDir = File(tempFolder.root, "configbucket")
+    configBucketDir.mkdirs()
+    val runtimeConfig = dataAvailabilitySyncConfigs {
+      configs += fileSystemDataAvailabilitySyncConfig()
+    }
+    File(configBucketDir, "config.textproto")
+      .writeText(TextFormat.printer().printToString(runtimeConfig))
+
+    return runBlocking {
+      functionProcess.start(
+        mapOf(
+          "KINGDOM_TARGET" to "localhost:${grpcServer.port}",
+          "KINGDOM_CERT_HOST" to "localhost",
+          "CHANNEL_SHUTDOWN_DURATION_SECONDS" to "3",
+          "IMPRESSION_METADATA_TARGET" to "localhost:${grpcServer.port}",
+          "IMPRESSION_METADATA_CERT_HOST" to "localhost",
+          "DATA_AVAILABILITY_FILE_SYSTEM_PATH" to tempFolder.root.path,
+          "EDPA_CONFIG_STORAGE_BUCKET" to "file://${configBucketDir.absolutePath}",
+          "CONFIG_BLOB_KEY" to "config.textproto",
+          "CLEANUP_BUFFER_ENABLED" to bufferEnabled.toString(),
+          "CLEANUP_BUFFER_BATCH_SIZE" to bufferBatchSize.toString(),
+          "CLEANUP_BUFFER_FLUSH_INTERVAL_SECONDS" to "300",
+          "OTEL_METRICS_EXPORTER" to "none",
+          "OTEL_TRACES_EXPORTER" to "none",
+          "OTEL_LOGS_EXPORTER" to "none",
+          "OTEL_PROPAGATORS" to "tracecontext,baggage",
+        )
+      )
+    }
+  }
+
+  @Test
+  fun `unbuffered cleanup deletes impression metadata by resource ID`() {
+    val port = startFunction(bufferEnabled = false)
+
+    val client = HttpClient.newHttpClient()
+    val request =
+      HttpRequest.newBuilder()
+        .uri(URI.create("http://localhost:$port"))
+        .header("X-DataWatcher-Path", "file:///edp/edp_name/timestamp/blob-1")
+        .header("X-Impression-Metadata-Resource-Id", "dataProviders/edp123/impressionMetadata/im-1")
+        .POST(HttpRequest.BodyPublishers.ofString(fileSystemDataAvailabilitySyncConfig().toJson()))
+        .build()
+    val response = client.send(request, HttpResponse.BodyHandlers.ofString())
+
+    logger.info("Response: ${response.statusCode()} ${response.body()}")
+    assertThat(response.statusCode()).isEqualTo(200)
+
+    verifyBlocking(impressionMetadataServiceMock, times(1)) { deleteImpressionMetadata(any()) }
+    verifyBlocking(impressionMetadataServiceMock, never()) { batchDeleteImpressionMetadata(any()) }
+  }
+
+  @Test
+  fun `buffered cleanup enqueues events and flushes at batch size`() {
+    // batchSize=3 with 4 requests: first 3 trigger batch flush, 4th remains pending
+    val port = startFunction(bufferEnabled = true, bufferBatchSize = 3)
+
+    val client = HttpClient.newHttpClient()
+    val config = fileSystemDataAvailabilitySyncConfig()
+
+    for (i in 1..4) {
+      val request =
+        HttpRequest.newBuilder()
+          .uri(URI.create("http://localhost:$port"))
+          .header("X-DataWatcher-Path", "file:///edp/edp_name/timestamp/blob-$i")
+          .header(
+            "X-Impression-Metadata-Resource-Id",
+            "dataProviders/edp123/impressionMetadata/im-$i",
+          )
+          .POST(HttpRequest.BodyPublishers.ofString(config.toJson()))
+          .build()
+      val response = client.send(request, HttpResponse.BodyHandlers.ofString())
+      logger.info("Request $i response: ${response.statusCode()} ${response.body()}")
+      assertThat(response.statusCode()).isEqualTo(200)
+    }
+
+    // Allow async flush to complete
+    Thread.sleep(1000)
+
+    verifyBlocking(impressionMetadataServiceMock, times(1)) { batchDeleteImpressionMetadata(any()) }
+    verifyBlocking(impressionMetadataServiceMock, never()) { deleteImpressionMetadata(any()) }
+  }
+
+  private fun fileSystemDataAvailabilitySyncConfig(): DataAvailabilitySyncConfig =
+    dataAvailabilitySyncConfig {
+      dataProvider = "dataProviders/edp123"
+      cmmsConnection = transportLayerSecurityParams {
+        certFilePath = SECRETS_DIR.resolve("edp7_tls.pem").toString()
+        privateKeyFilePath = SECRETS_DIR.resolve("edp7_tls.key").toString()
+        certCollectionFilePath = SECRETS_DIR.resolve("kingdom_root.pem").toString()
+      }
+      impressionMetadataStorageConnection = transportLayerSecurityParams {
+        certFilePath = SECRETS_DIR.resolve("edp7_tls.pem").toString()
+        privateKeyFilePath = SECRETS_DIR.resolve("edp7_tls.key").toString()
+        certCollectionFilePath = SECRETS_DIR.resolve("kingdom_root.pem").toString()
+      }
+      dataAvailabilityStorage = storageParams { fileSystem = fileSystemStorage {} }
+      edpImpressionPath = "edp/edp_name"
+      modelLineMap["modelProviders/mp1/modelSuites/ms1/modelLines/some-model-line"] =
+        modelLineList {
+          modelLines += "some-model-line-mapped"
+        }
+    }
+
+  companion object {
+    private val SECRETS_DIR: Path =
+      getRuntimePath(
+        Paths.get("wfa_measurement_system", "src", "main", "k8s", "testing", "secretfiles")
+      )!!
+    private val serverCerts =
+      SigningCerts.fromPemFiles(
+        certificateFile = SECRETS_DIR.resolve("kingdom_tls.pem").toFile(),
+        privateKeyFile = SECRETS_DIR.resolve("kingdom_tls.key").toFile(),
+        trustedCertCollectionFile = SECRETS_DIR.resolve("edp7_root.pem").toFile(),
+      )
+    private val logger: Logger = Logger.getLogger(this::class.java.name)
+
+    private val FUNCTION_BINARY_PATH =
+      Paths.get(
+        "wfa_measurement_system",
+        "src",
+        "main",
+        "kotlin",
+        "org",
+        "wfanet",
+        "measurement",
+        "edpaggregator",
+        "deploy",
+        "gcloud",
+        "dataavailability",
+        "testing",
+        "InvokeDataAvailabilityCleanupFunction",
+      )
+    private const val GCF_TARGET =
+      "org.wfanet.measurement.edpaggregator.deploy.gcloud.dataavailability.DataAvailabilityCleanupFunction"
+  }
+}


### PR DESCRIPTION
## Summary

Fixes #3798

- Replace ScheduledExecutorService background timer with synchronous lock-based flush in BufferedDataAvailabilityCleanup. Cloud Run kills instances when all HTTP requests complete, so background timers never fire.
- Every enqueue() call flushes synchronously under a ReentrantLock. Concurrent requests coalesce naturally (first thread drains queue, others find it empty).
- Batch-resolve blob URIs via ListImpressionMetadata with blobUris filter instead of individual lookups.
- Cap batch delete RPCs at configurable batchSize (default 100). Add NOT_FOUND fallback with individual delete retry.
- Replace N individual getBlob() calls with batch prefix listing in DataAvailabilitySync, reducing O(N) to O(K) storage RPCs.

## Test plan

- [x] Unit tests: BufferedDataAvailabilityCleanupTest (sequential + concurrent flush)
- [x] Integration tests: DataAvailabilityCleanupFunctionTest (unbuffered, buffered sequential, buffered concurrent)
- [x] Cloud test: 1330 campaigns (2660 GCS objects) through full EventArc pipeline with batch_size=100