### PR TITLE
feat: add Phase-0 DEK, pool offsets, and max event date to pool-assignment protos

### DIFF
--- a/src/main/proto/wfa/measurement/edpaggregator/v1alpha/BUILD.bazel
+++ b/src/main/proto/wfa/measurement/edpaggregator/v1alpha/BUILD.bazel
@@ -488,8 +488,10 @@ proto_library(
     srcs = ["raw_impression_upload_model_line.proto"],
     strip_import_prefix = _IMPORT_PREFIX,
     deps = [
+        ":encrypted_dek_proto",
         "@com_google_googleapis//google/api:field_behavior_proto",
         "@com_google_googleapis//google/api:resource_proto",
+        "@com_google_googleapis//google/type:date_proto",
         "@com_google_protobuf//:timestamp_proto",
     ],
 )
@@ -556,6 +558,7 @@ proto_library(
     srcs = ["pool_assignment_job.proto"],
     strip_import_prefix = _IMPORT_PREFIX,
     deps = [
+        ":encrypted_dek_proto",
         "@com_google_googleapis//google/api:field_behavior_proto",
         "@com_google_googleapis//google/api:resource_proto",
         "@com_google_protobuf//:timestamp_proto",
@@ -572,10 +575,12 @@ proto_library(
     srcs = ["pool_assignment_job_service.proto"],
     strip_import_prefix = _IMPORT_PREFIX,
     deps = [
+        ":encrypted_dek_proto",
         ":pool_assignment_job_proto",
         "@com_google_googleapis//google/api:field_behavior_proto",
         "@com_google_googleapis//google/api:field_info_proto",
         "@com_google_googleapis//google/api:resource_proto",
+        "@com_google_googleapis//google/type:date_proto",
         "@com_google_googleapis//google/type:interval_proto",
     ],
 )

--- a/src/main/proto/wfa/measurement/edpaggregator/v1alpha/pool_assignment_job.proto
+++ b/src/main/proto/wfa/measurement/edpaggregator/v1alpha/pool_assignment_job.proto
@@ -19,6 +19,7 @@ package wfa.measurement.edpaggregator.v1alpha;
 import "google/api/field_behavior.proto";
 import "google/api/resource.proto";
 import "google/protobuf/timestamp.proto";
+import "wfa/measurement/edpaggregator/v1alpha/encrypted_dek.proto";
 
 option java_package = "org.wfanet.measurement.edpaggregator.v1alpha";
 option java_multiple_files = true;
@@ -82,4 +83,10 @@ message PoolAssignmentJob {
 
   // Entity tag for optimistic concurrency control.
   string etag = 8 [(google.api.field_behavior) = OUTPUT_ONLY];
+
+  // The DEK used to encrypt every per-(shard, subpool) `SubpoolFingerprints`
+  // blob written by this shard's VM. Populated when the job is marked
+  // `SUCCEEDED`; read by the last-shard-out to decrypt this shard's blobs.
+  wfa.measurement.securecomputation.impressions.EncryptedDek encrypted_dek = 9
+      [(google.api.field_behavior) = OUTPUT_ONLY];
 }

--- a/src/main/proto/wfa/measurement/edpaggregator/v1alpha/pool_assignment_job_service.proto
+++ b/src/main/proto/wfa/measurement/edpaggregator/v1alpha/pool_assignment_job_service.proto
@@ -19,7 +19,9 @@ package wfa.measurement.edpaggregator.v1alpha;
 import "google/api/field_behavior.proto";
 import "google/api/field_info.proto";
 import "google/api/resource.proto";
+import "google/type/date.proto";
 import "google/type/interval.proto";
+import "wfa/measurement/edpaggregator/v1alpha/encrypted_dek.proto";
 import "wfa/measurement/edpaggregator/v1alpha/pool_assignment_job.proto";
 
 option java_package = "org.wfanet.measurement.edpaggregator.v1alpha";
@@ -216,6 +218,25 @@ message MarkPoolAssignmentJobSucceededRequest {
     (google.api.field_behavior) = OPTIONAL,
     (google.api.field_info).format = UUID4
   ];
+
+  // The DEK that encrypts this shard's `SubpoolFingerprints` blobs. Persisted by the server onto
+  // the job's OUTPUT_ONLY `PoolAssignmentJob.encrypted_dek` atomically with the `SUCCEEDED`
+  // transition, so the last-shard-out can recover every shard's DEK.
+  wfa.measurement.securecomputation.impressions.EncryptedDek encrypted_dek = 4
+      [(google.api.field_behavior) = REQUIRED];
+
+  // Subpool offsets discovered by this shard during Phase 0. The service unions these across all
+  // shards of the (upload, model line); on the last shard out it returns the union in
+  // `LastShardResult` and persists it on `RawImpressionUploadModelLine.pool_offsets`. May be empty
+  // for a shard that produced no subpools.
+  repeated int64 pool_offsets = 5 [(google.api.field_behavior) = OPTIONAL];
+
+  // The latest event date (UTC) among the impressions this shard wrote into its
+  // `SubpoolFingerprints` blobs. The service reduces these to a maximum across all shards of the
+  // (upload, model line); on the last shard out it returns that maximum in `LastShardResult` and
+  // persists it on `RawImpressionUploadModelLine.max_event_date`. Unset for a shard that wrote no
+  // impressions.
+  google.type.Date max_event_date = 6 [(google.api.field_behavior) = OPTIONAL];
 }
 
 // Response message for the
@@ -234,6 +255,11 @@ message MarkPoolAssignmentJobSucceededResponse {
   message LastShardResult {
     // The pool offsets discovered during Phase 0.
     repeated int64 pool_offsets = 1 [(google.api.field_behavior) = REQUIRED];
+
+    // The maximum event date (UTC) across all shards, reduced from every shard's reported
+    // `max_event_date`. Stamped onto each Phase-1 `VidRankBuilderParams.max_event_date` so the
+    // rank-map retention sweep can age out blobs. Always set on the last-shard result.
+    google.type.Date max_event_date = 2 [(google.api.field_behavior) = REQUIRED];
   }
 }
 

--- a/src/main/proto/wfa/measurement/edpaggregator/v1alpha/pool_assignment_job_service.proto
+++ b/src/main/proto/wfa/measurement/edpaggregator/v1alpha/pool_assignment_job_service.proto
@@ -219,23 +219,29 @@ message MarkPoolAssignmentJobSucceededRequest {
     (google.api.field_info).format = UUID4
   ];
 
-  // The DEK that encrypts this shard's `SubpoolFingerprints` blobs. Persisted by the server onto
-  // the job's OUTPUT_ONLY `PoolAssignmentJob.encrypted_dek` atomically with the `SUCCEEDED`
-  // transition, so the last-shard-out can recover every shard's DEK.
+  // The DEK that encrypts this shard's `SubpoolFingerprints` blobs.
+  // Persisted by the server onto the job's OUTPUT_ONLY
+  // `PoolAssignmentJob.encrypted_dek` atomically with the `SUCCEEDED`
+  // transition. On the last-shard mark, the server additionally promotes
+  // this DEK to the parent `RawImpressionUploadModelLine.encrypted_merged_dek`
+  // so a retrying SubpoolAssigner's merge stays consistent with the
+  // already-written merged blobs.
   wfa.measurement.securecomputation.impressions.EncryptedDek encrypted_dek = 4
       [(google.api.field_behavior) = REQUIRED];
 
-  // Subpool offsets discovered by this shard during Phase 0. The service unions these across all
-  // shards of the (upload, model line); on the last shard out it returns the union in
-  // `LastShardResult` and persists it on `RawImpressionUploadModelLine.pool_offsets`. May be empty
-  // for a shard that produced no subpools.
+  // Subpool offsets discovered by this shard during Phase 0. The service unions
+  // these across all shards of the (upload, model line); on the last shard out
+  // it returns the union in `LastShardResult` and persists it on
+  // `RawImpressionUploadModelLine.pool_offsets`. May be empty for a shard that
+  // produced no subpools.
   repeated int64 pool_offsets = 5 [(google.api.field_behavior) = OPTIONAL];
 
   // The latest event date (UTC) among the impressions this shard wrote into its
-  // `SubpoolFingerprints` blobs. The service reduces these to a maximum across all shards of the
-  // (upload, model line); on the last shard out it returns that maximum in `LastShardResult` and
-  // persists it on `RawImpressionUploadModelLine.max_event_date`. Unset for a shard that wrote no
-  // impressions.
+  // `SubpoolFingerprints` blobs. The service reduces these to a maximum across
+  // all shards of the (upload, model line); on the last shard out it returns
+  // that maximum in `LastShardResult` and persists it on
+  // `RawImpressionUploadModelLine.max_event_date`. Unset for a shard that wrote
+  // no impressions.
   google.type.Date max_event_date = 6 [(google.api.field_behavior) = OPTIONAL];
 }
 
@@ -251,15 +257,19 @@ message MarkPoolAssignmentJobSucceededResponse {
   // Phase 1.
   LastShardResult last_shard_result = 2;
 
-  // Result of the last shard completing.
+  // Result of the last shard completing. Present only when the
+  // last-shard mark resulted in non-empty cross-shard work; omitted
+  // if no shard wrote impressions.
   message LastShardResult {
     // The pool offsets discovered during Phase 0.
     repeated int64 pool_offsets = 1 [(google.api.field_behavior) = REQUIRED];
 
-    // The maximum event date (UTC) across all shards, reduced from every shard's reported
-    // `max_event_date`. Stamped onto each Phase-1 `VidRankBuilderParams.max_event_date` so the
-    // rank-map retention sweep can age out blobs. Always set on the last-shard result.
-    google.type.Date max_event_date = 2 [(google.api.field_behavior) = REQUIRED];
+    // The maximum event date (UTC) across all shards, reduced from every
+    // shard's reported `max_event_date`. Stamped onto each Phase-1
+    // `VidRankBuilderParams.max_event_date` so the rank-map retention sweep can
+    // age out blobs. Always set on the last-shard result.
+    google.type.Date max_event_date = 2
+        [(google.api.field_behavior) = REQUIRED];
   }
 }
 

--- a/src/main/proto/wfa/measurement/edpaggregator/v1alpha/raw_impression_upload_model_line.proto
+++ b/src/main/proto/wfa/measurement/edpaggregator/v1alpha/raw_impression_upload_model_line.proto
@@ -19,6 +19,8 @@ package wfa.measurement.edpaggregator.v1alpha;
 import "google/api/field_behavior.proto";
 import "google/api/resource.proto";
 import "google/protobuf/timestamp.proto";
+import "google/type/date.proto";
+import "wfa/measurement/edpaggregator/v1alpha/encrypted_dek.proto";
 
 option java_package = "org.wfanet.measurement.edpaggregator.v1alpha";
 option java_multiple_files = true;
@@ -81,4 +83,25 @@ message RawImpressionUploadModelLine {
   // Entity tag for optimistic concurrency control. Required on
   // `Mark*` requests (AIP-154); a mismatch returns `ABORTED`.
   string etag = 7 [(google.api.field_behavior) = OUTPUT_ONLY];
+
+  // Union of subpool offsets discovered across all shards during Phase 0. Populated atomically by
+  // the service when the last `PoolAssignmentJob` for this (upload, model line) is marked
+  // `SUCCEEDED`; read by a retrying SubpoolAssigner to recover the last-shard-out merge input list,
+  // and by the control-plane fan-out to bin-pack `RankerJob`s.
+  repeated int64 pool_offsets = 8 [(google.api.field_behavior) = OUTPUT_ONLY];
+
+  // Maximum event date (UTC) across all impressions discovered during Phase 0, reduced from every
+  // shard's reported max. Populated atomically with `pool_offsets` on last-shard-out; stamped onto
+  // each Phase-1 `VidRankBuilderParams.max_event_date` and read by a retrying SubpoolAssigner to
+  // recover the value for the fan-out.
+  google.type.Date max_event_date = 9 [(google.api.field_behavior) = OUTPUT_ONLY];
+
+  // DEK that encrypts the merged per-subpool `SubpoolFingerprints` blobs. On last-shard-out the
+  // service promotes the marking `PoolAssignmentJob.encrypted_dek` (the last shard's own DEK, which
+  // it also used for the merge) onto this field, atomically with `pool_offsets`/`max_event_date`. A
+  // retrying SubpoolAssigner reuses it so a re-run's merge — and every published
+  // `VidRankBuilderParams.encrypted_subpool_maps_dek` — stays consistent with the already-written
+  // merged blobs instead of diverging on a freshly generated DEK.
+  wfa.measurement.securecomputation.impressions.EncryptedDek encrypted_merged_dek = 10
+      [(google.api.field_behavior) = OUTPUT_ONLY];
 }

--- a/src/main/proto/wfa/measurement/edpaggregator/v1alpha/raw_impression_upload_model_line.proto
+++ b/src/main/proto/wfa/measurement/edpaggregator/v1alpha/raw_impression_upload_model_line.proto
@@ -84,24 +84,30 @@ message RawImpressionUploadModelLine {
   // `Mark*` requests (AIP-154); a mismatch returns `ABORTED`.
   string etag = 7 [(google.api.field_behavior) = OUTPUT_ONLY];
 
-  // Union of subpool offsets discovered across all shards during Phase 0. Populated atomically by
-  // the service when the last `PoolAssignmentJob` for this (upload, model line) is marked
-  // `SUCCEEDED`; read by a retrying SubpoolAssigner to recover the last-shard-out merge input list,
-  // and by the control-plane fan-out to bin-pack `RankerJob`s.
+  // Union of subpool offsets discovered across all shards during Phase 0.
+  // Populated atomically by the service when the last `PoolAssignmentJob` for
+  // this (upload, model line) is marked `SUCCEEDED`; read by a retrying
+  // SubpoolAssigner to recover the last-shard-out merge input list, and by the
+  // control-plane fan-out to bin-pack `RankerJob`s.
   repeated int64 pool_offsets = 8 [(google.api.field_behavior) = OUTPUT_ONLY];
 
-  // Maximum event date (UTC) across all impressions discovered during Phase 0, reduced from every
-  // shard's reported max. Populated atomically with `pool_offsets` on last-shard-out; stamped onto
-  // each Phase-1 `VidRankBuilderParams.max_event_date` and read by a retrying SubpoolAssigner to
-  // recover the value for the fan-out.
-  google.type.Date max_event_date = 9 [(google.api.field_behavior) = OUTPUT_ONLY];
-
-  // DEK that encrypts the merged per-subpool `SubpoolFingerprints` blobs. On last-shard-out the
-  // service promotes the marking `PoolAssignmentJob.encrypted_dek` (the last shard's own DEK, which
-  // it also used for the merge) onto this field, atomically with `pool_offsets`/`max_event_date`. A
-  // retrying SubpoolAssigner reuses it so a re-run's merge — and every published
-  // `VidRankBuilderParams.encrypted_subpool_maps_dek` — stays consistent with the already-written
-  // merged blobs instead of diverging on a freshly generated DEK.
-  wfa.measurement.securecomputation.impressions.EncryptedDek encrypted_merged_dek = 10
+  // Maximum event date (UTC) across all impressions discovered during Phase 0,
+  // reduced from every shard's reported max. Populated atomically with
+  // `pool_offsets` on last-shard-out; stamped onto each Phase-1
+  // `VidRankBuilderParams.max_event_date` and read by a retrying
+  // SubpoolAssigner to recover the value for the fan-out.
+  google.type.Date max_event_date = 9
       [(google.api.field_behavior) = OUTPUT_ONLY];
+
+  // DEK that encrypts the merged per-subpool `SubpoolFingerprints` blobs. On
+  // last-shard-out the service promotes the marking
+  // `PoolAssignmentJob.encrypted_dek` (the last shard's own DEK, which it also
+  // used for the merge) onto this field, atomically with
+  // `pool_offsets`/`max_event_date`. A retrying SubpoolAssigner reuses it so a
+  // re-run's merge — and every published
+  // `VidRankBuilderParams.encrypted_subpool_maps_dek` — stays consistent with
+  // the already-written merged blobs instead of diverging on a freshly
+  // generated DEK.
+  wfa.measurement.securecomputation.impressions.EncryptedDek
+      encrypted_merged_dek = 10 [(google.api.field_behavior) = OUTPUT_ONLY];
 }

--- a/src/main/proto/wfa/measurement/internal/edpaggregator/BUILD.bazel
+++ b/src/main/proto/wfa/measurement/internal/edpaggregator/BUILD.bazel
@@ -283,6 +283,8 @@ proto_library(
     strip_import_prefix = IMPORT_PREFIX,
     deps = [
         ":raw_impression_upload_model_line_state_proto",
+        "//src/main/proto/wfa/measurement/edpaggregator/v1alpha:encrypted_dek_proto",
+        "@com_google_googleapis//google/type:date_proto",
         "@com_google_protobuf//:timestamp_proto",
     ],
 )
@@ -369,6 +371,7 @@ proto_library(
     strip_import_prefix = IMPORT_PREFIX,
     deps = [
         ":pool_assignment_state_proto",
+        "//src/main/proto/wfa/measurement/edpaggregator/v1alpha:encrypted_dek_proto",
         "@com_google_protobuf//:timestamp_proto",
     ],
 )
@@ -385,6 +388,8 @@ proto_library(
     deps = [
         ":pool_assignment_job_proto",
         ":pool_assignment_state_proto",
+        "//src/main/proto/wfa/measurement/edpaggregator/v1alpha:encrypted_dek_proto",
+        "@com_google_googleapis//google/type:date_proto",
         "@com_google_googleapis//google/type:interval_proto",
         "@com_google_protobuf//:timestamp_proto",
     ],

--- a/src/main/proto/wfa/measurement/internal/edpaggregator/pool_assignment_job.proto
+++ b/src/main/proto/wfa/measurement/internal/edpaggregator/pool_assignment_job.proto
@@ -17,6 +17,7 @@ syntax = "proto3";
 package wfa.measurement.internal.edpaggregator;
 
 import "google/protobuf/timestamp.proto";
+import "wfa/measurement/edpaggregator/v1alpha/encrypted_dek.proto";
 import "wfa/measurement/internal/edpaggregator/pool_assignment_state.proto";
 
 option java_package = "org.wfanet.measurement.internal.edpaggregator";
@@ -58,4 +59,9 @@ message PoolAssignmentJob {
 
   // Entity tag for optimistic concurrency control.
   string etag = 10;
+
+  // The DEK used to encrypt every per-(shard, subpool) SubpoolFingerprints
+  // blob written by this shard's VM. Populated when the job is marked
+  // SUCCEEDED; read by the last-shard-out to decrypt this shard's blobs.
+  wfa.measurement.securecomputation.impressions.EncryptedDek encrypted_dek = 11;
 }

--- a/src/main/proto/wfa/measurement/internal/edpaggregator/pool_assignment_job_service.proto
+++ b/src/main/proto/wfa/measurement/internal/edpaggregator/pool_assignment_job_service.proto
@@ -17,7 +17,9 @@ syntax = "proto3";
 package wfa.measurement.internal.edpaggregator;
 
 import "google/protobuf/timestamp.proto";
+import "google/type/date.proto";
 import "google/type/interval.proto";
+import "wfa/measurement/edpaggregator/v1alpha/encrypted_dek.proto";
 import "wfa/measurement/internal/edpaggregator/pool_assignment_job.proto";
 import "wfa/measurement/internal/edpaggregator/pool_assignment_state.proto";
 
@@ -163,6 +165,16 @@ message MarkPoolAssignmentJobSucceededRequest {
 
   // A request ID provided by the client to ensure idempotency.
   string request_id = 5;
+
+  // DEK that encrypts this shard's SubpoolFingerprints blobs; persisted on the job.
+  wfa.measurement.securecomputation.impressions.EncryptedDek encrypted_dek = 6;
+
+  // Subpool offsets discovered by this shard during Phase 0; unioned across shards by the service.
+  repeated int64 pool_offsets = 7;
+
+  // Latest event date (UTC) among the impressions this shard wrote; reduced to a maximum across
+  // shards by the service. Unset for a shard that wrote no impressions.
+  google.type.Date max_event_date = 8;
 }
 
 // Response message for MarkPoolAssignmentJobSucceeded.
@@ -180,6 +192,9 @@ message MarkPoolAssignmentJobSucceededResponse {
   message LastShardResult {
     // The pool offsets discovered during Phase 0.
     repeated int64 pool_offsets = 1;
+
+    // The maximum event date (UTC) across all shards. Unset only if no shard wrote any impression.
+    google.type.Date max_event_date = 2;
   }
 }
 

--- a/src/main/proto/wfa/measurement/internal/edpaggregator/pool_assignment_job_service.proto
+++ b/src/main/proto/wfa/measurement/internal/edpaggregator/pool_assignment_job_service.proto
@@ -166,14 +166,17 @@ message MarkPoolAssignmentJobSucceededRequest {
   // A request ID provided by the client to ensure idempotency.
   string request_id = 5;
 
-  // DEK that encrypts this shard's SubpoolFingerprints blobs; persisted on the job.
+  // DEK that encrypts this shard's SubpoolFingerprints blobs; persisted on the
+  // job.
   wfa.measurement.securecomputation.impressions.EncryptedDek encrypted_dek = 6;
 
-  // Subpool offsets discovered by this shard during Phase 0; unioned across shards by the service.
+  // Subpool offsets discovered by this shard during Phase 0; unioned across
+  // shards by the service.
   repeated int64 pool_offsets = 7;
 
-  // Latest event date (UTC) among the impressions this shard wrote; reduced to a maximum across
-  // shards by the service. Unset for a shard that wrote no impressions.
+  // Latest event date (UTC) among the impressions this shard wrote; reduced to
+  // a maximum across shards by the service. Unset for a shard that wrote no
+  // impressions.
   google.type.Date max_event_date = 8;
 }
 
@@ -188,12 +191,15 @@ message MarkPoolAssignmentJobSucceededResponse {
   // Phase 1.
   LastShardResult last_shard_result = 2;
 
-  // Result of the last shard completing.
+  // Result of the last shard completing. Present only when the
+  // last-shard mark resulted in non-empty cross-shard work; omitted
+  // if no shard wrote impressions.
   message LastShardResult {
     // The pool offsets discovered during Phase 0.
     repeated int64 pool_offsets = 1;
 
-    // The maximum event date (UTC) across all shards. Unset only if no shard wrote any impression.
+    // The maximum event date (UTC) across all shards. Always set on the
+    // last-shard result.
     google.type.Date max_event_date = 2;
   }
 }

--- a/src/main/proto/wfa/measurement/internal/edpaggregator/raw_impression_upload_model_line.proto
+++ b/src/main/proto/wfa/measurement/internal/edpaggregator/raw_impression_upload_model_line.proto
@@ -53,15 +53,17 @@ message RawImpressionUploadModelLine {
   // Entity tag for optimistic concurrency control.
   string etag = 8;
 
-  // Union of subpool offsets discovered across all shards during Phase 0; populated on
-  // last-shard-out.
+  // Union of subpool offsets discovered across all shards during Phase 0;
+  // populated on last-shard-out.
   repeated int64 pool_offsets = 9;
 
-  // Maximum event date (UTC) across all impressions discovered during Phase 0; populated on
-  // last-shard-out alongside `pool_offsets`.
+  // Maximum event date (UTC) across all impressions discovered during Phase 0;
+  // populated on last-shard-out alongside `pool_offsets`.
   google.type.Date max_event_date = 10;
 
-  // DEK that encrypts the merged per-subpool SubpoolFingerprints blobs; the last shard's
-  // encrypted_dek, promoted on last-shard-out so a retrying SubpoolAssigner reuses it.
-  wfa.measurement.securecomputation.impressions.EncryptedDek encrypted_merged_dek = 11;
+  // DEK that encrypts the merged per-subpool SubpoolFingerprints blobs; the
+  // last shard's encrypted_dek, promoted on last-shard-out so a retrying
+  // SubpoolAssigner reuses it.
+  wfa.measurement.securecomputation.impressions.EncryptedDek
+      encrypted_merged_dek = 11;
 }

--- a/src/main/proto/wfa/measurement/internal/edpaggregator/raw_impression_upload_model_line.proto
+++ b/src/main/proto/wfa/measurement/internal/edpaggregator/raw_impression_upload_model_line.proto
@@ -17,6 +17,8 @@ syntax = "proto3";
 package wfa.measurement.internal.edpaggregator;
 
 import "google/protobuf/timestamp.proto";
+import "google/type/date.proto";
+import "wfa/measurement/edpaggregator/v1alpha/encrypted_dek.proto";
 import "wfa/measurement/internal/edpaggregator/raw_impression_upload_model_line_state.proto";
 
 option java_package = "org.wfanet.measurement.internal.edpaggregator";
@@ -50,4 +52,16 @@ message RawImpressionUploadModelLine {
 
   // Entity tag for optimistic concurrency control.
   string etag = 8;
+
+  // Union of subpool offsets discovered across all shards during Phase 0; populated on
+  // last-shard-out.
+  repeated int64 pool_offsets = 9;
+
+  // Maximum event date (UTC) across all impressions discovered during Phase 0; populated on
+  // last-shard-out alongside `pool_offsets`.
+  google.type.Date max_event_date = 10;
+
+  // DEK that encrypts the merged per-subpool SubpoolFingerprints blobs; the last shard's
+  // encrypted_dek, promoted on last-shard-out so a retrying SubpoolAssigner reuses it.
+  wfa.measurement.securecomputation.impressions.EncryptedDek encrypted_merged_dek = 11;
 }


### PR DESCRIPTION
## Summary
  
  Proto-only changes extracted from the SubpoolAssigner Phase-0 work into a
  standalone PR. Adds the fields the Phase-0 pipeline needs to (a) hand the
  per-shard data-encryption key (DEK) through the `MarkPoolAssignmentJobSucceeded`
  flow, and (b) carry the cross-shard reduction results (subpool offsets + max
  event date) that the last-shard-out persists for downstream Phase-1 fan-out and
  SubpoolAssigner retries.

  Changes are mirrored in both the **public** (`v1alpha`) and **internal**
  edpaggregator proto packages. No service-method signatures change — only message
  fields are added (all new field numbers, wire-compatible).

  > Part of a stack:
  > `pool-assigner-utility-classes` → **`update-proto-for-phase0`** → `subpool-assigner-phase0`
  > Merge this first; the Kotlin implementation lands in the follow-up PR.

  ## Changes

  ### Public API — `wfa/measurement/edpaggregator/v1alpha`
  - **`PoolAssignmentJob`** — add `EncryptedDek encrypted_dek = 9` (`OUTPUT_ONLY`): the DEK that encrypts this shard's `SubpoolFingerprints` blobs; read by last-shard-out to decrypt.
  - **`MarkPoolAssignmentJobSucceededRequest`** — add `encrypted_dek = 3` (`REQUIRED`), `repeated int64 pool_offsets = 4`, `Date max_event_date = 5` (`OPTIONAL`).
  - **`MarkPoolAssignmentJobSucceededResponse.LastShardResult`** — add `Date max_event_date = 2` (`OPTIONAL`): the max event date reduced across all shards.
  - **`RawImpressionUploadModelLine`** — add `repeated int64 pool_offsets = 7`, `Date max_event_date = 8`, `EncryptedDek encrypted_merged_dek = 9` (all `OUTPUT_ONLY`): the cross-shard union/max and the
  promoted merge DEK, written atomically on last-shard-out.

  ### Internal — `wfa/measurement/internal/edpaggregator`
  Same fields mirrored (no `field_behavior` annotations, internal field numbers):
  - `PoolAssignmentJob.encrypted_dek = 11`
  - `MarkPoolAssignmentJobSucceededRequest.encrypted_dek = 5`, `pool_offsets = 6`, `max_event_date = 7`
  - `MarkPoolAssignmentJobSucceededResponse.LastShardResult.max_event_date = 2`
  - `RawImpressionUploadModelLine.pool_offsets = 8`, `max_event_date = 9`, `encrypted_merged_dek = 10`

  ### Build
  - New proto deps: `:encrypted_dek_proto` (`v1alpha`) and `@com_google_googleapis//google/type:date_proto`, wired into the affected `proto_library` targets in both `v1alpha/BUILD.bazel` and
  `internal/edpaggregator/BUILD.bazel`.

  ## Compatibility
  - All additions use fresh field numbers → backward/forward wire-compatible.
  - New cross-package dependency on `wfa.measurement.securecomputation.impressions.EncryptedDek`.

  ## Testing
  - `bazel build //src/main/proto/wfa/measurement/edpaggregator/v1alpha/... //src/main/proto/wfa/measurement/internal/edpaggregator/...` — builds clean.

Issue: #3903 