### PR TITLE
ci: Update Renovate config to group grpc dependency update

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -43,7 +43,16 @@
         "MODULE.bazel",
         "requirements_lock.txt"
       ],
-      "matchPackageNames": ["grpcio", "grpc"]
+      "matchPackageNames": ["grpcio", "grpc"],
+      "prBodyTemplate": "{{{header}}}{{{notes}}}{{{table}}}{{{warnings}}}{{{changelogs}}}{{{configDescription}}}{{{controls}}}{{{footer}}}",
+      "prHeader": ":warning: This PR should also include the gRPC update in `rules_kotlin_jvm` and `common-jvm`. :warning:",
+      "prBodyNotes": [
+        "See example PRs:",
+        "- **CMM**: world-federation-of-advertisers/cross-media-measurement#2947",
+        "- **rules_kotlin_jvm**: world-federation-of-advertisers/rules_kotlin_jvm#16",
+        "- **common-jvm**: world-federation-of-advertisers/common-jvm#341",
+        "---"
+      ]
     }
   ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -32,6 +32,18 @@
       "matchFileNames": ["requirements_lock.txt"],
       "matchPackageNames": ["*", "!grpcio", "!protobuf"],      
       "recreateWhen": "never"
-    }    
+    },
+    {
+      "description": "Group grpc updates across Poetry, Bazel module, and pip requirements",
+      "groupName": "grpc",
+      "groupSlug": "grpc",
+      "matchManagers": ["poetry", "bazel-module", "pip_requirements"],
+      "matchFileNames": [
+        "pyproject.toml",
+        "MODULE.bazel",
+        "requirements_lock.txt"
+      ],
+      "matchPackageNames": ["grpcio", "grpc"]
+    }
   ]
 }


### PR DESCRIPTION
This PR adds a config to create a PR that groups the grpc update, which needs to be done in more than one place:

- bazel_dep
- pyproject.toml
- requirements_lock.txt

Issue: #3790