### PR TITLE
fix: Add 600s gRPC service config timeout to InProcess test infrastructure

### DIFF
--- a/src/main/kotlin/org/wfanet/measurement/integration/common/BUILD.bazel
+++ b/src/main/kotlin/org/wfanet/measurement/integration/common/BUILD.bazel
@@ -423,6 +423,7 @@ kt_jvm_library(
         "//src/main/kotlin/org/wfanet/measurement/access/service/internal:services",
         "//src/main/kotlin/org/wfanet/measurement/access/service/v1alpha:services",
         "@wfa_common_jvm//imports/java/org/junit",
+        "@wfa_common_jvm//src/main/kotlin/org/wfanet/measurement/common/grpc",
         "@wfa_common_jvm//src/main/kotlin/org/wfanet/measurement/common/grpc/testing",
         "@wfa_common_jvm//src/main/kotlin/org/wfanet/measurement/common/testing",
     ],

--- a/src/main/kotlin/org/wfanet/measurement/integration/common/InProcessAccess.kt
+++ b/src/main/kotlin/org/wfanet/measurement/integration/common/InProcessAccess.kt
@@ -16,12 +16,16 @@
 
 package org.wfanet.measurement.integration.common
 
+import com.google.protobuf.util.Durations
 import io.grpc.Channel
+import io.grpc.serviceconfig.methodConfig
+import io.grpc.serviceconfig.serviceConfig
 import org.junit.rules.TestRule
 import org.junit.runner.Description
 import org.junit.runners.model.Statement
 import org.wfanet.measurement.access.service.internal.Services as InternalServices
 import org.wfanet.measurement.access.service.v1alpha.Services
+import org.wfanet.measurement.common.grpc.ProtobufServiceConfig
 import org.wfanet.measurement.common.grpc.testing.GrpcTestServerRule
 import org.wfanet.measurement.common.testing.chainRulesSequentially
 
@@ -30,7 +34,10 @@ class InProcessAccess(
   private val getInternalServices: () -> InternalServices,
 ) : TestRule {
   private val internalAccessServer =
-    GrpcTestServerRule(logAllRequests = verboseGrpcLogging) {
+    GrpcTestServerRule(
+      logAllRequests = verboseGrpcLogging,
+      defaultServiceConfig = IN_PROCESS_SERVICE_CONFIG,
+    ) {
       val services = getInternalServices().toList()
       for (service in services) {
         addService(service)
@@ -38,7 +45,10 @@ class InProcessAccess(
     }
 
   private val accessServer =
-    GrpcTestServerRule(logAllRequests = verboseGrpcLogging) {
+    GrpcTestServerRule(
+      logAllRequests = verboseGrpcLogging,
+      defaultServiceConfig = IN_PROCESS_SERVICE_CONFIG,
+    ) {
       val internalChannel = internalAccessServer.channel
       val services = Services.build(internalChannel).toList()
       for (service in services) {
@@ -51,5 +61,18 @@ class InProcessAccess(
 
   override fun apply(base: Statement, description: Description): Statement {
     return chainRulesSequentially(internalAccessServer, accessServer).apply(base, description)
+  }
+
+  companion object {
+    private val IN_PROCESS_SERVICE_CONFIG =
+      ProtobufServiceConfig(
+        serviceConfig {
+          methodConfig += methodConfig {
+            name += io.grpc.serviceconfig.MethodConfig.Name.getDefaultInstance()
+            timeout = Durations.fromSeconds(600)
+            retryPolicy = ProtobufServiceConfig.DEFAULT.message.methodConfigList[0].retryPolicy
+          }
+        }
+      )
   }
 }

--- a/src/main/kotlin/org/wfanet/measurement/integration/common/InProcessEdpAggregatorSystemApi.kt
+++ b/src/main/kotlin/org/wfanet/measurement/integration/common/InProcessEdpAggregatorSystemApi.kt
@@ -14,13 +14,17 @@
 
 package org.wfanet.measurement.integration.common
 
+import com.google.protobuf.util.Durations
 import io.grpc.Channel
+import io.grpc.serviceconfig.methodConfig
+import io.grpc.serviceconfig.serviceConfig
 import java.util.logging.Logger
 import kotlin.coroutines.CoroutineContext
 import kotlin.coroutines.EmptyCoroutineContext
 import org.junit.rules.TestRule
 import org.junit.runner.Description
 import org.junit.runners.model.Statement
+import org.wfanet.measurement.common.grpc.ProtobufServiceConfig
 import org.wfanet.measurement.common.grpc.testing.GrpcTestServerRule
 import org.wfanet.measurement.common.testing.chainRulesSequentially
 import org.wfanet.measurement.edpaggregator.deploy.gcloud.spanner.InternalApiServices
@@ -40,7 +44,10 @@ class InProcessEdpAggregatorSystemApi(
     SpannerEmulatorDatabaseRule(emulatorDatabaseAdmin, Schemata.EDP_AGGREGATOR_CHANGELOG_PATH)
 
   private val internalApiServer =
-    GrpcTestServerRule(logAllRequests = verboseGrpcLogging) {
+    GrpcTestServerRule(
+      logAllRequests = verboseGrpcLogging,
+      defaultServiceConfig = IN_PROCESS_SERVICE_CONFIG,
+    ) {
       logger.info("Building Edp Aggregator's internal API services")
       InternalApiServices.build(spannerDatabase.databaseClient, serviceContext).toList().forEach {
         logger.info("Adding service $it")
@@ -49,7 +56,10 @@ class InProcessEdpAggregatorSystemApi(
     }
 
   private val publicApiServer =
-    GrpcTestServerRule(logAllRequests = verboseGrpcLogging) {
+    GrpcTestServerRule(
+      logAllRequests = verboseGrpcLogging,
+      defaultServiceConfig = IN_PROCESS_SERVICE_CONFIG,
+    ) {
       logger.info("Building Edp Aggregator's system API services")
       Services.build(internalApiChannel, serviceContext).toList().forEach {
         logger.info("Adding service $it")
@@ -70,6 +80,17 @@ class InProcessEdpAggregatorSystemApi(
   }
 
   companion object {
+    private val IN_PROCESS_SERVICE_CONFIG =
+      ProtobufServiceConfig(
+        serviceConfig {
+          methodConfig += methodConfig {
+            name += io.grpc.serviceconfig.MethodConfig.Name.getDefaultInstance()
+            timeout = Durations.fromSeconds(600)
+            retryPolicy = ProtobufServiceConfig.DEFAULT.message.methodConfigList[0].retryPolicy
+          }
+        }
+      )
+
     private val logger: Logger = Logger.getLogger(this::class.java.name)
   }
 }

--- a/src/main/kotlin/org/wfanet/measurement/integration/common/InProcessSecureComputationPublicApi.kt
+++ b/src/main/kotlin/org/wfanet/measurement/integration/common/InProcessSecureComputationPublicApi.kt
@@ -14,13 +14,17 @@
 
 package org.wfanet.measurement.integration.common
 
+import com.google.protobuf.util.Durations
 import io.grpc.Channel
+import io.grpc.serviceconfig.methodConfig
+import io.grpc.serviceconfig.serviceConfig
 import java.util.logging.Logger
 import kotlin.coroutines.CoroutineContext
 import kotlin.coroutines.EmptyCoroutineContext
 import org.junit.rules.TestRule
 import org.junit.runner.Description
 import org.junit.runners.model.Statement
+import org.wfanet.measurement.common.grpc.ProtobufServiceConfig
 import org.wfanet.measurement.common.grpc.testing.GrpcTestServerRule
 import org.wfanet.measurement.common.testing.chainRulesSequentially
 import org.wfanet.measurement.securecomputation.controlplane.v1alpha.Services
@@ -36,7 +40,10 @@ class InProcessSecureComputationPublicApi(
   private val internalServices: InternalApiServices by lazy { internalServicesProvider() }
 
   private val internalApiServer =
-    GrpcTestServerRule(logAllRequests = verboseGrpcLogging) {
+    GrpcTestServerRule(
+      logAllRequests = verboseGrpcLogging,
+      defaultServiceConfig = IN_PROCESS_SERVICE_CONFIG,
+    ) {
       logger.info("Building Control Plane's internal API services")
       internalServices.build(serviceContext).toList().forEach {
         logger.info("Adding service $it")
@@ -45,7 +52,10 @@ class InProcessSecureComputationPublicApi(
     }
 
   private val publicApiServer =
-    GrpcTestServerRule(logAllRequests = verboseGrpcLogging) {
+    GrpcTestServerRule(
+      logAllRequests = verboseGrpcLogging,
+      defaultServiceConfig = IN_PROCESS_SERVICE_CONFIG,
+    ) {
       logger.info("Building Control Plane's public API services")
       Services.build(internalApiChannel, serviceContext).toList().forEach {
         logger.info("Adding service $it")
@@ -65,6 +75,17 @@ class InProcessSecureComputationPublicApi(
   }
 
   companion object {
+    private val IN_PROCESS_SERVICE_CONFIG =
+      ProtobufServiceConfig(
+        serviceConfig {
+          methodConfig += methodConfig {
+            name += io.grpc.serviceconfig.MethodConfig.Name.getDefaultInstance()
+            timeout = Durations.fromSeconds(600)
+            retryPolicy = ProtobufServiceConfig.DEFAULT.message.methodConfigList[0].retryPolicy
+          }
+        }
+      )
+
     private val logger: Logger = Logger.getLogger(this::class.java.name)
   }
 }


### PR DESCRIPTION
Add explicit ProtobufServiceConfig with 600-second timeout and retry policy to GrpcTestServerRule instances in InProcessSecureComputationPublicApi, InProcessEdpAggregatorSystemApi, and InProcessAccess to prevent RPCs from hanging indefinitely during integration tests.

Issue: #3848