### PR TITLE
feat: propagate memoized_vid_assignment_enabled through Kingdom

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -49,7 +49,7 @@ bazel_dep(
 )
 bazel_dep(
     name = "cross-media-measurement-api",
-    version = "0.93.0",
+    version = "0.94.0",
     repo_name = "wfa_measurement_proto",
 )
 bazel_dep(

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -556,8 +556,8 @@
     "https://raw.githubusercontent.com/world-federation-of-advertisers/bazel-registry/main/modules/consent-signaling-client/0.23.0/source.json": "3798af185e6c71cabea6550303035ea4ad325a6d53854ab056ee6c93acf03b89",
     "https://raw.githubusercontent.com/world-federation-of-advertisers/bazel-registry/main/modules/crc32c/1.1.0/MODULE.bazel": "not found",
     "https://raw.githubusercontent.com/world-federation-of-advertisers/bazel-registry/main/modules/cross-media-measurement-api/0.87.0/MODULE.bazel": "c678b3f46885c8dea8e0de6215dc3b935ff93d632eec5d603e0690ce61571398",
-    "https://raw.githubusercontent.com/world-federation-of-advertisers/bazel-registry/main/modules/cross-media-measurement-api/0.93.0/MODULE.bazel": "fe7aeb4206d134f11db112638d753c910738467edb6013d62de88a3c7ace7d4e",
-    "https://raw.githubusercontent.com/world-federation-of-advertisers/bazel-registry/main/modules/cross-media-measurement-api/0.93.0/source.json": "474f1b0392388c418ebf8d2e78096287120d4fd633b8c3f1f3cbcd228ebb0ca8",
+    "https://raw.githubusercontent.com/world-federation-of-advertisers/bazel-registry/main/modules/cross-media-measurement-api/0.94.0/MODULE.bazel": "c47c3a60edd160e22cf491c4567347275909483bfd74aff233149f0a5c7124a5",
+    "https://raw.githubusercontent.com/world-federation-of-advertisers/bazel-registry/main/modules/cross-media-measurement-api/0.94.0/source.json": "8cab783dd7bb5b78b9145c009e493e3e3137481e581dc2461852e54d5be1f8d1",
     "https://raw.githubusercontent.com/world-federation-of-advertisers/bazel-registry/main/modules/curl/8.4.0/MODULE.bazel": "not found",
     "https://raw.githubusercontent.com/world-federation-of-advertisers/bazel-registry/main/modules/curl/8.7.1/MODULE.bazel": "not found",
     "https://raw.githubusercontent.com/world-federation-of-advertisers/bazel-registry/main/modules/curl/8.8.0.bcr.3/MODULE.bazel": "not found",
@@ -1705,7 +1705,7 @@
     "@@cross-media-measurement-api~//build:non_module_deps.bzl%non_module_deps": {
       "general": {
         "bzlTransitiveDigest": "tARYNwoTv9sVEd2saAAd0hgtPkV9rwO2ltHTb2278qs=",
-        "usagesDigest": "aY+hLELBpLlv69utQdIygJaoMnjqJEseZzKDIj6CKsA=",
+        "usagesDigest": "BGmF5zEDwAXa9hWfPChiWXSSk+DrofgwV2zAU47ZPy0=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
         "envVariables": {},

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/readers/ModelShardReader.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/readers/ModelShardReader.kt
@@ -40,6 +40,7 @@ class ModelShardReader : SpannerReader<ModelShardReader.Result>() {
      ModelShards.ModelShardId,
      ModelShards.ExternalModelShardId,
      ModelShards.ModelBlobPath,
+     ModelShards.MemoizedVidAssignmentEnabled,
      ModelShards.CreateTime,
      ModelReleases.ExternalModelReleaseId,
      DataProviders.ExternalDataProviderId,
@@ -67,6 +68,7 @@ class ModelShardReader : SpannerReader<ModelShardReader.Result>() {
     externalModelSuiteId = struct.getLong("ExternalModelSuiteId")
     externalModelReleaseId = struct.getLong("ExternalModelReleaseId")
     modelBlobPath = struct.getString("ModelBlobPath")
+    memoizedVidAssignmentEnabled = struct.getBoolean("MemoizedVidAssignmentEnabled")
     createTime = struct.getTimestamp("CreateTime").toProto()
   }
 

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/writers/CreateModelShard.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/gcloud/spanner/writers/CreateModelShard.kt
@@ -78,6 +78,7 @@ class CreateModelShard(private val modelShard: ModelShard) :
       set("ModelSuiteId" to modelReleaseIds.getLong("ModelSuiteId"))
       set("ModelReleaseId" to modelReleaseIds.getLong("ModelReleaseId"))
       set("ModelBlobPath" to modelShard.modelBlobPath)
+      set("MemoizedVidAssignmentEnabled" to modelShard.memoizedVidAssignmentEnabled)
       set("CreateTime" to Value.COMMIT_TIMESTAMP)
     }
 

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/service/api/v2alpha/ProtoConversions.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/service/api/v2alpha/ProtoConversions.kt
@@ -876,6 +876,7 @@ fun InternalModelShard.toModelShard(): ModelShard {
         )
         .toName()
     modelBlob = modelBlob { modelBlobPath = source.modelBlobPath }
+    memoizedVidAssignmentEnabled = source.memoizedVidAssignmentEnabled
     createTime = source.createTime
   }
 }
@@ -893,6 +894,7 @@ fun ModelShard.toInternal(
     externalModelSuiteId = apiIdToExternalId(modelReleaseKey.modelSuiteId)
     externalModelReleaseId = apiIdToExternalId(modelReleaseKey.modelReleaseId)
     modelBlobPath = publicModelShard.modelBlob.modelBlobPath
+    memoizedVidAssignmentEnabled = publicModelShard.memoizedVidAssignmentEnabled
   }
 }
 

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/service/internal/testing/ModelShardsServiceTest.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/service/internal/testing/ModelShardsServiceTest.kt
@@ -123,6 +123,7 @@ abstract class ModelShardsServiceTest<T : ModelShardsCoroutineImplBase> {
 
     val createdModelShard = modelShardsService.createModelShard(modelShard)
 
+    assertThat(createdModelShard.memoizedVidAssignmentEnabled).isFalse()
     assertThat(createdModelShard)
       .ignoringFields(ModelShard.CREATE_TIME_FIELD_NUMBER)
       .isEqualTo(

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/service/internal/testing/ModelShardsServiceTest.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/service/internal/testing/ModelShardsServiceTest.kt
@@ -138,6 +138,36 @@ abstract class ModelShardsServiceTest<T : ModelShardsCoroutineImplBase> {
   }
 
   @Test
+  fun `createModelShard with memoized VID assignment enabled succeeds`() = runBlocking {
+    val dataProvider = population.createDataProvider(dataProvidersService)
+    val modelSuite = population.createModelSuite(modelProvidersService, modelSuitesService)
+    val populationDataProvider = population.createDataProvider(dataProvidersService)
+    val createdPopulation = population.createPopulation(populationDataProvider, populationsService)
+    val modelRelease =
+      population.createModelRelease(
+        modelSuite {
+          externalModelProviderId = modelSuite.externalModelProviderId
+          externalModelSuiteId = modelSuite.externalModelSuiteId
+        },
+        createdPopulation,
+        modelReleasesService,
+      )
+
+    val modelShard = modelShard {
+      externalDataProviderId = dataProvider.externalDataProviderId
+      externalModelProviderId = modelRelease.externalModelProviderId
+      externalModelSuiteId = modelRelease.externalModelSuiteId
+      externalModelReleaseId = modelRelease.externalModelReleaseId
+      modelBlobPath = "modelBlobPath"
+      memoizedVidAssignmentEnabled = true
+    }
+
+    val createdModelShard = modelShardsService.createModelShard(modelShard)
+
+    assertThat(createdModelShard.memoizedVidAssignmentEnabled).isTrue()
+  }
+
+  @Test
   fun `createModelShard fails when Data Provider is not found`() = runBlocking {
     val modelShard = modelShard {
       externalDataProviderId = 123L

--- a/src/main/proto/wfa/measurement/internal/kingdom/model_shard.proto
+++ b/src/main/proto/wfa/measurement/internal/kingdom/model_shard.proto
@@ -34,4 +34,6 @@ message ModelShard {
   string model_blob_path = 6;
 
   google.protobuf.Timestamp create_time = 7;
+
+  bool memoized_vid_assignment_enabled = 8;
 }

--- a/src/main/resources/kingdom/spanner/add-model-shard-memoized-vid-assignment-flag.sql
+++ b/src/main/resources/kingdom/spanner/add-model-shard-memoized-vid-assignment-flag.sql
@@ -1,3 +1,5 @@
+-- liquibase formatted sql
+
 -- Copyright 2026 The Cross-Media Measurement Authors
 --
 -- Licensed under the Apache License, Version 2.0 (the "License");
@@ -11,6 +13,9 @@
 -- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 -- See the License for the specific language governing permissions and
 -- limitations under the License.
+
+-- changeset marcopremier:35 dbms:cloudspanner
+-- comment: Add MemoizedVidAssignmentEnabled column to ModelShards.
 
 START BATCH DDL;
 

--- a/src/main/resources/kingdom/spanner/add-model-shard-memoized-vid-assignment-flag.sql
+++ b/src/main/resources/kingdom/spanner/add-model-shard-memoized-vid-assignment-flag.sql
@@ -1,0 +1,20 @@
+-- Copyright 2026 The Cross-Media Measurement Authors
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--      http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+START BATCH DDL;
+
+ALTER TABLE ModelShards
+  ADD COLUMN MemoizedVidAssignmentEnabled BOOL NOT NULL DEFAULT (FALSE);
+
+RUN BATCH;

--- a/src/main/resources/kingdom/spanner/changelog.yaml
+++ b/src/main/resources/kingdom/spanner/changelog.yaml
@@ -119,3 +119,6 @@ databaseChangeLog:
 - include:
     file: add-event-group-entity-key.sql
     relativeToChangeLogFile: true
+- include:
+    file: add-model-shard-memoized-vid-assignment-flag.sql
+    relativeToChangeLogFile: true

--- a/src/test/kotlin/org/wfanet/measurement/kingdom/service/api/v2alpha/ModelShardsServiceTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/kingdom/service/api/v2alpha/ModelShardsServiceTest.kt
@@ -216,6 +216,33 @@ class ModelShardsServiceTest {
   }
 
   @Test
+  fun `createModelShard propagates memoizedVidAssignmentEnabled`() {
+    val publicModelShard = MODEL_SHARD.copy { memoizedVidAssignmentEnabled = true }
+    val request = createModelShardRequest {
+      parent = DATA_PROVIDER_NAME
+      modelShard = publicModelShard
+    }
+    val internalReturn = INTERNAL_MODEL_SHARD.copy { memoizedVidAssignmentEnabled = true }
+    internalModelShardsMock.stub {
+      onBlocking { createModelShard(any()) }.thenReturn(internalReturn)
+    }
+
+    val result =
+      withModelProviderPrincipal(MODEL_PROVIDER_NAME) {
+        runBlocking { service.createModelShard(request) }
+      }
+
+    verifyProtoArgument(internalModelShardsMock, ModelShardsCoroutineImplBase::createModelShard)
+      .isEqualTo(
+        internalReturn.copy {
+          clearCreateTime()
+          clearExternalModelShardId()
+        }
+      )
+    assertThat(result.memoizedVidAssignmentEnabled).isTrue()
+  }
+
+  @Test
   fun `createModelShard throws UNAUTHENTICATED when no principal is found`() {
     val request = createModelShardRequest {
       parent = DATA_PROVIDER_NAME


### PR DESCRIPTION
## Summary
  - Add the new `memoized_vid_assignment_enabled` flag (introduced on the public `ModelShard` proto by cross-media-measurement-api#280, released as v0.94.0) to the internal Kingdom proto, Spanner schema,
  DAOs, and the public/internal conversion layer.
  - Migration: `ALTER TABLE ModelShards ADD COLUMN MemoizedVidAssignmentEnabled BOOL NOT NULL DEFAULT (FALSE)` (non-breaking — existing rows backfill to `FALSE`).
  - Internal proto adds `bool memoized_vid_assignment_enabled = 8` on `wfa.measurement.internal.kingdom.ModelShard`.
  - `CreateModelShard` writes the new column; `ModelShardReader` reads it; `ProtoConversions` round-trips it in both directions.
  - `ListModelShards`/`GetModelShard` pick up the new field for free via the conversion layer (no service-layer changes needed).

Issue: #3902 