### PR TITLE
fix: Scope rollout status checks to own component in shared-cluster workflows

### DIFF
--- a/.github/workflows/configure-edp-aggregator.yml
+++ b/.github/workflows/configure-edp-aggregator.yml
@@ -144,6 +144,6 @@ jobs:
     - name: Wait for rollout
       if: ${{ inputs.apply }}
       run: |
-        for deployment in $(kubectl get deployments -o name); do
+        for deployment in $(kubectl get deployments -l app.kubernetes.io/component=edp-aggregator -o name); do
           kubectl rollout status "$deployment" --timeout=5m
         done

--- a/.github/workflows/configure-kingdom.yml
+++ b/.github/workflows/configure-kingdom.yml
@@ -150,6 +150,6 @@ jobs:
       - name: Wait for rollout
         if: ${{ inputs.apply }}
         run: |
-          for deployment in $(kubectl get deployments -o name); do
+          for deployment in $(kubectl get deployments -l app.kubernetes.io/component=kingdom -o name); do
             kubectl rollout status "$deployment" --timeout=5m
           done

--- a/.github/workflows/configure-population-fulfiller.yml
+++ b/.github/workflows/configure-population-fulfiller.yml
@@ -166,6 +166,6 @@ jobs:
       - name: Wait for rollout
         if: ${{ inputs.apply }}
         run: |
-          for deployment in $(kubectl get deployments -o name); do
+          for deployment in $(kubectl get deployments -l app.kubernetes.io/component=population -o name); do
             kubectl rollout status "$deployment" --timeout=5m
           done

--- a/.github/workflows/configure-secure-computation-control-plane.yml
+++ b/.github/workflows/configure-secure-computation-control-plane.yml
@@ -140,6 +140,6 @@ jobs:
     - name: Wait for rollout
       if: ${{ inputs.apply }}
       run: |
-        for deployment in $(kubectl get deployments -o name); do
+        for deployment in $(kubectl get deployments -l app.kubernetes.io/component=secure-computation -o name); do
           kubectl rollout status "$deployment" --timeout=5m
         done


### PR DESCRIPTION
Scope the "Wait for rollout" step in workflows that share the kingdom GKE cluster to only check their own component's deployments using the existing app.kubernetes.io/component label selector. Previously each workflow checked all deployments in the cluster, causing cascading failures when any component was unhealthy (e.g. EDPA crash-looping blocked kingdom deploy).

Verified with a successful update-cmms run on dev: https://github.com/world-federation-of-advertisers/cross-media-measurement/actions/runs/26312427612

Issue: #3835