### PR TITLE
fix: add gRPC service config timeouts to in-process tests

### DIFF
--- a/src/main/kotlin/org/wfanet/measurement/integration/common/InProcessDuchy.kt
+++ b/src/main/kotlin/org/wfanet/measurement/integration/common/InProcessDuchy.kt
@@ -19,8 +19,11 @@ import com.google.crypto.tink.KeyTemplates
 import com.google.crypto.tink.KeysetHandle
 import com.google.crypto.tink.KmsClient
 import com.google.protobuf.ByteString
+import com.google.protobuf.util.Durations
 import io.grpc.Channel
 import io.grpc.inprocess.InProcessChannelBuilder
+import io.grpc.serviceconfig.methodConfig
+import io.grpc.serviceconfig.serviceConfig
 import io.grpc.testing.GrpcCleanupRule
 import java.nio.file.Paths
 import java.security.cert.X509Certificate
@@ -50,6 +53,7 @@ import org.wfanet.measurement.common.crypto.tink.GCloudWifCredentials
 import org.wfanet.measurement.common.crypto.tink.KmsClientFactory
 import org.wfanet.measurement.common.crypto.tink.TinkKeyStorageProvider
 import org.wfanet.measurement.common.crypto.tink.testing.FakeKmsClient
+import org.wfanet.measurement.common.grpc.ProtobufServiceConfig
 import org.wfanet.measurement.common.grpc.testing.GrpcTestServerRule
 import org.wfanet.measurement.common.grpc.withVerboseLogging
 import org.wfanet.measurement.common.identity.testing.withMetadataDuchyIdentities
@@ -160,13 +164,19 @@ class InProcessDuchy(
   private val serviceDispatcher = Dispatchers.Default
 
   private val computationsServer =
-    GrpcTestServerRule(logAllRequests = verboseGrpcLogging) {
+    GrpcTestServerRule(
+      logAllRequests = verboseGrpcLogging,
+      defaultServiceConfig = IN_PROCESS_SERVICE_CONFIG,
+    ) {
       addService(duchyDependencies.duchyDataServices.computationsService)
       addService(duchyDependencies.duchyDataServices.computationStatsService)
       addService(duchyDependencies.duchyDataServices.continuationTokensService)
     }
   private val requisitionFulfillmentServer =
-    GrpcTestServerRule(logAllRequests = verboseGrpcLogging) {
+    GrpcTestServerRule(
+      logAllRequests = verboseGrpcLogging,
+      defaultServiceConfig = IN_PROCESS_SERVICE_CONFIG,
+    ) {
       addService(
         RequisitionFulfillmentService(
             externalDuchyId,
@@ -179,7 +189,10 @@ class InProcessDuchy(
       )
     }
   private val asyncComputationControlServer =
-    GrpcTestServerRule(logAllRequests = verboseGrpcLogging) {
+    GrpcTestServerRule(
+      logAllRequests = verboseGrpcLogging,
+      defaultServiceConfig = IN_PROCESS_SERVICE_CONFIG,
+    ) {
       addService(
         AsyncComputationControlService(
           computationsClient,
@@ -193,6 +206,7 @@ class InProcessDuchy(
     GrpcTestServerRule(
       computationControlChannelName(externalDuchyId),
       logAllRequests = verboseGrpcLogging,
+      defaultServiceConfig = IN_PROCESS_SERVICE_CONFIG,
     ) {
       addService(
         ComputationControlService(
@@ -405,6 +419,17 @@ class InProcessDuchy(
     }
 
   companion object {
+    private val IN_PROCESS_SERVICE_CONFIG =
+      ProtobufServiceConfig(
+        serviceConfig {
+          methodConfig += methodConfig {
+            name += io.grpc.serviceconfig.MethodConfig.Name.getDefaultInstance()
+            timeout = Durations.fromSeconds(600)
+            retryPolicy = ProtobufServiceConfig.DEFAULT.message.methodConfigList[0].retryPolicy
+          }
+        }
+      )
+
     private val logger: Logger = Logger.getLogger(this::class.java.name)
   }
 }

--- a/src/main/kotlin/org/wfanet/measurement/integration/common/InProcessKingdom.kt
+++ b/src/main/kotlin/org/wfanet/measurement/integration/common/InProcessKingdom.kt
@@ -15,13 +15,17 @@
 package org.wfanet.measurement.integration.common
 
 import com.google.protobuf.Descriptors
+import com.google.protobuf.util.Durations
 import io.grpc.Channel
+import io.grpc.serviceconfig.methodConfig
+import io.grpc.serviceconfig.serviceConfig
 import java.util.logging.Logger
 import org.junit.rules.TestRule
 import org.junit.runner.Description
 import org.junit.runners.model.Statement
 import org.wfanet.measurement.api.v2alpha.ProtocolConfig
 import org.wfanet.measurement.api.v2alpha.testing.withMetadataPrincipalIdentities
+import org.wfanet.measurement.common.grpc.ProtobufServiceConfig
 import org.wfanet.measurement.common.grpc.testing.GrpcTestServerRule
 import org.wfanet.measurement.common.identity.testing.withMetadataDuchyIdentities
 import org.wfanet.measurement.common.testing.chainRulesSequentially
@@ -83,6 +87,8 @@ class InProcessKingdom(
   /** The open id client redirect uri when creating the authentication uri. */
   private val redirectUri: String,
   val verboseGrpcLogging: Boolean = true,
+  private val hmssEnabled: Boolean = true,
+  private val trusTeeEnabled: Boolean = true,
 ) : TestRule {
   private val kingdomDataServices by lazy { dataServicesProvider() }
 
@@ -130,14 +136,17 @@ class InProcessKingdom(
   }
 
   private val internalDataServer =
-    GrpcTestServerRule(logAllRequests = verboseGrpcLogging) {
+    GrpcTestServerRule(
+      logAllRequests = verboseGrpcLogging,
+      defaultServiceConfig = IN_PROCESS_SERVICE_CONFIG,
+    ) {
       logger.info("Building Kingdom's internal Data services")
       kingdomDataServices.buildDataServices().toList().forEach { addService(it) }
     }
   private val systemApiServer =
     GrpcTestServerRule(
       logAllRequests = verboseGrpcLogging,
-      defaultServiceConfig = Herald.SERVICE_CONFIG,
+      defaultServiceConfig = IN_PROCESS_SYSTEM_API_SERVICE_CONFIG,
     ) {
       logger.info("Building Kingdom's system API services")
       listOf(
@@ -149,7 +158,10 @@ class InProcessKingdom(
         .forEach { addService(it.withMetadataDuchyIdentities()) }
     }
   private val publicApiServer =
-    GrpcTestServerRule(logAllRequests = verboseGrpcLogging) {
+    GrpcTestServerRule(
+      logAllRequests = verboseGrpcLogging,
+      defaultServiceConfig = IN_PROCESS_SERVICE_CONFIG,
+    ) {
       logger.info("Building Kingdom's public API services")
 
       listOf(
@@ -178,8 +190,8 @@ class InProcessKingdom(
               internalDataProvidersClient,
               MEASUREMENT_NOISE_MECHANISMS,
               reachOnlyLlV2Enabled = true,
-              hmssEnabled = true,
-              trusTeeEnabled = true,
+              hmssEnabled = hmssEnabled,
+              trusTeeEnabled = trusTeeEnabled,
             )
             .withMetadataPrincipalIdentities()
             .withApiKeyAuthenticationServerInterceptor(internalApiKeysClient),
@@ -275,6 +287,28 @@ class InProcessKingdom(
 
   companion object {
     private val logger: Logger = Logger.getLogger(this::class.java.name)
+    private val IN_PROCESS_SERVICE_CONFIG =
+      ProtobufServiceConfig(
+        io.grpc.serviceconfig.serviceConfig {
+          methodConfig += methodConfig {
+            name += io.grpc.serviceconfig.MethodConfig.Name.getDefaultInstance()
+            timeout = Durations.fromSeconds(600)
+            retryPolicy = ProtobufServiceConfig.DEFAULT.message.methodConfigList[0].retryPolicy
+          }
+        }
+      )
+
+    private val IN_PROCESS_SYSTEM_API_SERVICE_CONFIG =
+      Herald.SERVICE_CONFIG.copy {
+        methodConfig.clear()
+        methodConfig += methodConfig {
+          name += io.grpc.serviceconfig.MethodConfig.Name.getDefaultInstance()
+          timeout = Durations.fromSeconds(600)
+          retryPolicy = ProtobufServiceConfig.DEFAULT.message.methodConfigList[0].retryPolicy
+        }
+        methodConfig += Herald.SERVICE_CONFIG.message.methodConfigList[1]
+      }
+
     private val MEASUREMENT_NOISE_MECHANISMS: List<ProtocolConfig.NoiseMechanism> =
       listOf(
         ProtocolConfig.NoiseMechanism.NONE,

--- a/src/main/kotlin/org/wfanet/measurement/integration/common/reporting/v2/InProcessReportingServer.kt
+++ b/src/main/kotlin/org/wfanet/measurement/integration/common/reporting/v2/InProcessReportingServer.kt
@@ -22,6 +22,8 @@ import com.google.protobuf.util.Durations
 import io.grpc.Channel
 import io.grpc.Status
 import io.grpc.StatusException
+import io.grpc.serviceconfig.methodConfig
+import io.grpc.serviceconfig.serviceConfig
 import io.netty.handler.ssl.ClientAuth
 import java.io.File
 import java.nio.file.Paths
@@ -54,6 +56,7 @@ import org.wfanet.measurement.common.crypto.SigningCerts
 import org.wfanet.measurement.common.crypto.tink.loadPrivateKey
 import org.wfanet.measurement.common.getRuntimePath
 import org.wfanet.measurement.common.grpc.CommonServer
+import org.wfanet.measurement.common.grpc.ProtobufServiceConfig
 import org.wfanet.measurement.common.grpc.buildMutualTlsChannel
 import org.wfanet.measurement.common.grpc.testing.GrpcTestServerRule
 import org.wfanet.measurement.common.grpc.withVerboseLogging
@@ -127,8 +130,13 @@ class InProcessReportingServer(
   private val publicKingdomModelLinesClient =
     PublicKingdomModelLinesCoroutineStub(kingdomPublicApiChannel)
 
-  private val internalApiChannel
-    get() = buildMutualTlsChannel("localhost:${internalReportingServer.port}", SIGNING_CERTS)
+  private val internalApiChannel by lazy {
+    buildMutualTlsChannel(
+      "localhost:${internalReportingServer.port}",
+      SIGNING_CERTS,
+      defaultServiceConfig = IN_PROCESS_SERVICE_CONFIG,
+    )
+  }
 
   private val internalMeasurementConsumersClient by lazy {
     InternalMeasurementConsumersCoroutineStub(internalApiChannel)
@@ -192,7 +200,10 @@ class InProcessReportingServer(
     }
 
   private fun createPublicApiTestServerRule(): GrpcTestServerRule =
-    GrpcTestServerRule(logAllRequests = verboseGrpcLogging) {
+    GrpcTestServerRule(
+      logAllRequests = verboseGrpcLogging,
+      defaultServiceConfig = IN_PROCESS_SERVICE_CONFIG,
+    ) {
       runBlocking {
         logger.info("Building Reporting Server's public API services")
 
@@ -381,6 +392,17 @@ class InProcessReportingServer(
         REPORTING_TLS_CERT_FILE,
         REPORTING_TLS_KEY_FILE,
         ALL_ROOT_CERTS_FILE,
+      )
+
+    private val IN_PROCESS_SERVICE_CONFIG =
+      ProtobufServiceConfig(
+        serviceConfig {
+          methodConfig += methodConfig {
+            name += io.grpc.serviceconfig.MethodConfig.Name.getDefaultInstance()
+            timeout = Durations.fromSeconds(600)
+            retryPolicy = ProtobufServiceConfig.DEFAULT.message.methodConfigList[0].retryPolicy
+          }
+        }
       )
 
     private val logger: Logger = Logger.getLogger(this::class.java.name)


### PR DESCRIPTION
Add 600-second gRPC deadline timeout to all in-process test channels (Kingdom, Duchy, Reporting) via service config to prevent individual RPCs from hanging indefinitely. Change InProcessReportingServer.internalApiChannel from a get() getter to by lazy so it creates one channel instead of a new TLS connection on every access.

Issue: #3843