### PR TITLE
feat: Add request_id and etag-idempotency docs to MarkRankerJob/MarkPoolAssignmentJob*Succeeded RPCs

### DIFF
--- a/src/main/proto/wfa/measurement/edpaggregator/v1alpha/pool_assignment_job_service.proto
+++ b/src/main/proto/wfa/measurement/edpaggregator/v1alpha/pool_assignment_job_service.proto
@@ -47,7 +47,11 @@ service PoolAssignmentJobService {
 
   // Marks a `PoolAssignmentJob` as `SUCCEEDED`. Atomically
   // checks if this is the last shard for the (upload, model
-  // line) and returns the signal to the caller.
+  // line) and returns the signal to the caller. Throws
+  // ABORTED if etag does not match the current resource
+  // version (AIP-154). A retry with the same `request_id`
+  // returns the original response without modifying state
+  // (AIP-155).
   rpc MarkPoolAssignmentJobSucceeded(MarkPoolAssignmentJobSucceededRequest)
       returns (MarkPoolAssignmentJobSucceededResponse) {}
 
@@ -195,6 +199,16 @@ message MarkPoolAssignmentJobSucceededRequest {
 
   // The etag of the PoolAssignmentJob for optimistic locking.
   string etag = 2 [(google.api.field_behavior) = REQUIRED];
+
+  // A request ID provided by the client to ensure idempotency
+  // on retry. A retry with the same `request_id` returns the
+  // original response without re-transitioning the resource.
+  //
+  // This field must be a UUID4 (RFC 4122) string.
+  string request_id = 3 [
+    (google.api.field_behavior) = OPTIONAL,
+    (google.api.field_info).format = UUID4
+  ];
 }
 
 // Response message for the

--- a/src/main/proto/wfa/measurement/edpaggregator/v1alpha/ranker_job_service.proto
+++ b/src/main/proto/wfa/measurement/edpaggregator/v1alpha/ranker_job_service.proto
@@ -45,6 +45,10 @@ service RankerJobService {
   // this is the last job for the (upload, model line) and
   // returns the signal to the caller. Throws
   // FAILED_PRECONDITION if state is not CREATED or FAILED.
+  // Throws ABORTED if etag does not match the current resource
+  // version (AIP-154). A retry with the same `request_id`
+  // returns the original response without modifying state
+  // (AIP-155).
   rpc MarkRankerJobSucceeded(MarkRankerJobSucceededRequest)
       returns (MarkRankerJobSucceededResponse) {}
 
@@ -188,6 +192,16 @@ message MarkRankerJobSucceededRequest {
 
   // The etag of the RankerJob for optimistic locking.
   string etag = 2 [(google.api.field_behavior) = REQUIRED];
+
+  // A request ID provided by the client to ensure idempotency
+  // on retry. A retry with the same `request_id` returns the
+  // original response without re-transitioning the resource.
+  //
+  // This field must be a UUID4 (RFC 4122) string.
+  string request_id = 3 [
+    (google.api.field_behavior) = OPTIONAL,
+    (google.api.field_info).format = UUID4
+  ];
 }
 
 // Response message for the `MarkRankerJobSucceeded` method.

--- a/src/main/proto/wfa/measurement/internal/edpaggregator/pool_assignment_job_service.proto
+++ b/src/main/proto/wfa/measurement/internal/edpaggregator/pool_assignment_job_service.proto
@@ -44,7 +44,11 @@ service PoolAssignmentJobService {
   rpc ListPoolAssignmentJobs(ListPoolAssignmentJobsRequest)
       returns (ListPoolAssignmentJobsResponse);
 
-  // Marks a `PoolAssignmentJob` as `SUCCEEDED`.
+  // Marks a `PoolAssignmentJob` as `SUCCEEDED`. Throws
+  // FAILED_PRECONDITION if state is not CREATED or FAILED.
+  // Throws ABORTED if etag does not match (AIP-154).
+  // A retry with the same `request_id` returns the original
+  // response without modifying state (AIP-155).
   rpc MarkPoolAssignmentJobSucceeded(MarkPoolAssignmentJobSucceededRequest)
       returns (MarkPoolAssignmentJobSucceededResponse);
 
@@ -156,6 +160,9 @@ message MarkPoolAssignmentJobSucceededRequest {
 
   // Entity tag for optimistic concurrency control.
   string etag = 4;
+
+  // A request ID provided by the client to ensure idempotency.
+  string request_id = 5;
 }
 
 // Response message for MarkPoolAssignmentJobSucceeded.

--- a/src/main/proto/wfa/measurement/internal/edpaggregator/ranker_job_service.proto
+++ b/src/main/proto/wfa/measurement/internal/edpaggregator/ranker_job_service.proto
@@ -42,6 +42,9 @@ service RankerJobService {
 
   // Marks a `RankerJob` as `SUCCEEDED`. Throws
   // FAILED_PRECONDITION if state is not CREATED or FAILED.
+  // Throws ABORTED if etag does not match (AIP-154).
+  // A retry with the same `request_id` returns the original
+  // response without modifying state (AIP-155).
   rpc MarkRankerJobSucceeded(MarkRankerJobSucceededRequest)
       returns (MarkRankerJobSucceededResponse);
 
@@ -161,6 +164,9 @@ message MarkRankerJobSucceededRequest {
 
   // Entity tag for optimistic concurrency control.
   string etag = 4;
+
+  // A request ID provided by the client to ensure idempotency.
+  string request_id = 5;
 }
 
 // Response message for MarkRankerJobSucceeded.


### PR DESCRIPTION
Adds AIP-155 `request_id` field to `MarkRankerJobSucceeded` and `MarkPoolAssignmentJobSucceeded` request messages (public + internal) so retries can recover the original response payload after a lost network reply. Updates the RPC docstrings to describe the two-layer contract:

- **AIP-154 etag** on each request: optimistic locking. Server returns `ABORTED` on etag mismatch.
- **AIP-155 request_id** on each request: retry idempotency. Server returns the original response on retry with the same `request_id` without re-transitioning the resource.

The third RPC in the family (`MarkVidLabelingJobSucceeded`) is handled in #3984 directly with the same shape.

(History note: an earlier version of this PR proposed reusing `etag` as the idempotency key. That was rejected as inconsistent with AIP-154's strict ABORTED-on-mismatch rule; this version uses AIP-155 `request_id` instead, matching the rest of the family.)

Issue: #3996
