### PR TITLE
feat: scaffold SubpoolAssigner Phase-0 TEE app

### DIFF
--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/subpoolassigner/BUILD.bazel
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/subpoolassigner/BUILD.bazel
@@ -1,0 +1,22 @@
+load("@wfa_rules_kotlin_jvm//kotlin:defs.bzl", "kt_jvm_library")
+
+package(default_visibility = [
+    "//src/main/kotlin/org/wfanet/measurement/edpaggregator:__subpackages__",
+    "//src/test/kotlin/org/wfanet/measurement/edpaggregator:__subpackages__",
+])
+
+kt_jvm_library(
+    name = "subpool_assigner_app",
+    srcs = ["SubpoolAssignerApp.kt"],
+    deps = [
+        "//src/main/kotlin/org/wfanet/measurement/edpaggregator:storage_config",
+        "//src/main/kotlin/org/wfanet/measurement/securecomputation/teesdk:base_tee_application",
+        "//src/main/proto/wfa/measurement/edpaggregator/v1alpha:vid_labeler_params_kt_jvm_proto",
+        "//src/main/proto/wfa/measurement/securecomputation/controlplane/v1alpha:work_item_attempts_service_kt_jvm_grpc_proto",
+        "//src/main/proto/wfa/measurement/securecomputation/controlplane/v1alpha:work_item_kt_jvm_proto",
+        "//src/main/proto/wfa/measurement/securecomputation/controlplane/v1alpha:work_items_service_kt_jvm_grpc_proto",
+        "@wfa_common_jvm//imports/java/com/google/crypto/tink",
+        "@wfa_common_jvm//imports/java/com/google/protobuf",
+        "@wfa_common_jvm//src/main/kotlin/org/wfanet/measurement/queue:queue_subscriber",
+    ],
+)

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/subpoolassigner/BUILD.bazel
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/subpoolassigner/BUILD.bazel
@@ -11,7 +11,6 @@ kt_jvm_library(
     deps = [
         "//src/main/kotlin/org/wfanet/measurement/edpaggregator:storage_config",
         "//src/main/kotlin/org/wfanet/measurement/securecomputation/teesdk:base_tee_application",
-        "//src/main/proto/wfa/measurement/edpaggregator/v1alpha:impression_metadata_service_kt_jvm_grpc_proto",
         "//src/main/proto/wfa/measurement/edpaggregator/v1alpha:subpool_assigner_params_kt_jvm_proto",
         "//src/main/proto/wfa/measurement/securecomputation/controlplane/v1alpha:work_item_attempts_service_kt_jvm_grpc_proto",
         "//src/main/proto/wfa/measurement/securecomputation/controlplane/v1alpha:work_item_kt_jvm_proto",

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/subpoolassigner/BUILD.bazel
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/subpoolassigner/BUILD.bazel
@@ -11,7 +11,7 @@ kt_jvm_library(
     deps = [
         "//src/main/kotlin/org/wfanet/measurement/edpaggregator:storage_config",
         "//src/main/kotlin/org/wfanet/measurement/securecomputation/teesdk:base_tee_application",
-        "//src/main/proto/wfa/measurement/edpaggregator/v1alpha:vid_labeler_params_kt_jvm_proto",
+        "//src/main/proto/wfa/measurement/edpaggregator/v1alpha:subpool_assigner_params_kt_jvm_proto",
         "//src/main/proto/wfa/measurement/securecomputation/controlplane/v1alpha:work_item_attempts_service_kt_jvm_grpc_proto",
         "//src/main/proto/wfa/measurement/securecomputation/controlplane/v1alpha:work_item_kt_jvm_proto",
         "//src/main/proto/wfa/measurement/securecomputation/controlplane/v1alpha:work_items_service_kt_jvm_grpc_proto",

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/subpoolassigner/BUILD.bazel
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/subpoolassigner/BUILD.bazel
@@ -11,6 +11,7 @@ kt_jvm_library(
     deps = [
         "//src/main/kotlin/org/wfanet/measurement/edpaggregator:storage_config",
         "//src/main/kotlin/org/wfanet/measurement/securecomputation/teesdk:base_tee_application",
+        "//src/main/proto/wfa/measurement/edpaggregator/v1alpha:impression_metadata_service_kt_jvm_grpc_proto",
         "//src/main/proto/wfa/measurement/edpaggregator/v1alpha:subpool_assigner_params_kt_jvm_proto",
         "//src/main/proto/wfa/measurement/securecomputation/controlplane/v1alpha:work_item_attempts_service_kt_jvm_grpc_proto",
         "//src/main/proto/wfa/measurement/securecomputation/controlplane/v1alpha:work_item_kt_jvm_proto",

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/subpoolassigner/SubpoolAssignerApp.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/subpoolassigner/SubpoolAssignerApp.kt
@@ -20,7 +20,6 @@ import com.google.crypto.tink.KmsClient
 import com.google.protobuf.Any
 import com.google.protobuf.Parser
 import org.wfanet.measurement.edpaggregator.StorageConfig
-import org.wfanet.measurement.edpaggregator.v1alpha.ImpressionMetadataServiceGrpcKt.ImpressionMetadataServiceCoroutineStub
 import org.wfanet.measurement.edpaggregator.v1alpha.SubpoolAssignerParams
 import org.wfanet.measurement.edpaggregator.v1alpha.SubpoolAssignerParams.StorageParams
 import org.wfanet.measurement.queue.QueueSubscriber
@@ -70,11 +69,6 @@ import org.wfanet.measurement.securecomputation.teesdk.BaseTeeApplication
  * @param workItemsClient gRPC client stub for [WorkItemsGrpcKt.WorkItemsCoroutineStub].
  * @param workItemAttemptsClient gRPC client stub for
  *   [WorkItemAttemptsGrpcKt.WorkItemAttemptsCoroutineStub].
- * @param impressionMetadataStub gRPC client stub for the EDP Aggregator
- *   internal `ImpressionMetadataService`. Placeholder for the internal
- *   service stubs Phase-0 needs (`PoolAssignmentJob`,
- *   `RawImpressionUploadModelLine` — not yet defined); the constructor
- *   will grow as those services land.
  * @param kmsClients Per-DataProvider KMS clients used to wrap/unwrap DEKs
  *   for raw-impression and `SubpoolFingerprints` blobs.
  * @param getSubpoolMapStorageConfig Lambda to obtain the [StorageConfig] for
@@ -88,7 +82,13 @@ class SubpoolAssignerApp(
   parser: Parser<WorkItem>,
   workItemsClient: WorkItemsGrpcKt.WorkItemsCoroutineStub,
   workItemAttemptsClient: WorkItemAttemptsGrpcKt.WorkItemAttemptsCoroutineStub,
-  private val impressionMetadataStub: ImpressionMetadataServiceCoroutineStub,
+  // TODO(@Marco-Premier): wire EDP Aggregator internal gRPC service stubs
+  //   needed by Phase-0 as they become available:
+  //   - RawImpressionUpload
+  //   - RawImpressionUploadFile
+  //   - RawImpressionUploadModelLine
+  //   - PoolAssignmentJob
+  //   - RankerJob
   private val kmsClients: Map<String, KmsClient>,
   private val getSubpoolMapStorageConfig: (StorageParams) -> StorageConfig,
   private val getRawImpressionsStorageConfig: (StorageParams) -> StorageConfig,

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/subpoolassigner/SubpoolAssignerApp.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/subpoolassigner/SubpoolAssignerApp.kt
@@ -1,0 +1,122 @@
+/*
+ * Copyright 2026 The Cross-Media Measurement Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wfanet.measurement.edpaggregator.subpoolassigner
+
+import com.google.crypto.tink.KmsClient
+import com.google.protobuf.Any
+import com.google.protobuf.Parser
+import org.wfanet.measurement.edpaggregator.StorageConfig
+import org.wfanet.measurement.edpaggregator.v1alpha.VidLabelerParams
+import org.wfanet.measurement.edpaggregator.v1alpha.VidLabelerParams.StorageParams
+import org.wfanet.measurement.queue.QueueSubscriber
+import org.wfanet.measurement.securecomputation.controlplane.v1alpha.WorkItem
+import org.wfanet.measurement.securecomputation.controlplane.v1alpha.WorkItem.WorkItemParams
+import org.wfanet.measurement.securecomputation.controlplane.v1alpha.WorkItemAttemptsGrpcKt
+import org.wfanet.measurement.securecomputation.controlplane.v1alpha.WorkItemsGrpcKt
+import org.wfanet.measurement.securecomputation.teesdk.BaseTeeApplication
+
+/**
+ * Phase-0 TEE application for the memoized VID assignment pipeline.
+ *
+ * The dispatcher publishes one [WorkItem] per fingerprint shard for each
+ * (RawImpressionUpload, ModelLine) pair that has memoization enabled. Each
+ * [SubpoolAssignerApp] instance processes the shard identified by [shardIndex]:
+ * it reads the upload's raw impression files, filters to the impressions whose
+ * fingerprint falls into its shard, drops impressions whose event timestamp
+ * falls outside the model line's `[active_start_time, active_end_time)` window
+ * (see `ModelLine.active_start_time` / `active_end_time` in the public API),
+ * loads the compiled VID model from `ModelLineConfig.model_blob_path`, runs
+ * the labeler in pool-emit mode to resolve a subpool per fingerprint, and
+ * writes one [org.wfanet.measurement.edpaggregator.v1alpha.SubpoolFingerprints]
+ * blob per subpool to the SubpoolMap storage.
+ *
+ * Per-shard pipeline state is reported back through the EDP Aggregator's
+ * internal gRPC services: this app creates (or upserts) a
+ * `RawImpressionUploadModelLine` row for the (RawImpressionUpload, ModelLine)
+ * pair when it first runs, and updates its own `PoolAssignmentJob` row to
+ * `POOL_ASSIGNMENT_SUCCEEDED` once the per-shard blobs are durable.
+ *
+ * The last shard to complete is responsible for merging the per-shard
+ * per-subpool blobs into one cumulative blob per subpool, bin-packing
+ * subpools into `RankerJob` rows, flipping
+ * `RawImpressionUploadModelLineState` from `POOL_ASSIGNING` to `RANKING`,
+ * and triggering Phase-1 (rank allocation) with one `WorkItem` per
+ * `RankerJob`.
+ *
+ * @param subscriptionId The subscription ID for the queue subscriber.
+ * @param queueSubscriber The [QueueSubscriber] instance for receiving work items.
+ * @param parser The protobuf [Parser] for [WorkItem] messages.
+ * @param workItemsClient gRPC client stub for [WorkItemsGrpcKt.WorkItemsCoroutineStub].
+ * @param workItemAttemptsClient gRPC client stub for
+ *   [WorkItemAttemptsGrpcKt.WorkItemAttemptsCoroutineStub].
+ * @param shardIndex The fingerprint shard id this VM is responsible for. The
+ *   total shard count `N` lives in the per-WorkItem [VidLabelerParams]; this
+ *   VM keeps only impressions where `fingerprint.hash() % N == shardIndex`.
+ * @param kmsClients Per-DataProvider KMS clients used to wrap/unwrap DEKs
+ *   for raw-impression and SubpoolFingerprints blobs.
+ * @param getSubpoolMapStorageConfig Lambda to obtain the [StorageConfig] for
+ *   reading and writing the per-subpool fingerprint blobs.
+ * @param getRawImpressionsStorageConfig Lambda to obtain the [StorageConfig]
+ *   for reading the raw-impression files uploaded by the EDP.
+ */
+class SubpoolAssignerApp(
+  subscriptionId: String,
+  queueSubscriber: QueueSubscriber,
+  parser: Parser<WorkItem>,
+  workItemsClient: WorkItemsGrpcKt.WorkItemsCoroutineStub,
+  workItemAttemptsClient: WorkItemAttemptsGrpcKt.WorkItemAttemptsCoroutineStub,
+  private val shardIndex: Int,
+  private val kmsClients: MutableMap<String, KmsClient>,
+  private val getSubpoolMapStorageConfig: (StorageParams) -> StorageConfig,
+  private val getRawImpressionsStorageConfig: (StorageParams) -> StorageConfig,
+) :
+  BaseTeeApplication(
+    subscriptionId = subscriptionId,
+    queueSubscriber = queueSubscriber,
+    parser = parser,
+    workItemsStub = workItemsClient,
+    workItemAttemptsStub = workItemAttemptsClient,
+  ) {
+
+  override suspend fun runWork(message: Any) {
+    val workItemParams = message.unpack(WorkItemParams::class.java)
+    val vidLabelerParams = workItemParams.appParams.unpack(VidLabelerParams::class.java)
+
+    // TODO(@Marco-Premier): Implement Phase-0 pipeline:
+    //   1. Resolve storage configs via getRawImpressionsStorageConfig and
+    //      getSubpoolMapStorageConfig from vidLabelerParams storage params.
+    //   2. Resolve the per-DataProvider KmsClient from kmsClients.
+    //   3. For each entry in vidLabelerParams.modelLineConfigs, create (or
+    //      upsert) the RawImpressionUploadModelLine row via the EDP Aggregator
+    //      internal gRPC and load the model from
+    //      ModelLineConfig.modelBlobPath into the labeler.
+    //   4. Read raw-impression files for this upload from raw-impressions storage.
+    //   5. Decrypt within the TEE; drop impressions whose event timestamp falls
+    //      outside ModelLineConfig.[activeStartTime, activeEndTime).
+    //   6. Compute SHA-256 fingerprints; keep only those where
+    //      fingerprint.hash() % N == shardIndex (N from VidLabelerParams).
+    //   7. Run the labeler in pool-emit mode; bucket fingerprints by subpool.
+    //   8. Write per-shard per-subpool SubpoolFingerprints blobs (DEK-encrypted)
+    //      to the SubpoolMap storage.
+    //   9. Update this shard's PoolAssignmentJob row to POOL_ASSIGNMENT_SUCCEEDED
+    //      via the EDP Aggregator internal gRPC.
+    //  10. Last-shard-out: merge per-shard blobs into one cumulative blob per
+    //      subpool, bin-pack subpools into RankerJob rows, flip
+    //      RawImpressionUploadModelLineState POOL_ASSIGNING -> RANKING, and
+    //      publish one WorkItem per RankerJob.
+  }
+}

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/subpoolassigner/SubpoolAssignerApp.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/subpoolassigner/SubpoolAssignerApp.kt
@@ -20,8 +20,8 @@ import com.google.crypto.tink.KmsClient
 import com.google.protobuf.Any
 import com.google.protobuf.Parser
 import org.wfanet.measurement.edpaggregator.StorageConfig
-import org.wfanet.measurement.edpaggregator.v1alpha.VidLabelerParams
-import org.wfanet.measurement.edpaggregator.v1alpha.VidLabelerParams.StorageParams
+import org.wfanet.measurement.edpaggregator.v1alpha.SubpoolAssignerParams
+import org.wfanet.measurement.edpaggregator.v1alpha.SubpoolAssignerParams.StorageParams
 import org.wfanet.measurement.queue.QueueSubscriber
 import org.wfanet.measurement.securecomputation.controlplane.v1alpha.WorkItem
 import org.wfanet.measurement.securecomputation.controlplane.v1alpha.WorkItem.WorkItemParams
@@ -33,22 +33,28 @@ import org.wfanet.measurement.securecomputation.teesdk.BaseTeeApplication
  * Phase-0 TEE application for the memoized VID assignment pipeline.
  *
  * The dispatcher publishes one [WorkItem] per fingerprint shard for each
- * (RawImpressionUpload, ModelLine) pair that has memoization enabled. Each
- * [SubpoolAssignerApp] instance processes the shard identified by [shardIndex]:
- * it reads the upload's raw impression files, filters to the impressions whose
- * fingerprint falls into its shard, drops impressions whose event timestamp
- * falls outside the model line's `[active_start_time, active_end_time)` window
- * (see `ModelLine.active_start_time` / `active_end_time` in the public API),
- * loads the compiled VID model from `ModelLineConfig.model_blob_path`, runs
- * the labeler in pool-emit mode to resolve a subpool per fingerprint, and
- * writes one [org.wfanet.measurement.edpaggregator.v1alpha.SubpoolFingerprints]
- * blob per subpool to the SubpoolMap storage.
+ * (`RawImpressionUpload`, `ModelLine`) pair that has memoization enabled.
+ * The shard, model line, and per-dispatch knobs travel inside the WorkItem's
+ * [SubpoolAssignerParams] payload. Each VM:
+ *  - reads the upload's raw impression files,
+ *  - drops impressions whose event timestamp falls outside the model line's
+ *    `[active_start_time, active_end_time)` window (mirrors
+ *    `ModelLine.active_start_time` / `active_end_time` in the public API),
+ *  - keeps only impressions whose SHA-256 fingerprint matches its shard
+ *    (`fingerprint.hash() % total_shards == shard_index`),
+ *  - loads the compiled VID model from
+ *    [SubpoolAssignerParams.modelBlobPath] and runs the labeler in pool-emit
+ *    mode to resolve a subpool per fingerprint,
+ *  - writes one
+ *    [org.wfanet.measurement.edpaggregator.v1alpha.SubpoolFingerprints] blob
+ *    per (shard, subpool) to the subpool-map storage.
  *
  * Per-shard pipeline state is reported back through the EDP Aggregator's
  * internal gRPC services: this app creates (or upserts) a
- * `RawImpressionUploadModelLine` row for the (RawImpressionUpload, ModelLine)
- * pair when it first runs, and updates its own `PoolAssignmentJob` row to
- * `POOL_ASSIGNMENT_SUCCEEDED` once the per-shard blobs are durable.
+ * `RawImpressionUploadModelLine` row for the (`RawImpressionUpload`,
+ * `ModelLine`) pair when it first runs, and updates its own
+ * `PoolAssignmentJob` row to `POOL_ASSIGNMENT_SUCCEEDED` once the per-shard
+ * blobs are durable.
  *
  * The last shard to complete is responsible for merging the per-shard
  * per-subpool blobs into one cumulative blob per subpool, bin-packing
@@ -63,13 +69,10 @@ import org.wfanet.measurement.securecomputation.teesdk.BaseTeeApplication
  * @param workItemsClient gRPC client stub for [WorkItemsGrpcKt.WorkItemsCoroutineStub].
  * @param workItemAttemptsClient gRPC client stub for
  *   [WorkItemAttemptsGrpcKt.WorkItemAttemptsCoroutineStub].
- * @param shardIndex The fingerprint shard id this VM is responsible for. The
- *   total shard count `N` lives in the per-WorkItem [VidLabelerParams]; this
- *   VM keeps only impressions where `fingerprint.hash() % N == shardIndex`.
  * @param kmsClients Per-DataProvider KMS clients used to wrap/unwrap DEKs
- *   for raw-impression and SubpoolFingerprints blobs.
+ *   for raw-impression and `SubpoolFingerprints` blobs.
  * @param getSubpoolMapStorageConfig Lambda to obtain the [StorageConfig] for
- *   reading and writing the per-subpool fingerprint blobs.
+ *   reading and writing the per-(shard, subpool) `SubpoolFingerprints` blobs.
  * @param getRawImpressionsStorageConfig Lambda to obtain the [StorageConfig]
  *   for reading the raw-impression files uploaded by the EDP.
  */
@@ -79,8 +82,7 @@ class SubpoolAssignerApp(
   parser: Parser<WorkItem>,
   workItemsClient: WorkItemsGrpcKt.WorkItemsCoroutineStub,
   workItemAttemptsClient: WorkItemAttemptsGrpcKt.WorkItemAttemptsCoroutineStub,
-  private val shardIndex: Int,
-  private val kmsClients: MutableMap<String, KmsClient>,
+  private val kmsClients: Map<String, KmsClient>,
   private val getSubpoolMapStorageConfig: (StorageParams) -> StorageConfig,
   private val getRawImpressionsStorageConfig: (StorageParams) -> StorageConfig,
 ) :
@@ -94,26 +96,30 @@ class SubpoolAssignerApp(
 
   override suspend fun runWork(message: Any) {
     val workItemParams = message.unpack(WorkItemParams::class.java)
-    val vidLabelerParams = workItemParams.appParams.unpack(VidLabelerParams::class.java)
+    val subpoolAssignerParams =
+      workItemParams.appParams.unpack(SubpoolAssignerParams::class.java)
 
     // TODO(@Marco-Premier): Implement Phase-0 pipeline:
     //   1. Resolve storage configs via getRawImpressionsStorageConfig and
-    //      getSubpoolMapStorageConfig from vidLabelerParams storage params.
-    //   2. Resolve the per-DataProvider KmsClient from kmsClients.
-    //   3. For each entry in vidLabelerParams.modelLineConfigs, create (or
-    //      upsert) the RawImpressionUploadModelLine row via the EDP Aggregator
-    //      internal gRPC and load the model from
-    //      ModelLineConfig.modelBlobPath into the labeler.
-    //   4. Read raw-impression files for this upload from raw-impressions storage.
-    //   5. Decrypt within the TEE; drop impressions whose event timestamp falls
-    //      outside ModelLineConfig.[activeStartTime, activeEndTime).
+    //      getSubpoolMapStorageConfig from subpoolAssignerParams.
+    //   2. Resolve the per-DataProvider KmsClient from kmsClients keyed by
+    //      subpoolAssignerParams.dataProvider.
+    //   3. Create (or upsert) the RawImpressionUploadModelLine row via the
+    //      EDP Aggregator internal gRPC for
+    //      (rawImpressionUploadResourceId, modelLine), and load the compiled
+    //      VID model from subpoolAssignerParams.modelBlobPath into the labeler.
+    //   4. Read raw-impression files for this upload from raw-impressions
+    //      storage (URI is resolved from RawImpressionUpload.done_blob_uri via
+    //      the RawImpressionMetadata storage service).
+    //   5. Decrypt within the TEE; drop impressions whose event timestamp
+    //      falls outside [activeStartTime, activeEndTime).
     //   6. Compute SHA-256 fingerprints; keep only those where
-    //      fingerprint.hash() % N == shardIndex (N from VidLabelerParams).
+    //      `fingerprint.hash() % totalShards == shardIndex`.
     //   7. Run the labeler in pool-emit mode; bucket fingerprints by subpool.
-    //   8. Write per-shard per-subpool SubpoolFingerprints blobs (DEK-encrypted)
-    //      to the SubpoolMap storage.
-    //   9. Update this shard's PoolAssignmentJob row to POOL_ASSIGNMENT_SUCCEEDED
-    //      via the EDP Aggregator internal gRPC.
+    //   8. Write per-(shard, subpool) SubpoolFingerprints blobs (DEK-encrypted)
+    //      to the subpool-map storage.
+    //   9. Update this shard's PoolAssignmentJob row to
+    //      POOL_ASSIGNMENT_SUCCEEDED via the EDP Aggregator internal gRPC.
     //  10. Last-shard-out: merge per-shard blobs into one cumulative blob per
     //      subpool, bin-pack subpools into RankerJob rows, flip
     //      RawImpressionUploadModelLineState POOL_ASSIGNING -> RANKING, and

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/subpoolassigner/SubpoolAssignerApp.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/subpoolassigner/SubpoolAssignerApp.kt
@@ -32,36 +32,29 @@ import org.wfanet.measurement.securecomputation.teesdk.BaseTeeApplication
 /**
  * Phase-0 TEE application for the memoized VID assignment pipeline.
  *
- * The dispatcher publishes one [WorkItem] per fingerprint shard for each
- * (`RawImpressionUpload`, `ModelLine`) pair that has memoization enabled.
- * The shard, model line, and per-dispatch knobs travel inside the WorkItem's
- * [SubpoolAssignerParams] payload. Each VM:
- *  - reads the upload's raw impression files,
- *  - drops impressions whose event timestamp falls outside the model line's
- *    `[active_start_time, active_end_time)` window (mirrors
- *    `ModelLine.active_start_time` / `active_end_time` in the public API),
- *  - keeps only impressions whose SHA-256 fingerprint matches its shard
- *    (`fingerprint.hash() % total_shards == shard_index`),
- *  - loads the compiled VID model from
- *    [SubpoolAssignerParams.modelBlobPath] and runs the labeler in pool-emit
- *    mode to resolve a subpool per fingerprint,
- *  - writes one
- *    [org.wfanet.measurement.edpaggregator.v1alpha.SubpoolFingerprints] blob
- *    per (shard, subpool) to the subpool-map storage.
+ * The dispatcher publishes one [WorkItem] per fingerprint shard for each (`RawImpressionUpload`,
+ * `ModelLine`) pair that has memoization enabled. The shard, model line, and per-dispatch knobs
+ * travel inside the WorkItem's [SubpoolAssignerParams] payload. Each VM:
+ * - reads the upload's raw impression files,
+ * - drops impressions whose event timestamp falls outside the model line's `[active_start_time,
+ *   active_end_time)` window (mirrors `ModelLine.active_start_time` / `active_end_time` in the
+ *   public API),
+ * - keeps only impressions whose SHA-256 fingerprint matches its shard (`fingerprint.hash() %
+ *   total_shards == shard_index`),
+ * - loads the compiled VID model from [SubpoolAssignerParams.modelBlobPath] and runs the labeler in
+ *   pool-emit mode to resolve a subpool per fingerprint,
+ * - writes one [org.wfanet.measurement.edpaggregator.v1alpha.SubpoolFingerprints] blob per (shard,
+ *   subpool) to the subpool-map storage.
  *
- * Per-shard pipeline state is reported back through the EDP Aggregator's
- * internal gRPC services: this app creates (or upserts) a
- * `RawImpressionUploadModelLine` row for the (`RawImpressionUpload`,
- * `ModelLine`) pair when it first runs, and updates its own
- * `PoolAssignmentJob` row to `POOL_ASSIGNMENT_SUCCEEDED` once the per-shard
- * blobs are durable.
+ * Per-shard pipeline state is reported back through the EDP Aggregator's internal gRPC services:
+ * this app creates (or upserts) a `RawImpressionUploadModelLine` row for the
+ * (`RawImpressionUpload`, `ModelLine`) pair when it first runs, and updates its own
+ * `PoolAssignmentJob` row to `POOL_ASSIGNMENT_SUCCEEDED` once the per-shard blobs are durable.
  *
- * The last shard to complete is responsible for merging the per-shard
- * per-subpool blobs into one cumulative blob per subpool, bin-packing
- * subpools into `RankerJob` rows, flipping
- * `RawImpressionUploadModelLineState` from `POOL_ASSIGNING` to `RANKING`,
- * and triggering Phase-1 (rank allocation) with one `WorkItem` per
- * `RankerJob`.
+ * The last shard to complete is responsible for merging the per-shard per-subpool blobs into one
+ * cumulative blob per subpool, bin-packing subpools into `RankerJob` rows, flipping
+ * `RawImpressionUploadModelLineState` from `POOL_ASSIGNING` to `RANKING`, and triggering Phase-1
+ * (rank allocation) with one `WorkItem` per `RankerJob`.
  *
  * @param subscriptionId The subscription ID for the queue subscriber.
  * @param queueSubscriber The [QueueSubscriber] instance for receiving work items.
@@ -69,12 +62,12 @@ import org.wfanet.measurement.securecomputation.teesdk.BaseTeeApplication
  * @param workItemsClient gRPC client stub for [WorkItemsGrpcKt.WorkItemsCoroutineStub].
  * @param workItemAttemptsClient gRPC client stub for
  *   [WorkItemAttemptsGrpcKt.WorkItemAttemptsCoroutineStub].
- * @param kmsClients Per-DataProvider KMS clients used to wrap/unwrap DEKs
- *   for raw-impression and `SubpoolFingerprints` blobs.
- * @param getSubpoolMapStorageConfig Lambda to obtain the [StorageConfig] for
- *   reading and writing the per-(shard, subpool) `SubpoolFingerprints` blobs.
- * @param getRawImpressionsStorageConfig Lambda to obtain the [StorageConfig]
- *   for reading the raw-impression files uploaded by the EDP.
+ * @param kmsClients Per-DataProvider KMS clients used to wrap/unwrap DEKs for raw-impression and
+ *   `SubpoolFingerprints` blobs.
+ * @param getSubpoolMapStorageConfig Lambda to obtain the [StorageConfig] for reading and writing
+ *   the per-(shard, subpool) `SubpoolFingerprints` blobs.
+ * @param getRawImpressionsStorageConfig Lambda to obtain the [StorageConfig] for reading the
+ *   raw-impression files uploaded by the EDP.
  */
 class SubpoolAssignerApp(
   subscriptionId: String,
@@ -103,8 +96,7 @@ class SubpoolAssignerApp(
 
   override suspend fun runWork(message: Any) {
     val workItemParams = message.unpack(WorkItemParams::class.java)
-    val subpoolAssignerParams =
-      workItemParams.appParams.unpack(SubpoolAssignerParams::class.java)
+    val subpoolAssignerParams = workItemParams.appParams.unpack(SubpoolAssignerParams::class.java)
 
     // TODO(@Marco-Premier): Implement Phase-0 pipeline:
     //   1. Resolve storage configs via getRawImpressionsStorageConfig and

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/subpoolassigner/SubpoolAssignerApp.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/subpoolassigner/SubpoolAssignerApp.kt
@@ -20,6 +20,7 @@ import com.google.crypto.tink.KmsClient
 import com.google.protobuf.Any
 import com.google.protobuf.Parser
 import org.wfanet.measurement.edpaggregator.StorageConfig
+import org.wfanet.measurement.edpaggregator.v1alpha.ImpressionMetadataServiceGrpcKt.ImpressionMetadataServiceCoroutineStub
 import org.wfanet.measurement.edpaggregator.v1alpha.SubpoolAssignerParams
 import org.wfanet.measurement.edpaggregator.v1alpha.SubpoolAssignerParams.StorageParams
 import org.wfanet.measurement.queue.QueueSubscriber
@@ -69,6 +70,11 @@ import org.wfanet.measurement.securecomputation.teesdk.BaseTeeApplication
  * @param workItemsClient gRPC client stub for [WorkItemsGrpcKt.WorkItemsCoroutineStub].
  * @param workItemAttemptsClient gRPC client stub for
  *   [WorkItemAttemptsGrpcKt.WorkItemAttemptsCoroutineStub].
+ * @param impressionMetadataStub gRPC client stub for the EDP Aggregator
+ *   internal `ImpressionMetadataService`. Placeholder for the internal
+ *   service stubs Phase-0 needs (`PoolAssignmentJob`,
+ *   `RawImpressionUploadModelLine` — not yet defined); the constructor
+ *   will grow as those services land.
  * @param kmsClients Per-DataProvider KMS clients used to wrap/unwrap DEKs
  *   for raw-impression and `SubpoolFingerprints` blobs.
  * @param getSubpoolMapStorageConfig Lambda to obtain the [StorageConfig] for
@@ -82,6 +88,7 @@ class SubpoolAssignerApp(
   parser: Parser<WorkItem>,
   workItemsClient: WorkItemsGrpcKt.WorkItemsCoroutineStub,
   workItemAttemptsClient: WorkItemAttemptsGrpcKt.WorkItemAttemptsCoroutineStub,
+  private val impressionMetadataStub: ImpressionMetadataServiceCoroutineStub,
   private val kmsClients: Map<String, KmsClient>,
   private val getSubpoolMapStorageConfig: (StorageParams) -> StorageConfig,
   private val getRawImpressionsStorageConfig: (StorageParams) -> StorageConfig,
@@ -124,5 +131,27 @@ class SubpoolAssignerApp(
     //      subpool, bin-pack subpools into RankerJob rows, flip
     //      RawImpressionUploadModelLineState POOL_ASSIGNING -> RANKING, and
     //      publish one WorkItem per RankerJob.
+    //
+    // TODO(@Marco-Premier): runWork must be idempotent on Pub/Sub
+    // redelivery. The Spanner commit (PoolAssignmentJob ->
+    // POOL_ASSIGNMENT_SUCCEEDED, last-shard-out RankerJob inserts,
+    // RawImpressionUploadModelLineState flip) and the message ack are not
+    // atomic, so a crash between them leads to redelivery with state
+    // already advanced. The implementation must:
+    //   - detect that this PoolAssignmentJob is already
+    //     POOL_ASSIGNMENT_SUCCEEDED and treat its own per-shard steps as
+    //     no-ops, re-running only the last-shard-out check (step 10)
+    //     before acking,
+    //   - tolerate partially-written per-(shard, subpool)
+    //     SubpoolFingerprints blobs and partially-inserted RankerJob rows
+    //     from a prior attempt (e.g. resume rather than duplicate),
+    //   - keep fingerprint partitioning deterministic across attempts so
+    //     a redelivered run produces the same per-subpool sets.
+    // Cover with tests that inject failures at: (a) after Spanner state
+    // flip but before ack, (b) mid-blob-write, (c) after first subpool
+    // blob write but before second, (d) after last-shard-out
+    // RawImpressionUploadModelLineState flip but before any Phase-1
+    // WorkItem publish, (e) between RankerJob row inserts. Each case
+    // must converge to the same final state on redelivery.
   }
 }

--- a/src/main/proto/wfa/measurement/edpaggregator/v1alpha/BUILD.bazel
+++ b/src/main/proto/wfa/measurement/edpaggregator/v1alpha/BUILD.bazel
@@ -92,6 +92,7 @@ proto_library(
         ":transport_layer_security_params_proto",
         "@com_google_googleapis//google/api:field_behavior_proto",
         "@com_google_googleapis//google/api:resource_proto",
+        "@com_google_protobuf//:timestamp_proto",
     ],
 )
 

--- a/src/main/proto/wfa/measurement/edpaggregator/v1alpha/BUILD.bazel
+++ b/src/main/proto/wfa/measurement/edpaggregator/v1alpha/BUILD.bazel
@@ -92,7 +92,6 @@ proto_library(
         ":transport_layer_security_params_proto",
         "@com_google_googleapis//google/api:field_behavior_proto",
         "@com_google_googleapis//google/api:resource_proto",
-        "@com_google_protobuf//:timestamp_proto",
     ],
 )
 
@@ -100,6 +99,25 @@ kt_jvm_proto_library(
     name = "vid_labeler_params_kt_jvm_proto",
     deps = [
         ":vid_labeler_params_proto",
+    ],
+)
+
+proto_library(
+    name = "subpool_assigner_params_proto",
+    srcs = ["subpool_assigner_params.proto"],
+    strip_import_prefix = _IMPORT_PREFIX,
+    deps = [
+        ":transport_layer_security_params_proto",
+        "@com_google_googleapis//google/api:field_behavior_proto",
+        "@com_google_googleapis//google/api:resource_proto",
+        "@com_google_protobuf//:timestamp_proto",
+    ],
+)
+
+kt_jvm_proto_library(
+    name = "subpool_assigner_params_kt_jvm_proto",
+    deps = [
+        ":subpool_assigner_params_proto",
     ],
 )
 

--- a/src/main/proto/wfa/measurement/edpaggregator/v1alpha/subpool_assigner_params.proto
+++ b/src/main/proto/wfa/measurement/edpaggregator/v1alpha/subpool_assigner_params.proto
@@ -37,12 +37,12 @@ message SubpoolAssignerParams {
     (google.api.resource_reference).type = "halo.wfanet.org/DataProvider"
   ];
 
-  // GCS storage location used by the SubpoolAssigner.
+  // Cloud Storage location used by the SubpoolAssigner.
   message StorageParams {
     // The Google Cloud Storage project ID for the storage instance.
     string gcs_project_id = 1 [(google.api.field_behavior) = REQUIRED];
 
-    // The GCS blob URI prefix.
+    // The Cloud Storage blob URI prefix.
     //
     // Required for the subpool-map storage (a static, config-driven
     // location that does not change at runtime). May be left empty for the
@@ -102,7 +102,7 @@ message SubpoolAssignerParams {
     (google.api.resource_reference).type = "halo.wfanet.org/ModelLine"
   ];
 
-  // GCS blob path of the compiled VID model for this model line. Mirrors
+  // Cloud Storage blob path of the compiled VID model for this model line. Mirrors
   // `ModelShard.model_blob_path` from the public API.
   //
   // Used by the Phase-0 SubpoolAssigner to load the labeler in pool-emit

--- a/src/main/proto/wfa/measurement/edpaggregator/v1alpha/subpool_assigner_params.proto
+++ b/src/main/proto/wfa/measurement/edpaggregator/v1alpha/subpool_assigner_params.proto
@@ -152,4 +152,17 @@ message SubpoolAssignerParams {
   // for VidRankBuilder Phase-1 / VidLabeler Phase-2 WorkItem construction
   // by the last-shard-out.
   map<string, string> event_template_field_mapping = 15;
+
+  // Resource name of the `PoolAssignmentJob` row that tracks this
+  // (RawImpressionUpload, ModelLine, shard) WorkItem. Pre-created by the
+  // VID Labeling Dispatcher before the WorkItem is published; the TEE marks
+  // it `SUCCEEDED` (or `FAILED`) when processing completes.
+  //
+  // Format:
+  // `dataProviders/{data_provider}/rawImpressionUploads/{raw_impression_upload}/poolAssignmentJobs/{pool_assignment_job}`
+  string pool_assignment_job = 16 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference).type =
+        "edpaggregator.halo-cmm.org/PoolAssignmentJob"
+  ];
 }

--- a/src/main/proto/wfa/measurement/edpaggregator/v1alpha/subpool_assigner_params.proto
+++ b/src/main/proto/wfa/measurement/edpaggregator/v1alpha/subpool_assigner_params.proto
@@ -102,8 +102,8 @@ message SubpoolAssignerParams {
     (google.api.resource_reference).type = "halo.wfanet.org/ModelLine"
   ];
 
-  // Cloud Storage blob path of the compiled VID model for this model line. Mirrors
-  // `ModelShard.model_blob_path` from the public API.
+  // Cloud Storage blob path of the compiled VID model for this model line.
+  // Mirrors `ModelShard.model_blob_path` from the public API.
   //
   // Used by the Phase-0 SubpoolAssigner to load the labeler in pool-emit
   // mode. Also carried as pass-through so the last-shard-out can populate

--- a/src/main/proto/wfa/measurement/edpaggregator/v1alpha/subpool_assigner_params.proto
+++ b/src/main/proto/wfa/measurement/edpaggregator/v1alpha/subpool_assigner_params.proto
@@ -1,0 +1,107 @@
+// Copyright 2026 The Cross-Media Measurement Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package wfa.measurement.edpaggregator.v1alpha;
+
+import "google/api/field_behavior.proto";
+import "google/api/resource.proto";
+import "google/protobuf/timestamp.proto";
+import "wfa/measurement/edpaggregator/v1alpha/transport_layer_security_params.proto";
+
+option java_package = "org.wfanet.measurement.edpaggregator.v1alpha";
+option java_multiple_files = true;
+option java_outer_classname = "SubpoolAssignerParamsProto";
+
+// Parameters for the SubpoolAssigner Phase-0 TEE application, built by the
+// VID Labeling Dispatcher Cloud Function and passed to the Secure Computation
+// API as a google.protobuf.Any. One WorkItem (and therefore one
+// SubpoolAssignerParams) is published per (RawImpressionUpload, ModelLine,
+// shard) for model lines with memoized VID assignment enabled.
+message SubpoolAssignerParams {
+  // The CMMS resource name for the EDP.
+  string data_provider = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference).type = "halo.wfanet.org/DataProvider"
+  ];
+
+  // GCS storage location used by the SubpoolAssigner.
+  message StorageParams {
+    // The Google Cloud Storage project ID for the storage instance.
+    string gcs_project_id = 1 [(google.api.field_behavior) = REQUIRED];
+
+    // The GCS blob URI prefix.
+    //
+    // Required for the subpool-map storage (a static, config-driven
+    // location that does not change at runtime). May be left empty for the
+    // raw-impressions storage, where the location is supplied by the API
+    // via `RawImpressionUpload.done_blob_uri`.
+    string blob_prefix = 2 [(google.api.field_behavior) = OPTIONAL];
+  }
+
+  // Storage from which raw impressions are read.
+  StorageParams raw_impression_storage_params = 2
+      [(google.api.field_behavior) = REQUIRED];
+
+  // Storage to which per-(shard, subpool) SubpoolFingerprints blobs are
+  // written.
+  StorageParams subpool_map_storage_params = 3
+      [(google.api.field_behavior) = REQUIRED];
+
+  // TLS connection parameters used by the TEE app to talk to the
+  // RawImpressionMetadata storage service.
+  TransportLayerSecurityParams raw_impression_metadata_storage_connection = 4
+      [(google.api.field_behavior) = REQUIRED];
+
+  // Fully qualified resource name of the `RawImpressionUpload` this WorkItem
+  // is processing.
+  string raw_impression_upload_resource_id = 5 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference).type =
+        "edpaggregator.halo-cmm.org/RawImpressionUpload"
+  ];
+
+  // The `ModelLine` this WorkItem labels for. Exactly one model line per
+  // WorkItem.
+  string model_line = 6 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference).type = "halo.wfanet.org/ModelLine"
+  ];
+
+  // GCS blob path of the compiled VID model for this model line. Mirrors
+  // `ModelShard.model_blob_path` from the public API.
+  string model_blob_path = 7 [(google.api.field_behavior) = REQUIRED];
+
+  // Inclusive start of the model line's active window. Impressions whose
+  // event timestamp is before this point are dropped before labeling.
+  // Mirrors `ModelLine.active_start_time` from the public API.
+  google.protobuf.Timestamp active_start_time = 8
+      [(google.api.field_behavior) = REQUIRED];
+
+  // Exclusive end of the model line's active window. Impressions whose
+  // event timestamp is at or after this point are dropped before labeling.
+  // Unset means no upper bound. Mirrors `ModelLine.active_end_time` from
+  // the public API.
+  google.protobuf.Timestamp active_end_time = 9
+      [(google.api.field_behavior) = OPTIONAL];
+
+  // The fingerprint shard this WorkItem is responsible for. The VM keeps
+  // only impressions where `fingerprint.hash() % total_shards == shard_index`.
+  int32 shard_index = 10 [(google.api.field_behavior) = REQUIRED];
+
+  // Total number of fingerprint shards (`N`) across this dispatch. Used
+  // together with `shard_index` to select the impressions this VM owns.
+  int32 total_shards = 11 [(google.api.field_behavior) = REQUIRED];
+}

--- a/src/main/proto/wfa/measurement/edpaggregator/v1alpha/subpool_assigner_params.proto
+++ b/src/main/proto/wfa/measurement/edpaggregator/v1alpha/subpool_assigner_params.proto
@@ -104,4 +104,16 @@ message SubpoolAssignerParams {
   // Total number of fingerprint shards (`N`) across this dispatch. Used
   // together with `shard_index` to select the impressions this VM owns.
   int32 total_shards = 11 [(google.api.field_behavior) = REQUIRED];
+
+  // Mapping from labeler input field names to their corresponding raw
+  // impression field names. Used by the TEE to project raw EDP impressions
+  // into the `wfa_virtual_people.LabelerInput` shape before invoking the
+  // labeler in pool-emit mode. Mirrors the per-(EDP, model line) mapping
+  // configured in `VidLabelingConfig.ModelLineConfig.labeler_input_field_mapping`.
+  map<string, string> labeler_input_field_mapping = 12;
+
+  // Mapping from event template field names to their corresponding raw
+  // impression field names. Mirrors the per-(EDP, model line) mapping
+  // configured in `VidLabelingConfig.ModelLineConfig.event_template_field_mapping`.
+  map<string, string> event_template_field_mapping = 13;
 }

--- a/src/main/proto/wfa/measurement/edpaggregator/v1alpha/subpool_assigner_params.proto
+++ b/src/main/proto/wfa/measurement/edpaggregator/v1alpha/subpool_assigner_params.proto
@@ -67,7 +67,7 @@ message SubpoolAssignerParams {
 
   // Fully qualified resource name of the `RawImpressionUpload` this WorkItem
   // is processing.
-  string raw_impression_upload_resource_id = 5 [
+  string raw_impression_upload = 5 [
     (google.api.field_behavior) = REQUIRED,
     (google.api.resource_reference).type =
         "edpaggregator.halo-cmm.org/RawImpressionUpload"

--- a/src/main/proto/wfa/measurement/edpaggregator/v1alpha/subpool_assigner_params.proto
+++ b/src/main/proto/wfa/measurement/edpaggregator/v1alpha/subpool_assigner_params.proto
@@ -52,22 +52,44 @@ message SubpoolAssignerParams {
   }
 
   // Storage from which raw impressions are read.
+  //
+  // Read by the Phase-0 SubpoolAssigner. Also carried as pass-through so
+  // the last-shard-out can populate the VidRankBuilder Phase-1 WorkItem
+  // (and ultimately the VidLabeler Phase-2 WorkItem) without round-tripping
+  // back to the dispatcher for it.
   StorageParams raw_impression_storage_params = 2
+      [(google.api.field_behavior) = REQUIRED];
+
+  // Storage to which the VidLabeler will write the labeled impressions.
+  //
+  // Not consumed by the Phase-0 SubpoolAssigner. Pass-through for the
+  // VidRankBuilder Phase-1 WorkItem and the VidLabeler Phase-2 WorkItem
+  // construction by the last-shard-out.
+  StorageParams vid_labeled_impressions_storage_params = 3
+      [(google.api.field_behavior) = REQUIRED];
+
+  // Storage from which the VidRankBuilder reads prior cumulative rank-index
+  // blobs and to which it writes the new day-only + cumulative rank-index
+  // blobs.
+  //
+  // Not consumed by the Phase-0 SubpoolAssigner. Pass-through for the
+  // VidRankBuilder Phase-1 WorkItem construction by the last-shard-out.
+  StorageParams vid_rank_map_storage_params = 4
       [(google.api.field_behavior) = REQUIRED];
 
   // Storage to which per-(shard, subpool) SubpoolFingerprints blobs are
   // written.
-  StorageParams subpool_map_storage_params = 3
+  StorageParams subpool_map_storage_params = 5
       [(google.api.field_behavior) = REQUIRED];
 
   // TLS connection parameters used by the TEE app to talk to the
   // RawImpressionMetadata storage service.
-  TransportLayerSecurityParams raw_impression_metadata_storage_connection = 4
+  TransportLayerSecurityParams raw_impression_metadata_storage_connection = 6
       [(google.api.field_behavior) = REQUIRED];
 
   // Fully qualified resource name of the `RawImpressionUpload` this WorkItem
   // is processing.
-  string raw_impression_upload = 5 [
+  string raw_impression_upload = 7 [
     (google.api.field_behavior) = REQUIRED,
     (google.api.resource_reference).type =
         "edpaggregator.halo-cmm.org/RawImpressionUpload"
@@ -75,45 +97,59 @@ message SubpoolAssignerParams {
 
   // The `ModelLine` this WorkItem labels for. Exactly one model line per
   // WorkItem.
-  string model_line = 6 [
+  string model_line = 8 [
     (google.api.field_behavior) = REQUIRED,
     (google.api.resource_reference).type = "halo.wfanet.org/ModelLine"
   ];
 
   // GCS blob path of the compiled VID model for this model line. Mirrors
   // `ModelShard.model_blob_path` from the public API.
-  string model_blob_path = 7 [(google.api.field_behavior) = REQUIRED];
+  //
+  // Used by the Phase-0 SubpoolAssigner to load the labeler in pool-emit
+  // mode. Also carried as pass-through so the last-shard-out can populate
+  // the VidRankBuilder Phase-1 WorkItem (and ultimately the VidLabeler
+  // Phase-2 WorkItem).
+  string model_blob_path = 9 [(google.api.field_behavior) = REQUIRED];
 
   // Inclusive start of the model line's active window. Impressions whose
   // event timestamp is before this point are dropped before labeling.
   // Mirrors `ModelLine.active_start_time` from the public API.
-  google.protobuf.Timestamp active_start_time = 8
+  google.protobuf.Timestamp active_start_time = 10
       [(google.api.field_behavior) = REQUIRED];
 
   // Exclusive end of the model line's active window. Impressions whose
   // event timestamp is at or after this point are dropped before labeling.
   // Unset means no upper bound. Mirrors `ModelLine.active_end_time` from
   // the public API.
-  google.protobuf.Timestamp active_end_time = 9
+  google.protobuf.Timestamp active_end_time = 11
       [(google.api.field_behavior) = OPTIONAL];
 
   // The fingerprint shard this WorkItem is responsible for. The VM keeps
   // only impressions where `fingerprint.hash() % total_shards == shard_index`.
-  int32 shard_index = 10 [(google.api.field_behavior) = REQUIRED];
+  int32 shard_index = 12 [(google.api.field_behavior) = REQUIRED];
 
   // Total number of fingerprint shards (`N`) across this dispatch. Used
   // together with `shard_index` to select the impressions this VM owns.
-  int32 total_shards = 11 [(google.api.field_behavior) = REQUIRED];
+  int32 total_shards = 13 [(google.api.field_behavior) = REQUIRED];
 
   // Mapping from labeler input field names to their corresponding raw
-  // impression field names. Used by the TEE to project raw EDP impressions
-  // into the `wfa_virtual_people.LabelerInput` shape before invoking the
-  // labeler in pool-emit mode. Mirrors the per-(EDP, model line) mapping
-  // configured in `VidLabelingConfig.ModelLineConfig.labeler_input_field_mapping`.
-  map<string, string> labeler_input_field_mapping = 12;
+  // impression field names. Used by the Phase-0 SubpoolAssigner to project
+  // raw EDP impressions into the `wfa_virtual_people.LabelerInput` shape
+  // before invoking the labeler in pool-emit mode. Mirrors the per-(EDP,
+  // model line) mapping configured in
+  // `VidLabelingConfig.ModelLineConfig.labeler_input_field_mapping`.
+  //
+  // Also carried as pass-through for VidRankBuilder Phase-1 / VidLabeler
+  // Phase-2 WorkItem construction by the last-shard-out.
+  map<string, string> labeler_input_field_mapping = 14;
 
   // Mapping from event template field names to their corresponding raw
   // impression field names. Mirrors the per-(EDP, model line) mapping
-  // configured in `VidLabelingConfig.ModelLineConfig.event_template_field_mapping`.
-  map<string, string> event_template_field_mapping = 13;
+  // configured in
+  // `VidLabelingConfig.ModelLineConfig.event_template_field_mapping`.
+  //
+  // Used by the Phase-0 SubpoolAssigner and also carried as pass-through
+  // for VidRankBuilder Phase-1 / VidLabeler Phase-2 WorkItem construction
+  // by the last-shard-out.
+  map<string, string> event_template_field_mapping = 15;
 }

--- a/src/main/proto/wfa/measurement/edpaggregator/v1alpha/vid_labeler_params.proto
+++ b/src/main/proto/wfa/measurement/edpaggregator/v1alpha/vid_labeler_params.proto
@@ -18,7 +18,6 @@ package wfa.measurement.edpaggregator.v1alpha;
 
 import "google/api/field_behavior.proto";
 import "google/api/resource.proto";
-import "google/protobuf/timestamp.proto";
 import "wfa/measurement/edpaggregator/v1alpha/transport_layer_security_params.proto";
 
 option java_package = "org.wfanet.measurement.edpaggregator.v1alpha";
@@ -64,23 +63,6 @@ message VidLabelerParams {
 
     // Mapping from event template field names to their corresponding values.
     map<string, string> event_template_field_mapping = 2;
-
-    // GCS blob path of the compiled VID model used by the labeler for this
-    // model line. Mirrors `ModelShard.model_blob_path` from the public API.
-    string model_blob_path = 3 [(google.api.field_behavior) = REQUIRED];
-
-    // Inclusive start of this model line's active window. Impressions with
-    // event timestamps before this point are dropped before labeling. Mirrors
-    // `ModelLine.active_start_time` from the public API.
-    google.protobuf.Timestamp active_start_time = 4
-        [(google.api.field_behavior) = REQUIRED];
-
-    // Exclusive end of this model line's active window. Impressions with
-    // event timestamps at or after this point are dropped before labeling.
-    // Unset means the model line is still active (no upper bound). Mirrors
-    // `ModelLine.active_end_time` from the public API.
-    google.protobuf.Timestamp active_end_time = 5
-        [(google.api.field_behavior) = OPTIONAL];
   }
 
   // Map from model line resource name to its configuration.

--- a/src/main/proto/wfa/measurement/edpaggregator/v1alpha/vid_labeler_params.proto
+++ b/src/main/proto/wfa/measurement/edpaggregator/v1alpha/vid_labeler_params.proto
@@ -18,6 +18,7 @@ package wfa.measurement.edpaggregator.v1alpha;
 
 import "google/api/field_behavior.proto";
 import "google/api/resource.proto";
+import "google/protobuf/timestamp.proto";
 import "wfa/measurement/edpaggregator/v1alpha/transport_layer_security_params.proto";
 
 option java_package = "org.wfanet.measurement.edpaggregator.v1alpha";
@@ -63,6 +64,23 @@ message VidLabelerParams {
 
     // Mapping from event template field names to their corresponding values.
     map<string, string> event_template_field_mapping = 2;
+
+    // GCS blob path of the compiled VID model used by the labeler for this
+    // model line. Mirrors `ModelShard.model_blob_path` from the public API.
+    string model_blob_path = 3 [(google.api.field_behavior) = REQUIRED];
+
+    // Inclusive start of this model line's active window. Impressions with
+    // event timestamps before this point are dropped before labeling. Mirrors
+    // `ModelLine.active_start_time` from the public API.
+    google.protobuf.Timestamp active_start_time = 4
+        [(google.api.field_behavior) = REQUIRED];
+
+    // Exclusive end of this model line's active window. Impressions with
+    // event timestamps at or after this point are dropped before labeling.
+    // Unset means the model line is still active (no upper bound). Mirrors
+    // `ModelLine.active_end_time` from the public API.
+    google.protobuf.Timestamp active_end_time = 5
+        [(google.api.field_behavior) = OPTIONAL];
   }
 
   // Map from model line resource name to its configuration.


### PR DESCRIPTION
## Summary
  - Add `SubpoolAssignerApp` under `src/main/kotlin/org/wfanet/measurement/edpaggregator/subpoolassigner/`, the entry point for the Phase-0 stage of the memoized VID assignment pipeline. Extends
  `BaseTeeApplication` and mirrors the constructor shape of `ResultsFulfillerApp` / `VidLabelerApp`.
  - Scaffold only: `runWork` unpacks `WorkItemParams` + `VidLabelerParams` and stops. The rest of the pipeline (gRPC writes to `RawImpressionUploadModelLine` and `PoolAssignmentJob`, per-shard
  per-subpool blob production, last-shard-out merge + `RankerJob` fan-out into Phase-1) is captured as a 10-step TODO block in the file.
  - Extend `ModelLineConfig` in `vid_labeler_params.proto` with the three per-model-line fields the Phase-0 / Phase-2 apps need, keeping the existing `model_line_configs` map as the single source of
  truth keyed by model line resource name:
    - `model_blob_path` (REQUIRED) — mirrors `ModelShard.model_blob_path`.
    - `active_start_time` (REQUIRED) — mirrors `ModelLine.active_start_time`.
    - `active_end_time` (OPTIONAL) — mirrors `ModelLine.active_end_time`; unset means no upper bound.
  - BUILD: new `kt_jvm_library(name = "subpool_assigner_app", ...)` target wiring `BaseTeeApplication`, `QueueSubscriber`, `WorkItem*` gRPC/proto, `VidLabelerParams`, `StorageConfig`, KMS client, and
  protobuf. `vid_labeler_params_proto` gains `@com_google_protobuf//:timestamp_proto`.

Issue: #3913 