### PR TITLE
refactor!: Unify EDPA wire StorageParams into shared StorageParamsApi

### DIFF
--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/vidlabeling/VidLabelingDispatcherFunction.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/vidlabeling/VidLabelingDispatcherFunction.kt
@@ -47,6 +47,7 @@ import org.wfanet.measurement.edpaggregator.v1alpha.RawImpressionMetadataBatchSe
 import org.wfanet.measurement.edpaggregator.v1alpha.VidLabelerParams
 import org.wfanet.measurement.edpaggregator.v1alpha.VidLabelerParamsKt
 import org.wfanet.measurement.edpaggregator.v1alpha.VidLabelingDispatcherParams
+import org.wfanet.measurement.edpaggregator.v1alpha.storageParamsApi
 import org.wfanet.measurement.edpaggregator.v1alpha.transportLayerSecurityParams
 import org.wfanet.measurement.edpaggregator.v1alpha.vidLabelerParams
 import org.wfanet.measurement.edpaggregator.vidlabeling.VidLabelingDispatcher
@@ -336,15 +337,14 @@ class VidLabelingDispatcherFunction : HttpFunction {
       return vidLabelerParams {
         dataProvider = config.dataProvider
         vidLabeledImpressionsStorageParams =
-          VidLabelerParamsKt.storageParams {
+          storageParamsApi {
             gcsProjectId = config.vidLabeledImpressionsStorageParams.gcs.projectId
-            impressionsBlobPrefix =
-              "gs://${config.vidLabeledImpressionsStorageParams.gcs.bucketName}"
+            blobPrefix = "gs://${config.vidLabeledImpressionsStorageParams.gcs.bucketName}"
           }
         rawImpressionsStorageParams =
-          VidLabelerParamsKt.storageParams {
+          storageParamsApi {
             gcsProjectId = config.rawImpressionsStorageParams.gcs.projectId
-            impressionsBlobPrefix = "gs://${config.rawImpressionsStorageParams.gcs.bucketName}"
+            blobPrefix = "gs://${config.rawImpressionsStorageParams.gcs.bucketName}"
           }
         vidRepoConnection = transportLayerSecurityParams {
           clientCertResourcePath = config.vidRepoConnection.certFilePath

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/resultsfulfiller/ResultsFulfillerApp.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/resultsfulfiller/ResultsFulfillerApp.kt
@@ -38,7 +38,7 @@ import org.wfanet.measurement.edpaggregator.v1alpha.ImpressionMetadataServiceGrp
 import org.wfanet.measurement.edpaggregator.v1alpha.RequisitionMetadataServiceGrpcKt.RequisitionMetadataServiceCoroutineStub
 import org.wfanet.measurement.edpaggregator.v1alpha.ResultsFulfillerParams
 import org.wfanet.measurement.edpaggregator.v1alpha.ResultsFulfillerParams.NoiseParams.NoiseType
-import org.wfanet.measurement.edpaggregator.v1alpha.ResultsFulfillerParams.StorageParams
+import org.wfanet.measurement.edpaggregator.v1alpha.StorageParamsApi
 import org.wfanet.measurement.queue.QueueSubscriber
 import org.wfanet.measurement.securecomputation.controlplane.v1alpha.WorkItem
 import org.wfanet.measurement.securecomputation.controlplane.v1alpha.WorkItem.WorkItemParams
@@ -84,9 +84,9 @@ class ResultsFulfillerApp(
   private val requisitionStubFactory: RequisitionStubFactory,
   private val kmsClients: Map<String, KmsClient>,
   private val trusTeeConfigs: Map<String, TrusTeeConfig>,
-  private val getImpressionsMetadataStorageConfig: (StorageParams) -> StorageConfig,
-  private val getImpressionsStorageConfig: (StorageParams) -> StorageConfig,
-  private val getRequisitionsStorageConfig: (StorageParams) -> StorageConfig,
+  private val getImpressionsMetadataStorageConfig: (StorageParamsApi) -> StorageConfig,
+  private val getImpressionsStorageConfig: (StorageParamsApi) -> StorageConfig,
+  private val getRequisitionsStorageConfig: (StorageParamsApi) -> StorageConfig,
   private val modelLineInfoMap: Map<String, ModelLineInfo>,
   private val pipelineConfiguration: PipelineConfiguration = DEFAULT_PIPELINE_CONFIGURATION,
   private val metrics: ResultsFulfillerMetrics,

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/resultsfulfiller/ResultsFulfillerAppRunner.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/resultsfulfiller/ResultsFulfillerAppRunner.kt
@@ -37,7 +37,7 @@ import org.wfanet.measurement.edpaggregator.resultsfulfiller.ResultsFulfillerMet
 import org.wfanet.measurement.edpaggregator.runBlockingWithTelemetry
 import org.wfanet.measurement.edpaggregator.v1alpha.ImpressionMetadataServiceGrpcKt.ImpressionMetadataServiceCoroutineStub
 import org.wfanet.measurement.edpaggregator.v1alpha.RequisitionMetadataServiceGrpcKt.RequisitionMetadataServiceCoroutineStub
-import org.wfanet.measurement.edpaggregator.v1alpha.ResultsFulfillerParams.StorageParams
+import org.wfanet.measurement.edpaggregator.v1alpha.StorageParamsApi
 import org.wfanet.measurement.eventdataprovider.requisition.v2alpha.common.ParallelInMemoryVidIndexMap
 import org.wfanet.measurement.gcloud.pubsub.DefaultGooglePubSubClient
 import org.wfanet.measurement.securecomputation.controlplane.v1alpha.WorkItem
@@ -171,7 +171,7 @@ class ResultsFulfillerAppRunner : BaseTeeAppRunner() {
   )
   private var pipelineWorkers: Int = 0
 
-  private val getImpressionsStorageConfig: (StorageParams) -> StorageConfig = { storageParams ->
+  private val getImpressionsStorageConfig: (StorageParamsApi) -> StorageConfig = { storageParams ->
     StorageConfig(projectId = storageParams.gcsProjectId)
   }
 

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/vidlabeler/VidLabelerApp.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/vidlabeler/VidLabelerApp.kt
@@ -20,6 +20,7 @@ import com.google.crypto.tink.KmsClient
 import com.google.protobuf.Any
 import com.google.protobuf.Parser
 import org.wfanet.measurement.edpaggregator.StorageConfig
+import org.wfanet.measurement.edpaggregator.v1alpha.StorageParamsApi
 import org.wfanet.measurement.edpaggregator.v1alpha.VidLabelerParams
 import org.wfanet.measurement.queue.QueueSubscriber
 import org.wfanet.measurement.securecomputation.controlplane.v1alpha.WorkItem
@@ -42,7 +43,7 @@ import org.wfanet.measurement.securecomputation.teesdk.BaseTeeApplication
  * @param rawImpressionsKmsClient decrypt-only KMS clients keyed by data provider resource name.
  * @param vidLabeledImpressionsKmsClient encrypt/decrypt KMS clients keyed by data provider resource
  *   name.
- * @param getStorageConfig builds a [StorageConfig] from [VidLabelerParams.StorageParams].
+ * @param getStorageConfig builds a [StorageConfig] from [StorageParamsApi].
  */
 class VidLabelerApp(
   subscriptionId: String,
@@ -52,7 +53,7 @@ class VidLabelerApp(
   workItemAttemptsClient: WorkItemAttemptsGrpcKt.WorkItemAttemptsCoroutineStub,
   private val rawImpressionsKmsClient: Map<String, KmsClient>,
   private val vidLabeledImpressionsKmsClient: Map<String, KmsClient>,
-  private val getStorageConfig: (VidLabelerParams.StorageParams) -> StorageConfig,
+  private val getStorageConfig: (StorageParamsApi) -> StorageConfig,
 ) :
   BaseTeeApplication(
     subscriptionId = subscriptionId,

--- a/src/main/kotlin/org/wfanet/measurement/integration/common/Configs.kt
+++ b/src/main/kotlin/org/wfanet/measurement/integration/common/Configs.kt
@@ -45,6 +45,7 @@ import org.wfanet.measurement.config.securecomputation.watchedPath
 import org.wfanet.measurement.consent.client.common.toEncryptionPublicKey
 import org.wfanet.measurement.edpaggregator.v1alpha.ResultsFulfillerParams
 import org.wfanet.measurement.edpaggregator.v1alpha.ResultsFulfillerParamsKt
+import org.wfanet.measurement.edpaggregator.v1alpha.storageParamsApi
 import org.wfanet.measurement.edpaggregator.v1alpha.resultsFulfillerParams
 import org.wfanet.measurement.edpaggregator.v1alpha.transportLayerSecurityParams
 import org.wfanet.measurement.internal.duchy.config.ProtocolsSetupConfig
@@ -269,8 +270,8 @@ fun getResultsFulfillerParams(
   return resultsFulfillerParams {
     this.dataProvider = edpResourceName
     this.storageParams =
-      ResultsFulfillerParamsKt.storageParams {
-        this.labeledImpressionsBlobDetailsUriPrefix = labeledImpressionBlobUriPrefix
+      storageParamsApi {
+        this.blobPrefix = labeledImpressionBlobUriPrefix
       }
     this.cmmsConnection = transportLayerSecurityParams {
       clientCertResourcePath = SECRET_FILES_PATH.resolve("${edpDisplayName}_tls.pem").toString()

--- a/src/main/kotlin/org/wfanet/measurement/integration/common/InProcessEdpAggregatorComponents.kt
+++ b/src/main/kotlin/org/wfanet/measurement/integration/common/InProcessEdpAggregatorComponents.kt
@@ -91,6 +91,7 @@ import org.wfanet.measurement.edpaggregator.v1alpha.ImpressionMetadata
 import org.wfanet.measurement.edpaggregator.v1alpha.ImpressionMetadataServiceGrpcKt.ImpressionMetadataServiceCoroutineStub
 import org.wfanet.measurement.edpaggregator.v1alpha.RequisitionMetadataServiceGrpcKt.RequisitionMetadataServiceCoroutineStub
 import org.wfanet.measurement.edpaggregator.v1alpha.ResultsFulfillerParams
+import org.wfanet.measurement.edpaggregator.v1alpha.StorageParamsApi
 import org.wfanet.measurement.edpaggregator.v1alpha.createImpressionMetadataRequest
 import org.wfanet.measurement.edpaggregator.v1alpha.entityKey
 import org.wfanet.measurement.edpaggregator.v1alpha.impressionMetadata
@@ -190,7 +191,7 @@ class InProcessEdpAggregatorComponents(
         pullIntervalMillis = 100,
         blockingContext = Dispatchers.IO,
       )
-    val getStorageConfig = { _: ResultsFulfillerParams.StorageParams ->
+    val getStorageConfig = { _: StorageParamsApi ->
       StorageConfig(rootDirectory = storagePath.toFile())
     }
     ResultsFulfillerApp(

--- a/src/main/proto/wfa/measurement/edpaggregator/v1alpha/BUILD.bazel
+++ b/src/main/proto/wfa/measurement/edpaggregator/v1alpha/BUILD.bazel
@@ -67,10 +67,25 @@ kt_jvm_proto_library(
 )
 
 proto_library(
+    name = "storage_params_api_proto",
+    srcs = ["storage_params_api.proto"],
+    strip_import_prefix = _IMPORT_PREFIX,
+    deps = [
+        "@com_google_googleapis//google/api:field_behavior_proto",
+    ],
+)
+
+kt_jvm_proto_library(
+    name = "storage_params_api_kt_jvm_proto",
+    deps = [":storage_params_api_proto"],
+)
+
+proto_library(
     name = "results_fulfiller_params_proto",
     srcs = ["results_fulfiller_params.proto"],
     strip_import_prefix = _IMPORT_PREFIX,
     deps = [
+        ":storage_params_api_proto",
         ":transport_layer_security_params_proto",
         "@com_google_googleapis//google/api:field_behavior_proto",
         "@com_google_googleapis//google/api:resource_proto",
@@ -89,6 +104,7 @@ proto_library(
     srcs = ["vid_labeler_params.proto"],
     strip_import_prefix = _IMPORT_PREFIX,
     deps = [
+        ":storage_params_api_proto",
         ":transport_layer_security_params_proto",
         "@com_google_googleapis//google/api:field_behavior_proto",
         "@com_google_googleapis//google/api:resource_proto",
@@ -107,6 +123,7 @@ proto_library(
     srcs = ["subpool_assigner_params.proto"],
     strip_import_prefix = _IMPORT_PREFIX,
     deps = [
+        ":storage_params_api_proto",
         ":transport_layer_security_params_proto",
         "@com_google_googleapis//google/api:field_behavior_proto",
         "@com_google_googleapis//google/api:resource_proto",
@@ -126,6 +143,7 @@ proto_library(
     srcs = ["vid_rank_builder_params.proto"],
     strip_import_prefix = _IMPORT_PREFIX,
     deps = [
+        ":storage_params_api_proto",
         ":encrypted_dek_proto",
         "@com_google_googleapis//google/api:field_behavior_proto",
         "@com_google_googleapis//google/api:resource_proto",

--- a/src/main/proto/wfa/measurement/edpaggregator/v1alpha/results_fulfiller_params.proto
+++ b/src/main/proto/wfa/measurement/edpaggregator/v1alpha/results_fulfiller_params.proto
@@ -24,6 +24,7 @@ package wfa.measurement.edpaggregator.v1alpha;
 
 import "google/api/field_behavior.proto";
 import "google/api/resource.proto";
+import "wfa/measurement/edpaggregator/v1alpha/storage_params_api.proto";
 import "wfa/measurement/edpaggregator/v1alpha/transport_layer_security_params.proto";
 
 option java_package = "org.wfanet.measurement.edpaggregator.v1alpha";
@@ -34,22 +35,14 @@ option java_outer_classname = "ResultsFulfillerParamsProto";
 message ResultsFulfillerParams {
   // The Cmms Resource name for the EDP
   string data_provider = 1;
-  // Message representing the storage details used by the results fulfiller app
-  message StorageParams {
-    // The blob uri prefix for the labeled impressions `BlobDetails` that is
-    // stored in GCS for a given EDP
-    // See reference:
-    // https://github.com/world-federation-of-advertisers/common-jvm/blob/main/src/main/kotlin/org/wfanet/measurement/storage/SelectedStorageClient.kt
-    string labeled_impressions_blob_details_uri_prefix = 1
-        [(google.api.field_behavior) = REQUIRED];
 
-    // The Project ID for the requisitions GCS instance that can be
-    // used with a blob URI to retrieve the data. Optional.
-    string gcs_project_id = 4;
-  }
-
-  // The storage used by the tee app
-  StorageParams storage_params = 2 [(google.api.field_behavior) = REQUIRED];
+  // The storage used by the tee app. `blob_prefix` is the labeled-impressions
+  // `BlobDetails` URI prefix; `gcs_project_id` is the project for that storage
+  // instance.
+  //
+  // TODO: split into separate `impressions` (labeled impressions + BlobDetails,
+  // operator or EDP) and `requisitions` (always operator) roles.
+  StorageParamsApi storage_params = 2 [(google.api.field_behavior) = REQUIRED];
 
   // Message representing the details needed to generate certificates
   message ConsentParams {

--- a/src/main/proto/wfa/measurement/edpaggregator/v1alpha/storage_params_api.proto
+++ b/src/main/proto/wfa/measurement/edpaggregator/v1alpha/storage_params_api.proto
@@ -1,0 +1,51 @@
+// Copyright 2026 The Cross-Media Measurement Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package wfa.measurement.edpaggregator.v1alpha;
+
+import "google/api/field_behavior.proto";
+
+option java_package = "org.wfanet.measurement.edpaggregator.v1alpha";
+option java_multiple_files = true;
+option java_outer_classname = "StorageParamsApiProto";
+
+// Cloud Storage location for a wire/API params message: a GCS project ID plus a
+// gs:// blob URI prefix.
+//
+// Shared by every EDP Aggregator TEE WorkItem params message
+// (VidLabelerParams, SubpoolAssignerParams, VidRankBuilderParams,
+// ResultsFulfillerParams) so the wire layer has a single storage shape instead
+// of four near-identical copies. This is the API-layer counterpart to the
+// config-layer `wfa.measurement.config.edpaggregator.StorageParams`; the
+// dispatcher / param builders translate config -> this message.
+message StorageParamsApi {
+  // The Google Cloud Storage project ID for the storage instance.
+  //
+  // Conditionally required: MUST be non-empty when the bucket is EDP-owned
+  // (cross-project); MAY be empty for operator-owned buckets, where it
+  // defaults to the runtime project. Enforced by the dispatcher / param
+  // builders, since `field_behavior` is not enforced at runtime.
+  string gcs_project_id = 1 [(google.api.field_behavior) = OPTIONAL];
+
+  // The gs:// blob URI prefix (e.g. `gs://bucket-name` or
+  // `gs://bucket-name/path`).
+  //
+  // Conditionally required: MAY be empty when the location is supplied at
+  // runtime (e.g. raw impressions, via `RawImpressionUpload.done_blob_uri`);
+  // MUST be non-empty for static, config-driven locations (subpool-map,
+  // vid-rank-map, labeled impressions).
+  string blob_prefix = 2 [(google.api.field_behavior) = OPTIONAL];
+}

--- a/src/main/proto/wfa/measurement/edpaggregator/v1alpha/subpool_assigner_params.proto
+++ b/src/main/proto/wfa/measurement/edpaggregator/v1alpha/subpool_assigner_params.proto
@@ -19,6 +19,7 @@ package wfa.measurement.edpaggregator.v1alpha;
 import "google/api/field_behavior.proto";
 import "google/api/resource.proto";
 import "google/protobuf/timestamp.proto";
+import "wfa/measurement/edpaggregator/v1alpha/storage_params_api.proto";
 import "wfa/measurement/edpaggregator/v1alpha/transport_layer_security_params.proto";
 
 option java_package = "org.wfanet.measurement.edpaggregator.v1alpha";
@@ -37,27 +38,13 @@ message SubpoolAssignerParams {
     (google.api.resource_reference).type = "halo.wfanet.org/DataProvider"
   ];
 
-  // Cloud Storage location used by the SubpoolAssigner.
-  message StorageParams {
-    // The Google Cloud Storage project ID for the storage instance.
-    string gcs_project_id = 1 [(google.api.field_behavior) = REQUIRED];
-
-    // The Cloud Storage blob URI prefix.
-    //
-    // Required for the subpool-map storage (a static, config-driven
-    // location that does not change at runtime). May be left empty for the
-    // raw-impressions storage, where the location is supplied by the API
-    // via `RawImpressionUpload.done_blob_uri`.
-    string blob_prefix = 2 [(google.api.field_behavior) = OPTIONAL];
-  }
-
   // Storage from which raw impressions are read.
   //
   // Read by the Phase-0 SubpoolAssigner. Also carried as pass-through so
   // the last-shard-out can populate the VidRankBuilder Phase-1 WorkItem
   // (and ultimately the VidLabeler Phase-2 WorkItem) without round-tripping
   // back to the dispatcher for it.
-  StorageParams raw_impression_storage_params = 2
+  StorageParamsApi raw_impression_storage_params = 2
       [(google.api.field_behavior) = REQUIRED];
 
   // Storage to which the VidLabeler will write the labeled impressions.
@@ -65,7 +52,7 @@ message SubpoolAssignerParams {
   // Not consumed by the Phase-0 SubpoolAssigner. Pass-through for the
   // VidRankBuilder Phase-1 WorkItem and the VidLabeler Phase-2 WorkItem
   // construction by the last-shard-out.
-  StorageParams vid_labeled_impressions_storage_params = 3
+  StorageParamsApi vid_labeled_impressions_storage_params = 3
       [(google.api.field_behavior) = REQUIRED];
 
   // Storage from which the VidRankBuilder reads prior cumulative rank-index
@@ -74,12 +61,12 @@ message SubpoolAssignerParams {
   //
   // Not consumed by the Phase-0 SubpoolAssigner. Pass-through for the
   // VidRankBuilder Phase-1 WorkItem construction by the last-shard-out.
-  StorageParams vid_rank_map_storage_params = 4
+  StorageParamsApi vid_rank_map_storage_params = 4
       [(google.api.field_behavior) = REQUIRED];
 
   // Storage to which per-(shard, subpool) SubpoolFingerprints blobs are
   // written.
-  StorageParams subpool_map_storage_params = 5
+  StorageParamsApi subpool_map_storage_params = 5
       [(google.api.field_behavior) = REQUIRED];
 
   // TLS connection parameters used by the TEE app to talk to the

--- a/src/main/proto/wfa/measurement/edpaggregator/v1alpha/vid_labeler_params.proto
+++ b/src/main/proto/wfa/measurement/edpaggregator/v1alpha/vid_labeler_params.proto
@@ -18,6 +18,7 @@ package wfa.measurement.edpaggregator.v1alpha;
 
 import "google/api/field_behavior.proto";
 import "google/api/resource.proto";
+import "wfa/measurement/edpaggregator/v1alpha/storage_params_api.proto";
 import "wfa/measurement/edpaggregator/v1alpha/transport_layer_security_params.proto";
 
 option java_package = "org.wfanet.measurement.edpaggregator.v1alpha";
@@ -34,22 +35,12 @@ message VidLabelerParams {
     (google.api.resource_reference).type = "halo.wfanet.org/DataProvider"
   ];
 
-  // Message representing storage details for reading or writing impressions
-  // in Google Cloud Storage.
-  message StorageParams {
-    // The Google Cloud Storage project ID for the storage instance.
-    string gcs_project_id = 1 [(google.api.field_behavior) = REQUIRED];
-
-    // The blob URI prefix for impressions in Google Cloud Storage.
-    string impressions_blob_prefix = 2 [(google.api.field_behavior) = REQUIRED];
-  }
-
   // Storage for raw impressions read by the TEE app.
-  StorageParams raw_impressions_storage_params = 2
+  StorageParamsApi raw_impressions_storage_params = 2
       [(google.api.field_behavior) = REQUIRED];
 
   // Storage for VID-labeled impressions written by the TEE app.
-  StorageParams vid_labeled_impressions_storage_params = 3
+  StorageParamsApi vid_labeled_impressions_storage_params = 3
       [(google.api.field_behavior) = REQUIRED];
 
   // Connection used by TEE App to access the VID Repo.

--- a/src/main/proto/wfa/measurement/edpaggregator/v1alpha/vid_rank_builder_params.proto
+++ b/src/main/proto/wfa/measurement/edpaggregator/v1alpha/vid_rank_builder_params.proto
@@ -20,6 +20,7 @@ import "google/api/field_behavior.proto";
 import "google/api/resource.proto";
 import "google/type/date.proto";
 import "wfa/measurement/edpaggregator/v1alpha/encrypted_dek.proto";
+import "wfa/measurement/edpaggregator/v1alpha/storage_params_api.proto";
 
 option java_package = "org.wfanet.measurement.edpaggregator.v1alpha";
 option java_multiple_files = true;
@@ -42,20 +43,6 @@ message VidRankBuilderParams {
   wfa.measurement.securecomputation.impressions.EncryptedDek
       encrypted_subpool_maps_dek = 2 [(google.api.field_behavior) = REQUIRED];
 
-  // Cloud Storage location used by the VidRankBuilder.
-  message StorageParams {
-    // The Google Cloud Storage project ID for the storage instance.
-    string gcs_project_id = 1 [(google.api.field_behavior) = REQUIRED];
-
-    // The Cloud Storage blob URI prefix.
-    //
-    // Required for the subpool-map and vid-rank-map storage (static,
-    // config-driven locations that do not change at runtime). May be left
-    // empty for the raw-impressions storage, where the location is supplied
-    // by the API via `RawImpressionUpload.done_blob_uri`.
-    string blob_prefix = 2 [(google.api.field_behavior) = OPTIONAL];
-  }
-
   // Storage from which raw impressions are read.
   //
   // Not consumed by the Phase-1 ranker itself (Phase-1 reads only
@@ -64,24 +51,24 @@ message VidRankBuilderParams {
   // here only as pass-through so the last-`RankerJob`-out can populate the
   // VidLabeler Phase-2 WorkItem without round-tripping back to the
   // dispatcher for it.
-  StorageParams raw_impression_storage_params = 3
+  StorageParamsApi raw_impression_storage_params = 3
       [(google.api.field_behavior) = REQUIRED];
 
   // Storage to which the VidLabeler will write the labeled impressions.
   //
   // Not consumed by the Phase-1 ranker. Pass-through for Phase-2 WorkItem
   // construction by the last-`RankerJob`-out.
-  StorageParams vid_labeled_impressions_storage_params = 4
+  StorageParamsApi vid_labeled_impressions_storage_params = 4
       [(google.api.field_behavior) = REQUIRED];
 
   // Storage from which the per-(shard, subpool) `SubpoolFingerprints` blobs
   // produced by the SubpoolAssigner are read.
-  StorageParams subpool_map_storage_params = 5
+  StorageParamsApi subpool_map_storage_params = 5
       [(google.api.field_behavior) = REQUIRED];
 
   // Storage from which prior cumulative rank-index blobs are read and to
   // which the new day-only + cumulative rank-index blobs are written.
-  StorageParams vid_rank_map_storage_params = 6
+  StorageParamsApi vid_rank_map_storage_params = 6
       [(google.api.field_behavior) = REQUIRED];
 
   // Fully qualified resource name of the `RawImpressionUpload` this WorkItem

--- a/src/test/kotlin/org/wfanet/measurement/edpaggregator/resultsfulfiller/ResultsFulfillerAppTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/edpaggregator/resultsfulfiller/ResultsFulfillerAppTest.kt
@@ -135,6 +135,8 @@ import org.wfanet.measurement.edpaggregator.v1alpha.RequisitionMetadataServiceGr
 import org.wfanet.measurement.edpaggregator.v1alpha.RequisitionMetadataServiceGrpcKt.RequisitionMetadataServiceCoroutineStub
 import org.wfanet.measurement.edpaggregator.v1alpha.ResultsFulfillerParams
 import org.wfanet.measurement.edpaggregator.v1alpha.ResultsFulfillerParamsKt
+import org.wfanet.measurement.edpaggregator.v1alpha.StorageParamsApi
+import org.wfanet.measurement.edpaggregator.v1alpha.storageParamsApi
 import org.wfanet.measurement.edpaggregator.v1alpha.blobDetails
 import org.wfanet.measurement.edpaggregator.v1alpha.copy
 import org.wfanet.measurement.edpaggregator.v1alpha.encryptedDek
@@ -1610,8 +1612,8 @@ class ResultsFulfillerAppTest {
 
   private fun getStorageConfig(
     tmpPath: File
-  ): (ResultsFulfillerParams.StorageParams) -> StorageConfig {
-    return { _: ResultsFulfillerParams.StorageParams -> StorageConfig(rootDirectory = tmpPath) }
+  ): (StorageParamsApi) -> StorageConfig {
+    return { _: StorageParamsApi -> StorageConfig(rootDirectory = tmpPath) }
   }
 
   private fun createWorkItemParams(
@@ -1623,8 +1625,8 @@ class ResultsFulfillerAppTest {
         resultsFulfillerParams {
             dataProvider = EDP_NAME
             this.storageParams =
-              ResultsFulfillerParamsKt.storageParams {
-                labeledImpressionsBlobDetailsUriPrefix = IMPRESSIONS_METADATA_FILE_URI_PREFIX
+              storageParamsApi {
+                blobPrefix = IMPRESSIONS_METADATA_FILE_URI_PREFIX
               }
             this.cmmsConnection = transportLayerSecurityParams {
               clientCertResourcePath = SECRET_FILES_PATH.resolve("edp1_tls.pem").toString()

--- a/src/test/kotlin/org/wfanet/measurement/edpaggregator/vidlabeler/VidLabelerAppTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/edpaggregator/vidlabeler/VidLabelerAppTest.kt
@@ -31,6 +31,7 @@ import org.wfanet.measurement.common.pack
 import org.wfanet.measurement.edpaggregator.StorageConfig
 import org.wfanet.measurement.edpaggregator.v1alpha.VidLabelerParams
 import org.wfanet.measurement.edpaggregator.v1alpha.VidLabelerParamsKt
+import org.wfanet.measurement.edpaggregator.v1alpha.storageParamsApi
 import org.wfanet.measurement.edpaggregator.v1alpha.vidLabelerParams
 import org.wfanet.measurement.queue.QueueSubscriber
 import org.wfanet.measurement.securecomputation.controlplane.v1alpha.WorkItem
@@ -90,14 +91,14 @@ class VidLabelerAppTest {
     val params = vidLabelerParams {
       dataProvider = DATA_PROVIDER_NAME
       rawImpressionsStorageParams =
-        VidLabelerParamsKt.storageParams {
+        storageParamsApi {
           gcsProjectId = "test-project"
-          impressionsBlobPrefix = "gs://raw-bucket/impressions"
+          blobPrefix = "gs://raw-bucket/impressions"
         }
       vidLabeledImpressionsStorageParams =
-        VidLabelerParamsKt.storageParams {
+        storageParamsApi {
           gcsProjectId = "test-project"
-          impressionsBlobPrefix = "gs://output-bucket/labeled"
+          blobPrefix = "gs://output-bucket/labeled"
         }
     }
 
@@ -110,14 +111,14 @@ class VidLabelerAppTest {
     val params = vidLabelerParams {
       dataProvider = DATA_PROVIDER_NAME
       rawImpressionsStorageParams =
-        VidLabelerParamsKt.storageParams {
+        storageParamsApi {
           gcsProjectId = "test-project"
-          impressionsBlobPrefix = "gs://raw-bucket/impressions"
+          blobPrefix = "gs://raw-bucket/impressions"
         }
       vidLabeledImpressionsStorageParams =
-        VidLabelerParamsKt.storageParams {
+        storageParamsApi {
           gcsProjectId = "test-project"
-          impressionsBlobPrefix = "gs://output-bucket/labeled"
+          blobPrefix = "gs://output-bucket/labeled"
         }
     }
 
@@ -132,14 +133,14 @@ class VidLabelerAppTest {
     val params = vidLabelerParams {
       dataProvider = DATA_PROVIDER_NAME
       rawImpressionsStorageParams =
-        VidLabelerParamsKt.storageParams {
+        storageParamsApi {
           gcsProjectId = "test-project"
-          impressionsBlobPrefix = "gs://raw-bucket/impressions"
+          blobPrefix = "gs://raw-bucket/impressions"
         }
       vidLabeledImpressionsStorageParams =
-        VidLabelerParamsKt.storageParams {
+        storageParamsApi {
           gcsProjectId = "test-project"
-          impressionsBlobPrefix = "gs://output-bucket/labeled"
+          blobPrefix = "gs://output-bucket/labeled"
         }
     }
 
@@ -153,14 +154,14 @@ class VidLabelerAppTest {
     val app = createApp()
     val params = vidLabelerParams {
       rawImpressionsStorageParams =
-        VidLabelerParamsKt.storageParams {
+        storageParamsApi {
           gcsProjectId = "test-project"
-          impressionsBlobPrefix = "gs://raw-bucket/impressions"
+          blobPrefix = "gs://raw-bucket/impressions"
         }
       vidLabeledImpressionsStorageParams =
-        VidLabelerParamsKt.storageParams {
+        storageParamsApi {
           gcsProjectId = "test-project"
-          impressionsBlobPrefix = "gs://output-bucket/labeled"
+          blobPrefix = "gs://output-bucket/labeled"
         }
     }
 

--- a/src/test/kotlin/org/wfanet/measurement/edpaggregator/vidlabeling/VidLabelingDispatcherTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/edpaggregator/vidlabeling/VidLabelingDispatcherTest.kt
@@ -41,6 +41,7 @@ import org.wfanet.measurement.edpaggregator.v1alpha.RawImpressionMetadataBatchFi
 import org.wfanet.measurement.edpaggregator.v1alpha.RawImpressionMetadataBatchServiceGrpcKt
 import org.wfanet.measurement.edpaggregator.v1alpha.VidLabelerParams
 import org.wfanet.measurement.edpaggregator.v1alpha.VidLabelerParamsKt
+import org.wfanet.measurement.edpaggregator.v1alpha.storageParamsApi
 import org.wfanet.measurement.edpaggregator.v1alpha.rawImpressionMetadataBatch
 import org.wfanet.measurement.edpaggregator.v1alpha.vidLabelerParams
 import org.wfanet.measurement.securecomputation.controlplane.v1alpha.CreateWorkItemRequest
@@ -87,14 +88,14 @@ class VidLabelingDispatcherTest {
   private val vidLabelerParamsTemplate = vidLabelerParams {
     dataProvider = DATA_PROVIDER_NAME
     vidLabeledImpressionsStorageParams =
-      VidLabelerParamsKt.storageParams {
+      storageParamsApi {
         gcsProjectId = "test-project"
-        impressionsBlobPrefix = "gs://output-bucket/labeled"
+        blobPrefix = "gs://output-bucket/labeled"
       }
     rawImpressionsStorageParams =
-      VidLabelerParamsKt.storageParams {
+      storageParamsApi {
         gcsProjectId = "test-project"
-        impressionsBlobPrefix = "gs://input-bucket/raw"
+        blobPrefix = "gs://input-bucket/raw"
       }
   }
 


### PR DESCRIPTION
## Summary

  The four EDP Aggregator TEE WorkItem params messages each defined their own
  near-identical nested `StorageParams` (a `{project, location}` pair). This
  collapses them into a single shared wire-layer message,
  `StorageParamsApi { gcs_project_id, blob_prefix }`, reused everywhere, so the
  API layer has one storage shape instead of four divergent copies.

  This is the wire/API-layer counterpart to the config-layer
  `config.edpaggregator.StorageParams` (left unchanged); the dispatcher / param
  builders remain the single config → wire translation point.

  ## Changes

  - **New:** `storage_params_api.proto` — `StorageParamsApi { gcs_project_id, blob_prefix }` (`blob_prefix` optional: empty when the location is supplied at runtime, e.g. raw impressions via the done
  blob).
  - Migrated to `StorageParamsApi` and removed the nested `StorageParams` from:
    - `vid_labeler_params.proto` (`impressions_blob_prefix` → `blob_prefix`)
    - `subpool_assigner_params.proto`
    - `vid_rank_builder_params.proto`
    - `results_fulfiller_params.proto` (`labeled_impressions_blob_details_uri_prefix` → `blob_prefix`)
  - Updated `BUILD.bazel`, the Kotlin call sites (dispatcher, `VidLabelerApp`, `ResultsFulfiller` app/runner, integration configs) and the affected tests.

  > Out of scope: the `ResultsFulfillerParams` impressions/requisitions role-split
  > (tracked separately); only the type unification is here.

  ## BREAKING CHANGE

  `ResultsFulfillerParams.StorageParams` field name and numbers changed
  (`labeled_impressions_blob_details_uri_prefix` → `blob_prefix`; inner field
  numbers shifted). Adopting this requires, in one rollout:

  - **Static config:** update the **DataWatcher config blob** (and the DataWatcher
    *delete* config blob, if it carries a `ResultsFulfillerParams`) — rename
    `storage_params.labeled_impressions_blob_details_uri_prefix` →
    `storage_params.blob_prefix`. (`gcs_project_id` keeps its name.)
  - **Redeploy together:** DataWatcher, VID Labeling Dispatcher, ResultsFulfiller
    and VidLabeler binaries (the descriptors are compiled in).
  - **Drain the ResultsFulfiller queue** across the cut: in-flight WorkItems
    serialized before the deploy would mis-read `gcs_project_id` afterward.

  The other three messages kept `gcs_project_id=1` / `blob_prefix=2`, so they are
  binary-compatible (no in-flight hazard). No Spanner/schema or infra changes.

  ## Test plan

  - `bazel build` of the five proto targets — passes.
  - `bazel build` of the affected main packages (vidlabeling, vidlabeler,
    resultsfulfiller, integration/common) and test packages — passes.

Issue: #3981 