### PR TITLE
fix: Handle malformed and unresolved measurement consumer in EventGroupSync

### DIFF
--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/eventgroups/EventGroupSync.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/eventgroups/EventGroupSync.kt
@@ -61,6 +61,8 @@ import org.wfanet.measurement.edpaggregator.eventgroups.v1alpha.copy
 import org.wfanet.measurement.edpaggregator.eventgroups.v1alpha.mappedEventGroup
 import org.wfanet.measurement.edpaggregator.telemetry.withSpan
 
+class UnresolvedMeasurementConsumerException(message: String) : Exception(message)
+
 /**
  * Key used to uniquely identify an event group.
  *
@@ -71,8 +73,6 @@ import org.wfanet.measurement.edpaggregator.telemetry.withSpan
  * This is intended to be used as a map key when grouping or associating event groups by both
  * attributes, ensuring uniqueness across consumers.
  */
-class UnresolvedMeasurementConsumerException(message: String) : Exception(message)
-
 data class EventGroupKey(val eventGroupReferenceId: String, val measurementConsumer: String)
 
 /*

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/eventgroups/EventGroupSync.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/eventgroups/EventGroupSync.kt
@@ -176,8 +176,12 @@ class EventGroupSync(
             resolveMeasurementConsumers(eventGroup)
           } catch (e: BlankMeasurementConsumerException) {
             logger.log(Level.SEVERE, e) {
-              "Skipping Event Group ${eventGroup.eventGroupReferenceId}: " +
-                "No measurement consumer resolved"
+              "Skipping Event Group ${eventGroup.eventGroupReferenceId}" +
+                (if (eventGroup.hasEntityKey())
+                  " (entityType=${eventGroup.entityKey.entityType}," +
+                    " entityId=${eventGroup.entityKey.entityId})"
+                else "") +
+                ": No measurement consumer resolved"
             }
             metrics.syncFailure.add(1, metricAttributes())
             continue

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/eventgroups/EventGroupSync.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/eventgroups/EventGroupSync.kt
@@ -192,9 +192,18 @@ class EventGroupSync(
           }
 
         for (measurementConsumerKey in measurementConsumerKeys) {
-          val eventGroupWithConsumer =
-            eventGroup.copy { measurementConsumer = measurementConsumerKey.toName() }
-          syncEventGroupItem(eventGroupWithConsumer, cmmsEventGroups)?.let { emit(it) }
+          try {
+            val eventGroupWithConsumer =
+              eventGroup.copy { measurementConsumer = measurementConsumerKey.toName() }
+            syncEventGroupItem(eventGroupWithConsumer, cmmsEventGroups)?.let { emit(it) }
+          } catch (e: Exception) {
+            if (e is CancellationException) throw e
+            logger.log(Level.SEVERE, e) {
+              "Skipping Event Group ${eventGroup.eventGroupReferenceId}: " +
+                "Failed to process for measurement consumer"
+            }
+            metrics.syncFailure.add(1, metricAttributes())
+          }
         }
       }
     }

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/eventgroups/EventGroupSync.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/eventgroups/EventGroupSync.kt
@@ -185,14 +185,6 @@ class EventGroupSync(
             }
             metrics.syncFailure.add(1, metricAttributes())
             continue
-          } catch (e: Exception) {
-            if (e is CancellationException) throw e
-            logger.log(Level.SEVERE, e) {
-              "Skipping Event Group ${eventGroup.eventGroupReferenceId}: " +
-                "Failed to resolve measurement consumers"
-            }
-            metrics.syncFailure.add(1, metricAttributes())
-            continue
           }
 
         for (measurementConsumerKey in measurementConsumerKeys) {
@@ -511,9 +503,15 @@ class EventGroupSync(
       check(eventGroup.eventGroupReferenceId.isNotBlank()) {
         "Event Group Reference Id must be set"
       }
-      val hasClientAccountRef = eventGroup.clientAccountReferenceId.isNotEmpty()
-      check(eventGroup.measurementConsumer.isNotBlank() || hasClientAccountRef) {
-        "Either Measurement Consumer or Client Account Reference ID must be set"
+      if (eventGroup.measurementConsumer.isNotBlank()) {
+        val mcKey = MeasurementConsumerKey.fromName(eventGroup.measurementConsumer)
+        check(mcKey != null && mcKey.measurementConsumerId.isNotBlank()) {
+          "Malformed measurement_consumer: ${eventGroup.measurementConsumer}"
+        }
+      } else {
+        check(eventGroup.clientAccountReferenceId.isNotEmpty()) {
+          "Either Measurement Consumer or Client Account Reference ID must be set"
+        }
       }
     }
 

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/eventgroups/EventGroupSync.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/eventgroups/EventGroupSync.kt
@@ -145,8 +145,12 @@ class EventGroupSync(
             validateDeletedEventGroup(eventGroup)
           } catch (e: Exception) {
             logger.log(Level.SEVERE, e) {
-              "Skipping deleted Event Group ${eventGroup.eventGroupReferenceId}: " +
-                "Validation failed"
+              "Skipping deleted Event Group ${eventGroup.eventGroupReferenceId}" +
+                (if (eventGroup.hasEntityKey())
+                  " (entityType=${eventGroup.entityKey.entityType}," +
+                    " entityId=${eventGroup.entityKey.entityId})"
+                else "") +
+                ": Validation failed"
             }
             metrics.invalidEventGroupFailure.add(1, metricAttributes())
             continue
@@ -165,7 +169,12 @@ class EventGroupSync(
           validateEventGroup(eventGroup)
         } catch (e: Exception) {
           logger.log(Level.SEVERE, e) {
-            "Skipping Event Group ${eventGroup.eventGroupReferenceId}: " + "Validation failed"
+            "Skipping Event Group ${eventGroup.eventGroupReferenceId}" +
+              (if (eventGroup.hasEntityKey())
+                " (entityType=${eventGroup.entityKey.entityType}," +
+                  " entityId=${eventGroup.entityKey.entityId})"
+              else "") +
+              ": Validation failed"
           }
           metrics.invalidEventGroupFailure.add(1, metricAttributes())
           continue
@@ -195,8 +204,12 @@ class EventGroupSync(
           } catch (e: Exception) {
             if (e is CancellationException) throw e
             logger.log(Level.SEVERE, e) {
-              "Skipping Event Group ${eventGroup.eventGroupReferenceId}: " +
-                "Failed to process for measurement consumer"
+              "Skipping Event Group ${eventGroup.eventGroupReferenceId}" +
+                (if (eventGroup.hasEntityKey())
+                  " (entityType=${eventGroup.entityKey.entityType}," +
+                    " entityId=${eventGroup.entityKey.entityId})"
+                else "") +
+                ": Failed to process for measurement consumer"
             }
             metrics.syncFailure.add(1, metricAttributes())
           }
@@ -309,7 +322,12 @@ class EventGroupSync(
         measurementConsumerKeys.add(key)
       } else {
         logger.log(Level.WARNING) {
-          "Ignoring malformed measurement_consumer: ${eventGroup.measurementConsumer}"
+          "Ignoring malformed measurement_consumer: ${eventGroup.measurementConsumer}" +
+            " for Event Group ${eventGroup.eventGroupReferenceId}" +
+            (if (eventGroup.hasEntityKey())
+              " (entityType=${eventGroup.entityKey.entityType}," +
+                " entityId=${eventGroup.entityKey.entityId})"
+            else "")
         }
       }
     }

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/eventgroups/EventGroupSync.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/eventgroups/EventGroupSync.kt
@@ -71,7 +71,7 @@ import org.wfanet.measurement.edpaggregator.telemetry.withSpan
  * This is intended to be used as a map key when grouping or associating event groups by both
  * attributes, ensuring uniqueness across consumers.
  */
-class BlankMeasurementConsumerException(message: String) : Exception(message)
+class UnresolvedMeasurementConsumerException(message: String) : Exception(message)
 
 data class EventGroupKey(val eventGroupReferenceId: String, val measurementConsumer: String)
 
@@ -174,7 +174,7 @@ class EventGroupSync(
         val measurementConsumerKeys: Set<MeasurementConsumerKey> =
           try {
             resolveMeasurementConsumers(eventGroup)
-          } catch (e: BlankMeasurementConsumerException) {
+          } catch (e: UnresolvedMeasurementConsumerException) {
             logger.log(Level.SEVERE, e) {
               "Skipping Event Group ${eventGroup.eventGroupReferenceId}" +
                 (if (eventGroup.hasEntityKey())
@@ -365,7 +365,7 @@ class EventGroupSync(
 
     if (measurementConsumerKeys.isEmpty()) {
       metrics.unmappedEventGroups.add(1, metricAttributes())
-      throw BlankMeasurementConsumerException(
+      throw UnresolvedMeasurementConsumerException(
         "EventGroup ${eventGroup.eventGroupReferenceId} has neither measurementConsumer " +
           "nor clientAccountReferenceId, or both failed to resolve"
       )

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/eventgroups/EventGroupSync.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/eventgroups/EventGroupSync.kt
@@ -71,6 +71,8 @@ import org.wfanet.measurement.edpaggregator.telemetry.withSpan
  * This is intended to be used as a map key when grouping or associating event groups by both
  * attributes, ensuring uniqueness across consumers.
  */
+class BlankMeasurementConsumerException(message: String) : Exception(message)
+
 data class EventGroupKey(val eventGroupReferenceId: String, val measurementConsumer: String)
 
 /*
@@ -170,7 +172,24 @@ class EventGroupSync(
         }
 
         val measurementConsumerKeys: Set<MeasurementConsumerKey> =
-          resolveMeasurementConsumers(eventGroup)
+          try {
+            resolveMeasurementConsumers(eventGroup)
+          } catch (e: BlankMeasurementConsumerException) {
+            logger.log(Level.SEVERE, e) {
+              "Skipping Event Group ${eventGroup.eventGroupReferenceId}: " +
+                "No measurement consumer resolved"
+            }
+            metrics.syncFailure.add(1, metricAttributes())
+            continue
+          } catch (e: Exception) {
+            if (e is CancellationException) throw e
+            logger.log(Level.SEVERE, e) {
+              "Skipping Event Group ${eventGroup.eventGroupReferenceId}: " +
+                "Failed to resolve measurement consumers"
+            }
+            metrics.syncFailure.add(1, metricAttributes())
+            continue
+          }
 
         for (measurementConsumerKey in measurementConsumerKeys) {
           val eventGroupWithConsumer =
@@ -333,7 +352,7 @@ class EventGroupSync(
 
     if (measurementConsumerKeys.isEmpty()) {
       metrics.unmappedEventGroups.add(1, metricAttributes())
-      logger.warning(
+      throw BlankMeasurementConsumerException(
         "EventGroup ${eventGroup.eventGroupReferenceId} has neither measurementConsumer " +
           "nor clientAccountReferenceId, or both failed to resolve"
       )

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/eventgroups/EventGroupSync.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/eventgroups/EventGroupSync.kt
@@ -304,11 +304,14 @@ class EventGroupSync(
 
     // Collect direct measurement consumer (EDP's mapping)
     if (eventGroup.measurementConsumer.isNotEmpty()) {
-      val key =
-        requireNotNull(MeasurementConsumerKey.fromName(eventGroup.measurementConsumer)) {
-          "Invalid measurementConsumer resource name: ${eventGroup.measurementConsumer}"
+      val key = MeasurementConsumerKey.fromName(eventGroup.measurementConsumer)
+      if (key != null && key.measurementConsumerId.isNotBlank()) {
+        measurementConsumerKeys.add(key)
+      } else {
+        logger.log(Level.WARNING) {
+          "Ignoring malformed measurement_consumer: ${eventGroup.measurementConsumer}"
         }
-      measurementConsumerKeys.add(key)
+      }
     }
 
     // Also collect from client_account_reference_id lookup (operator's mapping)

--- a/src/test/kotlin/org/wfanet/measurement/edpaggregator/eventgroups/BUILD.bazel
+++ b/src/test/kotlin/org/wfanet/measurement/edpaggregator/eventgroups/BUILD.bazel
@@ -20,6 +20,7 @@ kt_jvm_test(
         "@wfa_common_jvm//imports/java/com/google/common/truth/extensions/proto",
         "@wfa_common_jvm//imports/java/com/google/events",
         "@wfa_common_jvm//imports/java/com/google/protobuf",
+        "@wfa_common_jvm//imports/java/io/grpc:api",
         "@wfa_common_jvm//imports/java/io/opentelemetry/api",
         "@wfa_common_jvm//imports/java/io/opentelemetry/sdk",
         "@wfa_common_jvm//imports/java/io/opentelemetry/sdk/testing",

--- a/src/test/kotlin/org/wfanet/measurement/edpaggregator/eventgroups/EventGroupSyncTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/edpaggregator/eventgroups/EventGroupSyncTest.kt
@@ -54,6 +54,7 @@ import org.mockito.kotlin.any
 import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verifyBlocking
+import org.mockito.kotlin.wheneverBlocking
 import org.wfanet.measurement.api.v2alpha.ClientAccountsGrpcKt.ClientAccountsCoroutineImplBase
 import org.wfanet.measurement.api.v2alpha.ClientAccountsGrpcKt.ClientAccountsCoroutineStub
 import org.wfanet.measurement.api.v2alpha.CreateEventGroupRequest
@@ -2019,63 +2020,50 @@ class EventGroupSyncTest {
 
   @Test
   fun `sync logs and skips event group when measurement consumer resolution fails`() {
-    val failingClientAccountsMock: ClientAccountsCoroutineImplBase = mockService {
-      onBlocking { listClientAccounts(any<ListClientAccountsRequest>()) }
-        .thenThrow(StatusRuntimeException(io.grpc.Status.INTERNAL.withDescription("API error")))
-    }
+    wheneverBlocking { clientAccountsServiceMock.listClientAccounts(any()) }
+      .thenThrow(StatusRuntimeException(io.grpc.Status.INTERNAL.withDescription("API error")))
 
-    val testRule = GrpcTestServerRule {
-      addService(eventGroupsServiceMock)
-      addService(failingClientAccountsMock)
-    }
-
-    val statement =
-      object : org.junit.runners.model.Statement() {
-        override fun evaluate() {
-          runBlocking {
-            val eventGroupWithFailingLookup = eventGroup {
-              eventGroupReferenceId = "reference-id-failing"
-              this.eventGroupMetadata = eventGroupMetadata {
-                this.adMetadata = adMetadata {
-                  this.campaignMetadata = campaignMetadata {
-                    brand = "brand-failing"
-                    campaign = "campaign-failing"
-                  }
-                }
-              }
-              clientAccountReferenceId = "client-ref-failing"
-              dataAvailabilityInterval = interval {
-                startTime = timestamp { seconds = 200 }
-                endTime = timestamp { seconds = 300 }
-              }
-              mediaTypes += listOf(MediaType.valueOf("OTHER"))
+    runBlocking {
+      val eventGroupWithFailingLookup = eventGroup {
+        eventGroupReferenceId = "reference-id-failing"
+        this.eventGroupMetadata = eventGroupMetadata {
+          this.adMetadata = adMetadata {
+            this.campaignMetadata = campaignMetadata {
+              brand = "brand-failing"
+              campaign = "campaign-failing"
             }
-
-            val eventGroupSync =
-              EventGroupSync(
-                "edp-name",
-                EventGroupsCoroutineStub(testRule.channel),
-                ClientAccountsCoroutineStub(testRule.channel),
-                listOf(eventGroupWithFailingLookup).asFlow(),
-                MinimumIntervalThrottler(Clock.systemUTC(), Duration.ofMillis(1000)),
-                100,
-              )
-
-            val result = eventGroupSync.sync().toList()
-
-            assertThat(result).isEmpty()
-
-            val metrics = getMetrics()
-            val syncFailureMetric = metrics.find { it.name == "edpa.event_group.sync_failure" }
-
-            assertThat(syncFailureMetric).isNotNull()
-            assertThat(syncFailureMetric!!.longSumData.points.sumOf { it.value }).isEqualTo(1)
-
-            verifyBlocking(eventGroupsServiceMock, times(0)) { createEventGroup(any()) }
           }
         }
+        clientAccountReferenceId = "client-ref-failing"
+        dataAvailabilityInterval = interval {
+          startTime = timestamp { seconds = 200 }
+          endTime = timestamp { seconds = 300 }
+        }
+        mediaTypes += listOf(MediaType.valueOf("OTHER"))
       }
-    testRule.apply(statement, org.junit.runner.Description.EMPTY).evaluate()
+
+      val eventGroupSync =
+        EventGroupSync(
+          "edp-name",
+          eventGroupsStub,
+          clientAccountsStub,
+          listOf(eventGroupWithFailingLookup).asFlow(),
+          MinimumIntervalThrottler(Clock.systemUTC(), Duration.ofMillis(1000)),
+          100,
+        )
+
+      val result = eventGroupSync.sync().toList()
+
+      assertThat(result).isEmpty()
+
+      val metrics = getMetrics()
+      val syncFailureMetric = metrics.find { it.name == "edpa.event_group.sync_failure" }
+
+      assertThat(syncFailureMetric).isNotNull()
+      assertThat(syncFailureMetric!!.longSumData.points.sumOf { it.value }).isEqualTo(1)
+
+      verifyBlocking(eventGroupsServiceMock, times(0)) { createEventGroup(any()) }
+    }
   }
 
   @Test

--- a/src/test/kotlin/org/wfanet/measurement/edpaggregator/eventgroups/EventGroupSyncTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/edpaggregator/eventgroups/EventGroupSyncTest.kt
@@ -23,6 +23,7 @@ import com.google.protobuf.struct
 import com.google.protobuf.timestamp
 import com.google.protobuf.value
 import com.google.type.interval
+import io.grpc.StatusRuntimeException
 import io.opentelemetry.api.GlobalOpenTelemetry
 import io.opentelemetry.api.common.AttributeKey
 import io.opentelemetry.api.trace.StatusCode
@@ -1942,9 +1943,139 @@ class EventGroupSyncTest {
         .isEqualTo("Number of Event Groups that could not be mapped to any MeasurementConsumer")
       assertThat(unmappedMetric.longSumData.points.sumOf { it.value }).isEqualTo(1)
 
+      val syncFailureMetric = metrics.find { it.name == "edpa.event_group.sync_failure" }
+      assertThat(syncFailureMetric).isNotNull()
+      assertThat(syncFailureMetric!!.longSumData.points.sumOf { it.value }).isEqualTo(1)
+
       // Verify no EventGroup was created
       verifyBlocking(eventGroupsServiceMock, times(0)) { createEventGroup(any()) }
     }
+  }
+
+  @Test
+  fun `sync continues processing after blank measurement consumer exception`() {
+    runBlocking {
+      val unmappableEventGroup = eventGroup {
+        eventGroupReferenceId = "reference-id-unmapped"
+        this.eventGroupMetadata = eventGroupMetadata {
+          this.adMetadata = adMetadata {
+            this.campaignMetadata = campaignMetadata {
+              brand = "brand-unmapped"
+              campaign = "campaign-unmapped"
+            }
+          }
+        }
+        clientAccountReferenceId = "client-ref-nonexistent"
+        dataAvailabilityInterval = interval {
+          startTime = timestamp { seconds = 200 }
+          endTime = timestamp { seconds = 300 }
+        }
+        mediaTypes += listOf(MediaType.valueOf("OTHER"))
+      }
+
+      val validEventGroup = eventGroup {
+        eventGroupReferenceId = "reference-id-1"
+        measurementConsumer = "measurementConsumers/measurement-consumer-1"
+        this.eventGroupMetadata = eventGroupMetadata {
+          this.adMetadata = adMetadata {
+            this.campaignMetadata = campaignMetadata {
+              brand = "brand-1"
+              campaign = "campaign-1"
+            }
+          }
+        }
+        dataAvailabilityInterval = interval {
+          startTime = timestamp { seconds = 200 }
+          endTime = timestamp { seconds = 300 }
+        }
+        mediaTypes += listOf(MediaType.valueOf("VIDEO"), MediaType.valueOf("DISPLAY"))
+      }
+
+      val eventGroupSync =
+        EventGroupSync(
+          "edp-name",
+          eventGroupsStub,
+          clientAccountsStub,
+          listOf(unmappableEventGroup, validEventGroup).asFlow(),
+          MinimumIntervalThrottler(Clock.systemUTC(), Duration.ofMillis(1000)),
+          100,
+        )
+
+      val result = eventGroupSync.sync().toList()
+
+      assertThat(result).hasSize(1)
+      assertThat(result[0].eventGroupReferenceId).isEqualTo("reference-id-1")
+
+      val metrics = getMetrics()
+      val syncFailureMetric = metrics.find { it.name == "edpa.event_group.sync_failure" }
+      assertThat(syncFailureMetric).isNotNull()
+      assertThat(syncFailureMetric!!.longSumData.points.sumOf { it.value }).isEqualTo(1)
+
+      val syncSuccessMetric = metrics.find { it.name == "edpa.event_group.sync_success" }
+      assertThat(syncSuccessMetric).isNotNull()
+      assertThat(syncSuccessMetric!!.longSumData.points.sumOf { it.value }).isEqualTo(1)
+    }
+  }
+
+  @Test
+  fun `sync logs and skips event group when measurement consumer resolution fails`() {
+    val failingClientAccountsMock: ClientAccountsCoroutineImplBase = mockService {
+      onBlocking { listClientAccounts(any<ListClientAccountsRequest>()) }
+        .thenThrow(StatusRuntimeException(io.grpc.Status.INTERNAL.withDescription("API error")))
+    }
+
+    val testRule = GrpcTestServerRule {
+      addService(eventGroupsServiceMock)
+      addService(failingClientAccountsMock)
+    }
+
+    val statement =
+      object : org.junit.runners.model.Statement() {
+        override fun evaluate() {
+          runBlocking {
+            val eventGroupWithFailingLookup = eventGroup {
+              eventGroupReferenceId = "reference-id-failing"
+              this.eventGroupMetadata = eventGroupMetadata {
+                this.adMetadata = adMetadata {
+                  this.campaignMetadata = campaignMetadata {
+                    brand = "brand-failing"
+                    campaign = "campaign-failing"
+                  }
+                }
+              }
+              clientAccountReferenceId = "client-ref-failing"
+              dataAvailabilityInterval = interval {
+                startTime = timestamp { seconds = 200 }
+                endTime = timestamp { seconds = 300 }
+              }
+              mediaTypes += listOf(MediaType.valueOf("OTHER"))
+            }
+
+            val eventGroupSync =
+              EventGroupSync(
+                "edp-name",
+                EventGroupsCoroutineStub(testRule.channel),
+                ClientAccountsCoroutineStub(testRule.channel),
+                listOf(eventGroupWithFailingLookup).asFlow(),
+                MinimumIntervalThrottler(Clock.systemUTC(), Duration.ofMillis(1000)),
+                100,
+              )
+
+            val result = eventGroupSync.sync().toList()
+
+            assertThat(result).isEmpty()
+
+            val metrics = getMetrics()
+            val syncFailureMetric = metrics.find { it.name == "edpa.event_group.sync_failure" }
+
+            assertThat(syncFailureMetric).isNotNull()
+            assertThat(syncFailureMetric!!.longSumData.points.sumOf { it.value }).isEqualTo(1)
+
+            verifyBlocking(eventGroupsServiceMock, times(0)) { createEventGroup(any()) }
+          }
+        }
+      }
+    testRule.apply(statement, org.junit.runner.Description.EMPTY).evaluate()
   }
 
   @Test

--- a/src/test/kotlin/org/wfanet/measurement/edpaggregator/eventgroups/EventGroupSyncTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/edpaggregator/eventgroups/EventGroupSyncTest.kt
@@ -2019,22 +2019,55 @@ class EventGroupSyncTest {
   }
 
   @Test
-  fun `sync logs and skips event group when measurement consumer resolution fails`() {
+  fun `throws exception if API returns malformed value`() {
     wheneverBlocking { clientAccountsServiceMock.listClientAccounts(any()) }
       .thenThrow(StatusRuntimeException(io.grpc.Status.INTERNAL.withDescription("API error")))
 
+    val eventGroupWithFailingLookup = eventGroup {
+      eventGroupReferenceId = "reference-id-failing"
+      this.eventGroupMetadata = eventGroupMetadata {
+        this.adMetadata = adMetadata {
+          this.campaignMetadata = campaignMetadata {
+            brand = "brand-failing"
+            campaign = "campaign-failing"
+          }
+        }
+      }
+      clientAccountReferenceId = "client-ref-failing"
+      dataAvailabilityInterval = interval {
+        startTime = timestamp { seconds = 200 }
+        endTime = timestamp { seconds = 300 }
+      }
+      mediaTypes += listOf(MediaType.valueOf("OTHER"))
+    }
+
+    val eventGroupSync =
+      EventGroupSync(
+        "edp-name",
+        eventGroupsStub,
+        clientAccountsStub,
+        listOf(eventGroupWithFailingLookup).asFlow(),
+        MinimumIntervalThrottler(Clock.systemUTC(), Duration.ofMillis(1000)),
+        100,
+      )
+
+    assertFailsWith<Exception> { runBlocking { eventGroupSync.sync().toList() } }
+  }
+
+  @Test
+  fun `sync skips event group with malformed measurement_consumer and records failure`() {
     runBlocking {
-      val eventGroupWithFailingLookup = eventGroup {
-        eventGroupReferenceId = "reference-id-failing"
+      val malformedEventGroup = eventGroup {
+        eventGroupReferenceId = "120238654476370672"
         this.eventGroupMetadata = eventGroupMetadata {
           this.adMetadata = adMetadata {
             this.campaignMetadata = campaignMetadata {
-              brand = "brand-failing"
-              campaign = "campaign-failing"
+              brand = "UNKNOWN"
+              campaign = "New Traffic Campaign"
             }
           }
         }
-        clientAccountReferenceId = "client-ref-failing"
+        measurementConsumer = "measurementConsumers/"
         dataAvailabilityInterval = interval {
           startTime = timestamp { seconds = 200 }
           endTime = timestamp { seconds = 300 }
@@ -2047,7 +2080,7 @@ class EventGroupSyncTest {
           "edp-name",
           eventGroupsStub,
           clientAccountsStub,
-          listOf(eventGroupWithFailingLookup).asFlow(),
+          listOf(malformedEventGroup).asFlow(),
           MinimumIntervalThrottler(Clock.systemUTC(), Duration.ofMillis(1000)),
           100,
         )
@@ -2057,10 +2090,9 @@ class EventGroupSyncTest {
       assertThat(result).isEmpty()
 
       val metrics = getMetrics()
-      val syncFailureMetric = metrics.find { it.name == "edpa.event_group.sync_failure" }
-
-      assertThat(syncFailureMetric).isNotNull()
-      assertThat(syncFailureMetric!!.longSumData.points.sumOf { it.value }).isEqualTo(1)
+      val invalidMetric = metrics.find { it.name == "edpa.event_group.invalid_event_group_failure" }
+      assertThat(invalidMetric).isNotNull()
+      assertThat(invalidMetric!!.longSumData.points.sumOf { it.value }).isEqualTo(1)
 
       verifyBlocking(eventGroupsServiceMock, times(0)) { createEventGroup(any()) }
     }
@@ -2283,6 +2315,31 @@ class EventGroupSyncTest {
       assertFailsWith<IllegalStateException> { EventGroupSync.validateEventGroup(eventGroup) }
     assertThat(exception.message)
       .contains("Either Measurement Consumer or Client Account Reference ID must be set")
+  }
+
+  @Test
+  fun `validateEventGroup rejects malformed measurement_consumer with empty ID`() {
+    val eventGroup = eventGroup {
+      eventGroupReferenceId = "reference-id"
+      measurementConsumer = "measurementConsumers/"
+      this.eventGroupMetadata = eventGroupMetadata {
+        this.adMetadata = adMetadata {
+          this.campaignMetadata = campaignMetadata {
+            brand = "brand"
+            campaign = "campaign"
+          }
+        }
+      }
+      dataAvailabilityInterval = interval {
+        startTime = timestamp { seconds = 200 }
+        endTime = timestamp { seconds = 300 }
+      }
+      mediaTypes += listOf(MediaType.valueOf("OTHER"))
+    }
+
+    val exception =
+      assertFailsWith<IllegalStateException> { EventGroupSync.validateEventGroup(eventGroup) }
+    assertThat(exception.message).contains("Malformed measurement_consumer")
   }
 
   companion object {

--- a/src/test/kotlin/org/wfanet/measurement/edpaggregator/eventgroups/EventGroupSyncTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/edpaggregator/eventgroups/EventGroupSyncTest.kt
@@ -1954,7 +1954,7 @@ class EventGroupSyncTest {
   }
 
   @Test
-  fun `sync continues processing after blank measurement consumer exception`() {
+  fun `sync continues processing after unresolved measurement consumer`() {
     runBlocking {
       val unmappableEventGroup = eventGroup {
         eventGroupReferenceId = "reference-id-unmapped"


### PR DESCRIPTION
EventGroupSync crashes when an event group has a malformed measurement_consumer (e.g. "measurementConsumers/" with an empty ID). MeasurementConsumerKey.fromName parses this as a non-null key with an empty ID, passing the existing checkNotNull guard, but then crashing on toName() with IllegalArgumentException: Missing value for measurement_consumer. This crash is fatal to the entire batch.

Fix: In resolveMeasurementConsumers, replace requireNotNull with a safe check that logs and skips malformed keys. Add input validation in validateEventGroup as an additional guard. Add UnresolvedMeasurementConsumerException for the case where MC resolution returns empty, replacing a silent skip that had no failure metric. Only catch UnresolvedMeasurementConsumerException in the sync loop so API errors propagate as expected. Include eventGroupReferenceId and entity key in all log messages.

Issue: #3862