### PR TITLE
feat: scaffold VidRankBuilder Phase-1 TEE app

### DIFF
--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/vidrankbuilder/BUILD.bazel
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/vidrankbuilder/BUILD.bazel
@@ -11,7 +11,6 @@ kt_jvm_library(
     deps = [
         "//src/main/kotlin/org/wfanet/measurement/edpaggregator:storage_config",
         "//src/main/kotlin/org/wfanet/measurement/securecomputation/teesdk:base_tee_application",
-        "//src/main/proto/wfa/measurement/edpaggregator/v1alpha:impression_metadata_service_kt_jvm_grpc_proto",
         "//src/main/proto/wfa/measurement/edpaggregator/v1alpha:vid_rank_builder_params_kt_jvm_proto",
         "//src/main/proto/wfa/measurement/securecomputation/controlplane/v1alpha:work_item_attempts_service_kt_jvm_grpc_proto",
         "//src/main/proto/wfa/measurement/securecomputation/controlplane/v1alpha:work_item_kt_jvm_proto",

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/vidrankbuilder/BUILD.bazel
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/vidrankbuilder/BUILD.bazel
@@ -11,6 +11,7 @@ kt_jvm_library(
     deps = [
         "//src/main/kotlin/org/wfanet/measurement/edpaggregator:storage_config",
         "//src/main/kotlin/org/wfanet/measurement/securecomputation/teesdk:base_tee_application",
+        "//src/main/proto/wfa/measurement/edpaggregator/v1alpha:impression_metadata_service_kt_jvm_grpc_proto",
         "//src/main/proto/wfa/measurement/edpaggregator/v1alpha:vid_rank_builder_params_kt_jvm_proto",
         "//src/main/proto/wfa/measurement/securecomputation/controlplane/v1alpha:work_item_attempts_service_kt_jvm_grpc_proto",
         "//src/main/proto/wfa/measurement/securecomputation/controlplane/v1alpha:work_item_kt_jvm_proto",

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/vidrankbuilder/BUILD.bazel
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/vidrankbuilder/BUILD.bazel
@@ -1,0 +1,22 @@
+load("@wfa_rules_kotlin_jvm//kotlin:defs.bzl", "kt_jvm_library")
+
+package(default_visibility = [
+    "//src/main/kotlin/org/wfanet/measurement/edpaggregator:__subpackages__",
+    "//src/test/kotlin/org/wfanet/measurement/edpaggregator:__subpackages__",
+])
+
+kt_jvm_library(
+    name = "vid_rank_builder_app",
+    srcs = ["VidRankBuilderApp.kt"],
+    deps = [
+        "//src/main/kotlin/org/wfanet/measurement/edpaggregator:storage_config",
+        "//src/main/kotlin/org/wfanet/measurement/securecomputation/teesdk:base_tee_application",
+        "//src/main/proto/wfa/measurement/edpaggregator/v1alpha:vid_rank_builder_params_kt_jvm_proto",
+        "//src/main/proto/wfa/measurement/securecomputation/controlplane/v1alpha:work_item_attempts_service_kt_jvm_grpc_proto",
+        "//src/main/proto/wfa/measurement/securecomputation/controlplane/v1alpha:work_item_kt_jvm_proto",
+        "//src/main/proto/wfa/measurement/securecomputation/controlplane/v1alpha:work_items_service_kt_jvm_grpc_proto",
+        "@wfa_common_jvm//imports/java/com/google/crypto/tink",
+        "@wfa_common_jvm//imports/java/com/google/protobuf",
+        "@wfa_common_jvm//src/main/kotlin/org/wfanet/measurement/queue:queue_subscriber",
+    ],
+)

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/vidrankbuilder/VidRankBuilderApp.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/vidrankbuilder/VidRankBuilderApp.kt
@@ -20,6 +20,7 @@ import com.google.crypto.tink.KmsClient
 import com.google.protobuf.Any
 import com.google.protobuf.Parser
 import org.wfanet.measurement.edpaggregator.StorageConfig
+import org.wfanet.measurement.edpaggregator.v1alpha.ImpressionMetadataServiceGrpcKt.ImpressionMetadataServiceCoroutineStub
 import org.wfanet.measurement.edpaggregator.v1alpha.VidRankBuilderParams
 import org.wfanet.measurement.edpaggregator.v1alpha.VidRankBuilderParams.StorageParams
 import org.wfanet.measurement.queue.QueueSubscriber
@@ -70,6 +71,11 @@ import org.wfanet.measurement.securecomputation.teesdk.BaseTeeApplication
  * @param workItemsClient gRPC client stub for [WorkItemsGrpcKt.WorkItemsCoroutineStub].
  * @param workItemAttemptsClient gRPC client stub for
  *   [WorkItemAttemptsGrpcKt.WorkItemAttemptsCoroutineStub].
+ * @param impressionMetadataStub gRPC client stub for the EDP Aggregator
+ *   internal `ImpressionMetadataService`. Placeholder for the internal
+ *   service stubs Phase-1 needs (`RankerJob`, `RankIndexBlob`,
+ *   `RawImpressionUploadModelLine` — not yet defined); the constructor will
+ *   grow as those services land.
  * @param kmsClients Per-DataProvider KMS clients used to wrap/unwrap DEKs
  *   for the rank-index blobs.
  * @param getRawImpressionStorageConfig Lambda to obtain the [StorageConfig]
@@ -88,6 +94,7 @@ class VidRankBuilderApp(
   parser: Parser<WorkItem>,
   workItemsClient: WorkItemsGrpcKt.WorkItemsCoroutineStub,
   workItemAttemptsClient: WorkItemAttemptsGrpcKt.WorkItemAttemptsCoroutineStub,
+  private val impressionMetadataStub: ImpressionMetadataServiceCoroutineStub,
   private val kmsClients: Map<String, KmsClient>,
   private val getRawImpressionStorageConfig: (StorageParams) -> StorageConfig,
   private val getSubpoolMapStorageConfig: (StorageParams) -> StorageConfig,
@@ -141,5 +148,23 @@ class VidRankBuilderApp(
     //      flip RawImpressionUploadModelLineState RANKING -> LABELING and
     //      publish one VidLabeler WorkItem per shard
     //      (vidRankBuilderParams.totalShards).
+    //
+    // TODO(@Marco-Premier): runWork must be idempotent on Pub/Sub
+    // redelivery. The Spanner commit (RankerJob -> RANKER_SUCCEEDED, new
+    // RankIndexBlob rows) and the message ack are not atomic, so a crash
+    // between them leads to redelivery with state already advanced. The
+    // implementation must:
+    //   - detect that this RankerJob is already RANKER_SUCCEEDED and treat
+    //     it as a no-op for the rank-allocation steps, re-running only the
+    //     last-RankerJob-out check (step 6) before acking,
+    //   - tolerate partially-written RankIndexBlob rows from a prior
+    //     attempt (e.g. resume rather than duplicate),
+    //   - keep the BitSet / Bytes12IntMap rebuild deterministic across
+    //     attempts so a redelivered run produces the same outcome.
+    // Cover with tests that inject failures at: (a) after Spanner state
+    // flip but before ack, (b) mid-blob-write, (c) after first subpool's
+    // RankIndexBlob row insert but before second subpool's, (d) after
+    // last-RankerJob-out Spanner flip but before Phase-2 WorkItem publish.
+    // Each case must converge to the same final state on redelivery.
   }
 }

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/vidrankbuilder/VidRankBuilderApp.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/vidrankbuilder/VidRankBuilderApp.kt
@@ -137,7 +137,9 @@ class VidRankBuilderApp(
     //      e. Write the new day-only and cumulative rank-index blobs
     //         (DEK-encrypted) to vid_rank_map_storage_params.
     //      f. Insert the new RankIndexBlob rows via the EDP Aggregator
-    //         internal gRPC.
+    //         internal gRPC, stamping
+    //         vidRankBuilderParams.maxEventDate on the day-only row(s)
+    //         so the retention sweep can identify aged-out blobs.
     //   5. Flip this RankerJob row from RANKING to RANKER_SUCCEEDED via
     //      the EDP Aggregator internal gRPC, keyed by
     //      (vidRankBuilderParams.dataProvider,
@@ -147,7 +149,11 @@ class VidRankBuilderApp(
     //   6. Last-RankerJob-out for this (RawImpressionUpload, ModelLine):
     //      flip RawImpressionUploadModelLineState RANKING -> LABELING and
     //      publish one VidLabeler WorkItem per shard
-    //      (vidRankBuilderParams.totalShards).
+    //      (vidRankBuilderParams.totalShards). The VidLabelerParams payload
+    //      is constructed from the pass-through fields on this proto:
+    //      rawImpressionStorageParams, vidLabeledImpressionsStorageParams,
+    //      modelBlobPath, labelerInputFieldMapping, and
+    //      eventTemplateFieldMapping.
     //
     // TODO(@Marco-Premier): runWork must be idempotent on Pub/Sub
     // redelivery. The Spanner commit (RankerJob -> RANKER_SUCCEEDED, new

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/vidrankbuilder/VidRankBuilderApp.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/vidrankbuilder/VidRankBuilderApp.kt
@@ -1,0 +1,145 @@
+/*
+ * Copyright 2026 The Cross-Media Measurement Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wfanet.measurement.edpaggregator.vidrankbuilder
+
+import com.google.crypto.tink.KmsClient
+import com.google.protobuf.Any
+import com.google.protobuf.Parser
+import org.wfanet.measurement.edpaggregator.StorageConfig
+import org.wfanet.measurement.edpaggregator.v1alpha.VidRankBuilderParams
+import org.wfanet.measurement.edpaggregator.v1alpha.VidRankBuilderParams.StorageParams
+import org.wfanet.measurement.queue.QueueSubscriber
+import org.wfanet.measurement.securecomputation.controlplane.v1alpha.WorkItem
+import org.wfanet.measurement.securecomputation.controlplane.v1alpha.WorkItem.WorkItemParams
+import org.wfanet.measurement.securecomputation.controlplane.v1alpha.WorkItemAttemptsGrpcKt
+import org.wfanet.measurement.securecomputation.controlplane.v1alpha.WorkItemsGrpcKt
+import org.wfanet.measurement.securecomputation.teesdk.BaseTeeApplication
+
+/**
+ * Phase-1 TEE application for the memoized VID assignment pipeline.
+ *
+ * One ranker VM per `RankerJob`. A `RankerJob` may cover one or more
+ * subpools: the SubpoolAssigner's last-shard-out bin-packs subpools into
+ * `RankerJob`s based on their fingerprint counts so that very small
+ * subpools share a VM instead of each spinning up their own, while a single
+ * very large subpool gets its own `RankerJob`. Within a subpool there is
+ * no intra-subpool sharding — the entire subpool is owned by exactly one
+ * `RankerJob`, and therefore one [VidRankBuilderApp] invocation. One
+ * WorkItem is published per `RankerJob` row. The WorkItem's
+ * [VidRankBuilderParams] carries the `(RawImpressionUpload, ModelLine,
+ * RankerJobId)` triple plus the (subpool, Phase-0 blob URI) set this VM
+ * ranks, supplied via [VidRankBuilderParams.subpool_map_blob_uris].
+ *
+ * Each VM:
+ *  - loads the prior cumulative rank-index blob for each of its subpools
+ *    from `vid_rank_map_storage_params` and rebuilds the in-heap
+ *    `Bytes12IntMap` (12-byte fingerprint -> rank) and rank `BitSet`,
+ *  - reads its subpools' `SubpoolFingerprints` blobs from
+ *    `subpool_map_storage_params`,
+ *  - prunes aged-out rank-index blobs per the retention policy and frees
+ *    their ranks,
+ *  - allocates ranks to new fingerprints, capping at `ranked_size` (overflow
+ *    fingerprints fall back to the unranked path at Phase-2),
+ *  - writes the new day-only and updated cumulative rank-index blobs
+ *    (DEK-encrypted) back to `vid_rank_map_storage_params`,
+ *  - flips its `RankerJob` row from `RANKING` to `RANKER_SUCCEEDED` via the
+ *    EDP Aggregator internal gRPC.
+ *
+ * The last `RankerJob` to complete for a `(RawImpressionUpload, ModelLine)`
+ * is responsible for flipping `RawImpressionUploadModelLineState` from
+ * `RANKING` to `LABELING` and publishing one VidLabeler WorkItem per shard
+ * (`total_shards` controls the fan-out).
+ *
+ * @param subscriptionId The subscription ID for the queue subscriber.
+ * @param queueSubscriber The [QueueSubscriber] instance for receiving work items.
+ * @param parser The protobuf [Parser] for [WorkItem] messages.
+ * @param workItemsClient gRPC client stub for [WorkItemsGrpcKt.WorkItemsCoroutineStub].
+ * @param workItemAttemptsClient gRPC client stub for
+ *   [WorkItemAttemptsGrpcKt.WorkItemAttemptsCoroutineStub].
+ * @param kmsClients Per-DataProvider KMS clients used to wrap/unwrap DEKs
+ *   for the rank-index blobs.
+ * @param getRawImpressionStorageConfig Lambda to obtain the [StorageConfig]
+ *   for reading raw-impression files (only consulted if Phase-1 ever needs
+ *   to touch raw impressions; not used by the canonical Phase-1 design).
+ * @param getSubpoolMapStorageConfig Lambda to obtain the [StorageConfig]
+ *   for reading the per-(shard, subpool) `SubpoolFingerprints` blobs
+ *   produced by the SubpoolAssigner.
+ * @param getVidRankMapStorageConfig Lambda to obtain the [StorageConfig]
+ *   for reading prior cumulative rank-index blobs and writing the new
+ *   day-only + cumulative blobs.
+ */
+class VidRankBuilderApp(
+  subscriptionId: String,
+  queueSubscriber: QueueSubscriber,
+  parser: Parser<WorkItem>,
+  workItemsClient: WorkItemsGrpcKt.WorkItemsCoroutineStub,
+  workItemAttemptsClient: WorkItemAttemptsGrpcKt.WorkItemAttemptsCoroutineStub,
+  private val kmsClients: Map<String, KmsClient>,
+  private val getRawImpressionStorageConfig: (StorageParams) -> StorageConfig,
+  private val getSubpoolMapStorageConfig: (StorageParams) -> StorageConfig,
+  private val getVidRankMapStorageConfig: (StorageParams) -> StorageConfig,
+) :
+  BaseTeeApplication(
+    subscriptionId = subscriptionId,
+    queueSubscriber = queueSubscriber,
+    parser = parser,
+    workItemsStub = workItemsClient,
+    workItemAttemptsStub = workItemAttemptsClient,
+  ) {
+
+  override suspend fun runWork(message: Any) {
+    val workItemParams = message.unpack(WorkItemParams::class.java)
+    val vidRankBuilderParams =
+      workItemParams.appParams.unpack(VidRankBuilderParams::class.java)
+
+    // TODO(@Marco-Premier): Implement Phase-1 pipeline:
+    //   1. Resolve storage configs via getSubpoolMapStorageConfig and
+    //      getVidRankMapStorageConfig from vidRankBuilderParams.
+    //   2. Resolve the per-DataProvider KmsClient from kmsClients keyed by
+    //      vidRankBuilderParams.dataProvider.
+    //   3. Unwrap vidRankBuilderParams.encryptedSubpoolMapsDek via the
+    //      DataProvider's KmsClient to obtain the plaintext DEK used by
+    //      Phase-0 to encrypt every SubpoolFingerprints blob referenced in
+    //      vidRankBuilderParams.subpoolMapBlobUrisMap.
+    //   4. For each (subpoolId, blobUri) entry in
+    //      vidRankBuilderParams.subpoolMapBlobUrisMap:
+    //      a. Load the prior cumulative rank-index blob for this subpool
+    //         from vid_rank_map_storage_params; decrypt and build the
+    //         in-heap Bytes12IntMap and rank BitSet.
+    //      b. Run the two-phase deletion pass (prune aged-out blobs whose
+    //         MaxEventDate is older than RETENTION_DAYS; free their ranks).
+    //      c. Read the SubpoolAssigner's merged SubpoolFingerprints blob
+    //         at blobUri from subpool_map_storage_params; decrypt with the
+    //         plaintext DEK from step 3.
+    //      d. Allocate ranks to new fingerprints via
+    //         bitSet.nextClearBit(cursor); cap at ranked_size.
+    //      e. Write the new day-only and cumulative rank-index blobs
+    //         (DEK-encrypted) to vid_rank_map_storage_params.
+    //      f. Insert the new RankIndexBlob rows via the EDP Aggregator
+    //         internal gRPC.
+    //   5. Flip this RankerJob row from RANKING to RANKER_SUCCEEDED via
+    //      the EDP Aggregator internal gRPC, keyed by
+    //      (vidRankBuilderParams.dataProvider,
+    //       vidRankBuilderParams.rawImpressionUpload,
+    //       vidRankBuilderParams.modelLine,
+    //       vidRankBuilderParams.rankerJobId).
+    //   6. Last-RankerJob-out for this (RawImpressionUpload, ModelLine):
+    //      flip RawImpressionUploadModelLineState RANKING -> LABELING and
+    //      publish one VidLabeler WorkItem per shard
+    //      (vidRankBuilderParams.totalShards).
+  }
+}

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/vidrankbuilder/VidRankBuilderApp.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/vidrankbuilder/VidRankBuilderApp.kt
@@ -20,7 +20,6 @@ import com.google.crypto.tink.KmsClient
 import com.google.protobuf.Any
 import com.google.protobuf.Parser
 import org.wfanet.measurement.edpaggregator.StorageConfig
-import org.wfanet.measurement.edpaggregator.v1alpha.ImpressionMetadataServiceGrpcKt.ImpressionMetadataServiceCoroutineStub
 import org.wfanet.measurement.edpaggregator.v1alpha.VidRankBuilderParams
 import org.wfanet.measurement.edpaggregator.v1alpha.VidRankBuilderParams.StorageParams
 import org.wfanet.measurement.queue.QueueSubscriber
@@ -71,11 +70,6 @@ import org.wfanet.measurement.securecomputation.teesdk.BaseTeeApplication
  * @param workItemsClient gRPC client stub for [WorkItemsGrpcKt.WorkItemsCoroutineStub].
  * @param workItemAttemptsClient gRPC client stub for
  *   [WorkItemAttemptsGrpcKt.WorkItemAttemptsCoroutineStub].
- * @param impressionMetadataStub gRPC client stub for the EDP Aggregator
- *   internal `ImpressionMetadataService`. Placeholder for the internal
- *   service stubs Phase-1 needs (`RankerJob`, `RankIndexBlob`,
- *   `RawImpressionUploadModelLine` — not yet defined); the constructor will
- *   grow as those services land.
  * @param kmsClients Per-DataProvider KMS clients used to wrap/unwrap DEKs
  *   for the rank-index blobs.
  * @param getRawImpressionStorageConfig Lambda to obtain the [StorageConfig]
@@ -94,7 +88,12 @@ class VidRankBuilderApp(
   parser: Parser<WorkItem>,
   workItemsClient: WorkItemsGrpcKt.WorkItemsCoroutineStub,
   workItemAttemptsClient: WorkItemAttemptsGrpcKt.WorkItemAttemptsCoroutineStub,
-  private val impressionMetadataStub: ImpressionMetadataServiceCoroutineStub,
+  // TODO(@Marco-Premier): wire EDP Aggregator internal gRPC service stubs
+  //   needed by Phase-1 as they become available:
+  //   - RawImpressionUpload
+  //   - RawImpressionUploadModelLine
+  //   - RankerJob
+  //   - RankIndexBlob
   private val kmsClients: Map<String, KmsClient>,
   private val getRawImpressionStorageConfig: (StorageParams) -> StorageConfig,
   private val getSubpoolMapStorageConfig: (StorageParams) -> StorageConfig,

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/vidrankbuilder/VidRankBuilderApp.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/vidrankbuilder/VidRankBuilderApp.kt
@@ -32,37 +32,32 @@ import org.wfanet.measurement.securecomputation.teesdk.BaseTeeApplication
 /**
  * Phase-1 TEE application for the memoized VID assignment pipeline.
  *
- * One ranker VM per `RankerJob`. A `RankerJob` may cover one or more
- * subpools: the SubpoolAssigner's last-shard-out bin-packs subpools into
- * `RankerJob`s based on their fingerprint counts so that very small
- * subpools share a VM instead of each spinning up their own, while a single
- * very large subpool gets its own `RankerJob`. Within a subpool there is
- * no intra-subpool sharding — the entire subpool is owned by exactly one
- * `RankerJob`, and therefore one [VidRankBuilderApp] invocation. One
- * WorkItem is published per `RankerJob` row. The WorkItem's
- * [VidRankBuilderParams] carries the `(RawImpressionUpload, ModelLine,
- * RankerJobId)` triple plus the (subpool, Phase-0 blob URI) set this VM
- * ranks, supplied via [VidRankBuilderParams.subpool_map_blob_uris].
+ * One ranker VM per `RankerJob`. A `RankerJob` may cover one or more subpools: the
+ * SubpoolAssigner's last-shard-out bin-packs subpools into `RankerJob`s based on their fingerprint
+ * counts so that very small subpools share a VM instead of each spinning up their own, while a
+ * single very large subpool gets its own `RankerJob`. Within a subpool there is no intra-subpool
+ * sharding — the entire subpool is owned by exactly one `RankerJob`, and therefore one
+ * [VidRankBuilderApp] invocation. One WorkItem is published per `RankerJob` row. The WorkItem's
+ * [VidRankBuilderParams] carries the `(RawImpressionUpload, ModelLine, RankerJobId)` triple plus
+ * the (subpool, Phase-0 blob URI) set this VM ranks, supplied via
+ * [VidRankBuilderParams.subpool_map_blob_uris].
  *
  * Each VM:
- *  - loads the prior cumulative rank-index blob for each of its subpools
- *    from `vid_rank_map_storage_params` and rebuilds the in-heap
- *    `Bytes12IntMap` (12-byte fingerprint -> rank) and rank `BitSet`,
- *  - reads its subpools' `SubpoolFingerprints` blobs from
- *    `subpool_map_storage_params`,
- *  - prunes aged-out rank-index blobs per the retention policy and frees
- *    their ranks,
- *  - allocates ranks to new fingerprints, capping at `ranked_size` (overflow
- *    fingerprints fall back to the unranked path at Phase-2),
- *  - writes the new day-only and updated cumulative rank-index blobs
- *    (DEK-encrypted) back to `vid_rank_map_storage_params`,
- *  - flips its `RankerJob` row from `RANKING` to `RANKER_SUCCEEDED` via the
- *    EDP Aggregator internal gRPC.
+ * - loads the prior cumulative rank-index blob for each of its subpools from
+ *   `vid_rank_map_storage_params` and rebuilds the in-heap `Bytes12IntMap` (12-byte fingerprint ->
+ *   rank) and rank `BitSet`,
+ * - reads its subpools' `SubpoolFingerprints` blobs from `subpool_map_storage_params`,
+ * - prunes aged-out rank-index blobs per the retention policy and frees their ranks,
+ * - allocates ranks to new fingerprints, capping at `ranked_size` (overflow fingerprints fall back
+ *   to the unranked path at Phase-2),
+ * - writes the new day-only and updated cumulative rank-index blobs (DEK-encrypted) back to
+ *   `vid_rank_map_storage_params`,
+ * - flips its `RankerJob` row from `RANKING` to `RANKER_SUCCEEDED` via the EDP Aggregator internal
+ *   gRPC.
  *
- * The last `RankerJob` to complete for a `(RawImpressionUpload, ModelLine)`
- * is responsible for flipping `RawImpressionUploadModelLineState` from
- * `RANKING` to `LABELING` and publishing one VidLabeler WorkItem per shard
- * (`total_shards` controls the fan-out).
+ * The last `RankerJob` to complete for a `(RawImpressionUpload, ModelLine)` is responsible for
+ * flipping `RawImpressionUploadModelLineState` from `RANKING` to `LABELING` and publishing one
+ * VidLabeler WorkItem per shard (`total_shards` controls the fan-out).
  *
  * @param subscriptionId The subscription ID for the queue subscriber.
  * @param queueSubscriber The [QueueSubscriber] instance for receiving work items.
@@ -70,17 +65,14 @@ import org.wfanet.measurement.securecomputation.teesdk.BaseTeeApplication
  * @param workItemsClient gRPC client stub for [WorkItemsGrpcKt.WorkItemsCoroutineStub].
  * @param workItemAttemptsClient gRPC client stub for
  *   [WorkItemAttemptsGrpcKt.WorkItemAttemptsCoroutineStub].
- * @param kmsClients Per-DataProvider KMS clients used to wrap/unwrap DEKs
- *   for the rank-index blobs.
- * @param getRawImpressionStorageConfig Lambda to obtain the [StorageConfig]
- *   for reading raw-impression files (only consulted if Phase-1 ever needs
- *   to touch raw impressions; not used by the canonical Phase-1 design).
- * @param getSubpoolMapStorageConfig Lambda to obtain the [StorageConfig]
- *   for reading the per-(shard, subpool) `SubpoolFingerprints` blobs
- *   produced by the SubpoolAssigner.
- * @param getVidRankMapStorageConfig Lambda to obtain the [StorageConfig]
- *   for reading prior cumulative rank-index blobs and writing the new
- *   day-only + cumulative blobs.
+ * @param kmsClients Per-DataProvider KMS clients used to wrap/unwrap DEKs for the rank-index blobs.
+ * @param getRawImpressionStorageConfig Lambda to obtain the [StorageConfig] for reading
+ *   raw-impression files (only consulted if Phase-1 ever needs to touch raw impressions; not used
+ *   by the canonical Phase-1 design).
+ * @param getSubpoolMapStorageConfig Lambda to obtain the [StorageConfig] for reading the
+ *   per-(shard, subpool) `SubpoolFingerprints` blobs produced by the SubpoolAssigner.
+ * @param getVidRankMapStorageConfig Lambda to obtain the [StorageConfig] for reading prior
+ *   cumulative rank-index blobs and writing the new day-only + cumulative blobs.
  */
 class VidRankBuilderApp(
   subscriptionId: String,
@@ -109,8 +101,7 @@ class VidRankBuilderApp(
 
   override suspend fun runWork(message: Any) {
     val workItemParams = message.unpack(WorkItemParams::class.java)
-    val vidRankBuilderParams =
-      workItemParams.appParams.unpack(VidRankBuilderParams::class.java)
+    val vidRankBuilderParams = workItemParams.appParams.unpack(VidRankBuilderParams::class.java)
 
     // TODO(@Marco-Premier): Implement Phase-1 pipeline:
     //   1. Resolve storage configs via getSubpoolMapStorageConfig and

--- a/src/main/proto/wfa/measurement/edpaggregator/v1alpha/BUILD.bazel
+++ b/src/main/proto/wfa/measurement/edpaggregator/v1alpha/BUILD.bazel
@@ -122,6 +122,24 @@ kt_jvm_proto_library(
 )
 
 proto_library(
+    name = "vid_rank_builder_params_proto",
+    srcs = ["vid_rank_builder_params.proto"],
+    strip_import_prefix = _IMPORT_PREFIX,
+    deps = [
+        ":encrypted_dek_proto",
+        "@com_google_googleapis//google/api:field_behavior_proto",
+        "@com_google_googleapis//google/api:resource_proto",
+    ],
+)
+
+kt_jvm_proto_library(
+    name = "vid_rank_builder_params_kt_jvm_proto",
+    deps = [
+        ":vid_rank_builder_params_proto",
+    ],
+)
+
+proto_library(
     name = "data_availability_sync_params_proto",
     srcs = ["data_availability_sync_params.proto"],
     strip_import_prefix = _IMPORT_PREFIX,

--- a/src/main/proto/wfa/measurement/edpaggregator/v1alpha/BUILD.bazel
+++ b/src/main/proto/wfa/measurement/edpaggregator/v1alpha/BUILD.bazel
@@ -129,6 +129,7 @@ proto_library(
         ":encrypted_dek_proto",
         "@com_google_googleapis//google/api:field_behavior_proto",
         "@com_google_googleapis//google/api:resource_proto",
+        "@com_google_googleapis//google/type:date_proto",
     ],
 )
 

--- a/src/main/proto/wfa/measurement/edpaggregator/v1alpha/vid_rank_builder_params.proto
+++ b/src/main/proto/wfa/measurement/edpaggregator/v1alpha/vid_rank_builder_params.proto
@@ -18,6 +18,7 @@ package wfa.measurement.edpaggregator.v1alpha;
 
 import "google/api/field_behavior.proto";
 import "google/api/resource.proto";
+import "google/type/date.proto";
 import "wfa/measurement/edpaggregator/v1alpha/encrypted_dek.proto";
 
 option java_package = "org.wfanet.measurement.edpaggregator.v1alpha";
@@ -56,22 +57,36 @@ message VidRankBuilderParams {
   }
 
   // Storage from which raw impressions are read.
+  //
+  // Not consumed by the Phase-1 ranker itself (Phase-1 reads only
+  // `SubpoolFingerprints` blobs from `subpool_map_storage_params` and the
+  // prior cumulative blobs from `vid_rank_map_storage_params`). Carried
+  // here only as pass-through so the last-`RankerJob`-out can populate the
+  // VidLabeler Phase-2 WorkItem without round-tripping back to the
+  // dispatcher for it.
   StorageParams raw_impression_storage_params = 3
       [(google.api.field_behavior) = REQUIRED];
 
-  // Storage from which the per-(shard, subpool) SubpoolFingerprints blobs
+  // Storage to which the VidLabeler will write the labeled impressions.
+  //
+  // Not consumed by the Phase-1 ranker. Pass-through for Phase-2 WorkItem
+  // construction by the last-`RankerJob`-out.
+  StorageParams vid_labeled_impressions_storage_params = 4
+      [(google.api.field_behavior) = REQUIRED];
+
+  // Storage from which the per-(shard, subpool) `SubpoolFingerprints` blobs
   // produced by the SubpoolAssigner are read.
-  StorageParams subpool_map_storage_params = 4
+  StorageParams subpool_map_storage_params = 5
       [(google.api.field_behavior) = REQUIRED];
 
   // Storage from which prior cumulative rank-index blobs are read and to
   // which the new day-only + cumulative rank-index blobs are written.
-  StorageParams vid_rank_map_storage_params = 5
+  StorageParams vid_rank_map_storage_params = 6
       [(google.api.field_behavior) = REQUIRED];
 
   // Fully qualified resource name of the `RawImpressionUpload` this WorkItem
   // is processing.
-  string raw_impression_upload = 6 [
+  string raw_impression_upload = 7 [
     (google.api.field_behavior) = REQUIRED,
     (google.api.resource_reference).type =
         "edpaggregator.halo-cmm.org/RawImpressionUpload"
@@ -79,28 +94,63 @@ message VidRankBuilderParams {
 
   // The `ModelLine` this WorkItem ranks for. Exactly one model line per
   // WorkItem.
-  string model_line = 7 [
+  string model_line = 8 [
     (google.api.field_behavior) = REQUIRED,
     (google.api.resource_reference).type = "halo.wfanet.org/ModelLine"
   ];
+
+  // GCS blob path of the compiled VID model for this model line. Mirrors
+  // `ModelShard.model_blob_path` from the public API.
+  //
+  // Not consumed by the Phase-1 ranker (Phase-1 does not call the labeler;
+  // Phase-0 has already resolved the subpool for every fingerprint).
+  // Pass-through for the Phase-2 VidLabeler WorkItem.
+  string model_blob_path = 9 [(google.api.field_behavior) = REQUIRED];
+
+  // Mapping from labeler input field names to their corresponding raw
+  // impression field names. Used by Phase-2 to project raw EDP impressions
+  // into the `wfa_virtual_people.LabelerInput` shape before invoking the
+  // labeler. Mirrors the per-(EDP, model line) mapping configured in
+  // `VidLabelingConfig.ModelLineConfig.labeler_input_field_mapping`.
+  //
+  // Not consumed by the Phase-1 ranker. Pass-through for the Phase-2
+  // VidLabeler WorkItem.
+  map<string, string> labeler_input_field_mapping = 10;
+
+  // Mapping from event template field names to their corresponding raw
+  // impression field names. Mirrors the per-(EDP, model line) mapping
+  // configured in `VidLabelingConfig.ModelLineConfig.event_template_field_mapping`.
+  //
+  // Not consumed by the Phase-1 ranker. Pass-through for the Phase-2
+  // VidLabeler WorkItem.
+  map<string, string> event_template_field_mapping = 11;
 
   // ID of the `RankerJob` row this WorkItem fulfils, assigned by Phase-0
   // during bin-packing. Together with [data_provider],
   // [raw_impression_upload] and [model_line] it forms the
   // `(DataProviderResourceId, RawImpressionUploadId, CmmsModelLine,
   // RankerJobId)` primary key the TEE uses to update its own row.
-  int64 ranker_job_id = 8 [(google.api.field_behavior) = REQUIRED];
+  int64 ranker_job_id = 12 [(google.api.field_behavior) = REQUIRED];
 
   // GCS blob URIs of the per-subpool `SubpoolFingerprints` blobs produced
   // by Phase-0 that this ranker is responsible for. The map keys are the
   // subpool IDs this `RankerJob` ranks (the bin-packed set carried as
   // `SubpoolIds ARRAY<INT64>` on the `RankerJob` row); the values are the
   // GCS blob URIs the TEE reads from `subpool_map_storage_params`.
-  map<int64, string> subpool_map_blob_uris = 9
+  map<int64, string> subpool_map_blob_uris = 13
       [(google.api.field_behavior) = REQUIRED];
 
   // Total number of fingerprint shards (`N`) across this dispatch. The
   // last-subpool-out uses this to fan out Phase-2 with one VidLabeler
   // WorkItem per shard.
-  int32 total_shards = 10 [(google.api.field_behavior) = REQUIRED];
+  int32 total_shards = 14 [(google.api.field_behavior) = REQUIRED];
+
+  // Largest impression event-date this dispatch covers, computed by the
+  // SubpoolAssigner Phase-0 last-shard-out while scanning impression
+  // timestamps (bounded by `ModelLine.active_end_time` when set). The
+  // ranker stamps this on the new day-only `RankIndexBlob` rows it
+  // inserts so the retention sweep can identify aged-out blobs via
+  // `MaxEventDate < today - RETENTION_DAYS`.
+  google.type.Date max_event_date = 15
+      [(google.api.field_behavior) = REQUIRED];
 }

--- a/src/main/proto/wfa/measurement/edpaggregator/v1alpha/vid_rank_builder_params.proto
+++ b/src/main/proto/wfa/measurement/edpaggregator/v1alpha/vid_rank_builder_params.proto
@@ -42,12 +42,12 @@ message VidRankBuilderParams {
   wfa.measurement.securecomputation.impressions.EncryptedDek
       encrypted_subpool_maps_dek = 2 [(google.api.field_behavior) = REQUIRED];
 
-  // GCS storage location used by the VidRankBuilder.
+  // Cloud Storage location used by the VidRankBuilder.
   message StorageParams {
     // The Google Cloud Storage project ID for the storage instance.
     string gcs_project_id = 1 [(google.api.field_behavior) = REQUIRED];
 
-    // The GCS blob URI prefix.
+    // The Cloud Storage blob URI prefix.
     //
     // Required for the subpool-map and vid-rank-map storage (static,
     // config-driven locations that do not change at runtime). May be left
@@ -99,8 +99,8 @@ message VidRankBuilderParams {
     (google.api.resource_reference).type = "halo.wfanet.org/ModelLine"
   ];
 
-  // GCS blob path of the compiled VID model for this model line. Mirrors
-  // `ModelShard.model_blob_path` from the public API.
+  // Cloud Storage blob path of the compiled VID model for this model line.
+  // Mirrors `ModelShard.model_blob_path` from the public API.
   //
   // Not consumed by the Phase-1 ranker (Phase-1 does not call the labeler;
   // Phase-0 has already resolved the subpool for every fingerprint).
@@ -138,11 +138,12 @@ message VidRankBuilderParams {
         "edpaggregator.halo-cmm.org/RankerJob"
   ];
 
-  // GCS blob URIs of the per-subpool `SubpoolFingerprints` blobs produced
-  // by Phase-0 that this ranker is responsible for. The map keys are the
-  // subpool IDs this `RankerJob` ranks (the bin-packed set carried as
-  // `SubpoolIds ARRAY<INT64>` on the `RankerJob` row); the values are the
-  // GCS blob URIs the TEE reads from `subpool_map_storage_params`.
+  // Cloud Storage blob URIs of the per-subpool `SubpoolFingerprints`
+  // blobs produced by Phase-0 that this ranker is responsible for. The
+  // map keys are the subpool IDs this `RankerJob` ranks (the bin-packed
+  // set carried as `SubpoolIds ARRAY<INT64>` on the `RankerJob` row); the
+  // values are the Cloud Storage blob URIs the TEE reads from
+  // `subpool_map_storage_params`.
   map<int64, string> subpool_map_blob_uris = 13
       [(google.api.field_behavior) = REQUIRED];
 

--- a/src/main/proto/wfa/measurement/edpaggregator/v1alpha/vid_rank_builder_params.proto
+++ b/src/main/proto/wfa/measurement/edpaggregator/v1alpha/vid_rank_builder_params.proto
@@ -125,12 +125,17 @@ message VidRankBuilderParams {
   // VidLabeler WorkItem.
   map<string, string> event_template_field_mapping = 11;
 
-  // ID of the `RankerJob` row this WorkItem fulfils, assigned by Phase-0
-  // during bin-packing. Together with [data_provider],
-  // [raw_impression_upload] and [model_line] it forms the
-  // `(DataProviderResourceId, RawImpressionUploadId, CmmsModelLine,
-  // RankerJobId)` primary key the TEE uses to update its own row.
-  int64 ranker_job_id = 12 [(google.api.field_behavior) = REQUIRED];
+  // Resource name of the `RankerJob` row this WorkItem fulfils, assigned by
+  // Phase-0 during bin-packing. The Phase-1 TEE marks it `SUCCEEDED` (or
+  // `FAILED`) when ranking completes.
+  //
+  // Format:
+  // `dataProviders/{data_provider}/rawImpressionUploads/{raw_impression_upload}/rankerJobs/{ranker_job}`
+  string ranker_job = 12 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference).type =
+        "edpaggregator.halo-cmm.org/RankerJob"
+  ];
 
   // GCS blob URIs of the per-subpool `SubpoolFingerprints` blobs produced
   // by Phase-0 that this ranker is responsible for. The map keys are the

--- a/src/main/proto/wfa/measurement/edpaggregator/v1alpha/vid_rank_builder_params.proto
+++ b/src/main/proto/wfa/measurement/edpaggregator/v1alpha/vid_rank_builder_params.proto
@@ -1,0 +1,106 @@
+// Copyright 2026 The Cross-Media Measurement Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package wfa.measurement.edpaggregator.v1alpha;
+
+import "google/api/field_behavior.proto";
+import "google/api/resource.proto";
+import "wfa/measurement/edpaggregator/v1alpha/encrypted_dek.proto";
+
+option java_package = "org.wfanet.measurement.edpaggregator.v1alpha";
+option java_multiple_files = true;
+option java_outer_classname = "VidRankBuilderParamsProto";
+
+// Parameters for the VidRankBuilder Phase-1 TEE application, built by the
+// SubpoolAssigner's last-shard-out and passed to the Secure Computation API
+// as a google.protobuf.Any. One WorkItem (and therefore one
+// VidRankBuilderParams) is published per `RankerJob` row.
+message VidRankBuilderParams {
+  // The CMMS resource name for the EDP.
+  string data_provider = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference).type = "halo.wfanet.org/DataProvider"
+  ];
+
+  // DEK needed by the ranker to decrypt the per-subpool
+  // `SubpoolFingerprints` blobs produced by Phase-0. The same DEK applies
+  // to every blob referenced in [subpool_map_blob_uris].
+  wfa.measurement.securecomputation.impressions.EncryptedDek
+      encrypted_subpool_maps_dek = 2 [(google.api.field_behavior) = REQUIRED];
+
+  // GCS storage location used by the VidRankBuilder.
+  message StorageParams {
+    // The Google Cloud Storage project ID for the storage instance.
+    string gcs_project_id = 1 [(google.api.field_behavior) = REQUIRED];
+
+    // The GCS blob URI prefix.
+    //
+    // Required for the subpool-map and vid-rank-map storage (static,
+    // config-driven locations that do not change at runtime). May be left
+    // empty for the raw-impressions storage, where the location is supplied
+    // by the API via `RawImpressionUpload.done_blob_uri`.
+    string blob_prefix = 2 [(google.api.field_behavior) = OPTIONAL];
+  }
+
+  // Storage from which raw impressions are read.
+  StorageParams raw_impression_storage_params = 3
+      [(google.api.field_behavior) = REQUIRED];
+
+  // Storage from which the per-(shard, subpool) SubpoolFingerprints blobs
+  // produced by the SubpoolAssigner are read.
+  StorageParams subpool_map_storage_params = 4
+      [(google.api.field_behavior) = REQUIRED];
+
+  // Storage from which prior cumulative rank-index blobs are read and to
+  // which the new day-only + cumulative rank-index blobs are written.
+  StorageParams vid_rank_map_storage_params = 5
+      [(google.api.field_behavior) = REQUIRED];
+
+  // Fully qualified resource name of the `RawImpressionUpload` this WorkItem
+  // is processing.
+  string raw_impression_upload = 6 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference).type =
+        "edpaggregator.halo-cmm.org/RawImpressionUpload"
+  ];
+
+  // The `ModelLine` this WorkItem ranks for. Exactly one model line per
+  // WorkItem.
+  string model_line = 7 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference).type = "halo.wfanet.org/ModelLine"
+  ];
+
+  // ID of the `RankerJob` row this WorkItem fulfils, assigned by Phase-0
+  // during bin-packing. Together with [data_provider],
+  // [raw_impression_upload] and [model_line] it forms the
+  // `(DataProviderResourceId, RawImpressionUploadId, CmmsModelLine,
+  // RankerJobId)` primary key the TEE uses to update its own row.
+  int64 ranker_job_id = 8 [(google.api.field_behavior) = REQUIRED];
+
+  // GCS blob URIs of the per-subpool `SubpoolFingerprints` blobs produced
+  // by Phase-0 that this ranker is responsible for. The map keys are the
+  // subpool IDs this `RankerJob` ranks (the bin-packed set carried as
+  // `SubpoolIds ARRAY<INT64>` on the `RankerJob` row); the values are the
+  // GCS blob URIs the TEE reads from `subpool_map_storage_params`.
+  map<int64, string> subpool_map_blob_uris = 9
+      [(google.api.field_behavior) = REQUIRED];
+
+  // Total number of fingerprint shards (`N`) across this dispatch. The
+  // last-subpool-out uses this to fan out Phase-2 with one VidLabeler
+  // WorkItem per shard.
+  int32 total_shards = 10 [(google.api.field_behavior) = REQUIRED];
+}

--- a/src/main/proto/wfa/measurement/edpaggregator/v1alpha/vid_rank_builder_params.proto
+++ b/src/main/proto/wfa/measurement/edpaggregator/v1alpha/vid_rank_builder_params.proto
@@ -119,7 +119,8 @@ message VidRankBuilderParams {
 
   // Mapping from event template field names to their corresponding raw
   // impression field names. Mirrors the per-(EDP, model line) mapping
-  // configured in `VidLabelingConfig.ModelLineConfig.event_template_field_mapping`.
+  // configured in
+  // `VidLabelingConfig.ModelLineConfig.event_template_field_mapping`.
   //
   // Not consumed by the Phase-1 ranker. Pass-through for the Phase-2
   // VidLabeler WorkItem.
@@ -156,6 +157,5 @@ message VidRankBuilderParams {
   // ranker stamps this on the new day-only `RankIndexBlob` rows it
   // inserts so the retention sweep can identify aged-out blobs via
   // `MaxEventDate < today - RETENTION_DAYS`.
-  google.type.Date max_event_date = 15
-      [(google.api.field_behavior) = REQUIRED];
+  google.type.Date max_event_date = 15 [(google.api.field_behavior) = REQUIRED];
 }


### PR DESCRIPTION
## Summary
  - Add `VidRankBuilderApp` under `src/main/kotlin/org/wfanet/measurement/edpaggregator/vidrankbuilder/`, the entry point for the Phase-1 stage of the memoized VID assignment pipeline. Extends
  `BaseTeeApplication` and mirrors the constructor shape of `SubpoolAssignerApp` / `VidLabelerApp`.
  - Scaffold only: `runWork` unpacks `WorkItemParams` + `VidRankBuilderParams` and stops. The full pipeline (DEK unwrap → per-subpool load/prune/read/allocate/write → `RankerJob` state flip → last-out
  `RawImpressionUploadModelLineState` transition + Phase-2 WorkItem fan-out) is captured as a 6-step TODO block in the file.
  - Add `subpool_assigner_params.proto`'s sibling `vid_rank_builder_params.proto` carrying everything the Phase-1 TEE needs per WorkItem:
    - `data_provider`
    - `encrypted_subpool_maps_dek` — Phase-0's `SubpoolFingerprints` DEK; uses the fully-qualified type `wfa.measurement.securecomputation.impressions.EncryptedDek` since that proto's package doesn't
  match its file path
    - inline `StorageParams { gcs_project_id, blob_prefix }` reused for `raw_impression_storage_params`, `subpool_map_storage_params`, and `vid_rank_map_storage_params` (`blob_prefix` OPTIONAL — required
  for the two static config-driven storages, may be empty for raw impressions where the URI comes from the API)
    - `raw_impression_upload`, `model_line`, `ranker_job_id` — together with `data_provider`, the four parts of the `RankerJob` primary key
    - `map<int64, string> subpool_map_blob_uris` — the bin-packed `(subpool_id → Phase-0 blob URI)` set this `RankerJob` ranks (replaces a naïve `repeated int64 subpool_ids` so the TEE doesn't have to
  recompute the URIs)
    - `total_shards` — last-`RankerJob`-out uses this to fan out Phase-2 with one VidLabeler WorkItem per shard
  - BUILD: new `kt_jvm_library(name = "vid_rank_builder_app", ...)` target wiring `BaseTeeApplication`, `QueueSubscriber`, `WorkItem*` gRPC/proto, `VidRankBuilderParams`, `StorageConfig`, KMS client, and
  protobuf. `vid_rank_builder_params_proto` depends on `:encrypted_dek_proto`.

Issue: #3921 