### PR TITLE
feat: subpool ranker, retention, and metrics

### DIFF
--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/rawimpressions/BUILD.bazel
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/rawimpressions/BUILD.bazel
@@ -99,3 +99,11 @@ kt_jvm_library(
         "@wfa_common_jvm//src/main/kotlin/org/wfanet/measurement/storage:mesos_recordio_storage_client",
     ],
 )
+
+kt_jvm_library(
+    name = "raw_impression_file_bin_packer",
+    srcs = ["RawImpressionFileBinPacker.kt"],
+    deps = [
+        "//src/main/proto/wfa/measurement/edpaggregator/v1alpha:raw_impression_upload_file_kt_jvm_proto",
+    ],
+)

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/rawimpressions/RawImpressionFileBinPacker.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/rawimpressions/RawImpressionFileBinPacker.kt
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2026 The Cross-Media Measurement Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wfanet.measurement.edpaggregator.rawimpressions
+
+import org.wfanet.measurement.edpaggregator.v1alpha.RawImpressionUploadFile
+
+/**
+ * Partitions an upload's [RawImpressionUploadFile]s into Phase-2 VID-labeling batches.
+ *
+ * Phase 2 partitions work by **whole file**, not by an integer fingerprint shard: an output blob's
+ * `entity_keys` and event-group attribution must stay intact, and fingerprint-sharding would
+ * scatter one event group's impressions across N output blobs. Each returned batch becomes one
+ * `VidLabelingJob` / Phase-2 WorkItem.
+ *
+ * Shared by the producers that fan out Phase 2 so they partition identically: the Phase-1
+ * last-job-out fan-out (`VidRankBuilder`, memoized) and the non-memoized dispatcher
+ * (`VidLabelingDispatcher`).
+ */
+object RawImpressionFileBinPacker {
+  /**
+   * Bin-packs [files] into batches whose total `size_bytes` stays within [maxFileBatchSizeBytes],
+   * using first-fit-decreasing: files are processed largest-first (ties broken by resource name),
+   * and each is placed into the first existing batch it still fits in, opening a new batch only
+   * when none has room. A single file whose `size_bytes` meets or exceeds the limit fits in no
+   * batch and lands in its own (best-effort) batch.
+   *
+   * The result is a pure function of [files] and [maxFileBatchSizeBytes] and is **deterministic**
+   * regardless of input order — so a job's batch-index-keyed `request_id` / `work_item_id` stays
+   * stable across redeliveries even if the upload's file set is re-listed.
+   *
+   * @param files the upload's `RawImpressionUploadFile`s to pack; each `size_bytes` must be
+   *   populated (the value the producer reads from storage metadata).
+   * @param maxFileBatchSizeBytes the bin-packing threshold: the maximum total `size_bytes` per
+   *   batch; must be `> 0`.
+   * @return batches of `RawImpressionUploadFile` resource names, in deterministic order.
+   */
+  fun pack(files: List<RawImpressionUploadFile>, maxFileBatchSizeBytes: Long): List<List<String>> {
+    require(maxFileBatchSizeBytes > 0) {
+      "maxFileBatchSizeBytes must be > 0, got $maxFileBatchSizeBytes"
+    }
+    val batchFiles = mutableListOf<MutableList<String>>()
+    val batchBytes = mutableListOf<Long>()
+    val ordered =
+      files.sortedWith(
+        compareByDescending<RawImpressionUploadFile> { it.sizeBytes }.thenBy { it.name }
+      )
+    for (file in ordered) {
+      val fit = batchBytes.indexOfFirst { it + file.sizeBytes <= maxFileBatchSizeBytes }
+      if (fit >= 0) {
+        batchFiles[fit].add(file.name)
+        batchBytes[fit] += file.sizeBytes
+      } else {
+        // No open batch has room (includes a file that alone meets/exceeds the cap): start a new
+        // one.
+        batchFiles.add(mutableListOf(file.name))
+        batchBytes.add(file.sizeBytes)
+      }
+    }
+    return batchFiles
+  }
+}

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/vidrankbuilder/BUILD.bazel
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/vidrankbuilder/BUILD.bazel
@@ -35,6 +35,49 @@ kt_jvm_library(
 )
 
 kt_jvm_library(
+    name = "vid_rank_builder_metrics",
+    srcs = ["VidRankBuilderMetrics.kt"],
+    deps = [
+        "@wfa_common_jvm//imports/java/io/opentelemetry/api",
+        "@wfa_common_jvm//src/main/kotlin/org/wfanet/measurement/common",
+    ],
+)
+
+kt_jvm_library(
+    name = "subpool_retention",
+    srcs = ["SubpoolRetention.kt"],
+    deps = [
+        "//src/main/kotlin/org/wfanet/measurement/common/api/grpc:list_resources",
+        "//src/main/kotlin/org/wfanet/measurement/edpaggregator/rawimpressions:rank_index_store",
+        "//src/main/proto/wfa/measurement/edpaggregator/v1alpha:rank_index_blob_kt_jvm_proto",
+        "//src/main/proto/wfa/measurement/edpaggregator/v1alpha:rank_index_blob_service_kt_jvm_grpc_proto",
+        "@wfa_common_jvm//imports/kotlin/com/google/type:date_kt_jvm_proto",
+        "@wfa_common_jvm//imports/kotlin/kotlinx/coroutines:core",
+    ],
+)
+
+kt_jvm_library(
+    name = "subpool_ranker",
+    srcs = ["SubpoolRanker.kt"],
+    deps = [
+        ":event_id_digest_bytes",
+        ":rank_allocator",
+        ":subpool_retention",
+        ":vid_rank_builder_metrics",
+        "//src/main/kotlin/org/wfanet/measurement/common/api/grpc:list_resources",
+        "//src/main/kotlin/org/wfanet/measurement/edpaggregator/rawimpressions:rank_index_store",
+        "//src/main/kotlin/org/wfanet/measurement/edpaggregator/rawimpressions:subpool_fingerprints_store",
+        "//src/main/kotlin/org/wfanet/measurement/edpaggregator/vidlabeler/utils:bytes12_int_map",
+        "//src/main/proto/wfa/measurement/edpaggregator/v1alpha:encrypted_dek_kt_jvm_proto",
+        "//src/main/proto/wfa/measurement/edpaggregator/v1alpha:rank_index_blob_kt_jvm_proto",
+        "//src/main/proto/wfa/measurement/edpaggregator/v1alpha:rank_index_blob_service_kt_jvm_grpc_proto",
+        "@wfa_common_jvm//imports/java/com/google/protobuf",
+        "@wfa_common_jvm//imports/kotlin/com/google/type:date_kt_jvm_proto",
+        "@wfa_common_jvm//imports/kotlin/kotlinx/coroutines:core",
+    ],
+)
+
+kt_jvm_library(
     name = "vid_rank_builder_app",
     srcs = ["VidRankBuilderApp.kt"],
     deps = [

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/vidrankbuilder/BUILD.bazel
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/vidrankbuilder/BUILD.bazel
@@ -47,6 +47,7 @@ kt_jvm_library(
     name = "subpool_retention",
     srcs = ["SubpoolRetention.kt"],
     deps = [
+        "//src/main/kotlin/org/wfanet/measurement/common/api:resource_key",
         "//src/main/kotlin/org/wfanet/measurement/common/api/grpc:list_resources",
         "//src/main/kotlin/org/wfanet/measurement/edpaggregator/rawimpressions:rank_index_store",
         "//src/main/proto/wfa/measurement/edpaggregator/v1alpha:rank_index_blob_kt_jvm_proto",
@@ -64,6 +65,7 @@ kt_jvm_library(
         ":rank_allocator",
         ":subpool_retention",
         ":vid_rank_builder_metrics",
+        "//src/main/kotlin/org/wfanet/measurement/common/api:resource_key",
         "//src/main/kotlin/org/wfanet/measurement/common/api/grpc:list_resources",
         "//src/main/kotlin/org/wfanet/measurement/edpaggregator/rawimpressions:rank_index_store",
         "//src/main/kotlin/org/wfanet/measurement/edpaggregator/rawimpressions:subpool_fingerprints_store",

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/vidrankbuilder/BUILD.bazel
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/vidrankbuilder/BUILD.bazel
@@ -59,7 +59,10 @@ kt_jvm_library(
 
 kt_jvm_library(
     name = "subpool_ranker",
-    srcs = ["SubpoolRanker.kt"],
+    srcs = [
+        "OutOfRetentionBackfillException.kt",
+        "SubpoolRanker.kt",
+    ],
     deps = [
         ":event_id_digest_bytes",
         ":rank_allocator",

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/vidrankbuilder/OutOfRetentionBackfillException.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/vidrankbuilder/OutOfRetentionBackfillException.kt
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2026 The Cross-Media Measurement Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wfanet.measurement.edpaggregator.vidrankbuilder
+
+/**
+ * Thrown when [SubpoolRanker] is asked to rank a backfill whose event date is older than the
+ * retention window (`latest_max_event_date - max_event_date > retention_days`).
+ *
+ * By then the rank state in force at the backfilled date has already aged out, so the fingerprint's
+ * original rank cannot be reclaimed (the design's "Problem 3", out of scope). Rather than silently
+ * forward-appending — which would re-rank fingerprints the data provider still tracks as the same
+ * person and corrupt produced labels — the ranker fails the dispatch loudly. The orchestrator
+ * ([VidRankBuilder]) marks the `RankerJob` `FAILED`, halting the pipeline on this subpool so an
+ * operator can extend retention, mark the dispatch skip-ranked, or backfill manually.
+ *
+ * @param poolOffset the subpool being ranked.
+ * @param modelLine the model line being ranked.
+ * @param gapDays `latest_max_event_date - max_event_date`, in days.
+ * @param retentionDays the configured retention window, in days.
+ */
+class OutOfRetentionBackfillException(
+  poolOffset: Long,
+  modelLine: String,
+  gapDays: Int,
+  retentionDays: Int,
+) :
+  Exception(
+    "Subpool $poolOffset for $modelLine: out-of-retention backfill " +
+      "(gap=$gapDays days, retention=$retentionDays). " +
+      "Forward-append would silently re-rank still-tracked fingerprints. " +
+      "Extend retention or mark the dispatch as skip-ranked before retrying."
+  )

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/vidrankbuilder/RankAllocator.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/vidrankbuilder/RankAllocator.kt
@@ -95,6 +95,17 @@ class RankAllocator(
   var freed: Long = 0L
     private set
 
+  /** Backfilled fingerprints whose DAY_ONLY label came from the old snapshot's rank. */
+  var backfillReusedOldRank: Long = 0L
+    private set
+
+  /**
+   * Backfilled fingerprints reassigned an old rank that differs from the rank they hold in the
+   * latest snapshot — the accepted reach-undercount sizing.
+   */
+  var backfillRankCollisions: Long = 0L
+    private set
+
   /**
    * Loads a single prior `(fp, rank)` entry with its persisted [lastSeenDay], marking the rank
    * taken and recording its recency. Used by [loadFrom]; safe to call directly in tests.
@@ -211,27 +222,81 @@ class RankAllocator(
   }
 
   /**
-   * Pins [keyHi]/[keyLo] to a specific [rank] for this dispatch, recording it in [dayOnly] (and the
-   * cumulative map / [taken] / [lastSeen]) at [eventDay]. Used by the **backfill** path to give a
-   * fingerprint back the rank it held in an older snapshot ([SubpoolRanker]).
+   * Assigns ranks for a fingerprint observed in a **backfill** dispatch, updating both the
+   * [dayOnly] delta (the rank used to label the backfilled day) and the cumulative `SNAPSHOT` (the
+   * live state carried forward), which may diverge.
    *
-   * Unlike [assign] this does not pick a free slot and does not bump [allocated] / [renewed]: the
-   * rank is supplied by the caller (sourced from a prior snapshot of the same subpool, so it is
-   * already within `[0, rankedSize)`). If [rank] is already taken by a *different* fingerprint the
-   * caller has detected an old-slot collision (accepted reach-undercount); this still pins the
-   * fingerprint to [rank] in [dayOnly] so the backfilled day is labeled with the original VID. The
-   * cumulative map produced here is not persisted on a backfill, so the transient two-keys-one-rank
-   * state never reaches storage.
+   * [oldRank] is the fingerprint's rank in the *old* snapshot (the cumulative just before the
+   * backfilled day), or any value outside `[0, rankedSize)` ([Bytes12IntMap.NOT_PRESENT]) if it had
+   * none.
    *
-   * @return the pinned [rank].
+   * The **DAY_ONLY label** gives the person back their original rank for that day:
+   * * in the old snapshot -> [oldRank],
+   * * else already ranked (in the latest snapshot) -> its current rank,
+   * * else -> a freshly allocated rank.
+   *
+   * The **cumulative `SNAPSHOT`** is built forward from the latest snapshot, only *adding* backfill
+   * fingerprints (so they are not re-ranked on a later dispatch) — never lowering an existing rank:
+   * * already ranked (case 3) -> keep its current rank (a renewal), refreshing `last_seen` only
+   *   upward (the backfill date is older, so usually a no-op),
+   * * else old rank still free (case 2) -> take it back,
+   * * else (case 1, or case 2 where the old rank was already re-handed to someone else) -> a
+   *   freshly allocated free slot. In the case-2 collision the cumulative gets a fresh rank while
+   *   the DAY_ONLY still labels the day with the (shared) old rank.
+   *
+   * @return the DAY_ONLY label rank, or `null` if the subpool is full (overflow — unranked).
    */
-  fun assignAt(keyHi: Long, keyLo: Int, rank: Int): Int {
-    require(rank in 0 until rankedSize) { "rank $rank out of range [0, $rankedSize)" }
-    taken.set(rank)
-    lastSeen[rank] = eventDay.toShort()
-    cumulative.put(keyHi, keyLo, rank)
-    dayOnly.put(keyHi, keyLo, rank)
-    return rank
+  fun assignBackfill(keyHi: Long, keyLo: Int, oldRank: Int): Int? {
+    val hasOld = oldRank in 0 until rankedSize
+    val recentRank = cumulative.get(keyHi, keyLo)
+
+    if (recentRank != Bytes12IntMap.NOT_PRESENT) {
+      // case 3: keep the latest rank in the cumulative; never lower last_seen with the older date.
+      if (recentRank in 0 until rankedSize) {
+        val current = lastSeen[recentRank].toInt() and 0xFFFF
+        if (eventDay > current) lastSeen[recentRank] = eventDay.toShort()
+      }
+      renewed++
+      if (hasOld) {
+        backfillReusedOldRank++
+        if (oldRank != recentRank) backfillRankCollisions++
+        dayOnly.put(keyHi, keyLo, oldRank)
+        return oldRank
+      }
+      dayOnly.put(keyHi, keyLo, recentRank)
+      return recentRank
+    }
+
+    if (hasOld && !taken.get(oldRank)) {
+      // case 2 (old rank still free): take it back in both the cumulative and the day-only delta.
+      taken.set(oldRank)
+      lastSeen[oldRank] = eventDay.toShort()
+      cumulative.put(keyHi, keyLo, oldRank)
+      dayOnly.put(keyHi, keyLo, oldRank)
+      allocated++
+      backfillReusedOldRank++
+      return oldRank
+    }
+
+    // case 1 (new fingerprint) or case 2 with the old rank already taken: allocate a fresh slot for
+    // the cumulative. The day-only label still prefers the old rank when there is one.
+    val newRank = taken.nextClearBit(cursor)
+    if (newRank >= rankedSize) {
+      overflow++
+      return null
+    }
+    taken.set(newRank)
+    cursor = newRank + 1
+    lastSeen[newRank] = eventDay.toShort()
+    cumulative.put(keyHi, keyLo, newRank)
+    allocated++
+    if (hasOld) {
+      dayOnly.put(keyHi, keyLo, oldRank)
+      backfillReusedOldRank++
+      return oldRank
+    }
+    dayOnly.put(keyHi, keyLo, newRank)
+    return newRank
   }
 
   /**

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/vidrankbuilder/RankAllocator.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/vidrankbuilder/RankAllocator.kt
@@ -211,6 +211,30 @@ class RankAllocator(
   }
 
   /**
+   * Pins [keyHi]/[keyLo] to a specific [rank] for this dispatch, recording it in [dayOnly] (and the
+   * cumulative map / [taken] / [lastSeen]) at [eventDay]. Used by the **backfill** path to give a
+   * fingerprint back the rank it held in an older snapshot ([SubpoolRanker]).
+   *
+   * Unlike [assign] this does not pick a free slot and does not bump [allocated] / [renewed]: the
+   * rank is supplied by the caller (sourced from a prior snapshot of the same subpool, so it is
+   * already within `[0, rankedSize)`). If [rank] is already taken by a *different* fingerprint the
+   * caller has detected an old-slot collision (accepted reach-undercount); this still pins the
+   * fingerprint to [rank] in [dayOnly] so the backfilled day is labeled with the original VID. The
+   * cumulative map produced here is not persisted on a backfill, so the transient two-keys-one-rank
+   * state never reaches storage.
+   *
+   * @return the pinned [rank].
+   */
+  fun assignAt(keyHi: Long, keyLo: Int, rank: Int): Int {
+    require(rank in 0 until rankedSize) { "rank $rank out of range [0, $rankedSize)" }
+    taken.set(rank)
+    lastSeen[rank] = eventDay.toShort()
+    cumulative.put(keyHi, keyLo, rank)
+    dayOnly.put(keyHi, keyLo, rank)
+    return rank
+  }
+
+  /**
    * Streams the cumulative map as chunked [RankIndexMap] records (the new `SNAPSHOT` blob), each
    * carrying its entries' persisted `last_seen` recency.
    */

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/vidrankbuilder/SubpoolRanker.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/vidrankbuilder/SubpoolRanker.kt
@@ -17,6 +17,7 @@
 package org.wfanet.measurement.edpaggregator.vidrankbuilder
 
 import com.google.type.Date
+import com.google.type.date
 import java.nio.ByteBuffer
 import java.security.MessageDigest
 import java.time.LocalDate
@@ -44,19 +45,78 @@ import org.wfanet.measurement.edpaggregator.vidlabeler.utils.Bytes12IntMap
  * `RankerJob` covers.
  *
  * For one subpool it:
- * 1. **idempotency gate** — if a `SNAPSHOT` `RankIndexBlob` row already exists for this (upload,
- *    subpool), a prior attempt already committed its blobs and rows atomically, so the subpool is
- *    done and is skipped (cheap re-delivery no-op),
- * 2. loads the prior cumulative `SNAPSHOT` (if any) into a [RankAllocator] (rebuilding its rank
- *    `BitSet` and per-rank `last_seen`), validating the blob checksum,
- * 3. materializes this dispatch's fingerprint set from the Phase-0 merged `SubpoolFingerprints`
+ * 1. loads the prior cumulative `SNAPSHOT` (the most recent by `create_time` across all uploads —
+ *    the current cumulative state) into a [RankAllocator] (rebuilding its rank `BitSet` and
+ *    per-rank `last_seen`), validating the blob checksum,
+ * 2. decides whether this dispatch is a **backfill** (see "Backfill" below),
+ * 3. **idempotency gate** — if the row this run would commit already exists for this (upload,
+ *    subpool), a prior attempt already finished, so the subpool is skipped (cheap re-delivery
+ *    no-op). The gate row is the `SNAPSHOT` on a normal dispatch and the `DAY_ONLY` on a backfill
+ *    (a backfill writes no `SNAPSHOT` — see below),
+ * 4. materializes this dispatch's fingerprint set from the Phase-0 merged `SubpoolFingerprints`
  *    blob,
- * 4. garbage-collects aged-out `DAY_ONLY` blobs ([SubpoolRetention]) and frees aged-out ranks in
+ * 5. garbage-collects aged-out `DAY_ONLY` blobs ([SubpoolRetention]) and frees aged-out ranks in
  *    heap via the `last_seen` index, excluding fingerprints seen this dispatch,
- * 5. allocates ranks to today's fingerprints (renewing already-ranked ones, capping at
- *    `ranked_size`),
- * 6. writes the new `DAY_ONLY` + `SNAPSHOT` blobs (DEK-encrypted) under **per-attempt-unique keys**
- *    and records both as `RankIndexBlob` rows.
+ * 6. allocates ranks to today's fingerprints (renewing already-ranked ones, capping at
+ *    `ranked_size`); on a backfill it instead replays each fingerprint's historical rank (see
+ *    below),
+ * 7. writes the new `DAY_ONLY` blob (DEK-encrypted) and — on a normal dispatch only — the new
+ *    cumulative `SNAPSHOT`, recording each as a `RankIndexBlob` row.
+ *
+ * ## Backfill (Problem 1 — give a person back their original rank)
+ *
+ * The pipeline keeps a single live cumulative snapshot per (EDP, model line, subpool). That is
+ * correct for forward data appended in chronological order, but a **backfill** — an upload whose
+ * newest event date ([maxEventDate]) is older than the most recent data already ranked — can land a
+ * fingerprint whose original rank was freed and re-handed to someone else by the time the latest
+ * snapshot was written. Giving it a brand-new rank then splits one person into two VIDs (reach
+ * overcount).
+ *
+ * A dispatch is treated as a backfill when **all** hold:
+ * * the latest cumulative `SNAPSHOT` carries a `max_event_date` (the snapshot-selection key) and
+ *   that date is strictly newer than this dispatch's [maxEventDate] — i.e. fresher data already
+ *   exists, so this is not forward append, and
+ * * the gap (`latest.max_event_date - this.max_event_date`) is within [retentionDays] — a dispatch
+ *   older than the retention window has no live ranks left to reclaim, so reassigning is pointless
+ *   (the residual corruption there is Problem 3, explicitly out of scope), and
+ * * an **old snapshot** exists: the `SNAPSHOT` whose `max_event_date` is the greatest value
+ *   strictly less than this dispatch's [maxEventDate] — the cumulative state as of just before the
+ *   backfilled day. If none exists (the data provider uploaded data older than anything on record),
+ *   it is not a backfill and the normal path runs.
+ *
+ * On a backfill, both the latest cumulative (already loaded into the allocator) and that old
+ * snapshot's `(fp -> rank)` map are held in heap, and each of today's fingerprints is assigned:
+ * 1. if present in the **old** snapshot -> its rank there (give the person back their original
+ *    rank),
+ * 2. else if present in the **latest** snapshot -> the rank it holds there,
+ * 3. else -> a freshly allocated rank.
+ *
+ * ### Backfill writes only a `DAY_ONLY` blob — never a new `SNAPSHOT`
+ *
+ * A backfill deliberately does **not** write a new cumulative `SNAPSHOT`. The prior-snapshot lookup
+ * ([findPriorSnapshot]) selects the latest snapshot by `create_time`, and a backfill run has the
+ * newest `create_time` but carries old data; persisting its cumulative would make the next forward
+ * dispatch load this stale, older-day cumulative as its baseline and corrupt the forward chain.
+ * Phase-2 labels each upload from that upload's own `DAY_ONLY` blob (the corrected `(fp -> rank)`
+ * for exactly this dispatch's fingerprints), so the backfilled day is labeled correctly without a
+ * snapshot. The idempotency gate therefore keys off the `DAY_ONLY` row on a backfill.
+ *
+ * ### Monitoring (the accepted undercount)
+ *
+ * When a fingerprint's old rank was already re-handed to a *different* fingerprint (the old slot is
+ * taken by "Bob" in the latest snapshot), reusing the old rank makes the two share a VID for the
+ * backfilled day (reach undercount). We still reuse the old rank (one-person-one-VID is the goal)
+ * but **count** these: [Result.backfillRankCollisions] is the number of backfilled fingerprints
+ * that reused an old rank while holding a *different* rank in the latest snapshot, so the size of
+ * the undercount is observable in metrics and logs.
+ *
+ * ## Memory
+ *
+ * A backfill holds **two** in-heap maps for the subpool — the latest cumulative and the old
+ * snapshot. At the India worst case (~1.5 B fingerprints) a single cumulative already dominates
+ * heap, so loading a second can OOM an `n2d-highmem-16`; backfill-capable rankers should run on a
+ * larger machine type (e.g. `n2d-highmem-32`+). Normal (non-backfill) dispatches hold only one map,
+ * as before.
  *
  * ## Idempotency & concurrency
  *
@@ -68,9 +128,9 @@ import org.wfanet.measurement.edpaggregator.vidlabeler.utils.Bytes12IntMap
  * write-before-CAS clobber hazard without needing a write-if-absent storage primitive.
  *
  * @param subpoolFingerprintsStore reads the Phase-0 merged `SubpoolFingerprints` blob.
- * @param rankIndexStore reads the prior snapshot and writes the new rank-index blobs.
+ * @param rankIndexStore reads the prior/old snapshots and writes the new rank-index blobs.
  * @param rankIndexBlobsStub metadata-storage service for the idempotency gate, locating the prior
- *   snapshot, and inserting the new blob rows.
+ *   and old snapshots, and inserting the new blob rows.
  * @param retention garbage-collects aged-out `DAY_ONLY` blobs.
  * @param dataProvider EDP resource name (`dataProviders/{dp}`), parent of the upload wildcard for
  *   the prior-snapshot lookup.
@@ -79,8 +139,9 @@ import org.wfanet.measurement.edpaggregator.vidlabeler.utils.Bytes12IntMap
  * @param vidRankMapBlobPrefix static blob prefix for the vid-rank-map bucket.
  * @param kekUri KEK URI used to wrap each new blob's DEK.
  * @param encryptedSubpoolMapsDek DEK that decrypts the Phase-0 merged blobs.
- * @param maxEventDate newest event date this dispatch covers; stamped as `last_seen` and on the
- *   `DAY_ONLY` row.
+ * @param maxEventDate newest event date this dispatch covers; stamped as `last_seen`, on the
+ *   `DAY_ONLY` row, and on the `SNAPSHOT` row (the snapshot-selection key), and used for backfill
+ *   detection.
  * @param retentionDays retention window in days (must exceed the max measurement-report window).
  * @param today the UTC date treated as "now" for the rank-age cutoff.
  * @param metrics OpenTelemetry instruments.
@@ -109,6 +170,10 @@ class SubpoolRanker(
    * @property freed ranks released by the retention pass.
    * @property cumulativeSize total ranked fingerprints after this dispatch.
    * @property skipped whether the subpool was already ranked for this upload (idempotency gate).
+   * @property backfill whether this dispatch was handled as a backfill.
+   * @property backfillReusedOldRank backfilled fingerprints given back their old-snapshot rank.
+   * @property backfillRankCollisions subset of [backfillReusedOldRank] whose old rank differs from
+   *   the rank they hold in the latest snapshot (the accepted reach-undercount sizing).
    */
   data class Result(
     val poolOffset: Long,
@@ -118,25 +183,37 @@ class SubpoolRanker(
     val freed: Long,
     val cumulativeSize: Long,
     val skipped: Boolean = false,
+    val backfill: Boolean = false,
+    val backfillReusedOldRank: Long = 0L,
+    val backfillRankCollisions: Long = 0L,
   )
 
   /** Ranks [poolOffset]; [subpoolBlobUri] is its Phase-0 merged blob; caps at [rankedSize]. */
   suspend fun rank(poolOffset: Long, subpoolBlobUri: String, rankedSize: Int): Result {
-    // Idempotency gate: an existing SNAPSHOT row for this (upload, subpool) means a prior attempt
-    // committed both blobs + rows atomically, so the subpool is already done — skip the re-rank.
-    if (findUploadSnapshot(poolOffset) != null) {
+    val eventDay = epochDayOf(maxEventDate)
+    val cutoffEpochDay = (today.toEpochDay() - retentionDays).toInt()
+
+    // 1. Locate the latest cumulative snapshot (most recent create_time), then decide whether this
+    // dispatch is a backfill and, if so, which older snapshot to replay ranks from.
+    val priorSnapshot = findPriorSnapshot(poolOffset)
+    val oldSnapshot = resolveBackfillOldSnapshot(poolOffset, eventDay, priorSnapshot)
+    val isBackfill = oldSnapshot != null
+
+    // 2. Idempotency gate, keyed on the row this run commits: SNAPSHOT on a normal dispatch,
+    // DAY_ONLY on a backfill (which writes no SNAPSHOT). A non-null result means a prior attempt
+    // already finished this (upload, subpool), so skip the re-rank.
+    val gateType =
+      if (isBackfill) RankIndexBlob.BlobType.DAY_ONLY else RankIndexBlob.BlobType.SNAPSHOT
+    if (findUploadBlob(poolOffset, gateType) != null) {
       logger.info(
         "Subpool $poolOffset for $modelLine already ranked for $rawImpressionUpload; skipping"
       )
       return Result(poolOffset, 0, 0, 0, 0, 0, skipped = true)
     }
 
-    val eventDay = epochDayOf(maxEventDate)
-    val cutoffEpochDay = (today.toEpochDay() - retentionDays).toInt()
     val allocator = RankAllocator(poolOffset, rankedSize, eventDay)
 
-    // 1. Load the prior cumulative snapshot (validating its checksum), if one exists.
-    val priorSnapshot = findPriorSnapshot(poolOffset)
+    // 3. Load the latest cumulative snapshot (validating its checksum), if one exists.
     if (priorSnapshot != null) {
       allocator.loadFrom(
         rankIndexStore.readBlob(
@@ -147,7 +224,7 @@ class SubpoolRanker(
       )
     }
 
-    // 2. Materialize this dispatch's fingerprint set for the subpool from the Phase-0 merged blob.
+    // 4. Materialize this dispatch's fingerprint set for the subpool from the Phase-0 merged blob.
     val todayFps = Bytes12IntMap()
     subpoolFingerprintsStore.readBlob(subpoolBlobUri, encryptedSubpoolMapsDek).collect { record ->
       val fps = record.fingerprints
@@ -163,30 +240,44 @@ class SubpoolRanker(
       }
     }
 
-    // 3a. Storage GC of aged-out DAY_ONLY blobs (independent of rank freeing).
+    // 5a. Storage GC of aged-out DAY_ONLY blobs (independent of rank freeing).
     retention.deleteAgedBlobs(poolOffset)
-    // 3b. Free aged-out ranks in heap from the `last_seen` index, before allocating so freed slots
+    // 5b. Free aged-out ranks in heap from the `last_seen` index, before allocating so freed slots
     // are reusable today. Fingerprints seen this dispatch are excluded so their ranks (VIDs)
     // survive.
     allocator.freeAgedRanks(cutoffEpochDay, todayFps)
 
-    // 4. Allocate / renew ranks for today's fingerprints.
-    todayFps.forEach { keyHi, keyLo, _ -> allocator.assign(keyHi, keyLo) }
+    // 6. Assign ranks to today's fingerprints.
+    var reusedOldRank = 0L
+    var rankCollisions = 0L
+    if (oldSnapshot != null) {
+      // Backfill: replay each fingerprint's historical rank (old -> latest -> new).
+      val oldRanks = loadFingerprintRanks(oldSnapshot)
+      todayFps.forEach { keyHi, keyLo, _ ->
+        val oldRank = oldRanks.get(keyHi, keyLo)
+        if (oldRank != Bytes12IntMap.NOT_PRESENT && oldRank in 0 until rankedSize) {
+          // The fingerprint's rank in the latest snapshot, captured before we overwrite it; a
+          // different value means the old slot was re-handed to someone else (accepted undercount).
+          val latestRank = allocator.get(keyHi, keyLo)
+          allocator.assignAt(keyHi, keyLo, oldRank)
+          reusedOldRank++
+          if (latestRank != Bytes12IntMap.NOT_PRESENT && latestRank != oldRank) {
+            rankCollisions++
+          }
+        } else {
+          allocator.assign(keyHi, keyLo)
+        }
+      }
+    } else {
+      todayFps.forEach { keyHi, keyLo, _ -> allocator.assign(keyHi, keyLo) }
+    }
 
-    // 5. Write the new DAY_ONLY + SNAPSHOT blobs and record both as RankIndexBlob rows. Keys carry
-    // a
-    // per-attempt UUID so a concurrent/re-delivered attempt never overwrites another's bytes; the
-    // winning (deterministic-request_id) row's blob_uri + DEK are always self-consistent.
+    // 7. Write the new blob(s) and record the RankIndexBlob row(s). Keys carry a per-attempt UUID
+    // so
+    // a concurrent/re-delivered attempt never overwrites another's bytes; the winning
+    // (deterministic-request_id) row's blob_uri + DEK are always self-consistent.
     val attemptId = UUID.randomUUID().toString()
     val dek = rankIndexStore.generateDek(kekUri)
-    val snapshotKey =
-      RankIndexStore.snapshotKey(
-        vidRankMapBlobPrefix,
-        rawImpressionUpload,
-        modelLine,
-        poolOffset,
-        attemptId,
-      )
     val dayOnlyKey =
       RankIndexStore.dayOnlyKey(
         vidRankMapBlobPrefix,
@@ -195,17 +286,43 @@ class SubpoolRanker(
         poolOffset,
         attemptId,
       )
-    val snapshotChecksum =
-      rankIndexStore.writeBlob(snapshotKey, dek, allocator.streamCumulativeChunks())
     val dayOnlyChecksum = rankIndexStore.writeBlob(dayOnlyKey, dek, allocator.streamDayOnlyChunks())
-    insertBlobRows(poolOffset, snapshotKey, snapshotChecksum, dayOnlyKey, dayOnlyChecksum, dek)
+    if (isBackfill) {
+      // Backfill: persist ONLY the corrected DAY_ONLY; writing a new cumulative SNAPSHOT here would
+      // poison the create_time-ordered forward chain (see class KDoc).
+      insertDayOnlyRow(poolOffset, dayOnlyKey, dayOnlyChecksum, dek)
+    } else {
+      val snapshotKey =
+        RankIndexStore.snapshotKey(
+          vidRankMapBlobPrefix,
+          rawImpressionUpload,
+          modelLine,
+          poolOffset,
+          attemptId,
+        )
+      val snapshotChecksum =
+        rankIndexStore.writeBlob(snapshotKey, dek, allocator.streamCumulativeChunks())
+      insertBlobRows(poolOffset, snapshotKey, snapshotChecksum, dayOnlyKey, dayOnlyChecksum, dek)
+    }
 
-    recordMetrics(allocator)
+    recordMetrics(allocator, reusedOldRank, rankCollisions)
     logger.info(
       "Subpool $poolOffset for $modelLine: allocated=${allocator.allocated}, " +
         "renewed=${allocator.renewed}, overflow=${allocator.overflow}, freed=${allocator.freed}, " +
-        "cumulative=${allocator.cumulativeSize}"
+        "cumulative=${allocator.cumulativeSize}" +
+        if (isBackfill) {
+          " [backfill: reusedOldRank=$reusedOldRank, rankCollisions=$rankCollisions]"
+        } else {
+          ""
+        }
     )
+    if (rankCollisions > 0) {
+      logger.warning(
+        "Subpool $poolOffset for $modelLine backfill reach-undercount: $rankCollisions " +
+          "fingerprint(s) reused an old rank already re-handed to a different fingerprint in the " +
+          "latest snapshot"
+      )
+    }
     return Result(
       poolOffset = poolOffset,
       allocated = allocator.allocated,
@@ -213,15 +330,21 @@ class SubpoolRanker(
       overflow = allocator.overflow,
       freed = allocator.freed,
       cumulativeSize = allocator.cumulativeSize,
+      backfill = isBackfill,
+      backfillReusedOldRank = reusedOldRank,
+      backfillRankCollisions = rankCollisions,
     )
   }
 
   /**
-   * The `SNAPSHOT` `RankIndexBlob` row for [poolOffset] under **this** upload, or `null`. A
+   * The [blobType] `RankIndexBlob` row for [poolOffset] under **this** upload, or `null`. A
    * non-null result is the idempotency-gate signal that the subpool was already ranked for this
    * dispatch.
    */
-  private suspend fun findUploadSnapshot(poolOffset: Long): RankIndexBlob? =
+  private suspend fun findUploadBlob(
+    poolOffset: Long,
+    blobType: RankIndexBlob.BlobType,
+  ): RankIndexBlob? =
     rankIndexBlobsStub
       .listResources { pageToken: String ->
         val response =
@@ -230,7 +353,7 @@ class SubpoolRanker(
               parent = rawImpressionUpload
               filter =
                 ListRankIndexBlobsRequestKt.filter {
-                  blobType = RankIndexBlob.BlobType.SNAPSHOT
+                  this.blobType = blobType
                   cmmsModelLine = modelLine
                   this.poolOffset = poolOffset
                 }
@@ -248,7 +371,8 @@ class SubpoolRanker(
   /**
    * The newest non-deleted `SNAPSHOT` blob for [poolOffset] of this (data provider, model line)
    * across all uploads, or `null` on a cold (Day-1) subpool. The most recent `create_time` is the
-   * current cumulative state (the design's N−1 recovery baseline).
+   * current cumulative state (the design's N−1 recovery baseline). A backfill writes no `SNAPSHOT`,
+   * so the most recent `create_time` is always a forward dispatch's cumulative.
    *
    * TODO(world-federation-of-advertisers/cross-media-measurement#4008): this lists every
    *   non-deleted SNAPSHOT across all uploads and scans for the newest — O(all snapshots), which
@@ -287,7 +411,88 @@ class SubpoolRanker(
     return latest
   }
 
-  /** Inserts the SNAPSHOT + DAY_ONLY rows in one idempotent batch. */
+  /**
+   * The `SNAPSHOT` to replay historical ranks from when [eventDay] is a backfill, or `null` when
+   * this dispatch is not a backfill.
+   *
+   * Returns the old snapshot — the `SNAPSHOT` whose `max_event_date` is the greatest value strictly
+   * less than [eventDay] (the cumulative state just before the backfilled day) — only when:
+   * * [priorSnapshot] (the latest cumulative) exists and carries a `max_event_date` that is
+   *   strictly newer than [eventDay] (fresher data already exists), and
+   * * the gap is within [retentionDays] (older dispatches have no live ranks left to reclaim —
+   *   Problem 3, out of scope), and
+   * * such an older snapshot actually exists (otherwise the data provider uploaded data older than
+   *   anything on record — not a backfill).
+   *
+   * The `max_event_date_on_or_before = eventDay - 1` filter selects snapshots strictly older than
+   * the backfilled day; the greatest among them is the closest prior cumulative.
+   */
+  private suspend fun resolveBackfillOldSnapshot(
+    poolOffset: Long,
+    eventDay: Int,
+    priorSnapshot: RankIndexBlob?,
+  ): RankIndexBlob? {
+    if (priorSnapshot == null || !priorSnapshot.hasMaxEventDate()) return null
+    val latestEventDay = priorSnapshot.maxEventDate.epochDay()
+    // Forward append (newest or same day) — not a backfill.
+    if (eventDay >= latestEventDay) return null
+    // Older than the retention window — no live ranks remain to reclaim (Problem 3, out of scope).
+    if (latestEventDay - eventDay > retentionDays) return null
+
+    val cutoff = epochDayToDate(eventDay - 1) // strictly older than the backfilled day
+    var best: RankIndexBlob? = null
+    rankIndexBlobsStub
+      .listResources { pageToken: String ->
+        val response =
+          listRankIndexBlobs(
+            listRankIndexBlobsRequest {
+              parent = "$dataProvider/rawImpressionUploads/${ResourceKey.WILDCARD_ID}"
+              filter =
+                ListRankIndexBlobsRequestKt.filter {
+                  blobType = RankIndexBlob.BlobType.SNAPSHOT
+                  cmmsModelLine = modelLine
+                  this.poolOffset = poolOffset
+                  maxEventDateOnOrBefore = cutoff
+                }
+              this.pageToken = pageToken
+            }
+          )
+        ResourceList(response.rankIndexBlobsList, response.nextPageToken)
+      }
+      .collect { page ->
+        for (blob in page) {
+          if (!blob.hasMaxEventDate()) continue
+          val current = best
+          if (current == null || blob.maxEventDate.epochDay() > current.maxEventDate.epochDay()) {
+            best = blob
+          }
+        }
+      }
+    return best
+  }
+
+  /** Loads a `SNAPSHOT` blob's `(fingerprint -> rank)` pairs into an in-heap map. */
+  private suspend fun loadFingerprintRanks(snapshot: RankIndexBlob): Bytes12IntMap {
+    val map = Bytes12IntMap()
+    rankIndexStore
+      .readBlob(snapshot.blobUri, snapshot.encryptedDek, snapshot.blobChecksum)
+      .collect { record ->
+        val fps = record.fingerprints
+        val count = record.ranksCount
+        var off = 0
+        for (i in 0 until count) {
+          map.put(
+            EventIdDigestBytes.readHi(fps, off),
+            EventIdDigestBytes.readLo(fps, off + 8),
+            record.getRanks(i),
+          )
+          off += EventIdDigestBytes.WIDTH
+        }
+      }
+    return map
+  }
+
+  /** Inserts the SNAPSHOT + DAY_ONLY rows in one idempotent batch (normal dispatch). */
   private suspend fun insertBlobRows(
     poolOffset: Long,
     snapshotKey: String,
@@ -308,6 +513,9 @@ class SubpoolRanker(
             blobUri = snapshotKey
             blobChecksum = snapshotChecksum
             encryptedDek = dek
+            // The snapshot-selection key: the newest event date of the upload that produced this
+            // cumulative state, used to locate the prior/old snapshot for a given event date.
+            maxEventDate = this@SubpoolRanker.maxEventDate
           }
           requestId = blobRequestId(poolOffset, RankIndexBlob.BlobType.SNAPSHOT)
         }
@@ -328,12 +536,44 @@ class SubpoolRanker(
     )
   }
 
-  private fun recordMetrics(allocator: RankAllocator) {
+  /**
+   * Inserts only the DAY_ONLY row (backfill). No SNAPSHOT is written — see the class KDoc for why a
+   * backfill must not advance the cumulative chain.
+   */
+  private suspend fun insertDayOnlyRow(
+    poolOffset: Long,
+    dayOnlyKey: String,
+    dayOnlyChecksum: com.google.protobuf.ByteString,
+    dek: EncryptedDek,
+  ) {
+    rankIndexBlobsStub.batchCreateRankIndexBlobs(
+      batchCreateRankIndexBlobsRequest {
+        parent = rawImpressionUpload
+        requests += createRankIndexBlobRequest {
+          parent = rawImpressionUpload
+          rankIndexBlob = rankIndexBlob {
+            blobType = RankIndexBlob.BlobType.DAY_ONLY
+            cmmsModelLine = modelLine
+            this.poolOffset = poolOffset
+            blobUri = dayOnlyKey
+            blobChecksum = dayOnlyChecksum
+            encryptedDek = dek
+            maxEventDate = this@SubpoolRanker.maxEventDate
+          }
+          requestId = blobRequestId(poolOffset, RankIndexBlob.BlobType.DAY_ONLY)
+        }
+      }
+    )
+  }
+
+  private fun recordMetrics(allocator: RankAllocator, reusedOldRank: Long, rankCollisions: Long) {
     metrics.ranksAllocatedCounter.add(allocator.allocated)
     metrics.ranksRenewedCounter.add(allocator.renewed)
     metrics.ranksFreedCounter.add(allocator.freed)
     metrics.overflowFingerprintsCounter.add(allocator.overflow)
     metrics.subpoolsRankedCounter.add(1)
+    if (reusedOldRank > 0) metrics.backfillReusedOldRankCounter.add(reusedOldRank)
+    if (rankCollisions > 0) metrics.backfillRankCollisionsCounter.add(rankCollisions)
   }
 
   /**
@@ -366,5 +606,17 @@ class SubpoolRanker(
     /** Orders timestamps for "newest snapshot" without depending on a proto comparator. */
     private fun com.google.protobuf.Timestamp.toComparable(): Long =
       seconds * 1_000_000_000L + nanos
+
+    /** Epoch-day of a set UTC [Date]. Caller must ensure the date is set (`hasMaxEventDate`). */
+    private fun Date.epochDay(): Int = LocalDate.of(year, month, day).toEpochDay().toInt()
+
+    private fun epochDayToDate(epochDay: Int): Date {
+      val localDate = LocalDate.ofEpochDay(epochDay.toLong())
+      return date {
+        year = localDate.year
+        month = localDate.monthValue
+        day = localDate.dayOfMonth
+      }
+    }
   }
 }

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/vidrankbuilder/SubpoolRanker.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/vidrankbuilder/SubpoolRanker.kt
@@ -244,6 +244,7 @@ class SubpoolRanker(
       // Backfill: replay each fingerprint's historical rank into the day-only delta while extending
       // the cumulative forward (see class KDoc and RankAllocator.assignBackfill).
       val oldRanks = loadFingerprintRanks(oldSnapshot)
+      metrics.backfillOldSnapshotEntriesHistogram.record(oldRanks.size)
       todayFps.forEach { keyHi, keyLo, _ ->
         allocator.assignBackfill(keyHi, keyLo, oldRanks.get(keyHi, keyLo))
       }
@@ -407,10 +408,13 @@ class SubpoolRanker(
    * less than [eventDay] (the cumulative state just before the backfilled day) — only when:
    * * [priorSnapshot] (the latest cumulative) exists and carries a `max_event_date` strictly newer
    *   than [eventDay] (fresher data already exists), and
-   * * the gap is within [retentionDays] (older dispatches have no live ranks left to reclaim —
-   *   Problem 3, out of scope), and
    * * such an older snapshot actually exists (otherwise the data provider uploaded data older than
    *   anything on record — not a backfill).
+   *
+   * Throws [OutOfRetentionBackfillException] (after incrementing the out-of-retention metric) when
+   * the gap exceeds [retentionDays]: the rank state in force at the backfilled date has already
+   * aged out, so the dispatch fails loudly instead of silently forward-appending (Problem 3, out of
+   * scope).
    *
    * The `max_event_date_on_or_before = eventDay - 1` filter selects snapshots strictly older than
    * the backfilled day; the greatest among them is the closest prior cumulative.
@@ -424,8 +428,19 @@ class SubpoolRanker(
     val latestEventDay = priorSnapshot.maxEventDate.epochDay()
     // Forward append (newest or same day) — not a backfill.
     if (eventDay >= latestEventDay) return null
-    // Older than the retention window — no live ranks remain to reclaim (Problem 3, out of scope).
-    if (latestEventDay - eventDay > retentionDays) return null
+    // Older than the retention window — the rank state in force at the backfilled date has already
+    // aged out, so the original rank cannot be reclaimed (Problem 3, out of scope). Fail loudly
+    // rather than silently forward-appending, which would re-rank still-tracked fingerprints and
+    // corrupt produced labels; the orchestrator marks the RankerJob FAILED so an operator can act.
+    if (latestEventDay - eventDay > retentionDays) {
+      metrics.outOfRetentionBackfillCounter.add(1)
+      throw OutOfRetentionBackfillException(
+        poolOffset,
+        modelLine,
+        latestEventDay - eventDay,
+        retentionDays,
+      )
+    }
 
     val cutoff = epochDayToDate(eventDay - 1) // strictly older than the backfilled day
     var best: RankIndexBlob? = null

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/vidrankbuilder/SubpoolRanker.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/vidrankbuilder/SubpoolRanker.kt
@@ -1,0 +1,363 @@
+/*
+ * Copyright 2026 The Cross-Media Measurement Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wfanet.measurement.edpaggregator.vidrankbuilder
+
+import com.google.type.Date
+import java.nio.ByteBuffer
+import java.security.MessageDigest
+import java.time.LocalDate
+import java.util.UUID
+import java.util.logging.Logger
+import kotlinx.coroutines.flow.collect
+import org.wfanet.measurement.common.api.grpc.ResourceList
+import org.wfanet.measurement.common.api.grpc.listResources
+import org.wfanet.measurement.edpaggregator.rawimpressions.RankIndexStore
+import org.wfanet.measurement.edpaggregator.rawimpressions.SubpoolFingerprintsStore
+import org.wfanet.measurement.edpaggregator.v1alpha.EncryptedDek
+import org.wfanet.measurement.edpaggregator.v1alpha.ListRankIndexBlobsRequestKt
+import org.wfanet.measurement.edpaggregator.v1alpha.RankIndexBlob
+import org.wfanet.measurement.edpaggregator.v1alpha.RankIndexBlobServiceGrpcKt.RankIndexBlobServiceCoroutineStub
+import org.wfanet.measurement.edpaggregator.v1alpha.batchCreateRankIndexBlobsRequest
+import org.wfanet.measurement.edpaggregator.v1alpha.createRankIndexBlobRequest
+import org.wfanet.measurement.edpaggregator.v1alpha.listRankIndexBlobsRequest
+import org.wfanet.measurement.edpaggregator.v1alpha.rankIndexBlob
+import org.wfanet.measurement.edpaggregator.vidlabeler.utils.Bytes12IntMap
+
+/**
+ * Ranks a **single** subpool: the per-subpool engine driven by [VidRankBuilder] for each subpool a
+ * `RankerJob` covers.
+ *
+ * For one subpool it:
+ * 1. **idempotency gate** — if a `SNAPSHOT` `RankIndexBlob` row already exists for this (upload,
+ *    subpool), a prior attempt already committed its blobs and rows atomically, so the subpool is
+ *    done and is skipped (cheap re-delivery no-op),
+ * 2. loads the prior cumulative `SNAPSHOT` (if any) into a [RankAllocator] (rebuilding its rank
+ *    `BitSet` and per-rank `last_seen`), validating the blob checksum,
+ * 3. materializes this dispatch's fingerprint set from the Phase-0 merged `SubpoolFingerprints`
+ *    blob,
+ * 4. garbage-collects aged-out `DAY_ONLY` blobs ([SubpoolRetention]) and frees aged-out ranks in
+ *    heap via the `last_seen` index, excluding fingerprints seen this dispatch,
+ * 5. allocates ranks to today's fingerprints (renewing already-ranked ones, capping at
+ *    `ranked_size`),
+ * 6. writes the new `DAY_ONLY` + `SNAPSHOT` blobs (DEK-encrypted) under **per-attempt-unique keys**
+ *    and records both as `RankIndexBlob` rows.
+ *
+ * ## Idempotency & concurrency
+ *
+ * Blob keys carry a per-attempt UUID, so a re-delivered or concurrent ranker never overwrites
+ * another attempt's bytes. The `RankIndexBlob` rows are created with deterministic `request_id`s,
+ * so exactly one row wins per (upload, subpool, blob type); that winning row's `blob_uri` + `DEK`
+ * are always self-consistent (the winner durably wrote those bytes before inserting). Losing
+ * attempts' blobs are orphaned and reclaimed by the bucket lifecycle / monitor. This removes the
+ * write-before-CAS clobber hazard without needing a write-if-absent storage primitive.
+ *
+ * @param subpoolFingerprintsStore reads the Phase-0 merged `SubpoolFingerprints` blob.
+ * @param rankIndexStore reads the prior snapshot and writes the new rank-index blobs.
+ * @param rankIndexBlobsStub metadata-storage service for the idempotency gate, locating the prior
+ *   snapshot, and inserting the new blob rows.
+ * @param retention garbage-collects aged-out `DAY_ONLY` blobs.
+ * @param dataProvider EDP resource name (`dataProviders/{dp}`), parent of the upload wildcard for
+ *   the prior-snapshot lookup.
+ * @param rawImpressionUpload the upload resource name (parent of the new blob rows + key scoping).
+ * @param modelLine the model line being ranked.
+ * @param vidRankMapBlobPrefix static blob prefix for the vid-rank-map bucket.
+ * @param kekUri KEK URI used to wrap each new blob's DEK.
+ * @param encryptedSubpoolMapsDek DEK that decrypts the Phase-0 merged blobs.
+ * @param maxEventDate newest event date this dispatch covers; stamped as `last_seen` and on the
+ *   `DAY_ONLY` row.
+ * @param retentionDays retention window in days (must exceed the max measurement-report window).
+ * @param today the UTC date treated as "now" for the rank-age cutoff.
+ * @param metrics OpenTelemetry instruments.
+ */
+class SubpoolRanker(
+  private val subpoolFingerprintsStore: SubpoolFingerprintsStore,
+  private val rankIndexStore: RankIndexStore,
+  private val rankIndexBlobsStub: RankIndexBlobServiceCoroutineStub,
+  private val retention: SubpoolRetention,
+  private val dataProvider: String,
+  private val rawImpressionUpload: String,
+  private val modelLine: String,
+  private val vidRankMapBlobPrefix: String,
+  private val kekUri: String,
+  private val encryptedSubpoolMapsDek: EncryptedDek,
+  private val maxEventDate: Date,
+  private val retentionDays: Int,
+  private val today: LocalDate,
+  private val metrics: VidRankBuilderMetrics = VidRankBuilderMetrics(),
+) {
+  /**
+   * @property poolOffset the subpool ranked.
+   * @property allocated ranks newly assigned to never-before-seen fingerprints.
+   * @property renewed already-ranked fingerprints re-observed (rank preserved).
+   * @property overflow fingerprints left unranked because the subpool was full.
+   * @property freed ranks released by the retention pass.
+   * @property cumulativeSize total ranked fingerprints after this dispatch.
+   * @property skipped whether the subpool was already ranked for this upload (idempotency gate).
+   */
+  data class Result(
+    val poolOffset: Long,
+    val allocated: Long,
+    val renewed: Long,
+    val overflow: Long,
+    val freed: Long,
+    val cumulativeSize: Long,
+    val skipped: Boolean = false,
+  )
+
+  /** Ranks [poolOffset]; [subpoolBlobUri] is its Phase-0 merged blob; caps at [rankedSize]. */
+  suspend fun rank(poolOffset: Long, subpoolBlobUri: String, rankedSize: Int): Result {
+    // Idempotency gate: an existing SNAPSHOT row for this (upload, subpool) means a prior attempt
+    // committed both blobs + rows atomically, so the subpool is already done — skip the re-rank.
+    if (findUploadSnapshot(poolOffset) != null) {
+      logger.info(
+        "Subpool $poolOffset for $modelLine already ranked for $rawImpressionUpload; skipping"
+      )
+      return Result(poolOffset, 0, 0, 0, 0, 0, skipped = true)
+    }
+
+    val eventDay = epochDayOf(maxEventDate)
+    val cutoffEpochDay = (today.toEpochDay() - retentionDays).toInt()
+    val allocator = RankAllocator(poolOffset, rankedSize, eventDay)
+
+    // 1. Load the prior cumulative snapshot (validating its checksum), if one exists.
+    val priorSnapshot = findPriorSnapshot(poolOffset)
+    if (priorSnapshot != null) {
+      allocator.loadFrom(
+        rankIndexStore.readBlob(
+          priorSnapshot.blobUri,
+          priorSnapshot.encryptedDek,
+          priorSnapshot.blobChecksum,
+        )
+      )
+    }
+
+    // 2. Materialize this dispatch's fingerprint set for the subpool from the Phase-0 merged blob.
+    val todayFps = Bytes12IntMap()
+    subpoolFingerprintsStore.readBlob(subpoolBlobUri, encryptedSubpoolMapsDek).collect { record ->
+      val fps = record.fingerprints
+      val count = fps.size() / EventIdDigestBytes.WIDTH
+      var off = 0
+      repeat(count) {
+        todayFps.put(
+          EventIdDigestBytes.readHi(fps, off),
+          EventIdDigestBytes.readLo(fps, off + 8),
+          1,
+        )
+        off += EventIdDigestBytes.WIDTH
+      }
+    }
+
+    // 3a. Storage GC of aged-out DAY_ONLY blobs (independent of rank freeing).
+    retention.deleteAgedBlobs(poolOffset)
+    // 3b. Free aged-out ranks in heap from the `last_seen` index, before allocating so freed slots
+    // are reusable today. Fingerprints seen this dispatch are excluded so their ranks (VIDs)
+    // survive.
+    allocator.freeAgedRanks(cutoffEpochDay, todayFps)
+
+    // 4. Allocate / renew ranks for today's fingerprints.
+    todayFps.forEach { keyHi, keyLo, _ -> allocator.assign(keyHi, keyLo) }
+
+    // 5. Write the new DAY_ONLY + SNAPSHOT blobs and record both as RankIndexBlob rows. Keys carry
+    // a
+    // per-attempt UUID so a concurrent/re-delivered attempt never overwrites another's bytes; the
+    // winning (deterministic-request_id) row's blob_uri + DEK are always self-consistent.
+    val attemptId = UUID.randomUUID().toString()
+    val dek = rankIndexStore.generateDek(kekUri)
+    val snapshotKey =
+      RankIndexStore.snapshotKey(
+        vidRankMapBlobPrefix,
+        rawImpressionUpload,
+        modelLine,
+        poolOffset,
+        attemptId,
+      )
+    val dayOnlyKey =
+      RankIndexStore.dayOnlyKey(
+        vidRankMapBlobPrefix,
+        rawImpressionUpload,
+        modelLine,
+        poolOffset,
+        attemptId,
+      )
+    val snapshotChecksum =
+      rankIndexStore.writeBlob(snapshotKey, dek, allocator.streamCumulativeChunks())
+    val dayOnlyChecksum = rankIndexStore.writeBlob(dayOnlyKey, dek, allocator.streamDayOnlyChunks())
+    insertBlobRows(poolOffset, snapshotKey, snapshotChecksum, dayOnlyKey, dayOnlyChecksum, dek)
+
+    recordMetrics(allocator)
+    logger.info(
+      "Subpool $poolOffset for $modelLine: allocated=${allocator.allocated}, " +
+        "renewed=${allocator.renewed}, overflow=${allocator.overflow}, freed=${allocator.freed}, " +
+        "cumulative=${allocator.cumulativeSize}"
+    )
+    return Result(
+      poolOffset = poolOffset,
+      allocated = allocator.allocated,
+      renewed = allocator.renewed,
+      overflow = allocator.overflow,
+      freed = allocator.freed,
+      cumulativeSize = allocator.cumulativeSize,
+    )
+  }
+
+  /**
+   * The `SNAPSHOT` `RankIndexBlob` row for [poolOffset] under **this** upload, or `null`. A
+   * non-null result is the idempotency-gate signal that the subpool was already ranked for this
+   * dispatch.
+   */
+  private suspend fun findUploadSnapshot(poolOffset: Long): RankIndexBlob? {
+    var existing: RankIndexBlob? = null
+    rankIndexBlobsStub
+      .listResources { pageToken: String ->
+        val response =
+          listRankIndexBlobs(
+            listRankIndexBlobsRequest {
+              parent = rawImpressionUpload
+              filter =
+                ListRankIndexBlobsRequestKt.filter {
+                  blobType = RankIndexBlob.BlobType.SNAPSHOT
+                  cmmsModelLine = modelLine
+                  this.poolOffset = poolOffset
+                }
+              this.pageToken = pageToken
+            }
+          )
+        ResourceList(response.rankIndexBlobsList, response.nextPageToken)
+      }
+      .collect { page -> page.firstOrNull()?.let { existing = it } }
+    return existing
+  }
+
+  /**
+   * The newest non-deleted `SNAPSHOT` blob for [poolOffset] of this (data provider, model line)
+   * across all uploads, or `null` on a cold (Day-1) subpool. The most recent `create_time` is the
+   * current cumulative state (the design's N−1 recovery baseline).
+   *
+   * TODO(world-federation-of-advertisers/cross-media-measurement#4008): this lists every
+   *   non-deleted SNAPSHOT across all uploads and scans for the newest — O(all snapshots), which
+   *   grows unbounded because SNAPSHOTs are never retention-pruned. Replace with an O(1)
+   *   latest-snapshot lookup and bound SNAPSHOT retention.
+   */
+  private suspend fun findPriorSnapshot(poolOffset: Long): RankIndexBlob? {
+    var latest: RankIndexBlob? = null
+    rankIndexBlobsStub
+      .listResources { pageToken: String ->
+        val response =
+          listRankIndexBlobs(
+            listRankIndexBlobsRequest {
+              parent = "$dataProvider/rawImpressionUploads/-"
+              filter =
+                ListRankIndexBlobsRequestKt.filter {
+                  blobType = RankIndexBlob.BlobType.SNAPSHOT
+                  cmmsModelLine = modelLine
+                  this.poolOffset = poolOffset
+                }
+              this.pageToken = pageToken
+            }
+          )
+        ResourceList(response.rankIndexBlobsList, response.nextPageToken)
+      }
+      .collect { page ->
+        for (blob in page) {
+          val current = latest
+          if (
+            current == null || blob.createTime.toComparable() > current.createTime.toComparable()
+          ) {
+            latest = blob
+          }
+        }
+      }
+    return latest
+  }
+
+  /** Inserts the SNAPSHOT + DAY_ONLY rows in one idempotent batch. */
+  private suspend fun insertBlobRows(
+    poolOffset: Long,
+    snapshotKey: String,
+    snapshotChecksum: com.google.protobuf.ByteString,
+    dayOnlyKey: String,
+    dayOnlyChecksum: com.google.protobuf.ByteString,
+    dek: EncryptedDek,
+  ) {
+    rankIndexBlobsStub.batchCreateRankIndexBlobs(
+      batchCreateRankIndexBlobsRequest {
+        parent = rawImpressionUpload
+        requests += createRankIndexBlobRequest {
+          parent = rawImpressionUpload
+          rankIndexBlob = rankIndexBlob {
+            blobType = RankIndexBlob.BlobType.SNAPSHOT
+            cmmsModelLine = modelLine
+            this.poolOffset = poolOffset
+            blobUri = snapshotKey
+            blobChecksum = snapshotChecksum
+            encryptedDek = dek
+          }
+          requestId = blobRequestId(poolOffset, RankIndexBlob.BlobType.SNAPSHOT)
+        }
+        requests += createRankIndexBlobRequest {
+          parent = rawImpressionUpload
+          rankIndexBlob = rankIndexBlob {
+            blobType = RankIndexBlob.BlobType.DAY_ONLY
+            cmmsModelLine = modelLine
+            this.poolOffset = poolOffset
+            blobUri = dayOnlyKey
+            blobChecksum = dayOnlyChecksum
+            encryptedDek = dek
+            maxEventDate = this@SubpoolRanker.maxEventDate
+          }
+          requestId = blobRequestId(poolOffset, RankIndexBlob.BlobType.DAY_ONLY)
+        }
+      }
+    )
+  }
+
+  private fun recordMetrics(allocator: RankAllocator) {
+    metrics.ranksAllocatedCounter.add(allocator.allocated)
+    metrics.ranksRenewedCounter.add(allocator.renewed)
+    metrics.ranksFreedCounter.add(allocator.freed)
+    metrics.overflowFingerprintsCounter.add(allocator.overflow)
+    metrics.subpoolsRankedCounter.add(1)
+  }
+
+  /** Epoch-day of a UTC [Date]; falls back to [today] when the date is unset. */
+  private fun epochDayOf(date: Date): Int {
+    if (date.year == 0) return today.toEpochDay().toInt()
+    return LocalDate.of(date.year, date.month, date.day).toEpochDay().toInt()
+  }
+
+  /**
+   * Deterministic UUID4 idempotency key for the (upload, model line, subpool, blob type) blob row,
+   * stable across redeliveries so the batch insert reuses existing rows rather than duplicating.
+   * Derived from an MD5 digest with the RFC-4122 version (4) and variant bits forced.
+   */
+  private fun blobRequestId(poolOffset: Long, blobType: RankIndexBlob.BlobType): String {
+    val seed = "$rawImpressionUpload|$modelLine|$poolOffset|${blobType.name}"
+    val bytes = MessageDigest.getInstance("MD5").digest(seed.toByteArray(Charsets.UTF_8))
+    bytes[6] = ((bytes[6].toInt() and 0x0f) or 0x40).toByte() // version 4
+    bytes[8] = ((bytes[8].toInt() and 0x3f) or 0x80).toByte() // variant 10xx
+    val buffer = ByteBuffer.wrap(bytes)
+    return UUID(buffer.long, buffer.long).toString()
+  }
+
+  companion object {
+    private val logger = Logger.getLogger(SubpoolRanker::class.java.name)
+
+    /** Orders timestamps for "newest snapshot" without depending on a proto comparator. */
+    private fun com.google.protobuf.Timestamp.toComparable(): Long =
+      seconds * 1_000_000_000L + nanos
+  }
+}

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/vidrankbuilder/SubpoolRanker.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/vidrankbuilder/SubpoolRanker.kt
@@ -45,23 +45,21 @@ import org.wfanet.measurement.edpaggregator.vidlabeler.utils.Bytes12IntMap
  * `RankerJob` covers.
  *
  * For one subpool it:
- * 1. loads the prior cumulative `SNAPSHOT` (the most recent by `create_time` across all uploads —
+ * 1. **idempotency gate** — if a `SNAPSHOT` `RankIndexBlob` row already exists for this (upload,
+ *    subpool), a prior attempt already committed its blobs and rows atomically, so the subpool is
+ *    done and is skipped (cheap re-delivery no-op),
+ * 2. loads the prior cumulative `SNAPSHOT` (the most recent by `create_time` across all uploads —
  *    the current cumulative state) into a [RankAllocator] (rebuilding its rank `BitSet` and
  *    per-rank `last_seen`), validating the blob checksum,
- * 2. decides whether this dispatch is a **backfill** (see "Backfill" below),
- * 3. **idempotency gate** — if the row this run would commit already exists for this (upload,
- *    subpool), a prior attempt already finished, so the subpool is skipped (cheap re-delivery
- *    no-op). The gate row is the `SNAPSHOT` on a normal dispatch and the `DAY_ONLY` on a backfill
- *    (a backfill writes no `SNAPSHOT` — see below),
+ * 3. decides whether this dispatch is a **backfill** (see below),
  * 4. materializes this dispatch's fingerprint set from the Phase-0 merged `SubpoolFingerprints`
  *    blob,
  * 5. garbage-collects aged-out `DAY_ONLY` blobs ([SubpoolRetention]) and frees aged-out ranks in
  *    heap via the `last_seen` index, excluding fingerprints seen this dispatch,
  * 6. allocates ranks to today's fingerprints (renewing already-ranked ones, capping at
- *    `ranked_size`); on a backfill it instead replays each fingerprint's historical rank (see
- *    below),
- * 7. writes the new `DAY_ONLY` blob (DEK-encrypted) and — on a normal dispatch only — the new
- *    cumulative `SNAPSHOT`, recording each as a `RankIndexBlob` row.
+ *    `ranked_size`); on a backfill it instead replays each fingerprint's historical rank (below),
+ * 7. writes the new `DAY_ONLY` + `SNAPSHOT` blobs (DEK-encrypted) under **per-attempt-unique keys**
+ *    and records both as `RankIndexBlob` rows.
  *
  * ## Backfill (Problem 1 — give a person back their original rank)
  *
@@ -69,46 +67,44 @@ import org.wfanet.measurement.edpaggregator.vidlabeler.utils.Bytes12IntMap
  * correct for forward data appended in chronological order, but a **backfill** — an upload whose
  * newest event date ([maxEventDate]) is older than the most recent data already ranked — can land a
  * fingerprint whose original rank was freed and re-handed to someone else by the time the latest
- * snapshot was written. Giving it a brand-new rank then splits one person into two VIDs (reach
- * overcount).
+ * snapshot was written. Giving it a brand-new rank then splits one person into two VIDs
+ * (overcount).
  *
- * A dispatch is treated as a backfill when **all** hold:
- * * the latest cumulative `SNAPSHOT` carries a `max_event_date` (the snapshot-selection key) and
- *   that date is strictly newer than this dispatch's [maxEventDate] — i.e. fresher data already
- *   exists, so this is not forward append, and
- * * the gap (`latest.max_event_date - this.max_event_date`) is within [retentionDays] — a dispatch
- *   older than the retention window has no live ranks left to reclaim, so reassigning is pointless
- *   (the residual corruption there is Problem 3, explicitly out of scope), and
+ * A dispatch is treated as a backfill when **all** hold (see [resolveBackfillOldSnapshot]):
+ * * the latest cumulative `SNAPSHOT` carries a `max_event_date` strictly newer than this dispatch's
+ *   [maxEventDate] (fresher data already exists — not forward append), and
+ * * the gap is within [retentionDays] (an older dispatch has no live ranks left to reclaim — that
+ *   residual corruption is Problem 3, explicitly out of scope), and
  * * an **old snapshot** exists: the `SNAPSHOT` whose `max_event_date` is the greatest value
- *   strictly less than this dispatch's [maxEventDate] — the cumulative state as of just before the
- *   backfilled day. If none exists (the data provider uploaded data older than anything on record),
- *   it is not a backfill and the normal path runs.
+ *   strictly less than this dispatch's [maxEventDate] (the cumulative just before the backfilled
+ *   day). If none exists (data older than anything on record), it is not a backfill.
  *
- * On a backfill, both the latest cumulative (already loaded into the allocator) and that old
- * snapshot's `(fp -> rank)` map are held in heap, and each of today's fingerprints is assigned:
- * 1. if present in the **old** snapshot -> its rank there (give the person back their original
- *    rank),
- * 2. else if present in the **latest** snapshot -> the rank it holds there,
- * 3. else -> a freshly allocated rank.
+ * On a backfill, both the latest cumulative (loaded into the allocator) and the old snapshot's `(fp
+ * -> rank)` map are held in heap, and [RankAllocator.assignBackfill] writes **two** outputs per
+ * fingerprint, which may diverge:
+ * * the **`DAY_ONLY`** blob — what Phase-2 uses to label the backfilled day — gets the rank from
+ *   the old snapshot if present, else the latest snapshot's rank, else a fresh rank, and
+ * * the **`SNAPSHOT`** blob — the cumulative carried forward — is the latest snapshot **plus** the
+ *   backfill's fingerprints: an already-ranked fingerprint keeps its latest rank, a fingerprint
+ *   only in the old snapshot takes its old rank back if still free, and a genuinely new fingerprint
+ *   gets a fresh rank.
  *
- * ### Backfill writes only a `DAY_ONLY` blob — never a new `SNAPSHOT`
+ * ### Why a backfill must still write a `SNAPSHOT`
  *
- * A backfill deliberately does **not** write a new cumulative `SNAPSHOT`. The prior-snapshot lookup
- * ([findPriorSnapshot]) selects the latest snapshot by `create_time`, and a backfill run has the
- * newest `create_time` but carries old data; persisting its cumulative would make the next forward
- * dispatch load this stale, older-day cumulative as its baseline and corrupt the forward chain.
- * Phase-2 labels each upload from that upload's own `DAY_ONLY` blob (the corrected `(fp -> rank)`
- * for exactly this dispatch's fingerprints), so the backfilled day is labeled correctly without a
- * snapshot. The idempotency gate therefore keys off the `DAY_ONLY` row on a backfill.
+ * If a backfill wrote only a `DAY_ONLY`, a fingerprint that is new on the backfilled day would
+ * never enter the cumulative, so a later forward dispatch would re-rank it — reintroducing the very
+ * split we are preventing. Writing the cumulative as "latest + backfill additions" persists those
+ * new fingerprints. Its `max_event_date` is inherited from the latest snapshot (the backfill only
+ * adds *older* fingerprints, so the newest data represented is unchanged); this keeps the
+ * `create_time`-newest snapshot the most complete cumulative and never regresses the forward chain.
  *
  * ### Monitoring (the accepted undercount)
  *
- * When a fingerprint's old rank was already re-handed to a *different* fingerprint (the old slot is
- * taken by "Bob" in the latest snapshot), reusing the old rank makes the two share a VID for the
- * backfilled day (reach undercount). We still reuse the old rank (one-person-one-VID is the goal)
- * but **count** these: [Result.backfillRankCollisions] is the number of backfilled fingerprints
- * that reused an old rank while holding a *different* rank in the latest snapshot, so the size of
- * the undercount is observable in metrics and logs.
+ * When a fingerprint's old rank was already re-handed to a *different* fingerprint in the latest
+ * snapshot, labeling the backfilled day with the old rank makes the two share a VID for that day
+ * (reach undercount). We still give back the old rank (one-person-one-VID is the goal) but
+ * **count** these: [Result.backfillRankCollisions] is the number of backfilled fingerprints whose
+ * reused old rank differs from their rank in the latest snapshot, so the undercount is observable.
  *
  * ## Memory
  *
@@ -140,7 +136,7 @@ import org.wfanet.measurement.edpaggregator.vidlabeler.utils.Bytes12IntMap
  * @param kekUri KEK URI used to wrap each new blob's DEK.
  * @param encryptedSubpoolMapsDek DEK that decrypts the Phase-0 merged blobs.
  * @param maxEventDate newest event date this dispatch covers; stamped as `last_seen`, on the
- *   `DAY_ONLY` row, and on the `SNAPSHOT` row (the snapshot-selection key), and used for backfill
+ *   `DAY_ONLY` row, and (for a forward dispatch) on the `SNAPSHOT` row, and used for backfill
  *   detection.
  * @param retentionDays retention window in days (must exceed the max measurement-report window).
  * @param today the UTC date treated as "now" for the rank-age cutoff.
@@ -190,30 +186,26 @@ class SubpoolRanker(
 
   /** Ranks [poolOffset]; [subpoolBlobUri] is its Phase-0 merged blob; caps at [rankedSize]. */
   suspend fun rank(poolOffset: Long, subpoolBlobUri: String, rankedSize: Int): Result {
-    val eventDay = epochDayOf(maxEventDate)
-    val cutoffEpochDay = (today.toEpochDay() - retentionDays).toInt()
-
-    // 1. Locate the latest cumulative snapshot (most recent create_time), then decide whether this
-    // dispatch is a backfill and, if so, which older snapshot to replay ranks from.
-    val priorSnapshot = findPriorSnapshot(poolOffset)
-    val oldSnapshot = resolveBackfillOldSnapshot(poolOffset, eventDay, priorSnapshot)
-    val isBackfill = oldSnapshot != null
-
-    // 2. Idempotency gate, keyed on the row this run commits: SNAPSHOT on a normal dispatch,
-    // DAY_ONLY on a backfill (which writes no SNAPSHOT). A non-null result means a prior attempt
-    // already finished this (upload, subpool), so skip the re-rank.
-    val gateType =
-      if (isBackfill) RankIndexBlob.BlobType.DAY_ONLY else RankIndexBlob.BlobType.SNAPSHOT
-    if (findUploadBlob(poolOffset, gateType) != null) {
+    // Idempotency gate: an existing SNAPSHOT row for this (upload, subpool) means a prior attempt
+    // committed both blobs + rows atomically (a backfill writes a SNAPSHOT too), so skip the
+    // re-rank.
+    if (findUploadBlob(poolOffset, RankIndexBlob.BlobType.SNAPSHOT) != null) {
       logger.info(
         "Subpool $poolOffset for $modelLine already ranked for $rawImpressionUpload; skipping"
       )
       return Result(poolOffset, 0, 0, 0, 0, 0, skipped = true)
     }
 
-    val allocator = RankAllocator(poolOffset, rankedSize, eventDay)
+    val eventDay = epochDayOf(maxEventDate)
+    val cutoffEpochDay = (today.toEpochDay() - retentionDays).toInt()
 
-    // 3. Load the latest cumulative snapshot (validating its checksum), if one exists.
+    // 1. Load the latest cumulative snapshot, then decide whether this dispatch is a backfill and,
+    // if so, which older snapshot to replay ranks from.
+    val priorSnapshot = findPriorSnapshot(poolOffset)
+    val oldSnapshot = resolveBackfillOldSnapshot(poolOffset, eventDay, priorSnapshot)
+    val isBackfill = oldSnapshot != null
+
+    val allocator = RankAllocator(poolOffset, rankedSize, eventDay)
     if (priorSnapshot != null) {
       allocator.loadFrom(
         rankIndexStore.readBlob(
@@ -224,7 +216,7 @@ class SubpoolRanker(
       )
     }
 
-    // 4. Materialize this dispatch's fingerprint set for the subpool from the Phase-0 merged blob.
+    // 2. Materialize this dispatch's fingerprint set for the subpool from the Phase-0 merged blob.
     val todayFps = Bytes12IntMap()
     subpoolFingerprintsStore.readBlob(subpoolBlobUri, encryptedSubpoolMapsDek).collect { record ->
       val fps = record.fingerprints
@@ -240,44 +232,39 @@ class SubpoolRanker(
       }
     }
 
-    // 5a. Storage GC of aged-out DAY_ONLY blobs (independent of rank freeing).
+    // 3a. Storage GC of aged-out DAY_ONLY blobs (independent of rank freeing).
     retention.deleteAgedBlobs(poolOffset)
-    // 5b. Free aged-out ranks in heap from the `last_seen` index, before allocating so freed slots
+    // 3b. Free aged-out ranks in heap from the `last_seen` index, before allocating so freed slots
     // are reusable today. Fingerprints seen this dispatch are excluded so their ranks (VIDs)
     // survive.
     allocator.freeAgedRanks(cutoffEpochDay, todayFps)
 
-    // 6. Assign ranks to today's fingerprints.
-    var reusedOldRank = 0L
-    var rankCollisions = 0L
+    // 4. Assign ranks to today's fingerprints.
     if (oldSnapshot != null) {
-      // Backfill: replay each fingerprint's historical rank (old -> latest -> new).
+      // Backfill: replay each fingerprint's historical rank into the day-only delta while extending
+      // the cumulative forward (see class KDoc and RankAllocator.assignBackfill).
       val oldRanks = loadFingerprintRanks(oldSnapshot)
       todayFps.forEach { keyHi, keyLo, _ ->
-        val oldRank = oldRanks.get(keyHi, keyLo)
-        if (oldRank != Bytes12IntMap.NOT_PRESENT && oldRank in 0 until rankedSize) {
-          // The fingerprint's rank in the latest snapshot, captured before we overwrite it; a
-          // different value means the old slot was re-handed to someone else (accepted undercount).
-          val latestRank = allocator.get(keyHi, keyLo)
-          allocator.assignAt(keyHi, keyLo, oldRank)
-          reusedOldRank++
-          if (latestRank != Bytes12IntMap.NOT_PRESENT && latestRank != oldRank) {
-            rankCollisions++
-          }
-        } else {
-          allocator.assign(keyHi, keyLo)
-        }
+        allocator.assignBackfill(keyHi, keyLo, oldRanks.get(keyHi, keyLo))
       }
     } else {
       todayFps.forEach { keyHi, keyLo, _ -> allocator.assign(keyHi, keyLo) }
     }
 
-    // 7. Write the new blob(s) and record the RankIndexBlob row(s). Keys carry a per-attempt UUID
-    // so
-    // a concurrent/re-delivered attempt never overwrites another's bytes; the winning
-    // (deterministic-request_id) row's blob_uri + DEK are always self-consistent.
+    // 5. Write the new DAY_ONLY + SNAPSHOT blobs and record both as RankIndexBlob rows. Keys carry
+    // a
+    // per-attempt UUID so a concurrent/re-delivered attempt never overwrites another's bytes; the
+    // winning (deterministic-request_id) row's blob_uri + DEK are always self-consistent.
     val attemptId = UUID.randomUUID().toString()
     val dek = rankIndexStore.generateDek(kekUri)
+    val snapshotKey =
+      RankIndexStore.snapshotKey(
+        vidRankMapBlobPrefix,
+        rawImpressionUpload,
+        modelLine,
+        poolOffset,
+        attemptId,
+      )
     val dayOnlyKey =
       RankIndexStore.dayOnlyKey(
         vidRankMapBlobPrefix,
@@ -286,41 +273,41 @@ class SubpoolRanker(
         poolOffset,
         attemptId,
       )
+    val snapshotChecksum =
+      rankIndexStore.writeBlob(snapshotKey, dek, allocator.streamCumulativeChunks())
     val dayOnlyChecksum = rankIndexStore.writeBlob(dayOnlyKey, dek, allocator.streamDayOnlyChunks())
-    if (isBackfill) {
-      // Backfill: persist ONLY the corrected DAY_ONLY; writing a new cumulative SNAPSHOT here would
-      // poison the create_time-ordered forward chain (see class KDoc).
-      insertDayOnlyRow(poolOffset, dayOnlyKey, dayOnlyChecksum, dek)
-    } else {
-      val snapshotKey =
-        RankIndexStore.snapshotKey(
-          vidRankMapBlobPrefix,
-          rawImpressionUpload,
-          modelLine,
-          poolOffset,
-          attemptId,
-        )
-      val snapshotChecksum =
-        rankIndexStore.writeBlob(snapshotKey, dek, allocator.streamCumulativeChunks())
-      insertBlobRows(poolOffset, snapshotKey, snapshotChecksum, dayOnlyKey, dayOnlyChecksum, dek)
-    }
+    // The SNAPSHOT's max_event_date is the newest event date in the cumulative: this dispatch's
+    // date
+    // for a forward upload, but the prior snapshot's (unchanged) date for a backfill, which only
+    // adds older fingerprints.
+    val snapshotMaxEventDate = if (isBackfill) priorSnapshot!!.maxEventDate else maxEventDate
+    insertBlobRows(
+      poolOffset,
+      snapshotKey,
+      snapshotChecksum,
+      dayOnlyKey,
+      dayOnlyChecksum,
+      dek,
+      snapshotMaxEventDate,
+    )
 
-    recordMetrics(allocator, reusedOldRank, rankCollisions)
+    recordMetrics(allocator)
     logger.info(
       "Subpool $poolOffset for $modelLine: allocated=${allocator.allocated}, " +
         "renewed=${allocator.renewed}, overflow=${allocator.overflow}, freed=${allocator.freed}, " +
         "cumulative=${allocator.cumulativeSize}" +
         if (isBackfill) {
-          " [backfill: reusedOldRank=$reusedOldRank, rankCollisions=$rankCollisions]"
+          " [backfill: reusedOldRank=${allocator.backfillReusedOldRank}, " +
+            "rankCollisions=${allocator.backfillRankCollisions}]"
         } else {
           ""
         }
     )
-    if (rankCollisions > 0) {
+    if (allocator.backfillRankCollisions > 0) {
       logger.warning(
-        "Subpool $poolOffset for $modelLine backfill reach-undercount: $rankCollisions " +
-          "fingerprint(s) reused an old rank already re-handed to a different fingerprint in the " +
-          "latest snapshot"
+        "Subpool $poolOffset for $modelLine backfill reach-undercount: " +
+          "${allocator.backfillRankCollisions} fingerprint(s) reused an old rank already re-handed " +
+          "to a different fingerprint in the latest snapshot"
       )
     }
     return Result(
@@ -331,8 +318,8 @@ class SubpoolRanker(
       freed = allocator.freed,
       cumulativeSize = allocator.cumulativeSize,
       backfill = isBackfill,
-      backfillReusedOldRank = reusedOldRank,
-      backfillRankCollisions = rankCollisions,
+      backfillReusedOldRank = allocator.backfillReusedOldRank,
+      backfillRankCollisions = allocator.backfillRankCollisions,
     )
   }
 
@@ -371,8 +358,9 @@ class SubpoolRanker(
   /**
    * The newest non-deleted `SNAPSHOT` blob for [poolOffset] of this (data provider, model line)
    * across all uploads, or `null` on a cold (Day-1) subpool. The most recent `create_time` is the
-   * current cumulative state (the design's N−1 recovery baseline). A backfill writes no `SNAPSHOT`,
-   * so the most recent `create_time` is always a forward dispatch's cumulative.
+   * current cumulative state (the design's N−1 recovery baseline). A backfill writes a `SNAPSHOT`
+   * too (the latest cumulative plus the backfill's fingerprints), so the most recent `create_time`
+   * always reflects the most complete cumulative.
    *
    * TODO(world-federation-of-advertisers/cross-media-measurement#4008): this lists every
    *   non-deleted SNAPSHOT across all uploads and scans for the newest — O(all snapshots), which
@@ -417,8 +405,8 @@ class SubpoolRanker(
    *
    * Returns the old snapshot — the `SNAPSHOT` whose `max_event_date` is the greatest value strictly
    * less than [eventDay] (the cumulative state just before the backfilled day) — only when:
-   * * [priorSnapshot] (the latest cumulative) exists and carries a `max_event_date` that is
-   *   strictly newer than [eventDay] (fresher data already exists), and
+   * * [priorSnapshot] (the latest cumulative) exists and carries a `max_event_date` strictly newer
+   *   than [eventDay] (fresher data already exists), and
    * * the gap is within [retentionDays] (older dispatches have no live ranks left to reclaim —
    *   Problem 3, out of scope), and
    * * such an older snapshot actually exists (otherwise the data provider uploaded data older than
@@ -492,7 +480,12 @@ class SubpoolRanker(
     return map
   }
 
-  /** Inserts the SNAPSHOT + DAY_ONLY rows in one idempotent batch (normal dispatch). */
+  /**
+   * Inserts the SNAPSHOT + DAY_ONLY rows in one idempotent batch. [snapshotMaxEventDate] is the
+   * newest event date represented in the cumulative (this dispatch's date for a forward upload, the
+   * prior snapshot's date for a backfill); the DAY_ONLY row always carries this dispatch's date so
+   * the retention sweep ages it by the day it actually covers.
+   */
   private suspend fun insertBlobRows(
     poolOffset: Long,
     snapshotKey: String,
@@ -500,6 +493,7 @@ class SubpoolRanker(
     dayOnlyKey: String,
     dayOnlyChecksum: com.google.protobuf.ByteString,
     dek: EncryptedDek,
+    snapshotMaxEventDate: Date,
   ) {
     rankIndexBlobsStub.batchCreateRankIndexBlobs(
       batchCreateRankIndexBlobsRequest {
@@ -513,9 +507,7 @@ class SubpoolRanker(
             blobUri = snapshotKey
             blobChecksum = snapshotChecksum
             encryptedDek = dek
-            // The snapshot-selection key: the newest event date of the upload that produced this
-            // cumulative state, used to locate the prior/old snapshot for a given event date.
-            maxEventDate = this@SubpoolRanker.maxEventDate
+            maxEventDate = snapshotMaxEventDate
           }
           requestId = blobRequestId(poolOffset, RankIndexBlob.BlobType.SNAPSHOT)
         }
@@ -536,44 +528,18 @@ class SubpoolRanker(
     )
   }
 
-  /**
-   * Inserts only the DAY_ONLY row (backfill). No SNAPSHOT is written — see the class KDoc for why a
-   * backfill must not advance the cumulative chain.
-   */
-  private suspend fun insertDayOnlyRow(
-    poolOffset: Long,
-    dayOnlyKey: String,
-    dayOnlyChecksum: com.google.protobuf.ByteString,
-    dek: EncryptedDek,
-  ) {
-    rankIndexBlobsStub.batchCreateRankIndexBlobs(
-      batchCreateRankIndexBlobsRequest {
-        parent = rawImpressionUpload
-        requests += createRankIndexBlobRequest {
-          parent = rawImpressionUpload
-          rankIndexBlob = rankIndexBlob {
-            blobType = RankIndexBlob.BlobType.DAY_ONLY
-            cmmsModelLine = modelLine
-            this.poolOffset = poolOffset
-            blobUri = dayOnlyKey
-            blobChecksum = dayOnlyChecksum
-            encryptedDek = dek
-            maxEventDate = this@SubpoolRanker.maxEventDate
-          }
-          requestId = blobRequestId(poolOffset, RankIndexBlob.BlobType.DAY_ONLY)
-        }
-      }
-    )
-  }
-
-  private fun recordMetrics(allocator: RankAllocator, reusedOldRank: Long, rankCollisions: Long) {
+  private fun recordMetrics(allocator: RankAllocator) {
     metrics.ranksAllocatedCounter.add(allocator.allocated)
     metrics.ranksRenewedCounter.add(allocator.renewed)
     metrics.ranksFreedCounter.add(allocator.freed)
     metrics.overflowFingerprintsCounter.add(allocator.overflow)
     metrics.subpoolsRankedCounter.add(1)
-    if (reusedOldRank > 0) metrics.backfillReusedOldRankCounter.add(reusedOldRank)
-    if (rankCollisions > 0) metrics.backfillRankCollisionsCounter.add(rankCollisions)
+    if (allocator.backfillReusedOldRank > 0) {
+      metrics.backfillReusedOldRankCounter.add(allocator.backfillReusedOldRank)
+    }
+    if (allocator.backfillRankCollisions > 0) {
+      metrics.backfillRankCollisionsCounter.add(allocator.backfillRankCollisions)
+    }
   }
 
   /**

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/vidrankbuilder/SubpoolRanker.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/vidrankbuilder/SubpoolRanker.kt
@@ -23,6 +23,8 @@ import java.time.LocalDate
 import java.util.UUID
 import java.util.logging.Logger
 import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.firstOrNull
+import org.wfanet.measurement.common.api.ResourceKey
 import org.wfanet.measurement.common.api.grpc.ResourceList
 import org.wfanet.measurement.common.api.grpc.listResources
 import org.wfanet.measurement.edpaggregator.rawimpressions.RankIndexStore
@@ -219,8 +221,7 @@ class SubpoolRanker(
    * non-null result is the idempotency-gate signal that the subpool was already ranked for this
    * dispatch.
    */
-  private suspend fun findUploadSnapshot(poolOffset: Long): RankIndexBlob? {
-    var existing: RankIndexBlob? = null
+  private suspend fun findUploadSnapshot(poolOffset: Long): RankIndexBlob? =
     rankIndexBlobsStub
       .listResources { pageToken: String ->
         val response =
@@ -233,14 +234,16 @@ class SubpoolRanker(
                   cmmsModelLine = modelLine
                   this.poolOffset = poolOffset
                 }
+              pageSize = 1
               this.pageToken = pageToken
             }
           )
         ResourceList(response.rankIndexBlobsList, response.nextPageToken)
       }
-      .collect { page -> page.firstOrNull()?.let { existing = it } }
-    return existing
-  }
+      // Short-circuit at the first page that has a match: cancels pagination instead of scanning
+      // the whole filter result for a question whose answer is binary (exists / not).
+      .firstOrNull { page -> page.firstOrNull() != null }
+      ?.firstOrNull()
 
   /**
    * The newest non-deleted `SNAPSHOT` blob for [poolOffset] of this (data provider, model line)
@@ -259,7 +262,7 @@ class SubpoolRanker(
         val response =
           listRankIndexBlobs(
             listRankIndexBlobsRequest {
-              parent = "$dataProvider/rawImpressionUploads/-"
+              parent = "$dataProvider/rawImpressionUploads/${ResourceKey.WILDCARD_ID}"
               filter =
                 ListRankIndexBlobsRequestKt.filter {
                   blobType = RankIndexBlob.BlobType.SNAPSHOT
@@ -333,9 +336,13 @@ class SubpoolRanker(
     metrics.subpoolsRankedCounter.add(1)
   }
 
-  /** Epoch-day of a UTC [Date]; falls back to [today] when the date is unset. */
+  /**
+   * Epoch-day of a UTC [Date]. [maxEventDate] is REQUIRED: it drives both `last_seen` stamping and
+   * the `DAY_ONLY` row's `MaxEventDate` (which retention ages blobs by), so an unset value would
+   * silently corrupt rank state. Fail loudly instead of defaulting.
+   */
   private fun epochDayOf(date: Date): Int {
-    if (date.year == 0) return today.toEpochDay().toInt()
+    require(date.year != 0) { "maxEventDate must be set on VidRankBuilderParams" }
     return LocalDate.of(date.year, date.month, date.day).toEpochDay().toInt()
   }
 

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/vidrankbuilder/SubpoolRetention.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/vidrankbuilder/SubpoolRetention.kt
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2026 The Cross-Media Measurement Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wfanet.measurement.edpaggregator.vidrankbuilder
+
+import com.google.type.Date
+import com.google.type.date
+import java.time.LocalDate
+import java.util.logging.Logger
+import kotlinx.coroutines.flow.collect
+import org.wfanet.measurement.common.api.grpc.ResourceList
+import org.wfanet.measurement.common.api.grpc.listResources
+import org.wfanet.measurement.edpaggregator.rawimpressions.RankIndexStore
+import org.wfanet.measurement.edpaggregator.v1alpha.ListRankIndexBlobsRequestKt
+import org.wfanet.measurement.edpaggregator.v1alpha.RankIndexBlob
+import org.wfanet.measurement.edpaggregator.v1alpha.RankIndexBlobServiceGrpcKt.RankIndexBlobServiceCoroutineStub
+import org.wfanet.measurement.edpaggregator.v1alpha.deleteRankIndexBlobRequest
+import org.wfanet.measurement.edpaggregator.v1alpha.listRankIndexBlobsRequest
+
+/**
+ * Storage garbage-collection of aged-out `DAY_ONLY` rank-index blobs for a single subpool.
+ *
+ * Since the cumulative `SNAPSHOT` now carries each fingerprint's `last_seen` recency (see
+ * [RankAllocator]), the **rank-freeing** decision is made entirely in heap by
+ * [RankAllocator.freeAgedRanks] and no longer depends on these blobs. This class is therefore pure
+ * storage cleanup: it soft-deletes the `RankIndexBlob` rows whose `max_event_date` is older than
+ * the retention window and deletes their bytes from Cloud Storage. It reads no blob contents and
+ * scans no history.
+ *
+ * A `DAY_ONLY` blob is eligible when `today - MaxEventDate(blob) > RETENTION_DAYS`. The retention
+ * window MUST exceed the deployment's maximum measurement-report window (see Data Deletion).
+ *
+ * @param rankIndexBlobsStub metadata-storage service for listing/soft-deleting `RankIndexBlob`s.
+ * @param rankIndexStore deletes the aged blobs' bytes from Cloud Storage.
+ * @param dataProvider the EDP resource name (`dataProviders/{dp}`), parent of the upload wildcard.
+ * @param modelLine the model line scoping the retention query.
+ * @param retentionDays retention window in days.
+ * @param today the UTC date treated as "now" for the age computation.
+ */
+class SubpoolRetention(
+  private val rankIndexBlobsStub: RankIndexBlobServiceCoroutineStub,
+  private val rankIndexStore: RankIndexStore,
+  private val dataProvider: String,
+  private val modelLine: String,
+  private val retentionDays: Int,
+  private val today: LocalDate,
+) {
+  /** Soft-deletes and hard-deletes the aged-out `DAY_ONLY` blobs of [poolOffset]. */
+  suspend fun deleteAgedBlobs(poolOffset: Long) {
+    val cutoff = today.minusDays(retentionDays.toLong() + 1L) // strictly older than RETENTION_DAYS
+    val candidates = listDeletionCandidates(poolOffset, cutoff)
+    if (candidates.isEmpty()) return
+
+    logger.info(
+      "Subpool $poolOffset for $modelLine: garbage-collecting ${candidates.size} aged DAY_ONLY blob(s)"
+    )
+    for (candidate in candidates) {
+      // Soft-delete the row first so a concurrent retry skips it, then delete the bytes.
+      rankIndexBlobsStub.deleteRankIndexBlob(deleteRankIndexBlobRequest { name = candidate.name })
+      rankIndexStore.delete(candidate.blobUri)
+    }
+  }
+
+  /**
+   * `DAY_ONLY` blobs for [poolOffset] whose `max_event_date` is on or before [cutoff], not deleted.
+   */
+  private suspend fun listDeletionCandidates(
+    poolOffset: Long,
+    cutoff: LocalDate,
+  ): List<RankIndexBlob> {
+    val candidates = mutableListOf<RankIndexBlob>()
+    rankIndexBlobsStub
+      .listResources { pageToken: String ->
+        val response =
+          listRankIndexBlobs(
+            listRankIndexBlobsRequest {
+              parent = "$dataProvider/rawImpressionUploads/-"
+              filter =
+                ListRankIndexBlobsRequestKt.filter {
+                  blobType = RankIndexBlob.BlobType.DAY_ONLY
+                  cmmsModelLine = modelLine
+                  this.poolOffset = poolOffset
+                  maxEventDateOnOrBefore = cutoff.toDate()
+                }
+              this.pageToken = pageToken
+            }
+          )
+        ResourceList(response.rankIndexBlobsList, response.nextPageToken)
+      }
+      .collect { page -> candidates.addAll(page) }
+    return candidates
+  }
+
+  private fun LocalDate.toDate(): Date = date {
+    year = this@toDate.year
+    month = this@toDate.monthValue
+    day = this@toDate.dayOfMonth
+  }
+
+  companion object {
+    private val logger = Logger.getLogger(SubpoolRetention::class.java.name)
+  }
+}

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/vidrankbuilder/SubpoolRetention.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/vidrankbuilder/SubpoolRetention.kt
@@ -21,6 +21,7 @@ import com.google.type.date
 import java.time.LocalDate
 import java.util.logging.Logger
 import kotlinx.coroutines.flow.collect
+import org.wfanet.measurement.common.api.ResourceKey
 import org.wfanet.measurement.common.api.grpc.ResourceList
 import org.wfanet.measurement.common.api.grpc.listResources
 import org.wfanet.measurement.edpaggregator.rawimpressions.RankIndexStore
@@ -68,7 +69,10 @@ class SubpoolRetention(
       "Subpool $poolOffset for $modelLine: garbage-collecting ${candidates.size} aged DAY_ONLY blob(s)"
     )
     for (candidate in candidates) {
-      // Soft-delete the row first so a concurrent retry skips it, then delete the bytes.
+      // Soft-delete the row first so a concurrent retry skips it, then delete the bytes. A failure
+      // between the two leaks the bytes (no corruption — the row is gone, so nothing references
+      // them) and they're reclaimed by the monitor
+      // (world-federation-of-advertisers/cross-media-measurement#3958) or the bucket lifecycle.
       rankIndexBlobsStub.deleteRankIndexBlob(deleteRankIndexBlobRequest { name = candidate.name })
       rankIndexStore.delete(candidate.blobUri)
     }
@@ -87,7 +91,7 @@ class SubpoolRetention(
         val response =
           listRankIndexBlobs(
             listRankIndexBlobsRequest {
-              parent = "$dataProvider/rawImpressionUploads/-"
+              parent = "$dataProvider/rawImpressionUploads/${ResourceKey.WILDCARD_ID}"
               filter =
                 ListRankIndexBlobsRequestKt.filter {
                   blobType = RankIndexBlob.BlobType.DAY_ONLY

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/vidrankbuilder/VidRankBuilderMetrics.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/vidrankbuilder/VidRankBuilderMetrics.kt
@@ -64,4 +64,23 @@ class VidRankBuilderMetrics(meter: Meter = Instrumentation.meter) {
       .counterBuilder("edpa.vid_rank_builder.subpools_ranked")
       .setDescription("Number of subpools ranked")
       .build()
+
+  /** Backfilled fingerprints given back the rank they held in an older snapshot. */
+  val backfillReusedOldRankCounter: LongCounter =
+    meter
+      .counterBuilder("edpa.vid_rank_builder.backfill_reused_old_rank")
+      .setDescription("Backfilled fingerprints reassigned the rank from their old snapshot")
+      .build()
+
+  /**
+   * Backfilled fingerprints reassigned an old rank that the latest snapshot had already re-handed
+   * to a different fingerprint — the accepted reach-undercount sizing.
+   */
+  val backfillRankCollisionsCounter: LongCounter =
+    meter
+      .counterBuilder("edpa.vid_rank_builder.backfill_rank_collisions")
+      .setDescription(
+        "Backfilled fingerprints whose reused old rank differs from their rank in the latest snapshot"
+      )
+      .build()
 }

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/vidrankbuilder/VidRankBuilderMetrics.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/vidrankbuilder/VidRankBuilderMetrics.kt
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2026 The Cross-Media Measurement Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wfanet.measurement.edpaggregator.vidrankbuilder
+
+import io.opentelemetry.api.metrics.LongCounter
+import io.opentelemetry.api.metrics.Meter
+import org.wfanet.measurement.common.Instrumentation
+
+/**
+ * OpenTelemetry instruments for the Phase-1 ranker ([SubpoolRanker] / [VidRankBuilder]).
+ *
+ * Mirrors `SubpoolAssignerMetrics`: counters integrate with `EdpaTelemetry` so rank-allocation
+ * rates surface on operator dashboards. The in-process [SubpoolRanker.Result] tallies are kept
+ * separately for the completion log because OpenTelemetry counters are not readable in-process.
+ *
+ * @param meter the OpenTelemetry [Meter] used to create instruments.
+ */
+class VidRankBuilderMetrics(meter: Meter = Instrumentation.meter) {
+  /** Ranks newly assigned to never-before-seen fingerprints. */
+  val ranksAllocatedCounter: LongCounter =
+    meter
+      .counterBuilder("edpa.vid_rank_builder.ranks_allocated")
+      .setDescription("Ranks newly assigned to never-before-seen fingerprints")
+      .build()
+
+  /** Already-ranked fingerprints re-observed this dispatch (rank preserved). */
+  val ranksRenewedCounter: LongCounter =
+    meter
+      .counterBuilder("edpa.vid_rank_builder.ranks_renewed")
+      .setDescription("Already-ranked fingerprints re-observed this dispatch")
+      .build()
+
+  /** Ranks freed by the retention pass. */
+  val ranksFreedCounter: LongCounter =
+    meter
+      .counterBuilder("edpa.vid_rank_builder.ranks_freed")
+      .setDescription("Ranks freed by the retention pass")
+      .build()
+
+  /** Fingerprints left unranked because their subpool reached `ranked_size`. */
+  val overflowFingerprintsCounter: LongCounter =
+    meter
+      .counterBuilder("edpa.vid_rank_builder.overflow_fingerprints")
+      .setDescription("Fingerprints left unranked because the subpool was full")
+      .build()
+
+  /** Subpools ranked. */
+  val subpoolsRankedCounter: LongCounter =
+    meter
+      .counterBuilder("edpa.vid_rank_builder.subpools_ranked")
+      .setDescription("Number of subpools ranked")
+      .build()
+}

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/vidrankbuilder/VidRankBuilderMetrics.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/vidrankbuilder/VidRankBuilderMetrics.kt
@@ -17,6 +17,7 @@
 package org.wfanet.measurement.edpaggregator.vidrankbuilder
 
 import io.opentelemetry.api.metrics.LongCounter
+import io.opentelemetry.api.metrics.LongHistogram
 import io.opentelemetry.api.metrics.Meter
 import org.wfanet.measurement.common.Instrumentation
 
@@ -82,5 +83,29 @@ class VidRankBuilderMetrics(meter: Meter = Instrumentation.meter) {
       .setDescription(
         "Backfilled fingerprints whose reused old rank differs from their rank in the latest snapshot"
       )
+      .build()
+
+  /**
+   * Fingerprint count of the old snapshot loaded for a backfill. A backfill holds two in-heap maps
+   * (latest cumulative + old snapshot), which can OOM the ranker at India scale (see
+   * [SubpoolRanker]); this lets ops alert on growth before the load dies.
+   */
+  val backfillOldSnapshotEntriesHistogram: LongHistogram =
+    meter
+      .histogramBuilder("edpa.vid_rank_builder.backfill_old_snapshot_entries")
+      .ofLongs()
+      .setDescription("Fingerprint count of the old snapshot loaded for a backfill")
+      .setUnit("{fingerprints}")
+      .build()
+
+  /**
+   * Backfills rejected because the dispatch is older than the retention window (the original rank
+   * has already aged out — Problem 3). The ranker fails the dispatch loudly rather than silently
+   * re-ranking still-tracked fingerprints; this counts how often that happens.
+   */
+  val outOfRetentionBackfillCounter: LongCounter =
+    meter
+      .counterBuilder("edpa.vid_rank_builder.out_of_retention_backfill")
+      .setDescription("Backfills rejected for being older than the retention window")
       .build()
 }

--- a/src/main/proto/wfa/measurement/edpaggregator/v1alpha/rank_index_blob.proto
+++ b/src/main/proto/wfa/measurement/edpaggregator/v1alpha/rank_index_blob.proto
@@ -27,12 +27,10 @@ option java_multiple_files = true;
 option java_outer_classname = "RankIndexBlobProto";
 
 // A pointer to a rank index blob in Cloud Storage, with its
-// encrypted DEK. A normal (forward) upload writes two rows per
-// (upload, model line, subpool): one DAY_ONLY and one SNAPSHOT.
-// A backfill upload (one whose max_event_date is older than the
-// latest snapshot) writes only a DAY_ONLY row, so as not to
-// advance the cumulative chain. Day-only blobs persist until
-// aged out by the retention policy; snapshots are not pruned.
+// encrypted DEK. Every upload (forward or backfill) writes two
+// rows per (upload, model line, subpool): one DAY_ONLY and one
+// SNAPSHOT. Day-only blobs persist until aged out by the
+// retention policy; snapshots are not pruned.
 message RankIndexBlob {
   option (google.api.resource) = {
     type: "edpaggregator.halo-cmm.org/RankIndexBlob"
@@ -95,12 +93,14 @@ message RankIndexBlob {
   ];
 
   // The newest event date among the impressions covered by this
-  // blob. Set on both row types: on DAY_ONLY it is the dispatch's
-  // max event date (used by the retention sweep); on SNAPSHOT it
-  // is the max event date of the upload that produced the
-  // cumulative state, used as the snapshot-selection key to locate
-  // the prior/old snapshot for a given event date during backfill
-  // (see SubpoolRanker).
+  // blob. Set on both row types. On DAY_ONLY it is the dispatch's
+  // max event date (used by the retention sweep). On SNAPSHOT it
+  // is the newest event date represented in the cumulative state:
+  // for a forward upload, this upload's max event date; for a
+  // backfill, the prior snapshot's max event date (a backfill only
+  // adds older fingerprints, so the newest data is unchanged). Used
+  // as the snapshot-selection key to locate the prior/old snapshot
+  // for a given event date during backfill (see SubpoolRanker).
   google.type.Date max_event_date = 8 [
     (google.api.field_behavior) = OPTIONAL,
     (google.api.field_behavior) = IMMUTABLE

--- a/src/main/proto/wfa/measurement/edpaggregator/v1alpha/rank_index_blob.proto
+++ b/src/main/proto/wfa/measurement/edpaggregator/v1alpha/rank_index_blob.proto
@@ -27,10 +27,12 @@ option java_multiple_files = true;
 option java_outer_classname = "RankIndexBlobProto";
 
 // A pointer to a rank index blob in Cloud Storage, with its
-// encrypted DEK. Two rows per (upload, model line, subpool):
-// one DAY_ONLY and one SNAPSHOT. Snapshots are replaced each
-// upload; day-only blobs persist until aged out by the
-// retention policy.
+// encrypted DEK. A normal (forward) upload writes two rows per
+// (upload, model line, subpool): one DAY_ONLY and one SNAPSHOT.
+// A backfill upload (one whose max_event_date is older than the
+// latest snapshot) writes only a DAY_ONLY row, so as not to
+// advance the cumulative chain. Day-only blobs persist until
+// aged out by the retention policy; snapshots are not pruned.
 message RankIndexBlob {
   option (google.api.resource) = {
     type: "edpaggregator.halo-cmm.org/RankIndexBlob"
@@ -92,8 +94,13 @@ message RankIndexBlob {
     (google.api.field_behavior) = IMMUTABLE
   ];
 
-  // The newest event date among the impressions in this blob.
-  // Only set for DAY_ONLY blobs; unset for SNAPSHOT blobs.
+  // The newest event date among the impressions covered by this
+  // blob. Set on both row types: on DAY_ONLY it is the dispatch's
+  // max event date (used by the retention sweep); on SNAPSHOT it
+  // is the max event date of the upload that produced the
+  // cumulative state, used as the snapshot-selection key to locate
+  // the prior/old snapshot for a given event date during backfill
+  // (see SubpoolRanker).
   google.type.Date max_event_date = 8 [
     (google.api.field_behavior) = OPTIONAL,
     (google.api.field_behavior) = IMMUTABLE

--- a/src/test/kotlin/org/wfanet/measurement/edpaggregator/rawimpressions/BUILD.bazel
+++ b/src/test/kotlin/org/wfanet/measurement/edpaggregator/rawimpressions/BUILD.bazel
@@ -94,3 +94,16 @@ kt_jvm_test(
         "@wfa_common_jvm//src/main/kotlin/org/wfanet/measurement/storage/testing",
     ],
 )
+
+kt_jvm_test(
+    name = "RawImpressionFileBinPackerTest",
+    srcs = ["RawImpressionFileBinPackerTest.kt"],
+    test_class = "org.wfanet.measurement.edpaggregator.rawimpressions.RawImpressionFileBinPackerTest",
+    deps = [
+        "//src/main/kotlin/org/wfanet/measurement/edpaggregator/rawimpressions:raw_impression_file_bin_packer",
+        "//src/main/proto/wfa/measurement/edpaggregator/v1alpha:raw_impression_upload_file_kt_jvm_proto",
+        "@wfa_common_jvm//imports/java/com/google/common/truth",
+        "@wfa_common_jvm//imports/java/org/junit",
+        "@wfa_common_jvm//imports/kotlin/kotlin/test",
+    ],
+)

--- a/src/test/kotlin/org/wfanet/measurement/edpaggregator/rawimpressions/RawImpressionFileBinPackerTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/edpaggregator/rawimpressions/RawImpressionFileBinPackerTest.kt
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2026 The Cross-Media Measurement Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wfanet.measurement.edpaggregator.rawimpressions
+
+import com.google.common.truth.Truth.assertThat
+import kotlin.test.assertFailsWith
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+import org.wfanet.measurement.edpaggregator.v1alpha.RawImpressionUploadFile
+import org.wfanet.measurement.edpaggregator.v1alpha.rawImpressionUploadFile
+
+@RunWith(JUnit4::class)
+class RawImpressionFileBinPackerTest {
+
+  private fun file(resourceName: String, bytes: Long): RawImpressionUploadFile =
+    rawImpressionUploadFile {
+      name = resourceName
+      sizeBytes = bytes
+    }
+
+  @Test
+  fun `empty input produces no batches`() {
+    assertThat(RawImpressionFileBinPacker.pack(emptyList(), maxFileBatchSizeBytes = 100)).isEmpty()
+  }
+
+  @Test
+  fun `files within the cap pack into a single batch`() {
+    val files = listOf(file("a", 10), file("b", 20), file("c", 30))
+
+    val batches = RawImpressionFileBinPacker.pack(files, maxFileBatchSizeBytes = 100)
+
+    assertThat(batches).hasSize(1)
+    // Sorted largest-first within the batch (60 total <= 100).
+    assertThat(batches[0]).containsExactly("c", "b", "a").inOrder()
+  }
+
+  @Test
+  fun `a batch may be filled exactly up to the cap`() {
+    val files = listOf(file("a", 60), file("b", 40))
+
+    val batches = RawImpressionFileBinPacker.pack(files, maxFileBatchSizeBytes = 100)
+
+    // 60 + 40 == 100 is allowed (inclusive bound), so both fit in one batch.
+    assertThat(batches).hasSize(1)
+    assertThat(batches[0]).containsExactly("a", "b").inOrder()
+  }
+
+  @Test
+  fun `files over the cap split first-fit-decreasing across batches`() {
+    // Sizes 60, 50, 40, 10 with cap 100. FFD largest-first:
+    //   60 -> batch0[60]; 50 -> batch1[50]; 40 -> batch0[60,40]=100; 10 -> batch1[50,10]=60.
+    val files = listOf(file("s10", 10), file("s40", 40), file("s50", 50), file("s60", 60))
+
+    val batches = RawImpressionFileBinPacker.pack(files, maxFileBatchSizeBytes = 100)
+
+    assertThat(batches).hasSize(2)
+    assertThat(batches[0]).containsExactly("s60", "s40").inOrder()
+    assertThat(batches[1]).containsExactly("s50", "s10").inOrder()
+  }
+
+  @Test
+  fun `a single file at or above the cap gets its own batch`() {
+    val files = listOf(file("big", 150), file("small", 30))
+
+    val batches = RawImpressionFileBinPacker.pack(files, maxFileBatchSizeBytes = 100)
+
+    assertThat(batches).hasSize(2)
+    // The oversized file is isolated (best-effort); the rest pack normally.
+    assertThat(batches[0]).containsExactly("big")
+    assertThat(batches[1]).containsExactly("small")
+  }
+
+  @Test
+  fun `equal-size files break ties by resource name for determinism`() {
+    val files = listOf(file("c", 10), file("a", 10), file("b", 10))
+
+    val batches = RawImpressionFileBinPacker.pack(files, maxFileBatchSizeBytes = 100)
+
+    assertThat(batches).hasSize(1)
+    assertThat(batches[0]).containsExactly("a", "b", "c").inOrder()
+  }
+
+  @Test
+  fun `packing is independent of input order`() {
+    val files = listOf(file("d", 40), file("c", 30), file("b", 20), file("a", 10))
+
+    val fromOrder = RawImpressionFileBinPacker.pack(files, maxFileBatchSizeBytes = 50)
+    val fromShuffled = RawImpressionFileBinPacker.pack(files.reversed(), maxFileBatchSizeBytes = 50)
+
+    // Internal sort makes the result a pure function of the set + cap, not the input order.
+    assertThat(fromOrder).isEqualTo(fromShuffled)
+    assertThat(fromOrder).hasSize(2)
+    assertThat(fromOrder[0]).containsExactly("d", "a").inOrder()
+    assertThat(fromOrder[1]).containsExactly("c", "b").inOrder()
+  }
+
+  @Test
+  fun `non-positive cap is rejected`() {
+    assertFailsWith<IllegalArgumentException> {
+      RawImpressionFileBinPacker.pack(listOf(file("a", 10)), maxFileBatchSizeBytes = 0)
+    }
+    assertFailsWith<IllegalArgumentException> {
+      RawImpressionFileBinPacker.pack(listOf(file("a", 10)), maxFileBatchSizeBytes = -1)
+    }
+  }
+}

--- a/src/test/kotlin/org/wfanet/measurement/edpaggregator/vidrankbuilder/BUILD.bazel
+++ b/src/test/kotlin/org/wfanet/measurement/edpaggregator/vidrankbuilder/BUILD.bazel
@@ -29,3 +29,51 @@ kt_jvm_test(
         "@wfa_common_jvm//imports/java/org/junit",
     ],
 )
+
+kt_jvm_test(
+    name = "SubpoolRetentionTest",
+    srcs = ["SubpoolRetentionTest.kt"],
+    test_class = "org.wfanet.measurement.edpaggregator.vidrankbuilder.SubpoolRetentionTest",
+    deps = [
+        "//src/main/kotlin/org/wfanet/measurement/edpaggregator/rawimpressions:rank_index_store",
+        "//src/main/kotlin/org/wfanet/measurement/edpaggregator/vidrankbuilder:subpool_retention",
+        "//src/main/proto/wfa/measurement/edpaggregator/v1alpha:rank_index_blob_kt_jvm_proto",
+        "//src/main/proto/wfa/measurement/edpaggregator/v1alpha:rank_index_blob_service_kt_jvm_grpc_proto",
+        "//src/main/proto/wfa/measurement/edpaggregator/v1alpha:rank_index_map_kt_jvm_proto",
+        "@wfa_common_jvm//imports/java/com/google/common/truth",
+        "@wfa_common_jvm//imports/java/com/google/crypto/tink",
+        "@wfa_common_jvm//imports/java/org/junit",
+        "@wfa_common_jvm//imports/kotlin/com/google/type:date_kt_jvm_proto",
+        "@wfa_common_jvm//imports/kotlin/kotlinx/coroutines:core",
+        "@wfa_common_jvm//imports/kotlin/org/mockito/kotlin",
+        "@wfa_common_jvm//src/main/kotlin/org/wfanet/measurement/common/crypto/tink/testing",
+        "@wfa_common_jvm//src/main/kotlin/org/wfanet/measurement/storage/testing",
+    ],
+)
+
+kt_jvm_test(
+    name = "SubpoolRankerTest",
+    srcs = ["SubpoolRankerTest.kt"],
+    test_class = "org.wfanet.measurement.edpaggregator.vidrankbuilder.SubpoolRankerTest",
+    deps = [
+        "//src/main/kotlin/org/wfanet/measurement/edpaggregator/rawimpressions:rank_index_store",
+        "//src/main/kotlin/org/wfanet/measurement/edpaggregator/rawimpressions:subpool_fingerprints_store",
+        "//src/main/kotlin/org/wfanet/measurement/edpaggregator/vidrankbuilder:event_id_digest_bytes",
+        "//src/main/kotlin/org/wfanet/measurement/edpaggregator/vidrankbuilder:last_seen_day_bytes",
+        "//src/main/kotlin/org/wfanet/measurement/edpaggregator/vidrankbuilder:subpool_ranker",
+        "//src/main/kotlin/org/wfanet/measurement/edpaggregator/vidrankbuilder:subpool_retention",
+        "//src/main/proto/wfa/measurement/edpaggregator/v1alpha:encrypted_dek_kt_jvm_proto",
+        "//src/main/proto/wfa/measurement/edpaggregator/v1alpha:rank_index_blob_kt_jvm_proto",
+        "//src/main/proto/wfa/measurement/edpaggregator/v1alpha:rank_index_blob_service_kt_jvm_grpc_proto",
+        "//src/main/proto/wfa/measurement/edpaggregator/v1alpha:rank_index_map_kt_jvm_proto",
+        "@wfa_common_jvm//imports/java/com/google/common/truth",
+        "@wfa_common_jvm//imports/java/com/google/crypto/tink",
+        "@wfa_common_jvm//imports/java/com/google/protobuf",
+        "@wfa_common_jvm//imports/java/org/junit",
+        "@wfa_common_jvm//imports/kotlin/com/google/type:date_kt_jvm_proto",
+        "@wfa_common_jvm//imports/kotlin/kotlinx/coroutines:core",
+        "@wfa_common_jvm//imports/kotlin/org/mockito/kotlin",
+        "@wfa_common_jvm//src/main/kotlin/org/wfanet/measurement/common/crypto/tink/testing",
+        "@wfa_common_jvm//src/main/kotlin/org/wfanet/measurement/storage/testing",
+    ],
+)

--- a/src/test/kotlin/org/wfanet/measurement/edpaggregator/vidrankbuilder/BUILD.bazel
+++ b/src/test/kotlin/org/wfanet/measurement/edpaggregator/vidrankbuilder/BUILD.bazel
@@ -14,7 +14,6 @@ kt_jvm_test(
         "@wfa_common_jvm//imports/java/com/google/common/truth",
         "@wfa_common_jvm//imports/java/com/google/protobuf",
         "@wfa_common_jvm//imports/java/org/junit",
-        "@wfa_common_jvm//imports/kotlin/kotlin/test",
         "@wfa_common_jvm//imports/kotlin/kotlinx/coroutines:core",
     ],
 )

--- a/src/test/kotlin/org/wfanet/measurement/edpaggregator/vidrankbuilder/BUILD.bazel
+++ b/src/test/kotlin/org/wfanet/measurement/edpaggregator/vidrankbuilder/BUILD.bazel
@@ -14,6 +14,7 @@ kt_jvm_test(
         "@wfa_common_jvm//imports/java/com/google/common/truth",
         "@wfa_common_jvm//imports/java/com/google/protobuf",
         "@wfa_common_jvm//imports/java/org/junit",
+        "@wfa_common_jvm//imports/kotlin/kotlin/test",
         "@wfa_common_jvm//imports/kotlin/kotlinx/coroutines:core",
     ],
 )

--- a/src/test/kotlin/org/wfanet/measurement/edpaggregator/vidrankbuilder/RankAllocatorTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/edpaggregator/vidrankbuilder/RankAllocatorTest.kt
@@ -309,6 +309,29 @@ class RankAllocatorTest {
     assertThat(allocator.overflow).isEqualTo(1)
   }
 
+  @Test
+  fun `assignBackfill treats an out-of-range old rank as no old rank`() {
+    val allocator = RankAllocator(poolOffset = 7L, rankedSize = 3, eventDay = EVENT_DAY)
+
+    // oldRank 9 is outside [0, 3) (e.g. ranked_size shrank): ignored, fingerprint allocated fresh.
+    val label = allocator.assignBackfill(1L, 0, oldRank = 9)
+
+    assertThat(label).isEqualTo(0)
+    assertThat(allocator.get(1L, 0)).isEqualTo(0)
+    assertThat(allocator.backfillReusedOldRank).isEqualTo(0)
+  }
+
+  @Test
+  fun `assignBackfill never lowers last_seen with an older backfill date`() {
+    // eventDay 80 is the (older) backfill date; the fingerprint's stored recency is the newer 90.
+    val allocator = RankAllocator(poolOffset = 7L, rankedSize = 100, eventDay = 80)
+    allocator.loadEntry(1L, 0, rank = 2, lastSeenDay = 90)
+
+    allocator.assignBackfill(1L, 0, oldRank = Bytes12IntMap.NOT_PRESENT)
+
+    assertThat(allocator.lastSeenOf(2)).isEqualTo(90) // kept, not lowered to 80
+  }
+
   private data class Entry(val hi: Long, val lo: Int, val rank: Int, val day: Int)
 
   private fun packFingerprint(hi: Long, lo: Int): com.google.protobuf.ByteString {

--- a/src/test/kotlin/org/wfanet/measurement/edpaggregator/vidrankbuilder/RankAllocatorTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/edpaggregator/vidrankbuilder/RankAllocatorTest.kt
@@ -17,7 +17,6 @@
 package org.wfanet.measurement.edpaggregator.vidrankbuilder
 
 import com.google.common.truth.Truth.assertThat
-import kotlin.test.assertFailsWith
 import kotlinx.coroutines.flow.asFlow
 import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.runBlocking
@@ -208,46 +207,106 @@ class RankAllocatorTest {
   }
 
   @Test
-  fun `assignAt pins a fingerprint to the given rank without counting an allocation`() =
-    runBlocking {
-      val allocator = RankAllocator(poolOffset = 7L, rankedSize = 100, eventDay = EVENT_DAY)
+  fun `assignBackfill allocates a new rank for a fingerprint in neither snapshot`() {
+    val allocator = RankAllocator(poolOffset = 7L, rankedSize = 100, eventDay = EVENT_DAY)
 
-      val rank = allocator.assignAt(1L, 0, rank = 5)
+    val label = allocator.assignBackfill(1L, 0, oldRank = Bytes12IntMap.NOT_PRESENT)
 
-      assertThat(rank).isEqualTo(5)
-      assertThat(allocator.get(1L, 0)).isEqualTo(5)
-      assertThat(allocator.lastSeenOf(5)).isEqualTo(EVENT_DAY)
-      assertThat(allocator.allocated).isEqualTo(0)
-      assertThat(allocator.renewed).isEqualTo(0)
-      // The pinned rank is marked taken, so a fresh assign skips it.
-      assertThat(allocator.assign(2L, 0)).isEqualTo(0)
-      assertThat(allocator.assign(3L, 0)).isEqualTo(1)
-      // It is recorded in the day-only delta for Phase-2 labeling.
-      assertThat(allocator.streamDayOnlyChunks().toList().flatMap { it.ranksList }).contains(5)
-    }
+    assertThat(label).isEqualTo(0)
+    assertThat(allocator.get(1L, 0)).isEqualTo(0)
+    assertThat(allocator.allocated).isEqualTo(1)
+    assertThat(allocator.backfillReusedOldRank).isEqualTo(0)
+  }
 
   @Test
-  fun `assignAt reuses a rank already held by another fingerprint`() =
+  fun `assignBackfill takes a free old rank back into both the cumulative and day-only`() =
     runBlocking<Unit> {
       val allocator = RankAllocator(poolOffset = 7L, rankedSize = 100, eventDay = EVENT_DAY)
-      allocator.loadEntry(2L, 0, rank = 5, lastSeenDay = 3) // a different fingerprint holds rank 5
+      allocator.loadEntry(2L, 0, rank = 0, lastSeenDay = 90) // someone else at rank 0; rank 5 free
 
-      val rank = allocator.assignAt(1L, 0, rank = 5)
+      val label = allocator.assignBackfill(1L, 0, oldRank = 5)
 
-      assertThat(rank).isEqualTo(5)
-      assertThat(allocator.get(1L, 0)).isEqualTo(5)
-      assertThat(allocator.allocated).isEqualTo(0)
-      assertThat(allocator.renewed).isEqualTo(0)
-      // The backfilled fingerprint is recorded at the shared rank in the day-only delta.
+      assertThat(label).isEqualTo(5)
+      assertThat(allocator.get(1L, 0)).isEqualTo(5) // cumulative took the old rank back
+      assertThat(allocator.allocated).isEqualTo(1)
+      assertThat(allocator.backfillReusedOldRank).isEqualTo(1)
+      assertThat(allocator.backfillRankCollisions).isEqualTo(0)
       assertThat(allocator.streamDayOnlyChunks().toList().flatMap { it.ranksList })
         .containsExactly(5)
     }
 
   @Test
-  fun `assignAt rejects a rank outside the ranked range`() {
-    val allocator = RankAllocator(poolOffset = 7L, rankedSize = 3, eventDay = EVENT_DAY)
+  fun `assignBackfill labels with the old rank but takes a fresh cumulative rank when it is taken`() {
+    val allocator = RankAllocator(poolOffset = 7L, rankedSize = 100, eventDay = EVENT_DAY)
+    allocator.loadEntry(2L, 0, rank = 5, lastSeenDay = 90) // a different fp already holds rank 5
 
-    assertFailsWith<IllegalArgumentException> { allocator.assignAt(1L, 0, rank = 9) }
+    val label = allocator.assignBackfill(1L, 0, oldRank = 5)
+
+    assertThat(label).isEqualTo(5) // day-only still labels with the original rank
+    assertThat(allocator.get(1L, 0)).isEqualTo(0) // cumulative gets a fresh free rank instead
+    assertThat(allocator.allocated).isEqualTo(1)
+    assertThat(allocator.backfillReusedOldRank).isEqualTo(1)
+    assertThat(allocator.backfillRankCollisions).isEqualTo(0) // not in the latest snapshot
+  }
+
+  @Test
+  fun `assignBackfill keeps the latest rank when the fingerprint has no old rank`() {
+    val allocator = RankAllocator(poolOffset = 7L, rankedSize = 100, eventDay = EVENT_DAY)
+    allocator.loadEntry(1L, 0, rank = 2, lastSeenDay = 90)
+
+    val label = allocator.assignBackfill(1L, 0, oldRank = Bytes12IntMap.NOT_PRESENT)
+
+    assertThat(label).isEqualTo(2)
+    assertThat(allocator.get(1L, 0)).isEqualTo(2)
+    assertThat(allocator.renewed).isEqualTo(1)
+    assertThat(allocator.backfillReusedOldRank).isEqualTo(0)
+    // last_seen is refreshed upward to the dispatch's eventDay (never lowered).
+    assertThat(allocator.lastSeenOf(2)).isEqualTo(EVENT_DAY)
+  }
+
+  @Test
+  fun `assignBackfill keeps the latest rank and labels with the matching old rank`() =
+    runBlocking<Unit> {
+      val allocator = RankAllocator(poolOffset = 7L, rankedSize = 100, eventDay = EVENT_DAY)
+      allocator.loadEntry(1L, 0, rank = 5, lastSeenDay = 90) // latest rank == old rank
+
+      val label = allocator.assignBackfill(1L, 0, oldRank = 5)
+
+      assertThat(label).isEqualTo(5)
+      assertThat(allocator.get(1L, 0)).isEqualTo(5)
+      assertThat(allocator.renewed).isEqualTo(1)
+      assertThat(allocator.backfillReusedOldRank).isEqualTo(1)
+      assertThat(allocator.backfillRankCollisions).isEqualTo(0) // old == latest, no divergence
+      assertThat(allocator.streamDayOnlyChunks().toList().flatMap { it.ranksList })
+        .containsExactly(5)
+    }
+
+  @Test
+  fun `assignBackfill counts a collision when the old rank differs from the latest rank`() =
+    runBlocking<Unit> {
+      val allocator = RankAllocator(poolOffset = 7L, rankedSize = 100, eventDay = EVENT_DAY)
+      allocator.loadEntry(1L, 0, rank = 8, lastSeenDay = 90) // latest rank 8, old rank 5
+
+      val label = allocator.assignBackfill(1L, 0, oldRank = 5)
+
+      assertThat(label).isEqualTo(5) // day-only labels with the old rank
+      assertThat(allocator.get(1L, 0)).isEqualTo(8) // cumulative keeps the latest rank
+      assertThat(allocator.renewed).isEqualTo(1)
+      assertThat(allocator.backfillReusedOldRank).isEqualTo(1)
+      assertThat(allocator.backfillRankCollisions).isEqualTo(1)
+      assertThat(allocator.streamDayOnlyChunks().toList().flatMap { it.ranksList })
+        .containsExactly(5)
+    }
+
+  @Test
+  fun `assignBackfill overflows when the subpool is full and the fingerprint is new`() {
+    val allocator = RankAllocator(poolOffset = 7L, rankedSize = 1, eventDay = EVENT_DAY)
+    allocator.loadEntry(2L, 0, rank = 0, lastSeenDay = 90) // subpool full
+
+    val label = allocator.assignBackfill(1L, 0, oldRank = Bytes12IntMap.NOT_PRESENT)
+
+    assertThat(label).isNull()
+    assertThat(allocator.overflow).isEqualTo(1)
   }
 
   private data class Entry(val hi: Long, val lo: Int, val rank: Int, val day: Int)

--- a/src/test/kotlin/org/wfanet/measurement/edpaggregator/vidrankbuilder/RankAllocatorTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/edpaggregator/vidrankbuilder/RankAllocatorTest.kt
@@ -17,6 +17,7 @@
 package org.wfanet.measurement.edpaggregator.vidrankbuilder
 
 import com.google.common.truth.Truth.assertThat
+import kotlin.test.assertFailsWith
 import kotlinx.coroutines.flow.asFlow
 import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.runBlocking
@@ -204,6 +205,49 @@ class RankAllocatorTest {
     val allocator = RankAllocator(poolOffset = 7L, rankedSize = 0, eventDay = EVENT_DAY)
     assertThat(allocator.assign(1L, 0)).isNull()
     assertThat(allocator.overflow).isEqualTo(1)
+  }
+
+  @Test
+  fun `assignAt pins a fingerprint to the given rank without counting an allocation`() =
+    runBlocking {
+      val allocator = RankAllocator(poolOffset = 7L, rankedSize = 100, eventDay = EVENT_DAY)
+
+      val rank = allocator.assignAt(1L, 0, rank = 5)
+
+      assertThat(rank).isEqualTo(5)
+      assertThat(allocator.get(1L, 0)).isEqualTo(5)
+      assertThat(allocator.lastSeenOf(5)).isEqualTo(EVENT_DAY)
+      assertThat(allocator.allocated).isEqualTo(0)
+      assertThat(allocator.renewed).isEqualTo(0)
+      // The pinned rank is marked taken, so a fresh assign skips it.
+      assertThat(allocator.assign(2L, 0)).isEqualTo(0)
+      assertThat(allocator.assign(3L, 0)).isEqualTo(1)
+      // It is recorded in the day-only delta for Phase-2 labeling.
+      assertThat(allocator.streamDayOnlyChunks().toList().flatMap { it.ranksList }).contains(5)
+    }
+
+  @Test
+  fun `assignAt reuses a rank already held by another fingerprint`() =
+    runBlocking<Unit> {
+      val allocator = RankAllocator(poolOffset = 7L, rankedSize = 100, eventDay = EVENT_DAY)
+      allocator.loadEntry(2L, 0, rank = 5, lastSeenDay = 3) // a different fingerprint holds rank 5
+
+      val rank = allocator.assignAt(1L, 0, rank = 5)
+
+      assertThat(rank).isEqualTo(5)
+      assertThat(allocator.get(1L, 0)).isEqualTo(5)
+      assertThat(allocator.allocated).isEqualTo(0)
+      assertThat(allocator.renewed).isEqualTo(0)
+      // The backfilled fingerprint is recorded at the shared rank in the day-only delta.
+      assertThat(allocator.streamDayOnlyChunks().toList().flatMap { it.ranksList })
+        .containsExactly(5)
+    }
+
+  @Test
+  fun `assignAt rejects a rank outside the ranked range`() {
+    val allocator = RankAllocator(poolOffset = 7L, rankedSize = 3, eventDay = EVENT_DAY)
+
+    assertFailsWith<IllegalArgumentException> { allocator.assignAt(1L, 0, rank = 9) }
   }
 
   private data class Entry(val hi: Long, val lo: Int, val rank: Int, val day: Int)

--- a/src/test/kotlin/org/wfanet/measurement/edpaggregator/vidrankbuilder/SubpoolRankerTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/edpaggregator/vidrankbuilder/SubpoolRankerTest.kt
@@ -1,0 +1,329 @@
+/*
+ * Copyright 2026 The Cross-Media Measurement Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wfanet.measurement.edpaggregator.vidrankbuilder
+
+import com.google.common.truth.Truth.assertThat
+import com.google.crypto.tink.Aead
+import com.google.crypto.tink.KeyTemplates
+import com.google.crypto.tink.KeysetHandle
+import com.google.crypto.tink.aead.AeadConfig
+import com.google.protobuf.ByteString
+import com.google.protobuf.timestamp
+import com.google.type.Date
+import com.google.type.date
+import java.time.LocalDate
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.runBlocking
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doAnswer
+import org.mockito.kotlin.mock
+import org.wfanet.measurement.common.crypto.tink.testing.FakeKmsClient
+import org.wfanet.measurement.edpaggregator.rawimpressions.RankIndexStore
+import org.wfanet.measurement.edpaggregator.rawimpressions.SubpoolFingerprintsStore
+import org.wfanet.measurement.edpaggregator.v1alpha.BatchCreateRankIndexBlobsRequest
+import org.wfanet.measurement.edpaggregator.v1alpha.DeleteRankIndexBlobRequest
+import org.wfanet.measurement.edpaggregator.v1alpha.EncryptedDek
+import org.wfanet.measurement.edpaggregator.v1alpha.ListRankIndexBlobsRequest
+import org.wfanet.measurement.edpaggregator.v1alpha.RankIndexBlob
+import org.wfanet.measurement.edpaggregator.v1alpha.RankIndexBlobServiceGrpcKt.RankIndexBlobServiceCoroutineStub
+import org.wfanet.measurement.edpaggregator.v1alpha.RankIndexMap
+import org.wfanet.measurement.edpaggregator.v1alpha.batchCreateRankIndexBlobsResponse
+import org.wfanet.measurement.edpaggregator.v1alpha.copy
+import org.wfanet.measurement.edpaggregator.v1alpha.listRankIndexBlobsResponse
+import org.wfanet.measurement.edpaggregator.v1alpha.rankIndexBlob
+import org.wfanet.measurement.edpaggregator.v1alpha.rankIndexMap
+import org.wfanet.measurement.storage.testing.InMemoryStorageClient
+
+private const val DP = "dataProviders/dp"
+private const val UPLOAD = "dataProviders/dp/rawImpressionUploads/up1"
+private const val PRIOR_UPLOAD = "dataProviders/dp/rawImpressionUploads/up0"
+private const val MODEL_LINE = "modelProviders/mp/modelSuites/ms/modelLines/ml1"
+private const val PREFIX = "ranks"
+private const val POOL = 7L
+private const val RETENTION_DAYS = 30
+private val TODAY = LocalDate.ofEpochDay(100)
+private const val TODAY_EPOCH_DAY = 100 // == eventDay stamped on touched fingerprints
+
+@RunWith(JUnit4::class)
+class SubpoolRankerTest {
+  private val kekUri = FakeKmsClient.KEY_URI_PREFIX + "key1"
+  private lateinit var kmsClient: FakeKmsClient
+  private lateinit var storageClient: InMemoryStorageClient
+  private lateinit var subpoolStore: SubpoolFingerprintsStore
+  private lateinit var rankStore: RankIndexStore
+  private lateinit var subpoolDek: EncryptedDek
+  private lateinit var fake: FakeRankIndexBlobs
+
+  @Before
+  fun setUp() {
+    AeadConfig.register()
+    kmsClient =
+      FakeKmsClient().apply {
+        setAead(
+          kekUri,
+          KeysetHandle.generateNew(KeyTemplates.get("AES128_GCM")).getPrimitive(Aead::class.java),
+        )
+      }
+    storageClient = InMemoryStorageClient()
+    subpoolStore = SubpoolFingerprintsStore(storageClient, kmsClient)
+    rankStore = RankIndexStore(storageClient, kmsClient)
+    subpoolDek = subpoolStore.generateDek(kekUri)
+    fake = FakeRankIndexBlobs()
+  }
+
+  private fun ranker(): SubpoolRanker {
+    val retention = SubpoolRetention(fake.stub, rankStore, DP, MODEL_LINE, RETENTION_DAYS, TODAY)
+    return SubpoolRanker(
+      subpoolFingerprintsStore = subpoolStore,
+      rankIndexStore = rankStore,
+      rankIndexBlobsStub = fake.stub,
+      retention = retention,
+      dataProvider = DP,
+      rawImpressionUpload = UPLOAD,
+      modelLine = MODEL_LINE,
+      vidRankMapBlobPrefix = PREFIX,
+      kekUri = kekUri,
+      encryptedSubpoolMapsDek = subpoolDek,
+      maxEventDate = epochDayToDate(TODAY_EPOCH_DAY),
+      retentionDays = RETENTION_DAYS,
+      today = TODAY,
+    )
+  }
+
+  /** Writes the Phase-0 merged blob for the subpool and returns its key. */
+  private suspend fun writePhase0(fps: List<Pair<Long, Int>>): String {
+    val key = "phase0/merged/$POOL"
+    subpoolStore.writeBlob(key, subpoolDek, POOL, flowOf(pack(fps)))
+    return key
+  }
+
+  /** Seeds a prior SNAPSHOT blob under [PRIOR_UPLOAD] plus its `RankIndexBlob` row. */
+  private suspend fun seedPriorSnapshot(entries: List<Triple<Pair<Long, Int>, Int, Int>>) {
+    val dek = rankStore.generateDek(kekUri)
+    val key = "ranks/prior/snapshot/$POOL"
+    val lastSeenBytes = ByteArray(entries.size * LastSeenDayBytes.WIDTH)
+    entries.forEachIndexed { i, e ->
+      LastSeenDayBytes.write(lastSeenBytes, i * LastSeenDayBytes.WIDTH, e.third)
+    }
+    val record = rankIndexMap {
+      poolOffset = POOL
+      rankedSize = 100
+      fingerprints = pack(entries.map { it.first })
+      entries.forEach { ranks += it.second }
+      lastSeenDays = ByteString.copyFrom(lastSeenBytes)
+    }
+    val checksum = rankStore.writeBlob(key, dek, flowOf(record))
+    fake.seed(
+      rankIndexBlob {
+        name = "$PRIOR_UPLOAD/rankIndexBlobs/snap-prior"
+        blobType = RankIndexBlob.BlobType.SNAPSHOT
+        cmmsModelLine = MODEL_LINE
+        poolOffset = POOL
+        blobUri = key
+        blobChecksum = checksum
+        encryptedDek = dek
+        createTime = timestamp { seconds = 1 }
+      }
+    )
+  }
+
+  /** Reads back the SNAPSHOT row's blob as `(hi, lo) -> (rank, lastSeen)`. */
+  private suspend fun readSnapshot(): Map<Pair<Long, Int>, Pair<Int, Int>> {
+    val row =
+      fake.rows.single {
+        it.blobType == RankIndexBlob.BlobType.SNAPSHOT && it.name.startsWith("$UPLOAD/")
+      }
+    return decode(rankStore.readBlob(row.blobUri, row.encryptedDek).toList())
+  }
+
+  @Test
+  fun `cold subpool allocates sequential ranks and stamps last_seen`() = runBlocking {
+    val key = writePhase0(listOf(1L to 0, 2L to 0, 3L to 0))
+
+    val result = ranker().rank(POOL, key, rankedSize = 100)
+
+    assertThat(result.skipped).isFalse()
+    assertThat(result.allocated).isEqualTo(3)
+    val snapshot = readSnapshot()
+    assertThat(snapshot.mapValues { it.value.first })
+      .containsExactly(1L to 0, 0, 2L to 0, 1, 3L to 0, 2)
+    assertThat(snapshot.values.map { it.second }.toSet()).containsExactly(TODAY_EPOCH_DAY)
+    // A DAY_ONLY row is recorded with the dispatch's max event date.
+    assertThat(
+        fake.rows.any { it.blobType == RankIndexBlob.BlobType.DAY_ONLY && it.hasMaxEventDate() }
+      )
+      .isTrue()
+  }
+
+  @Test
+  fun `idempotency gate skips a subpool already ranked for this upload`() = runBlocking {
+    // A SNAPSHOT row already exists under THIS upload (a prior attempt committed).
+    fake.seed(
+      rankIndexBlob {
+        name = "$UPLOAD/rankIndexBlobs/snap-existing"
+        blobType = RankIndexBlob.BlobType.SNAPSHOT
+        cmmsModelLine = MODEL_LINE
+        poolOffset = POOL
+      }
+    )
+    val key = writePhase0(listOf(1L to 0))
+    val before = fake.rows.size
+
+    val result = ranker().rank(POOL, key, rankedSize = 100)
+
+    assertThat(result.skipped).isTrue()
+    assertThat(fake.rows.size).isEqualTo(before) // no new rows created
+  }
+
+  @Test
+  fun `warm subpool renews existing fingerprints and allocates new ones`() = runBlocking {
+    seedPriorSnapshot(
+      listOf(Triple(10L to 0, 0, 90), Triple(20L to 0, 1, 90)) // both recent (>= cutoff 70)
+    )
+    val key = writePhase0(listOf(20L to 0, 30L to 0)) // 20 renewed, 30 new
+
+    ranker().rank(POOL, key, rankedSize = 100)
+
+    val snapshot = readSnapshot()
+    assertThat(snapshot.keys).containsExactly(10L to 0, 20L to 0, 30L to 0)
+    assertThat(snapshot[10L to 0]).isEqualTo(0 to 90) // untouched: rank + old last_seen preserved
+    assertThat(snapshot[20L to 0]).isEqualTo(1 to TODAY_EPOCH_DAY) // renewed: last_seen refreshed
+    assertThat(snapshot[30L to 0]!!.first).isEqualTo(2) // new rank
+  }
+
+  @Test
+  fun `retention frees an aged rank and a new fingerprint reuses the freed slot`() = runBlocking {
+    seedPriorSnapshot(
+      listOf(
+        Triple(10L to 0, 0, 50), // aged (last_seen 50 < cutoff 70), not seen today -> freed
+        Triple(20L to 0, 1, 90), // recent -> kept
+      )
+    )
+    val key = writePhase0(listOf(30L to 0)) // only a new fingerprint
+
+    val result = ranker().rank(POOL, key, rankedSize = 100)
+
+    assertThat(result.freed).isEqualTo(1)
+    val snapshot = readSnapshot()
+    assertThat(snapshot.keys).containsExactly(20L to 0, 30L to 0)
+    assertThat(snapshot[20L to 0]!!.first).isEqualTo(1)
+    assertThat(snapshot[30L to 0]!!.first).isEqualTo(0) // reused the freed rank 0
+  }
+
+  @Test
+  fun `overflow leaves fingerprints unranked once the subpool is full`() = runBlocking {
+    val key = writePhase0(listOf(1L to 0, 2L to 0, 3L to 0))
+
+    val result = ranker().rank(POOL, key, rankedSize = 2)
+
+    assertThat(result.allocated).isEqualTo(2)
+    assertThat(result.overflow).isEqualTo(1)
+    assertThat(readSnapshot()).hasSize(2)
+  }
+
+  companion object {
+    private fun pack(fps: List<Pair<Long, Int>>): ByteString {
+      val bytes = ByteArray(fps.size * 12)
+      fps.forEachIndexed { i, (hi, lo) ->
+        EventIdDigestBytes.writeHi(bytes, i * 12, hi)
+        EventIdDigestBytes.writeLo(bytes, i * 12 + 8, lo)
+      }
+      return ByteString.copyFrom(bytes)
+    }
+
+    private fun decode(records: List<RankIndexMap>): Map<Pair<Long, Int>, Pair<Int, Int>> {
+      val out = mutableMapOf<Pair<Long, Int>, Pair<Int, Int>>()
+      for (record in records) {
+        val fps = record.fingerprints
+        for (i in 0 until record.ranksCount) {
+          val hi = EventIdDigestBytes.readHi(fps, i * 12)
+          val lo = EventIdDigestBytes.readLo(fps, i * 12 + 8)
+          out[hi to lo] =
+            record.getRanks(i) to
+              LastSeenDayBytes.read(record.lastSeenDays, i * LastSeenDayBytes.WIDTH)
+        }
+      }
+      return out
+    }
+
+    private fun epochDayToDate(epochDay: Int): Date {
+      val d = LocalDate.ofEpochDay(epochDay.toLong())
+      return date {
+        year = d.year
+        month = d.monthValue
+        day = d.dayOfMonth
+      }
+    }
+
+    private fun epochDayOf(d: Date): Long = LocalDate.of(d.year, d.month, d.day).toEpochDay()
+
+    private fun matchesParent(name: String, parent: String): Boolean =
+      if (parent.endsWith("/-")) true else name.startsWith("$parent/")
+  }
+
+  /** In-memory fake of the `RankIndexBlobService` honoring parent wildcard + filters. */
+  private class FakeRankIndexBlobs {
+    val rows = mutableListOf<RankIndexBlob>()
+    private var clock = 10L
+
+    fun seed(row: RankIndexBlob) {
+      rows.add(row)
+    }
+
+    val stub: RankIndexBlobServiceCoroutineStub = mock {
+      onBlocking { listRankIndexBlobs(any(), any()) } doAnswer
+        { invocation ->
+          val request = invocation.getArgument<ListRankIndexBlobsRequest>(0)
+          val filter = request.filter
+          val matched =
+            rows.filter { row ->
+              matchesParent(row.name, request.parent) &&
+                row.blobType == filter.blobType &&
+                (filter.cmmsModelLine.isEmpty() || row.cmmsModelLine == filter.cmmsModelLine) &&
+                (!filter.hasPoolOffset() || row.poolOffset == filter.poolOffset) &&
+                (!filter.hasMaxEventDateOnOrBefore() ||
+                  epochDayOf(row.maxEventDate) <= epochDayOf(filter.maxEventDateOnOrBefore))
+            }
+          listRankIndexBlobsResponse { rankIndexBlobs += matched }
+        }
+      onBlocking { batchCreateRankIndexBlobs(any(), any()) } doAnswer
+        { invocation ->
+          val request = invocation.getArgument<BatchCreateRankIndexBlobsRequest>(0)
+          val created =
+            request.requestsList.map { createRequest ->
+              createRequest.rankIndexBlob.copy {
+                name = "${request.parent}/rankIndexBlobs/${blobType.name}-$poolOffset-${clock++}"
+                createTime = timestamp { seconds = clock }
+              }
+            }
+          rows.addAll(created)
+          batchCreateRankIndexBlobsResponse { rankIndexBlobs += created }
+        }
+      onBlocking { deleteRankIndexBlob(any(), any()) } doAnswer
+        { invocation ->
+          val request = invocation.getArgument<DeleteRankIndexBlobRequest>(0)
+          rows.removeAll { it.name == request.name }
+          rankIndexBlob {}
+        }
+    }
+  }
+}

--- a/src/test/kotlin/org/wfanet/measurement/edpaggregator/vidrankbuilder/SubpoolRankerTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/edpaggregator/vidrankbuilder/SubpoolRankerTest.kt
@@ -498,21 +498,156 @@ class SubpoolRankerTest {
     }
 
   @Test
-  fun `a backfill with no older snapshot runs the default path`() =
+  fun `backfill keeps the shared rank when the old and latest snapshots agree`() =
     runBlocking<Unit> {
-      // Only the latest snapshot exists; nothing is strictly older than the backfilled day.
+      // The common case: a stable fingerprint holds the same rank in both snapshots.
       seedPriorSnapshot(
-        listOf(Triple(7L to 0, 0, 90)),
+        listOf(Triple(1L to 0, 5, 75)),
+        uploadName = "dataProviders/dp/rawImpressionUploads/upOld",
+        createTimeSeconds = 1L,
+        maxEventDate = epochDayToDate(75),
+      )
+      seedPriorSnapshot(
+        listOf(Triple(1L to 0, 5, 90)),
         uploadName = "dataProviders/dp/rawImpressionUploads/upLatest",
         createTimeSeconds = 5L,
         maxEventDate = epochDayToDate(100),
       )
-      val key = writePhase0(listOf(5L to 0))
+      val key = writePhase0(listOf(1L to 0))
 
       val result = ranker(maxEventDate = epochDayToDate(80)).rank(POOL, key, rankedSize = 100)
 
+      assertThat(result.backfill).isTrue()
+      assertThat(result.backfillReusedOldRank).isEqualTo(1)
+      assertThat(result.backfillRankCollisions).isEqualTo(0) // old == latest, no divergence
+      assertThat(readDayOnly().mapValues { it.value.first }).containsExactly(1L to 0, 5)
+      assertThat(readSnapshot().mapValues { it.value.first }).containsExactly(1L to 0, 5)
+    }
+
+  @Test
+  fun `backfill labels with the old rank but gives a fresh snapshot rank when the old slot is taken`() =
+    runBlocking<Unit> {
+      // F1 held rank 5 in the old snapshot, then aged out; rank 5 is now Bob's in the latest.
+      seedPriorSnapshot(
+        listOf(Triple(1L to 0, 5, 75)),
+        uploadName = "dataProviders/dp/rawImpressionUploads/upOld",
+        createTimeSeconds = 1L,
+        maxEventDate = epochDayToDate(75),
+      )
+      seedPriorSnapshot(
+        listOf(Triple(2L to 0, 5, 90)), // Bob (2L) holds rank 5 now
+        uploadName = "dataProviders/dp/rawImpressionUploads/upLatest",
+        createTimeSeconds = 5L,
+        maxEventDate = epochDayToDate(100),
+      )
+      val key = writePhase0(listOf(1L to 0)) // backfill F1
+
+      val result = ranker(maxEventDate = epochDayToDate(80)).rank(POOL, key, rankedSize = 100)
+
+      assertThat(result.backfill).isTrue()
+      assertThat(result.backfillReusedOldRank).isEqualTo(1)
+      assertThat(result.backfillRankCollisions).isEqualTo(0) // F1 is not in the latest snapshot
+      // The backfilled day is labeled with the original rank 5 (shared with Bob — accepted
+      // undercount)...
+      assertThat(readDayOnly().mapValues { it.value.first }).containsExactly(1L to 0, 5)
+      // ...but the cumulative gives F1 a fresh rank so it never shares Bob's rank going forward.
+      assertThat(readSnapshot().mapValues { it.value.first })
+        .containsExactly(2L to 0, 5, 1L to 0, 0)
+    }
+
+  @Test
+  fun `backfill is active at exactly the retention-window boundary`() =
+    runBlocking<Unit> {
+      seedPriorSnapshot(
+        listOf(Triple(1L to 0, 5, 65)),
+        uploadName = "dataProviders/dp/rawImpressionUploads/upOld",
+        createTimeSeconds = 1L,
+        maxEventDate = epochDayToDate(65),
+      )
+      seedPriorSnapshot(
+        listOf(Triple(2L to 0, 0, 90)),
+        uploadName = "dataProviders/dp/rawImpressionUploads/upLatest",
+        createTimeSeconds = 5L,
+        maxEventDate = epochDayToDate(100),
+      )
+      val key = writePhase0(listOf(1L to 0))
+
+      // 100 - 70 == RETENTION_DAYS (30): on the boundary, still a backfill.
+      val result = ranker(maxEventDate = epochDayToDate(70)).rank(POOL, key, rankedSize = 100)
+
+      assertThat(result.backfill).isTrue()
+      assertThat(result.backfillReusedOldRank).isEqualTo(1)
+    }
+
+  @Test
+  fun `an upload one day past the retention window is not a backfill`() =
+    runBlocking<Unit> {
+      seedPriorSnapshot(
+        listOf(Triple(1L to 0, 5, 60)),
+        uploadName = "dataProviders/dp/rawImpressionUploads/upOld",
+        createTimeSeconds = 1L,
+        maxEventDate = epochDayToDate(60),
+      )
+      seedPriorSnapshot(
+        listOf(Triple(2L to 0, 0, 90)),
+        uploadName = "dataProviders/dp/rawImpressionUploads/upLatest",
+        createTimeSeconds = 5L,
+        maxEventDate = epochDayToDate(100),
+      )
+      val key = writePhase0(listOf(1L to 0))
+
+      // 100 - 69 == RETENTION_DAYS + 1 (31): just outside the window, so the normal path runs.
+      val result = ranker(maxEventDate = epochDayToDate(69)).rank(POOL, key, rankedSize = 100)
+
       assertThat(result.backfill).isFalse()
-      assertThat(hasUploadRow(RankIndexBlob.BlobType.SNAPSHOT)).isTrue()
+    }
+
+  @Test
+  fun `backfill replays the closest older snapshot when several exist`() =
+    runBlocking<Unit> {
+      // Two snapshots are older than the backfilled day; the closer (Day 60) must win over Day 40.
+      seedPriorSnapshot(
+        listOf(Triple(1L to 0, 3, 38)),
+        uploadName = "dataProviders/dp/rawImpressionUploads/upFar",
+        createTimeSeconds = 1L,
+        maxEventDate = epochDayToDate(40),
+      )
+      seedPriorSnapshot(
+        listOf(Triple(1L to 0, 7, 58)),
+        uploadName = "dataProviders/dp/rawImpressionUploads/upMid",
+        createTimeSeconds = 3L,
+        maxEventDate = epochDayToDate(60),
+      )
+      seedPriorSnapshot(
+        listOf(Triple(2L to 0, 0, 90)),
+        uploadName = "dataProviders/dp/rawImpressionUploads/upLatest",
+        createTimeSeconds = 5L,
+        maxEventDate = epochDayToDate(100),
+      )
+      val key = writePhase0(listOf(1L to 0))
+
+      val result = ranker(maxEventDate = epochDayToDate(70)).rank(POOL, key, rankedSize = 100)
+
+      assertThat(result.backfill).isTrue()
+      // F1's rank comes from the Day-60 snapshot (7), not the Day-40 one (3).
+      assertThat(readDayOnly().mapValues { it.value.first }).containsExactly(1L to 0, 7)
+    }
+
+  @Test
+  fun `an upload on the latest event date is not a backfill`() =
+    runBlocking<Unit> {
+      seedPriorSnapshot(
+        listOf(Triple(2L to 0, 0, 90)),
+        uploadName = "dataProviders/dp/rawImpressionUploads/upLatest",
+        createTimeSeconds = 5L,
+        maxEventDate = epochDayToDate(100),
+      )
+      val key = writePhase0(listOf(1L to 0))
+
+      // Same event date as the latest snapshot: forward append, not a backfill.
+      val result = ranker(maxEventDate = epochDayToDate(100)).rank(POOL, key, rankedSize = 100)
+
+      assertThat(result.backfill).isFalse()
     }
 
   companion object {

--- a/src/test/kotlin/org/wfanet/measurement/edpaggregator/vidrankbuilder/SubpoolRankerTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/edpaggregator/vidrankbuilder/SubpoolRankerTest.kt
@@ -26,6 +26,7 @@ import com.google.protobuf.timestamp
 import com.google.type.Date
 import com.google.type.date
 import java.time.LocalDate
+import kotlin.test.assertFailsWith
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.runBlocking
@@ -90,7 +91,7 @@ class SubpoolRankerTest {
     fake = FakeRankIndexBlobs()
   }
 
-  private fun ranker(): SubpoolRanker {
+  private fun ranker(maxEventDate: Date = epochDayToDate(TODAY_EPOCH_DAY)): SubpoolRanker {
     val retention = SubpoolRetention(fake.stub, rankStore, DP, MODEL_LINE, RETENTION_DAYS, TODAY)
     return SubpoolRanker(
       subpoolFingerprintsStore = subpoolStore,
@@ -103,7 +104,7 @@ class SubpoolRankerTest {
       vidRankMapBlobPrefix = PREFIX,
       kekUri = kekUri,
       encryptedSubpoolMapsDek = subpoolDek,
-      maxEventDate = epochDayToDate(TODAY_EPOCH_DAY),
+      maxEventDate = maxEventDate,
       retentionDays = RETENTION_DAYS,
       today = TODAY,
     )
@@ -116,10 +117,15 @@ class SubpoolRankerTest {
     return key
   }
 
-  /** Seeds a prior SNAPSHOT blob under [PRIOR_UPLOAD] plus its `RankIndexBlob` row. */
-  private suspend fun seedPriorSnapshot(entries: List<Triple<Pair<Long, Int>, Int, Int>>) {
+  /** Seeds a prior SNAPSHOT blob under [uploadName] plus its `RankIndexBlob` row. */
+  private suspend fun seedPriorSnapshot(
+    entries: List<Triple<Pair<Long, Int>, Int, Int>>,
+    uploadName: String = PRIOR_UPLOAD,
+    createTimeSeconds: Long = 1L,
+    blobKey: String = "ranks/prior/snapshot/$POOL/$createTimeSeconds",
+    rowName: String = "$uploadName/rankIndexBlobs/snap-$createTimeSeconds",
+  ) {
     val dek = rankStore.generateDek(kekUri)
-    val key = "ranks/prior/snapshot/$POOL"
     val lastSeenBytes = ByteArray(entries.size * LastSeenDayBytes.WIDTH)
     entries.forEachIndexed { i, e ->
       LastSeenDayBytes.write(lastSeenBytes, i * LastSeenDayBytes.WIDTH, e.third)
@@ -131,17 +137,17 @@ class SubpoolRankerTest {
       entries.forEach { ranks += it.second }
       lastSeenDays = ByteString.copyFrom(lastSeenBytes)
     }
-    val checksum = rankStore.writeBlob(key, dek, flowOf(record))
+    val checksum = rankStore.writeBlob(blobKey, dek, flowOf(record))
     fake.seed(
       rankIndexBlob {
-        name = "$PRIOR_UPLOAD/rankIndexBlobs/snap-prior"
+        name = rowName
         blobType = RankIndexBlob.BlobType.SNAPSHOT
         cmmsModelLine = MODEL_LINE
         poolOffset = POOL
-        blobUri = key
+        blobUri = blobKey
         blobChecksum = checksum
         encryptedDek = dek
-        createTime = timestamp { seconds = 1 }
+        createTime = timestamp { seconds = createTimeSeconds }
       }
     )
   }
@@ -238,6 +244,69 @@ class SubpoolRankerTest {
     assertThat(result.allocated).isEqualTo(2)
     assertThat(result.overflow).isEqualTo(1)
     assertThat(readSnapshot()).hasSize(2)
+  }
+
+  @Test
+  fun `prior snapshot with a mismatched checksum fails the rank`() =
+    runBlocking<Unit> {
+      seedPriorSnapshot(listOf(Triple(10L to 0, 0, 90)))
+      // Corrupt the seeded snapshot's recorded checksum so it no longer matches the bytes; the
+      // integrity guard in RankIndexStore.readBlob must fire when the allocator loads it.
+      val idx = fake.rows.indexOfFirst { it.blobType == RankIndexBlob.BlobType.SNAPSHOT }
+      fake.rows[idx] =
+        fake.rows[idx].copy { blobChecksum = ByteString.copyFromUtf8("not-the-real-checksum") }
+      val key = writePhase0(listOf(20L to 0))
+
+      assertFailsWith<IllegalStateException> { ranker().rank(POOL, key, rankedSize = 100) }
+    }
+
+  @Test
+  fun `loads the newest prior snapshot across uploads`() =
+    runBlocking<Unit> {
+      // Two prior SNAPSHOTs for this subpool under different uploads; the newer create_time wins.
+      seedPriorSnapshot(
+        listOf(Triple(10L to 0, 0, 90)),
+        uploadName = "dataProviders/dp/rawImpressionUploads/upOld",
+        createTimeSeconds = 1L,
+      )
+      seedPriorSnapshot(
+        listOf(Triple(99L to 0, 0, 90)),
+        uploadName = "dataProviders/dp/rawImpressionUploads/upNew",
+        createTimeSeconds = 5L,
+      )
+      val key = writePhase0(emptyList()) // no new fingerprints; result mirrors the loaded prior
+
+      ranker().rank(POOL, key, rankedSize = 100)
+
+      // The allocator loaded the newer snapshot (99), not the older one (10).
+      assertThat(readSnapshot().keys).containsExactly(99L to 0)
+    }
+
+  @Test
+  fun `empty subpool still writes a snapshot carrying the prior cumulative unchanged`() =
+    runBlocking<Unit> {
+      seedPriorSnapshot(listOf(Triple(10L to 0, 0, 90)))
+      val key = writePhase0(emptyList())
+
+      val result = ranker().rank(POOL, key, rankedSize = 100)
+
+      assertThat(result.allocated).isEqualTo(0)
+      assertThat(result.renewed).isEqualTo(0)
+      assertThat(result.overflow).isEqualTo(0)
+      // A SNAPSHOT row is still inserted under this upload, carrying the prior cumulative
+      // unchanged.
+      assertThat(readSnapshot()).containsExactly(10L to 0, 0 to 90)
+    }
+
+  @Test
+  fun `rank fails when maxEventDate is unset`() = runBlocking {
+    val key = writePhase0(listOf(1L to 0))
+
+    val exception =
+      assertFailsWith<IllegalArgumentException> {
+        ranker(maxEventDate = Date.getDefaultInstance()).rank(POOL, key, rankedSize = 100)
+      }
+    assertThat(exception).hasMessageThat().contains("maxEventDate must be set")
   }
 
   companion object {

--- a/src/test/kotlin/org/wfanet/measurement/edpaggregator/vidrankbuilder/SubpoolRankerTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/edpaggregator/vidrankbuilder/SubpoolRankerTest.kt
@@ -56,6 +56,7 @@ import org.wfanet.measurement.storage.testing.InMemoryStorageClient
 
 private const val DP = "dataProviders/dp"
 private const val UPLOAD = "dataProviders/dp/rawImpressionUploads/up1"
+private const val UPLOAD2 = "dataProviders/dp/rawImpressionUploads/up2"
 private const val PRIOR_UPLOAD = "dataProviders/dp/rawImpressionUploads/up0"
 private const val MODEL_LINE = "modelProviders/mp/modelSuites/ms/modelLines/ml1"
 private const val PREFIX = "ranks"
@@ -91,7 +92,10 @@ class SubpoolRankerTest {
     fake = FakeRankIndexBlobs()
   }
 
-  private fun ranker(maxEventDate: Date = epochDayToDate(TODAY_EPOCH_DAY)): SubpoolRanker {
+  private fun ranker(
+    maxEventDate: Date = epochDayToDate(TODAY_EPOCH_DAY),
+    upload: String = UPLOAD,
+  ): SubpoolRanker {
     val retention = SubpoolRetention(fake.stub, rankStore, DP, MODEL_LINE, RETENTION_DAYS, TODAY)
     return SubpoolRanker(
       subpoolFingerprintsStore = subpoolStore,
@@ -99,7 +103,7 @@ class SubpoolRankerTest {
       rankIndexBlobsStub = fake.stub,
       retention = retention,
       dataProvider = DP,
-      rawImpressionUpload = UPLOAD,
+      rawImpressionUpload = upload,
       modelLine = MODEL_LINE,
       vidRankMapBlobPrefix = PREFIX,
       kekUri = kekUri,
@@ -110,9 +114,11 @@ class SubpoolRankerTest {
     )
   }
 
-  /** Writes the Phase-0 merged blob for the subpool and returns its key. */
-  private suspend fun writePhase0(fps: List<Pair<Long, Int>>): String {
-    val key = "phase0/merged/$POOL"
+  /** Writes a Phase-0 merged blob for the subpool at [key] and returns it. */
+  private suspend fun writePhase0(
+    fps: List<Pair<Long, Int>>,
+    key: String = "phase0/merged/$POOL",
+  ): String {
     subpoolStore.writeBlob(key, subpoolDek, POOL, flowOf(pack(fps)))
     return key
   }
@@ -158,27 +164,27 @@ class SubpoolRankerTest {
     )
   }
 
-  /** Reads back the SNAPSHOT row's blob as `(hi, lo) -> (rank, lastSeen)`. */
-  private suspend fun readSnapshot(): Map<Pair<Long, Int>, Pair<Int, Int>> {
+  /** Reads back the SNAPSHOT row's blob under [upload] as `(hi, lo) -> (rank, lastSeen)`. */
+  private suspend fun readSnapshot(upload: String = UPLOAD): Map<Pair<Long, Int>, Pair<Int, Int>> {
     val row =
       fake.rows.single {
-        it.blobType == RankIndexBlob.BlobType.SNAPSHOT && it.name.startsWith("$UPLOAD/")
+        it.blobType == RankIndexBlob.BlobType.SNAPSHOT && it.name.startsWith("$upload/")
       }
     return decode(rankStore.readBlob(row.blobUri, row.encryptedDek).toList())
   }
 
-  /** Reads back the DAY_ONLY row's blob under this upload as `(hi, lo) -> (rank, lastSeen)`. */
-  private suspend fun readDayOnly(): Map<Pair<Long, Int>, Pair<Int, Int>> {
+  /** Reads back the DAY_ONLY row's blob under [upload] as `(hi, lo) -> (rank, lastSeen)`. */
+  private suspend fun readDayOnly(upload: String = UPLOAD): Map<Pair<Long, Int>, Pair<Int, Int>> {
     val row =
       fake.rows.single {
-        it.blobType == RankIndexBlob.BlobType.DAY_ONLY && it.name.startsWith("$UPLOAD/")
+        it.blobType == RankIndexBlob.BlobType.DAY_ONLY && it.name.startsWith("$upload/")
       }
     return decode(rankStore.readBlob(row.blobUri, row.encryptedDek).toList())
   }
 
-  /** Whether a row of [blobType] exists under this upload. */
-  private fun hasUploadRow(blobType: RankIndexBlob.BlobType): Boolean =
-    fake.rows.any { it.blobType == blobType && it.name.startsWith("$UPLOAD/") }
+  /** Whether a row of [blobType] exists under [upload]. */
+  private fun hasUploadRow(blobType: RankIndexBlob.BlobType, upload: String = UPLOAD): Boolean =
+    fake.rows.any { it.blobType == blobType && it.name.startsWith("$upload/") }
 
   @Test
   fun `cold subpool allocates sequential ranks and stamps last_seen`() = runBlocking {
@@ -329,7 +335,7 @@ class SubpoolRankerTest {
   }
 
   @Test
-  fun `backfill reuses the old rank for a fingerprint absent from the latest snapshot`() =
+  fun `backfill takes a free old rank back into both the day-only and the snapshot`() =
     runBlocking<Unit> {
       // Old snapshot (just before the backfilled day) holds F1 at rank 5.
       seedPriorSnapshot(
@@ -352,15 +358,14 @@ class SubpoolRankerTest {
       assertThat(result.backfill).isTrue()
       assertThat(result.backfillReusedOldRank).isEqualTo(1)
       assertThat(result.backfillRankCollisions).isEqualTo(0)
-      // F1 gets its old rank 5 back in the day-only blob.
-      assertThat(readDayOnly().mapValues { it.value.first }).containsExactly(1L to 0, 5)
-      // A backfill writes only a DAY_ONLY row — never a new SNAPSHOT.
-      assertThat(hasUploadRow(RankIndexBlob.BlobType.DAY_ONLY)).isTrue()
-      assertThat(hasUploadRow(RankIndexBlob.BlobType.SNAPSHOT)).isFalse()
+      // F1 gets its old rank 5 back in the day-only blob (stamped with the backfill date).
+      assertThat(readDayOnly()).containsExactly(1L to 0, 5 to 80)
+      // The snapshot is the latest cumulative plus F1 at its reclaimed rank.
+      assertThat(readSnapshot()).containsExactly(2L to 0, 0 to 90, 1L to 0, 5 to 80)
     }
 
   @Test
-  fun `backfill counts a collision when the old rank differs from the latest rank`() =
+  fun `backfill counts a collision but keeps the latest rank in the snapshot`() =
     runBlocking<Unit> {
       seedPriorSnapshot(
         listOf(Triple(1L to 0, 5, 75)), // old: F1 at rank 5
@@ -380,8 +385,10 @@ class SubpoolRankerTest {
 
       assertThat(result.backfillReusedOldRank).isEqualTo(1)
       assertThat(result.backfillRankCollisions).isEqualTo(1)
-      // The old rank still wins for the backfilled day (one person, one VID).
+      // The old rank wins for the backfilled day (one person, one VID for that day)...
       assertThat(readDayOnly().mapValues { it.value.first }).containsExactly(1L to 0, 5)
+      // ...but the snapshot keeps the latest rank so the forward chain is undisturbed.
+      assertThat(readSnapshot().mapValues { it.value.first }).containsExactly(1L to 0, 8)
     }
 
   @Test
@@ -406,10 +413,11 @@ class SubpoolRankerTest {
       assertThat(result.backfill).isTrue()
       assertThat(result.backfillReusedOldRank).isEqualTo(0)
       assertThat(readDayOnly().mapValues { it.value.first }).containsExactly(3L to 0, 2)
+      assertThat(readSnapshot().mapValues { it.value.first }).containsExactly(3L to 0, 2)
     }
 
   @Test
-  fun `backfill allocates a new rank for a fingerprint in neither snapshot`() =
+  fun `backfill adds a brand-new fingerprint to both the day-only and the snapshot`() =
     runBlocking<Unit> {
       seedPriorSnapshot(
         listOf(Triple(9L to 0, 3, 75)),
@@ -431,6 +439,44 @@ class SubpoolRankerTest {
       assertThat(result.backfillReusedOldRank).isEqualTo(0)
       // rank 0 is taken in the loaded latest cumulative, so F4 gets the next free rank 1.
       assertThat(readDayOnly().mapValues { it.value.first }).containsExactly(4L to 0, 1)
+      // The new fingerprint is persisted in the snapshot so a later upload will not re-rank it.
+      assertThat(readSnapshot().mapValues { it.value.first })
+        .containsExactly(8L to 0, 0, 4L to 0, 1)
+    }
+
+  @Test
+  fun `a fingerprint new in a backfill keeps its rank on a later forward upload`() =
+    runBlocking<Unit> {
+      seedPriorSnapshot(
+        listOf(Triple(9L to 0, 3, 75)),
+        uploadName = "dataProviders/dp/rawImpressionUploads/upOld",
+        createTimeSeconds = 1L,
+        maxEventDate = epochDayToDate(75),
+      )
+      seedPriorSnapshot(
+        listOf(Triple(2L to 0, 0, 90)),
+        uploadName = "dataProviders/dp/rawImpressionUploads/upLatest",
+        createTimeSeconds = 5L,
+        maxEventDate = epochDayToDate(100),
+      )
+      // Backfill Day 80 introduces a brand-new fingerprint (in neither snapshot).
+      val backfillKey = writePhase0(listOf(7L to 0), key = "phase0/backfill")
+      val backfillResult =
+        ranker(maxEventDate = epochDayToDate(80), upload = UPLOAD)
+          .rank(POOL, backfillKey, rankedSize = 100)
+      assertThat(backfillResult.backfill).isTrue()
+      val backfillRank = readSnapshot(UPLOAD).getValue(7L to 0).first
+
+      // A later forward upload (Day 101) must renew it at the same rank, not re-rank it.
+      val forwardKey = writePhase0(listOf(7L to 0), key = "phase0/forward")
+      val forwardResult =
+        ranker(maxEventDate = epochDayToDate(101), upload = UPLOAD2)
+          .rank(POOL, forwardKey, rankedSize = 100)
+
+      assertThat(forwardResult.backfill).isFalse()
+      assertThat(forwardResult.renewed).isEqualTo(1) // renewed, not re-allocated
+      assertThat(forwardResult.allocated).isEqualTo(0)
+      assertThat(readSnapshot(UPLOAD2).getValue(7L to 0).first).isEqualTo(backfillRank)
     }
 
   @Test
@@ -467,40 +513,6 @@ class SubpoolRankerTest {
 
       assertThat(result.backfill).isFalse()
       assertThat(hasUploadRow(RankIndexBlob.BlobType.SNAPSHOT)).isTrue()
-    }
-
-  @Test
-  fun `backfill idempotency gate skips when a day-only row already exists for this upload`() =
-    runBlocking<Unit> {
-      seedPriorSnapshot(
-        listOf(Triple(1L to 0, 5, 75)),
-        uploadName = "dataProviders/dp/rawImpressionUploads/upOld",
-        createTimeSeconds = 1L,
-        maxEventDate = epochDayToDate(75),
-      )
-      seedPriorSnapshot(
-        listOf(Triple(2L to 0, 0, 90)),
-        uploadName = "dataProviders/dp/rawImpressionUploads/upLatest",
-        createTimeSeconds = 5L,
-        maxEventDate = epochDayToDate(100),
-      )
-      // A DAY_ONLY row already committed under THIS upload (a prior backfill attempt).
-      fake.seed(
-        rankIndexBlob {
-          name = "$UPLOAD/rankIndexBlobs/day-existing"
-          blobType = RankIndexBlob.BlobType.DAY_ONLY
-          cmmsModelLine = MODEL_LINE
-          poolOffset = POOL
-          maxEventDate = epochDayToDate(80)
-        }
-      )
-      val key = writePhase0(listOf(1L to 0))
-      val before = fake.rows.size
-
-      val result = ranker(maxEventDate = epochDayToDate(80)).rank(POOL, key, rankedSize = 100)
-
-      assertThat(result.skipped).isTrue()
-      assertThat(fake.rows.size).isEqualTo(before) // no new rows created
     }
 
   companion object {

--- a/src/test/kotlin/org/wfanet/measurement/edpaggregator/vidrankbuilder/SubpoolRankerTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/edpaggregator/vidrankbuilder/SubpoolRankerTest.kt
@@ -117,11 +117,16 @@ class SubpoolRankerTest {
     return key
   }
 
-  /** Seeds a prior SNAPSHOT blob under [uploadName] plus its `RankIndexBlob` row. */
+  /**
+   * Seeds a prior SNAPSHOT blob under [uploadName] plus its `RankIndexBlob` row. When
+   * [maxEventDate] is non-null it is stamped on the row (the snapshot-selection key that backfill
+   * detection reads).
+   */
   private suspend fun seedPriorSnapshot(
     entries: List<Triple<Pair<Long, Int>, Int, Int>>,
     uploadName: String = PRIOR_UPLOAD,
     createTimeSeconds: Long = 1L,
+    maxEventDate: Date? = null,
     blobKey: String = "ranks/prior/snapshot/$POOL/$createTimeSeconds",
     rowName: String = "$uploadName/rankIndexBlobs/snap-$createTimeSeconds",
   ) {
@@ -148,6 +153,7 @@ class SubpoolRankerTest {
         blobChecksum = checksum
         encryptedDek = dek
         createTime = timestamp { seconds = createTimeSeconds }
+        if (maxEventDate != null) this.maxEventDate = maxEventDate
       }
     )
   }
@@ -160,6 +166,19 @@ class SubpoolRankerTest {
       }
     return decode(rankStore.readBlob(row.blobUri, row.encryptedDek).toList())
   }
+
+  /** Reads back the DAY_ONLY row's blob under this upload as `(hi, lo) -> (rank, lastSeen)`. */
+  private suspend fun readDayOnly(): Map<Pair<Long, Int>, Pair<Int, Int>> {
+    val row =
+      fake.rows.single {
+        it.blobType == RankIndexBlob.BlobType.DAY_ONLY && it.name.startsWith("$UPLOAD/")
+      }
+    return decode(rankStore.readBlob(row.blobUri, row.encryptedDek).toList())
+  }
+
+  /** Whether a row of [blobType] exists under this upload. */
+  private fun hasUploadRow(blobType: RankIndexBlob.BlobType): Boolean =
+    fake.rows.any { it.blobType == blobType && it.name.startsWith("$UPLOAD/") }
 
   @Test
   fun `cold subpool allocates sequential ranks and stamps last_seen`() = runBlocking {
@@ -308,6 +327,181 @@ class SubpoolRankerTest {
       }
     assertThat(exception).hasMessageThat().contains("maxEventDate must be set")
   }
+
+  @Test
+  fun `backfill reuses the old rank for a fingerprint absent from the latest snapshot`() =
+    runBlocking<Unit> {
+      // Old snapshot (just before the backfilled day) holds F1 at rank 5.
+      seedPriorSnapshot(
+        listOf(Triple(1L to 0, 5, 75)),
+        uploadName = "dataProviders/dp/rawImpressionUploads/upOld",
+        createTimeSeconds = 1L,
+        maxEventDate = epochDayToDate(75),
+      )
+      // Latest snapshot is newer; F1 has aged out so rank 5 is free there.
+      seedPriorSnapshot(
+        listOf(Triple(2L to 0, 0, 90)),
+        uploadName = "dataProviders/dp/rawImpressionUploads/upLatest",
+        createTimeSeconds = 5L,
+        maxEventDate = epochDayToDate(100),
+      )
+      val key = writePhase0(listOf(1L to 0)) // the backfilled upload contains F1
+
+      val result = ranker(maxEventDate = epochDayToDate(80)).rank(POOL, key, rankedSize = 100)
+
+      assertThat(result.backfill).isTrue()
+      assertThat(result.backfillReusedOldRank).isEqualTo(1)
+      assertThat(result.backfillRankCollisions).isEqualTo(0)
+      // F1 gets its old rank 5 back in the day-only blob.
+      assertThat(readDayOnly().mapValues { it.value.first }).containsExactly(1L to 0, 5)
+      // A backfill writes only a DAY_ONLY row — never a new SNAPSHOT.
+      assertThat(hasUploadRow(RankIndexBlob.BlobType.DAY_ONLY)).isTrue()
+      assertThat(hasUploadRow(RankIndexBlob.BlobType.SNAPSHOT)).isFalse()
+    }
+
+  @Test
+  fun `backfill counts a collision when the old rank differs from the latest rank`() =
+    runBlocking<Unit> {
+      seedPriorSnapshot(
+        listOf(Triple(1L to 0, 5, 75)), // old: F1 at rank 5
+        uploadName = "dataProviders/dp/rawImpressionUploads/upOld",
+        createTimeSeconds = 1L,
+        maxEventDate = epochDayToDate(75),
+      )
+      seedPriorSnapshot(
+        listOf(Triple(1L to 0, 8, 90)), // latest: F1 re-handed a different rank 8
+        uploadName = "dataProviders/dp/rawImpressionUploads/upLatest",
+        createTimeSeconds = 5L,
+        maxEventDate = epochDayToDate(100),
+      )
+      val key = writePhase0(listOf(1L to 0))
+
+      val result = ranker(maxEventDate = epochDayToDate(80)).rank(POOL, key, rankedSize = 100)
+
+      assertThat(result.backfillReusedOldRank).isEqualTo(1)
+      assertThat(result.backfillRankCollisions).isEqualTo(1)
+      // The old rank still wins for the backfilled day (one person, one VID).
+      assertThat(readDayOnly().mapValues { it.value.first }).containsExactly(1L to 0, 5)
+    }
+
+  @Test
+  fun `backfill keeps the latest rank for a fingerprint only in the latest snapshot`() =
+    runBlocking<Unit> {
+      seedPriorSnapshot(
+        listOf(Triple(9L to 0, 3, 75)), // old snapshot exists (a different fp)
+        uploadName = "dataProviders/dp/rawImpressionUploads/upOld",
+        createTimeSeconds = 1L,
+        maxEventDate = epochDayToDate(75),
+      )
+      seedPriorSnapshot(
+        listOf(Triple(3L to 0, 2, 90)), // latest: F3 at rank 2
+        uploadName = "dataProviders/dp/rawImpressionUploads/upLatest",
+        createTimeSeconds = 5L,
+        maxEventDate = epochDayToDate(100),
+      )
+      val key = writePhase0(listOf(3L to 0)) // F3 is only in the latest snapshot
+
+      val result = ranker(maxEventDate = epochDayToDate(80)).rank(POOL, key, rankedSize = 100)
+
+      assertThat(result.backfill).isTrue()
+      assertThat(result.backfillReusedOldRank).isEqualTo(0)
+      assertThat(readDayOnly().mapValues { it.value.first }).containsExactly(3L to 0, 2)
+    }
+
+  @Test
+  fun `backfill allocates a new rank for a fingerprint in neither snapshot`() =
+    runBlocking<Unit> {
+      seedPriorSnapshot(
+        listOf(Triple(9L to 0, 3, 75)),
+        uploadName = "dataProviders/dp/rawImpressionUploads/upOld",
+        createTimeSeconds = 1L,
+        maxEventDate = epochDayToDate(75),
+      )
+      seedPriorSnapshot(
+        listOf(Triple(8L to 0, 0, 90)), // latest holds rank 0
+        uploadName = "dataProviders/dp/rawImpressionUploads/upLatest",
+        createTimeSeconds = 5L,
+        maxEventDate = epochDayToDate(100),
+      )
+      val key = writePhase0(listOf(4L to 0)) // F4 is in neither snapshot
+
+      val result = ranker(maxEventDate = epochDayToDate(80)).rank(POOL, key, rankedSize = 100)
+
+      assertThat(result.backfill).isTrue()
+      assertThat(result.backfillReusedOldRank).isEqualTo(0)
+      // rank 0 is taken in the loaded latest cumulative, so F4 gets the next free rank 1.
+      assertThat(readDayOnly().mapValues { it.value.first }).containsExactly(4L to 0, 1)
+    }
+
+  @Test
+  fun `an upload older than the retention window is not treated as a backfill`() =
+    runBlocking<Unit> {
+      seedPriorSnapshot(
+        listOf(Triple(7L to 0, 0, 90)),
+        uploadName = "dataProviders/dp/rawImpressionUploads/upLatest",
+        createTimeSeconds = 5L,
+        maxEventDate = epochDayToDate(100),
+      )
+      val key = writePhase0(listOf(5L to 0))
+
+      // 100 - 60 = 40 > RETENTION_DAYS (30): outside the window, so the normal path runs.
+      val result = ranker(maxEventDate = epochDayToDate(60)).rank(POOL, key, rankedSize = 100)
+
+      assertThat(result.backfill).isFalse()
+      assertThat(hasUploadRow(RankIndexBlob.BlobType.SNAPSHOT)).isTrue()
+    }
+
+  @Test
+  fun `a backfill with no older snapshot runs the default path`() =
+    runBlocking<Unit> {
+      // Only the latest snapshot exists; nothing is strictly older than the backfilled day.
+      seedPriorSnapshot(
+        listOf(Triple(7L to 0, 0, 90)),
+        uploadName = "dataProviders/dp/rawImpressionUploads/upLatest",
+        createTimeSeconds = 5L,
+        maxEventDate = epochDayToDate(100),
+      )
+      val key = writePhase0(listOf(5L to 0))
+
+      val result = ranker(maxEventDate = epochDayToDate(80)).rank(POOL, key, rankedSize = 100)
+
+      assertThat(result.backfill).isFalse()
+      assertThat(hasUploadRow(RankIndexBlob.BlobType.SNAPSHOT)).isTrue()
+    }
+
+  @Test
+  fun `backfill idempotency gate skips when a day-only row already exists for this upload`() =
+    runBlocking<Unit> {
+      seedPriorSnapshot(
+        listOf(Triple(1L to 0, 5, 75)),
+        uploadName = "dataProviders/dp/rawImpressionUploads/upOld",
+        createTimeSeconds = 1L,
+        maxEventDate = epochDayToDate(75),
+      )
+      seedPriorSnapshot(
+        listOf(Triple(2L to 0, 0, 90)),
+        uploadName = "dataProviders/dp/rawImpressionUploads/upLatest",
+        createTimeSeconds = 5L,
+        maxEventDate = epochDayToDate(100),
+      )
+      // A DAY_ONLY row already committed under THIS upload (a prior backfill attempt).
+      fake.seed(
+        rankIndexBlob {
+          name = "$UPLOAD/rankIndexBlobs/day-existing"
+          blobType = RankIndexBlob.BlobType.DAY_ONLY
+          cmmsModelLine = MODEL_LINE
+          poolOffset = POOL
+          maxEventDate = epochDayToDate(80)
+        }
+      )
+      val key = writePhase0(listOf(1L to 0))
+      val before = fake.rows.size
+
+      val result = ranker(maxEventDate = epochDayToDate(80)).rank(POOL, key, rankedSize = 100)
+
+      assertThat(result.skipped).isTrue()
+      assertThat(fake.rows.size).isEqualTo(before) // no new rows created
+    }
 
   companion object {
     private fun pack(fps: List<Pair<Long, Int>>): ByteString {

--- a/src/test/kotlin/org/wfanet/measurement/edpaggregator/vidrankbuilder/SubpoolRankerTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/edpaggregator/vidrankbuilder/SubpoolRankerTest.kt
@@ -480,7 +480,7 @@ class SubpoolRankerTest {
     }
 
   @Test
-  fun `an upload older than the retention window is not treated as a backfill`() =
+  fun `an upload older than the retention window fails loud instead of silently re-ranking`() =
     runBlocking<Unit> {
       seedPriorSnapshot(
         listOf(Triple(7L to 0, 0, 90)),
@@ -490,11 +490,15 @@ class SubpoolRankerTest {
       )
       val key = writePhase0(listOf(5L to 0))
 
-      // 100 - 60 = 40 > RETENTION_DAYS (30): outside the window, so the normal path runs.
-      val result = ranker(maxEventDate = epochDayToDate(60)).rank(POOL, key, rankedSize = 100)
-
-      assertThat(result.backfill).isFalse()
-      assertThat(hasUploadRow(RankIndexBlob.BlobType.SNAPSHOT)).isTrue()
+      // 100 - 60 = 40 > RETENTION_DAYS (30): the original rank has already aged out (Problem 3), so
+      // the dispatch fails loudly rather than silently forward-appending.
+      val exception =
+        assertFailsWith<OutOfRetentionBackfillException> {
+          ranker(maxEventDate = epochDayToDate(60)).rank(POOL, key, rankedSize = 100)
+        }
+      assertThat(exception).hasMessageThat().contains("out-of-retention backfill")
+      // No SNAPSHOT was written for the rejected dispatch.
+      assertThat(hasUploadRow(RankIndexBlob.BlobType.SNAPSHOT)).isFalse()
     }
 
   @Test
@@ -580,7 +584,7 @@ class SubpoolRankerTest {
     }
 
   @Test
-  fun `an upload one day past the retention window is not a backfill`() =
+  fun `a backfill one day past the retention window fails loud`() =
     runBlocking<Unit> {
       seedPriorSnapshot(
         listOf(Triple(1L to 0, 5, 60)),
@@ -596,10 +600,10 @@ class SubpoolRankerTest {
       )
       val key = writePhase0(listOf(1L to 0))
 
-      // 100 - 69 == RETENTION_DAYS + 1 (31): just outside the window, so the normal path runs.
-      val result = ranker(maxEventDate = epochDayToDate(69)).rank(POOL, key, rankedSize = 100)
-
-      assertThat(result.backfill).isFalse()
+      // 100 - 69 == RETENTION_DAYS + 1 (31): one day past the window — out of retention, fail loud.
+      assertFailsWith<OutOfRetentionBackfillException> {
+        ranker(maxEventDate = epochDayToDate(69)).rank(POOL, key, rankedSize = 100)
+      }
     }
 
   @Test

--- a/src/test/kotlin/org/wfanet/measurement/edpaggregator/vidrankbuilder/SubpoolRetentionTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/edpaggregator/vidrankbuilder/SubpoolRetentionTest.kt
@@ -48,6 +48,7 @@ import org.wfanet.measurement.edpaggregator.v1alpha.RankIndexBlobServiceGrpcKt.R
 import org.wfanet.measurement.edpaggregator.v1alpha.listRankIndexBlobsResponse
 import org.wfanet.measurement.edpaggregator.v1alpha.rankIndexBlob
 import org.wfanet.measurement.edpaggregator.v1alpha.rankIndexMap
+import org.wfanet.measurement.storage.ConditionalOperationStorageClient
 import org.wfanet.measurement.storage.StorageClient
 import org.wfanet.measurement.storage.testing.InMemoryStorageClient
 
@@ -176,7 +177,7 @@ class SubpoolRetentionTest {
     val throwingBlob: StorageClient.Blob = mock {
       onBlocking { delete() } doAnswer { throw IOException("transient GCS error") }
     }
-    val throwingStorage: StorageClient = mock {
+    val throwingStorage: ConditionalOperationStorageClient = mock {
       onBlocking { getBlob(any()) } doReturn throwingBlob
     }
     val rankStoreThatFailsDelete = RankIndexStore(throwingStorage, kmsClient)

--- a/src/test/kotlin/org/wfanet/measurement/edpaggregator/vidrankbuilder/SubpoolRetentionTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/edpaggregator/vidrankbuilder/SubpoolRetentionTest.kt
@@ -21,8 +21,11 @@ import com.google.crypto.tink.Aead
 import com.google.crypto.tink.KeyTemplates
 import com.google.crypto.tink.KeysetHandle
 import com.google.crypto.tink.aead.AeadConfig
+import com.google.type.Date
 import com.google.type.date
+import java.io.IOException
 import java.time.LocalDate
+import kotlin.test.assertFailsWith
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.runBlocking
@@ -31,22 +34,27 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 import org.mockito.kotlin.any
+import org.mockito.kotlin.doAnswer
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
 import org.mockito.kotlin.verifyBlocking
 import org.wfanet.measurement.common.crypto.tink.testing.FakeKmsClient
 import org.wfanet.measurement.edpaggregator.rawimpressions.RankIndexStore
+import org.wfanet.measurement.edpaggregator.v1alpha.DeleteRankIndexBlobRequest
+import org.wfanet.measurement.edpaggregator.v1alpha.ListRankIndexBlobsRequest
 import org.wfanet.measurement.edpaggregator.v1alpha.RankIndexBlob
 import org.wfanet.measurement.edpaggregator.v1alpha.RankIndexBlobServiceGrpcKt.RankIndexBlobServiceCoroutineStub
 import org.wfanet.measurement.edpaggregator.v1alpha.listRankIndexBlobsResponse
 import org.wfanet.measurement.edpaggregator.v1alpha.rankIndexBlob
 import org.wfanet.measurement.edpaggregator.v1alpha.rankIndexMap
+import org.wfanet.measurement.storage.StorageClient
 import org.wfanet.measurement.storage.testing.InMemoryStorageClient
 
 private const val DP = "dataProviders/dp"
 private const val MODEL_LINE = "modelProviders/mp/modelSuites/ms/modelLines/ml1"
 private const val POOL = 7L
+private const val RETENTION_DAYS = 30
 private val TODAY = LocalDate.ofEpochDay(100)
 
 @RunWith(JUnit4::class)
@@ -70,7 +78,14 @@ class SubpoolRetentionTest {
     rankStore = RankIndexStore(storageClient, kmsClient)
   }
 
-  private suspend fun writeBlob(key: String): RankIndexBlob {
+  private suspend fun writeBlob(
+    key: String,
+    maxEventDate: Date = date {
+      year = 2000
+      month = 1
+      day = 1
+    }, // old
+  ): RankIndexBlob {
     val dek = rankStore.generateDek(kekUri)
     val checksum =
       rankStore.writeBlob(
@@ -91,13 +106,35 @@ class SubpoolRetentionTest {
       blobUri = key
       blobChecksum = checksum
       encryptedDek = dek
-      maxEventDate = date {
-        year = 2000
-        month = 1
-        day = 1
-      } // old
+      this.maxEventDate = maxEventDate
     }
   }
+
+  /**
+   * A stub that honors the `max_event_date_on_or_before` filter against [candidates], mirroring the
+   * real service so the deletion-cutoff computation is exercised end-to-end.
+   */
+  private fun filteringStub(candidates: List<RankIndexBlob>): RankIndexBlobServiceCoroutineStub =
+    mock {
+      onBlocking { listRankIndexBlobs(any(), any()) } doAnswer
+        { invocation ->
+          val request = invocation.getArgument<ListRankIndexBlobsRequest>(0)
+          val filter = request.filter
+          val matched =
+            candidates.filter { row ->
+              row.blobType == filter.blobType &&
+                (!filter.hasPoolOffset() || row.poolOffset == filter.poolOffset) &&
+                (!filter.hasMaxEventDateOnOrBefore() ||
+                  epochDayOf(row.maxEventDate) <= epochDayOf(filter.maxEventDateOnOrBefore))
+            }
+          listRankIndexBlobsResponse { rankIndexBlobs += matched }
+        }
+      onBlocking { deleteRankIndexBlob(any(), any()) } doAnswer
+        { invocation ->
+          val name = invocation.getArgument<DeleteRankIndexBlobRequest>(0).name
+          candidates.first { it.name == name }
+        }
+    }
 
   @Test
   fun `deleteAgedBlobs soft-deletes the row and removes the blob bytes`() = runBlocking {
@@ -129,5 +166,101 @@ class SubpoolRetentionTest {
 
     verifyBlocking(stub, never()) { deleteRankIndexBlob(any(), any()) }
     assertThat(rankStore.readBlob("day/keep", kept.encryptedDek).toList()).isNotEmpty()
+  }
+
+  @Test
+  fun `deleteAgedBlobs deletes the row then surfaces a failed bytes delete`() = runBlocking {
+    // The row soft-delete succeeds, but deleting the bytes throws (transient GCS error). Per the
+    // "row first, then bytes" ordering this leaks bytes (no corruption); assert the failure
+    // propagates rather than being silently swallowed, and that the row was deleted first.
+    val throwingBlob: StorageClient.Blob = mock {
+      onBlocking { delete() } doAnswer { throw IOException("transient GCS error") }
+    }
+    val throwingStorage: StorageClient = mock {
+      onBlocking { getBlob(any()) } doReturn throwingBlob
+    }
+    val rankStoreThatFailsDelete = RankIndexStore(throwingStorage, kmsClient)
+    val candidate = rankIndexBlob {
+      name = "dataProviders/dp/rawImpressionUploads/up0/rankIndexBlobs/day/leak"
+      blobType = RankIndexBlob.BlobType.DAY_ONLY
+      cmmsModelLine = MODEL_LINE
+      poolOffset = POOL
+      blobUri = "day/leak"
+    }
+    val stub: RankIndexBlobServiceCoroutineStub = mock {
+      onBlocking { listRankIndexBlobs(any(), any()) } doReturn
+        listRankIndexBlobsResponse { rankIndexBlobs += candidate }
+      onBlocking { deleteRankIndexBlob(any(), any()) } doReturn candidate
+    }
+    val retention =
+      SubpoolRetention(
+        stub,
+        rankStoreThatFailsDelete,
+        DP,
+        MODEL_LINE,
+        retentionDays = 30,
+        today = TODAY,
+      )
+
+    assertFailsWith<IOException> { retention.deleteAgedBlobs(POOL) }
+    verifyBlocking(stub) {
+      deleteRankIndexBlob(any(), any())
+    } // row removed before the bytes failed
+  }
+
+  @Test
+  fun `deleteAgedBlobs deletes a blob one day past the retention window`() = runBlocking {
+    // today - (RETENTION_DAYS + 1) == cutoff; a blob exactly at the cutoff must be deleted.
+    val candidate =
+      writeBlob("day/boundary-delete", epochDayToDate(TODAY.toEpochDay() - (RETENTION_DAYS + 1)))
+    val stub = filteringStub(listOf(candidate))
+    val retention =
+      SubpoolRetention(
+        stub,
+        rankStore,
+        DP,
+        MODEL_LINE,
+        retentionDays = RETENTION_DAYS,
+        today = TODAY,
+      )
+
+    retention.deleteAgedBlobs(POOL)
+
+    verifyBlocking(stub) { deleteRankIndexBlob(any(), any()) }
+    assertThat(rankStore.readBlob("day/boundary-delete", candidate.encryptedDek).toList()).isEmpty()
+  }
+
+  @Test
+  fun `deleteAgedBlobs keeps a blob exactly at the retention window`() = runBlocking {
+    // today - RETENTION_DAYS is still within retention (strictly-older predicate); must NOT delete.
+    val kept = writeBlob("day/boundary-keep", epochDayToDate(TODAY.toEpochDay() - RETENTION_DAYS))
+    val stub = filteringStub(listOf(kept))
+    val retention =
+      SubpoolRetention(
+        stub,
+        rankStore,
+        DP,
+        MODEL_LINE,
+        retentionDays = RETENTION_DAYS,
+        today = TODAY,
+      )
+
+    retention.deleteAgedBlobs(POOL)
+
+    verifyBlocking(stub, never()) { deleteRankIndexBlob(any(), any()) }
+    assertThat(rankStore.readBlob("day/boundary-keep", kept.encryptedDek).toList()).isNotEmpty()
+  }
+
+  companion object {
+    private fun epochDayOf(d: Date): Long = LocalDate.of(d.year, d.month, d.day).toEpochDay()
+
+    private fun epochDayToDate(epochDay: Long): Date =
+      LocalDate.ofEpochDay(epochDay).let {
+        date {
+          year = it.year
+          month = it.monthValue
+          day = it.dayOfMonth
+        }
+      }
   }
 }

--- a/src/test/kotlin/org/wfanet/measurement/edpaggregator/vidrankbuilder/SubpoolRetentionTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/edpaggregator/vidrankbuilder/SubpoolRetentionTest.kt
@@ -1,0 +1,133 @@
+/*
+ * Copyright 2026 The Cross-Media Measurement Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wfanet.measurement.edpaggregator.vidrankbuilder
+
+import com.google.common.truth.Truth.assertThat
+import com.google.crypto.tink.Aead
+import com.google.crypto.tink.KeyTemplates
+import com.google.crypto.tink.KeysetHandle
+import com.google.crypto.tink.aead.AeadConfig
+import com.google.type.date
+import java.time.LocalDate
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.runBlocking
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verifyBlocking
+import org.wfanet.measurement.common.crypto.tink.testing.FakeKmsClient
+import org.wfanet.measurement.edpaggregator.rawimpressions.RankIndexStore
+import org.wfanet.measurement.edpaggregator.v1alpha.RankIndexBlob
+import org.wfanet.measurement.edpaggregator.v1alpha.RankIndexBlobServiceGrpcKt.RankIndexBlobServiceCoroutineStub
+import org.wfanet.measurement.edpaggregator.v1alpha.listRankIndexBlobsResponse
+import org.wfanet.measurement.edpaggregator.v1alpha.rankIndexBlob
+import org.wfanet.measurement.edpaggregator.v1alpha.rankIndexMap
+import org.wfanet.measurement.storage.testing.InMemoryStorageClient
+
+private const val DP = "dataProviders/dp"
+private const val MODEL_LINE = "modelProviders/mp/modelSuites/ms/modelLines/ml1"
+private const val POOL = 7L
+private val TODAY = LocalDate.ofEpochDay(100)
+
+@RunWith(JUnit4::class)
+class SubpoolRetentionTest {
+  private val kekUri = FakeKmsClient.KEY_URI_PREFIX + "key1"
+  private lateinit var kmsClient: FakeKmsClient
+  private lateinit var storageClient: InMemoryStorageClient
+  private lateinit var rankStore: RankIndexStore
+
+  @Before
+  fun setUp() {
+    AeadConfig.register()
+    kmsClient =
+      FakeKmsClient().apply {
+        setAead(
+          kekUri,
+          KeysetHandle.generateNew(KeyTemplates.get("AES128_GCM")).getPrimitive(Aead::class.java),
+        )
+      }
+    storageClient = InMemoryStorageClient()
+    rankStore = RankIndexStore(storageClient, kmsClient)
+  }
+
+  private suspend fun writeBlob(key: String): RankIndexBlob {
+    val dek = rankStore.generateDek(kekUri)
+    val checksum =
+      rankStore.writeBlob(
+        key,
+        dek,
+        flowOf(
+          rankIndexMap {
+            poolOffset = POOL
+            rankedSize = 100
+          }
+        ),
+      )
+    return rankIndexBlob {
+      name = "dataProviders/dp/rawImpressionUploads/up0/rankIndexBlobs/$key"
+      blobType = RankIndexBlob.BlobType.DAY_ONLY
+      cmmsModelLine = MODEL_LINE
+      poolOffset = POOL
+      blobUri = key
+      blobChecksum = checksum
+      encryptedDek = dek
+      maxEventDate = date {
+        year = 2000
+        month = 1
+        day = 1
+      } // old
+    }
+  }
+
+  @Test
+  fun `deleteAgedBlobs soft-deletes the row and removes the blob bytes`() = runBlocking {
+    val candidate = writeBlob("day/old")
+    val stub: RankIndexBlobServiceCoroutineStub = mock {
+      onBlocking { listRankIndexBlobs(any(), any()) } doReturn
+        listRankIndexBlobsResponse { rankIndexBlobs += candidate }
+      onBlocking { deleteRankIndexBlob(any(), any()) } doReturn candidate
+    }
+    val retention =
+      SubpoolRetention(stub, rankStore, DP, MODEL_LINE, retentionDays = 30, today = TODAY)
+
+    retention.deleteAgedBlobs(POOL)
+
+    verifyBlocking(stub) { deleteRankIndexBlob(any(), any()) }
+    assertThat(rankStore.readBlob("day/old", candidate.encryptedDek).toList()).isEmpty()
+  }
+
+  @Test
+  fun `deleteAgedBlobs is a no-op when nothing is aged out`() = runBlocking {
+    val kept = writeBlob("day/keep")
+    val stub: RankIndexBlobServiceCoroutineStub = mock {
+      onBlocking { listRankIndexBlobs(any(), any()) } doReturn listRankIndexBlobsResponse {}
+    }
+    val retention =
+      SubpoolRetention(stub, rankStore, DP, MODEL_LINE, retentionDays = 30, today = TODAY)
+
+    retention.deleteAgedBlobs(POOL)
+
+    verifyBlocking(stub, never()) { deleteRankIndexBlob(any(), any()) }
+    assertThat(rankStore.readBlob("day/keep", kept.encryptedDek).toList()).isNotEmpty()
+  }
+}


### PR DESCRIPTION
# SUMMARY

Adds the per-subpool ranking domain logic that drives one subpool through a dispatch, built on the storage + allocator primitives from #4016.

  ## What's included
  
  **`SubpoolRanker`** — ranks a single subpool end-to-end:
  1. **Idempotency gate** — if a `SNAPSHOT` row already exists for this `(upload, subpool)`, the subpool is already done; skip.
  2. **Load prior state** — read the prior cumulative `SNAPSHOT` (checksum-validated) into a `RankAllocator`, rebuilding the rank `BitSet` and `last_seen` index.
  3. **Materialize today's fingerprints** from the Phase-0 merged blob.
  4. **Retention** — GC aged-out `DAY_ONLY` blobs, then free aged ranks in-heap (`last_seen < cutoff`), **excluding** fingerprints seen this dispatch so their VIDs stay stable.
  5. **Allocate / renew** ranks for today's fingerprints (renewal preserves the existing rank → stable VID; overflow past `ranked_size` falls back to the unranked path).
  6. **Persist** the new `DAY_ONLY` + `SNAPSHOT` blobs and rows under per-attempt-unique keys so a concurrent or redelivered attempt never overwrites another's bytes.

  **`SubpoolRetention`** — deletes `DAY_ONLY` blobs older than the retention window (storage GC, independent of in-heap rank freeing).

  **`VidRankBuilderMetrics`** — OpenTelemetry counters for allocated / renewed / overflow / freed / cumulative size.

  ## Design notes
  Retention is an in-heap pass over the cumulative map's `last_seen` index rather than a re-scan of every surviving `DAY_ONLY` blob. Renewal keeps already-ranked fingerprints on their existing rank so
  VIDs are stable across dispatches.

  ## Testing
  `SubpoolRankerTest` (cold subpool, warm renew + allocate, retention free-and-reuse, overflow, idempotency-skip) and `SubpoolRetentionTest`.

Issue: #3921 