### PR TITLE
feat: Add VidAssigner over VirtualPeople Labeler

### DIFF
--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/vidlabeler/BUILD.bazel
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/vidlabeler/BUILD.bazel
@@ -6,6 +6,18 @@ package(default_visibility = [
 ])
 
 kt_jvm_library(
+    name = "vid_assigner",
+    srcs = ["VidAssigner.kt"],
+    deps = [
+        "@wfa_common_jvm//imports/java/com/google/protobuf",
+        "@wfa_common_jvm//imports/kotlin/kotlinx/coroutines:core",
+        "@wfa_virtual_people_common//src/main/proto/wfa/virtual_people/common:event_kt_jvm_proto",
+        "@wfa_virtual_people_common//src/main/proto/wfa/virtual_people/common:model_kt_jvm_proto",
+        "@wfa_virtual_people_core_serving//src/main/kotlin/org/wfanet/virtualpeople/core/labeler",
+    ],
+)
+
+kt_jvm_library(
     name = "vid_labeler_app",
     srcs = ["VidLabelerApp.kt"],
     deps = [

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/vidlabeler/VidAssigner.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/vidlabeler/VidAssigner.kt
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2026 The Cross-Media Measurement Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wfanet.measurement.edpaggregator.vidlabeler
+
+import com.google.protobuf.ByteString
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import org.wfanet.virtualpeople.common.CompiledNode
+import org.wfanet.virtualpeople.common.LabelerInput
+import org.wfanet.virtualpeople.common.LabelerOutput
+import org.wfanet.virtualpeople.core.labeler.Labeler
+
+/**
+ * Assigns virtual person IDs (VIDs) to impressions by evaluating a compiled VirtualPeople model.
+ *
+ * This is a thin abstraction over the canonical [Labeler] from `virtual-people-core-serving`. The
+ * VID-assignment math (model-tree traversal plus the hashing/Feistel logic) lives entirely in that
+ * library — this interface exists only so the VID Labeler TEE app can depend on a small, testable
+ * seam rather than the labeler implementation directly.
+ */
+interface VidAssigner {
+  /**
+   * Assigns VIDs to [input] using the bound model.
+   *
+   * @return the [LabelerOutput]; each assigned person is available via
+   *   `output.getPeople(i).virtualPersonId`.
+   */
+  fun assign(input: LabelerInput): LabelerOutput
+}
+
+/**
+ * [VidAssigner] backed by a VirtualPeople [Labeler] built from a single compiled model.
+ *
+ * One instance is bound to one model line's compiled model. Construct via [fromCompiledNodeBlob],
+ * which parses a serialized [CompiledNode] (the `model_blob_path` payload resolved by the
+ * `VidLabelingDispatcher`).
+ */
+class VirtualPeopleVidAssigner(private val labeler: Labeler) : VidAssigner {
+  override fun assign(input: LabelerInput): LabelerOutput = labeler.label(input)
+
+  companion object {
+    /**
+     * Builds a [VirtualPeopleVidAssigner] from the binary-serialized [CompiledNode] root of a
+     * compiled VID model.
+     */
+    fun fromCompiledNodeBlob(modelBlob: ByteString): VirtualPeopleVidAssigner =
+      VirtualPeopleVidAssigner(Labeler.build(CompiledNode.parseFrom(modelBlob)))
+  }
+}
+
+/**
+ * Loads and caches one [VidAssigner] per model blob URI so each compiled model is read from storage
+ * and built into a [Labeler] at most once per process.
+ *
+ * @param loadAssigner builds a [VidAssigner] for a model blob URI — typically reads the serialized
+ *   `CompiledNode` from storage and calls [VirtualPeopleVidAssigner.fromCompiledNodeBlob].
+ *
+ * TODO(world-federation-of-advertisers/cross-media-measurement#3899): replace with the shared EDP
+ *   Aggregator VID model cache once it is available.
+ */
+class VidModelLoader(private val loadAssigner: suspend (modelBlobUri: String) -> VidAssigner) {
+  private val mutex = Mutex()
+  private val assignersByModelBlobUri = mutableMapOf<String, VidAssigner>()
+
+  /** Returns the [VidAssigner] for [modelBlobUri], loading and caching it on first use. */
+  suspend fun getAssigner(modelBlobUri: String): VidAssigner =
+    mutex.withLock {
+      assignersByModelBlobUri[modelBlobUri]
+        ?: loadAssigner(modelBlobUri).also { assignersByModelBlobUri[modelBlobUri] = it }
+    }
+}

--- a/src/test/kotlin/org/wfanet/measurement/edpaggregator/vidlabeler/BUILD.bazel
+++ b/src/test/kotlin/org/wfanet/measurement/edpaggregator/vidlabeler/BUILD.bazel
@@ -1,6 +1,28 @@
 load("@wfa_rules_kotlin_jvm//kotlin:defs.bzl", "kt_jvm_test")
 
 kt_jvm_test(
+    name = "VidModelLoaderTest",
+    srcs = ["VidModelLoaderTest.kt"],
+    test_class = "org.wfanet.measurement.edpaggregator.vidlabeler.VidModelLoaderTest",
+    deps = [
+        "//src/main/kotlin/org/wfanet/measurement/edpaggregator/vidlabeler:vid_assigner",
+        "@wfa_common_jvm//imports/java/com/google/common/truth",
+        "@wfa_common_jvm//imports/java/org/junit",
+        "@wfa_common_jvm//imports/kotlin/kotlinx/coroutines:core",
+        "@wfa_virtual_people_common//src/main/proto/wfa/virtual_people/common:event_kt_jvm_proto",
+    ],
+)
+
+kt_jvm_test(
+    name = "VirtualPeopleVidAssignerTest",
+    srcs = ["VirtualPeopleVidAssignerTest.kt"],
+    test_class = "org.wfanet.measurement.edpaggregator.vidlabeler.VirtualPeopleVidAssignerTest",
+    deps = [
+        "@wfa_common_jvm//imports/java/org/junit",
+    ],
+)
+
+kt_jvm_test(
     name = "VidLabelerAppTest",
     srcs = ["VidLabelerAppTest.kt"],
     test_class = "org.wfanet.measurement.edpaggregator.vidlabeler.VidLabelerAppTest",

--- a/src/test/kotlin/org/wfanet/measurement/edpaggregator/vidlabeler/VidModelLoaderTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/edpaggregator/vidlabeler/VidModelLoaderTest.kt
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2026 The Cross-Media Measurement Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wfanet.measurement.edpaggregator.vidlabeler
+
+import com.google.common.truth.Truth.assertThat
+import kotlinx.coroutines.runBlocking
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+import org.wfanet.virtualpeople.common.LabelerInput
+import org.wfanet.virtualpeople.common.LabelerOutput
+
+@RunWith(JUnit4::class)
+class VidModelLoaderTest {
+  @Test
+  fun `getAssigner loads once per model blob uri and reuses the cached assigner`() =
+    runBlocking<Unit> {
+      val loadCounts = mutableMapOf<String, Int>()
+      val loader = VidModelLoader { uri ->
+        loadCounts[uri] = (loadCounts[uri] ?: 0) + 1
+        FakeVidAssigner()
+      }
+
+      val first = loader.getAssigner("model-a")
+      val second = loader.getAssigner("model-a")
+      val other = loader.getAssigner("model-b")
+
+      assertThat(second).isSameInstanceAs(first)
+      assertThat(other).isNotSameInstanceAs(first)
+      assertThat(loadCounts).containsExactly("model-a", 1, "model-b", 1)
+    }
+
+  /** Distinct instance per construction so cache hits are observable via reference identity. */
+  private class FakeVidAssigner : VidAssigner {
+    override fun assign(input: LabelerInput): LabelerOutput = LabelerOutput.getDefaultInstance()
+  }
+}

--- a/src/test/kotlin/org/wfanet/measurement/edpaggregator/vidlabeler/VirtualPeopleVidAssignerTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/edpaggregator/vidlabeler/VirtualPeopleVidAssignerTest.kt
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2026 The Cross-Media Measurement Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wfanet.measurement.edpaggregator.vidlabeler
+
+import org.junit.Ignore
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+
+@RunWith(JUnit4::class)
+class VirtualPeopleVidAssignerTest {
+  /**
+   * Verifies that `VirtualPeopleVidAssigner.fromCompiledNodeBlob` parses a serialized
+   * `CompiledNode` and produces an assigner that returns the expected VID for a known input.
+   *
+   * Ignored until the reference model fixture lands on main.
+   *
+   * TODO(world-federation-of-advertisers/cross-media-measurement#3951): Once PR #3951 lands
+   *   `src/main/resources/testing/labeler/reference_test_model.textproto` on main:
+   *     1. Add that fixture as a `data` dependency of this target and depend on `:vid_assigner`.
+   *     2. Read the fixture, serialize the parsed `CompiledNode`, and build the assigner via
+   *        `VirtualPeopleVidAssigner.fromCompiledNodeBlob`.
+   *     3. Assign a known `LabelerInput` and assert the expected `virtualPersonId` using the golden
+   *        input/VID pairs defined alongside the fixture.
+   *     4. Remove the `@Ignore`.
+   */
+  @Ignore("Pending reference_test_model.textproto from #3951; see TODO")
+  @Test
+  fun `fromCompiledNodeBlob builds an assigner that returns the expected VID`() {
+    TODO("Implement once #3951 lands the reference model fixture on main")
+  }
+}


### PR DESCRIPTION
## Summary

Adds the VID Labeler "labeler core" — a thin, testable seam over the canonical VirtualPeople `Labeler`, so the TEE app assigns VIDs without reimplementing the model-tree traversal/hashing.

- `VidAssigner` — interface `assign(LabelerInput): LabelerOutput`.
- `VirtualPeopleVidAssigner` — wraps a `Labeler`; `fromCompiledNodeBlob(...)` builds it from a serialized `CompiledNode` (the `model_blob_path` payload resolved by the dispatcher).
- `VidModelLoader` — loads and builds each compiled model at most once per process, keyed by model blob URI.

Stacked on #3966 (adds `virtual-people-core-serving`).

Follow-ups (separate PRs): the impression → `LabelerInput` mapping (depends on the raw-impression Parquet schema) and the full Path-A VidLabeler pipeline (stacked on the `RawImpressionStream` reader).

## Test plan

- [x] `bazel test //src/test/.../vidlabeler:VidModelLoaderTest` passes
- [x] `bazel build //src/main/.../vidlabeler:vid_assigner` (against virtual-people-core-serving)
- [x] `VirtualPeopleVidAssignerTest` added as an `@Ignore`'d stub for the `fromCompiledNodeBlob` round-trip; activates once #3951 lands `reference_test_model.textproto` on main.

Issue: #3899
