### PR TITLE
ci: Update Renovate config to group rules_oci image digest updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -11,6 +11,19 @@
       "groupName": "GitHub Actions",
       "matchManagers": ["github-actions"],
       "recreateWhen": "never"
-    }
+    },
+    {
+      "groupName": "Bazel rules_oci image digests",
+      "description": "Group Bazel rules_oci image digest updates",
+      "groupSlug": "bazel-rules-oci-image-digests",
+      "matchFileNames": ["MODULE.bazel"],
+      "matchDepNames": [
+        "go_image_base",
+        "java_image_base_root",
+        "py_image_base"
+      ],
+      "matchUpdateTypes": ["digest"],
+      "recreateWhen": "never"
+    }    
   ]
 }


### PR DESCRIPTION
This PR allows Renovate to group rules_oci image digest updates into one PR.

Issue: #3790