### PR TITLE
feat: A large noise correction now causes a report failure

### DIFF
--- a/src/main/python/wfa/measurement/reporting/postprocessing/tools/post_process_report_result.py
+++ b/src/main/python/wfa/measurement/reporting/postprocessing/tools/post_process_report_result.py
@@ -143,6 +143,10 @@ class PostProcessReportResult:
                     PARTIAL_SOLUTION_FOUND_WITH_HIGHS,
                     ReportPostProcessorStatus.PARTIAL_SOLUTION_FOUND_WITH_OSQP,
             ]:
+                if result.large_corrections:
+                    raise ValueError(
+                        "Noise correction produced large corrections for a"
+                        f" report summary: {list(result.large_corrections)}")
                 all_updated_measurements.update(result.updated_measurements)
             else:
                 raise ValueError(

--- a/src/test/python/wfa/measurement/reporting/postprocessing/tools/post_process_report_result_test.py
+++ b/src/test/python/wfa/measurement/reporting/postprocessing/tools/post_process_report_result_test.py
@@ -233,7 +233,6 @@ class PostProcessReportResultTest(unittest.TestCase):
                 'reporting_set_id_edp1',
                 'reporting_set_id_edp2',
                 'reporting_set_id_edp3',
-                'reporting_set_id_edp1_edp2',
                 'reporting_set_id_edp1_edp2_edp3',
             ],
         )
@@ -249,9 +248,9 @@ class PostProcessReportResultTest(unittest.TestCase):
             self.external_report_result_id,
         )
 
-        # Verifies that there are 25 reporting set results in the sample data.
+        # Verifies that there are 20 reporting set results in the sample data.
         self.assertEqual(
-            len(add_processed_result_value_request.reporting_set_results), 25)
+            len(add_processed_result_value_request.reporting_set_results), 20)
 
         # Verifies the set result with exteral_reporting_set_result_id = 25.
         # This set result has noise added.
@@ -272,14 +271,14 @@ class PostProcessReportResultTest(unittest.TestCase):
 
         # Verifies the cumulative results.
         cumulative_results = window_result.value.cumulative_results
-        self.assertEqual(cumulative_results.reach, 19021118)
-        self.assertAlmostEqual(cumulative_results.percent_reach, 34.5838509)
+        self.assertEqual(cumulative_results.reach, 19021120)
+        self.assertAlmostEqual(cumulative_results.percent_reach, 34.5838547)
         self.assertAlmostEqual(cumulative_results.average_frequency,
-                               1.88917196)
-        self.assertEqual(cumulative_results.impressions, 35934162)
-        self.assertAlmostEqual(cumulative_results.grps, 65.3348389)
+                               1.88917184)
+        self.assertEqual(cumulative_results.impressions, 35934165)
+        self.assertAlmostEqual(cumulative_results.grps, 65.3348465)
         expected_k_plus_reach = [
-            19021119,
+            19021120,
             9200728,
             4291494,
             1837838,
@@ -288,7 +287,7 @@ class PostProcessReportResultTest(unittest.TestCase):
         self.assertCountEqual(cumulative_results.k_plus_reach,
                               expected_k_plus_reach)
         expected_percent_k_plus_reach = [
-            34.5838509,
+            34.5838547,
             16.7285957,
             7.80271626,
             3.34152365,

--- a/src/test/python/wfa/measurement/reporting/postprocessing/tools/post_process_report_result_test.py
+++ b/src/test/python/wfa/measurement/reporting/postprocessing/tools/post_process_report_result_test.py
@@ -272,14 +272,14 @@ class PostProcessReportResultTest(unittest.TestCase):
 
         # Verifies the cumulative results.
         cumulative_results = window_result.value.cumulative_results
-        self.assertEqual(cumulative_results.reach, 19021120)
-        self.assertAlmostEqual(cumulative_results.percent_reach, 34.5838547)
+        self.assertEqual(cumulative_results.reach, 19021118)
+        self.assertAlmostEqual(cumulative_results.percent_reach, 34.5838509)
         self.assertAlmostEqual(cumulative_results.average_frequency,
-                               1.88917184)
-        self.assertEqual(cumulative_results.impressions, 35934165)
-        self.assertAlmostEqual(cumulative_results.grps, 65.3348465)
+                               1.88917196)
+        self.assertEqual(cumulative_results.impressions, 35934162)
+        self.assertAlmostEqual(cumulative_results.grps, 65.3348389)
         expected_k_plus_reach = [
-            19021120,
+            19021119,
             9200728,
             4291494,
             1837838,
@@ -288,7 +288,7 @@ class PostProcessReportResultTest(unittest.TestCase):
         self.assertCountEqual(cumulative_results.k_plus_reach,
                               expected_k_plus_reach)
         expected_percent_k_plus_reach = [
-            34.5838547,
+            34.5838509,
             16.7285957,
             7.80271626,
             3.34152365,
@@ -388,6 +388,7 @@ class PostProcessReportResultTest(unittest.TestCase):
         mock_result = MagicMock()
         mock_result.status.status_code = report_post_processor_result_pb2.ReportPostProcessorStatus.SOLUTION_FOUND_WITH_HIGHS
         mock_result.updated_measurements = {}
+        mock_result.large_corrections = []
         mock_processor_instance.process.return_value = mock_result
 
         report_result_processor = PostProcessReportResult(
@@ -402,6 +403,29 @@ class PostProcessReportResultTest(unittest.TestCase):
             ANY,
             ['reporting_set_id_edp1']
         )
+
+    def test_post_process_report_result_raises_on_large_corrections(self):
+        # Loads a real fixture whose noisy values force the solver to apply
+        # corrections that exceed 7 sigma (e.g. reach going from 16.6M to 0).
+        with open(
+                'src/test/python/wfa/measurement/reporting/postprocessing/tools/sample_report_result_with_large_corrections.textproto',
+                'r') as file:
+            large_correction_response = text_format.Parse(
+                file.read(),
+                report_results_service_pb2.ListReportingSetResultsResponse(),
+            )
+        self.mock_report_results_stub.ListReportingSetResults.return_value = (
+            large_correction_response)
+        self.mock_reporting_sets_stub.BatchGetReportingSets.return_value = (
+            self.mock_batch_get_reporting_set_response)
+
+        report_result_processor = PostProcessReportResult(
+            self.mock_report_results_stub, self.mock_reporting_sets_stub)
+
+        with self.assertRaisesRegex(ValueError, 'large corrections'):
+            report_result_processor.process(
+                self.cmms_measurement_consumer_id,
+                self.external_report_result_id, [])
 
     def test_get_ami_mrc_exempted_reporting_set_id(self):
         self.mock_reporting_sets_stub.BatchGetReportingSets.return_value = (

--- a/src/test/python/wfa/measurement/reporting/postprocessing/tools/report_conversion_test.py
+++ b/src/test/python/wfa/measurement/reporting/postprocessing/tools/report_conversion_test.py
@@ -1032,9 +1032,9 @@ class ReportConversionTest(unittest.TestCase):
         self.assertIsNotNone(report_summary_18_34)
         self.assertIsNotNone(report_summary_35_54)
 
-        # Verifies that there are 17 results for the 18-34 age group.
+        # Verifies that there are 12 results for the 18-34 age group.
         self.assertEqual(len(report_summary_18_34.report_summary_set_results),
-                         17)
+                         12)
         # Verifies that there are 8 results for the 35-54 age group.
         self.assertEqual(len(report_summary_35_54.report_summary_set_results),
                          8)

--- a/src/test/python/wfa/measurement/reporting/postprocessing/tools/sample_report_result.textproto
+++ b/src/test/python/wfa/measurement/reporting/postprocessing/tools/sample_report_result.textproto
@@ -8,33 +8,28 @@ reporting_set_results {
     external_reporting_set_id: "reporting_set_id_edp1"
     venn_diagram_region_type: UNION
     external_impression_qualification_filter_id: "ami"
-    metric_frequency_spec {
-      weekly: MONDAY
-    }
+    metric_frequency_spec { weekly: MONDAY }
     grouping {
       value_by_path {
         key: "person.age_group"
-        value {
-          enum_value: "YEARS_35_TO_54"
-        }
+        value { enum_value: "YEARS_35_TO_54" }
       }
       value_by_path {
         key: "person.gender"
-        value {
-          enum_value: "MALE"
-        }
+        value { enum_value: "MALE" }
       }
     }
     event_filters {
       terms {
         path: "banner_ad.viewable"
-        value {
-          bool_value: true
-        }
+        value { bool_value: true }
       }
     }
   }
   population_size: 55000000
+  metric_frequency_spec_fingerprint: 1234
+  grouping_dimension_fingerprint: 1
+  filter_fingerprint: 5
   reporting_window_results {
     key {
       non_cumulative_start {
@@ -53,69 +48,53 @@ reporting_set_results {
         cumulative_results {
           reach {
             value: 10011521
-            univariate_statistics {
-              standard_deviation: 10000.0
-            }
+            univariate_statistics { standard_deviation: 10000 }
           }
         }
         non_cumulative_results {
           reach {
             value: 10013194
-            univariate_statistics {
-              standard_deviation: 10000.0
-            }
-          }
-          frequency_histogram {
-            bin_results {
-              key: 1
-              value {
-                value: 5173374
-                univariate_statistics {
-                  standard_deviation: 10000.0
-                }
-              }
-            }
-            bin_results {
-              key: 2
-              value {
-                value: 2587194
-                univariate_statistics {
-                  standard_deviation: 10000.0
-                }
-              }
-            }
-            bin_results {
-              key: 3
-              value {
-                value: 1292385
-                univariate_statistics {
-                  standard_deviation: 10000.0
-                }
-              }
-            }
-            bin_results {
-              key: 4
-              value {
-                value: 643261
-                univariate_statistics {
-                  standard_deviation: 10000.0
-                }
-              }
-            }
-            bin_results {
-              key: 5
-              value {
-                value: 316980
-                univariate_statistics {
-                  standard_deviation: 10000.0
-                }
-              }
-            }
+            univariate_statistics { standard_deviation: 10000 }
           }
           impression_count {
             value: 18382862
-            univariate_statistics {
-              standard_deviation: 10000.0
+            univariate_statistics { standard_deviation: 10000 }
+          }
+          frequency_histogram {
+            bin_results: {
+              key: 1
+              value: {
+                value: 5173374
+                univariate_statistics { standard_deviation: 10000 }
+              }
+            }
+            bin_results: {
+              key: 2
+              value: {
+                value: 2587194
+                univariate_statistics { standard_deviation: 10000 }
+              }
+            }
+            bin_results: {
+              key: 3
+              value: {
+                value: 1292385
+                univariate_statistics { standard_deviation: 10000 }
+              }
+            }
+            bin_results: {
+              key: 4
+              value: {
+                value: 643261
+                univariate_statistics { standard_deviation: 10000 }
+              }
+            }
+            bin_results: {
+              key: 5
+              value: {
+                value: 316980
+                univariate_statistics { standard_deviation: 10000 }
+              }
             }
           }
         }
@@ -140,78 +119,59 @@ reporting_set_results {
         cumulative_results {
           reach {
             value: 12002237
-            univariate_statistics {
-              standard_deviation: 10000.0
-            }
+            univariate_statistics { standard_deviation: 10000 }
           }
         }
         non_cumulative_results {
           reach {
             value: 2451953
-            univariate_statistics {
-              standard_deviation: 10000.0
-            }
-          }
-          frequency_histogram {
-            bin_results {
-              key: 1
-              value {
-                value: 1268962
-                univariate_statistics {
-                  standard_deviation: 10000.0
-                }
-              }
-            }
-            bin_results {
-              key: 2
-              value {
-                value: 634477
-                univariate_statistics {
-                  standard_deviation: 10000.0
-                }
-              }
-            }
-            bin_results {
-              key: 3
-              value {
-                value: 316378
-                univariate_statistics {
-                  standard_deviation: 10000.0
-                }
-              }
-            }
-            bin_results {
-              key: 4
-              value {
-                value: 156473
-                univariate_statistics {
-                  standard_deviation: 10000.0
-                }
-              }
-            }
-            bin_results {
-              key: 5
-              value {
-                value: 75663
-                univariate_statistics {
-                  standard_deviation: 10000.0
-                }
-              }
-            }
+            univariate_statistics { standard_deviation: 10000 }
           }
           impression_count {
             value: 4491260
-            univariate_statistics {
-              standard_deviation: 10000.0
+            univariate_statistics { standard_deviation: 10000 }
+          }
+          frequency_histogram {
+            bin_results: {
+              key: 1
+              value: {
+                value: 1268962
+                univariate_statistics { standard_deviation: 10000 }
+              }
+            }
+            bin_results: {
+              key: 2
+              value: {
+                value: 634477
+                univariate_statistics { standard_deviation: 10000 }
+              }
+            }
+            bin_results: {
+              key: 3
+              value: {
+                value: 316378
+                univariate_statistics { standard_deviation: 10000 }
+              }
+            }
+            bin_results: {
+              key: 4
+              value: {
+                value: 156473
+                univariate_statistics { standard_deviation: 10000 }
+              }
+            }
+            bin_results: {
+              key: 5
+              value: {
+                value: 75663
+                univariate_statistics { standard_deviation: 10000 }
+              }
             }
           }
         }
       }
     }
   }
-  metric_frequency_spec_fingerprint: 1234
-  grouping_dimension_fingerprint: 1
-  filter_fingerprint: 5
 }
 reporting_set_results {
   cmms_measurement_consumer_id: "abcd"
@@ -221,33 +181,28 @@ reporting_set_results {
     external_reporting_set_id: "reporting_set_id_edp1"
     venn_diagram_region_type: UNION
     external_impression_qualification_filter_id: "ami"
-    metric_frequency_spec {
-      total: true
-    }
+    metric_frequency_spec { total: true }
     grouping {
       value_by_path {
         key: "person.age_group"
-        value {
-          enum_value: "YEARS_35_TO_54"
-        }
+        value { enum_value: "YEARS_35_TO_54" }
       }
       value_by_path {
         key: "person.gender"
-        value {
-          enum_value: "MALE"
-        }
+        value { enum_value: "MALE" }
       }
     }
     event_filters {
       terms {
         path: "banner_ad.viewable"
-        value {
-          bool_value: true
-        }
+        value { bool_value: true }
       }
     }
   }
   population_size: 55000000
+  metric_frequency_spec_fingerprint: 1234
+  grouping_dimension_fingerprint: 1
+  filter_fingerprint: 5
   reporting_window_results {
     key {
       non_cumulative_start {
@@ -266,70 +221,53 @@ reporting_set_results {
         cumulative_results {
           reach {
             value: 12002237
-            univariate_statistics {
-              standard_deviation: 10000.0
-            }
-          }
-          frequency_histogram {
-            bin_results {
-              key: 1
-              value {
-                value: 6187323
-                univariate_statistics {
-                  standard_deviation: 10000.0
-                }
-              }
-            }
-            bin_results {
-              key: 2
-              value {
-                value: 3095997
-                univariate_statistics {
-                  standard_deviation: 10000.0
-                }
-              }
-            }
-            bin_results {
-              key: 3
-              value {
-                value: 1550333
-                univariate_statistics {
-                  standard_deviation: 10000.0
-                }
-              }
-            }
-            bin_results {
-              key: 4
-              value {
-                value: 777501
-                univariate_statistics {
-                  standard_deviation: 10000.0
-                }
-              }
-            }
-            bin_results {
-              key: 5
-              value {
-                value: 391084
-                univariate_statistics {
-                  standard_deviation: 10000.0
-                }
-              }
-            }
+            univariate_statistics { standard_deviation: 10000 }
           }
           impression_count {
             value: 22868543
-            univariate_statistics {
-              standard_deviation: 10000.0
+            univariate_statistics { standard_deviation: 10000 }
+          }
+          frequency_histogram {
+            bin_results: {
+              key: 1
+              value: {
+                value: 6187323
+                univariate_statistics { standard_deviation: 10000 }
+              }
+            }
+            bin_results: {
+              key: 2
+              value: {
+                value: 3095997
+                univariate_statistics { standard_deviation: 10000 }
+              }
+            }
+            bin_results: {
+              key: 3
+              value: {
+                value: 1550333
+                univariate_statistics { standard_deviation: 10000 }
+              }
+            }
+            bin_results: {
+              key: 4
+              value: {
+                value: 777501
+                univariate_statistics { standard_deviation: 10000 }
+              }
+            }
+            bin_results: {
+              key: 5
+              value: {
+                value: 391084
+                univariate_statistics { standard_deviation: 10000 }
+              }
             }
           }
         }
       }
     }
   }
-  metric_frequency_spec_fingerprint: 1234
-  grouping_dimension_fingerprint: 1
-  filter_fingerprint: 5
 }
 reporting_set_results {
   cmms_measurement_consumer_id: "abcd"
@@ -339,33 +277,29 @@ reporting_set_results {
     external_reporting_set_id: "reporting_set_id_edp2"
     venn_diagram_region_type: UNION
     external_impression_qualification_filter_id: "ami"
-    metric_frequency_spec {
-      weekly: MONDAY
-    }
+    metric_frequency_spec { weekly: MONDAY }
     grouping {
       value_by_path {
         key: "person.age_group"
-        value {
-          enum_value: "YEARS_35_TO_54"
-        }
+        value { enum_value: "YEARS_35_TO_54" }
       }
       value_by_path {
         key: "person.gender"
-        value {
-          enum_value: "MALE"
-        }
+        value { enum_value: "MALE" }
       }
     }
+
     event_filters {
       terms {
         path: "banner_ad.viewable"
-        value {
-          bool_value: true
-        }
+        value { bool_value: true }
       }
     }
   }
   population_size: 55000000
+  metric_frequency_spec_fingerprint: 1234
+  grouping_dimension_fingerprint: 1
+  filter_fingerprint: 5
   reporting_window_results {
     key {
       non_cumulative_start {
@@ -382,48 +316,32 @@ reporting_set_results {
     value {
       unprocessed_report_result_values {
         cumulative_results {
-          reach {
-            value: 5000000
-          }
+          reach { value: 5000000 }
         }
         non_cumulative_results {
-          reach {
-            value: 5000000
-          }
+          reach { value: 5000000 }
+          impression_count { value: 9193546 }
           frequency_histogram {
-            bin_results {
+            bin_results: {
               key: 1
-              value {
-                value: 2580645
-              }
+              value: { value: 2580645 }
             }
-            bin_results {
+            bin_results: {
               key: 2
-              value {
-                value: 1290323
-              }
+              value: { value: 1290323 }
             }
-            bin_results {
+            bin_results: {
               key: 3
-              value {
-                value: 645162
-              }
+              value: { value: 645162 }
             }
-            bin_results {
+            bin_results: {
               key: 4
-              value {
-                value: 322581
-              }
+              value: { value: 322581 }
             }
-            bin_results {
+            bin_results: {
               key: 5
-              value {
-                value: 161289
-              }
+              value: { value: 161289 }
             }
-          }
-          impression_count {
-            value: 9193546
           }
         }
       }
@@ -445,56 +363,37 @@ reporting_set_results {
     value {
       unprocessed_report_result_values {
         cumulative_results {
-          reach {
-            value: 6000000
-          }
+          reach { value: 6000000 }
         }
         non_cumulative_results {
-          reach {
-            value: 1100000
-          }
+          reach { value: 1100000 }
+          impression_count { value: 2022579 }
           frequency_histogram {
-            bin_results {
+            bin_results: {
               key: 1
-              value {
-                value: 567742
-              }
+              value: { value: 567742 }
             }
-            bin_results {
+            bin_results: {
               key: 2
-              value {
-                value: 283871
-              }
+              value: { value: 283871 }
             }
-            bin_results {
+            bin_results: {
               key: 3
-              value {
-                value: 141936
-              }
+              value: { value: 141936 }
             }
-            bin_results {
+            bin_results: {
               key: 4
-              value {
-                value: 70968
-              }
+              value: { value: 70968 }
             }
-            bin_results {
+            bin_results: {
               key: 5
-              value {
-                value: 35483
-              }
+              value: { value: 35483 }
             }
-          }
-          impression_count {
-            value: 2022579
           }
         }
       }
     }
   }
-  metric_frequency_spec_fingerprint: 1234
-  grouping_dimension_fingerprint: 1
-  filter_fingerprint: 5
 }
 reporting_set_results {
   cmms_measurement_consumer_id: "abcd"
@@ -504,33 +403,28 @@ reporting_set_results {
     external_reporting_set_id: "reporting_set_id_edp2"
     venn_diagram_region_type: UNION
     external_impression_qualification_filter_id: "ami"
-    metric_frequency_spec {
-      total: true
-    }
+    metric_frequency_spec { total: true }
     grouping {
       value_by_path {
         key: "person.age_group"
-        value {
-          enum_value: "YEARS_35_TO_54"
-        }
+        value { enum_value: "YEARS_35_TO_54" }
       }
       value_by_path {
         key: "person.gender"
-        value {
-          enum_value: "MALE"
-        }
+        value { enum_value: "MALE" }
       }
     }
     event_filters {
       terms {
         path: "banner_ad.viewable"
-        value {
-          bool_value: true
-        }
+        value { bool_value: true }
       }
     }
   }
   population_size: 55000000
+  metric_frequency_spec_fingerprint: 1234
+  grouping_dimension_fingerprint: 1
+  filter_fingerprint: 5
   reporting_window_results {
     key {
       non_cumulative_start {
@@ -547,51 +441,34 @@ reporting_set_results {
     value {
       unprocessed_report_result_values {
         cumulative_results {
-          reach {
-            value: 6000000
-          }
+          reach { value: 6000000 }
+          impression_count { value: 11216125 }
           frequency_histogram {
-            bin_results {
+            bin_results: {
               key: 1
-              value {
-                value: 3096774
-              }
+              value: { value: 3096774 }
             }
-            bin_results {
+            bin_results: {
               key: 2
-              value {
-                value: 1548387
-              }
+              value: { value: 1548387 }
             }
-            bin_results {
+            bin_results: {
               key: 3
-              value {
-                value: 774194
-              }
+              value: { value: 774194 }
             }
-            bin_results {
+            bin_results: {
               key: 4
-              value {
-                value: 387097
-              }
+              value: { value: 387097 }
             }
-            bin_results {
+            bin_results: {
               key: 5
-              value {
-                value: 193548
-              }
+              value: { value: 193548 }
             }
-          }
-          impression_count {
-            value: 11216125
           }
         }
       }
     }
   }
-  metric_frequency_spec_fingerprint: 1234
-  grouping_dimension_fingerprint: 1
-  filter_fingerprint: 5
 }
 reporting_set_results {
   cmms_measurement_consumer_id: "abcd"
@@ -601,33 +478,28 @@ reporting_set_results {
     external_reporting_set_id: "reporting_set_id_edp3"
     venn_diagram_region_type: UNION
     external_impression_qualification_filter_id: "ami"
-    metric_frequency_spec {
-      weekly: MONDAY
-    }
+    metric_frequency_spec { weekly: MONDAY }
     grouping {
       value_by_path {
         key: "person.age_group"
-        value {
-          enum_value: "YEARS_35_TO_54"
-        }
+        value { enum_value: "YEARS_35_TO_54" }
       }
       value_by_path {
         key: "person.gender"
-        value {
-          enum_value: "MALE"
-        }
+        value { enum_value: "MALE" }
       }
     }
     event_filters {
       terms {
         path: "banner_ad.viewable"
-        value {
-          bool_value: true
-        }
+        value { bool_value: true }
       }
     }
   }
   population_size: 55000000
+  metric_frequency_spec_fingerprint: 1234
+  grouping_dimension_fingerprint: 1
+  filter_fingerprint: 5
   reporting_window_results {
     key {
       non_cumulative_start {
@@ -644,48 +516,32 @@ reporting_set_results {
     value {
       unprocessed_report_result_values {
         cumulative_results {
-          reach {
-            value: 800000
-          }
+          reach { value: 800000 }
         }
         non_cumulative_results {
-          reach {
-            value: 800000
-          }
+          reach { value: 800000 }
+          impression_count { value: 1470967 }
           frequency_histogram {
-            bin_results {
+            bin_results: {
               key: 1
-              value {
-                value: 412903
-              }
+              value: { value: 412903 }
             }
-            bin_results {
+            bin_results: {
               key: 2
-              value {
-                value: 206452
-              }
+              value: { value: 206452 }
             }
-            bin_results {
+            bin_results: {
               key: 3
-              value {
-                value: 103226
-              }
+              value: { value: 103226 }
             }
-            bin_results {
+            bin_results: {
               key: 4
-              value {
-                value: 51613
-              }
+              value: { value: 51613 }
             }
-            bin_results {
+            bin_results: {
               key: 5
-              value {
-                value: 25806
-              }
+              value: { value: 25806 }
             }
-          }
-          impression_count {
-            value: 1470967
           }
         }
       }
@@ -707,56 +563,37 @@ reporting_set_results {
     value {
       unprocessed_report_result_values {
         cumulative_results {
-          reach {
-            value: 1000000
-          }
+          reach { value: 1000000 }
         }
         non_cumulative_results {
-          reach {
-            value: 202952
-          }
+          reach { value: 202952 }
+          impression_count { value: 373169 }
           frequency_histogram {
-            bin_results {
+            bin_results: {
               key: 1
-              value {
-                value: 104749
-              }
+              value: { value: 104749 }
             }
-            bin_results {
+            bin_results: {
               key: 2
-              value {
-                value: 52375
-              }
+              value: { value: 52375 }
             }
-            bin_results {
+            bin_results: {
               key: 3
-              value {
-                value: 26188
-              }
+              value: { value: 26188 }
             }
-            bin_results {
+            bin_results: {
               key: 4
-              value {
-                value: 13094
-              }
+              value: { value: 13094 }
             }
-            bin_results {
+            bin_results: {
               key: 5
-              value {
-                value: 6546
-              }
+              value: { value: 6546 }
             }
-          }
-          impression_count {
-            value: 373169
           }
         }
       }
     }
   }
-  metric_frequency_spec_fingerprint: 1234
-  grouping_dimension_fingerprint: 1
-  filter_fingerprint: 5
 }
 reporting_set_results {
   cmms_measurement_consumer_id: "abcd"
@@ -766,33 +603,28 @@ reporting_set_results {
     external_reporting_set_id: "reporting_set_id_edp3"
     venn_diagram_region_type: UNION
     external_impression_qualification_filter_id: "ami"
-    metric_frequency_spec {
-      total: true
-    }
+    metric_frequency_spec { total: true }
     grouping {
       value_by_path {
         key: "person.age_group"
-        value {
-          enum_value: "YEARS_35_TO_54"
-        }
+        value { enum_value: "YEARS_35_TO_54" }
       }
       value_by_path {
         key: "person.gender"
-        value {
-          enum_value: "MALE"
-        }
+        value { enum_value: "MALE" }
       }
     }
     event_filters {
       terms {
         path: "banner_ad.viewable"
-        value {
-          bool_value: true
-        }
+        value { bool_value: true }
       }
     }
   }
   population_size: 55000000
+  metric_frequency_spec_fingerprint: 1234
+  grouping_dimension_fingerprint: 1
+  filter_fingerprint: 5
   reporting_window_results {
     key {
       non_cumulative_start {
@@ -809,51 +641,34 @@ reporting_set_results {
     value {
       unprocessed_report_result_values {
         cumulative_results {
-          reach {
-            value: 1000000
-          }
+          reach { value: 1000000 }
+          impression_count { value: 1844136 }
           frequency_histogram {
-            bin_results {
+            bin_results: {
               key: 1
-              value {
-                value: 516129
-              }
+              value: { value: 516129 }
             }
-            bin_results {
+            bin_results: {
               key: 2
-              value {
-                value: 258065
-              }
+              value: { value: 258065 }
             }
-            bin_results {
+            bin_results: {
               key: 3
-              value {
-                value: 129033
-              }
+              value: { value: 129033 }
             }
-            bin_results {
+            bin_results: {
               key: 4
-              value {
-                value: 64517
-              }
+              value: { value: 64517 }
             }
-            bin_results {
+            bin_results: {
               key: 5
-              value {
-                value: 32256
-              }
+              value: { value: 32256 }
             }
-          }
-          impression_count {
-            value: 1844136
           }
         }
       }
     }
   }
-  metric_frequency_spec_fingerprint: 1234
-  grouping_dimension_fingerprint: 1
-  filter_fingerprint: 5
 }
 reporting_set_results {
   cmms_measurement_consumer_id: "abcd"
@@ -863,33 +678,28 @@ reporting_set_results {
     external_reporting_set_id: "reporting_set_id_edp1_edp2_edp3"
     venn_diagram_region_type: UNION
     external_impression_qualification_filter_id: "ami"
-    metric_frequency_spec {
-      weekly: MONDAY
-    }
+    metric_frequency_spec { weekly: MONDAY }
     grouping {
       value_by_path {
         key: "person.age_group"
-        value {
-          enum_value: "YEARS_35_TO_54"
-        }
+        value { enum_value: "YEARS_35_TO_54" }
       }
       value_by_path {
         key: "person.gender"
-        value {
-          enum_value: "MALE"
-        }
+        value { enum_value: "MALE" }
       }
     }
     event_filters {
       terms {
         path: "banner_ad.viewable"
-        value {
-          bool_value: true
-        }
+        value { bool_value: true }
       }
     }
   }
   population_size: 55000000
+  metric_frequency_spec_fingerprint: 1234
+  grouping_dimension_fingerprint: 1
+  filter_fingerprint: 5
   reporting_window_results {
     key {
       non_cumulative_start {
@@ -908,69 +718,53 @@ reporting_set_results {
         cumulative_results {
           reach {
             value: 15811521
-            univariate_statistics {
-              standard_deviation: 10000.0
-            }
+            univariate_statistics { standard_deviation: 10000 }
           }
         }
         non_cumulative_results {
           reach {
             value: 15813194
-            univariate_statistics {
-              standard_deviation: 10000.0
-            }
-          }
-          frequency_histogram {
-            bin_results {
-              key: 1
-              value {
-                value: 8168699
-                univariate_statistics {
-                  standard_deviation: 10000.0
-                }
-              }
-            }
-            bin_results {
-              key: 2
-              value {
-                value: 4082739
-                univariate_statistics {
-                  standard_deviation: 10000.0
-                }
-              }
-            }
-            bin_results {
-              key: 3
-              value {
-                value: 2039269
-                univariate_statistics {
-                  standard_deviation: 10000.0
-                }
-              }
-            }
-            bin_results {
-              key: 4
-              value {
-                value: 1017045
-                univariate_statistics {
-                  standard_deviation: 10000.0
-                }
-              }
-            }
-            bin_results {
-              key: 5
-              value {
-                value: 505442
-                univariate_statistics {
-                  standard_deviation: 10000.0
-                }
-              }
-            }
+            univariate_statistics { standard_deviation: 10000 }
           }
           impression_count {
             value: 29047375
-            univariate_statistics {
-              standard_deviation: 10000.0
+            univariate_statistics { standard_deviation: 10000 }
+          }
+          frequency_histogram {
+            bin_results: {
+              key: 1
+              value: {
+                value: 8168699
+                univariate_statistics { standard_deviation: 10000 }
+              }
+            }
+            bin_results: {
+              key: 2
+              value: {
+                value: 4082739
+                univariate_statistics { standard_deviation: 10000 }
+              }
+            }
+            bin_results: {
+              key: 3
+              value: {
+                value: 2039269
+                univariate_statistics { standard_deviation: 10000 }
+              }
+            }
+            bin_results: {
+              key: 4
+              value: {
+                value: 1017045
+                univariate_statistics { standard_deviation: 10000 }
+              }
+            }
+            bin_results: {
+              key: 5
+              value: {
+                value: 505442
+                univariate_statistics { standard_deviation: 10000 }
+              }
             }
           }
         }
@@ -995,78 +789,59 @@ reporting_set_results {
         cumulative_results {
           reach {
             value: 19002237
-            univariate_statistics {
-              standard_deviation: 10000.0
-            }
+            univariate_statistics { standard_deviation: 10000 }
           }
         }
         non_cumulative_results {
           reach {
             value: 3754905
-            univariate_statistics {
-              standard_deviation: 10000.0
-            }
-          }
-          frequency_histogram {
-            bin_results {
-              key: 1
-              value {
-                value: 1942003
-                univariate_statistics {
-                  standard_deviation: 10000.0
-                }
-              }
-            }
-            bin_results {
-              key: 2
-              value {
-                value: 970342
-                univariate_statistics {
-                  standard_deviation: 10000.0
-                }
-              }
-            }
-            bin_results {
-              key: 3
-              value {
-                value: 484036
-                univariate_statistics {
-                  standard_deviation: 10000.0
-                }
-              }
-            }
-            bin_results {
-              key: 4
-              value {
-                value: 240408
-                univariate_statistics {
-                  standard_deviation: 10000.0
-                }
-              }
-            }
-            bin_results {
-              key: 5
-              value {
-                value: 118116
-                univariate_statistics {
-                  standard_deviation: 10000.0
-                }
-              }
-            }
+            univariate_statistics { standard_deviation: 10000 }
           }
           impression_count {
             value: 6887008
-            univariate_statistics {
-              standard_deviation: 10000.0
+            univariate_statistics { standard_deviation: 10000 }
+          }
+          frequency_histogram {
+            bin_results: {
+              key: 1
+              value: {
+                value: 1942003
+                univariate_statistics { standard_deviation: 10000 }
+              }
+            }
+            bin_results: {
+              key: 2
+              value: {
+                value: 970342
+                univariate_statistics { standard_deviation: 10000 }
+              }
+            }
+            bin_results: {
+              key: 3
+              value: {
+                value: 484036
+                univariate_statistics { standard_deviation: 10000 }
+              }
+            }
+            bin_results: {
+              key: 4
+              value: {
+                value: 240408
+                univariate_statistics { standard_deviation: 10000 }
+              }
+            }
+            bin_results: {
+              key: 5
+              value: {
+                value: 118116
+                univariate_statistics { standard_deviation: 10000 }
+              }
             }
           }
         }
       }
     }
   }
-  metric_frequency_spec_fingerprint: 1234
-  grouping_dimension_fingerprint: 1
-  filter_fingerprint: 5
 }
 reporting_set_results {
   cmms_measurement_consumer_id: "abcd"
@@ -1076,33 +851,28 @@ reporting_set_results {
     external_reporting_set_id: "reporting_set_id_edp1_edp2_edp3"
     venn_diagram_region_type: UNION
     external_impression_qualification_filter_id: "ami"
-    metric_frequency_spec {
-      total: true
-    }
+    metric_frequency_spec { total: true }
     grouping {
       value_by_path {
         key: "person.age_group"
-        value {
-          enum_value: "YEARS_35_TO_54"
-        }
+        value { enum_value: "YEARS_35_TO_54" }
       }
       value_by_path {
         key: "person.gender"
-        value {
-          enum_value: "MALE"
-        }
+        value { enum_value: "MALE" }
       }
     }
     event_filters {
       terms {
         path: "banner_ad.viewable"
-        value {
-          bool_value: true
-        }
+        value { bool_value: true }
       }
     }
   }
   population_size: 55000000
+  metric_frequency_spec_fingerprint: 1234
+  grouping_dimension_fingerprint: 1
+  filter_fingerprint: 5
   reporting_window_results {
     key {
       non_cumulative_start {
@@ -1121,70 +891,53 @@ reporting_set_results {
         cumulative_results {
           reach {
             value: 19002237
-            univariate_statistics {
-              standard_deviation: 10000.0
-            }
-          }
-          frequency_histogram {
-            bin_results {
-              key: 1
-              value {
-                value: 9813770
-                univariate_statistics {
-                  standard_deviation: 10000.0
-                }
-              }
-            }
-            bin_results {
-              key: 2
-              value {
-                value: 4904936
-                univariate_statistics {
-                  standard_deviation: 10000.0
-                }
-              }
-            }
-            bin_results {
-              key: 3
-              value {
-                value: 2450518
-                univariate_statistics {
-                  standard_deviation: 10000.0
-                }
-              }
-            }
-            bin_results {
-              key: 4
-              value {
-                value: 1223309
-                univariate_statistics {
-                  standard_deviation: 10000.0
-                }
-              }
-            }
-            bin_results {
-              key: 5
-              value {
-                value: 609704
-                univariate_statistics {
-                  standard_deviation: 10000.0
-                }
-              }
-            }
+            univariate_statistics { standard_deviation: 10000 }
           }
           impression_count {
             value: 35928804
-            univariate_statistics {
-              standard_deviation: 10000.0
+            univariate_statistics { standard_deviation: 10000 }
+          }
+          frequency_histogram {
+            bin_results: {
+              key: 1
+              value: {
+                value: 9813770
+                univariate_statistics { standard_deviation: 10000 }
+              }
+            }
+            bin_results: {
+              key: 2
+              value: {
+                value: 4904936
+                univariate_statistics { standard_deviation: 10000 }
+              }
+            }
+            bin_results: {
+              key: 3
+              value: {
+                value: 2450518
+                univariate_statistics { standard_deviation: 10000 }
+              }
+            }
+            bin_results: {
+              key: 4
+              value: {
+                value: 1223309
+                univariate_statistics { standard_deviation: 10000 }
+              }
+            }
+            bin_results: {
+              key: 5
+              value: {
+                value: 609704
+                univariate_statistics { standard_deviation: 10000 }
+              }
             }
           }
         }
       }
     }
   }
-  metric_frequency_spec_fingerprint: 1234
-  grouping_dimension_fingerprint: 1
-  filter_fingerprint: 5
 }
 reporting_set_results {
   cmms_measurement_consumer_id: "abcd"
@@ -1194,33 +947,28 @@ reporting_set_results {
     external_reporting_set_id: "reporting_set_id_edp1_edp2"
     venn_diagram_region_type: UNION
     external_impression_qualification_filter_id: "ami"
-    metric_frequency_spec {
-      total: true
-    }
+    metric_frequency_spec { total: true }
     grouping {
       value_by_path {
         key: "person.age_group"
-        value {
-          enum_value: "YEARS_18_TO_34"
-        }
+        value { enum_value: "YEARS_18_TO_34" }
       }
       value_by_path {
         key: "person.gender"
-        value {
-          enum_value: "MALE"
-        }
+        value { enum_value: "MALE" }
       }
     }
     event_filters {
       terms {
         path: "banner_ad.viewable"
-        value {
-          bool_value: true
-        }
+        value { bool_value: true }
       }
     }
   }
   population_size: 55000000
+  metric_frequency_spec_fingerprint: 1234
+  grouping_dimension_fingerprint: 2
+  filter_fingerprint: 5
   reporting_window_results {
     key {
       non_cumulative_start {
@@ -1238,22 +986,17 @@ reporting_set_results {
       unprocessed_report_result_values {
         cumulative_results {
           reach {
-            univariate_statistics {
-              standard_deviation: 10000.0
-            }
+            value: 0
+            univariate_statistics { standard_deviation: 10000 }
           }
           impression_count {
-            univariate_statistics {
-              standard_deviation: 10000.0
-            }
+            value: 0
+            univariate_statistics { standard_deviation: 10000 }
           }
         }
       }
     }
   }
-  metric_frequency_spec_fingerprint: 1234
-  grouping_dimension_fingerprint: 2
-  filter_fingerprint: 5
 }
 reporting_set_results {
   cmms_measurement_consumer_id: "abcd"
@@ -1263,33 +1006,28 @@ reporting_set_results {
     external_reporting_set_id: "reporting_set_id_edp1"
     venn_diagram_region_type: UNION
     external_impression_qualification_filter_id: "mrc"
-    metric_frequency_spec {
-      weekly: MONDAY
-    }
+    metric_frequency_spec { weekly: MONDAY }
     grouping {
       value_by_path {
         key: "person.age_group"
-        value {
-          enum_value: "YEARS_18_TO_34"
-        }
+        value { enum_value: "YEARS_18_TO_34" }
       }
       value_by_path {
         key: "person.gender"
-        value {
-          enum_value: "MALE"
-        }
+        value { enum_value: "MALE" }
       }
     }
     event_filters {
       terms {
         path: "banner_ad.viewable"
-        value {
-          bool_value: true
-        }
+        value { bool_value: true }
       }
     }
   }
   population_size: 55000000
+  metric_frequency_spec_fingerprint: 1234
+  grouping_dimension_fingerprint: 2
+  filter_fingerprint: 5
   reporting_window_results {
     key {
       non_cumulative_start {
@@ -1308,69 +1046,53 @@ reporting_set_results {
         cumulative_results {
           reach {
             value: 9501617
-            univariate_statistics {
-              standard_deviation: 10000.0
-            }
+            univariate_statistics { standard_deviation: 10000 }
           }
         }
         non_cumulative_results {
           reach {
             value: 9406880
-            univariate_statistics {
-              standard_deviation: 10000.0
-            }
-          }
-          frequency_histogram {
-            bin_results {
-              key: 1
-              value {
-                value: 4962943
-                univariate_statistics {
-                  standard_deviation: 10000.0
-                }
-              }
-            }
-            bin_results {
-              key: 2
-              value {
-                value: 2471815
-                univariate_statistics {
-                  standard_deviation: 10000.0
-                }
-              }
-            }
-            bin_results {
-              key: 3
-              value {
-                value: 1206938
-                univariate_statistics {
-                  standard_deviation: 10000.0
-                }
-              }
-            }
-            bin_results {
-              key: 4
-              value {
-                value: 555187
-                univariate_statistics {
-                  standard_deviation: 10000.0
-                }
-              }
-            }
-            bin_results {
-              key: 5
-              value {
-                value: 209998
-                univariate_statistics {
-                  standard_deviation: 10000.0
-                }
-              }
-            }
+            univariate_statistics { standard_deviation: 10000 }
           }
           impression_count {
             value: 16798121
-            univariate_statistics {
-              standard_deviation: 10000.0
+            univariate_statistics { standard_deviation: 10000 }
+          }
+          frequency_histogram {
+            bin_results: {
+              key: 1
+              value: {
+                value: 4962943
+                univariate_statistics { standard_deviation: 10000 }
+              }
+            }
+            bin_results: {
+              key: 2
+              value: {
+                value: 2471815
+                univariate_statistics { standard_deviation: 10000 }
+              }
+            }
+            bin_results: {
+              key: 3
+              value: {
+                value: 1206938
+                univariate_statistics { standard_deviation: 10000 }
+              }
+            }
+            bin_results: {
+              key: 4
+              value: {
+                value: 555187
+                univariate_statistics { standard_deviation: 10000 }
+              }
+            }
+            bin_results: {
+              key: 5
+              value: {
+                value: 209998
+                univariate_statistics { standard_deviation: 10000 }
+              }
             }
           }
         }
@@ -1395,78 +1117,59 @@ reporting_set_results {
         cumulative_results {
           reach {
             value: 11374247
-            univariate_statistics {
-              standard_deviation: 10000.0
-            }
+            univariate_statistics { standard_deviation: 10000 }
           }
         }
         non_cumulative_results {
           reach {
             value: 2267580
-            univariate_statistics {
-              standard_deviation: 10000.0
-            }
-          }
-          frequency_histogram {
-            bin_results {
-              key: 1
-              value {
-                value: 1194552
-                univariate_statistics {
-                  standard_deviation: 10000.0
-                }
-              }
-            }
-            bin_results {
-              key: 2
-              value {
-                value: 595109
-                univariate_statistics {
-                  standard_deviation: 10000.0
-                }
-              }
-            }
-            bin_results {
-              key: 3
-              value {
-                value: 291054
-                univariate_statistics {
-                  standard_deviation: 10000.0
-                }
-              }
-            }
-            bin_results {
-              key: 4
-              value {
-                value: 134691
-                univariate_statistics {
-                  standard_deviation: 10000.0
-                }
-              }
-            }
-            bin_results {
-              key: 5
-              value {
-                value: 52175
-                univariate_statistics {
-                  standard_deviation: 10000.0
-                }
-              }
-            }
+            univariate_statistics { standard_deviation: 10000 }
           }
           impression_count {
             value: 4057569
-            univariate_statistics {
-              standard_deviation: 10000.0
+            univariate_statistics { standard_deviation: 10000 }
+          }
+          frequency_histogram {
+            bin_results: {
+              key: 1
+              value: {
+                value: 1194552
+                univariate_statistics { standard_deviation: 10000 }
+              }
+            }
+            bin_results: {
+              key: 2
+              value: {
+                value: 595109
+                univariate_statistics { standard_deviation: 10000 }
+              }
+            }
+            bin_results: {
+              key: 3
+              value: {
+                value: 291054
+                univariate_statistics { standard_deviation: 10000 }
+              }
+            }
+            bin_results: {
+              key: 4
+              value: {
+                value: 134691
+                univariate_statistics { standard_deviation: 10000 }
+              }
+            }
+            bin_results: {
+              key: 5
+              value: {
+                value: 52175
+                univariate_statistics { standard_deviation: 10000 }
+              }
             }
           }
         }
       }
     }
   }
-  metric_frequency_spec_fingerprint: 1234
-  grouping_dimension_fingerprint: 2
-  filter_fingerprint: 5
 }
 reporting_set_results {
   cmms_measurement_consumer_id: "abcd"
@@ -1476,33 +1179,28 @@ reporting_set_results {
     external_reporting_set_id: "reporting_set_id_edp1"
     venn_diagram_region_type: UNION
     external_impression_qualification_filter_id: "mrc"
-    metric_frequency_spec {
-      total: true
-    }
+    metric_frequency_spec { total: true }
     grouping {
       value_by_path {
         key: "person.age_group"
-        value {
-          enum_value: "YEARS_18_TO_34"
-        }
+        value { enum_value: "YEARS_18_TO_34" }
       }
       value_by_path {
         key: "person.gender"
-        value {
-          enum_value: "MALE"
-        }
+        value { enum_value: "MALE" }
       }
     }
     event_filters {
       terms {
         path: "banner_ad.viewable"
-        value {
-          bool_value: true
-        }
+        value { bool_value: true }
       }
     }
   }
   population_size: 55000000
+  metric_frequency_spec_fingerprint: 1234
+  grouping_dimension_fingerprint: 2
+  filter_fingerprint: 5
   reporting_window_results {
     key {
       non_cumulative_start {
@@ -1521,70 +1219,53 @@ reporting_set_results {
         cumulative_results {
           reach {
             value: 11374247
-            univariate_statistics {
-              standard_deviation: 10000.0
-            }
-          }
-          frequency_histogram {
-            bin_results {
-              key: 1
-              value {
-                value: 5889543
-                univariate_statistics {
-                  standard_deviation: 10000.0
-                }
-              }
-            }
-            bin_results {
-              key: 2
-              value {
-                value: 2943972
-                univariate_statistics {
-                  standard_deviation: 10000.0
-                }
-              }
-            }
-            bin_results {
-              key: 3
-              value {
-                value: 1467078
-                univariate_statistics {
-                  standard_deviation: 10000.0
-                }
-              }
-            }
-            bin_results {
-              key: 4
-              value {
-                value: 724521
-                univariate_statistics {
-                  standard_deviation: 10000.0
-                }
-              }
-            }
-            bin_results {
-              key: 5
-              value {
-                value: 349132
-                univariate_statistics {
-                  standard_deviation: 10000.0
-                }
-              }
-            }
+            univariate_statistics { standard_deviation: 10000 }
           }
           impression_count {
             value: 20822466
-            univariate_statistics {
-              standard_deviation: 10000.0
+            univariate_statistics { standard_deviation: 10000 }
+          }
+          frequency_histogram {
+            bin_results: {
+              key: 1
+              value: {
+                value: 5889543
+                univariate_statistics { standard_deviation: 10000 }
+              }
+            }
+            bin_results: {
+              key: 2
+              value: {
+                value: 2943972
+                univariate_statistics { standard_deviation: 10000 }
+              }
+            }
+            bin_results: {
+              key: 3
+              value: {
+                value: 1467078
+                univariate_statistics { standard_deviation: 10000 }
+              }
+            }
+            bin_results: {
+              key: 4
+              value: {
+                value: 724521
+                univariate_statistics { standard_deviation: 10000 }
+              }
+            }
+            bin_results: {
+              key: 5
+              value: {
+                value: 349132
+                univariate_statistics { standard_deviation: 10000 }
+              }
             }
           }
         }
       }
     }
   }
-  metric_frequency_spec_fingerprint: 1234
-  grouping_dimension_fingerprint: 2
-  filter_fingerprint: 5
 }
 reporting_set_results {
   cmms_measurement_consumer_id: "abcd"
@@ -1594,33 +1275,28 @@ reporting_set_results {
     external_reporting_set_id: "reporting_set_id_edp2"
     venn_diagram_region_type: UNION
     external_impression_qualification_filter_id: "mrc"
-    metric_frequency_spec {
-      weekly: MONDAY
-    }
+    metric_frequency_spec { weekly: MONDAY }
     grouping {
       value_by_path {
         key: "person.age_group"
-        value {
-          enum_value: "YEARS_18_TO_34"
-        }
+        value { enum_value: "YEARS_18_TO_34" }
       }
       value_by_path {
         key: "person.gender"
-        value {
-          enum_value: "MALE"
-        }
+        value { enum_value: "MALE" }
       }
     }
     event_filters {
       terms {
         path: "banner_ad.viewable"
-        value {
-          bool_value: true
-        }
+        value { bool_value: true }
       }
     }
   }
   population_size: 55000000
+  metric_frequency_spec_fingerprint: 1234
+  grouping_dimension_fingerprint: 2
+  filter_fingerprint: 5
   reporting_window_results {
     key {
       non_cumulative_start {
@@ -1637,48 +1313,32 @@ reporting_set_results {
     value {
       unprocessed_report_result_values {
         cumulative_results {
-          reach {
-            value: 4750000
-          }
+          reach { value: 4750000 }
         }
         non_cumulative_results {
-          reach {
-            value: 4750000
-          }
+          reach { value: 4750000 }
+          impression_count { value: 8733867 }
           frequency_histogram {
-            bin_results {
+            bin_results: {
               key: 1
-              value {
-                value: 2451613
-              }
+              value: { value: 2451613 }
             }
-            bin_results {
+            bin_results: {
               key: 2
-              value {
-                value: 1225807
-              }
+              value: { value: 1225807 }
             }
-            bin_results {
+            bin_results: {
               key: 3
-              value {
-                value: 612904
-              }
+              value: { value: 612904 }
             }
-            bin_results {
+            bin_results: {
               key: 4
-              value {
-                value: 306452
-              }
+              value: { value: 306452 }
             }
-            bin_results {
+            bin_results: {
               key: 5
-              value {
-                value: 153224
-              }
+              value: { value: 153224 }
             }
-          }
-          impression_count {
-            value: 8733867
           }
         }
       }
@@ -1700,56 +1360,37 @@ reporting_set_results {
     value {
       unprocessed_report_result_values {
         cumulative_results {
-          reach {
-            value: 5700000
-          }
+          reach { value: 5700000 }
         }
         non_cumulative_results {
-          reach {
-            value: 1039801
-          }
+          reach { value: 1039801 }
+          impression_count { value: 1911893 }
           frequency_histogram {
-            bin_results {
+            bin_results: {
               key: 1
-              value {
-                value: 536671
-              }
+              value: { value: 536671 }
             }
-            bin_results {
+            bin_results: {
               key: 2
-              value {
-                value: 268336
-              }
+              value: { value: 268336 }
             }
-            bin_results {
+            bin_results: {
               key: 3
-              value {
-                value: 134168
-              }
+              value: { value: 134168 }
             }
-            bin_results {
+            bin_results: {
               key: 4
-              value {
-                value: 67084
-              }
+              value: { value: 67084 }
             }
-            bin_results {
+            bin_results: {
               key: 5
-              value {
-                value: 33542
-              }
+              value: { value: 33542 }
             }
-          }
-          impression_count {
-            value: 1911893
           }
         }
       }
     }
   }
-  metric_frequency_spec_fingerprint: 1234
-  grouping_dimension_fingerprint: 2
-  filter_fingerprint: 5
 }
 reporting_set_results {
   cmms_measurement_consumer_id: "abcd"
@@ -1759,33 +1400,28 @@ reporting_set_results {
     external_reporting_set_id: "reporting_set_id_edp2"
     venn_diagram_region_type: UNION
     external_impression_qualification_filter_id: "mrc"
-    metric_frequency_spec {
-      total: true
-    }
+    metric_frequency_spec { total: true }
     grouping {
       value_by_path {
         key: "person.age_group"
-        value {
-          enum_value: "YEARS_18_TO_34"
-        }
+        value { enum_value: "YEARS_18_TO_34" }
       }
       value_by_path {
         key: "person.gender"
-        value {
-          enum_value: "MALE"
-        }
+        value { enum_value: "MALE" }
       }
     }
     event_filters {
       terms {
         path: "banner_ad.viewable"
-        value {
-          bool_value: true
-        }
+        value { bool_value: true }
       }
     }
   }
   population_size: 55000000
+  metric_frequency_spec_fingerprint: 1234
+  grouping_dimension_fingerprint: 2
+  filter_fingerprint: 5
   reporting_window_results {
     key {
       non_cumulative_start {
@@ -1802,51 +1438,34 @@ reporting_set_results {
     value {
       unprocessed_report_result_values {
         cumulative_results {
-          reach {
-            value: 5700000
-          }
+          reach { value: 5700000 }
+          impression_count { value: 10645760 }
           frequency_histogram {
-            bin_results {
+            bin_results: {
               key: 1
-              value {
-                value: 2941935
-              }
+              value: { value: 2941935 }
             }
-            bin_results {
+            bin_results: {
               key: 2
-              value {
-                value: 1470968
-              }
+              value: { value: 1470968 }
             }
-            bin_results {
+            bin_results: {
               key: 3
-              value {
-                value: 735484
-              }
+              value: { value: 735484 }
             }
-            bin_results {
+            bin_results: {
               key: 4
-              value {
-                value: 367742
-              }
+              value: { value: 367742 }
             }
-            bin_results {
+            bin_results: {
               key: 5
-              value {
-                value: 183871
-              }
+              value: { value: 183871 }
             }
-          }
-          impression_count {
-            value: 10645760
           }
         }
       }
     }
   }
-  metric_frequency_spec_fingerprint: 1234
-  grouping_dimension_fingerprint: 2
-  filter_fingerprint: 5
 }
 reporting_set_results {
   cmms_measurement_consumer_id: "abcd"
@@ -1856,33 +1475,28 @@ reporting_set_results {
     external_reporting_set_id: "reporting_set_id_edp3"
     venn_diagram_region_type: UNION
     external_impression_qualification_filter_id: "mrc"
-    metric_frequency_spec {
-      weekly: MONDAY
-    }
+    metric_frequency_spec { weekly: MONDAY }
     grouping {
       value_by_path {
         key: "person.age_group"
-        value {
-          enum_value: "YEARS_18_TO_34"
-        }
+        value { enum_value: "YEARS_18_TO_34" }
       }
       value_by_path {
         key: "person.gender"
-        value {
-          enum_value: "MALE"
-        }
+        value { enum_value: "MALE" }
       }
     }
     event_filters {
       terms {
         path: "banner_ad.viewable"
-        value {
-          bool_value: true
-        }
+        value { bool_value: true }
       }
     }
   }
   population_size: 55000000
+  metric_frequency_spec_fingerprint: 1234
+  grouping_dimension_fingerprint: 2
+  filter_fingerprint: 5
   reporting_window_results {
     key {
       non_cumulative_start {
@@ -1899,48 +1513,32 @@ reporting_set_results {
     value {
       unprocessed_report_result_values {
         cumulative_results {
-          reach {
-            value: 760000
-          }
+          reach { value: 760000 }
         }
         non_cumulative_results {
-          reach {
-            value: 760000
-          }
+          reach { value: 760000 }
+          impression_count { value: 1397418 }
           frequency_histogram {
-            bin_results {
+            bin_results: {
               key: 1
-              value {
-                value: 392258
-              }
+              value: { value: 392258 }
             }
-            bin_results {
+            bin_results: {
               key: 2
-              value {
-                value: 196129
-              }
+              value: { value: 196129 }
             }
-            bin_results {
+            bin_results: {
               key: 3
-              value {
-                value: 98065
-              }
+              value: { value: 98065 }
             }
-            bin_results {
+            bin_results: {
               key: 4
-              value {
-                value: 49033
-              }
+              value: { value: 49033 }
             }
-            bin_results {
+            bin_results: {
               key: 5
-              value {
-                value: 24515
-              }
+              value: { value: 24515 }
             }
-          }
-          impression_count {
-            value: 1397418
           }
         }
       }
@@ -1962,56 +1560,37 @@ reporting_set_results {
     value {
       unprocessed_report_result_values {
         cumulative_results {
-          reach {
-            value: 950000
-          }
+          reach { value: 950000 }
         }
         non_cumulative_results {
-          reach {
-            value: 192662
-          }
+          reach { value: 192662 }
+          impression_count { value: 354251 }
           frequency_histogram {
-            bin_results {
+            bin_results: {
               key: 1
-              value {
-                value: 99438
-              }
+              value: { value: 99438 }
             }
-            bin_results {
+            bin_results: {
               key: 2
-              value {
-                value: 49719
-              }
+              value: { value: 49719 }
             }
-            bin_results {
+            bin_results: {
               key: 3
-              value {
-                value: 24860
-              }
+              value: { value: 24860 }
             }
-            bin_results {
+            bin_results: {
               key: 4
-              value {
-                value: 12430
-              }
+              value: { value: 12430 }
             }
-            bin_results {
+            bin_results: {
               key: 5
-              value {
-                value: 6215
-              }
+              value: { value: 6215 }
             }
-          }
-          impression_count {
-            value: 354251
           }
         }
       }
     }
   }
-  metric_frequency_spec_fingerprint: 1234
-  grouping_dimension_fingerprint: 2
-  filter_fingerprint: 5
 }
 reporting_set_results {
   cmms_measurement_consumer_id: "abcd"
@@ -2021,33 +1600,28 @@ reporting_set_results {
     external_reporting_set_id: "reporting_set_id_edp3"
     venn_diagram_region_type: UNION
     external_impression_qualification_filter_id: "mrc"
-    metric_frequency_spec {
-      total: true
-    }
+    metric_frequency_spec { total: true }
     grouping {
       value_by_path {
         key: "person.age_group"
-        value {
-          enum_value: "YEARS_18_TO_34"
-        }
+        value { enum_value: "YEARS_18_TO_34" }
       }
       value_by_path {
         key: "person.gender"
-        value {
-          enum_value: "MALE"
-        }
+        value { enum_value: "MALE" }
       }
     }
     event_filters {
       terms {
         path: "banner_ad.viewable"
-        value {
-          bool_value: true
-        }
+        value { bool_value: true }
       }
     }
   }
   population_size: 55000000
+  metric_frequency_spec_fingerprint: 1234
+  grouping_dimension_fingerprint: 2
+  filter_fingerprint: 5
   reporting_window_results {
     key {
       non_cumulative_start {
@@ -2064,51 +1638,34 @@ reporting_set_results {
     value {
       unprocessed_report_result_values {
         cumulative_results {
-          reach {
-            value: 950000
-          }
+          reach { value: 950000 }
+          impression_count { value: 1751669 }
           frequency_histogram {
-            bin_results {
+            bin_results: {
               key: 1
-              value {
-                value: 490323
-              }
+              value: { value: 490323 }
             }
-            bin_results {
+            bin_results: {
               key: 2
-              value {
-                value: 245162
-              }
+              value: { value: 245162 }
             }
-            bin_results {
+            bin_results: {
               key: 3
-              value {
-                value: 122581
-              }
+              value: { value: 122581 }
             }
-            bin_results {
+            bin_results: {
               key: 4
-              value {
-                value: 61291
-              }
+              value: { value: 61291 }
             }
-            bin_results {
+            bin_results: {
               key: 5
-              value {
-                value: 30643
-              }
+              value: { value: 30643 }
             }
-          }
-          impression_count {
-            value: 1751669
           }
         }
       }
     }
   }
-  metric_frequency_spec_fingerprint: 1234
-  grouping_dimension_fingerprint: 2
-  filter_fingerprint: 5
 }
 reporting_set_results {
   cmms_measurement_consumer_id: "abcd"
@@ -2118,33 +1675,28 @@ reporting_set_results {
     external_reporting_set_id: "reporting_set_id_edp1_edp2_edp3"
     venn_diagram_region_type: UNION
     external_impression_qualification_filter_id: "mrc"
-    metric_frequency_spec {
-      weekly: MONDAY
-    }
+    metric_frequency_spec { weekly: MONDAY }
     grouping {
       value_by_path {
         key: "person.age_group"
-        value {
-          enum_value: "YEARS_18_TO_34"
-        }
+        value { enum_value: "YEARS_18_TO_34" }
       }
       value_by_path {
         key: "person.gender"
-        value {
-          enum_value: "MALE"
-        }
+        value { enum_value: "MALE" }
       }
     }
     event_filters {
       terms {
         path: "banner_ad.viewable"
-        value {
-          bool_value: true
-        }
+        value { bool_value: true }
       }
     }
   }
   population_size: 55000000
+  metric_frequency_spec_fingerprint: 1234
+  grouping_dimension_fingerprint: 2
+  filter_fingerprint: 5
   reporting_window_results {
     key {
       non_cumulative_start {
@@ -2163,69 +1715,53 @@ reporting_set_results {
         cumulative_results {
           reach {
             value: 13427249
-            univariate_statistics {
-              standard_deviation: 10000.0
-            }
+            univariate_statistics { standard_deviation: 10000 }
           }
         }
         non_cumulative_results {
           reach {
             value: 13426463
-            univariate_statistics {
-              standard_deviation: 10000.0
-            }
-          }
-          frequency_histogram {
-            bin_results {
-              key: 1
-              value {
-                value: 6929787
-                univariate_statistics {
-                  standard_deviation: 10000.0
-                }
-              }
-            }
-            bin_results {
-              key: 2
-              value {
-                value: 3464894
-                univariate_statistics {
-                  standard_deviation: 10000.0
-                }
-              }
-            }
-            bin_results {
-              key: 3
-              value {
-                value: 1732447
-                univariate_statistics {
-                  standard_deviation: 10000.0
-                }
-              }
-            }
-            bin_results {
-              key: 4
-              value {
-                value: 866224
-                univariate_statistics {
-                  standard_deviation: 10000.0
-                }
-              }
-            }
-            bin_results {
-              key: 5
-              value {
-                value: 433111
-                univariate_statistics {
-                  standard_deviation: 10000.0
-                }
-              }
-            }
+            univariate_statistics { standard_deviation: 10000 }
           }
           impression_count {
             value: 26929406
-            univariate_statistics {
-              standard_deviation: 10000.0
+            univariate_statistics { standard_deviation: 10000 }
+          }
+          frequency_histogram {
+            bin_results: {
+              key: 1
+              value: {
+                value: 6929787
+                univariate_statistics { standard_deviation: 10000 }
+              }
+            }
+            bin_results: {
+              key: 2
+              value: {
+                value: 3464894
+                univariate_statistics { standard_deviation: 10000 }
+              }
+            }
+            bin_results: {
+              key: 3
+              value: {
+                value: 1732447
+                univariate_statistics { standard_deviation: 10000 }
+              }
+            }
+            bin_results: {
+              key: 4
+              value: {
+                value: 866224
+                univariate_statistics { standard_deviation: 10000 }
+              }
+            }
+            bin_results: {
+              key: 5
+              value: {
+                value: 433111
+                univariate_statistics { standard_deviation: 10000 }
+              }
             }
           }
         }
@@ -2250,78 +1786,59 @@ reporting_set_results {
         cumulative_results {
           reach {
             value: 15914078
-            univariate_statistics {
-              standard_deviation: 10000.0
-            }
+            univariate_statistics { standard_deviation: 10000 }
           }
         }
         non_cumulative_results {
           reach {
             value: 3278136
-            univariate_statistics {
-              standard_deviation: 10000.0
-            }
-          }
-          frequency_histogram {
-            bin_results {
-              key: 1
-              value {
-                value: 1691941
-                univariate_statistics {
-                  standard_deviation: 10000.0
-                }
-              }
-            }
-            bin_results {
-              key: 2
-              value {
-                value: 845971
-                univariate_statistics {
-                  standard_deviation: 10000.0
-                }
-              }
-            }
-            bin_results {
-              key: 3
-              value {
-                value: 422986
-                univariate_statistics {
-                  standard_deviation: 10000.0
-                }
-              }
-            }
-            bin_results {
-              key: 4
-              value {
-                value: 211493
-                univariate_statistics {
-                  standard_deviation: 10000.0
-                }
-              }
-            }
-            bin_results {
-              key: 5
-              value {
-                value: 105745
-                univariate_statistics {
-                  standard_deviation: 10000.0
-                }
-              }
-            }
+            univariate_statistics { standard_deviation: 10000 }
           }
           impression_count {
             value: 6323713
-            univariate_statistics {
-              standard_deviation: 10000.0
+            univariate_statistics { standard_deviation: 10000 }
+          }
+          frequency_histogram {
+            bin_results: {
+              key: 1
+              value: {
+                value: 1691941
+                univariate_statistics { standard_deviation: 10000 }
+              }
+            }
+            bin_results: {
+              key: 2
+              value: {
+                value: 845971
+                univariate_statistics { standard_deviation: 10000 }
+              }
+            }
+            bin_results: {
+              key: 3
+              value: {
+                value: 422986
+                univariate_statistics { standard_deviation: 10000 }
+              }
+            }
+            bin_results: {
+              key: 4
+              value: {
+                value: 211493
+                univariate_statistics { standard_deviation: 10000 }
+              }
+            }
+            bin_results: {
+              key: 5
+              value: {
+                value: 105745
+                univariate_statistics { standard_deviation: 10000 }
+              }
             }
           }
         }
       }
     }
   }
-  metric_frequency_spec_fingerprint: 1234
-  grouping_dimension_fingerprint: 2
-  filter_fingerprint: 5
 }
 reporting_set_results {
   cmms_measurement_consumer_id: "abcd"
@@ -2331,33 +1848,28 @@ reporting_set_results {
     external_reporting_set_id: "reporting_set_id_edp1_edp2_edp3"
     venn_diagram_region_type: UNION
     external_impression_qualification_filter_id: "mrc"
-    metric_frequency_spec {
-      total: true
-    }
+    metric_frequency_spec { total: true }
     grouping {
       value_by_path {
         key: "person.age_group"
-        value {
-          enum_value: "YEARS_18_TO_34"
-        }
+        value { enum_value: "YEARS_18_TO_34" }
       }
       value_by_path {
         key: "person.gender"
-        value {
-          enum_value: "MALE"
-        }
+        value { enum_value: "MALE" }
       }
     }
     event_filters {
       terms {
         path: "banner_ad.viewable"
-        value {
-          bool_value: true
-        }
+        value { bool_value: true }
       }
     }
   }
   population_size: 55000000
+  metric_frequency_spec_fingerprint: 1234
+  grouping_dimension_fingerprint: 2
+  filter_fingerprint: 5
   reporting_window_results {
     key {
       non_cumulative_start {
@@ -2376,70 +1888,53 @@ reporting_set_results {
         cumulative_results {
           reach {
             value: 15914078
-            univariate_statistics {
-              standard_deviation: 10000.0
-            }
-          }
-          frequency_histogram {
-            bin_results {
-              key: 1
-              value {
-                value: 8212074
-                univariate_statistics {
-                  standard_deviation: 10000.0
-                }
-              }
-            }
-            bin_results {
-              key: 2
-              value {
-                value: 4106557
-                univariate_statistics {
-                  standard_deviation: 10000.0
-                }
-              }
-            }
-            bin_results {
-              key: 3
-              value {
-                value: 2053798
-                univariate_statistics {
-                  standard_deviation: 10000.0
-                }
-              }
-            }
-            bin_results {
-              key: 4
-              value {
-                value: 1027420
-                univariate_statistics {
-                  standard_deviation: 10000.0
-                }
-              }
-            }
-            bin_results {
-              key: 5
-              value {
-                value: 514229
-                univariate_statistics {
-                  standard_deviation: 10000.0
-                }
-              }
-            }
+            univariate_statistics { standard_deviation: 10000 }
           }
           impression_count {
             value: 33219895
-            univariate_statistics {
-              standard_deviation: 10000.0
+            univariate_statistics { standard_deviation: 10000 }
+          }
+          frequency_histogram {
+            bin_results: {
+              key: 1
+              value: {
+                value: 8212074
+                univariate_statistics { standard_deviation: 10000 }
+              }
+            }
+            bin_results: {
+              key: 2
+              value: {
+                value: 4106557
+                univariate_statistics { standard_deviation: 10000 }
+              }
+            }
+            bin_results: {
+              key: 3
+              value: {
+                value: 2053798
+                univariate_statistics { standard_deviation: 10000 }
+              }
+            }
+            bin_results: {
+              key: 4
+              value: {
+                value: 1027420
+                univariate_statistics { standard_deviation: 10000 }
+              }
+            }
+            bin_results: {
+              key: 5
+              value: {
+                value: 514229
+                univariate_statistics { standard_deviation: 10000 }
+              }
             }
           }
         }
       }
     }
   }
-  metric_frequency_spec_fingerprint: 1234
-  grouping_dimension_fingerprint: 2
-  filter_fingerprint: 5
 }
 reporting_set_results {
   cmms_measurement_consumer_id: "abcd"
@@ -2449,33 +1944,29 @@ reporting_set_results {
     external_reporting_set_id: "reporting_set_id_edp1"
     venn_diagram_region_type: UNION
     custom: true
-    metric_frequency_spec {
-      weekly: MONDAY
-    }
+    metric_frequency_spec { weekly: MONDAY }
     grouping {
       value_by_path {
         key: "person.age_group"
-        value {
-          enum_value: "YEARS_18_TO_34"
-        }
+        value { enum_value: "YEARS_18_TO_34" }
       }
       value_by_path {
         key: "person.gender"
-        value {
-          enum_value: "MALE"
-        }
+        value { enum_value: "MALE" }
       }
     }
     event_filters {
       terms {
         path: "banner_ad.viewable"
-        value {
-          bool_value: true
-        }
+        value { bool_value: true }
       }
     }
   }
+
   population_size: 55000000
+  metric_frequency_spec_fingerprint: 1234
+  grouping_dimension_fingerprint: 2
+  filter_fingerprint: 5
   reporting_window_results {
     key {
       non_cumulative_start {
@@ -2494,69 +1985,53 @@ reporting_set_results {
         cumulative_results {
           reach {
             value: 9991826
-            univariate_statistics {
-              standard_deviation: 10000.0
-            }
+            univariate_statistics { standard_deviation: 10000 }
           }
         }
         non_cumulative_results {
           reach {
             value: 10007663
-            univariate_statistics {
-              standard_deviation: 10000.0
-            }
-          }
-          frequency_histogram {
-            bin_results {
-              key: 1
-              value {
-                value: 5167588
-                univariate_statistics {
-                  standard_deviation: 10000.0
-                }
-              }
-            }
-            bin_results {
-              key: 2
-              value {
-                value: 2584463
-                univariate_statistics {
-                  standard_deviation: 10000.0
-                }
-              }
-            }
-            bin_results {
-              key: 3
-              value {
-                value: 1291787
-                univariate_statistics {
-                  standard_deviation: 10000.0
-                }
-              }
-            }
-            bin_results {
-              key: 4
-              value {
-                value: 644334
-                univariate_statistics {
-                  standard_deviation: 10000.0
-                }
-              }
-            }
-            bin_results {
-              key: 5
-              value {
-                value: 319491
-                univariate_statistics {
-                  standard_deviation: 10000.0
-                }
-              }
-            }
+            univariate_statistics { standard_deviation: 10000 }
           }
           impression_count {
             value: 18386667
-            univariate_statistics {
-              standard_deviation: 10000.0
+            univariate_statistics { standard_deviation: 10000 }
+          }
+          frequency_histogram {
+            bin_results: {
+              key: 1
+              value: {
+                value: 5167588
+                univariate_statistics { standard_deviation: 10000 }
+              }
+            }
+            bin_results: {
+              key: 2
+              value: {
+                value: 2584463
+                univariate_statistics { standard_deviation: 10000 }
+              }
+            }
+            bin_results: {
+              key: 3
+              value: {
+                value: 1291787
+                univariate_statistics { standard_deviation: 10000 }
+              }
+            }
+            bin_results: {
+              key: 4
+              value: {
+                value: 644334
+                univariate_statistics { standard_deviation: 10000 }
+              }
+            }
+            bin_results: {
+              key: 5
+              value: {
+                value: 319491
+                univariate_statistics { standard_deviation: 10000 }
+              }
             }
           }
         }
@@ -2581,78 +2056,59 @@ reporting_set_results {
         cumulative_results {
           reach {
             value: 12021120
-            univariate_statistics {
-              standard_deviation: 10000.0
-            }
+            univariate_statistics { standard_deviation: 10000 }
           }
         }
         non_cumulative_results {
           reach {
             value: 2443823
-            univariate_statistics {
-              standard_deviation: 10000.0
-            }
-          }
-          frequency_histogram {
-            bin_results {
-              key: 1
-              value {
-                value: 1262038
-                univariate_statistics {
-                  standard_deviation: 10000.0
-                }
-              }
-            }
-            bin_results {
-              key: 2
-              value {
-                value: 631298
-                univariate_statistics {
-                  standard_deviation: 10000.0
-                }
-              }
-            }
-            bin_results {
-              key: 3
-              value {
-                value: 315530
-                univariate_statistics {
-                  standard_deviation: 10000.0
-                }
-              }
-            }
-            bin_results {
-              key: 4
-              value {
-                value: 157249
-                univariate_statistics {
-                  standard_deviation: 10000.0
-                }
-              }
-            }
-            bin_results {
-              key: 5
-              value {
-                value: 77708
-                univariate_statistics {
-                  standard_deviation: 10000.0
-                }
-              }
-            }
+            univariate_statistics { standard_deviation: 10000 }
           }
           impression_count {
             value: 4488759
-            univariate_statistics {
-              standard_deviation: 10000.0
+            univariate_statistics { standard_deviation: 10000 }
+          }
+          frequency_histogram {
+            bin_results: {
+              key: 1
+              value: {
+                value: 1262038
+                univariate_statistics { standard_deviation: 10000 }
+              }
+            }
+            bin_results: {
+              key: 2
+              value: {
+                value: 631298
+                univariate_statistics { standard_deviation: 10000 }
+              }
+            }
+            bin_results: {
+              key: 3
+              value: {
+                value: 315530
+                univariate_statistics { standard_deviation: 10000 }
+              }
+            }
+            bin_results: {
+              key: 4
+              value: {
+                value: 157249
+                univariate_statistics { standard_deviation: 10000 }
+              }
+            }
+            bin_results: {
+              key: 5
+              value: {
+                value: 77708
+                univariate_statistics { standard_deviation: 10000 }
+              }
             }
           }
         }
       }
     }
   }
-  metric_frequency_spec_fingerprint: 1234
-  grouping_dimension_fingerprint: 2
-  filter_fingerprint: 5
 }
 reporting_set_results {
   cmms_measurement_consumer_id: "abcd"
@@ -2662,33 +2118,29 @@ reporting_set_results {
     external_reporting_set_id: "reporting_set_id_edp1"
     venn_diagram_region_type: UNION
     custom: true
-    metric_frequency_spec {
-      total: true
-    }
+    metric_frequency_spec { total: true }
     grouping {
       value_by_path {
         key: "person.age_group"
-        value {
-          enum_value: "YEARS_18_TO_34"
-        }
+        value { enum_value: "YEARS_18_TO_34" }
       }
       value_by_path {
         key: "person.gender"
-        value {
-          enum_value: "MALE"
-        }
+        value { enum_value: "MALE" }
       }
     }
     event_filters {
       terms {
         path: "banner_ad.viewable"
-        value {
-          bool_value: true
-        }
+        value { bool_value: true }
       }
     }
   }
+
   population_size: 55000000
+  metric_frequency_spec_fingerprint: 1234
+  grouping_dimension_fingerprint: 2
+  filter_fingerprint: 5
   reporting_window_results {
     key {
       non_cumulative_start {
@@ -2707,70 +2159,53 @@ reporting_set_results {
         cumulative_results {
           reach {
             value: 12021120
-            univariate_statistics {
-              standard_deviation: 10000.0
-            }
-          }
-          frequency_histogram {
-            bin_results {
-              key: 1
-              value {
-                value: 6203154
-                univariate_statistics {
-                  standard_deviation: 10000.0
-                }
-              }
-            }
-            bin_results {
-              key: 2
-              value {
-                value: 3101987
-                univariate_statistics {
-                  standard_deviation: 10000.0
-                }
-              }
-            }
-            bin_results {
-              key: 3
-              value {
-                value: 1551403
-                univariate_statistics {
-                  standard_deviation: 10000.0
-                }
-              }
-            }
-            bin_results {
-              key: 4
-              value {
-                value: 776111
-                univariate_statistics {
-                  standard_deviation: 10000.0
-                }
-              }
-            }
-            bin_results {
-              key: 5
-              value {
-                value: 388465
-                univariate_statistics {
-                  standard_deviation: 10000.0
-                }
-              }
-            }
+            univariate_statistics { standard_deviation: 10000 }
           }
           impression_count {
             value: 22873904
-            univariate_statistics {
-              standard_deviation: 10000.0
+            univariate_statistics { standard_deviation: 10000 }
+          }
+          frequency_histogram {
+            bin_results: {
+              key: 1
+              value: {
+                value: 6203154
+                univariate_statistics { standard_deviation: 10000 }
+              }
+            }
+            bin_results: {
+              key: 2
+              value: {
+                value: 3101987
+                univariate_statistics { standard_deviation: 10000 }
+              }
+            }
+            bin_results: {
+              key: 3
+              value: {
+                value: 1551403
+                univariate_statistics { standard_deviation: 10000 }
+              }
+            }
+            bin_results: {
+              key: 4
+              value: {
+                value: 776111
+                univariate_statistics { standard_deviation: 10000 }
+              }
+            }
+            bin_results: {
+              key: 5
+              value: {
+                value: 388465
+                univariate_statistics { standard_deviation: 10000 }
+              }
             }
           }
         }
       }
     }
   }
-  metric_frequency_spec_fingerprint: 1234
-  grouping_dimension_fingerprint: 2
-  filter_fingerprint: 5
 }
 reporting_set_results {
   cmms_measurement_consumer_id: "abcd"
@@ -2780,33 +2215,29 @@ reporting_set_results {
     external_reporting_set_id: "reporting_set_id_edp2"
     venn_diagram_region_type: UNION
     custom: true
-    metric_frequency_spec {
-      weekly: MONDAY
-    }
+    metric_frequency_spec { weekly: MONDAY }
     grouping {
       value_by_path {
         key: "person.age_group"
-        value {
-          enum_value: "YEARS_18_TO_34"
-        }
+        value { enum_value: "YEARS_18_TO_34" }
       }
       value_by_path {
         key: "person.gender"
-        value {
-          enum_value: "MALE"
-        }
+        value { enum_value: "MALE" }
       }
     }
     event_filters {
       terms {
         path: "banner_ad.viewable"
-        value {
-          bool_value: true
-        }
+        value { bool_value: true }
       }
     }
   }
+
   population_size: 55000000
+  metric_frequency_spec_fingerprint: 1234
+  grouping_dimension_fingerprint: 2
+  filter_fingerprint: 5
   reporting_window_results {
     key {
       non_cumulative_start {
@@ -2823,48 +2254,32 @@ reporting_set_results {
     value {
       unprocessed_report_result_values {
         cumulative_results {
-          reach {
-            value: 5000000
-          }
+          reach { value: 5000000 }
         }
         non_cumulative_results {
-          reach {
-            value: 5000000
-          }
+          reach { value: 5000000 }
+          impression_count { value: 9193546 }
           frequency_histogram {
-            bin_results {
+            bin_results: {
               key: 1
-              value {
-                value: 2580645
-              }
+              value: { value: 2580645 }
             }
-            bin_results {
+            bin_results: {
               key: 2
-              value {
-                value: 1290323
-              }
+              value: { value: 1290323 }
             }
-            bin_results {
+            bin_results: {
               key: 3
-              value {
-                value: 645162
-              }
+              value: { value: 645162 }
             }
-            bin_results {
+            bin_results: {
               key: 4
-              value {
-                value: 322581
-              }
+              value: { value: 322581 }
             }
-            bin_results {
+            bin_results: {
               key: 5
-              value {
-                value: 161289
-              }
+              value: { value: 161289 }
             }
-          }
-          impression_count {
-            value: 9193546
           }
         }
       }
@@ -2886,56 +2301,37 @@ reporting_set_results {
     value {
       unprocessed_report_result_values {
         cumulative_results {
-          reach {
-            value: 6000000
-          }
+          reach { value: 6000000 }
         }
         non_cumulative_results {
-          reach {
-            value: 1100000
-          }
+          reach { value: 1100000 }
+          impression_count { value: 2022579 }
           frequency_histogram {
-            bin_results {
+            bin_results: {
               key: 1
-              value {
-                value: 567742
-              }
+              value: { value: 567742 }
             }
-            bin_results {
+            bin_results: {
               key: 2
-              value {
-                value: 283871
-              }
+              value: { value: 283871 }
             }
-            bin_results {
+            bin_results: {
               key: 3
-              value {
-                value: 141936
-              }
+              value: { value: 141936 }
             }
-            bin_results {
+            bin_results: {
               key: 4
-              value {
-                value: 70968
-              }
+              value: { value: 70968 }
             }
-            bin_results {
+            bin_results: {
               key: 5
-              value {
-                value: 35483
-              }
+              value: { value: 35483 }
             }
-          }
-          impression_count {
-            value: 2022579
           }
         }
       }
     }
   }
-  metric_frequency_spec_fingerprint: 1234
-  grouping_dimension_fingerprint: 2
-  filter_fingerprint: 5
 }
 reporting_set_results {
   cmms_measurement_consumer_id: "abcd"
@@ -2945,33 +2341,29 @@ reporting_set_results {
     external_reporting_set_id: "reporting_set_id_edp2"
     venn_diagram_region_type: UNION
     custom: true
-    metric_frequency_spec {
-      total: true
-    }
+    metric_frequency_spec { total: true }
     grouping {
       value_by_path {
         key: "person.age_group"
-        value {
-          enum_value: "YEARS_18_TO_34"
-        }
+        value { enum_value: "YEARS_18_TO_34" }
       }
       value_by_path {
         key: "person.gender"
-        value {
-          enum_value: "MALE"
-        }
+        value { enum_value: "MALE" }
       }
     }
     event_filters {
       terms {
         path: "banner_ad.viewable"
-        value {
-          bool_value: true
-        }
+        value { bool_value: true }
       }
     }
   }
+
   population_size: 55000000
+  metric_frequency_spec_fingerprint: 1234
+  grouping_dimension_fingerprint: 2
+  filter_fingerprint: 5
   reporting_window_results {
     key {
       non_cumulative_start {
@@ -2988,51 +2380,34 @@ reporting_set_results {
     value {
       unprocessed_report_result_values {
         cumulative_results {
-          reach {
-            value: 6000000
-          }
+          reach { value: 6000000 }
+          impression_count { value: 11216125 }
           frequency_histogram {
-            bin_results {
+            bin_results: {
               key: 1
-              value {
-                value: 3096774
-              }
+              value: { value: 3096774 }
             }
-            bin_results {
+            bin_results: {
               key: 2
-              value {
-                value: 1548387
-              }
+              value: { value: 1548387 }
             }
-            bin_results {
+            bin_results: {
               key: 3
-              value {
-                value: 774194
-              }
+              value: { value: 774194 }
             }
-            bin_results {
+            bin_results: {
               key: 4
-              value {
-                value: 387097
-              }
+              value: { value: 387097 }
             }
-            bin_results {
+            bin_results: {
               key: 5
-              value {
-                value: 193548
-              }
+              value: { value: 193548 }
             }
-          }
-          impression_count {
-            value: 11216125
           }
         }
       }
     }
   }
-  metric_frequency_spec_fingerprint: 1234
-  grouping_dimension_fingerprint: 2
-  filter_fingerprint: 5
 }
 reporting_set_results {
   cmms_measurement_consumer_id: "abcd"
@@ -3042,33 +2417,29 @@ reporting_set_results {
     external_reporting_set_id: "reporting_set_id_edp3"
     venn_diagram_region_type: UNION
     custom: true
-    metric_frequency_spec {
-      weekly: MONDAY
-    }
+    metric_frequency_spec { weekly: MONDAY }
     grouping {
       value_by_path {
         key: "person.age_group"
-        value {
-          enum_value: "YEARS_18_TO_34"
-        }
+        value { enum_value: "YEARS_18_TO_34" }
       }
       value_by_path {
         key: "person.gender"
-        value {
-          enum_value: "MALE"
-        }
+        value { enum_value: "MALE" }
       }
     }
     event_filters {
       terms {
         path: "banner_ad.viewable"
-        value {
-          bool_value: true
-        }
+        value { bool_value: true }
       }
     }
   }
+
   population_size: 55000000
+  metric_frequency_spec_fingerprint: 1234
+  grouping_dimension_fingerprint: 2
+  filter_fingerprint: 5
   reporting_window_results {
     key {
       non_cumulative_start {
@@ -3085,48 +2456,32 @@ reporting_set_results {
     value {
       unprocessed_report_result_values {
         cumulative_results {
-          reach {
-            value: 800000
-          }
+          reach { value: 800000 }
         }
         non_cumulative_results {
-          reach {
-            value: 800000
-          }
+          reach { value: 800000 }
+          impression_count { value: 1470967 }
           frequency_histogram {
-            bin_results {
+            bin_results: {
               key: 1
-              value {
-                value: 412903
-              }
+              value: { value: 412903 }
             }
-            bin_results {
+            bin_results: {
               key: 2
-              value {
-                value: 206452
-              }
+              value: { value: 206452 }
             }
-            bin_results {
+            bin_results: {
               key: 3
-              value {
-                value: 103226
-              }
+              value: { value: 103226 }
             }
-            bin_results {
+            bin_results: {
               key: 4
-              value {
-                value: 51613
-              }
+              value: { value: 51613 }
             }
-            bin_results {
+            bin_results: {
               key: 5
-              value {
-                value: 25806
-              }
+              value: { value: 25806 }
             }
-          }
-          impression_count {
-            value: 1470967
           }
         }
       }
@@ -3148,56 +2503,37 @@ reporting_set_results {
     value {
       unprocessed_report_result_values {
         cumulative_results {
-          reach {
-            value: 1000000
-          }
+          reach { value: 1000000 }
         }
         non_cumulative_results {
-          reach {
-            value: 202952
-          }
+          reach { value: 202952 }
+          impression_count { value: 373169 }
           frequency_histogram {
-            bin_results {
+            bin_results: {
               key: 1
-              value {
-                value: 104749
-              }
+              value: { value: 104749 }
             }
-            bin_results {
+            bin_results: {
               key: 2
-              value {
-                value: 52375
-              }
+              value: { value: 52375 }
             }
-            bin_results {
+            bin_results: {
               key: 3
-              value {
-                value: 26188
-              }
+              value: { value: 26188 }
             }
-            bin_results {
+            bin_results: {
               key: 4
-              value {
-                value: 13094
-              }
+              value: { value: 13094 }
             }
-            bin_results {
+            bin_results: {
               key: 5
-              value {
-                value: 6546
-              }
+              value: { value: 6546 }
             }
-          }
-          impression_count {
-            value: 373169
           }
         }
       }
     }
   }
-  metric_frequency_spec_fingerprint: 1234
-  grouping_dimension_fingerprint: 2
-  filter_fingerprint: 5
 }
 reporting_set_results {
   cmms_measurement_consumer_id: "abcd"
@@ -3207,33 +2543,29 @@ reporting_set_results {
     external_reporting_set_id: "reporting_set_id_edp3"
     venn_diagram_region_type: UNION
     custom: true
-    metric_frequency_spec {
-      total: true
-    }
+    metric_frequency_spec { total: true }
     grouping {
       value_by_path {
         key: "person.age_group"
-        value {
-          enum_value: "YEARS_18_TO_34"
-        }
+        value { enum_value: "YEARS_18_TO_34" }
       }
       value_by_path {
         key: "person.gender"
-        value {
-          enum_value: "MALE"
-        }
+        value { enum_value: "MALE" }
       }
     }
     event_filters {
       terms {
         path: "banner_ad.viewable"
-        value {
-          bool_value: true
-        }
+        value { bool_value: true }
       }
     }
   }
+
   population_size: 55000000
+  metric_frequency_spec_fingerprint: 1234
+  grouping_dimension_fingerprint: 2
+  filter_fingerprint: 5
   reporting_window_results {
     key {
       non_cumulative_start {
@@ -3250,51 +2582,34 @@ reporting_set_results {
     value {
       unprocessed_report_result_values {
         cumulative_results {
-          reach {
-            value: 1000000
-          }
+          reach { value: 1000000 }
+          impression_count { value: 1844136 }
           frequency_histogram {
-            bin_results {
+            bin_results: {
               key: 1
-              value {
-                value: 516129
-              }
+              value: { value: 516129 }
             }
-            bin_results {
+            bin_results: {
               key: 2
-              value {
-                value: 258065
-              }
+              value: { value: 258065 }
             }
-            bin_results {
+            bin_results: {
               key: 3
-              value {
-                value: 129033
-              }
+              value: { value: 129033 }
             }
-            bin_results {
+            bin_results: {
               key: 4
-              value {
-                value: 64517
-              }
+              value: { value: 64517 }
             }
-            bin_results {
+            bin_results: {
               key: 5
-              value {
-                value: 32256
-              }
+              value: { value: 32256 }
             }
-          }
-          impression_count {
-            value: 1844136
           }
         }
       }
     }
   }
-  metric_frequency_spec_fingerprint: 1234
-  grouping_dimension_fingerprint: 2
-  filter_fingerprint: 5
 }
 reporting_set_results {
   cmms_measurement_consumer_id: "abcd"
@@ -3304,33 +2619,29 @@ reporting_set_results {
     external_reporting_set_id: "reporting_set_id_edp1_edp2_edp3"
     venn_diagram_region_type: UNION
     custom: true
-    metric_frequency_spec {
-      weekly: MONDAY
-    }
+    metric_frequency_spec { weekly: MONDAY }
     grouping {
       value_by_path {
         key: "person.age_group"
-        value {
-          enum_value: "YEARS_18_TO_34"
-        }
+        value { enum_value: "YEARS_18_TO_34" }
       }
       value_by_path {
         key: "person.gender"
-        value {
-          enum_value: "MALE"
-        }
+        value { enum_value: "MALE" }
       }
     }
     event_filters {
       terms {
         path: "banner_ad.viewable"
-        value {
-          bool_value: true
-        }
+        value { bool_value: true }
       }
     }
   }
+
   population_size: 55000000
+  metric_frequency_spec_fingerprint: 1234
+  grouping_dimension_fingerprint: 2
+  filter_fingerprint: 5
   reporting_window_results {
     key {
       non_cumulative_start {
@@ -3349,69 +2660,53 @@ reporting_set_results {
         cumulative_results {
           reach {
             value: 15791826
-            univariate_statistics {
-              standard_deviation: 10000.0
-            }
+            univariate_statistics { standard_deviation: 10000 }
           }
         }
         non_cumulative_results {
           reach {
             value: 15807663
-            univariate_statistics {
-              standard_deviation: 10000.0
-            }
-          }
-          frequency_histogram {
-            bin_results {
-              key: 1
-              value {
-                value: 8162731
-                univariate_statistics {
-                  standard_deviation: 10000.0
-                }
-              }
-            }
-            bin_results {
-              key: 2
-              value {
-                value: 4080135
-                univariate_statistics {
-                  standard_deviation: 10000.0
-                }
-              }
-            }
-            bin_results {
-              key: 3
-              value {
-                value: 2038825
-                univariate_statistics {
-                  standard_deviation: 10000.0
-                }
-              }
-            }
-            bin_results {
-              key: 4
-              value {
-                value: 1018159
-                univariate_statistics {
-                  standard_deviation: 10000.0
-                }
-              }
-            }
-            bin_results {
-              key: 5
-              value {
-                value: 507814
-                univariate_statistics {
-                  standard_deviation: 10000.0
-                }
-              }
-            }
+            univariate_statistics { standard_deviation: 10000 }
           }
           impression_count {
             value: 29051180
-            univariate_statistics {
-              standard_deviation: 10000.0
+            univariate_statistics { standard_deviation: 10000 }
+          }
+          frequency_histogram {
+            bin_results: {
+              key: 1
+              value: {
+                value: 8162731
+                univariate_statistics { standard_deviation: 10000 }
+              }
+            }
+            bin_results: {
+              key: 2
+              value: {
+                value: 4080135
+                univariate_statistics { standard_deviation: 10000 }
+              }
+            }
+            bin_results: {
+              key: 3
+              value: {
+                value: 2038825
+                univariate_statistics { standard_deviation: 10000 }
+              }
+            }
+            bin_results: {
+              key: 4
+              value: {
+                value: 1018159
+                univariate_statistics { standard_deviation: 10000 }
+              }
+            }
+            bin_results: {
+              key: 5
+              value: {
+                value: 507814
+                univariate_statistics { standard_deviation: 10000 }
+              }
             }
           }
         }
@@ -3436,78 +2731,59 @@ reporting_set_results {
         cumulative_results {
           reach {
             value: 19021120
-            univariate_statistics {
-              standard_deviation: 10000.0
-            }
+            univariate_statistics { standard_deviation: 10000 }
           }
         }
         non_cumulative_results {
           reach {
             value: 3746775
-            univariate_statistics {
-              standard_deviation: 10000.0
-            }
-          }
-          frequency_histogram {
-            bin_results {
-              key: 1
-              value {
-                value: 1935326
-                univariate_statistics {
-                  standard_deviation: 10000.0
-                }
-              }
-            }
-            bin_results {
-              key: 2
-              value {
-                value: 967186
-                univariate_statistics {
-                  standard_deviation: 10000.0
-                }
-              }
-            }
-            bin_results {
-              key: 3
-              value {
-                value: 483117
-                univariate_statistics {
-                  standard_deviation: 10000.0
-                }
-              }
-            }
-            bin_results {
-              key: 4
-              value {
-                value: 241082
-                univariate_statistics {
-                  standard_deviation: 10000.0
-                }
-              }
-            }
-            bin_results {
-              key: 5
-              value {
-                value: 120064
-                univariate_statistics {
-                  standard_deviation: 10000.0
-                }
-              }
-            }
+            univariate_statistics { standard_deviation: 10000 }
           }
           impression_count {
             value: 6884507
-            univariate_statistics {
-              standard_deviation: 10000.0
+            univariate_statistics { standard_deviation: 10000 }
+          }
+          frequency_histogram {
+            bin_results: {
+              key: 1
+              value: {
+                value: 1935326
+                univariate_statistics { standard_deviation: 10000 }
+              }
+            }
+            bin_results: {
+              key: 2
+              value: {
+                value: 967186
+                univariate_statistics { standard_deviation: 10000 }
+              }
+            }
+            bin_results: {
+              key: 3
+              value: {
+                value: 483117
+                univariate_statistics { standard_deviation: 10000 }
+              }
+            }
+            bin_results: {
+              key: 4
+              value: {
+                value: 241082
+                univariate_statistics { standard_deviation: 10000 }
+              }
+            }
+            bin_results: {
+              key: 5
+              value: {
+                value: 120064
+                univariate_statistics { standard_deviation: 10000 }
+              }
             }
           }
         }
       }
     }
   }
-  metric_frequency_spec_fingerprint: 1234
-  grouping_dimension_fingerprint: 2
-  filter_fingerprint: 5
 }
 reporting_set_results {
   cmms_measurement_consumer_id: "abcd"
@@ -3517,33 +2793,29 @@ reporting_set_results {
     external_reporting_set_id: "reporting_set_id_edp1_edp2_edp3"
     venn_diagram_region_type: UNION
     custom: true
-    metric_frequency_spec {
-      total: true
-    }
+    metric_frequency_spec { total: true }
     grouping {
       value_by_path {
         key: "person.age_group"
-        value {
-          enum_value: "YEARS_18_TO_34"
-        }
+        value { enum_value: "YEARS_18_TO_34" }
       }
       value_by_path {
         key: "person.gender"
-        value {
-          enum_value: "MALE"
-        }
+        value { enum_value: "MALE" }
       }
     }
     event_filters {
       terms {
         path: "banner_ad.viewable"
-        value {
-          bool_value: true
-        }
+        value { bool_value: true }
       }
     }
   }
+
   population_size: 55000000
+  metric_frequency_spec_fingerprint: 1234
+  grouping_dimension_fingerprint: 2
+  filter_fingerprint: 5
   reporting_window_results {
     key {
       non_cumulative_start {
@@ -3562,68 +2834,51 @@ reporting_set_results {
         cumulative_results {
           reach {
             value: 19021120
-            univariate_statistics {
-              standard_deviation: 10000.0
-            }
-          }
-          frequency_histogram {
-            bin_results {
-              key: 1
-              value {
-                value: 9820392
-                univariate_statistics {
-                  standard_deviation: 10000.0
-                }
-              }
-            }
-            bin_results {
-              key: 2
-              value {
-                value: 4909234
-                univariate_statistics {
-                  standard_deviation: 10000.0
-                }
-              }
-            }
-            bin_results {
-              key: 3
-              value {
-                value: 2453656
-                univariate_statistics {
-                  standard_deviation: 10000.0
-                }
-              }
-            }
-            bin_results {
-              key: 4
-              value {
-                value: 1225867
-                univariate_statistics {
-                  standard_deviation: 10000.0
-                }
-              }
-            }
-            bin_results {
-              key: 5
-              value {
-                value: 611971
-                univariate_statistics {
-                  standard_deviation: 10000.0
-                }
-              }
-            }
+            univariate_statistics { standard_deviation: 10000 }
           }
           impression_count {
             value: 35934165
-            univariate_statistics {
-              standard_deviation: 10000.0
+            univariate_statistics { standard_deviation: 10000 }
+          }
+          frequency_histogram {
+            bin_results: {
+              key: 1
+              value: {
+                value: 9820392
+                univariate_statistics { standard_deviation: 10000 }
+              }
+            }
+            bin_results: {
+              key: 2
+              value: {
+                value: 4909234
+                univariate_statistics { standard_deviation: 10000 }
+              }
+            }
+            bin_results: {
+              key: 3
+              value: {
+                value: 2453656
+                univariate_statistics { standard_deviation: 10000 }
+              }
+            }
+            bin_results: {
+              key: 4
+              value: {
+                value: 1225867
+                univariate_statistics { standard_deviation: 10000 }
+              }
+            }
+            bin_results: {
+              key: 5
+              value: {
+                value: 611971
+                univariate_statistics { standard_deviation: 10000 }
+              }
             }
           }
         }
       }
     }
   }
-  metric_frequency_spec_fingerprint: 1234
-  grouping_dimension_fingerprint: 2
-  filter_fingerprint: 5
 }

--- a/src/test/python/wfa/measurement/reporting/postprocessing/tools/sample_report_result.textproto
+++ b/src/test/python/wfa/measurement/reporting/postprocessing/tools/sample_report_result.textproto
@@ -47,52 +47,52 @@ reporting_set_results {
       unprocessed_report_result_values {
         cumulative_results {
           reach {
-            value: 10011521
+            value: 9992500
             univariate_statistics { standard_deviation: 10000 }
           }
         }
         non_cumulative_results {
           reach {
-            value: 10013194
+            value: 10008130
             univariate_statistics { standard_deviation: 10000 }
           }
           impression_count {
-            value: 18382862
+            value: 18379493
             univariate_statistics { standard_deviation: 10000 }
           }
           frequency_histogram {
             bin_results: {
               key: 1
               value: {
-                value: 5173374
+                value: 5165486
                 univariate_statistics { standard_deviation: 10000 }
               }
             }
             bin_results: {
               key: 2
               value: {
-                value: 2587194
+                value: 2582743
                 univariate_statistics { standard_deviation: 10000 }
               }
             }
             bin_results: {
               key: 3
               value: {
-                value: 1292385
+                value: 1291372
                 univariate_statistics { standard_deviation: 10000 }
               }
             }
             bin_results: {
               key: 4
               value: {
-                value: 643261
+                value: 645686
                 univariate_statistics { standard_deviation: 10000 }
               }
             }
             bin_results: {
               key: 5
               value: {
-                value: 316980
+                value: 322843
                 univariate_statistics { standard_deviation: 10000 }
               }
             }
@@ -118,52 +118,52 @@ reporting_set_results {
       unprocessed_report_result_values {
         cumulative_results {
           reach {
-            value: 12002237
+            value: 11998422
             univariate_statistics { standard_deviation: 10000 }
           }
         }
         non_cumulative_results {
           reach {
-            value: 2451953
+            value: 2452001
             univariate_statistics { standard_deviation: 10000 }
           }
           impression_count {
-            value: 4491260
+            value: 4471035
             univariate_statistics { standard_deviation: 10000 }
           }
           frequency_histogram {
             bin_results: {
               key: 1
               value: {
-                value: 1268962
+                value: 1265549
                 univariate_statistics { standard_deviation: 10000 }
               }
             }
             bin_results: {
               key: 2
               value: {
-                value: 634477
+                value: 632775
                 univariate_statistics { standard_deviation: 10000 }
               }
             }
             bin_results: {
               key: 3
               value: {
-                value: 316378
+                value: 316388
                 univariate_statistics { standard_deviation: 10000 }
               }
             }
             bin_results: {
               key: 4
               value: {
-                value: 156473
+                value: 158194
                 univariate_statistics { standard_deviation: 10000 }
               }
             }
             bin_results: {
               key: 5
               value: {
-                value: 75663
+                value: 79095
                 univariate_statistics { standard_deviation: 10000 }
               }
             }
@@ -220,46 +220,46 @@ reporting_set_results {
       unprocessed_report_result_values {
         cumulative_results {
           reach {
-            value: 12002237
+            value: 11978894
             univariate_statistics { standard_deviation: 10000 }
           }
           impression_count {
-            value: 22868543
+            value: 22870892
             univariate_statistics { standard_deviation: 10000 }
           }
           frequency_histogram {
             bin_results: {
               key: 1
               value: {
-                value: 6187323
+                value: 6182655
                 univariate_statistics { standard_deviation: 10000 }
               }
             }
             bin_results: {
               key: 2
               value: {
-                value: 3095997
+                value: 3091328
                 univariate_statistics { standard_deviation: 10000 }
               }
             }
             bin_results: {
               key: 3
               value: {
-                value: 1550333
+                value: 1545664
                 univariate_statistics { standard_deviation: 10000 }
               }
             }
             bin_results: {
               key: 4
               value: {
-                value: 777501
+                value: 772832
                 univariate_statistics { standard_deviation: 10000 }
               }
             }
             bin_results: {
               key: 5
               value: {
-                value: 391084
+                value: 386415
                 univariate_statistics { standard_deviation: 10000 }
               }
             }
@@ -717,52 +717,52 @@ reporting_set_results {
       unprocessed_report_result_values {
         cumulative_results {
           reach {
-            value: 15811521
+            value: 15830545
             univariate_statistics { standard_deviation: 10000 }
           }
         }
         non_cumulative_results {
           reach {
-            value: 15813194
+            value: 15829304
             univariate_statistics { standard_deviation: 10000 }
           }
           impression_count {
-            value: 29047375
+            value: 29046331
             univariate_statistics { standard_deviation: 10000 }
           }
           frequency_histogram {
             bin_results: {
               key: 1
               value: {
-                value: 8168699
+                value: 8169963
                 univariate_statistics { standard_deviation: 10000 }
               }
             }
             bin_results: {
               key: 2
               value: {
-                value: 4082739
+                value: 4084982
                 univariate_statistics { standard_deviation: 10000 }
               }
             }
             bin_results: {
               key: 3
               value: {
-                value: 2039269
+                value: 2042491
                 univariate_statistics { standard_deviation: 10000 }
               }
             }
             bin_results: {
               key: 4
               value: {
-                value: 1017045
+                value: 1021246
                 univariate_statistics { standard_deviation: 10000 }
               }
             }
             bin_results: {
               key: 5
               value: {
-                value: 505442
+                value: 510622
                 univariate_statistics { standard_deviation: 10000 }
               }
             }
@@ -788,52 +788,52 @@ reporting_set_results {
       unprocessed_report_result_values {
         cumulative_results {
           reach {
-            value: 19002237
+            value: 19010669
             univariate_statistics { standard_deviation: 10000 }
           }
         }
         non_cumulative_results {
           reach {
-            value: 3754905
+            value: 3761510
             univariate_statistics { standard_deviation: 10000 }
           }
           impression_count {
-            value: 6887008
+            value: 6904573
             univariate_statistics { standard_deviation: 10000 }
           }
           frequency_histogram {
             bin_results: {
               key: 1
               value: {
-                value: 1942003
+                value: 1941425
                 univariate_statistics { standard_deviation: 10000 }
               }
             }
             bin_results: {
               key: 2
               value: {
-                value: 970342
+                value: 970713
                 univariate_statistics { standard_deviation: 10000 }
               }
             }
             bin_results: {
               key: 3
               value: {
-                value: 484036
+                value: 485357
                 univariate_statistics { standard_deviation: 10000 }
               }
             }
             bin_results: {
               key: 4
               value: {
-                value: 240408
+                value: 242679
                 univariate_statistics { standard_deviation: 10000 }
               }
             }
             bin_results: {
               key: 5
               value: {
-                value: 118116
+                value: 121336
                 univariate_statistics { standard_deviation: 10000 }
               }
             }
@@ -890,374 +890,46 @@ reporting_set_results {
       unprocessed_report_result_values {
         cumulative_results {
           reach {
-            value: 19002237
+            value: 19021738
             univariate_statistics { standard_deviation: 10000 }
           }
           impression_count {
-            value: 35928804
+            value: 35926461
             univariate_statistics { standard_deviation: 10000 }
           }
           frequency_histogram {
             bin_results: {
               key: 1
               value: {
-                value: 9813770
+                value: 9817671
                 univariate_statistics { standard_deviation: 10000 }
               }
             }
             bin_results: {
               key: 2
               value: {
-                value: 4904936
+                value: 4908836
                 univariate_statistics { standard_deviation: 10000 }
               }
             }
             bin_results: {
               key: 3
               value: {
-                value: 2450518
+                value: 2454418
                 univariate_statistics { standard_deviation: 10000 }
               }
             }
             bin_results: {
               key: 4
               value: {
-                value: 1223309
+                value: 1227209
                 univariate_statistics { standard_deviation: 10000 }
               }
             }
             bin_results: {
               key: 5
               value: {
-                value: 609704
-                univariate_statistics { standard_deviation: 10000 }
-              }
-            }
-          }
-        }
-      }
-    }
-  }
-}
-reporting_set_results {
-  cmms_measurement_consumer_id: "abcd"
-  external_report_result_id: 123456
-  external_reporting_set_result_id: 9
-  dimension {
-    external_reporting_set_id: "reporting_set_id_edp1_edp2"
-    venn_diagram_region_type: UNION
-    external_impression_qualification_filter_id: "ami"
-    metric_frequency_spec { total: true }
-    grouping {
-      value_by_path {
-        key: "person.age_group"
-        value { enum_value: "YEARS_18_TO_34" }
-      }
-      value_by_path {
-        key: "person.gender"
-        value { enum_value: "MALE" }
-      }
-    }
-    event_filters {
-      terms {
-        path: "banner_ad.viewable"
-        value { bool_value: true }
-      }
-    }
-  }
-  population_size: 55000000
-  metric_frequency_spec_fingerprint: 1234
-  grouping_dimension_fingerprint: 2
-  filter_fingerprint: 5
-  reporting_window_results {
-    key {
-      non_cumulative_start {
-        year: 2025
-        month: 10
-        day: 1
-      }
-      end {
-        year: 2025
-        month: 10
-        day: 15
-      }
-    }
-    value {
-      unprocessed_report_result_values {
-        cumulative_results {
-          reach {
-            value: 0
-            univariate_statistics { standard_deviation: 10000 }
-          }
-          impression_count {
-            value: 0
-            univariate_statistics { standard_deviation: 10000 }
-          }
-        }
-      }
-    }
-  }
-}
-reporting_set_results {
-  cmms_measurement_consumer_id: "abcd"
-  external_report_result_id: 123456
-  external_reporting_set_result_id: 10
-  dimension {
-    external_reporting_set_id: "reporting_set_id_edp1"
-    venn_diagram_region_type: UNION
-    external_impression_qualification_filter_id: "mrc"
-    metric_frequency_spec { weekly: MONDAY }
-    grouping {
-      value_by_path {
-        key: "person.age_group"
-        value { enum_value: "YEARS_18_TO_34" }
-      }
-      value_by_path {
-        key: "person.gender"
-        value { enum_value: "MALE" }
-      }
-    }
-    event_filters {
-      terms {
-        path: "banner_ad.viewable"
-        value { bool_value: true }
-      }
-    }
-  }
-  population_size: 55000000
-  metric_frequency_spec_fingerprint: 1234
-  grouping_dimension_fingerprint: 2
-  filter_fingerprint: 5
-  reporting_window_results {
-    key {
-      non_cumulative_start {
-        year: 2025
-        month: 10
-        day: 1
-      }
-      end {
-        year: 2025
-        month: 10
-        day: 8
-      }
-    }
-    value {
-      unprocessed_report_result_values {
-        cumulative_results {
-          reach {
-            value: 9501617
-            univariate_statistics { standard_deviation: 10000 }
-          }
-        }
-        non_cumulative_results {
-          reach {
-            value: 9406880
-            univariate_statistics { standard_deviation: 10000 }
-          }
-          impression_count {
-            value: 16798121
-            univariate_statistics { standard_deviation: 10000 }
-          }
-          frequency_histogram {
-            bin_results: {
-              key: 1
-              value: {
-                value: 4962943
-                univariate_statistics { standard_deviation: 10000 }
-              }
-            }
-            bin_results: {
-              key: 2
-              value: {
-                value: 2471815
-                univariate_statistics { standard_deviation: 10000 }
-              }
-            }
-            bin_results: {
-              key: 3
-              value: {
-                value: 1206938
-                univariate_statistics { standard_deviation: 10000 }
-              }
-            }
-            bin_results: {
-              key: 4
-              value: {
-                value: 555187
-                univariate_statistics { standard_deviation: 10000 }
-              }
-            }
-            bin_results: {
-              key: 5
-              value: {
-                value: 209998
-                univariate_statistics { standard_deviation: 10000 }
-              }
-            }
-          }
-        }
-      }
-    }
-  }
-  reporting_window_results {
-    key {
-      non_cumulative_start {
-        year: 2025
-        month: 10
-        day: 8
-      }
-      end {
-        year: 2025
-        month: 10
-        day: 15
-      }
-    }
-    value {
-      unprocessed_report_result_values {
-        cumulative_results {
-          reach {
-            value: 11374247
-            univariate_statistics { standard_deviation: 10000 }
-          }
-        }
-        non_cumulative_results {
-          reach {
-            value: 2267580
-            univariate_statistics { standard_deviation: 10000 }
-          }
-          impression_count {
-            value: 4057569
-            univariate_statistics { standard_deviation: 10000 }
-          }
-          frequency_histogram {
-            bin_results: {
-              key: 1
-              value: {
-                value: 1194552
-                univariate_statistics { standard_deviation: 10000 }
-              }
-            }
-            bin_results: {
-              key: 2
-              value: {
-                value: 595109
-                univariate_statistics { standard_deviation: 10000 }
-              }
-            }
-            bin_results: {
-              key: 3
-              value: {
-                value: 291054
-                univariate_statistics { standard_deviation: 10000 }
-              }
-            }
-            bin_results: {
-              key: 4
-              value: {
-                value: 134691
-                univariate_statistics { standard_deviation: 10000 }
-              }
-            }
-            bin_results: {
-              key: 5
-              value: {
-                value: 52175
-                univariate_statistics { standard_deviation: 10000 }
-              }
-            }
-          }
-        }
-      }
-    }
-  }
-}
-reporting_set_results {
-  cmms_measurement_consumer_id: "abcd"
-  external_report_result_id: 123456
-  external_reporting_set_result_id: 11
-  dimension {
-    external_reporting_set_id: "reporting_set_id_edp1"
-    venn_diagram_region_type: UNION
-    external_impression_qualification_filter_id: "mrc"
-    metric_frequency_spec { total: true }
-    grouping {
-      value_by_path {
-        key: "person.age_group"
-        value { enum_value: "YEARS_18_TO_34" }
-      }
-      value_by_path {
-        key: "person.gender"
-        value { enum_value: "MALE" }
-      }
-    }
-    event_filters {
-      terms {
-        path: "banner_ad.viewable"
-        value { bool_value: true }
-      }
-    }
-  }
-  population_size: 55000000
-  metric_frequency_spec_fingerprint: 1234
-  grouping_dimension_fingerprint: 2
-  filter_fingerprint: 5
-  reporting_window_results {
-    key {
-      non_cumulative_start {
-        year: 2025
-        month: 10
-        day: 1
-      }
-      end {
-        year: 2025
-        month: 10
-        day: 15
-      }
-    }
-    value {
-      unprocessed_report_result_values {
-        cumulative_results {
-          reach {
-            value: 11374247
-            univariate_statistics { standard_deviation: 10000 }
-          }
-          impression_count {
-            value: 20822466
-            univariate_statistics { standard_deviation: 10000 }
-          }
-          frequency_histogram {
-            bin_results: {
-              key: 1
-              value: {
-                value: 5889543
-                univariate_statistics { standard_deviation: 10000 }
-              }
-            }
-            bin_results: {
-              key: 2
-              value: {
-                value: 2943972
-                univariate_statistics { standard_deviation: 10000 }
-              }
-            }
-            bin_results: {
-              key: 3
-              value: {
-                value: 1467078
-                univariate_statistics { standard_deviation: 10000 }
-              }
-            }
-            bin_results: {
-              key: 4
-              value: {
-                value: 724521
-                univariate_statistics { standard_deviation: 10000 }
-              }
-            }
-            bin_results: {
-              key: 5
-              value: {
-                value: 349132
+                value: 613604
                 univariate_statistics { standard_deviation: 10000 }
               }
             }
@@ -1670,275 +1342,6 @@ reporting_set_results {
 reporting_set_results {
   cmms_measurement_consumer_id: "abcd"
   external_report_result_id: 123456
-  external_reporting_set_result_id: 16
-  dimension {
-    external_reporting_set_id: "reporting_set_id_edp1_edp2_edp3"
-    venn_diagram_region_type: UNION
-    external_impression_qualification_filter_id: "mrc"
-    metric_frequency_spec { weekly: MONDAY }
-    grouping {
-      value_by_path {
-        key: "person.age_group"
-        value { enum_value: "YEARS_18_TO_34" }
-      }
-      value_by_path {
-        key: "person.gender"
-        value { enum_value: "MALE" }
-      }
-    }
-    event_filters {
-      terms {
-        path: "banner_ad.viewable"
-        value { bool_value: true }
-      }
-    }
-  }
-  population_size: 55000000
-  metric_frequency_spec_fingerprint: 1234
-  grouping_dimension_fingerprint: 2
-  filter_fingerprint: 5
-  reporting_window_results {
-    key {
-      non_cumulative_start {
-        year: 2025
-        month: 10
-        day: 1
-      }
-      end {
-        year: 2025
-        month: 10
-        day: 8
-      }
-    }
-    value {
-      unprocessed_report_result_values {
-        cumulative_results {
-          reach {
-            value: 13427249
-            univariate_statistics { standard_deviation: 10000 }
-          }
-        }
-        non_cumulative_results {
-          reach {
-            value: 13426463
-            univariate_statistics { standard_deviation: 10000 }
-          }
-          impression_count {
-            value: 26929406
-            univariate_statistics { standard_deviation: 10000 }
-          }
-          frequency_histogram {
-            bin_results: {
-              key: 1
-              value: {
-                value: 6929787
-                univariate_statistics { standard_deviation: 10000 }
-              }
-            }
-            bin_results: {
-              key: 2
-              value: {
-                value: 3464894
-                univariate_statistics { standard_deviation: 10000 }
-              }
-            }
-            bin_results: {
-              key: 3
-              value: {
-                value: 1732447
-                univariate_statistics { standard_deviation: 10000 }
-              }
-            }
-            bin_results: {
-              key: 4
-              value: {
-                value: 866224
-                univariate_statistics { standard_deviation: 10000 }
-              }
-            }
-            bin_results: {
-              key: 5
-              value: {
-                value: 433111
-                univariate_statistics { standard_deviation: 10000 }
-              }
-            }
-          }
-        }
-      }
-    }
-  }
-  reporting_window_results {
-    key {
-      non_cumulative_start {
-        year: 2025
-        month: 10
-        day: 8
-      }
-      end {
-        year: 2025
-        month: 10
-        day: 15
-      }
-    }
-    value {
-      unprocessed_report_result_values {
-        cumulative_results {
-          reach {
-            value: 15914078
-            univariate_statistics { standard_deviation: 10000 }
-          }
-        }
-        non_cumulative_results {
-          reach {
-            value: 3278136
-            univariate_statistics { standard_deviation: 10000 }
-          }
-          impression_count {
-            value: 6323713
-            univariate_statistics { standard_deviation: 10000 }
-          }
-          frequency_histogram {
-            bin_results: {
-              key: 1
-              value: {
-                value: 1691941
-                univariate_statistics { standard_deviation: 10000 }
-              }
-            }
-            bin_results: {
-              key: 2
-              value: {
-                value: 845971
-                univariate_statistics { standard_deviation: 10000 }
-              }
-            }
-            bin_results: {
-              key: 3
-              value: {
-                value: 422986
-                univariate_statistics { standard_deviation: 10000 }
-              }
-            }
-            bin_results: {
-              key: 4
-              value: {
-                value: 211493
-                univariate_statistics { standard_deviation: 10000 }
-              }
-            }
-            bin_results: {
-              key: 5
-              value: {
-                value: 105745
-                univariate_statistics { standard_deviation: 10000 }
-              }
-            }
-          }
-        }
-      }
-    }
-  }
-}
-reporting_set_results {
-  cmms_measurement_consumer_id: "abcd"
-  external_report_result_id: 123456
-  external_reporting_set_result_id: 17
-  dimension {
-    external_reporting_set_id: "reporting_set_id_edp1_edp2_edp3"
-    venn_diagram_region_type: UNION
-    external_impression_qualification_filter_id: "mrc"
-    metric_frequency_spec { total: true }
-    grouping {
-      value_by_path {
-        key: "person.age_group"
-        value { enum_value: "YEARS_18_TO_34" }
-      }
-      value_by_path {
-        key: "person.gender"
-        value { enum_value: "MALE" }
-      }
-    }
-    event_filters {
-      terms {
-        path: "banner_ad.viewable"
-        value { bool_value: true }
-      }
-    }
-  }
-  population_size: 55000000
-  metric_frequency_spec_fingerprint: 1234
-  grouping_dimension_fingerprint: 2
-  filter_fingerprint: 5
-  reporting_window_results {
-    key {
-      non_cumulative_start {
-        year: 2025
-        month: 10
-        day: 1
-      }
-      end {
-        year: 2025
-        month: 10
-        day: 15
-      }
-    }
-    value {
-      unprocessed_report_result_values {
-        cumulative_results {
-          reach {
-            value: 15914078
-            univariate_statistics { standard_deviation: 10000 }
-          }
-          impression_count {
-            value: 33219895
-            univariate_statistics { standard_deviation: 10000 }
-          }
-          frequency_histogram {
-            bin_results: {
-              key: 1
-              value: {
-                value: 8212074
-                univariate_statistics { standard_deviation: 10000 }
-              }
-            }
-            bin_results: {
-              key: 2
-              value: {
-                value: 4106557
-                univariate_statistics { standard_deviation: 10000 }
-              }
-            }
-            bin_results: {
-              key: 3
-              value: {
-                value: 2053798
-                univariate_statistics { standard_deviation: 10000 }
-              }
-            }
-            bin_results: {
-              key: 4
-              value: {
-                value: 1027420
-                univariate_statistics { standard_deviation: 10000 }
-              }
-            }
-            bin_results: {
-              key: 5
-              value: {
-                value: 514229
-                univariate_statistics { standard_deviation: 10000 }
-              }
-            }
-          }
-        }
-      }
-    }
-  }
-}
-reporting_set_results {
-  cmms_measurement_consumer_id: "abcd"
-  external_report_result_id: 123456
   external_reporting_set_result_id: 18
   dimension {
     external_reporting_set_id: "reporting_set_id_edp1"
@@ -1984,52 +1387,52 @@ reporting_set_results {
       unprocessed_report_result_values {
         cumulative_results {
           reach {
-            value: 9991826
+            value: 9984642
             univariate_statistics { standard_deviation: 10000 }
           }
         }
         non_cumulative_results {
           reach {
-            value: 10007663
+            value: 10000981
             univariate_statistics { standard_deviation: 10000 }
           }
           impression_count {
-            value: 18386667
+            value: 18382797
             univariate_statistics { standard_deviation: 10000 }
           }
           frequency_histogram {
             bin_results: {
               key: 1
               value: {
-                value: 5167588
+                value: 5161797
                 univariate_statistics { standard_deviation: 10000 }
               }
             }
             bin_results: {
               key: 2
               value: {
-                value: 2584463
+                value: 2580899
                 univariate_statistics { standard_deviation: 10000 }
               }
             }
             bin_results: {
               key: 3
               value: {
-                value: 1291787
+                value: 1290450
                 univariate_statistics { standard_deviation: 10000 }
               }
             }
             bin_results: {
               key: 4
               value: {
-                value: 644334
+                value: 645225
                 univariate_statistics { standard_deviation: 10000 }
               }
             }
             bin_results: {
               key: 5
               value: {
-                value: 319491
+                value: 322610
                 univariate_statistics { standard_deviation: 10000 }
               }
             }
@@ -2055,52 +1458,52 @@ reporting_set_results {
       unprocessed_report_result_values {
         cumulative_results {
           reach {
-            value: 12021120
+            value: 12020226
             univariate_statistics { standard_deviation: 10000 }
           }
         }
         non_cumulative_results {
           reach {
-            value: 2443823
+            value: 2441042
             univariate_statistics { standard_deviation: 10000 }
           }
           impression_count {
-            value: 4488759
+            value: 4488362
             univariate_statistics { standard_deviation: 10000 }
           }
           frequency_histogram {
             bin_results: {
               key: 1
               value: {
-                value: 1262038
+                value: 1259893
                 univariate_statistics { standard_deviation: 10000 }
               }
             }
             bin_results: {
               key: 2
               value: {
-                value: 631298
+                value: 629947
                 univariate_statistics { standard_deviation: 10000 }
               }
             }
             bin_results: {
               key: 3
               value: {
-                value: 315530
+                value: 314974
                 univariate_statistics { standard_deviation: 10000 }
               }
             }
             bin_results: {
               key: 4
               value: {
-                value: 157249
+                value: 157487
                 univariate_statistics { standard_deviation: 10000 }
               }
             }
             bin_results: {
               key: 5
               value: {
-                value: 77708
+                value: 78741
                 univariate_statistics { standard_deviation: 10000 }
               }
             }
@@ -2158,46 +1561,46 @@ reporting_set_results {
       unprocessed_report_result_values {
         cumulative_results {
           reach {
-            value: 12021120
+            value: 12017026
             univariate_statistics { standard_deviation: 10000 }
           }
           impression_count {
-            value: 22873904
+            value: 22871159
             univariate_statistics { standard_deviation: 10000 }
           }
           frequency_histogram {
             bin_results: {
               key: 1
               value: {
-                value: 6203154
+                value: 6202336
                 univariate_statistics { standard_deviation: 10000 }
               }
             }
             bin_results: {
               key: 2
               value: {
-                value: 3101987
+                value: 3101168
                 univariate_statistics { standard_deviation: 10000 }
               }
             }
             bin_results: {
               key: 3
               value: {
-                value: 1551403
+                value: 1550584
                 univariate_statistics { standard_deviation: 10000 }
               }
             }
             bin_results: {
               key: 4
               value: {
-                value: 776111
+                value: 775292
                 univariate_statistics { standard_deviation: 10000 }
               }
             }
             bin_results: {
               key: 5
               value: {
-                value: 388465
+                value: 387646
                 univariate_statistics { standard_deviation: 10000 }
               }
             }
@@ -2659,52 +2062,52 @@ reporting_set_results {
       unprocessed_report_result_values {
         cumulative_results {
           reach {
-            value: 15791826
+            value: 15799013
             univariate_statistics { standard_deviation: 10000 }
           }
         }
         non_cumulative_results {
           reach {
-            value: 15807663
+            value: 15819974
             univariate_statistics { standard_deviation: 10000 }
           }
           impression_count {
-            value: 29051180
+            value: 29052805
             univariate_statistics { standard_deviation: 10000 }
           }
           frequency_histogram {
             bin_results: {
               key: 1
               value: {
-                value: 8162731
+                value: 8165148
                 univariate_statistics { standard_deviation: 10000 }
               }
             }
             bin_results: {
               key: 2
               value: {
-                value: 4080135
+                value: 4082574
                 univariate_statistics { standard_deviation: 10000 }
               }
             }
             bin_results: {
               key: 3
               value: {
-                value: 2038825
+                value: 2041287
                 univariate_statistics { standard_deviation: 10000 }
               }
             }
             bin_results: {
               key: 4
               value: {
-                value: 1018159
+                value: 1020644
                 univariate_statistics { standard_deviation: 10000 }
               }
             }
             bin_results: {
               key: 5
               value: {
-                value: 507814
+                value: 510321
                 univariate_statistics { standard_deviation: 10000 }
               }
             }
@@ -2730,52 +2133,52 @@ reporting_set_results {
       unprocessed_report_result_values {
         cumulative_results {
           reach {
-            value: 19021120
+            value: 19015392
             univariate_statistics { standard_deviation: 10000 }
           }
         }
         non_cumulative_results {
           reach {
-            value: 3746775
+            value: 3751542
             univariate_statistics { standard_deviation: 10000 }
           }
           impression_count {
-            value: 6884507
+            value: 6884110
             univariate_statistics { standard_deviation: 10000 }
           }
           frequency_histogram {
             bin_results: {
               key: 1
               value: {
-                value: 1935326
+                value: 1936280
                 univariate_statistics { standard_deviation: 10000 }
               }
             }
             bin_results: {
               key: 2
               value: {
-                value: 967186
+                value: 968140
                 univariate_statistics { standard_deviation: 10000 }
               }
             }
             bin_results: {
               key: 3
               value: {
-                value: 483117
+                value: 484070
                 univariate_statistics { standard_deviation: 10000 }
               }
             }
             bin_results: {
               key: 4
               value: {
-                value: 241082
+                value: 242035
                 univariate_statistics { standard_deviation: 10000 }
               }
             }
             bin_results: {
               key: 5
               value: {
-                value: 120064
+                value: 121017
                 univariate_statistics { standard_deviation: 10000 }
               }
             }
@@ -2833,46 +2236,46 @@ reporting_set_results {
       unprocessed_report_result_values {
         cumulative_results {
           reach {
-            value: 19021120
+            value: 19030737
             univariate_statistics { standard_deviation: 10000 }
           }
           impression_count {
-            value: 35934165
+            value: 35936915
             univariate_statistics { standard_deviation: 10000 }
           }
           frequency_histogram {
             bin_results: {
               key: 1
               value: {
-                value: 9820392
+                value: 9822316
                 univariate_statistics { standard_deviation: 10000 }
               }
             }
             bin_results: {
               key: 2
               value: {
-                value: 4909234
+                value: 4911158
                 univariate_statistics { standard_deviation: 10000 }
               }
             }
             bin_results: {
               key: 3
               value: {
-                value: 2453656
+                value: 2455579
                 univariate_statistics { standard_deviation: 10000 }
               }
             }
             bin_results: {
               key: 4
               value: {
-                value: 1225867
+                value: 1227790
                 univariate_statistics { standard_deviation: 10000 }
               }
             }
             bin_results: {
               key: 5
               value: {
-                value: 611971
+                value: 613894
                 univariate_statistics { standard_deviation: 10000 }
               }
             }

--- a/src/test/python/wfa/measurement/reporting/postprocessing/tools/sample_report_result.textproto
+++ b/src/test/python/wfa/measurement/reporting/postprocessing/tools/sample_report_result.textproto
@@ -8,28 +8,33 @@ reporting_set_results {
     external_reporting_set_id: "reporting_set_id_edp1"
     venn_diagram_region_type: UNION
     external_impression_qualification_filter_id: "ami"
-    metric_frequency_spec { weekly: MONDAY }
+    metric_frequency_spec {
+      weekly: MONDAY
+    }
     grouping {
       value_by_path {
         key: "person.age_group"
-        value { enum_value: "YEARS_35_TO_54" }
+        value {
+          enum_value: "YEARS_35_TO_54"
+        }
       }
       value_by_path {
         key: "person.gender"
-        value { enum_value: "MALE" }
+        value {
+          enum_value: "MALE"
+        }
       }
     }
     event_filters {
       terms {
         path: "banner_ad.viewable"
-        value { bool_value: true }
+        value {
+          bool_value: true
+        }
       }
     }
   }
   population_size: 55000000
-  metric_frequency_spec_fingerprint: 1234
-  grouping_dimension_fingerprint: 1
-  filter_fingerprint: 5
   reporting_window_results {
     key {
       non_cumulative_start {
@@ -47,54 +52,70 @@ reporting_set_results {
       unprocessed_report_result_values {
         cumulative_results {
           reach {
-            value: 9992500
-            univariate_statistics { standard_deviation: 10000 }
+            value: 10011521
+            univariate_statistics {
+              standard_deviation: 10000.0
+            }
           }
         }
         non_cumulative_results {
           reach {
-            value: 10008130
-            univariate_statistics { standard_deviation: 10000 }
-          }
-          impression_count {
-            value: 18379493
-            univariate_statistics { standard_deviation: 10000 }
+            value: 10013194
+            univariate_statistics {
+              standard_deviation: 10000.0
+            }
           }
           frequency_histogram {
-            bin_results: {
+            bin_results {
               key: 1
-              value: {
-                value: 5165486
-                univariate_statistics { standard_deviation: 10000 }
+              value {
+                value: 5173374
+                univariate_statistics {
+                  standard_deviation: 10000.0
+                }
               }
             }
-            bin_results: {
+            bin_results {
               key: 2
-              value: {
-                value: 2582743
-                univariate_statistics { standard_deviation: 10000 }
+              value {
+                value: 2587194
+                univariate_statistics {
+                  standard_deviation: 10000.0
+                }
               }
             }
-            bin_results: {
+            bin_results {
               key: 3
-              value: {
-                value: 1291372
-                univariate_statistics { standard_deviation: 10000 }
+              value {
+                value: 1292385
+                univariate_statistics {
+                  standard_deviation: 10000.0
+                }
               }
             }
-            bin_results: {
+            bin_results {
               key: 4
-              value: {
-                value: 645686
-                univariate_statistics { standard_deviation: 10000 }
+              value {
+                value: 643261
+                univariate_statistics {
+                  standard_deviation: 10000.0
+                }
               }
             }
-            bin_results: {
+            bin_results {
               key: 5
-              value: {
-                value: 322843
-                univariate_statistics { standard_deviation: 10000 }
+              value {
+                value: 316980
+                univariate_statistics {
+                  standard_deviation: 10000.0
+                }
               }
+            }
+          }
+          impression_count {
+            value: 18382862
+            univariate_statistics {
+              standard_deviation: 10000.0
             }
           }
         }
@@ -118,60 +139,79 @@ reporting_set_results {
       unprocessed_report_result_values {
         cumulative_results {
           reach {
-            value: 11998422
-            univariate_statistics { standard_deviation: 10000 }
+            value: 12002237
+            univariate_statistics {
+              standard_deviation: 10000.0
+            }
           }
         }
         non_cumulative_results {
           reach {
-            value: 2452001
-            univariate_statistics { standard_deviation: 10000 }
-          }
-          impression_count {
-            value: 4471035
-            univariate_statistics { standard_deviation: 10000 }
+            value: 2451953
+            univariate_statistics {
+              standard_deviation: 10000.0
+            }
           }
           frequency_histogram {
-            bin_results: {
+            bin_results {
               key: 1
-              value: {
-                value: 1265549
-                univariate_statistics { standard_deviation: 10000 }
+              value {
+                value: 1268962
+                univariate_statistics {
+                  standard_deviation: 10000.0
+                }
               }
             }
-            bin_results: {
+            bin_results {
               key: 2
-              value: {
-                value: 632775
-                univariate_statistics { standard_deviation: 10000 }
+              value {
+                value: 634477
+                univariate_statistics {
+                  standard_deviation: 10000.0
+                }
               }
             }
-            bin_results: {
+            bin_results {
               key: 3
-              value: {
-                value: 316388
-                univariate_statistics { standard_deviation: 10000 }
+              value {
+                value: 316378
+                univariate_statistics {
+                  standard_deviation: 10000.0
+                }
               }
             }
-            bin_results: {
+            bin_results {
               key: 4
-              value: {
-                value: 158194
-                univariate_statistics { standard_deviation: 10000 }
+              value {
+                value: 156473
+                univariate_statistics {
+                  standard_deviation: 10000.0
+                }
               }
             }
-            bin_results: {
+            bin_results {
               key: 5
-              value: {
-                value: 79095
-                univariate_statistics { standard_deviation: 10000 }
+              value {
+                value: 75663
+                univariate_statistics {
+                  standard_deviation: 10000.0
+                }
               }
+            }
+          }
+          impression_count {
+            value: 4491260
+            univariate_statistics {
+              standard_deviation: 10000.0
             }
           }
         }
       }
     }
   }
+  metric_frequency_spec_fingerprint: 1234
+  grouping_dimension_fingerprint: 1
+  filter_fingerprint: 5
 }
 reporting_set_results {
   cmms_measurement_consumer_id: "abcd"
@@ -181,28 +221,33 @@ reporting_set_results {
     external_reporting_set_id: "reporting_set_id_edp1"
     venn_diagram_region_type: UNION
     external_impression_qualification_filter_id: "ami"
-    metric_frequency_spec { total: true }
+    metric_frequency_spec {
+      total: true
+    }
     grouping {
       value_by_path {
         key: "person.age_group"
-        value { enum_value: "YEARS_35_TO_54" }
+        value {
+          enum_value: "YEARS_35_TO_54"
+        }
       }
       value_by_path {
         key: "person.gender"
-        value { enum_value: "MALE" }
+        value {
+          enum_value: "MALE"
+        }
       }
     }
     event_filters {
       terms {
         path: "banner_ad.viewable"
-        value { bool_value: true }
+        value {
+          bool_value: true
+        }
       }
     }
   }
   population_size: 55000000
-  metric_frequency_spec_fingerprint: 1234
-  grouping_dimension_fingerprint: 1
-  filter_fingerprint: 5
   reporting_window_results {
     key {
       non_cumulative_start {
@@ -220,54 +265,71 @@ reporting_set_results {
       unprocessed_report_result_values {
         cumulative_results {
           reach {
-            value: 11978894
-            univariate_statistics { standard_deviation: 10000 }
-          }
-          impression_count {
-            value: 22870892
-            univariate_statistics { standard_deviation: 10000 }
+            value: 12002237
+            univariate_statistics {
+              standard_deviation: 10000.0
+            }
           }
           frequency_histogram {
-            bin_results: {
+            bin_results {
               key: 1
-              value: {
-                value: 6182655
-                univariate_statistics { standard_deviation: 10000 }
+              value {
+                value: 6187323
+                univariate_statistics {
+                  standard_deviation: 10000.0
+                }
               }
             }
-            bin_results: {
+            bin_results {
               key: 2
-              value: {
-                value: 3091328
-                univariate_statistics { standard_deviation: 10000 }
+              value {
+                value: 3095997
+                univariate_statistics {
+                  standard_deviation: 10000.0
+                }
               }
             }
-            bin_results: {
+            bin_results {
               key: 3
-              value: {
-                value: 1545664
-                univariate_statistics { standard_deviation: 10000 }
+              value {
+                value: 1550333
+                univariate_statistics {
+                  standard_deviation: 10000.0
+                }
               }
             }
-            bin_results: {
+            bin_results {
               key: 4
-              value: {
-                value: 772832
-                univariate_statistics { standard_deviation: 10000 }
+              value {
+                value: 777501
+                univariate_statistics {
+                  standard_deviation: 10000.0
+                }
               }
             }
-            bin_results: {
+            bin_results {
               key: 5
-              value: {
-                value: 386415
-                univariate_statistics { standard_deviation: 10000 }
+              value {
+                value: 391084
+                univariate_statistics {
+                  standard_deviation: 10000.0
+                }
               }
+            }
+          }
+          impression_count {
+            value: 22868543
+            univariate_statistics {
+              standard_deviation: 10000.0
             }
           }
         }
       }
     }
   }
+  metric_frequency_spec_fingerprint: 1234
+  grouping_dimension_fingerprint: 1
+  filter_fingerprint: 5
 }
 reporting_set_results {
   cmms_measurement_consumer_id: "abcd"
@@ -277,29 +339,33 @@ reporting_set_results {
     external_reporting_set_id: "reporting_set_id_edp2"
     venn_diagram_region_type: UNION
     external_impression_qualification_filter_id: "ami"
-    metric_frequency_spec { weekly: MONDAY }
+    metric_frequency_spec {
+      weekly: MONDAY
+    }
     grouping {
       value_by_path {
         key: "person.age_group"
-        value { enum_value: "YEARS_35_TO_54" }
+        value {
+          enum_value: "YEARS_35_TO_54"
+        }
       }
       value_by_path {
         key: "person.gender"
-        value { enum_value: "MALE" }
+        value {
+          enum_value: "MALE"
+        }
       }
     }
-
     event_filters {
       terms {
         path: "banner_ad.viewable"
-        value { bool_value: true }
+        value {
+          bool_value: true
+        }
       }
     }
   }
   population_size: 55000000
-  metric_frequency_spec_fingerprint: 1234
-  grouping_dimension_fingerprint: 1
-  filter_fingerprint: 5
   reporting_window_results {
     key {
       non_cumulative_start {
@@ -316,32 +382,48 @@ reporting_set_results {
     value {
       unprocessed_report_result_values {
         cumulative_results {
-          reach { value: 5000000 }
+          reach {
+            value: 5000000
+          }
         }
         non_cumulative_results {
-          reach { value: 5000000 }
-          impression_count { value: 9193546 }
+          reach {
+            value: 5000000
+          }
           frequency_histogram {
-            bin_results: {
+            bin_results {
               key: 1
-              value: { value: 2580645 }
+              value {
+                value: 2580645
+              }
             }
-            bin_results: {
+            bin_results {
               key: 2
-              value: { value: 1290323 }
+              value {
+                value: 1290323
+              }
             }
-            bin_results: {
+            bin_results {
               key: 3
-              value: { value: 645162 }
+              value {
+                value: 645162
+              }
             }
-            bin_results: {
+            bin_results {
               key: 4
-              value: { value: 322581 }
+              value {
+                value: 322581
+              }
             }
-            bin_results: {
+            bin_results {
               key: 5
-              value: { value: 161289 }
+              value {
+                value: 161289
+              }
             }
+          }
+          impression_count {
+            value: 9193546
           }
         }
       }
@@ -363,37 +445,56 @@ reporting_set_results {
     value {
       unprocessed_report_result_values {
         cumulative_results {
-          reach { value: 6000000 }
+          reach {
+            value: 6000000
+          }
         }
         non_cumulative_results {
-          reach { value: 1100000 }
-          impression_count { value: 2022579 }
+          reach {
+            value: 1100000
+          }
           frequency_histogram {
-            bin_results: {
+            bin_results {
               key: 1
-              value: { value: 567742 }
+              value {
+                value: 567742
+              }
             }
-            bin_results: {
+            bin_results {
               key: 2
-              value: { value: 283871 }
+              value {
+                value: 283871
+              }
             }
-            bin_results: {
+            bin_results {
               key: 3
-              value: { value: 141936 }
+              value {
+                value: 141936
+              }
             }
-            bin_results: {
+            bin_results {
               key: 4
-              value: { value: 70968 }
+              value {
+                value: 70968
+              }
             }
-            bin_results: {
+            bin_results {
               key: 5
-              value: { value: 35483 }
+              value {
+                value: 35483
+              }
             }
+          }
+          impression_count {
+            value: 2022579
           }
         }
       }
     }
   }
+  metric_frequency_spec_fingerprint: 1234
+  grouping_dimension_fingerprint: 1
+  filter_fingerprint: 5
 }
 reporting_set_results {
   cmms_measurement_consumer_id: "abcd"
@@ -403,28 +504,33 @@ reporting_set_results {
     external_reporting_set_id: "reporting_set_id_edp2"
     venn_diagram_region_type: UNION
     external_impression_qualification_filter_id: "ami"
-    metric_frequency_spec { total: true }
+    metric_frequency_spec {
+      total: true
+    }
     grouping {
       value_by_path {
         key: "person.age_group"
-        value { enum_value: "YEARS_35_TO_54" }
+        value {
+          enum_value: "YEARS_35_TO_54"
+        }
       }
       value_by_path {
         key: "person.gender"
-        value { enum_value: "MALE" }
+        value {
+          enum_value: "MALE"
+        }
       }
     }
     event_filters {
       terms {
         path: "banner_ad.viewable"
-        value { bool_value: true }
+        value {
+          bool_value: true
+        }
       }
     }
   }
   population_size: 55000000
-  metric_frequency_spec_fingerprint: 1234
-  grouping_dimension_fingerprint: 1
-  filter_fingerprint: 5
   reporting_window_results {
     key {
       non_cumulative_start {
@@ -441,34 +547,51 @@ reporting_set_results {
     value {
       unprocessed_report_result_values {
         cumulative_results {
-          reach { value: 6000000 }
-          impression_count { value: 11216125 }
+          reach {
+            value: 6000000
+          }
           frequency_histogram {
-            bin_results: {
+            bin_results {
               key: 1
-              value: { value: 3096774 }
+              value {
+                value: 3096774
+              }
             }
-            bin_results: {
+            bin_results {
               key: 2
-              value: { value: 1548387 }
+              value {
+                value: 1548387
+              }
             }
-            bin_results: {
+            bin_results {
               key: 3
-              value: { value: 774194 }
+              value {
+                value: 774194
+              }
             }
-            bin_results: {
+            bin_results {
               key: 4
-              value: { value: 387097 }
+              value {
+                value: 387097
+              }
             }
-            bin_results: {
+            bin_results {
               key: 5
-              value: { value: 193548 }
+              value {
+                value: 193548
+              }
             }
+          }
+          impression_count {
+            value: 11216125
           }
         }
       }
     }
   }
+  metric_frequency_spec_fingerprint: 1234
+  grouping_dimension_fingerprint: 1
+  filter_fingerprint: 5
 }
 reporting_set_results {
   cmms_measurement_consumer_id: "abcd"
@@ -478,28 +601,33 @@ reporting_set_results {
     external_reporting_set_id: "reporting_set_id_edp3"
     venn_diagram_region_type: UNION
     external_impression_qualification_filter_id: "ami"
-    metric_frequency_spec { weekly: MONDAY }
+    metric_frequency_spec {
+      weekly: MONDAY
+    }
     grouping {
       value_by_path {
         key: "person.age_group"
-        value { enum_value: "YEARS_35_TO_54" }
+        value {
+          enum_value: "YEARS_35_TO_54"
+        }
       }
       value_by_path {
         key: "person.gender"
-        value { enum_value: "MALE" }
+        value {
+          enum_value: "MALE"
+        }
       }
     }
     event_filters {
       terms {
         path: "banner_ad.viewable"
-        value { bool_value: true }
+        value {
+          bool_value: true
+        }
       }
     }
   }
   population_size: 55000000
-  metric_frequency_spec_fingerprint: 1234
-  grouping_dimension_fingerprint: 1
-  filter_fingerprint: 5
   reporting_window_results {
     key {
       non_cumulative_start {
@@ -516,32 +644,48 @@ reporting_set_results {
     value {
       unprocessed_report_result_values {
         cumulative_results {
-          reach { value: 800000 }
+          reach {
+            value: 800000
+          }
         }
         non_cumulative_results {
-          reach { value: 800000 }
-          impression_count { value: 1470967 }
+          reach {
+            value: 800000
+          }
           frequency_histogram {
-            bin_results: {
+            bin_results {
               key: 1
-              value: { value: 412903 }
+              value {
+                value: 412903
+              }
             }
-            bin_results: {
+            bin_results {
               key: 2
-              value: { value: 206452 }
+              value {
+                value: 206452
+              }
             }
-            bin_results: {
+            bin_results {
               key: 3
-              value: { value: 103226 }
+              value {
+                value: 103226
+              }
             }
-            bin_results: {
+            bin_results {
               key: 4
-              value: { value: 51613 }
+              value {
+                value: 51613
+              }
             }
-            bin_results: {
+            bin_results {
               key: 5
-              value: { value: 25806 }
+              value {
+                value: 25806
+              }
             }
+          }
+          impression_count {
+            value: 1470967
           }
         }
       }
@@ -563,37 +707,56 @@ reporting_set_results {
     value {
       unprocessed_report_result_values {
         cumulative_results {
-          reach { value: 1000000 }
+          reach {
+            value: 1000000
+          }
         }
         non_cumulative_results {
-          reach { value: 202952 }
-          impression_count { value: 373169 }
+          reach {
+            value: 202952
+          }
           frequency_histogram {
-            bin_results: {
+            bin_results {
               key: 1
-              value: { value: 104749 }
+              value {
+                value: 104749
+              }
             }
-            bin_results: {
+            bin_results {
               key: 2
-              value: { value: 52375 }
+              value {
+                value: 52375
+              }
             }
-            bin_results: {
+            bin_results {
               key: 3
-              value: { value: 26188 }
+              value {
+                value: 26188
+              }
             }
-            bin_results: {
+            bin_results {
               key: 4
-              value: { value: 13094 }
+              value {
+                value: 13094
+              }
             }
-            bin_results: {
+            bin_results {
               key: 5
-              value: { value: 6546 }
+              value {
+                value: 6546
+              }
             }
+          }
+          impression_count {
+            value: 373169
           }
         }
       }
     }
   }
+  metric_frequency_spec_fingerprint: 1234
+  grouping_dimension_fingerprint: 1
+  filter_fingerprint: 5
 }
 reporting_set_results {
   cmms_measurement_consumer_id: "abcd"
@@ -603,28 +766,33 @@ reporting_set_results {
     external_reporting_set_id: "reporting_set_id_edp3"
     venn_diagram_region_type: UNION
     external_impression_qualification_filter_id: "ami"
-    metric_frequency_spec { total: true }
+    metric_frequency_spec {
+      total: true
+    }
     grouping {
       value_by_path {
         key: "person.age_group"
-        value { enum_value: "YEARS_35_TO_54" }
+        value {
+          enum_value: "YEARS_35_TO_54"
+        }
       }
       value_by_path {
         key: "person.gender"
-        value { enum_value: "MALE" }
+        value {
+          enum_value: "MALE"
+        }
       }
     }
     event_filters {
       terms {
         path: "banner_ad.viewable"
-        value { bool_value: true }
+        value {
+          bool_value: true
+        }
       }
     }
   }
   population_size: 55000000
-  metric_frequency_spec_fingerprint: 1234
-  grouping_dimension_fingerprint: 1
-  filter_fingerprint: 5
   reporting_window_results {
     key {
       non_cumulative_start {
@@ -641,34 +809,51 @@ reporting_set_results {
     value {
       unprocessed_report_result_values {
         cumulative_results {
-          reach { value: 1000000 }
-          impression_count { value: 1844136 }
+          reach {
+            value: 1000000
+          }
           frequency_histogram {
-            bin_results: {
+            bin_results {
               key: 1
-              value: { value: 516129 }
+              value {
+                value: 516129
+              }
             }
-            bin_results: {
+            bin_results {
               key: 2
-              value: { value: 258065 }
+              value {
+                value: 258065
+              }
             }
-            bin_results: {
+            bin_results {
               key: 3
-              value: { value: 129033 }
+              value {
+                value: 129033
+              }
             }
-            bin_results: {
+            bin_results {
               key: 4
-              value: { value: 64517 }
+              value {
+                value: 64517
+              }
             }
-            bin_results: {
+            bin_results {
               key: 5
-              value: { value: 32256 }
+              value {
+                value: 32256
+              }
             }
+          }
+          impression_count {
+            value: 1844136
           }
         }
       }
     }
   }
+  metric_frequency_spec_fingerprint: 1234
+  grouping_dimension_fingerprint: 1
+  filter_fingerprint: 5
 }
 reporting_set_results {
   cmms_measurement_consumer_id: "abcd"
@@ -678,28 +863,33 @@ reporting_set_results {
     external_reporting_set_id: "reporting_set_id_edp1_edp2_edp3"
     venn_diagram_region_type: UNION
     external_impression_qualification_filter_id: "ami"
-    metric_frequency_spec { weekly: MONDAY }
+    metric_frequency_spec {
+      weekly: MONDAY
+    }
     grouping {
       value_by_path {
         key: "person.age_group"
-        value { enum_value: "YEARS_35_TO_54" }
+        value {
+          enum_value: "YEARS_35_TO_54"
+        }
       }
       value_by_path {
         key: "person.gender"
-        value { enum_value: "MALE" }
+        value {
+          enum_value: "MALE"
+        }
       }
     }
     event_filters {
       terms {
         path: "banner_ad.viewable"
-        value { bool_value: true }
+        value {
+          bool_value: true
+        }
       }
     }
   }
   population_size: 55000000
-  metric_frequency_spec_fingerprint: 1234
-  grouping_dimension_fingerprint: 1
-  filter_fingerprint: 5
   reporting_window_results {
     key {
       non_cumulative_start {
@@ -717,54 +907,70 @@ reporting_set_results {
       unprocessed_report_result_values {
         cumulative_results {
           reach {
-            value: 15830545
-            univariate_statistics { standard_deviation: 10000 }
+            value: 15811521
+            univariate_statistics {
+              standard_deviation: 10000.0
+            }
           }
         }
         non_cumulative_results {
           reach {
-            value: 15829304
-            univariate_statistics { standard_deviation: 10000 }
-          }
-          impression_count {
-            value: 29046331
-            univariate_statistics { standard_deviation: 10000 }
+            value: 15813194
+            univariate_statistics {
+              standard_deviation: 10000.0
+            }
           }
           frequency_histogram {
-            bin_results: {
+            bin_results {
               key: 1
-              value: {
-                value: 8169963
-                univariate_statistics { standard_deviation: 10000 }
+              value {
+                value: 8168699
+                univariate_statistics {
+                  standard_deviation: 10000.0
+                }
               }
             }
-            bin_results: {
+            bin_results {
               key: 2
-              value: {
-                value: 4084982
-                univariate_statistics { standard_deviation: 10000 }
+              value {
+                value: 4082739
+                univariate_statistics {
+                  standard_deviation: 10000.0
+                }
               }
             }
-            bin_results: {
+            bin_results {
               key: 3
-              value: {
-                value: 2042491
-                univariate_statistics { standard_deviation: 10000 }
+              value {
+                value: 2039269
+                univariate_statistics {
+                  standard_deviation: 10000.0
+                }
               }
             }
-            bin_results: {
+            bin_results {
               key: 4
-              value: {
-                value: 1021246
-                univariate_statistics { standard_deviation: 10000 }
+              value {
+                value: 1017045
+                univariate_statistics {
+                  standard_deviation: 10000.0
+                }
               }
             }
-            bin_results: {
+            bin_results {
               key: 5
-              value: {
-                value: 510622
-                univariate_statistics { standard_deviation: 10000 }
+              value {
+                value: 505442
+                univariate_statistics {
+                  standard_deviation: 10000.0
+                }
               }
+            }
+          }
+          impression_count {
+            value: 29047375
+            univariate_statistics {
+              standard_deviation: 10000.0
             }
           }
         }
@@ -788,60 +994,79 @@ reporting_set_results {
       unprocessed_report_result_values {
         cumulative_results {
           reach {
-            value: 19010669
-            univariate_statistics { standard_deviation: 10000 }
+            value: 19002237
+            univariate_statistics {
+              standard_deviation: 10000.0
+            }
           }
         }
         non_cumulative_results {
           reach {
-            value: 3761510
-            univariate_statistics { standard_deviation: 10000 }
-          }
-          impression_count {
-            value: 6904573
-            univariate_statistics { standard_deviation: 10000 }
+            value: 3754905
+            univariate_statistics {
+              standard_deviation: 10000.0
+            }
           }
           frequency_histogram {
-            bin_results: {
+            bin_results {
               key: 1
-              value: {
-                value: 1941425
-                univariate_statistics { standard_deviation: 10000 }
+              value {
+                value: 1942003
+                univariate_statistics {
+                  standard_deviation: 10000.0
+                }
               }
             }
-            bin_results: {
+            bin_results {
               key: 2
-              value: {
-                value: 970713
-                univariate_statistics { standard_deviation: 10000 }
+              value {
+                value: 970342
+                univariate_statistics {
+                  standard_deviation: 10000.0
+                }
               }
             }
-            bin_results: {
+            bin_results {
               key: 3
-              value: {
-                value: 485357
-                univariate_statistics { standard_deviation: 10000 }
+              value {
+                value: 484036
+                univariate_statistics {
+                  standard_deviation: 10000.0
+                }
               }
             }
-            bin_results: {
+            bin_results {
               key: 4
-              value: {
-                value: 242679
-                univariate_statistics { standard_deviation: 10000 }
+              value {
+                value: 240408
+                univariate_statistics {
+                  standard_deviation: 10000.0
+                }
               }
             }
-            bin_results: {
+            bin_results {
               key: 5
-              value: {
-                value: 121336
-                univariate_statistics { standard_deviation: 10000 }
+              value {
+                value: 118116
+                univariate_statistics {
+                  standard_deviation: 10000.0
+                }
               }
+            }
+          }
+          impression_count {
+            value: 6887008
+            univariate_statistics {
+              standard_deviation: 10000.0
             }
           }
         }
       }
     }
   }
+  metric_frequency_spec_fingerprint: 1234
+  grouping_dimension_fingerprint: 1
+  filter_fingerprint: 5
 }
 reporting_set_results {
   cmms_measurement_consumer_id: "abcd"
@@ -851,28 +1076,33 @@ reporting_set_results {
     external_reporting_set_id: "reporting_set_id_edp1_edp2_edp3"
     venn_diagram_region_type: UNION
     external_impression_qualification_filter_id: "ami"
-    metric_frequency_spec { total: true }
+    metric_frequency_spec {
+      total: true
+    }
     grouping {
       value_by_path {
         key: "person.age_group"
-        value { enum_value: "YEARS_35_TO_54" }
+        value {
+          enum_value: "YEARS_35_TO_54"
+        }
       }
       value_by_path {
         key: "person.gender"
-        value { enum_value: "MALE" }
+        value {
+          enum_value: "MALE"
+        }
       }
     }
     event_filters {
       terms {
         path: "banner_ad.viewable"
-        value { bool_value: true }
+        value {
+          bool_value: true
+        }
       }
     }
   }
   population_size: 55000000
-  metric_frequency_spec_fingerprint: 1234
-  grouping_dimension_fingerprint: 1
-  filter_fingerprint: 5
   reporting_window_results {
     key {
       non_cumulative_start {
@@ -890,54 +1120,71 @@ reporting_set_results {
       unprocessed_report_result_values {
         cumulative_results {
           reach {
-            value: 19021738
-            univariate_statistics { standard_deviation: 10000 }
-          }
-          impression_count {
-            value: 35926461
-            univariate_statistics { standard_deviation: 10000 }
+            value: 19002237
+            univariate_statistics {
+              standard_deviation: 10000.0
+            }
           }
           frequency_histogram {
-            bin_results: {
+            bin_results {
               key: 1
-              value: {
-                value: 9817671
-                univariate_statistics { standard_deviation: 10000 }
+              value {
+                value: 9813770
+                univariate_statistics {
+                  standard_deviation: 10000.0
+                }
               }
             }
-            bin_results: {
+            bin_results {
               key: 2
-              value: {
-                value: 4908836
-                univariate_statistics { standard_deviation: 10000 }
+              value {
+                value: 4904936
+                univariate_statistics {
+                  standard_deviation: 10000.0
+                }
               }
             }
-            bin_results: {
+            bin_results {
               key: 3
-              value: {
-                value: 2454418
-                univariate_statistics { standard_deviation: 10000 }
+              value {
+                value: 2450518
+                univariate_statistics {
+                  standard_deviation: 10000.0
+                }
               }
             }
-            bin_results: {
+            bin_results {
               key: 4
-              value: {
-                value: 1227209
-                univariate_statistics { standard_deviation: 10000 }
+              value {
+                value: 1223309
+                univariate_statistics {
+                  standard_deviation: 10000.0
+                }
               }
             }
-            bin_results: {
+            bin_results {
               key: 5
-              value: {
-                value: 613604
-                univariate_statistics { standard_deviation: 10000 }
+              value {
+                value: 609704
+                univariate_statistics {
+                  standard_deviation: 10000.0
+                }
               }
+            }
+          }
+          impression_count {
+            value: 35928804
+            univariate_statistics {
+              standard_deviation: 10000.0
             }
           }
         }
       }
     }
   }
+  metric_frequency_spec_fingerprint: 1234
+  grouping_dimension_fingerprint: 1
+  filter_fingerprint: 5
 }
 reporting_set_results {
   cmms_measurement_consumer_id: "abcd"
@@ -947,28 +1194,33 @@ reporting_set_results {
     external_reporting_set_id: "reporting_set_id_edp1_edp2"
     venn_diagram_region_type: UNION
     external_impression_qualification_filter_id: "ami"
-    metric_frequency_spec { total: true }
+    metric_frequency_spec {
+      total: true
+    }
     grouping {
       value_by_path {
         key: "person.age_group"
-        value { enum_value: "YEARS_18_TO_34" }
+        value {
+          enum_value: "YEARS_18_TO_34"
+        }
       }
       value_by_path {
         key: "person.gender"
-        value { enum_value: "MALE" }
+        value {
+          enum_value: "MALE"
+        }
       }
     }
     event_filters {
       terms {
         path: "banner_ad.viewable"
-        value { bool_value: true }
+        value {
+          bool_value: true
+        }
       }
     }
   }
   population_size: 55000000
-  metric_frequency_spec_fingerprint: 1234
-  grouping_dimension_fingerprint: 2
-  filter_fingerprint: 5
   reporting_window_results {
     key {
       non_cumulative_start {
@@ -986,17 +1238,22 @@ reporting_set_results {
       unprocessed_report_result_values {
         cumulative_results {
           reach {
-            value: 16686873
-            univariate_statistics { standard_deviation: 10000 }
+            univariate_statistics {
+              standard_deviation: 10000.0
+            }
           }
           impression_count {
-            value: 34113188
-            univariate_statistics { standard_deviation: 10000 }
+            univariate_statistics {
+              standard_deviation: 10000.0
+            }
           }
         }
       }
     }
   }
+  metric_frequency_spec_fingerprint: 1234
+  grouping_dimension_fingerprint: 2
+  filter_fingerprint: 5
 }
 reporting_set_results {
   cmms_measurement_consumer_id: "abcd"
@@ -1006,28 +1263,33 @@ reporting_set_results {
     external_reporting_set_id: "reporting_set_id_edp1"
     venn_diagram_region_type: UNION
     external_impression_qualification_filter_id: "mrc"
-    metric_frequency_spec { weekly: MONDAY }
+    metric_frequency_spec {
+      weekly: MONDAY
+    }
     grouping {
       value_by_path {
         key: "person.age_group"
-        value { enum_value: "YEARS_18_TO_34" }
+        value {
+          enum_value: "YEARS_18_TO_34"
+        }
       }
       value_by_path {
         key: "person.gender"
-        value { enum_value: "MALE" }
+        value {
+          enum_value: "MALE"
+        }
       }
     }
     event_filters {
       terms {
         path: "banner_ad.viewable"
-        value { bool_value: true }
+        value {
+          bool_value: true
+        }
       }
     }
   }
   population_size: 55000000
-  metric_frequency_spec_fingerprint: 1234
-  grouping_dimension_fingerprint: 2
-  filter_fingerprint: 5
   reporting_window_results {
     key {
       non_cumulative_start {
@@ -1045,54 +1307,70 @@ reporting_set_results {
       unprocessed_report_result_values {
         cumulative_results {
           reach {
-            value: 9501618
-            univariate_statistics { standard_deviation: 10000 }
+            value: 9501617
+            univariate_statistics {
+              standard_deviation: 10000.0
+            }
           }
         }
         non_cumulative_results {
           reach {
-            value: 9503446
-            univariate_statistics { standard_deviation: 10000 }
-          }
-          impression_count {
-            value: 17473517
-            univariate_statistics { standard_deviation: 10000 }
+            value: 9406880
+            univariate_statistics {
+              standard_deviation: 10000.0
+            }
           }
           frequency_histogram {
-            bin_results: {
+            bin_results {
               key: 1
-              value: {
-                value: 4905004
-                univariate_statistics { standard_deviation: 10000 }
+              value {
+                value: 4962943
+                univariate_statistics {
+                  standard_deviation: 10000.0
+                }
               }
             }
-            bin_results: {
+            bin_results {
               key: 2
-              value: {
-                value: 2452502
-                univariate_statistics { standard_deviation: 10000 }
+              value {
+                value: 2471815
+                univariate_statistics {
+                  standard_deviation: 10000.0
+                }
               }
             }
-            bin_results: {
+            bin_results {
               key: 3
-              value: {
-                value: 1226251
-                univariate_statistics { standard_deviation: 10000 }
+              value {
+                value: 1206938
+                univariate_statistics {
+                  standard_deviation: 10000.0
+                }
               }
             }
-            bin_results: {
+            bin_results {
               key: 4
-              value: {
-                value: 613126
-                univariate_statistics { standard_deviation: 10000 }
+              value {
+                value: 555187
+                univariate_statistics {
+                  standard_deviation: 10000.0
+                }
               }
             }
-            bin_results: {
+            bin_results {
               key: 5
-              value: {
-                value: 306563
-                univariate_statistics { standard_deviation: 10000 }
+              value {
+                value: 209998
+                univariate_statistics {
+                  standard_deviation: 10000.0
+                }
               }
+            }
+          }
+          impression_count {
+            value: 16798121
+            univariate_statistics {
+              standard_deviation: 10000.0
             }
           }
         }
@@ -1116,60 +1394,79 @@ reporting_set_results {
       unprocessed_report_result_values {
         cumulative_results {
           reach {
-            value: 11389309
-            univariate_statistics { standard_deviation: 10000 }
+            value: 11374247
+            univariate_statistics {
+              standard_deviation: 10000.0
+            }
           }
         }
         non_cumulative_results {
           reach {
-            value: 2289252
-            univariate_statistics { standard_deviation: 10000 }
-          }
-          impression_count {
-            value: 4236753
-            univariate_statistics { standard_deviation: 10000 }
+            value: 2267580
+            univariate_statistics {
+              standard_deviation: 10000.0
+            }
           }
           frequency_histogram {
-            bin_results: {
+            bin_results {
               key: 1
-              value: {
-                value: 1181549
-                univariate_statistics { standard_deviation: 10000 }
+              value {
+                value: 1194552
+                univariate_statistics {
+                  standard_deviation: 10000.0
+                }
               }
             }
-            bin_results: {
+            bin_results {
               key: 2
-              value: {
-                value: 590775
-                univariate_statistics { standard_deviation: 10000 }
+              value {
+                value: 595109
+                univariate_statistics {
+                  standard_deviation: 10000.0
+                }
               }
             }
-            bin_results: {
+            bin_results {
               key: 3
-              value: {
-                value: 295388
-                univariate_statistics { standard_deviation: 10000 }
+              value {
+                value: 291054
+                univariate_statistics {
+                  standard_deviation: 10000.0
+                }
               }
             }
-            bin_results: {
+            bin_results {
               key: 4
-              value: {
-                value: 147694
-                univariate_statistics { standard_deviation: 10000 }
+              value {
+                value: 134691
+                univariate_statistics {
+                  standard_deviation: 10000.0
+                }
               }
             }
-            bin_results: {
+            bin_results {
               key: 5
-              value: {
-                value: 73846
-                univariate_statistics { standard_deviation: 10000 }
+              value {
+                value: 52175
+                univariate_statistics {
+                  standard_deviation: 10000.0
+                }
               }
+            }
+          }
+          impression_count {
+            value: 4057569
+            univariate_statistics {
+              standard_deviation: 10000.0
             }
           }
         }
       }
     }
   }
+  metric_frequency_spec_fingerprint: 1234
+  grouping_dimension_fingerprint: 2
+  filter_fingerprint: 5
 }
 reporting_set_results {
   cmms_measurement_consumer_id: "abcd"
@@ -1179,28 +1476,33 @@ reporting_set_results {
     external_reporting_set_id: "reporting_set_id_edp1"
     venn_diagram_region_type: UNION
     external_impression_qualification_filter_id: "mrc"
-    metric_frequency_spec { total: true }
+    metric_frequency_spec {
+      total: true
+    }
     grouping {
       value_by_path {
         key: "person.age_group"
-        value { enum_value: "YEARS_18_TO_34" }
+        value {
+          enum_value: "YEARS_18_TO_34"
+        }
       }
       value_by_path {
         key: "person.gender"
-        value { enum_value: "MALE" }
+        value {
+          enum_value: "MALE"
+        }
       }
     }
     event_filters {
       terms {
         path: "banner_ad.viewable"
-        value { bool_value: true }
+        value {
+          bool_value: true
+        }
       }
     }
   }
   population_size: 55000000
-  metric_frequency_spec_fingerprint: 1234
-  grouping_dimension_fingerprint: 2
-  filter_fingerprint: 5
   reporting_window_results {
     key {
       non_cumulative_start {
@@ -1218,54 +1520,71 @@ reporting_set_results {
       unprocessed_report_result_values {
         cumulative_results {
           reach {
-            value: 11382243
-            univariate_statistics { standard_deviation: 10000 }
-          }
-          impression_count {
-            value: 21696322
-            univariate_statistics { standard_deviation: 10000 }
+            value: 11374247
+            univariate_statistics {
+              standard_deviation: 10000.0
+            }
           }
           frequency_histogram {
-            bin_results: {
+            bin_results {
               key: 1
-              value: {
-                value: 5874706
-                univariate_statistics { standard_deviation: 10000 }
+              value {
+                value: 5889543
+                univariate_statistics {
+                  standard_deviation: 10000.0
+                }
               }
             }
-            bin_results: {
+            bin_results {
               key: 2
-              value: {
-                value: 2937353
-                univariate_statistics { standard_deviation: 10000 }
+              value {
+                value: 2943972
+                univariate_statistics {
+                  standard_deviation: 10000.0
+                }
               }
             }
-            bin_results: {
+            bin_results {
               key: 3
-              value: {
-                value: 1468677
-                univariate_statistics { standard_deviation: 10000 }
+              value {
+                value: 1467078
+                univariate_statistics {
+                  standard_deviation: 10000.0
+                }
               }
             }
-            bin_results: {
+            bin_results {
               key: 4
-              value: {
-                value: 734339
-                univariate_statistics { standard_deviation: 10000 }
+              value {
+                value: 724521
+                univariate_statistics {
+                  standard_deviation: 10000.0
+                }
               }
             }
-            bin_results: {
+            bin_results {
               key: 5
-              value: {
-                value: 367168
-                univariate_statistics { standard_deviation: 10000 }
+              value {
+                value: 349132
+                univariate_statistics {
+                  standard_deviation: 10000.0
+                }
               }
+            }
+          }
+          impression_count {
+            value: 20822466
+            univariate_statistics {
+              standard_deviation: 10000.0
             }
           }
         }
       }
     }
   }
+  metric_frequency_spec_fingerprint: 1234
+  grouping_dimension_fingerprint: 2
+  filter_fingerprint: 5
 }
 reporting_set_results {
   cmms_measurement_consumer_id: "abcd"
@@ -1275,28 +1594,33 @@ reporting_set_results {
     external_reporting_set_id: "reporting_set_id_edp2"
     venn_diagram_region_type: UNION
     external_impression_qualification_filter_id: "mrc"
-    metric_frequency_spec { weekly: MONDAY }
+    metric_frequency_spec {
+      weekly: MONDAY
+    }
     grouping {
       value_by_path {
         key: "person.age_group"
-        value { enum_value: "YEARS_18_TO_34" }
+        value {
+          enum_value: "YEARS_18_TO_34"
+        }
       }
       value_by_path {
         key: "person.gender"
-        value { enum_value: "MALE" }
+        value {
+          enum_value: "MALE"
+        }
       }
     }
     event_filters {
       terms {
         path: "banner_ad.viewable"
-        value { bool_value: true }
+        value {
+          bool_value: true
+        }
       }
     }
   }
   population_size: 55000000
-  metric_frequency_spec_fingerprint: 1234
-  grouping_dimension_fingerprint: 2
-  filter_fingerprint: 5
   reporting_window_results {
     key {
       non_cumulative_start {
@@ -1313,32 +1637,48 @@ reporting_set_results {
     value {
       unprocessed_report_result_values {
         cumulative_results {
-          reach { value: 4750000 }
+          reach {
+            value: 4750000
+          }
         }
         non_cumulative_results {
-          reach { value: 4750000 }
-          impression_count { value: 8733867 }
+          reach {
+            value: 4750000
+          }
           frequency_histogram {
-            bin_results: {
+            bin_results {
               key: 1
-              value: { value: 2451613 }
+              value {
+                value: 2451613
+              }
             }
-            bin_results: {
+            bin_results {
               key: 2
-              value: { value: 1225807 }
+              value {
+                value: 1225807
+              }
             }
-            bin_results: {
+            bin_results {
               key: 3
-              value: { value: 612904 }
+              value {
+                value: 612904
+              }
             }
-            bin_results: {
+            bin_results {
               key: 4
-              value: { value: 306452 }
+              value {
+                value: 306452
+              }
             }
-            bin_results: {
+            bin_results {
               key: 5
-              value: { value: 153224 }
+              value {
+                value: 153224
+              }
             }
+          }
+          impression_count {
+            value: 8733867
           }
         }
       }
@@ -1360,37 +1700,56 @@ reporting_set_results {
     value {
       unprocessed_report_result_values {
         cumulative_results {
-          reach { value: 5700000 }
+          reach {
+            value: 5700000
+          }
         }
         non_cumulative_results {
-          reach { value: 1039801 }
-          impression_count { value: 1911893 }
+          reach {
+            value: 1039801
+          }
           frequency_histogram {
-            bin_results: {
+            bin_results {
               key: 1
-              value: { value: 536671 }
+              value {
+                value: 536671
+              }
             }
-            bin_results: {
+            bin_results {
               key: 2
-              value: { value: 268336 }
+              value {
+                value: 268336
+              }
             }
-            bin_results: {
+            bin_results {
               key: 3
-              value: { value: 134168 }
+              value {
+                value: 134168
+              }
             }
-            bin_results: {
+            bin_results {
               key: 4
-              value: { value: 67084 }
+              value {
+                value: 67084
+              }
             }
-            bin_results: {
+            bin_results {
               key: 5
-              value: { value: 33542 }
+              value {
+                value: 33542
+              }
             }
+          }
+          impression_count {
+            value: 1911893
           }
         }
       }
     }
   }
+  metric_frequency_spec_fingerprint: 1234
+  grouping_dimension_fingerprint: 2
+  filter_fingerprint: 5
 }
 reporting_set_results {
   cmms_measurement_consumer_id: "abcd"
@@ -1400,28 +1759,33 @@ reporting_set_results {
     external_reporting_set_id: "reporting_set_id_edp2"
     venn_diagram_region_type: UNION
     external_impression_qualification_filter_id: "mrc"
-    metric_frequency_spec { total: true }
+    metric_frequency_spec {
+      total: true
+    }
     grouping {
       value_by_path {
         key: "person.age_group"
-        value { enum_value: "YEARS_18_TO_34" }
+        value {
+          enum_value: "YEARS_18_TO_34"
+        }
       }
       value_by_path {
         key: "person.gender"
-        value { enum_value: "MALE" }
+        value {
+          enum_value: "MALE"
+        }
       }
     }
     event_filters {
       terms {
         path: "banner_ad.viewable"
-        value { bool_value: true }
+        value {
+          bool_value: true
+        }
       }
     }
   }
   population_size: 55000000
-  metric_frequency_spec_fingerprint: 1234
-  grouping_dimension_fingerprint: 2
-  filter_fingerprint: 5
   reporting_window_results {
     key {
       non_cumulative_start {
@@ -1438,34 +1802,51 @@ reporting_set_results {
     value {
       unprocessed_report_result_values {
         cumulative_results {
-          reach { value: 5700000 }
-          impression_count { value: 10645760 }
+          reach {
+            value: 5700000
+          }
           frequency_histogram {
-            bin_results: {
+            bin_results {
               key: 1
-              value: { value: 2941935 }
+              value {
+                value: 2941935
+              }
             }
-            bin_results: {
+            bin_results {
               key: 2
-              value: { value: 1470968 }
+              value {
+                value: 1470968
+              }
             }
-            bin_results: {
+            bin_results {
               key: 3
-              value: { value: 735484 }
+              value {
+                value: 735484
+              }
             }
-            bin_results: {
+            bin_results {
               key: 4
-              value: { value: 367742 }
+              value {
+                value: 367742
+              }
             }
-            bin_results: {
+            bin_results {
               key: 5
-              value: { value: 183871 }
+              value {
+                value: 183871
+              }
             }
+          }
+          impression_count {
+            value: 10645760
           }
         }
       }
     }
   }
+  metric_frequency_spec_fingerprint: 1234
+  grouping_dimension_fingerprint: 2
+  filter_fingerprint: 5
 }
 reporting_set_results {
   cmms_measurement_consumer_id: "abcd"
@@ -1475,28 +1856,33 @@ reporting_set_results {
     external_reporting_set_id: "reporting_set_id_edp3"
     venn_diagram_region_type: UNION
     external_impression_qualification_filter_id: "mrc"
-    metric_frequency_spec { weekly: MONDAY }
+    metric_frequency_spec {
+      weekly: MONDAY
+    }
     grouping {
       value_by_path {
         key: "person.age_group"
-        value { enum_value: "YEARS_18_TO_34" }
+        value {
+          enum_value: "YEARS_18_TO_34"
+        }
       }
       value_by_path {
         key: "person.gender"
-        value { enum_value: "MALE" }
+        value {
+          enum_value: "MALE"
+        }
       }
     }
     event_filters {
       terms {
         path: "banner_ad.viewable"
-        value { bool_value: true }
+        value {
+          bool_value: true
+        }
       }
     }
   }
   population_size: 55000000
-  metric_frequency_spec_fingerprint: 1234
-  grouping_dimension_fingerprint: 2
-  filter_fingerprint: 5
   reporting_window_results {
     key {
       non_cumulative_start {
@@ -1513,32 +1899,48 @@ reporting_set_results {
     value {
       unprocessed_report_result_values {
         cumulative_results {
-          reach { value: 760000 }
+          reach {
+            value: 760000
+          }
         }
         non_cumulative_results {
-          reach { value: 760000 }
-          impression_count { value: 1397418 }
+          reach {
+            value: 760000
+          }
           frequency_histogram {
-            bin_results: {
+            bin_results {
               key: 1
-              value: { value: 392258 }
+              value {
+                value: 392258
+              }
             }
-            bin_results: {
+            bin_results {
               key: 2
-              value: { value: 196129 }
+              value {
+                value: 196129
+              }
             }
-            bin_results: {
+            bin_results {
               key: 3
-              value: { value: 98065 }
+              value {
+                value: 98065
+              }
             }
-            bin_results: {
+            bin_results {
               key: 4
-              value: { value: 49033 }
+              value {
+                value: 49033
+              }
             }
-            bin_results: {
+            bin_results {
               key: 5
-              value: { value: 24515 }
+              value {
+                value: 24515
+              }
             }
+          }
+          impression_count {
+            value: 1397418
           }
         }
       }
@@ -1560,37 +1962,56 @@ reporting_set_results {
     value {
       unprocessed_report_result_values {
         cumulative_results {
-          reach { value: 950000 }
+          reach {
+            value: 950000
+          }
         }
         non_cumulative_results {
-          reach { value: 192662 }
-          impression_count { value: 354251 }
+          reach {
+            value: 192662
+          }
           frequency_histogram {
-            bin_results: {
+            bin_results {
               key: 1
-              value: { value: 99438 }
+              value {
+                value: 99438
+              }
             }
-            bin_results: {
+            bin_results {
               key: 2
-              value: { value: 49719 }
+              value {
+                value: 49719
+              }
             }
-            bin_results: {
+            bin_results {
               key: 3
-              value: { value: 24860 }
+              value {
+                value: 24860
+              }
             }
-            bin_results: {
+            bin_results {
               key: 4
-              value: { value: 12430 }
+              value {
+                value: 12430
+              }
             }
-            bin_results: {
+            bin_results {
               key: 5
-              value: { value: 6215 }
+              value {
+                value: 6215
+              }
             }
+          }
+          impression_count {
+            value: 354251
           }
         }
       }
     }
   }
+  metric_frequency_spec_fingerprint: 1234
+  grouping_dimension_fingerprint: 2
+  filter_fingerprint: 5
 }
 reporting_set_results {
   cmms_measurement_consumer_id: "abcd"
@@ -1600,28 +2021,33 @@ reporting_set_results {
     external_reporting_set_id: "reporting_set_id_edp3"
     venn_diagram_region_type: UNION
     external_impression_qualification_filter_id: "mrc"
-    metric_frequency_spec { total: true }
+    metric_frequency_spec {
+      total: true
+    }
     grouping {
       value_by_path {
         key: "person.age_group"
-        value { enum_value: "YEARS_18_TO_34" }
+        value {
+          enum_value: "YEARS_18_TO_34"
+        }
       }
       value_by_path {
         key: "person.gender"
-        value { enum_value: "MALE" }
+        value {
+          enum_value: "MALE"
+        }
       }
     }
     event_filters {
       terms {
         path: "banner_ad.viewable"
-        value { bool_value: true }
+        value {
+          bool_value: true
+        }
       }
     }
   }
   population_size: 55000000
-  metric_frequency_spec_fingerprint: 1234
-  grouping_dimension_fingerprint: 2
-  filter_fingerprint: 5
   reporting_window_results {
     key {
       non_cumulative_start {
@@ -1638,34 +2064,51 @@ reporting_set_results {
     value {
       unprocessed_report_result_values {
         cumulative_results {
-          reach { value: 950000 }
-          impression_count { value: 1751669 }
+          reach {
+            value: 950000
+          }
           frequency_histogram {
-            bin_results: {
+            bin_results {
               key: 1
-              value: { value: 490323 }
+              value {
+                value: 490323
+              }
             }
-            bin_results: {
+            bin_results {
               key: 2
-              value: { value: 245162 }
+              value {
+                value: 245162
+              }
             }
-            bin_results: {
+            bin_results {
               key: 3
-              value: { value: 122581 }
+              value {
+                value: 122581
+              }
             }
-            bin_results: {
+            bin_results {
               key: 4
-              value: { value: 61291 }
+              value {
+                value: 61291
+              }
             }
-            bin_results: {
+            bin_results {
               key: 5
-              value: { value: 30643 }
+              value {
+                value: 30643
+              }
             }
+          }
+          impression_count {
+            value: 1751669
           }
         }
       }
     }
   }
+  metric_frequency_spec_fingerprint: 1234
+  grouping_dimension_fingerprint: 2
+  filter_fingerprint: 5
 }
 reporting_set_results {
   cmms_measurement_consumer_id: "abcd"
@@ -1675,28 +2118,33 @@ reporting_set_results {
     external_reporting_set_id: "reporting_set_id_edp1_edp2_edp3"
     venn_diagram_region_type: UNION
     external_impression_qualification_filter_id: "mrc"
-    metric_frequency_spec { weekly: MONDAY }
+    metric_frequency_spec {
+      weekly: MONDAY
+    }
     grouping {
       value_by_path {
         key: "person.age_group"
-        value { enum_value: "YEARS_18_TO_34" }
+        value {
+          enum_value: "YEARS_18_TO_34"
+        }
       }
       value_by_path {
         key: "person.gender"
-        value { enum_value: "MALE" }
+        value {
+          enum_value: "MALE"
+        }
       }
     }
     event_filters {
       terms {
         path: "banner_ad.viewable"
-        value { bool_value: true }
+        value {
+          bool_value: true
+        }
       }
     }
   }
   population_size: 55000000
-  metric_frequency_spec_fingerprint: 1234
-  grouping_dimension_fingerprint: 2
-  filter_fingerprint: 5
   reporting_window_results {
     key {
       non_cumulative_start {
@@ -1714,54 +2162,70 @@ reporting_set_results {
       unprocessed_report_result_values {
         cumulative_results {
           reach {
-            value: 13427250
-            univariate_statistics { standard_deviation: 10000 }
+            value: 13427249
+            univariate_statistics {
+              standard_deviation: 10000.0
+            }
           }
         }
         non_cumulative_results {
           reach {
-            value: 13426464
-            univariate_statistics { standard_deviation: 10000 }
-          }
-          impression_count {
-            value: 26215389
-            univariate_statistics { standard_deviation: 10000 }
+            value: 13426463
+            univariate_statistics {
+              standard_deviation: 10000.0
+            }
           }
           frequency_histogram {
-            bin_results: {
+            bin_results {
               key: 1
-              value: {
-                value: 6929788
-                univariate_statistics { standard_deviation: 10000 }
+              value {
+                value: 6929787
+                univariate_statistics {
+                  standard_deviation: 10000.0
+                }
               }
             }
-            bin_results: {
+            bin_results {
               key: 2
-              value: {
+              value {
                 value: 3464894
-                univariate_statistics { standard_deviation: 10000 }
+                univariate_statistics {
+                  standard_deviation: 10000.0
+                }
               }
             }
-            bin_results: {
+            bin_results {
               key: 3
-              value: {
+              value {
                 value: 1732447
-                univariate_statistics { standard_deviation: 10000 }
+                univariate_statistics {
+                  standard_deviation: 10000.0
+                }
               }
             }
-            bin_results: {
+            bin_results {
               key: 4
-              value: {
+              value {
                 value: 866224
-                univariate_statistics { standard_deviation: 10000 }
+                univariate_statistics {
+                  standard_deviation: 10000.0
+                }
               }
             }
-            bin_results: {
+            bin_results {
               key: 5
-              value: {
+              value {
                 value: 433111
-                univariate_statistics { standard_deviation: 10000 }
+                univariate_statistics {
+                  standard_deviation: 10000.0
+                }
               }
+            }
+          }
+          impression_count {
+            value: 26929406
+            univariate_statistics {
+              standard_deviation: 10000.0
             }
           }
         }
@@ -1785,60 +2249,79 @@ reporting_set_results {
       unprocessed_report_result_values {
         cumulative_results {
           reach {
-            value: 15920317
-            univariate_statistics { standard_deviation: 10000 }
+            value: 15914078
+            univariate_statistics {
+              standard_deviation: 10000.0
+            }
           }
         }
         non_cumulative_results {
           reach {
             value: 3278136
-            univariate_statistics { standard_deviation: 10000 }
-          }
-          impression_count {
-            value: 6135862
-            univariate_statistics { standard_deviation: 10000 }
+            univariate_statistics {
+              standard_deviation: 10000.0
+            }
           }
           frequency_histogram {
-            bin_results: {
+            bin_results {
               key: 1
-              value: {
+              value {
                 value: 1691941
-                univariate_statistics { standard_deviation: 10000 }
+                univariate_statistics {
+                  standard_deviation: 10000.0
+                }
               }
             }
-            bin_results: {
+            bin_results {
               key: 2
-              value: {
+              value {
                 value: 845971
-                univariate_statistics { standard_deviation: 10000 }
+                univariate_statistics {
+                  standard_deviation: 10000.0
+                }
               }
             }
-            bin_results: {
+            bin_results {
               key: 3
-              value: {
+              value {
                 value: 422986
-                univariate_statistics { standard_deviation: 10000 }
+                univariate_statistics {
+                  standard_deviation: 10000.0
+                }
               }
             }
-            bin_results: {
+            bin_results {
               key: 4
-              value: {
+              value {
                 value: 211493
-                univariate_statistics { standard_deviation: 10000 }
+                univariate_statistics {
+                  standard_deviation: 10000.0
+                }
               }
             }
-            bin_results: {
+            bin_results {
               key: 5
-              value: {
+              value {
                 value: 105745
-                univariate_statistics { standard_deviation: 10000 }
+                univariate_statistics {
+                  standard_deviation: 10000.0
+                }
               }
+            }
+          }
+          impression_count {
+            value: 6323713
+            univariate_statistics {
+              standard_deviation: 10000.0
             }
           }
         }
       }
     }
   }
+  metric_frequency_spec_fingerprint: 1234
+  grouping_dimension_fingerprint: 2
+  filter_fingerprint: 5
 }
 reporting_set_results {
   cmms_measurement_consumer_id: "abcd"
@@ -1848,28 +2331,33 @@ reporting_set_results {
     external_reporting_set_id: "reporting_set_id_edp1_edp2_edp3"
     venn_diagram_region_type: UNION
     external_impression_qualification_filter_id: "mrc"
-    metric_frequency_spec { total: true }
+    metric_frequency_spec {
+      total: true
+    }
     grouping {
       value_by_path {
         key: "person.age_group"
-        value { enum_value: "YEARS_18_TO_34" }
+        value {
+          enum_value: "YEARS_18_TO_34"
+        }
       }
       value_by_path {
         key: "person.gender"
-        value { enum_value: "MALE" }
+        value {
+          enum_value: "MALE"
+        }
       }
     }
     event_filters {
       terms {
         path: "banner_ad.viewable"
-        value { bool_value: true }
+        value {
+          bool_value: true
+        }
       }
     }
   }
   population_size: 55000000
-  metric_frequency_spec_fingerprint: 1234
-  grouping_dimension_fingerprint: 2
-  filter_fingerprint: 5
   reporting_window_results {
     key {
       non_cumulative_start {
@@ -1887,54 +2375,71 @@ reporting_set_results {
       unprocessed_report_result_values {
         cumulative_results {
           reach {
-            value: 15908881
-            univariate_statistics { standard_deviation: 10000 }
-          }
-          impression_count {
-            value: 32337826
-            univariate_statistics { standard_deviation: 10000 }
+            value: 15914078
+            univariate_statistics {
+              standard_deviation: 10000.0
+            }
           }
           frequency_histogram {
-            bin_results: {
+            bin_results {
               key: 1
-              value: {
-                value: 8211035
-                univariate_statistics { standard_deviation: 10000 }
+              value {
+                value: 8212074
+                univariate_statistics {
+                  standard_deviation: 10000.0
+                }
               }
             }
-            bin_results: {
+            bin_results {
               key: 2
-              value: {
-                value: 4105518
-                univariate_statistics { standard_deviation: 10000 }
+              value {
+                value: 4106557
+                univariate_statistics {
+                  standard_deviation: 10000.0
+                }
               }
             }
-            bin_results: {
+            bin_results {
               key: 3
-              value: {
-                value: 2052759
-                univariate_statistics { standard_deviation: 10000 }
+              value {
+                value: 2053798
+                univariate_statistics {
+                  standard_deviation: 10000.0
+                }
               }
             }
-            bin_results: {
+            bin_results {
               key: 4
-              value: {
-                value: 1026380
-                univariate_statistics { standard_deviation: 10000 }
+              value {
+                value: 1027420
+                univariate_statistics {
+                  standard_deviation: 10000.0
+                }
               }
             }
-            bin_results: {
+            bin_results {
               key: 5
-              value: {
-                value: 513189
-                univariate_statistics { standard_deviation: 10000 }
+              value {
+                value: 514229
+                univariate_statistics {
+                  standard_deviation: 10000.0
+                }
               }
+            }
+          }
+          impression_count {
+            value: 33219895
+            univariate_statistics {
+              standard_deviation: 10000.0
             }
           }
         }
       }
     }
   }
+  metric_frequency_spec_fingerprint: 1234
+  grouping_dimension_fingerprint: 2
+  filter_fingerprint: 5
 }
 reporting_set_results {
   cmms_measurement_consumer_id: "abcd"
@@ -1944,29 +2449,33 @@ reporting_set_results {
     external_reporting_set_id: "reporting_set_id_edp1"
     venn_diagram_region_type: UNION
     custom: true
-    metric_frequency_spec { weekly: MONDAY }
+    metric_frequency_spec {
+      weekly: MONDAY
+    }
     grouping {
       value_by_path {
         key: "person.age_group"
-        value { enum_value: "YEARS_18_TO_34" }
+        value {
+          enum_value: "YEARS_18_TO_34"
+        }
       }
       value_by_path {
         key: "person.gender"
-        value { enum_value: "MALE" }
+        value {
+          enum_value: "MALE"
+        }
       }
     }
     event_filters {
       terms {
         path: "banner_ad.viewable"
-        value { bool_value: true }
+        value {
+          bool_value: true
+        }
       }
     }
   }
-
   population_size: 55000000
-  metric_frequency_spec_fingerprint: 1234
-  grouping_dimension_fingerprint: 2
-  filter_fingerprint: 5
   reporting_window_results {
     key {
       non_cumulative_start {
@@ -1984,54 +2493,70 @@ reporting_set_results {
       unprocessed_report_result_values {
         cumulative_results {
           reach {
-            value: 9984642
-            univariate_statistics { standard_deviation: 10000 }
+            value: 9991826
+            univariate_statistics {
+              standard_deviation: 10000.0
+            }
           }
         }
         non_cumulative_results {
           reach {
-            value: 10000981
-            univariate_statistics { standard_deviation: 10000 }
-          }
-          impression_count {
-            value: 18382797
-            univariate_statistics { standard_deviation: 10000 }
+            value: 10007663
+            univariate_statistics {
+              standard_deviation: 10000.0
+            }
           }
           frequency_histogram {
-            bin_results: {
+            bin_results {
               key: 1
-              value: {
-                value: 5161797
-                univariate_statistics { standard_deviation: 10000 }
+              value {
+                value: 5167588
+                univariate_statistics {
+                  standard_deviation: 10000.0
+                }
               }
             }
-            bin_results: {
+            bin_results {
               key: 2
-              value: {
-                value: 2580899
-                univariate_statistics { standard_deviation: 10000 }
+              value {
+                value: 2584463
+                univariate_statistics {
+                  standard_deviation: 10000.0
+                }
               }
             }
-            bin_results: {
+            bin_results {
               key: 3
-              value: {
-                value: 1290450
-                univariate_statistics { standard_deviation: 10000 }
+              value {
+                value: 1291787
+                univariate_statistics {
+                  standard_deviation: 10000.0
+                }
               }
             }
-            bin_results: {
+            bin_results {
               key: 4
-              value: {
-                value: 645225
-                univariate_statistics { standard_deviation: 10000 }
+              value {
+                value: 644334
+                univariate_statistics {
+                  standard_deviation: 10000.0
+                }
               }
             }
-            bin_results: {
+            bin_results {
               key: 5
-              value: {
-                value: 322610
-                univariate_statistics { standard_deviation: 10000 }
+              value {
+                value: 319491
+                univariate_statistics {
+                  standard_deviation: 10000.0
+                }
               }
+            }
+          }
+          impression_count {
+            value: 18386667
+            univariate_statistics {
+              standard_deviation: 10000.0
             }
           }
         }
@@ -2055,60 +2580,79 @@ reporting_set_results {
       unprocessed_report_result_values {
         cumulative_results {
           reach {
-            value: 12020226
-            univariate_statistics { standard_deviation: 10000 }
+            value: 12021120
+            univariate_statistics {
+              standard_deviation: 10000.0
+            }
           }
         }
         non_cumulative_results {
           reach {
-            value: 2441042
-            univariate_statistics { standard_deviation: 10000 }
-          }
-          impression_count {
-            value: 4488362
-            univariate_statistics { standard_deviation: 10000 }
+            value: 2443823
+            univariate_statistics {
+              standard_deviation: 10000.0
+            }
           }
           frequency_histogram {
-            bin_results: {
+            bin_results {
               key: 1
-              value: {
-                value: 1259893
-                univariate_statistics { standard_deviation: 10000 }
+              value {
+                value: 1262038
+                univariate_statistics {
+                  standard_deviation: 10000.0
+                }
               }
             }
-            bin_results: {
+            bin_results {
               key: 2
-              value: {
-                value: 629947
-                univariate_statistics { standard_deviation: 10000 }
+              value {
+                value: 631298
+                univariate_statistics {
+                  standard_deviation: 10000.0
+                }
               }
             }
-            bin_results: {
+            bin_results {
               key: 3
-              value: {
-                value: 314974
-                univariate_statistics { standard_deviation: 10000 }
+              value {
+                value: 315530
+                univariate_statistics {
+                  standard_deviation: 10000.0
+                }
               }
             }
-            bin_results: {
+            bin_results {
               key: 4
-              value: {
-                value: 157487
-                univariate_statistics { standard_deviation: 10000 }
+              value {
+                value: 157249
+                univariate_statistics {
+                  standard_deviation: 10000.0
+                }
               }
             }
-            bin_results: {
+            bin_results {
               key: 5
-              value: {
-                value: 78741
-                univariate_statistics { standard_deviation: 10000 }
+              value {
+                value: 77708
+                univariate_statistics {
+                  standard_deviation: 10000.0
+                }
               }
+            }
+          }
+          impression_count {
+            value: 4488759
+            univariate_statistics {
+              standard_deviation: 10000.0
             }
           }
         }
       }
     }
   }
+  metric_frequency_spec_fingerprint: 1234
+  grouping_dimension_fingerprint: 2
+  filter_fingerprint: 5
 }
 reporting_set_results {
   cmms_measurement_consumer_id: "abcd"
@@ -2118,29 +2662,33 @@ reporting_set_results {
     external_reporting_set_id: "reporting_set_id_edp1"
     venn_diagram_region_type: UNION
     custom: true
-    metric_frequency_spec { total: true }
+    metric_frequency_spec {
+      total: true
+    }
     grouping {
       value_by_path {
         key: "person.age_group"
-        value { enum_value: "YEARS_18_TO_34" }
+        value {
+          enum_value: "YEARS_18_TO_34"
+        }
       }
       value_by_path {
         key: "person.gender"
-        value { enum_value: "MALE" }
+        value {
+          enum_value: "MALE"
+        }
       }
     }
     event_filters {
       terms {
         path: "banner_ad.viewable"
-        value { bool_value: true }
+        value {
+          bool_value: true
+        }
       }
     }
   }
-
   population_size: 55000000
-  metric_frequency_spec_fingerprint: 1234
-  grouping_dimension_fingerprint: 2
-  filter_fingerprint: 5
   reporting_window_results {
     key {
       non_cumulative_start {
@@ -2158,54 +2706,71 @@ reporting_set_results {
       unprocessed_report_result_values {
         cumulative_results {
           reach {
-            value: 12017026
-            univariate_statistics { standard_deviation: 10000 }
-          }
-          impression_count {
-            value: 22871159
-            univariate_statistics { standard_deviation: 10000 }
+            value: 12021120
+            univariate_statistics {
+              standard_deviation: 10000.0
+            }
           }
           frequency_histogram {
-            bin_results: {
+            bin_results {
               key: 1
-              value: {
-                value: 6202336
-                univariate_statistics { standard_deviation: 10000 }
+              value {
+                value: 6203154
+                univariate_statistics {
+                  standard_deviation: 10000.0
+                }
               }
             }
-            bin_results: {
+            bin_results {
               key: 2
-              value: {
-                value: 3101168
-                univariate_statistics { standard_deviation: 10000 }
+              value {
+                value: 3101987
+                univariate_statistics {
+                  standard_deviation: 10000.0
+                }
               }
             }
-            bin_results: {
+            bin_results {
               key: 3
-              value: {
-                value: 1550584
-                univariate_statistics { standard_deviation: 10000 }
+              value {
+                value: 1551403
+                univariate_statistics {
+                  standard_deviation: 10000.0
+                }
               }
             }
-            bin_results: {
+            bin_results {
               key: 4
-              value: {
-                value: 775292
-                univariate_statistics { standard_deviation: 10000 }
+              value {
+                value: 776111
+                univariate_statistics {
+                  standard_deviation: 10000.0
+                }
               }
             }
-            bin_results: {
+            bin_results {
               key: 5
-              value: {
-                value: 387646
-                univariate_statistics { standard_deviation: 10000 }
+              value {
+                value: 388465
+                univariate_statistics {
+                  standard_deviation: 10000.0
+                }
               }
+            }
+          }
+          impression_count {
+            value: 22873904
+            univariate_statistics {
+              standard_deviation: 10000.0
             }
           }
         }
       }
     }
   }
+  metric_frequency_spec_fingerprint: 1234
+  grouping_dimension_fingerprint: 2
+  filter_fingerprint: 5
 }
 reporting_set_results {
   cmms_measurement_consumer_id: "abcd"
@@ -2215,29 +2780,33 @@ reporting_set_results {
     external_reporting_set_id: "reporting_set_id_edp2"
     venn_diagram_region_type: UNION
     custom: true
-    metric_frequency_spec { weekly: MONDAY }
+    metric_frequency_spec {
+      weekly: MONDAY
+    }
     grouping {
       value_by_path {
         key: "person.age_group"
-        value { enum_value: "YEARS_18_TO_34" }
+        value {
+          enum_value: "YEARS_18_TO_34"
+        }
       }
       value_by_path {
         key: "person.gender"
-        value { enum_value: "MALE" }
+        value {
+          enum_value: "MALE"
+        }
       }
     }
     event_filters {
       terms {
         path: "banner_ad.viewable"
-        value { bool_value: true }
+        value {
+          bool_value: true
+        }
       }
     }
   }
-
   population_size: 55000000
-  metric_frequency_spec_fingerprint: 1234
-  grouping_dimension_fingerprint: 2
-  filter_fingerprint: 5
   reporting_window_results {
     key {
       non_cumulative_start {
@@ -2254,32 +2823,48 @@ reporting_set_results {
     value {
       unprocessed_report_result_values {
         cumulative_results {
-          reach { value: 5000000 }
+          reach {
+            value: 5000000
+          }
         }
         non_cumulative_results {
-          reach { value: 5000000 }
-          impression_count { value: 9193546 }
+          reach {
+            value: 5000000
+          }
           frequency_histogram {
-            bin_results: {
+            bin_results {
               key: 1
-              value: { value: 2580645 }
+              value {
+                value: 2580645
+              }
             }
-            bin_results: {
+            bin_results {
               key: 2
-              value: { value: 1290323 }
+              value {
+                value: 1290323
+              }
             }
-            bin_results: {
+            bin_results {
               key: 3
-              value: { value: 645162 }
+              value {
+                value: 645162
+              }
             }
-            bin_results: {
+            bin_results {
               key: 4
-              value: { value: 322581 }
+              value {
+                value: 322581
+              }
             }
-            bin_results: {
+            bin_results {
               key: 5
-              value: { value: 161289 }
+              value {
+                value: 161289
+              }
             }
+          }
+          impression_count {
+            value: 9193546
           }
         }
       }
@@ -2301,37 +2886,56 @@ reporting_set_results {
     value {
       unprocessed_report_result_values {
         cumulative_results {
-          reach { value: 6000000 }
+          reach {
+            value: 6000000
+          }
         }
         non_cumulative_results {
-          reach { value: 1100000 }
-          impression_count { value: 2022579 }
+          reach {
+            value: 1100000
+          }
           frequency_histogram {
-            bin_results: {
+            bin_results {
               key: 1
-              value: { value: 567742 }
+              value {
+                value: 567742
+              }
             }
-            bin_results: {
+            bin_results {
               key: 2
-              value: { value: 283871 }
+              value {
+                value: 283871
+              }
             }
-            bin_results: {
+            bin_results {
               key: 3
-              value: { value: 141936 }
+              value {
+                value: 141936
+              }
             }
-            bin_results: {
+            bin_results {
               key: 4
-              value: { value: 70968 }
+              value {
+                value: 70968
+              }
             }
-            bin_results: {
+            bin_results {
               key: 5
-              value: { value: 35483 }
+              value {
+                value: 35483
+              }
             }
+          }
+          impression_count {
+            value: 2022579
           }
         }
       }
     }
   }
+  metric_frequency_spec_fingerprint: 1234
+  grouping_dimension_fingerprint: 2
+  filter_fingerprint: 5
 }
 reporting_set_results {
   cmms_measurement_consumer_id: "abcd"
@@ -2341,29 +2945,33 @@ reporting_set_results {
     external_reporting_set_id: "reporting_set_id_edp2"
     venn_diagram_region_type: UNION
     custom: true
-    metric_frequency_spec { total: true }
+    metric_frequency_spec {
+      total: true
+    }
     grouping {
       value_by_path {
         key: "person.age_group"
-        value { enum_value: "YEARS_18_TO_34" }
+        value {
+          enum_value: "YEARS_18_TO_34"
+        }
       }
       value_by_path {
         key: "person.gender"
-        value { enum_value: "MALE" }
+        value {
+          enum_value: "MALE"
+        }
       }
     }
     event_filters {
       terms {
         path: "banner_ad.viewable"
-        value { bool_value: true }
+        value {
+          bool_value: true
+        }
       }
     }
   }
-
   population_size: 55000000
-  metric_frequency_spec_fingerprint: 1234
-  grouping_dimension_fingerprint: 2
-  filter_fingerprint: 5
   reporting_window_results {
     key {
       non_cumulative_start {
@@ -2380,34 +2988,51 @@ reporting_set_results {
     value {
       unprocessed_report_result_values {
         cumulative_results {
-          reach { value: 6000000 }
-          impression_count { value: 11216125 }
+          reach {
+            value: 6000000
+          }
           frequency_histogram {
-            bin_results: {
+            bin_results {
               key: 1
-              value: { value: 3096774 }
+              value {
+                value: 3096774
+              }
             }
-            bin_results: {
+            bin_results {
               key: 2
-              value: { value: 1548387 }
+              value {
+                value: 1548387
+              }
             }
-            bin_results: {
+            bin_results {
               key: 3
-              value: { value: 774194 }
+              value {
+                value: 774194
+              }
             }
-            bin_results: {
+            bin_results {
               key: 4
-              value: { value: 387097 }
+              value {
+                value: 387097
+              }
             }
-            bin_results: {
+            bin_results {
               key: 5
-              value: { value: 193548 }
+              value {
+                value: 193548
+              }
             }
+          }
+          impression_count {
+            value: 11216125
           }
         }
       }
     }
   }
+  metric_frequency_spec_fingerprint: 1234
+  grouping_dimension_fingerprint: 2
+  filter_fingerprint: 5
 }
 reporting_set_results {
   cmms_measurement_consumer_id: "abcd"
@@ -2417,29 +3042,33 @@ reporting_set_results {
     external_reporting_set_id: "reporting_set_id_edp3"
     venn_diagram_region_type: UNION
     custom: true
-    metric_frequency_spec { weekly: MONDAY }
+    metric_frequency_spec {
+      weekly: MONDAY
+    }
     grouping {
       value_by_path {
         key: "person.age_group"
-        value { enum_value: "YEARS_18_TO_34" }
+        value {
+          enum_value: "YEARS_18_TO_34"
+        }
       }
       value_by_path {
         key: "person.gender"
-        value { enum_value: "MALE" }
+        value {
+          enum_value: "MALE"
+        }
       }
     }
     event_filters {
       terms {
         path: "banner_ad.viewable"
-        value { bool_value: true }
+        value {
+          bool_value: true
+        }
       }
     }
   }
-
   population_size: 55000000
-  metric_frequency_spec_fingerprint: 1234
-  grouping_dimension_fingerprint: 2
-  filter_fingerprint: 5
   reporting_window_results {
     key {
       non_cumulative_start {
@@ -2456,32 +3085,48 @@ reporting_set_results {
     value {
       unprocessed_report_result_values {
         cumulative_results {
-          reach { value: 800000 }
+          reach {
+            value: 800000
+          }
         }
         non_cumulative_results {
-          reach { value: 800000 }
-          impression_count { value: 1470967 }
+          reach {
+            value: 800000
+          }
           frequency_histogram {
-            bin_results: {
+            bin_results {
               key: 1
-              value: { value: 412903 }
+              value {
+                value: 412903
+              }
             }
-            bin_results: {
+            bin_results {
               key: 2
-              value: { value: 206452 }
+              value {
+                value: 206452
+              }
             }
-            bin_results: {
+            bin_results {
               key: 3
-              value: { value: 103226 }
+              value {
+                value: 103226
+              }
             }
-            bin_results: {
+            bin_results {
               key: 4
-              value: { value: 51613 }
+              value {
+                value: 51613
+              }
             }
-            bin_results: {
+            bin_results {
               key: 5
-              value: { value: 25806 }
+              value {
+                value: 25806
+              }
             }
+          }
+          impression_count {
+            value: 1470967
           }
         }
       }
@@ -2503,37 +3148,56 @@ reporting_set_results {
     value {
       unprocessed_report_result_values {
         cumulative_results {
-          reach { value: 1000000 }
+          reach {
+            value: 1000000
+          }
         }
         non_cumulative_results {
-          reach { value: 202952 }
-          impression_count { value: 373169 }
+          reach {
+            value: 202952
+          }
           frequency_histogram {
-            bin_results: {
+            bin_results {
               key: 1
-              value: { value: 104749 }
+              value {
+                value: 104749
+              }
             }
-            bin_results: {
+            bin_results {
               key: 2
-              value: { value: 52375 }
+              value {
+                value: 52375
+              }
             }
-            bin_results: {
+            bin_results {
               key: 3
-              value: { value: 26188 }
+              value {
+                value: 26188
+              }
             }
-            bin_results: {
+            bin_results {
               key: 4
-              value: { value: 13094 }
+              value {
+                value: 13094
+              }
             }
-            bin_results: {
+            bin_results {
               key: 5
-              value: { value: 6546 }
+              value {
+                value: 6546
+              }
             }
+          }
+          impression_count {
+            value: 373169
           }
         }
       }
     }
   }
+  metric_frequency_spec_fingerprint: 1234
+  grouping_dimension_fingerprint: 2
+  filter_fingerprint: 5
 }
 reporting_set_results {
   cmms_measurement_consumer_id: "abcd"
@@ -2543,29 +3207,33 @@ reporting_set_results {
     external_reporting_set_id: "reporting_set_id_edp3"
     venn_diagram_region_type: UNION
     custom: true
-    metric_frequency_spec { total: true }
+    metric_frequency_spec {
+      total: true
+    }
     grouping {
       value_by_path {
         key: "person.age_group"
-        value { enum_value: "YEARS_18_TO_34" }
+        value {
+          enum_value: "YEARS_18_TO_34"
+        }
       }
       value_by_path {
         key: "person.gender"
-        value { enum_value: "MALE" }
+        value {
+          enum_value: "MALE"
+        }
       }
     }
     event_filters {
       terms {
         path: "banner_ad.viewable"
-        value { bool_value: true }
+        value {
+          bool_value: true
+        }
       }
     }
   }
-
   population_size: 55000000
-  metric_frequency_spec_fingerprint: 1234
-  grouping_dimension_fingerprint: 2
-  filter_fingerprint: 5
   reporting_window_results {
     key {
       non_cumulative_start {
@@ -2582,34 +3250,51 @@ reporting_set_results {
     value {
       unprocessed_report_result_values {
         cumulative_results {
-          reach { value: 1000000 }
-          impression_count { value: 1844136 }
+          reach {
+            value: 1000000
+          }
           frequency_histogram {
-            bin_results: {
+            bin_results {
               key: 1
-              value: { value: 516129 }
+              value {
+                value: 516129
+              }
             }
-            bin_results: {
+            bin_results {
               key: 2
-              value: { value: 258065 }
+              value {
+                value: 258065
+              }
             }
-            bin_results: {
+            bin_results {
               key: 3
-              value: { value: 129033 }
+              value {
+                value: 129033
+              }
             }
-            bin_results: {
+            bin_results {
               key: 4
-              value: { value: 64517 }
+              value {
+                value: 64517
+              }
             }
-            bin_results: {
+            bin_results {
               key: 5
-              value: { value: 32256 }
+              value {
+                value: 32256
+              }
             }
+          }
+          impression_count {
+            value: 1844136
           }
         }
       }
     }
   }
+  metric_frequency_spec_fingerprint: 1234
+  grouping_dimension_fingerprint: 2
+  filter_fingerprint: 5
 }
 reporting_set_results {
   cmms_measurement_consumer_id: "abcd"
@@ -2619,29 +3304,33 @@ reporting_set_results {
     external_reporting_set_id: "reporting_set_id_edp1_edp2_edp3"
     venn_diagram_region_type: UNION
     custom: true
-    metric_frequency_spec { weekly: MONDAY }
+    metric_frequency_spec {
+      weekly: MONDAY
+    }
     grouping {
       value_by_path {
         key: "person.age_group"
-        value { enum_value: "YEARS_18_TO_34" }
+        value {
+          enum_value: "YEARS_18_TO_34"
+        }
       }
       value_by_path {
         key: "person.gender"
-        value { enum_value: "MALE" }
+        value {
+          enum_value: "MALE"
+        }
       }
     }
     event_filters {
       terms {
         path: "banner_ad.viewable"
-        value { bool_value: true }
+        value {
+          bool_value: true
+        }
       }
     }
   }
-
   population_size: 55000000
-  metric_frequency_spec_fingerprint: 1234
-  grouping_dimension_fingerprint: 2
-  filter_fingerprint: 5
   reporting_window_results {
     key {
       non_cumulative_start {
@@ -2659,54 +3348,70 @@ reporting_set_results {
       unprocessed_report_result_values {
         cumulative_results {
           reach {
-            value: 15799013
-            univariate_statistics { standard_deviation: 10000 }
+            value: 15791826
+            univariate_statistics {
+              standard_deviation: 10000.0
+            }
           }
         }
         non_cumulative_results {
           reach {
-            value: 15819974
-            univariate_statistics { standard_deviation: 10000 }
-          }
-          impression_count {
-            value: 29052805
-            univariate_statistics { standard_deviation: 10000 }
+            value: 15807663
+            univariate_statistics {
+              standard_deviation: 10000.0
+            }
           }
           frequency_histogram {
-            bin_results: {
+            bin_results {
               key: 1
-              value: {
-                value: 8165148
-                univariate_statistics { standard_deviation: 10000 }
+              value {
+                value: 8162731
+                univariate_statistics {
+                  standard_deviation: 10000.0
+                }
               }
             }
-            bin_results: {
+            bin_results {
               key: 2
-              value: {
-                value: 4082574
-                univariate_statistics { standard_deviation: 10000 }
+              value {
+                value: 4080135
+                univariate_statistics {
+                  standard_deviation: 10000.0
+                }
               }
             }
-            bin_results: {
+            bin_results {
               key: 3
-              value: {
-                value: 2041287
-                univariate_statistics { standard_deviation: 10000 }
+              value {
+                value: 2038825
+                univariate_statistics {
+                  standard_deviation: 10000.0
+                }
               }
             }
-            bin_results: {
+            bin_results {
               key: 4
-              value: {
-                value: 1020644
-                univariate_statistics { standard_deviation: 10000 }
+              value {
+                value: 1018159
+                univariate_statistics {
+                  standard_deviation: 10000.0
+                }
               }
             }
-            bin_results: {
+            bin_results {
               key: 5
-              value: {
-                value: 510321
-                univariate_statistics { standard_deviation: 10000 }
+              value {
+                value: 507814
+                univariate_statistics {
+                  standard_deviation: 10000.0
+                }
               }
+            }
+          }
+          impression_count {
+            value: 29051180
+            univariate_statistics {
+              standard_deviation: 10000.0
             }
           }
         }
@@ -2730,60 +3435,79 @@ reporting_set_results {
       unprocessed_report_result_values {
         cumulative_results {
           reach {
-            value: 19015392
-            univariate_statistics { standard_deviation: 10000 }
+            value: 19021120
+            univariate_statistics {
+              standard_deviation: 10000.0
+            }
           }
         }
         non_cumulative_results {
           reach {
-            value: 3751542
-            univariate_statistics { standard_deviation: 10000 }
-          }
-          impression_count {
-            value: 6884110
-            univariate_statistics { standard_deviation: 10000 }
+            value: 3746775
+            univariate_statistics {
+              standard_deviation: 10000.0
+            }
           }
           frequency_histogram {
-            bin_results: {
+            bin_results {
               key: 1
-              value: {
-                value: 1936280
-                univariate_statistics { standard_deviation: 10000 }
+              value {
+                value: 1935326
+                univariate_statistics {
+                  standard_deviation: 10000.0
+                }
               }
             }
-            bin_results: {
+            bin_results {
               key: 2
-              value: {
-                value: 968140
-                univariate_statistics { standard_deviation: 10000 }
+              value {
+                value: 967186
+                univariate_statistics {
+                  standard_deviation: 10000.0
+                }
               }
             }
-            bin_results: {
+            bin_results {
               key: 3
-              value: {
-                value: 484070
-                univariate_statistics { standard_deviation: 10000 }
+              value {
+                value: 483117
+                univariate_statistics {
+                  standard_deviation: 10000.0
+                }
               }
             }
-            bin_results: {
+            bin_results {
               key: 4
-              value: {
-                value: 242035
-                univariate_statistics { standard_deviation: 10000 }
+              value {
+                value: 241082
+                univariate_statistics {
+                  standard_deviation: 10000.0
+                }
               }
             }
-            bin_results: {
+            bin_results {
               key: 5
-              value: {
-                value: 121017
-                univariate_statistics { standard_deviation: 10000 }
+              value {
+                value: 120064
+                univariate_statistics {
+                  standard_deviation: 10000.0
+                }
               }
+            }
+          }
+          impression_count {
+            value: 6884507
+            univariate_statistics {
+              standard_deviation: 10000.0
             }
           }
         }
       }
     }
   }
+  metric_frequency_spec_fingerprint: 1234
+  grouping_dimension_fingerprint: 2
+  filter_fingerprint: 5
 }
 reporting_set_results {
   cmms_measurement_consumer_id: "abcd"
@@ -2793,29 +3517,33 @@ reporting_set_results {
     external_reporting_set_id: "reporting_set_id_edp1_edp2_edp3"
     venn_diagram_region_type: UNION
     custom: true
-    metric_frequency_spec { total: true }
+    metric_frequency_spec {
+      total: true
+    }
     grouping {
       value_by_path {
         key: "person.age_group"
-        value { enum_value: "YEARS_18_TO_34" }
+        value {
+          enum_value: "YEARS_18_TO_34"
+        }
       }
       value_by_path {
         key: "person.gender"
-        value { enum_value: "MALE" }
+        value {
+          enum_value: "MALE"
+        }
       }
     }
     event_filters {
       terms {
         path: "banner_ad.viewable"
-        value { bool_value: true }
+        value {
+          bool_value: true
+        }
       }
     }
   }
-
   population_size: 55000000
-  metric_frequency_spec_fingerprint: 1234
-  grouping_dimension_fingerprint: 2
-  filter_fingerprint: 5
   reporting_window_results {
     key {
       non_cumulative_start {
@@ -2833,52 +3561,69 @@ reporting_set_results {
       unprocessed_report_result_values {
         cumulative_results {
           reach {
-            value: 19030737
-            univariate_statistics { standard_deviation: 10000 }
-          }
-          impression_count {
-            value: 35936915
-            univariate_statistics { standard_deviation: 10000 }
+            value: 19021120
+            univariate_statistics {
+              standard_deviation: 10000.0
+            }
           }
           frequency_histogram {
-            bin_results: {
+            bin_results {
               key: 1
-              value: {
-                value: 9822316
-                univariate_statistics { standard_deviation: 10000 }
+              value {
+                value: 9820392
+                univariate_statistics {
+                  standard_deviation: 10000.0
+                }
               }
             }
-            bin_results: {
+            bin_results {
               key: 2
-              value: {
-                value: 4911158
-                univariate_statistics { standard_deviation: 10000 }
+              value {
+                value: 4909234
+                univariate_statistics {
+                  standard_deviation: 10000.0
+                }
               }
             }
-            bin_results: {
+            bin_results {
               key: 3
-              value: {
-                value: 2455579
-                univariate_statistics { standard_deviation: 10000 }
+              value {
+                value: 2453656
+                univariate_statistics {
+                  standard_deviation: 10000.0
+                }
               }
             }
-            bin_results: {
+            bin_results {
               key: 4
-              value: {
-                value: 1227790
-                univariate_statistics { standard_deviation: 10000 }
+              value {
+                value: 1225867
+                univariate_statistics {
+                  standard_deviation: 10000.0
+                }
               }
             }
-            bin_results: {
+            bin_results {
               key: 5
-              value: {
-                value: 613894
-                univariate_statistics { standard_deviation: 10000 }
+              value {
+                value: 611971
+                univariate_statistics {
+                  standard_deviation: 10000.0
+                }
               }
+            }
+          }
+          impression_count {
+            value: 35934165
+            univariate_statistics {
+              standard_deviation: 10000.0
             }
           }
         }
       }
     }
   }
+  metric_frequency_spec_fingerprint: 1234
+  grouping_dimension_fingerprint: 2
+  filter_fingerprint: 5
 }

--- a/src/test/python/wfa/measurement/reporting/postprocessing/tools/sample_report_result_with_large_corrections.textproto
+++ b/src/test/python/wfa/measurement/reporting/postprocessing/tools/sample_report_result_with_large_corrections.textproto
@@ -1,0 +1,2884 @@
+# proto-file: wfa/measurement/internal/reporting/v2/report_results_service.proto
+# proto-message: wfa.measurement.internal.reporting.v2.ListReportingSetResultsResponse
+reporting_set_results {
+  cmms_measurement_consumer_id: "abcd"
+  external_report_result_id: 123456
+  external_reporting_set_result_id: 1
+  dimension {
+    external_reporting_set_id: "reporting_set_id_edp1"
+    venn_diagram_region_type: UNION
+    external_impression_qualification_filter_id: "ami"
+    metric_frequency_spec { weekly: MONDAY }
+    grouping {
+      value_by_path {
+        key: "person.age_group"
+        value { enum_value: "YEARS_35_TO_54" }
+      }
+      value_by_path {
+        key: "person.gender"
+        value { enum_value: "MALE" }
+      }
+    }
+    event_filters {
+      terms {
+        path: "banner_ad.viewable"
+        value { bool_value: true }
+      }
+    }
+  }
+  population_size: 55000000
+  metric_frequency_spec_fingerprint: 1234
+  grouping_dimension_fingerprint: 1
+  filter_fingerprint: 5
+  reporting_window_results {
+    key {
+      non_cumulative_start {
+        year: 2025
+        month: 10
+        day: 1
+      }
+      end {
+        year: 2025
+        month: 10
+        day: 8
+      }
+    }
+    value {
+      unprocessed_report_result_values {
+        cumulative_results {
+          reach {
+            value: 9992500
+            univariate_statistics { standard_deviation: 10000 }
+          }
+        }
+        non_cumulative_results {
+          reach {
+            value: 10008130
+            univariate_statistics { standard_deviation: 10000 }
+          }
+          impression_count {
+            value: 18379493
+            univariate_statistics { standard_deviation: 10000 }
+          }
+          frequency_histogram {
+            bin_results: {
+              key: 1
+              value: {
+                value: 5165486
+                univariate_statistics { standard_deviation: 10000 }
+              }
+            }
+            bin_results: {
+              key: 2
+              value: {
+                value: 2582743
+                univariate_statistics { standard_deviation: 10000 }
+              }
+            }
+            bin_results: {
+              key: 3
+              value: {
+                value: 1291372
+                univariate_statistics { standard_deviation: 10000 }
+              }
+            }
+            bin_results: {
+              key: 4
+              value: {
+                value: 645686
+                univariate_statistics { standard_deviation: 10000 }
+              }
+            }
+            bin_results: {
+              key: 5
+              value: {
+                value: 322843
+                univariate_statistics { standard_deviation: 10000 }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+  reporting_window_results {
+    key {
+      non_cumulative_start {
+        year: 2025
+        month: 10
+        day: 8
+      }
+      end {
+        year: 2025
+        month: 10
+        day: 15
+      }
+    }
+    value {
+      unprocessed_report_result_values {
+        cumulative_results {
+          reach {
+            value: 11998422
+            univariate_statistics { standard_deviation: 10000 }
+          }
+        }
+        non_cumulative_results {
+          reach {
+            value: 2452001
+            univariate_statistics { standard_deviation: 10000 }
+          }
+          impression_count {
+            value: 4471035
+            univariate_statistics { standard_deviation: 10000 }
+          }
+          frequency_histogram {
+            bin_results: {
+              key: 1
+              value: {
+                value: 1265549
+                univariate_statistics { standard_deviation: 10000 }
+              }
+            }
+            bin_results: {
+              key: 2
+              value: {
+                value: 632775
+                univariate_statistics { standard_deviation: 10000 }
+              }
+            }
+            bin_results: {
+              key: 3
+              value: {
+                value: 316388
+                univariate_statistics { standard_deviation: 10000 }
+              }
+            }
+            bin_results: {
+              key: 4
+              value: {
+                value: 158194
+                univariate_statistics { standard_deviation: 10000 }
+              }
+            }
+            bin_results: {
+              key: 5
+              value: {
+                value: 79095
+                univariate_statistics { standard_deviation: 10000 }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+reporting_set_results {
+  cmms_measurement_consumer_id: "abcd"
+  external_report_result_id: 123456
+  external_reporting_set_result_id: 2
+  dimension {
+    external_reporting_set_id: "reporting_set_id_edp1"
+    venn_diagram_region_type: UNION
+    external_impression_qualification_filter_id: "ami"
+    metric_frequency_spec { total: true }
+    grouping {
+      value_by_path {
+        key: "person.age_group"
+        value { enum_value: "YEARS_35_TO_54" }
+      }
+      value_by_path {
+        key: "person.gender"
+        value { enum_value: "MALE" }
+      }
+    }
+    event_filters {
+      terms {
+        path: "banner_ad.viewable"
+        value { bool_value: true }
+      }
+    }
+  }
+  population_size: 55000000
+  metric_frequency_spec_fingerprint: 1234
+  grouping_dimension_fingerprint: 1
+  filter_fingerprint: 5
+  reporting_window_results {
+    key {
+      non_cumulative_start {
+        year: 2025
+        month: 10
+        day: 1
+      }
+      end {
+        year: 2025
+        month: 10
+        day: 15
+      }
+    }
+    value {
+      unprocessed_report_result_values {
+        cumulative_results {
+          reach {
+            value: 11978894
+            univariate_statistics { standard_deviation: 10000 }
+          }
+          impression_count {
+            value: 22870892
+            univariate_statistics { standard_deviation: 10000 }
+          }
+          frequency_histogram {
+            bin_results: {
+              key: 1
+              value: {
+                value: 6182655
+                univariate_statistics { standard_deviation: 10000 }
+              }
+            }
+            bin_results: {
+              key: 2
+              value: {
+                value: 3091328
+                univariate_statistics { standard_deviation: 10000 }
+              }
+            }
+            bin_results: {
+              key: 3
+              value: {
+                value: 1545664
+                univariate_statistics { standard_deviation: 10000 }
+              }
+            }
+            bin_results: {
+              key: 4
+              value: {
+                value: 772832
+                univariate_statistics { standard_deviation: 10000 }
+              }
+            }
+            bin_results: {
+              key: 5
+              value: {
+                value: 386415
+                univariate_statistics { standard_deviation: 10000 }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+reporting_set_results {
+  cmms_measurement_consumer_id: "abcd"
+  external_report_result_id: 123456
+  external_reporting_set_result_id: 3
+  dimension {
+    external_reporting_set_id: "reporting_set_id_edp2"
+    venn_diagram_region_type: UNION
+    external_impression_qualification_filter_id: "ami"
+    metric_frequency_spec { weekly: MONDAY }
+    grouping {
+      value_by_path {
+        key: "person.age_group"
+        value { enum_value: "YEARS_35_TO_54" }
+      }
+      value_by_path {
+        key: "person.gender"
+        value { enum_value: "MALE" }
+      }
+    }
+
+    event_filters {
+      terms {
+        path: "banner_ad.viewable"
+        value { bool_value: true }
+      }
+    }
+  }
+  population_size: 55000000
+  metric_frequency_spec_fingerprint: 1234
+  grouping_dimension_fingerprint: 1
+  filter_fingerprint: 5
+  reporting_window_results {
+    key {
+      non_cumulative_start {
+        year: 2025
+        month: 10
+        day: 1
+      }
+      end {
+        year: 2025
+        month: 10
+        day: 8
+      }
+    }
+    value {
+      unprocessed_report_result_values {
+        cumulative_results {
+          reach { value: 5000000 }
+        }
+        non_cumulative_results {
+          reach { value: 5000000 }
+          impression_count { value: 9193546 }
+          frequency_histogram {
+            bin_results: {
+              key: 1
+              value: { value: 2580645 }
+            }
+            bin_results: {
+              key: 2
+              value: { value: 1290323 }
+            }
+            bin_results: {
+              key: 3
+              value: { value: 645162 }
+            }
+            bin_results: {
+              key: 4
+              value: { value: 322581 }
+            }
+            bin_results: {
+              key: 5
+              value: { value: 161289 }
+            }
+          }
+        }
+      }
+    }
+  }
+  reporting_window_results {
+    key {
+      non_cumulative_start {
+        year: 2025
+        month: 10
+        day: 8
+      }
+      end {
+        year: 2025
+        month: 10
+        day: 15
+      }
+    }
+    value {
+      unprocessed_report_result_values {
+        cumulative_results {
+          reach { value: 6000000 }
+        }
+        non_cumulative_results {
+          reach { value: 1100000 }
+          impression_count { value: 2022579 }
+          frequency_histogram {
+            bin_results: {
+              key: 1
+              value: { value: 567742 }
+            }
+            bin_results: {
+              key: 2
+              value: { value: 283871 }
+            }
+            bin_results: {
+              key: 3
+              value: { value: 141936 }
+            }
+            bin_results: {
+              key: 4
+              value: { value: 70968 }
+            }
+            bin_results: {
+              key: 5
+              value: { value: 35483 }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+reporting_set_results {
+  cmms_measurement_consumer_id: "abcd"
+  external_report_result_id: 123456
+  external_reporting_set_result_id: 4
+  dimension {
+    external_reporting_set_id: "reporting_set_id_edp2"
+    venn_diagram_region_type: UNION
+    external_impression_qualification_filter_id: "ami"
+    metric_frequency_spec { total: true }
+    grouping {
+      value_by_path {
+        key: "person.age_group"
+        value { enum_value: "YEARS_35_TO_54" }
+      }
+      value_by_path {
+        key: "person.gender"
+        value { enum_value: "MALE" }
+      }
+    }
+    event_filters {
+      terms {
+        path: "banner_ad.viewable"
+        value { bool_value: true }
+      }
+    }
+  }
+  population_size: 55000000
+  metric_frequency_spec_fingerprint: 1234
+  grouping_dimension_fingerprint: 1
+  filter_fingerprint: 5
+  reporting_window_results {
+    key {
+      non_cumulative_start {
+        year: 2025
+        month: 10
+        day: 1
+      }
+      end {
+        year: 2025
+        month: 10
+        day: 15
+      }
+    }
+    value {
+      unprocessed_report_result_values {
+        cumulative_results {
+          reach { value: 6000000 }
+          impression_count { value: 11216125 }
+          frequency_histogram {
+            bin_results: {
+              key: 1
+              value: { value: 3096774 }
+            }
+            bin_results: {
+              key: 2
+              value: { value: 1548387 }
+            }
+            bin_results: {
+              key: 3
+              value: { value: 774194 }
+            }
+            bin_results: {
+              key: 4
+              value: { value: 387097 }
+            }
+            bin_results: {
+              key: 5
+              value: { value: 193548 }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+reporting_set_results {
+  cmms_measurement_consumer_id: "abcd"
+  external_report_result_id: 123456
+  external_reporting_set_result_id: 5
+  dimension {
+    external_reporting_set_id: "reporting_set_id_edp3"
+    venn_diagram_region_type: UNION
+    external_impression_qualification_filter_id: "ami"
+    metric_frequency_spec { weekly: MONDAY }
+    grouping {
+      value_by_path {
+        key: "person.age_group"
+        value { enum_value: "YEARS_35_TO_54" }
+      }
+      value_by_path {
+        key: "person.gender"
+        value { enum_value: "MALE" }
+      }
+    }
+    event_filters {
+      terms {
+        path: "banner_ad.viewable"
+        value { bool_value: true }
+      }
+    }
+  }
+  population_size: 55000000
+  metric_frequency_spec_fingerprint: 1234
+  grouping_dimension_fingerprint: 1
+  filter_fingerprint: 5
+  reporting_window_results {
+    key {
+      non_cumulative_start {
+        year: 2025
+        month: 10
+        day: 1
+      }
+      end {
+        year: 2025
+        month: 10
+        day: 8
+      }
+    }
+    value {
+      unprocessed_report_result_values {
+        cumulative_results {
+          reach { value: 800000 }
+        }
+        non_cumulative_results {
+          reach { value: 800000 }
+          impression_count { value: 1470967 }
+          frequency_histogram {
+            bin_results: {
+              key: 1
+              value: { value: 412903 }
+            }
+            bin_results: {
+              key: 2
+              value: { value: 206452 }
+            }
+            bin_results: {
+              key: 3
+              value: { value: 103226 }
+            }
+            bin_results: {
+              key: 4
+              value: { value: 51613 }
+            }
+            bin_results: {
+              key: 5
+              value: { value: 25806 }
+            }
+          }
+        }
+      }
+    }
+  }
+  reporting_window_results {
+    key {
+      non_cumulative_start {
+        year: 2025
+        month: 10
+        day: 8
+      }
+      end {
+        year: 2025
+        month: 10
+        day: 15
+      }
+    }
+    value {
+      unprocessed_report_result_values {
+        cumulative_results {
+          reach { value: 1000000 }
+        }
+        non_cumulative_results {
+          reach { value: 202952 }
+          impression_count { value: 373169 }
+          frequency_histogram {
+            bin_results: {
+              key: 1
+              value: { value: 104749 }
+            }
+            bin_results: {
+              key: 2
+              value: { value: 52375 }
+            }
+            bin_results: {
+              key: 3
+              value: { value: 26188 }
+            }
+            bin_results: {
+              key: 4
+              value: { value: 13094 }
+            }
+            bin_results: {
+              key: 5
+              value: { value: 6546 }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+reporting_set_results {
+  cmms_measurement_consumer_id: "abcd"
+  external_report_result_id: 123456
+  external_reporting_set_result_id: 6
+  dimension {
+    external_reporting_set_id: "reporting_set_id_edp3"
+    venn_diagram_region_type: UNION
+    external_impression_qualification_filter_id: "ami"
+    metric_frequency_spec { total: true }
+    grouping {
+      value_by_path {
+        key: "person.age_group"
+        value { enum_value: "YEARS_35_TO_54" }
+      }
+      value_by_path {
+        key: "person.gender"
+        value { enum_value: "MALE" }
+      }
+    }
+    event_filters {
+      terms {
+        path: "banner_ad.viewable"
+        value { bool_value: true }
+      }
+    }
+  }
+  population_size: 55000000
+  metric_frequency_spec_fingerprint: 1234
+  grouping_dimension_fingerprint: 1
+  filter_fingerprint: 5
+  reporting_window_results {
+    key {
+      non_cumulative_start {
+        year: 2025
+        month: 10
+        day: 1
+      }
+      end {
+        year: 2025
+        month: 10
+        day: 15
+      }
+    }
+    value {
+      unprocessed_report_result_values {
+        cumulative_results {
+          reach { value: 1000000 }
+          impression_count { value: 1844136 }
+          frequency_histogram {
+            bin_results: {
+              key: 1
+              value: { value: 516129 }
+            }
+            bin_results: {
+              key: 2
+              value: { value: 258065 }
+            }
+            bin_results: {
+              key: 3
+              value: { value: 129033 }
+            }
+            bin_results: {
+              key: 4
+              value: { value: 64517 }
+            }
+            bin_results: {
+              key: 5
+              value: { value: 32256 }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+reporting_set_results {
+  cmms_measurement_consumer_id: "abcd"
+  external_report_result_id: 123456
+  external_reporting_set_result_id: 7
+  dimension {
+    external_reporting_set_id: "reporting_set_id_edp1_edp2_edp3"
+    venn_diagram_region_type: UNION
+    external_impression_qualification_filter_id: "ami"
+    metric_frequency_spec { weekly: MONDAY }
+    grouping {
+      value_by_path {
+        key: "person.age_group"
+        value { enum_value: "YEARS_35_TO_54" }
+      }
+      value_by_path {
+        key: "person.gender"
+        value { enum_value: "MALE" }
+      }
+    }
+    event_filters {
+      terms {
+        path: "banner_ad.viewable"
+        value { bool_value: true }
+      }
+    }
+  }
+  population_size: 55000000
+  metric_frequency_spec_fingerprint: 1234
+  grouping_dimension_fingerprint: 1
+  filter_fingerprint: 5
+  reporting_window_results {
+    key {
+      non_cumulative_start {
+        year: 2025
+        month: 10
+        day: 1
+      }
+      end {
+        year: 2025
+        month: 10
+        day: 8
+      }
+    }
+    value {
+      unprocessed_report_result_values {
+        cumulative_results {
+          reach {
+            value: 15830545
+            univariate_statistics { standard_deviation: 10000 }
+          }
+        }
+        non_cumulative_results {
+          reach {
+            value: 15829304
+            univariate_statistics { standard_deviation: 10000 }
+          }
+          impression_count {
+            value: 29046331
+            univariate_statistics { standard_deviation: 10000 }
+          }
+          frequency_histogram {
+            bin_results: {
+              key: 1
+              value: {
+                value: 8169963
+                univariate_statistics { standard_deviation: 10000 }
+              }
+            }
+            bin_results: {
+              key: 2
+              value: {
+                value: 4084982
+                univariate_statistics { standard_deviation: 10000 }
+              }
+            }
+            bin_results: {
+              key: 3
+              value: {
+                value: 2042491
+                univariate_statistics { standard_deviation: 10000 }
+              }
+            }
+            bin_results: {
+              key: 4
+              value: {
+                value: 1021246
+                univariate_statistics { standard_deviation: 10000 }
+              }
+            }
+            bin_results: {
+              key: 5
+              value: {
+                value: 510622
+                univariate_statistics { standard_deviation: 10000 }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+  reporting_window_results {
+    key {
+      non_cumulative_start {
+        year: 2025
+        month: 10
+        day: 8
+      }
+      end {
+        year: 2025
+        month: 10
+        day: 15
+      }
+    }
+    value {
+      unprocessed_report_result_values {
+        cumulative_results {
+          reach {
+            value: 19010669
+            univariate_statistics { standard_deviation: 10000 }
+          }
+        }
+        non_cumulative_results {
+          reach {
+            value: 3761510
+            univariate_statistics { standard_deviation: 10000 }
+          }
+          impression_count {
+            value: 6904573
+            univariate_statistics { standard_deviation: 10000 }
+          }
+          frequency_histogram {
+            bin_results: {
+              key: 1
+              value: {
+                value: 1941425
+                univariate_statistics { standard_deviation: 10000 }
+              }
+            }
+            bin_results: {
+              key: 2
+              value: {
+                value: 970713
+                univariate_statistics { standard_deviation: 10000 }
+              }
+            }
+            bin_results: {
+              key: 3
+              value: {
+                value: 485357
+                univariate_statistics { standard_deviation: 10000 }
+              }
+            }
+            bin_results: {
+              key: 4
+              value: {
+                value: 242679
+                univariate_statistics { standard_deviation: 10000 }
+              }
+            }
+            bin_results: {
+              key: 5
+              value: {
+                value: 121336
+                univariate_statistics { standard_deviation: 10000 }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+reporting_set_results {
+  cmms_measurement_consumer_id: "abcd"
+  external_report_result_id: 123456
+  external_reporting_set_result_id: 8
+  dimension {
+    external_reporting_set_id: "reporting_set_id_edp1_edp2_edp3"
+    venn_diagram_region_type: UNION
+    external_impression_qualification_filter_id: "ami"
+    metric_frequency_spec { total: true }
+    grouping {
+      value_by_path {
+        key: "person.age_group"
+        value { enum_value: "YEARS_35_TO_54" }
+      }
+      value_by_path {
+        key: "person.gender"
+        value { enum_value: "MALE" }
+      }
+    }
+    event_filters {
+      terms {
+        path: "banner_ad.viewable"
+        value { bool_value: true }
+      }
+    }
+  }
+  population_size: 55000000
+  metric_frequency_spec_fingerprint: 1234
+  grouping_dimension_fingerprint: 1
+  filter_fingerprint: 5
+  reporting_window_results {
+    key {
+      non_cumulative_start {
+        year: 2025
+        month: 10
+        day: 1
+      }
+      end {
+        year: 2025
+        month: 10
+        day: 15
+      }
+    }
+    value {
+      unprocessed_report_result_values {
+        cumulative_results {
+          reach {
+            value: 19021738
+            univariate_statistics { standard_deviation: 10000 }
+          }
+          impression_count {
+            value: 35926461
+            univariate_statistics { standard_deviation: 10000 }
+          }
+          frequency_histogram {
+            bin_results: {
+              key: 1
+              value: {
+                value: 9817671
+                univariate_statistics { standard_deviation: 10000 }
+              }
+            }
+            bin_results: {
+              key: 2
+              value: {
+                value: 4908836
+                univariate_statistics { standard_deviation: 10000 }
+              }
+            }
+            bin_results: {
+              key: 3
+              value: {
+                value: 2454418
+                univariate_statistics { standard_deviation: 10000 }
+              }
+            }
+            bin_results: {
+              key: 4
+              value: {
+                value: 1227209
+                univariate_statistics { standard_deviation: 10000 }
+              }
+            }
+            bin_results: {
+              key: 5
+              value: {
+                value: 613604
+                univariate_statistics { standard_deviation: 10000 }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+reporting_set_results {
+  cmms_measurement_consumer_id: "abcd"
+  external_report_result_id: 123456
+  external_reporting_set_result_id: 9
+  dimension {
+    external_reporting_set_id: "reporting_set_id_edp1_edp2"
+    venn_diagram_region_type: UNION
+    external_impression_qualification_filter_id: "ami"
+    metric_frequency_spec { total: true }
+    grouping {
+      value_by_path {
+        key: "person.age_group"
+        value { enum_value: "YEARS_18_TO_34" }
+      }
+      value_by_path {
+        key: "person.gender"
+        value { enum_value: "MALE" }
+      }
+    }
+    event_filters {
+      terms {
+        path: "banner_ad.viewable"
+        value { bool_value: true }
+      }
+    }
+  }
+  population_size: 55000000
+  metric_frequency_spec_fingerprint: 1234
+  grouping_dimension_fingerprint: 2
+  filter_fingerprint: 5
+  reporting_window_results {
+    key {
+      non_cumulative_start {
+        year: 2025
+        month: 10
+        day: 1
+      }
+      end {
+        year: 2025
+        month: 10
+        day: 15
+      }
+    }
+    value {
+      unprocessed_report_result_values {
+        cumulative_results {
+          reach {
+            value: 16686873
+            univariate_statistics { standard_deviation: 10000 }
+          }
+          impression_count {
+            value: 34113188
+            univariate_statistics { standard_deviation: 10000 }
+          }
+        }
+      }
+    }
+  }
+}
+reporting_set_results {
+  cmms_measurement_consumer_id: "abcd"
+  external_report_result_id: 123456
+  external_reporting_set_result_id: 10
+  dimension {
+    external_reporting_set_id: "reporting_set_id_edp1"
+    venn_diagram_region_type: UNION
+    external_impression_qualification_filter_id: "mrc"
+    metric_frequency_spec { weekly: MONDAY }
+    grouping {
+      value_by_path {
+        key: "person.age_group"
+        value { enum_value: "YEARS_18_TO_34" }
+      }
+      value_by_path {
+        key: "person.gender"
+        value { enum_value: "MALE" }
+      }
+    }
+    event_filters {
+      terms {
+        path: "banner_ad.viewable"
+        value { bool_value: true }
+      }
+    }
+  }
+  population_size: 55000000
+  metric_frequency_spec_fingerprint: 1234
+  grouping_dimension_fingerprint: 2
+  filter_fingerprint: 5
+  reporting_window_results {
+    key {
+      non_cumulative_start {
+        year: 2025
+        month: 10
+        day: 1
+      }
+      end {
+        year: 2025
+        month: 10
+        day: 8
+      }
+    }
+    value {
+      unprocessed_report_result_values {
+        cumulative_results {
+          reach {
+            value: 9501618
+            univariate_statistics { standard_deviation: 10000 }
+          }
+        }
+        non_cumulative_results {
+          reach {
+            value: 9503446
+            univariate_statistics { standard_deviation: 10000 }
+          }
+          impression_count {
+            value: 17473517
+            univariate_statistics { standard_deviation: 10000 }
+          }
+          frequency_histogram {
+            bin_results: {
+              key: 1
+              value: {
+                value: 4905004
+                univariate_statistics { standard_deviation: 10000 }
+              }
+            }
+            bin_results: {
+              key: 2
+              value: {
+                value: 2452502
+                univariate_statistics { standard_deviation: 10000 }
+              }
+            }
+            bin_results: {
+              key: 3
+              value: {
+                value: 1226251
+                univariate_statistics { standard_deviation: 10000 }
+              }
+            }
+            bin_results: {
+              key: 4
+              value: {
+                value: 613126
+                univariate_statistics { standard_deviation: 10000 }
+              }
+            }
+            bin_results: {
+              key: 5
+              value: {
+                value: 306563
+                univariate_statistics { standard_deviation: 10000 }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+  reporting_window_results {
+    key {
+      non_cumulative_start {
+        year: 2025
+        month: 10
+        day: 8
+      }
+      end {
+        year: 2025
+        month: 10
+        day: 15
+      }
+    }
+    value {
+      unprocessed_report_result_values {
+        cumulative_results {
+          reach {
+            value: 11389309
+            univariate_statistics { standard_deviation: 10000 }
+          }
+        }
+        non_cumulative_results {
+          reach {
+            value: 2289252
+            univariate_statistics { standard_deviation: 10000 }
+          }
+          impression_count {
+            value: 4236753
+            univariate_statistics { standard_deviation: 10000 }
+          }
+          frequency_histogram {
+            bin_results: {
+              key: 1
+              value: {
+                value: 1181549
+                univariate_statistics { standard_deviation: 10000 }
+              }
+            }
+            bin_results: {
+              key: 2
+              value: {
+                value: 590775
+                univariate_statistics { standard_deviation: 10000 }
+              }
+            }
+            bin_results: {
+              key: 3
+              value: {
+                value: 295388
+                univariate_statistics { standard_deviation: 10000 }
+              }
+            }
+            bin_results: {
+              key: 4
+              value: {
+                value: 147694
+                univariate_statistics { standard_deviation: 10000 }
+              }
+            }
+            bin_results: {
+              key: 5
+              value: {
+                value: 73846
+                univariate_statistics { standard_deviation: 10000 }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+reporting_set_results {
+  cmms_measurement_consumer_id: "abcd"
+  external_report_result_id: 123456
+  external_reporting_set_result_id: 11
+  dimension {
+    external_reporting_set_id: "reporting_set_id_edp1"
+    venn_diagram_region_type: UNION
+    external_impression_qualification_filter_id: "mrc"
+    metric_frequency_spec { total: true }
+    grouping {
+      value_by_path {
+        key: "person.age_group"
+        value { enum_value: "YEARS_18_TO_34" }
+      }
+      value_by_path {
+        key: "person.gender"
+        value { enum_value: "MALE" }
+      }
+    }
+    event_filters {
+      terms {
+        path: "banner_ad.viewable"
+        value { bool_value: true }
+      }
+    }
+  }
+  population_size: 55000000
+  metric_frequency_spec_fingerprint: 1234
+  grouping_dimension_fingerprint: 2
+  filter_fingerprint: 5
+  reporting_window_results {
+    key {
+      non_cumulative_start {
+        year: 2025
+        month: 10
+        day: 1
+      }
+      end {
+        year: 2025
+        month: 10
+        day: 15
+      }
+    }
+    value {
+      unprocessed_report_result_values {
+        cumulative_results {
+          reach {
+            value: 11382243
+            univariate_statistics { standard_deviation: 10000 }
+          }
+          impression_count {
+            value: 21696322
+            univariate_statistics { standard_deviation: 10000 }
+          }
+          frequency_histogram {
+            bin_results: {
+              key: 1
+              value: {
+                value: 5874706
+                univariate_statistics { standard_deviation: 10000 }
+              }
+            }
+            bin_results: {
+              key: 2
+              value: {
+                value: 2937353
+                univariate_statistics { standard_deviation: 10000 }
+              }
+            }
+            bin_results: {
+              key: 3
+              value: {
+                value: 1468677
+                univariate_statistics { standard_deviation: 10000 }
+              }
+            }
+            bin_results: {
+              key: 4
+              value: {
+                value: 734339
+                univariate_statistics { standard_deviation: 10000 }
+              }
+            }
+            bin_results: {
+              key: 5
+              value: {
+                value: 367168
+                univariate_statistics { standard_deviation: 10000 }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+reporting_set_results {
+  cmms_measurement_consumer_id: "abcd"
+  external_report_result_id: 123456
+  external_reporting_set_result_id: 12
+  dimension {
+    external_reporting_set_id: "reporting_set_id_edp2"
+    venn_diagram_region_type: UNION
+    external_impression_qualification_filter_id: "mrc"
+    metric_frequency_spec { weekly: MONDAY }
+    grouping {
+      value_by_path {
+        key: "person.age_group"
+        value { enum_value: "YEARS_18_TO_34" }
+      }
+      value_by_path {
+        key: "person.gender"
+        value { enum_value: "MALE" }
+      }
+    }
+    event_filters {
+      terms {
+        path: "banner_ad.viewable"
+        value { bool_value: true }
+      }
+    }
+  }
+  population_size: 55000000
+  metric_frequency_spec_fingerprint: 1234
+  grouping_dimension_fingerprint: 2
+  filter_fingerprint: 5
+  reporting_window_results {
+    key {
+      non_cumulative_start {
+        year: 2025
+        month: 10
+        day: 1
+      }
+      end {
+        year: 2025
+        month: 10
+        day: 8
+      }
+    }
+    value {
+      unprocessed_report_result_values {
+        cumulative_results {
+          reach { value: 4750000 }
+        }
+        non_cumulative_results {
+          reach { value: 4750000 }
+          impression_count { value: 8733867 }
+          frequency_histogram {
+            bin_results: {
+              key: 1
+              value: { value: 2451613 }
+            }
+            bin_results: {
+              key: 2
+              value: { value: 1225807 }
+            }
+            bin_results: {
+              key: 3
+              value: { value: 612904 }
+            }
+            bin_results: {
+              key: 4
+              value: { value: 306452 }
+            }
+            bin_results: {
+              key: 5
+              value: { value: 153224 }
+            }
+          }
+        }
+      }
+    }
+  }
+  reporting_window_results {
+    key {
+      non_cumulative_start {
+        year: 2025
+        month: 10
+        day: 8
+      }
+      end {
+        year: 2025
+        month: 10
+        day: 15
+      }
+    }
+    value {
+      unprocessed_report_result_values {
+        cumulative_results {
+          reach { value: 5700000 }
+        }
+        non_cumulative_results {
+          reach { value: 1039801 }
+          impression_count { value: 1911893 }
+          frequency_histogram {
+            bin_results: {
+              key: 1
+              value: { value: 536671 }
+            }
+            bin_results: {
+              key: 2
+              value: { value: 268336 }
+            }
+            bin_results: {
+              key: 3
+              value: { value: 134168 }
+            }
+            bin_results: {
+              key: 4
+              value: { value: 67084 }
+            }
+            bin_results: {
+              key: 5
+              value: { value: 33542 }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+reporting_set_results {
+  cmms_measurement_consumer_id: "abcd"
+  external_report_result_id: 123456
+  external_reporting_set_result_id: 13
+  dimension {
+    external_reporting_set_id: "reporting_set_id_edp2"
+    venn_diagram_region_type: UNION
+    external_impression_qualification_filter_id: "mrc"
+    metric_frequency_spec { total: true }
+    grouping {
+      value_by_path {
+        key: "person.age_group"
+        value { enum_value: "YEARS_18_TO_34" }
+      }
+      value_by_path {
+        key: "person.gender"
+        value { enum_value: "MALE" }
+      }
+    }
+    event_filters {
+      terms {
+        path: "banner_ad.viewable"
+        value { bool_value: true }
+      }
+    }
+  }
+  population_size: 55000000
+  metric_frequency_spec_fingerprint: 1234
+  grouping_dimension_fingerprint: 2
+  filter_fingerprint: 5
+  reporting_window_results {
+    key {
+      non_cumulative_start {
+        year: 2025
+        month: 10
+        day: 1
+      }
+      end {
+        year: 2025
+        month: 10
+        day: 15
+      }
+    }
+    value {
+      unprocessed_report_result_values {
+        cumulative_results {
+          reach { value: 5700000 }
+          impression_count { value: 10645760 }
+          frequency_histogram {
+            bin_results: {
+              key: 1
+              value: { value: 2941935 }
+            }
+            bin_results: {
+              key: 2
+              value: { value: 1470968 }
+            }
+            bin_results: {
+              key: 3
+              value: { value: 735484 }
+            }
+            bin_results: {
+              key: 4
+              value: { value: 367742 }
+            }
+            bin_results: {
+              key: 5
+              value: { value: 183871 }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+reporting_set_results {
+  cmms_measurement_consumer_id: "abcd"
+  external_report_result_id: 123456
+  external_reporting_set_result_id: 14
+  dimension {
+    external_reporting_set_id: "reporting_set_id_edp3"
+    venn_diagram_region_type: UNION
+    external_impression_qualification_filter_id: "mrc"
+    metric_frequency_spec { weekly: MONDAY }
+    grouping {
+      value_by_path {
+        key: "person.age_group"
+        value { enum_value: "YEARS_18_TO_34" }
+      }
+      value_by_path {
+        key: "person.gender"
+        value { enum_value: "MALE" }
+      }
+    }
+    event_filters {
+      terms {
+        path: "banner_ad.viewable"
+        value { bool_value: true }
+      }
+    }
+  }
+  population_size: 55000000
+  metric_frequency_spec_fingerprint: 1234
+  grouping_dimension_fingerprint: 2
+  filter_fingerprint: 5
+  reporting_window_results {
+    key {
+      non_cumulative_start {
+        year: 2025
+        month: 10
+        day: 1
+      }
+      end {
+        year: 2025
+        month: 10
+        day: 8
+      }
+    }
+    value {
+      unprocessed_report_result_values {
+        cumulative_results {
+          reach { value: 760000 }
+        }
+        non_cumulative_results {
+          reach { value: 760000 }
+          impression_count { value: 1397418 }
+          frequency_histogram {
+            bin_results: {
+              key: 1
+              value: { value: 392258 }
+            }
+            bin_results: {
+              key: 2
+              value: { value: 196129 }
+            }
+            bin_results: {
+              key: 3
+              value: { value: 98065 }
+            }
+            bin_results: {
+              key: 4
+              value: { value: 49033 }
+            }
+            bin_results: {
+              key: 5
+              value: { value: 24515 }
+            }
+          }
+        }
+      }
+    }
+  }
+  reporting_window_results {
+    key {
+      non_cumulative_start {
+        year: 2025
+        month: 10
+        day: 8
+      }
+      end {
+        year: 2025
+        month: 10
+        day: 15
+      }
+    }
+    value {
+      unprocessed_report_result_values {
+        cumulative_results {
+          reach { value: 950000 }
+        }
+        non_cumulative_results {
+          reach { value: 192662 }
+          impression_count { value: 354251 }
+          frequency_histogram {
+            bin_results: {
+              key: 1
+              value: { value: 99438 }
+            }
+            bin_results: {
+              key: 2
+              value: { value: 49719 }
+            }
+            bin_results: {
+              key: 3
+              value: { value: 24860 }
+            }
+            bin_results: {
+              key: 4
+              value: { value: 12430 }
+            }
+            bin_results: {
+              key: 5
+              value: { value: 6215 }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+reporting_set_results {
+  cmms_measurement_consumer_id: "abcd"
+  external_report_result_id: 123456
+  external_reporting_set_result_id: 15
+  dimension {
+    external_reporting_set_id: "reporting_set_id_edp3"
+    venn_diagram_region_type: UNION
+    external_impression_qualification_filter_id: "mrc"
+    metric_frequency_spec { total: true }
+    grouping {
+      value_by_path {
+        key: "person.age_group"
+        value { enum_value: "YEARS_18_TO_34" }
+      }
+      value_by_path {
+        key: "person.gender"
+        value { enum_value: "MALE" }
+      }
+    }
+    event_filters {
+      terms {
+        path: "banner_ad.viewable"
+        value { bool_value: true }
+      }
+    }
+  }
+  population_size: 55000000
+  metric_frequency_spec_fingerprint: 1234
+  grouping_dimension_fingerprint: 2
+  filter_fingerprint: 5
+  reporting_window_results {
+    key {
+      non_cumulative_start {
+        year: 2025
+        month: 10
+        day: 1
+      }
+      end {
+        year: 2025
+        month: 10
+        day: 15
+      }
+    }
+    value {
+      unprocessed_report_result_values {
+        cumulative_results {
+          reach { value: 950000 }
+          impression_count { value: 1751669 }
+          frequency_histogram {
+            bin_results: {
+              key: 1
+              value: { value: 490323 }
+            }
+            bin_results: {
+              key: 2
+              value: { value: 245162 }
+            }
+            bin_results: {
+              key: 3
+              value: { value: 122581 }
+            }
+            bin_results: {
+              key: 4
+              value: { value: 61291 }
+            }
+            bin_results: {
+              key: 5
+              value: { value: 30643 }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+reporting_set_results {
+  cmms_measurement_consumer_id: "abcd"
+  external_report_result_id: 123456
+  external_reporting_set_result_id: 16
+  dimension {
+    external_reporting_set_id: "reporting_set_id_edp1_edp2_edp3"
+    venn_diagram_region_type: UNION
+    external_impression_qualification_filter_id: "mrc"
+    metric_frequency_spec { weekly: MONDAY }
+    grouping {
+      value_by_path {
+        key: "person.age_group"
+        value { enum_value: "YEARS_18_TO_34" }
+      }
+      value_by_path {
+        key: "person.gender"
+        value { enum_value: "MALE" }
+      }
+    }
+    event_filters {
+      terms {
+        path: "banner_ad.viewable"
+        value { bool_value: true }
+      }
+    }
+  }
+  population_size: 55000000
+  metric_frequency_spec_fingerprint: 1234
+  grouping_dimension_fingerprint: 2
+  filter_fingerprint: 5
+  reporting_window_results {
+    key {
+      non_cumulative_start {
+        year: 2025
+        month: 10
+        day: 1
+      }
+      end {
+        year: 2025
+        month: 10
+        day: 8
+      }
+    }
+    value {
+      unprocessed_report_result_values {
+        cumulative_results {
+          reach {
+            value: 13427250
+            univariate_statistics { standard_deviation: 10000 }
+          }
+        }
+        non_cumulative_results {
+          reach {
+            value: 13426464
+            univariate_statistics { standard_deviation: 10000 }
+          }
+          impression_count {
+            value: 26215389
+            univariate_statistics { standard_deviation: 10000 }
+          }
+          frequency_histogram {
+            bin_results: {
+              key: 1
+              value: {
+                value: 6929788
+                univariate_statistics { standard_deviation: 10000 }
+              }
+            }
+            bin_results: {
+              key: 2
+              value: {
+                value: 3464894
+                univariate_statistics { standard_deviation: 10000 }
+              }
+            }
+            bin_results: {
+              key: 3
+              value: {
+                value: 1732447
+                univariate_statistics { standard_deviation: 10000 }
+              }
+            }
+            bin_results: {
+              key: 4
+              value: {
+                value: 866224
+                univariate_statistics { standard_deviation: 10000 }
+              }
+            }
+            bin_results: {
+              key: 5
+              value: {
+                value: 433111
+                univariate_statistics { standard_deviation: 10000 }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+  reporting_window_results {
+    key {
+      non_cumulative_start {
+        year: 2025
+        month: 10
+        day: 8
+      }
+      end {
+        year: 2025
+        month: 10
+        day: 15
+      }
+    }
+    value {
+      unprocessed_report_result_values {
+        cumulative_results {
+          reach {
+            value: 15920317
+            univariate_statistics { standard_deviation: 10000 }
+          }
+        }
+        non_cumulative_results {
+          reach {
+            value: 3278136
+            univariate_statistics { standard_deviation: 10000 }
+          }
+          impression_count {
+            value: 6135862
+            univariate_statistics { standard_deviation: 10000 }
+          }
+          frequency_histogram {
+            bin_results: {
+              key: 1
+              value: {
+                value: 1691941
+                univariate_statistics { standard_deviation: 10000 }
+              }
+            }
+            bin_results: {
+              key: 2
+              value: {
+                value: 845971
+                univariate_statistics { standard_deviation: 10000 }
+              }
+            }
+            bin_results: {
+              key: 3
+              value: {
+                value: 422986
+                univariate_statistics { standard_deviation: 10000 }
+              }
+            }
+            bin_results: {
+              key: 4
+              value: {
+                value: 211493
+                univariate_statistics { standard_deviation: 10000 }
+              }
+            }
+            bin_results: {
+              key: 5
+              value: {
+                value: 105745
+                univariate_statistics { standard_deviation: 10000 }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+reporting_set_results {
+  cmms_measurement_consumer_id: "abcd"
+  external_report_result_id: 123456
+  external_reporting_set_result_id: 17
+  dimension {
+    external_reporting_set_id: "reporting_set_id_edp1_edp2_edp3"
+    venn_diagram_region_type: UNION
+    external_impression_qualification_filter_id: "mrc"
+    metric_frequency_spec { total: true }
+    grouping {
+      value_by_path {
+        key: "person.age_group"
+        value { enum_value: "YEARS_18_TO_34" }
+      }
+      value_by_path {
+        key: "person.gender"
+        value { enum_value: "MALE" }
+      }
+    }
+    event_filters {
+      terms {
+        path: "banner_ad.viewable"
+        value { bool_value: true }
+      }
+    }
+  }
+  population_size: 55000000
+  metric_frequency_spec_fingerprint: 1234
+  grouping_dimension_fingerprint: 2
+  filter_fingerprint: 5
+  reporting_window_results {
+    key {
+      non_cumulative_start {
+        year: 2025
+        month: 10
+        day: 1
+      }
+      end {
+        year: 2025
+        month: 10
+        day: 15
+      }
+    }
+    value {
+      unprocessed_report_result_values {
+        cumulative_results {
+          reach {
+            value: 15908881
+            univariate_statistics { standard_deviation: 10000 }
+          }
+          impression_count {
+            value: 32337826
+            univariate_statistics { standard_deviation: 10000 }
+          }
+          frequency_histogram {
+            bin_results: {
+              key: 1
+              value: {
+                value: 8211035
+                univariate_statistics { standard_deviation: 10000 }
+              }
+            }
+            bin_results: {
+              key: 2
+              value: {
+                value: 4105518
+                univariate_statistics { standard_deviation: 10000 }
+              }
+            }
+            bin_results: {
+              key: 3
+              value: {
+                value: 2052759
+                univariate_statistics { standard_deviation: 10000 }
+              }
+            }
+            bin_results: {
+              key: 4
+              value: {
+                value: 1026380
+                univariate_statistics { standard_deviation: 10000 }
+              }
+            }
+            bin_results: {
+              key: 5
+              value: {
+                value: 513189
+                univariate_statistics { standard_deviation: 10000 }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+reporting_set_results {
+  cmms_measurement_consumer_id: "abcd"
+  external_report_result_id: 123456
+  external_reporting_set_result_id: 18
+  dimension {
+    external_reporting_set_id: "reporting_set_id_edp1"
+    venn_diagram_region_type: UNION
+    custom: true
+    metric_frequency_spec { weekly: MONDAY }
+    grouping {
+      value_by_path {
+        key: "person.age_group"
+        value { enum_value: "YEARS_18_TO_34" }
+      }
+      value_by_path {
+        key: "person.gender"
+        value { enum_value: "MALE" }
+      }
+    }
+    event_filters {
+      terms {
+        path: "banner_ad.viewable"
+        value { bool_value: true }
+      }
+    }
+  }
+
+  population_size: 55000000
+  metric_frequency_spec_fingerprint: 1234
+  grouping_dimension_fingerprint: 2
+  filter_fingerprint: 5
+  reporting_window_results {
+    key {
+      non_cumulative_start {
+        year: 2025
+        month: 10
+        day: 1
+      }
+      end {
+        year: 2025
+        month: 10
+        day: 8
+      }
+    }
+    value {
+      unprocessed_report_result_values {
+        cumulative_results {
+          reach {
+            value: 9984642
+            univariate_statistics { standard_deviation: 10000 }
+          }
+        }
+        non_cumulative_results {
+          reach {
+            value: 10000981
+            univariate_statistics { standard_deviation: 10000 }
+          }
+          impression_count {
+            value: 18382797
+            univariate_statistics { standard_deviation: 10000 }
+          }
+          frequency_histogram {
+            bin_results: {
+              key: 1
+              value: {
+                value: 5161797
+                univariate_statistics { standard_deviation: 10000 }
+              }
+            }
+            bin_results: {
+              key: 2
+              value: {
+                value: 2580899
+                univariate_statistics { standard_deviation: 10000 }
+              }
+            }
+            bin_results: {
+              key: 3
+              value: {
+                value: 1290450
+                univariate_statistics { standard_deviation: 10000 }
+              }
+            }
+            bin_results: {
+              key: 4
+              value: {
+                value: 645225
+                univariate_statistics { standard_deviation: 10000 }
+              }
+            }
+            bin_results: {
+              key: 5
+              value: {
+                value: 322610
+                univariate_statistics { standard_deviation: 10000 }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+  reporting_window_results {
+    key {
+      non_cumulative_start {
+        year: 2025
+        month: 10
+        day: 8
+      }
+      end {
+        year: 2025
+        month: 10
+        day: 15
+      }
+    }
+    value {
+      unprocessed_report_result_values {
+        cumulative_results {
+          reach {
+            value: 12020226
+            univariate_statistics { standard_deviation: 10000 }
+          }
+        }
+        non_cumulative_results {
+          reach {
+            value: 2441042
+            univariate_statistics { standard_deviation: 10000 }
+          }
+          impression_count {
+            value: 4488362
+            univariate_statistics { standard_deviation: 10000 }
+          }
+          frequency_histogram {
+            bin_results: {
+              key: 1
+              value: {
+                value: 1259893
+                univariate_statistics { standard_deviation: 10000 }
+              }
+            }
+            bin_results: {
+              key: 2
+              value: {
+                value: 629947
+                univariate_statistics { standard_deviation: 10000 }
+              }
+            }
+            bin_results: {
+              key: 3
+              value: {
+                value: 314974
+                univariate_statistics { standard_deviation: 10000 }
+              }
+            }
+            bin_results: {
+              key: 4
+              value: {
+                value: 157487
+                univariate_statistics { standard_deviation: 10000 }
+              }
+            }
+            bin_results: {
+              key: 5
+              value: {
+                value: 78741
+                univariate_statistics { standard_deviation: 10000 }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+reporting_set_results {
+  cmms_measurement_consumer_id: "abcd"
+  external_report_result_id: 123456
+  external_reporting_set_result_id: 19
+  dimension {
+    external_reporting_set_id: "reporting_set_id_edp1"
+    venn_diagram_region_type: UNION
+    custom: true
+    metric_frequency_spec { total: true }
+    grouping {
+      value_by_path {
+        key: "person.age_group"
+        value { enum_value: "YEARS_18_TO_34" }
+      }
+      value_by_path {
+        key: "person.gender"
+        value { enum_value: "MALE" }
+      }
+    }
+    event_filters {
+      terms {
+        path: "banner_ad.viewable"
+        value { bool_value: true }
+      }
+    }
+  }
+
+  population_size: 55000000
+  metric_frequency_spec_fingerprint: 1234
+  grouping_dimension_fingerprint: 2
+  filter_fingerprint: 5
+  reporting_window_results {
+    key {
+      non_cumulative_start {
+        year: 2025
+        month: 10
+        day: 1
+      }
+      end {
+        year: 2025
+        month: 10
+        day: 15
+      }
+    }
+    value {
+      unprocessed_report_result_values {
+        cumulative_results {
+          reach {
+            value: 12017026
+            univariate_statistics { standard_deviation: 10000 }
+          }
+          impression_count {
+            value: 22871159
+            univariate_statistics { standard_deviation: 10000 }
+          }
+          frequency_histogram {
+            bin_results: {
+              key: 1
+              value: {
+                value: 6202336
+                univariate_statistics { standard_deviation: 10000 }
+              }
+            }
+            bin_results: {
+              key: 2
+              value: {
+                value: 3101168
+                univariate_statistics { standard_deviation: 10000 }
+              }
+            }
+            bin_results: {
+              key: 3
+              value: {
+                value: 1550584
+                univariate_statistics { standard_deviation: 10000 }
+              }
+            }
+            bin_results: {
+              key: 4
+              value: {
+                value: 775292
+                univariate_statistics { standard_deviation: 10000 }
+              }
+            }
+            bin_results: {
+              key: 5
+              value: {
+                value: 387646
+                univariate_statistics { standard_deviation: 10000 }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+reporting_set_results {
+  cmms_measurement_consumer_id: "abcd"
+  external_report_result_id: 123456
+  external_reporting_set_result_id: 20
+  dimension {
+    external_reporting_set_id: "reporting_set_id_edp2"
+    venn_diagram_region_type: UNION
+    custom: true
+    metric_frequency_spec { weekly: MONDAY }
+    grouping {
+      value_by_path {
+        key: "person.age_group"
+        value { enum_value: "YEARS_18_TO_34" }
+      }
+      value_by_path {
+        key: "person.gender"
+        value { enum_value: "MALE" }
+      }
+    }
+    event_filters {
+      terms {
+        path: "banner_ad.viewable"
+        value { bool_value: true }
+      }
+    }
+  }
+
+  population_size: 55000000
+  metric_frequency_spec_fingerprint: 1234
+  grouping_dimension_fingerprint: 2
+  filter_fingerprint: 5
+  reporting_window_results {
+    key {
+      non_cumulative_start {
+        year: 2025
+        month: 10
+        day: 1
+      }
+      end {
+        year: 2025
+        month: 10
+        day: 8
+      }
+    }
+    value {
+      unprocessed_report_result_values {
+        cumulative_results {
+          reach { value: 5000000 }
+        }
+        non_cumulative_results {
+          reach { value: 5000000 }
+          impression_count { value: 9193546 }
+          frequency_histogram {
+            bin_results: {
+              key: 1
+              value: { value: 2580645 }
+            }
+            bin_results: {
+              key: 2
+              value: { value: 1290323 }
+            }
+            bin_results: {
+              key: 3
+              value: { value: 645162 }
+            }
+            bin_results: {
+              key: 4
+              value: { value: 322581 }
+            }
+            bin_results: {
+              key: 5
+              value: { value: 161289 }
+            }
+          }
+        }
+      }
+    }
+  }
+  reporting_window_results {
+    key {
+      non_cumulative_start {
+        year: 2025
+        month: 10
+        day: 8
+      }
+      end {
+        year: 2025
+        month: 10
+        day: 15
+      }
+    }
+    value {
+      unprocessed_report_result_values {
+        cumulative_results {
+          reach { value: 6000000 }
+        }
+        non_cumulative_results {
+          reach { value: 1100000 }
+          impression_count { value: 2022579 }
+          frequency_histogram {
+            bin_results: {
+              key: 1
+              value: { value: 567742 }
+            }
+            bin_results: {
+              key: 2
+              value: { value: 283871 }
+            }
+            bin_results: {
+              key: 3
+              value: { value: 141936 }
+            }
+            bin_results: {
+              key: 4
+              value: { value: 70968 }
+            }
+            bin_results: {
+              key: 5
+              value: { value: 35483 }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+reporting_set_results {
+  cmms_measurement_consumer_id: "abcd"
+  external_report_result_id: 123456
+  external_reporting_set_result_id: 21
+  dimension {
+    external_reporting_set_id: "reporting_set_id_edp2"
+    venn_diagram_region_type: UNION
+    custom: true
+    metric_frequency_spec { total: true }
+    grouping {
+      value_by_path {
+        key: "person.age_group"
+        value { enum_value: "YEARS_18_TO_34" }
+      }
+      value_by_path {
+        key: "person.gender"
+        value { enum_value: "MALE" }
+      }
+    }
+    event_filters {
+      terms {
+        path: "banner_ad.viewable"
+        value { bool_value: true }
+      }
+    }
+  }
+
+  population_size: 55000000
+  metric_frequency_spec_fingerprint: 1234
+  grouping_dimension_fingerprint: 2
+  filter_fingerprint: 5
+  reporting_window_results {
+    key {
+      non_cumulative_start {
+        year: 2025
+        month: 10
+        day: 1
+      }
+      end {
+        year: 2025
+        month: 10
+        day: 15
+      }
+    }
+    value {
+      unprocessed_report_result_values {
+        cumulative_results {
+          reach { value: 6000000 }
+          impression_count { value: 11216125 }
+          frequency_histogram {
+            bin_results: {
+              key: 1
+              value: { value: 3096774 }
+            }
+            bin_results: {
+              key: 2
+              value: { value: 1548387 }
+            }
+            bin_results: {
+              key: 3
+              value: { value: 774194 }
+            }
+            bin_results: {
+              key: 4
+              value: { value: 387097 }
+            }
+            bin_results: {
+              key: 5
+              value: { value: 193548 }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+reporting_set_results {
+  cmms_measurement_consumer_id: "abcd"
+  external_report_result_id: 123456
+  external_reporting_set_result_id: 22
+  dimension {
+    external_reporting_set_id: "reporting_set_id_edp3"
+    venn_diagram_region_type: UNION
+    custom: true
+    metric_frequency_spec { weekly: MONDAY }
+    grouping {
+      value_by_path {
+        key: "person.age_group"
+        value { enum_value: "YEARS_18_TO_34" }
+      }
+      value_by_path {
+        key: "person.gender"
+        value { enum_value: "MALE" }
+      }
+    }
+    event_filters {
+      terms {
+        path: "banner_ad.viewable"
+        value { bool_value: true }
+      }
+    }
+  }
+
+  population_size: 55000000
+  metric_frequency_spec_fingerprint: 1234
+  grouping_dimension_fingerprint: 2
+  filter_fingerprint: 5
+  reporting_window_results {
+    key {
+      non_cumulative_start {
+        year: 2025
+        month: 10
+        day: 1
+      }
+      end {
+        year: 2025
+        month: 10
+        day: 8
+      }
+    }
+    value {
+      unprocessed_report_result_values {
+        cumulative_results {
+          reach { value: 800000 }
+        }
+        non_cumulative_results {
+          reach { value: 800000 }
+          impression_count { value: 1470967 }
+          frequency_histogram {
+            bin_results: {
+              key: 1
+              value: { value: 412903 }
+            }
+            bin_results: {
+              key: 2
+              value: { value: 206452 }
+            }
+            bin_results: {
+              key: 3
+              value: { value: 103226 }
+            }
+            bin_results: {
+              key: 4
+              value: { value: 51613 }
+            }
+            bin_results: {
+              key: 5
+              value: { value: 25806 }
+            }
+          }
+        }
+      }
+    }
+  }
+  reporting_window_results {
+    key {
+      non_cumulative_start {
+        year: 2025
+        month: 10
+        day: 8
+      }
+      end {
+        year: 2025
+        month: 10
+        day: 15
+      }
+    }
+    value {
+      unprocessed_report_result_values {
+        cumulative_results {
+          reach { value: 1000000 }
+        }
+        non_cumulative_results {
+          reach { value: 202952 }
+          impression_count { value: 373169 }
+          frequency_histogram {
+            bin_results: {
+              key: 1
+              value: { value: 104749 }
+            }
+            bin_results: {
+              key: 2
+              value: { value: 52375 }
+            }
+            bin_results: {
+              key: 3
+              value: { value: 26188 }
+            }
+            bin_results: {
+              key: 4
+              value: { value: 13094 }
+            }
+            bin_results: {
+              key: 5
+              value: { value: 6546 }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+reporting_set_results {
+  cmms_measurement_consumer_id: "abcd"
+  external_report_result_id: 123456
+  external_reporting_set_result_id: 23
+  dimension {
+    external_reporting_set_id: "reporting_set_id_edp3"
+    venn_diagram_region_type: UNION
+    custom: true
+    metric_frequency_spec { total: true }
+    grouping {
+      value_by_path {
+        key: "person.age_group"
+        value { enum_value: "YEARS_18_TO_34" }
+      }
+      value_by_path {
+        key: "person.gender"
+        value { enum_value: "MALE" }
+      }
+    }
+    event_filters {
+      terms {
+        path: "banner_ad.viewable"
+        value { bool_value: true }
+      }
+    }
+  }
+
+  population_size: 55000000
+  metric_frequency_spec_fingerprint: 1234
+  grouping_dimension_fingerprint: 2
+  filter_fingerprint: 5
+  reporting_window_results {
+    key {
+      non_cumulative_start {
+        year: 2025
+        month: 10
+        day: 1
+      }
+      end {
+        year: 2025
+        month: 10
+        day: 15
+      }
+    }
+    value {
+      unprocessed_report_result_values {
+        cumulative_results {
+          reach { value: 1000000 }
+          impression_count { value: 1844136 }
+          frequency_histogram {
+            bin_results: {
+              key: 1
+              value: { value: 516129 }
+            }
+            bin_results: {
+              key: 2
+              value: { value: 258065 }
+            }
+            bin_results: {
+              key: 3
+              value: { value: 129033 }
+            }
+            bin_results: {
+              key: 4
+              value: { value: 64517 }
+            }
+            bin_results: {
+              key: 5
+              value: { value: 32256 }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+reporting_set_results {
+  cmms_measurement_consumer_id: "abcd"
+  external_report_result_id: 123456
+  external_reporting_set_result_id: 24
+  dimension {
+    external_reporting_set_id: "reporting_set_id_edp1_edp2_edp3"
+    venn_diagram_region_type: UNION
+    custom: true
+    metric_frequency_spec { weekly: MONDAY }
+    grouping {
+      value_by_path {
+        key: "person.age_group"
+        value { enum_value: "YEARS_18_TO_34" }
+      }
+      value_by_path {
+        key: "person.gender"
+        value { enum_value: "MALE" }
+      }
+    }
+    event_filters {
+      terms {
+        path: "banner_ad.viewable"
+        value { bool_value: true }
+      }
+    }
+  }
+
+  population_size: 55000000
+  metric_frequency_spec_fingerprint: 1234
+  grouping_dimension_fingerprint: 2
+  filter_fingerprint: 5
+  reporting_window_results {
+    key {
+      non_cumulative_start {
+        year: 2025
+        month: 10
+        day: 1
+      }
+      end {
+        year: 2025
+        month: 10
+        day: 8
+      }
+    }
+    value {
+      unprocessed_report_result_values {
+        cumulative_results {
+          reach {
+            value: 15799013
+            univariate_statistics { standard_deviation: 10000 }
+          }
+        }
+        non_cumulative_results {
+          reach {
+            value: 15819974
+            univariate_statistics { standard_deviation: 10000 }
+          }
+          impression_count {
+            value: 29052805
+            univariate_statistics { standard_deviation: 10000 }
+          }
+          frequency_histogram {
+            bin_results: {
+              key: 1
+              value: {
+                value: 8165148
+                univariate_statistics { standard_deviation: 10000 }
+              }
+            }
+            bin_results: {
+              key: 2
+              value: {
+                value: 4082574
+                univariate_statistics { standard_deviation: 10000 }
+              }
+            }
+            bin_results: {
+              key: 3
+              value: {
+                value: 2041287
+                univariate_statistics { standard_deviation: 10000 }
+              }
+            }
+            bin_results: {
+              key: 4
+              value: {
+                value: 1020644
+                univariate_statistics { standard_deviation: 10000 }
+              }
+            }
+            bin_results: {
+              key: 5
+              value: {
+                value: 510321
+                univariate_statistics { standard_deviation: 10000 }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+  reporting_window_results {
+    key {
+      non_cumulative_start {
+        year: 2025
+        month: 10
+        day: 8
+      }
+      end {
+        year: 2025
+        month: 10
+        day: 15
+      }
+    }
+    value {
+      unprocessed_report_result_values {
+        cumulative_results {
+          reach {
+            value: 19015392
+            univariate_statistics { standard_deviation: 10000 }
+          }
+        }
+        non_cumulative_results {
+          reach {
+            value: 3751542
+            univariate_statistics { standard_deviation: 10000 }
+          }
+          impression_count {
+            value: 6884110
+            univariate_statistics { standard_deviation: 10000 }
+          }
+          frequency_histogram {
+            bin_results: {
+              key: 1
+              value: {
+                value: 1936280
+                univariate_statistics { standard_deviation: 10000 }
+              }
+            }
+            bin_results: {
+              key: 2
+              value: {
+                value: 968140
+                univariate_statistics { standard_deviation: 10000 }
+              }
+            }
+            bin_results: {
+              key: 3
+              value: {
+                value: 484070
+                univariate_statistics { standard_deviation: 10000 }
+              }
+            }
+            bin_results: {
+              key: 4
+              value: {
+                value: 242035
+                univariate_statistics { standard_deviation: 10000 }
+              }
+            }
+            bin_results: {
+              key: 5
+              value: {
+                value: 121017
+                univariate_statistics { standard_deviation: 10000 }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+reporting_set_results {
+  cmms_measurement_consumer_id: "abcd"
+  external_report_result_id: 123456
+  external_reporting_set_result_id: 25
+  dimension {
+    external_reporting_set_id: "reporting_set_id_edp1_edp2_edp3"
+    venn_diagram_region_type: UNION
+    custom: true
+    metric_frequency_spec { total: true }
+    grouping {
+      value_by_path {
+        key: "person.age_group"
+        value { enum_value: "YEARS_18_TO_34" }
+      }
+      value_by_path {
+        key: "person.gender"
+        value { enum_value: "MALE" }
+      }
+    }
+    event_filters {
+      terms {
+        path: "banner_ad.viewable"
+        value { bool_value: true }
+      }
+    }
+  }
+
+  population_size: 55000000
+  metric_frequency_spec_fingerprint: 1234
+  grouping_dimension_fingerprint: 2
+  filter_fingerprint: 5
+  reporting_window_results {
+    key {
+      non_cumulative_start {
+        year: 2025
+        month: 10
+        day: 1
+      }
+      end {
+        year: 2025
+        month: 10
+        day: 15
+      }
+    }
+    value {
+      unprocessed_report_result_values {
+        cumulative_results {
+          reach {
+            value: 19030737
+            univariate_statistics { standard_deviation: 10000 }
+          }
+          impression_count {
+            value: 35936915
+            univariate_statistics { standard_deviation: 10000 }
+          }
+          frequency_histogram {
+            bin_results: {
+              key: 1
+              value: {
+                value: 9822316
+                univariate_statistics { standard_deviation: 10000 }
+              }
+            }
+            bin_results: {
+              key: 2
+              value: {
+                value: 4911158
+                univariate_statistics { standard_deviation: 10000 }
+              }
+            }
+            bin_results: {
+              key: 3
+              value: {
+                value: 2455579
+                univariate_statistics { standard_deviation: 10000 }
+              }
+            }
+            bin_results: {
+              key: 4
+              value: {
+                value: 1227790
+                univariate_statistics { standard_deviation: 10000 }
+              }
+            }
+            bin_results: {
+              key: 5
+              value: {
+                value: 613894
+                univariate_statistics { standard_deviation: 10000 }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Fix BasicReport post-processor to fail reports when noise correction produces statistically improbable adjustments (>7σ or >1.0 absolute).  The fix raises a ValueError when large_corrections is non-empty, which the existing _process_basic_report handler converts into a FailBasicReport call. Only the BasicReport job-executor path is affected; the origin-report CLI is untouched.

The sample test fixture is split: sample_report_result_with_large_corrections.textproto preserves the original data and drives a new test that asserts the raise, while sample_report_result.textproto has the five reporting_set_results containing large-correction measurements (IDs 9, 10, 11, 16, 17) removed so the success test runs against internally-consistent data. The success test's expected reporting_set_ids list, result count (25 → 20), and set-25 value assertions are updated accordingly.

Issue: #4048 