### PR TITLE
feat: Add RankerJob proto definitions for internal and public API

### DIFF
--- a/src/main/proto/wfa/measurement/edpaggregator/v1alpha/BUILD.bazel
+++ b/src/main/proto/wfa/measurement/edpaggregator/v1alpha/BUILD.bazel
@@ -476,3 +476,37 @@ kt_jvm_grpc_proto_library(
     name = "raw_impression_upload_model_line_service_kt_jvm_grpc_proto",
     deps = [":raw_impression_upload_model_line_service_proto"],
 )
+
+proto_library(
+    name = "ranker_job_proto",
+    srcs = ["ranker_job.proto"],
+    strip_import_prefix = _IMPORT_PREFIX,
+    deps = [
+        "@com_google_googleapis//google/api:field_behavior_proto",
+        "@com_google_googleapis//google/api:resource_proto",
+        "@com_google_protobuf//:timestamp_proto",
+    ],
+)
+
+kt_jvm_proto_library(
+    name = "ranker_job_kt_jvm_proto",
+    deps = [":ranker_job_proto"],
+)
+
+proto_library(
+    name = "ranker_job_service_proto",
+    srcs = ["ranker_job_service.proto"],
+    strip_import_prefix = _IMPORT_PREFIX,
+    deps = [
+        ":ranker_job_proto",
+        "@com_google_googleapis//google/api:field_behavior_proto",
+        "@com_google_googleapis//google/api:field_info_proto",
+        "@com_google_googleapis//google/api:resource_proto",
+        "@com_google_googleapis//google/type:interval_proto",
+    ],
+)
+
+kt_jvm_grpc_proto_library(
+    name = "ranker_job_service_kt_jvm_grpc_proto",
+    deps = [":ranker_job_service_proto"],
+)

--- a/src/main/proto/wfa/measurement/edpaggregator/v1alpha/ranker_job.proto
+++ b/src/main/proto/wfa/measurement/edpaggregator/v1alpha/ranker_job.proto
@@ -43,7 +43,7 @@ message RankerJob {
     STATE_UNSPECIFIED = 0;
     // The job has been created and is awaiting processing.
     CREATED = 1;
-    // The job completed successfully.
+    // The job completed successfully. Terminal state.
     SUCCEEDED = 2;
     // The job failed. Not terminal — operator can retry after
     // fixing the root cause.
@@ -69,21 +69,17 @@ message RankerJob {
     (google.api.field_behavior) = IMMUTABLE
   ];
 
-  // The timestamp when processing completed (success or failure).
-  google.protobuf.Timestamp completion_time = 5
-      [(google.api.field_behavior) = OUTPUT_ONLY];
-
   // The timestamp when this record was created.
-  google.protobuf.Timestamp create_time = 6
+  google.protobuf.Timestamp create_time = 5
       [(google.api.field_behavior) = OUTPUT_ONLY];
 
   // The timestamp when this record was last updated.
-  google.protobuf.Timestamp update_time = 7
+  google.protobuf.Timestamp update_time = 6
       [(google.api.field_behavior) = OUTPUT_ONLY];
 
   // Detail about the failure, set when state is FAILED.
-  string error_message = 8 [(google.api.field_behavior) = OUTPUT_ONLY];
+  string error_message = 7 [(google.api.field_behavior) = OUTPUT_ONLY];
 
   // Entity tag for optimistic concurrency control.
-  string etag = 9 [(google.api.field_behavior) = OUTPUT_ONLY];
+  string etag = 8 [(google.api.field_behavior) = OUTPUT_ONLY];
 }

--- a/src/main/proto/wfa/measurement/edpaggregator/v1alpha/ranker_job.proto
+++ b/src/main/proto/wfa/measurement/edpaggregator/v1alpha/ranker_job.proto
@@ -1,0 +1,89 @@
+// Copyright 2026 The Cross-Media Measurement Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package wfa.measurement.edpaggregator.v1alpha;
+
+import "google/api/field_behavior.proto";
+import "google/api/resource.proto";
+import "google/protobuf/timestamp.proto";
+
+option java_package = "org.wfanet.measurement.edpaggregator.v1alpha";
+option java_multiple_files = true;
+option java_outer_classname = "RankerJobProto";
+
+// A Phase-1 ranker job for a RawImpressionUpload.
+// One record per (upload, model line, ranker job), pre-created by
+// the Phase-0 last-out trigger. The "last job out" of a (upload,
+// model line) flips the parent RawImpressionUploadModelLine state
+// from RANKING to LABELING and triggers Phase 2.
+message RankerJob {
+  option (google.api.resource) = {
+    type: "edpaggregator.halo-cmm.org/RankerJob"
+    pattern: "dataProviders/{data_provider}/rawImpressionUploads/{raw_impression_upload}/rankerJobs/{ranker_job}"
+    singular: "rankerJob"
+    plural: "rankerJobs"
+  };
+
+  // Processing state for a RankerJob.
+  enum State {
+    // Default, unspecified state. Should not be used.
+    STATE_UNSPECIFIED = 0;
+    // The job has been created and is awaiting processing.
+    CREATED = 1;
+    // The job completed successfully.
+    SUCCEEDED = 2;
+    // The job failed. Not terminal — operator can retry after
+    // fixing the root cause.
+    FAILED = 3;
+  }
+
+  // Resource name.
+  string name = 1 [(google.api.field_behavior) = IDENTIFIER];
+
+  // The processing state of this job.
+  State state = 2 [(google.api.field_behavior) = OUTPUT_ONLY];
+
+  // The CMMS model line resource name that this job processes.
+  string cmms_model_line = 3 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.field_behavior) = IMMUTABLE,
+    (google.api.resource_reference) = { type: "halo.wfanet.org/ModelLine" }
+  ];
+
+  // The subpool IDs this ranker job is responsible for processing.
+  repeated int32 subpool_ids = 4 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.field_behavior) = IMMUTABLE
+  ];
+
+  // The timestamp when processing completed (success or failure).
+  google.protobuf.Timestamp completion_time = 5
+      [(google.api.field_behavior) = OUTPUT_ONLY];
+
+  // The timestamp when this record was created.
+  google.protobuf.Timestamp create_time = 6
+      [(google.api.field_behavior) = OUTPUT_ONLY];
+
+  // The timestamp when this record was last updated.
+  google.protobuf.Timestamp update_time = 7
+      [(google.api.field_behavior) = OUTPUT_ONLY];
+
+  // Detail about the failure, set when state is FAILED.
+  string error_message = 8 [(google.api.field_behavior) = OUTPUT_ONLY];
+
+  // Entity tag for optimistic concurrency control.
+  string etag = 9 [(google.api.field_behavior) = OUTPUT_ONLY];
+}

--- a/src/main/proto/wfa/measurement/edpaggregator/v1alpha/ranker_job.proto
+++ b/src/main/proto/wfa/measurement/edpaggregator/v1alpha/ranker_job.proto
@@ -26,7 +26,7 @@ option java_outer_classname = "RankerJobProto";
 
 // A Phase-1 ranker job for a RawImpressionUpload.
 // One record per (upload, model line, ranker job), pre-created by
-// the Phase-0 last-out trigger. The "last job out" of a (upload,
+// the Phase-0 last-out trigger. The "last ranker job out" of a (upload,
 // model line) flips the parent RawImpressionUploadModelLine state
 // from RANKING to LABELING and triggers Phase 2.
 message RankerJob {
@@ -63,8 +63,8 @@ message RankerJob {
     (google.api.resource_reference) = { type: "halo.wfanet.org/ModelLine" }
   ];
 
-  // The subpool IDs this ranker job is responsible for processing.
-  repeated int32 subpool_ids = 4 [
+  // The pool offsets this ranker job is responsible for processing.
+  repeated int64 pool_offsets = 4 [
     (google.api.field_behavior) = REQUIRED,
     (google.api.field_behavior) = IMMUTABLE
   ];

--- a/src/main/proto/wfa/measurement/edpaggregator/v1alpha/ranker_job_service.proto
+++ b/src/main/proto/wfa/measurement/edpaggregator/v1alpha/ranker_job_service.proto
@@ -43,11 +43,13 @@ service RankerJobService {
 
   // Marks a `RankerJob` as `SUCCEEDED`. Atomically checks if
   // this is the last job for the (upload, model line) and
-  // returns the signal to the caller.
+  // returns the signal to the caller. Throws
+  // FAILED_PRECONDITION if state is not CREATED or FAILED.
   rpc MarkRankerJobSucceeded(MarkRankerJobSucceededRequest)
       returns (MarkRankerJobSucceededResponse) {}
 
-  // Marks a `RankerJob` as `FAILED`.
+  // Marks a `RankerJob` as `FAILED`. Throws
+  // FAILED_PRECONDITION if state is not CREATED or FAILED.
   rpc MarkRankerJobFailed(MarkRankerJobFailedRequest) returns (RankerJob) {}
 }
 

--- a/src/main/proto/wfa/measurement/edpaggregator/v1alpha/ranker_job_service.proto
+++ b/src/main/proto/wfa/measurement/edpaggregator/v1alpha/ranker_job_service.proto
@@ -1,0 +1,218 @@
+// Copyright 2026 The Cross-Media Measurement Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package wfa.measurement.edpaggregator.v1alpha;
+
+import "google/api/field_behavior.proto";
+import "google/api/field_info.proto";
+import "google/api/resource.proto";
+import "google/type/interval.proto";
+import "wfa/measurement/edpaggregator/v1alpha/ranker_job.proto";
+
+option java_package = "org.wfanet.measurement.edpaggregator.v1alpha";
+option java_multiple_files = true;
+option java_outer_classname = "RankerJobServiceProto";
+
+// Service for managing `RankerJob` resources.
+service RankerJobService {
+  // Creates a new `RankerJob`.
+  rpc CreateRankerJob(CreateRankerJobRequest) returns (RankerJob) {}
+
+  // Creates multiple `RankerJob` resources in a single request.
+  rpc BatchCreateRankerJobs(BatchCreateRankerJobsRequest)
+      returns (BatchCreateRankerJobsResponse) {}
+
+  // Retrieves a specific `RankerJob`.
+  rpc GetRankerJob(GetRankerJobRequest) returns (RankerJob) {}
+
+  // Lists `RankerJob` resources for an upload.
+  rpc ListRankerJobs(ListRankerJobsRequest) returns (ListRankerJobsResponse) {}
+
+  // Marks a `RankerJob` as `SUCCEEDED`. Atomically checks if
+  // this is the last job for the (upload, model line) and
+  // returns the signal to the caller.
+  rpc MarkRankerJobSucceeded(MarkRankerJobSucceededRequest)
+      returns (MarkRankerJobSucceededResponse) {}
+
+  // Marks a `RankerJob` as `FAILED`.
+  rpc MarkRankerJobFailed(MarkRankerJobFailedRequest) returns (RankerJob) {}
+}
+
+// Request message for the `CreateRankerJob` method.
+message CreateRankerJobRequest {
+  // The parent upload resource name.
+  // Format:
+  // `dataProviders/{data_provider}/rawImpressionUploads/{raw_impression_upload}`
+  string parent = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference) = {
+      child_type: "edpaggregator.halo-cmm.org/RankerJob"
+    }
+  ];
+
+  // The `RankerJob` to create.
+  // The `name` and output-only fields are ignored.
+  RankerJob ranker_job = 2 [(google.api.field_behavior) = REQUIRED];
+
+  // A request ID provided by the client to ensure idempotency.
+  //
+  // This field must be a UUID4 (RFC 4122) string.
+  string request_id = 3 [
+    (google.api.field_behavior) = OPTIONAL,
+    (google.api.field_info).format = UUID4
+  ];
+}
+
+// Request message for the `BatchCreateRankerJobs` method.
+message BatchCreateRankerJobsRequest {
+  // The parent upload resource name.
+  // Format:
+  // `dataProviders/{data_provider}/rawImpressionUploads/{raw_impression_upload}`
+  string parent = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference) = {
+      child_type: "edpaggregator.halo-cmm.org/RankerJob"
+    }
+  ];
+
+  // Individual create requests. Maximum 50 per batch.
+  repeated CreateRankerJobRequest requests = 2
+      [(google.api.field_behavior) = REQUIRED];
+}
+
+// Response message for the `BatchCreateRankerJobs` method.
+message BatchCreateRankerJobsResponse {
+  // The created ranker jobs.
+  repeated RankerJob ranker_jobs = 1;
+}
+
+// Request message for the `GetRankerJob` method.
+message GetRankerJobRequest {
+  // The resource name of the job to retrieve.
+  // Format:
+  // `dataProviders/{data_provider}/rawImpressionUploads/{raw_impression_upload}/rankerJobs/{ranker_job}`
+  string name = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference) = {
+      type: "edpaggregator.halo-cmm.org/RankerJob"
+    }
+  ];
+}
+
+// Request message for the `ListRankerJobs` method.
+// (-- api-linter: core::0132::request-field-types=disabled
+//     aip.dev/not-precedent: Using a customized message for the
+//     filter. --)
+message ListRankerJobsRequest {
+  // The parent upload resource name.
+  // Format:
+  // `dataProviders/{data_provider}/rawImpressionUploads/{raw_impression_upload}`
+  //
+  // The upload segment may be the wildcard `-` to list
+  // jobs across all uploads for a data provider. See
+  // AIP-159.
+  string parent = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference) = {
+      child_type: "edpaggregator.halo-cmm.org/RankerJob"
+    }
+  ];
+
+  // The maximum number of results to return.
+  int32 page_size = 2 [(google.api.field_behavior) = OPTIONAL];
+
+  // A page token, received from a previous call.
+  string page_token = 3 [(google.api.field_behavior) = OPTIONAL];
+
+  // Structured filter for narrowing results.
+  message Filter {
+    // Filter by processing state.
+    // (-- api-linter: core::0216::state-field-output-only=disabled
+    //     aip.dev/not-precedent: This is a filter input field, not
+    //     a resource state field. --)
+    RankerJob.State state = 1 [(google.api.field_behavior) = OPTIONAL];
+
+    // Filter for resources whose create_time falls within this
+    // interval. Start and end are both optional: omitting start
+    // returns resources created before end, omitting end returns
+    // resources created after start.
+    google.type.Interval create_time_interval = 2
+        [(google.api.field_behavior) = OPTIONAL];
+
+    // Filter by CMMS model line resource name.
+    string cmms_model_line = 3 [
+      (google.api.field_behavior) = OPTIONAL,
+      (google.api.resource_reference) = { type: "halo.wfanet.org/ModelLine" }
+    ];
+  }
+
+  // Optional. A filter to apply to the results.
+  Filter filter = 4 [(google.api.field_behavior) = OPTIONAL];
+}
+
+// Response message for the `ListRankerJobs` method.
+message ListRankerJobsResponse {
+  // The list of ranker jobs matching the request.
+  repeated RankerJob ranker_jobs = 1;
+
+  // A token to retrieve the next page of results.
+  string next_page_token = 2;
+}
+
+// Request message for the `MarkRankerJobSucceeded` method.
+message MarkRankerJobSucceededRequest {
+  // The resource name of the job.
+  // Format:
+  // `dataProviders/{data_provider}/rawImpressionUploads/{raw_impression_upload}/rankerJobs/{ranker_job}`
+  string name = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference) = {
+      type: "edpaggregator.halo-cmm.org/RankerJob"
+    }
+  ];
+
+  // The etag of the RankerJob for optimistic locking.
+  string etag = 2 [(google.api.field_behavior) = REQUIRED];
+}
+
+// Response message for the `MarkRankerJobSucceeded` method.
+message MarkRankerJobSucceededResponse {
+  // The updated RankerJob.
+  RankerJob ranker_job = 1;
+
+  // Whether this was the last ranker job to complete for the
+  // (upload, model line).
+  bool is_last_job = 2;
+}
+
+// Request message for the `MarkRankerJobFailed` method.
+message MarkRankerJobFailedRequest {
+  // The resource name of the job.
+  // Format:
+  // `dataProviders/{data_provider}/rawImpressionUploads/{raw_impression_upload}/rankerJobs/{ranker_job}`
+  string name = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference) = {
+      type: "edpaggregator.halo-cmm.org/RankerJob"
+    }
+  ];
+
+  // The etag of the RankerJob for optimistic locking.
+  string etag = 2 [(google.api.field_behavior) = REQUIRED];
+
+  // Human-readable detail about the failure.
+  string error_message = 3 [(google.api.field_behavior) = OPTIONAL];
+}

--- a/src/main/proto/wfa/measurement/internal/edpaggregator/BUILD.bazel
+++ b/src/main/proto/wfa/measurement/internal/edpaggregator/BUILD.bazel
@@ -304,3 +304,46 @@ kt_jvm_grpc_proto_library(
     name = "raw_impression_upload_model_line_service_kt_jvm_grpc_proto",
     deps = [":raw_impression_upload_model_line_service_proto"],
 )
+
+proto_library(
+    name = "ranker_state_proto",
+    srcs = ["ranker_state.proto"],
+    strip_import_prefix = IMPORT_PREFIX,
+)
+
+kt_jvm_proto_library(
+    name = "ranker_state_kt_jvm_proto",
+    deps = [":ranker_state_proto"],
+)
+
+proto_library(
+    name = "ranker_job_proto",
+    srcs = ["ranker_job.proto"],
+    strip_import_prefix = IMPORT_PREFIX,
+    deps = [
+        ":ranker_state_proto",
+        "@com_google_protobuf//:timestamp_proto",
+    ],
+)
+
+kt_jvm_proto_library(
+    name = "ranker_job_kt_jvm_proto",
+    deps = [":ranker_job_proto"],
+)
+
+proto_library(
+    name = "ranker_job_service_proto",
+    srcs = ["ranker_job_service.proto"],
+    strip_import_prefix = IMPORT_PREFIX,
+    deps = [
+        ":ranker_job_proto",
+        ":ranker_state_proto",
+        "@com_google_googleapis//google/type:interval_proto",
+        "@com_google_protobuf//:timestamp_proto",
+    ],
+)
+
+kt_jvm_grpc_proto_library(
+    name = "ranker_job_service_kt_jvm_grpc_proto",
+    deps = [":ranker_job_service_proto"],
+)

--- a/src/main/proto/wfa/measurement/internal/edpaggregator/ranker_job.proto
+++ b/src/main/proto/wfa/measurement/internal/edpaggregator/ranker_job.proto
@@ -47,18 +47,15 @@ message RankerJob {
   // The processing state of this job.
   RankerState state = 6;
 
-  // The timestamp when processing completed (success or failure).
-  google.protobuf.Timestamp completion_time = 7;
-
   // The timestamp when this record was created.
-  google.protobuf.Timestamp create_time = 8;
+  google.protobuf.Timestamp create_time = 7;
 
   // The timestamp when this record was last updated.
-  google.protobuf.Timestamp update_time = 9;
+  google.protobuf.Timestamp update_time = 8;
 
   // Detail about the failure, set when state is FAILED.
-  string error_message = 10;
+  string error_message = 9;
 
   // Entity tag for optimistic concurrency control.
-  string etag = 11;
+  string etag = 10;
 }

--- a/src/main/proto/wfa/measurement/internal/edpaggregator/ranker_job.proto
+++ b/src/main/proto/wfa/measurement/internal/edpaggregator/ranker_job.proto
@@ -25,7 +25,7 @@ option java_outer_classname = "RankerJobProto";
 
 // Internal representation of a Phase-1 ranker job.
 // One row per (upload, model line, ranker job), pre-created by the
-// Phase-0 last-out trigger. The "last subpool out" of a (upload,
+// Phase-0 last-out trigger. The "last ranker job out" of a (upload,
 // model line) flips the parent RawImpressionUploadModelLine state
 // from RANKING to LABELING and triggers Phase 2.
 message RankerJob {
@@ -41,8 +41,8 @@ message RankerJob {
   // The CMMS model line resource name.
   string cmms_model_line = 4;
 
-  // The subpool IDs this ranker job is responsible for processing.
-  repeated int32 subpool_ids = 5;
+  // The pool offsets this ranker job is responsible for processing.
+  repeated int64 pool_offsets = 5;
 
   // The processing state of this job.
   RankerState state = 6;

--- a/src/main/proto/wfa/measurement/internal/edpaggregator/ranker_job.proto
+++ b/src/main/proto/wfa/measurement/internal/edpaggregator/ranker_job.proto
@@ -1,0 +1,64 @@
+// Copyright 2026 The Cross-Media Measurement Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package wfa.measurement.internal.edpaggregator;
+
+import "google/protobuf/timestamp.proto";
+import "wfa/measurement/internal/edpaggregator/ranker_state.proto";
+
+option java_package = "org.wfanet.measurement.internal.edpaggregator";
+option java_multiple_files = true;
+option java_outer_classname = "RankerJobProto";
+
+// Internal representation of a Phase-1 ranker job.
+// One row per (upload, model line, ranker job), pre-created by the
+// Phase-0 last-out trigger. The "last subpool out" of a (upload,
+// model line) flips the parent RawImpressionUploadModelLine state
+// from RANKING to LABELING and triggers Phase 2.
+message RankerJob {
+  // Resource ID of the DataProvider.
+  string data_provider_resource_id = 1;
+
+  // Resource ID of the parent upload.
+  string raw_impression_upload_resource_id = 2;
+
+  // Resource ID of this job.
+  string ranker_job_resource_id = 3;
+
+  // The CMMS model line resource name.
+  string cmms_model_line = 4;
+
+  // The subpool IDs this ranker job is responsible for processing.
+  repeated int32 subpool_ids = 5;
+
+  // The processing state of this job.
+  RankerState state = 6;
+
+  // The timestamp when processing completed (success or failure).
+  google.protobuf.Timestamp completion_time = 7;
+
+  // The timestamp when this record was created.
+  google.protobuf.Timestamp create_time = 8;
+
+  // The timestamp when this record was last updated.
+  google.protobuf.Timestamp update_time = 9;
+
+  // Detail about the failure, set when state is FAILED.
+  string error_message = 10;
+
+  // Entity tag for optimistic concurrency control.
+  string etag = 11;
+}

--- a/src/main/proto/wfa/measurement/internal/edpaggregator/ranker_job_service.proto
+++ b/src/main/proto/wfa/measurement/internal/edpaggregator/ranker_job_service.proto
@@ -40,11 +40,13 @@ service RankerJobService {
   // Lists `RankerJob` resources.
   rpc ListRankerJobs(ListRankerJobsRequest) returns (ListRankerJobsResponse);
 
-  // Marks a `RankerJob` as `SUCCEEDED`.
+  // Marks a `RankerJob` as `SUCCEEDED`. Throws
+  // FAILED_PRECONDITION if state is not CREATED or FAILED.
   rpc MarkRankerJobSucceeded(MarkRankerJobSucceededRequest)
       returns (MarkRankerJobSucceededResponse);
 
-  // Marks a `RankerJob` as `FAILED`.
+  // Marks a `RankerJob` as `FAILED`. Throws
+  // FAILED_PRECONDITION if state is not CREATED or FAILED.
   rpc MarkRankerJobFailed(MarkRankerJobFailedRequest) returns (RankerJob);
 }
 

--- a/src/main/proto/wfa/measurement/internal/edpaggregator/ranker_job_service.proto
+++ b/src/main/proto/wfa/measurement/internal/edpaggregator/ranker_job_service.proto
@@ -1,0 +1,190 @@
+// Copyright 2026 The Cross-Media Measurement Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package wfa.measurement.internal.edpaggregator;
+
+import "google/protobuf/timestamp.proto";
+import "google/type/interval.proto";
+import "wfa/measurement/internal/edpaggregator/ranker_job.proto";
+import "wfa/measurement/internal/edpaggregator/ranker_state.proto";
+
+option java_package = "org.wfanet.measurement.internal.edpaggregator";
+option java_multiple_files = true;
+option java_outer_classname = "RankerJobServiceProto";
+
+// Service for managing `RankerJob` resources.
+service RankerJobService {
+  // Creates a new `RankerJob`.
+  rpc CreateRankerJob(CreateRankerJobRequest) returns (RankerJob);
+
+  // Creates multiple `RankerJob` resources in a single request.
+  rpc BatchCreateRankerJobs(BatchCreateRankerJobsRequest)
+      returns (BatchCreateRankerJobsResponse);
+
+  // Retrieves a specific `RankerJob`.
+  rpc GetRankerJob(GetRankerJobRequest) returns (RankerJob);
+
+  // Lists `RankerJob` resources.
+  rpc ListRankerJobs(ListRankerJobsRequest) returns (ListRankerJobsResponse);
+
+  // Marks a `RankerJob` as `SUCCEEDED`.
+  rpc MarkRankerJobSucceeded(MarkRankerJobSucceededRequest)
+      returns (MarkRankerJobSucceededResponse);
+
+  // Marks a `RankerJob` as `FAILED`.
+  rpc MarkRankerJobFailed(MarkRankerJobFailedRequest) returns (RankerJob);
+}
+
+// Request message for CreateRankerJob.
+message CreateRankerJobRequest {
+  // Resource ID of the DataProvider.
+  string data_provider_resource_id = 1;
+
+  // Resource ID of the parent upload.
+  string raw_impression_upload_resource_id = 2;
+
+  // The RankerJob to create.
+  RankerJob ranker_job = 3;
+
+  // A request ID provided by the client to ensure idempotency.
+  string request_id = 4;
+}
+
+// Request message for BatchCreateRankerJobs.
+message BatchCreateRankerJobsRequest {
+  // Resource ID of the DataProvider.
+  string data_provider_resource_id = 1;
+
+  // Resource ID of the parent upload.
+  string raw_impression_upload_resource_id = 2;
+
+  // Individual create requests. Maximum 50 per batch.
+  repeated CreateRankerJobRequest requests = 3;
+}
+
+// Response message for BatchCreateRankerJobs.
+message BatchCreateRankerJobsResponse {
+  // The created ranker jobs.
+  repeated RankerJob ranker_jobs = 1;
+}
+
+// Request message for GetRankerJob.
+message GetRankerJobRequest {
+  // Resource ID of the DataProvider.
+  string data_provider_resource_id = 1;
+
+  // Resource ID of the parent upload.
+  string raw_impression_upload_resource_id = 2;
+
+  // Resource ID of this job.
+  string ranker_job_resource_id = 3;
+}
+
+// Request message for ListRankerJobs.
+message ListRankerJobsRequest {
+  // Resource ID of the DataProvider.
+  string data_provider_resource_id = 1;
+
+  // Resource ID of the parent upload.
+  string raw_impression_upload_resource_id = 2;
+
+  // The maximum number of results to return.
+  //
+  // If unspecified, at most 50 results will be returned.
+  // The maximum value is 100; values above this will be
+  // coerced to the maximum value.
+  int32 page_size = 3;
+
+  // Page token from a previous list call.
+  ListRankerJobsPageToken page_token = 4;
+
+  // Filter for narrowing results.
+  message Filter {
+    // Filter by processing state.
+    RankerState state = 1;
+
+    // Filter for resources whose create_time falls within this
+    // interval. Start and end are both optional: omitting start
+    // returns resources created before end, omitting end returns
+    // resources created after start.
+    google.type.Interval create_time_interval = 2;
+
+    // Filter by CMMS model line resource name.
+    string cmms_model_line = 3;
+  }
+  Filter filter = 5;
+}
+
+// Response message for ListRankerJobs.
+message ListRankerJobsResponse {
+  // The list of ranker jobs matching the request.
+  repeated RankerJob ranker_jobs = 1;
+
+  // A token to retrieve the next page of results.
+  ListRankerJobsPageToken next_page_token = 2;
+}
+
+// Page token for ListRankerJobs.
+message ListRankerJobsPageToken {
+  message After {
+    google.protobuf.Timestamp create_time = 1;
+    string ranker_job_resource_id = 2;
+  }
+  After after = 1;
+}
+
+// Request message for MarkRankerJobSucceeded.
+message MarkRankerJobSucceededRequest {
+  // Resource ID of the DataProvider.
+  string data_provider_resource_id = 1;
+
+  // Resource ID of the parent upload.
+  string raw_impression_upload_resource_id = 2;
+
+  // Resource ID of this job.
+  string ranker_job_resource_id = 3;
+
+  // Entity tag for optimistic concurrency control.
+  string etag = 4;
+}
+
+// Response message for MarkRankerJobSucceeded.
+message MarkRankerJobSucceededResponse {
+  // The updated RankerJob.
+  RankerJob ranker_job = 1;
+
+  // Whether this was the last ranker job to complete for the
+  // (upload, model line).
+  bool is_last_job = 2;
+}
+
+// Request message for MarkRankerJobFailed.
+message MarkRankerJobFailedRequest {
+  // Resource ID of the DataProvider.
+  string data_provider_resource_id = 1;
+
+  // Resource ID of the parent upload.
+  string raw_impression_upload_resource_id = 2;
+
+  // Resource ID of this job.
+  string ranker_job_resource_id = 3;
+
+  // Entity tag for optimistic concurrency control.
+  string etag = 4;
+
+  // Human-readable detail about the failure.
+  string error_message = 5;
+}

--- a/src/main/proto/wfa/measurement/internal/edpaggregator/ranker_state.proto
+++ b/src/main/proto/wfa/measurement/internal/edpaggregator/ranker_state.proto
@@ -1,0 +1,34 @@
+// Copyright 2026 The Cross-Media Measurement Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package wfa.measurement.internal.edpaggregator;
+
+option java_package = "org.wfanet.measurement.internal.edpaggregator";
+option java_multiple_files = true;
+option java_outer_classname = "RankerStateProto";
+
+// Processing state for a RankerJob.
+enum RankerState {
+  // Default, unspecified state. Should not be used.
+  RANKER_STATE_UNSPECIFIED = 0;
+  // The job has been created and is awaiting processing.
+  RANKER_STATE_CREATED = 1;
+  // The job completed successfully.
+  RANKER_STATE_SUCCEEDED = 2;
+  // The job failed. Not terminal — operator can retry after
+  // fixing the root cause.
+  RANKER_STATE_FAILED = 3;
+}

--- a/src/main/proto/wfa/measurement/internal/edpaggregator/ranker_state.proto
+++ b/src/main/proto/wfa/measurement/internal/edpaggregator/ranker_state.proto
@@ -26,7 +26,7 @@ enum RankerState {
   RANKER_STATE_UNSPECIFIED = 0;
   // The job has been created and is awaiting processing.
   RANKER_STATE_CREATED = 1;
-  // The job completed successfully.
+  // The job completed successfully. Terminal state.
   RANKER_STATE_SUCCEEDED = 2;
   // The job failed. Not terminal — operator can retry after
   // fixing the root cause.


### PR DESCRIPTION
## Summary
- Add proto message and service definitions for RankerJob, a Phase-1 ranker job resource for the VID labeling pipeline.
- Includes create, batch create, get, list, MarkSucceeded (custom response with is_last_job), and MarkFailed methods for both internal and public (v1alpha) APIs.
- State enum: CREATED, SUCCEEDED, FAILED (not terminal — operator can retry).
- cmms_model_line as REQUIRED+IMMUTABLE field with resource_reference to halo.wfanet.org/ModelLine.
- subpool_ids (repeated int32) for the subpools this ranker job processes.
- etag for optimistic concurrency control on Mark requests.
- AIP-159 wildcard support on List parent with cmms_model_line filter for cross-upload queries.

## Test plan
- bazel build passes for all proto targets (internal state, internal message, internal service, public message, public service)

Closes: #3896
Issue: #3896