### PR TITLE
fix: query ImpressionMetadata by entity key when EventGroup has one

### DIFF
--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/resultsfulfiller/BUILD.bazel
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/resultsfulfiller/BUILD.bazel
@@ -105,11 +105,19 @@ kt_jvm_library(
 )
 
 kt_jvm_library(
+    name = "event_group_identifier",
+    srcs = ["EventGroupIdentifier.kt"],
+    deps = [
+        "//src/main/proto/wfa/measurement/edpaggregator/v1alpha:blob_details_kt_jvm_proto",
+    ],
+)
+
+kt_jvm_library(
     name = "event_batch",
     srcs = ["EventBatch.kt"],
     deps = [
+        ":event_group_identifier",
         ":labeled_event",
-        "//src/main/proto/wfa/measurement/edpaggregator/v1alpha:blob_details_kt_jvm_proto",
         "@wfa_common_jvm//imports/java/com/google/protobuf",
     ],
 )
@@ -135,6 +143,7 @@ kt_jvm_library(
     srcs = ["StorageEventSource.kt"],
     deps = [
         ":event_batch",
+        ":event_group_identifier",
         ":event_reader",
         ":event_source",
         ":impression_data_source_provider",
@@ -180,6 +189,7 @@ kt_jvm_library(
     srcs = ["FilterProcessor.kt"],
     deps = [
         ":event_batch",
+        ":event_group_identifier",
         ":event_source",
         ":filter_spec",
         ":labeled_event",

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/resultsfulfiller/BUILD.bazel
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/resultsfulfiller/BUILD.bazel
@@ -165,7 +165,9 @@ kt_jvm_library(
     name = "filter_spec",
     srcs = ["FilterSpec.kt"],
     deps = [
+        ":event_group_identifier",
         "//src/main/proto/wfa/measurement/api/v2alpha:requisition_spec_kt_jvm_proto",
+        "//src/main/proto/wfa/measurement/edpaggregator/v1alpha:blob_details_kt_jvm_proto",
         "//src/main/proto/wfa/measurement/edpaggregator/v1alpha:labeled_impression_kt_jvm_proto",
         "@wfa_common_jvm//imports/java/com/google/protobuf",
         "@wfa_common_jvm//src/main/kotlin/org/wfanet/measurement/common",
@@ -189,7 +191,6 @@ kt_jvm_library(
     srcs = ["FilterProcessor.kt"],
     deps = [
         ":event_batch",
-        ":event_group_identifier",
         ":event_source",
         ":filter_spec",
         ":labeled_event",

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/resultsfulfiller/BUILD.bazel
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/resultsfulfiller/BUILD.bazel
@@ -138,6 +138,7 @@ kt_jvm_library(
         ":event_reader",
         ":event_source",
         ":impression_data_source_provider",
+        ":impression_query_selector",
         ":kms_constants",
         ":labeled_event",
         ":storage_event_reader",
@@ -250,11 +251,20 @@ kt_jvm_library(
 )
 
 kt_jvm_library(
+    name = "impression_query_selector",
+    srcs = ["ImpressionQuerySelector.kt"],
+    deps = [
+        "//src/main/proto/wfa/measurement/edpaggregator/v1alpha:impression_metadata_kt_jvm_proto",
+    ],
+)
+
+kt_jvm_library(
     name = "impression_data_source_provider",
     srcs = [
         "ImpressionDataSourceProvider.kt",
     ],
     deps = [
+        ":impression_query_selector",
         ":impression_read_exception",
         "//src/main/kotlin/org/wfanet/measurement/common/api/grpc:list_resources",
         "//src/main/kotlin/org/wfanet/measurement/edpaggregator:storage_config",

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/resultsfulfiller/EventBatch.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/resultsfulfiller/EventBatch.kt
@@ -17,7 +17,6 @@
 package org.wfanet.measurement.edpaggregator.resultsfulfiller
 
 import com.google.protobuf.Message
-import org.wfanet.measurement.edpaggregator.v1alpha.EntityKeyGroup
 
 /**
  * Simple event batch container for efficient processing.
@@ -28,19 +27,14 @@ import org.wfanet.measurement.edpaggregator.v1alpha.EntityKeyGroup
  * @param events A batch of parsed events
  * @param minTime The earliest event time in the batch, used for fast filtering.
  * @param maxTime The latest event time in the batch, used for filtering.
- * @param eventGroupReferenceId identifier linking this event to a specific event group or campaign.
- *   Used for filtering events by group membership.
- * @param entityKeys Entity keys (grouped by type) carried by the blob that produced this batch,
- *   propagated from `BlobDetails.entity_keys`. The blob will have at least one impression for each
- *   listed entity key; every impression is associated with at least one of these entity keys; an
- *   individual impression may not be associated with all of them.
+ * @param eventGroupIdentifier Identifies how this batch is associated with its event group, either
+ *   by a single reference ID or by a list of entity keys from the blob.
  */
 data class EventBatch<T : Message>(
   val events: List<LabeledEvent<T>>,
   val minTime: java.time.Instant,
   val maxTime: java.time.Instant,
-  val eventGroupReferenceId: String,
-  val entityKeys: List<EntityKeyGroup>,
+  val eventGroupIdentifier: EventGroupIdentifier,
 ) {
   val size: Int
     get() = events.size

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/resultsfulfiller/EventGroupIdentifier.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/resultsfulfiller/EventGroupIdentifier.kt
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2025 The Cross-Media Measurement Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wfanet.measurement.edpaggregator.resultsfulfiller
+
+import org.wfanet.measurement.edpaggregator.v1alpha.EntityKeyGroup
+
+/**
+ * Sealed class identifying how an [EventBatch] is associated with its event group.
+ *
+ * A batch is produced from a single blob whose metadata was queried by exactly one strategy. This
+ * type encodes that strategy so downstream processors (e.g. [FilterProcessor]) can dispatch without
+ * carrying two mutually-exclusive nullable fields.
+ */
+sealed class EventGroupIdentifier {
+  data class ByReferenceId(val refId: String) : EventGroupIdentifier()
+
+  data class ByEntityKeys(val entityKeys: List<EntityKeyGroup>) : EventGroupIdentifier()
+}

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/resultsfulfiller/FilterProcessor.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/resultsfulfiller/FilterProcessor.kt
@@ -94,7 +94,7 @@ class FilterProcessor<T : Message>(
     }
 
     val matchResult = filterSpec.matchBatch(batch.eventGroupIdentifier)
-    if (matchResult is BatchMatchResult.Skip) {
+    if (matchResult is BatchMatchResult.NoMatch) {
       return emptyBatchLike(batch)
     }
 

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/resultsfulfiller/FilterProcessor.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/resultsfulfiller/FilterProcessor.kt
@@ -86,7 +86,8 @@ class FilterProcessor<T : Message>(
    * @return An EventBatch containing events that match all configured filters. The batch may be
    *   empty if no events match the criteria.
    * @throws MissingBatchEntityKeysException when [filterSpec] is [FilterSpec.ByEntityKeys] and
-   *   [batch.eventGroupIdentifier] is not [EventGroupIdentifier.ByEntityKeys].
+   *   [batch.eventGroupIdentifier] is [EventGroupIdentifier.ByEntityKeys] with an empty entity keys
+   *   list.
    */
   fun processBatch(batch: EventBatch<T>): EventBatch<T> {
     if (batch.events.isEmpty()) {

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/resultsfulfiller/FilterProcessor.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/resultsfulfiller/FilterProcessor.kt
@@ -93,12 +93,10 @@ class FilterProcessor<T : Message>(
       return batch
     }
 
-    val entityKeyFilter: Set<LabeledImpression.EntityKey>? =
-      when (val result = filterSpec.matchBatch(batch.eventGroupIdentifier)) {
-        is BatchMatchResult.Skip -> return emptyBatchLike(batch)
-        is BatchMatchResult.MatchedByReferenceId -> null
-        is BatchMatchResult.MatchedByEntityKeys -> result.entityKeyFilter
-      }
+    val matchResult = filterSpec.matchBatch(batch.eventGroupIdentifier)
+    if (matchResult is BatchMatchResult.Skip) {
+      return emptyBatchLike(batch)
+    }
 
     // Fast batch-level time range check: skip entire batch if no overlap
     if (!batchTimeRangeOverlaps(batch)) {
@@ -111,7 +109,10 @@ class FilterProcessor<T : Message>(
           return@filter false
         }
 
-        if (entityKeyFilter != null && !eventMatchesEntityKeyFilter(event, entityKeyFilter)) {
+        if (
+          matchResult is BatchMatchResult.MatchedByEntityKeys &&
+            !eventMatchesEntityKeyFilter(event, matchResult.entityKeyFilter)
+        ) {
           return@filter false
         }
 

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/resultsfulfiller/FilterProcessor.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/resultsfulfiller/FilterProcessor.kt
@@ -115,14 +115,20 @@ class FilterProcessor<T : Message>(
     val entityKeyFilter: Set<LabeledImpression.EntityKey>? =
       when (val spec = filterSpec) {
         is FilterSpec.ByEventGroupReferenceIds -> {
-          if (!spec.eventGroupReferenceIds.contains(batch.eventGroupReferenceId)) {
+          val identifier =
+            batch.eventGroupIdentifier as? EventGroupIdentifier.ByReferenceId
+              ?: return emptyBatchLike(batch)
+          if (!spec.eventGroupReferenceIds.contains(identifier.refId)) {
             return emptyBatchLike(batch)
           }
           null
         }
         is FilterSpec.ByEntityKeys -> {
-          if (batch.entityKeys.isEmpty()) throw MissingBatchEntityKeysException()
-          if (!batchEntityKeysOverlap(batch, spec.entityKeys)) {
+          val identifier =
+            batch.eventGroupIdentifier as? EventGroupIdentifier.ByEntityKeys
+              ?: throw MissingBatchEntityKeysException()
+          if (identifier.entityKeys.isEmpty()) throw MissingBatchEntityKeysException()
+          if (!batchEntityKeysOverlap(identifier.entityKeys, spec.entityKeys)) {
             return emptyBatchLike(batch)
           }
           spec.entityKeys
@@ -151,8 +157,7 @@ class FilterProcessor<T : Message>(
       filteredEvents,
       minTime = batch.minTime,
       maxTime = batch.maxTime,
-      eventGroupReferenceId = batch.eventGroupReferenceId,
-      entityKeys = batch.entityKeys,
+      eventGroupIdentifier = batch.eventGroupIdentifier,
     )
   }
 
@@ -167,8 +172,7 @@ class FilterProcessor<T : Message>(
       emptyList(),
       minTime = batch.minTime,
       maxTime = batch.maxTime,
-      eventGroupReferenceId = batch.eventGroupReferenceId,
-      entityKeys = batch.entityKeys,
+      eventGroupIdentifier = batch.eventGroupIdentifier,
     )
   }
 
@@ -216,11 +220,11 @@ class FilterProcessor<T : Message>(
    * Caller must ensure `batch.entityKeys` is non-empty before invoking.
    */
   private fun batchEntityKeysOverlap(
-    batch: EventBatch<T>,
+    batchEntityKeys: List<org.wfanet.measurement.edpaggregator.v1alpha.EntityKeyGroup>,
     filter: Set<LabeledImpression.EntityKey>,
   ): Boolean {
     val batchKeyPairs: Set<EntityKeyPair> =
-      batch.entityKeys
+      batchEntityKeys
         .flatMap { g -> g.entityIdsList.map { id -> EntityKeyPair(g.entityType, id) } }
         .toSet()
     return filter.any { fk -> EntityKeyPair(fk.entityType, fk.entityId) in batchKeyPairs }

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/resultsfulfiller/FilterProcessor.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/resultsfulfiller/FilterProcessor.kt
@@ -48,12 +48,24 @@ class FilterProcessor<T : Message>(
       EventFilters.compileProgram(eventDescriptor, filterSpec.celExpression)
     }
 
+  /**
+   * Start time instant from the collection interval.
+   *
+   * Pre-computed to avoid repeated conversion from protobuf Timestamp to Java Instant during batch
+   * processing.
+   */
   private val startInstant: Instant =
     Instant.ofEpochSecond(
       filterSpec.collectionInterval.startTime.seconds,
       filterSpec.collectionInterval.startTime.nanos.toLong(),
     )
 
+  /**
+   * End time instant from the collection interval.
+   *
+   * Pre-computed to avoid repeated conversion from protobuf Timestamp to Java Instant during batch
+   * processing.
+   */
   private val endInstant: Instant =
     Instant.ofEpochSecond(
       filterSpec.collectionInterval.endTime.seconds,
@@ -87,6 +99,7 @@ class FilterProcessor<T : Message>(
         is BatchMatchResult.Matched -> result.entityKeyFilter
       }
 
+    // Fast batch-level time range check: skip entire batch if no overlap
     if (!batchTimeRangeOverlaps(batch)) {
       return emptyBatchLike(batch)
     }
@@ -112,6 +125,12 @@ class FilterProcessor<T : Message>(
     )
   }
 
+  /**
+   * Returns an empty `EventBatch` carrying the same metadata as [batch].
+   *
+   * Used to short-circuit a batch without dropping its identifying metadata so downstream
+   * accounting can still distinguish per-batch outputs.
+   */
   private fun emptyBatchLike(batch: EventBatch<T>): EventBatch<T> {
     return EventBatch(
       emptyList(),
@@ -121,15 +140,32 @@ class FilterProcessor<T : Message>(
     )
   }
 
+  /**
+   * Checks if the batch's time range overlaps with the filter's collection interval.
+   *
+   * This is a fast batch-level check to avoid processing events when the entire batch is outside
+   * the collection interval.
+   */
   private fun batchTimeRangeOverlaps(batch: EventBatch<T>): Boolean {
     return !batch.maxTime.isBefore(startInstant) && batch.minTime.isBefore(endInstant)
   }
 
+  /**
+   * Checks if an event's timestamp falls within the collection interval.
+   *
+   * Uses a half-open interval [start, end) where the start time is inclusive and the end time is
+   * exclusive.
+   */
   private fun isEventInTimeRange(event: LabeledEvent<T>): Boolean {
     val eventTime = event.timestamp
     return !eventTime.isBefore(startInstant) && eventTime.isBefore(endInstant)
   }
 
+  /**
+   * Checks whether [event]'s `entityKeys` intersect [filter].
+   *
+   * An event with empty `entityKeys` always fails this check (cannot match a non-empty filter).
+   */
   private fun eventMatchesEntityKeyFilter(
     event: LabeledEvent<T>,
     filter: Set<LabeledImpression.EntityKey>,

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/resultsfulfiller/FilterProcessor.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/resultsfulfiller/FilterProcessor.kt
@@ -96,7 +96,8 @@ class FilterProcessor<T : Message>(
     val entityKeyFilter: Set<LabeledImpression.EntityKey>? =
       when (val result = filterSpec.matchBatch(batch.eventGroupIdentifier)) {
         is BatchMatchResult.Skip -> return emptyBatchLike(batch)
-        is BatchMatchResult.Matched -> result.entityKeyFilter
+        is BatchMatchResult.MatchedByReferenceId -> null
+        is BatchMatchResult.MatchedByEntityKeys -> result.entityKeyFilter
       }
 
     // Fast batch-level time range check: skip entire batch if no overlap

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/resultsfulfiller/FilterProcessor.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/resultsfulfiller/FilterProcessor.kt
@@ -25,28 +25,13 @@ import org.wfanet.measurement.edpaggregator.v1alpha.LabeledImpression
 import org.wfanet.measurement.eventdataprovider.eventfiltration.EventFilters
 
 /**
- * Thrown by [FilterProcessor.processBatch] when the active selector is [FilterSpec.ByEntityKeys]
- * but the incoming [EventBatch] carries no `entity_keys`.
- *
- * Indicates a wiring/data invariant violation upstream (the blob's `BlobDetails.entity_keys` was
- * not populated despite the consumer requesting entity-key filtering).
- */
-class MissingBatchEntityKeysException :
-  IllegalStateException(
-    "ByEntityKeys filter requires the batch to carry entity_keys, but batch.entityKeys is empty"
-  )
-
-/**
  * Filter processor for event filtering with CEL expressions and time ranges.
  *
  * This processor compiles a CEL expression once and reuses it for batch processing. It processes
  * events sequentially through the CEL filter and identifies matching events.
  *
- * The processor dispatches on [FilterSpec]'s variant to choose the EventGroup selector:
- * - [FilterSpec.ByEventGroupReferenceIds] uses the legacy `eventGroupReferenceId` batch-level
- *   match.
- * - [FilterSpec.ByEntityKeys] uses a batch-level entity-key intersection short-circuit followed by
- *   a per-event entity-key check.
+ * Batch-level selector dispatch (reference-id vs entity-key) is handled by [FilterSpec.matchBatch],
+ * which returns a [BatchMatchResult].
  *
  * @param filterSpec immutable specification containing all filtering criteria
  */
@@ -63,24 +48,12 @@ class FilterProcessor<T : Message>(
       EventFilters.compileProgram(eventDescriptor, filterSpec.celExpression)
     }
 
-  /**
-   * Start time instant from the collection interval.
-   *
-   * Pre-computed to avoid repeated conversion from protobuf Timestamp to Java Instant during batch
-   * processing.
-   */
   private val startInstant: Instant =
     Instant.ofEpochSecond(
       filterSpec.collectionInterval.startTime.seconds,
       filterSpec.collectionInterval.startTime.nanos.toLong(),
     )
 
-  /**
-   * End time instant from the collection interval.
-   *
-   * Pre-computed to avoid repeated conversion from protobuf Timestamp to Java Instant during batch
-   * processing.
-   */
   private val endInstant: Instant =
     Instant.ofEpochSecond(
       filterSpec.collectionInterval.endTime.seconds,
@@ -91,11 +64,7 @@ class FilterProcessor<T : Message>(
    * Processes a batch of events and returns the matching events.
    *
    * Applies filtering in the following order for optimal performance:
-   * 1. Selector check, dispatched on [FilterSpec] variant:
-   *     - [FilterSpec.ByEventGroupReferenceIds]: batch-level `event_group_reference_id` match.
-   *     - [FilterSpec.ByEntityKeys]: batch-level entity-key intersection short-circuit. Throws
-   *       [MissingBatchEntityKeysException] when the batch carries no entity_keys (data invariant
-   *       violation).
+   * 1. Batch-level selector check via [FilterSpec.matchBatch].
    * 2. Batch time range overlap check (fast, avoids processing entire batch).
    * 3. Per-event time range filter.
    * 4. Per-event entity-key intersection (only for [FilterSpec.ByEntityKeys]).
@@ -105,7 +74,7 @@ class FilterProcessor<T : Message>(
    * @return An EventBatch containing events that match all configured filters. The batch may be
    *   empty if no events match the criteria.
    * @throws MissingBatchEntityKeysException when [filterSpec] is [FilterSpec.ByEntityKeys] and
-   *   [batch.entityKeys] is empty.
+   *   [batch.eventGroupIdentifier] is not [EventGroupIdentifier.ByEntityKeys].
    */
   fun processBatch(batch: EventBatch<T>): EventBatch<T> {
     if (batch.events.isEmpty()) {
@@ -113,29 +82,11 @@ class FilterProcessor<T : Message>(
     }
 
     val entityKeyFilter: Set<LabeledImpression.EntityKey>? =
-      when (val spec = filterSpec) {
-        is FilterSpec.ByEventGroupReferenceIds -> {
-          val identifier =
-            batch.eventGroupIdentifier as? EventGroupIdentifier.ByReferenceId
-              ?: return emptyBatchLike(batch)
-          if (!spec.eventGroupReferenceIds.contains(identifier.refId)) {
-            return emptyBatchLike(batch)
-          }
-          null
-        }
-        is FilterSpec.ByEntityKeys -> {
-          val identifier =
-            batch.eventGroupIdentifier as? EventGroupIdentifier.ByEntityKeys
-              ?: throw MissingBatchEntityKeysException()
-          if (identifier.entityKeys.isEmpty()) throw MissingBatchEntityKeysException()
-          if (!batchEntityKeysOverlap(identifier.entityKeys, spec.entityKeys)) {
-            return emptyBatchLike(batch)
-          }
-          spec.entityKeys
-        }
+      when (val result = filterSpec.matchBatch(batch.eventGroupIdentifier)) {
+        is BatchMatchResult.Skip -> return emptyBatchLike(batch)
+        is BatchMatchResult.Matched -> result.entityKeyFilter
       }
 
-    // Fast batch-level time range check: skip entire batch if no overlap
     if (!batchTimeRangeOverlaps(batch)) {
       return emptyBatchLike(batch)
     }
@@ -161,12 +112,6 @@ class FilterProcessor<T : Message>(
     )
   }
 
-  /**
-   * Returns an empty `EventBatch` carrying the same metadata as [batch].
-   *
-   * Used to short-circuit a batch without dropping its identifying metadata so downstream
-   * accounting can still distinguish per-batch outputs.
-   */
   private fun emptyBatchLike(batch: EventBatch<T>): EventBatch<T> {
     return EventBatch(
       emptyList(),
@@ -176,60 +121,19 @@ class FilterProcessor<T : Message>(
     )
   }
 
-  /**
-   * Checks if the batch's time range overlaps with the filter's collection interval.
-   *
-   * This is a fast batch-level check to avoid processing events when the entire batch is outside
-   * the collection interval.
-   */
   private fun batchTimeRangeOverlaps(batch: EventBatch<T>): Boolean {
     return !batch.maxTime.isBefore(startInstant) && batch.minTime.isBefore(endInstant)
   }
 
-  /**
-   * Checks if an event's timestamp falls within the collection interval.
-   *
-   * Uses a half-open interval [start, end) where the start time is inclusive and the end time is
-   * exclusive.
-   */
   private fun isEventInTimeRange(event: LabeledEvent<T>): Boolean {
     val eventTime = event.timestamp
     return !eventTime.isBefore(startInstant) && eventTime.isBefore(endInstant)
   }
 
-  /**
-   * Checks whether [event]'s `entityKeys` intersect [filter].
-   *
-   * An event with empty `entityKeys` always fails this check (cannot match a non-empty filter).
-   */
   private fun eventMatchesEntityKeyFilter(
     event: LabeledEvent<T>,
     filter: Set<LabeledImpression.EntityKey>,
   ): Boolean {
     return event.entityKeys.any { it in filter }
   }
-
-  /**
-   * Checks whether any [org.wfanet.measurement.edpaggregator.v1alpha.EntityKeyGroup] on [batch]
-   * contains an `(entity_type, entity_id)` pair that matches [filter].
-   *
-   * Pre-flattens the batch's grouped entity keys into a `Set<EntityKeyPair>` once, then performs
-   * O(1) membership lookups for each filter element. Faster than nested `any { contains(...) }` for
-   * batches with many entity keys.
-   *
-   * Caller must ensure `batch.entityKeys` is non-empty before invoking.
-   */
-  private fun batchEntityKeysOverlap(
-    batchEntityKeys: List<org.wfanet.measurement.edpaggregator.v1alpha.EntityKeyGroup>,
-    filter: Set<LabeledImpression.EntityKey>,
-  ): Boolean {
-    val batchKeyPairs: Set<EntityKeyPair> =
-      batchEntityKeys
-        .flatMap { g -> g.entityIdsList.map { id -> EntityKeyPair(g.entityType, id) } }
-        .toSet()
-    return filter.any { fk -> EntityKeyPair(fk.entityType, fk.entityId) in batchKeyPairs }
-  }
-
-  /** Flattened (entity_type, entity_id) pair for O(1) batch entity-key lookups. */
-  private data class EntityKeyPair(val entityType: String, val entityId: String)
 }

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/resultsfulfiller/FilterSpec.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/resultsfulfiller/FilterSpec.kt
@@ -53,13 +53,16 @@ sealed class BatchMatchResult {
   /** The batch does not match this filter; skip it entirely. */
   object Skip : BatchMatchResult()
 
+  /** The batch matched by reference ID; no per-event entity-key filtering needed. */
+  object MatchedByReferenceId : BatchMatchResult()
+
   /**
-   * The batch passed the batch-level selector check.
+   * The batch matched by entity keys; per-event entity-key filtering is required.
    *
-   * @property entityKeyFilter When non-null, per-event entity-key filtering is required using this
-   *   set. Null means no per-event entity-key check is needed (reference-id path).
+   * @property entityKeyFilter The set of entity keys to filter individual events against.
    */
-  data class Matched(val entityKeyFilter: Set<LabeledImpression.EntityKey>?) : BatchMatchResult()
+  data class MatchedByEntityKeys(val entityKeyFilter: Set<LabeledImpression.EntityKey>) :
+    BatchMatchResult()
 }
 
 /**
@@ -84,8 +87,9 @@ sealed class FilterSpec {
   /**
    * Checks whether [identifier] matches this filter's batch-level selector.
    *
-   * @return [BatchMatchResult.Skip] if the batch should be skipped, [BatchMatchResult.Matched] if
-   *   it passed (with an optional per-event entity-key filter set).
+   * @return [BatchMatchResult.Skip] if the batch should be skipped,
+   *   [BatchMatchResult.MatchedByReferenceId] or [BatchMatchResult.MatchedByEntityKeys] if it
+   *   passed.
    * @throws MissingBatchEntityKeysException when this is [ByEntityKeys] and [identifier] is not
    *   [EventGroupIdentifier.ByEntityKeys].
    */
@@ -118,7 +122,7 @@ sealed class FilterSpec {
         is EventGroupIdentifier.ByEntityKeys -> return BatchMatchResult.Skip
         is EventGroupIdentifier.ByReferenceId -> {
           return if (eventGroupReferenceIds.contains(identifier.refId)) {
-            BatchMatchResult.Matched(entityKeyFilter = null)
+            BatchMatchResult.MatchedByReferenceId
           } else {
             BatchMatchResult.Skip
           }
@@ -151,7 +155,7 @@ sealed class FilterSpec {
         is EventGroupIdentifier.ByEntityKeys -> {
           if (identifier.entityKeys.isEmpty()) throw MissingBatchEntityKeysException()
           return if (batchEntityKeysOverlap(identifier.entityKeys)) {
-            BatchMatchResult.Matched(entityKeyFilter = entityKeys)
+            BatchMatchResult.MatchedByEntityKeys(entityKeyFilter = entityKeys)
           } else {
             BatchMatchResult.Skip
           }

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/resultsfulfiller/FilterSpec.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/resultsfulfiller/FilterSpec.kt
@@ -18,7 +18,6 @@ package org.wfanet.measurement.edpaggregator.resultsfulfiller
 
 import com.google.type.Interval
 import org.wfanet.measurement.common.toInstant
-import org.wfanet.measurement.edpaggregator.v1alpha.EntityKeyGroup
 import org.wfanet.measurement.edpaggregator.v1alpha.LabeledImpression
 
 /** Thrown when a [FilterSpec] is constructed with an empty `eventGroupReferenceIds` selector. */
@@ -162,6 +161,9 @@ sealed class FilterSpec {
       requireValidCollectionInterval(collectionInterval)
     }
 
+    private val filterKeyPairs: Set<Pair<String, String>> =
+      entityKeys.map { Pair(it.entityType, it.entityId) }.toSet()
+
     override fun matchBatch(identifier: EventGroupIdentifier): BatchMatchResult {
       when (identifier) {
         is EventGroupIdentifier.ByReferenceId ->
@@ -170,10 +172,14 @@ sealed class FilterSpec {
           )
         is EventGroupIdentifier.ByEntityKeys -> {
           if (identifier.entityKeys.isEmpty()) throw MissingBatchEntityKeysException()
-          if (!batchEntityKeysOverlap(identifier.entityKeys)) {
+          val batchKeyPairs: Set<Pair<String, String>> =
+            identifier.entityKeys
+              .flatMap { g -> g.entityIdsList.map { id -> Pair(g.entityType, id) } }
+              .toSet()
+          if (filterKeyPairs.none { it in batchKeyPairs }) {
             return BatchMatchResult.NoMatch
           }
-          return if (allBatchKeysContained(identifier.entityKeys)) {
+          return if (batchKeyPairs.all { it in filterKeyPairs }) {
             BatchMatchResult.MatchedAllEvents
           } else {
             BatchMatchResult.MatchedByEntityKeys(entityKeyFilter = entityKeys)
@@ -181,35 +187,5 @@ sealed class FilterSpec {
         }
       }
     }
-
-    /**
-     * Checks whether any [EntityKeyGroup] in [batchEntityKeys] contains an `(entity_type,
-     * entity_id)` pair that matches this spec's [entityKeys].
-     *
-     * Pre-flattens the batch's grouped entity keys into a `Set<EntityKeyPair>` once, then performs
-     * O(1) membership lookups for each filter element.
-     */
-    private fun batchEntityKeysOverlap(batchEntityKeys: List<EntityKeyGroup>): Boolean {
-      val batchKeyPairs: Set<EntityKeyPair> =
-        batchEntityKeys
-          .flatMap { g -> g.entityIdsList.map { id -> EntityKeyPair(g.entityType, id) } }
-          .toSet()
-      return entityKeys.any { fk -> EntityKeyPair(fk.entityType, fk.entityId) in batchKeyPairs }
-    }
-
-    /**
-     * Checks whether all entity keys in [batchEntityKeys] are contained within this spec's
-     * [entityKeys].
-     */
-    private fun allBatchKeysContained(batchEntityKeys: List<EntityKeyGroup>): Boolean {
-      val filterKeyPairs: Set<EntityKeyPair> =
-        entityKeys.map { fk -> EntityKeyPair(fk.entityType, fk.entityId) }.toSet()
-      return batchEntityKeys.all { g ->
-        g.entityIdsList.all { id -> EntityKeyPair(g.entityType, id) in filterKeyPairs }
-      }
-    }
-
-    /** Flattened (entity_type, entity_id) pair for O(1) batch entity-key lookups. */
-    private data class EntityKeyPair(val entityType: String, val entityId: String)
   }
 }

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/resultsfulfiller/FilterSpec.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/resultsfulfiller/FilterSpec.kt
@@ -56,8 +56,8 @@ class MismatchedBatchIdentifierException(message: String) : IllegalStateExceptio
  * @see FilterSpec.matchBatch
  */
 sealed class BatchMatchResult {
-  /** The batch does not match this filter; skip it entirely. */
-  object Skip : BatchMatchResult()
+  /** The batch does not match this filter. */
+  object NoMatch : BatchMatchResult()
 
   /**
    * All events in the batch match the filter; no per-event entity-key filtering needed.
@@ -98,7 +98,7 @@ sealed class FilterSpec {
   /**
    * Checks whether [identifier] matches this filter's batch-level selector.
    *
-   * @return [BatchMatchResult.Skip] if the batch should be skipped,
+   * @return [BatchMatchResult.NoMatch] if the batch should be skipped,
    *   [BatchMatchResult.MatchedAllEvents] or [BatchMatchResult.MatchedByEntityKeys] if it passed.
    * @throws MissingBatchEntityKeysException when this is [ByEntityKeys] and [identifier] is not
    *   [EventGroupIdentifier.ByEntityKeys].
@@ -137,7 +137,7 @@ sealed class FilterSpec {
           return if (eventGroupReferenceIds.contains(identifier.refId)) {
             BatchMatchResult.MatchedAllEvents
           } else {
-            BatchMatchResult.Skip
+            BatchMatchResult.NoMatch
           }
         }
       }
@@ -171,7 +171,7 @@ sealed class FilterSpec {
         is EventGroupIdentifier.ByEntityKeys -> {
           if (identifier.entityKeys.isEmpty()) throw MissingBatchEntityKeysException()
           if (!batchEntityKeysOverlap(identifier.entityKeys)) {
-            return BatchMatchResult.Skip
+            return BatchMatchResult.NoMatch
           }
           return if (allBatchKeysContained(identifier.entityKeys)) {
             BatchMatchResult.MatchedAllEvents

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/resultsfulfiller/FilterSpec.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/resultsfulfiller/FilterSpec.kt
@@ -97,8 +97,10 @@ sealed class FilterSpec {
    *
    * @return [BatchMatchResult.NoMatch] if the batch should be skipped,
    *   [BatchMatchResult.MatchedAllEvents] or [BatchMatchResult.MatchedByEntityKeys] if it passed.
-   * @throws MissingBatchEntityKeysException when this is [ByEntityKeys] and [identifier] is not
-   *   [EventGroupIdentifier.ByEntityKeys].
+   * @throws MismatchedBatchIdentifierException when [identifier]'s variant does not match this
+   *   [FilterSpec] variant.
+   * @throws MissingBatchEntityKeysException when this is [ByEntityKeys] and [identifier] is
+   *   [EventGroupIdentifier.ByEntityKeys] with an empty entity keys list.
    */
   abstract fun matchBatch(identifier: EventGroupIdentifier): BatchMatchResult
 

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/resultsfulfiller/FilterSpec.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/resultsfulfiller/FilterSpec.kt
@@ -35,13 +35,11 @@ class InvalidCollectionIntervalException :
   IllegalArgumentException("collectionInterval startTime must be before endTime")
 
 /**
- * Thrown by [FilterSpec.ByEntityKeys.matchBatch] when the incoming [EventGroupIdentifier] is not
- * [EventGroupIdentifier.ByEntityKeys].
+ * Thrown by [FilterSpec.ByEntityKeys.matchBatch] when the batch carries
+ * [EventGroupIdentifier.ByEntityKeys] with an empty entity keys list.
  */
 class MissingBatchEntityKeysException :
-  IllegalStateException(
-    "ByEntityKeys filter requires the batch to carry EventGroupIdentifier.ByEntityKeys"
-  )
+  IllegalStateException("Batch EventGroupIdentifier.ByEntityKeys has an empty entity keys list")
 
 /**
  * Thrown by [FilterSpec.matchBatch] when the [EventGroupIdentifier] variant does not match the

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/resultsfulfiller/FilterSpec.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/resultsfulfiller/FilterSpec.kt
@@ -59,11 +59,16 @@ sealed class BatchMatchResult {
   /** The batch does not match this filter; skip it entirely. */
   object Skip : BatchMatchResult()
 
-  /** The batch matched by reference ID; no per-event entity-key filtering needed. */
-  object MatchedByReferenceId : BatchMatchResult()
+  /**
+   * All events in the batch match the filter; no per-event entity-key filtering needed.
+   *
+   * Returned when matching by reference ID, or when the batch's entity keys are fully contained
+   * within the filter's entity keys.
+   */
+  object MatchedAllEvents : BatchMatchResult()
 
   /**
-   * The batch matched by entity keys; per-event entity-key filtering is required.
+   * The batch partially overlaps the filter's entity keys; per-event filtering is required.
    *
    * @property entityKeyFilter The set of entity keys to filter individual events against.
    */
@@ -94,8 +99,7 @@ sealed class FilterSpec {
    * Checks whether [identifier] matches this filter's batch-level selector.
    *
    * @return [BatchMatchResult.Skip] if the batch should be skipped,
-   *   [BatchMatchResult.MatchedByReferenceId] or [BatchMatchResult.MatchedByEntityKeys] if it
-   *   passed.
+   *   [BatchMatchResult.MatchedAllEvents] or [BatchMatchResult.MatchedByEntityKeys] if it passed.
    * @throws MissingBatchEntityKeysException when this is [ByEntityKeys] and [identifier] is not
    *   [EventGroupIdentifier.ByEntityKeys].
    */
@@ -131,7 +135,7 @@ sealed class FilterSpec {
           )
         is EventGroupIdentifier.ByReferenceId -> {
           return if (eventGroupReferenceIds.contains(identifier.refId)) {
-            BatchMatchResult.MatchedByReferenceId
+            BatchMatchResult.MatchedAllEvents
           } else {
             BatchMatchResult.Skip
           }
@@ -166,10 +170,13 @@ sealed class FilterSpec {
           )
         is EventGroupIdentifier.ByEntityKeys -> {
           if (identifier.entityKeys.isEmpty()) throw MissingBatchEntityKeysException()
-          return if (batchEntityKeysOverlap(identifier.entityKeys)) {
-            BatchMatchResult.MatchedByEntityKeys(entityKeyFilter = entityKeys)
+          if (!batchEntityKeysOverlap(identifier.entityKeys)) {
+            return BatchMatchResult.Skip
+          }
+          return if (allBatchKeysContained(identifier.entityKeys)) {
+            BatchMatchResult.MatchedAllEvents
           } else {
-            BatchMatchResult.Skip
+            BatchMatchResult.MatchedByEntityKeys(entityKeyFilter = entityKeys)
           }
         }
       }
@@ -188,6 +195,18 @@ sealed class FilterSpec {
           .flatMap { g -> g.entityIdsList.map { id -> EntityKeyPair(g.entityType, id) } }
           .toSet()
       return entityKeys.any { fk -> EntityKeyPair(fk.entityType, fk.entityId) in batchKeyPairs }
+    }
+
+    /**
+     * Checks whether all entity keys in [batchEntityKeys] are contained within this spec's
+     * [entityKeys].
+     */
+    private fun allBatchKeysContained(batchEntityKeys: List<EntityKeyGroup>): Boolean {
+      val filterKeyPairs: Set<EntityKeyPair> =
+        entityKeys.map { fk -> EntityKeyPair(fk.entityType, fk.entityId) }.toSet()
+      return batchEntityKeys.all { g ->
+        g.entityIdsList.all { id -> EntityKeyPair(g.entityType, id) in filterKeyPairs }
+      }
     }
 
     /** Flattened (entity_type, entity_id) pair for O(1) batch entity-key lookups. */

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/resultsfulfiller/FilterSpec.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/resultsfulfiller/FilterSpec.kt
@@ -18,6 +18,7 @@ package org.wfanet.measurement.edpaggregator.resultsfulfiller
 
 import com.google.type.Interval
 import org.wfanet.measurement.common.toInstant
+import org.wfanet.measurement.edpaggregator.v1alpha.EntityKeyGroup
 import org.wfanet.measurement.edpaggregator.v1alpha.LabeledImpression
 
 /** Thrown when a [FilterSpec] is constructed with an empty `eventGroupReferenceIds` selector. */
@@ -33,6 +34,33 @@ class EmptyEntityKeysException : IllegalArgumentException("entityKeys must not b
  */
 class InvalidCollectionIntervalException :
   IllegalArgumentException("collectionInterval startTime must be before endTime")
+
+/**
+ * Thrown by [FilterSpec.ByEntityKeys.matchBatch] when the incoming [EventGroupIdentifier] is not
+ * [EventGroupIdentifier.ByEntityKeys].
+ */
+class MissingBatchEntityKeysException :
+  IllegalStateException(
+    "ByEntityKeys filter requires the batch to carry EventGroupIdentifier.ByEntityKeys"
+  )
+
+/**
+ * Result of [FilterSpec.matchBatch].
+ *
+ * @see FilterSpec.matchBatch
+ */
+sealed class BatchMatchResult {
+  /** The batch does not match this filter; skip it entirely. */
+  object Skip : BatchMatchResult()
+
+  /**
+   * The batch passed the batch-level selector check.
+   *
+   * @property entityKeyFilter When non-null, per-event entity-key filtering is required using this
+   *   set. Null means no per-event entity-key check is needed (reference-id path).
+   */
+  data class Matched(val entityKeyFilter: Set<LabeledImpression.EntityKey>?) : BatchMatchResult()
+}
 
 /**
  * Immutable specification for event filtering.
@@ -52,6 +80,16 @@ sealed class FilterSpec {
 
   /** The time interval for event collection. */
   abstract val collectionInterval: Interval
+
+  /**
+   * Checks whether [identifier] matches this filter's batch-level selector.
+   *
+   * @return [BatchMatchResult.Skip] if the batch should be skipped, [BatchMatchResult.Matched] if
+   *   it passed (with an optional per-event entity-key filter set).
+   * @throws MissingBatchEntityKeysException when this is [ByEntityKeys] and [identifier] is not
+   *   [EventGroupIdentifier.ByEntityKeys].
+   */
+  abstract fun matchBatch(identifier: EventGroupIdentifier): BatchMatchResult
 
   protected fun requireValidCollectionInterval(interval: Interval) {
     if (!interval.startTime.toInstant().isBefore(interval.endTime.toInstant())) {
@@ -74,6 +112,16 @@ sealed class FilterSpec {
       if (eventGroupReferenceIds.isEmpty()) throw EmptyEventGroupReferenceIdsException()
       requireValidCollectionInterval(collectionInterval)
     }
+
+    override fun matchBatch(identifier: EventGroupIdentifier): BatchMatchResult {
+      val refId =
+        (identifier as? EventGroupIdentifier.ByReferenceId)?.refId ?: return BatchMatchResult.Skip
+      return if (eventGroupReferenceIds.contains(refId)) {
+        BatchMatchResult.Matched(entityKeyFilter = null)
+      } else {
+        BatchMatchResult.Skip
+      }
+    }
   }
 
   /**
@@ -93,5 +141,27 @@ sealed class FilterSpec {
       if (entityKeys.isEmpty()) throw EmptyEntityKeysException()
       requireValidCollectionInterval(collectionInterval)
     }
+
+    override fun matchBatch(identifier: EventGroupIdentifier): BatchMatchResult {
+      val batchKeys =
+        (identifier as? EventGroupIdentifier.ByEntityKeys)?.entityKeys
+          ?: throw MissingBatchEntityKeysException()
+      if (batchKeys.isEmpty()) throw MissingBatchEntityKeysException()
+      return if (batchEntityKeysOverlap(batchKeys)) {
+        BatchMatchResult.Matched(entityKeyFilter = entityKeys)
+      } else {
+        BatchMatchResult.Skip
+      }
+    }
+
+    private fun batchEntityKeysOverlap(batchEntityKeys: List<EntityKeyGroup>): Boolean {
+      val batchKeyPairs: Set<EntityKeyPair> =
+        batchEntityKeys
+          .flatMap { g -> g.entityIdsList.map { id -> EntityKeyPair(g.entityType, id) } }
+          .toSet()
+      return entityKeys.any { fk -> EntityKeyPair(fk.entityType, fk.entityId) in batchKeyPairs }
+    }
+
+    private data class EntityKeyPair(val entityType: String, val entityId: String)
   }
 }

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/resultsfulfiller/FilterSpec.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/resultsfulfiller/FilterSpec.kt
@@ -45,6 +45,12 @@ class MissingBatchEntityKeysException :
   )
 
 /**
+ * Thrown by [FilterSpec.matchBatch] when the [EventGroupIdentifier] variant does not match the
+ * [FilterSpec] variant.
+ */
+class MismatchedBatchIdentifierException(message: String) : IllegalStateException(message)
+
+/**
  * Result of [FilterSpec.matchBatch].
  *
  * @see FilterSpec.matchBatch
@@ -119,7 +125,10 @@ sealed class FilterSpec {
 
     override fun matchBatch(identifier: EventGroupIdentifier): BatchMatchResult {
       when (identifier) {
-        is EventGroupIdentifier.ByEntityKeys -> return BatchMatchResult.Skip
+        is EventGroupIdentifier.ByEntityKeys ->
+          throw MismatchedBatchIdentifierException(
+            "ByEventGroupReferenceIds filter requires EventGroupIdentifier.ByReferenceId"
+          )
         is EventGroupIdentifier.ByReferenceId -> {
           return if (eventGroupReferenceIds.contains(identifier.refId)) {
             BatchMatchResult.MatchedByReferenceId
@@ -151,7 +160,10 @@ sealed class FilterSpec {
 
     override fun matchBatch(identifier: EventGroupIdentifier): BatchMatchResult {
       when (identifier) {
-        is EventGroupIdentifier.ByReferenceId -> throw MissingBatchEntityKeysException()
+        is EventGroupIdentifier.ByReferenceId ->
+          throw MismatchedBatchIdentifierException(
+            "ByEntityKeys filter requires EventGroupIdentifier.ByEntityKeys"
+          )
         is EventGroupIdentifier.ByEntityKeys -> {
           if (identifier.entityKeys.isEmpty()) throw MissingBatchEntityKeysException()
           return if (batchEntityKeysOverlap(identifier.entityKeys)) {

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/resultsfulfiller/FilterSpec.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/resultsfulfiller/FilterSpec.kt
@@ -114,12 +114,15 @@ sealed class FilterSpec {
     }
 
     override fun matchBatch(identifier: EventGroupIdentifier): BatchMatchResult {
-      val refId =
-        (identifier as? EventGroupIdentifier.ByReferenceId)?.refId ?: return BatchMatchResult.Skip
-      return if (eventGroupReferenceIds.contains(refId)) {
-        BatchMatchResult.Matched(entityKeyFilter = null)
-      } else {
-        BatchMatchResult.Skip
+      when (identifier) {
+        is EventGroupIdentifier.ByEntityKeys -> return BatchMatchResult.Skip
+        is EventGroupIdentifier.ByReferenceId -> {
+          return if (eventGroupReferenceIds.contains(identifier.refId)) {
+            BatchMatchResult.Matched(entityKeyFilter = null)
+          } else {
+            BatchMatchResult.Skip
+          }
+        }
       }
     }
   }

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/resultsfulfiller/FilterSpec.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/resultsfulfiller/FilterSpec.kt
@@ -143,14 +143,16 @@ sealed class FilterSpec {
     }
 
     override fun matchBatch(identifier: EventGroupIdentifier): BatchMatchResult {
-      val batchKeys =
-        (identifier as? EventGroupIdentifier.ByEntityKeys)?.entityKeys
-          ?: throw MissingBatchEntityKeysException()
-      if (batchKeys.isEmpty()) throw MissingBatchEntityKeysException()
-      return if (batchEntityKeysOverlap(batchKeys)) {
-        BatchMatchResult.Matched(entityKeyFilter = entityKeys)
-      } else {
-        BatchMatchResult.Skip
+      when (identifier) {
+        is EventGroupIdentifier.ByReferenceId -> throw MissingBatchEntityKeysException()
+        is EventGroupIdentifier.ByEntityKeys -> {
+          if (identifier.entityKeys.isEmpty()) throw MissingBatchEntityKeysException()
+          return if (batchEntityKeysOverlap(identifier.entityKeys)) {
+            BatchMatchResult.Matched(entityKeyFilter = entityKeys)
+          } else {
+            BatchMatchResult.Skip
+          }
+        }
       }
     }
 

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/resultsfulfiller/FilterSpec.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/resultsfulfiller/FilterSpec.kt
@@ -154,6 +154,13 @@ sealed class FilterSpec {
       }
     }
 
+    /**
+     * Checks whether any [EntityKeyGroup] in [batchEntityKeys] contains an `(entity_type,
+     * entity_id)` pair that matches this spec's [entityKeys].
+     *
+     * Pre-flattens the batch's grouped entity keys into a `Set<EntityKeyPair>` once, then performs
+     * O(1) membership lookups for each filter element.
+     */
     private fun batchEntityKeysOverlap(batchEntityKeys: List<EntityKeyGroup>): Boolean {
       val batchKeyPairs: Set<EntityKeyPair> =
         batchEntityKeys
@@ -162,6 +169,7 @@ sealed class FilterSpec {
       return entityKeys.any { fk -> EntityKeyPair(fk.entityType, fk.entityId) in batchKeyPairs }
     }
 
+    /** Flattened (entity_type, entity_id) pair for O(1) batch entity-key lookups. */
     private data class EntityKeyPair(val entityType: String, val entityId: String)
   }
 }

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/resultsfulfiller/ImpressionDataSourceProvider.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/resultsfulfiller/ImpressionDataSourceProvider.kt
@@ -46,7 +46,6 @@ import org.wfanet.measurement.storage.SelectedStorageClient
  */
 data class ImpressionDataSource(
   val modelLine: String,
-  val eventGroupReferenceId: String,
   val interval: Interval,
   val blobDetails: BlobDetails,
 )
@@ -89,7 +88,6 @@ class ImpressionDataSourceProvider(
             val blobDetails = readBlobDetails(metadata.blobUri)
             ImpressionDataSource(
               modelLine = modelLine,
-              eventGroupReferenceId = selector.refId,
               interval = metadata.interval,
               blobDetails = blobDetails,
             )
@@ -106,7 +104,6 @@ class ImpressionDataSourceProvider(
             val blobDetails = readBlobDetails(metadata.blobUri)
             ImpressionDataSource(
               modelLine = modelLine,
-              eventGroupReferenceId = metadata.eventGroupReferenceId,
               interval = metadata.interval,
               blobDetails = blobDetails,
             )

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/resultsfulfiller/ImpressionDataSourceProvider.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/resultsfulfiller/ImpressionDataSourceProvider.kt
@@ -176,7 +176,7 @@ class ImpressionDataSourceProvider(
    * @param period the time period to filter by
    */
   @OptIn(ExperimentalCoroutinesApi::class) // For `flattenConcat`.
-  fun getImpressionsMetadataByEntityKey(
+  private fun getImpressionsMetadataByEntityKey(
     reportModelLine: String,
     entityKey: EntityKey,
     period: Interval,

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/resultsfulfiller/ImpressionDataSourceProvider.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/resultsfulfiller/ImpressionDataSourceProvider.kt
@@ -31,7 +31,6 @@ import org.wfanet.measurement.common.api.grpc.listResources
 import org.wfanet.measurement.common.flatten
 import org.wfanet.measurement.edpaggregator.StorageConfig
 import org.wfanet.measurement.edpaggregator.v1alpha.BlobDetails
-import org.wfanet.measurement.edpaggregator.v1alpha.EntityKey
 import org.wfanet.measurement.edpaggregator.v1alpha.ImpressionMetadata
 import org.wfanet.measurement.edpaggregator.v1alpha.ImpressionMetadataServiceGrpcKt.ImpressionMetadataServiceCoroutineStub
 import org.wfanet.measurement.edpaggregator.v1alpha.ListImpressionMetadataRequestKt
@@ -77,57 +76,33 @@ class ImpressionDataSourceProvider(
     selector: ImpressionQuerySelector,
     period: Interval,
   ): List<ImpressionDataSource> {
-    return when (selector) {
-      is ImpressionQuerySelector.ByEventGroupReferenceId -> {
-        logger.info("Listing impression Data Sources...")
-        val impressionMetadata: Flow<ImpressionMetadata> =
-          getImpressionsMetadata(modelLine, selector.refId, period)
-        impressionMetadata
-          .map { metadata ->
-            logger.info("Processing impression metadata: $metadata")
-            val blobDetails = readBlobDetails(metadata.blobUri)
-            ImpressionDataSource(
-              modelLine = modelLine,
-              interval = metadata.interval,
-              blobDetails = blobDetails,
-            )
-          }
-          .toList()
+    return getImpressionsMetadata(modelLine, selector, period)
+      .map { metadata ->
+        logger.info("Processing impression metadata: $metadata")
+        val blobDetails = readBlobDetails(metadata.blobUri)
+        ImpressionDataSource(
+          modelLine = modelLine,
+          interval = metadata.interval,
+          blobDetails = blobDetails,
+        )
       }
-      is ImpressionQuerySelector.ByEntityKey -> {
-        logger.info("Listing impression Data Sources by entity key...")
-        val impressionMetadata: Flow<ImpressionMetadata> =
-          getImpressionsMetadataByEntityKey(modelLine, selector.entityKey, period)
-        impressionMetadata
-          .map { metadata ->
-            logger.info("Processing impression metadata: $metadata")
-            val blobDetails = readBlobDetails(metadata.blobUri)
-            ImpressionDataSource(
-              modelLine = modelLine,
-              interval = metadata.interval,
-              blobDetails = blobDetails,
-            )
-          }
-          .toList()
-      }
-    }
+      .toList()
   }
 
   /**
-   * Resolve a path to a blob details protobuf record.
+   * Queries impression metadata using the given [selector] strategy.
    *
    * @param reportModelLine the model line
-   * @param egReferenceId referenced event group
+   * @param selector determines whether to query by entity key or event group reference ID.
    * @param period the time period to filter by
    */
   @OptIn(ExperimentalCoroutinesApi::class) // For `flattenConcat`.
   private fun getImpressionsMetadata(
     reportModelLine: String,
-    egReferenceId: String,
+    selector: ImpressionQuerySelector,
     period: Interval,
   ): Flow<ImpressionMetadata> {
-
-    logger.info("Resolving path for impression metadata: $reportModelLine, $egReferenceId, $period")
+    logger.info("Resolving path for impression metadata: $reportModelLine, $selector, $period")
     return impressionMetadataStub
       .listResources { pageToken: String ->
         val response =
@@ -138,55 +113,19 @@ class ImpressionDataSourceProvider(
                 filter =
                   ListImpressionMetadataRequestKt.filter {
                     modelLine = reportModelLine
-                    eventGroupReferenceId = egReferenceId
+                    when (selector) {
+                      is ImpressionQuerySelector.ByEventGroupReferenceId ->
+                        eventGroupReferenceId = selector.refId
+                      is ImpressionQuerySelector.ByEntityKey ->
+                        this.entityKeys += selector.entityKey
+                    }
                     intervalOverlaps = period
                   }
                 this.pageToken = pageToken
               }
             )
           } catch (e: StatusException) {
-            throw Exception("Error listing EventGroups", e)
-          }
-        ResourceList(response.impressionMetadataList, response.nextPageToken)
-      }
-      .flattenConcat()
-  }
-
-  /**
-   * Queries impression metadata by entity key.
-   *
-   * @param reportModelLine the model line
-   * @param entityKey the entity key to query by
-   * @param period the time period to filter by
-   */
-  @OptIn(ExperimentalCoroutinesApi::class) // For `flattenConcat`.
-  private fun getImpressionsMetadataByEntityKey(
-    reportModelLine: String,
-    entityKey: EntityKey,
-    period: Interval,
-  ): Flow<ImpressionMetadata> {
-
-    logger.info(
-      "Resolving path for impression metadata by entity key: $reportModelLine, $entityKey, $period"
-    )
-    return impressionMetadataStub
-      .listResources { pageToken: String ->
-        val response =
-          try {
-            impressionMetadataStub.listImpressionMetadata(
-              listImpressionMetadataRequest {
-                parent = dataProvider
-                filter =
-                  ListImpressionMetadataRequestKt.filter {
-                    modelLine = reportModelLine
-                    this.entityKeys += entityKey
-                    intervalOverlaps = period
-                  }
-                this.pageToken = pageToken
-              }
-            )
-          } catch (e: StatusException) {
-            throw Exception("Error listing ImpressionMetadata by entity key", e)
+            throw Exception("Error listing ImpressionMetadata", e)
           }
         ResourceList(response.impressionMetadataList, response.nextPageToken)
       }

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/resultsfulfiller/ImpressionDataSourceProvider.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/resultsfulfiller/ImpressionDataSourceProvider.kt
@@ -31,9 +31,11 @@ import org.wfanet.measurement.common.api.grpc.listResources
 import org.wfanet.measurement.common.flatten
 import org.wfanet.measurement.edpaggregator.StorageConfig
 import org.wfanet.measurement.edpaggregator.v1alpha.BlobDetails
+import org.wfanet.measurement.edpaggregator.v1alpha.EntityKey
 import org.wfanet.measurement.edpaggregator.v1alpha.ImpressionMetadata
 import org.wfanet.measurement.edpaggregator.v1alpha.ImpressionMetadataServiceGrpcKt.ImpressionMetadataServiceCoroutineStub
 import org.wfanet.measurement.edpaggregator.v1alpha.ListImpressionMetadataRequestKt
+import org.wfanet.measurement.edpaggregator.v1alpha.entityKey
 import org.wfanet.measurement.edpaggregator.v1alpha.listImpressionMetadataRequest
 import org.wfanet.measurement.storage.SelectedStorageClient
 
@@ -95,6 +97,39 @@ class ImpressionDataSourceProvider(
   }
 
   /**
+   * Lists impression data sources for an entity key within a period.
+   *
+   * @param entityKey entity key to query by.
+   * @param period closed-open time interval in UTC.
+   * @return sources covering the requested period; empty if the period maps to no dates.
+   * @throws ImpressionReadException if a required metadata blob does not exist.
+   * @throws com.google.protobuf.InvalidProtocolBufferException if a metadata blob is present but
+   *   contains invalid `BlobDetails`.
+   */
+  suspend fun listImpressionDataSources(
+    modelLine: String,
+    entityKey: EntityKey,
+    period: Interval,
+  ): List<ImpressionDataSource> {
+    logger.info("Listing impression Data Sources by entity key...")
+    val impressionMetadata: Flow<ImpressionMetadata> =
+      getImpressionsMetadataByEntityKey(modelLine, entityKey, period)
+    return impressionMetadata
+      .map { metadata ->
+        logger.info("Processing impression metadata: $metadata")
+        val blobDetails = readBlobDetails(metadata.blobUri)
+
+        ImpressionDataSource(
+          modelLine = modelLine,
+          eventGroupReferenceId = metadata.eventGroupReferenceId,
+          interval = metadata.interval,
+          blobDetails = blobDetails,
+        )
+      }
+      .toList()
+  }
+
+  /**
    * Resolve a path to a blob details protobuf record.
    *
    * @param reportModelLine the model line
@@ -127,6 +162,47 @@ class ImpressionDataSourceProvider(
             )
           } catch (e: StatusException) {
             throw Exception("Error listing EventGroups", e)
+          }
+        ResourceList(response.impressionMetadataList, response.nextPageToken)
+      }
+      .flattenConcat()
+  }
+
+  /**
+   * Queries impression metadata by entity key.
+   *
+   * @param reportModelLine the model line
+   * @param entityKey the entity key to query by
+   * @param period the time period to filter by
+   */
+  @OptIn(ExperimentalCoroutinesApi::class) // For `flattenConcat`.
+  fun getImpressionsMetadataByEntityKey(
+    reportModelLine: String,
+    entityKey: EntityKey,
+    period: Interval,
+  ): Flow<ImpressionMetadata> {
+
+    logger.info(
+      "Resolving path for impression metadata by entity key: $reportModelLine, $entityKey, $period"
+    )
+    return impressionMetadataStub
+      .listResources { pageToken: String ->
+        val response =
+          try {
+            impressionMetadataStub.listImpressionMetadata(
+              listImpressionMetadataRequest {
+                parent = dataProvider
+                filter =
+                  ListImpressionMetadataRequestKt.filter {
+                    modelLine = reportModelLine
+                    this.entityKeys += entityKey
+                    intervalOverlaps = period
+                  }
+                this.pageToken = pageToken
+              }
+            )
+          } catch (e: StatusException) {
+            throw Exception("Error listing ImpressionMetadata by entity key", e)
           }
         ResourceList(response.impressionMetadataList, response.nextPageToken)
       }

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/resultsfulfiller/ImpressionDataSourceProvider.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/resultsfulfiller/ImpressionDataSourceProvider.kt
@@ -35,7 +35,6 @@ import org.wfanet.measurement.edpaggregator.v1alpha.EntityKey
 import org.wfanet.measurement.edpaggregator.v1alpha.ImpressionMetadata
 import org.wfanet.measurement.edpaggregator.v1alpha.ImpressionMetadataServiceGrpcKt.ImpressionMetadataServiceCoroutineStub
 import org.wfanet.measurement.edpaggregator.v1alpha.ListImpressionMetadataRequestKt
-import org.wfanet.measurement.edpaggregator.v1alpha.entityKey
 import org.wfanet.measurement.edpaggregator.v1alpha.listImpressionMetadataRequest
 import org.wfanet.measurement.storage.SelectedStorageClient
 
@@ -64,9 +63,10 @@ class ImpressionDataSourceProvider(
 ) {
 
   /**
-   * Lists impression data sources for an event group within a period.
+   * Lists impression data sources for a given selector within a period.
    *
-   * @param eventGroupReferenceId event group reference identifier.
+   * @param modelLine the model line to query.
+   * @param selector determines whether to query by entity key or event group reference ID.
    * @param period closed-open time interval in UTC.
    * @return sources covering the requested period; empty if the period maps to no dates.
    * @throws ImpressionReadException if a required metadata blob does not exist.
@@ -75,69 +75,56 @@ class ImpressionDataSourceProvider(
    */
   suspend fun listImpressionDataSources(
     modelLine: String,
-    eventGroupReferenceId: String,
+    selector: ImpressionQuerySelector,
     period: Interval,
   ): List<ImpressionDataSource> {
-    logger.info("Listing impression Data Sources...")
-    val impressionMetadata: Flow<ImpressionMetadata> =
-      getImpressionsMetadata(modelLine, eventGroupReferenceId, period)
-    return impressionMetadata
-      .map { metadata ->
-        logger.info("Processing impression metadata: $metadata")
-        val blobDetails = readBlobDetails(metadata.blobUri)
-
-        ImpressionDataSource(
-          modelLine = modelLine,
-          eventGroupReferenceId = eventGroupReferenceId,
-          interval = metadata.interval,
-          blobDetails = blobDetails,
-        )
+    return when (selector) {
+      is ImpressionQuerySelector.ByEventGroupReferenceId -> {
+        logger.info("Listing impression Data Sources...")
+        val impressionMetadata: Flow<ImpressionMetadata> =
+          getImpressionsMetadata(modelLine, selector.refId, period)
+        impressionMetadata
+          .map { metadata ->
+            logger.info("Processing impression metadata: $metadata")
+            val blobDetails = readBlobDetails(metadata.blobUri)
+            ImpressionDataSource(
+              modelLine = modelLine,
+              eventGroupReferenceId = selector.refId,
+              interval = metadata.interval,
+              blobDetails = blobDetails,
+            )
+          }
+          .toList()
       }
-      .toList()
-  }
-
-  /**
-   * Lists impression data sources for an entity key within a period.
-   *
-   * @param entityKey entity key to query by.
-   * @param period closed-open time interval in UTC.
-   * @return sources covering the requested period; empty if the period maps to no dates.
-   * @throws ImpressionReadException if a required metadata blob does not exist.
-   * @throws com.google.protobuf.InvalidProtocolBufferException if a metadata blob is present but
-   *   contains invalid `BlobDetails`.
-   */
-  suspend fun listImpressionDataSources(
-    modelLine: String,
-    entityKey: EntityKey,
-    period: Interval,
-  ): List<ImpressionDataSource> {
-    logger.info("Listing impression Data Sources by entity key...")
-    val impressionMetadata: Flow<ImpressionMetadata> =
-      getImpressionsMetadataByEntityKey(modelLine, entityKey, period)
-    return impressionMetadata
-      .map { metadata ->
-        logger.info("Processing impression metadata: $metadata")
-        val blobDetails = readBlobDetails(metadata.blobUri)
-
-        ImpressionDataSource(
-          modelLine = modelLine,
-          eventGroupReferenceId = metadata.eventGroupReferenceId,
-          interval = metadata.interval,
-          blobDetails = blobDetails,
-        )
+      is ImpressionQuerySelector.ByEntityKey -> {
+        logger.info("Listing impression Data Sources by entity key...")
+        val impressionMetadata: Flow<ImpressionMetadata> =
+          getImpressionsMetadataByEntityKey(modelLine, selector.entityKey, period)
+        impressionMetadata
+          .map { metadata ->
+            logger.info("Processing impression metadata: $metadata")
+            val blobDetails = readBlobDetails(metadata.blobUri)
+            ImpressionDataSource(
+              modelLine = modelLine,
+              eventGroupReferenceId = metadata.eventGroupReferenceId,
+              interval = metadata.interval,
+              blobDetails = blobDetails,
+            )
+          }
+          .toList()
       }
-      .toList()
+    }
   }
 
   /**
    * Resolve a path to a blob details protobuf record.
    *
    * @param reportModelLine the model line
-   * @param date the of the event data
    * @param egReferenceId referenced event group
+   * @param period the time period to filter by
    */
   @OptIn(ExperimentalCoroutinesApi::class) // For `flattenConcat`.
-  fun getImpressionsMetadata(
+  private fun getImpressionsMetadata(
     reportModelLine: String,
     egReferenceId: String,
     period: Interval,

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/resultsfulfiller/ImpressionQuerySelector.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/resultsfulfiller/ImpressionQuerySelector.kt
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2025 The Cross-Media Measurement Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wfanet.measurement.edpaggregator.resultsfulfiller
+
+import org.wfanet.measurement.edpaggregator.v1alpha.EntityKey
+
+/**
+ * Sealed class representing the two strategies for querying impression metadata.
+ *
+ * This replaces runtime if/else dispatch with a type-safe selector, following the same pattern as
+ * [FilterSpec].
+ */
+sealed class ImpressionQuerySelector {
+  /** Query impression metadata by entity key. */
+  data class ByEntityKey(val entityKey: EntityKey) : ImpressionQuerySelector()
+
+  /** Query impression metadata by event group reference ID. */
+  data class ByEventGroupReferenceId(val refId: String) : ImpressionQuerySelector()
+}

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/resultsfulfiller/StorageEventSource.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/resultsfulfiller/StorageEventSource.kt
@@ -202,7 +202,7 @@ class StorageEventSource(
       eventGroupDetailsList.flatMap { details ->
         logger.info("EventGroup details: $details")
         val selector =
-          if (hasEntityKey(details)) {
+          if (useEntityKeyStrategy) {
             ImpressionQuerySelector.ByEntityKey(
               entityKey {
                 entityType = details.entityKey.entityType

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/resultsfulfiller/StorageEventSource.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/resultsfulfiller/StorageEventSource.kt
@@ -243,14 +243,20 @@ class StorageEventSource(
 
     logger.fine("Reading events from ${blobDetails.blobUri}")
 
+    val eventGroupIdentifier =
+      if (blobDetails.entityKeysList.isNotEmpty()) {
+        EventGroupIdentifier.ByEntityKeys(blobDetails.entityKeysList)
+      } else {
+        EventGroupIdentifier.ByReferenceId(blobDetails.eventGroupReferenceId)
+      }
+
     eventReader.readEvents().collect { events ->
       val eventBatch =
         EventBatch(
           events = events,
           minTime = events.minOf { it.timestamp },
           maxTime = events.maxOf { it.timestamp },
-          eventGroupReferenceId = blobDetails.eventGroupReferenceId,
-          entityKeys = blobDetails.entityKeysList,
+          eventGroupIdentifier = eventGroupIdentifier,
         )
       sendEventBatch(eventBatch)
       batchCount++

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/resultsfulfiller/StorageEventSource.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/resultsfulfiller/StorageEventSource.kt
@@ -32,6 +32,7 @@ import kotlinx.coroutines.flow.channelFlow
 import kotlinx.coroutines.launch
 import org.wfanet.measurement.edpaggregator.StorageConfig
 import org.wfanet.measurement.edpaggregator.v1alpha.GroupedRequisitions.EventGroupDetails
+import org.wfanet.measurement.edpaggregator.v1alpha.entityKey
 
 /** Result of processing a single EventReader. */
 data class EventReaderResult(val batchCount: Int, val eventCount: Int)
@@ -182,11 +183,19 @@ class StorageEventSource(
         logger.info("EventGroup details: $details")
         details.collectionIntervalsList.flatMap { interval ->
           logger.info("EventGroup collection interval: $interval")
-          impressionDataSourceProvider.listImpressionDataSources(
-            modelLine,
-            details.eventGroupReferenceId,
-            interval,
-          )
+          if (details.hasEntityKey() && details.entityKey.entityId.isNotEmpty()) {
+            val ek = entityKey {
+              entityType = details.entityKey.entityType
+              entityId = details.entityKey.entityId
+            }
+            impressionDataSourceProvider.listImpressionDataSources(modelLine, ek, interval)
+          } else {
+            impressionDataSourceProvider.listImpressionDataSources(
+              modelLine,
+              details.eventGroupReferenceId,
+              interval,
+            )
+          }
         }
       }
     val result = allSources.distinctBy { it.blobDetails.blobUri }

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/resultsfulfiller/StorageEventSource.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/resultsfulfiller/StorageEventSource.kt
@@ -172,30 +172,44 @@ class StorageEventSource(
     }
   }
 
+  /** Returns true if [details] has an entity key with a non-empty entity ID. */
+  private fun hasEntityKey(details: EventGroupDetails): Boolean {
+    return details.hasEntityKey() && details.entityKey.entityId.isNotEmpty()
+  }
+
   /** Collects all impression data sources and deduplicates by blob URI. */
   private suspend fun getUniqueImpressionDataSources(): List<ImpressionDataSource> {
     cachedImpressionDataSources?.let {
       return it
     }
 
+    // Validate that all event group details use the same query strategy.
+    if (eventGroupDetailsList.isNotEmpty()) {
+      val hasEntityKeys = eventGroupDetailsList.map { hasEntityKey(it) }
+      val allEntityKey = hasEntityKeys.all { it }
+      val noneEntityKey = hasEntityKeys.none { it }
+      require(allEntityKey || noneEntityKey) {
+        "Cannot mix entity-key and reference-id event groups"
+      }
+    }
+
     val allSources =
       eventGroupDetailsList.flatMap { details ->
         logger.info("EventGroup details: $details")
+        val selector =
+          if (hasEntityKey(details)) {
+            ImpressionQuerySelector.ByEntityKey(
+              entityKey {
+                entityType = details.entityKey.entityType
+                entityId = details.entityKey.entityId
+              }
+            )
+          } else {
+            ImpressionQuerySelector.ByEventGroupReferenceId(details.eventGroupReferenceId)
+          }
         details.collectionIntervalsList.flatMap { interval ->
           logger.info("EventGroup collection interval: $interval")
-          if (details.hasEntityKey() && details.entityKey.entityId.isNotEmpty()) {
-            val ek = entityKey {
-              entityType = details.entityKey.entityType
-              entityId = details.entityKey.entityId
-            }
-            impressionDataSourceProvider.listImpressionDataSources(modelLine, ek, interval)
-          } else {
-            impressionDataSourceProvider.listImpressionDataSources(
-              modelLine,
-              details.eventGroupReferenceId,
-              interval,
-            )
-          }
+          impressionDataSourceProvider.listImpressionDataSources(modelLine, selector, interval)
         }
       }
     val result = allSources.distinctBy { it.blobDetails.blobUri }

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/resultsfulfiller/StorageEventSource.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/resultsfulfiller/StorageEventSource.kt
@@ -129,7 +129,13 @@ class StorageEventSource(
   /** Cache for unique impression data sources to avoid duplicate API calls. */
   private var cachedImpressionDataSources: List<ImpressionDataSource>? = null
 
-  private var useEntityKeyStrategy = false
+  private val useEntityKeyStrategy: Boolean = run {
+    require(eventGroupDetailsList.isNotEmpty()) { "eventGroupDetailsList must not be empty" }
+    val allEntityKey = eventGroupDetailsList.all { hasEntityKey(it) }
+    val noneEntityKey = eventGroupDetailsList.none { hasEntityKey(it) }
+    require(allEntityKey || noneEntityKey) { "Cannot mix entity-key and reference-id event groups" }
+    allEntityKey
+  }
 
   /**
    * Generates batches of events by reading from storage in parallel.
@@ -190,17 +196,6 @@ class StorageEventSource(
   private suspend fun getUniqueImpressionDataSources(): List<ImpressionDataSource> {
     cachedImpressionDataSources?.let {
       return it
-    }
-
-    // Validate that all event group details use the same query strategy.
-    if (eventGroupDetailsList.isNotEmpty()) {
-      val hasEntityKeys = eventGroupDetailsList.map { hasEntityKey(it) }
-      val allEntityKey = hasEntityKeys.all { it }
-      val noneEntityKey = hasEntityKeys.none { it }
-      require(allEntityKey || noneEntityKey) {
-        "Cannot mix entity-key and reference-id event groups"
-      }
-      useEntityKeyStrategy = allEntityKey
     }
 
     val allSources =

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/resultsfulfiller/StorageEventSource.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/resultsfulfiller/StorageEventSource.kt
@@ -37,6 +37,13 @@ import org.wfanet.measurement.edpaggregator.v1alpha.entityKey
 /** Result of processing a single EventReader. */
 data class EventReaderResult(val batchCount: Int, val eventCount: Int)
 
+/** A [StorageEventReader] paired with its resolved [EventGroupIdentifier] and blob URI. */
+data class ResolvedEventReader(
+  val reader: StorageEventReader,
+  val eventGroupIdentifier: EventGroupIdentifier,
+  val blobUri: String,
+)
+
 /**
  * Account identifier and location/region extracted from a KMS KEK URI.
  *
@@ -122,6 +129,8 @@ class StorageEventSource(
   /** Cache for unique impression data sources to avoid duplicate API calls. */
   private var cachedImpressionDataSources: List<ImpressionDataSource>? = null
 
+  private var useEntityKeyStrategy = false
+
   /**
    * Generates batches of events by reading from storage in parallel.
    *
@@ -153,16 +162,16 @@ class StorageEventSource(
     logger.info("Starting storage-based event generation with batching")
 
     return channelFlow {
-      val eventReaders: List<StorageEventReader> = createEventReaders()
+      val eventReaders: List<ResolvedEventReader> = createEventReaders()
       ProgressTracker(eventReaders.size).use { progressTracker ->
         logger.info(
           "Processing ${eventReaders.size} EventReaders across ${eventGroupDetailsList.size} event groups"
         )
         // Launch one coroutine per EventReader
         coroutineScope {
-          eventReaders.forEach { eventReader ->
+          eventReaders.forEach { resolvedReader ->
             launch {
-              val result = processEventReader(eventReader) { eventBatch -> send(eventBatch) }
+              val result = processEventReader(resolvedReader) { eventBatch -> send(eventBatch) }
               progressTracker.updateProgress(result.eventCount, result.batchCount)
             }
           }
@@ -191,6 +200,7 @@ class StorageEventSource(
       require(allEntityKey || noneEntityKey) {
         "Cannot mix entity-key and reference-id event groups"
       }
+      useEntityKeyStrategy = allEntityKey
     }
 
     val allSources =
@@ -217,53 +227,56 @@ class StorageEventSource(
     return result
   }
 
-  private suspend fun createEventReaders(): List<StorageEventReader> {
+  private suspend fun createEventReaders(): List<ResolvedEventReader> {
     logger.info("Creating event readers... ")
     val uniqueSources = getUniqueImpressionDataSources()
 
     return uniqueSources.map { source ->
-      StorageEventReader(
-        source.blobDetails,
-        kmsClient,
-        impressionsStorageConfig,
-        descriptor,
-        batchSize,
+      val eventGroupIdentifier =
+        if (useEntityKeyStrategy) {
+          EventGroupIdentifier.ByEntityKeys(source.blobDetails.entityKeysList)
+        } else {
+          EventGroupIdentifier.ByReferenceId(source.blobDetails.eventGroupReferenceId)
+        }
+      ResolvedEventReader(
+        reader =
+          StorageEventReader(
+            source.blobDetails,
+            kmsClient,
+            impressionsStorageConfig,
+            descriptor,
+            batchSize,
+          ),
+        eventGroupIdentifier = eventGroupIdentifier,
+        blobUri = source.blobDetails.blobUri,
       )
     }
   }
 
   /** Processes events from a single EventReader and returns batch and event counts. */
   private suspend fun processEventReader(
-    eventReader: StorageEventReader,
+    resolvedReader: ResolvedEventReader,
     sendEventBatch: suspend (EventBatch<Message>) -> Unit,
   ): EventReaderResult {
     var batchCount = 0
     var eventCount = 0
-    val blobDetails = eventReader.getBlobDetails()
 
-    logger.fine("Reading events from ${blobDetails.blobUri}")
+    logger.fine("Reading events from ${resolvedReader.blobUri}")
 
-    val eventGroupIdentifier =
-      if (blobDetails.entityKeysList.isNotEmpty()) {
-        EventGroupIdentifier.ByEntityKeys(blobDetails.entityKeysList)
-      } else {
-        EventGroupIdentifier.ByReferenceId(blobDetails.eventGroupReferenceId)
-      }
-
-    eventReader.readEvents().collect { events ->
+    resolvedReader.reader.readEvents().collect { events ->
       val eventBatch =
         EventBatch(
           events = events,
           minTime = events.minOf { it.timestamp },
           maxTime = events.maxOf { it.timestamp },
-          eventGroupIdentifier = eventGroupIdentifier,
+          eventGroupIdentifier = resolvedReader.eventGroupIdentifier,
         )
       sendEventBatch(eventBatch)
       batchCount++
       eventCount += events.size
     }
 
-    logger.fine("Read $eventCount events in $batchCount batches for ${blobDetails.blobUri}")
+    logger.fine("Read $eventCount events in $batchCount batches for ${resolvedReader.blobUri}")
     return EventReaderResult(batchCount, eventCount)
   }
 

--- a/src/main/kotlin/org/wfanet/measurement/integration/common/InProcessEdpAggregatorComponents.kt
+++ b/src/main/kotlin/org/wfanet/measurement/integration/common/InProcessEdpAggregatorComponents.kt
@@ -365,92 +365,96 @@ class InProcessEdpAggregatorComponents(
       val configByRefId: Map<String, EventGroupConfig> =
         resolveSpecsByReferenceId(edpAggregatorShortName)
 
-      // Create metadata for multi-entity-key configs under the shared ref ID.
-      val handledMultiEntityKeyRefIds = mutableSetOf<String>()
-      for ((refId, config) in originalConfigs) {
-        if (config is EventGroupConfig.MultiEntityKey) {
-          handledMultiEntityKeyRefIds += refId
-          config.entityKeySpecs.forEach { entityKeySpec ->
-            handledMultiEntityKeyRefIds +=
-              "${entityKeySpec.entityKey.entityType}/${entityKeySpec.entityKey.entityId}"
-          }
-          val allDates: List<LocalDate> =
-            config.entityKeySpecs
-              .flatMap { entityKeySpec ->
-                SyntheticDataGeneration.generateEvents(
-                    TestEvent.getDefaultInstance(),
-                    populationSpec,
-                    entityKeySpec.spec,
-                  )
-                  .map { it.localDate }
-                  .toList()
-              }
-              .distinct()
-          val startDate = allDates.min()
-          val endExclusive = allDates.max().plusDays(1)
-
-          val eventGroupPath = "model-line/$modelLineName/event-group-reference-id/$refId"
-          val impressionsMetadataBucket = "$IMPRESSIONS_METADATA_BUCKET-$edpAggregatorShortName"
-
-          val entityKeys: List<org.wfanet.measurement.edpaggregator.v1alpha.EntityKey> =
-            config.entityKeySpecs.map { entityKeySpec ->
-              entityKey {
-                entityType = entityKeySpec.entityKey.entityType
-                entityId = entityKeySpec.entityKey.entityId
-              }
+      // Map each derived ref ID back to the original ref ID from the config.
+      val originalRefIdByDerivedRefId: Map<String, String> =
+        originalConfigs
+          .flatMap { (originalRefId, config) ->
+            when (config) {
+              is EventGroupConfig.LegacySpec -> listOf(originalRefId to originalRefId)
+              is EventGroupConfig.MultiEntityKey ->
+                config.entityKeySpecs.map { entityKeySpec ->
+                  "${entityKeySpec.entityKey.entityType}/${entityKeySpec.entityKey.entityId}" to
+                    originalRefId
+                }
             }
-          val impressionsMetadata: List<ImpressionMetadata> =
-            buildImpressionMetadataForDateRange(
-              startInclusive = startDate,
-              endExclusive = endExclusive,
-              eventGroupPath = eventGroupPath,
-              modelLine = modelLineName,
-              eventGroupReferenceId = refId,
-              impressionsMetadataBucket = impressionsMetadataBucket,
-              entityKeys = entityKeys,
-            )
-          logger.info("Storing impression metadata for edp: $edpResourceName (shared ref=$refId)")
-          saveImpressionMetadata(impressionsMetadata, edpResourceName)
-        }
-      }
+          }
+          .toMap()
 
-      // Create metadata for legacy/single-entity-key mapped event groups.
+      // Create impression metadata in a single pass over mapped event groups.
+      val processedOriginalRefIds = mutableSetOf<String>()
       mappedEventGroups.forEach { mappedEventGroup ->
         val mappedRefId = mappedEventGroup.eventGroupReferenceId
-        if (handledMultiEntityKeyRefIds.contains(mappedRefId)) return@forEach
         val resolvedConfig = configByRefId[mappedRefId] ?: return@forEach
-        val metaSpec =
-          when (resolvedConfig) {
-            is EventGroupConfig.LegacySpec -> resolvedConfig.spec
-            is EventGroupConfig.MultiEntityKey -> resolvedConfig.entityKeySpecs.single().spec
-          }
-        val allDates: List<LocalDate> =
-          SyntheticDataGeneration.generateEvents(
-              TestEvent.getDefaultInstance(),
-              populationSpec,
-              metaSpec,
-            )
-            .map { it.localDate }
-            .toList()
-        val startDate = allDates.min()
-        val endExclusive = allDates.max().plusDays(1)
-
-        val eventGroupReferenceId = mappedRefId
-        val eventGroupPath =
-          "model-line/$modelLineName/event-group-reference-id/$eventGroupReferenceId"
         val impressionsMetadataBucket = "$IMPRESSIONS_METADATA_BUCKET-$edpAggregatorShortName"
 
-        val impressionsMetadata: List<ImpressionMetadata> =
-          buildImpressionMetadataForDateRange(
-            startInclusive = startDate,
-            endExclusive = endExclusive,
-            eventGroupPath = eventGroupPath,
-            modelLine = modelLineName,
-            eventGroupReferenceId = eventGroupReferenceId,
-            impressionsMetadataBucket = impressionsMetadataBucket,
-          )
-        logger.info("Storing impression metadata for edp: $edpResourceName")
-        saveImpressionMetadata(impressionsMetadata, edpResourceName)
+        when (resolvedConfig) {
+          is EventGroupConfig.MultiEntityKey -> {
+            val originalRefId = originalRefIdByDerivedRefId.getValue(mappedRefId)
+            if (!processedOriginalRefIds.add(originalRefId)) return@forEach
+            val originalConfig =
+              originalConfigs.getValue(originalRefId) as EventGroupConfig.MultiEntityKey
+            val allDates: List<LocalDate> =
+              originalConfig.entityKeySpecs
+                .flatMap { entityKeySpec ->
+                  SyntheticDataGeneration.generateEvents(
+                      TestEvent.getDefaultInstance(),
+                      populationSpec,
+                      entityKeySpec.spec,
+                    )
+                    .map { it.localDate }
+                    .toList()
+                }
+                .distinct()
+            val startDate = allDates.min()
+            val endExclusive = allDates.max().plusDays(1)
+            val eventGroupPath = "model-line/$modelLineName/event-group-reference-id/$originalRefId"
+            val entityKeys: List<org.wfanet.measurement.edpaggregator.v1alpha.EntityKey> =
+              originalConfig.entityKeySpecs.map { entityKeySpec ->
+                entityKey {
+                  entityType = entityKeySpec.entityKey.entityType
+                  entityId = entityKeySpec.entityKey.entityId
+                }
+              }
+            val impressionsMetadata: List<ImpressionMetadata> =
+              buildImpressionMetadataForDateRange(
+                startInclusive = startDate,
+                endExclusive = endExclusive,
+                eventGroupPath = eventGroupPath,
+                modelLine = modelLineName,
+                eventGroupReferenceId = originalRefId,
+                impressionsMetadataBucket = impressionsMetadataBucket,
+                entityKeys = entityKeys,
+              )
+            logger.info(
+              "Storing impression metadata for edp: $edpResourceName (shared ref=$originalRefId)"
+            )
+            saveImpressionMetadata(impressionsMetadata, edpResourceName)
+          }
+          is EventGroupConfig.LegacySpec -> {
+            val allDates: List<LocalDate> =
+              SyntheticDataGeneration.generateEvents(
+                  TestEvent.getDefaultInstance(),
+                  populationSpec,
+                  resolvedConfig.spec,
+                )
+                .map { it.localDate }
+                .toList()
+            val startDate = allDates.min()
+            val endExclusive = allDates.max().plusDays(1)
+            val eventGroupPath = "model-line/$modelLineName/event-group-reference-id/$mappedRefId"
+            val impressionsMetadata: List<ImpressionMetadata> =
+              buildImpressionMetadataForDateRange(
+                startInclusive = startDate,
+                endExclusive = endExclusive,
+                eventGroupPath = eventGroupPath,
+                modelLine = modelLineName,
+                eventGroupReferenceId = mappedRefId,
+                impressionsMetadataBucket = impressionsMetadataBucket,
+              )
+            logger.info("Storing impression metadata for edp: $edpResourceName")
+            saveImpressionMetadata(impressionsMetadata, edpResourceName)
+          }
+        }
       }
     }
     backgroundScope.launch { resultFulfillerApp.run() }

--- a/src/main/kotlin/org/wfanet/measurement/integration/common/InProcessEdpAggregatorComponents.kt
+++ b/src/main/kotlin/org/wfanet/measurement/integration/common/InProcessEdpAggregatorComponents.kt
@@ -92,6 +92,7 @@ import org.wfanet.measurement.edpaggregator.v1alpha.ImpressionMetadataServiceGrp
 import org.wfanet.measurement.edpaggregator.v1alpha.RequisitionMetadataServiceGrpcKt.RequisitionMetadataServiceCoroutineStub
 import org.wfanet.measurement.edpaggregator.v1alpha.ResultsFulfillerParams
 import org.wfanet.measurement.edpaggregator.v1alpha.createImpressionMetadataRequest
+import org.wfanet.measurement.edpaggregator.v1alpha.entityKey
 import org.wfanet.measurement.edpaggregator.v1alpha.impressionMetadata
 import org.wfanet.measurement.gcloud.pubsub.Subscriber
 import org.wfanet.measurement.gcloud.pubsub.testing.GooglePubSubEmulatorClient
@@ -359,14 +360,69 @@ class InProcessEdpAggregatorComponents(
       logger.info("Received mappedEventGroups: $mappedEventGroups")
       runBlocking { writeImpressionData(mappedEventGroups, edpAggregatorShortName) }
 
+      val originalConfigs: Map<String, EventGroupConfig> =
+        eventGroupConfigsByEdp.getValue(edpAggregatorShortName)
       val configByRefId: Map<String, EventGroupConfig> =
         resolveSpecsByReferenceId(edpAggregatorShortName)
 
+      // Create metadata for multi-entity-key configs under the shared ref ID.
+      val handledMultiEntityKeyRefIds = mutableSetOf<String>()
+      for ((refId, config) in originalConfigs) {
+        if (config is EventGroupConfig.MultiEntityKey) {
+          handledMultiEntityKeyRefIds += refId
+          config.entityKeySpecs.forEach { entityKeySpec ->
+            handledMultiEntityKeyRefIds +=
+              "${entityKeySpec.entityKey.entityType}/${entityKeySpec.entityKey.entityId}"
+          }
+          val allDates: List<LocalDate> =
+            config.entityKeySpecs
+              .flatMap { entityKeySpec ->
+                SyntheticDataGeneration.generateEvents(
+                    TestEvent.getDefaultInstance(),
+                    populationSpec,
+                    entityKeySpec.spec,
+                  )
+                  .map { it.localDate }
+                  .toList()
+              }
+              .distinct()
+          val startDate = allDates.min()
+          val endExclusive = allDates.max().plusDays(1)
+
+          val eventGroupPath = "model-line/$modelLineName/event-group-reference-id/$refId"
+          val impressionsMetadataBucket = "$IMPRESSIONS_METADATA_BUCKET-$edpAggregatorShortName"
+
+          val entityKeys: List<org.wfanet.measurement.edpaggregator.v1alpha.EntityKey> =
+            config.entityKeySpecs.map { entityKeySpec ->
+              entityKey {
+                entityType = entityKeySpec.entityKey.entityType
+                entityId = entityKeySpec.entityKey.entityId
+              }
+            }
+          val impressionsMetadata: List<ImpressionMetadata> =
+            buildImpressionMetadataForDateRange(
+              startInclusive = startDate,
+              endExclusive = endExclusive,
+              eventGroupPath = eventGroupPath,
+              modelLine = modelLineName,
+              eventGroupReferenceId = refId,
+              impressionsMetadataBucket = impressionsMetadataBucket,
+              entityKeys = entityKeys,
+            )
+          logger.info("Storing impression metadata for edp: $edpResourceName (shared ref=$refId)")
+          saveImpressionMetadata(impressionsMetadata, edpResourceName)
+        }
+      }
+
+      // Create metadata for legacy/single-entity-key mapped event groups.
       mappedEventGroups.forEach { mappedEventGroup ->
+        val mappedRefId = mappedEventGroup.eventGroupReferenceId
+        if (handledMultiEntityKeyRefIds.contains(mappedRefId)) return@forEach
+        val resolvedConfig = configByRefId[mappedRefId] ?: return@forEach
         val metaSpec =
-          when (val config = configByRefId.getValue(mappedEventGroup.eventGroupReferenceId)) {
-            is EventGroupConfig.LegacySpec -> config.spec
-            is EventGroupConfig.MultiEntityKey -> config.entityKeySpecs.single().spec
+          when (resolvedConfig) {
+            is EventGroupConfig.LegacySpec -> resolvedConfig.spec
+            is EventGroupConfig.MultiEntityKey -> resolvedConfig.entityKeySpecs.single().spec
           }
         val allDates: List<LocalDate> =
           SyntheticDataGeneration.generateEvents(
@@ -379,7 +435,7 @@ class InProcessEdpAggregatorComponents(
         val startDate = allDates.min()
         val endExclusive = allDates.max().plusDays(1)
 
-        val eventGroupReferenceId = mappedEventGroup.eventGroupReferenceId
+        val eventGroupReferenceId = mappedRefId
         val eventGroupPath =
           "model-line/$modelLineName/event-group-reference-id/$eventGroupReferenceId"
         val impressionsMetadataBucket = "$IMPRESSIONS_METADATA_BUCKET-$edpAggregatorShortName"
@@ -425,6 +481,7 @@ class InProcessEdpAggregatorComponents(
     eventGroupReferenceId: String,
     impressionsMetadataBucket: String,
     zoneId: ZoneId = ZONE_ID,
+    entityKeys: List<org.wfanet.measurement.edpaggregator.v1alpha.EntityKey> = emptyList(),
   ): List<ImpressionMetadata> {
 
     fun dailyInterval(day: LocalDate): Interval = interval {
@@ -450,6 +507,7 @@ class InProcessEdpAggregatorComponents(
         this.eventGroupReferenceId = eventGroupReferenceId
         this.modelLine = modelLine
         interval = perDayInterval
+        this.entityKeys += entityKeys
       }
       logger.info("Impression metadata object: $impressionMetadata")
       out += impressionMetadata
@@ -578,12 +636,65 @@ class InProcessEdpAggregatorComponents(
       )
     }
 
+    val originalConfigs: Map<String, EventGroupConfig> =
+      eventGroupConfigsByEdp.getValue(edpAggregatorShortName)
+
+    // Write multi-entity-key configs as shared blobs under their original ref ID.
+    val writtenMultiEntityKeyRefIds = mutableSetOf<String>()
+    for ((refId, config) in originalConfigs) {
+      when (config) {
+        is EventGroupConfig.MultiEntityKey -> {
+          writtenMultiEntityKeyRefIds += refId
+          config.entityKeySpecs.forEach { entityKeySpec ->
+            writtenMultiEntityKeyRefIds +=
+              "${entityKeySpec.entityKey.entityType}/${entityKeySpec.entityKey.entityId}"
+          }
+          val impressionWriter =
+            ImpressionsWriter(
+              refId,
+              "model-line/$modelLineName/event-group-reference-id/$refId",
+              kekUri,
+              kmsClient,
+              "$IMPRESSIONS_BUCKET-$edpAggregatorShortName",
+              "$IMPRESSIONS_METADATA_BUCKET-$edpAggregatorShortName",
+              storagePath.toFile(),
+              "file:///",
+            )
+          val shardsByDate =
+            mutableMapOf<LocalDate, MutableList<EntityKeysWithLabeledEvents<TestEvent>>>()
+          for (entityKeySpec in config.entityKeySpecs) {
+            val events =
+              SyntheticDataGeneration.generateEvents(
+                TestEvent.getDefaultInstance(),
+                populationSpec,
+                entityKeySpec.spec,
+              )
+            for (shard in events) {
+              shardsByDate
+                .getOrPut(shard.localDate) { mutableListOf() }
+                .add(
+                  EntityKeysWithLabeledEvents(listOf(entityKeySpec.entityKey), shard.labeledEvents)
+                )
+            }
+          }
+          val entityKeyedEvents: Sequence<EntityKeyedLabeledEventDateShard<TestEvent>> =
+            shardsByDate.entries
+              .sortedBy { it.key }
+              .asSequence()
+              .map { (date, groups) -> EntityKeyedLabeledEventDateShard(date, groups.asSequence()) }
+          impressionWriter.writeLabeledImpressionData(entityKeyedEvents, modelLineName, null)
+        }
+        is EventGroupConfig.LegacySpec -> {}
+      }
+    }
+
+    // Write legacy (non-multi-entity-key) configs as before.
     val configByRefId: Map<String, EventGroupConfig> =
       resolveSpecsByReferenceId(edpAggregatorShortName)
-
     mappedEventGroups.forEach { mappedEventGroup ->
       val refId = mappedEventGroup.eventGroupReferenceId
-      val resolvedConfig = configByRefId.getValue(refId)
+      if (refId in writtenMultiEntityKeyRefIds) return@forEach
+      val resolvedConfig = configByRefId[refId] ?: return@forEach
       val entityKey =
         when (resolvedConfig) {
           is EventGroupConfig.LegacySpec -> null

--- a/src/test/kotlin/org/wfanet/measurement/edpaggregator/resultsfulfiller/BUILD.bazel
+++ b/src/test/kotlin/org/wfanet/measurement/edpaggregator/resultsfulfiller/BUILD.bazel
@@ -200,6 +200,7 @@ kt_jvm_test(
     test_class = "org.wfanet.measurement.edpaggregator.resultsfulfiller.FilterProcessorTest",
     deps = [
         "//src/main/kotlin/org/wfanet/measurement/edpaggregator/resultsfulfiller:event_batch",
+        "//src/main/kotlin/org/wfanet/measurement/edpaggregator/resultsfulfiller:event_group_identifier",
         "//src/main/kotlin/org/wfanet/measurement/edpaggregator/resultsfulfiller:filter_processor",
         "//src/main/kotlin/org/wfanet/measurement/edpaggregator/resultsfulfiller:filter_spec",
         "//src/main/kotlin/org/wfanet/measurement/edpaggregator/resultsfulfiller:labeled_event",
@@ -273,6 +274,7 @@ kt_jvm_test(
     deps = [
         "//src/main/kotlin/org/wfanet/measurement/edpaggregator:storage_config",
         "//src/main/kotlin/org/wfanet/measurement/edpaggregator/resultsfulfiller:event_batch",
+        "//src/main/kotlin/org/wfanet/measurement/edpaggregator/resultsfulfiller:event_group_identifier",
         "//src/main/kotlin/org/wfanet/measurement/edpaggregator/resultsfulfiller:filter_processor",
         "//src/main/kotlin/org/wfanet/measurement/edpaggregator/resultsfulfiller:filter_spec",
         "//src/main/kotlin/org/wfanet/measurement/edpaggregator/resultsfulfiller:frequency_vector",
@@ -310,6 +312,7 @@ kt_jvm_test(
         "//src/main/kotlin/org/wfanet/measurement/edpaggregator:encrypted_storage",
         "//src/main/kotlin/org/wfanet/measurement/edpaggregator:storage_config",
         "//src/main/kotlin/org/wfanet/measurement/edpaggregator/resultsfulfiller:event_batch",
+        "//src/main/kotlin/org/wfanet/measurement/edpaggregator/resultsfulfiller:event_group_identifier",
         "//src/main/kotlin/org/wfanet/measurement/edpaggregator/resultsfulfiller:event_processing_orchestrator",
         "//src/main/kotlin/org/wfanet/measurement/edpaggregator/resultsfulfiller:event_reader",
         "//src/main/kotlin/org/wfanet/measurement/edpaggregator/resultsfulfiller:event_source",
@@ -351,6 +354,8 @@ kt_jvm_test(
     test_class = "org.wfanet.measurement.edpaggregator.resultsfulfiller.ParallelBatchedPipelineTest",
     deps = [
         "//src/main/kotlin/org/wfanet/measurement/edpaggregator:encrypted_storage",
+        "//src/main/kotlin/org/wfanet/measurement/edpaggregator/resultsfulfiller:event_batch",
+        "//src/main/kotlin/org/wfanet/measurement/edpaggregator/resultsfulfiller:event_group_identifier",
         "//src/main/kotlin/org/wfanet/measurement/edpaggregator:storage_config",
         "//src/main/kotlin/org/wfanet/measurement/edpaggregator/resultsfulfiller:event_reader",
         "//src/main/kotlin/org/wfanet/measurement/edpaggregator/resultsfulfiller:filter_spec",

--- a/src/test/kotlin/org/wfanet/measurement/edpaggregator/resultsfulfiller/BUILD.bazel
+++ b/src/test/kotlin/org/wfanet/measurement/edpaggregator/resultsfulfiller/BUILD.bazel
@@ -220,6 +220,7 @@ kt_jvm_test(
     test_class = "org.wfanet.measurement.edpaggregator.resultsfulfiller.StorageEventSourceTest",
     deps = [
         "//src/main/kotlin/org/wfanet/measurement/edpaggregator:storage_config",
+        "//src/main/kotlin/org/wfanet/measurement/edpaggregator/resultsfulfiller:impression_query_selector",
         "//src/main/kotlin/org/wfanet/measurement/edpaggregator/resultsfulfiller:event_reader",
         "//src/main/kotlin/org/wfanet/measurement/edpaggregator/resultsfulfiller:impression_data_source_provider",
         "//src/main/kotlin/org/wfanet/measurement/edpaggregator/resultsfulfiller:impression_read_exception",
@@ -253,6 +254,7 @@ kt_jvm_test(
     deps = [
         "//src/main/kotlin/org/wfanet/measurement/edpaggregator:storage_config",
         "//src/main/kotlin/org/wfanet/measurement/edpaggregator/resultsfulfiller:impression_data_source_provider",
+        "//src/main/kotlin/org/wfanet/measurement/edpaggregator/resultsfulfiller:impression_query_selector",
         "//src/main/proto/wfa/measurement/edpaggregator/v1alpha:blob_details_kt_jvm_proto",
         "@wfa_common_jvm//imports/java/com/google/common/truth",
         "@wfa_common_jvm//imports/java/com/google/protobuf",

--- a/src/test/kotlin/org/wfanet/measurement/edpaggregator/resultsfulfiller/BUILD.bazel
+++ b/src/test/kotlin/org/wfanet/measurement/edpaggregator/resultsfulfiller/BUILD.bazel
@@ -221,9 +221,9 @@ kt_jvm_test(
     test_class = "org.wfanet.measurement.edpaggregator.resultsfulfiller.StorageEventSourceTest",
     deps = [
         "//src/main/kotlin/org/wfanet/measurement/edpaggregator:storage_config",
-        "//src/main/kotlin/org/wfanet/measurement/edpaggregator/resultsfulfiller:impression_query_selector",
         "//src/main/kotlin/org/wfanet/measurement/edpaggregator/resultsfulfiller:event_reader",
         "//src/main/kotlin/org/wfanet/measurement/edpaggregator/resultsfulfiller:impression_data_source_provider",
+        "//src/main/kotlin/org/wfanet/measurement/edpaggregator/resultsfulfiller:impression_query_selector",
         "//src/main/kotlin/org/wfanet/measurement/edpaggregator/resultsfulfiller:impression_read_exception",
         "//src/main/kotlin/org/wfanet/measurement/edpaggregator/resultsfulfiller:labeled_event",
         "//src/main/kotlin/org/wfanet/measurement/edpaggregator/resultsfulfiller:storage_event_source",
@@ -354,9 +354,9 @@ kt_jvm_test(
     test_class = "org.wfanet.measurement.edpaggregator.resultsfulfiller.ParallelBatchedPipelineTest",
     deps = [
         "//src/main/kotlin/org/wfanet/measurement/edpaggregator:encrypted_storage",
+        "//src/main/kotlin/org/wfanet/measurement/edpaggregator:storage_config",
         "//src/main/kotlin/org/wfanet/measurement/edpaggregator/resultsfulfiller:event_batch",
         "//src/main/kotlin/org/wfanet/measurement/edpaggregator/resultsfulfiller:event_group_identifier",
-        "//src/main/kotlin/org/wfanet/measurement/edpaggregator:storage_config",
         "//src/main/kotlin/org/wfanet/measurement/edpaggregator/resultsfulfiller:event_reader",
         "//src/main/kotlin/org/wfanet/measurement/edpaggregator/resultsfulfiller:filter_spec",
         "//src/main/kotlin/org/wfanet/measurement/edpaggregator/resultsfulfiller:labeled_event",

--- a/src/test/kotlin/org/wfanet/measurement/edpaggregator/resultsfulfiller/EventProcessingIntegrationTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/edpaggregator/resultsfulfiller/EventProcessingIntegrationTest.kt
@@ -1119,8 +1119,7 @@ class EventProcessingIntegrationTest {
                   eventList,
                   minTime,
                   maxTime,
-                  eventGroupReferenceId = eventGroupReferenceId,
-                  entityKeys = emptyList(),
+                  eventGroupIdentifier = EventGroupIdentifier.ByReferenceId(eventGroupReferenceId),
                 )
               )
             }
@@ -1153,8 +1152,7 @@ class EventProcessingIntegrationTest {
                 eventList,
                 minTime,
                 maxTime,
-                eventGroupReferenceId = eventGroupReferenceId,
-                entityKeys = emptyList(),
+                eventGroupIdentifier = EventGroupIdentifier.ByReferenceId(eventGroupReferenceId),
               )
             )
           }
@@ -1725,8 +1723,7 @@ class EventProcessingIntegrationTest {
               labeledEvents,
               minTime,
               maxTime,
-              eventGroupReferenceId = eventGroupReferenceId,
-              entityKeys = groupedBatchEntityKeys,
+              eventGroupIdentifier = EventGroupIdentifier.ByEntityKeys(groupedBatchEntityKeys),
             )
           )
         }

--- a/src/test/kotlin/org/wfanet/measurement/edpaggregator/resultsfulfiller/FilterProcessorTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/edpaggregator/resultsfulfiller/FilterProcessorTest.kt
@@ -631,7 +631,9 @@ class FilterProcessorTest {
         filterProcessor.processBatch(
           createEventBatch(
             events,
-            EventGroupIdentifier.ByEntityKeys(listOf(makeEntityKeyGroup("ad", "X"))),
+            EventGroupIdentifier.ByEntityKeys(
+              listOf(makeEntityKeyGroup("ad", "X", "Y"), makeEntityKeyGroup("placement", "X"))
+            ),
           )
         )
 
@@ -754,7 +756,7 @@ class FilterProcessorTest {
         filterProcessor.processBatch(
           createEventBatch(
             events,
-            EventGroupIdentifier.ByEntityKeys(listOf(makeEntityKeyGroup("ad", "X"))),
+            EventGroupIdentifier.ByEntityKeys(listOf(makeEntityKeyGroup("ad", "X", "Y"))),
           )
         )
 

--- a/src/test/kotlin/org/wfanet/measurement/edpaggregator/resultsfulfiller/FilterProcessorTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/edpaggregator/resultsfulfiller/FilterProcessorTest.kt
@@ -649,14 +649,14 @@ class FilterProcessorTest {
 
       assertFailsWith<MissingBatchEntityKeysException> {
         filterProcessor.processBatch(
-          createEventBatch(events, EventGroupIdentifier.ByReferenceId("test-group"))
+          createEventBatch(events, EventGroupIdentifier.ByEntityKeys(emptyList()))
         )
       }
     }
   }
 
   @Test
-  fun `processBatch throws MissingBatchEntityKeysException when ByEntityKeys filter receives ByReferenceId batch`() {
+  fun `processBatch throws MismatchedBatchIdentifierException when ByEntityKeys filter receives ByReferenceId batch`() {
     runBlocking {
       val filterSpec = createTestFilterSpec(entityKeys = setOf(makeEntityKey("ad", "X")))
       val filterProcessor = FilterProcessor<Message>(filterSpec, testEventDescriptor)
@@ -670,12 +670,12 @@ class FilterProcessorTest {
           eventGroupIdentifier = EventGroupIdentifier.ByReferenceId("some-ref-id"),
         )
 
-      assertFailsWith<MissingBatchEntityKeysException> { filterProcessor.processBatch(batch) }
+      assertFailsWith<MismatchedBatchIdentifierException> { filterProcessor.processBatch(batch) }
     }
   }
 
   @Test
-  fun `processBatch with ByEventGroupReferenceIds filter skips ByEntityKeys batch`() {
+  fun `processBatch with ByEventGroupReferenceIds filter throws on ByEntityKeys batch`() {
     runBlocking {
       val filterSpec = createTestFilterSpec(eventGroupReferenceIds = listOf("test-group"))
       val filterProcessor = FilterProcessor<Message>(filterSpec, testEventDescriptor)
@@ -690,9 +690,7 @@ class FilterProcessorTest {
             EventGroupIdentifier.ByEntityKeys(listOf(makeEntityKeyGroup("ad", "X"))),
         )
 
-      val result = filterProcessor.processBatch(batch)
-
-      assertThat(result.events).isEmpty()
+      assertFailsWith<MismatchedBatchIdentifierException> { filterProcessor.processBatch(batch) }
     }
   }
 

--- a/src/test/kotlin/org/wfanet/measurement/edpaggregator/resultsfulfiller/FilterProcessorTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/edpaggregator/resultsfulfiller/FilterProcessorTest.kt
@@ -92,13 +92,13 @@ class FilterProcessorTest {
     val timestamps = events.map { it.timestamp }
     val minTime = timestamps.minOrNull() ?: Instant.now()
     val maxTime = timestamps.maxOrNull() ?: Instant.now()
-    return EventBatch(
-      events,
-      minTime,
-      maxTime,
-      eventGroupReferenceId = eventGroupReferenceId,
-      entityKeys = entityKeys,
-    )
+    val identifier =
+      if (entityKeys.isNotEmpty()) {
+        EventGroupIdentifier.ByEntityKeys(entityKeys)
+      } else {
+        EventGroupIdentifier.ByReferenceId(eventGroupReferenceId)
+      }
+    return EventBatch(events, minTime, maxTime, eventGroupIdentifier = identifier)
   }
 
   /** Helper function to create a default interval that covers a wide time range. */
@@ -648,6 +648,48 @@ class FilterProcessorTest {
       assertFailsWith<MissingBatchEntityKeysException> {
         filterProcessor.processBatch(createEventBatch(events))
       }
+    }
+  }
+
+  @Test
+  fun `processBatch throws MissingBatchEntityKeysException when ByEntityKeys filter receives ByReferenceId batch`() {
+    runBlocking {
+      val filterSpec = createTestFilterSpec(entityKeys = setOf(makeEntityKey("ad", "X")))
+      val filterProcessor = FilterProcessor<Message>(filterSpec, testEventDescriptor)
+
+      val events = listOf(createTestLabeledEvent(1, entityKeys = listOf(makeEntityKey("ad", "X"))))
+      val batch =
+        EventBatch(
+          events,
+          minTime = events.minOf { it.timestamp },
+          maxTime = events.maxOf { it.timestamp },
+          eventGroupIdentifier = EventGroupIdentifier.ByReferenceId("some-ref-id"),
+        )
+
+      assertFailsWith<MissingBatchEntityKeysException> { filterProcessor.processBatch(batch) }
+    }
+  }
+
+  @Test
+  fun `processBatch with entityKeys filter works when batch eventGroupReferenceId would be empty`() {
+    runBlocking {
+      val targetKey = makeEntityKey("ad", "X")
+      val filterSpec = createTestFilterSpec(entityKeys = setOf(targetKey))
+      val filterProcessor = FilterProcessor<Message>(filterSpec, testEventDescriptor)
+
+      val events = listOf(createTestLabeledEvent(1, entityKeys = listOf(targetKey)))
+      val batch =
+        EventBatch(
+          events,
+          minTime = events.minOf { it.timestamp },
+          maxTime = events.maxOf { it.timestamp },
+          eventGroupIdentifier =
+            EventGroupIdentifier.ByEntityKeys(listOf(makeEntityKeyGroup("ad", "X"))),
+        )
+
+      val result = filterProcessor.processBatch(batch)
+
+      assertThat(result.events.map { it.vid }).containsExactly(1L)
     }
   }
 

--- a/src/test/kotlin/org/wfanet/measurement/edpaggregator/resultsfulfiller/FilterProcessorTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/edpaggregator/resultsfulfiller/FilterProcessorTest.kt
@@ -86,19 +86,12 @@ class FilterProcessorTest {
   /** Helper function to create an EventBatch with proper minTime and maxTime. */
   private fun createEventBatch(
     events: List<LabeledEvent<Message>>,
-    eventGroupReferenceId: String = "test-group",
-    entityKeys: List<EntityKeyGroup> = emptyList(),
+    eventGroupIdentifier: EventGroupIdentifier,
   ): EventBatch<Message> {
     val timestamps = events.map { it.timestamp }
     val minTime = timestamps.minOrNull() ?: Instant.now()
     val maxTime = timestamps.maxOrNull() ?: Instant.now()
-    val identifier =
-      if (entityKeys.isNotEmpty()) {
-        EventGroupIdentifier.ByEntityKeys(entityKeys)
-      } else {
-        EventGroupIdentifier.ByReferenceId(eventGroupReferenceId)
-      }
-    return EventBatch(events, minTime, maxTime, eventGroupIdentifier = identifier)
+    return EventBatch(events, minTime, maxTime, eventGroupIdentifier = eventGroupIdentifier)
   }
 
   /** Helper function to create a default interval that covers a wide time range. */
@@ -177,7 +170,7 @@ class FilterProcessorTest {
           ),
         )
 
-      val batch = createEventBatch(events)
+      val batch = createEventBatch(events, EventGroupIdentifier.ByReferenceId("test-group"))
       val result = filterProcessor.processBatch(batch)
 
       assertThat(result.events).hasSize(2)
@@ -210,7 +203,7 @@ class FilterProcessorTest {
           ),
         )
 
-      val batch = createEventBatch(events)
+      val batch = createEventBatch(events, EventGroupIdentifier.ByReferenceId("test-group"))
       val result = filterProcessor.processBatch(batch)
 
       assertThat(result.events).hasSize(3)
@@ -252,7 +245,7 @@ class FilterProcessorTest {
           ), // After range
         )
 
-      val batch = createEventBatch(events)
+      val batch = createEventBatch(events, EventGroupIdentifier.ByReferenceId("test-group"))
       val result = filterProcessor.processBatch(batch)
 
       // Only event 2 should match (within time range)
@@ -280,7 +273,7 @@ class FilterProcessorTest {
           createTestLabeledEvent(3, entityKeys = emptyList()),
         )
 
-      val batch = createEventBatch(events)
+      val batch = createEventBatch(events, EventGroupIdentifier.ByReferenceId("test-group"))
       val result = filterProcessor.processBatch(batch)
 
       // All events should pass since the batch's eventGroupReferenceId matches
@@ -339,7 +332,7 @@ class FilterProcessorTest {
           ),
         )
 
-      val batch = createEventBatch(events)
+      val batch = createEventBatch(events, EventGroupIdentifier.ByReferenceId("test-group"))
       val result = filterProcessor.processBatch(batch)
 
       // Events 1 and 3 should match (male, within time range); event 4 is outside time range
@@ -383,7 +376,7 @@ class FilterProcessorTest {
           ),
         )
 
-      val batch = createEventBatch(events)
+      val batch = createEventBatch(events, EventGroupIdentifier.ByReferenceId("test-group"))
       val result = filterProcessor.processBatch(batch)
 
       assertThat(result.events).hasSize(2)
@@ -426,7 +419,7 @@ class FilterProcessorTest {
           ),
         )
 
-      val batch = createEventBatch(events)
+      val batch = createEventBatch(events, EventGroupIdentifier.ByReferenceId("test-group"))
       val result = filterProcessor.processBatch(batch)
 
       // Should return empty batch since no time overlap
@@ -469,7 +462,7 @@ class FilterProcessorTest {
           ), // After interval
         )
 
-      val batch = createEventBatch(events)
+      val batch = createEventBatch(events, EventGroupIdentifier.ByReferenceId("test-group"))
       val result = filterProcessor.processBatch(batch)
 
       // Should process batch and filter individual events - only event 2 should match
@@ -513,7 +506,7 @@ class FilterProcessorTest {
           ),
         )
 
-      val batch = createEventBatch(events)
+      val batch = createEventBatch(events, EventGroupIdentifier.ByReferenceId("test-group"))
       val result = filterProcessor.processBatch(batch)
 
       // Should return empty batch since no time overlap
@@ -565,7 +558,7 @@ class FilterProcessorTest {
           ), // Exactly at end (exclusive)
         )
 
-      val batch = createEventBatch(events)
+      val batch = createEventBatch(events, EventGroupIdentifier.ByReferenceId("test-group"))
       val result = filterProcessor.processBatch(batch)
 
       // Events 2, 3, and 4 should match (start inclusive, end exclusive)
@@ -588,7 +581,10 @@ class FilterProcessorTest {
           createTestLabeledEvent(3, entityKeys = listOf(makeEntityKey("placement", "P"))),
         )
 
-      val result = filterProcessor.processBatch(createEventBatch(events))
+      val result =
+        filterProcessor.processBatch(
+          createEventBatch(events, EventGroupIdentifier.ByReferenceId("test-group"))
+        )
 
       assertThat(result.events.map { it.vid }).containsExactly(1L, 2L, 3L).inOrder()
     }
@@ -609,7 +605,10 @@ class FilterProcessorTest {
 
       val result =
         filterProcessor.processBatch(
-          createEventBatch(events, entityKeys = listOf(makeEntityKeyGroup("ad", "X", "Y")))
+          createEventBatch(
+            events,
+            EventGroupIdentifier.ByEntityKeys(listOf(makeEntityKeyGroup("ad", "X", "Y"))),
+          )
         )
 
       assertThat(result.events.map { it.vid }).containsExactly(1L, 2L).inOrder()
@@ -630,7 +629,10 @@ class FilterProcessorTest {
 
       val result =
         filterProcessor.processBatch(
-          createEventBatch(events, entityKeys = listOf(makeEntityKeyGroup("ad", "X")))
+          createEventBatch(
+            events,
+            EventGroupIdentifier.ByEntityKeys(listOf(makeEntityKeyGroup("ad", "X"))),
+          )
         )
 
       assertThat(result.events).isEmpty()
@@ -646,7 +648,9 @@ class FilterProcessorTest {
       val events = listOf(createTestLabeledEvent(1, entityKeys = emptyList()))
 
       assertFailsWith<MissingBatchEntityKeysException> {
-        filterProcessor.processBatch(createEventBatch(events))
+        filterProcessor.processBatch(
+          createEventBatch(events, EventGroupIdentifier.ByReferenceId("test-group"))
+        )
       }
     }
   }
@@ -667,6 +671,28 @@ class FilterProcessorTest {
         )
 
       assertFailsWith<MissingBatchEntityKeysException> { filterProcessor.processBatch(batch) }
+    }
+  }
+
+  @Test
+  fun `processBatch with ByEventGroupReferenceIds filter skips ByEntityKeys batch`() {
+    runBlocking {
+      val filterSpec = createTestFilterSpec(eventGroupReferenceIds = listOf("test-group"))
+      val filterProcessor = FilterProcessor<Message>(filterSpec, testEventDescriptor)
+
+      val events = listOf(createTestLabeledEvent(1, entityKeys = listOf(makeEntityKey("ad", "X"))))
+      val batch =
+        EventBatch(
+          events,
+          minTime = events.minOf { it.timestamp },
+          maxTime = events.maxOf { it.timestamp },
+          eventGroupIdentifier =
+            EventGroupIdentifier.ByEntityKeys(listOf(makeEntityKeyGroup("ad", "X"))),
+        )
+
+      val result = filterProcessor.processBatch(batch)
+
+      assertThat(result.events).isEmpty()
     }
   }
 
@@ -728,7 +754,10 @@ class FilterProcessorTest {
 
       val result =
         filterProcessor.processBatch(
-          createEventBatch(events, entityKeys = listOf(makeEntityKeyGroup("ad", "X")))
+          createEventBatch(
+            events,
+            EventGroupIdentifier.ByEntityKeys(listOf(makeEntityKeyGroup("ad", "X"))),
+          )
         )
 
       assertThat(result.events.map { it.vid }).containsExactly(1L)
@@ -757,7 +786,10 @@ class FilterProcessorTest {
 
       val result =
         filterProcessor.processBatch(
-          createEventBatch(events, entityKeys = listOf(makeEntityKeyGroup("ad", "X", "Y")))
+          createEventBatch(
+            events,
+            EventGroupIdentifier.ByEntityKeys(listOf(makeEntityKeyGroup("ad", "X", "Y"))),
+          )
         )
 
       // Batch's event_group_reference_id "test-group" is NOT in the spec, but it is processed
@@ -846,7 +878,10 @@ class FilterProcessorTest {
         )
       val batchKeys = listOf(makeEntityKeyGroup("ad", "X", "Y"))
 
-      val result = filterProcessor.processBatch(createEventBatch(events, entityKeys = batchKeys))
+      val result =
+        filterProcessor.processBatch(
+          createEventBatch(events, EventGroupIdentifier.ByEntityKeys(batchKeys))
+        )
 
       assertThat(result.events.map { it.vid }).containsExactly(1L)
     }
@@ -863,7 +898,10 @@ class FilterProcessorTest {
       val events = listOf(createTestLabeledEvent(1, entityKeys = listOf(makeEntityKey("ad", "X"))))
       val batchKeys = listOf(makeEntityKeyGroup("placement", "P"))
 
-      val result = filterProcessor.processBatch(createEventBatch(events, entityKeys = batchKeys))
+      val result =
+        filterProcessor.processBatch(
+          createEventBatch(events, EventGroupIdentifier.ByEntityKeys(batchKeys))
+        )
 
       assertThat(result.events).isEmpty()
     }

--- a/src/test/kotlin/org/wfanet/measurement/edpaggregator/resultsfulfiller/FilterProcessorTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/edpaggregator/resultsfulfiller/FilterProcessorTest.kt
@@ -906,4 +906,93 @@ class FilterProcessorTest {
       assertThat(result.events).isEmpty()
     }
   }
+
+  @Test
+  fun `processBatch MatchedAllEvents when batch keys are proper subset of filter keys`() {
+    runBlocking {
+      val filterSpec =
+        createTestFilterSpec(entityKeys = setOf(makeEntityKey("ad", "X"), makeEntityKey("ad", "Y")))
+      val filterProcessor = FilterProcessor<Message>(filterSpec, testEventDescriptor)
+
+      val events =
+        listOf(
+          createTestLabeledEvent(1, entityKeys = listOf(makeEntityKey("ad", "X"))),
+          createTestLabeledEvent(2, entityKeys = listOf(makeEntityKey("ad", "X"))),
+        )
+
+      val result =
+        filterProcessor.processBatch(
+          createEventBatch(
+            events,
+            EventGroupIdentifier.ByEntityKeys(listOf(makeEntityKeyGroup("ad", "X"))),
+          )
+        )
+
+      assertThat(result.events.map { it.vid }).containsExactly(1L, 2L).inOrder()
+    }
+  }
+
+  @Test
+  fun `processBatch MatchedAllEvents when multiple batch keys all contained in filter`() {
+    runBlocking {
+      val filterSpec =
+        createTestFilterSpec(
+          entityKeys =
+            setOf(
+              makeEntityKey("ad", "X"),
+              makeEntityKey("ad", "Y"),
+              makeEntityKey("placement", "P"),
+            )
+        )
+      val filterProcessor = FilterProcessor<Message>(filterSpec, testEventDescriptor)
+
+      val events =
+        listOf(
+          createTestLabeledEvent(1, entityKeys = listOf(makeEntityKey("ad", "X"))),
+          createTestLabeledEvent(2, entityKeys = listOf(makeEntityKey("ad", "Y"))),
+          createTestLabeledEvent(3, entityKeys = listOf(makeEntityKey("placement", "P"))),
+        )
+
+      val result =
+        filterProcessor.processBatch(
+          createEventBatch(
+            events,
+            EventGroupIdentifier.ByEntityKeys(
+              listOf(makeEntityKeyGroup("ad", "X", "Y"), makeEntityKeyGroup("placement", "P"))
+            ),
+          )
+        )
+
+      assertThat(result.events.map { it.vid }).containsExactly(1L, 2L, 3L).inOrder()
+    }
+  }
+
+  @Test
+  fun `processBatch MatchedAllEvents keeps all events without per-event filtering`() {
+    runBlocking {
+      val filterSpec =
+        createTestFilterSpec(entityKeys = setOf(makeEntityKey("ad", "X"), makeEntityKey("ad", "Y")))
+      val filterProcessor = FilterProcessor<Message>(filterSpec, testEventDescriptor)
+
+      val events =
+        listOf(
+          createTestLabeledEvent(1, entityKeys = listOf(makeEntityKey("ad", "X"))),
+          createTestLabeledEvent(2, entityKeys = listOf(makeEntityKey("ad", "Y"))),
+          createTestLabeledEvent(
+            3,
+            entityKeys = listOf(makeEntityKey("ad", "X"), makeEntityKey("ad", "Y")),
+          ),
+        )
+
+      val result =
+        filterProcessor.processBatch(
+          createEventBatch(
+            events,
+            EventGroupIdentifier.ByEntityKeys(listOf(makeEntityKeyGroup("ad", "X", "Y"))),
+          )
+        )
+
+      assertThat(result.events.map { it.vid }).containsExactly(1L, 2L, 3L).inOrder()
+    }
+  }
 }

--- a/src/test/kotlin/org/wfanet/measurement/edpaggregator/resultsfulfiller/FilterProcessorTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/edpaggregator/resultsfulfiller/FilterProcessorTest.kt
@@ -995,4 +995,55 @@ class FilterProcessorTest {
       assertThat(result.events.map { it.vid }).containsExactly(1L, 2L, 3L).inOrder()
     }
   }
+
+  @Test
+  fun `matchBatch returns NoMatch for disjoint entity key sets`() {
+    val filterSpec =
+      FilterSpec.ByEntityKeys(
+        celExpression = "",
+        collectionInterval = createDefaultInterval(),
+        entityKeys = setOf(makeEntityKey("ad", "X")),
+      )
+
+    val result =
+      filterSpec.matchBatch(
+        EventGroupIdentifier.ByEntityKeys(listOf(makeEntityKeyGroup("placement", "P")))
+      )
+
+    assertThat(result).isEqualTo(BatchMatchResult.NoMatch)
+  }
+
+  @Test
+  fun `matchBatch returns MatchedAllEvents when batch keys are subset of filter keys`() {
+    val filterSpec =
+      FilterSpec.ByEntityKeys(
+        celExpression = "",
+        collectionInterval = createDefaultInterval(),
+        entityKeys = setOf(makeEntityKey("ad", "X"), makeEntityKey("ad", "Y")),
+      )
+
+    val result =
+      filterSpec.matchBatch(
+        EventGroupIdentifier.ByEntityKeys(listOf(makeEntityKeyGroup("ad", "X")))
+      )
+
+    assertThat(result).isEqualTo(BatchMatchResult.MatchedAllEvents)
+  }
+
+  @Test
+  fun `matchBatch returns MatchedByEntityKeys when batch keys partially overlap filter keys`() {
+    val filterSpec =
+      FilterSpec.ByEntityKeys(
+        celExpression = "",
+        collectionInterval = createDefaultInterval(),
+        entityKeys = setOf(makeEntityKey("ad", "X")),
+      )
+
+    val result =
+      filterSpec.matchBatch(
+        EventGroupIdentifier.ByEntityKeys(listOf(makeEntityKeyGroup("ad", "X", "Y")))
+      )
+
+    assertThat(result).isInstanceOf(BatchMatchResult.MatchedByEntityKeys::class.java)
+  }
 }

--- a/src/test/kotlin/org/wfanet/measurement/edpaggregator/resultsfulfiller/FrequencyVectorSinkTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/edpaggregator/resultsfulfiller/FrequencyVectorSinkTest.kt
@@ -55,8 +55,7 @@ class FrequencyVectorSinkTest {
         events = events,
         minTime = testInstant,
         maxTime = testInstant,
-        eventGroupReferenceId = "test-group",
-        entityKeys = emptyList(),
+        eventGroupIdentifier = EventGroupIdentifier.ByReferenceId("test-group"),
       )
     }
 

--- a/src/test/kotlin/org/wfanet/measurement/edpaggregator/resultsfulfiller/ImpressionDataSourceProviderTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/edpaggregator/resultsfulfiller/ImpressionDataSourceProviderTest.kt
@@ -29,6 +29,8 @@ import org.junit.rules.TemporaryFolder
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.wfanet.measurement.common.grpc.testing.GrpcTestServerRule
 import org.wfanet.measurement.common.grpc.testing.mockService
@@ -37,7 +39,9 @@ import org.wfanet.measurement.edpaggregator.StorageConfig
 import org.wfanet.measurement.edpaggregator.v1alpha.EncryptedDek
 import org.wfanet.measurement.edpaggregator.v1alpha.ImpressionMetadata
 import org.wfanet.measurement.edpaggregator.v1alpha.ImpressionMetadataServiceGrpcKt
+import org.wfanet.measurement.edpaggregator.v1alpha.ListImpressionMetadataRequest
 import org.wfanet.measurement.edpaggregator.v1alpha.blobDetails
+import org.wfanet.measurement.edpaggregator.v1alpha.entityKey
 import org.wfanet.measurement.edpaggregator.v1alpha.impressionMetadata
 import org.wfanet.measurement.edpaggregator.v1alpha.listImpressionMetadataResponse
 import org.wfanet.measurement.storage.filesystem.FileSystemStorageClient
@@ -176,5 +180,83 @@ class ImpressionDataSourceProviderTest {
     } catch (e: ImpressionReadException) {
       assertThat(e.code).isEqualTo(ImpressionReadException.Code.BLOB_NOT_FOUND)
     }
+  }
+
+  @Test
+  fun `storage-backed returns one source for entity key query`(): Unit = runBlocking {
+    val svc = createService()
+    val bucketName = "meta-bucket"
+    val bucketDir = File(tmp.root, bucketName)
+    bucketDir.mkdirs()
+
+    val date = LocalDate.of(2025, 1, 15)
+    val sharedRefId = "multi-creative"
+    val key = "ds/$date/model-line/$modelLine/event-group-reference-id/$sharedRefId/metadata"
+    val blobDetailsBytes =
+      blobDetails {
+          blobUri = "file:///impressions/$date/$sharedRefId"
+          encryptedDek = EncryptedDek.getDefaultInstance()
+        }
+        .toByteString()
+    val fs = FileSystemStorageClient(bucketDir)
+    fs.writeBlob(key, blobDetailsBytes)
+
+    val start = date.atStartOfDay(ZoneId.of("UTC")).toInstant()
+    val end = date.plusDays(1).atStartOfDay(ZoneId.of("UTC")).toInstant()
+
+    val queryEntityKey = entityKey {
+      entityType = "creative-id"
+      entityId = "creative-a"
+    }
+
+    whenever(impressionMetadataServiceMock.listImpressionMetadata(any()))
+      .thenReturn(
+        listImpressionMetadataResponse {
+          impressionMetadata += impressionMetadata {
+            state = ImpressionMetadata.State.ACTIVE
+            blobUri = "file:///$bucketName/$key"
+            eventGroupReferenceId = sharedRefId
+            interval = interval {
+              startTime = timestamp {
+                seconds = start.epochSecond
+                nanos = start.nano
+              }
+              endTime = timestamp {
+                seconds = end.epochSecond
+                nanos = end.nano
+              }
+            }
+          }
+        }
+      )
+
+    val sources =
+      svc.listImpressionDataSources(
+        modelLine = modelLine,
+        entityKey = queryEntityKey,
+        period =
+          interval {
+            startTime = timestamp {
+              seconds = start.epochSecond
+              nanos = start.nano
+            }
+            endTime = timestamp {
+              seconds = end.epochSecond
+              nanos = end.nano
+            }
+          },
+      )
+
+    assertThat(sources).hasSize(1)
+    assertThat(sources[0].blobDetails.blobUri).isEqualTo("file:///impressions/$date/$sharedRefId")
+    assertThat(sources[0].eventGroupReferenceId).isEqualTo(sharedRefId)
+
+    val captor = argumentCaptor<ListImpressionMetadataRequest>()
+    verify(impressionMetadataServiceMock).listImpressionMetadata(captor.capture())
+    val request = captor.firstValue
+    assertThat(request.filter.entityKeysList).hasSize(1)
+    assertThat(request.filter.entityKeysList[0].entityType).isEqualTo("creative-id")
+    assertThat(request.filter.entityKeysList[0].entityId).isEqualTo("creative-a")
+    assertThat(request.filter.eventGroupReferenceId).isEmpty()
   }
 }

--- a/src/test/kotlin/org/wfanet/measurement/edpaggregator/resultsfulfiller/ImpressionDataSourceProviderTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/edpaggregator/resultsfulfiller/ImpressionDataSourceProviderTest.kt
@@ -22,7 +22,6 @@ import com.google.type.interval
 import java.io.File
 import java.time.LocalDate
 import java.time.ZoneId
-import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.runBlocking
 import org.junit.Rule
 import org.junit.Test
@@ -392,7 +391,7 @@ class ImpressionDataSourceProviderTest {
     }
 
   @Test
-  fun `getImpressionsMetadataByEntityKey builds correct filter`(): Unit = runBlocking {
+  fun `listImpressionDataSources by entity key builds correct filter`(): Unit = runBlocking {
     val svc = createService()
 
     whenever(impressionMetadataServiceMock.listImpressionMetadata(any()))
@@ -418,7 +417,7 @@ class ImpressionDataSourceProviderTest {
       }
     }
 
-    val results = svc.getImpressionsMetadataByEntityKey(modelLine, queryEntityKey, period).toList()
+    val results = svc.listImpressionDataSources(modelLine, queryEntityKey, period)
 
     assertThat(results).isEmpty()
 

--- a/src/test/kotlin/org/wfanet/measurement/edpaggregator/resultsfulfiller/ImpressionDataSourceProviderTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/edpaggregator/resultsfulfiller/ImpressionDataSourceProviderTest.kt
@@ -249,7 +249,6 @@ class ImpressionDataSourceProviderTest {
 
     assertThat(sources).hasSize(1)
     assertThat(sources[0].blobDetails.blobUri).isEqualTo("file:///impressions/$date/$sharedRefId")
-    assertThat(sources[0].eventGroupReferenceId).isEqualTo(sharedRefId)
 
     val captor = argumentCaptor<ListImpressionMetadataRequest>()
     verify(impressionMetadataServiceMock).listImpressionMetadata(captor.capture())
@@ -342,7 +341,6 @@ class ImpressionDataSourceProviderTest {
       for ((i, source) in sources.withIndex()) {
         assertThat(source.blobDetails.blobUri)
           .isEqualTo("file:///impressions/${dates[i]}/${sharedRefIds[i]}")
-        assertThat(source.eventGroupReferenceId).isEqualTo(sharedRefIds[i])
       }
 
       val captor = argumentCaptor<ListImpressionMetadataRequest>()

--- a/src/test/kotlin/org/wfanet/measurement/edpaggregator/resultsfulfiller/ImpressionDataSourceProviderTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/edpaggregator/resultsfulfiller/ImpressionDataSourceProviderTest.kt
@@ -41,7 +41,6 @@ import org.wfanet.measurement.edpaggregator.v1alpha.ImpressionMetadata
 import org.wfanet.measurement.edpaggregator.v1alpha.ImpressionMetadataServiceGrpcKt
 import org.wfanet.measurement.edpaggregator.v1alpha.ListImpressionMetadataRequest
 import org.wfanet.measurement.edpaggregator.v1alpha.blobDetails
-import org.wfanet.measurement.edpaggregator.v1alpha.entityKey
 import org.wfanet.measurement.edpaggregator.v1alpha.impressionMetadata
 import org.wfanet.measurement.edpaggregator.v1alpha.listImpressionMetadataResponse
 import org.wfanet.measurement.storage.filesystem.FileSystemStorageClient
@@ -119,7 +118,7 @@ class ImpressionDataSourceProviderTest {
     val sources =
       svc.listImpressionDataSources(
         modelLine = modelLine,
-        eventGroupReferenceId = eventGroupRef,
+        selector = ImpressionQuerySelector.ByEventGroupReferenceId(eventGroupRef),
         period =
           interval {
             startTime = timestamp {
@@ -163,7 +162,7 @@ class ImpressionDataSourceProviderTest {
     try {
       svc.listImpressionDataSources(
         modelLine = modelLine,
-        eventGroupReferenceId = "eg-3",
+        selector = ImpressionQuerySelector.ByEventGroupReferenceId("eg-3"),
         period =
           interval {
             startTime = timestamp {
@@ -204,10 +203,11 @@ class ImpressionDataSourceProviderTest {
     val start = date.atStartOfDay(ZoneId.of("UTC")).toInstant()
     val end = date.plusDays(1).atStartOfDay(ZoneId.of("UTC")).toInstant()
 
-    val queryEntityKey = entityKey {
-      entityType = "creative-id"
-      entityId = "creative-a"
-    }
+    val queryEntityKey =
+      org.wfanet.measurement.edpaggregator.v1alpha.entityKey {
+        entityType = "creative-id"
+        entityId = "creative-a"
+      }
 
     whenever(impressionMetadataServiceMock.listImpressionMetadata(any()))
       .thenReturn(
@@ -233,7 +233,7 @@ class ImpressionDataSourceProviderTest {
     val sources =
       svc.listImpressionDataSources(
         modelLine = modelLine,
-        entityKey = queryEntityKey,
+        selector = ImpressionQuerySelector.ByEntityKey(queryEntityKey),
         period =
           interval {
             startTime = timestamp {
@@ -315,15 +315,16 @@ class ImpressionDataSourceProviderTest {
       whenever(impressionMetadataServiceMock.listImpressionMetadata(any()))
         .thenReturn(listImpressionMetadataResponse { impressionMetadata += metadataEntries })
 
-      val queryEntityKey = entityKey {
-        entityType = "campaign-id"
-        entityId = "campaign-123"
-      }
+      val queryEntityKey =
+        org.wfanet.measurement.edpaggregator.v1alpha.entityKey {
+          entityType = "campaign-id"
+          entityId = "campaign-123"
+        }
 
       val sources =
         svc.listImpressionDataSources(
           modelLine = modelLine,
-          entityKey = queryEntityKey,
+          selector = ImpressionQuerySelector.ByEntityKey(queryEntityKey),
           period =
             interval {
               startTime = timestamp {
@@ -361,10 +362,11 @@ class ImpressionDataSourceProviderTest {
       whenever(impressionMetadataServiceMock.listImpressionMetadata(any()))
         .thenReturn(listImpressionMetadataResponse {})
 
-      val queryEntityKey = entityKey {
-        entityType = "creative-id"
-        entityId = "nonexistent"
-      }
+      val queryEntityKey =
+        org.wfanet.measurement.edpaggregator.v1alpha.entityKey {
+          entityType = "creative-id"
+          entityId = "nonexistent"
+        }
 
       val date = LocalDate.of(2025, 3, 1)
       val start = date.atStartOfDay(ZoneId.of("UTC")).toInstant()
@@ -373,7 +375,7 @@ class ImpressionDataSourceProviderTest {
       val sources =
         svc.listImpressionDataSources(
           modelLine = modelLine,
-          entityKey = queryEntityKey,
+          selector = ImpressionQuerySelector.ByEntityKey(queryEntityKey),
           period =
             interval {
               startTime = timestamp {
@@ -397,10 +399,11 @@ class ImpressionDataSourceProviderTest {
     whenever(impressionMetadataServiceMock.listImpressionMetadata(any()))
       .thenReturn(listImpressionMetadataResponse {})
 
-    val queryEntityKey = entityKey {
-      entityType = "placement-id"
-      entityId = "placement-42"
-    }
+    val queryEntityKey =
+      org.wfanet.measurement.edpaggregator.v1alpha.entityKey {
+        entityType = "placement-id"
+        entityId = "placement-42"
+      }
 
     val date = LocalDate.of(2025, 4, 10)
     val start = date.atStartOfDay(ZoneId.of("UTC")).toInstant()
@@ -417,7 +420,12 @@ class ImpressionDataSourceProviderTest {
       }
     }
 
-    val results = svc.listImpressionDataSources(modelLine, queryEntityKey, period)
+    val results =
+      svc.listImpressionDataSources(
+        modelLine,
+        ImpressionQuerySelector.ByEntityKey(queryEntityKey),
+        period,
+      )
 
     assertThat(results).isEmpty()
 

--- a/src/test/kotlin/org/wfanet/measurement/edpaggregator/resultsfulfiller/ImpressionDataSourceProviderTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/edpaggregator/resultsfulfiller/ImpressionDataSourceProviderTest.kt
@@ -22,6 +22,7 @@ import com.google.type.interval
 import java.io.File
 import java.time.LocalDate
 import java.time.ZoneId
+import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.runBlocking
 import org.junit.Rule
 import org.junit.Test
@@ -258,5 +259,177 @@ class ImpressionDataSourceProviderTest {
     assertThat(request.filter.entityKeysList[0].entityType).isEqualTo("creative-id")
     assertThat(request.filter.entityKeysList[0].entityId).isEqualTo("creative-a")
     assertThat(request.filter.eventGroupReferenceId).isEmpty()
+  }
+
+  @Test
+  fun `storage-backed returns multiple sources for multi-day entity key query`(): Unit =
+    runBlocking {
+      val svc = createService()
+      val bucketName = "meta-bucket"
+      val bucketDir = File(tmp.root, bucketName)
+      bucketDir.mkdirs()
+
+      val dates =
+        listOf(LocalDate.of(2025, 1, 15), LocalDate.of(2025, 1, 16), LocalDate.of(2025, 1, 17))
+      val sharedRefIds = listOf("ref-a", "ref-b", "ref-c")
+      val fs = FileSystemStorageClient(bucketDir)
+
+      for ((i, date) in dates.withIndex()) {
+        val refId = sharedRefIds[i]
+        val key = "ds/$date/model-line/$modelLine/event-group-reference-id/$refId/metadata"
+        val blobDetailsBytes =
+          blobDetails {
+              blobUri = "file:///impressions/$date/$refId"
+              encryptedDek = EncryptedDek.getDefaultInstance()
+            }
+            .toByteString()
+        fs.writeBlob(key, blobDetailsBytes)
+      }
+
+      val start = dates.first().atStartOfDay(ZoneId.of("UTC")).toInstant()
+      val end = dates.last().plusDays(1).atStartOfDay(ZoneId.of("UTC")).toInstant()
+
+      val testModelLine = modelLine
+      val metadataEntries =
+        dates.mapIndexed { i, date ->
+          val refId = sharedRefIds[i]
+          val dayStart = date.atStartOfDay(ZoneId.of("UTC")).toInstant()
+          val dayEnd = date.plusDays(1).atStartOfDay(ZoneId.of("UTC")).toInstant()
+          impressionMetadata {
+            state = ImpressionMetadata.State.ACTIVE
+            blobUri =
+              "file:///$bucketName/ds/$date/model-line/$testModelLine/event-group-reference-id/$refId/metadata"
+            eventGroupReferenceId = refId
+            interval = interval {
+              startTime = timestamp {
+                seconds = dayStart.epochSecond
+                nanos = dayStart.nano
+              }
+              endTime = timestamp {
+                seconds = dayEnd.epochSecond
+                nanos = dayEnd.nano
+              }
+            }
+          }
+        }
+
+      whenever(impressionMetadataServiceMock.listImpressionMetadata(any()))
+        .thenReturn(listImpressionMetadataResponse { impressionMetadata += metadataEntries })
+
+      val queryEntityKey = entityKey {
+        entityType = "campaign-id"
+        entityId = "campaign-123"
+      }
+
+      val sources =
+        svc.listImpressionDataSources(
+          modelLine = modelLine,
+          entityKey = queryEntityKey,
+          period =
+            interval {
+              startTime = timestamp {
+                seconds = start.epochSecond
+                nanos = start.nano
+              }
+              endTime = timestamp {
+                seconds = end.epochSecond
+                nanos = end.nano
+              }
+            },
+        )
+
+      assertThat(sources).hasSize(3)
+      for ((i, source) in sources.withIndex()) {
+        assertThat(source.blobDetails.blobUri)
+          .isEqualTo("file:///impressions/${dates[i]}/${sharedRefIds[i]}")
+        assertThat(source.eventGroupReferenceId).isEqualTo(sharedRefIds[i])
+      }
+
+      val captor = argumentCaptor<ListImpressionMetadataRequest>()
+      verify(impressionMetadataServiceMock).listImpressionMetadata(captor.capture())
+      val request = captor.firstValue
+      assertThat(request.filter.entityKeysList).hasSize(1)
+      assertThat(request.filter.entityKeysList[0].entityType).isEqualTo("campaign-id")
+      assertThat(request.filter.entityKeysList[0].entityId).isEqualTo("campaign-123")
+      assertThat(request.filter.eventGroupReferenceId).isEmpty()
+    }
+
+  @Test
+  fun `storage-backed returns empty list when no metadata matches entity key`(): Unit =
+    runBlocking {
+      val svc = createService()
+
+      whenever(impressionMetadataServiceMock.listImpressionMetadata(any()))
+        .thenReturn(listImpressionMetadataResponse {})
+
+      val queryEntityKey = entityKey {
+        entityType = "creative-id"
+        entityId = "nonexistent"
+      }
+
+      val date = LocalDate.of(2025, 3, 1)
+      val start = date.atStartOfDay(ZoneId.of("UTC")).toInstant()
+      val end = date.plusDays(1).atStartOfDay(ZoneId.of("UTC")).toInstant()
+
+      val sources =
+        svc.listImpressionDataSources(
+          modelLine = modelLine,
+          entityKey = queryEntityKey,
+          period =
+            interval {
+              startTime = timestamp {
+                seconds = start.epochSecond
+                nanos = start.nano
+              }
+              endTime = timestamp {
+                seconds = end.epochSecond
+                nanos = end.nano
+              }
+            },
+        )
+
+      assertThat(sources).isEmpty()
+    }
+
+  @Test
+  fun `getImpressionsMetadataByEntityKey builds correct filter`(): Unit = runBlocking {
+    val svc = createService()
+
+    whenever(impressionMetadataServiceMock.listImpressionMetadata(any()))
+      .thenReturn(listImpressionMetadataResponse {})
+
+    val queryEntityKey = entityKey {
+      entityType = "placement-id"
+      entityId = "placement-42"
+    }
+
+    val date = LocalDate.of(2025, 4, 10)
+    val start = date.atStartOfDay(ZoneId.of("UTC")).toInstant()
+    val end = date.plusDays(5).atStartOfDay(ZoneId.of("UTC")).toInstant()
+
+    val period = interval {
+      startTime = timestamp {
+        seconds = start.epochSecond
+        nanos = start.nano
+      }
+      endTime = timestamp {
+        seconds = end.epochSecond
+        nanos = end.nano
+      }
+    }
+
+    val results = svc.getImpressionsMetadataByEntityKey(modelLine, queryEntityKey, period).toList()
+
+    assertThat(results).isEmpty()
+
+    val captor = argumentCaptor<ListImpressionMetadataRequest>()
+    verify(impressionMetadataServiceMock).listImpressionMetadata(captor.capture())
+    val request = captor.firstValue
+    assertThat(request.filter.entityKeysList).hasSize(1)
+    assertThat(request.filter.entityKeysList[0].entityType).isEqualTo("placement-id")
+    assertThat(request.filter.entityKeysList[0].entityId).isEqualTo("placement-42")
+    assertThat(request.filter.eventGroupReferenceId).isEmpty()
+    assertThat(request.filter.modelLine).isEqualTo(modelLine)
+    assertThat(request.filter.hasIntervalOverlaps()).isTrue()
   }
 }

--- a/src/test/kotlin/org/wfanet/measurement/edpaggregator/resultsfulfiller/ParallelBatchedPipelineTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/edpaggregator/resultsfulfiller/ParallelBatchedPipelineTest.kt
@@ -77,8 +77,7 @@ class ParallelBatchedPipelineTest {
           events = events,
           minTime = minTime,
           maxTime = maxTime,
-          eventGroupReferenceId = "test-group",
-          entityKeys = emptyList(),
+          eventGroupIdentifier = EventGroupIdentifier.ByReferenceId("test-group"),
         )
       }
     }
@@ -478,8 +477,7 @@ class ParallelBatchedPipelineTest {
                 events = listOf(e),
                 minTime = now,
                 maxTime = now.plusSeconds(1),
-                eventGroupReferenceId = "reference-id-1",
-                entityKeys = emptyList(),
+                eventGroupIdentifier = EventGroupIdentifier.ByReferenceId("reference-id-1"),
               )
             )
           }
@@ -623,8 +621,7 @@ class ParallelBatchedPipelineTest {
                 events = listOf(e),
                 minTime = now,
                 maxTime = now.plusSeconds(1),
-                eventGroupReferenceId = "reference-id-1",
-                entityKeys = emptyList(),
+                eventGroupIdentifier = EventGroupIdentifier.ByReferenceId("reference-id-1"),
               )
             )
           }
@@ -695,8 +692,7 @@ class ParallelBatchedPipelineTest {
                 events = listOf(e),
                 minTime = now,
                 maxTime = now.plusSeconds(1),
-                eventGroupReferenceId = "reference-id-1",
-                entityKeys = emptyList(),
+                eventGroupIdentifier = EventGroupIdentifier.ByReferenceId("reference-id-1"),
               )
             )
             kotlinx.coroutines.yield() // Allow cancellation

--- a/src/test/kotlin/org/wfanet/measurement/edpaggregator/resultsfulfiller/ResultsFulfillerTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/edpaggregator/resultsfulfiller/ResultsFulfillerTest.kt
@@ -63,6 +63,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verifyBlocking
 import org.mockito.kotlin.whenever
@@ -150,6 +151,10 @@ import org.wfanet.measurement.edpaggregator.resultsfulfiller.fulfillers.HMShuffl
 import org.wfanet.measurement.edpaggregator.resultsfulfiller.fulfillers.TrusTeeMeasurementFulfiller
 import org.wfanet.measurement.edpaggregator.v1alpha.BlobDetails
 import org.wfanet.measurement.edpaggregator.v1alpha.EncryptedDek
+import org.wfanet.measurement.edpaggregator.v1alpha.GroupedRequisitionsKt
+import org.wfanet.measurement.edpaggregator.v1alpha.GroupedRequisitionsKt.eventGroupDetails
+import org.wfanet.measurement.edpaggregator.v1alpha.GroupedRequisitionsKt.eventGroupMapEntry
+import org.wfanet.measurement.edpaggregator.v1alpha.GroupedRequisitionsKt.requisitionEntry
 import org.wfanet.measurement.edpaggregator.v1alpha.ImpressionMetadata
 import org.wfanet.measurement.edpaggregator.v1alpha.ImpressionMetadataServiceGrpcKt
 import org.wfanet.measurement.edpaggregator.v1alpha.ImpressionMetadataServiceGrpcKt.ImpressionMetadataServiceCoroutineImplBase
@@ -160,6 +165,7 @@ import org.wfanet.measurement.edpaggregator.v1alpha.RequisitionMetadataServiceGr
 import org.wfanet.measurement.edpaggregator.v1alpha.RequisitionMetadataServiceGrpcKt.RequisitionMetadataServiceCoroutineStub
 import org.wfanet.measurement.edpaggregator.v1alpha.copy
 import org.wfanet.measurement.edpaggregator.v1alpha.encryptedDek
+import org.wfanet.measurement.edpaggregator.v1alpha.groupedRequisitions
 import org.wfanet.measurement.edpaggregator.v1alpha.impressionMetadata
 import org.wfanet.measurement.edpaggregator.v1alpha.listImpressionMetadataResponse
 import org.wfanet.measurement.edpaggregator.v1alpha.listRequisitionMetadataResponse
@@ -2751,6 +2757,112 @@ class ResultsFulfillerTest {
         startProcessingRequisitionMetadata(any())
       }
       verifyBlocking(requisitionMetadataServiceMock, times(1)) { fulfillRequisitionMetadata(any()) }
+    }
+
+  @Test
+  fun `runWork queries impression metadata by entity key when entity key is present`() =
+    runBlocking {
+      val impressionsTmpPath = Files.createTempDirectory(null).toFile()
+      val metadataTmpPath = Files.createTempDirectory(null).toFile()
+
+      whenever(impressionMetadataServiceMock.listImpressionMetadata(any()))
+        .thenReturn(listImpressionMetadataResponse {})
+
+      whenever(requisitionMetadataServiceMock.listRequisitionMetadata(any()))
+        .thenReturn(
+          listRequisitionMetadataResponse {
+            requisitionMetadata += requisitionMetadata {
+              state = RequisitionMetadata.State.STORED
+              cmmsCreateTime = timestamp { seconds = 12345 }
+              cmmsRequisition = REQUISITION_NAME
+              blobUri = "some-prefix"
+              blobTypeUrl = "some-blob-type-url"
+              groupId = "an-existing-group-id"
+              report = "report-name"
+            }
+          }
+        )
+      whenever(requisitionsServiceMock.getRequisition(any()))
+        .thenReturn(requisition { state = Requisition.State.UNFULFILLED })
+
+      val kmsClient = FakeKmsClient()
+      val kekUri = FakeKmsClient.KEY_URI_PREFIX + "kek"
+      val kmsKeyHandle = KeysetHandle.generateNew(KeyTemplates.get("AES128_GCM"))
+      kmsClient.setAead(kekUri, kmsKeyHandle.getPrimitive(Aead::class.java))
+
+      val impressionsMetadataService =
+        ImpressionDataSourceProvider(
+          impressionMetadataStub = impressionMetadataStub,
+          dataProvider = "dataProviders/123",
+          impressionsMetadataStorageConfig = StorageConfig(rootDirectory = metadataTmpPath),
+        )
+
+      val fulfillerSelector =
+        DefaultFulfillerSelector(
+          requisitionsStub = requisitionsStub,
+          requisitionFulfillmentStubMap = emptyMap<String, RequisitionFulfillmentCoroutineStub>(),
+          dataProviderCertificateKey = DATA_PROVIDER_CERTIFICATE_KEY,
+          dataProviderSigningKeyHandle = EDP_RESULT_SIGNING_KEY,
+          noiserSelector = ContinuousGaussianNoiseSelector(),
+          resultMinimumThresholds = null,
+          overrideImpressionMaxFrequencyPerUser = null,
+          supportedMultiPartyNoiseMechanisms = emptySet(),
+          trusTeeConfig =
+            TrusTeeConfig(
+              kmsClient = kmsClient,
+              workloadIdentityProvider = "test-wip",
+              impersonatedServiceAccount = "test-sa@example.com",
+              awsKmsParams = null,
+            ),
+          kekUriToKeyNameMap = emptyMap(),
+        )
+
+      val groupedReqs = groupedRequisitions {
+        modelLine = "some-model-line"
+        groupId = "entity-key-group"
+        eventGroupMap += eventGroupMapEntry {
+          eventGroup = EVENT_GROUP_NAME
+          details = eventGroupDetails {
+            eventGroupReferenceId = "creative-id/creative-a"
+            collectionIntervals += interval {
+              startTime = TIME_RANGE.start.toProtoTime()
+              endTime = TIME_RANGE.endExclusive.toProtoTime()
+            }
+            entityKey =
+              GroupedRequisitionsKt.EventGroupDetailsKt.entityKey {
+                entityType = "creative-id"
+                entityId = "creative-a"
+              }
+          }
+        }
+        requisitions += requisitionEntry { requisition = Any.pack(DIRECT_RNF_REQUISITION) }
+      }
+
+      val resultsFulfiller =
+        ResultsFulfiller(
+          dataProvider = EDP_NAME,
+          privateEncryptionKey = PRIVATE_ENCRYPTION_KEY,
+          requisitionMetadataStub = requisitionMetadataStub,
+          requisitionsStub = requisitionsStub,
+          groupedRequisitions = groupedReqs,
+          modelLineInfoMap = mapOf("some-model-line" to MODEL_LINE_INFO),
+          pipelineConfiguration = DEFAULT_PIPELINE_CONFIGURATION,
+          impressionDataSourceProvider = impressionsMetadataService,
+          impressionsStorageConfig = StorageConfig(rootDirectory = impressionsTmpPath),
+          kmsClient = kmsClient,
+          fulfillerSelector = fulfillerSelector,
+          metrics = metrics,
+        )
+
+      resultsFulfiller.fulfillRequisitions()
+
+      val captor = argumentCaptor<ListImpressionMetadataRequest>()
+      verifyBlocking(impressionMetadataServiceMock) { listImpressionMetadata(captor.capture()) }
+      val request = captor.firstValue
+      assertThat(request.filter.entityKeysList).hasSize(1)
+      assertThat(request.filter.entityKeysList[0].entityType).isEqualTo("creative-id")
+      assertThat(request.filter.entityKeysList[0].entityId).isEqualTo("creative-a")
+      assertThat(request.filter.eventGroupReferenceId).isEmpty()
     }
 
   private suspend fun createData(

--- a/src/test/kotlin/org/wfanet/measurement/edpaggregator/resultsfulfiller/ResultsFulfillerTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/edpaggregator/resultsfulfiller/ResultsFulfillerTest.kt
@@ -2865,6 +2865,110 @@ class ResultsFulfillerTest {
       assertThat(request.filter.eventGroupReferenceId).isEmpty()
     }
 
+  @Test
+  fun `runWork queries by entity key when eventGroupReferenceId is empty`() = runBlocking {
+    val impressionsTmpPath = Files.createTempDirectory(null).toFile()
+    val metadataTmpPath = Files.createTempDirectory(null).toFile()
+
+    whenever(impressionMetadataServiceMock.listImpressionMetadata(any()))
+      .thenReturn(listImpressionMetadataResponse {})
+
+    whenever(requisitionMetadataServiceMock.listRequisitionMetadata(any()))
+      .thenReturn(
+        listRequisitionMetadataResponse {
+          requisitionMetadata += requisitionMetadata {
+            state = RequisitionMetadata.State.STORED
+            cmmsCreateTime = timestamp { seconds = 12345 }
+            cmmsRequisition = REQUISITION_NAME
+            blobUri = "some-prefix"
+            blobTypeUrl = "some-blob-type-url"
+            groupId = "an-existing-group-id"
+            report = "report-name"
+          }
+        }
+      )
+    whenever(requisitionsServiceMock.getRequisition(any()))
+      .thenReturn(requisition { state = Requisition.State.UNFULFILLED })
+
+    val kmsClient = FakeKmsClient()
+    val kekUri = FakeKmsClient.KEY_URI_PREFIX + "kek"
+    val kmsKeyHandle = KeysetHandle.generateNew(KeyTemplates.get("AES128_GCM"))
+    kmsClient.setAead(kekUri, kmsKeyHandle.getPrimitive(Aead::class.java))
+
+    val impressionsMetadataService =
+      ImpressionDataSourceProvider(
+        impressionMetadataStub = impressionMetadataStub,
+        dataProvider = "dataProviders/123",
+        impressionsMetadataStorageConfig = StorageConfig(rootDirectory = metadataTmpPath),
+      )
+
+    val fulfillerSelector =
+      DefaultFulfillerSelector(
+        requisitionsStub = requisitionsStub,
+        requisitionFulfillmentStubMap = emptyMap<String, RequisitionFulfillmentCoroutineStub>(),
+        dataProviderCertificateKey = DATA_PROVIDER_CERTIFICATE_KEY,
+        dataProviderSigningKeyHandle = EDP_RESULT_SIGNING_KEY,
+        noiserSelector = ContinuousGaussianNoiseSelector(),
+        resultMinimumThresholds = null,
+        overrideImpressionMaxFrequencyPerUser = null,
+        supportedMultiPartyNoiseMechanisms = emptySet(),
+        trusTeeConfig =
+          TrusTeeConfig(
+            kmsClient = kmsClient,
+            workloadIdentityProvider = "test-wip",
+            impersonatedServiceAccount = "test-sa@example.com",
+            awsKmsParams = null,
+          ),
+        kekUriToKeyNameMap = emptyMap(),
+      )
+
+    val groupedReqs = groupedRequisitions {
+      modelLine = "some-model-line"
+      groupId = "entity-key-no-ref-id-group"
+      eventGroupMap += eventGroupMapEntry {
+        eventGroup = EVENT_GROUP_NAME
+        details = eventGroupDetails {
+          collectionIntervals += interval {
+            startTime = TIME_RANGE.start.toProtoTime()
+            endTime = TIME_RANGE.endExclusive.toProtoTime()
+          }
+          entityKey =
+            GroupedRequisitionsKt.EventGroupDetailsKt.entityKey {
+              entityType = "placement-id"
+              entityId = "placement-99"
+            }
+        }
+      }
+      requisitions += requisitionEntry { requisition = Any.pack(DIRECT_RNF_REQUISITION) }
+    }
+
+    val resultsFulfiller =
+      ResultsFulfiller(
+        dataProvider = EDP_NAME,
+        privateEncryptionKey = PRIVATE_ENCRYPTION_KEY,
+        requisitionMetadataStub = requisitionMetadataStub,
+        requisitionsStub = requisitionsStub,
+        groupedRequisitions = groupedReqs,
+        modelLineInfoMap = mapOf("some-model-line" to MODEL_LINE_INFO),
+        pipelineConfiguration = DEFAULT_PIPELINE_CONFIGURATION,
+        impressionDataSourceProvider = impressionsMetadataService,
+        impressionsStorageConfig = StorageConfig(rootDirectory = impressionsTmpPath),
+        kmsClient = kmsClient,
+        fulfillerSelector = fulfillerSelector,
+        metrics = metrics,
+      )
+
+    resultsFulfiller.fulfillRequisitions()
+
+    val captor = argumentCaptor<ListImpressionMetadataRequest>()
+    verifyBlocking(impressionMetadataServiceMock) { listImpressionMetadata(captor.capture()) }
+    val request = captor.firstValue
+    assertThat(request.filter.entityKeysList).hasSize(1)
+    assertThat(request.filter.entityKeysList[0].entityType).isEqualTo("placement-id")
+    assertThat(request.filter.entityKeysList[0].entityId).isEqualTo("placement-99")
+    assertThat(request.filter.eventGroupReferenceId).isEmpty()
+  }
+
   private suspend fun createData(
     kmsClient: KmsClient,
     kekUri: String,

--- a/src/test/kotlin/org/wfanet/measurement/edpaggregator/resultsfulfiller/StorageEventSourceTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/edpaggregator/resultsfulfiller/StorageEventSourceTest.kt
@@ -1278,6 +1278,56 @@ class StorageEventSourceTest {
     assertThat(request.filter.entityKeysList).isEmpty()
   }
 
+  @Test
+  fun `generateEventBatches throws when mixing entity-key and reference-id event groups`(): Unit =
+    runBlocking {
+      val (kmsClient, _, _) = createKmsSetup()
+
+      whenever(impressionMetadataServiceMock.listImpressionMetadata(any()))
+        .thenReturn(ListImpressionMetadataResponse.getDefaultInstance())
+
+      // One event group with entity key, one without
+      val eventGroupDetailsList =
+        listOf(
+          eventGroupDetails {
+            eventGroupReferenceId = "creative-id/creative-a"
+            entityKey =
+              EventGroupDetailsKt.entityKey {
+                entityType = "creative-id"
+                entityId = "creative-a"
+              }
+            collectionIntervals += interval {
+              startTime =
+                LocalDate.of(2025, 1, 1).atStartOfDay(ZoneId.of("UTC")).toInstant().toProtoTime()
+              endTime =
+                LocalDate.of(2025, 1, 2).atStartOfDay(ZoneId.of("UTC")).toInstant().toProtoTime()
+            }
+          },
+          createEventGroupDetails(
+            "standard-ref",
+            LocalDate.of(2025, 1, 1),
+            LocalDate.of(2025, 1, 2),
+            ZoneId.of("UTC"),
+          ),
+        )
+
+      val impressionService = createImpressionDataSourceProvider(tmp.root)
+      val eventSource =
+        StorageEventSource(
+          impressionDataSourceProvider = impressionService,
+          eventGroupDetailsList = eventGroupDetailsList,
+          modelLine = modelLine,
+          kmsClient = kmsClient,
+          impressionsStorageConfig = StorageConfig(rootDirectory = tmp.root),
+          descriptor = TestEvent.getDescriptor(),
+          batchSize = 1000,
+        )
+
+      val exception =
+        assertFailsWith<IllegalArgumentException> { eventSource.generateEventBatches().toList() }
+      assertThat(exception.message).isEqualTo("Cannot mix entity-key and reference-id event groups")
+    }
+
   companion object {
     private val TEST_EVENT = testEvent {
       person = person {

--- a/src/test/kotlin/org/wfanet/measurement/edpaggregator/resultsfulfiller/StorageEventSourceTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/edpaggregator/resultsfulfiller/StorageEventSourceTest.kt
@@ -1154,6 +1154,130 @@ class StorageEventSourceTest {
       assertThat(request.filter.eventGroupReferenceId).isEmpty()
     }
 
+  @Test
+  fun `generateEventBatches queries by eventGroupReferenceId when no entity key set`(): Unit =
+    runBlocking {
+      val date = LocalDate.of(2025, 1, 1)
+      val eventGroupRef = "standard-ref"
+
+      val (kmsClient, kekUri, serializedEncryptionKey) = createKmsSetup()
+
+      val impressionsTmpPath = tmp.newFolder("impressions-no-entity-key")
+      val metadataTmpPath = tmp.newFolder("metadata-no-entity-key")
+
+      createImpressionFilesForDate(
+        impressionsTmpPath,
+        metadataTmpPath,
+        date,
+        eventGroupRef,
+        kmsClient,
+        kekUri,
+        serializedEncryptionKey,
+      )
+
+      val metadataList =
+        createImpressionMetadataList(listOf(date), eventGroupRef, "meta-bucket", modelLine)
+
+      whenever(impressionMetadataServiceMock.listImpressionMetadata(any()))
+        .thenReturn(listImpressionMetadataResponse { impressionMetadata += metadataList })
+
+      val eventGroupDetailsList =
+        listOf(createEventGroupDetails(eventGroupRef, date, date.plusDays(1), ZoneId.of("UTC")))
+
+      val impressionService = createImpressionDataSourceProvider(metadataTmpPath)
+      val eventSource =
+        StorageEventSource(
+          impressionDataSourceProvider = impressionService,
+          eventGroupDetailsList = eventGroupDetailsList,
+          modelLine = modelLine,
+          kmsClient = kmsClient,
+          impressionsStorageConfig = StorageConfig(rootDirectory = impressionsTmpPath),
+          descriptor = TestEvent.getDescriptor(),
+          batchSize = 1000,
+        )
+
+      val batches = eventSource.generateEventBatches().toList()
+
+      assertThat(batches).isNotEmpty()
+      assertThat(batches.flatMap { it.events }).hasSize(5)
+
+      // Verify the request used eventGroupReferenceId filter, not entity_keys
+      val captor = argumentCaptor<ListImpressionMetadataRequest>()
+      verify(impressionMetadataServiceMock).listImpressionMetadata(captor.capture())
+      val request = captor.firstValue
+      assertThat(request.filter.eventGroupReferenceId).isEqualTo(eventGroupRef)
+      assertThat(request.filter.entityKeysList).isEmpty()
+    }
+
+  @Test
+  fun `generateEventBatches queries by eventGroupReferenceId when entity key has empty entityId`():
+    Unit = runBlocking {
+    val date = LocalDate.of(2025, 1, 1)
+    val eventGroupRef = "ref-with-empty-entity"
+
+    val (kmsClient, kekUri, serializedEncryptionKey) = createKmsSetup()
+
+    val impressionsTmpPath = tmp.newFolder("impressions-empty-entity")
+    val metadataTmpPath = tmp.newFolder("metadata-empty-entity")
+
+    createImpressionFilesForDate(
+      impressionsTmpPath,
+      metadataTmpPath,
+      date,
+      eventGroupRef,
+      kmsClient,
+      kekUri,
+      serializedEncryptionKey,
+    )
+
+    val metadataList =
+      createImpressionMetadataList(listOf(date), eventGroupRef, "meta-bucket", modelLine)
+
+    whenever(impressionMetadataServiceMock.listImpressionMetadata(any()))
+      .thenReturn(listImpressionMetadataResponse { impressionMetadata += metadataList })
+
+    // Entity key is present but entityId is empty - should fall back to ref ID query
+    val eventGroupDetailsList =
+      listOf(
+        eventGroupDetails {
+          eventGroupReferenceId = eventGroupRef
+          entityKey =
+            EventGroupDetailsKt.entityKey {
+              entityType = "creative-id"
+              entityId = ""
+            }
+          collectionIntervals += interval {
+            startTime = date.atStartOfDay(ZoneId.of("UTC")).toInstant().toProtoTime()
+            endTime = date.plusDays(1).atStartOfDay(ZoneId.of("UTC")).toInstant().toProtoTime()
+          }
+        }
+      )
+
+    val impressionService = createImpressionDataSourceProvider(metadataTmpPath)
+    val eventSource =
+      StorageEventSource(
+        impressionDataSourceProvider = impressionService,
+        eventGroupDetailsList = eventGroupDetailsList,
+        modelLine = modelLine,
+        kmsClient = kmsClient,
+        impressionsStorageConfig = StorageConfig(rootDirectory = impressionsTmpPath),
+        descriptor = TestEvent.getDescriptor(),
+        batchSize = 1000,
+      )
+
+    val batches = eventSource.generateEventBatches().toList()
+
+    assertThat(batches).isNotEmpty()
+    assertThat(batches.flatMap { it.events }).hasSize(5)
+
+    // Verify the request used eventGroupReferenceId filter, not entity_keys
+    val captor = argumentCaptor<ListImpressionMetadataRequest>()
+    verify(impressionMetadataServiceMock).listImpressionMetadata(captor.capture())
+    val request = captor.firstValue
+    assertThat(request.filter.eventGroupReferenceId).isEqualTo(eventGroupRef)
+    assertThat(request.filter.entityKeysList).isEmpty()
+  }
+
   companion object {
     private val TEST_EVENT = testEvent {
       person = person {

--- a/src/test/kotlin/org/wfanet/measurement/edpaggregator/resultsfulfiller/StorageEventSourceTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/edpaggregator/resultsfulfiller/StorageEventSourceTest.kt
@@ -346,7 +346,7 @@ class StorageEventSourceTest {
   }
 
   @Test
-  fun `generateEventBatches handles empty event group list`() {
+  fun `construction rejects empty event group list`() {
     val impressionService = createImpressionDataSourceProvider(tmp.root)
     val (kmsClient, kekUri, serializedEncryptionKey) = createKmsSetup()
 
@@ -1274,7 +1274,7 @@ class StorageEventSourceTest {
   }
 
   @Test
-  fun `generateEventBatches throws when mixing entity-key and reference-id event groups`(): Unit =
+  fun `construction throws when mixing entity-key and reference-id event groups`(): Unit =
     runBlocking {
       val (kmsClient, _, _) = createKmsSetup()
 

--- a/src/test/kotlin/org/wfanet/measurement/edpaggregator/resultsfulfiller/StorageEventSourceTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/edpaggregator/resultsfulfiller/StorageEventSourceTest.kt
@@ -45,6 +45,8 @@ import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 import org.mockito.Mockito.reset
 import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.wfanet.measurement.api.v2alpha.event_templates.testing.Person
 import org.wfanet.measurement.api.v2alpha.event_templates.testing.TestEvent
@@ -59,11 +61,13 @@ import org.wfanet.measurement.common.toProtoTime
 import org.wfanet.measurement.edpaggregator.StorageConfig
 import org.wfanet.measurement.edpaggregator.v1alpha.EncryptedDek
 import org.wfanet.measurement.edpaggregator.v1alpha.GroupedRequisitions
+import org.wfanet.measurement.edpaggregator.v1alpha.GroupedRequisitionsKt.EventGroupDetailsKt
 import org.wfanet.measurement.edpaggregator.v1alpha.GroupedRequisitionsKt.eventGroupDetails
 import org.wfanet.measurement.edpaggregator.v1alpha.ImpressionMetadata
 import org.wfanet.measurement.edpaggregator.v1alpha.ImpressionMetadataServiceGrpcKt.ImpressionMetadataServiceCoroutineImplBase
 import org.wfanet.measurement.edpaggregator.v1alpha.ImpressionMetadataServiceGrpcKt.ImpressionMetadataServiceCoroutineStub
 import org.wfanet.measurement.edpaggregator.v1alpha.LabeledImpression
+import org.wfanet.measurement.edpaggregator.v1alpha.ListImpressionMetadataRequest
 import org.wfanet.measurement.edpaggregator.v1alpha.ListImpressionMetadataResponse
 import org.wfanet.measurement.edpaggregator.v1alpha.blobDetails
 import org.wfanet.measurement.edpaggregator.v1alpha.encryptedDek
@@ -1072,6 +1076,83 @@ class StorageEventSourceTest {
 
     assertFailsWith<IllegalArgumentException> { eventSource.getKekUri() }
   }
+
+  @Test
+  fun `generateEventBatches queries by entity key when EventGroupDetails has entity key`(): Unit =
+    runBlocking {
+      val date = LocalDate.of(2025, 1, 1)
+      val sharedRefId = "multi-creative"
+      val entityKeyType = "creative-id"
+      val entityKeyId = "creative-a"
+
+      val (kmsClient, kekUri, serializedEncryptionKey) = createKmsSetup()
+
+      val impressionsTmpPath = tmp.newFolder("impressions-entity-key")
+      val metadataTmpPath = tmp.newFolder("metadata-entity-key")
+
+      createImpressionFilesForDate(
+        impressionsTmpPath,
+        metadataTmpPath,
+        date,
+        sharedRefId,
+        kmsClient,
+        kekUri,
+        serializedEncryptionKey,
+      )
+
+      val metadataList =
+        createImpressionMetadataList(listOf(date), sharedRefId, "meta-bucket", modelLine)
+
+      whenever(impressionMetadataServiceMock.listImpressionMetadata(any()))
+        .thenReturn(
+          listImpressionMetadataResponse { impressionMetadata += metadataList },
+          ListImpressionMetadataResponse.getDefaultInstance(),
+        )
+
+      val eventGroupDetailsList =
+        listOf(
+          eventGroupDetails {
+            eventGroupReferenceId = "$entityKeyType/$entityKeyId"
+            entityKey =
+              EventGroupDetailsKt.entityKey {
+                this.entityType = entityKeyType
+                this.entityId = entityKeyId
+              }
+            collectionIntervals += interval {
+              startTime = date.atStartOfDay(ZoneId.of("UTC")).toInstant().toProtoTime()
+              endTime = date.plusDays(1).atStartOfDay(ZoneId.of("UTC")).toInstant().toProtoTime()
+            }
+          }
+        )
+
+      val impressionService = createImpressionDataSourceProvider(metadataTmpPath)
+      val eventSource =
+        StorageEventSource(
+          impressionDataSourceProvider = impressionService,
+          eventGroupDetailsList = eventGroupDetailsList,
+          modelLine = modelLine,
+          kmsClient = kmsClient,
+          impressionsStorageConfig = StorageConfig(rootDirectory = impressionsTmpPath),
+          descriptor = TestEvent.getDescriptor(),
+          batchSize = 1000,
+        )
+
+      val batches = eventSource.generateEventBatches().toList()
+
+      assertThat(batches).isNotEmpty()
+      assertThat(batches.flatMap { it.events }).hasSize(5)
+
+      // Verify the request used entity_keys filter, not eventGroupReferenceId
+      val captor = argumentCaptor<ListImpressionMetadataRequest>()
+      org.mockito.kotlin
+        .verify(impressionMetadataServiceMock)
+        .listImpressionMetadata(captor.capture())
+      val request = captor.firstValue
+      assertThat(request.filter.entityKeysList).isNotEmpty()
+      assertThat(request.filter.entityKeysList.first().entityType).isEqualTo(entityKeyType)
+      assertThat(request.filter.entityKeysList.first().entityId).isEqualTo(entityKeyId)
+      assertThat(request.filter.eventGroupReferenceId).isEmpty()
+    }
 
   companion object {
     private val TEST_EVENT = testEvent {

--- a/src/test/kotlin/org/wfanet/measurement/edpaggregator/resultsfulfiller/StorageEventSourceTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/edpaggregator/resultsfulfiller/StorageEventSourceTest.kt
@@ -346,28 +346,23 @@ class StorageEventSourceTest {
   }
 
   @Test
-  fun `generateEventBatches handles empty event group list`(): Unit = runBlocking {
-    whenever(impressionMetadataServiceMock.listImpressionMetadata(any()))
-      .thenReturn(ListImpressionMetadataResponse.getDefaultInstance())
-
-    val eventGroupDetailsList = emptyList<GroupedRequisitions.EventGroupDetails>()
-
+  fun `generateEventBatches handles empty event group list`() {
     val impressionService = createImpressionDataSourceProvider(tmp.root)
     val (kmsClient, kekUri, serializedEncryptionKey) = createKmsSetup()
-    val eventSource =
-      StorageEventSource(
-        impressionDataSourceProvider = impressionService,
-        eventGroupDetailsList = eventGroupDetailsList,
-        modelLine = modelLine,
-        kmsClient = kmsClient,
-        impressionsStorageConfig = StorageConfig(rootDirectory = tmp.root),
-        descriptor = Empty.getDescriptor(),
-        batchSize = 1000,
-      )
 
-    val batches = eventSource.generateEventBatches().toList()
-
-    assertThat(batches).isEmpty()
+    val exception =
+      assertFailsWith<IllegalArgumentException> {
+        StorageEventSource(
+          impressionDataSourceProvider = impressionService,
+          eventGroupDetailsList = emptyList(),
+          modelLine = modelLine,
+          kmsClient = kmsClient,
+          impressionsStorageConfig = StorageConfig(rootDirectory = tmp.root),
+          descriptor = Empty.getDescriptor(),
+          batchSize = 1000,
+        )
+      }
+    assertThat(exception.message).isEqualTo("eventGroupDetailsList must not be empty")
   }
 
   @Test
@@ -1312,19 +1307,19 @@ class StorageEventSourceTest {
         )
 
       val impressionService = createImpressionDataSourceProvider(tmp.root)
-      val eventSource =
-        StorageEventSource(
-          impressionDataSourceProvider = impressionService,
-          eventGroupDetailsList = eventGroupDetailsList,
-          modelLine = modelLine,
-          kmsClient = kmsClient,
-          impressionsStorageConfig = StorageConfig(rootDirectory = tmp.root),
-          descriptor = TestEvent.getDescriptor(),
-          batchSize = 1000,
-        )
 
       val exception =
-        assertFailsWith<IllegalArgumentException> { eventSource.generateEventBatches().toList() }
+        assertFailsWith<IllegalArgumentException> {
+          StorageEventSource(
+            impressionDataSourceProvider = impressionService,
+            eventGroupDetailsList = eventGroupDetailsList,
+            modelLine = modelLine,
+            kmsClient = kmsClient,
+            impressionsStorageConfig = StorageConfig(rootDirectory = tmp.root),
+            descriptor = TestEvent.getDescriptor(),
+            batchSize = 1000,
+          )
+        }
       assertThat(exception.message).isEqualTo("Cannot mix entity-key and reference-id event groups")
     }
 


### PR DESCRIPTION
StorageEventSource.getUniqueImpressionDataSources() always queried ImpressionMetadata by eventGroupReferenceId. For per-entity-key EventGroups, the ref ID differs from the stored ref ID, returning zero results and producing reach=0.

This bug was not caught earlier because the in-process test also had a bug: it wrote each entity key impressions to separate files instead of combining them into a single shared blob per date (as the real cloud pipeline does). With separate files, the eventGroupReferenceId query happened to work. Fixing both the test data layout and the query logic surfaces and resolves the issue.

Introduces sealed EventGroupIdentifier on EventBatch (replacing two mutually-exclusive fields), sealed ImpressionQuerySelector for type-safe impression metadata queries, and moves batch-level selector dispatch into FilterSpec.matchBatch with a three-variant BatchMatchResult (NoMatch, MatchedAllEvents, MatchedByEntityKeys). The entity-key vs reference-id strategy is determined once at StorageEventSource construction as an immutable val and threaded through ResolvedEventReader to processEventReader without re-derivation. When all batch entity keys are contained in the filter, returns MatchedAllEvents to skip per-event filtering. Removes dead ImpressionDataSource.eventGroupReferenceId field and deduplicates ImpressionDataSourceProvider query methods.

Successful runs:
- Update CMMS (deploy): https://github.com/world-federation-of-advertisers/cross-media-measurement/actions/runs/26777935456

Issue: #3871