### PR TITLE
feat: add ListEventGroupActivities to internal kingdom service

### DIFF
--- a/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/SpannerEventGroupActivitiesService.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/SpannerEventGroupActivitiesService.kt
@@ -228,18 +228,6 @@ class SpannerEventGroupActivitiesService(
         .asStatusRuntimeException(Status.Code.INVALID_ARGUMENT)
     }
 
-    // Validate DataProvider exists.
-    val dataProviderResult =
-      DataProviderReader()
-        .readByExternalDataProviderId(
-          client.singleUse(),
-          ExternalId(request.externalDataProviderId),
-        )
-    if (dataProviderResult == null) {
-      throw DataProviderNotFoundException(ExternalId(request.externalDataProviderId))
-        .asStatusRuntimeException(Status.Code.NOT_FOUND, "DataProvider not found.")
-    }
-
     val pageSize =
       if (request.pageSize == 0) {
         DEFAULT_PAGE_SIZE
@@ -264,16 +252,27 @@ class SpannerEventGroupActivitiesService(
       }
 
     val resultList =
-      EventGroupActivityReader()
-        .readEventGroupActivities(
-          client.singleUse(),
-          request.externalDataProviderId,
-          externalEventGroupIds,
-          pageSize + 1,
-          after,
-          dateInterval,
-        )
-        .map { it.eventGroupActivity }
+      client.readOnlyTransaction().use { txn ->
+        // Validate DataProvider exists.
+        val dataProviderResult =
+          DataProviderReader()
+            .readByExternalDataProviderId(txn, ExternalId(request.externalDataProviderId))
+        if (dataProviderResult == null) {
+          throw DataProviderNotFoundException(ExternalId(request.externalDataProviderId))
+            .asStatusRuntimeException(Status.Code.NOT_FOUND)
+        }
+
+        EventGroupActivityReader()
+          .readEventGroupActivities(
+            txn,
+            request.externalDataProviderId,
+            externalEventGroupIds,
+            pageSize + 1,
+            after,
+            dateInterval,
+          )
+          .map { it.eventGroupActivity }
+      }
 
     if (resultList.isEmpty()) {
       return ListEventGroupActivitiesResponse.getDefaultInstance()

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/SpannerEventGroupActivitiesService.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/SpannerEventGroupActivitiesService.kt
@@ -20,6 +20,7 @@ import io.grpc.Status
 import kotlin.coroutines.CoroutineContext
 import kotlin.coroutines.EmptyCoroutineContext
 import org.wfanet.measurement.common.grpc.grpcRequire
+import org.wfanet.measurement.common.identity.ExternalId
 import org.wfanet.measurement.common.identity.IdGenerator
 import org.wfanet.measurement.gcloud.spanner.AsyncDatabaseClient
 import org.wfanet.measurement.internal.kingdom.BatchDeleteEventGroupActivitiesRequest
@@ -39,6 +40,7 @@ import org.wfanet.measurement.kingdom.deploy.gcloud.spanner.common.EventGroupNot
 import org.wfanet.measurement.kingdom.deploy.gcloud.spanner.common.InvalidFieldValueException
 import org.wfanet.measurement.kingdom.deploy.gcloud.spanner.common.KingdomInternalException
 import org.wfanet.measurement.kingdom.deploy.gcloud.spanner.common.RequiredFieldNotSetException
+import org.wfanet.measurement.kingdom.deploy.gcloud.spanner.readers.DataProviderReader
 import org.wfanet.measurement.kingdom.deploy.gcloud.spanner.readers.EventGroupActivityReader
 import org.wfanet.measurement.kingdom.deploy.gcloud.spanner.writers.BatchDeleteEventGroupActivities
 import org.wfanet.measurement.kingdom.deploy.gcloud.spanner.writers.BatchUpdateEventGroupActivities
@@ -226,9 +228,16 @@ class SpannerEventGroupActivitiesService(
         .asStatusRuntimeException(Status.Code.INVALID_ARGUMENT)
     }
 
-    if (request.externalEventGroupId == 0L) {
-      throw RequiredFieldNotSetException("external_event_group_id")
-        .asStatusRuntimeException(Status.Code.INVALID_ARGUMENT)
+    // Validate DataProvider exists.
+    val dataProviderResult =
+      DataProviderReader()
+        .readByExternalDataProviderId(
+          client.singleUse(),
+          ExternalId(request.externalDataProviderId),
+        )
+    if (dataProviderResult == null) {
+      throw DataProviderNotFoundException(ExternalId(request.externalDataProviderId))
+        .asStatusRuntimeException(Status.Code.NOT_FOUND, "DataProvider not found.")
     }
 
     val pageSize =
@@ -240,12 +249,19 @@ class SpannerEventGroupActivitiesService(
 
     val after = if (request.hasPageToken()) request.pageToken.after else null
 
+    val externalEventGroupIds =
+      if (request.hasFilter()) {
+        request.filter.externalEventGroupIdsList
+      } else {
+        emptyList()
+      }
+
     val resultList =
       EventGroupActivityReader()
         .readEventGroupActivities(
           client.singleUse(),
           request.externalDataProviderId,
-          request.externalEventGroupId,
+          externalEventGroupIds,
           pageSize + 1,
           after,
         )
@@ -258,10 +274,12 @@ class SpannerEventGroupActivitiesService(
     return listEventGroupActivitiesResponse {
       for ((index, activity) in resultList.withIndex()) {
         if (index == pageSize) {
+          val lastActivity = this@listEventGroupActivitiesResponse.eventGroupActivities.last()
           nextPageToken = listEventGroupActivitiesPageToken {
             this.after =
               ListEventGroupActivitiesPageTokenKt.after {
-                date = this@listEventGroupActivitiesResponse.eventGroupActivities.last().date
+                date = lastActivity.date
+                externalEventGroupId = lastActivity.externalEventGroupId
               }
           }
         } else {

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/SpannerEventGroupActivitiesService.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/SpannerEventGroupActivitiesService.kt
@@ -42,6 +42,7 @@ import org.wfanet.measurement.kingdom.deploy.gcloud.spanner.common.KingdomIntern
 import org.wfanet.measurement.kingdom.deploy.gcloud.spanner.common.RequiredFieldNotSetException
 import org.wfanet.measurement.kingdom.deploy.gcloud.spanner.readers.DataProviderReader
 import org.wfanet.measurement.kingdom.deploy.gcloud.spanner.readers.EventGroupActivityReader
+import org.wfanet.measurement.kingdom.deploy.gcloud.spanner.readers.EventGroupReader
 import org.wfanet.measurement.kingdom.deploy.gcloud.spanner.writers.BatchDeleteEventGroupActivities
 import org.wfanet.measurement.kingdom.deploy.gcloud.spanner.writers.BatchUpdateEventGroupActivities
 
@@ -223,6 +224,11 @@ class SpannerEventGroupActivitiesService(
   ): ListEventGroupActivitiesResponse {
     grpcRequire(request.pageSize >= 0) { "Page size cannot be less than 0" }
 
+    if (request.externalDataProviderId == 0L) {
+      throw RequiredFieldNotSetException("external_data_provider_id")
+        .asStatusRuntimeException(Status.Code.INVALID_ARGUMENT)
+    }
+
     val pageSize =
       if (request.pageSize == 0) {
         DEFAULT_PAGE_SIZE
@@ -239,11 +245,6 @@ class SpannerEventGroupActivitiesService(
         null
       }
 
-    if (request.externalDataProviderId == 0L) {
-      throw RequiredFieldNotSetException("external_data_provider_id")
-        .asStatusRuntimeException(Status.Code.INVALID_ARGUMENT)
-    }
-
     val resultList =
       client.readOnlyTransaction().use { txn ->
         // Validate DataProvider exists.
@@ -255,11 +256,29 @@ class SpannerEventGroupActivitiesService(
             .asStatusRuntimeException(Status.Code.NOT_FOUND)
         }
 
+        // Validate EventGroup exists if specified.
+        if (request.externalEventGroupId != 0L) {
+          val eventGroupResult =
+            EventGroupReader()
+              .readByDataProvider(
+                txn,
+                ExternalId(request.externalDataProviderId),
+                ExternalId(request.externalEventGroupId),
+              )
+          if (eventGroupResult == null) {
+            throw EventGroupNotFoundException(
+                ExternalId(request.externalDataProviderId),
+                ExternalId(request.externalEventGroupId),
+              )
+              .asStatusRuntimeException(Status.Code.NOT_FOUND)
+          }
+        }
+
         EventGroupActivityReader()
           .readEventGroupActivities(
             txn,
             request.externalDataProviderId,
-            if (request.hasExternalEventGroupId()) request.externalEventGroupId else null,
+            request.externalEventGroupId,
             pageSize + 1,
             after,
             dateInterval,

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/SpannerEventGroupActivitiesService.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/SpannerEventGroupActivitiesService.kt
@@ -256,6 +256,13 @@ class SpannerEventGroupActivitiesService(
         emptyList()
       }
 
+    val dateInterval =
+      if (request.hasFilter() && request.filter.hasDateInterval()) {
+        request.filter.dateInterval
+      } else {
+        null
+      }
+
     val resultList =
       EventGroupActivityReader()
         .readEventGroupActivities(
@@ -264,6 +271,7 @@ class SpannerEventGroupActivitiesService(
           externalEventGroupIds,
           pageSize + 1,
           after,
+          dateInterval,
         )
         .map { it.eventGroupActivity }
 

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/SpannerEventGroupActivitiesService.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/SpannerEventGroupActivitiesService.kt
@@ -239,24 +239,27 @@ class SpannerEventGroupActivitiesService(
         null
       }
 
+    if (request.externalDataProviderId == 0L) {
+      throw RequiredFieldNotSetException("external_data_provider_id")
+        .asStatusRuntimeException(Status.Code.INVALID_ARGUMENT)
+    }
+
     val resultList =
       client.readOnlyTransaction().use { txn ->
-        // Validate DataProvider exists if specified.
-        if (request.externalDataProviderId != 0L) {
-          val dataProviderResult =
-            DataProviderReader()
-              .readByExternalDataProviderId(txn, ExternalId(request.externalDataProviderId))
-          if (dataProviderResult == null) {
-            throw DataProviderNotFoundException(ExternalId(request.externalDataProviderId))
-              .asStatusRuntimeException(Status.Code.NOT_FOUND)
-          }
+        // Validate DataProvider exists.
+        val dataProviderResult =
+          DataProviderReader()
+            .readByExternalDataProviderId(txn, ExternalId(request.externalDataProviderId))
+        if (dataProviderResult == null) {
+          throw DataProviderNotFoundException(ExternalId(request.externalDataProviderId))
+            .asStatusRuntimeException(Status.Code.NOT_FOUND)
         }
 
         EventGroupActivityReader()
           .readEventGroupActivities(
             txn,
             request.externalDataProviderId,
-            request.externalEventGroupId,
+            if (request.hasExternalEventGroupId()) request.externalEventGroupId else null,
             pageSize + 1,
             after,
             dateInterval,

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/SpannerEventGroupActivitiesService.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/SpannerEventGroupActivitiesService.kt
@@ -19,6 +19,7 @@ import com.google.type.Date
 import io.grpc.Status
 import kotlin.coroutines.CoroutineContext
 import kotlin.coroutines.EmptyCoroutineContext
+import org.wfanet.measurement.common.grpc.grpcRequire
 import org.wfanet.measurement.common.identity.IdGenerator
 import org.wfanet.measurement.gcloud.spanner.AsyncDatabaseClient
 import org.wfanet.measurement.internal.kingdom.BatchDeleteEventGroupActivitiesRequest
@@ -26,13 +27,19 @@ import org.wfanet.measurement.internal.kingdom.BatchUpdateEventGroupActivitiesRe
 import org.wfanet.measurement.internal.kingdom.BatchUpdateEventGroupActivitiesResponse
 import org.wfanet.measurement.internal.kingdom.DeleteEventGroupActivityRequest
 import org.wfanet.measurement.internal.kingdom.EventGroupActivitiesGrpcKt.EventGroupActivitiesCoroutineImplBase
+import org.wfanet.measurement.internal.kingdom.ListEventGroupActivitiesPageTokenKt
+import org.wfanet.measurement.internal.kingdom.ListEventGroupActivitiesRequest
+import org.wfanet.measurement.internal.kingdom.ListEventGroupActivitiesResponse
 import org.wfanet.measurement.internal.kingdom.batchDeleteEventGroupActivitiesRequest
+import org.wfanet.measurement.internal.kingdom.listEventGroupActivitiesPageToken
+import org.wfanet.measurement.internal.kingdom.listEventGroupActivitiesResponse
 import org.wfanet.measurement.kingdom.deploy.gcloud.spanner.common.DataProviderNotFoundException
 import org.wfanet.measurement.kingdom.deploy.gcloud.spanner.common.EventGroupActivityNotFoundException
 import org.wfanet.measurement.kingdom.deploy.gcloud.spanner.common.EventGroupNotFoundException
 import org.wfanet.measurement.kingdom.deploy.gcloud.spanner.common.InvalidFieldValueException
 import org.wfanet.measurement.kingdom.deploy.gcloud.spanner.common.KingdomInternalException
 import org.wfanet.measurement.kingdom.deploy.gcloud.spanner.common.RequiredFieldNotSetException
+import org.wfanet.measurement.kingdom.deploy.gcloud.spanner.readers.EventGroupActivityReader
 import org.wfanet.measurement.kingdom.deploy.gcloud.spanner.writers.BatchDeleteEventGroupActivities
 import org.wfanet.measurement.kingdom.deploy.gcloud.spanner.writers.BatchUpdateEventGroupActivities
 
@@ -207,5 +214,65 @@ class SpannerEventGroupActivitiesService(
     }
 
     return Empty.getDefaultInstance()
+  }
+
+  override suspend fun listEventGroupActivities(
+    request: ListEventGroupActivitiesRequest
+  ): ListEventGroupActivitiesResponse {
+    grpcRequire(request.pageSize >= 0) { "Page size cannot be less than 0" }
+
+    if (request.externalDataProviderId == 0L) {
+      throw RequiredFieldNotSetException("external_data_provider_id")
+        .asStatusRuntimeException(Status.Code.INVALID_ARGUMENT)
+    }
+
+    if (request.externalEventGroupId == 0L) {
+      throw RequiredFieldNotSetException("external_event_group_id")
+        .asStatusRuntimeException(Status.Code.INVALID_ARGUMENT)
+    }
+
+    val pageSize =
+      if (request.pageSize == 0) {
+        DEFAULT_PAGE_SIZE
+      } else {
+        request.pageSize.coerceAtMost(MAX_PAGE_SIZE)
+      }
+
+    val after = if (request.hasPageToken()) request.pageToken.after else null
+
+    val resultList =
+      EventGroupActivityReader()
+        .readEventGroupActivities(
+          client.singleUse(),
+          request.externalDataProviderId,
+          request.externalEventGroupId,
+          pageSize + 1,
+          after,
+        )
+        .map { it.eventGroupActivity }
+
+    if (resultList.isEmpty()) {
+      return ListEventGroupActivitiesResponse.getDefaultInstance()
+    }
+
+    return listEventGroupActivitiesResponse {
+      for ((index, activity) in resultList.withIndex()) {
+        if (index == pageSize) {
+          nextPageToken = listEventGroupActivitiesPageToken {
+            this.after =
+              ListEventGroupActivitiesPageTokenKt.after {
+                date = this@listEventGroupActivitiesResponse.eventGroupActivities.last().date
+              }
+          }
+        } else {
+          this.eventGroupActivities += activity
+        }
+      }
+    }
+  }
+
+  companion object {
+    private const val MAX_PAGE_SIZE = 1000
+    private const val DEFAULT_PAGE_SIZE = 50
   }
 }

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/SpannerEventGroupActivitiesService.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/SpannerEventGroupActivitiesService.kt
@@ -223,11 +223,6 @@ class SpannerEventGroupActivitiesService(
   ): ListEventGroupActivitiesResponse {
     grpcRequire(request.pageSize >= 0) { "Page size cannot be less than 0" }
 
-    if (request.externalDataProviderId == 0L) {
-      throw RequiredFieldNotSetException("external_data_provider_id")
-        .asStatusRuntimeException(Status.Code.INVALID_ARGUMENT)
-    }
-
     val pageSize =
       if (request.pageSize == 0) {
         DEFAULT_PAGE_SIZE
@@ -236,13 +231,6 @@ class SpannerEventGroupActivitiesService(
       }
 
     val after = if (request.hasPageToken()) request.pageToken.after else null
-
-    val externalEventGroupIds =
-      if (request.hasFilter()) {
-        request.filter.externalEventGroupIdsList
-      } else {
-        emptyList()
-      }
 
     val dateInterval =
       if (request.hasFilter() && request.filter.hasDateInterval()) {
@@ -253,20 +241,22 @@ class SpannerEventGroupActivitiesService(
 
     val resultList =
       client.readOnlyTransaction().use { txn ->
-        // Validate DataProvider exists.
-        val dataProviderResult =
-          DataProviderReader()
-            .readByExternalDataProviderId(txn, ExternalId(request.externalDataProviderId))
-        if (dataProviderResult == null) {
-          throw DataProviderNotFoundException(ExternalId(request.externalDataProviderId))
-            .asStatusRuntimeException(Status.Code.NOT_FOUND)
+        // Validate DataProvider exists if specified.
+        if (request.externalDataProviderId != 0L) {
+          val dataProviderResult =
+            DataProviderReader()
+              .readByExternalDataProviderId(txn, ExternalId(request.externalDataProviderId))
+          if (dataProviderResult == null) {
+            throw DataProviderNotFoundException(ExternalId(request.externalDataProviderId))
+              .asStatusRuntimeException(Status.Code.NOT_FOUND)
+          }
         }
 
         EventGroupActivityReader()
           .readEventGroupActivities(
             txn,
             request.externalDataProviderId,
-            externalEventGroupIds,
+            request.externalEventGroupId,
             pageSize + 1,
             after,
             dateInterval,

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/readers/EventGroupActivityReader.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/readers/EventGroupActivityReader.kt
@@ -19,10 +19,12 @@ import com.google.cloud.spanner.KeySet
 import com.google.cloud.spanner.Statement
 import com.google.cloud.spanner.Struct
 import com.google.type.Date
+import com.google.type.Interval
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.toList
 import org.wfanet.measurement.common.identity.InternalId
 import org.wfanet.measurement.gcloud.common.toCloudDate
+import org.wfanet.measurement.gcloud.common.toGcloudTimestamp
 import org.wfanet.measurement.gcloud.common.toProtoDate
 import org.wfanet.measurement.gcloud.spanner.AsyncDatabaseClient
 import org.wfanet.measurement.gcloud.spanner.appendClause
@@ -95,6 +97,7 @@ class EventGroupActivityReader : BaseSpannerReader<EventGroupActivityReader.Resu
     externalEventGroupIds: List<Long>,
     limit: Int,
     after: ListEventGroupActivitiesPageToken.After? = null,
+    dateInterval: Interval? = null,
   ): List<Result> {
     return fillStatementBuilder {
         val conjuncts = mutableListOf<String>()
@@ -103,6 +106,16 @@ class EventGroupActivityReader : BaseSpannerReader<EventGroupActivityReader.Resu
         if (externalEventGroupIds.isNotEmpty()) {
           conjuncts.add("EventGroups.ExternalEventGroupId IN UNNEST(@externalEventGroupIds)")
           bind("externalEventGroupIds").toInt64Array(externalEventGroupIds)
+        }
+        if (dateInterval != null) {
+          if (dateInterval.hasStartTime()) {
+            conjuncts.add("ActivityDate >= CAST(@startTime AS DATE)")
+            bind("startTime").to(dateInterval.startTime.toGcloudTimestamp())
+          }
+          if (dateInterval.hasEndTime()) {
+            conjuncts.add("ActivityDate < CAST(@endTime AS DATE)")
+            bind("endTime").to(dateInterval.endTime.toGcloudTimestamp())
+          }
         }
         if (after != null) {
           conjuncts.add(

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/readers/EventGroupActivityReader.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/readers/EventGroupActivityReader.kt
@@ -20,6 +20,7 @@ import com.google.cloud.spanner.Statement
 import com.google.cloud.spanner.Struct
 import com.google.type.Date
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.toList
 import org.wfanet.measurement.common.identity.InternalId
 import org.wfanet.measurement.gcloud.common.toCloudDate
 import org.wfanet.measurement.gcloud.common.toProtoDate
@@ -27,6 +28,7 @@ import org.wfanet.measurement.gcloud.spanner.AsyncDatabaseClient
 import org.wfanet.measurement.gcloud.spanner.appendClause
 import org.wfanet.measurement.gcloud.spanner.bind
 import org.wfanet.measurement.internal.kingdom.EventGroupActivity
+import org.wfanet.measurement.internal.kingdom.ListEventGroupActivitiesPageToken
 import org.wfanet.measurement.internal.kingdom.eventGroupActivity
 
 class EventGroupActivityReader : BaseSpannerReader<EventGroupActivityReader.Result>() {
@@ -85,6 +87,31 @@ class EventGroupActivityReader : BaseSpannerReader<EventGroupActivityReader.Resu
       date = struct.getDate("ActivityDate").toProtoDate()
       createTime = struct.getTimestamp("CreateTime").toProto()
     }
+  }
+
+  suspend fun readEventGroupActivities(
+    readContext: AsyncDatabaseClient.ReadContext,
+    externalDataProviderId: Long,
+    externalEventGroupId: Long,
+    limit: Int,
+    after: ListEventGroupActivitiesPageToken.After? = null,
+  ): List<Result> {
+    return fillStatementBuilder {
+        val conjuncts = mutableListOf<String>()
+        conjuncts.add("DataProviders.ExternalDataProviderId = @externalDataProviderId")
+        conjuncts.add("EventGroups.ExternalEventGroupId = @externalEventGroupId")
+        bind("externalDataProviderId").to(externalDataProviderId)
+        bind("externalEventGroupId").to(externalEventGroupId)
+        if (after != null) {
+          conjuncts.add("ActivityDate > @afterDate")
+          bind("afterDate").to(after.date.toCloudDate())
+        }
+        appendClause("WHERE " + conjuncts.joinToString(" AND "))
+        appendClause("ORDER BY ActivityDate ASC")
+        appendClause("LIMIT $limit")
+      }
+      .execute(readContext)
+      .toList()
   }
 
   companion object {

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/readers/EventGroupActivityReader.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/readers/EventGroupActivityReader.kt
@@ -93,7 +93,7 @@ class EventGroupActivityReader : BaseSpannerReader<EventGroupActivityReader.Resu
   suspend fun readEventGroupActivities(
     readContext: AsyncDatabaseClient.ReadContext,
     externalDataProviderId: Long,
-    externalEventGroupId: Long? = null,
+    externalEventGroupId: Long,
     limit: Int,
     after: ListEventGroupActivitiesPageToken.After? = null,
     dateInterval: DateInterval? = null,
@@ -102,7 +102,7 @@ class EventGroupActivityReader : BaseSpannerReader<EventGroupActivityReader.Resu
         val conjuncts = mutableListOf<String>()
         conjuncts.add("DataProviders.ExternalDataProviderId = @externalDataProviderId")
         bind("externalDataProviderId").to(externalDataProviderId)
-        if (externalEventGroupId != null) {
+        if (externalEventGroupId != 0L) {
           conjuncts.add("EventGroups.ExternalEventGroupId = @externalEventGroupId")
           bind("externalEventGroupId").to(externalEventGroupId)
         }

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/readers/EventGroupActivityReader.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/readers/EventGroupActivityReader.kt
@@ -92,19 +92,21 @@ class EventGroupActivityReader : BaseSpannerReader<EventGroupActivityReader.Resu
 
   suspend fun readEventGroupActivities(
     readContext: AsyncDatabaseClient.ReadContext,
-    externalDataProviderId: Long,
-    externalEventGroupIds: List<Long>,
+    externalDataProviderId: Long = 0L,
+    externalEventGroupId: Long = 0L,
     limit: Int,
     after: ListEventGroupActivitiesPageToken.After? = null,
     dateInterval: DateInterval? = null,
   ): List<Result> {
     return fillStatementBuilder {
         val conjuncts = mutableListOf<String>()
-        conjuncts.add("DataProviders.ExternalDataProviderId = @externalDataProviderId")
-        bind("externalDataProviderId").to(externalDataProviderId)
-        if (externalEventGroupIds.isNotEmpty()) {
-          conjuncts.add("EventGroups.ExternalEventGroupId IN UNNEST(@externalEventGroupIds)")
-          bind("externalEventGroupIds").toInt64Array(externalEventGroupIds)
+        if (externalDataProviderId != 0L) {
+          conjuncts.add("DataProviders.ExternalDataProviderId = @externalDataProviderId")
+          bind("externalDataProviderId").to(externalDataProviderId)
+        }
+        if (externalEventGroupId != 0L) {
+          conjuncts.add("EventGroups.ExternalEventGroupId = @externalEventGroupId")
+          bind("externalEventGroupId").to(externalEventGroupId)
         }
         if (dateInterval != null) {
           if (dateInterval.hasStartDate()) {
@@ -123,7 +125,9 @@ class EventGroupActivityReader : BaseSpannerReader<EventGroupActivityReader.Resu
           bind("afterDate").to(after.date.toCloudDate())
           bind("afterEventGroupId").to(after.externalEventGroupId)
         }
-        appendClause("WHERE " + conjuncts.joinToString(" AND "))
+        if (conjuncts.isNotEmpty()) {
+          appendClause("WHERE " + conjuncts.joinToString(" AND "))
+        }
         appendClause("ORDER BY ActivityDate ASC, EventGroups.ExternalEventGroupId ASC")
         appendClause("LIMIT $limit")
       }

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/readers/EventGroupActivityReader.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/readers/EventGroupActivityReader.kt
@@ -1,4 +1,4 @@
-// Copyright 2025 The Cross-Media Measurement Authors
+// Copyright 2026 The Cross-Media Measurement Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -92,22 +92,27 @@ class EventGroupActivityReader : BaseSpannerReader<EventGroupActivityReader.Resu
   suspend fun readEventGroupActivities(
     readContext: AsyncDatabaseClient.ReadContext,
     externalDataProviderId: Long,
-    externalEventGroupId: Long,
+    externalEventGroupIds: List<Long>,
     limit: Int,
     after: ListEventGroupActivitiesPageToken.After? = null,
   ): List<Result> {
     return fillStatementBuilder {
         val conjuncts = mutableListOf<String>()
         conjuncts.add("DataProviders.ExternalDataProviderId = @externalDataProviderId")
-        conjuncts.add("EventGroups.ExternalEventGroupId = @externalEventGroupId")
         bind("externalDataProviderId").to(externalDataProviderId)
-        bind("externalEventGroupId").to(externalEventGroupId)
+        if (externalEventGroupIds.isNotEmpty()) {
+          conjuncts.add("EventGroups.ExternalEventGroupId IN UNNEST(@externalEventGroupIds)")
+          bind("externalEventGroupIds").toInt64Array(externalEventGroupIds)
+        }
         if (after != null) {
-          conjuncts.add("ActivityDate > @afterDate")
+          conjuncts.add(
+            "((ActivityDate > @afterDate) OR (ActivityDate = @afterDate AND EventGroups.ExternalEventGroupId > @afterEventGroupId))"
+          )
           bind("afterDate").to(after.date.toCloudDate())
+          bind("afterEventGroupId").to(after.externalEventGroupId)
         }
         appendClause("WHERE " + conjuncts.joinToString(" AND "))
-        appendClause("ORDER BY ActivityDate ASC")
+        appendClause("ORDER BY ActivityDate ASC, EventGroups.ExternalEventGroupId ASC")
         appendClause("LIMIT $limit")
       }
       .execute(readContext)

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/readers/EventGroupActivityReader.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/readers/EventGroupActivityReader.kt
@@ -19,16 +19,15 @@ import com.google.cloud.spanner.KeySet
 import com.google.cloud.spanner.Statement
 import com.google.cloud.spanner.Struct
 import com.google.type.Date
-import com.google.type.Interval
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.toList
 import org.wfanet.measurement.common.identity.InternalId
 import org.wfanet.measurement.gcloud.common.toCloudDate
-import org.wfanet.measurement.gcloud.common.toGcloudTimestamp
 import org.wfanet.measurement.gcloud.common.toProtoDate
 import org.wfanet.measurement.gcloud.spanner.AsyncDatabaseClient
 import org.wfanet.measurement.gcloud.spanner.appendClause
 import org.wfanet.measurement.gcloud.spanner.bind
+import org.wfanet.measurement.internal.kingdom.DateInterval
 import org.wfanet.measurement.internal.kingdom.EventGroupActivity
 import org.wfanet.measurement.internal.kingdom.ListEventGroupActivitiesPageToken
 import org.wfanet.measurement.internal.kingdom.eventGroupActivity
@@ -97,7 +96,7 @@ class EventGroupActivityReader : BaseSpannerReader<EventGroupActivityReader.Resu
     externalEventGroupIds: List<Long>,
     limit: Int,
     after: ListEventGroupActivitiesPageToken.After? = null,
-    dateInterval: Interval? = null,
+    dateInterval: DateInterval? = null,
   ): List<Result> {
     return fillStatementBuilder {
         val conjuncts = mutableListOf<String>()
@@ -108,13 +107,13 @@ class EventGroupActivityReader : BaseSpannerReader<EventGroupActivityReader.Resu
           bind("externalEventGroupIds").toInt64Array(externalEventGroupIds)
         }
         if (dateInterval != null) {
-          if (dateInterval.hasStartTime()) {
-            conjuncts.add("ActivityDate >= CAST(@startTime AS DATE)")
-            bind("startTime").to(dateInterval.startTime.toGcloudTimestamp())
+          if (dateInterval.hasStartDate()) {
+            conjuncts.add("ActivityDate >= @startDate")
+            bind("startDate").to(dateInterval.startDate.toCloudDate())
           }
-          if (dateInterval.hasEndTime()) {
-            conjuncts.add("ActivityDate < CAST(@endTime AS DATE)")
-            bind("endTime").to(dateInterval.endTime.toGcloudTimestamp())
+          if (dateInterval.hasEndDate()) {
+            conjuncts.add("ActivityDate < @endDate")
+            bind("endDate").to(dateInterval.endDate.toCloudDate())
           }
         }
         if (after != null) {

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/readers/EventGroupActivityReader.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/readers/EventGroupActivityReader.kt
@@ -92,19 +92,17 @@ class EventGroupActivityReader : BaseSpannerReader<EventGroupActivityReader.Resu
 
   suspend fun readEventGroupActivities(
     readContext: AsyncDatabaseClient.ReadContext,
-    externalDataProviderId: Long = 0L,
-    externalEventGroupId: Long = 0L,
+    externalDataProviderId: Long,
+    externalEventGroupId: Long? = null,
     limit: Int,
     after: ListEventGroupActivitiesPageToken.After? = null,
     dateInterval: DateInterval? = null,
   ): List<Result> {
     return fillStatementBuilder {
         val conjuncts = mutableListOf<String>()
-        if (externalDataProviderId != 0L) {
-          conjuncts.add("DataProviders.ExternalDataProviderId = @externalDataProviderId")
-          bind("externalDataProviderId").to(externalDataProviderId)
-        }
-        if (externalEventGroupId != 0L) {
+        conjuncts.add("DataProviders.ExternalDataProviderId = @externalDataProviderId")
+        bind("externalDataProviderId").to(externalDataProviderId)
+        if (externalEventGroupId != null) {
           conjuncts.add("EventGroups.ExternalEventGroupId = @externalEventGroupId")
           bind("externalEventGroupId").to(externalEventGroupId)
         }

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/service/internal/testing/BUILD.bazel
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/service/internal/testing/BUILD.bazel
@@ -16,6 +16,7 @@ kt_jvm_library(
         "//src/main/kotlin/org/wfanet/measurement/kingdom/deploy/common:trus_tee_protocol_config",
         "//src/main/kotlin/org/wfanet/measurement/kingdom/deploy/common/testing",
         "//src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/common",
+        "//src/main/proto/google/rpc:error_details_kt_jvm_proto",
         "//src/main/proto/wfa/measurement/api/v2alpha/event_group_metadata/testing:test_metadata_message_2_kt_jvm_proto",
         "//src/main/proto/wfa/measurement/api/v2alpha/event_group_metadata/testing:test_metadata_message_kt_jvm_proto",
         "@wfa_common_jvm//imports/java/com/google/cloud/spanner",

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/service/internal/testing/EventGroupActivitiesServiceTest.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/service/internal/testing/EventGroupActivitiesServiceTest.kt
@@ -1046,7 +1046,7 @@ abstract class EventGroupActivitiesServiceTest<T : EventGroupActivitiesCoroutine
       eventGroupActivitiesService.listEventGroupActivities(
         listEventGroupActivitiesRequest {
           externalDataProviderId = dataProvider.externalDataProviderId
-          filter = filter { externalEventGroupIds += eventGroup.externalEventGroupId }
+          externalEventGroupId = eventGroup.externalEventGroupId
         }
       )
 
@@ -1121,7 +1121,7 @@ abstract class EventGroupActivitiesServiceTest<T : EventGroupActivitiesCoroutine
       eventGroupActivitiesService.listEventGroupActivities(
         listEventGroupActivitiesRequest {
           externalDataProviderId = dataProvider.externalDataProviderId
-          filter = filter { externalEventGroupIds += eventGroup.externalEventGroupId }
+          externalEventGroupId = eventGroup.externalEventGroupId
           pageSize = 1
         }
       )
@@ -1133,7 +1133,7 @@ abstract class EventGroupActivitiesServiceTest<T : EventGroupActivitiesCoroutine
       eventGroupActivitiesService.listEventGroupActivities(
         listEventGroupActivitiesRequest {
           externalDataProviderId = dataProvider.externalDataProviderId
-          filter = filter { externalEventGroupIds += eventGroup.externalEventGroupId }
+          externalEventGroupId = eventGroup.externalEventGroupId
           pageToken = firstResponse.nextPageToken
         }
       )
@@ -1171,32 +1171,12 @@ abstract class EventGroupActivitiesServiceTest<T : EventGroupActivitiesCoroutine
       eventGroupActivitiesService.listEventGroupActivities(
         listEventGroupActivitiesRequest {
           externalDataProviderId = dataProvider.externalDataProviderId
-          filter = filter { externalEventGroupIds += eventGroup.externalEventGroupId }
+          externalEventGroupId = eventGroup.externalEventGroupId
         }
       )
 
     assertThat(response.eventGroupActivitiesList).isEmpty()
     assertThat(response.hasNextPageToken()).isFalse()
-  }
-
-  @Test
-  fun `listEventGroupActivities throws INVALID_ARGUMENT when external_data_provider_id is missing`() {
-    runBlocking {
-      val exception =
-        assertFailsWith<StatusRuntimeException> {
-          eventGroupActivitiesService.listEventGroupActivities(listEventGroupActivitiesRequest {})
-        }
-
-      assertThat(exception.status.code).isEqualTo(Status.Code.INVALID_ARGUMENT)
-      assertThat(exception.errorInfo)
-        .isEqualTo(
-          errorInfo {
-            domain = KingdomInternalException.DOMAIN
-            reason = ErrorCode.REQUIRED_FIELD_NOT_SET.name
-            metadata["field_name"] = "external_data_provider_id"
-          }
-        )
-    }
   }
 
   @Test
@@ -1245,7 +1225,7 @@ abstract class EventGroupActivitiesServiceTest<T : EventGroupActivitiesCoroutine
       eventGroupActivitiesService.listEventGroupActivities(
         listEventGroupActivitiesRequest {
           externalDataProviderId = dataProvider.externalDataProviderId
-          filter = filter { externalEventGroupIds += eventGroup.externalEventGroupId }
+          externalEventGroupId = eventGroup.externalEventGroupId
           pageSize = 1
         }
       )
@@ -1312,7 +1292,7 @@ abstract class EventGroupActivitiesServiceTest<T : EventGroupActivitiesCoroutine
       eventGroupActivitiesService.listEventGroupActivities(
         listEventGroupActivitiesRequest {
           externalDataProviderId = dataProvider.externalDataProviderId
-          filter = filter { externalEventGroupIds += eventGroup.externalEventGroupId }
+          externalEventGroupId = eventGroup.externalEventGroupId
           pageSize = 1
         }
       )
@@ -1324,7 +1304,7 @@ abstract class EventGroupActivitiesServiceTest<T : EventGroupActivitiesCoroutine
       eventGroupActivitiesService.listEventGroupActivities(
         listEventGroupActivitiesRequest {
           externalDataProviderId = dataProvider.externalDataProviderId
-          filter = filter { externalEventGroupIds += eventGroup.externalEventGroupId }
+          externalEventGroupId = eventGroup.externalEventGroupId
           pageSize = 1
           pageToken = firstResponse.nextPageToken
         }
@@ -1372,7 +1352,7 @@ abstract class EventGroupActivitiesServiceTest<T : EventGroupActivitiesCoroutine
       eventGroupActivitiesService.listEventGroupActivities(
         listEventGroupActivitiesRequest {
           externalDataProviderId = dataProvider.externalDataProviderId
-          filter = filter { externalEventGroupIds += eventGroup.externalEventGroupId }
+          externalEventGroupId = eventGroup.externalEventGroupId
           pageSize = 5000
         }
       )
@@ -1522,7 +1502,7 @@ abstract class EventGroupActivitiesServiceTest<T : EventGroupActivitiesCoroutine
         eventGroupActivitiesService.listEventGroupActivities(
           listEventGroupActivitiesRequest {
             externalDataProviderId = dataProvider.externalDataProviderId
-            filter = filter { externalEventGroupIds += eventGroup.externalEventGroupId }
+            externalEventGroupId = eventGroup.externalEventGroupId
           }
         )
 
@@ -1588,8 +1568,8 @@ abstract class EventGroupActivitiesServiceTest<T : EventGroupActivitiesCoroutine
       eventGroupActivitiesService.listEventGroupActivities(
         listEventGroupActivitiesRequest {
           externalDataProviderId = dataProvider.externalDataProviderId
+          externalEventGroupId = eventGroup.externalEventGroupId
           filter = filter {
-            externalEventGroupIds += eventGroup.externalEventGroupId
             dateInterval = dateInterval {
               startDate = date {
                 year = 2025

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/service/internal/testing/EventGroupActivitiesServiceTest.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/service/internal/testing/EventGroupActivitiesServiceTest.kt
@@ -1,4 +1,4 @@
-// Copyright 2025 The Cross-Media Measurement Authors
+// Copyright 2026 The Cross-Media Measurement Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -47,6 +47,7 @@ import org.wfanet.measurement.internal.kingdom.EventGroupDetailsKt.EventGroupMet
 import org.wfanet.measurement.internal.kingdom.EventGroupDetailsKt.EventGroupMetadataKt.adMetadata
 import org.wfanet.measurement.internal.kingdom.EventGroupDetailsKt.eventGroupMetadata
 import org.wfanet.measurement.internal.kingdom.EventGroupsGrpcKt.EventGroupsCoroutineImplBase
+import org.wfanet.measurement.internal.kingdom.ListEventGroupActivitiesRequest
 import org.wfanet.measurement.internal.kingdom.MeasurementConsumersGrpcKt.MeasurementConsumersCoroutineImplBase
 import org.wfanet.measurement.internal.kingdom.MediaType
 import org.wfanet.measurement.internal.kingdom.batchDeleteEventGroupActivitiesRequest
@@ -1040,7 +1041,10 @@ abstract class EventGroupActivitiesServiceTest<T : EventGroupActivitiesCoroutine
       eventGroupActivitiesService.listEventGroupActivities(
         listEventGroupActivitiesRequest {
           externalDataProviderId = dataProvider.externalDataProviderId
-          externalEventGroupId = eventGroup.externalEventGroupId
+          filter =
+            ListEventGroupActivitiesRequest.Filter.newBuilder()
+              .addExternalEventGroupIds(eventGroup.externalEventGroupId)
+              .build()
         }
       )
 
@@ -1109,7 +1113,10 @@ abstract class EventGroupActivitiesServiceTest<T : EventGroupActivitiesCoroutine
       eventGroupActivitiesService.listEventGroupActivities(
         listEventGroupActivitiesRequest {
           externalDataProviderId = dataProvider.externalDataProviderId
-          externalEventGroupId = eventGroup.externalEventGroupId
+          filter =
+            ListEventGroupActivitiesRequest.Filter.newBuilder()
+              .addExternalEventGroupIds(eventGroup.externalEventGroupId)
+              .build()
           pageSize = 1
         }
       )
@@ -1121,7 +1128,10 @@ abstract class EventGroupActivitiesServiceTest<T : EventGroupActivitiesCoroutine
       eventGroupActivitiesService.listEventGroupActivities(
         listEventGroupActivitiesRequest {
           externalDataProviderId = dataProvider.externalDataProviderId
-          externalEventGroupId = eventGroup.externalEventGroupId
+          filter =
+            ListEventGroupActivitiesRequest.Filter.newBuilder()
+              .addExternalEventGroupIds(eventGroup.externalEventGroupId)
+              .build()
           pageToken = firstResponse.nextPageToken
         }
       )
@@ -1143,6 +1153,8 @@ abstract class EventGroupActivitiesServiceTest<T : EventGroupActivitiesCoroutine
           day = 10
         }
       )
+    assertThat(secondResponse.eventGroupActivitiesList.map { it.date })
+      .containsNoneIn(firstResponse.eventGroupActivitiesList.map { it.date })
   }
 
   @Test
@@ -1151,7 +1163,10 @@ abstract class EventGroupActivitiesServiceTest<T : EventGroupActivitiesCoroutine
       eventGroupActivitiesService.listEventGroupActivities(
         listEventGroupActivitiesRequest {
           externalDataProviderId = dataProvider.externalDataProviderId
-          externalEventGroupId = eventGroup.externalEventGroupId
+          filter =
+            ListEventGroupActivitiesRequest.Filter.newBuilder()
+              .addExternalEventGroupIds(eventGroup.externalEventGroupId)
+              .build()
         }
       )
 
@@ -1164,31 +1179,11 @@ abstract class EventGroupActivitiesServiceTest<T : EventGroupActivitiesCoroutine
     runBlocking {
       val exception =
         assertFailsWith<StatusRuntimeException> {
-          eventGroupActivitiesService.listEventGroupActivities(
-            listEventGroupActivitiesRequest {
-              externalEventGroupId = eventGroup.externalEventGroupId
-            }
-          )
+          eventGroupActivitiesService.listEventGroupActivities(listEventGroupActivitiesRequest {})
         }
 
       assertThat(exception.status.code).isEqualTo(Status.Code.INVALID_ARGUMENT)
       assertThat(exception).hasMessageThat().contains("external_data_provider_id")
-    }
-
-  @Test
-  fun `listEventGroupActivities throws INVALID_ARGUMENT when external_event_group_id is missing`() =
-    runBlocking {
-      val exception =
-        assertFailsWith<StatusRuntimeException> {
-          eventGroupActivitiesService.listEventGroupActivities(
-            listEventGroupActivitiesRequest {
-              externalDataProviderId = dataProvider.externalDataProviderId
-            }
-          )
-        }
-
-      assertThat(exception.status.code).isEqualTo(Status.Code.INVALID_ARGUMENT)
-      assertThat(exception).hasMessageThat().contains("external_event_group_id")
     }
 
   @Test
@@ -1237,7 +1232,10 @@ abstract class EventGroupActivitiesServiceTest<T : EventGroupActivitiesCoroutine
       eventGroupActivitiesService.listEventGroupActivities(
         listEventGroupActivitiesRequest {
           externalDataProviderId = dataProvider.externalDataProviderId
-          externalEventGroupId = eventGroup.externalEventGroupId
+          filter =
+            ListEventGroupActivitiesRequest.Filter.newBuilder()
+              .addExternalEventGroupIds(eventGroup.externalEventGroupId)
+              .build()
           pageSize = 1
         }
       )
@@ -1300,7 +1298,10 @@ abstract class EventGroupActivitiesServiceTest<T : EventGroupActivitiesCoroutine
       eventGroupActivitiesService.listEventGroupActivities(
         listEventGroupActivitiesRequest {
           externalDataProviderId = dataProvider.externalDataProviderId
-          externalEventGroupId = eventGroup.externalEventGroupId
+          filter =
+            ListEventGroupActivitiesRequest.Filter.newBuilder()
+              .addExternalEventGroupIds(eventGroup.externalEventGroupId)
+              .build()
           pageSize = 1
         }
       )
@@ -1312,7 +1313,10 @@ abstract class EventGroupActivitiesServiceTest<T : EventGroupActivitiesCoroutine
       eventGroupActivitiesService.listEventGroupActivities(
         listEventGroupActivitiesRequest {
           externalDataProviderId = dataProvider.externalDataProviderId
-          externalEventGroupId = eventGroup.externalEventGroupId
+          filter =
+            ListEventGroupActivitiesRequest.Filter.newBuilder()
+              .addExternalEventGroupIds(eventGroup.externalEventGroupId)
+              .build()
           pageSize = 1
           pageToken = firstResponse.nextPageToken
         }
@@ -1328,6 +1332,56 @@ abstract class EventGroupActivitiesServiceTest<T : EventGroupActivitiesCoroutine
         }
       )
     assertThat(secondResponse.hasNextPageToken()).isTrue()
+    assertThat(secondResponse.eventGroupActivitiesList.map { it.date })
+      .containsNoneIn(firstResponse.eventGroupActivitiesList.map { it.date })
+  }
+
+  @Test
+  fun `listEventGroupActivities coerces page_size above MAX_PAGE_SIZE`() = runBlocking {
+    val createRequest = batchUpdateEventGroupActivitiesRequest {
+      externalDataProviderId = dataProvider.externalDataProviderId
+      externalEventGroupId = eventGroup.externalEventGroupId
+      requests += updateEventGroupActivityRequest {
+        allowMissing = true
+        eventGroupActivity = eventGroupActivity {
+          externalEventGroupId = eventGroup.externalEventGroupId
+          date = date {
+            year = 2025
+            month = 12
+            day = 1
+          }
+        }
+      }
+    }
+
+    eventGroupActivitiesService.batchUpdateEventGroupActivities(createRequest)
+
+    val response =
+      eventGroupActivitiesService.listEventGroupActivities(
+        listEventGroupActivitiesRequest {
+          externalDataProviderId = dataProvider.externalDataProviderId
+          filter =
+            ListEventGroupActivitiesRequest.Filter.newBuilder()
+              .addExternalEventGroupIds(eventGroup.externalEventGroupId)
+              .build()
+          pageSize = 5000
+        }
+      )
+
+    assertThat(response.eventGroupActivitiesList).hasSize(1)
+  }
+
+  @Test
+  fun `listEventGroupActivities throws NOT_FOUND for non existent DataProvider`() = runBlocking {
+    val exception =
+      assertFailsWith<StatusRuntimeException> {
+        eventGroupActivitiesService.listEventGroupActivities(
+          listEventGroupActivitiesRequest { externalDataProviderId = 999999L }
+        )
+      }
+
+    assertThat(exception.status.code).isEqualTo(Status.Code.NOT_FOUND)
+    assertThat(exception).hasMessageThat().contains("DataProvider not found")
   }
 
   private suspend fun createEventGroup(dataProvider: DataProvider): EventGroup {

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/service/internal/testing/EventGroupActivitiesServiceTest.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/service/internal/testing/EventGroupActivitiesServiceTest.kt
@@ -56,6 +56,7 @@ import org.wfanet.measurement.internal.kingdom.deleteEventGroupActivityRequest
 import org.wfanet.measurement.internal.kingdom.eventGroup
 import org.wfanet.measurement.internal.kingdom.eventGroupActivity
 import org.wfanet.measurement.internal.kingdom.eventGroupDetails
+import org.wfanet.measurement.internal.kingdom.listEventGroupActivitiesRequest
 import org.wfanet.measurement.internal.kingdom.updateEventGroupActivityRequest
 
 private const val RANDOM_SEED = 1
@@ -1003,6 +1004,331 @@ abstract class EventGroupActivitiesServiceTest<T : EventGroupActivitiesCoroutine
 
       assertThat(exception.status.code).isEqualTo(Status.Code.INVALID_ARGUMENT)
     }
+
+  @Test
+  fun `listEventGroupActivities returns activities for event group`() = runBlocking {
+    val createRequest = batchUpdateEventGroupActivitiesRequest {
+      externalDataProviderId = dataProvider.externalDataProviderId
+      externalEventGroupId = eventGroup.externalEventGroupId
+      requests += updateEventGroupActivityRequest {
+        allowMissing = true
+        eventGroupActivity = eventGroupActivity {
+          externalEventGroupId = eventGroup.externalEventGroupId
+          date = date {
+            year = 2025
+            month = 12
+            day = 1
+          }
+        }
+      }
+      requests += updateEventGroupActivityRequest {
+        allowMissing = true
+        eventGroupActivity = eventGroupActivity {
+          externalEventGroupId = eventGroup.externalEventGroupId
+          date = date {
+            year = 2025
+            month = 12
+            day = 10
+          }
+        }
+      }
+    }
+
+    eventGroupActivitiesService.batchUpdateEventGroupActivities(createRequest)
+
+    val response =
+      eventGroupActivitiesService.listEventGroupActivities(
+        listEventGroupActivitiesRequest {
+          externalDataProviderId = dataProvider.externalDataProviderId
+          externalEventGroupId = eventGroup.externalEventGroupId
+        }
+      )
+
+    assertThat(response.eventGroupActivitiesList).hasSize(2)
+    assertThat(response.eventGroupActivitiesList[0].date)
+      .isEqualTo(
+        date {
+          year = 2025
+          month = 12
+          day = 1
+        }
+      )
+    assertThat(response.eventGroupActivitiesList[1].date)
+      .isEqualTo(
+        date {
+          year = 2025
+          month = 12
+          day = 10
+        }
+      )
+  }
+
+  @Test
+  fun `listEventGroupActivities paginates with page_token`() = runBlocking {
+    val createRequest = batchUpdateEventGroupActivitiesRequest {
+      externalDataProviderId = dataProvider.externalDataProviderId
+      externalEventGroupId = eventGroup.externalEventGroupId
+      requests += updateEventGroupActivityRequest {
+        allowMissing = true
+        eventGroupActivity = eventGroupActivity {
+          externalEventGroupId = eventGroup.externalEventGroupId
+          date = date {
+            year = 2025
+            month = 12
+            day = 1
+          }
+        }
+      }
+      requests += updateEventGroupActivityRequest {
+        allowMissing = true
+        eventGroupActivity = eventGroupActivity {
+          externalEventGroupId = eventGroup.externalEventGroupId
+          date = date {
+            year = 2025
+            month = 12
+            day = 5
+          }
+        }
+      }
+      requests += updateEventGroupActivityRequest {
+        allowMissing = true
+        eventGroupActivity = eventGroupActivity {
+          externalEventGroupId = eventGroup.externalEventGroupId
+          date = date {
+            year = 2025
+            month = 12
+            day = 10
+          }
+        }
+      }
+    }
+
+    eventGroupActivitiesService.batchUpdateEventGroupActivities(createRequest)
+
+    val firstResponse =
+      eventGroupActivitiesService.listEventGroupActivities(
+        listEventGroupActivitiesRequest {
+          externalDataProviderId = dataProvider.externalDataProviderId
+          externalEventGroupId = eventGroup.externalEventGroupId
+          pageSize = 1
+        }
+      )
+
+    assertThat(firstResponse.eventGroupActivitiesList).hasSize(1)
+    assertThat(firstResponse.hasNextPageToken()).isTrue()
+
+    val secondResponse =
+      eventGroupActivitiesService.listEventGroupActivities(
+        listEventGroupActivitiesRequest {
+          externalDataProviderId = dataProvider.externalDataProviderId
+          externalEventGroupId = eventGroup.externalEventGroupId
+          pageToken = firstResponse.nextPageToken
+        }
+      )
+
+    assertThat(secondResponse.eventGroupActivitiesList).hasSize(2)
+    assertThat(secondResponse.eventGroupActivitiesList[0].date)
+      .isEqualTo(
+        date {
+          year = 2025
+          month = 12
+          day = 5
+        }
+      )
+    assertThat(secondResponse.eventGroupActivitiesList[1].date)
+      .isEqualTo(
+        date {
+          year = 2025
+          month = 12
+          day = 10
+        }
+      )
+  }
+
+  @Test
+  fun `listEventGroupActivities returns empty when no activities exist`() = runBlocking {
+    val response =
+      eventGroupActivitiesService.listEventGroupActivities(
+        listEventGroupActivitiesRequest {
+          externalDataProviderId = dataProvider.externalDataProviderId
+          externalEventGroupId = eventGroup.externalEventGroupId
+        }
+      )
+
+    assertThat(response.eventGroupActivitiesList).isEmpty()
+    assertThat(response.hasNextPageToken()).isFalse()
+  }
+
+  @Test
+  fun `listEventGroupActivities throws INVALID_ARGUMENT when external_data_provider_id is missing`() =
+    runBlocking {
+      val exception =
+        assertFailsWith<StatusRuntimeException> {
+          eventGroupActivitiesService.listEventGroupActivities(
+            listEventGroupActivitiesRequest {
+              externalEventGroupId = eventGroup.externalEventGroupId
+            }
+          )
+        }
+
+      assertThat(exception.status.code).isEqualTo(Status.Code.INVALID_ARGUMENT)
+      assertThat(exception).hasMessageThat().contains("external_data_provider_id")
+    }
+
+  @Test
+  fun `listEventGroupActivities throws INVALID_ARGUMENT when external_event_group_id is missing`() =
+    runBlocking {
+      val exception =
+        assertFailsWith<StatusRuntimeException> {
+          eventGroupActivitiesService.listEventGroupActivities(
+            listEventGroupActivitiesRequest {
+              externalDataProviderId = dataProvider.externalDataProviderId
+            }
+          )
+        }
+
+      assertThat(exception.status.code).isEqualTo(Status.Code.INVALID_ARGUMENT)
+      assertThat(exception).hasMessageThat().contains("external_event_group_id")
+    }
+
+  @Test
+  fun `listEventGroupActivities respects page_size`() = runBlocking {
+    val createRequest = batchUpdateEventGroupActivitiesRequest {
+      externalDataProviderId = dataProvider.externalDataProviderId
+      externalEventGroupId = eventGroup.externalEventGroupId
+      requests += updateEventGroupActivityRequest {
+        allowMissing = true
+        eventGroupActivity = eventGroupActivity {
+          externalEventGroupId = eventGroup.externalEventGroupId
+          date = date {
+            year = 2025
+            month = 12
+            day = 1
+          }
+        }
+      }
+      requests += updateEventGroupActivityRequest {
+        allowMissing = true
+        eventGroupActivity = eventGroupActivity {
+          externalEventGroupId = eventGroup.externalEventGroupId
+          date = date {
+            year = 2025
+            month = 12
+            day = 5
+          }
+        }
+      }
+      requests += updateEventGroupActivityRequest {
+        allowMissing = true
+        eventGroupActivity = eventGroupActivity {
+          externalEventGroupId = eventGroup.externalEventGroupId
+          date = date {
+            year = 2025
+            month = 12
+            day = 10
+          }
+        }
+      }
+    }
+
+    eventGroupActivitiesService.batchUpdateEventGroupActivities(createRequest)
+
+    val response =
+      eventGroupActivitiesService.listEventGroupActivities(
+        listEventGroupActivitiesRequest {
+          externalDataProviderId = dataProvider.externalDataProviderId
+          externalEventGroupId = eventGroup.externalEventGroupId
+          pageSize = 1
+        }
+      )
+
+    assertThat(response.eventGroupActivitiesList).hasSize(1)
+    assertThat(response.eventGroupActivitiesList[0].date)
+      .isEqualTo(
+        date {
+          year = 2025
+          month = 12
+          day = 1
+        }
+      )
+    assertThat(response.hasNextPageToken()).isTrue()
+  }
+
+  @Test
+  fun `listEventGroupActivities paginates with page_token and page_size`() = runBlocking {
+    val createRequest = batchUpdateEventGroupActivitiesRequest {
+      externalDataProviderId = dataProvider.externalDataProviderId
+      externalEventGroupId = eventGroup.externalEventGroupId
+      requests += updateEventGroupActivityRequest {
+        allowMissing = true
+        eventGroupActivity = eventGroupActivity {
+          externalEventGroupId = eventGroup.externalEventGroupId
+          date = date {
+            year = 2025
+            month = 12
+            day = 1
+          }
+        }
+      }
+      requests += updateEventGroupActivityRequest {
+        allowMissing = true
+        eventGroupActivity = eventGroupActivity {
+          externalEventGroupId = eventGroup.externalEventGroupId
+          date = date {
+            year = 2025
+            month = 12
+            day = 5
+          }
+        }
+      }
+      requests += updateEventGroupActivityRequest {
+        allowMissing = true
+        eventGroupActivity = eventGroupActivity {
+          externalEventGroupId = eventGroup.externalEventGroupId
+          date = date {
+            year = 2025
+            month = 12
+            day = 10
+          }
+        }
+      }
+    }
+
+    eventGroupActivitiesService.batchUpdateEventGroupActivities(createRequest)
+
+    val firstResponse =
+      eventGroupActivitiesService.listEventGroupActivities(
+        listEventGroupActivitiesRequest {
+          externalDataProviderId = dataProvider.externalDataProviderId
+          externalEventGroupId = eventGroup.externalEventGroupId
+          pageSize = 1
+        }
+      )
+
+    assertThat(firstResponse.eventGroupActivitiesList).hasSize(1)
+    assertThat(firstResponse.hasNextPageToken()).isTrue()
+
+    val secondResponse =
+      eventGroupActivitiesService.listEventGroupActivities(
+        listEventGroupActivitiesRequest {
+          externalDataProviderId = dataProvider.externalDataProviderId
+          externalEventGroupId = eventGroup.externalEventGroupId
+          pageSize = 1
+          pageToken = firstResponse.nextPageToken
+        }
+      )
+
+    assertThat(secondResponse.eventGroupActivitiesList).hasSize(1)
+    assertThat(secondResponse.eventGroupActivitiesList[0].date)
+      .isEqualTo(
+        date {
+          year = 2025
+          month = 12
+          day = 5
+        }
+      )
+    assertThat(secondResponse.hasNextPageToken()).isTrue()
+  }
 
   private suspend fun createEventGroup(dataProvider: DataProvider): EventGroup {
     val measurementConsumer =

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/service/internal/testing/EventGroupActivitiesServiceTest.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/service/internal/testing/EventGroupActivitiesServiceTest.kt
@@ -18,6 +18,7 @@ import com.google.common.truth.Truth.assertThat
 import com.google.common.truth.extensions.proto.ProtoTruth.assertThat
 import com.google.protobuf.ByteString
 import com.google.protobuf.Empty
+import com.google.protobuf.timestamp
 import com.google.type.Date
 import com.google.type.date
 import com.google.type.interval
@@ -1382,6 +1383,206 @@ abstract class EventGroupActivitiesServiceTest<T : EventGroupActivitiesCoroutine
 
     assertThat(exception.status.code).isEqualTo(Status.Code.NOT_FOUND)
     assertThat(exception).hasMessageThat().contains("DataProvider not found")
+  }
+
+  @Test
+  fun `listEventGroupActivities returns activities across multiple event groups with empty filter`() =
+    runBlocking {
+      val eventGroup2 = createEventGroup(dataProvider)
+
+      // Create activities on event group 1
+      eventGroupActivitiesService.batchUpdateEventGroupActivities(
+        batchUpdateEventGroupActivitiesRequest {
+          externalDataProviderId = dataProvider.externalDataProviderId
+          externalEventGroupId = eventGroup.externalEventGroupId
+          requests += updateEventGroupActivityRequest {
+            allowMissing = true
+            eventGroupActivity = eventGroupActivity {
+              externalEventGroupId = eventGroup.externalEventGroupId
+              date = date {
+                year = 2025
+                month = 12
+                day = 1
+              }
+            }
+          }
+        }
+      )
+
+      // Create activities on event group 2
+      eventGroupActivitiesService.batchUpdateEventGroupActivities(
+        batchUpdateEventGroupActivitiesRequest {
+          externalDataProviderId = dataProvider.externalDataProviderId
+          externalEventGroupId = eventGroup2.externalEventGroupId
+          requests += updateEventGroupActivityRequest {
+            allowMissing = true
+            eventGroupActivity = eventGroupActivity {
+              externalEventGroupId = eventGroup2.externalEventGroupId
+              date = date {
+                year = 2025
+                month = 12
+                day = 1
+              }
+            }
+          }
+        }
+      )
+
+      // List with no event group filter — should return all
+      val response =
+        eventGroupActivitiesService.listEventGroupActivities(
+          listEventGroupActivitiesRequest {
+            externalDataProviderId = dataProvider.externalDataProviderId
+          }
+        )
+
+      assertThat(response.eventGroupActivitiesList).hasSize(2)
+      // Both have the same date — ordering tiebreaks on ExternalEventGroupId ASC
+      assertThat(response.eventGroupActivitiesList[0].externalEventGroupId)
+        .isLessThan(response.eventGroupActivitiesList[1].externalEventGroupId)
+      assertThat(response.eventGroupActivitiesList[0].date)
+        .isEqualTo(response.eventGroupActivitiesList[1].date)
+    }
+
+  @Test
+  fun `listEventGroupActivities filters to subset of event groups`() = runBlocking {
+    val eventGroup2 = createEventGroup(dataProvider)
+
+    // Create activities on event group 1
+    eventGroupActivitiesService.batchUpdateEventGroupActivities(
+      batchUpdateEventGroupActivitiesRequest {
+        externalDataProviderId = dataProvider.externalDataProviderId
+        externalEventGroupId = eventGroup.externalEventGroupId
+        requests += updateEventGroupActivityRequest {
+          allowMissing = true
+          eventGroupActivity = eventGroupActivity {
+            externalEventGroupId = eventGroup.externalEventGroupId
+            date = date {
+              year = 2025
+              month = 12
+              day = 1
+            }
+          }
+        }
+      }
+    )
+
+    // Create activities on event group 2
+    eventGroupActivitiesService.batchUpdateEventGroupActivities(
+      batchUpdateEventGroupActivitiesRequest {
+        externalDataProviderId = dataProvider.externalDataProviderId
+        externalEventGroupId = eventGroup2.externalEventGroupId
+        requests += updateEventGroupActivityRequest {
+          allowMissing = true
+          eventGroupActivity = eventGroupActivity {
+            externalEventGroupId = eventGroup2.externalEventGroupId
+            date = date {
+              year = 2025
+              month = 12
+              day = 5
+            }
+          }
+        }
+      }
+    )
+
+    // Filter to only event group 1
+    val response =
+      eventGroupActivitiesService.listEventGroupActivities(
+        listEventGroupActivitiesRequest {
+          externalDataProviderId = dataProvider.externalDataProviderId
+          filter =
+            ListEventGroupActivitiesRequest.Filter.newBuilder()
+              .addExternalEventGroupIds(eventGroup.externalEventGroupId)
+              .build()
+        }
+      )
+
+    assertThat(response.eventGroupActivitiesList).hasSize(1)
+    assertThat(response.eventGroupActivitiesList[0].externalEventGroupId)
+      .isEqualTo(eventGroup.externalEventGroupId)
+  }
+
+  @Test
+  fun `listEventGroupActivities filters by date_interval`() = runBlocking {
+    eventGroupActivitiesService.batchUpdateEventGroupActivities(
+      batchUpdateEventGroupActivitiesRequest {
+        externalDataProviderId = dataProvider.externalDataProviderId
+        externalEventGroupId = eventGroup.externalEventGroupId
+        requests += updateEventGroupActivityRequest {
+          allowMissing = true
+          eventGroupActivity = eventGroupActivity {
+            externalEventGroupId = eventGroup.externalEventGroupId
+            date = date {
+              year = 2025
+              month = 11
+              day = 15
+            }
+          }
+        }
+        requests += updateEventGroupActivityRequest {
+          allowMissing = true
+          eventGroupActivity = eventGroupActivity {
+            externalEventGroupId = eventGroup.externalEventGroupId
+            date = date {
+              year = 2025
+              month = 12
+              day = 1
+            }
+          }
+        }
+        requests += updateEventGroupActivityRequest {
+          allowMissing = true
+          eventGroupActivity = eventGroupActivity {
+            externalEventGroupId = eventGroup.externalEventGroupId
+            date = date {
+              year = 2025
+              month = 12
+              day = 15
+            }
+          }
+        }
+      }
+    )
+
+    val response =
+      eventGroupActivitiesService.listEventGroupActivities(
+        listEventGroupActivitiesRequest {
+          externalDataProviderId = dataProvider.externalDataProviderId
+          filter =
+            ListEventGroupActivitiesRequest.Filter.newBuilder()
+              .addExternalEventGroupIds(eventGroup.externalEventGroupId)
+              .setDateInterval(
+                interval {
+                  startTime = timestamp {
+                    seconds = 1764565200 // 2025-12-01T00:00:00Z
+                  }
+                  endTime = timestamp {
+                    seconds = 1767243600 // 2026-01-01T00:00:00Z
+                  }
+                }
+              )
+              .build()
+        }
+      )
+
+    assertThat(response.eventGroupActivitiesList).hasSize(2)
+    assertThat(response.eventGroupActivitiesList[0].date)
+      .isEqualTo(
+        date {
+          year = 2025
+          month = 12
+          day = 1
+        }
+      )
+    assertThat(response.eventGroupActivitiesList[1].date)
+      .isEqualTo(
+        date {
+          year = 2025
+          month = 12
+          day = 15
+        }
+      )
   }
 
   private suspend fun createEventGroup(dataProvider: DataProvider): EventGroup {

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/service/internal/testing/EventGroupActivitiesServiceTest.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/service/internal/testing/EventGroupActivitiesServiceTest.kt
@@ -18,7 +18,6 @@ import com.google.common.truth.Truth.assertThat
 import com.google.common.truth.extensions.proto.ProtoTruth.assertThat
 import com.google.protobuf.ByteString
 import com.google.protobuf.Empty
-import com.google.protobuf.timestamp
 import com.google.type.Date
 import com.google.type.date
 import com.google.type.interval
@@ -54,6 +53,7 @@ import org.wfanet.measurement.internal.kingdom.MediaType
 import org.wfanet.measurement.internal.kingdom.batchDeleteEventGroupActivitiesRequest
 import org.wfanet.measurement.internal.kingdom.batchUpdateEventGroupActivitiesRequest
 import org.wfanet.measurement.internal.kingdom.createEventGroupRequest
+import org.wfanet.measurement.internal.kingdom.dateInterval
 import org.wfanet.measurement.internal.kingdom.deleteEventGroupActivityRequest
 import org.wfanet.measurement.internal.kingdom.eventGroup
 import org.wfanet.measurement.internal.kingdom.eventGroupActivity
@@ -1553,12 +1553,16 @@ abstract class EventGroupActivitiesServiceTest<T : EventGroupActivitiesCoroutine
             ListEventGroupActivitiesRequest.Filter.newBuilder()
               .addExternalEventGroupIds(eventGroup.externalEventGroupId)
               .setDateInterval(
-                interval {
-                  startTime = timestamp {
-                    seconds = 1764565200 // 2025-12-01T00:00:00Z
+                dateInterval {
+                  startDate = date {
+                    year = 2025
+                    month = 12
+                    day = 1
                   }
-                  endTime = timestamp {
-                    seconds = 1767243600 // 2026-01-01T00:00:00Z
+                  endDate = date {
+                    year = 2026
+                    month = 1
+                    day = 1
                   }
                 }
               )

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/service/internal/testing/EventGroupActivitiesServiceTest.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/service/internal/testing/EventGroupActivitiesServiceTest.kt
@@ -18,6 +18,7 @@ import com.google.common.truth.Truth.assertThat
 import com.google.common.truth.extensions.proto.ProtoTruth.assertThat
 import com.google.protobuf.ByteString
 import com.google.protobuf.Empty
+import com.google.rpc.errorInfo
 import com.google.type.Date
 import com.google.type.date
 import com.google.type.interval
@@ -41,6 +42,7 @@ import org.wfanet.measurement.common.toProtoTime
 import org.wfanet.measurement.internal.kingdom.AccountsGrpcKt.AccountsCoroutineImplBase
 import org.wfanet.measurement.internal.kingdom.DataProvider
 import org.wfanet.measurement.internal.kingdom.DataProvidersGrpcKt.DataProvidersCoroutineImplBase
+import org.wfanet.measurement.internal.kingdom.ErrorCode
 import org.wfanet.measurement.internal.kingdom.EventGroup
 import org.wfanet.measurement.internal.kingdom.EventGroupActivitiesGrpcKt.EventGroupActivitiesCoroutineImplBase
 import org.wfanet.measurement.internal.kingdom.EventGroupActivity
@@ -61,6 +63,7 @@ import org.wfanet.measurement.internal.kingdom.eventGroupActivity
 import org.wfanet.measurement.internal.kingdom.eventGroupDetails
 import org.wfanet.measurement.internal.kingdom.listEventGroupActivitiesRequest
 import org.wfanet.measurement.internal.kingdom.updateEventGroupActivityRequest
+import org.wfanet.measurement.kingdom.deploy.gcloud.spanner.common.KingdomInternalException
 
 private const val RANDOM_SEED = 1
 private const val PROVIDED_EVENT_GROUP_ID = "ProvidedEventGroupId"
@@ -1185,8 +1188,14 @@ abstract class EventGroupActivitiesServiceTest<T : EventGroupActivitiesCoroutine
         }
 
       assertThat(exception.status.code).isEqualTo(Status.Code.INVALID_ARGUMENT)
-      assertThat(exception.errorInfo?.metadataMap)
-        .containsAtLeast("field_name", "external_data_provider_id")
+      assertThat(exception.errorInfo)
+        .isEqualTo(
+          errorInfo {
+            domain = KingdomInternalException.DOMAIN
+            reason = ErrorCode.REQUIRED_FIELD_NOT_SET.name
+            metadata["field_name"] = "external_data_provider_id"
+          }
+        )
     }
   }
 
@@ -1382,8 +1391,14 @@ abstract class EventGroupActivitiesServiceTest<T : EventGroupActivitiesCoroutine
         }
 
       assertThat(exception.status.code).isEqualTo(Status.Code.NOT_FOUND)
-      assertThat(exception.errorInfo?.metadataMap)
-        .containsAtLeast("external_data_provider_id", "999999")
+      assertThat(exception.errorInfo)
+        .isEqualTo(
+          errorInfo {
+            domain = KingdomInternalException.DOMAIN
+            reason = ErrorCode.DATA_PROVIDER_NOT_FOUND.name
+            metadata["external_data_provider_id"] = "999999"
+          }
+        )
     }
   }
 

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/service/internal/testing/EventGroupActivitiesServiceTest.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/service/internal/testing/EventGroupActivitiesServiceTest.kt
@@ -1631,6 +1631,150 @@ abstract class EventGroupActivitiesServiceTest<T : EventGroupActivitiesCoroutine
       .inOrder()
   }
 
+  @Test
+  fun `listEventGroupActivities throws NOT_FOUND for non existent EventGroup`() {
+    runBlocking {
+      val exception =
+        assertFailsWith<StatusRuntimeException> {
+          eventGroupActivitiesService.listEventGroupActivities(
+            listEventGroupActivitiesRequest {
+              externalDataProviderId = dataProvider.externalDataProviderId
+              externalEventGroupId = 999999L
+            }
+          )
+        }
+
+      assertThat(exception.status.code).isEqualTo(Status.Code.NOT_FOUND)
+      assertThat(exception.errorInfo)
+        .isEqualTo(
+          errorInfo {
+            domain = KingdomInternalException.DOMAIN
+            reason = ErrorCode.EVENT_GROUP_NOT_FOUND.name
+            metadata["external_data_provider_id"] = dataProvider.externalDataProviderId.toString()
+            metadata["external_event_group_id"] = "999999"
+          }
+        )
+    }
+  }
+
+  @Test
+  fun `listEventGroupActivities paginates across multiple event groups`() {
+    runBlocking {
+      val eventGroup2 = createEventGroup(dataProvider)
+
+      // Determine sorted order by externalEventGroupId.
+      val sortedEgs = listOf(eventGroup, eventGroup2).sortedBy { it.externalEventGroupId }
+
+      // Create activities on both EGs on 2025-12-01 and 2025-12-05.
+      for (eg in listOf(eventGroup, eventGroup2)) {
+        eventGroupActivitiesService.batchUpdateEventGroupActivities(
+          batchUpdateEventGroupActivitiesRequest {
+            externalDataProviderId = dataProvider.externalDataProviderId
+            externalEventGroupId = eg.externalEventGroupId
+            requests += updateEventGroupActivityRequest {
+              allowMissing = true
+              eventGroupActivity = eventGroupActivity {
+                externalEventGroupId = eg.externalEventGroupId
+                date = date {
+                  year = 2025
+                  month = 12
+                  day = 1
+                }
+              }
+            }
+            requests += updateEventGroupActivityRequest {
+              allowMissing = true
+              eventGroupActivity = eventGroupActivity {
+                externalEventGroupId = eg.externalEventGroupId
+                date = date {
+                  year = 2025
+                  month = 12
+                  day = 5
+                }
+              }
+            }
+          }
+        )
+      }
+
+      // List with no externalEventGroupId filter, pageSize = 2.
+      val firstResponse =
+        eventGroupActivitiesService.listEventGroupActivities(
+          listEventGroupActivitiesRequest {
+            externalDataProviderId = dataProvider.externalDataProviderId
+            pageSize = 2
+          }
+        )
+
+      assertThat(firstResponse.eventGroupActivitiesList).hasSize(2)
+      assertThat(firstResponse.hasNextPageToken()).isTrue()
+      // Page 1: both activities on 2025-12-01, ordered by externalEventGroupId ASC.
+      assertThat(firstResponse.eventGroupActivitiesList)
+        .ignoringFields(EventGroupActivity.CREATE_TIME_FIELD_NUMBER)
+        .containsExactly(
+          eventGroupActivity {
+            externalDataProviderId = dataProvider.externalDataProviderId
+            externalEventGroupId = sortedEgs[0].externalEventGroupId
+            date = date {
+              year = 2025
+              month = 12
+              day = 1
+            }
+          },
+          eventGroupActivity {
+            externalDataProviderId = dataProvider.externalDataProviderId
+            externalEventGroupId = sortedEgs[1].externalEventGroupId
+            date = date {
+              year = 2025
+              month = 12
+              day = 1
+            }
+          },
+        )
+        .inOrder()
+
+      // Page 2.
+      val secondResponse =
+        eventGroupActivitiesService.listEventGroupActivities(
+          listEventGroupActivitiesRequest {
+            externalDataProviderId = dataProvider.externalDataProviderId
+            pageSize = 2
+            pageToken = firstResponse.nextPageToken
+          }
+        )
+
+      assertThat(secondResponse.eventGroupActivitiesList).hasSize(2)
+      // Page 2: both activities on 2025-12-05.
+      assertThat(secondResponse.eventGroupActivitiesList)
+        .ignoringFields(EventGroupActivity.CREATE_TIME_FIELD_NUMBER)
+        .containsExactly(
+          eventGroupActivity {
+            externalDataProviderId = dataProvider.externalDataProviderId
+            externalEventGroupId = sortedEgs[0].externalEventGroupId
+            date = date {
+              year = 2025
+              month = 12
+              day = 5
+            }
+          },
+          eventGroupActivity {
+            externalDataProviderId = dataProvider.externalDataProviderId
+            externalEventGroupId = sortedEgs[1].externalEventGroupId
+            date = date {
+              year = 2025
+              month = 12
+              day = 5
+            }
+          },
+        )
+        .inOrder()
+
+      // No row repeated across pages.
+      assertThat(secondResponse.eventGroupActivitiesList)
+        .containsNoneIn(firstResponse.eventGroupActivitiesList)
+    }
+  }
+
   private suspend fun createEventGroup(dataProvider: DataProvider): EventGroup {
     val measurementConsumer =
       population.createMeasurementConsumer(measurementConsumersService, accountsService)

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/service/internal/testing/EventGroupActivitiesServiceTest.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/service/internal/testing/EventGroupActivitiesServiceTest.kt
@@ -1180,6 +1180,26 @@ abstract class EventGroupActivitiesServiceTest<T : EventGroupActivitiesCoroutine
   }
 
   @Test
+  fun `listEventGroupActivities throws INVALID_ARGUMENT when external_data_provider_id is missing`() {
+    runBlocking {
+      val exception =
+        assertFailsWith<StatusRuntimeException> {
+          eventGroupActivitiesService.listEventGroupActivities(listEventGroupActivitiesRequest {})
+        }
+
+      assertThat(exception.status.code).isEqualTo(Status.Code.INVALID_ARGUMENT)
+      assertThat(exception.errorInfo)
+        .isEqualTo(
+          errorInfo {
+            domain = KingdomInternalException.DOMAIN
+            reason = ErrorCode.REQUIRED_FIELD_NOT_SET.name
+            metadata["field_name"] = "external_data_provider_id"
+          }
+        )
+    }
+  }
+
+  @Test
   fun `listEventGroupActivities respects page_size`() = runBlocking {
     val createRequest = batchUpdateEventGroupActivitiesRequest {
       externalDataProviderId = dataProvider.externalDataProviderId

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/service/internal/testing/EventGroupActivitiesServiceTest.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/service/internal/testing/EventGroupActivitiesServiceTest.kt
@@ -33,6 +33,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 import org.wfanet.measurement.api.Version
+import org.wfanet.measurement.common.grpc.errorInfo
 import org.wfanet.measurement.common.identity.IdGenerator
 import org.wfanet.measurement.common.identity.RandomIdGenerator
 import org.wfanet.measurement.common.toInstant
@@ -47,7 +48,7 @@ import org.wfanet.measurement.internal.kingdom.EventGroupDetailsKt.EventGroupMet
 import org.wfanet.measurement.internal.kingdom.EventGroupDetailsKt.EventGroupMetadataKt.adMetadata
 import org.wfanet.measurement.internal.kingdom.EventGroupDetailsKt.eventGroupMetadata
 import org.wfanet.measurement.internal.kingdom.EventGroupsGrpcKt.EventGroupsCoroutineImplBase
-import org.wfanet.measurement.internal.kingdom.ListEventGroupActivitiesRequest
+import org.wfanet.measurement.internal.kingdom.ListEventGroupActivitiesRequestKt.filter
 import org.wfanet.measurement.internal.kingdom.MeasurementConsumersGrpcKt.MeasurementConsumersCoroutineImplBase
 import org.wfanet.measurement.internal.kingdom.MediaType
 import org.wfanet.measurement.internal.kingdom.batchDeleteEventGroupActivitiesRequest
@@ -1042,30 +1043,33 @@ abstract class EventGroupActivitiesServiceTest<T : EventGroupActivitiesCoroutine
       eventGroupActivitiesService.listEventGroupActivities(
         listEventGroupActivitiesRequest {
           externalDataProviderId = dataProvider.externalDataProviderId
-          filter =
-            ListEventGroupActivitiesRequest.Filter.newBuilder()
-              .addExternalEventGroupIds(eventGroup.externalEventGroupId)
-              .build()
+          filter = filter { externalEventGroupIds += eventGroup.externalEventGroupId }
         }
       )
 
-    assertThat(response.eventGroupActivitiesList).hasSize(2)
-    assertThat(response.eventGroupActivitiesList[0].date)
-      .isEqualTo(
-        date {
-          year = 2025
-          month = 12
-          day = 1
-        }
+    assertThat(response.eventGroupActivitiesList)
+      .ignoringFields(EventGroupActivity.CREATE_TIME_FIELD_NUMBER)
+      .containsExactly(
+        eventGroupActivity {
+          externalDataProviderId = dataProvider.externalDataProviderId
+          externalEventGroupId = eventGroup.externalEventGroupId
+          date = date {
+            year = 2025
+            month = 12
+            day = 1
+          }
+        },
+        eventGroupActivity {
+          externalDataProviderId = dataProvider.externalDataProviderId
+          externalEventGroupId = eventGroup.externalEventGroupId
+          date = date {
+            year = 2025
+            month = 12
+            day = 10
+          }
+        },
       )
-    assertThat(response.eventGroupActivitiesList[1].date)
-      .isEqualTo(
-        date {
-          year = 2025
-          month = 12
-          day = 10
-        }
-      )
+      .inOrder()
   }
 
   @Test
@@ -1114,10 +1118,7 @@ abstract class EventGroupActivitiesServiceTest<T : EventGroupActivitiesCoroutine
       eventGroupActivitiesService.listEventGroupActivities(
         listEventGroupActivitiesRequest {
           externalDataProviderId = dataProvider.externalDataProviderId
-          filter =
-            ListEventGroupActivitiesRequest.Filter.newBuilder()
-              .addExternalEventGroupIds(eventGroup.externalEventGroupId)
-              .build()
+          filter = filter { externalEventGroupIds += eventGroup.externalEventGroupId }
           pageSize = 1
         }
       )
@@ -1129,31 +1130,34 @@ abstract class EventGroupActivitiesServiceTest<T : EventGroupActivitiesCoroutine
       eventGroupActivitiesService.listEventGroupActivities(
         listEventGroupActivitiesRequest {
           externalDataProviderId = dataProvider.externalDataProviderId
-          filter =
-            ListEventGroupActivitiesRequest.Filter.newBuilder()
-              .addExternalEventGroupIds(eventGroup.externalEventGroupId)
-              .build()
+          filter = filter { externalEventGroupIds += eventGroup.externalEventGroupId }
           pageToken = firstResponse.nextPageToken
         }
       )
 
-    assertThat(secondResponse.eventGroupActivitiesList).hasSize(2)
-    assertThat(secondResponse.eventGroupActivitiesList[0].date)
-      .isEqualTo(
-        date {
-          year = 2025
-          month = 12
-          day = 5
-        }
+    assertThat(secondResponse.eventGroupActivitiesList)
+      .ignoringFields(EventGroupActivity.CREATE_TIME_FIELD_NUMBER)
+      .containsExactly(
+        eventGroupActivity {
+          externalDataProviderId = dataProvider.externalDataProviderId
+          externalEventGroupId = eventGroup.externalEventGroupId
+          date = date {
+            year = 2025
+            month = 12
+            day = 5
+          }
+        },
+        eventGroupActivity {
+          externalDataProviderId = dataProvider.externalDataProviderId
+          externalEventGroupId = eventGroup.externalEventGroupId
+          date = date {
+            year = 2025
+            month = 12
+            day = 10
+          }
+        },
       )
-    assertThat(secondResponse.eventGroupActivitiesList[1].date)
-      .isEqualTo(
-        date {
-          year = 2025
-          month = 12
-          day = 10
-        }
-      )
+      .inOrder()
     assertThat(secondResponse.eventGroupActivitiesList.map { it.date })
       .containsNoneIn(firstResponse.eventGroupActivitiesList.map { it.date })
   }
@@ -1164,10 +1168,7 @@ abstract class EventGroupActivitiesServiceTest<T : EventGroupActivitiesCoroutine
       eventGroupActivitiesService.listEventGroupActivities(
         listEventGroupActivitiesRequest {
           externalDataProviderId = dataProvider.externalDataProviderId
-          filter =
-            ListEventGroupActivitiesRequest.Filter.newBuilder()
-              .addExternalEventGroupIds(eventGroup.externalEventGroupId)
-              .build()
+          filter = filter { externalEventGroupIds += eventGroup.externalEventGroupId }
         }
       )
 
@@ -1176,7 +1177,7 @@ abstract class EventGroupActivitiesServiceTest<T : EventGroupActivitiesCoroutine
   }
 
   @Test
-  fun `listEventGroupActivities throws INVALID_ARGUMENT when external_data_provider_id is missing`() =
+  fun `listEventGroupActivities throws INVALID_ARGUMENT when external_data_provider_id is missing`() {
     runBlocking {
       val exception =
         assertFailsWith<StatusRuntimeException> {
@@ -1184,8 +1185,10 @@ abstract class EventGroupActivitiesServiceTest<T : EventGroupActivitiesCoroutine
         }
 
       assertThat(exception.status.code).isEqualTo(Status.Code.INVALID_ARGUMENT)
-      assertThat(exception).hasMessageThat().contains("external_data_provider_id")
+      assertThat(exception.errorInfo?.metadataMap)
+        .containsAtLeast("field_name", "external_data_provider_id")
     }
+  }
 
   @Test
   fun `listEventGroupActivities respects page_size`() = runBlocking {
@@ -1233,21 +1236,22 @@ abstract class EventGroupActivitiesServiceTest<T : EventGroupActivitiesCoroutine
       eventGroupActivitiesService.listEventGroupActivities(
         listEventGroupActivitiesRequest {
           externalDataProviderId = dataProvider.externalDataProviderId
-          filter =
-            ListEventGroupActivitiesRequest.Filter.newBuilder()
-              .addExternalEventGroupIds(eventGroup.externalEventGroupId)
-              .build()
+          filter = filter { externalEventGroupIds += eventGroup.externalEventGroupId }
           pageSize = 1
         }
       )
 
-    assertThat(response.eventGroupActivitiesList).hasSize(1)
-    assertThat(response.eventGroupActivitiesList[0].date)
-      .isEqualTo(
-        date {
-          year = 2025
-          month = 12
-          day = 1
+    assertThat(response.eventGroupActivitiesList)
+      .ignoringFields(EventGroupActivity.CREATE_TIME_FIELD_NUMBER)
+      .containsExactly(
+        eventGroupActivity {
+          externalDataProviderId = dataProvider.externalDataProviderId
+          externalEventGroupId = eventGroup.externalEventGroupId
+          date = date {
+            year = 2025
+            month = 12
+            day = 1
+          }
         }
       )
     assertThat(response.hasNextPageToken()).isTrue()
@@ -1299,10 +1303,7 @@ abstract class EventGroupActivitiesServiceTest<T : EventGroupActivitiesCoroutine
       eventGroupActivitiesService.listEventGroupActivities(
         listEventGroupActivitiesRequest {
           externalDataProviderId = dataProvider.externalDataProviderId
-          filter =
-            ListEventGroupActivitiesRequest.Filter.newBuilder()
-              .addExternalEventGroupIds(eventGroup.externalEventGroupId)
-              .build()
+          filter = filter { externalEventGroupIds += eventGroup.externalEventGroupId }
           pageSize = 1
         }
       )
@@ -1314,22 +1315,23 @@ abstract class EventGroupActivitiesServiceTest<T : EventGroupActivitiesCoroutine
       eventGroupActivitiesService.listEventGroupActivities(
         listEventGroupActivitiesRequest {
           externalDataProviderId = dataProvider.externalDataProviderId
-          filter =
-            ListEventGroupActivitiesRequest.Filter.newBuilder()
-              .addExternalEventGroupIds(eventGroup.externalEventGroupId)
-              .build()
+          filter = filter { externalEventGroupIds += eventGroup.externalEventGroupId }
           pageSize = 1
           pageToken = firstResponse.nextPageToken
         }
       )
 
-    assertThat(secondResponse.eventGroupActivitiesList).hasSize(1)
-    assertThat(secondResponse.eventGroupActivitiesList[0].date)
-      .isEqualTo(
-        date {
-          year = 2025
-          month = 12
-          day = 5
+    assertThat(secondResponse.eventGroupActivitiesList)
+      .ignoringFields(EventGroupActivity.CREATE_TIME_FIELD_NUMBER)
+      .containsExactly(
+        eventGroupActivity {
+          externalDataProviderId = dataProvider.externalDataProviderId
+          externalEventGroupId = eventGroup.externalEventGroupId
+          date = date {
+            year = 2025
+            month = 12
+            day = 5
+          }
         }
       )
     assertThat(secondResponse.hasNextPageToken()).isTrue()
@@ -1361,10 +1363,7 @@ abstract class EventGroupActivitiesServiceTest<T : EventGroupActivitiesCoroutine
       eventGroupActivitiesService.listEventGroupActivities(
         listEventGroupActivitiesRequest {
           externalDataProviderId = dataProvider.externalDataProviderId
-          filter =
-            ListEventGroupActivitiesRequest.Filter.newBuilder()
-              .addExternalEventGroupIds(eventGroup.externalEventGroupId)
-              .build()
+          filter = filter { externalEventGroupIds += eventGroup.externalEventGroupId }
           pageSize = 5000
         }
       )
@@ -1373,16 +1372,19 @@ abstract class EventGroupActivitiesServiceTest<T : EventGroupActivitiesCoroutine
   }
 
   @Test
-  fun `listEventGroupActivities throws NOT_FOUND for non existent DataProvider`() = runBlocking {
-    val exception =
-      assertFailsWith<StatusRuntimeException> {
-        eventGroupActivitiesService.listEventGroupActivities(
-          listEventGroupActivitiesRequest { externalDataProviderId = 999999L }
-        )
-      }
+  fun `listEventGroupActivities throws NOT_FOUND for non existent DataProvider`() {
+    runBlocking {
+      val exception =
+        assertFailsWith<StatusRuntimeException> {
+          eventGroupActivitiesService.listEventGroupActivities(
+            listEventGroupActivitiesRequest { externalDataProviderId = 999999L }
+          )
+        }
 
-    assertThat(exception.status.code).isEqualTo(Status.Code.NOT_FOUND)
-    assertThat(exception).hasMessageThat().contains("DataProvider not found")
+      assertThat(exception.status.code).isEqualTo(Status.Code.NOT_FOUND)
+      assertThat(exception.errorInfo?.metadataMap)
+        .containsAtLeast("external_data_provider_id", "999999")
+    }
   }
 
   @Test
@@ -1436,26 +1438,84 @@ abstract class EventGroupActivitiesServiceTest<T : EventGroupActivitiesCoroutine
           }
         )
 
-      assertThat(response.eventGroupActivitiesList).hasSize(2)
-      // Both have the same date — ordering tiebreaks on ExternalEventGroupId ASC
-      assertThat(response.eventGroupActivitiesList[0].externalEventGroupId)
-        .isLessThan(response.eventGroupActivitiesList[1].externalEventGroupId)
-      assertThat(response.eventGroupActivitiesList[0].date)
-        .isEqualTo(response.eventGroupActivitiesList[1].date)
+      val expectedActivities =
+        listOf(eventGroup, eventGroup2)
+          .sortedBy { it.externalEventGroupId }
+          .map { eg ->
+            eventGroupActivity {
+              externalDataProviderId = dataProvider.externalDataProviderId
+              externalEventGroupId = eg.externalEventGroupId
+              date = date {
+                year = 2025
+                month = 12
+                day = 1
+              }
+            }
+          }
+
+      assertThat(response.eventGroupActivitiesList)
+        .ignoringFields(EventGroupActivity.CREATE_TIME_FIELD_NUMBER)
+        .containsExactlyElementsIn(expectedActivities)
+        .inOrder()
     }
 
   @Test
-  fun `listEventGroupActivities filters to subset of event groups`() = runBlocking {
-    val eventGroup2 = createEventGroup(dataProvider)
+  fun `listEventGroupActivities filters to subset of event groups`() {
+    runBlocking {
+      val eventGroup2 = createEventGroup(dataProvider)
 
-    // Create activities on event group 1
-    eventGroupActivitiesService.batchUpdateEventGroupActivities(
-      batchUpdateEventGroupActivitiesRequest {
-        externalDataProviderId = dataProvider.externalDataProviderId
-        externalEventGroupId = eventGroup.externalEventGroupId
-        requests += updateEventGroupActivityRequest {
-          allowMissing = true
-          eventGroupActivity = eventGroupActivity {
+      // Create activities on event group 1
+      eventGroupActivitiesService.batchUpdateEventGroupActivities(
+        batchUpdateEventGroupActivitiesRequest {
+          externalDataProviderId = dataProvider.externalDataProviderId
+          externalEventGroupId = eventGroup.externalEventGroupId
+          requests += updateEventGroupActivityRequest {
+            allowMissing = true
+            eventGroupActivity = eventGroupActivity {
+              externalEventGroupId = eventGroup.externalEventGroupId
+              date = date {
+                year = 2025
+                month = 12
+                day = 1
+              }
+            }
+          }
+        }
+      )
+
+      // Create activities on event group 2
+      eventGroupActivitiesService.batchUpdateEventGroupActivities(
+        batchUpdateEventGroupActivitiesRequest {
+          externalDataProviderId = dataProvider.externalDataProviderId
+          externalEventGroupId = eventGroup2.externalEventGroupId
+          requests += updateEventGroupActivityRequest {
+            allowMissing = true
+            eventGroupActivity = eventGroupActivity {
+              externalEventGroupId = eventGroup2.externalEventGroupId
+              date = date {
+                year = 2025
+                month = 12
+                day = 5
+              }
+            }
+          }
+        }
+      )
+
+      // Filter to only event group 1
+      val response =
+        eventGroupActivitiesService.listEventGroupActivities(
+          listEventGroupActivitiesRequest {
+            externalDataProviderId = dataProvider.externalDataProviderId
+            filter = filter { externalEventGroupIds += eventGroup.externalEventGroupId }
+          }
+        )
+
+      assertThat(response.eventGroupActivitiesList)
+        .ignoringFields(EventGroupActivity.CREATE_TIME_FIELD_NUMBER)
+        .containsExactly(
+          eventGroupActivity {
+            externalDataProviderId = dataProvider.externalDataProviderId
             externalEventGroupId = eventGroup.externalEventGroupId
             date = date {
               year = 2025
@@ -1463,44 +1523,8 @@ abstract class EventGroupActivitiesServiceTest<T : EventGroupActivitiesCoroutine
               day = 1
             }
           }
-        }
-      }
-    )
-
-    // Create activities on event group 2
-    eventGroupActivitiesService.batchUpdateEventGroupActivities(
-      batchUpdateEventGroupActivitiesRequest {
-        externalDataProviderId = dataProvider.externalDataProviderId
-        externalEventGroupId = eventGroup2.externalEventGroupId
-        requests += updateEventGroupActivityRequest {
-          allowMissing = true
-          eventGroupActivity = eventGroupActivity {
-            externalEventGroupId = eventGroup2.externalEventGroupId
-            date = date {
-              year = 2025
-              month = 12
-              day = 5
-            }
-          }
-        }
-      }
-    )
-
-    // Filter to only event group 1
-    val response =
-      eventGroupActivitiesService.listEventGroupActivities(
-        listEventGroupActivitiesRequest {
-          externalDataProviderId = dataProvider.externalDataProviderId
-          filter =
-            ListEventGroupActivitiesRequest.Filter.newBuilder()
-              .addExternalEventGroupIds(eventGroup.externalEventGroupId)
-              .build()
-        }
-      )
-
-    assertThat(response.eventGroupActivitiesList).hasSize(1)
-    assertThat(response.eventGroupActivitiesList[0].externalEventGroupId)
-      .isEqualTo(eventGroup.externalEventGroupId)
+        )
+    }
   }
 
   @Test
@@ -1549,44 +1573,47 @@ abstract class EventGroupActivitiesServiceTest<T : EventGroupActivitiesCoroutine
       eventGroupActivitiesService.listEventGroupActivities(
         listEventGroupActivitiesRequest {
           externalDataProviderId = dataProvider.externalDataProviderId
-          filter =
-            ListEventGroupActivitiesRequest.Filter.newBuilder()
-              .addExternalEventGroupIds(eventGroup.externalEventGroupId)
-              .setDateInterval(
-                dateInterval {
-                  startDate = date {
-                    year = 2025
-                    month = 12
-                    day = 1
-                  }
-                  endDate = date {
-                    year = 2026
-                    month = 1
-                    day = 1
-                  }
-                }
-              )
-              .build()
+          filter = filter {
+            externalEventGroupIds += eventGroup.externalEventGroupId
+            dateInterval = dateInterval {
+              startDate = date {
+                year = 2025
+                month = 12
+                day = 1
+              }
+              endDate = date {
+                year = 2026
+                month = 1
+                day = 1
+              }
+            }
+          }
         }
       )
 
-    assertThat(response.eventGroupActivitiesList).hasSize(2)
-    assertThat(response.eventGroupActivitiesList[0].date)
-      .isEqualTo(
-        date {
-          year = 2025
-          month = 12
-          day = 1
-        }
+    assertThat(response.eventGroupActivitiesList)
+      .ignoringFields(EventGroupActivity.CREATE_TIME_FIELD_NUMBER)
+      .containsExactly(
+        eventGroupActivity {
+          externalDataProviderId = dataProvider.externalDataProviderId
+          externalEventGroupId = eventGroup.externalEventGroupId
+          date = date {
+            year = 2025
+            month = 12
+            day = 1
+          }
+        },
+        eventGroupActivity {
+          externalDataProviderId = dataProvider.externalDataProviderId
+          externalEventGroupId = eventGroup.externalEventGroupId
+          date = date {
+            year = 2025
+            month = 12
+            day = 15
+          }
+        },
       )
-    assertThat(response.eventGroupActivitiesList[1].date)
-      .isEqualTo(
-        date {
-          year = 2025
-          month = 12
-          day = 15
-        }
-      )
+      .inOrder()
   }
 
   private suspend fun createEventGroup(dataProvider: DataProvider): EventGroup {

--- a/src/main/proto/wfa/measurement/internal/kingdom/BUILD.bazel
+++ b/src/main/proto/wfa/measurement/internal/kingdom/BUILD.bazel
@@ -378,6 +378,7 @@ proto_library(
     deps = [
         ":event_group_activity_proto",
         "@com_google_googleapis//google/type:date_proto",
+        "@com_google_googleapis//google/type:interval_proto",
         "@com_google_protobuf//:empty_proto",
         "@com_google_protobuf//:timestamp_proto",
     ],

--- a/src/main/proto/wfa/measurement/internal/kingdom/BUILD.bazel
+++ b/src/main/proto/wfa/measurement/internal/kingdom/BUILD.bazel
@@ -376,9 +376,9 @@ proto_library(
     srcs = ["event_group_activities_service.proto"],
     strip_import_prefix = IMPORT_PREFIX,
     deps = [
+        ":date_interval_proto",
         ":event_group_activity_proto",
         "@com_google_googleapis//google/type:date_proto",
-        "@com_google_googleapis//google/type:interval_proto",
         "@com_google_protobuf//:empty_proto",
         "@com_google_protobuf//:timestamp_proto",
     ],

--- a/src/main/proto/wfa/measurement/internal/kingdom/event_group_activities_service.proto
+++ b/src/main/proto/wfa/measurement/internal/kingdom/event_group_activities_service.proto
@@ -33,6 +33,10 @@ service EventGroupActivities {
 
   rpc BatchDeleteEventGroupActivities(BatchDeleteEventGroupActivitiesRequest)
       returns (google.protobuf.Empty);
+
+  // Lists `EventGroupActivity`s.
+  rpc ListEventGroupActivities(ListEventGroupActivitiesRequest)
+      returns (ListEventGroupActivitiesResponse);
 }
 
 message UpdateEventGroupActivityRequest {
@@ -73,4 +77,34 @@ message BatchDeleteEventGroupActivitiesRequest {
   // The external ids specifying the EventGroupActivity to permanently
   // delete. A maximum of 1000 EventGroupActivity can be deleted in a batch.
   repeated google.type.Date external_event_group_activity_ids = 3;
+}
+
+message ListEventGroupActivitiesRequest {
+  // External ID of the parent DataProvider. Required.
+  fixed64 external_data_provider_id = 1;
+  // External ID of the parent EventGroup. Required.
+  fixed64 external_event_group_id = 2;
+
+  // The maximum number of results to return.
+  //
+  // If unspecified, at most 50 results will be returned. The maximum value is
+  // 1000; values above this will be coerced to the maximum value.
+  int32 page_size = 3;
+  ListEventGroupActivitiesPageToken page_token = 4;
+}
+
+message ListEventGroupActivitiesResponse {
+  repeated EventGroupActivity event_group_activities = 1;
+
+  // Token for requesting subsequent pages.
+  //
+  // If not specified, there are no more results.
+  ListEventGroupActivitiesPageToken next_page_token = 2;
+}
+
+message ListEventGroupActivitiesPageToken {
+  message After {
+    google.type.Date date = 1;
+  }
+  After after = 1;
 }

--- a/src/main/proto/wfa/measurement/internal/kingdom/event_group_activities_service.proto
+++ b/src/main/proto/wfa/measurement/internal/kingdom/event_group_activities_service.proto
@@ -1,4 +1,4 @@
-// Copyright 2025 The Cross-Media Measurement Authors
+// Copyright 2026 The Cross-Media Measurement Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -19,6 +19,7 @@ package wfa.measurement.internal.kingdom;
 import "wfa/measurement/internal/kingdom/event_group_activity.proto";
 import "google/protobuf/empty.proto";
 import "google/type/date.proto";
+import "google/type/interval.proto";
 
 option java_package = "org.wfanet.measurement.internal.kingdom";
 option java_multiple_files = true;
@@ -82,15 +83,22 @@ message BatchDeleteEventGroupActivitiesRequest {
 message ListEventGroupActivitiesRequest {
   // External ID of the parent DataProvider. Required.
   fixed64 external_data_provider_id = 1;
-  // External ID of the parent EventGroup. Required.
-  fixed64 external_event_group_id = 2;
 
   // The maximum number of results to return.
   //
   // If unspecified, at most 50 results will be returned. The maximum value is
   // 1000; values above this will be coerced to the maximum value.
-  int32 page_size = 3;
-  ListEventGroupActivitiesPageToken page_token = 4;
+  int32 page_size = 2;
+  ListEventGroupActivitiesPageToken page_token = 3;
+
+  message Filter {
+    // Filter by activity date range.
+    google.type.Interval date_interval = 1;
+    // Filter to specific event groups. If empty, returns activities
+    // across all event groups for the data provider.
+    repeated fixed64 external_event_group_ids = 2;
+  }
+  Filter filter = 4;
 }
 
 message ListEventGroupActivitiesResponse {
@@ -105,6 +113,7 @@ message ListEventGroupActivitiesResponse {
 message ListEventGroupActivitiesPageToken {
   message After {
     google.type.Date date = 1;
+    fixed64 external_event_group_id = 2;
   }
   After after = 1;
 }

--- a/src/main/proto/wfa/measurement/internal/kingdom/event_group_activities_service.proto
+++ b/src/main/proto/wfa/measurement/internal/kingdom/event_group_activities_service.proto
@@ -85,7 +85,7 @@ message ListEventGroupActivitiesRequest {
   fixed64 external_data_provider_id = 1;
   // External ID of the parent EventGroup. If unset, lists across all
   // EventGroups for the scoped DataProvider.
-  optional fixed64 external_event_group_id = 2;
+  fixed64 external_event_group_id = 2;
 
   // The maximum number of results to return.
   //
@@ -95,7 +95,9 @@ message ListEventGroupActivitiesRequest {
   ListEventGroupActivitiesPageToken page_token = 4;
 
   message Filter {
-    // Filter by activity date range.
+    // Filter by activity date range. Half-open: includes activities on or
+    // after `start_date` and strictly before `end_date`. Either bound may
+    // be unset (open-ended).
     DateInterval date_interval = 1;
   }
   Filter filter = 5;

--- a/src/main/proto/wfa/measurement/internal/kingdom/event_group_activities_service.proto
+++ b/src/main/proto/wfa/measurement/internal/kingdom/event_group_activities_service.proto
@@ -19,7 +19,7 @@ package wfa.measurement.internal.kingdom;
 import "wfa/measurement/internal/kingdom/event_group_activity.proto";
 import "google/protobuf/empty.proto";
 import "google/type/date.proto";
-import "google/type/interval.proto";
+import "wfa/measurement/internal/kingdom/date_interval.proto";
 
 option java_package = "org.wfanet.measurement.internal.kingdom";
 option java_multiple_files = true;
@@ -93,7 +93,7 @@ message ListEventGroupActivitiesRequest {
 
   message Filter {
     // Filter by activity date range.
-    google.type.Interval date_interval = 1;
+    DateInterval date_interval = 1;
     // Filter to specific event groups. If empty, returns activities
     // across all event groups for the data provider.
     repeated fixed64 external_event_group_ids = 2;

--- a/src/main/proto/wfa/measurement/internal/kingdom/event_group_activities_service.proto
+++ b/src/main/proto/wfa/measurement/internal/kingdom/event_group_activities_service.proto
@@ -81,12 +81,11 @@ message BatchDeleteEventGroupActivitiesRequest {
 }
 
 message ListEventGroupActivitiesRequest {
-  // External ID of the parent DataProvider. If unset, lists across all
-  // DataProviders.
+  // External ID of the parent DataProvider. Required.
   fixed64 external_data_provider_id = 1;
   // External ID of the parent EventGroup. If unset, lists across all
-  // EventGroups for the scoped DataProvider (or all DataProviders).
-  fixed64 external_event_group_id = 2;
+  // EventGroups for the scoped DataProvider.
+  optional fixed64 external_event_group_id = 2;
 
   // The maximum number of results to return.
   //

--- a/src/main/proto/wfa/measurement/internal/kingdom/event_group_activities_service.proto
+++ b/src/main/proto/wfa/measurement/internal/kingdom/event_group_activities_service.proto
@@ -95,9 +95,8 @@ message ListEventGroupActivitiesRequest {
   ListEventGroupActivitiesPageToken page_token = 4;
 
   message Filter {
-    // Filter by activity date range. Half-open: includes activities on or
-    // after `start_date` and strictly before `end_date`. Either bound may
-    // be unset (open-ended).
+    // Filter by activity date range. Only activities with
+    // dates within this interval are returned.
     DateInterval date_interval = 1;
   }
   Filter filter = 5;

--- a/src/main/proto/wfa/measurement/internal/kingdom/event_group_activities_service.proto
+++ b/src/main/proto/wfa/measurement/internal/kingdom/event_group_activities_service.proto
@@ -81,24 +81,25 @@ message BatchDeleteEventGroupActivitiesRequest {
 }
 
 message ListEventGroupActivitiesRequest {
-  // External ID of the parent DataProvider. Required.
+  // External ID of the parent DataProvider. If unset, lists across all
+  // DataProviders.
   fixed64 external_data_provider_id = 1;
+  // External ID of the parent EventGroup. If unset, lists across all
+  // EventGroups for the scoped DataProvider (or all DataProviders).
+  fixed64 external_event_group_id = 2;
 
   // The maximum number of results to return.
   //
   // If unspecified, at most 50 results will be returned. The maximum value is
   // 1000; values above this will be coerced to the maximum value.
-  int32 page_size = 2;
-  ListEventGroupActivitiesPageToken page_token = 3;
+  int32 page_size = 3;
+  ListEventGroupActivitiesPageToken page_token = 4;
 
   message Filter {
     // Filter by activity date range.
     DateInterval date_interval = 1;
-    // Filter to specific event groups. If empty, returns activities
-    // across all event groups for the data provider.
-    repeated fixed64 external_event_group_ids = 2;
   }
-  Filter filter = 4;
+  Filter filter = 5;
 }
 
 message ListEventGroupActivitiesResponse {


### PR DESCRIPTION
Add ListEventGroupActivities to internal kingdom service with Spanner query, keyset pagination via typed page token, Filter message with date_interval and event_groups, composite page token tiebreaker, and DataProvider existence validation.

Issue: #3952