### PR TITLE
feat: Add RankerJob proto and gRPC service definitions

### DIFF
--- a/src/main/proto/wfa/measurement/edpaggregator/v1alpha/BUILD.bazel
+++ b/src/main/proto/wfa/measurement/edpaggregator/v1alpha/BUILD.bazel
@@ -375,6 +375,7 @@ proto_library(
         "@com_google_googleapis//google/api:field_behavior_proto",
         "@com_google_googleapis//google/api:field_info_proto",
         "@com_google_googleapis//google/api:resource_proto",
+        "@com_google_googleapis//google/type:interval_proto",
     ],
 )
 

--- a/src/main/proto/wfa/measurement/edpaggregator/v1alpha/BUILD.bazel
+++ b/src/main/proto/wfa/measurement/edpaggregator/v1alpha/BUILD.bazel
@@ -349,3 +349,36 @@ kt_jvm_grpc_proto_library(
     name = "raw_impression_upload_service_kt_jvm_grpc_proto",
     deps = [":raw_impression_upload_service_proto"],
 )
+
+proto_library(
+    name = "ranker_job_proto",
+    srcs = ["ranker_job.proto"],
+    strip_import_prefix = _IMPORT_PREFIX,
+    deps = [
+        "@com_google_googleapis//google/api:field_behavior_proto",
+        "@com_google_googleapis//google/api:resource_proto",
+        "@com_google_protobuf//:timestamp_proto",
+    ],
+)
+
+kt_jvm_proto_library(
+    name = "ranker_job_kt_jvm_proto",
+    deps = [":ranker_job_proto"],
+)
+
+proto_library(
+    name = "ranker_job_service_proto",
+    srcs = ["ranker_job_service.proto"],
+    strip_import_prefix = _IMPORT_PREFIX,
+    deps = [
+        ":ranker_job_proto",
+        "@com_google_googleapis//google/api:field_behavior_proto",
+        "@com_google_googleapis//google/api:field_info_proto",
+        "@com_google_googleapis//google/api:resource_proto",
+    ],
+)
+
+kt_jvm_grpc_proto_library(
+    name = "ranker_job_service_kt_jvm_grpc_proto",
+    deps = [":ranker_job_service_proto"],
+)

--- a/src/main/proto/wfa/measurement/edpaggregator/v1alpha/ranker_job.proto
+++ b/src/main/proto/wfa/measurement/edpaggregator/v1alpha/ranker_job.proto
@@ -1,0 +1,79 @@
+// Copyright 2026 The Cross-Media Measurement Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package wfa.measurement.edpaggregator.v1alpha;
+
+import "google/api/field_behavior.proto";
+import "google/api/resource.proto";
+import "google/protobuf/timestamp.proto";
+
+option java_package = "org.wfanet.measurement.edpaggregator.v1alpha";
+option java_multiple_files = true;
+option java_outer_classname = "RankerJobProto";
+
+// A Phase-1 ranker job that assigns rank values to fingerprints per subpool.
+// Pre-created by Phase-0 once pool assignment completes. The last ranker job
+// to complete for a given (upload, model line) triggers Phase-2 (VID labeling).
+message RankerJob {
+  option (google.api.resource) = {
+    type: "edpaggregator.halo-cmm.org/RankerJob"
+    pattern: "dataProviders/{data_provider}/rawImpressionUploads/{raw_impression_upload}/rankerJobs/{ranker_job}"
+    singular: "rankerJob"
+    plural: "rankerJobs"
+  };
+
+  // Ranker job state.
+  enum State {
+    // Default, unspecified state. Should not be used.
+    STATE_UNSPECIFIED = 0;
+    // The ranker job has been created but not yet started.
+    CREATED = 1;
+    // The ranker job completed successfully.
+    SUCCEEDED = 2;
+    // The ranker job failed.
+    FAILED = 3;
+  }
+
+  // Resource name.
+  string name = 1 [(google.api.field_behavior) = IDENTIFIER];
+
+  // The CMMS model line resource name that this ranker job is associated with.
+  string cmms_model_line = 2 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.field_behavior) = IMMUTABLE
+  ];
+
+  // Subpool IDs batched into this ranker job.
+  repeated int64 subpool_ids = 3 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.field_behavior) = IMMUTABLE
+  ];
+
+  // The state of this ranker job.
+  State state = 4 [(google.api.field_behavior) = OUTPUT_ONLY];
+
+  // The timestamp when this job completed (success or failure).
+  google.protobuf.Timestamp completion_time = 5
+      [(google.api.field_behavior) = OUTPUT_ONLY];
+
+  // The timestamp when this job was created.
+  google.protobuf.Timestamp create_time = 6
+      [(google.api.field_behavior) = OUTPUT_ONLY];
+
+  // The timestamp when this job was last updated.
+  google.protobuf.Timestamp update_time = 7
+      [(google.api.field_behavior) = OUTPUT_ONLY];
+}

--- a/src/main/proto/wfa/measurement/edpaggregator/v1alpha/ranker_job.proto
+++ b/src/main/proto/wfa/measurement/edpaggregator/v1alpha/ranker_job.proto
@@ -43,7 +43,8 @@ message RankerJob {
     CREATED = 1;
     // The ranker job completed successfully.
     SUCCEEDED = 2;
-    // The ranker job failed.
+    // The ranker job failed. Not terminal — operator can retry after
+    // fixing the root cause.
     FAILED = 3;
   }
 
@@ -53,7 +54,8 @@ message RankerJob {
   // The CMMS model line resource name that this ranker job is associated with.
   string cmms_model_line = 2 [
     (google.api.field_behavior) = REQUIRED,
-    (google.api.field_behavior) = IMMUTABLE
+    (google.api.field_behavior) = IMMUTABLE,
+    (google.api.resource_reference) = { type: "halo.wfanet.org/ModelLine" }
   ];
 
   // Subpool IDs batched into this ranker job.
@@ -76,4 +78,10 @@ message RankerJob {
   // The timestamp when this job was last updated.
   google.protobuf.Timestamp update_time = 7
       [(google.api.field_behavior) = OUTPUT_ONLY];
+
+  // Detail about the failure, set when state is `FAILED`.
+  string error_message = 8 [(google.api.field_behavior) = OUTPUT_ONLY];
+
+  // Opaque token for optimistic concurrency control.
+  string etag = 9 [(google.api.field_behavior) = OUTPUT_ONLY];
 }

--- a/src/main/proto/wfa/measurement/edpaggregator/v1alpha/ranker_job.proto
+++ b/src/main/proto/wfa/measurement/edpaggregator/v1alpha/ranker_job.proto
@@ -57,7 +57,7 @@ message RankerJob {
   ];
 
   // Subpool IDs batched into this ranker job.
-  repeated int64 subpool_ids = 3 [
+  repeated int32 subpool_ids = 3 [
     (google.api.field_behavior) = REQUIRED,
     (google.api.field_behavior) = IMMUTABLE
   ];

--- a/src/main/proto/wfa/measurement/edpaggregator/v1alpha/ranker_job_service.proto
+++ b/src/main/proto/wfa/measurement/edpaggregator/v1alpha/ranker_job_service.proto
@@ -30,6 +30,10 @@ service RankerJobService {
   // Creates a new `RankerJob`.
   rpc CreateRankerJob(CreateRankerJobRequest) returns (RankerJob) {}
 
+  // Creates multiple `RankerJob` resources in a single request.
+  rpc BatchCreateRankerJobs(BatchCreateRankerJobsRequest)
+      returns (BatchCreateRankerJobsResponse) {}
+
   // Retrieves a specific `RankerJob`.
   rpc GetRankerJob(GetRankerJobRequest) returns (RankerJob) {}
 
@@ -64,6 +68,28 @@ message CreateRankerJobRequest {
     (google.api.field_behavior) = OPTIONAL,
     (google.api.field_info).format = UUID4
   ];
+}
+
+// Request message for the `BatchCreateRankerJobs` method.
+message BatchCreateRankerJobsRequest {
+  // The parent upload resource name.
+  // Format:
+  // `dataProviders/{data_provider}/rawImpressionUploads/{raw_impression_upload}`
+  string parent = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference) = {
+      child_type: "edpaggregator.halo-cmm.org/RankerJob"
+    }
+  ];
+
+  // Individual create requests. Maximum 100 per batch.
+  repeated CreateRankerJobRequest requests = 2
+      [(google.api.field_behavior) = REQUIRED];
+}
+
+// Response message for the `BatchCreateRankerJobs` method.
+message BatchCreateRankerJobsResponse {
+  repeated RankerJob ranker_jobs = 1;
 }
 
 // Request message for the `GetRankerJob` method.
@@ -110,6 +136,9 @@ message ListRankerJobsRequest {
     //     aip.dev/not-precedent: This is a filter input field, not a
     //     resource state field. --)
     RankerJob.State state = 1 [(google.api.field_behavior) = OPTIONAL];
+
+    // Filter by CMMS model line resource name.
+    string cmms_model_line = 2 [(google.api.field_behavior) = OPTIONAL];
   }
 
   // Optional. A filter to apply to the results.

--- a/src/main/proto/wfa/measurement/edpaggregator/v1alpha/ranker_job_service.proto
+++ b/src/main/proto/wfa/measurement/edpaggregator/v1alpha/ranker_job_service.proto
@@ -1,0 +1,138 @@
+// Copyright 2026 The Cross-Media Measurement Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package wfa.measurement.edpaggregator.v1alpha;
+
+import "google/api/field_behavior.proto";
+import "google/api/field_info.proto";
+import "google/api/resource.proto";
+import "wfa/measurement/edpaggregator/v1alpha/ranker_job.proto";
+
+option java_package = "org.wfanet.measurement.edpaggregator.v1alpha";
+option java_multiple_files = true;
+option java_outer_classname = "RankerJobServiceProto";
+
+// Service for managing `RankerJob` resources.
+service RankerJobService {
+  // Creates a new `RankerJob`.
+  rpc CreateRankerJob(CreateRankerJobRequest) returns (RankerJob) {}
+
+  // Retrieves a specific `RankerJob`.
+  rpc GetRankerJob(GetRankerJobRequest) returns (RankerJob) {}
+
+  // Lists `RankerJob` resources for an upload.
+  rpc ListRankerJobs(ListRankerJobsRequest)
+      returns (ListRankerJobsResponse) {}
+
+  // Deletes a `RankerJob`.
+  rpc DeleteRankerJob(DeleteRankerJobRequest) returns (RankerJob) {}
+}
+
+// Request message for the `CreateRankerJob` method.
+message CreateRankerJobRequest {
+  // The parent upload resource name.
+  // Format:
+  // `dataProviders/{data_provider}/rawImpressionUploads/{raw_impression_upload}`
+  string parent = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference) = {
+      child_type: "edpaggregator.halo-cmm.org/RankerJob"
+    }
+  ];
+
+  // The `RankerJob` to create.
+  // The `name` and output-only fields are ignored.
+  RankerJob ranker_job = 2 [(google.api.field_behavior) = REQUIRED];
+
+  // A request ID provided by the client to ensure idempotency.
+  //
+  // This field must be a UUID4 (RFC 4122) string.
+  string request_id = 3 [
+    (google.api.field_behavior) = OPTIONAL,
+    (google.api.field_info).format = UUID4
+  ];
+}
+
+// Request message for the `GetRankerJob` method.
+message GetRankerJobRequest {
+  // The resource name of the ranker job to retrieve.
+  // Format:
+  // `dataProviders/{data_provider}/rawImpressionUploads/{raw_impression_upload}/rankerJobs/{ranker_job}`
+  string name = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference) = {
+      type: "edpaggregator.halo-cmm.org/RankerJob"
+    }
+  ];
+}
+
+// Request message for the `ListRankerJobs` method.
+// (-- api-linter: core::0132::request-field-types=disabled
+//     aip.dev/not-precedent: Using a customized message for the filter. --)
+message ListRankerJobsRequest {
+  // The parent upload resource name.
+  // Format:
+  // `dataProviders/{data_provider}/rawImpressionUploads/{raw_impression_upload}`
+  //
+  // The upload segment may be the wildcard `-` to list
+  // ranker jobs across all uploads for a data provider. See
+  // AIP-159.
+  string parent = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference) = {
+      child_type: "edpaggregator.halo-cmm.org/RankerJob"
+    }
+  ];
+
+  // The maximum number of results to return.
+  int32 page_size = 2 [(google.api.field_behavior) = OPTIONAL];
+
+  // A page token, received from a previous call.
+  string page_token = 3 [(google.api.field_behavior) = OPTIONAL];
+
+  // Structured filter for narrowing results.
+  message Filter {
+    // Filter by ranker job state.
+    // (-- api-linter: core::0216::state-field-output-only=disabled
+    //     aip.dev/not-precedent: This is a filter input field, not a
+    //     resource state field. --)
+    RankerJob.State state = 1 [(google.api.field_behavior) = OPTIONAL];
+  }
+
+  // Optional. A filter to apply to the results.
+  Filter filter = 4 [(google.api.field_behavior) = OPTIONAL];
+}
+
+// Response message for the `ListRankerJobs` method.
+message ListRankerJobsResponse {
+  repeated RankerJob ranker_jobs = 1;
+
+  // A token to retrieve the next page of results.
+  string next_page_token = 2;
+}
+
+// Request message for the `DeleteRankerJob` method.
+message DeleteRankerJobRequest {
+  // The resource name of the ranker job to delete.
+  // Format:
+  // `dataProviders/{data_provider}/rawImpressionUploads/{raw_impression_upload}/rankerJobs/{ranker_job}`
+  string name = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference) = {
+      type: "edpaggregator.halo-cmm.org/RankerJob"
+    }
+  ];
+}

--- a/src/main/proto/wfa/measurement/edpaggregator/v1alpha/ranker_job_service.proto
+++ b/src/main/proto/wfa/measurement/edpaggregator/v1alpha/ranker_job_service.proto
@@ -19,6 +19,7 @@ package wfa.measurement.edpaggregator.v1alpha;
 import "google/api/field_behavior.proto";
 import "google/api/field_info.proto";
 import "google/api/resource.proto";
+import "google/type/interval.proto";
 import "wfa/measurement/edpaggregator/v1alpha/ranker_job.proto";
 
 option java_package = "org.wfanet.measurement.edpaggregator.v1alpha";
@@ -41,8 +42,13 @@ service RankerJobService {
   rpc ListRankerJobs(ListRankerJobsRequest)
       returns (ListRankerJobsResponse) {}
 
-  // Deletes a `RankerJob`.
-  rpc DeleteRankerJob(DeleteRankerJobRequest) returns (RankerJob) {}
+  // Marks a `RankerJob` as `SUCCEEDED`.
+  rpc MarkRankerJobSucceeded(MarkRankerJobSucceededRequest)
+      returns (RankerJob) {}
+
+  // Marks a `RankerJob` as `FAILED`.
+  rpc MarkRankerJobFailed(MarkRankerJobFailedRequest)
+      returns (RankerJob) {}
 }
 
 // Request message for the `CreateRankerJob` method.
@@ -82,7 +88,7 @@ message BatchCreateRankerJobsRequest {
     }
   ];
 
-  // Individual create requests. Maximum 100 per batch.
+  // Individual create requests. Maximum 50 per batch.
   repeated CreateRankerJobRequest requests = 2
       [(google.api.field_behavior) = REQUIRED];
 }
@@ -137,8 +143,18 @@ message ListRankerJobsRequest {
     //     resource state field. --)
     RankerJob.State state = 1 [(google.api.field_behavior) = OPTIONAL];
 
+    // Filter for resources whose create_time falls within this
+    // interval. Start and end are both optional: omitting start
+    // returns resources created before end, omitting end returns
+    // resources created after start.
+    google.type.Interval create_time_interval = 2
+        [(google.api.field_behavior) = OPTIONAL];
+
     // Filter by CMMS model line resource name.
-    string cmms_model_line = 2 [(google.api.field_behavior) = OPTIONAL];
+    string cmms_model_line = 3 [
+      (google.api.field_behavior) = OPTIONAL,
+      (google.api.resource_reference) = { type: "halo.wfanet.org/ModelLine" }
+    ];
   }
 
   // Optional. A filter to apply to the results.
@@ -153,9 +169,9 @@ message ListRankerJobsResponse {
   string next_page_token = 2;
 }
 
-// Request message for the `DeleteRankerJob` method.
-message DeleteRankerJobRequest {
-  // The resource name of the ranker job to delete.
+// Request message for the `MarkRankerJobSucceeded` method.
+message MarkRankerJobSucceededRequest {
+  // The resource name of the ranker job.
   // Format:
   // `dataProviders/{data_provider}/rawImpressionUploads/{raw_impression_upload}/rankerJobs/{ranker_job}`
   string name = 1 [
@@ -164,4 +180,20 @@ message DeleteRankerJobRequest {
       type: "edpaggregator.halo-cmm.org/RankerJob"
     }
   ];
+}
+
+// Request message for the `MarkRankerJobFailed` method.
+message MarkRankerJobFailedRequest {
+  // The resource name of the ranker job.
+  // Format:
+  // `dataProviders/{data_provider}/rawImpressionUploads/{raw_impression_upload}/rankerJobs/{ranker_job}`
+  string name = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference) = {
+      type: "edpaggregator.halo-cmm.org/RankerJob"
+    }
+  ];
+
+  // Human-readable detail about the failure.
+  string error_message = 2 [(google.api.field_behavior) = OPTIONAL];
 }

--- a/src/main/proto/wfa/measurement/internal/edpaggregator/BUILD.bazel
+++ b/src/main/proto/wfa/measurement/internal/edpaggregator/BUILD.bazel
@@ -125,6 +125,7 @@ proto_descriptor_set(
     name = "descriptor_set",
     deps = [
         ":impression_metadata_state_proto",
+        ":ranker_state_proto",
         ":raw_impression_batch_state_proto",
         ":requisition_metadata_state_proto",
     ],
@@ -231,4 +232,46 @@ proto_library(
 kt_jvm_grpc_proto_library(
     name = "raw_impression_upload_service_kt_jvm_grpc_proto",
     deps = [":raw_impression_upload_service_proto"],
+)
+
+proto_library(
+    name = "ranker_state_proto",
+    srcs = ["ranker_state.proto"],
+    strip_import_prefix = IMPORT_PREFIX,
+)
+
+kt_jvm_proto_library(
+    name = "ranker_state_kt_jvm_proto",
+    deps = [":ranker_state_proto"],
+)
+
+proto_library(
+    name = "ranker_job_proto",
+    srcs = ["ranker_job.proto"],
+    strip_import_prefix = IMPORT_PREFIX,
+    deps = [
+        ":ranker_state_proto",
+        "@com_google_protobuf//:timestamp_proto",
+    ],
+)
+
+kt_jvm_proto_library(
+    name = "ranker_job_kt_jvm_proto",
+    deps = [":ranker_job_proto"],
+)
+
+proto_library(
+    name = "ranker_job_service_proto",
+    srcs = ["ranker_job_service.proto"],
+    strip_import_prefix = IMPORT_PREFIX,
+    deps = [
+        ":ranker_job_proto",
+        ":ranker_state_proto",
+        "@com_google_protobuf//:timestamp_proto",
+    ],
+)
+
+kt_jvm_grpc_proto_library(
+    name = "ranker_job_service_kt_jvm_grpc_proto",
+    deps = [":ranker_job_service_proto"],
 )

--- a/src/main/proto/wfa/measurement/internal/edpaggregator/BUILD.bazel
+++ b/src/main/proto/wfa/measurement/internal/edpaggregator/BUILD.bazel
@@ -267,6 +267,7 @@ proto_library(
     deps = [
         ":ranker_job_proto",
         ":ranker_state_proto",
+        "@com_google_googleapis//google/type:interval_proto",
         "@com_google_protobuf//:timestamp_proto",
     ],
 )

--- a/src/main/proto/wfa/measurement/internal/edpaggregator/ranker_job.proto
+++ b/src/main/proto/wfa/measurement/internal/edpaggregator/ranker_job.proto
@@ -24,7 +24,7 @@ option java_multiple_files = true;
 option java_outer_classname = "RankerJobProto";
 
 // Internal representation of a ranker job for Phase-1 ranking.
-// One row per (upload, model line, ranker job), pre-created by Phase-0.
+// One row per (upload, ranker job), pre-created by Phase-0.
 // The "last subpool out" of an (upload, model line) triggers Phase-2.
 message RankerJob {
   // Resource ID of the `DataProvider` that owns this job.
@@ -33,14 +33,14 @@ message RankerJob {
   // Resource ID of the parent `RawImpressionUpload`.
   string raw_impression_upload_resource_id = 2;
 
-  // The CMMS model line resource name.
-  string cmms_model_line = 3;
+  // Resource ID of this ranker job.
+  string ranker_job_id = 3;
 
-  // Resource ID of this ranker job, assigned by Phase-0.
-  int64 ranker_job_id = 4;
+  // The CMMS model line resource name.
+  string cmms_model_line = 4;
 
   // Subpool IDs batched into this ranker job.
-  repeated int64 subpool_ids = 5;
+  repeated int32 subpool_ids = 5;
 
   // The state of this ranker job.
   RankerState state = 6;

--- a/src/main/proto/wfa/measurement/internal/edpaggregator/ranker_job.proto
+++ b/src/main/proto/wfa/measurement/internal/edpaggregator/ranker_job.proto
@@ -1,0 +1,56 @@
+// Copyright 2026 The Cross-Media Measurement Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package wfa.measurement.internal.edpaggregator;
+
+import "google/protobuf/timestamp.proto";
+import "wfa/measurement/internal/edpaggregator/ranker_state.proto";
+
+option java_package = "org.wfanet.measurement.internal.edpaggregator";
+option java_multiple_files = true;
+option java_outer_classname = "RankerJobProto";
+
+// Internal representation of a ranker job for Phase-1 ranking.
+// One row per (upload, model line, ranker job), pre-created by Phase-0.
+// The "last subpool out" of an (upload, model line) triggers Phase-2.
+message RankerJob {
+  // Resource ID of the `DataProvider` that owns this job.
+  string data_provider_resource_id = 1;
+
+  // Resource ID of the parent `RawImpressionUpload`.
+  string raw_impression_upload_resource_id = 2;
+
+  // The CMMS model line resource name.
+  string cmms_model_line = 3;
+
+  // Resource ID of this ranker job, assigned by Phase-0.
+  int64 ranker_job_id = 4;
+
+  // Subpool IDs batched into this ranker job.
+  repeated int64 subpool_ids = 5;
+
+  // The state of this ranker job.
+  RankerState state = 6;
+
+  // The timestamp when this job completed (success or failure).
+  google.protobuf.Timestamp completion_time = 7;
+
+  // The timestamp when this job was created.
+  google.protobuf.Timestamp create_time = 8;
+
+  // The timestamp when this job was last updated.
+  google.protobuf.Timestamp update_time = 9;
+}

--- a/src/main/proto/wfa/measurement/internal/edpaggregator/ranker_job.proto
+++ b/src/main/proto/wfa/measurement/internal/edpaggregator/ranker_job.proto
@@ -53,4 +53,10 @@ message RankerJob {
 
   // The timestamp when this job was last updated.
   google.protobuf.Timestamp update_time = 9;
+
+  // Detail about the failure, set when state is FAILED.
+  string error_message = 10;
+
+  // Opaque token for optimistic concurrency control.
+  string etag = 11;
 }

--- a/src/main/proto/wfa/measurement/internal/edpaggregator/ranker_job_service.proto
+++ b/src/main/proto/wfa/measurement/internal/edpaggregator/ranker_job_service.proto
@@ -1,0 +1,125 @@
+// Copyright 2026 The Cross-Media Measurement Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package wfa.measurement.internal.edpaggregator;
+
+import "google/protobuf/timestamp.proto";
+import "wfa/measurement/internal/edpaggregator/ranker_job.proto";
+import "wfa/measurement/internal/edpaggregator/ranker_state.proto";
+
+option java_package = "org.wfanet.measurement.internal.edpaggregator";
+option java_multiple_files = true;
+option java_outer_classname = "RankerJobServiceProto";
+
+// Service for managing `RankerJob` resources.
+service RankerJobService {
+  // Creates a new `RankerJob`.
+  rpc CreateRankerJob(CreateRankerJobRequest) returns (RankerJob);
+
+  // Retrieves a specific `RankerJob`.
+  rpc GetRankerJob(GetRankerJobRequest) returns (RankerJob);
+
+  // Lists `RankerJob` resources.
+  rpc ListRankerJobs(ListRankerJobsRequest)
+      returns (ListRankerJobsResponse);
+
+  // Deletes a `RankerJob`.
+  rpc DeleteRankerJob(DeleteRankerJobRequest) returns (RankerJob);
+}
+
+// Request message for `CreateRankerJob`.
+message CreateRankerJobRequest {
+  // The `RankerJob` to create.
+  RankerJob ranker_job = 1;
+
+  // A request ID provided by the client to ensure idempotency.
+  string request_id = 2;
+}
+
+// Request message for `GetRankerJob`.
+message GetRankerJobRequest {
+  // Resource ID of the `DataProvider`.
+  string data_provider_resource_id = 1;
+
+  // Resource ID of the parent `RawImpressionUpload`.
+  string raw_impression_upload_resource_id = 2;
+
+  // The CMMS model line resource name.
+  string cmms_model_line = 3;
+
+  // Resource ID of the ranker job.
+  int64 ranker_job_id = 4;
+}
+
+// Request message for `ListRankerJobs`.
+message ListRankerJobsRequest {
+  // Resource ID of the `DataProvider`.
+  string data_provider_resource_id = 1;
+
+  // Resource ID of the parent `RawImpressionUpload`.
+  string raw_impression_upload_resource_id = 2;
+
+  // The maximum number of results to return.
+  //
+  // If unspecified, at most 50 results will be returned.
+  // The maximum value is 100; values above this will be
+  // coerced to the maximum value.
+  int32 page_size = 3;
+
+  // Page token from a previous list call.
+  ListRankerJobsPageToken page_token = 4;
+
+  // Filter for narrowing results.
+  message Filter {
+    // Filter by ranker job state.
+    RankerState state = 1;
+  }
+  Filter filter = 5;
+}
+
+// Response message for `ListRankerJobs`.
+message ListRankerJobsResponse {
+  repeated RankerJob ranker_jobs = 1;
+
+  // A token to retrieve the next page of results.
+  ListRankerJobsPageToken next_page_token = 2;
+}
+
+// Page token for `ListRankerJobs`.
+message ListRankerJobsPageToken {
+  message After {
+    google.protobuf.Timestamp create_time = 1;
+    string raw_impression_upload_resource_id = 2;
+    string cmms_model_line = 3;
+    int64 ranker_job_id = 4;
+  }
+  After after = 1;
+}
+
+// Request message for `DeleteRankerJob`.
+message DeleteRankerJobRequest {
+  // Resource ID of the `DataProvider`.
+  string data_provider_resource_id = 1;
+
+  // Resource ID of the parent `RawImpressionUpload`.
+  string raw_impression_upload_resource_id = 2;
+
+  // The CMMS model line resource name.
+  string cmms_model_line = 3;
+
+  // Resource ID of the ranker job.
+  int64 ranker_job_id = 4;
+}

--- a/src/main/proto/wfa/measurement/internal/edpaggregator/ranker_job_service.proto
+++ b/src/main/proto/wfa/measurement/internal/edpaggregator/ranker_job_service.proto
@@ -29,6 +29,10 @@ service RankerJobService {
   // Creates a new `RankerJob`.
   rpc CreateRankerJob(CreateRankerJobRequest) returns (RankerJob);
 
+  // Creates multiple `RankerJob` resources in a single request.
+  rpc BatchCreateRankerJobs(BatchCreateRankerJobsRequest)
+      returns (BatchCreateRankerJobsResponse);
+
   // Retrieves a specific `RankerJob`.
   rpc GetRankerJob(GetRankerJobRequest) returns (RankerJob);
 
@@ -49,6 +53,23 @@ message CreateRankerJobRequest {
   string request_id = 2;
 }
 
+// Request message for `BatchCreateRankerJobs`.
+message BatchCreateRankerJobsRequest {
+  // Resource ID of the `DataProvider`.
+  string data_provider_resource_id = 1;
+
+  // Resource ID of the parent `RawImpressionUpload`.
+  string raw_impression_upload_resource_id = 2;
+
+  // Individual create requests. Maximum 100 per batch.
+  repeated CreateRankerJobRequest requests = 3;
+}
+
+// Response message for `BatchCreateRankerJobs`.
+message BatchCreateRankerJobsResponse {
+  repeated RankerJob ranker_jobs = 1;
+}
+
 // Request message for `GetRankerJob`.
 message GetRankerJobRequest {
   // Resource ID of the `DataProvider`.
@@ -57,11 +78,8 @@ message GetRankerJobRequest {
   // Resource ID of the parent `RawImpressionUpload`.
   string raw_impression_upload_resource_id = 2;
 
-  // The CMMS model line resource name.
-  string cmms_model_line = 3;
-
   // Resource ID of the ranker job.
-  int64 ranker_job_id = 4;
+  string ranker_job_id = 3;
 }
 
 // Request message for `ListRankerJobs`.
@@ -86,6 +104,9 @@ message ListRankerJobsRequest {
   message Filter {
     // Filter by ranker job state.
     RankerState state = 1;
+
+    // Filter by CMMS model line resource name.
+    string cmms_model_line = 2;
   }
   Filter filter = 5;
 }
@@ -103,8 +124,7 @@ message ListRankerJobsPageToken {
   message After {
     google.protobuf.Timestamp create_time = 1;
     string raw_impression_upload_resource_id = 2;
-    string cmms_model_line = 3;
-    int64 ranker_job_id = 4;
+    string ranker_job_id = 3;
   }
   After after = 1;
 }
@@ -117,9 +137,6 @@ message DeleteRankerJobRequest {
   // Resource ID of the parent `RawImpressionUpload`.
   string raw_impression_upload_resource_id = 2;
 
-  // The CMMS model line resource name.
-  string cmms_model_line = 3;
-
   // Resource ID of the ranker job.
-  int64 ranker_job_id = 4;
+  string ranker_job_id = 3;
 }

--- a/src/main/proto/wfa/measurement/internal/edpaggregator/ranker_job_service.proto
+++ b/src/main/proto/wfa/measurement/internal/edpaggregator/ranker_job_service.proto
@@ -17,6 +17,7 @@ syntax = "proto3";
 package wfa.measurement.internal.edpaggregator;
 
 import "google/protobuf/timestamp.proto";
+import "google/type/interval.proto";
 import "wfa/measurement/internal/edpaggregator/ranker_job.proto";
 import "wfa/measurement/internal/edpaggregator/ranker_state.proto";
 
@@ -40,8 +41,13 @@ service RankerJobService {
   rpc ListRankerJobs(ListRankerJobsRequest)
       returns (ListRankerJobsResponse);
 
-  // Deletes a `RankerJob`.
-  rpc DeleteRankerJob(DeleteRankerJobRequest) returns (RankerJob);
+  // Marks a `RankerJob` as `SUCCEEDED`.
+  rpc MarkRankerJobSucceeded(MarkRankerJobSucceededRequest)
+      returns (MarkRankerJobSucceededResponse);
+
+  // Marks a `RankerJob` as `FAILED`.
+  rpc MarkRankerJobFailed(MarkRankerJobFailedRequest)
+      returns (RankerJob);
 }
 
 // Request message for `CreateRankerJob`.
@@ -61,7 +67,7 @@ message BatchCreateRankerJobsRequest {
   // Resource ID of the parent `RawImpressionUpload`.
   string raw_impression_upload_resource_id = 2;
 
-  // Individual create requests. Maximum 100 per batch.
+  // Individual create requests. Maximum 50 per batch.
   repeated CreateRankerJobRequest requests = 3;
 }
 
@@ -105,8 +111,14 @@ message ListRankerJobsRequest {
     // Filter by ranker job state.
     RankerState state = 1;
 
+    // Filter for resources whose create_time falls within this
+    // interval. Start and end are both optional: omitting start
+    // returns resources created before end, omitting end returns
+    // resources created after start.
+    google.type.Interval create_time_interval = 2;
+
     // Filter by CMMS model line resource name.
-    string cmms_model_line = 2;
+    string cmms_model_line = 3;
   }
   Filter filter = 5;
 }
@@ -129,8 +141,8 @@ message ListRankerJobsPageToken {
   After after = 1;
 }
 
-// Request message for `DeleteRankerJob`.
-message DeleteRankerJobRequest {
+// Request message for `MarkRankerJobSucceeded`.
+message MarkRankerJobSucceededRequest {
   // Resource ID of the `DataProvider`.
   string data_provider_resource_id = 1;
 
@@ -139,4 +151,37 @@ message DeleteRankerJobRequest {
 
   // Resource ID of the ranker job.
   string ranker_job_id = 3;
+
+  // Opaque token for optimistic concurrency control. Must match the
+  // current `etag` value of the `RankerJob`.
+  string etag = 4;
+}
+
+// Response message for `MarkRankerJobSucceeded`.
+message MarkRankerJobSucceededResponse {
+  // The updated `RankerJob`.
+  RankerJob ranker_job = 1;
+
+  // Whether this was the last `RankerJob` for the (upload, model line) to
+  // reach SUCCEEDED, indicating Phase-2 (VID labeling) should be triggered.
+  bool is_last_job = 2;
+}
+
+// Request message for `MarkRankerJobFailed`.
+message MarkRankerJobFailedRequest {
+  // Resource ID of the `DataProvider`.
+  string data_provider_resource_id = 1;
+
+  // Resource ID of the parent `RawImpressionUpload`.
+  string raw_impression_upload_resource_id = 2;
+
+  // Resource ID of the ranker job.
+  string ranker_job_id = 3;
+
+  // Opaque token for optimistic concurrency control. Must match the
+  // current `etag` value of the `RankerJob`.
+  string etag = 4;
+
+  // Human-readable detail about the failure.
+  string error_message = 5;
 }

--- a/src/main/proto/wfa/measurement/internal/edpaggregator/ranker_state.proto
+++ b/src/main/proto/wfa/measurement/internal/edpaggregator/ranker_state.proto
@@ -1,0 +1,33 @@
+// Copyright 2026 The Cross-Media Measurement Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package wfa.measurement.internal.edpaggregator;
+
+option java_package = "org.wfanet.measurement.internal.edpaggregator";
+option java_multiple_files = true;
+option java_outer_classname = "RankerStateProto";
+
+// State of a `RankerJob`.
+enum RankerState {
+  // Default, unspecified state. Should not be used.
+  RANKER_STATE_UNSPECIFIED = 0;
+  // The ranker job has been created but not yet started.
+  RANKER_CREATED = 1;
+  // The ranker job completed successfully.
+  RANKER_SUCCEEDED = 2;
+  // The ranker job failed.
+  RANKER_FAILED = 3;
+}

--- a/src/main/proto/wfa/measurement/internal/edpaggregator/ranker_state.proto
+++ b/src/main/proto/wfa/measurement/internal/edpaggregator/ranker_state.proto
@@ -20,14 +20,15 @@ option java_package = "org.wfanet.measurement.internal.edpaggregator";
 option java_multiple_files = true;
 option java_outer_classname = "RankerStateProto";
 
-// State of a `RankerJob`.
+// Processing state for a `RankerJob`.
 enum RankerState {
   // Default, unspecified state. Should not be used.
   RANKER_STATE_UNSPECIFIED = 0;
-  // The ranker job has been created but not yet started.
-  RANKER_CREATED = 1;
-  // The ranker job completed successfully.
-  RANKER_SUCCEEDED = 2;
-  // The ranker job failed.
-  RANKER_FAILED = 3;
+  // The job has been created and is awaiting processing.
+  RANKER_STATE_CREATED = 1;
+  // The job completed successfully.
+  RANKER_STATE_SUCCEEDED = 2;
+  // The job failed. Not terminal — operator can retry after
+  // fixing the root cause.
+  RANKER_STATE_FAILED = 3;
 }


### PR DESCRIPTION
## Summary
- Add internal and public (v1alpha) proto message and service definitions for `RankerJob`, the Phase-1 ranking gate in the VID labeling pipeline.
- Includes Create, Get, List, and Delete methods for both internal and public APIs.
- Both internal and public proto definitions in a single PR per task guidance.
- Internal state enum (`RankerState`) in a separate proto file, matching the `RawImpressionUploadModelLineState` pattern.
- Resource pattern: `dataProviders/{data_provider}/rawImpressionUploads/{raw_impression_upload}/rankerJobs/{ranker_job}`

## Test plan
- `bazel build` passes for all 6 new proto targets (internal state, internal message, internal service, public message, public service, and their kt_jvm counterparts)

Closes: #3896
Issue: #3896