### PR TITLE
ci: Update Renovate config to group Python requirements

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -24,6 +24,14 @@
       ],
       "matchUpdateTypes": ["digest"],
       "recreateWhen": "never"
+    },
+    {
+      "groupName": "Python requirements",
+      "groupSlug": "python-requirements",
+      "matchManagers": ["pip_requirements"],
+      "matchFileNames": ["requirements_lock.txt"],
+      "matchPackageNames": ["*", "!grpcio", "!protobuf"],      
+      "recreateWhen": "never"
     }    
   ]
 }


### PR DESCRIPTION
This PR updates the Renovate config by adding a group for Python requirements, excluding `grpcio` and `protobuf`.

Issue: #3790