### PR TITLE
feat: Make Filter.state repeated across EDPA v1alpha List services

### DIFF
--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/spanner/db/RawImpressionMetadataBatch.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/spanner/db/RawImpressionMetadataBatch.kt
@@ -207,7 +207,7 @@ fun AsyncDatabaseClient.ReadContext.readRawImpressionMetadataBatches(
     }
 
     if (filter.statesList.isNotEmpty()) {
-      conjuncts.add("State IN UNNEST(@states)")
+      conjuncts.add("CAST(State AS INT64) IN UNNEST(@states)")
     }
 
     if (after != null) {

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/spanner/db/RawImpressionMetadataBatch.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/spanner/db/RawImpressionMetadataBatch.kt
@@ -206,8 +206,8 @@ fun AsyncDatabaseClient.ReadContext.readRawImpressionMetadataBatches(
       conjuncts.add("DeleteTime IS NULL")
     }
 
-    if (filter.statesList.isNotEmpty()) {
-      conjuncts.add("CAST(State AS INT64) IN UNNEST(@states)")
+    if (filter.stateInList.isNotEmpty()) {
+      conjuncts.add("CAST(State AS INT64) IN UNNEST(@state_in)")
     }
 
     if (after != null) {
@@ -226,8 +226,8 @@ fun AsyncDatabaseClient.ReadContext.readRawImpressionMetadataBatches(
       bind("dataProviderResourceId").to(dataProviderResourceId)
       bind("limit").to(limit.toLong())
 
-      if (filter.statesList.isNotEmpty()) {
-        bind("states").toInt64Array(filter.statesList.map { it.number.toLong() })
+      if (filter.stateInList.isNotEmpty()) {
+        bind("state_in").toInt64Array(filter.stateInList.map { it.number.toLong() })
       }
 
       if (after != null) {

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/spanner/db/RawImpressionMetadataBatch.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/spanner/db/RawImpressionMetadataBatch.kt
@@ -206,8 +206,8 @@ fun AsyncDatabaseClient.ReadContext.readRawImpressionMetadataBatches(
       conjuncts.add("DeleteTime IS NULL")
     }
 
-    if (filter.state != RawImpressionBatchState.RAW_IMPRESSION_BATCH_STATE_UNSPECIFIED) {
-      conjuncts.add("State = @state")
+    if (filter.statesList.isNotEmpty()) {
+      conjuncts.add("State IN UNNEST(@states)")
     }
 
     if (after != null) {
@@ -226,8 +226,8 @@ fun AsyncDatabaseClient.ReadContext.readRawImpressionMetadataBatches(
       bind("dataProviderResourceId").to(dataProviderResourceId)
       bind("limit").to(limit.toLong())
 
-      if (filter.state != RawImpressionBatchState.RAW_IMPRESSION_BATCH_STATE_UNSPECIFIED) {
-        bind("state").to(filter.state.number.toLong())
+      if (filter.statesList.isNotEmpty()) {
+        bind("states").toInt64Array(filter.statesList.map { it.number.toLong() })
       }
 
       if (after != null) {

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/spanner/db/RequisitionMetadata.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/spanner/db/RequisitionMetadata.kt
@@ -255,7 +255,7 @@ fun AsyncDatabaseClient.ReadContext.readRequisitionMetadata(
 
     if (filter != null) {
       if (filter.statesList.isNotEmpty()) {
-        conjuncts.add("State IN UNNEST(@states)")
+        conjuncts.add("CAST(State AS INT64) IN UNNEST(@states)")
       }
       if (filter.groupId.isNotEmpty()) {
         conjuncts.add("GroupId = @groupId")

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/spanner/db/RequisitionMetadata.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/spanner/db/RequisitionMetadata.kt
@@ -254,8 +254,8 @@ fun AsyncDatabaseClient.ReadContext.readRequisitionMetadata(
     val conjuncts = mutableListOf("DataProviderResourceId = @dataProviderResourceId")
 
     if (filter != null) {
-      if (filter.statesList.isNotEmpty()) {
-        conjuncts.add("CAST(State AS INT64) IN UNNEST(@states)")
+      if (filter.stateInList.isNotEmpty()) {
+        conjuncts.add("CAST(State AS INT64) IN UNNEST(@state_in)")
       }
       if (filter.groupId.isNotEmpty()) {
         conjuncts.add("GroupId = @groupId")
@@ -285,8 +285,8 @@ fun AsyncDatabaseClient.ReadContext.readRequisitionMetadata(
       bind("dataProviderResourceId").to(dataProviderResourceId)
 
       if (filter != null) {
-        if (filter.statesList.isNotEmpty()) {
-          bind("states").toInt64Array(filter.statesList.map { it.number.toLong() })
+        if (filter.stateInList.isNotEmpty()) {
+          bind("state_in").toInt64Array(filter.stateInList.map { it.number.toLong() })
         }
         if (filter.groupId.isNotEmpty()) {
           bind("groupId").to(filter.groupId)

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/spanner/db/RequisitionMetadata.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/spanner/db/RequisitionMetadata.kt
@@ -254,8 +254,8 @@ fun AsyncDatabaseClient.ReadContext.readRequisitionMetadata(
     val conjuncts = mutableListOf("DataProviderResourceId = @dataProviderResourceId")
 
     if (filter != null) {
-      if (filter.state != State.REQUISITION_METADATA_STATE_UNSPECIFIED) {
-        conjuncts.add("State = @state")
+      if (filter.statesList.isNotEmpty()) {
+        conjuncts.add("State IN UNNEST(@states)")
       }
       if (filter.groupId.isNotEmpty()) {
         conjuncts.add("GroupId = @groupId")
@@ -285,8 +285,8 @@ fun AsyncDatabaseClient.ReadContext.readRequisitionMetadata(
       bind("dataProviderResourceId").to(dataProviderResourceId)
 
       if (filter != null) {
-        if (filter.state != State.REQUISITION_METADATA_STATE_UNSPECIFIED) {
-          bind("state").to(filter.state.number.toLong())
+        if (filter.statesList.isNotEmpty()) {
+          bind("states").toInt64Array(filter.statesList.map { it.number.toLong() })
         }
         if (filter.groupId.isNotEmpty()) {
           bind("groupId").to(filter.groupId)

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/service/internal/testing/RawImpressionMetadataBatchServiceTest.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/service/internal/testing/RawImpressionMetadataBatchServiceTest.kt
@@ -243,7 +243,7 @@ abstract class RawImpressionMetadataBatchServiceTest {
           dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
           filter =
             ListRawImpressionMetadataBatchesRequestKt.filter {
-              state = RawImpressionBatchState.RAW_IMPRESSION_BATCH_STATE_PROCESSED
+              states += RawImpressionBatchState.RAW_IMPRESSION_BATCH_STATE_PROCESSED
             }
         }
       )

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/service/internal/testing/RawImpressionMetadataBatchServiceTest.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/service/internal/testing/RawImpressionMetadataBatchServiceTest.kt
@@ -243,7 +243,7 @@ abstract class RawImpressionMetadataBatchServiceTest {
           dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
           filter =
             ListRawImpressionMetadataBatchesRequestKt.filter {
-              states += RawImpressionBatchState.RAW_IMPRESSION_BATCH_STATE_PROCESSED
+              stateIn += RawImpressionBatchState.RAW_IMPRESSION_BATCH_STATE_PROCESSED
             }
         }
       )
@@ -294,8 +294,8 @@ abstract class RawImpressionMetadataBatchServiceTest {
             dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
             filter =
               ListRawImpressionMetadataBatchesRequestKt.filter {
-                states += RawImpressionBatchState.RAW_IMPRESSION_BATCH_STATE_PROCESSED
-                states += RawImpressionBatchState.RAW_IMPRESSION_BATCH_STATE_FAILED
+                stateIn += RawImpressionBatchState.RAW_IMPRESSION_BATCH_STATE_PROCESSED
+                stateIn += RawImpressionBatchState.RAW_IMPRESSION_BATCH_STATE_FAILED
               }
           }
         )

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/service/internal/testing/RawImpressionMetadataBatchServiceTest.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/service/internal/testing/RawImpressionMetadataBatchServiceTest.kt
@@ -254,6 +254,92 @@ abstract class RawImpressionMetadataBatchServiceTest {
   }
 
   @Test
+  fun `listRawImpressionMetadataBatches filters by multiple states (OR)`() =
+    runBlocking<Unit> {
+      val processedBatch: RawImpressionMetadataBatch =
+        service.createRawImpressionMetadataBatch(
+          createRawImpressionMetadataBatchRequest {
+            dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
+          }
+        )
+      val failedBatch: RawImpressionMetadataBatch =
+        service.createRawImpressionMetadataBatch(
+          createRawImpressionMetadataBatchRequest {
+            dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
+          }
+        )
+      // A third batch that stays in CREATED — must NOT be returned.
+      service.createRawImpressionMetadataBatch(
+        createRawImpressionMetadataBatchRequest {
+          dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
+        }
+      )
+
+      service.markRawImpressionMetadataBatchProcessed(
+        markRawImpressionMetadataBatchProcessedRequest {
+          dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
+          batchResourceId = processedBatch.batchResourceId
+        }
+      )
+      service.markRawImpressionMetadataBatchFailed(
+        markRawImpressionMetadataBatchFailedRequest {
+          dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
+          batchResourceId = failedBatch.batchResourceId
+        }
+      )
+
+      val response: ListRawImpressionMetadataBatchesResponse =
+        service.listRawImpressionMetadataBatches(
+          listRawImpressionMetadataBatchesRequest {
+            dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
+            filter =
+              ListRawImpressionMetadataBatchesRequestKt.filter {
+                states += RawImpressionBatchState.RAW_IMPRESSION_BATCH_STATE_PROCESSED
+                states += RawImpressionBatchState.RAW_IMPRESSION_BATCH_STATE_FAILED
+              }
+          }
+        )
+
+      assertThat(response.rawImpressionMetadataBatchesList.map { it.batchResourceId })
+        .containsExactly(processedBatch.batchResourceId, failedBatch.batchResourceId)
+    }
+
+  @Test
+  fun `listRawImpressionMetadataBatches with empty states filter returns all states`() =
+    runBlocking<Unit> {
+      val batch1: RawImpressionMetadataBatch =
+        service.createRawImpressionMetadataBatch(
+          createRawImpressionMetadataBatchRequest {
+            dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
+          }
+        )
+      val batch2: RawImpressionMetadataBatch =
+        service.createRawImpressionMetadataBatch(
+          createRawImpressionMetadataBatchRequest {
+            dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
+          }
+        )
+
+      service.markRawImpressionMetadataBatchProcessed(
+        markRawImpressionMetadataBatchProcessedRequest {
+          dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
+          batchResourceId = batch2.batchResourceId
+        }
+      )
+
+      val response: ListRawImpressionMetadataBatchesResponse =
+        service.listRawImpressionMetadataBatches(
+          listRawImpressionMetadataBatchesRequest {
+            dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
+            filter = ListRawImpressionMetadataBatchesRequestKt.filter {}
+          }
+        )
+
+      assertThat(response.rawImpressionMetadataBatchesList.map { it.batchResourceId })
+        .containsExactly(batch1.batchResourceId, batch2.batchResourceId)
+    }
+
+  @Test
   fun `deleteRawImpressionMetadataBatch soft deletes a batch`() = runBlocking {
     val created: RawImpressionMetadataBatch =
       service.createRawImpressionMetadataBatch(

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/service/internal/testing/RequisitionMetadataServiceTest.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/service/internal/testing/RequisitionMetadataServiceTest.kt
@@ -1503,7 +1503,7 @@ abstract class RequisitionMetadataServiceTest {
       service.listRequisitionMetadata(
         listRequisitionMetadataRequest {
           dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
-          filter = ListRequisitionMetadataRequestKt.filter { states += queuedRequisition.state }
+          filter = ListRequisitionMetadataRequestKt.filter { stateIn += queuedRequisition.state }
         }
       )
 
@@ -1547,8 +1547,8 @@ abstract class RequisitionMetadataServiceTest {
             dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
             filter =
               ListRequisitionMetadataRequestKt.filter {
-                states += queuedRequisition.state
-                states += refusedRequisition.state
+                stateIn += queuedRequisition.state
+                stateIn += refusedRequisition.state
               }
           }
         )

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/service/internal/testing/RequisitionMetadataServiceTest.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/service/internal/testing/RequisitionMetadataServiceTest.kt
@@ -1512,6 +1512,85 @@ abstract class RequisitionMetadataServiceTest {
   }
 
   @Test
+  fun `listRequisitionMetadata filters by multiple states (OR)`() =
+    runBlocking<Unit> {
+      val created =
+        createRequisitionMetadata(
+          REQUISITION_METADATA_2,
+          REQUISITION_METADATA_3,
+          REQUISITION_METADATA_4,
+        )
+
+      val queuedRequisition =
+        service.queueRequisitionMetadata(
+          queueRequisitionMetadataRequest {
+            dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
+            requisitionMetadataResourceId = REQUISITION_METADATA_RESOURCE_ID_4
+            workItem = WORK_ITEM
+            etag = created.last().etag
+          }
+        )
+
+      val refusedRequisition =
+        service.refuseRequisitionMetadata(
+          refuseRequisitionMetadataRequest {
+            dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
+            requisitionMetadataResourceId = REQUISITION_METADATA_RESOURCE_ID_3
+            refusalMessage = "Refused for test"
+            etag = created[1].etag
+          }
+        )
+
+      val response =
+        service.listRequisitionMetadata(
+          listRequisitionMetadataRequest {
+            dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
+            filter =
+              ListRequisitionMetadataRequestKt.filter {
+                states += queuedRequisition.state
+                states += refusedRequisition.state
+              }
+          }
+        )
+
+      assertThat(response.requisitionMetadataList.map { it.requisitionMetadataResourceId })
+        .containsExactly(
+          refusedRequisition.requisitionMetadataResourceId,
+          queuedRequisition.requisitionMetadataResourceId,
+        )
+    }
+
+  @Test
+  fun `listRequisitionMetadata with empty states filter returns all states`() =
+    runBlocking<Unit> {
+      val created =
+        createRequisitionMetadata(
+          REQUISITION_METADATA_2,
+          REQUISITION_METADATA_3,
+          REQUISITION_METADATA_4,
+        )
+
+      service.queueRequisitionMetadata(
+        queueRequisitionMetadataRequest {
+          dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
+          requisitionMetadataResourceId = REQUISITION_METADATA_RESOURCE_ID_4
+          workItem = WORK_ITEM
+          etag = created.last().etag
+        }
+      )
+
+      val response =
+        service.listRequisitionMetadata(
+          listRequisitionMetadataRequest {
+            dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
+            filter = ListRequisitionMetadataRequestKt.filter {}
+          }
+        )
+
+      assertThat(response.requisitionMetadataList).hasSize(3)
+    }
+
+  @Test
   fun `listRequisitionMetadata throws INVALID_ARGUMENT if dataProviderResourceId not set`() =
     runBlocking {
       val exception =

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/service/internal/testing/RequisitionMetadataServiceTest.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/service/internal/testing/RequisitionMetadataServiceTest.kt
@@ -1503,7 +1503,7 @@ abstract class RequisitionMetadataServiceTest {
       service.listRequisitionMetadata(
         listRequisitionMetadataRequest {
           dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
-          filter = ListRequisitionMetadataRequestKt.filter { state = queuedRequisition.state }
+          filter = ListRequisitionMetadataRequestKt.filter { states += queuedRequisition.state }
         }
       )
 

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/service/v1alpha/RawImpressionMetadataBatchService.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/service/v1alpha/RawImpressionMetadataBatchService.kt
@@ -214,11 +214,11 @@ class RawImpressionMetadataBatchService(
             if (internalPageToken != null) {
               pageToken = internalPageToken
             }
-            if (request.hasFilter() && request.filter.statesList.isNotEmpty()) {
+            if (request.hasFilter() && request.filter.stateInList.isNotEmpty()) {
               filter =
                 org.wfanet.measurement.internal.edpaggregator
                   .ListRawImpressionMetadataBatchesRequestKt
-                  .filter { states += request.filter.statesList.map { it.toInternal() } }
+                  .filter { stateIn += request.filter.stateInList.map { it.toInternal() } }
             }
             showDeleted = request.showDeleted
           }

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/service/v1alpha/RawImpressionMetadataBatchService.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/service/v1alpha/RawImpressionMetadataBatchService.kt
@@ -218,9 +218,7 @@ class RawImpressionMetadataBatchService(
               filter =
                 org.wfanet.measurement.internal.edpaggregator
                   .ListRawImpressionMetadataBatchesRequestKt
-                  .filter {
-                    states += request.filter.statesList.map { it.toInternal() }
-                  }
+                  .filter { states += request.filter.statesList.map { it.toInternal() } }
             }
             showDeleted = request.showDeleted
           }

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/service/v1alpha/RawImpressionMetadataBatchService.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/service/v1alpha/RawImpressionMetadataBatchService.kt
@@ -214,14 +214,13 @@ class RawImpressionMetadataBatchService(
             if (internalPageToken != null) {
               pageToken = internalPageToken
             }
-            if (
-              request.hasFilter() &&
-                request.filter.state != RawImpressionMetadataBatch.State.STATE_UNSPECIFIED
-            ) {
+            if (request.hasFilter() && request.filter.statesList.isNotEmpty()) {
               filter =
                 org.wfanet.measurement.internal.edpaggregator
                   .ListRawImpressionMetadataBatchesRequestKt
-                  .filter { state = request.filter.state.toInternal() }
+                  .filter {
+                    states += request.filter.statesList.map { it.toInternal() }
+                  }
             }
             showDeleted = request.showDeleted
           }

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/service/v1alpha/RequisitionMetadataService.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/service/v1alpha/RequisitionMetadataService.kt
@@ -354,7 +354,7 @@ class RequisitionMetadataService(
     val internalFilter: InternalListRequisitionMetadataFilter =
       internalListRequisitionMetadataRequestFilter {
         if (request.hasFilter()) {
-          state = request.filter.state.toInternalState()
+          states += request.filter.statesList.map { it.toInternalState() }
           if (request.filter.groupId.isNotEmpty()) {
             groupId = request.filter.groupId
           }

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/service/v1alpha/RequisitionMetadataService.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/service/v1alpha/RequisitionMetadataService.kt
@@ -354,7 +354,7 @@ class RequisitionMetadataService(
     val internalFilter: InternalListRequisitionMetadataFilter =
       internalListRequisitionMetadataRequestFilter {
         if (request.hasFilter()) {
-          states += request.filter.statesList.map { it.toInternalState() }
+          stateIn += request.filter.stateInList.map { it.toInternalState() }
           if (request.filter.groupId.isNotEmpty()) {
             groupId = request.filter.groupId
           }

--- a/src/main/proto/wfa/measurement/edpaggregator/v1alpha/pool_assignment_job_service.proto
+++ b/src/main/proto/wfa/measurement/edpaggregator/v1alpha/pool_assignment_job_service.proto
@@ -155,7 +155,10 @@ message ListPoolAssignmentJobsRequest {
     // (-- api-linter: core::0216::state-field-output-only=disabled
     //     aip.dev/not-precedent: This is a filter input field, not
     //     a resource state field. --)
-    repeated PoolAssignmentJob.State states = 1
+    // (-- api-linter: core::0140::prepositions=disabled
+    //     aip.dev/not-precedent: `_in` is the established repo convention
+    //     for set-membership filter fields. --)
+    repeated PoolAssignmentJob.State state_in = 1
         [(google.api.field_behavior) = OPTIONAL];
 
     // Filter for resources whose create_time falls within this

--- a/src/main/proto/wfa/measurement/edpaggregator/v1alpha/pool_assignment_job_service.proto
+++ b/src/main/proto/wfa/measurement/edpaggregator/v1alpha/pool_assignment_job_service.proto
@@ -147,11 +147,11 @@ message ListPoolAssignmentJobsRequest {
 
   // Structured filter for narrowing results.
   message Filter {
-    // Filter by processing state.
+    // Filter to resources whose state is in this set. Empty matches all states.
     // (-- api-linter: core::0216::state-field-output-only=disabled
     //     aip.dev/not-precedent: This is a filter input field, not
     //     a resource state field. --)
-    PoolAssignmentJob.State state = 1 [(google.api.field_behavior) = OPTIONAL];
+    repeated PoolAssignmentJob.State states = 1 [(google.api.field_behavior) = OPTIONAL];
 
     // Filter for resources whose create_time falls within this
     // interval. Start and end are both optional: omitting start

--- a/src/main/proto/wfa/measurement/edpaggregator/v1alpha/pool_assignment_job_service.proto
+++ b/src/main/proto/wfa/measurement/edpaggregator/v1alpha/pool_assignment_job_service.proto
@@ -151,7 +151,8 @@ message ListPoolAssignmentJobsRequest {
     // (-- api-linter: core::0216::state-field-output-only=disabled
     //     aip.dev/not-precedent: This is a filter input field, not
     //     a resource state field. --)
-    repeated PoolAssignmentJob.State states = 1 [(google.api.field_behavior) = OPTIONAL];
+    repeated PoolAssignmentJob.State states = 1
+        [(google.api.field_behavior) = OPTIONAL];
 
     // Filter for resources whose create_time falls within this
     // interval. Start and end are both optional: omitting start

--- a/src/main/proto/wfa/measurement/edpaggregator/v1alpha/ranker_job_service.proto
+++ b/src/main/proto/wfa/measurement/edpaggregator/v1alpha/ranker_job_service.proto
@@ -145,7 +145,8 @@ message ListRankerJobsRequest {
     // (-- api-linter: core::0216::state-field-output-only=disabled
     //     aip.dev/not-precedent: This is a filter input field, not
     //     a resource state field. --)
-    repeated RankerJob.State states = 1 [(google.api.field_behavior) = OPTIONAL];
+    repeated RankerJob.State states = 1
+        [(google.api.field_behavior) = OPTIONAL];
 
     // Filter for resources whose create_time falls within this
     // interval. Start and end are both optional: omitting start

--- a/src/main/proto/wfa/measurement/edpaggregator/v1alpha/ranker_job_service.proto
+++ b/src/main/proto/wfa/measurement/edpaggregator/v1alpha/ranker_job_service.proto
@@ -141,11 +141,11 @@ message ListRankerJobsRequest {
 
   // Structured filter for narrowing results.
   message Filter {
-    // Filter by processing state.
+    // Filter to resources whose state is in this set. Empty matches all states.
     // (-- api-linter: core::0216::state-field-output-only=disabled
     //     aip.dev/not-precedent: This is a filter input field, not
     //     a resource state field. --)
-    RankerJob.State state = 1 [(google.api.field_behavior) = OPTIONAL];
+    repeated RankerJob.State states = 1 [(google.api.field_behavior) = OPTIONAL];
 
     // Filter for resources whose create_time falls within this
     // interval. Start and end are both optional: omitting start

--- a/src/main/proto/wfa/measurement/edpaggregator/v1alpha/ranker_job_service.proto
+++ b/src/main/proto/wfa/measurement/edpaggregator/v1alpha/ranker_job_service.proto
@@ -149,7 +149,10 @@ message ListRankerJobsRequest {
     // (-- api-linter: core::0216::state-field-output-only=disabled
     //     aip.dev/not-precedent: This is a filter input field, not
     //     a resource state field. --)
-    repeated RankerJob.State states = 1
+    // (-- api-linter: core::0140::prepositions=disabled
+    //     aip.dev/not-precedent: `_in` is the established repo convention
+    //     for set-membership filter fields. --)
+    repeated RankerJob.State state_in = 1
         [(google.api.field_behavior) = OPTIONAL];
 
     // Filter for resources whose create_time falls within this

--- a/src/main/proto/wfa/measurement/edpaggregator/v1alpha/raw_impression_metadata_batch_service.proto
+++ b/src/main/proto/wfa/measurement/edpaggregator/v1alpha/raw_impression_metadata_batch_service.proto
@@ -117,7 +117,10 @@ message ListRawImpressionMetadataBatchesRequest {
     // (-- api-linter: core::0216::state-field-output-only=disabled
     //     aip.dev/not-precedent: This is a filter input field, not a
     //     resource state field. --)
-    repeated RawImpressionMetadataBatch.State states = 1
+    // (-- api-linter: core::0140::prepositions=disabled
+    //     aip.dev/not-precedent: `_in` is the established repo convention
+    //     for set-membership filter fields. --)
+    repeated RawImpressionMetadataBatch.State state_in = 1
         [(google.api.field_behavior) = OPTIONAL];
   }
 

--- a/src/main/proto/wfa/measurement/edpaggregator/v1alpha/raw_impression_metadata_batch_service.proto
+++ b/src/main/proto/wfa/measurement/edpaggregator/v1alpha/raw_impression_metadata_batch_service.proto
@@ -113,11 +113,11 @@ message ListRawImpressionMetadataBatchesRequest {
 
   // Filter for `ListRawImpressionMetadataBatches` method.
   message Filter {
-    // The state to filter by.
+    // Filter to resources whose state is in this set. Empty matches all states.
     // (-- api-linter: core::0216::state-field-output-only=disabled
     //     aip.dev/not-precedent: This is a filter input field, not a
     //     resource state field. --)
-    RawImpressionMetadataBatch.State state = 1
+    repeated RawImpressionMetadataBatch.State states = 1
         [(google.api.field_behavior) = OPTIONAL];
   }
 

--- a/src/main/proto/wfa/measurement/edpaggregator/v1alpha/raw_impression_upload_model_line_service.proto
+++ b/src/main/proto/wfa/measurement/edpaggregator/v1alpha/raw_impression_upload_model_line_service.proto
@@ -170,11 +170,11 @@ message ListRawImpressionUploadModelLinesRequest {
 
   // Structured filter for narrowing results.
   message Filter {
-    // Filter by pipeline state.
+    // Filter to resources whose state is in this set. Empty matches all states.
     // (-- api-linter: core::0216::state-field-output-only=disabled
     //     aip.dev/not-precedent: This is a filter input field, not
     //     a resource state field. --)
-    RawImpressionUploadModelLine.State state = 1
+    repeated RawImpressionUploadModelLine.State states = 1
         [(google.api.field_behavior) = OPTIONAL];
 
     // Filter for resources whose create_time falls within this

--- a/src/main/proto/wfa/measurement/edpaggregator/v1alpha/raw_impression_upload_model_line_service.proto
+++ b/src/main/proto/wfa/measurement/edpaggregator/v1alpha/raw_impression_upload_model_line_service.proto
@@ -174,7 +174,10 @@ message ListRawImpressionUploadModelLinesRequest {
     // (-- api-linter: core::0216::state-field-output-only=disabled
     //     aip.dev/not-precedent: This is a filter input field, not
     //     a resource state field. --)
-    repeated RawImpressionUploadModelLine.State states = 1
+    // (-- api-linter: core::0140::prepositions=disabled
+    //     aip.dev/not-precedent: `_in` is the established repo convention
+    //     for set-membership filter fields. --)
+    repeated RawImpressionUploadModelLine.State state_in = 1
         [(google.api.field_behavior) = OPTIONAL];
 
     // Filter for resources whose create_time falls within this

--- a/src/main/proto/wfa/measurement/edpaggregator/v1alpha/raw_impression_upload_service.proto
+++ b/src/main/proto/wfa/measurement/edpaggregator/v1alpha/raw_impression_upload_service.proto
@@ -101,11 +101,11 @@ message ListRawImpressionUploadsRequest {
   // Structured filter for narrowing results.
   // All fields are combined with `AND` logic.
   message Filter {
-    // Filter by pipeline state.
+    // Filter to resources whose state is in this set. Empty matches all states.
     // (-- api-linter: core::0216::state-field-output-only=disabled
     //     aip.dev/not-precedent: This is a filter input field, not a
     //     resource state field. --)
-    RawImpressionUpload.State state = 1
+    repeated RawImpressionUpload.State states = 1
         [(google.api.field_behavior) = OPTIONAL];
 
     // Filter for resources whose create_time falls within this

--- a/src/main/proto/wfa/measurement/edpaggregator/v1alpha/raw_impression_upload_service.proto
+++ b/src/main/proto/wfa/measurement/edpaggregator/v1alpha/raw_impression_upload_service.proto
@@ -105,7 +105,10 @@ message ListRawImpressionUploadsRequest {
     // (-- api-linter: core::0216::state-field-output-only=disabled
     //     aip.dev/not-precedent: This is a filter input field, not a
     //     resource state field. --)
-    repeated RawImpressionUpload.State states = 1
+    // (-- api-linter: core::0140::prepositions=disabled
+    //     aip.dev/not-precedent: `_in` is the established repo convention
+    //     for set-membership filter fields. --)
+    repeated RawImpressionUpload.State state_in = 1
         [(google.api.field_behavior) = OPTIONAL];
 
     // Filter for resources whose create_time falls within this

--- a/src/main/proto/wfa/measurement/edpaggregator/v1alpha/requisition_metadata_service.proto
+++ b/src/main/proto/wfa/measurement/edpaggregator/v1alpha/requisition_metadata_service.proto
@@ -203,11 +203,11 @@ message ListRequisitionMetadataRequest {
 
   // Filtering criteria for the list request.
   message Filter {
-    // Filter by the state of the requisition.
+    // Filter to resources whose state is in this set. Empty matches all states.
     // (-- api-linter: core::0216::state-field-output-only=disabled
     //     aip.dev/not-precedent: The state field is used for filtering input.
     //     --)
-    RequisitionMetadata.State state = 1
+    repeated RequisitionMetadata.State states = 1
         [(google.api.field_behavior) = OPTIONAL];
     // Filter by the group ID of the requisition.
     string group_id = 2 [(google.api.field_behavior) = OPTIONAL];

--- a/src/main/proto/wfa/measurement/edpaggregator/v1alpha/requisition_metadata_service.proto
+++ b/src/main/proto/wfa/measurement/edpaggregator/v1alpha/requisition_metadata_service.proto
@@ -207,7 +207,10 @@ message ListRequisitionMetadataRequest {
     // (-- api-linter: core::0216::state-field-output-only=disabled
     //     aip.dev/not-precedent: The state field is used for filtering input.
     //     --)
-    repeated RequisitionMetadata.State states = 1
+    // (-- api-linter: core::0140::prepositions=disabled
+    //     aip.dev/not-precedent: `_in` is the established repo convention
+    //     for set-membership filter fields. --)
+    repeated RequisitionMetadata.State state_in = 1
         [(google.api.field_behavior) = OPTIONAL];
     // Filter by the group ID of the requisition.
     string group_id = 2 [(google.api.field_behavior) = OPTIONAL];

--- a/src/main/proto/wfa/measurement/internal/edpaggregator/pool_assignment_job_service.proto
+++ b/src/main/proto/wfa/measurement/internal/edpaggregator/pool_assignment_job_service.proto
@@ -116,7 +116,7 @@ message ListPoolAssignmentJobsRequest {
   // Filter for narrowing results.
   message Filter {
     // Filter to resources whose state is in this set. Empty matches all states.
-    repeated PoolAssignmentState states = 1;
+    repeated PoolAssignmentState state_in = 1;
 
     // Filter for resources whose create_time falls within this
     // interval. Start and end are both optional: omitting start

--- a/src/main/proto/wfa/measurement/internal/edpaggregator/pool_assignment_job_service.proto
+++ b/src/main/proto/wfa/measurement/internal/edpaggregator/pool_assignment_job_service.proto
@@ -111,8 +111,8 @@ message ListPoolAssignmentJobsRequest {
 
   // Filter for narrowing results.
   message Filter {
-    // Filter by processing state.
-    PoolAssignmentState state = 1;
+    // Filter to resources whose state is in this set. Empty matches all states.
+    repeated PoolAssignmentState states = 1;
 
     // Filter for resources whose create_time falls within this
     // interval. Start and end are both optional: omitting start

--- a/src/main/proto/wfa/measurement/internal/edpaggregator/ranker_job_service.proto
+++ b/src/main/proto/wfa/measurement/internal/edpaggregator/ranker_job_service.proto
@@ -115,8 +115,8 @@ message ListRankerJobsRequest {
 
   // Filter for narrowing results.
   message Filter {
-    // Filter by processing state.
-    RankerState state = 1;
+    // Filter to resources whose state is in this set. Empty matches all states.
+    repeated RankerState states = 1;
 
     // Filter for resources whose create_time falls within this
     // interval. Start and end are both optional: omitting start

--- a/src/main/proto/wfa/measurement/internal/edpaggregator/ranker_job_service.proto
+++ b/src/main/proto/wfa/measurement/internal/edpaggregator/ranker_job_service.proto
@@ -119,7 +119,7 @@ message ListRankerJobsRequest {
   // Filter for narrowing results.
   message Filter {
     // Filter to resources whose state is in this set. Empty matches all states.
-    repeated RankerState states = 1;
+    repeated RankerState state_in = 1;
 
     // Filter for resources whose create_time falls within this
     // interval. Start and end are both optional: omitting start

--- a/src/main/proto/wfa/measurement/internal/edpaggregator/raw_impression_metadata_batch_service.proto
+++ b/src/main/proto/wfa/measurement/internal/edpaggregator/raw_impression_metadata_batch_service.proto
@@ -79,7 +79,7 @@ message ListRawImpressionMetadataBatchesRequest {
 
   message Filter {
     // Filter to resources whose state is in this set. Empty matches all states.
-    repeated RawImpressionBatchState states = 1;
+    repeated RawImpressionBatchState state_in = 1;
   }
   Filter filter = 4;
 

--- a/src/main/proto/wfa/measurement/internal/edpaggregator/raw_impression_metadata_batch_service.proto
+++ b/src/main/proto/wfa/measurement/internal/edpaggregator/raw_impression_metadata_batch_service.proto
@@ -78,7 +78,8 @@ message ListRawImpressionMetadataBatchesRequest {
   ListRawImpressionMetadataBatchesPageToken page_token = 3;
 
   message Filter {
-    RawImpressionBatchState state = 1;
+    // Filter to resources whose state is in this set. Empty matches all states.
+    repeated RawImpressionBatchState states = 1;
   }
   Filter filter = 4;
 

--- a/src/main/proto/wfa/measurement/internal/edpaggregator/raw_impression_upload_model_line_service.proto
+++ b/src/main/proto/wfa/measurement/internal/edpaggregator/raw_impression_upload_model_line_service.proto
@@ -139,7 +139,7 @@ message ListRawImpressionUploadModelLinesRequest {
   // Filter for narrowing results.
   message Filter {
     // Filter to resources whose state is in this set. Empty matches all states.
-    repeated RawImpressionUploadModelLineState states = 1;
+    repeated RawImpressionUploadModelLineState state_in = 1;
 
     // Filter for resources whose create_time falls within this
     // interval. Start and end are both optional: omitting start

--- a/src/main/proto/wfa/measurement/internal/edpaggregator/raw_impression_upload_model_line_service.proto
+++ b/src/main/proto/wfa/measurement/internal/edpaggregator/raw_impression_upload_model_line_service.proto
@@ -138,8 +138,8 @@ message ListRawImpressionUploadModelLinesRequest {
 
   // Filter for narrowing results.
   message Filter {
-    // Filter by pipeline state.
-    RawImpressionUploadModelLineState state = 1;
+    // Filter to resources whose state is in this set. Empty matches all states.
+    repeated RawImpressionUploadModelLineState states = 1;
 
     // Filter for resources whose create_time falls within this
     // interval. Start and end are both optional: omitting start

--- a/src/main/proto/wfa/measurement/internal/edpaggregator/raw_impression_upload_service.proto
+++ b/src/main/proto/wfa/measurement/internal/edpaggregator/raw_impression_upload_service.proto
@@ -79,7 +79,7 @@ message ListRawImpressionUploadsRequest {
   // Filter for narrowing results.
   message Filter {
     // Filter to resources whose state is in this set. Empty matches all states.
-    repeated RawImpressionUploadState states = 1;
+    repeated RawImpressionUploadState state_in = 1;
 
     // Filter for resources whose create_time falls within this
     // interval. Start and end are both optional: omitting start

--- a/src/main/proto/wfa/measurement/internal/edpaggregator/raw_impression_upload_service.proto
+++ b/src/main/proto/wfa/measurement/internal/edpaggregator/raw_impression_upload_service.proto
@@ -78,8 +78,8 @@ message ListRawImpressionUploadsRequest {
 
   // Filter for narrowing results.
   message Filter {
-    // Filter by pipeline state.
-    RawImpressionUploadState state = 1;
+    // Filter to resources whose state is in this set. Empty matches all states.
+    repeated RawImpressionUploadState states = 1;
 
     // Filter for resources whose create_time falls within this
     // interval. Start and end are both optional: omitting start

--- a/src/main/proto/wfa/measurement/internal/edpaggregator/requisition_metadata_service.proto
+++ b/src/main/proto/wfa/measurement/internal/edpaggregator/requisition_metadata_service.proto
@@ -119,7 +119,7 @@ message ListRequisitionMetadataPageToken {
 message ListRequisitionMetadataRequest {
   message Filter {
     // Filter to resources whose state is in this set. Empty matches all states.
-    repeated RequisitionMetadataState states = 1;
+    repeated RequisitionMetadataState state_in = 1;
     string group_id = 2;
     string report = 3;
   }

--- a/src/main/proto/wfa/measurement/internal/edpaggregator/requisition_metadata_service.proto
+++ b/src/main/proto/wfa/measurement/internal/edpaggregator/requisition_metadata_service.proto
@@ -118,7 +118,8 @@ message ListRequisitionMetadataPageToken {
 
 message ListRequisitionMetadataRequest {
   message Filter {
-    RequisitionMetadataState state = 1;
+    // Filter to resources whose state is in this set. Empty matches all states.
+    repeated RequisitionMetadataState states = 1;
     string group_id = 2;
     string report = 3;
   }


### PR DESCRIPTION
Replaces singular `state` filter field with `repeated state_in` on every ListXxx.Filter in the edpaggregator v1alpha surface (plus internal mirrors). Lets callers — most notably the VidLabelingMonitorFunction (#3958) — ask "any of these states" in one List RPC instead of fanning out per state.

The `_in` suffix follows the established repo convention for set-membership filter fields (`blob_uri_in`, `entity_type_in`, `type_in`), reads naturally as the SQL `IN` operator, and disambiguates that the field is a filter set rather than the resource's state vector. Each public proto carries an `api-linter: core::0140::prepositions=disabled` block with an aip.dev/not-precedent justification.

Source-incompatible (callers using the old `filter.state` symbol need a rename to `filter.stateInList`, and DSL `state = X` becomes `stateIn += X`), but **wire-compatible**: field number 1 is preserved and proto3's wire format treats singular and repeated as the same encoding for scalar fields. An older client writing a single `state` value to field 1 is interpreted by the new server as a one-element list, and a new client writing a single `state_in` element produces the same wire bytes as the old singular write.

12 protos: 6 resources × public + internal. Doc on every Filter is uniform: "Filter to resources whose state is in this set. Empty matches all states."

VidLabelingJob (#3984, open) should adopt this shape directly.

Issue: #4000