### PR TITLE
feat: Add RawImpressionUploadModelLine proto definitions for internal and public API

### DIFF
--- a/src/main/proto/wfa/measurement/edpaggregator/v1alpha/BUILD.bazel
+++ b/src/main/proto/wfa/measurement/edpaggregator/v1alpha/BUILD.bazel
@@ -442,3 +442,37 @@ kt_jvm_proto_library(
     name = "subpool_fingerprints_kt_jvm_proto",
     deps = [":subpool_fingerprints_proto"],
 )
+
+proto_library(
+    name = "raw_impression_upload_model_line_proto",
+    srcs = ["raw_impression_upload_model_line.proto"],
+    strip_import_prefix = _IMPORT_PREFIX,
+    deps = [
+        "@com_google_googleapis//google/api:field_behavior_proto",
+        "@com_google_googleapis//google/api:resource_proto",
+        "@com_google_protobuf//:timestamp_proto",
+    ],
+)
+
+kt_jvm_proto_library(
+    name = "raw_impression_upload_model_line_kt_jvm_proto",
+    deps = [":raw_impression_upload_model_line_proto"],
+)
+
+proto_library(
+    name = "raw_impression_upload_model_line_service_proto",
+    srcs = ["raw_impression_upload_model_line_service.proto"],
+    strip_import_prefix = _IMPORT_PREFIX,
+    deps = [
+        ":raw_impression_upload_model_line_proto",
+        "@com_google_googleapis//google/api:field_behavior_proto",
+        "@com_google_googleapis//google/api:field_info_proto",
+        "@com_google_googleapis//google/api:resource_proto",
+        "@com_google_googleapis//google/type:interval_proto",
+    ],
+)
+
+kt_jvm_grpc_proto_library(
+    name = "raw_impression_upload_model_line_service_kt_jvm_grpc_proto",
+    deps = [":raw_impression_upload_model_line_service_proto"],
+)

--- a/src/main/proto/wfa/measurement/edpaggregator/v1alpha/raw_impression_upload_model_line.proto
+++ b/src/main/proto/wfa/measurement/edpaggregator/v1alpha/raw_impression_upload_model_line.proto
@@ -47,7 +47,7 @@ message RawImpressionUploadModelLine {
     RANKING = 3;
     // VID labeling (Phase 2) is in progress.
     LABELING = 4;
-    // All phases completed successfully.
+    // All phases completed successfully. Terminal state.
     COMPLETED = 5;
     // Processing failed. Not terminal — operator can retry after
     // fixing the root cause.
@@ -67,7 +67,8 @@ message RawImpressionUploadModelLine {
     (google.api.resource_reference) = { type: "halo.wfanet.org/ModelLine" }
   ];
 
-  // The timestamp when processing completed (success or failure).
+  // The timestamp when processing completed. Only set when
+  // state is COMPLETED or FAILED. Cleared on retry.
   google.protobuf.Timestamp completion_time = 4
       [(google.api.field_behavior) = OUTPUT_ONLY];
 

--- a/src/main/proto/wfa/measurement/edpaggregator/v1alpha/raw_impression_upload_model_line.proto
+++ b/src/main/proto/wfa/measurement/edpaggregator/v1alpha/raw_impression_upload_model_line.proto
@@ -30,7 +30,7 @@ option java_outer_classname = "RawImpressionUploadModelLineProto";
 message RawImpressionUploadModelLine {
   option (google.api.resource) = {
     type: "edpaggregator.halo-cmm.org/RawImpressionUploadModelLine"
-    pattern: "dataProviders/{data_provider}/rawImpressionUploads/{raw_impression_upload}/modelLines/{model_line}"
+    pattern: "dataProviders/{data_provider}/rawImpressionUploads/{raw_impression_upload}/rawImpressionUploadModelLines/{raw_impression_upload_model_line}"
     singular: "rawImpressionUploadModelLine"
     plural: "rawImpressionUploadModelLines"
   };
@@ -49,7 +49,8 @@ message RawImpressionUploadModelLine {
     LABELING = 4;
     // All phases completed successfully.
     COMPLETED = 5;
-    // Processing failed.
+    // Processing failed. Not terminal — operator can retry after
+    // fixing the root cause.
     FAILED = 6;
   }
 
@@ -59,15 +60,25 @@ message RawImpressionUploadModelLine {
   // The pipeline state for this model line.
   State state = 2 [(google.api.field_behavior) = OUTPUT_ONLY];
 
+  // The CMMS model line resource name that this record tracks.
+  string cmms_model_line = 3 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.field_behavior) = IMMUTABLE,
+    (google.api.resource_reference) = { type: "halo.wfanet.org/ModelLine" }
+  ];
+
   // The timestamp when processing completed (success or failure).
-  google.protobuf.Timestamp completion_time = 3
+  google.protobuf.Timestamp completion_time = 4
       [(google.api.field_behavior) = OUTPUT_ONLY];
 
   // The timestamp when this record was created.
-  google.protobuf.Timestamp create_time = 4
+  google.protobuf.Timestamp create_time = 5
       [(google.api.field_behavior) = OUTPUT_ONLY];
 
   // The timestamp when this record was last updated.
-  google.protobuf.Timestamp update_time = 5
+  google.protobuf.Timestamp update_time = 6
       [(google.api.field_behavior) = OUTPUT_ONLY];
+
+  // Detail about the failure, set when state is FAILED.
+  string error_message = 7 [(google.api.field_behavior) = OUTPUT_ONLY];
 }

--- a/src/main/proto/wfa/measurement/edpaggregator/v1alpha/raw_impression_upload_model_line.proto
+++ b/src/main/proto/wfa/measurement/edpaggregator/v1alpha/raw_impression_upload_model_line.proto
@@ -67,19 +67,14 @@ message RawImpressionUploadModelLine {
     (google.api.resource_reference) = { type: "halo.wfanet.org/ModelLine" }
   ];
 
-  // The timestamp when processing completed. Only set when
-  // state is COMPLETED or FAILED. Cleared on retry.
-  google.protobuf.Timestamp completion_time = 4
-      [(google.api.field_behavior) = OUTPUT_ONLY];
-
   // The timestamp when this record was created.
-  google.protobuf.Timestamp create_time = 5
+  google.protobuf.Timestamp create_time = 4
       [(google.api.field_behavior) = OUTPUT_ONLY];
 
   // The timestamp when this record was last updated.
-  google.protobuf.Timestamp update_time = 6
+  google.protobuf.Timestamp update_time = 5
       [(google.api.field_behavior) = OUTPUT_ONLY];
 
   // Detail about the failure, set when state is FAILED.
-  string error_message = 7 [(google.api.field_behavior) = OUTPUT_ONLY];
+  string error_message = 6 [(google.api.field_behavior) = OUTPUT_ONLY];
 }

--- a/src/main/proto/wfa/measurement/edpaggregator/v1alpha/raw_impression_upload_model_line.proto
+++ b/src/main/proto/wfa/measurement/edpaggregator/v1alpha/raw_impression_upload_model_line.proto
@@ -1,0 +1,73 @@
+// Copyright 2026 The Cross-Media Measurement Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package wfa.measurement.edpaggregator.v1alpha;
+
+import "google/api/field_behavior.proto";
+import "google/api/resource.proto";
+import "google/protobuf/timestamp.proto";
+
+option java_package = "org.wfanet.measurement.edpaggregator.v1alpha";
+option java_multiple_files = true;
+option java_outer_classname = "RawImpressionUploadModelLineProto";
+
+// Per-model-line pipeline state for a RawImpressionUpload.
+// One record per (upload, model line), pre-created by the dispatcher
+// once it resolves which model lines apply to this upload.
+message RawImpressionUploadModelLine {
+  option (google.api.resource) = {
+    type: "edpaggregator.halo-cmm.org/RawImpressionUploadModelLine"
+    pattern: "dataProviders/{data_provider}/rawImpressionUploads/{raw_impression_upload}/modelLines/{model_line}"
+    singular: "rawImpressionUploadModelLine"
+    plural: "rawImpressionUploadModelLines"
+  };
+
+  // Per-model-line pipeline state.
+  enum State {
+    // Default, unspecified state. Should not be used.
+    STATE_UNSPECIFIED = 0;
+    // The model line record has been created.
+    CREATED = 1;
+    // Pool assignment (Phase 0) is in progress.
+    POOL_ASSIGNING = 2;
+    // Ranking (Phase 1) is in progress.
+    RANKING = 3;
+    // VID labeling (Phase 2) is in progress.
+    LABELING = 4;
+    // All phases completed successfully.
+    COMPLETED = 5;
+    // Processing failed.
+    FAILED = 6;
+  }
+
+  // Resource name.
+  string name = 1 [(google.api.field_behavior) = IDENTIFIER];
+
+  // The pipeline state for this model line.
+  State state = 2 [(google.api.field_behavior) = OUTPUT_ONLY];
+
+  // The timestamp when processing completed (success or failure).
+  google.protobuf.Timestamp completion_time = 3
+      [(google.api.field_behavior) = OUTPUT_ONLY];
+
+  // The timestamp when this record was created.
+  google.protobuf.Timestamp create_time = 4
+      [(google.api.field_behavior) = OUTPUT_ONLY];
+
+  // The timestamp when this record was last updated.
+  google.protobuf.Timestamp update_time = 5
+      [(google.api.field_behavior) = OUTPUT_ONLY];
+}

--- a/src/main/proto/wfa/measurement/edpaggregator/v1alpha/raw_impression_upload_model_line_service.proto
+++ b/src/main/proto/wfa/measurement/edpaggregator/v1alpha/raw_impression_upload_model_line_service.proto
@@ -1,0 +1,223 @@
+// Copyright 2026 The Cross-Media Measurement Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package wfa.measurement.edpaggregator.v1alpha;
+
+import "google/api/field_behavior.proto";
+import "google/api/field_info.proto";
+import "google/api/resource.proto";
+import "google/type/interval.proto";
+import "wfa/measurement/edpaggregator/v1alpha/raw_impression_upload_model_line.proto";
+
+option java_package = "org.wfanet.measurement.edpaggregator.v1alpha";
+option java_multiple_files = true;
+option java_outer_classname = "RawImpressionUploadModelLineServiceProto";
+
+// Service for managing RawImpressionUploadModelLine resources.
+service RawImpressionUploadModelLineService {
+  // Creates a new `RawImpressionUploadModelLine`.
+  rpc CreateRawImpressionUploadModelLine(
+      CreateRawImpressionUploadModelLineRequest)
+      returns (RawImpressionUploadModelLine) {}
+
+  // Retrieves a specific `RawImpressionUploadModelLine`.
+  rpc GetRawImpressionUploadModelLine(GetRawImpressionUploadModelLineRequest)
+      returns (RawImpressionUploadModelLine) {}
+
+  // Lists `RawImpressionUploadModelLine` resources for an upload.
+  rpc ListRawImpressionUploadModelLines(
+      ListRawImpressionUploadModelLinesRequest)
+      returns (ListRawImpressionUploadModelLinesResponse) {}
+
+  // Marks a `RawImpressionUploadModelLine` as `POOL_ASSIGNING`.
+  rpc MarkRawImpressionUploadModelLinePoolAssigning(
+      MarkRawImpressionUploadModelLinePoolAssigningRequest)
+      returns (RawImpressionUploadModelLine) {}
+
+  // Marks a `RawImpressionUploadModelLine` as `RANKING`.
+  rpc MarkRawImpressionUploadModelLineRanking(
+      MarkRawImpressionUploadModelLineRankingRequest)
+      returns (RawImpressionUploadModelLine) {}
+
+  // Marks a `RawImpressionUploadModelLine` as `LABELING`.
+  rpc MarkRawImpressionUploadModelLineLabeling(
+      MarkRawImpressionUploadModelLineLabelingRequest)
+      returns (RawImpressionUploadModelLine) {}
+
+  // Marks a `RawImpressionUploadModelLine` as `COMPLETED`.
+  rpc MarkRawImpressionUploadModelLineCompleted(
+      MarkRawImpressionUploadModelLineCompletedRequest)
+      returns (RawImpressionUploadModelLine) {}
+
+  // Marks a `RawImpressionUploadModelLine` as `FAILED`.
+  rpc MarkRawImpressionUploadModelLineFailed(
+      MarkRawImpressionUploadModelLineFailedRequest)
+      returns (RawImpressionUploadModelLine) {}
+}
+
+// Request message for the
+// `CreateRawImpressionUploadModelLine` method.
+message CreateRawImpressionUploadModelLineRequest {
+  // The parent upload resource name.
+  // Format:
+  // `dataProviders/{data_provider}/rawImpressionUploads/{raw_impression_upload}`
+  string parent = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference) = {
+      child_type: "edpaggregator.halo-cmm.org/RawImpressionUploadModelLine"
+    }
+  ];
+
+  // The RawImpressionUploadModelLine to create.
+  // The `name` and output-only fields are ignored.
+  RawImpressionUploadModelLine raw_impression_upload_model_line = 2
+      [(google.api.field_behavior) = REQUIRED];
+
+  // A request ID provided by the client to ensure idempotency.
+  //
+  // This field must be a UUID4 (RFC 4122) string.
+  string request_id = 3 [
+    (google.api.field_behavior) = OPTIONAL,
+    (google.api.field_info).format = UUID4
+  ];
+}
+
+// Request message for the
+// `GetRawImpressionUploadModelLine` method.
+message GetRawImpressionUploadModelLineRequest {
+  // The resource name of the model line to retrieve.
+  // Format:
+  // `dataProviders/{data_provider}/rawImpressionUploads/{raw_impression_upload}/modelLines/{model_line}`
+  string name = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference) = {
+      type: "edpaggregator.halo-cmm.org/RawImpressionUploadModelLine"
+    }
+  ];
+}
+
+// Request message for the
+// `ListRawImpressionUploadModelLines` method.
+// (-- api-linter: core::0132::request-field-types=disabled
+//     aip.dev/not-precedent: Using a customized message for the
+//     filter. --)
+message ListRawImpressionUploadModelLinesRequest {
+  // The parent upload resource name.
+  // Format:
+  // `dataProviders/{data_provider}/rawImpressionUploads/{raw_impression_upload}`
+  //
+  // The upload segment may be the wildcard `-` to list
+  // model lines across all uploads for a data provider.
+  // See AIP-159.
+  string parent = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference) = {
+      child_type: "edpaggregator.halo-cmm.org/RawImpressionUploadModelLine"
+    }
+  ];
+
+  // The maximum number of results to return.
+  int32 page_size = 2 [(google.api.field_behavior) = OPTIONAL];
+
+  // A page token, received from a previous call.
+  string page_token = 3 [(google.api.field_behavior) = OPTIONAL];
+
+  // Structured filter for narrowing results.
+  message Filter {
+    // Filter by pipeline state.
+    // (-- api-linter: core::0216::state-field-output-only=disabled
+    //     aip.dev/not-precedent: This is a filter input field, not
+    //     a resource state field. --)
+    RawImpressionUploadModelLine.State state = 1
+        [(google.api.field_behavior) = OPTIONAL];
+
+    // Filter by create time range.
+    google.type.Interval create_time_interval = 2
+        [(google.api.field_behavior) = OPTIONAL];
+  }
+
+  // Optional. A filter to apply to the results.
+  Filter filter = 4 [(google.api.field_behavior) = OPTIONAL];
+}
+
+// Response message for the
+// `ListRawImpressionUploadModelLines` method.
+message ListRawImpressionUploadModelLinesResponse {
+  repeated RawImpressionUploadModelLine raw_impression_upload_model_lines = 1;
+
+  // A token to retrieve the next page of results.
+  string next_page_token = 2;
+}
+
+// Request message for the
+// `MarkRawImpressionUploadModelLinePoolAssigning` method.
+message MarkRawImpressionUploadModelLinePoolAssigningRequest {
+  // The resource name of the model line.
+  string name = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference) = {
+      type: "edpaggregator.halo-cmm.org/RawImpressionUploadModelLine"
+    }
+  ];
+}
+
+// Request message for the
+// `MarkRawImpressionUploadModelLineRanking` method.
+message MarkRawImpressionUploadModelLineRankingRequest {
+  // The resource name of the model line.
+  string name = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference) = {
+      type: "edpaggregator.halo-cmm.org/RawImpressionUploadModelLine"
+    }
+  ];
+}
+
+// Request message for the
+// `MarkRawImpressionUploadModelLineLabeling` method.
+message MarkRawImpressionUploadModelLineLabelingRequest {
+  // The resource name of the model line.
+  string name = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference) = {
+      type: "edpaggregator.halo-cmm.org/RawImpressionUploadModelLine"
+    }
+  ];
+}
+
+// Request message for the
+// `MarkRawImpressionUploadModelLineCompleted` method.
+message MarkRawImpressionUploadModelLineCompletedRequest {
+  // The resource name of the model line.
+  string name = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference) = {
+      type: "edpaggregator.halo-cmm.org/RawImpressionUploadModelLine"
+    }
+  ];
+}
+
+// Request message for the
+// `MarkRawImpressionUploadModelLineFailed` method.
+message MarkRawImpressionUploadModelLineFailedRequest {
+  // The resource name of the model line.
+  string name = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference) = {
+      type: "edpaggregator.halo-cmm.org/RawImpressionUploadModelLine"
+    }
+  ];
+}

--- a/src/main/proto/wfa/measurement/edpaggregator/v1alpha/raw_impression_upload_model_line_service.proto
+++ b/src/main/proto/wfa/measurement/edpaggregator/v1alpha/raw_impression_upload_model_line_service.proto
@@ -26,12 +26,18 @@ option java_package = "org.wfanet.measurement.edpaggregator.v1alpha";
 option java_multiple_files = true;
 option java_outer_classname = "RawImpressionUploadModelLineServiceProto";
 
-// Service for managing RawImpressionUploadModelLine resources.
+// Service for managing `RawImpressionUploadModelLine` resources.
 service RawImpressionUploadModelLineService {
   // Creates a new `RawImpressionUploadModelLine`.
   rpc CreateRawImpressionUploadModelLine(
       CreateRawImpressionUploadModelLineRequest)
       returns (RawImpressionUploadModelLine) {}
+
+  // Creates multiple `RawImpressionUploadModelLine` resources
+  // in a single request.
+  rpc BatchCreateRawImpressionUploadModelLines(
+      BatchCreateRawImpressionUploadModelLinesRequest)
+      returns (BatchCreateRawImpressionUploadModelLinesResponse) {}
 
   // Retrieves a specific `RawImpressionUploadModelLine`.
   rpc GetRawImpressionUploadModelLine(GetRawImpressionUploadModelLineRequest)
@@ -81,7 +87,7 @@ message CreateRawImpressionUploadModelLineRequest {
     }
   ];
 
-  // The RawImpressionUploadModelLine to create.
+  // The `RawImpressionUploadModelLine` to create.
   // The `name` and output-only fields are ignored.
   RawImpressionUploadModelLine raw_impression_upload_model_line = 2
       [(google.api.field_behavior) = REQUIRED];
@@ -96,11 +102,35 @@ message CreateRawImpressionUploadModelLineRequest {
 }
 
 // Request message for the
+// `BatchCreateRawImpressionUploadModelLines` method.
+message BatchCreateRawImpressionUploadModelLinesRequest {
+  // The parent upload resource name.
+  // Format:
+  // `dataProviders/{data_provider}/rawImpressionUploads/{raw_impression_upload}`
+  string parent = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference) = {
+      child_type: "edpaggregator.halo-cmm.org/RawImpressionUploadModelLine"
+    }
+  ];
+
+  // Individual create requests. Maximum 50 per batch.
+  repeated CreateRawImpressionUploadModelLineRequest requests = 2
+      [(google.api.field_behavior) = REQUIRED];
+}
+
+// Response message for the
+// `BatchCreateRawImpressionUploadModelLines` method.
+message BatchCreateRawImpressionUploadModelLinesResponse {
+  repeated RawImpressionUploadModelLine raw_impression_upload_model_lines = 1;
+}
+
+// Request message for the
 // `GetRawImpressionUploadModelLine` method.
 message GetRawImpressionUploadModelLineRequest {
   // The resource name of the model line to retrieve.
   // Format:
-  // `dataProviders/{data_provider}/rawImpressionUploads/{raw_impression_upload}/modelLines/{model_line}`
+  // `dataProviders/{data_provider}/rawImpressionUploads/{raw_impression_upload}/rawImpressionUploadModelLines/{raw_impression_upload_model_line}`
   string name = 1 [
     (google.api.field_behavior) = REQUIRED,
     (google.api.resource_reference) = {
@@ -144,9 +174,18 @@ message ListRawImpressionUploadModelLinesRequest {
     RawImpressionUploadModelLine.State state = 1
         [(google.api.field_behavior) = OPTIONAL];
 
-    // Filter by create time range.
+    // Filter for resources whose create_time falls within this
+    // interval. Start and end are both optional: omitting start
+    // returns resources created before end, omitting end returns
+    // resources created after start.
     google.type.Interval create_time_interval = 2
         [(google.api.field_behavior) = OPTIONAL];
+
+    // Filter by CMMS model line resource name.
+    string cmms_model_line = 3 [
+      (google.api.field_behavior) = OPTIONAL,
+      (google.api.resource_reference) = { type: "halo.wfanet.org/ModelLine" }
+    ];
   }
 
   // Optional. A filter to apply to the results.
@@ -220,4 +259,7 @@ message MarkRawImpressionUploadModelLineFailedRequest {
       type: "edpaggregator.halo-cmm.org/RawImpressionUploadModelLine"
     }
   ];
+
+  // Human-readable detail about the failure.
+  string error_message = 2;
 }

--- a/src/main/proto/wfa/measurement/edpaggregator/v1alpha/raw_impression_upload_model_line_service.proto
+++ b/src/main/proto/wfa/measurement/edpaggregator/v1alpha/raw_impression_upload_model_line_service.proto
@@ -26,7 +26,9 @@ option java_package = "org.wfanet.measurement.edpaggregator.v1alpha";
 option java_multiple_files = true;
 option java_outer_classname = "RawImpressionUploadModelLineServiceProto";
 
-// Service for managing `RawImpressionUploadModelLine` resources.
+// Service for managing `RawImpressionUploadModelLine` resources,
+// which track per-model-line processing state for a raw
+// impression upload.
 service RawImpressionUploadModelLineService {
   // Creates a new `RawImpressionUploadModelLine`.
   rpc CreateRawImpressionUploadModelLine(
@@ -122,6 +124,7 @@ message BatchCreateRawImpressionUploadModelLinesRequest {
 // Response message for the
 // `BatchCreateRawImpressionUploadModelLines` method.
 message BatchCreateRawImpressionUploadModelLinesResponse {
+  // The created model line records.
   repeated RawImpressionUploadModelLine raw_impression_upload_model_lines = 1;
 }
 
@@ -195,6 +198,7 @@ message ListRawImpressionUploadModelLinesRequest {
 // Response message for the
 // `ListRawImpressionUploadModelLines` method.
 message ListRawImpressionUploadModelLinesResponse {
+  // The list of model line records matching the request.
   repeated RawImpressionUploadModelLine raw_impression_upload_model_lines = 1;
 
   // A token to retrieve the next page of results.
@@ -261,5 +265,5 @@ message MarkRawImpressionUploadModelLineFailedRequest {
   ];
 
   // Human-readable detail about the failure.
-  string error_message = 2;
+  string error_message = 2 [(google.api.field_behavior) = OPTIONAL];
 }

--- a/src/main/proto/wfa/measurement/internal/edpaggregator/BUILD.bazel
+++ b/src/main/proto/wfa/measurement/internal/edpaggregator/BUILD.bazel
@@ -261,3 +261,46 @@ kt_jvm_grpc_proto_library(
     name = "raw_impression_upload_file_service_kt_jvm_grpc_proto",
     deps = [":raw_impression_upload_file_service_proto"],
 )
+
+proto_library(
+    name = "raw_impression_upload_model_line_state_proto",
+    srcs = ["raw_impression_upload_model_line_state.proto"],
+    strip_import_prefix = IMPORT_PREFIX,
+)
+
+kt_jvm_proto_library(
+    name = "raw_impression_upload_model_line_state_kt_jvm_proto",
+    deps = [":raw_impression_upload_model_line_state_proto"],
+)
+
+proto_library(
+    name = "raw_impression_upload_model_line_proto",
+    srcs = ["raw_impression_upload_model_line.proto"],
+    strip_import_prefix = IMPORT_PREFIX,
+    deps = [
+        ":raw_impression_upload_model_line_state_proto",
+        "@com_google_protobuf//:timestamp_proto",
+    ],
+)
+
+kt_jvm_proto_library(
+    name = "raw_impression_upload_model_line_kt_jvm_proto",
+    deps = [":raw_impression_upload_model_line_proto"],
+)
+
+proto_library(
+    name = "raw_impression_upload_model_line_service_proto",
+    srcs = ["raw_impression_upload_model_line_service.proto"],
+    strip_import_prefix = IMPORT_PREFIX,
+    deps = [
+        ":raw_impression_upload_model_line_proto",
+        ":raw_impression_upload_model_line_state_proto",
+        "@com_google_googleapis//google/type:interval_proto",
+        "@com_google_protobuf//:timestamp_proto",
+    ],
+)
+
+kt_jvm_grpc_proto_library(
+    name = "raw_impression_upload_model_line_service_kt_jvm_grpc_proto",
+    deps = [":raw_impression_upload_model_line_service_proto"],
+)

--- a/src/main/proto/wfa/measurement/internal/edpaggregator/raw_impression_upload_model_line.proto
+++ b/src/main/proto/wfa/measurement/internal/edpaggregator/raw_impression_upload_model_line.proto
@@ -39,16 +39,12 @@ message RawImpressionUploadModelLine {
   // The pipeline state for this model line.
   RawImpressionUploadModelLineState state = 4;
 
-  // The timestamp when processing completed. Only set when
-  // state is COMPLETED or FAILED. Cleared on retry.
-  google.protobuf.Timestamp completion_time = 5;
-
   // The timestamp when this record was created.
-  google.protobuf.Timestamp create_time = 6;
+  google.protobuf.Timestamp create_time = 5;
 
   // The timestamp when this record was last updated.
-  google.protobuf.Timestamp update_time = 7;
+  google.protobuf.Timestamp update_time = 6;
 
   // Detail about the failure, set when state is FAILED.
-  string error_message = 8;
+  string error_message = 7;
 }

--- a/src/main/proto/wfa/measurement/internal/edpaggregator/raw_impression_upload_model_line.proto
+++ b/src/main/proto/wfa/measurement/internal/edpaggregator/raw_impression_upload_model_line.proto
@@ -39,7 +39,8 @@ message RawImpressionUploadModelLine {
   // The pipeline state for this model line.
   RawImpressionUploadModelLineState state = 4;
 
-  // The timestamp when processing completed (success or failure).
+  // The timestamp when processing completed. Only set when
+  // state is COMPLETED or FAILED. Cleared on retry.
   google.protobuf.Timestamp completion_time = 5;
 
   // The timestamp when this record was created.

--- a/src/main/proto/wfa/measurement/internal/edpaggregator/raw_impression_upload_model_line.proto
+++ b/src/main/proto/wfa/measurement/internal/edpaggregator/raw_impression_upload_model_line.proto
@@ -1,0 +1,52 @@
+// Copyright 2026 The Cross-Media Measurement Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package wfa.measurement.internal.edpaggregator;
+
+import "google/protobuf/timestamp.proto";
+import "wfa/measurement/internal/edpaggregator/raw_impression_upload_model_line_state.proto";
+
+option java_package = "org.wfanet.measurement.internal.edpaggregator";
+option java_multiple_files = true;
+option java_outer_classname = "RawImpressionUploadModelLineProto";
+
+// Internal representation of a per-model-line pipeline state for an upload.
+// One row per (upload, model line), pre-created by the dispatcher once it
+// resolves which model lines apply to this upload.
+message RawImpressionUploadModelLine {
+  // Resource ID of the DataProvider that owns this record.
+  string data_provider_resource_id = 1;
+
+  // Resource ID of the parent upload.
+  string raw_impression_upload_resource_id = 2;
+
+  // The CMMS model line resource name.
+  // This serves as the resource ID for this record, mapping to the
+  // `{model_line}` segment in the public resource pattern.
+  string cmms_model_line = 3;
+
+  // The pipeline state for this model line.
+  RawImpressionUploadModelLineState state = 4;
+
+  // The timestamp when processing completed (success or failure).
+  google.protobuf.Timestamp completion_time = 5;
+
+  // The timestamp when this record was created.
+  google.protobuf.Timestamp create_time = 6;
+
+  // The timestamp when this record was last updated.
+  google.protobuf.Timestamp update_time = 7;
+}

--- a/src/main/proto/wfa/measurement/internal/edpaggregator/raw_impression_upload_model_line.proto
+++ b/src/main/proto/wfa/measurement/internal/edpaggregator/raw_impression_upload_model_line.proto
@@ -49,4 +49,7 @@ message RawImpressionUploadModelLine {
 
   // The timestamp when this record was last updated.
   google.protobuf.Timestamp update_time = 7;
+
+  // Detail about the failure, set when state is FAILED.
+  string error_message = 8;
 }

--- a/src/main/proto/wfa/measurement/internal/edpaggregator/raw_impression_upload_model_line.proto
+++ b/src/main/proto/wfa/measurement/internal/edpaggregator/raw_impression_upload_model_line.proto
@@ -33,9 +33,7 @@ message RawImpressionUploadModelLine {
   // Resource ID of the parent upload.
   string raw_impression_upload_resource_id = 2;
 
-  // The CMMS model line resource name.
-  // This serves as the resource ID for this record, mapping to the
-  // `{model_line}` segment in the public resource pattern.
+  // The CMMS model line resource name this record tracks.
   string cmms_model_line = 3;
 
   // The pipeline state for this model line.

--- a/src/main/proto/wfa/measurement/internal/edpaggregator/raw_impression_upload_model_line_service.proto
+++ b/src/main/proto/wfa/measurement/internal/edpaggregator/raw_impression_upload_model_line_service.proto
@@ -1,0 +1,196 @@
+// Copyright 2026 The Cross-Media Measurement Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package wfa.measurement.internal.edpaggregator;
+
+import "google/protobuf/timestamp.proto";
+import "google/type/interval.proto";
+import "wfa/measurement/internal/edpaggregator/raw_impression_upload_model_line.proto";
+import "wfa/measurement/internal/edpaggregator/raw_impression_upload_model_line_state.proto";
+
+option java_package = "org.wfanet.measurement.internal.edpaggregator";
+option java_multiple_files = true;
+option java_outer_classname = "RawImpressionUploadModelLineServiceProto";
+
+// Service for managing RawImpressionUploadModelLine resources.
+service RawImpressionUploadModelLineService {
+  // Creates a new `RawImpressionUploadModelLine`.
+  rpc CreateRawImpressionUploadModelLine(
+      CreateRawImpressionUploadModelLineRequest)
+      returns (RawImpressionUploadModelLine);
+
+  // Retrieves a specific `RawImpressionUploadModelLine`.
+  rpc GetRawImpressionUploadModelLine(GetRawImpressionUploadModelLineRequest)
+      returns (RawImpressionUploadModelLine);
+
+  // Lists `RawImpressionUploadModelLine` resources for an upload.
+  rpc ListRawImpressionUploadModelLines(
+      ListRawImpressionUploadModelLinesRequest)
+      returns (ListRawImpressionUploadModelLinesResponse);
+
+  // Marks a `RawImpressionUploadModelLine` as `POOL_ASSIGNING`.
+  rpc MarkRawImpressionUploadModelLinePoolAssigning(
+      MarkRawImpressionUploadModelLinePoolAssigningRequest)
+      returns (RawImpressionUploadModelLine);
+
+  // Marks a `RawImpressionUploadModelLine` as `RANKING`.
+  rpc MarkRawImpressionUploadModelLineRanking(
+      MarkRawImpressionUploadModelLineRankingRequest)
+      returns (RawImpressionUploadModelLine);
+
+  // Marks a `RawImpressionUploadModelLine` as `LABELING`.
+  rpc MarkRawImpressionUploadModelLineLabeling(
+      MarkRawImpressionUploadModelLineLabelingRequest)
+      returns (RawImpressionUploadModelLine);
+
+  // Marks a `RawImpressionUploadModelLine` as `COMPLETED`.
+  rpc MarkRawImpressionUploadModelLineCompleted(
+      MarkRawImpressionUploadModelLineCompletedRequest)
+      returns (RawImpressionUploadModelLine);
+
+  // Marks a `RawImpressionUploadModelLine` as `FAILED`.
+  rpc MarkRawImpressionUploadModelLineFailed(
+      MarkRawImpressionUploadModelLineFailedRequest)
+      returns (RawImpressionUploadModelLine);
+}
+
+// Request message for CreateRawImpressionUploadModelLine.
+message CreateRawImpressionUploadModelLineRequest {
+  // The RawImpressionUploadModelLine to create.
+  RawImpressionUploadModelLine raw_impression_upload_model_line = 1;
+
+  // A request ID provided by the client to ensure idempotency.
+  string request_id = 2;
+}
+
+// Request message for GetRawImpressionUploadModelLine.
+message GetRawImpressionUploadModelLineRequest {
+  // Resource ID of the DataProvider.
+  string data_provider_resource_id = 1;
+
+  // Resource ID of the parent upload.
+  string raw_impression_upload_resource_id = 2;
+
+  // The CMMS model line resource name.
+  string cmms_model_line = 3;
+}
+
+// Request message for ListRawImpressionUploadModelLines.
+message ListRawImpressionUploadModelLinesRequest {
+  // Resource ID of the DataProvider.
+  string data_provider_resource_id = 1;
+
+  // Resource ID of the parent upload.
+  string raw_impression_upload_resource_id = 2;
+
+  // The maximum number of results to return.
+  //
+  // If unspecified, at most 50 results will be returned.
+  // The maximum value is 100; values above this will be
+  // coerced to the maximum value.
+  int32 page_size = 3;
+
+  // Page token from a previous list call.
+  ListRawImpressionUploadModelLinesPageToken page_token = 4;
+
+  // Filter for narrowing results.
+  message Filter {
+    // Filter by pipeline state.
+    RawImpressionUploadModelLineState state = 1;
+
+    // Filter by create time range.
+    google.type.Interval create_time_interval = 2;
+  }
+  Filter filter = 5;
+}
+
+// Response message for ListRawImpressionUploadModelLines.
+message ListRawImpressionUploadModelLinesResponse {
+  repeated RawImpressionUploadModelLine raw_impression_upload_model_lines = 1;
+
+  // A token to retrieve the next page of results.
+  ListRawImpressionUploadModelLinesPageToken next_page_token = 2;
+}
+
+// Page token for ListRawImpressionUploadModelLines.
+message ListRawImpressionUploadModelLinesPageToken {
+  message After {
+    google.protobuf.Timestamp create_time = 1;
+    string raw_impression_upload_resource_id = 2;
+    string cmms_model_line = 3;
+  }
+  After after = 1;
+}
+
+// Request message for MarkRawImpressionUploadModelLinePoolAssigning.
+message MarkRawImpressionUploadModelLinePoolAssigningRequest {
+  // Resource ID of the DataProvider.
+  string data_provider_resource_id = 1;
+
+  // Resource ID of the parent upload.
+  string raw_impression_upload_resource_id = 2;
+
+  // The CMMS model line resource name.
+  string cmms_model_line = 3;
+}
+
+// Request message for MarkRawImpressionUploadModelLineRanking.
+message MarkRawImpressionUploadModelLineRankingRequest {
+  // Resource ID of the DataProvider.
+  string data_provider_resource_id = 1;
+
+  // Resource ID of the parent upload.
+  string raw_impression_upload_resource_id = 2;
+
+  // The CMMS model line resource name.
+  string cmms_model_line = 3;
+}
+
+// Request message for MarkRawImpressionUploadModelLineLabeling.
+message MarkRawImpressionUploadModelLineLabelingRequest {
+  // Resource ID of the DataProvider.
+  string data_provider_resource_id = 1;
+
+  // Resource ID of the parent upload.
+  string raw_impression_upload_resource_id = 2;
+
+  // The CMMS model line resource name.
+  string cmms_model_line = 3;
+}
+
+// Request message for MarkRawImpressionUploadModelLineCompleted.
+message MarkRawImpressionUploadModelLineCompletedRequest {
+  // Resource ID of the DataProvider.
+  string data_provider_resource_id = 1;
+
+  // Resource ID of the parent upload.
+  string raw_impression_upload_resource_id = 2;
+
+  // The CMMS model line resource name.
+  string cmms_model_line = 3;
+}
+
+// Request message for MarkRawImpressionUploadModelLineFailed.
+message MarkRawImpressionUploadModelLineFailedRequest {
+  // Resource ID of the DataProvider.
+  string data_provider_resource_id = 1;
+
+  // Resource ID of the parent upload.
+  string raw_impression_upload_resource_id = 2;
+
+  // The CMMS model line resource name.
+  string cmms_model_line = 3;
+}

--- a/src/main/proto/wfa/measurement/internal/edpaggregator/raw_impression_upload_model_line_service.proto
+++ b/src/main/proto/wfa/measurement/internal/edpaggregator/raw_impression_upload_model_line_service.proto
@@ -76,6 +76,23 @@ message CreateRawImpressionUploadModelLineRequest {
   string request_id = 2;
 }
 
+// Request message for BatchCreateRawImpressionUploadModelLines.
+message BatchCreateRawImpressionUploadModelLinesRequest {
+  // Resource ID of the DataProvider.
+  string data_provider_resource_id = 1;
+
+  // Resource ID of the parent upload.
+  string raw_impression_upload_resource_id = 2;
+
+  // Individual create requests. Maximum 50 per batch.
+  repeated CreateRawImpressionUploadModelLineRequest requests = 3;
+}
+
+// Response message for BatchCreateRawImpressionUploadModelLines.
+message BatchCreateRawImpressionUploadModelLinesResponse {
+  repeated RawImpressionUploadModelLine raw_impression_upload_model_lines = 1;
+}
+
 // Request message for GetRawImpressionUploadModelLine.
 message GetRawImpressionUploadModelLineRequest {
   // Resource ID of the DataProvider.
@@ -111,8 +128,14 @@ message ListRawImpressionUploadModelLinesRequest {
     // Filter by pipeline state.
     RawImpressionUploadModelLineState state = 1;
 
-    // Filter by create time range.
+    // Filter for resources whose create_time falls within this
+    // interval. Start and end are both optional: omitting start
+    // returns resources created before end, omitting end returns
+    // resources created after start.
     google.type.Interval create_time_interval = 2;
+
+    // Filter by CMMS model line resource name.
+    string cmms_model_line = 3;
   }
   Filter filter = 5;
 }
@@ -193,4 +216,7 @@ message MarkRawImpressionUploadModelLineFailedRequest {
 
   // The CMMS model line resource name.
   string cmms_model_line = 3;
+
+  // Human-readable detail about the failure.
+  string error_message = 4;
 }

--- a/src/main/proto/wfa/measurement/internal/edpaggregator/raw_impression_upload_model_line_service.proto
+++ b/src/main/proto/wfa/measurement/internal/edpaggregator/raw_impression_upload_model_line_service.proto
@@ -25,7 +25,9 @@ option java_package = "org.wfanet.measurement.internal.edpaggregator";
 option java_multiple_files = true;
 option java_outer_classname = "RawImpressionUploadModelLineServiceProto";
 
-// Service for managing RawImpressionUploadModelLine resources.
+// Service for managing `RawImpressionUploadModelLine` resources,
+// which track per-model-line processing state for a raw
+// impression upload.
 service RawImpressionUploadModelLineService {
   // Creates a new `RawImpressionUploadModelLine`.
   rpc CreateRawImpressionUploadModelLine(

--- a/src/main/proto/wfa/measurement/internal/edpaggregator/raw_impression_upload_model_line_service.proto
+++ b/src/main/proto/wfa/measurement/internal/edpaggregator/raw_impression_upload_model_line_service.proto
@@ -69,11 +69,17 @@ service RawImpressionUploadModelLineService {
 
 // Request message for CreateRawImpressionUploadModelLine.
 message CreateRawImpressionUploadModelLineRequest {
+  // Resource ID of the DataProvider.
+  string data_provider_resource_id = 1;
+
+  // Resource ID of the parent upload.
+  string raw_impression_upload_resource_id = 2;
+
   // The RawImpressionUploadModelLine to create.
-  RawImpressionUploadModelLine raw_impression_upload_model_line = 1;
+  RawImpressionUploadModelLine raw_impression_upload_model_line = 3;
 
   // A request ID provided by the client to ensure idempotency.
-  string request_id = 2;
+  string request_id = 4;
 }
 
 // Request message for BatchCreateRawImpressionUploadModelLines.

--- a/src/main/proto/wfa/measurement/internal/edpaggregator/raw_impression_upload_model_line_service.proto
+++ b/src/main/proto/wfa/measurement/internal/edpaggregator/raw_impression_upload_model_line_service.proto
@@ -32,6 +32,11 @@ service RawImpressionUploadModelLineService {
       CreateRawImpressionUploadModelLineRequest)
       returns (RawImpressionUploadModelLine);
 
+  // Creates multiple `RawImpressionUploadModelLine` resources.
+  rpc BatchCreateRawImpressionUploadModelLines(
+      BatchCreateRawImpressionUploadModelLinesRequest)
+      returns (BatchCreateRawImpressionUploadModelLinesResponse);
+
   // Retrieves a specific `RawImpressionUploadModelLine`.
   rpc GetRawImpressionUploadModelLine(GetRawImpressionUploadModelLineRequest)
       returns (RawImpressionUploadModelLine);

--- a/src/main/proto/wfa/measurement/internal/edpaggregator/raw_impression_upload_model_line_state.proto
+++ b/src/main/proto/wfa/measurement/internal/edpaggregator/raw_impression_upload_model_line_state.proto
@@ -1,0 +1,39 @@
+// Copyright 2026 The Cross-Media Measurement Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package wfa.measurement.internal.edpaggregator;
+
+option java_package = "org.wfanet.measurement.internal.edpaggregator";
+option java_multiple_files = true;
+option java_outer_classname = "RawImpressionUploadModelLineStateProto";
+
+// Per-model-line pipeline state for a RawImpressionUpload.
+enum RawImpressionUploadModelLineState {
+  // Default, unspecified state. Should not be used.
+  RAW_IMPRESSION_UPLOAD_MODEL_LINE_STATE_UNSPECIFIED = 0;
+  // The model line record has been created.
+  RAW_IMPRESSION_UPLOAD_MODEL_LINE_STATE_CREATED = 1;
+  // Pool assignment (Phase 0) is in progress.
+  RAW_IMPRESSION_UPLOAD_MODEL_LINE_STATE_POOL_ASSIGNING = 2;
+  // Ranking (Phase 1) is in progress.
+  RAW_IMPRESSION_UPLOAD_MODEL_LINE_STATE_RANKING = 3;
+  // VID labeling (Phase 2) is in progress.
+  RAW_IMPRESSION_UPLOAD_MODEL_LINE_STATE_LABELING = 4;
+  // All phases completed successfully.
+  RAW_IMPRESSION_UPLOAD_MODEL_LINE_STATE_COMPLETED = 5;
+  // Processing failed.
+  RAW_IMPRESSION_UPLOAD_MODEL_LINE_STATE_FAILED = 6;
+}

--- a/src/main/proto/wfa/measurement/internal/edpaggregator/raw_impression_upload_model_line_state.proto
+++ b/src/main/proto/wfa/measurement/internal/edpaggregator/raw_impression_upload_model_line_state.proto
@@ -32,7 +32,7 @@ enum RawImpressionUploadModelLineState {
   RAW_IMPRESSION_UPLOAD_MODEL_LINE_STATE_RANKING = 3;
   // VID labeling (Phase 2) is in progress.
   RAW_IMPRESSION_UPLOAD_MODEL_LINE_STATE_LABELING = 4;
-  // All phases completed successfully.
+  // All phases completed successfully. Terminal state.
   RAW_IMPRESSION_UPLOAD_MODEL_LINE_STATE_COMPLETED = 5;
   // Processing failed.
   RAW_IMPRESSION_UPLOAD_MODEL_LINE_STATE_FAILED = 6;

--- a/src/main/proto/wfa/measurement/internal/edpaggregator/raw_impression_upload_service.proto
+++ b/src/main/proto/wfa/measurement/internal/edpaggregator/raw_impression_upload_service.proto
@@ -45,11 +45,14 @@ message CreateRawImpressionUploadRequest {
   // Resource ID of the DataProvider.
   string data_provider_resource_id = 1;
 
+  // Resource ID for the new upload.
+  string raw_impression_upload_id = 2;
+
   // The RawImpressionUpload to create.
-  RawImpressionUpload raw_impression_upload = 2;
+  RawImpressionUpload raw_impression_upload = 3;
 
   // A request ID provided by the client to ensure idempotency.
-  string request_id = 3;
+  string request_id = 4;
 }
 
 // Request message for GetRawImpressionUpload.

--- a/src/main/proto/wfa/measurement/internal/edpaggregator/raw_impression_upload_service.proto
+++ b/src/main/proto/wfa/measurement/internal/edpaggregator/raw_impression_upload_service.proto
@@ -45,14 +45,11 @@ message CreateRawImpressionUploadRequest {
   // Resource ID of the DataProvider.
   string data_provider_resource_id = 1;
 
-  // Resource ID for the new upload.
-  string raw_impression_upload_id = 2;
-
   // The RawImpressionUpload to create.
-  RawImpressionUpload raw_impression_upload = 3;
+  RawImpressionUpload raw_impression_upload = 2;
 
   // A request ID provided by the client to ensure idempotency.
-  string request_id = 4;
+  string request_id = 3;
 }
 
 // Request message for GetRawImpressionUpload.


### PR DESCRIPTION
## Summary
- Add proto message and service definitions for RawImpressionUploadModelLine, the per-model-line pipeline state resource for the VID labeling pipeline.
- Includes create, get, list, and 5 state transition Mark RPCs (PoolAssigning, Ranking, Labeling, Completed, Failed) for both internal and public (v1alpha) APIs.
- State enum: CREATED, POOL_ASSIGNING, RANKING, LABELING, COMPLETED, FAILED.
- Both internal and public proto definitions in a single PR per task guidance.
- AIP-159 wildcard support documented on public List parent field.

## Test plan
- bazel build passes for all proto targets (internal state, internal message, internal service, public message, public service)

Issue: #3882