### PR TITLE
fix: exclude multi-entity-key event group from direct RF/reach tests

### DIFF
--- a/src/main/kotlin/org/wfanet/measurement/integration/common/InProcessEdpAggregatorLifeOfAMeasurementIntegrationTest.kt
+++ b/src/main/kotlin/org/wfanet/measurement/integration/common/InProcessEdpAggregatorLifeOfAMeasurementIntegrationTest.kt
@@ -306,7 +306,11 @@ abstract class InProcessEdpAggregatorLifeOfAMeasurementIntegrationTest(
       // Use frontend simulator to create a direct reach and frequency measurement and verify
       // its
       // result.
-      mcSimulator.testDirectReachAndFrequency(runId = "1234", numMeasurements = 1)
+      mcSimulator.testDirectReachAndFrequency(
+        runId = "1234",
+        numMeasurements = 1,
+        eventGroupFilter = { it.eventGroupReferenceId != MULTI_ENTITY_KEY_EVENT_GROUP_REF_ID },
+      )
     }
 
   @Test
@@ -315,7 +319,11 @@ abstract class InProcessEdpAggregatorLifeOfAMeasurementIntegrationTest(
       // Use frontend simulator to create a direct reach and frequency measurement and verify
       // its
       // result.
-      mcSimulator.testDirectReachOnly(runId = "1234", numMeasurements = 1)
+      mcSimulator.testDirectReachOnly(
+        runId = "1234",
+        numMeasurements = 1,
+        eventGroupFilter = { it.eventGroupReferenceId != MULTI_ENTITY_KEY_EVENT_GROUP_REF_ID },
+      )
     }
 
   @Test


### PR DESCRIPTION
## Summary

- Add `eventGroupFilter` to direct RF and reach-only tests to exclude the multi-entity-key event group
- All other tests in `InProcessEdpAggregatorLifeOfAMeasurementIntegrationTest` already exclude this event group; these two were the only ones missing it
- Without the filter, non-deterministic event group selection can pick the multi-entity-key group, causing expected/actual value divergence

Fixes #3808

## Test plan

- [x] `GCloudEdpAggregatorLifeOfAMeasurementIntegrationTest` passes 3/3 runs with `--runs_per_test=3`