### PR TITLE
feat: Add RawImpressionUploadFile proto definitions for internal and public API

### DIFF
--- a/src/main/proto/wfa/measurement/edpaggregator/v1alpha/BUILD.bazel
+++ b/src/main/proto/wfa/measurement/edpaggregator/v1alpha/BUILD.bazel
@@ -349,3 +349,36 @@ kt_jvm_grpc_proto_library(
     name = "raw_impression_upload_service_kt_jvm_grpc_proto",
     deps = [":raw_impression_upload_service_proto"],
 )
+
+proto_library(
+    name = "raw_impression_upload_file_proto",
+    srcs = ["raw_impression_upload_file.proto"],
+    strip_import_prefix = _IMPORT_PREFIX,
+    deps = [
+        "@com_google_googleapis//google/api:field_behavior_proto",
+        "@com_google_googleapis//google/api:resource_proto",
+        "@com_google_protobuf//:timestamp_proto",
+    ],
+)
+
+kt_jvm_proto_library(
+    name = "raw_impression_upload_file_kt_jvm_proto",
+    deps = [":raw_impression_upload_file_proto"],
+)
+
+proto_library(
+    name = "raw_impression_upload_file_service_proto",
+    srcs = ["raw_impression_upload_file_service.proto"],
+    strip_import_prefix = _IMPORT_PREFIX,
+    deps = [
+        ":raw_impression_upload_file_proto",
+        "@com_google_googleapis//google/api:field_behavior_proto",
+        "@com_google_googleapis//google/api:field_info_proto",
+        "@com_google_googleapis//google/api:resource_proto",
+    ],
+)
+
+kt_jvm_grpc_proto_library(
+    name = "raw_impression_upload_file_service_kt_jvm_grpc_proto",
+    deps = [":raw_impression_upload_file_service_proto"],
+)

--- a/src/main/proto/wfa/measurement/edpaggregator/v1alpha/raw_impression_upload_file.proto
+++ b/src/main/proto/wfa/measurement/edpaggregator/v1alpha/raw_impression_upload_file.proto
@@ -1,0 +1,57 @@
+// Copyright 2026 The Cross-Media Measurement Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package wfa.measurement.edpaggregator.v1alpha;
+
+import "google/api/field_behavior.proto";
+import "google/api/resource.proto";
+import "google/protobuf/timestamp.proto";
+
+option java_package = "org.wfanet.measurement.edpaggregator.v1alpha";
+option java_multiple_files = true;
+option java_outer_classname = "RawImpressionUploadFileProto";
+
+// A raw impression file belonging to a RawImpressionUpload.
+message RawImpressionUploadFile {
+  option (google.api.resource) = {
+    type: "edpaggregator.halo-cmm.org/RawImpressionUploadFile"
+    pattern: "dataProviders/{data_provider}/rawImpressionUploads/{raw_impression_upload}/files/{file}"
+    singular: "rawImpressionUploadFile"
+    plural: "rawImpressionUploadFiles"
+  };
+
+  // Resource name.
+  string name = 1 [(google.api.field_behavior) = IDENTIFIER];
+
+  // Cloud Storage URI of the raw impression file.
+  string blob_uri = 2 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.field_behavior) = IMMUTABLE
+  ];
+
+  // The timestamp when this file was created.
+  google.protobuf.Timestamp create_time = 3
+      [(google.api.field_behavior) = OUTPUT_ONLY];
+
+  // The timestamp when this file was last updated.
+  google.protobuf.Timestamp update_time = 4
+      [(google.api.field_behavior) = OUTPUT_ONLY];
+
+  // The timestamp when this file was soft-deleted.
+  // Only populated if the file has been deleted.
+  google.protobuf.Timestamp delete_time = 5
+      [(google.api.field_behavior) = OUTPUT_ONLY];
+}

--- a/src/main/proto/wfa/measurement/edpaggregator/v1alpha/raw_impression_upload_file_service.proto
+++ b/src/main/proto/wfa/measurement/edpaggregator/v1alpha/raw_impression_upload_file_service.proto
@@ -99,6 +99,7 @@ message BatchCreateRawImpressionUploadFilesRequest {
 
 // Response message for the `BatchCreateRawImpressionUploadFiles` method.
 message BatchCreateRawImpressionUploadFilesResponse {
+  // The created files.
   repeated RawImpressionUploadFile raw_impression_upload_files = 1;
 }
 
@@ -157,6 +158,7 @@ message ListRawImpressionUploadFilesRequest {
 
 // Response message for the `ListRawImpressionUploadFiles` method.
 message ListRawImpressionUploadFilesResponse {
+  // The list of files matching the request.
   repeated RawImpressionUploadFile raw_impression_upload_files = 1;
 
   // A token to retrieve the next page of results.
@@ -195,5 +197,6 @@ message BatchDeleteRawImpressionUploadFilesRequest {
 
 // Response message for the `BatchDeleteRawImpressionUploadFiles` method.
 message BatchDeleteRawImpressionUploadFilesResponse {
+  // The deleted files.
   repeated RawImpressionUploadFile raw_impression_upload_files = 1;
 }

--- a/src/main/proto/wfa/measurement/edpaggregator/v1alpha/raw_impression_upload_file_service.proto
+++ b/src/main/proto/wfa/measurement/edpaggregator/v1alpha/raw_impression_upload_file_service.proto
@@ -188,7 +188,7 @@ message BatchDeleteRawImpressionUploadFilesRequest {
     }
   ];
 
-  // Individual delete requests. Maximum 100 per batch.
+  // Individual delete requests. Maximum 1000 per batch.
   repeated DeleteRawImpressionUploadFileRequest requests = 2
       [(google.api.field_behavior) = REQUIRED];
 }

--- a/src/main/proto/wfa/measurement/edpaggregator/v1alpha/raw_impression_upload_file_service.proto
+++ b/src/main/proto/wfa/measurement/edpaggregator/v1alpha/raw_impression_upload_file_service.proto
@@ -1,0 +1,199 @@
+// Copyright 2026 The Cross-Media Measurement Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package wfa.measurement.edpaggregator.v1alpha;
+
+import "google/api/field_behavior.proto";
+import "google/api/field_info.proto";
+import "google/api/resource.proto";
+import "wfa/measurement/edpaggregator/v1alpha/raw_impression_upload_file.proto";
+
+option java_package = "org.wfanet.measurement.edpaggregator.v1alpha";
+option java_multiple_files = true;
+option java_outer_classname = "RawImpressionUploadFileServiceProto";
+
+// Service for managing RawImpressionUploadFile resources.
+service RawImpressionUploadFileService {
+  // Creates a new RawImpressionUploadFile.
+  rpc CreateRawImpressionUploadFile(CreateRawImpressionUploadFileRequest)
+      returns (RawImpressionUploadFile) {}
+
+  // Creates multiple RawImpressionUploadFiles in a single request.
+  rpc BatchCreateRawImpressionUploadFiles(
+      BatchCreateRawImpressionUploadFilesRequest)
+      returns (BatchCreateRawImpressionUploadFilesResponse) {}
+
+  // Retrieves a specific RawImpressionUploadFile.
+  rpc GetRawImpressionUploadFile(GetRawImpressionUploadFileRequest)
+      returns (RawImpressionUploadFile) {}
+
+  // Lists RawImpressionUploadFiles for an upload.
+  rpc ListRawImpressionUploadFiles(ListRawImpressionUploadFilesRequest)
+      returns (ListRawImpressionUploadFilesResponse) {}
+
+  // Soft-deletes a RawImpressionUploadFile.
+  rpc DeleteRawImpressionUploadFile(DeleteRawImpressionUploadFileRequest)
+      returns (RawImpressionUploadFile) {}
+
+  // Soft-deletes multiple RawImpressionUploadFiles.
+  rpc BatchDeleteRawImpressionUploadFiles(
+      BatchDeleteRawImpressionUploadFilesRequest)
+      returns (BatchDeleteRawImpressionUploadFilesResponse) {}
+}
+
+// Request message for the `CreateRawImpressionUploadFile` method.
+message CreateRawImpressionUploadFileRequest {
+  // The parent upload resource name.
+  // Format:
+  // `dataProviders/{data_provider}/rawImpressionUploads/{raw_impression_upload}`
+  string parent = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference) = {
+      child_type: "edpaggregator.halo-cmm.org/RawImpressionUploadFile"
+    }
+  ];
+
+  // The RawImpressionUploadFile to create.
+  // The `name` and output-only fields are ignored.
+  RawImpressionUploadFile raw_impression_upload_file = 2
+      [(google.api.field_behavior) = REQUIRED];
+
+  // A request ID provided by the client to ensure idempotency.
+  //
+  // This field must be a UUID4 (RFC 4122) string.
+  string request_id = 3 [
+    (google.api.field_behavior) = OPTIONAL,
+    (google.api.field_info).format = UUID4
+  ];
+}
+
+// Request message for the `BatchCreateRawImpressionUploadFiles` method.
+message BatchCreateRawImpressionUploadFilesRequest {
+  // The parent upload resource name.
+  // Format:
+  // `dataProviders/{data_provider}/rawImpressionUploads/{raw_impression_upload}`
+  string parent = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference) = {
+      child_type: "edpaggregator.halo-cmm.org/RawImpressionUploadFile"
+    }
+  ];
+
+  // Individual create requests. Maximum 100 per batch.
+  repeated CreateRawImpressionUploadFileRequest requests = 2
+      [(google.api.field_behavior) = REQUIRED];
+}
+
+// Response message for the `BatchCreateRawImpressionUploadFiles` method.
+message BatchCreateRawImpressionUploadFilesResponse {
+  repeated RawImpressionUploadFile raw_impression_upload_files = 1;
+}
+
+// Request message for the `GetRawImpressionUploadFile` method.
+message GetRawImpressionUploadFileRequest {
+  // The resource name of the file to retrieve.
+  // Format:
+  // `dataProviders/{data_provider}/rawImpressionUploads/{raw_impression_upload}/files/{file}`
+  string name = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference) = {
+      type: "edpaggregator.halo-cmm.org/RawImpressionUploadFile"
+    }
+  ];
+}
+
+// Request message for the `ListRawImpressionUploadFiles` method.
+// (-- api-linter: core::0132::request-field-types=disabled
+//     aip.dev/not-precedent: Using a customized message for the filter. --)
+message ListRawImpressionUploadFilesRequest {
+  // The parent upload resource name.
+  // Format:
+  // `dataProviders/{data_provider}/rawImpressionUploads/{raw_impression_upload}`
+  //
+  // The upload segment may be the wildcard `-` to list
+  // files across all uploads for a data provider. See
+  // AIP-159.
+  string parent = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference) = {
+      child_type: "edpaggregator.halo-cmm.org/RawImpressionUploadFile"
+    }
+  ];
+
+  // The maximum number of results to return.
+  int32 page_size = 2 [(google.api.field_behavior) = OPTIONAL];
+
+  // A page token, received from a previous call.
+  string page_token = 3 [(google.api.field_behavior) = OPTIONAL];
+
+  // Structured filter for narrowing results.
+  // (-- api-linter: core::0140::prepositions=disabled
+  //     aip.dev/not-precedent: Using verb suffix per newer API
+  //     conventions. --)
+  message Filter {
+    // Filter by blob URIs.
+    repeated string blob_uri_in = 1 [(google.api.field_behavior) = OPTIONAL];
+  }
+
+  // Optional. A filter to apply to the results.
+  Filter filter = 4 [(google.api.field_behavior) = OPTIONAL];
+
+  // Whether to include soft-deleted entries.
+  bool show_deleted = 5 [(google.api.field_behavior) = OPTIONAL];
+}
+
+// Response message for the `ListRawImpressionUploadFiles` method.
+message ListRawImpressionUploadFilesResponse {
+  repeated RawImpressionUploadFile raw_impression_upload_files = 1;
+
+  // A token to retrieve the next page of results.
+  string next_page_token = 2;
+}
+
+// Request message for the `DeleteRawImpressionUploadFile` method.
+message DeleteRawImpressionUploadFileRequest {
+  // The resource name of the file to delete.
+  // Format:
+  // `dataProviders/{data_provider}/rawImpressionUploads/{raw_impression_upload}/files/{file}`
+  string name = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference) = {
+      type: "edpaggregator.halo-cmm.org/RawImpressionUploadFile"
+    }
+  ];
+}
+
+// Request message for the `BatchDeleteRawImpressionUploadFiles` method.
+message BatchDeleteRawImpressionUploadFilesRequest {
+  // The parent upload resource name.
+  // Format:
+  // `dataProviders/{data_provider}/rawImpressionUploads/{raw_impression_upload}`
+  string parent = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference) = {
+      child_type: "edpaggregator.halo-cmm.org/RawImpressionUploadFile"
+    }
+  ];
+
+  // Individual delete requests. Maximum 100 per batch.
+  repeated DeleteRawImpressionUploadFileRequest requests = 2
+      [(google.api.field_behavior) = REQUIRED];
+}
+
+// Response message for the `BatchDeleteRawImpressionUploadFiles` method.
+message BatchDeleteRawImpressionUploadFilesResponse {
+  repeated RawImpressionUploadFile raw_impression_upload_files = 1;
+}

--- a/src/main/proto/wfa/measurement/internal/edpaggregator/BUILD.bazel
+++ b/src/main/proto/wfa/measurement/internal/edpaggregator/BUILD.bazel
@@ -232,3 +232,32 @@ kt_jvm_grpc_proto_library(
     name = "raw_impression_upload_service_kt_jvm_grpc_proto",
     deps = [":raw_impression_upload_service_proto"],
 )
+
+proto_library(
+    name = "raw_impression_upload_file_proto",
+    srcs = ["raw_impression_upload_file.proto"],
+    strip_import_prefix = IMPORT_PREFIX,
+    deps = [
+        "@com_google_protobuf//:timestamp_proto",
+    ],
+)
+
+kt_jvm_proto_library(
+    name = "raw_impression_upload_file_kt_jvm_proto",
+    deps = [":raw_impression_upload_file_proto"],
+)
+
+proto_library(
+    name = "raw_impression_upload_file_service_proto",
+    srcs = ["raw_impression_upload_file_service.proto"],
+    strip_import_prefix = IMPORT_PREFIX,
+    deps = [
+        ":raw_impression_upload_file_proto",
+        "@com_google_protobuf//:timestamp_proto",
+    ],
+)
+
+kt_jvm_grpc_proto_library(
+    name = "raw_impression_upload_file_service_kt_jvm_grpc_proto",
+    deps = [":raw_impression_upload_file_service_proto"],
+)

--- a/src/main/proto/wfa/measurement/internal/edpaggregator/raw_impression_upload_file.proto
+++ b/src/main/proto/wfa/measurement/internal/edpaggregator/raw_impression_upload_file.proto
@@ -1,0 +1,47 @@
+// Copyright 2026 The Cross-Media Measurement Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package wfa.measurement.internal.edpaggregator;
+
+import "google/protobuf/timestamp.proto";
+
+option java_package = "org.wfanet.measurement.internal.edpaggregator";
+option java_multiple_files = true;
+option java_outer_classname = "RawImpressionUploadFileProto";
+
+// Internal representation of a raw impression file belonging to an upload.
+message RawImpressionUploadFile {
+  // Resource ID of the DataProvider that owns this file.
+  string data_provider_resource_id = 1;
+
+  // Resource ID of the parent upload.
+  string raw_impression_upload_resource_id = 2;
+
+  // Resource ID of this file.
+  string file_resource_id = 3;
+
+  // Cloud Storage URI of the raw impression file.
+  string blob_uri = 4;
+
+  // The timestamp when this file was created.
+  google.protobuf.Timestamp create_time = 5;
+
+  // The timestamp when this file was last updated.
+  google.protobuf.Timestamp update_time = 6;
+
+  // The timestamp when this file was soft-deleted.
+  google.protobuf.Timestamp delete_time = 7;
+}

--- a/src/main/proto/wfa/measurement/internal/edpaggregator/raw_impression_upload_file_service.proto
+++ b/src/main/proto/wfa/measurement/internal/edpaggregator/raw_impression_upload_file_service.proto
@@ -1,0 +1,167 @@
+// Copyright 2026 The Cross-Media Measurement Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package wfa.measurement.internal.edpaggregator;
+
+import "google/protobuf/timestamp.proto";
+import "wfa/measurement/internal/edpaggregator/raw_impression_upload_file.proto";
+
+option java_package = "org.wfanet.measurement.internal.edpaggregator";
+option java_multiple_files = true;
+option java_outer_classname = "RawImpressionUploadFileServiceProto";
+
+// Service for managing RawImpressionUploadFile resources.
+service RawImpressionUploadFileService {
+  // Creates a new RawImpressionUploadFile.
+  rpc CreateRawImpressionUploadFile(CreateRawImpressionUploadFileRequest)
+      returns (RawImpressionUploadFile);
+
+  // Creates multiple RawImpressionUploadFiles in a single request.
+  rpc BatchCreateRawImpressionUploadFiles(
+      BatchCreateRawImpressionUploadFilesRequest)
+      returns (BatchCreateRawImpressionUploadFilesResponse);
+
+  // Retrieves a specific RawImpressionUploadFile.
+  rpc GetRawImpressionUploadFile(GetRawImpressionUploadFileRequest)
+      returns (RawImpressionUploadFile);
+
+  // Lists RawImpressionUploadFiles for an upload.
+  rpc ListRawImpressionUploadFiles(ListRawImpressionUploadFilesRequest)
+      returns (ListRawImpressionUploadFilesResponse);
+
+  // Soft-deletes a RawImpressionUploadFile.
+  rpc DeleteRawImpressionUploadFile(DeleteRawImpressionUploadFileRequest)
+      returns (RawImpressionUploadFile);
+
+  // Soft-deletes multiple RawImpressionUploadFiles in a single request.
+  rpc BatchDeleteRawImpressionUploadFiles(
+      BatchDeleteRawImpressionUploadFilesRequest)
+      returns (BatchDeleteRawImpressionUploadFilesResponse);
+}
+
+// Request message for CreateRawImpressionUploadFile.
+message CreateRawImpressionUploadFileRequest {
+  // The RawImpressionUploadFile to create.
+  RawImpressionUploadFile raw_impression_upload_file = 1;
+
+  // A request ID provided by the client to ensure idempotency.
+  string request_id = 2;
+}
+
+// Request message for BatchCreateRawImpressionUploadFiles.
+message BatchCreateRawImpressionUploadFilesRequest {
+  // Resource ID of the DataProvider.
+  string data_provider_resource_id = 1;
+
+  // Resource ID of the parent upload.
+  string raw_impression_upload_resource_id = 2;
+
+  // Individual create requests. Maximum 100 per batch.
+  repeated CreateRawImpressionUploadFileRequest requests = 3;
+}
+
+// Response message for BatchCreateRawImpressionUploadFiles.
+message BatchCreateRawImpressionUploadFilesResponse {
+  repeated RawImpressionUploadFile raw_impression_upload_files = 1;
+}
+
+// Request message for GetRawImpressionUploadFile.
+message GetRawImpressionUploadFileRequest {
+  // Resource ID of the DataProvider.
+  string data_provider_resource_id = 1;
+
+  // Resource ID of the parent upload.
+  string raw_impression_upload_resource_id = 2;
+
+  // Resource ID of the file.
+  string file_resource_id = 3;
+}
+
+// Request message for ListRawImpressionUploadFiles.
+message ListRawImpressionUploadFilesRequest {
+  // Resource ID of the DataProvider.
+  string data_provider_resource_id = 1;
+
+  // Resource ID of the parent upload.
+  string raw_impression_upload_resource_id = 2;
+
+  // The maximum number of results to return.
+  //
+  // If unspecified, at most 50 results will be returned.
+  // The maximum value is 100; values above this will be
+  // coerced to the maximum value.
+  int32 page_size = 3;
+
+  // Page token from a previous list call.
+  ListRawImpressionUploadFilesPageToken page_token = 4;
+
+  // Filter for narrowing results.
+  message Filter {
+    // Filter by blob URIs.
+    repeated string blob_uri_in = 1;
+  }
+  Filter filter = 5;
+
+  // Whether to include soft-deleted entries.
+  bool show_deleted = 6;
+}
+
+// Response message for ListRawImpressionUploadFiles.
+message ListRawImpressionUploadFilesResponse {
+  repeated RawImpressionUploadFile raw_impression_upload_files = 1;
+
+  // A token to retrieve the next page of results.
+  ListRawImpressionUploadFilesPageToken next_page_token = 2;
+}
+
+// Page token for ListRawImpressionUploadFiles.
+message ListRawImpressionUploadFilesPageToken {
+  message After {
+    google.protobuf.Timestamp create_time = 1;
+    string raw_impression_upload_resource_id = 2;
+    string file_resource_id = 3;
+  }
+  After after = 1;
+}
+
+// Request message for DeleteRawImpressionUploadFile.
+message DeleteRawImpressionUploadFileRequest {
+  // Resource ID of the DataProvider.
+  string data_provider_resource_id = 1;
+
+  // Resource ID of the parent upload.
+  string raw_impression_upload_resource_id = 2;
+
+  // Resource ID of the file.
+  string file_resource_id = 3;
+}
+
+// Request message for BatchDeleteRawImpressionUploadFiles.
+message BatchDeleteRawImpressionUploadFilesRequest {
+  // Resource ID of the DataProvider.
+  string data_provider_resource_id = 1;
+
+  // Resource ID of the parent upload.
+  string raw_impression_upload_resource_id = 2;
+
+  // Individual delete requests.
+  repeated DeleteRawImpressionUploadFileRequest requests = 3;
+}
+
+// Response message for BatchDeleteRawImpressionUploadFiles.
+message BatchDeleteRawImpressionUploadFilesResponse {
+  repeated RawImpressionUploadFile raw_impression_upload_files = 1;
+}

--- a/src/main/proto/wfa/measurement/internal/edpaggregator/raw_impression_upload_service.proto
+++ b/src/main/proto/wfa/measurement/internal/edpaggregator/raw_impression_upload_service.proto
@@ -45,11 +45,14 @@ message CreateRawImpressionUploadRequest {
   // Resource ID of the DataProvider.
   string data_provider_resource_id = 1;
 
+  // Resource ID for the new upload.
+  string raw_impression_upload_id = 2;
+
   // The RawImpressionUpload to create.
-  RawImpressionUpload raw_impression_upload = 2;
+  RawImpressionUpload raw_impression_upload = 3;
 
   // A request ID provided by the client to ensure idempotency.
-  string request_id = 3;
+  string request_id = 4;
 }
 
 // Request message for GetRawImpressionUpload.

--- a/src/main/proto/wfa/measurement/internal/edpaggregator/raw_impression_upload_service.proto
+++ b/src/main/proto/wfa/measurement/internal/edpaggregator/raw_impression_upload_service.proto
@@ -45,14 +45,11 @@ message CreateRawImpressionUploadRequest {
   // Resource ID of the DataProvider.
   string data_provider_resource_id = 1;
 
-  // Resource ID for the new upload.
-  string raw_impression_upload_id = 2;
-
   // The RawImpressionUpload to create.
-  RawImpressionUpload raw_impression_upload = 3;
+  RawImpressionUpload raw_impression_upload = 2;
 
   // A request ID provided by the client to ensure idempotency.
-  string request_id = 4;
+  string request_id = 3;
 }
 
 // Request message for GetRawImpressionUpload.


### PR DESCRIPTION
## Summary
- Add proto message and service definitions for RawImpressionUploadFile, a child resource of RawImpressionUpload for tracking individual raw impression files.
- Includes create, batch create, get, list, delete (soft), and batch delete methods for both internal and public (v1alpha) APIs.
- Both internal and public proto definitions in a single PR per task guidance.
- Soft-delete via delete_time with show_deleted on List, matching existing RawImpressionMetadataBatchFile pattern.
- AIP-159 wildcard support documented on public List parent field.

## Test plan
- bazel build passes for all 4 new proto targets (internal message, internal service, public message, public service)

Closes: #3881
Issue: #3881 