### PR TITLE
build: Set both tag and digest in oci.pull rules

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -389,14 +389,16 @@ use_repo(pip, "pip")
 oci = use_extension("@rules_oci//oci:extensions.bzl", "oci")
 oci.pull(
     name = "go_image_base",
-    # Digest of `nonroot` tag.
+    reproducible = True,
+    tag = "nonroot",
     digest = "sha256:fb282f8ed3057f71dbfe3ea0f5fa7e961415dafe4761c23948a9d4628c6166fe",
     image = "gcr.io/distroless/base-debian13",
     platforms = ["linux/amd64"],
 )
 oci.pull(
     name = "py_image_base",
-    # Digest of `nonroot` tag.
+    reproducible = True,
+    tag = "nonroot",
     digest = "sha256:51b1acc177d535f20fa30a175a657079ee7dce6e326541cfd83a474d9928e123",
     image = "gcr.io/distroless/python3-debian13",
     platforms = ["linux/amd64"],
@@ -405,7 +407,8 @@ oci.pull(
 # TODO(world-federation-of-advertisers/cross-media-measurement#2729): Remove root Java image when Confidential Spaces properly supports nonroot images.
 oci.pull(
     name = "java_image_base_root",
-    # Digest of `latest` tag.
+    reproducible = True,
+    tag = "latest",
     digest = "sha256:44774ae0ebcab067d8479c4325d37b29151408f03f8d1d200fd71fc435eaa51a",
     image = "gcr.io/distroless/java17-debian13",
     platforms = ["linux/amd64"],

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -2354,7 +2354,7 @@
     "@@rules_oci~//oci:extensions.bzl%oci": {
       "general": {
         "bzlTransitiveDigest": "yyTvBSVukHEf+iGms4+jq+/Zy1xLOGnxYiCLJFatSUE=",
-        "usagesDigest": "JMh9TDF3jqMoDwRuR9QQeHXVBwy8UonA0gSXhQ4zWJc=",
+        "usagesDigest": "WKc5pDgr6e9qJH3TYvmMbhy/hpH0ARPFp2dy/SiPsI8=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
         "envVariables": {},


### PR DESCRIPTION
This PR sets the tag, in addition to the digest, in the oci_pull usages. This is only allowed if `reproducible = True` is also declared; see https://github.com/bazel-contrib/rules_oci/pull/587.

This allows tools like Renovate to correctly update the digests.

Issue: #3790