### PR TITLE
fix: move Gaussian noise EDP restriction tests to no-noise subclass

### DIFF
--- a/src/main/kotlin/org/wfanet/measurement/integration/common/reporting/v2/InProcessEdpAggregatorLifeOfAReportTest.kt
+++ b/src/main/kotlin/org/wfanet/measurement/integration/common/reporting/v2/InProcessEdpAggregatorLifeOfAReportTest.kt
@@ -636,8 +636,7 @@ abstract class InProcessEdpAggregatorLifeOfAReportTest(
     )
   }
 
-  @Test
-  fun `HMSS no noise basic report fails when EDP requires Gaussian noise`() = runBlocking {
+  protected suspend fun assertHmssReportFailsWhenEdpRequiresGaussianNoise() {
     val hmssEventGroups = getHmssEventGroupsIncludingRestrictedEdp()
     check(hmssEventGroups.size > 1)
 
@@ -664,8 +663,7 @@ abstract class InProcessEdpAggregatorLifeOfAReportTest(
     assertThat(completedBasicReport.state).isEqualTo(BasicReport.State.FAILED)
   }
 
-  @Test
-  fun `TrusTee no noise basic report fails when EDP requires Gaussian noise`() = runBlocking {
+  protected suspend fun assertTrusTeeReportFailsWhenEdpRequiresGaussianNoise() {
     val trusTeeEventGroups = getTrusTeeEventGroupsIncludingRestrictedEdp()
     check(trusTeeEventGroups.size > 1)
 

--- a/src/test/kotlin/org/wfanet/measurement/integration/common/reporting/v2/GCloudEdpAggregatorLifeOfAReportTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/integration/common/reporting/v2/GCloudEdpAggregatorLifeOfAReportTest.kt
@@ -14,8 +14,10 @@
 
 package org.wfanet.measurement.integration.common.reporting.v2
 
+import kotlinx.coroutines.runBlocking
 import org.junit.ClassRule
 import org.junit.Rule
+import org.junit.Test
 import org.junit.rules.Timeout
 import org.wfanet.measurement.common.db.r2dbc.postgres.testing.PostgresDatabaseProviderRule
 import org.wfanet.measurement.gcloud.spanner.testing.SpannerEmulatorRule
@@ -51,6 +53,16 @@ class GCloudEdpAggregatorLifeOfAReportTest :
    * TODO(Kotlin/kotlinx.coroutines#3865): Switch back to CoroutinesTimeout when fixed.
    */
   @get:Rule val timeout: Timeout = Timeout.seconds(180)
+
+  @Test
+  fun `HMSS no noise basic report fails when EDP requires Gaussian noise`() = runBlocking {
+    assertHmssReportFailsWhenEdpRequiresGaussianNoise()
+  }
+
+  @Test
+  fun `TrusTee no noise basic report fails when EDP requires Gaussian noise`() = runBlocking {
+    assertTrusTeeReportFailsWhenEdpRequiresGaussianNoise()
+  }
 
   companion object {
     @get:ClassRule @JvmStatic val spannerEmulator = SpannerEmulatorRule()


### PR DESCRIPTION
Fixes #3814

## Summary
- The Gaussian noise EDP restriction tests should not be in the abstract base class — they only apply to implementations that use NoiseMechanism.NONE in their protocol config. In implementations that use CONTINUOUS_GAUSSIAN, the EDP restriction is satisfied and the report correctly succeeds, so the tests are not valid there.
- Extract the test bodies into protected helper methods in InProcessEdpAggregatorLifeOfAReportTest so implementations can opt in
- Add @Test methods in GCloudEdpAggregatorLifeOfAReportTest (which uses NoiseMechanism.NONE) to exercise the restriction

## Test plan
- [x] Both tests pass in GCloudEdpAggregatorLifeOfAReportTest (no-noise config)
- [x] Build succeeds for all subclasses

Issue: #3814