### PR TITLE
feat: Add create_time_interval filter to EDPA v1alpha List services

### DIFF
--- a/src/main/proto/wfa/measurement/edpaggregator/v1alpha/BUILD.bazel
+++ b/src/main/proto/wfa/measurement/edpaggregator/v1alpha/BUILD.bazel
@@ -253,6 +253,7 @@ proto_library(
         "@com_google_googleapis//google/api:field_behavior_proto",
         "@com_google_googleapis//google/api:field_info_proto",
         "@com_google_googleapis//google/api:resource_proto",
+        "@com_google_googleapis//google/type:interval_proto",
         "@com_google_protobuf//:timestamp_proto",
     ],
 )
@@ -329,6 +330,7 @@ proto_library(
         "@com_google_googleapis//google/api:field_behavior_proto",
         "@com_google_googleapis//google/api:field_info_proto",
         "@com_google_googleapis//google/api:resource_proto",
+        "@com_google_googleapis//google/type:interval_proto",
     ],
 )
 
@@ -346,6 +348,7 @@ proto_library(
         "@com_google_googleapis//google/api:field_behavior_proto",
         "@com_google_googleapis//google/api:field_info_proto",
         "@com_google_googleapis//google/api:resource_proto",
+        "@com_google_googleapis//google/type:interval_proto",
     ],
 )
 
@@ -413,6 +416,7 @@ proto_library(
         "@com_google_googleapis//google/api:field_behavior_proto",
         "@com_google_googleapis//google/api:field_info_proto",
         "@com_google_googleapis//google/api:resource_proto",
+        "@com_google_googleapis//google/type:interval_proto",
     ],
 )
 

--- a/src/main/proto/wfa/measurement/edpaggregator/v1alpha/pool_assignment_job_service.proto
+++ b/src/main/proto/wfa/measurement/edpaggregator/v1alpha/pool_assignment_job_service.proto
@@ -161,11 +161,14 @@ message ListPoolAssignmentJobsRequest {
     repeated PoolAssignmentJob.State state_in = 1
         [(google.api.field_behavior) = OPTIONAL];
 
-    // Filter for resources whose create_time falls within this
-    // interval. Start and end are both optional: omitting start
-    // returns resources created before end, omitting end returns
-    // resources created after start.
-    google.type.Interval create_time_interval = 2
+    // Filter for resources whose create_time is in the given interval.
+    // Start and end are both optional: omitting start_time matches
+    // resources created before end_time; omitting end_time matches
+    // resources created at or after start_time.
+    // (-- api-linter: core::0140::prepositions=disabled
+    //     aip.dev/not-precedent: `_in` is the established repo convention
+    //     for set-membership filter fields. --)
+    google.type.Interval create_time_in = 2
         [(google.api.field_behavior) = OPTIONAL];
 
     // Filter by CMMS model line resource name.

--- a/src/main/proto/wfa/measurement/edpaggregator/v1alpha/ranker_job_service.proto
+++ b/src/main/proto/wfa/measurement/edpaggregator/v1alpha/ranker_job_service.proto
@@ -155,11 +155,14 @@ message ListRankerJobsRequest {
     repeated RankerJob.State state_in = 1
         [(google.api.field_behavior) = OPTIONAL];
 
-    // Filter for resources whose create_time falls within this
-    // interval. Start and end are both optional: omitting start
-    // returns resources created before end, omitting end returns
-    // resources created after start.
-    google.type.Interval create_time_interval = 2
+    // Filter for resources whose create_time is in the given interval.
+    // Start and end are both optional: omitting start_time matches
+    // resources created before end_time; omitting end_time matches
+    // resources created at or after start_time.
+    // (-- api-linter: core::0140::prepositions=disabled
+    //     aip.dev/not-precedent: `_in` is the established repo convention
+    //     for set-membership filter fields. --)
+    google.type.Interval create_time_in = 2
         [(google.api.field_behavior) = OPTIONAL];
 
     // Filter by CMMS model line resource name.

--- a/src/main/proto/wfa/measurement/edpaggregator/v1alpha/raw_impression_metadata_batch_file_service.proto
+++ b/src/main/proto/wfa/measurement/edpaggregator/v1alpha/raw_impression_metadata_batch_file_service.proto
@@ -19,6 +19,7 @@ package wfa.measurement.edpaggregator.v1alpha;
 import "google/api/field_behavior.proto";
 import "google/api/field_info.proto";
 import "google/api/resource.proto";
+import "google/type/interval.proto";
 import "wfa/measurement/edpaggregator/v1alpha/raw_impression_metadata_batch_file.proto";
 
 option java_package = "org.wfanet.measurement.edpaggregator.v1alpha";
@@ -164,6 +165,13 @@ message ListRawImpressionMetadataBatchFilesRequest {
   message Filter {
     // Filter where blob URI of the file is in the given list.
     repeated string blob_uri_in = 1 [(google.api.field_behavior) = REQUIRED];
+
+    // Filter for resources whose create_time falls within this interval.
+    // Start and end are both optional: omitting start returns resources
+    // created before end, omitting end returns resources created after
+    // start.
+    google.type.Interval create_time_interval = 2
+        [(google.api.field_behavior) = OPTIONAL];
   }
 
   // A filter to apply to the list results.

--- a/src/main/proto/wfa/measurement/edpaggregator/v1alpha/raw_impression_metadata_batch_file_service.proto
+++ b/src/main/proto/wfa/measurement/edpaggregator/v1alpha/raw_impression_metadata_batch_file_service.proto
@@ -166,11 +166,14 @@ message ListRawImpressionMetadataBatchFilesRequest {
     // Filter where blob URI of the file is in the given list.
     repeated string blob_uri_in = 1 [(google.api.field_behavior) = REQUIRED];
 
-    // Filter for resources whose create_time falls within this interval.
-    // Start and end are both optional: omitting start returns resources
-    // created before end, omitting end returns resources created after
-    // start.
-    google.type.Interval create_time_interval = 2
+    // Filter for resources whose create_time is in the given interval.
+    // Start and end are both optional: omitting start_time matches
+    // resources created before end_time; omitting end_time matches
+    // resources created at or after start_time.
+    // (-- api-linter: core::0140::prepositions=disabled
+    //     aip.dev/not-precedent: `_in` is the established repo convention
+    //     for set-membership filter fields. --)
+    google.type.Interval create_time_in = 2
         [(google.api.field_behavior) = OPTIONAL];
   }
 

--- a/src/main/proto/wfa/measurement/edpaggregator/v1alpha/raw_impression_metadata_batch_service.proto
+++ b/src/main/proto/wfa/measurement/edpaggregator/v1alpha/raw_impression_metadata_batch_service.proto
@@ -124,11 +124,14 @@ message ListRawImpressionMetadataBatchesRequest {
     repeated RawImpressionMetadataBatch.State state_in = 1
         [(google.api.field_behavior) = OPTIONAL];
 
-    // Filter for resources whose create_time falls within this interval.
-    // Start and end are both optional: omitting start returns resources
-    // created before end, omitting end returns resources created after
-    // start.
-    google.type.Interval create_time_interval = 2
+    // Filter for resources whose create_time is in the given interval.
+    // Start and end are both optional: omitting start_time matches
+    // resources created before end_time; omitting end_time matches
+    // resources created at or after start_time.
+    // (-- api-linter: core::0140::prepositions=disabled
+    //     aip.dev/not-precedent: `_in` is the established repo convention
+    //     for set-membership filter fields. --)
+    google.type.Interval create_time_in = 2
         [(google.api.field_behavior) = OPTIONAL];
   }
 

--- a/src/main/proto/wfa/measurement/edpaggregator/v1alpha/raw_impression_metadata_batch_service.proto
+++ b/src/main/proto/wfa/measurement/edpaggregator/v1alpha/raw_impression_metadata_batch_service.proto
@@ -19,6 +19,7 @@ package wfa.measurement.edpaggregator.v1alpha;
 import "google/api/field_behavior.proto";
 import "google/api/field_info.proto";
 import "google/api/resource.proto";
+import "google/type/interval.proto";
 import "wfa/measurement/edpaggregator/v1alpha/raw_impression_metadata_batch.proto";
 
 option java_package = "org.wfanet.measurement.edpaggregator.v1alpha";
@@ -118,6 +119,13 @@ message ListRawImpressionMetadataBatchesRequest {
     //     aip.dev/not-precedent: This is a filter input field, not a
     //     resource state field. --)
     RawImpressionMetadataBatch.State state = 1
+        [(google.api.field_behavior) = OPTIONAL];
+
+    // Filter for resources whose create_time falls within this interval.
+    // Start and end are both optional: omitting start returns resources
+    // created before end, omitting end returns resources created after
+    // start.
+    google.type.Interval create_time_interval = 2
         [(google.api.field_behavior) = OPTIONAL];
   }
 

--- a/src/main/proto/wfa/measurement/edpaggregator/v1alpha/raw_impression_upload_file_service.proto
+++ b/src/main/proto/wfa/measurement/edpaggregator/v1alpha/raw_impression_upload_file_service.proto
@@ -19,6 +19,7 @@ package wfa.measurement.edpaggregator.v1alpha;
 import "google/api/field_behavior.proto";
 import "google/api/field_info.proto";
 import "google/api/resource.proto";
+import "google/type/interval.proto";
 import "wfa/measurement/edpaggregator/v1alpha/raw_impression_upload_file.proto";
 
 option java_package = "org.wfanet.measurement.edpaggregator.v1alpha";
@@ -147,6 +148,13 @@ message ListRawImpressionUploadFilesRequest {
   message Filter {
     // Filter by blob URIs.
     repeated string blob_uri_in = 1 [(google.api.field_behavior) = OPTIONAL];
+
+    // Filter for resources whose create_time falls within this interval.
+    // Start and end are both optional: omitting start returns resources
+    // created before end, omitting end returns resources created after
+    // start.
+    google.type.Interval create_time_interval = 2
+        [(google.api.field_behavior) = OPTIONAL];
   }
 
   // Optional. A filter to apply to the results.

--- a/src/main/proto/wfa/measurement/edpaggregator/v1alpha/raw_impression_upload_file_service.proto
+++ b/src/main/proto/wfa/measurement/edpaggregator/v1alpha/raw_impression_upload_file_service.proto
@@ -149,11 +149,14 @@ message ListRawImpressionUploadFilesRequest {
     // Filter by blob URIs.
     repeated string blob_uri_in = 1 [(google.api.field_behavior) = OPTIONAL];
 
-    // Filter for resources whose create_time falls within this interval.
-    // Start and end are both optional: omitting start returns resources
-    // created before end, omitting end returns resources created after
-    // start.
-    google.type.Interval create_time_interval = 2
+    // Filter for resources whose create_time is in the given interval.
+    // Start and end are both optional: omitting start_time matches
+    // resources created before end_time; omitting end_time matches
+    // resources created at or after start_time.
+    // (-- api-linter: core::0140::prepositions=disabled
+    //     aip.dev/not-precedent: `_in` is the established repo convention
+    //     for set-membership filter fields. --)
+    google.type.Interval create_time_in = 2
         [(google.api.field_behavior) = OPTIONAL];
   }
 

--- a/src/main/proto/wfa/measurement/edpaggregator/v1alpha/raw_impression_upload_model_line_service.proto
+++ b/src/main/proto/wfa/measurement/edpaggregator/v1alpha/raw_impression_upload_model_line_service.proto
@@ -180,11 +180,14 @@ message ListRawImpressionUploadModelLinesRequest {
     repeated RawImpressionUploadModelLine.State state_in = 1
         [(google.api.field_behavior) = OPTIONAL];
 
-    // Filter for resources whose create_time falls within this
-    // interval. Start and end are both optional: omitting start
-    // returns resources created before end, omitting end returns
-    // resources created after start.
-    google.type.Interval create_time_interval = 2
+    // Filter for resources whose create_time is in the given interval.
+    // Start and end are both optional: omitting start_time matches
+    // resources created before end_time; omitting end_time matches
+    // resources created at or after start_time.
+    // (-- api-linter: core::0140::prepositions=disabled
+    //     aip.dev/not-precedent: `_in` is the established repo convention
+    //     for set-membership filter fields. --)
+    google.type.Interval create_time_in = 2
         [(google.api.field_behavior) = OPTIONAL];
 
     // Filter by CMMS model line resource name.

--- a/src/main/proto/wfa/measurement/edpaggregator/v1alpha/raw_impression_upload_service.proto
+++ b/src/main/proto/wfa/measurement/edpaggregator/v1alpha/raw_impression_upload_service.proto
@@ -111,11 +111,14 @@ message ListRawImpressionUploadsRequest {
     repeated RawImpressionUpload.State state_in = 1
         [(google.api.field_behavior) = OPTIONAL];
 
-    // Filter for resources whose create_time falls within this
-    // interval. Start and end are both optional: omitting start
-    // returns resources created before end, omitting end returns
-    // resources created after start.
-    google.type.Interval create_time_interval = 2
+    // Filter for resources whose create_time is in the given interval.
+    // Start and end are both optional: omitting start_time matches
+    // resources created before end_time; omitting end_time matches
+    // resources created at or after start_time.
+    // (-- api-linter: core::0140::prepositions=disabled
+    //     aip.dev/not-precedent: `_in` is the established repo convention
+    //     for set-membership filter fields. --)
+    google.type.Interval create_time_in = 2
         [(google.api.field_behavior) = OPTIONAL];
   }
 

--- a/src/main/proto/wfa/measurement/edpaggregator/v1alpha/requisition_metadata_service.proto
+++ b/src/main/proto/wfa/measurement/edpaggregator/v1alpha/requisition_metadata_service.proto
@@ -22,6 +22,7 @@ import "google/api/field_behavior.proto";
 import "google/api/field_info.proto";
 import "google/api/resource.proto";
 import "google/protobuf/timestamp.proto";
+import "google/type/interval.proto";
 import "wfa/measurement/edpaggregator/v1alpha/requisition_metadata.proto";
 
 option java_package = "org.wfanet.measurement.edpaggregator.v1alpha";
@@ -213,6 +214,12 @@ message ListRequisitionMetadataRequest {
     string group_id = 2 [(google.api.field_behavior) = OPTIONAL];
     // Filter by the report resource name of the requisition.
     string report = 3 [(google.api.field_behavior) = OPTIONAL];
+    // Filter for resources whose create_time falls within this interval.
+    // Start and end are both optional: omitting start returns resources
+    // created before end, omitting end returns resources created after
+    // start.
+    google.type.Interval create_time_interval = 4
+        [(google.api.field_behavior) = OPTIONAL];
   }
   // The filter to apply to the list. All filter fields are optional.
   // (-- api-linter: core::0132::request-field-types=disabled

--- a/src/main/proto/wfa/measurement/edpaggregator/v1alpha/requisition_metadata_service.proto
+++ b/src/main/proto/wfa/measurement/edpaggregator/v1alpha/requisition_metadata_service.proto
@@ -217,11 +217,14 @@ message ListRequisitionMetadataRequest {
     string group_id = 2 [(google.api.field_behavior) = OPTIONAL];
     // Filter by the report resource name of the requisition.
     string report = 3 [(google.api.field_behavior) = OPTIONAL];
-    // Filter for resources whose create_time falls within this interval.
-    // Start and end are both optional: omitting start returns resources
-    // created before end, omitting end returns resources created after
-    // start.
-    google.type.Interval create_time_interval = 4
+    // Filter for resources whose create_time is in the given interval.
+    // Start and end are both optional: omitting start_time matches
+    // resources created before end_time; omitting end_time matches
+    // resources created at or after start_time.
+    // (-- api-linter: core::0140::prepositions=disabled
+    //     aip.dev/not-precedent: `_in` is the established repo convention
+    //     for set-membership filter fields. --)
+    google.type.Interval create_time_in = 4
         [(google.api.field_behavior) = OPTIONAL];
   }
   // The filter to apply to the list. All filter fields are optional.

--- a/src/main/proto/wfa/measurement/internal/edpaggregator/BUILD.bazel
+++ b/src/main/proto/wfa/measurement/internal/edpaggregator/BUILD.bazel
@@ -90,6 +90,7 @@ proto_library(
     deps = [
         ":requisition_metadata_proto",
         ":requisition_metadata_state_proto",
+        "@com_google_googleapis//google/type:interval_proto",
         "@com_google_protobuf//:timestamp_proto",
     ],
 )
@@ -166,6 +167,7 @@ proto_library(
     deps = [
         ":raw_impression_batch_state_proto",
         ":raw_impression_metadata_batch_proto",
+        "@com_google_googleapis//google/type:interval_proto",
         "@com_google_protobuf//:timestamp_proto",
     ],
 )
@@ -181,6 +183,7 @@ proto_library(
     strip_import_prefix = IMPORT_PREFIX,
     deps = [
         ":raw_impression_metadata_batch_file_proto",
+        "@com_google_googleapis//google/type:interval_proto",
         "@com_google_protobuf//:timestamp_proto",
     ],
 )
@@ -253,6 +256,7 @@ proto_library(
     strip_import_prefix = IMPORT_PREFIX,
     deps = [
         ":raw_impression_upload_file_proto",
+        "@com_google_googleapis//google/type:interval_proto",
         "@com_google_protobuf//:timestamp_proto",
     ],
 )

--- a/src/main/proto/wfa/measurement/internal/edpaggregator/pool_assignment_job_service.proto
+++ b/src/main/proto/wfa/measurement/internal/edpaggregator/pool_assignment_job_service.proto
@@ -122,7 +122,7 @@ message ListPoolAssignmentJobsRequest {
     // interval. Start and end are both optional: omitting start
     // returns resources created before end, omitting end returns
     // resources created after start.
-    google.type.Interval create_time_interval = 2;
+    google.type.Interval create_time_in = 2;
 
     // Filter by CMMS model line resource name.
     string cmms_model_line = 3;

--- a/src/main/proto/wfa/measurement/internal/edpaggregator/ranker_job_service.proto
+++ b/src/main/proto/wfa/measurement/internal/edpaggregator/ranker_job_service.proto
@@ -125,7 +125,7 @@ message ListRankerJobsRequest {
     // interval. Start and end are both optional: omitting start
     // returns resources created before end, omitting end returns
     // resources created after start.
-    google.type.Interval create_time_interval = 2;
+    google.type.Interval create_time_in = 2;
 
     // Filter by CMMS model line resource name.
     string cmms_model_line = 3;

--- a/src/main/proto/wfa/measurement/internal/edpaggregator/raw_impression_metadata_batch_file_service.proto
+++ b/src/main/proto/wfa/measurement/internal/edpaggregator/raw_impression_metadata_batch_file_service.proto
@@ -17,6 +17,7 @@ syntax = "proto3";
 package wfa.measurement.internal.edpaggregator;
 
 import "google/protobuf/timestamp.proto";
+import "google/type/interval.proto";
 import "wfa/measurement/internal/edpaggregator/raw_impression_metadata_batch_file.proto";
 
 option java_package = "org.wfanet.measurement.internal.edpaggregator";
@@ -99,6 +100,9 @@ message ListRawImpressionMetadataBatchFilesRequest {
 
   message Filter {
     repeated string blob_uri_in = 1;
+
+    // Filter for resources whose create_time falls within this interval.
+    google.type.Interval create_time_interval = 2;
   }
   Filter filter = 5;
 

--- a/src/main/proto/wfa/measurement/internal/edpaggregator/raw_impression_metadata_batch_file_service.proto
+++ b/src/main/proto/wfa/measurement/internal/edpaggregator/raw_impression_metadata_batch_file_service.proto
@@ -101,8 +101,9 @@ message ListRawImpressionMetadataBatchFilesRequest {
   message Filter {
     repeated string blob_uri_in = 1;
 
-    // Filter for resources whose create_time falls within this interval.
-    google.type.Interval create_time_interval = 2;
+    // Filter for resources whose create_time is in the given interval. At least
+    // one of `start_time` or `end_time` must be set.
+    google.type.Interval create_time_in = 2;
   }
   Filter filter = 5;
 

--- a/src/main/proto/wfa/measurement/internal/edpaggregator/raw_impression_metadata_batch_service.proto
+++ b/src/main/proto/wfa/measurement/internal/edpaggregator/raw_impression_metadata_batch_service.proto
@@ -82,8 +82,9 @@ message ListRawImpressionMetadataBatchesRequest {
     // Filter to resources whose state is in this set. Empty matches all states.
     repeated RawImpressionBatchState state_in = 1;
 
-    // Filter for resources whose create_time falls within this interval.
-    google.type.Interval create_time_interval = 2;
+    // Filter for resources whose create_time is in the given interval. At least
+    // one of `start_time` or `end_time` must be set.
+    google.type.Interval create_time_in = 2;
   }
   Filter filter = 4;
 

--- a/src/main/proto/wfa/measurement/internal/edpaggregator/raw_impression_metadata_batch_service.proto
+++ b/src/main/proto/wfa/measurement/internal/edpaggregator/raw_impression_metadata_batch_service.proto
@@ -17,6 +17,7 @@ syntax = "proto3";
 package wfa.measurement.internal.edpaggregator;
 
 import "google/protobuf/timestamp.proto";
+import "google/type/interval.proto";
 import "wfa/measurement/internal/edpaggregator/raw_impression_batch_state.proto";
 import "wfa/measurement/internal/edpaggregator/raw_impression_metadata_batch.proto";
 
@@ -79,6 +80,9 @@ message ListRawImpressionMetadataBatchesRequest {
 
   message Filter {
     RawImpressionBatchState state = 1;
+
+    // Filter for resources whose create_time falls within this interval.
+    google.type.Interval create_time_interval = 2;
   }
   Filter filter = 4;
 

--- a/src/main/proto/wfa/measurement/internal/edpaggregator/raw_impression_upload_file_service.proto
+++ b/src/main/proto/wfa/measurement/internal/edpaggregator/raw_impression_upload_file_service.proto
@@ -17,6 +17,7 @@ syntax = "proto3";
 package wfa.measurement.internal.edpaggregator;
 
 import "google/protobuf/timestamp.proto";
+import "google/type/interval.proto";
 import "wfa/measurement/internal/edpaggregator/raw_impression_upload_file.proto";
 
 option java_package = "org.wfanet.measurement.internal.edpaggregator";
@@ -112,6 +113,9 @@ message ListRawImpressionUploadFilesRequest {
   message Filter {
     // Filter by blob URIs.
     repeated string blob_uri_in = 1;
+
+    // Filter for resources whose create_time falls within this interval.
+    google.type.Interval create_time_interval = 2;
   }
   Filter filter = 5;
 

--- a/src/main/proto/wfa/measurement/internal/edpaggregator/raw_impression_upload_file_service.proto
+++ b/src/main/proto/wfa/measurement/internal/edpaggregator/raw_impression_upload_file_service.proto
@@ -114,8 +114,9 @@ message ListRawImpressionUploadFilesRequest {
     // Filter by blob URIs.
     repeated string blob_uri_in = 1;
 
-    // Filter for resources whose create_time falls within this interval.
-    google.type.Interval create_time_interval = 2;
+    // Filter for resources whose create_time is in the given interval. At least
+    // one of `start_time` or `end_time` must be set.
+    google.type.Interval create_time_in = 2;
   }
   Filter filter = 5;
 

--- a/src/main/proto/wfa/measurement/internal/edpaggregator/raw_impression_upload_model_line_service.proto
+++ b/src/main/proto/wfa/measurement/internal/edpaggregator/raw_impression_upload_model_line_service.proto
@@ -145,7 +145,7 @@ message ListRawImpressionUploadModelLinesRequest {
     // interval. Start and end are both optional: omitting start
     // returns resources created before end, omitting end returns
     // resources created after start.
-    google.type.Interval create_time_interval = 2;
+    google.type.Interval create_time_in = 2;
 
     // Filter by CMMS model line resource name.
     string cmms_model_line = 3;

--- a/src/main/proto/wfa/measurement/internal/edpaggregator/raw_impression_upload_service.proto
+++ b/src/main/proto/wfa/measurement/internal/edpaggregator/raw_impression_upload_service.proto
@@ -85,7 +85,7 @@ message ListRawImpressionUploadsRequest {
     // interval. Start and end are both optional: omitting start
     // returns resources created before end, omitting end returns
     // resources created after start.
-    google.type.Interval create_time_interval = 2;
+    google.type.Interval create_time_in = 2;
   }
   Filter filter = 4;
 }

--- a/src/main/proto/wfa/measurement/internal/edpaggregator/requisition_metadata_service.proto
+++ b/src/main/proto/wfa/measurement/internal/edpaggregator/requisition_metadata_service.proto
@@ -17,6 +17,7 @@ syntax = "proto3";
 package wfa.measurement.internal.edpaggregator;
 
 import "google/protobuf/timestamp.proto";
+import "google/type/interval.proto";
 // Import the message definitions used by this service.
 import "wfa/measurement/internal/edpaggregator/requisition_metadata.proto";
 import "wfa/measurement/internal/edpaggregator/requisition_metadata_state.proto";
@@ -121,6 +122,9 @@ message ListRequisitionMetadataRequest {
     RequisitionMetadataState state = 1;
     string group_id = 2;
     string report = 3;
+
+    // Filter for resources whose create_time falls within this interval.
+    google.type.Interval create_time_interval = 4;
   }
   Filter filter = 1;
 

--- a/src/main/proto/wfa/measurement/internal/edpaggregator/requisition_metadata_service.proto
+++ b/src/main/proto/wfa/measurement/internal/edpaggregator/requisition_metadata_service.proto
@@ -124,8 +124,9 @@ message ListRequisitionMetadataRequest {
     string group_id = 2;
     string report = 3;
 
-    // Filter for resources whose create_time falls within this interval.
-    google.type.Interval create_time_interval = 4;
+    // Filter for resources whose create_time is in the given interval. At least
+    // one of `start_time` or `end_time` must be set.
+    google.type.Interval create_time_in = 4;
   }
   Filter filter = 1;
 


### PR DESCRIPTION
Adds google.type.Interval create_time_interval to the Filter messages of RawImpressionMetadataBatch, RawImpressionMetadataBatchFile, RawImpressionUploadFile, and RequisitionMetadata (public v1alpha + internal mirrors). Brings these services in line with the phase-job services (PoolAssignmentJob, RankerJob, RawImpressionUploadModelLine, RawImpressionUpload) which already have it.

Required for the VidLabelingMonitorFunction (#3958) staleness sweeps. Wire-compatible additive change; no existing callers break.

Issue: #4002