### PR TITLE
fix: Add --cpu-throttling to cloud function deploy commands

### DIFF
--- a/src/main/terraform/gcloud/modules/gcs-bucket-cloud-function/main.tf
+++ b/src/main/terraform/gcloud/modules/gcs-bucket-cloud-function/main.tf
@@ -115,6 +115,7 @@ resource "terraform_data" "deploy_gcs_cloud_function" {
         "--trigger-event-filters=bucket=$TRIGGER_BUCKET"
         "--trigger-service-account=$TRIGGER_SERVICE_ACCOUNT"
         "--no-allow-unauthenticated"
+        "--cpu-throttling"
       )
 
       if [[ -n "$EXTRA_ENV_VARS" ]]; then

--- a/src/main/terraform/gcloud/modules/http-cloud-function/main.tf
+++ b/src/main/terraform/gcloud/modules/http-cloud-function/main.tf
@@ -69,6 +69,7 @@ resource "terraform_data" "deploy_http_cloud_function" {
         "--source=$UBER_JAR_DIRECTORY"
         "--trigger-http"
         "--no-allow-unauthenticated"
+        "--cpu-throttling"
       )
 
       if [[ -n "$EXTRA_ENV_VARS" ]]; then


### PR DESCRIPTION
## Summary

- **Root cause**: The `http-cloud-function` and `gcs-bucket-cloud-function` terraform modules deploy Gen2 cloud functions without specifying `--cpu-throttling`. If the existing Cloud Run service was previously configured with CPU always-allocated (`--no-cpu-throttling`) and has fractional CPU (e.g. `0.3333`), GCP rejects the deploy with `Total cpu < 1 is not supported with cpu always allocated`.
- **Impact**: All `update-cmms` workflow runs fail at the terraform step because the `data-availability-cleanup` function in dev and head hits this error.
- **Fix**: Add `--cpu-throttling` to the `gcloud functions deploy` args in both modules. This explicitly enables CPU throttling (the correct default for on-demand functions), which allows fractional CPU values.

## Changes

- `src/main/terraform/gcloud/modules/http-cloud-function/main.tf` — add `--cpu-throttling`
- `src/main/terraform/gcloud/modules/gcs-bucket-cloud-function/main.tf` — add `--cpu-throttling`

## Test plan

- [ ] Merge PR #3831 (base branch) first
- [ ] Run `update-cmms` on dev with `apply=true` — terraform step should pass

Issue: #3832