### PR TITLE
ci: Add config so Renovate does not create special PRs for vulnerabilities

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -6,6 +6,9 @@
     "abandonments:recommended"
   ],
   "assignees": ["laureanobrs"],
+  "vulnerabilityAlerts": {
+    "enabled": false
+  },  
   "packageRules": [
     {
       "groupName": "GitHub Actions",


### PR DESCRIPTION
This PR adds a configuration so Renovate doesn’t create special PRs for vulnerabilities and therefore respects the grouping criteria we have defined.

Issue: NA