### PR TITLE
feat: add ValidationCloudFunctionClient for impression validation

### DIFF
--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/validation/BUILD.bazel
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/validation/BUILD.bazel
@@ -12,3 +12,14 @@ kt_jvm_library(
         "//src/main/proto/wfa/measurement/config/edpaggregator:data_provider_validation_config_kt_jvm_proto",
     ],
 )
+
+kt_jvm_library(
+    name = "validation_cloud_function_client",
+    srcs = ["ValidationCloudFunctionClient.kt"],
+    deps = [
+        "//imports/java/com/google/auth:credentials",
+        "//imports/java/com/google/auth:oauth_http2",
+        "//src/main/proto/wfa/measurement/api/v2alpha:data_provider_impression_query_kt_jvm_proto",
+        "@wfa_common_jvm//imports/java/com/google/protobuf",
+    ],
+)

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/validation/ValidationCloudFunctionClient.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/validation/ValidationCloudFunctionClient.kt
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2026 The Cross-Media Measurement Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wfanet.measurement.edpaggregator.validation
+
+import com.google.auth.oauth2.GoogleCredentials
+import com.google.auth.oauth2.IdToken
+import com.google.auth.oauth2.IdTokenProvider
+import com.google.protobuf.InvalidProtocolBufferException
+import java.io.IOException
+import java.net.URI
+import java.net.http.HttpClient
+import java.net.http.HttpRequest
+import java.net.http.HttpResponse
+import java.time.Duration
+import org.wfanet.measurement.api.v2alpha.DataProviderImpressionQueryRequest
+import org.wfanet.measurement.api.v2alpha.DataProviderImpressionQueryResponse
+
+/**
+ * Thrown when a call to a DataProvider's impression validation cloud function fails.
+ *
+ * @param httpStatus the HTTP status code, or null if the request failed before receiving a
+ *   response.
+ */
+class CloudFunctionException(
+  message: String,
+  val httpStatus: Int? = null,
+  cause: Throwable? = null,
+) : Exception(message, cause)
+
+/**
+ * HTTP client for calling a DataProvider's impression validation cloud function.
+ *
+ * Serializes a [DataProviderImpressionQueryRequest] as binary protobuf, posts it to the cloud
+ * function endpoint with a Google-issued ID token, and deserializes the
+ * [DataProviderImpressionQueryResponse].
+ *
+ * @param httpClient the [HttpClient] to use for requests.
+ * @param idTokenProvider provider of audience-scoped ID tokens for authenticating to the cloud
+ *   function.
+ */
+class ValidationCloudFunctionClient(
+  private val httpClient: HttpClient = HttpClient.newHttpClient(),
+  private val idTokenProvider: IdTokenProvider =
+    GoogleCredentials.getApplicationDefault() as? IdTokenProvider
+      ?: throw IllegalArgumentException("Application Default Credentials do not provide ID token"),
+) {
+
+  /**
+   * Calls the cloud function at the given endpoint.
+   *
+   * @param endpointUri HTTPS URI of the cloud function.
+   * @param request the validation request to send.
+   * @param timeout request timeout.
+   * @return the parsed response.
+   * @throws CloudFunctionException if the call fails or returns a non-success status.
+   */
+  fun call(
+    endpointUri: String,
+    request: DataProviderImpressionQueryRequest,
+    timeout: Duration,
+  ): DataProviderImpressionQueryResponse {
+    val idToken: IdToken = idTokenProvider.idTokenWithAudience(endpointUri, emptyList())
+    val httpRequest =
+      HttpRequest.newBuilder()
+        .uri(URI.create(endpointUri))
+        .timeout(timeout)
+        .header("Authorization", "Bearer ${idToken.tokenValue}")
+        .header("Content-Type", CONTENT_TYPE_PROTOBUF)
+        .POST(HttpRequest.BodyPublishers.ofByteArray(request.toByteArray()))
+        .build()
+
+    val httpResponse =
+      try {
+        httpClient.send(httpRequest, HttpResponse.BodyHandlers.ofByteArray())
+      } catch (e: IOException) {
+        throw CloudFunctionException("Cloud function call to $endpointUri failed", cause = e)
+      } catch (e: InterruptedException) {
+        Thread.currentThread().interrupt()
+        throw CloudFunctionException(
+          "Cloud function call to $endpointUri was interrupted",
+          cause = e,
+        )
+      }
+
+    val statusCode = httpResponse.statusCode()
+    if (statusCode !in 200..299) {
+      throw CloudFunctionException(
+        "Cloud function at $endpointUri returned HTTP $statusCode",
+        httpStatus = statusCode,
+      )
+    }
+
+    return try {
+      DataProviderImpressionQueryResponse.parseFrom(httpResponse.body())
+    } catch (e: InvalidProtocolBufferException) {
+      throw CloudFunctionException(
+        "Cloud function at $endpointUri returned an unparseable response",
+        httpStatus = statusCode,
+        cause = e,
+      )
+    }
+  }
+
+  companion object {
+    private const val CONTENT_TYPE_PROTOBUF = "application/x-protobuf"
+  }
+}

--- a/src/main/proto/wfa/measurement/api/v2alpha/BUILD.bazel
+++ b/src/main/proto/wfa/measurement/api/v2alpha/BUILD.bazel
@@ -19,6 +19,7 @@ MESSAGE_LIBS = [
     ":certificate_proto",
     ":client_account_proto",
     ":crypto_proto",
+    ":data_provider_impression_query_proto",
     ":data_provider_proto",
     ":date_interval_proto",
     ":differential_privacy_proto",

--- a/src/test/kotlin/org/wfanet/measurement/edpaggregator/validation/BUILD.bazel
+++ b/src/test/kotlin/org/wfanet/measurement/edpaggregator/validation/BUILD.bazel
@@ -12,3 +12,17 @@ kt_jvm_test(
         "@wfa_common_jvm//imports/kotlin/kotlin/test",
     ],
 )
+
+kt_jvm_test(
+    name = "ValidationCloudFunctionClientTest",
+    srcs = ["ValidationCloudFunctionClientTest.kt"],
+    test_class = "org.wfanet.measurement.edpaggregator.validation.ValidationCloudFunctionClientTest",
+    deps = [
+        "//imports/java/com/google/auth:oauth_http2",
+        "//src/main/kotlin/org/wfanet/measurement/edpaggregator/validation:validation_cloud_function_client",
+        "//src/main/proto/wfa/measurement/api/v2alpha:data_provider_impression_query_kt_jvm_proto",
+        "@wfa_common_jvm//imports/java/com/google/common/truth",
+        "@wfa_common_jvm//imports/java/org/junit",
+        "@wfa_common_jvm//imports/kotlin/kotlin/test",
+    ],
+)

--- a/src/test/kotlin/org/wfanet/measurement/edpaggregator/validation/ValidationCloudFunctionClientTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/edpaggregator/validation/ValidationCloudFunctionClientTest.kt
@@ -1,0 +1,191 @@
+/*
+ * Copyright 2026 The Cross-Media Measurement Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wfanet.measurement.edpaggregator.validation
+
+import com.google.auth.oauth2.IdToken
+import com.google.auth.oauth2.IdTokenProvider
+import com.google.common.truth.Truth.assertThat
+import com.sun.net.httpserver.HttpServer
+import java.net.InetSocketAddress
+import java.net.ServerSocket
+import java.time.Duration
+import kotlin.test.assertFailsWith
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+import org.wfanet.measurement.api.v2alpha.DataProviderImpressionQueryRequest
+import org.wfanet.measurement.api.v2alpha.DataProviderImpressionQueryResponseKt.impressionCount
+import org.wfanet.measurement.api.v2alpha.dataProviderImpressionQueryRequest
+import org.wfanet.measurement.api.v2alpha.dataProviderImpressionQueryResponse
+
+@RunWith(JUnit4::class)
+class ValidationCloudFunctionClientTest {
+
+  private lateinit var fakeCloudFunction: FakeCloudFunction
+  private lateinit var endpointUri: String
+
+  private val client = ValidationCloudFunctionClient(idTokenProvider = FakeIdTokenProvider())
+
+  @Before
+  fun startServer() {
+    val port = ServerSocket(0).use { it.localPort }
+    fakeCloudFunction = FakeCloudFunction()
+    fakeCloudFunction.start(port)
+    endpointUri = "http://localhost:$port"
+  }
+
+  @After
+  fun stopServer() {
+    fakeCloudFunction.stop()
+  }
+
+  @Test
+  fun `call returns parsed response on success`() {
+    fakeCloudFunction.responseBody =
+      dataProviderImpressionQueryResponse {
+          requestId = REQUEST_ID
+          result = impressionCount { value = 12_345L }
+        }
+        .toByteArray()
+
+    val response = client.call(endpointUri, REQUEST, TIMEOUT)
+
+    assertThat(response.hasResult()).isTrue()
+    assertThat(response.result.value).isEqualTo(12_345L)
+    // The request was transmitted to the endpoint as binary protobuf.
+    assertThat(DataProviderImpressionQueryRequest.parseFrom(fakeCloudFunction.lastRequestBody))
+      .isEqualTo(REQUEST)
+  }
+
+  @Test
+  fun `call sends bearer authorization header`() {
+    fakeCloudFunction.responseBody =
+      dataProviderImpressionQueryResponse {
+          requestId = REQUEST_ID
+          result = impressionCount { value = 1L }
+        }
+        .toByteArray()
+
+    client.call(endpointUri, REQUEST, TIMEOUT)
+
+    assertThat(fakeCloudFunction.lastAuthorizationHeader).isEqualTo("Bearer $JWT_TOKEN")
+  }
+
+  @Test
+  fun `call throws with http status on server error`() {
+    fakeCloudFunction.responseStatus = 500
+
+    val exception =
+      assertFailsWith<CloudFunctionException> { client.call(endpointUri, REQUEST, TIMEOUT) }
+    assertThat(exception.httpStatus).isEqualTo(500)
+  }
+
+  @Test
+  fun `call throws with http status on client error`() {
+    fakeCloudFunction.responseStatus = 404
+
+    val exception =
+      assertFailsWith<CloudFunctionException> { client.call(endpointUri, REQUEST, TIMEOUT) }
+    assertThat(exception.httpStatus).isEqualTo(404)
+  }
+
+  @Test
+  fun `call throws with http status on unparseable response body`() {
+    // A lone field tag with no payload is a truncated, malformed protobuf message.
+    fakeCloudFunction.responseBody = byteArrayOf(0x0A)
+
+    val exception =
+      assertFailsWith<CloudFunctionException> { client.call(endpointUri, REQUEST, TIMEOUT) }
+    assertThat(exception.httpStatus).isEqualTo(200)
+  }
+
+  @Test
+  fun `call throws without http status when endpoint is unreachable`() {
+    val unusedPort = ServerSocket(0).use { it.localPort }
+
+    val exception =
+      assertFailsWith<CloudFunctionException> {
+        client.call("http://localhost:$unusedPort", REQUEST, TIMEOUT)
+      }
+    assertThat(exception.httpStatus).isNull()
+  }
+
+  companion object {
+    private const val REQUEST_ID = "f47ac10b-58cc-4372-a567-0e02b2c3d479"
+    private val TIMEOUT: Duration = Duration.ofSeconds(10)
+
+    // Sample (expired) JWT used only to satisfy IdToken parsing in tests.
+    private const val JWT_TOKEN =
+      "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWUsImlhdCI6MTUxNjIzOTAyMiwiZXhwIjoxNTE2MjQyNjIyfQ.KMUFsIDTnFmyG3nMiGM6H9FNFUROf3wh7SmqJp-QV30"
+
+    private val REQUEST: DataProviderImpressionQueryRequest = dataProviderImpressionQueryRequest {
+      requestId = REQUEST_ID
+      dataProvider = "dataProviders/edp-1"
+    }
+  }
+}
+
+/** [IdTokenProvider] that returns a fixed sample token without contacting Google. */
+private class FakeIdTokenProvider : IdTokenProvider {
+  override fun idTokenWithAudience(
+    targetAudience: String,
+    options: MutableList<IdTokenProvider.Option>?,
+  ): IdToken = IdToken.create(JWT_TOKEN)
+
+  companion object {
+    private const val JWT_TOKEN =
+      "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWUsImlhdCI6MTUxNjIzOTAyMiwiZXhwIjoxNTE2MjQyNjIyfQ.KMUFsIDTnFmyG3nMiGM6H9FNFUROf3wh7SmqJp-QV30"
+  }
+}
+
+/** In-process HTTP server standing in for a DataProvider's validation cloud function. */
+private class FakeCloudFunction {
+  private lateinit var server: HttpServer
+
+  /** HTTP status code to return. */
+  var responseStatus: Int = 200
+
+  /** Response body bytes to return. */
+  var responseBody: ByteArray = ByteArray(0)
+
+  /** Body of the most recently received request. */
+  var lastRequestBody: ByteArray = ByteArray(0)
+    private set
+
+  /** `Authorization` header of the most recently received request. */
+  var lastAuthorizationHeader: String? = null
+    private set
+
+  fun start(port: Int) {
+    server = HttpServer.create(InetSocketAddress(port), 0)
+    server.createContext("/") { exchange ->
+      lastRequestBody = exchange.requestBody.readBytes()
+      lastAuthorizationHeader = exchange.requestHeaders.getFirst("Authorization")
+      val contentLength = if (responseBody.isEmpty()) -1L else responseBody.size.toLong()
+      exchange.sendResponseHeaders(responseStatus, contentLength)
+      exchange.responseBody.use { it.write(responseBody) }
+    }
+    server.executor = null
+    server.start()
+  }
+
+  fun stop() {
+    server.stop(0)
+  }
+}


### PR DESCRIPTION
## Summary

Adds `ValidationCloudFunctionClient` — HTTP client for calling a `DataProvider`'s impression-query cloud function, mirroring the existing `DataWatcher.sendToHttpEndpoint()` precedent.

- Serializes `DataProviderImpressionQueryRequest` as binary protobuf and POSTs it to the endpoint.
- Authenticates with a Google ID token (`Authorization: Bearer …`) for the endpoint audience.
- Single blocking `send`, no in-client retry (matches the DataWatcher precedent); throws `CloudFunctionException` carrying the HTTP status (or null when no response was received).
- Deserializes `DataProviderImpressionQueryResponse`.
- Uses the JDK `java.net.http.HttpClient` — no new third-party dependencies.

Stacked on #3960.


## Test plan

`ValidationCloudFunctionClientTest` (real in-process `HttpServer` + fake `IdTokenProvider`):
- [x] 2xx success + response parse; request transmitted as binary protobuf; bearer-auth header sent
- [x] 4xx and 5xx → `CloudFunctionException` with the correct `httpStatus`
- [x] unparseable 2xx body
- [x] unreachable endpoint → null status

Issue: #3963
