### PR TITLE
feat: Add RankIndexBlob proto definitions for internal and public API

### DIFF
--- a/src/main/proto/wfa/measurement/edpaggregator/v1alpha/BUILD.bazel
+++ b/src/main/proto/wfa/measurement/edpaggregator/v1alpha/BUILD.bazel
@@ -426,6 +426,7 @@ proto_library(
     srcs = ["rank_index_blob.proto"],
     strip_import_prefix = _IMPORT_PREFIX,
     deps = [
+        ":encrypted_dek_proto",
         "@com_google_googleapis//google/api:field_behavior_proto",
         "@com_google_googleapis//google/api:resource_proto",
         "@com_google_googleapis//google/type:date_proto",

--- a/src/main/proto/wfa/measurement/edpaggregator/v1alpha/BUILD.bazel
+++ b/src/main/proto/wfa/measurement/edpaggregator/v1alpha/BUILD.bazel
@@ -448,7 +448,6 @@ proto_library(
         "@com_google_googleapis//google/api:field_info_proto",
         "@com_google_googleapis//google/api:resource_proto",
         "@com_google_googleapis//google/type:date_proto",
-        "@com_google_protobuf//:wrappers_proto",
     ],
 )
 

--- a/src/main/proto/wfa/measurement/edpaggregator/v1alpha/BUILD.bazel
+++ b/src/main/proto/wfa/measurement/edpaggregator/v1alpha/BUILD.bazel
@@ -422,6 +422,41 @@ kt_jvm_grpc_proto_library(
 )
 
 proto_library(
+    name = "rank_index_blob_proto",
+    srcs = ["rank_index_blob.proto"],
+    strip_import_prefix = _IMPORT_PREFIX,
+    deps = [
+        "@com_google_googleapis//google/api:field_behavior_proto",
+        "@com_google_googleapis//google/api:resource_proto",
+        "@com_google_googleapis//google/type:date_proto",
+        "@com_google_protobuf//:timestamp_proto",
+    ],
+)
+
+kt_jvm_proto_library(
+    name = "rank_index_blob_kt_jvm_proto",
+    deps = [":rank_index_blob_proto"],
+)
+
+proto_library(
+    name = "rank_index_blob_service_proto",
+    srcs = ["rank_index_blob_service.proto"],
+    strip_import_prefix = _IMPORT_PREFIX,
+    deps = [
+        ":rank_index_blob_proto",
+        "@com_google_googleapis//google/api:field_behavior_proto",
+        "@com_google_googleapis//google/api:field_info_proto",
+        "@com_google_googleapis//google/api:resource_proto",
+        "@com_google_googleapis//google/type:date_proto",
+    ],
+)
+
+kt_jvm_grpc_proto_library(
+    name = "rank_index_blob_service_kt_jvm_grpc_proto",
+    deps = [":rank_index_blob_service_proto"],
+)
+
+proto_library(
     name = "rank_index_map_proto",
     srcs = ["rank_index_map.proto"],
     strip_import_prefix = _IMPORT_PREFIX,

--- a/src/main/proto/wfa/measurement/edpaggregator/v1alpha/BUILD.bazel
+++ b/src/main/proto/wfa/measurement/edpaggregator/v1alpha/BUILD.bazel
@@ -448,6 +448,7 @@ proto_library(
         "@com_google_googleapis//google/api:field_info_proto",
         "@com_google_googleapis//google/api:resource_proto",
         "@com_google_googleapis//google/type:date_proto",
+        "@com_google_protobuf//:wrappers_proto",
     ],
 )
 

--- a/src/main/proto/wfa/measurement/edpaggregator/v1alpha/rank_index_blob.proto
+++ b/src/main/proto/wfa/measurement/edpaggregator/v1alpha/rank_index_blob.proto
@@ -66,8 +66,8 @@ message RankIndexBlob {
     (google.api.resource_reference) = { type: "halo.wfanet.org/ModelLine" }
   ];
 
-  // The subpool ID this blob belongs to.
-  int32 subpool_id = 4 [
+  // The pool offset this blob belongs to.
+  int64 pool_offset = 4 [
     (google.api.field_behavior) = REQUIRED,
     (google.api.field_behavior) = IMMUTABLE
   ];

--- a/src/main/proto/wfa/measurement/edpaggregator/v1alpha/rank_index_blob.proto
+++ b/src/main/proto/wfa/measurement/edpaggregator/v1alpha/rank_index_blob.proto
@@ -20,6 +20,7 @@ import "google/api/field_behavior.proto";
 import "google/api/resource.proto";
 import "google/protobuf/timestamp.proto";
 import "google/type/date.proto";
+import "wfa/measurement/edpaggregator/v1alpha/encrypted_dek.proto";
 
 option java_package = "org.wfanet.measurement.edpaggregator.v1alpha";
 option java_multiple_files = true;
@@ -85,9 +86,8 @@ message RankIndexBlob {
     (google.api.field_behavior) = IMMUTABLE
   ];
 
-  // The encrypted data encryption key (DEK) used to encrypt
-  // the blob, itself encrypted via the DataProvider's KMS.
-  bytes encrypted_dek = 7 [
+  // The encrypted data encryption key (DEK) for this blob.
+  wfa.measurement.securecomputation.impressions.EncryptedDek encrypted_dek = 7 [
     (google.api.field_behavior) = REQUIRED,
     (google.api.field_behavior) = IMMUTABLE
   ];

--- a/src/main/proto/wfa/measurement/edpaggregator/v1alpha/rank_index_blob.proto
+++ b/src/main/proto/wfa/measurement/edpaggregator/v1alpha/rank_index_blob.proto
@@ -78,26 +78,33 @@ message RankIndexBlob {
     (google.api.field_behavior) = IMMUTABLE
   ];
 
+  // SHA-256 checksum of the plaintext blob payload. Used to
+  // detect corruption after decryption.
+  bytes blob_checksum = 6 [
+    (google.api.field_behavior) = OPTIONAL,
+    (google.api.field_behavior) = IMMUTABLE
+  ];
+
   // The encrypted data encryption key (DEK) used to encrypt
   // the blob, itself encrypted via the DataProvider's KMS.
-  bytes encrypted_dek = 6 [
+  bytes encrypted_dek = 7 [
     (google.api.field_behavior) = REQUIRED,
     (google.api.field_behavior) = IMMUTABLE
   ];
 
   // The newest event date among the impressions in this blob.
   // Only set for DAY_ONLY blobs; unset for SNAPSHOT blobs.
-  google.type.Date max_event_date = 7 [
+  google.type.Date max_event_date = 8 [
     (google.api.field_behavior) = OPTIONAL,
     (google.api.field_behavior) = IMMUTABLE
   ];
 
   // The timestamp when this record was created.
-  google.protobuf.Timestamp create_time = 8
+  google.protobuf.Timestamp create_time = 9
       [(google.api.field_behavior) = OUTPUT_ONLY];
 
   // The timestamp when this blob was soft-deleted.
   // Only populated if the blob has been deleted.
-  google.protobuf.Timestamp delete_time = 9
+  google.protobuf.Timestamp delete_time = 10
       [(google.api.field_behavior) = OUTPUT_ONLY];
 }

--- a/src/main/proto/wfa/measurement/edpaggregator/v1alpha/rank_index_blob.proto
+++ b/src/main/proto/wfa/measurement/edpaggregator/v1alpha/rank_index_blob.proto
@@ -1,0 +1,103 @@
+// Copyright 2026 The Cross-Media Measurement Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package wfa.measurement.edpaggregator.v1alpha;
+
+import "google/api/field_behavior.proto";
+import "google/api/resource.proto";
+import "google/protobuf/timestamp.proto";
+import "google/type/date.proto";
+
+option java_package = "org.wfanet.measurement.edpaggregator.v1alpha";
+option java_multiple_files = true;
+option java_outer_classname = "RankIndexBlobProto";
+
+// A pointer to a rank index blob in Cloud Storage, with its
+// encrypted DEK. Two rows per (upload, model line, subpool):
+// one DAY_ONLY and one SNAPSHOT. Snapshots are replaced each
+// upload; day-only blobs persist until aged out by the
+// retention policy.
+message RankIndexBlob {
+  option (google.api.resource) = {
+    type: "edpaggregator.halo-cmm.org/RankIndexBlob"
+    pattern: "dataProviders/{data_provider}/rawImpressionUploads/{raw_impression_upload}/rankIndexBlobs/{rank_index_blob}"
+    singular: "rankIndexBlob"
+    plural: "rankIndexBlobs"
+  };
+
+  // The type of rank index blob.
+  enum BlobType {
+    // Default, unspecified type. Should not be used.
+    BLOB_TYPE_UNSPECIFIED = 0;
+    // Contains only fingerprints seen during this dispatch.
+    // Used for renewal tracking and deletion bookkeeping.
+    DAY_ONLY = 1;
+    // Contains the full cumulative set of fingerprints with
+    // assigned ranks for this subpool.
+    SNAPSHOT = 2;
+  }
+
+  // Resource name.
+  string name = 1 [(google.api.field_behavior) = IDENTIFIER];
+
+  // The type of this blob.
+  BlobType blob_type = 2 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.field_behavior) = IMMUTABLE
+  ];
+
+  // The CMMS model line resource name that this blob belongs to.
+  string cmms_model_line = 3 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.field_behavior) = IMMUTABLE,
+    (google.api.resource_reference) = { type: "halo.wfanet.org/ModelLine" }
+  ];
+
+  // The subpool ID this blob belongs to.
+  int32 subpool_id = 4 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.field_behavior) = IMMUTABLE
+  ];
+
+  // Cloud Storage URI of the rank index blob.
+  string blob_uri = 5 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.field_behavior) = IMMUTABLE
+  ];
+
+  // The encrypted data encryption key (DEK) used to encrypt
+  // the blob, itself encrypted via the DataProvider's KMS.
+  bytes encrypted_dek = 6 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.field_behavior) = IMMUTABLE
+  ];
+
+  // The newest event date among the impressions in this blob.
+  // Only set for DAY_ONLY blobs; unset for SNAPSHOT blobs.
+  google.type.Date max_event_date = 7 [
+    (google.api.field_behavior) = OPTIONAL,
+    (google.api.field_behavior) = IMMUTABLE
+  ];
+
+  // The timestamp when this record was created.
+  google.protobuf.Timestamp create_time = 8
+      [(google.api.field_behavior) = OUTPUT_ONLY];
+
+  // The timestamp when this blob was soft-deleted.
+  // Only populated if the blob has been deleted.
+  google.protobuf.Timestamp delete_time = 9
+      [(google.api.field_behavior) = OUTPUT_ONLY];
+}

--- a/src/main/proto/wfa/measurement/edpaggregator/v1alpha/rank_index_blob_service.proto
+++ b/src/main/proto/wfa/measurement/edpaggregator/v1alpha/rank_index_blob_service.proto
@@ -155,6 +155,9 @@ message ListRankIndexBlobsRequest {
 
     // Filter for blobs with max_event_date on or before this
     // date. Used for retention policy queries.
+    // (-- api-linter: core::0140::prepositions=disabled
+    //     aip.dev/not-precedent: Using verb suffix per newer
+    //     API conventions. --)
     google.type.Date max_event_date_before = 4
         [(google.api.field_behavior) = OPTIONAL];
   }

--- a/src/main/proto/wfa/measurement/edpaggregator/v1alpha/rank_index_blob_service.proto
+++ b/src/main/proto/wfa/measurement/edpaggregator/v1alpha/rank_index_blob_service.proto
@@ -19,7 +19,6 @@ package wfa.measurement.edpaggregator.v1alpha;
 import "google/api/field_behavior.proto";
 import "google/api/field_info.proto";
 import "google/api/resource.proto";
-import "google/protobuf/wrappers.proto";
 import "google/type/date.proto";
 import "wfa/measurement/edpaggregator/v1alpha/rank_index_blob.proto";
 
@@ -46,6 +45,10 @@ service RankIndexBlobService {
 
   // Soft-deletes a `RankIndexBlob`.
   rpc DeleteRankIndexBlob(DeleteRankIndexBlobRequest) returns (RankIndexBlob) {}
+
+  // Soft-deletes multiple `RankIndexBlob` resources.
+  rpc BatchDeleteRankIndexBlobs(BatchDeleteRankIndexBlobsRequest)
+      returns (BatchDeleteRankIndexBlobsResponse) {}
 }
 
 // Request message for the `CreateRankIndexBlob` method.
@@ -151,10 +154,8 @@ message ListRankIndexBlobsRequest {
       (google.api.resource_reference) = { type: "halo.wfanet.org/ModelLine" }
     ];
 
-    // Filter by subpool ID. Uses wrapper type because 0 is
-    // a valid subpool ID.
-    google.protobuf.Int32Value subpool_id = 3
-        [(google.api.field_behavior) = OPTIONAL];
+    // Filter by subpool ID.
+    optional int32 subpool_id = 3 [(google.api.field_behavior) = OPTIONAL];
 
     // Filter for blobs with max_event_date on or before
     // this value. Used for retention policy queries.

--- a/src/main/proto/wfa/measurement/edpaggregator/v1alpha/rank_index_blob_service.proto
+++ b/src/main/proto/wfa/measurement/edpaggregator/v1alpha/rank_index_blob_service.proto
@@ -1,0 +1,189 @@
+// Copyright 2026 The Cross-Media Measurement Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package wfa.measurement.edpaggregator.v1alpha;
+
+import "google/api/field_behavior.proto";
+import "google/api/field_info.proto";
+import "google/api/resource.proto";
+import "google/type/date.proto";
+import "wfa/measurement/edpaggregator/v1alpha/rank_index_blob.proto";
+
+option java_package = "org.wfanet.measurement.edpaggregator.v1alpha";
+option java_multiple_files = true;
+option java_outer_classname = "RankIndexBlobServiceProto";
+
+// Service for managing `RankIndexBlob` resources.
+service RankIndexBlobService {
+  // Creates a new `RankIndexBlob`.
+  rpc CreateRankIndexBlob(CreateRankIndexBlobRequest) returns (RankIndexBlob) {}
+
+  // Creates multiple `RankIndexBlob` resources in a single
+  // request.
+  rpc BatchCreateRankIndexBlobs(BatchCreateRankIndexBlobsRequest)
+      returns (BatchCreateRankIndexBlobsResponse) {}
+
+  // Retrieves a specific `RankIndexBlob`.
+  rpc GetRankIndexBlob(GetRankIndexBlobRequest) returns (RankIndexBlob) {}
+
+  // Lists `RankIndexBlob` resources for an upload.
+  rpc ListRankIndexBlobs(ListRankIndexBlobsRequest)
+      returns (ListRankIndexBlobsResponse) {}
+
+  // Soft-deletes a `RankIndexBlob`.
+  rpc DeleteRankIndexBlob(DeleteRankIndexBlobRequest) returns (RankIndexBlob) {}
+}
+
+// Request message for the `CreateRankIndexBlob` method.
+message CreateRankIndexBlobRequest {
+  // The parent upload resource name.
+  // Format:
+  // `dataProviders/{data_provider}/rawImpressionUploads/{raw_impression_upload}`
+  string parent = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference) = {
+      child_type: "edpaggregator.halo-cmm.org/RankIndexBlob"
+    }
+  ];
+
+  // The `RankIndexBlob` to create.
+  // The `name` and output-only fields are ignored.
+  RankIndexBlob rank_index_blob = 2 [(google.api.field_behavior) = REQUIRED];
+
+  // A request ID provided by the client to ensure idempotency.
+  //
+  // This field must be a UUID4 (RFC 4122) string.
+  string request_id = 3 [
+    (google.api.field_behavior) = OPTIONAL,
+    (google.api.field_info).format = UUID4
+  ];
+}
+
+// Request message for the
+// `BatchCreateRankIndexBlobs` method.
+message BatchCreateRankIndexBlobsRequest {
+  // The parent upload resource name.
+  // Format:
+  // `dataProviders/{data_provider}/rawImpressionUploads/{raw_impression_upload}`
+  string parent = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference) = {
+      child_type: "edpaggregator.halo-cmm.org/RankIndexBlob"
+    }
+  ];
+
+  // Individual create requests. Maximum 50 per batch.
+  repeated CreateRankIndexBlobRequest requests = 2
+      [(google.api.field_behavior) = REQUIRED];
+}
+
+// Response message for the
+// `BatchCreateRankIndexBlobs` method.
+message BatchCreateRankIndexBlobsResponse {
+  // The created rank index blobs.
+  repeated RankIndexBlob rank_index_blobs = 1;
+}
+
+// Request message for the `GetRankIndexBlob` method.
+message GetRankIndexBlobRequest {
+  // The resource name of the blob to retrieve.
+  // Format:
+  // `dataProviders/{data_provider}/rawImpressionUploads/{raw_impression_upload}/rankIndexBlobs/{rank_index_blob}`
+  string name = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference) = {
+      type: "edpaggregator.halo-cmm.org/RankIndexBlob"
+    }
+  ];
+}
+
+// Request message for the `ListRankIndexBlobs` method.
+// (-- api-linter: core::0132::request-field-types=disabled
+//     aip.dev/not-precedent: Using a customized message for the
+//     filter. --)
+message ListRankIndexBlobsRequest {
+  // The parent upload resource name.
+  // Format:
+  // `dataProviders/{data_provider}/rawImpressionUploads/{raw_impression_upload}`
+  //
+  // The upload segment may be the wildcard `-` to list
+  // blobs across all uploads for a data provider. See
+  // AIP-159.
+  string parent = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference) = {
+      child_type: "edpaggregator.halo-cmm.org/RankIndexBlob"
+    }
+  ];
+
+  // The maximum number of results to return.
+  int32 page_size = 2 [(google.api.field_behavior) = OPTIONAL];
+
+  // A page token, received from a previous call.
+  string page_token = 3 [(google.api.field_behavior) = OPTIONAL];
+
+  // Structured filter for narrowing results.
+  message Filter {
+    // Filter by blob type.
+    // (-- api-linter: core::0216::state-field-output-only=disabled
+    //     aip.dev/not-precedent: This is a filter input field, not
+    //     a resource state field. --)
+    RankIndexBlob.BlobType blob_type = 1
+        [(google.api.field_behavior) = OPTIONAL];
+
+    // Filter by CMMS model line resource name.
+    string cmms_model_line = 2 [
+      (google.api.field_behavior) = OPTIONAL,
+      (google.api.resource_reference) = { type: "halo.wfanet.org/ModelLine" }
+    ];
+
+    // Filter by subpool ID.
+    int32 subpool_id = 3 [(google.api.field_behavior) = OPTIONAL];
+
+    // Filter for blobs with max_event_date on or before this
+    // date. Used for retention policy queries.
+    google.type.Date max_event_date_before = 4
+        [(google.api.field_behavior) = OPTIONAL];
+  }
+
+  // Optional. A filter to apply to the results.
+  Filter filter = 4 [(google.api.field_behavior) = OPTIONAL];
+
+  // Whether to include soft-deleted entries.
+  bool show_deleted = 5 [(google.api.field_behavior) = OPTIONAL];
+}
+
+// Response message for the `ListRankIndexBlobs` method.
+message ListRankIndexBlobsResponse {
+  // The list of rank index blobs matching the request.
+  repeated RankIndexBlob rank_index_blobs = 1;
+
+  // A token to retrieve the next page of results.
+  string next_page_token = 2;
+}
+
+// Request message for the `DeleteRankIndexBlob` method.
+message DeleteRankIndexBlobRequest {
+  // The resource name of the blob to delete.
+  // Format:
+  // `dataProviders/{data_provider}/rawImpressionUploads/{raw_impression_upload}/rankIndexBlobs/{rank_index_blob}`
+  string name = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference) = {
+      type: "edpaggregator.halo-cmm.org/RankIndexBlob"
+    }
+  ];
+}

--- a/src/main/proto/wfa/measurement/edpaggregator/v1alpha/rank_index_blob_service.proto
+++ b/src/main/proto/wfa/measurement/edpaggregator/v1alpha/rank_index_blob_service.proto
@@ -154,7 +154,7 @@ message ListRankIndexBlobsRequest {
       (google.api.resource_reference) = { type: "halo.wfanet.org/ModelLine" }
     ];
 
-    // Filter by subpool ID.
+    // Filter by subpool ID. Optional because 0 is a valid subpool ID.
     optional int32 subpool_id = 3 [(google.api.field_behavior) = OPTIONAL];
 
     // Filter for blobs with max_event_date on or before

--- a/src/main/proto/wfa/measurement/edpaggregator/v1alpha/rank_index_blob_service.proto
+++ b/src/main/proto/wfa/measurement/edpaggregator/v1alpha/rank_index_blob_service.proto
@@ -159,11 +159,14 @@ message ListRankIndexBlobsRequest {
 
     // Filter for blobs with max_event_date on or before
     // this value. Used for retention policy queries.
-    google.type.Date max_event_date_cutoff = 4
+    // (-- api-linter: core::0140::prepositions=disabled
+    //     aip.dev/not-precedent: Explicit semantics for
+    //     date comparison filter. --)
+    google.type.Date max_event_date_on_or_before = 4
         [(google.api.field_behavior) = OPTIONAL];
   }
 
-  // Optional. A filter to apply to the results.
+  // A filter to apply to the results.
   Filter filter = 4 [(google.api.field_behavior) = OPTIONAL];
 
   // Whether to include soft-deleted entries.

--- a/src/main/proto/wfa/measurement/edpaggregator/v1alpha/rank_index_blob_service.proto
+++ b/src/main/proto/wfa/measurement/edpaggregator/v1alpha/rank_index_blob_service.proto
@@ -154,8 +154,8 @@ message ListRankIndexBlobsRequest {
       (google.api.resource_reference) = { type: "halo.wfanet.org/ModelLine" }
     ];
 
-    // Filter by subpool ID. Optional because 0 is a valid subpool ID.
-    optional int32 subpool_id = 3 [(google.api.field_behavior) = OPTIONAL];
+    // Filter by pool offset. Optional because 0 is a valid pool offset.
+    optional int64 pool_offset = 3 [(google.api.field_behavior) = OPTIONAL];
 
     // Filter for blobs with max_event_date on or before
     // this value. Used for retention policy queries.

--- a/src/main/proto/wfa/measurement/edpaggregator/v1alpha/rank_index_blob_service.proto
+++ b/src/main/proto/wfa/measurement/edpaggregator/v1alpha/rank_index_blob_service.proto
@@ -19,6 +19,7 @@ package wfa.measurement.edpaggregator.v1alpha;
 import "google/api/field_behavior.proto";
 import "google/api/field_info.proto";
 import "google/api/resource.proto";
+import "google/protobuf/wrappers.proto";
 import "google/type/date.proto";
 import "wfa/measurement/edpaggregator/v1alpha/rank_index_blob.proto";
 
@@ -150,8 +151,10 @@ message ListRankIndexBlobsRequest {
       (google.api.resource_reference) = { type: "halo.wfanet.org/ModelLine" }
     ];
 
-    // Filter by subpool ID.
-    int32 subpool_id = 3 [(google.api.field_behavior) = OPTIONAL];
+    // Filter by subpool ID. Uses wrapper type because 0 is
+    // a valid subpool ID.
+    google.protobuf.Int32Value subpool_id = 3
+        [(google.api.field_behavior) = OPTIONAL];
 
     // Filter for blobs with max_event_date on or before
     // this value. Used for retention policy queries.
@@ -186,4 +189,27 @@ message DeleteRankIndexBlobRequest {
       type: "edpaggregator.halo-cmm.org/RankIndexBlob"
     }
   ];
+}
+
+// Request message for the `BatchDeleteRankIndexBlobs` method.
+message BatchDeleteRankIndexBlobsRequest {
+  // The parent upload resource name.
+  // Format:
+  // `dataProviders/{data_provider}/rawImpressionUploads/{raw_impression_upload}`
+  string parent = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference) = {
+      child_type: "edpaggregator.halo-cmm.org/RankIndexBlob"
+    }
+  ];
+
+  // Individual delete requests. Maximum 1000 per batch.
+  repeated DeleteRankIndexBlobRequest requests = 2
+      [(google.api.field_behavior) = REQUIRED];
+}
+
+// Response message for the `BatchDeleteRankIndexBlobs` method.
+message BatchDeleteRankIndexBlobsResponse {
+  // The deleted rank index blobs.
+  repeated RankIndexBlob rank_index_blobs = 1;
 }

--- a/src/main/proto/wfa/measurement/edpaggregator/v1alpha/rank_index_blob_service.proto
+++ b/src/main/proto/wfa/measurement/edpaggregator/v1alpha/rank_index_blob_service.proto
@@ -153,12 +153,9 @@ message ListRankIndexBlobsRequest {
     // Filter by subpool ID.
     int32 subpool_id = 3 [(google.api.field_behavior) = OPTIONAL];
 
-    // Filter for blobs with max_event_date on or before this
-    // date. Used for retention policy queries.
-    // (-- api-linter: core::0140::prepositions=disabled
-    //     aip.dev/not-precedent: Using verb suffix per newer
-    //     API conventions. --)
-    google.type.Date max_event_date_before = 4
+    // Filter for blobs with max_event_date on or before
+    // this value. Used for retention policy queries.
+    google.type.Date max_event_date_cutoff = 4
         [(google.api.field_behavior) = OPTIONAL];
   }
 

--- a/src/main/proto/wfa/measurement/internal/edpaggregator/BUILD.bazel
+++ b/src/main/proto/wfa/measurement/internal/edpaggregator/BUILD.bazel
@@ -427,6 +427,7 @@ proto_library(
         ":rank_index_blob_proto",
         "@com_google_googleapis//google/type:date_proto",
         "@com_google_protobuf//:timestamp_proto",
+        "@com_google_protobuf//:wrappers_proto",
     ],
 )
 

--- a/src/main/proto/wfa/measurement/internal/edpaggregator/BUILD.bazel
+++ b/src/main/proto/wfa/measurement/internal/edpaggregator/BUILD.bazel
@@ -427,7 +427,6 @@ proto_library(
         ":rank_index_blob_proto",
         "@com_google_googleapis//google/type:date_proto",
         "@com_google_protobuf//:timestamp_proto",
-        "@com_google_protobuf//:wrappers_proto",
     ],
 )
 

--- a/src/main/proto/wfa/measurement/internal/edpaggregator/BUILD.bazel
+++ b/src/main/proto/wfa/measurement/internal/edpaggregator/BUILD.bazel
@@ -390,3 +390,47 @@ kt_jvm_grpc_proto_library(
     name = "pool_assignment_job_service_kt_jvm_grpc_proto",
     deps = [":pool_assignment_job_service_proto"],
 )
+
+proto_library(
+    name = "blob_type_proto",
+    srcs = ["blob_type.proto"],
+    strip_import_prefix = IMPORT_PREFIX,
+)
+
+kt_jvm_proto_library(
+    name = "blob_type_kt_jvm_proto",
+    deps = [":blob_type_proto"],
+)
+
+proto_library(
+    name = "rank_index_blob_proto",
+    srcs = ["rank_index_blob.proto"],
+    strip_import_prefix = IMPORT_PREFIX,
+    deps = [
+        ":blob_type_proto",
+        "@com_google_googleapis//google/type:date_proto",
+        "@com_google_protobuf//:timestamp_proto",
+    ],
+)
+
+kt_jvm_proto_library(
+    name = "rank_index_blob_kt_jvm_proto",
+    deps = [":rank_index_blob_proto"],
+)
+
+proto_library(
+    name = "rank_index_blob_service_proto",
+    srcs = ["rank_index_blob_service.proto"],
+    strip_import_prefix = IMPORT_PREFIX,
+    deps = [
+        ":blob_type_proto",
+        ":rank_index_blob_proto",
+        "@com_google_googleapis//google/type:date_proto",
+        "@com_google_protobuf//:timestamp_proto",
+    ],
+)
+
+kt_jvm_grpc_proto_library(
+    name = "rank_index_blob_service_kt_jvm_grpc_proto",
+    deps = [":rank_index_blob_service_proto"],
+)

--- a/src/main/proto/wfa/measurement/internal/edpaggregator/BUILD.bazel
+++ b/src/main/proto/wfa/measurement/internal/edpaggregator/BUILD.bazel
@@ -392,6 +392,17 @@ kt_jvm_grpc_proto_library(
 )
 
 proto_library(
+    name = "encrypted_dek_proto",
+    srcs = ["encrypted_dek.proto"],
+    strip_import_prefix = IMPORT_PREFIX,
+)
+
+kt_jvm_proto_library(
+    name = "encrypted_dek_kt_jvm_proto",
+    deps = [":encrypted_dek_proto"],
+)
+
+proto_library(
     name = "blob_type_proto",
     srcs = ["blob_type.proto"],
     strip_import_prefix = IMPORT_PREFIX,
@@ -408,6 +419,7 @@ proto_library(
     strip_import_prefix = IMPORT_PREFIX,
     deps = [
         ":blob_type_proto",
+        ":encrypted_dek_proto",
         "@com_google_googleapis//google/type:date_proto",
         "@com_google_protobuf//:timestamp_proto",
     ],

--- a/src/main/proto/wfa/measurement/internal/edpaggregator/blob_type.proto
+++ b/src/main/proto/wfa/measurement/internal/edpaggregator/blob_type.proto
@@ -1,0 +1,32 @@
+// Copyright 2026 The Cross-Media Measurement Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package wfa.measurement.internal.edpaggregator;
+
+option java_package = "org.wfanet.measurement.internal.edpaggregator";
+option java_multiple_files = true;
+option java_outer_classname = "BlobTypeProto";
+
+// The type of rank index blob.
+enum BlobType {
+  // Default, unspecified type. Should not be used.
+  BLOB_TYPE_UNSPECIFIED = 0;
+  // Contains only fingerprints seen during this dispatch.
+  BLOB_TYPE_DAY_ONLY = 1;
+  // Contains the full cumulative set of fingerprints with
+  // assigned ranks for this subpool.
+  BLOB_TYPE_SNAPSHOT = 2;
+}

--- a/src/main/proto/wfa/measurement/internal/edpaggregator/encrypted_dek.proto
+++ b/src/main/proto/wfa/measurement/internal/edpaggregator/encrypted_dek.proto
@@ -1,0 +1,44 @@
+// Copyright 2026 The Cross-Media Measurement Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+syntax = "proto3";
+
+package wfa.measurement.internal.edpaggregator;
+
+option java_package = "org.wfanet.measurement.internal.edpaggregator";
+option java_multiple_files = true;
+option java_outer_classname = "EncryptedDekProto";
+
+// Encrypted data encryption key (DEK).
+message EncryptedDek {
+  // The URI for the key encryption key used with KMS.
+  string kek_uri = 1;
+
+  // Protobuf type URL of the serialized key.
+  string type_url = 2;
+
+  // Supported Protobuf format.
+  enum ProtobufFormat {
+    // Default value.
+    PROTOBUF_FORMAT_UNSPECIFIED = 0;
+    // Binary protobuf format.
+    BINARY = 1;
+    // JSON protobuf format.
+    JSON = 2;
+  }
+  ProtobufFormat protobuf_format = 3;
+
+  // DEK ciphertext encrypted with kek_uri.
+  bytes ciphertext = 4;
+}

--- a/src/main/proto/wfa/measurement/internal/edpaggregator/rank_index_blob.proto
+++ b/src/main/proto/wfa/measurement/internal/edpaggregator/rank_index_blob.proto
@@ -44,8 +44,8 @@ message RankIndexBlob {
   // The type of rank index blob.
   BlobType blob_type = 5;
 
-  // The subpool ID this blob belongs to.
-  int32 subpool_id = 6;
+  // The pool offset this blob belongs to.
+  int64 pool_offset = 6;
 
   // Cloud Storage URI of the rank index blob.
   string blob_uri = 7;

--- a/src/main/proto/wfa/measurement/internal/edpaggregator/rank_index_blob.proto
+++ b/src/main/proto/wfa/measurement/internal/edpaggregator/rank_index_blob.proto
@@ -54,8 +54,7 @@ message RankIndexBlob {
   // detect corruption after decryption.
   bytes blob_checksum = 8;
 
-  // The encrypted data encryption key (DEK) used to encrypt
-  // the blob, itself encrypted via the DataProvider's KMS.
+  // Serialized EncryptedDek for this blob.
   bytes encrypted_dek = 9;
 
   // The newest event date among the impressions in this blob.

--- a/src/main/proto/wfa/measurement/internal/edpaggregator/rank_index_blob.proto
+++ b/src/main/proto/wfa/measurement/internal/edpaggregator/rank_index_blob.proto
@@ -1,0 +1,66 @@
+// Copyright 2026 The Cross-Media Measurement Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package wfa.measurement.internal.edpaggregator;
+
+import "google/protobuf/timestamp.proto";
+import "google/type/date.proto";
+import "wfa/measurement/internal/edpaggregator/blob_type.proto";
+
+option java_package = "org.wfanet.measurement.internal.edpaggregator";
+option java_multiple_files = true;
+option java_outer_classname = "RankIndexBlobProto";
+
+// Internal representation of a rank index blob pointer.
+// Two rows per (upload, model line, subpool): one DAY_ONLY and one
+// SNAPSHOT. Snapshots are replaced each upload; day-only blobs
+// persist until aged out by the retention policy.
+message RankIndexBlob {
+  // Resource ID of the DataProvider.
+  string data_provider_resource_id = 1;
+
+  // Resource ID of the parent upload.
+  string raw_impression_upload_resource_id = 2;
+
+  // Resource ID of this blob.
+  string rank_index_blob_resource_id = 3;
+
+  // The CMMS model line resource name.
+  string cmms_model_line = 4;
+
+  // The type of rank index blob.
+  BlobType blob_type = 5;
+
+  // The subpool ID this blob belongs to.
+  int32 subpool_id = 6;
+
+  // Cloud Storage URI of the rank index blob.
+  string blob_uri = 7;
+
+  // The encrypted data encryption key (DEK) used to encrypt
+  // the blob, itself encrypted via the DataProvider's KMS.
+  bytes encrypted_dek = 8;
+
+  // The newest event date among the impressions in this blob.
+  // NULL for SNAPSHOT blobs, set for DAY_ONLY blobs.
+  google.type.Date max_event_date = 9;
+
+  // The timestamp when this record was created.
+  google.protobuf.Timestamp create_time = 10;
+
+  // The timestamp when this blob was soft-deleted.
+  google.protobuf.Timestamp delete_time = 11;
+}

--- a/src/main/proto/wfa/measurement/internal/edpaggregator/rank_index_blob.proto
+++ b/src/main/proto/wfa/measurement/internal/edpaggregator/rank_index_blob.proto
@@ -19,6 +19,7 @@ package wfa.measurement.internal.edpaggregator;
 import "google/protobuf/timestamp.proto";
 import "google/type/date.proto";
 import "wfa/measurement/internal/edpaggregator/blob_type.proto";
+import "wfa/measurement/internal/edpaggregator/encrypted_dek.proto";
 
 option java_package = "org.wfanet.measurement.internal.edpaggregator";
 option java_multiple_files = true;
@@ -54,8 +55,8 @@ message RankIndexBlob {
   // detect corruption after decryption.
   bytes blob_checksum = 8;
 
-  // Serialized EncryptedDek for this blob.
-  bytes encrypted_dek = 9;
+  // The encrypted data encryption key (DEK) for this blob.
+  EncryptedDek encrypted_dek = 9;
 
   // The newest event date among the impressions in this blob.
   // NULL for SNAPSHOT blobs, set for DAY_ONLY blobs.

--- a/src/main/proto/wfa/measurement/internal/edpaggregator/rank_index_blob.proto
+++ b/src/main/proto/wfa/measurement/internal/edpaggregator/rank_index_blob.proto
@@ -50,17 +50,21 @@ message RankIndexBlob {
   // Cloud Storage URI of the rank index blob.
   string blob_uri = 7;
 
+  // SHA-256 checksum of the plaintext blob payload. Used to
+  // detect corruption after decryption.
+  bytes blob_checksum = 8;
+
   // The encrypted data encryption key (DEK) used to encrypt
   // the blob, itself encrypted via the DataProvider's KMS.
-  bytes encrypted_dek = 8;
+  bytes encrypted_dek = 9;
 
   // The newest event date among the impressions in this blob.
   // NULL for SNAPSHOT blobs, set for DAY_ONLY blobs.
-  google.type.Date max_event_date = 9;
+  google.type.Date max_event_date = 10;
 
   // The timestamp when this record was created.
-  google.protobuf.Timestamp create_time = 10;
+  google.protobuf.Timestamp create_time = 11;
 
   // The timestamp when this blob was soft-deleted.
-  google.protobuf.Timestamp delete_time = 11;
+  google.protobuf.Timestamp delete_time = 12;
 }

--- a/src/main/proto/wfa/measurement/internal/edpaggregator/rank_index_blob_service.proto
+++ b/src/main/proto/wfa/measurement/internal/edpaggregator/rank_index_blob_service.proto
@@ -121,7 +121,7 @@ message ListRankIndexBlobsRequest {
     // Filter by CMMS model line resource name.
     string cmms_model_line = 2;
 
-    // Filter by subpool ID.
+    // Filter by subpool ID. Optional because 0 is a valid subpool ID.
     optional int32 subpool_id = 3;
 
     // Filter for blobs with max_event_date on or before

--- a/src/main/proto/wfa/measurement/internal/edpaggregator/rank_index_blob_service.proto
+++ b/src/main/proto/wfa/measurement/internal/edpaggregator/rank_index_blob_service.proto
@@ -1,0 +1,160 @@
+// Copyright 2026 The Cross-Media Measurement Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package wfa.measurement.internal.edpaggregator;
+
+import "google/protobuf/timestamp.proto";
+import "google/type/date.proto";
+import "wfa/measurement/internal/edpaggregator/blob_type.proto";
+import "wfa/measurement/internal/edpaggregator/rank_index_blob.proto";
+
+option java_package = "org.wfanet.measurement.internal.edpaggregator";
+option java_multiple_files = true;
+option java_outer_classname = "RankIndexBlobServiceProto";
+
+// Service for managing `RankIndexBlob` resources.
+service RankIndexBlobService {
+  // Creates a new `RankIndexBlob`.
+  rpc CreateRankIndexBlob(CreateRankIndexBlobRequest) returns (RankIndexBlob);
+
+  // Creates multiple `RankIndexBlob` resources in a single
+  // request.
+  rpc BatchCreateRankIndexBlobs(BatchCreateRankIndexBlobsRequest)
+      returns (BatchCreateRankIndexBlobsResponse);
+
+  // Retrieves a specific `RankIndexBlob`.
+  rpc GetRankIndexBlob(GetRankIndexBlobRequest) returns (RankIndexBlob);
+
+  // Lists `RankIndexBlob` resources.
+  rpc ListRankIndexBlobs(ListRankIndexBlobsRequest)
+      returns (ListRankIndexBlobsResponse);
+
+  // Soft-deletes a `RankIndexBlob`.
+  rpc DeleteRankIndexBlob(DeleteRankIndexBlobRequest) returns (RankIndexBlob);
+}
+
+// Request message for CreateRankIndexBlob.
+message CreateRankIndexBlobRequest {
+  // Resource ID of the DataProvider.
+  string data_provider_resource_id = 1;
+
+  // Resource ID of the parent upload.
+  string raw_impression_upload_resource_id = 2;
+
+  // The RankIndexBlob to create.
+  RankIndexBlob rank_index_blob = 3;
+
+  // A request ID provided by the client to ensure idempotency.
+  string request_id = 4;
+}
+
+// Request message for BatchCreateRankIndexBlobs.
+message BatchCreateRankIndexBlobsRequest {
+  // Resource ID of the DataProvider.
+  string data_provider_resource_id = 1;
+
+  // Resource ID of the parent upload.
+  string raw_impression_upload_resource_id = 2;
+
+  // Individual create requests. Maximum 50 per batch.
+  repeated CreateRankIndexBlobRequest requests = 3;
+}
+
+// Response message for BatchCreateRankIndexBlobs.
+message BatchCreateRankIndexBlobsResponse {
+  // The created rank index blobs.
+  repeated RankIndexBlob rank_index_blobs = 1;
+}
+
+// Request message for GetRankIndexBlob.
+message GetRankIndexBlobRequest {
+  // Resource ID of the DataProvider.
+  string data_provider_resource_id = 1;
+
+  // Resource ID of the parent upload.
+  string raw_impression_upload_resource_id = 2;
+
+  // Resource ID of this blob.
+  string rank_index_blob_resource_id = 3;
+}
+
+// Request message for ListRankIndexBlobs.
+message ListRankIndexBlobsRequest {
+  // Resource ID of the DataProvider.
+  string data_provider_resource_id = 1;
+
+  // Resource ID of the parent upload.
+  string raw_impression_upload_resource_id = 2;
+
+  // The maximum number of results to return.
+  //
+  // If unspecified, at most 50 results will be returned.
+  // The maximum value is 100; values above this will be
+  // coerced to the maximum value.
+  int32 page_size = 3;
+
+  // Page token from a previous list call.
+  ListRankIndexBlobsPageToken page_token = 4;
+
+  // Filter for narrowing results.
+  message Filter {
+    // Filter by blob type.
+    BlobType blob_type = 1;
+
+    // Filter by CMMS model line resource name.
+    string cmms_model_line = 2;
+
+    // Filter by subpool ID.
+    int32 subpool_id = 3;
+
+    // Filter by max event date on or before this date.
+    google.type.Date max_event_date_before = 4;
+  }
+  Filter filter = 5;
+
+  // Whether to include soft-deleted entries.
+  bool show_deleted = 6;
+}
+
+// Response message for ListRankIndexBlobs.
+message ListRankIndexBlobsResponse {
+  // The list of rank index blobs matching the request.
+  repeated RankIndexBlob rank_index_blobs = 1;
+
+  // A token to retrieve the next page of results.
+  ListRankIndexBlobsPageToken next_page_token = 2;
+}
+
+// Page token for ListRankIndexBlobs.
+message ListRankIndexBlobsPageToken {
+  message After {
+    google.protobuf.Timestamp create_time = 1;
+    string rank_index_blob_resource_id = 2;
+  }
+  After after = 1;
+}
+
+// Request message for DeleteRankIndexBlob.
+message DeleteRankIndexBlobRequest {
+  // Resource ID of the DataProvider.
+  string data_provider_resource_id = 1;
+
+  // Resource ID of the parent upload.
+  string raw_impression_upload_resource_id = 2;
+
+  // Resource ID of this blob.
+  string rank_index_blob_resource_id = 3;
+}

--- a/src/main/proto/wfa/measurement/internal/edpaggregator/rank_index_blob_service.proto
+++ b/src/main/proto/wfa/measurement/internal/edpaggregator/rank_index_blob_service.proto
@@ -120,8 +120,9 @@ message ListRankIndexBlobsRequest {
     // Filter by subpool ID.
     int32 subpool_id = 3;
 
-    // Filter by max event date on or before this date.
-    google.type.Date max_event_date_before = 4;
+    // Filter for blobs with max_event_date on or before
+    // this value. Used for retention policy queries.
+    google.type.Date max_event_date_cutoff = 4;
   }
   Filter filter = 5;
 

--- a/src/main/proto/wfa/measurement/internal/edpaggregator/rank_index_blob_service.proto
+++ b/src/main/proto/wfa/measurement/internal/edpaggregator/rank_index_blob_service.proto
@@ -17,7 +17,6 @@ syntax = "proto3";
 package wfa.measurement.internal.edpaggregator;
 
 import "google/protobuf/timestamp.proto";
-import "google/protobuf/wrappers.proto";
 import "google/type/date.proto";
 import "wfa/measurement/internal/edpaggregator/blob_type.proto";
 import "wfa/measurement/internal/edpaggregator/rank_index_blob.proto";
@@ -45,6 +44,10 @@ service RankIndexBlobService {
 
   // Soft-deletes a `RankIndexBlob`.
   rpc DeleteRankIndexBlob(DeleteRankIndexBlobRequest) returns (RankIndexBlob);
+
+  // Soft-deletes multiple `RankIndexBlob` resources.
+  rpc BatchDeleteRankIndexBlobs(BatchDeleteRankIndexBlobsRequest)
+      returns (BatchDeleteRankIndexBlobsResponse);
 }
 
 // Request message for CreateRankIndexBlob.
@@ -118,9 +121,8 @@ message ListRankIndexBlobsRequest {
     // Filter by CMMS model line resource name.
     string cmms_model_line = 2;
 
-    // Filter by subpool ID. Uses wrapper type because 0 is
-    // a valid subpool ID.
-    google.protobuf.Int32Value subpool_id = 3;
+    // Filter by subpool ID.
+    optional int32 subpool_id = 3;
 
     // Filter for blobs with max_event_date on or before
     // this value. Used for retention policy queries.

--- a/src/main/proto/wfa/measurement/internal/edpaggregator/rank_index_blob_service.proto
+++ b/src/main/proto/wfa/measurement/internal/edpaggregator/rank_index_blob_service.proto
@@ -17,6 +17,7 @@ syntax = "proto3";
 package wfa.measurement.internal.edpaggregator;
 
 import "google/protobuf/timestamp.proto";
+import "google/protobuf/wrappers.proto";
 import "google/type/date.proto";
 import "wfa/measurement/internal/edpaggregator/blob_type.proto";
 import "wfa/measurement/internal/edpaggregator/rank_index_blob.proto";
@@ -117,8 +118,9 @@ message ListRankIndexBlobsRequest {
     // Filter by CMMS model line resource name.
     string cmms_model_line = 2;
 
-    // Filter by subpool ID.
-    int32 subpool_id = 3;
+    // Filter by subpool ID. Uses wrapper type because 0 is
+    // a valid subpool ID.
+    google.protobuf.Int32Value subpool_id = 3;
 
     // Filter for blobs with max_event_date on or before
     // this value. Used for retention policy queries.
@@ -158,4 +160,22 @@ message DeleteRankIndexBlobRequest {
 
   // Resource ID of this blob.
   string rank_index_blob_resource_id = 3;
+}
+
+// Request message for BatchDeleteRankIndexBlobs.
+message BatchDeleteRankIndexBlobsRequest {
+  // Resource ID of the DataProvider.
+  string data_provider_resource_id = 1;
+
+  // Resource ID of the parent upload.
+  string raw_impression_upload_resource_id = 2;
+
+  // Individual delete requests.
+  repeated DeleteRankIndexBlobRequest requests = 3;
+}
+
+// Response message for BatchDeleteRankIndexBlobs.
+message BatchDeleteRankIndexBlobsResponse {
+  // The deleted rank index blobs.
+  repeated RankIndexBlob rank_index_blobs = 1;
 }

--- a/src/main/proto/wfa/measurement/internal/edpaggregator/rank_index_blob_service.proto
+++ b/src/main/proto/wfa/measurement/internal/edpaggregator/rank_index_blob_service.proto
@@ -126,7 +126,7 @@ message ListRankIndexBlobsRequest {
 
     // Filter for blobs with max_event_date on or before
     // this value. Used for retention policy queries.
-    google.type.Date max_event_date_cutoff = 4;
+    google.type.Date max_event_date_on_or_before = 4;
   }
   Filter filter = 5;
 

--- a/src/main/proto/wfa/measurement/internal/edpaggregator/rank_index_blob_service.proto
+++ b/src/main/proto/wfa/measurement/internal/edpaggregator/rank_index_blob_service.proto
@@ -121,8 +121,8 @@ message ListRankIndexBlobsRequest {
     // Filter by CMMS model line resource name.
     string cmms_model_line = 2;
 
-    // Filter by subpool ID. Optional because 0 is a valid subpool ID.
-    optional int32 subpool_id = 3;
+    // Filter by pool offset. Optional because 0 is a valid pool offset.
+    optional int64 pool_offset = 3;
 
     // Filter for blobs with max_event_date on or before
     // this value. Used for retention policy queries.


### PR DESCRIPTION
## Summary
- Add proto message and service definitions for RankIndexBlob, a pointer to rank index blobs in Cloud Storage with encrypted DEKs.
- Includes create, batch create, get, list, and delete (soft-delete) methods for both internal and public (v1alpha) APIs.
- BlobType enum: DAY_ONLY (per-dispatch fingerprints), SNAPSHOT (cumulative set).
- Soft-delete via delete_time with show_deleted on List.
- cmms_model_line, subpool_id, and blob_type filters for cross-upload queries with AIP-159 wildcard support.
- max_event_date (google.type.Date) for retention policy queries.
- encrypted_dek (bytes) for blob encryption key material.

## Test plan
- bazel build passes for all proto targets (internal blob type, internal message, internal service, public message, public service)

Closes: #3885

Issue: #3885