### PR TITLE
feat(edpaggregator): Add RankerJob public and internal API

### DIFF
--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/spanner/BUILD.bazel
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/spanner/BUILD.bazel
@@ -143,6 +143,7 @@ kt_jvm_library(
     srcs = ["SpannerRankerJobService.kt"],
     deps = [
         "//src/main/kotlin/org/wfanet/measurement/common:id_generator",
+        "//src/main/kotlin/org/wfanet/measurement/common/api:etags",
         "//src/main/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/spanner/db",
         "//src/main/kotlin/org/wfanet/measurement/edpaggregator/service/internal:errors",
         "//src/main/proto/wfa/measurement/internal/edpaggregator:ranker_job_kt_jvm_proto",

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/spanner/BUILD.bazel
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/spanner/BUILD.bazel
@@ -138,6 +138,22 @@ java_image(
 )
 
 kt_jvm_library(
+    name = "spanner_ranker_job_service",
+    srcs = ["SpannerRankerJobService.kt"],
+    deps = [
+        "//src/main/kotlin/org/wfanet/measurement/common:id_generator",
+        "//src/main/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/spanner/db",
+        "//src/main/kotlin/org/wfanet/measurement/edpaggregator/service/internal:errors",
+        "//src/main/proto/wfa/measurement/internal/edpaggregator:ranker_job_kt_jvm_proto",
+        "//src/main/proto/wfa/measurement/internal/edpaggregator:ranker_job_service_kt_jvm_grpc_proto",
+        "//src/main/proto/wfa/measurement/internal/edpaggregator:ranker_state_kt_jvm_proto",
+        "@wfa_common_jvm//imports/java/com/google/cloud/spanner",
+        "@wfa_common_jvm//src/main/kotlin/org/wfanet/measurement/common",
+        "@wfa_common_jvm//src/main/kotlin/org/wfanet/measurement/gcloud/spanner",
+    ],
+)
+
+kt_jvm_library(
     name = "spanner_vid_labeling_job_service",
     srcs = ["SpannerVidLabelingJobService.kt"],
     deps = [

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/spanner/BUILD.bazel
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/spanner/BUILD.bazel
@@ -98,6 +98,7 @@ kt_jvm_library(
     srcs = ["InternalApiServices.kt"],
     deps = [
         ":spanner_impression_metadata_service",
+        ":spanner_ranker_job_service",
         ":spanner_raw_impression_metadata_batch_file_service",
         ":spanner_raw_impression_metadata_batch_service",
         ":spanner_raw_impression_upload_file_service",

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/spanner/InternalApiServices.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/spanner/InternalApiServices.kt
@@ -35,6 +35,7 @@ object InternalApiServices {
       SpannerRawImpressionUploadService(databaseClient, coroutineContext, idGenerator),
       SpannerRawImpressionUploadFileService(databaseClient, coroutineContext, idGenerator),
       SpannerVidLabelingJobService(databaseClient, coroutineContext, idGenerator),
+      SpannerRankerJobService(databaseClient, coroutineContext, idGenerator),
     )
   }
 }

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/spanner/SpannerRankerJobService.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/spanner/SpannerRankerJobService.kt
@@ -29,6 +29,7 @@ import kotlinx.coroutines.flow.collectIndexed
 import org.wfanet.measurement.common.IdGenerator
 import org.wfanet.measurement.common.generateNewId
 import org.wfanet.measurement.edpaggregator.deploy.gcloud.spanner.db.RankerJobResult
+import org.wfanet.measurement.edpaggregator.deploy.gcloud.spanner.db.countOtherNonSucceededRankerJobs
 import org.wfanet.measurement.edpaggregator.deploy.gcloud.spanner.db.findRankerJobByRequestId
 import org.wfanet.measurement.edpaggregator.deploy.gcloud.spanner.db.findRankerJobsByRequestIds
 import org.wfanet.measurement.edpaggregator.deploy.gcloud.spanner.db.getRankerJobByResourceId
@@ -36,7 +37,6 @@ import org.wfanet.measurement.edpaggregator.deploy.gcloud.spanner.db.getRawImpre
 import org.wfanet.measurement.edpaggregator.deploy.gcloud.spanner.db.insertRankerJob
 import org.wfanet.measurement.edpaggregator.deploy.gcloud.spanner.db.rankerJobExists
 import org.wfanet.measurement.edpaggregator.deploy.gcloud.spanner.db.readRankerJobs
-import org.wfanet.measurement.edpaggregator.deploy.gcloud.spanner.db.readRankerJobsForModelLine
 import org.wfanet.measurement.edpaggregator.deploy.gcloud.spanner.db.updateRankerJobState
 import org.wfanet.measurement.edpaggregator.service.internal.EtagMismatchException
 import org.wfanet.measurement.edpaggregator.service.internal.InvalidFieldValueException
@@ -446,14 +446,12 @@ class SpannerRankerJobService(
           return@run TransactionResult(
             currentJob,
             isLastJob =
-              computeIsLastJob(
-                txn.readRankerJobsForModelLine(
-                  request.dataProviderResourceId,
-                  result.rawImpressionUploadId,
-                  currentJob.cmmsModelLine,
-                ),
+              txn.countOtherNonSucceededRankerJobs(
+                request.dataProviderResourceId,
+                result.rawImpressionUploadId,
+                currentJob.cmmsModelLine,
                 result.rankerJobId,
-              ),
+              ) == 0L,
             isReplay = true,
           )
         }
@@ -475,26 +473,27 @@ class SpannerRankerJobService(
           etag = newEtag,
         ) {
           set("MarkRequestId").to(request.requestId)
+          // Clear any error message from a prior FAILED attempt; it is only set while FAILED.
+          set("ErrorMessage").to(null as String?)
         }
 
-        // Read all jobs for this (upload, model line). The buffered update above is not visible in
-        // this read, so the current job still shows its previous state; it is treated as SUCCEEDED
-        // via its ID below.
+        // Count sibling jobs in this (upload, model line) that are not yet SUCCEEDED, excluding the
+        // current job. The buffered update above is not visible in this read, so excluding the
+        // current job by ID yields the correct "last job out" semantics.
         val isLastJob =
-          computeIsLastJob(
-            txn.readRankerJobsForModelLine(
-              request.dataProviderResourceId,
-              result.rawImpressionUploadId,
-              currentJob.cmmsModelLine,
-            ),
+          txn.countOtherNonSucceededRankerJobs(
+            request.dataProviderResourceId,
+            result.rawImpressionUploadId,
+            currentJob.cmmsModelLine,
             result.rankerJobId,
-          )
+          ) == 0L
 
         TransactionResult(
           updatedJob =
             currentJob.copy {
               state = State.RANKER_STATE_SUCCEEDED
               etag = newEtag
+              clearErrorMessage()
               clearUpdateTime()
             },
           isLastJob = isLastJob,
@@ -690,19 +689,5 @@ class SpannerRankerJobService(
 
     private val VALID_MARK_PREVIOUS_STATES =
       setOf(State.RANKER_STATE_CREATED, State.RANKER_STATE_FAILED)
-
-    /**
-     * Returns whether marking [currentJobId] as SUCCEEDED makes it the last ranker job to complete
-     * for its (upload, model line). [jobsForModelLine] are the sibling jobs as read before the
-     * buffered transition is visible, so [currentJobId] is treated as already SUCCEEDED.
-     */
-    private fun computeIsLastJob(
-      jobsForModelLine: List<RankerJobResult>,
-      currentJobId: Long,
-    ): Boolean {
-      return jobsForModelLine.all {
-        it.rankerJob.state == State.RANKER_STATE_SUCCEEDED || it.rankerJobId == currentJobId
-      }
-    }
   }
 }

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/spanner/SpannerRankerJobService.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/spanner/SpannerRankerJobService.kt
@@ -27,9 +27,7 @@ import kotlin.coroutines.EmptyCoroutineContext
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.collectIndexed
 import org.wfanet.measurement.common.IdGenerator
-import org.wfanet.measurement.common.api.ETags
 import org.wfanet.measurement.common.generateNewId
-import org.wfanet.measurement.common.toInstant
 import org.wfanet.measurement.edpaggregator.deploy.gcloud.spanner.db.RankerJobResult
 import org.wfanet.measurement.edpaggregator.deploy.gcloud.spanner.db.findRankerJobByRequestId
 import org.wfanet.measurement.edpaggregator.deploy.gcloud.spanner.db.findRankerJobsByRequestIds
@@ -128,6 +126,7 @@ class SpannerRankerJobService(
             }
 
           val resourceId = "$RANKER_JOB_RESOURCE_ID_PREFIX-${UUID.randomUUID()}"
+          val newEtag = UUID.randomUUID().toString()
 
           txn.insertRankerJob(
             rawImpressionUploadId = rawImpressionUploadId,
@@ -137,7 +136,7 @@ class SpannerRankerJobService(
             cmmsModelLine = job.cmmsModelLine,
             poolOffsets = job.poolOffsetsList,
             createRequestId = request.requestId,
-            etag = "", // Placeholder; real etag computed from commit timestamp.
+            etag = newEtag,
           )
 
           job.copy {
@@ -145,9 +144,9 @@ class SpannerRankerJobService(
             this.rawImpressionUploadResourceId = rawImpressionUploadResourceId
             rankerJobResourceId = resourceId
             state = State.RANKER_STATE_CREATED
+            etag = newEtag
             clearCreateTime()
             clearUpdateTime()
-            clearEtag()
           }
         }
       } catch (e: SpannerException) {
@@ -169,7 +168,6 @@ class SpannerRankerJobService(
       createdJob.copy {
         createTime = commitTimestamp
         updateTime = commitTimestamp
-        etag = ETags.computeETag(commitTimestamp.toInstant())
       }
     }
   }
@@ -267,6 +265,7 @@ class SpannerRankerJobService(
                 }
 
               val resourceId = "$RANKER_JOB_RESOURCE_ID_PREFIX-${UUID.randomUUID()}"
+              val newEtag = UUID.randomUUID().toString()
 
               txn.insertRankerJob(
                 rawImpressionUploadId = rawImpressionUploadId,
@@ -276,7 +275,7 @@ class SpannerRankerJobService(
                 cmmsModelLine = subRequest.rankerJob.cmmsModelLine,
                 poolOffsets = subRequest.rankerJob.poolOffsetsList,
                 createRequestId = subRequest.requestId,
-                etag = "", // Placeholder; real etag computed from commit timestamp.
+                etag = newEtag,
               )
 
               subRequest.rankerJob.copy {
@@ -284,9 +283,9 @@ class SpannerRankerJobService(
                 this.rawImpressionUploadResourceId = rawImpressionUploadResourceId
                 rankerJobResourceId = resourceId
                 state = State.RANKER_STATE_CREATED
+                etag = newEtag
                 clearCreateTime()
                 clearUpdateTime()
-                clearEtag()
               }
             }
           }
@@ -304,7 +303,6 @@ class SpannerRankerJobService(
       }
 
     val commitTimestamp: Timestamp = transactionRunner.getCommitTimestamp().toProto()
-    val computedEtag = ETags.computeETag(commitTimestamp.toInstant())
     return batchCreateRankerJobsResponse {
       rankerJobs +=
         results.map { result ->
@@ -314,7 +312,6 @@ class SpannerRankerJobService(
             result.copy {
               createTime = commitTimestamp
               updateTime = commitTimestamp
-              etag = computedEtag
             }
           }
         }
@@ -407,6 +404,7 @@ class SpannerRankerJobService(
       request.rankerJobResourceId,
       request.etag,
       request.requestId,
+      requireRequestId = true,
     )
 
     val transactionRunner =
@@ -469,12 +467,14 @@ class SpannerRankerJobService(
           currentJob = currentJob,
         )
 
+        val newEtag = UUID.randomUUID().toString()
+
         txn.updateRankerJobState(
           dataProviderResourceId = request.dataProviderResourceId,
           rawImpressionUploadId = result.rawImpressionUploadId,
           rankerJobId = result.rankerJobId,
           state = State.RANKER_STATE_SUCCEEDED,
-          etag = "", // Placeholder; real etag computed from commit timestamp.
+          etag = newEtag,
         ) {
           set("MarkRequestId").to(request.requestId)
         }
@@ -496,8 +496,8 @@ class SpannerRankerJobService(
           updatedJob =
             currentJob.copy {
               state = State.RANKER_STATE_SUCCEEDED
+              etag = newEtag
               clearUpdateTime()
-              clearEtag()
             },
           isLastJob = isLastJob,
         )
@@ -509,10 +509,7 @@ class SpannerRankerJobService(
           txnResult.updatedJob
         } else {
           val commitTimestamp: Timestamp = transactionRunner.getCommitTimestamp().toProto()
-          txnResult.updatedJob.copy {
-            updateTime = commitTimestamp
-            etag = ETags.computeETag(commitTimestamp.toInstant())
-          }
+          txnResult.updatedJob.copy { updateTime = commitTimestamp }
         }
       isLastJob = txnResult.isLastJob
     }
@@ -525,6 +522,7 @@ class SpannerRankerJobService(
       request.rankerJobResourceId,
       request.etag,
       requestId = "",
+      requireRequestId = false,
     )
 
     val transactionRunner =
@@ -554,12 +552,14 @@ class SpannerRankerJobService(
           currentJob = currentJob,
         )
 
+        val newEtag = UUID.randomUUID().toString()
+
         txn.updateRankerJobState(
           dataProviderResourceId = request.dataProviderResourceId,
           rawImpressionUploadId = result.rawImpressionUploadId,
           rankerJobId = result.rankerJobId,
           state = State.RANKER_STATE_FAILED,
-          etag = "", // Placeholder; real etag computed from commit timestamp.
+          etag = newEtag,
         ) {
           set("ErrorMessage").to(request.errorMessage)
         }
@@ -567,21 +567,19 @@ class SpannerRankerJobService(
         currentJob.copy {
           state = State.RANKER_STATE_FAILED
           errorMessage = request.errorMessage
+          etag = newEtag
           clearUpdateTime()
-          clearEtag()
         }
       }
 
     val commitTimestamp: Timestamp = transactionRunner.getCommitTimestamp().toProto()
-    return updatedJob.copy {
-      updateTime = commitTimestamp
-      etag = ETags.computeETag(commitTimestamp.toInstant())
-    }
+    return updatedJob.copy { updateTime = commitTimestamp }
   }
 
   /**
    * Validates parent identifiers, the job resource ID, the etag, and the request ID common to the
-   * Mark requests. [requestId] may be empty when the RPC does not support idempotency.
+   * Mark requests. When [requireRequestId] is true, [requestId] must be set; it may be empty only
+   * for Mark RPCs that do not support idempotency.
    */
   private fun validateMarkRequest(
     dataProviderResourceId: String,
@@ -589,6 +587,7 @@ class SpannerRankerJobService(
     rankerJobResourceId: String,
     etag: String,
     requestId: String,
+    requireRequestId: Boolean,
   ) {
     if (dataProviderResourceId.isEmpty()) {
       throw RequiredFieldNotSetException("data_provider_resource_id")
@@ -604,6 +603,10 @@ class SpannerRankerJobService(
     }
     if (etag.isEmpty()) {
       throw RequiredFieldNotSetException("etag")
+        .asStatusRuntimeException(Status.Code.INVALID_ARGUMENT)
+    }
+    if (requireRequestId && requestId.isEmpty()) {
+      throw RequiredFieldNotSetException("request_id")
         .asStatusRuntimeException(Status.Code.INVALID_ARGUMENT)
     }
     if (requestId.isNotEmpty()) {
@@ -671,7 +674,7 @@ class SpannerRankerJobService(
   }
 
   companion object {
-    private const val RANKER_JOB_RESOURCE_ID_PREFIX = "rj"
+    private const val RANKER_JOB_RESOURCE_ID_PREFIX = "rankerJob"
     private const val MAX_PAGE_SIZE = 100
     private const val MAX_BATCH_SIZE = 50
     private const val DEFAULT_PAGE_SIZE = 50

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/spanner/SpannerRankerJobService.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/spanner/SpannerRankerJobService.kt
@@ -1,0 +1,696 @@
+/*
+ * Copyright 2026 The Cross-Media Measurement Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wfanet.measurement.edpaggregator.deploy.gcloud.spanner
+
+import com.google.cloud.spanner.ErrorCode
+import com.google.cloud.spanner.Options
+import com.google.cloud.spanner.SpannerException
+import com.google.protobuf.Timestamp
+import io.grpc.Status
+import java.util.UUID
+import kotlin.coroutines.CoroutineContext
+import kotlin.coroutines.EmptyCoroutineContext
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.collectIndexed
+import org.wfanet.measurement.common.IdGenerator
+import org.wfanet.measurement.common.api.ETags
+import org.wfanet.measurement.common.generateNewId
+import org.wfanet.measurement.common.toInstant
+import org.wfanet.measurement.edpaggregator.deploy.gcloud.spanner.db.RankerJobResult
+import org.wfanet.measurement.edpaggregator.deploy.gcloud.spanner.db.findRankerJobByRequestId
+import org.wfanet.measurement.edpaggregator.deploy.gcloud.spanner.db.findRankerJobsByRequestIds
+import org.wfanet.measurement.edpaggregator.deploy.gcloud.spanner.db.getRankerJobByResourceId
+import org.wfanet.measurement.edpaggregator.deploy.gcloud.spanner.db.getRawImpressionUploadIdForRanker
+import org.wfanet.measurement.edpaggregator.deploy.gcloud.spanner.db.insertRankerJob
+import org.wfanet.measurement.edpaggregator.deploy.gcloud.spanner.db.rankerJobExists
+import org.wfanet.measurement.edpaggregator.deploy.gcloud.spanner.db.readRankerJobs
+import org.wfanet.measurement.edpaggregator.deploy.gcloud.spanner.db.readRankerJobsForModelLine
+import org.wfanet.measurement.edpaggregator.deploy.gcloud.spanner.db.updateRankerJobState
+import org.wfanet.measurement.edpaggregator.service.internal.EtagMismatchException
+import org.wfanet.measurement.edpaggregator.service.internal.InvalidFieldValueException
+import org.wfanet.measurement.edpaggregator.service.internal.RankerJobAlreadyExistsException
+import org.wfanet.measurement.edpaggregator.service.internal.RankerJobNotFoundException
+import org.wfanet.measurement.edpaggregator.service.internal.RankerJobStateInvalidException
+import org.wfanet.measurement.edpaggregator.service.internal.RawImpressionUploadNotFoundException
+import org.wfanet.measurement.edpaggregator.service.internal.RequiredFieldNotSetException
+import org.wfanet.measurement.gcloud.spanner.AsyncDatabaseClient
+import org.wfanet.measurement.internal.edpaggregator.BatchCreateRankerJobsRequest
+import org.wfanet.measurement.internal.edpaggregator.BatchCreateRankerJobsResponse
+import org.wfanet.measurement.internal.edpaggregator.CreateRankerJobRequest
+import org.wfanet.measurement.internal.edpaggregator.GetRankerJobRequest
+import org.wfanet.measurement.internal.edpaggregator.ListRankerJobsPageTokenKt
+import org.wfanet.measurement.internal.edpaggregator.ListRankerJobsRequest
+import org.wfanet.measurement.internal.edpaggregator.ListRankerJobsResponse
+import org.wfanet.measurement.internal.edpaggregator.MarkRankerJobFailedRequest
+import org.wfanet.measurement.internal.edpaggregator.MarkRankerJobSucceededRequest
+import org.wfanet.measurement.internal.edpaggregator.MarkRankerJobSucceededResponse
+import org.wfanet.measurement.internal.edpaggregator.RankerJob
+import org.wfanet.measurement.internal.edpaggregator.RankerJobServiceGrpcKt.RankerJobServiceCoroutineImplBase
+import org.wfanet.measurement.internal.edpaggregator.RankerState as State
+import org.wfanet.measurement.internal.edpaggregator.batchCreateRankerJobsResponse
+import org.wfanet.measurement.internal.edpaggregator.copy
+import org.wfanet.measurement.internal.edpaggregator.listRankerJobsPageToken
+import org.wfanet.measurement.internal.edpaggregator.listRankerJobsResponse
+import org.wfanet.measurement.internal.edpaggregator.markRankerJobSucceededResponse
+
+/**
+ * Cloud Spanner implementation of the internal [RankerJob] service.
+ *
+ * Persists RankerJob rows interleaved under their parent RawImpressionUpload and enforces the job
+ * state machine, request-ID idempotency, and etag optimistic concurrency. The "last ranker job out"
+ * of a (upload, model line) is detected and reported via `is_last_job` so the caller can transition
+ * the parent state from RANKING to LABELING (Phase-2).
+ */
+class SpannerRankerJobService(
+  private val databaseClient: AsyncDatabaseClient,
+  coroutineContext: CoroutineContext = EmptyCoroutineContext,
+  private val idGenerator: IdGenerator = IdGenerator.Default,
+) : RankerJobServiceCoroutineImplBase(coroutineContext) {
+
+  override suspend fun createRankerJob(request: CreateRankerJobRequest): RankerJob {
+    try {
+      validateCreateRequest(request)
+    } catch (e: RequiredFieldNotSetException) {
+      throw e.asStatusRuntimeException(Status.Code.INVALID_ARGUMENT)
+    } catch (e: InvalidFieldValueException) {
+      throw e.asStatusRuntimeException(Status.Code.INVALID_ARGUMENT)
+    }
+
+    val dataProviderResourceId = request.dataProviderResourceId
+    val rawImpressionUploadResourceId = request.rawImpressionUploadResourceId
+    val job = request.rankerJob
+
+    val transactionRunner =
+      databaseClient.readWriteTransaction(Options.tag("action=createRankerJob"))
+    val createdJob: RankerJob =
+      try {
+        transactionRunner.run { txn ->
+          if (request.requestId.isNotEmpty()) {
+            val existing =
+              txn.findRankerJobByRequestId(
+                dataProviderResourceId,
+                rawImpressionUploadResourceId,
+                request.requestId,
+              )
+            if (existing != null) {
+              return@run existing.rankerJob
+            }
+          }
+
+          val rawImpressionUploadId =
+            txn.getRawImpressionUploadIdForRanker(
+              dataProviderResourceId,
+              rawImpressionUploadResourceId,
+            )
+              ?: throw RawImpressionUploadNotFoundException(
+                  dataProviderResourceId,
+                  rawImpressionUploadResourceId,
+                )
+                .asStatusRuntimeException(Status.Code.NOT_FOUND)
+
+          val rankerJobId =
+            idGenerator.generateNewId { id ->
+              txn.rankerJobExists(dataProviderResourceId, rawImpressionUploadId, id)
+            }
+
+          val resourceId = "$RANKER_JOB_RESOURCE_ID_PREFIX-${UUID.randomUUID()}"
+
+          txn.insertRankerJob(
+            rawImpressionUploadId = rawImpressionUploadId,
+            rankerJobId = rankerJobId,
+            rankerJobResourceId = resourceId,
+            dataProviderResourceId = dataProviderResourceId,
+            cmmsModelLine = job.cmmsModelLine,
+            poolOffsets = job.poolOffsetsList,
+            createRequestId = request.requestId,
+            etag = "", // Placeholder; real etag computed from commit timestamp.
+          )
+
+          job.copy {
+            this.dataProviderResourceId = dataProviderResourceId
+            this.rawImpressionUploadResourceId = rawImpressionUploadResourceId
+            rankerJobResourceId = resourceId
+            state = State.RANKER_STATE_CREATED
+            clearCreateTime()
+            clearUpdateTime()
+            clearEtag()
+          }
+        }
+      } catch (e: SpannerException) {
+        if (e.errorCode == ErrorCode.ALREADY_EXISTS) {
+          throw RankerJobAlreadyExistsException(
+              dataProviderResourceId,
+              rawImpressionUploadResourceId,
+              e,
+            )
+            .asStatusRuntimeException(Status.Code.ALREADY_EXISTS)
+        }
+        throw e
+      }
+
+    return if (createdJob.hasCreateTime()) {
+      createdJob
+    } else {
+      val commitTimestamp: Timestamp = transactionRunner.getCommitTimestamp().toProto()
+      createdJob.copy {
+        createTime = commitTimestamp
+        updateTime = commitTimestamp
+        etag = ETags.computeETag(commitTimestamp.toInstant())
+      }
+    }
+  }
+
+  override suspend fun batchCreateRankerJobs(
+    request: BatchCreateRankerJobsRequest
+  ): BatchCreateRankerJobsResponse {
+    if (request.requestsList.size > MAX_BATCH_SIZE) {
+      throw InvalidFieldValueException("requests") {
+          "$it must contain at most $MAX_BATCH_SIZE elements"
+        }
+        .asStatusRuntimeException(Status.Code.INVALID_ARGUMENT)
+    }
+    if (request.requestsList.isEmpty()) {
+      return BatchCreateRankerJobsResponse.getDefaultInstance()
+    }
+
+    val dataProviderResourceId = request.dataProviderResourceId
+    val rawImpressionUploadResourceId = request.rawImpressionUploadResourceId
+
+    if (dataProviderResourceId.isEmpty()) {
+      throw RequiredFieldNotSetException("data_provider_resource_id")
+        .asStatusRuntimeException(Status.Code.INVALID_ARGUMENT)
+    }
+    if (rawImpressionUploadResourceId.isEmpty()) {
+      throw RequiredFieldNotSetException("raw_impression_upload_resource_id")
+        .asStatusRuntimeException(Status.Code.INVALID_ARGUMENT)
+    }
+
+    val requestIdSet = mutableSetOf<String>()
+
+    request.requestsList.forEachIndexed { index, subRequest ->
+      if (!subRequest.hasRankerJob()) {
+        throw RequiredFieldNotSetException("requests[$index].ranker_job")
+          .asStatusRuntimeException(Status.Code.INVALID_ARGUMENT)
+      }
+      if (subRequest.rankerJob.cmmsModelLine.isEmpty()) {
+        throw RequiredFieldNotSetException("requests[$index].ranker_job.cmms_model_line")
+          .asStatusRuntimeException(Status.Code.INVALID_ARGUMENT)
+      }
+      if (subRequest.rankerJob.poolOffsetsList.isEmpty()) {
+        throw RequiredFieldNotSetException("requests[$index].ranker_job.pool_offsets")
+          .asStatusRuntimeException(Status.Code.INVALID_ARGUMENT)
+      }
+
+      val requestId = subRequest.requestId
+      if (requestId.isNotEmpty()) {
+        try {
+          UUID.fromString(requestId)
+        } catch (e: IllegalArgumentException) {
+          throw InvalidFieldValueException("requests[$index].request_id", e)
+            .asStatusRuntimeException(Status.Code.INVALID_ARGUMENT)
+        }
+        if (!requestIdSet.add(requestId)) {
+          throw InvalidFieldValueException("requests[$index].request_id") {
+              "Duplicate request_id $requestId in batch"
+            }
+            .asStatusRuntimeException(Status.Code.INVALID_ARGUMENT)
+        }
+      }
+    }
+
+    val transactionRunner =
+      databaseClient.readWriteTransaction(Options.tag("action=batchCreateRankerJobs"))
+
+    val results: List<RankerJob> =
+      try {
+        transactionRunner.run { txn ->
+          val rawImpressionUploadId =
+            txn.getRawImpressionUploadIdForRanker(
+              dataProviderResourceId,
+              rawImpressionUploadResourceId,
+            )
+              ?: throw RawImpressionUploadNotFoundException(
+                  dataProviderResourceId,
+                  rawImpressionUploadResourceId,
+                )
+                .asStatusRuntimeException(Status.Code.NOT_FOUND)
+
+          val existingByRequestId: Map<String, RankerJobResult> =
+            txn.findRankerJobsByRequestIds(
+              dataProviderResourceId,
+              rawImpressionUploadResourceId,
+              request.requestsList.mapNotNull { it.requestId.ifEmpty { null } },
+            )
+
+          request.requestsList.map { subRequest ->
+            val existing = existingByRequestId[subRequest.requestId]
+            if (subRequest.requestId.isNotEmpty() && existing != null) {
+              existing.rankerJob
+            } else {
+              val rankerJobId =
+                idGenerator.generateNewId { id ->
+                  txn.rankerJobExists(dataProviderResourceId, rawImpressionUploadId, id)
+                }
+
+              val resourceId = "$RANKER_JOB_RESOURCE_ID_PREFIX-${UUID.randomUUID()}"
+
+              txn.insertRankerJob(
+                rawImpressionUploadId = rawImpressionUploadId,
+                rankerJobId = rankerJobId,
+                rankerJobResourceId = resourceId,
+                dataProviderResourceId = dataProviderResourceId,
+                cmmsModelLine = subRequest.rankerJob.cmmsModelLine,
+                poolOffsets = subRequest.rankerJob.poolOffsetsList,
+                createRequestId = subRequest.requestId,
+                etag = "", // Placeholder; real etag computed from commit timestamp.
+              )
+
+              subRequest.rankerJob.copy {
+                this.dataProviderResourceId = dataProviderResourceId
+                this.rawImpressionUploadResourceId = rawImpressionUploadResourceId
+                rankerJobResourceId = resourceId
+                state = State.RANKER_STATE_CREATED
+                clearCreateTime()
+                clearUpdateTime()
+                clearEtag()
+              }
+            }
+          }
+        }
+      } catch (e: SpannerException) {
+        if (e.errorCode == ErrorCode.ALREADY_EXISTS) {
+          throw RankerJobAlreadyExistsException(
+              dataProviderResourceId,
+              rawImpressionUploadResourceId,
+              e,
+            )
+            .asStatusRuntimeException(Status.Code.ALREADY_EXISTS)
+        }
+        throw e
+      }
+
+    val commitTimestamp: Timestamp = transactionRunner.getCommitTimestamp().toProto()
+    val computedEtag = ETags.computeETag(commitTimestamp.toInstant())
+    return batchCreateRankerJobsResponse {
+      rankerJobs +=
+        results.map { result ->
+          if (result.hasCreateTime()) {
+            result
+          } else {
+            result.copy {
+              createTime = commitTimestamp
+              updateTime = commitTimestamp
+              etag = computedEtag
+            }
+          }
+        }
+    }
+  }
+
+  override suspend fun getRankerJob(request: GetRankerJobRequest): RankerJob {
+    if (request.dataProviderResourceId.isEmpty()) {
+      throw RequiredFieldNotSetException("data_provider_resource_id")
+        .asStatusRuntimeException(Status.Code.INVALID_ARGUMENT)
+    }
+    if (request.rawImpressionUploadResourceId.isEmpty()) {
+      throw RequiredFieldNotSetException("raw_impression_upload_resource_id")
+        .asStatusRuntimeException(Status.Code.INVALID_ARGUMENT)
+    }
+    if (request.rankerJobResourceId.isEmpty()) {
+      throw RequiredFieldNotSetException("ranker_job_resource_id")
+        .asStatusRuntimeException(Status.Code.INVALID_ARGUMENT)
+    }
+
+    return databaseClient.singleUse().use { txn ->
+      txn
+        .getRankerJobByResourceId(
+          request.dataProviderResourceId,
+          request.rawImpressionUploadResourceId,
+          request.rankerJobResourceId,
+        )
+        ?.rankerJob
+        ?: throw RankerJobNotFoundException(
+            request.dataProviderResourceId,
+            request.rawImpressionUploadResourceId,
+            request.rankerJobResourceId,
+          )
+          .asStatusRuntimeException(Status.Code.NOT_FOUND)
+    }
+  }
+
+  override suspend fun listRankerJobs(request: ListRankerJobsRequest): ListRankerJobsResponse {
+    if (request.dataProviderResourceId.isEmpty()) {
+      throw RequiredFieldNotSetException("data_provider_resource_id")
+        .asStatusRuntimeException(Status.Code.INVALID_ARGUMENT)
+    }
+    if (request.pageSize < 0) {
+      throw InvalidFieldValueException("page_size") { fieldName ->
+          "$fieldName must be non-negative"
+        }
+        .asStatusRuntimeException(Status.Code.INVALID_ARGUMENT)
+    }
+
+    val pageSize =
+      if (request.pageSize == 0) DEFAULT_PAGE_SIZE else request.pageSize.coerceAtMost(MAX_PAGE_SIZE)
+
+    val after = if (request.hasPageToken()) request.pageToken.after else null
+
+    databaseClient.singleUse().use { txn ->
+      val rows: Flow<RankerJobResult> =
+        txn.readRankerJobs(
+          request.dataProviderResourceId,
+          request.rawImpressionUploadResourceId.ifEmpty { null },
+          filter = if (request.hasFilter()) request.filter else null,
+          limit = pageSize + 1,
+          after = after,
+        )
+
+      return listRankerJobsResponse {
+        rows.collectIndexed { index, result ->
+          if (index == pageSize) {
+            val lastIncluded = rankerJobs.last()
+            nextPageToken = listRankerJobsPageToken {
+              this.after =
+                ListRankerJobsPageTokenKt.after {
+                  createTime = lastIncluded.createTime
+                  rankerJobResourceId = lastIncluded.rankerJobResourceId
+                }
+            }
+          } else {
+            rankerJobs += result.rankerJob
+          }
+        }
+      }
+    }
+  }
+
+  override suspend fun markRankerJobSucceeded(
+    request: MarkRankerJobSucceededRequest
+  ): MarkRankerJobSucceededResponse {
+    validateMarkRequest(
+      request.dataProviderResourceId,
+      request.rawImpressionUploadResourceId,
+      request.rankerJobResourceId,
+      request.etag,
+      request.requestId,
+    )
+
+    val transactionRunner =
+      databaseClient.readWriteTransaction(Options.tag("action=markRankerJobSucceeded"))
+
+    data class TransactionResult(
+      val updatedJob: RankerJob,
+      val isLastJob: Boolean,
+      val isReplay: Boolean = false,
+    )
+
+    val txnResult: TransactionResult =
+      transactionRunner.run { txn ->
+        val result =
+          txn.getRankerJobByResourceId(
+            request.dataProviderResourceId,
+            request.rawImpressionUploadResourceId,
+            request.rankerJobResourceId,
+          )
+            ?: throw RankerJobNotFoundException(
+                request.dataProviderResourceId,
+                request.rawImpressionUploadResourceId,
+                request.rankerJobResourceId,
+              )
+              .asStatusRuntimeException(Status.Code.NOT_FOUND)
+
+        val currentJob = result.rankerJob
+
+        // Idempotency: if already succeeded by this same request_id, do not transition again.
+        // is_last_job is recomputed from the current committed state of the sibling jobs, so it
+        // reflects whether the (upload, model line) is now complete rather than the exact value
+        // returned by the original call: a replay issued after later siblings have also succeeded
+        // can observe is_last_job=true where the original returned false. The caller MUST therefore
+        // treat the resulting Phase-2 (RANKING -> LABELING) transition as idempotent, since both
+        // the original "last job out" call and any later replay can report completion.
+        if (
+          currentJob.state == State.RANKER_STATE_SUCCEEDED &&
+            request.requestId.isNotEmpty() &&
+            result.markRequestId == request.requestId
+        ) {
+          return@run TransactionResult(
+            currentJob,
+            isLastJob =
+              computeIsLastJob(
+                txn.readRankerJobsForModelLine(
+                  request.dataProviderResourceId,
+                  result.rawImpressionUploadId,
+                  currentJob.cmmsModelLine,
+                ),
+                result.rankerJobId,
+              ),
+            isReplay = true,
+          )
+        }
+
+        checkMarkPrecondition(
+          dataProviderResourceId = request.dataProviderResourceId,
+          rawImpressionUploadResourceId = request.rawImpressionUploadResourceId,
+          requestEtag = request.etag,
+          currentJob = currentJob,
+        )
+
+        txn.updateRankerJobState(
+          dataProviderResourceId = request.dataProviderResourceId,
+          rawImpressionUploadId = result.rawImpressionUploadId,
+          rankerJobId = result.rankerJobId,
+          state = State.RANKER_STATE_SUCCEEDED,
+          etag = "", // Placeholder; real etag computed from commit timestamp.
+        ) {
+          set("MarkRequestId").to(request.requestId)
+        }
+
+        // Read all jobs for this (upload, model line). The buffered update above is not visible in
+        // this read, so the current job still shows its previous state; it is treated as SUCCEEDED
+        // via its ID below.
+        val isLastJob =
+          computeIsLastJob(
+            txn.readRankerJobsForModelLine(
+              request.dataProviderResourceId,
+              result.rawImpressionUploadId,
+              currentJob.cmmsModelLine,
+            ),
+            result.rankerJobId,
+          )
+
+        TransactionResult(
+          updatedJob =
+            currentJob.copy {
+              state = State.RANKER_STATE_SUCCEEDED
+              clearUpdateTime()
+              clearEtag()
+            },
+          isLastJob = isLastJob,
+        )
+      }
+
+    return markRankerJobSucceededResponse {
+      rankerJob =
+        if (txnResult.isReplay) {
+          txnResult.updatedJob
+        } else {
+          val commitTimestamp: Timestamp = transactionRunner.getCommitTimestamp().toProto()
+          txnResult.updatedJob.copy {
+            updateTime = commitTimestamp
+            etag = ETags.computeETag(commitTimestamp.toInstant())
+          }
+        }
+      isLastJob = txnResult.isLastJob
+    }
+  }
+
+  override suspend fun markRankerJobFailed(request: MarkRankerJobFailedRequest): RankerJob {
+    validateMarkRequest(
+      request.dataProviderResourceId,
+      request.rawImpressionUploadResourceId,
+      request.rankerJobResourceId,
+      request.etag,
+      requestId = "",
+    )
+
+    val transactionRunner =
+      databaseClient.readWriteTransaction(Options.tag("action=markRankerJobFailed"))
+
+    val updatedJob: RankerJob =
+      transactionRunner.run { txn ->
+        val result =
+          txn.getRankerJobByResourceId(
+            request.dataProviderResourceId,
+            request.rawImpressionUploadResourceId,
+            request.rankerJobResourceId,
+          )
+            ?: throw RankerJobNotFoundException(
+                request.dataProviderResourceId,
+                request.rawImpressionUploadResourceId,
+                request.rankerJobResourceId,
+              )
+              .asStatusRuntimeException(Status.Code.NOT_FOUND)
+
+        val currentJob = result.rankerJob
+
+        checkMarkPrecondition(
+          dataProviderResourceId = request.dataProviderResourceId,
+          rawImpressionUploadResourceId = request.rawImpressionUploadResourceId,
+          requestEtag = request.etag,
+          currentJob = currentJob,
+        )
+
+        txn.updateRankerJobState(
+          dataProviderResourceId = request.dataProviderResourceId,
+          rawImpressionUploadId = result.rawImpressionUploadId,
+          rankerJobId = result.rankerJobId,
+          state = State.RANKER_STATE_FAILED,
+          etag = "", // Placeholder; real etag computed from commit timestamp.
+        ) {
+          set("ErrorMessage").to(request.errorMessage)
+        }
+
+        currentJob.copy {
+          state = State.RANKER_STATE_FAILED
+          errorMessage = request.errorMessage
+          clearUpdateTime()
+          clearEtag()
+        }
+      }
+
+    val commitTimestamp: Timestamp = transactionRunner.getCommitTimestamp().toProto()
+    return updatedJob.copy {
+      updateTime = commitTimestamp
+      etag = ETags.computeETag(commitTimestamp.toInstant())
+    }
+  }
+
+  /**
+   * Validates parent identifiers, the job resource ID, the etag, and the request ID common to the
+   * Mark requests. [requestId] may be empty when the RPC does not support idempotency.
+   */
+  private fun validateMarkRequest(
+    dataProviderResourceId: String,
+    rawImpressionUploadResourceId: String,
+    rankerJobResourceId: String,
+    etag: String,
+    requestId: String,
+  ) {
+    if (dataProviderResourceId.isEmpty()) {
+      throw RequiredFieldNotSetException("data_provider_resource_id")
+        .asStatusRuntimeException(Status.Code.INVALID_ARGUMENT)
+    }
+    if (rawImpressionUploadResourceId.isEmpty()) {
+      throw RequiredFieldNotSetException("raw_impression_upload_resource_id")
+        .asStatusRuntimeException(Status.Code.INVALID_ARGUMENT)
+    }
+    if (rankerJobResourceId.isEmpty()) {
+      throw RequiredFieldNotSetException("ranker_job_resource_id")
+        .asStatusRuntimeException(Status.Code.INVALID_ARGUMENT)
+    }
+    if (etag.isEmpty()) {
+      throw RequiredFieldNotSetException("etag")
+        .asStatusRuntimeException(Status.Code.INVALID_ARGUMENT)
+    }
+    if (requestId.isNotEmpty()) {
+      try {
+        UUID.fromString(requestId)
+      } catch (e: IllegalArgumentException) {
+        throw InvalidFieldValueException("request_id", e)
+          .asStatusRuntimeException(Status.Code.INVALID_ARGUMENT)
+      }
+    }
+  }
+
+  /**
+   * Verifies that [currentJob] is in a state that can transition to a terminal state and that the
+   * request etag matches.
+   */
+  private fun checkMarkPrecondition(
+    dataProviderResourceId: String,
+    rawImpressionUploadResourceId: String,
+    requestEtag: String,
+    currentJob: RankerJob,
+  ) {
+    if (currentJob.state !in VALID_MARK_PREVIOUS_STATES) {
+      throw RankerJobStateInvalidException(
+          dataProviderResourceId,
+          rawImpressionUploadResourceId,
+          currentJob.rankerJobResourceId,
+          currentJob.state,
+          VALID_MARK_PREVIOUS_STATES,
+        )
+        .asStatusRuntimeException(Status.Code.FAILED_PRECONDITION)
+    }
+
+    try {
+      EtagMismatchException.check(requestEtag, currentJob.etag)
+    } catch (e: EtagMismatchException) {
+      throw e.asStatusRuntimeException(Status.Code.ABORTED)
+    }
+  }
+
+  private fun validateCreateRequest(request: CreateRankerJobRequest) {
+    if (request.requestId.isNotEmpty()) {
+      try {
+        UUID.fromString(request.requestId)
+      } catch (e: IllegalArgumentException) {
+        throw InvalidFieldValueException("request_id", e)
+      }
+    }
+
+    if (!request.hasRankerJob()) {
+      throw RequiredFieldNotSetException("ranker_job")
+    }
+    if (request.dataProviderResourceId.isEmpty()) {
+      throw RequiredFieldNotSetException("data_provider_resource_id")
+    }
+    if (request.rawImpressionUploadResourceId.isEmpty()) {
+      throw RequiredFieldNotSetException("raw_impression_upload_resource_id")
+    }
+    if (request.rankerJob.cmmsModelLine.isEmpty()) {
+      throw RequiredFieldNotSetException("ranker_job.cmms_model_line")
+    }
+    if (request.rankerJob.poolOffsetsList.isEmpty()) {
+      throw RequiredFieldNotSetException("ranker_job.pool_offsets")
+    }
+  }
+
+  companion object {
+    private const val RANKER_JOB_RESOURCE_ID_PREFIX = "rj"
+    private const val MAX_PAGE_SIZE = 100
+    private const val MAX_BATCH_SIZE = 50
+    private const val DEFAULT_PAGE_SIZE = 50
+
+    private val VALID_MARK_PREVIOUS_STATES =
+      setOf(State.RANKER_STATE_CREATED, State.RANKER_STATE_FAILED)
+
+    /**
+     * Returns whether marking [currentJobId] as SUCCEEDED makes it the last ranker job to complete
+     * for its (upload, model line). [jobsForModelLine] are the sibling jobs as read before the
+     * buffered transition is visible, so [currentJobId] is treated as already SUCCEEDED.
+     */
+    private fun computeIsLastJob(
+      jobsForModelLine: List<RankerJobResult>,
+      currentJobId: Long,
+    ): Boolean {
+      return jobsForModelLine.all {
+        it.rankerJob.state == State.RANKER_STATE_SUCCEEDED || it.rankerJobId == currentJobId
+      }
+    }
+  }
+}

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/spanner/SpannerRankerJobService.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/spanner/SpannerRankerJobService.kt
@@ -27,7 +27,9 @@ import kotlin.coroutines.EmptyCoroutineContext
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.collectIndexed
 import org.wfanet.measurement.common.IdGenerator
+import org.wfanet.measurement.common.api.ETags
 import org.wfanet.measurement.common.generateNewId
+import org.wfanet.measurement.common.toInstant
 import org.wfanet.measurement.edpaggregator.deploy.gcloud.spanner.db.RankerJobResult
 import org.wfanet.measurement.edpaggregator.deploy.gcloud.spanner.db.countOtherNonSucceededRankerJobs
 import org.wfanet.measurement.edpaggregator.deploy.gcloud.spanner.db.findRankerJobByRequestId
@@ -124,8 +126,6 @@ class SpannerRankerJobService(
             }
 
           val resourceId = "$RANKER_JOB_RESOURCE_ID_PREFIX-${UUID.randomUUID()}"
-          val newEtag = UUID.randomUUID().toString()
-
           txn.insertRankerJob(
             rawImpressionUploadId = rawImpressionUploadId,
             rankerJobId = rankerJobId,
@@ -134,7 +134,6 @@ class SpannerRankerJobService(
             cmmsModelLine = job.cmmsModelLine,
             poolOffsets = job.poolOffsetsList,
             createRequestId = request.requestId,
-            etag = newEtag,
           )
 
           job.copy {
@@ -142,7 +141,6 @@ class SpannerRankerJobService(
             this.rawImpressionUploadResourceId = rawImpressionUploadResourceId
             rankerJobResourceId = resourceId
             state = State.RANKER_STATE_CREATED
-            etag = newEtag
             clearCreateTime()
             clearUpdateTime()
           }
@@ -166,6 +164,7 @@ class SpannerRankerJobService(
       createdJob.copy {
         createTime = commitTimestamp
         updateTime = commitTimestamp
+        etag = ETags.computeETag(commitTimestamp.toInstant())
       }
     }
   }
@@ -265,8 +264,6 @@ class SpannerRankerJobService(
                 }
 
               val resourceId = "$RANKER_JOB_RESOURCE_ID_PREFIX-${UUID.randomUUID()}"
-              val newEtag = UUID.randomUUID().toString()
-
               txn.insertRankerJob(
                 rawImpressionUploadId = rawImpressionUploadId,
                 rankerJobId = rankerJobId,
@@ -275,7 +272,6 @@ class SpannerRankerJobService(
                 cmmsModelLine = subRequest.rankerJob.cmmsModelLine,
                 poolOffsets = subRequest.rankerJob.poolOffsetsList,
                 createRequestId = subRequest.requestId,
-                etag = newEtag,
               )
 
               subRequest.rankerJob.copy {
@@ -283,7 +279,6 @@ class SpannerRankerJobService(
                 this.rawImpressionUploadResourceId = rawImpressionUploadResourceId
                 rankerJobResourceId = resourceId
                 state = State.RANKER_STATE_CREATED
-                etag = newEtag
                 clearCreateTime()
                 clearUpdateTime()
               }
@@ -312,6 +307,7 @@ class SpannerRankerJobService(
             result.copy {
               createTime = commitTimestamp
               updateTime = commitTimestamp
+              etag = ETags.computeETag(commitTimestamp.toInstant())
             }
           }
         }
@@ -441,7 +437,7 @@ class SpannerRankerJobService(
         // the original "last job out" call and any later replay can report completion.
         if (
           currentJob.state == State.RANKER_STATE_SUCCEEDED &&
-            result.markRequestId == request.requestId
+            result.markSucceededRequestId == request.requestId
         ) {
           return@run TransactionResult(
             currentJob,
@@ -463,16 +459,13 @@ class SpannerRankerJobService(
           currentJob = currentJob,
         )
 
-        val newEtag = UUID.randomUUID().toString()
-
         txn.updateRankerJobState(
           dataProviderResourceId = request.dataProviderResourceId,
           rawImpressionUploadId = result.rawImpressionUploadId,
           rankerJobId = result.rankerJobId,
           state = State.RANKER_STATE_SUCCEEDED,
-          etag = newEtag,
         ) {
-          set("MarkRequestId").to(request.requestId)
+          set("MarkSucceededRequestId").to(request.requestId)
           // Clear any error message from a prior FAILED attempt; it is only set while FAILED.
           set("ErrorMessage").to(null as String?)
         }
@@ -492,7 +485,6 @@ class SpannerRankerJobService(
           updatedJob =
             currentJob.copy {
               state = State.RANKER_STATE_SUCCEEDED
-              etag = newEtag
               clearErrorMessage()
               clearUpdateTime()
             },
@@ -506,7 +498,10 @@ class SpannerRankerJobService(
           txnResult.updatedJob
         } else {
           val commitTimestamp: Timestamp = transactionRunner.getCommitTimestamp().toProto()
-          txnResult.updatedJob.copy { updateTime = commitTimestamp }
+          txnResult.updatedJob.copy {
+            updateTime = commitTimestamp
+            etag = ETags.computeETag(commitTimestamp.toInstant())
+          }
         }
       isLastJob = txnResult.isLastJob
     }
@@ -545,7 +540,8 @@ class SpannerRankerJobService(
 
         // Idempotency: if already failed by this same request_id, return as-is.
         if (
-          currentJob.state == State.RANKER_STATE_FAILED && result.markRequestId == request.requestId
+          currentJob.state == State.RANKER_STATE_FAILED &&
+            result.markFailedRequestId == request.requestId
         ) {
           return@run TransactionResult(currentJob, isReplay = true)
         }
@@ -557,24 +553,20 @@ class SpannerRankerJobService(
           currentJob = currentJob,
         )
 
-        val newEtag = UUID.randomUUID().toString()
-
         txn.updateRankerJobState(
           dataProviderResourceId = request.dataProviderResourceId,
           rawImpressionUploadId = result.rawImpressionUploadId,
           rankerJobId = result.rankerJobId,
           state = State.RANKER_STATE_FAILED,
-          etag = newEtag,
         ) {
           set("ErrorMessage").to(request.errorMessage)
-          set("MarkRequestId").to(request.requestId)
+          set("MarkFailedRequestId").to(request.requestId)
         }
 
         TransactionResult(
           currentJob.copy {
             state = State.RANKER_STATE_FAILED
             errorMessage = request.errorMessage
-            etag = newEtag
             clearUpdateTime()
           }
         )
@@ -584,7 +576,10 @@ class SpannerRankerJobService(
       txnResult.updatedJob
     } else {
       val commitTimestamp: Timestamp = transactionRunner.getCommitTimestamp().toProto()
-      txnResult.updatedJob.copy { updateTime = commitTimestamp }
+      txnResult.updatedJob.copy {
+        updateTime = commitTimestamp
+        etag = ETags.computeETag(commitTimestamp.toInstant())
+      }
     }
   }
 

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/spanner/SpannerRankerJobService.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/spanner/SpannerRankerJobService.kt
@@ -35,7 +35,7 @@ import org.wfanet.measurement.edpaggregator.deploy.gcloud.spanner.db.countOtherN
 import org.wfanet.measurement.edpaggregator.deploy.gcloud.spanner.db.findRankerJobByRequestId
 import org.wfanet.measurement.edpaggregator.deploy.gcloud.spanner.db.findRankerJobsByRequestIds
 import org.wfanet.measurement.edpaggregator.deploy.gcloud.spanner.db.getRankerJobByResourceId
-import org.wfanet.measurement.edpaggregator.deploy.gcloud.spanner.db.getRawImpressionUploadIdForRanker
+import org.wfanet.measurement.edpaggregator.deploy.gcloud.spanner.db.getRawImpressionUploadId
 import org.wfanet.measurement.edpaggregator.deploy.gcloud.spanner.db.insertRankerJob
 import org.wfanet.measurement.edpaggregator.deploy.gcloud.spanner.db.rankerJobExists
 import org.wfanet.measurement.edpaggregator.deploy.gcloud.spanner.db.readRankerJobs
@@ -110,10 +110,7 @@ class SpannerRankerJobService(
           }
 
           val rawImpressionUploadId =
-            txn.getRawImpressionUploadIdForRanker(
-              dataProviderResourceId,
-              rawImpressionUploadResourceId,
-            )
+            txn.getRawImpressionUploadId(dataProviderResourceId, rawImpressionUploadResourceId)
               ?: throw RawImpressionUploadNotFoundException(
                   dataProviderResourceId,
                   rawImpressionUploadResourceId,
@@ -236,10 +233,7 @@ class SpannerRankerJobService(
       try {
         transactionRunner.run { txn ->
           val rawImpressionUploadId =
-            txn.getRawImpressionUploadIdForRanker(
-              dataProviderResourceId,
-              rawImpressionUploadResourceId,
-            )
+            txn.getRawImpressionUploadId(dataProviderResourceId, rawImpressionUploadResourceId)
               ?: throw RawImpressionUploadNotFoundException(
                   dataProviderResourceId,
                   rawImpressionUploadResourceId,

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/spanner/SpannerRankerJobService.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/spanner/SpannerRankerJobService.kt
@@ -32,6 +32,7 @@ import org.wfanet.measurement.common.generateNewId
 import org.wfanet.measurement.common.toInstant
 import org.wfanet.measurement.edpaggregator.deploy.gcloud.spanner.db.RankerJobResult
 import org.wfanet.measurement.edpaggregator.deploy.gcloud.spanner.db.countOtherNonSucceededRankerJobs
+import org.wfanet.measurement.edpaggregator.deploy.gcloud.spanner.db.countRankerJobs
 import org.wfanet.measurement.edpaggregator.deploy.gcloud.spanner.db.findRankerJobByRequestId
 import org.wfanet.measurement.edpaggregator.deploy.gcloud.spanner.db.findRankerJobsByRequestIds
 import org.wfanet.measurement.edpaggregator.deploy.gcloud.spanner.db.getRankerJobByResourceId
@@ -111,11 +112,6 @@ class SpannerRankerJobService(
 
           val rawImpressionUploadId =
             txn.getRawImpressionUploadId(dataProviderResourceId, rawImpressionUploadResourceId)
-              ?: throw RawImpressionUploadNotFoundException(
-                  dataProviderResourceId,
-                  rawImpressionUploadResourceId,
-                )
-                .asStatusRuntimeException(Status.Code.NOT_FOUND)
 
           val rankerJobId =
             idGenerator.generateNewId { id ->
@@ -142,6 +138,8 @@ class SpannerRankerJobService(
             clearUpdateTime()
           }
         }
+      } catch (e: RawImpressionUploadNotFoundException) {
+        throw e.asStatusRuntimeException(Status.Code.NOT_FOUND)
       } catch (e: SpannerException) {
         if (e.errorCode == ErrorCode.ALREADY_EXISTS) {
           throw RankerJobAlreadyExistsException(
@@ -234,11 +232,6 @@ class SpannerRankerJobService(
         transactionRunner.run { txn ->
           val rawImpressionUploadId =
             txn.getRawImpressionUploadId(dataProviderResourceId, rawImpressionUploadResourceId)
-              ?: throw RawImpressionUploadNotFoundException(
-                  dataProviderResourceId,
-                  rawImpressionUploadResourceId,
-                )
-                .asStatusRuntimeException(Status.Code.NOT_FOUND)
 
           val existingByRequestId: Map<String, RankerJobResult> =
             txn.findRankerJobsByRequestIds(
@@ -279,6 +272,8 @@ class SpannerRankerJobService(
             }
           }
         }
+      } catch (e: RawImpressionUploadNotFoundException) {
+        throw e.asStatusRuntimeException(Status.Code.NOT_FOUND)
       } catch (e: SpannerException) {
         if (e.errorCode == ErrorCode.ALREADY_EXISTS) {
           throw RankerJobAlreadyExistsException(
@@ -356,6 +351,15 @@ class SpannerRankerJobService(
 
     val after = if (request.hasPageToken()) request.pageToken.after else null
 
+    val totalSize: Long =
+      databaseClient.singleUse().use { txn ->
+        txn.countRankerJobs(
+          request.dataProviderResourceId,
+          request.rawImpressionUploadResourceId.ifEmpty { null },
+          if (request.hasFilter()) request.filter else null,
+        )
+      }
+
     databaseClient.singleUse().use { txn ->
       val rows: Flow<RankerJobResult> =
         txn.readRankerJobs(
@@ -367,6 +371,7 @@ class SpannerRankerJobService(
         )
 
       return listRankerJobsResponse {
+        this.totalSize = totalSize.toInt()
         rows.collectIndexed { index, result ->
           if (index == pageSize) {
             val lastIncluded = rankerJobs.last()

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/spanner/SpannerRankerJobService.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/spanner/SpannerRankerJobService.kt
@@ -97,16 +97,14 @@ class SpannerRankerJobService(
     val createdJob: RankerJob =
       try {
         transactionRunner.run { txn ->
-          if (request.requestId.isNotEmpty()) {
-            val existing =
-              txn.findRankerJobByRequestId(
-                dataProviderResourceId,
-                rawImpressionUploadResourceId,
-                request.requestId,
-              )
-            if (existing != null) {
-              return@run existing.rankerJob
-            }
+          val existing =
+            txn.findRankerJobByRequestId(
+              dataProviderResourceId,
+              rawImpressionUploadResourceId,
+              request.requestId,
+            )
+          if (existing != null) {
+            return@run existing.rankerJob
           }
 
           val rawImpressionUploadId =
@@ -214,19 +212,21 @@ class SpannerRankerJobService(
       }
 
       val requestId = subRequest.requestId
-      if (requestId.isNotEmpty()) {
-        try {
-          UUID.fromString(requestId)
-        } catch (e: IllegalArgumentException) {
-          throw InvalidFieldValueException("requests[$index].request_id", e)
-            .asStatusRuntimeException(Status.Code.INVALID_ARGUMENT)
-        }
-        if (!requestIdSet.add(requestId)) {
-          throw InvalidFieldValueException("requests[$index].request_id") {
-              "Duplicate request_id $requestId in batch"
-            }
-            .asStatusRuntimeException(Status.Code.INVALID_ARGUMENT)
-        }
+      if (requestId.isEmpty()) {
+        throw RequiredFieldNotSetException("requests[$index].request_id")
+          .asStatusRuntimeException(Status.Code.INVALID_ARGUMENT)
+      }
+      try {
+        UUID.fromString(requestId)
+      } catch (e: IllegalArgumentException) {
+        throw InvalidFieldValueException("requests[$index].request_id", e)
+          .asStatusRuntimeException(Status.Code.INVALID_ARGUMENT)
+      }
+      if (!requestIdSet.add(requestId)) {
+        throw InvalidFieldValueException("requests[$index].request_id") {
+            "Duplicate request_id $requestId in batch"
+          }
+          .asStatusRuntimeException(Status.Code.INVALID_ARGUMENT)
       }
     }
 
@@ -251,12 +251,12 @@ class SpannerRankerJobService(
             txn.findRankerJobsByRequestIds(
               dataProviderResourceId,
               rawImpressionUploadResourceId,
-              request.requestsList.mapNotNull { it.requestId.ifEmpty { null } },
+              request.requestsList.map { it.requestId },
             )
 
           request.requestsList.map { subRequest ->
             val existing = existingByRequestId[subRequest.requestId]
-            if (subRequest.requestId.isNotEmpty() && existing != null) {
+            if (existing != null) {
               existing.rankerJob
             } else {
               val rankerJobId =
@@ -404,7 +404,6 @@ class SpannerRankerJobService(
       request.rankerJobResourceId,
       request.etag,
       request.requestId,
-      requireRequestId = true,
     )
 
     val transactionRunner =
@@ -442,7 +441,6 @@ class SpannerRankerJobService(
         // the original "last job out" call and any later replay can report completion.
         if (
           currentJob.state == State.RANKER_STATE_SUCCEEDED &&
-            request.requestId.isNotEmpty() &&
             result.markRequestId == request.requestId
         ) {
           return@run TransactionResult(
@@ -521,14 +519,15 @@ class SpannerRankerJobService(
       request.rawImpressionUploadResourceId,
       request.rankerJobResourceId,
       request.etag,
-      requestId = "",
-      requireRequestId = false,
+      request.requestId,
     )
 
     val transactionRunner =
       databaseClient.readWriteTransaction(Options.tag("action=markRankerJobFailed"))
 
-    val updatedJob: RankerJob =
+    data class TransactionResult(val updatedJob: RankerJob, val isReplay: Boolean = false)
+
+    val txnResult: TransactionResult =
       transactionRunner.run { txn ->
         val result =
           txn.getRankerJobByResourceId(
@@ -544,6 +543,13 @@ class SpannerRankerJobService(
               .asStatusRuntimeException(Status.Code.NOT_FOUND)
 
         val currentJob = result.rankerJob
+
+        // Idempotency: if already failed by this same request_id, return as-is.
+        if (
+          currentJob.state == State.RANKER_STATE_FAILED && result.markRequestId == request.requestId
+        ) {
+          return@run TransactionResult(currentJob, isReplay = true)
+        }
 
         checkMarkPrecondition(
           dataProviderResourceId = request.dataProviderResourceId,
@@ -562,24 +568,30 @@ class SpannerRankerJobService(
           etag = newEtag,
         ) {
           set("ErrorMessage").to(request.errorMessage)
+          set("MarkRequestId").to(request.requestId)
         }
 
-        currentJob.copy {
-          state = State.RANKER_STATE_FAILED
-          errorMessage = request.errorMessage
-          etag = newEtag
-          clearUpdateTime()
-        }
+        TransactionResult(
+          currentJob.copy {
+            state = State.RANKER_STATE_FAILED
+            errorMessage = request.errorMessage
+            etag = newEtag
+            clearUpdateTime()
+          }
+        )
       }
 
-    val commitTimestamp: Timestamp = transactionRunner.getCommitTimestamp().toProto()
-    return updatedJob.copy { updateTime = commitTimestamp }
+    return if (txnResult.isReplay) {
+      txnResult.updatedJob
+    } else {
+      val commitTimestamp: Timestamp = transactionRunner.getCommitTimestamp().toProto()
+      txnResult.updatedJob.copy { updateTime = commitTimestamp }
+    }
   }
 
   /**
    * Validates parent identifiers, the job resource ID, the etag, and the request ID common to the
-   * Mark requests. When [requireRequestId] is true, [requestId] must be set; it may be empty only
-   * for Mark RPCs that do not support idempotency.
+   * Mark requests. [requestId] is required on every Mark RPC for AIP-155 idempotency.
    */
   private fun validateMarkRequest(
     dataProviderResourceId: String,
@@ -587,7 +599,6 @@ class SpannerRankerJobService(
     rankerJobResourceId: String,
     etag: String,
     requestId: String,
-    requireRequestId: Boolean,
   ) {
     if (dataProviderResourceId.isEmpty()) {
       throw RequiredFieldNotSetException("data_provider_resource_id")
@@ -605,17 +616,15 @@ class SpannerRankerJobService(
       throw RequiredFieldNotSetException("etag")
         .asStatusRuntimeException(Status.Code.INVALID_ARGUMENT)
     }
-    if (requireRequestId && requestId.isEmpty()) {
+    if (requestId.isEmpty()) {
       throw RequiredFieldNotSetException("request_id")
         .asStatusRuntimeException(Status.Code.INVALID_ARGUMENT)
     }
-    if (requestId.isNotEmpty()) {
-      try {
-        UUID.fromString(requestId)
-      } catch (e: IllegalArgumentException) {
-        throw InvalidFieldValueException("request_id", e)
-          .asStatusRuntimeException(Status.Code.INVALID_ARGUMENT)
-      }
+    try {
+      UUID.fromString(requestId)
+    } catch (e: IllegalArgumentException) {
+      throw InvalidFieldValueException("request_id", e)
+        .asStatusRuntimeException(Status.Code.INVALID_ARGUMENT)
     }
   }
 
@@ -648,14 +657,6 @@ class SpannerRankerJobService(
   }
 
   private fun validateCreateRequest(request: CreateRankerJobRequest) {
-    if (request.requestId.isNotEmpty()) {
-      try {
-        UUID.fromString(request.requestId)
-      } catch (e: IllegalArgumentException) {
-        throw InvalidFieldValueException("request_id", e)
-      }
-    }
-
     if (!request.hasRankerJob()) {
       throw RequiredFieldNotSetException("ranker_job")
     }
@@ -670,6 +671,14 @@ class SpannerRankerJobService(
     }
     if (request.rankerJob.poolOffsetsList.isEmpty()) {
       throw RequiredFieldNotSetException("ranker_job.pool_offsets")
+    }
+    if (request.requestId.isEmpty()) {
+      throw RequiredFieldNotSetException("request_id")
+    }
+    try {
+      UUID.fromString(request.requestId)
+    } catch (e: IllegalArgumentException) {
+      throw InvalidFieldValueException("request_id", e)
     }
   }
 

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/spanner/db/BUILD.bazel
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/spanner/db/BUILD.bazel
@@ -11,6 +11,7 @@ kt_jvm_library(
     name = "db",
     srcs = [
         "ImpressionMetadata.kt",
+        "RankerJob.kt",
         "RawImpressionMetadataBatch.kt",
         "RawImpressionMetadataBatchFile.kt",
         "RawImpressionUpload.kt",
@@ -26,6 +27,9 @@ kt_jvm_library(
         "//src/main/kotlin/org/wfanet/measurement/edpaggregator/service/internal:errors",
         "//src/main/proto/wfa/measurement/internal/edpaggregator:impression_metadata_kt_jvm_proto",
         "//src/main/proto/wfa/measurement/internal/edpaggregator:impression_metadata_service_kt_jvm_proto",
+        "//src/main/proto/wfa/measurement/internal/edpaggregator:ranker_job_kt_jvm_proto",
+        "//src/main/proto/wfa/measurement/internal/edpaggregator:ranker_job_service_kt_jvm_grpc_proto",
+        "//src/main/proto/wfa/measurement/internal/edpaggregator:ranker_state_kt_jvm_proto",
         "//src/main/proto/wfa/measurement/internal/edpaggregator:raw_impression_batch_state_kt_jvm_proto",
         "//src/main/proto/wfa/measurement/internal/edpaggregator:raw_impression_metadata_batch_file_kt_jvm_proto",
         "//src/main/proto/wfa/measurement/internal/edpaggregator:raw_impression_metadata_batch_file_service_kt_jvm_proto",

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/spanner/db/RankerJob.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/spanner/db/RankerJob.kt
@@ -64,36 +64,6 @@ suspend fun AsyncDatabaseClient.ReadContext.rankerJobExists(
 }
 
 /**
- * Resolves a [RawImpressionUpload]'s internal ID from its resource ID.
- *
- * @return The internal `RawImpressionUploadId`, or `null` if not found
- */
-suspend fun AsyncDatabaseClient.ReadContext.getRawImpressionUploadIdForRanker(
-  dataProviderResourceId: String,
-  rawImpressionUploadResourceId: String,
-): Long? {
-  val sql =
-    """
-    SELECT RawImpressionUploadId
-    FROM RawImpressionUpload
-    WHERE DataProviderResourceId = @dataProviderResourceId
-      AND RawImpressionUploadResourceId = @rawImpressionUploadResourceId
-    """
-      .trimIndent()
-
-  val row: Struct =
-    executeQuery(
-        statement(sql) {
-          bind("dataProviderResourceId").to(dataProviderResourceId)
-          bind("rawImpressionUploadResourceId").to(rawImpressionUploadResourceId)
-        }
-      )
-      .singleOrNullIfEmpty() ?: return null
-
-  return row.getLong("RawImpressionUploadId")
-}
-
-/**
  * Reads a [RankerJob] by its resource ID.
  *
  * @return The [RankerJobResult], or `null` if not found

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/spanner/db/RankerJob.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/spanner/db/RankerJob.kt
@@ -1,0 +1,423 @@
+/*
+ * Copyright 2026 The Cross-Media Measurement Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wfanet.measurement.edpaggregator.deploy.gcloud.spanner.db
+
+import com.google.cloud.spanner.Key
+import com.google.cloud.spanner.Mutation
+import com.google.cloud.spanner.Options
+import com.google.cloud.spanner.Struct
+import com.google.cloud.spanner.Value
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+import org.wfanet.measurement.common.api.ETags
+import org.wfanet.measurement.common.singleOrNullIfEmpty
+import org.wfanet.measurement.common.toInstant
+import org.wfanet.measurement.gcloud.common.toGcloudTimestamp
+import org.wfanet.measurement.gcloud.spanner.AsyncDatabaseClient
+import org.wfanet.measurement.gcloud.spanner.bufferInsertMutation
+import org.wfanet.measurement.gcloud.spanner.bufferUpdateMutation
+import org.wfanet.measurement.gcloud.spanner.statement
+import org.wfanet.measurement.internal.edpaggregator.ListRankerJobsPageToken
+import org.wfanet.measurement.internal.edpaggregator.ListRankerJobsRequest
+import org.wfanet.measurement.internal.edpaggregator.RankerJob
+import org.wfanet.measurement.internal.edpaggregator.RankerState as State
+import org.wfanet.measurement.internal.edpaggregator.rankerJob
+
+/**
+ * Result of reading a [RankerJob] row, exposing internal identifiers and the [markRequestId] that
+ * are needed by the service layer but not part of the public resource.
+ */
+data class RankerJobResult(
+  val rankerJob: RankerJob,
+  val rawImpressionUploadId: Long,
+  val rankerJobId: Long,
+  val markRequestId: String,
+)
+
+/** Returns whether a [RankerJob] with the specified keys exists. */
+suspend fun AsyncDatabaseClient.ReadContext.rankerJobExists(
+  dataProviderResourceId: String,
+  rawImpressionUploadId: Long,
+  rankerJobId: Long,
+): Boolean {
+  return readRow(
+    "RankerJob",
+    Key.of(dataProviderResourceId, rawImpressionUploadId, rankerJobId),
+    listOf("RankerJobId"),
+  ) != null
+}
+
+/**
+ * Resolves a [RawImpressionUpload]'s internal ID from its resource ID.
+ *
+ * @return The internal `RawImpressionUploadId`, or `null` if not found
+ */
+suspend fun AsyncDatabaseClient.ReadContext.getRawImpressionUploadIdForRanker(
+  dataProviderResourceId: String,
+  rawImpressionUploadResourceId: String,
+): Long? {
+  val sql =
+    """
+    SELECT RawImpressionUploadId
+    FROM RawImpressionUpload
+    WHERE DataProviderResourceId = @dataProviderResourceId
+      AND RawImpressionUploadResourceId = @rawImpressionUploadResourceId
+    """
+      .trimIndent()
+
+  val row: Struct =
+    executeQuery(
+        statement(sql) {
+          bind("dataProviderResourceId").to(dataProviderResourceId)
+          bind("rawImpressionUploadResourceId").to(rawImpressionUploadResourceId)
+        }
+      )
+      .singleOrNullIfEmpty() ?: return null
+
+  return row.getLong("RawImpressionUploadId")
+}
+
+/**
+ * Reads a [RankerJob] by its resource ID.
+ *
+ * @return The [RankerJobResult], or `null` if not found
+ */
+suspend fun AsyncDatabaseClient.ReadContext.getRankerJobByResourceId(
+  dataProviderResourceId: String,
+  rawImpressionUploadResourceId: String,
+  rankerJobResourceId: String,
+): RankerJobResult? {
+  val sql = buildString {
+    appendLine(RankerJobEntity.BASE_SQL)
+    appendLine(
+      """
+      JOIN RawImpressionUpload USING (DataProviderResourceId, RawImpressionUploadId)
+      WHERE RankerJob.DataProviderResourceId = @dataProviderResourceId
+        AND RawImpressionUpload.RawImpressionUploadResourceId = @rawImpressionUploadResourceId
+        AND RankerJob.RankerJobResourceId = @rankerJobResourceId
+      """
+        .trimIndent()
+    )
+  }
+
+  val row: Struct =
+    executeQuery(
+        statement(sql) {
+          bind("dataProviderResourceId").to(dataProviderResourceId)
+          bind("rawImpressionUploadResourceId").to(rawImpressionUploadResourceId)
+          bind("rankerJobResourceId").to(rankerJobResourceId)
+        }
+      )
+      .singleOrNullIfEmpty() ?: return null
+
+  return RankerJobEntity.buildResult(row)
+}
+
+/** Finds an existing [RankerJob] by request ID for idempotency. */
+suspend fun AsyncDatabaseClient.ReadContext.findRankerJobByRequestId(
+  dataProviderResourceId: String,
+  rawImpressionUploadResourceId: String,
+  requestId: String,
+): RankerJobResult? {
+  if (requestId.isEmpty()) return null
+
+  val sql = buildString {
+    appendLine(RankerJobEntity.BASE_SQL)
+    appendLine(
+      """
+      JOIN RawImpressionUpload USING (DataProviderResourceId, RawImpressionUploadId)
+      WHERE RankerJob.DataProviderResourceId = @dataProviderResourceId
+        AND RawImpressionUpload.RawImpressionUploadResourceId = @rawImpressionUploadResourceId
+        AND RankerJob.CreateRequestId = @createRequestId
+      """
+        .trimIndent()
+    )
+  }
+
+  val row: Struct =
+    executeQuery(
+        statement(sql) {
+          bind("dataProviderResourceId").to(dataProviderResourceId)
+          bind("rawImpressionUploadResourceId").to(rawImpressionUploadResourceId)
+          bind("createRequestId").to(requestId)
+        }
+      )
+      .singleOrNullIfEmpty() ?: return null
+
+  return RankerJobEntity.buildResult(row)
+}
+
+/** Finds existing [RankerJob] entries by request IDs for batch idempotency. */
+suspend fun AsyncDatabaseClient.ReadContext.findRankerJobsByRequestIds(
+  dataProviderResourceId: String,
+  rawImpressionUploadResourceId: String,
+  requestIds: List<String>,
+): Map<String, RankerJobResult> {
+  if (requestIds.isEmpty()) return emptyMap()
+
+  val sql = buildString {
+    appendLine(RankerJobEntity.BASE_SQL)
+    appendLine(
+      """
+      JOIN RawImpressionUpload USING (DataProviderResourceId, RawImpressionUploadId)
+      WHERE RankerJob.DataProviderResourceId = @dataProviderResourceId
+        AND RawImpressionUpload.RawImpressionUploadResourceId = @rawImpressionUploadResourceId
+        AND RankerJob.CreateRequestId IN UNNEST(@createRequestIds)
+      """
+        .trimIndent()
+    )
+  }
+
+  return buildMap {
+    executeQuery(
+        statement(sql) {
+          bind("dataProviderResourceId").to(dataProviderResourceId)
+          bind("rawImpressionUploadResourceId").to(rawImpressionUploadResourceId)
+          bind("createRequestIds").toStringArray(requestIds)
+        },
+        Options.tag("action=findRankerJobsByRequestIds"),
+      )
+      .collect { row ->
+        val result = RankerJobEntity.buildResult(row)
+        if (!row.isNull("CreateRequestId")) {
+          put(row.getString("CreateRequestId"), result)
+        }
+      }
+  }
+}
+
+/** Reads [RankerJob] entries for the same (upload, model line) group. */
+suspend fun AsyncDatabaseClient.ReadContext.readRankerJobsForModelLine(
+  dataProviderResourceId: String,
+  rawImpressionUploadId: Long,
+  cmmsModelLine: String,
+): List<RankerJobResult> {
+  val sql =
+    """
+    SELECT
+      RankerJob.RankerJobId,
+      RankerJob.State,
+    FROM RankerJob
+    WHERE RankerJob.DataProviderResourceId = @dataProviderResourceId
+      AND RankerJob.RawImpressionUploadId = @rawImpressionUploadId
+      AND RankerJob.CmmsModelLine = @cmmsModelLine
+    """
+      .trimIndent()
+
+  return buildList {
+    executeQuery(
+        statement(sql) {
+          bind("dataProviderResourceId").to(dataProviderResourceId)
+          bind("rawImpressionUploadId").to(rawImpressionUploadId)
+          bind("cmmsModelLine").to(cmmsModelLine)
+        },
+        Options.tag("action=readRankerJobsForModelLine"),
+      )
+      .collect { row ->
+        add(
+          RankerJobResult(
+            rankerJob { state = row.getProtoEnum("State", State::forNumber) },
+            rawImpressionUploadId,
+            row.getLong("RankerJobId"),
+            "",
+          )
+        )
+      }
+  }
+}
+
+/** Reads [RankerJob] entries with filtering and pagination. */
+fun AsyncDatabaseClient.ReadContext.readRankerJobs(
+  dataProviderResourceId: String,
+  rawImpressionUploadResourceId: String?,
+  filter: ListRankerJobsRequest.Filter?,
+  limit: Int,
+  after: ListRankerJobsPageToken.After? = null,
+): Flow<RankerJobResult> {
+  val sql = buildString {
+    appendLine(RankerJobEntity.BASE_SQL)
+    appendLine("JOIN RawImpressionUpload USING (DataProviderResourceId, RawImpressionUploadId)")
+
+    val conjuncts = mutableListOf("RankerJob.DataProviderResourceId = @dataProviderResourceId")
+
+    if (rawImpressionUploadResourceId != null) {
+      conjuncts.add(
+        "RawImpressionUpload.RawImpressionUploadResourceId = @rawImpressionUploadResourceId"
+      )
+    }
+
+    if (filter != null) {
+      if (filter.stateInList.isNotEmpty()) {
+        conjuncts.add("CAST(RankerJob.State AS INT64) IN UNNEST(@state_in)")
+      }
+      if (filter.hasCreateTimeIn()) {
+        if (filter.createTimeIn.hasStartTime()) {
+          conjuncts.add("RankerJob.CreateTime >= @createTimeStart")
+        }
+        if (filter.createTimeIn.hasEndTime()) {
+          conjuncts.add("RankerJob.CreateTime < @createTimeEnd")
+        }
+      }
+      if (filter.cmmsModelLine.isNotEmpty()) {
+        conjuncts.add("RankerJob.CmmsModelLine = @cmmsModelLine")
+      }
+    }
+
+    if (after != null) {
+      conjuncts.add(
+        "(RankerJob.CreateTime > @afterCreateTime OR " +
+          "(RankerJob.CreateTime = @afterCreateTime AND " +
+          "RankerJob.RankerJobResourceId > @afterRankerJobResourceId))"
+      )
+    }
+
+    appendLine("WHERE " + conjuncts.joinToString(" AND "))
+    appendLine("ORDER BY RankerJob.CreateTime ASC, RankerJob.RankerJobResourceId ASC")
+    appendLine("LIMIT @limit")
+  }
+
+  val query =
+    statement(sql) {
+      bind("dataProviderResourceId").to(dataProviderResourceId)
+      if (rawImpressionUploadResourceId != null) {
+        bind("rawImpressionUploadResourceId").to(rawImpressionUploadResourceId)
+      }
+      bind("limit").to(limit.toLong())
+
+      if (filter != null) {
+        if (filter.stateInList.isNotEmpty()) {
+          bind("state_in").toInt64Array(filter.stateInList.map { it.number.toLong() })
+        }
+        if (filter.hasCreateTimeIn()) {
+          if (filter.createTimeIn.hasStartTime()) {
+            bind("createTimeStart").to(filter.createTimeIn.startTime.toGcloudTimestamp())
+          }
+          if (filter.createTimeIn.hasEndTime()) {
+            bind("createTimeEnd").to(filter.createTimeIn.endTime.toGcloudTimestamp())
+          }
+        }
+        if (filter.cmmsModelLine.isNotEmpty()) {
+          bind("cmmsModelLine").to(filter.cmmsModelLine)
+        }
+      }
+
+      if (after != null) {
+        bind("afterCreateTime").to(after.createTime.toGcloudTimestamp())
+        bind("afterRankerJobResourceId").to(after.rankerJobResourceId)
+      }
+    }
+
+  return executeQuery(query, Options.tag("action=readRankerJobs")).map { row ->
+    RankerJobEntity.buildResult(row)
+  }
+}
+
+/** Buffers an insert mutation for a [RankerJob] row. */
+fun AsyncDatabaseClient.TransactionContext.insertRankerJob(
+  rawImpressionUploadId: Long,
+  rankerJobId: Long,
+  rankerJobResourceId: String,
+  dataProviderResourceId: String,
+  cmmsModelLine: String,
+  poolOffsets: List<Long>,
+  createRequestId: String,
+  etag: String,
+) {
+  bufferInsertMutation("RankerJob") {
+    set("DataProviderResourceId").to(dataProviderResourceId)
+    set("RawImpressionUploadId").to(rawImpressionUploadId)
+    set("RankerJobId").to(rankerJobId)
+    set("RankerJobResourceId").to(rankerJobResourceId)
+    set("CmmsModelLine").to(cmmsModelLine)
+    set("PoolOffsets").toInt64Array(poolOffsets)
+    if (createRequestId.isNotEmpty()) {
+      set("CreateRequestId").to(createRequestId)
+    }
+    set("State").to(State.RANKER_STATE_CREATED)
+    set("Etag").to(etag)
+    set("CreateTime").to(Value.COMMIT_TIMESTAMP)
+    set("UpdateTime").to(Value.COMMIT_TIMESTAMP)
+  }
+}
+
+/** Buffers an update to a [RankerJob] row's state and related fields. */
+fun AsyncDatabaseClient.TransactionContext.updateRankerJobState(
+  dataProviderResourceId: String,
+  rawImpressionUploadId: Long,
+  rankerJobId: Long,
+  state: State,
+  etag: String,
+  block: (Mutation.WriteBuilder.() -> Unit)? = null,
+) {
+  bufferUpdateMutation("RankerJob") {
+    set("DataProviderResourceId").to(dataProviderResourceId)
+    set("RawImpressionUploadId").to(rawImpressionUploadId)
+    set("RankerJobId").to(rankerJobId)
+    set("State").to(state)
+    set("Etag").to(etag)
+    set("UpdateTime").to(Value.COMMIT_TIMESTAMP)
+    if (block != null) {
+      block()
+    }
+  }
+}
+
+private object RankerJobEntity {
+  val BASE_SQL =
+    """
+    SELECT
+      RankerJob.DataProviderResourceId,
+      RawImpressionUpload.RawImpressionUploadResourceId,
+      RankerJob.RawImpressionUploadId,
+      RankerJob.RankerJobId,
+      RankerJob.RankerJobResourceId,
+      RankerJob.CmmsModelLine,
+      RankerJob.PoolOffsets,
+      RankerJob.CreateRequestId,
+      RankerJob.MarkRequestId,
+      RankerJob.State,
+      RankerJob.ErrorMessage,
+      RankerJob.Etag,
+      RankerJob.CreateTime,
+      RankerJob.UpdateTime,
+    FROM
+      RankerJob
+    """
+      .trimIndent()
+
+  fun buildResult(struct: Struct): RankerJobResult {
+    return RankerJobResult(
+      rankerJob {
+        dataProviderResourceId = struct.getString("DataProviderResourceId")
+        rawImpressionUploadResourceId = struct.getString("RawImpressionUploadResourceId")
+        rankerJobResourceId = struct.getString("RankerJobResourceId")
+        cmmsModelLine = struct.getString("CmmsModelLine")
+        poolOffsets += struct.getLongList("PoolOffsets")
+        state = struct.getProtoEnum("State", State::forNumber)
+        createTime = struct.getTimestamp("CreateTime").toProto()
+        updateTime = struct.getTimestamp("UpdateTime").toProto()
+        if (!struct.isNull("ErrorMessage")) {
+          errorMessage = struct.getString("ErrorMessage")
+        }
+        etag = ETags.computeETag(struct.getTimestamp("UpdateTime").toProto().toInstant())
+      },
+      struct.getLong("RawImpressionUploadId"),
+      struct.getLong("RankerJobId"),
+      if (struct.isNull("MarkRequestId")) "" else struct.getString("MarkRequestId"),
+    )
+  }
+}

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/spanner/db/RankerJob.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/spanner/db/RankerJob.kt
@@ -300,6 +300,76 @@ fun AsyncDatabaseClient.ReadContext.readRankerJobs(
   }
 }
 
+/**
+ * Counts the [RankerJob] rows matching the same predicate as [readRankerJobs], ignoring pagination.
+ *
+ * Used to populate `total_size` on the list response (AIP-132).
+ */
+suspend fun AsyncDatabaseClient.ReadContext.countRankerJobs(
+  dataProviderResourceId: String,
+  rawImpressionUploadResourceId: String?,
+  filter: ListRankerJobsRequest.Filter?,
+): Long {
+  val sql = buildString {
+    appendLine("SELECT COUNT(*) AS Cnt")
+    appendLine("FROM RankerJob")
+    appendLine("JOIN RawImpressionUpload USING (DataProviderResourceId, RawImpressionUploadId)")
+
+    val conjuncts = mutableListOf("RankerJob.DataProviderResourceId = @dataProviderResourceId")
+
+    if (rawImpressionUploadResourceId != null) {
+      conjuncts.add(
+        "RawImpressionUpload.RawImpressionUploadResourceId = @rawImpressionUploadResourceId"
+      )
+    }
+
+    if (filter != null) {
+      if (filter.stateInList.isNotEmpty()) {
+        conjuncts.add("CAST(RankerJob.State AS INT64) IN UNNEST(@state_in)")
+      }
+      if (filter.hasCreateTimeIn()) {
+        if (filter.createTimeIn.hasStartTime()) {
+          conjuncts.add("RankerJob.CreateTime >= @createTimeStart")
+        }
+        if (filter.createTimeIn.hasEndTime()) {
+          conjuncts.add("RankerJob.CreateTime < @createTimeEnd")
+        }
+      }
+      if (filter.cmmsModelLine.isNotEmpty()) {
+        conjuncts.add("RankerJob.CmmsModelLine = @cmmsModelLine")
+      }
+    }
+
+    appendLine("WHERE " + conjuncts.joinToString(" AND "))
+  }
+
+  val query =
+    statement(sql) {
+      bind("dataProviderResourceId").to(dataProviderResourceId)
+      if (rawImpressionUploadResourceId != null) {
+        bind("rawImpressionUploadResourceId").to(rawImpressionUploadResourceId)
+      }
+      if (filter != null) {
+        if (filter.stateInList.isNotEmpty()) {
+          bind("state_in").toInt64Array(filter.stateInList.map { it.number.toLong() })
+        }
+        if (filter.hasCreateTimeIn()) {
+          if (filter.createTimeIn.hasStartTime()) {
+            bind("createTimeStart").to(filter.createTimeIn.startTime.toGcloudTimestamp())
+          }
+          if (filter.createTimeIn.hasEndTime()) {
+            bind("createTimeEnd").to(filter.createTimeIn.endTime.toGcloudTimestamp())
+          }
+        }
+        if (filter.cmmsModelLine.isNotEmpty()) {
+          bind("cmmsModelLine").to(filter.cmmsModelLine)
+        }
+      }
+    }
+
+  return executeQuery(query, Options.tag("action=countRankerJobs")).single().getLong("Cnt")
+}
+
 /** Buffers an insert mutation for a [RankerJob] row. */
 fun AsyncDatabaseClient.TransactionContext.insertRankerJob(
   rawImpressionUploadId: Long,

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/spanner/db/RankerJob.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/spanner/db/RankerJob.kt
@@ -23,9 +23,7 @@ import com.google.cloud.spanner.Struct
 import com.google.cloud.spanner.Value
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
-import org.wfanet.measurement.common.api.ETags
 import org.wfanet.measurement.common.singleOrNullIfEmpty
-import org.wfanet.measurement.common.toInstant
 import org.wfanet.measurement.gcloud.common.toGcloudTimestamp
 import org.wfanet.measurement.gcloud.spanner.AsyncDatabaseClient
 import org.wfanet.measurement.gcloud.spanner.bufferInsertMutation
@@ -413,7 +411,9 @@ private object RankerJobEntity {
         if (!struct.isNull("ErrorMessage")) {
           errorMessage = struct.getString("ErrorMessage")
         }
-        etag = ETags.computeETag(struct.getTimestamp("UpdateTime").toProto().toInstant())
+        if (!struct.isNull("Etag")) {
+          etag = struct.getString("Etag")
+        }
       },
       struct.getLong("RawImpressionUploadId"),
       struct.getLong("RankerJobId"),

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/spanner/db/RankerJob.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/spanner/db/RankerJob.kt
@@ -24,7 +24,9 @@ import com.google.cloud.spanner.Value
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.single
+import org.wfanet.measurement.common.api.ETags
 import org.wfanet.measurement.common.singleOrNullIfEmpty
+import org.wfanet.measurement.common.toInstant
 import org.wfanet.measurement.gcloud.common.toGcloudTimestamp
 import org.wfanet.measurement.gcloud.spanner.AsyncDatabaseClient
 import org.wfanet.measurement.gcloud.spanner.bufferInsertMutation
@@ -44,7 +46,8 @@ data class RankerJobResult(
   val rankerJob: RankerJob,
   val rawImpressionUploadId: Long,
   val rankerJobId: Long,
-  val markRequestId: String,
+  val markSucceededRequestId: String,
+  val markFailedRequestId: String,
 )
 
 /** Returns whether a [RankerJob] with the specified keys exists. */
@@ -336,7 +339,6 @@ fun AsyncDatabaseClient.TransactionContext.insertRankerJob(
   cmmsModelLine: String,
   poolOffsets: List<Long>,
   createRequestId: String,
-  etag: String,
 ) {
   bufferInsertMutation("RankerJob") {
     set("DataProviderResourceId").to(dataProviderResourceId)
@@ -349,7 +351,6 @@ fun AsyncDatabaseClient.TransactionContext.insertRankerJob(
       set("CreateRequestId").to(createRequestId)
     }
     set("State").to(State.RANKER_STATE_CREATED)
-    set("Etag").to(etag)
     set("CreateTime").to(Value.COMMIT_TIMESTAMP)
     set("UpdateTime").to(Value.COMMIT_TIMESTAMP)
   }
@@ -361,7 +362,6 @@ fun AsyncDatabaseClient.TransactionContext.updateRankerJobState(
   rawImpressionUploadId: Long,
   rankerJobId: Long,
   state: State,
-  etag: String,
   block: (Mutation.WriteBuilder.() -> Unit)? = null,
 ) {
   bufferUpdateMutation("RankerJob") {
@@ -369,7 +369,6 @@ fun AsyncDatabaseClient.TransactionContext.updateRankerJobState(
     set("RawImpressionUploadId").to(rawImpressionUploadId)
     set("RankerJobId").to(rankerJobId)
     set("State").to(state)
-    set("Etag").to(etag)
     set("UpdateTime").to(Value.COMMIT_TIMESTAMP)
     if (block != null) {
       block()
@@ -389,10 +388,10 @@ private object RankerJobEntity {
       RankerJob.CmmsModelLine,
       RankerJob.PoolOffsets,
       RankerJob.CreateRequestId,
-      RankerJob.MarkRequestId,
+      RankerJob.MarkSucceededRequestId,
+      RankerJob.MarkFailedRequestId,
       RankerJob.State,
       RankerJob.ErrorMessage,
-      RankerJob.Etag,
       RankerJob.CreateTime,
       RankerJob.UpdateTime,
     FROM
@@ -414,13 +413,13 @@ private object RankerJobEntity {
         if (!struct.isNull("ErrorMessage")) {
           errorMessage = struct.getString("ErrorMessage")
         }
-        if (!struct.isNull("Etag")) {
-          etag = struct.getString("Etag")
-        }
+        etag = ETags.computeETag(updateTime.toInstant())
       },
       struct.getLong("RawImpressionUploadId"),
       struct.getLong("RankerJobId"),
-      if (struct.isNull("MarkRequestId")) "" else struct.getString("MarkRequestId"),
+      if (struct.isNull("MarkSucceededRequestId")) ""
+      else struct.getString("MarkSucceededRequestId"),
+      if (struct.isNull("MarkFailedRequestId")) "" else struct.getString("MarkFailedRequestId"),
     )
   }
 }

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/spanner/db/RankerJob.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/spanner/db/RankerJob.kt
@@ -23,6 +23,7 @@ import com.google.cloud.spanner.Struct
 import com.google.cloud.spanner.Value
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.single
 import org.wfanet.measurement.common.singleOrNullIfEmpty
 import org.wfanet.measurement.gcloud.common.toGcloudTimestamp
 import org.wfanet.measurement.gcloud.spanner.AsyncDatabaseClient
@@ -198,44 +199,46 @@ suspend fun AsyncDatabaseClient.ReadContext.findRankerJobsByRequestIds(
   }
 }
 
-/** Reads [RankerJob] entries for the same (upload, model line) group. */
-suspend fun AsyncDatabaseClient.ReadContext.readRankerJobsForModelLine(
+/**
+ * Counts the [RankerJob] entries in the same (upload, model line) group that are not yet SUCCEEDED,
+ * excluding [excludeRankerJobId].
+ *
+ * This detects the "last job out" of a (upload, model line) in O(1) without materializing every
+ * sibling row. The current job's buffered state update is not visible within the same transaction,
+ * so it is excluded by ID rather than relying on its persisted state.
+ */
+suspend fun AsyncDatabaseClient.ReadContext.countOtherNonSucceededRankerJobs(
   dataProviderResourceId: String,
   rawImpressionUploadId: Long,
   cmmsModelLine: String,
-): List<RankerJobResult> {
+  excludeRankerJobId: Long,
+): Long {
   val sql =
     """
-    SELECT
-      RankerJob.RankerJobId,
-      RankerJob.State,
+    SELECT COUNT(*) AS Cnt
     FROM RankerJob
     WHERE RankerJob.DataProviderResourceId = @dataProviderResourceId
       AND RankerJob.RawImpressionUploadId = @rawImpressionUploadId
       AND RankerJob.CmmsModelLine = @cmmsModelLine
+      AND RankerJob.RankerJobId != @excludeRankerJobId
+      AND CAST(RankerJob.State AS INT64) != @succeededState
     """
       .trimIndent()
 
-  return buildList {
+  val row: Struct =
     executeQuery(
         statement(sql) {
           bind("dataProviderResourceId").to(dataProviderResourceId)
           bind("rawImpressionUploadId").to(rawImpressionUploadId)
           bind("cmmsModelLine").to(cmmsModelLine)
+          bind("excludeRankerJobId").to(excludeRankerJobId)
+          bind("succeededState").to(State.RANKER_STATE_SUCCEEDED.number.toLong())
         },
-        Options.tag("action=readRankerJobsForModelLine"),
+        Options.tag("action=countOtherNonSucceededRankerJobs"),
       )
-      .collect { row ->
-        add(
-          RankerJobResult(
-            rankerJob { state = row.getProtoEnum("State", State::forNumber) },
-            rawImpressionUploadId,
-            row.getLong("RankerJobId"),
-            "",
-          )
-        )
-      }
-  }
+      .single()
+
+  return row.getLong("Cnt")
 }
 
 /** Reads [RankerJob] entries with filtering and pagination. */

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/service/BUILD.bazel
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/service/BUILD.bazel
@@ -14,6 +14,7 @@ kt_jvm_library(
     srcs = [
         "IdVariable.kt",
         "ImpressionMetadataKey.kt",
+        "RankerJobKey.kt",
         "RawImpressionMetadataKey.kt",
         "RawImpressionUploadKey.kt",
         "RequisitionMetadataKey.kt",

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/service/IdVariable.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/service/IdVariable.kt
@@ -30,6 +30,7 @@ internal enum class IdVariable {
   RAW_IMPRESSION_UPLOAD,
   FILE,
   VID_LABELING_JOB,
+  RANKER_JOB,
   WORK_ITEM,
 }
 

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/service/RankerJobKey.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/service/RankerJobKey.kt
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2026 The Cross-Media Measurement Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wfanet.measurement.edpaggregator.service
+
+import org.wfanet.measurement.common.ResourceNameParser
+import org.wfanet.measurement.common.api.ChildResourceKey
+import org.wfanet.measurement.common.api.ResourceKey
+
+/** [ResourceKey] of a RankerJob. */
+data class RankerJobKey(override val parentKey: RawImpressionUploadKey, val rankerJobId: String) :
+  ChildResourceKey {
+  constructor(
+    dataProviderId: String,
+    rawImpressionUploadId: String,
+    rankerJobId: String,
+  ) : this(RawImpressionUploadKey(dataProviderId, rawImpressionUploadId), rankerJobId)
+
+  val dataProviderId: String
+    get() = parentKey.dataProviderId
+
+  val rawImpressionUploadId: String
+    get() = parentKey.rawImpressionUploadId
+
+  override fun toName(): String {
+    return parser.assembleName(
+      mapOf(
+        IdVariable.DATA_PROVIDER to dataProviderId,
+        IdVariable.RAW_IMPRESSION_UPLOAD to rawImpressionUploadId,
+        IdVariable.RANKER_JOB to rankerJobId,
+      )
+    )
+  }
+
+  companion object FACTORY : ResourceKey.Factory<RankerJobKey> {
+    const val PATTERN = "${RawImpressionUploadKey.PATTERN}/rankerJobs/{ranker_job}"
+    private val parser = ResourceNameParser(PATTERN)
+
+    override fun fromName(resourceName: String): RankerJobKey? {
+      val idVars: Map<IdVariable, String> = parser.parseIdVars(resourceName) ?: return null
+      return RankerJobKey(
+        idVars.getValue(IdVariable.DATA_PROVIDER),
+        idVars.getValue(IdVariable.RAW_IMPRESSION_UPLOAD),
+        idVars.getValue(IdVariable.RANKER_JOB),
+      )
+    }
+  }
+}

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/service/internal/BUILD.bazel
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/service/internal/BUILD.bazel
@@ -16,6 +16,7 @@ kt_jvm_library(
         "//src/main/kotlin/org/wfanet/measurement/common/grpc:error_info",
         "//src/main/proto/google/rpc:error_details_kt_jvm_proto",
         "//src/main/proto/wfa/measurement/internal/edpaggregator:impression_metadata_kt_jvm_proto",
+        "//src/main/proto/wfa/measurement/internal/edpaggregator:ranker_state_kt_jvm_proto",
         "//src/main/proto/wfa/measurement/internal/edpaggregator:raw_impression_batch_state_kt_jvm_proto",
         "//src/main/proto/wfa/measurement/internal/edpaggregator:requisition_metadata_kt_jvm_proto",
         "//src/main/proto/wfa/measurement/internal/edpaggregator:vid_labeling_state_kt_jvm_proto",
@@ -28,6 +29,7 @@ kt_jvm_library(
     srcs = ["Services.kt"],
     deps = [
         "//src/main/proto/wfa/measurement/internal/edpaggregator:impression_metadata_service_kt_jvm_grpc_proto",
+        "//src/main/proto/wfa/measurement/internal/edpaggregator:ranker_job_service_kt_jvm_grpc_proto",
         "//src/main/proto/wfa/measurement/internal/edpaggregator:raw_impression_metadata_batch_file_service_kt_jvm_grpc_proto",
         "//src/main/proto/wfa/measurement/internal/edpaggregator:raw_impression_metadata_batch_service_kt_jvm_grpc_proto",
         "//src/main/proto/wfa/measurement/internal/edpaggregator:raw_impression_upload_file_service_kt_jvm_grpc_proto",

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/service/internal/Errors.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/service/internal/Errors.kt
@@ -23,9 +23,9 @@ import io.grpc.StatusRuntimeException
 import org.wfanet.measurement.common.grpc.Errors as CommonErrors
 import org.wfanet.measurement.common.grpc.errorInfo
 import org.wfanet.measurement.internal.edpaggregator.ImpressionMetadataState
+import org.wfanet.measurement.internal.edpaggregator.RankerState
 import org.wfanet.measurement.internal.edpaggregator.RawImpressionBatchState
 import org.wfanet.measurement.internal.edpaggregator.RequisitionMetadataState
-import org.wfanet.measurement.internal.edpaggregator.RankerState
 import org.wfanet.measurement.internal.edpaggregator.VidLabelingState
 
 object Errors {

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/service/internal/Errors.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/service/internal/Errors.kt
@@ -25,6 +25,7 @@ import org.wfanet.measurement.common.grpc.errorInfo
 import org.wfanet.measurement.internal.edpaggregator.ImpressionMetadataState
 import org.wfanet.measurement.internal.edpaggregator.RawImpressionBatchState
 import org.wfanet.measurement.internal.edpaggregator.RequisitionMetadataState
+import org.wfanet.measurement.internal.edpaggregator.RankerState
 import org.wfanet.measurement.internal.edpaggregator.VidLabelingState
 
 object Errors {
@@ -46,6 +47,9 @@ object Errors {
     VID_LABELING_JOB_NOT_FOUND,
     VID_LABELING_JOB_STATE_INVALID,
     VID_LABELING_JOB_ALREADY_EXISTS,
+    RANKER_JOB_NOT_FOUND,
+    RANKER_JOB_ALREADY_EXISTS,
+    RANKER_JOB_STATE_INVALID,
     REQUISITION_METADATA_NOT_FOUND,
     REQUISITION_METADATA_NOT_FOUND_BY_CMMS_REQUISITION,
     REQUISITION_METADATA_ALREADY_EXISTS,
@@ -76,6 +80,9 @@ object Errors {
     VID_LABELING_JOB_RESOURCE_ID("vidLabelingJobResourceId"),
     VID_LABELING_JOB_STATE("vidLabelingJobState"),
     EXPECTED_VID_LABELING_JOB_STATES("expectedVidLabelingJobStates"),
+    RANKER_JOB_RESOURCE_ID("rankerJobResourceId"),
+    RANKER_JOB_STATE("rankerJobState"),
+    EXPECTED_RANKER_JOB_STATES("expectedRankerJobStates"),
     FIELD_NAME("fieldName");
 
     companion object {
@@ -486,6 +493,60 @@ class VidLabelingJobAlreadyExistsException(
     mapOf(
       Errors.Metadata.DATA_PROVIDER_RESOURCE_ID to dataProviderResourceId,
       Errors.Metadata.RAW_IMPRESSION_UPLOAD_RESOURCE_ID to rawImpressionUploadResourceId,
+    ),
+    cause,
+  )
+
+class RankerJobNotFoundException(
+  dataProviderResourceId: String,
+  rawImpressionUploadResourceId: String,
+  rankerJobResourceId: String,
+  cause: Throwable? = null,
+) :
+  ServiceException(
+    Errors.Reason.RANKER_JOB_NOT_FOUND,
+    "RankerJob not found",
+    mapOf(
+      Errors.Metadata.DATA_PROVIDER_RESOURCE_ID to dataProviderResourceId,
+      Errors.Metadata.RAW_IMPRESSION_UPLOAD_RESOURCE_ID to rawImpressionUploadResourceId,
+      Errors.Metadata.RANKER_JOB_RESOURCE_ID to rankerJobResourceId,
+    ),
+    cause,
+  )
+
+class RankerJobAlreadyExistsException(
+  dataProviderResourceId: String,
+  rawImpressionUploadResourceId: String,
+  cause: Throwable? = null,
+) :
+  ServiceException(
+    Errors.Reason.RANKER_JOB_ALREADY_EXISTS,
+    "RankerJob already exists",
+    mapOf(
+      Errors.Metadata.DATA_PROVIDER_RESOURCE_ID to dataProviderResourceId,
+      Errors.Metadata.RAW_IMPRESSION_UPLOAD_RESOURCE_ID to rawImpressionUploadResourceId,
+    ),
+    cause,
+  )
+
+class RankerJobStateInvalidException(
+  dataProviderResourceId: String,
+  rawImpressionUploadResourceId: String,
+  rankerJobResourceId: String,
+  actualState: RankerState,
+  expectedStates: Collection<RankerState>,
+  cause: Throwable? = null,
+) :
+  ServiceException(
+    Errors.Reason.RANKER_JOB_STATE_INVALID,
+    "RankerJob state invalid: expected one of $expectedStates but was $actualState",
+    mapOf(
+      Errors.Metadata.DATA_PROVIDER_RESOURCE_ID to dataProviderResourceId,
+      Errors.Metadata.RAW_IMPRESSION_UPLOAD_RESOURCE_ID to rawImpressionUploadResourceId,
+      Errors.Metadata.RANKER_JOB_RESOURCE_ID to rankerJobResourceId,
+      Errors.Metadata.RANKER_JOB_STATE to actualState.name,
+      Errors.Metadata.EXPECTED_RANKER_JOB_STATES to
+        expectedStates.joinToString(",") { state -> state.name },
     ),
     cause,
   )

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/service/internal/Services.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/service/internal/Services.kt
@@ -18,6 +18,7 @@ package org.wfanet.measurement.edpaggregator.service.internal
 
 import io.grpc.BindableService
 import org.wfanet.measurement.internal.edpaggregator.ImpressionMetadataServiceGrpcKt
+import org.wfanet.measurement.internal.edpaggregator.RankerJobServiceGrpcKt
 import org.wfanet.measurement.internal.edpaggregator.RawImpressionMetadataBatchFileServiceGrpcKt
 import org.wfanet.measurement.internal.edpaggregator.RawImpressionMetadataBatchServiceGrpcKt
 import org.wfanet.measurement.internal.edpaggregator.RawImpressionUploadFileServiceGrpcKt
@@ -40,6 +41,7 @@ data class Services(
   val rawImpressionUploadFile:
     RawImpressionUploadFileServiceGrpcKt.RawImpressionUploadFileServiceCoroutineImplBase,
   val vidLabelingJob: VidLabelingJobServiceGrpcKt.VidLabelingJobServiceCoroutineImplBase,
+  val rankerJob: RankerJobServiceGrpcKt.RankerJobServiceCoroutineImplBase,
 ) {
   fun toList(): List<BindableService> =
     listOf(
@@ -50,5 +52,6 @@ data class Services(
       rawImpressionUpload,
       rawImpressionUploadFile,
       vidLabelingJob,
+      rankerJob,
     )
 }

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/service/internal/testing/BUILD.bazel
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/service/internal/testing/BUILD.bazel
@@ -116,6 +116,25 @@ kt_jvm_library(
 )
 
 kt_jvm_library(
+    name = "ranker_job_service_test",
+    srcs = ["RankerJobServiceTest.kt"],
+    deps = [
+        "//src/main/kotlin/org/wfanet/measurement/common:id_generator",
+        "//src/main/kotlin/org/wfanet/measurement/common/grpc:error_info",
+        "//src/main/kotlin/org/wfanet/measurement/edpaggregator/service/internal:errors",
+        "//src/main/proto/wfa/measurement/internal/edpaggregator:ranker_job_kt_jvm_proto",
+        "//src/main/proto/wfa/measurement/internal/edpaggregator:ranker_job_service_kt_jvm_grpc_proto",
+        "//src/main/proto/wfa/measurement/internal/edpaggregator:ranker_state_kt_jvm_proto",
+        "@wfa_common_jvm//imports/java/com/google/common/truth",
+        "@wfa_common_jvm//imports/java/com/google/common/truth/extensions/proto",
+        "@wfa_common_jvm//imports/java/org/junit",
+        "@wfa_common_jvm//imports/kotlin/kotlin/test",
+        "@wfa_common_jvm//imports/kotlin/kotlinx/coroutines:core",
+        "@wfa_common_jvm//src/main/kotlin/org/wfanet/measurement/common",
+    ],
+)
+
+kt_jvm_library(
     name = "vid_labeling_job_service_test",
     srcs = ["VidLabelingJobServiceTest.kt"],
     deps = [

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/service/internal/testing/RankerJobServiceTest.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/service/internal/testing/RankerJobServiceTest.kt
@@ -421,6 +421,7 @@ abstract class RankerJobServiceTest {
         rawImpressionUploadResourceId = RAW_IMPRESSION_UPLOAD_RESOURCE_ID
         rankerJobResourceId = created.rankerJobResourceId
         etag = created.etag
+        requestId = UUID.randomUUID().toString()
       }
     )
 
@@ -499,6 +500,7 @@ abstract class RankerJobServiceTest {
           rawImpressionUploadResourceId = RAW_IMPRESSION_UPLOAD_RESOURCE_ID
           rankerJobResourceId = created.rankerJobResourceId
           etag = created.etag
+          requestId = UUID.randomUUID().toString()
         }
       )
 
@@ -516,6 +518,7 @@ abstract class RankerJobServiceTest {
           rawImpressionUploadResourceId = RAW_IMPRESSION_UPLOAD_RESOURCE_ID
           rankerJobResourceId = created.rankerJobResourceId
           etag = created.etag
+          requestId = UUID.randomUUID().toString()
         }
       )
 
@@ -534,6 +537,7 @@ abstract class RankerJobServiceTest {
           rawImpressionUploadResourceId = RAW_IMPRESSION_UPLOAD_RESOURCE_ID
           rankerJobResourceId = created1.rankerJobResourceId
           etag = created1.etag
+          requestId = UUID.randomUUID().toString()
         }
       )
 
@@ -551,6 +555,7 @@ abstract class RankerJobServiceTest {
         rawImpressionUploadResourceId = RAW_IMPRESSION_UPLOAD_RESOURCE_ID
         rankerJobResourceId = created1.rankerJobResourceId
         etag = created1.etag
+        requestId = UUID.randomUUID().toString()
       }
     )
 
@@ -561,6 +566,7 @@ abstract class RankerJobServiceTest {
           rawImpressionUploadResourceId = RAW_IMPRESSION_UPLOAD_RESOURCE_ID
           rankerJobResourceId = created2.rankerJobResourceId
           etag = created2.etag
+          requestId = UUID.randomUUID().toString()
         }
       )
 
@@ -579,6 +585,7 @@ abstract class RankerJobServiceTest {
           rawImpressionUploadResourceId = RAW_IMPRESSION_UPLOAD_RESOURCE_ID
           rankerJobResourceId = created.rankerJobResourceId
           etag = created.etag
+          requestId = UUID.randomUUID().toString()
         }
       )
 
@@ -628,6 +635,7 @@ abstract class RankerJobServiceTest {
             rawImpressionUploadResourceId = RAW_IMPRESSION_UPLOAD_RESOURCE_ID
             rankerJobResourceId = created.rankerJobResourceId
             etag = "wrong-etag"
+            requestId = UUID.randomUUID().toString()
           }
         )
       }
@@ -646,6 +654,7 @@ abstract class RankerJobServiceTest {
           rawImpressionUploadResourceId = RAW_IMPRESSION_UPLOAD_RESOURCE_ID
           rankerJobResourceId = created.rankerJobResourceId
           etag = created.etag
+          requestId = UUID.randomUUID().toString()
         }
       )
 
@@ -657,6 +666,7 @@ abstract class RankerJobServiceTest {
             rawImpressionUploadResourceId = RAW_IMPRESSION_UPLOAD_RESOURCE_ID
             rankerJobResourceId = created.rankerJobResourceId
             etag = response.rankerJob.etag
+            requestId = UUID.randomUUID().toString()
           }
         )
       }
@@ -674,11 +684,37 @@ abstract class RankerJobServiceTest {
             rawImpressionUploadResourceId = RAW_IMPRESSION_UPLOAD_RESOURCE_ID
             rankerJobResourceId = "nonexistent-job"
             etag = "some-etag"
+            requestId = UUID.randomUUID().toString()
           }
         )
       }
 
     assertThat(exception.status.code).isEqualTo(Status.Code.NOT_FOUND)
+  }
+
+  @Test
+  fun `markRankerJobSucceeded throws INVALID_ARGUMENT for empty request_id`() = runBlocking {
+    val exception: StatusRuntimeException =
+      assertFailsWith<StatusRuntimeException> {
+        service.markRankerJobSucceeded(
+          markRankerJobSucceededRequest {
+            dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
+            rawImpressionUploadResourceId = RAW_IMPRESSION_UPLOAD_RESOURCE_ID
+            rankerJobResourceId = "some-job"
+            etag = "some-etag"
+          }
+        )
+      }
+
+    assertThat(exception.status.code).isEqualTo(Status.Code.INVALID_ARGUMENT)
+    assertThat(exception.errorInfo)
+      .isEqualTo(
+        errorInfo {
+          domain = Errors.DOMAIN
+          reason = Errors.Reason.REQUIRED_FIELD_NOT_SET.name
+          metadata[Errors.Metadata.FIELD_NAME.key] = "request_id"
+        }
+      )
   }
 
   @Test
@@ -722,6 +758,7 @@ abstract class RankerJobServiceTest {
           rawImpressionUploadResourceId = RAW_IMPRESSION_UPLOAD_RESOURCE_ID
           rankerJobResourceId = created.rankerJobResourceId
           etag = failed.etag
+          requestId = UUID.randomUUID().toString()
         }
       )
 

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/service/internal/testing/RankerJobServiceTest.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/service/internal/testing/RankerJobServiceTest.kt
@@ -1,0 +1,900 @@
+/*
+ * Copyright 2026 The Cross-Media Measurement Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wfanet.measurement.edpaggregator.service.internal.testing
+
+import com.google.common.truth.Truth.assertThat
+import com.google.common.truth.extensions.proto.ProtoTruth.assertThat
+import com.google.rpc.errorInfo
+import com.google.type.interval
+import io.grpc.Status
+import io.grpc.StatusRuntimeException
+import java.time.Instant
+import java.util.UUID
+import kotlin.test.assertFailsWith
+import kotlinx.coroutines.runBlocking
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+import org.wfanet.measurement.common.IdGenerator
+import org.wfanet.measurement.common.grpc.errorInfo
+import org.wfanet.measurement.common.toInstant
+import org.wfanet.measurement.edpaggregator.service.internal.Errors
+import org.wfanet.measurement.internal.edpaggregator.ListRankerJobsRequestKt
+import org.wfanet.measurement.internal.edpaggregator.ListRankerJobsResponse
+import org.wfanet.measurement.internal.edpaggregator.MarkRankerJobSucceededResponse
+import org.wfanet.measurement.internal.edpaggregator.RankerJob
+import org.wfanet.measurement.internal.edpaggregator.RankerJobServiceGrpcKt.RankerJobServiceCoroutineImplBase
+import org.wfanet.measurement.internal.edpaggregator.RankerState
+import org.wfanet.measurement.internal.edpaggregator.batchCreateRankerJobsRequest
+import org.wfanet.measurement.internal.edpaggregator.createRankerJobRequest
+import org.wfanet.measurement.internal.edpaggregator.getRankerJobRequest
+import org.wfanet.measurement.internal.edpaggregator.listRankerJobsRequest
+import org.wfanet.measurement.internal.edpaggregator.markRankerJobFailedRequest
+import org.wfanet.measurement.internal.edpaggregator.markRankerJobSucceededRequest
+import org.wfanet.measurement.internal.edpaggregator.rankerJob
+
+@RunWith(JUnit4::class)
+abstract class RankerJobServiceTest {
+  private lateinit var service: RankerJobServiceCoroutineImplBase
+
+  protected abstract fun newService(
+    idGenerator: IdGenerator = IdGenerator.Default
+  ): RankerJobServiceCoroutineImplBase
+
+  /**
+   * Creates a parent [RawImpressionUpload] row so that child ranker job rows can be inserted
+   * (interleaved table).
+   */
+  protected abstract suspend fun createParentUpload(
+    dataProviderResourceId: String,
+    rawImpressionUploadResourceId: String,
+  )
+
+  @Before
+  fun initService() {
+    service = newService()
+    runBlocking { createParentUpload(DATA_PROVIDER_RESOURCE_ID, RAW_IMPRESSION_UPLOAD_RESOURCE_ID) }
+  }
+
+  @Test
+  fun `createRankerJob creates successfully`() = runBlocking {
+    val startTime: Instant = Instant.now()
+
+    val job: RankerJob =
+      service.createRankerJob(
+        createRankerJobRequest {
+          dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
+          rawImpressionUploadResourceId = RAW_IMPRESSION_UPLOAD_RESOURCE_ID
+          rankerJob = rankerJob {
+            cmmsModelLine = CMMS_MODEL_LINE
+            poolOffsets += POOL_OFFSETS
+          }
+        }
+      )
+
+    assertThat(job.dataProviderResourceId).isEqualTo(DATA_PROVIDER_RESOURCE_ID)
+    assertThat(job.rawImpressionUploadResourceId).isEqualTo(RAW_IMPRESSION_UPLOAD_RESOURCE_ID)
+    assertThat(job.cmmsModelLine).isEqualTo(CMMS_MODEL_LINE)
+    assertThat(job.poolOffsetsList).containsExactlyElementsIn(POOL_OFFSETS).inOrder()
+    assertThat(job.state).isEqualTo(RankerState.RANKER_STATE_CREATED)
+    assertThat(job.createTime.toInstant()).isGreaterThan(startTime)
+    assertThat(job.updateTime).isEqualTo(job.createTime)
+    assertThat(job.etag).isNotEmpty()
+  }
+
+  @Test
+  fun `createRankerJob is idempotent with same request_id`() = runBlocking {
+    val requestId: String = UUID.randomUUID().toString()
+
+    val job1: RankerJob =
+      service.createRankerJob(
+        createRankerJobRequest {
+          this.requestId = requestId
+          dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
+          rawImpressionUploadResourceId = RAW_IMPRESSION_UPLOAD_RESOURCE_ID
+          rankerJob = rankerJob {
+            cmmsModelLine = CMMS_MODEL_LINE
+            poolOffsets += POOL_OFFSETS
+          }
+        }
+      )
+
+    val job2: RankerJob =
+      service.createRankerJob(
+        createRankerJobRequest {
+          this.requestId = requestId
+          dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
+          rawImpressionUploadResourceId = RAW_IMPRESSION_UPLOAD_RESOURCE_ID
+          rankerJob = rankerJob {
+            cmmsModelLine = CMMS_MODEL_LINE
+            poolOffsets += POOL_OFFSETS
+          }
+        }
+      )
+
+    assertThat(job2).isEqualTo(job1)
+  }
+
+  @Test
+  fun `createRankerJob throws NOT_FOUND when parent upload missing`() = runBlocking {
+    val exception: StatusRuntimeException =
+      assertFailsWith<StatusRuntimeException> {
+        service.createRankerJob(
+          createRankerJobRequest {
+            dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
+            rawImpressionUploadResourceId = "uploads/missing"
+            rankerJob = rankerJob {
+              cmmsModelLine = CMMS_MODEL_LINE
+              poolOffsets += POOL_OFFSETS
+            }
+          }
+        )
+      }
+
+    assertThat(exception.status.code).isEqualTo(Status.Code.NOT_FOUND)
+  }
+
+  @Test
+  fun `createRankerJob throws INVALID_ARGUMENT if data_provider_resource_id not set`() =
+    runBlocking {
+      val exception: StatusRuntimeException =
+        assertFailsWith<StatusRuntimeException> {
+          service.createRankerJob(
+            createRankerJobRequest {
+              rawImpressionUploadResourceId = RAW_IMPRESSION_UPLOAD_RESOURCE_ID
+              rankerJob = rankerJob {
+                cmmsModelLine = CMMS_MODEL_LINE
+                poolOffsets += POOL_OFFSETS
+              }
+            }
+          )
+        }
+
+      assertThat(exception.status.code).isEqualTo(Status.Code.INVALID_ARGUMENT)
+      assertThat(exception.errorInfo)
+        .isEqualTo(
+          errorInfo {
+            domain = Errors.DOMAIN
+            reason = Errors.Reason.REQUIRED_FIELD_NOT_SET.name
+            metadata[Errors.Metadata.FIELD_NAME.key] = "data_provider_resource_id"
+          }
+        )
+    }
+
+  @Test
+  fun `createRankerJob throws INVALID_ARGUMENT if ranker_job not set`() = runBlocking {
+    val exception: StatusRuntimeException =
+      assertFailsWith<StatusRuntimeException> { service.createRankerJob(createRankerJobRequest {}) }
+
+    assertThat(exception.status.code).isEqualTo(Status.Code.INVALID_ARGUMENT)
+    assertThat(exception.errorInfo)
+      .isEqualTo(
+        errorInfo {
+          domain = Errors.DOMAIN
+          reason = Errors.Reason.REQUIRED_FIELD_NOT_SET.name
+          metadata[Errors.Metadata.FIELD_NAME.key] = "ranker_job"
+        }
+      )
+  }
+
+  @Test
+  fun `createRankerJob throws INVALID_ARGUMENT if cmms_model_line not set`() = runBlocking {
+    val exception: StatusRuntimeException =
+      assertFailsWith<StatusRuntimeException> {
+        service.createRankerJob(
+          createRankerJobRequest {
+            dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
+            rawImpressionUploadResourceId = RAW_IMPRESSION_UPLOAD_RESOURCE_ID
+            rankerJob = rankerJob { poolOffsets += POOL_OFFSETS }
+          }
+        )
+      }
+
+    assertThat(exception.status.code).isEqualTo(Status.Code.INVALID_ARGUMENT)
+    assertThat(exception.errorInfo)
+      .isEqualTo(
+        errorInfo {
+          domain = Errors.DOMAIN
+          reason = Errors.Reason.REQUIRED_FIELD_NOT_SET.name
+          metadata[Errors.Metadata.FIELD_NAME.key] = "ranker_job.cmms_model_line"
+        }
+      )
+  }
+
+  @Test
+  fun `createRankerJob throws INVALID_ARGUMENT if pool_offsets not set`() = runBlocking {
+    val exception: StatusRuntimeException =
+      assertFailsWith<StatusRuntimeException> {
+        service.createRankerJob(
+          createRankerJobRequest {
+            dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
+            rawImpressionUploadResourceId = RAW_IMPRESSION_UPLOAD_RESOURCE_ID
+            rankerJob = rankerJob { cmmsModelLine = CMMS_MODEL_LINE }
+          }
+        )
+      }
+
+    assertThat(exception.status.code).isEqualTo(Status.Code.INVALID_ARGUMENT)
+    assertThat(exception.errorInfo)
+      .isEqualTo(
+        errorInfo {
+          domain = Errors.DOMAIN
+          reason = Errors.Reason.REQUIRED_FIELD_NOT_SET.name
+          metadata[Errors.Metadata.FIELD_NAME.key] = "ranker_job.pool_offsets"
+        }
+      )
+  }
+
+  @Test
+  fun `createRankerJob throws INVALID_ARGUMENT for malformed request_id`() = runBlocking {
+    val exception: StatusRuntimeException =
+      assertFailsWith<StatusRuntimeException> {
+        service.createRankerJob(
+          createRankerJobRequest {
+            requestId = "not-a-valid-uuid"
+            dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
+            rawImpressionUploadResourceId = RAW_IMPRESSION_UPLOAD_RESOURCE_ID
+            rankerJob = rankerJob {
+              cmmsModelLine = CMMS_MODEL_LINE
+              poolOffsets += POOL_OFFSETS
+            }
+          }
+        )
+      }
+
+    assertThat(exception.status.code).isEqualTo(Status.Code.INVALID_ARGUMENT)
+    assertThat(exception.errorInfo)
+      .isEqualTo(
+        errorInfo {
+          domain = Errors.DOMAIN
+          reason = Errors.Reason.INVALID_FIELD_VALUE.name
+          metadata[Errors.Metadata.FIELD_NAME.key] = "request_id"
+        }
+      )
+  }
+
+  @Test
+  fun `batchCreateRankerJobs creates multiple`() =
+    runBlocking<Unit> {
+      val response =
+        service.batchCreateRankerJobs(
+          batchCreateRankerJobsRequest {
+            dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
+            rawImpressionUploadResourceId = RAW_IMPRESSION_UPLOAD_RESOURCE_ID
+            requests += createRankerJobRequest {
+              rankerJob = rankerJob {
+                cmmsModelLine = CMMS_MODEL_LINE
+                poolOffsets += listOf(0L, 1L)
+              }
+            }
+            requests += createRankerJobRequest {
+              rankerJob = rankerJob {
+                cmmsModelLine = CMMS_MODEL_LINE
+                poolOffsets += listOf(2L, 3L)
+              }
+            }
+          }
+        )
+
+      assertThat(response.rankerJobsList).hasSize(2)
+      assertThat(response.rankerJobsList.flatMap { it.poolOffsetsList })
+        .containsExactly(0L, 1L, 2L, 3L)
+    }
+
+  @Test
+  fun `batchCreateRankerJobs is idempotent on repeated request_ids`() =
+    runBlocking<Unit> {
+      val requestId = UUID.randomUUID().toString()
+      val request = batchCreateRankerJobsRequest {
+        dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
+        rawImpressionUploadResourceId = RAW_IMPRESSION_UPLOAD_RESOURCE_ID
+        requests += createRankerJobRequest {
+          this.requestId = requestId
+          rankerJob = rankerJob {
+            cmmsModelLine = CMMS_MODEL_LINE
+            poolOffsets += POOL_OFFSETS
+          }
+        }
+      }
+
+      val first = service.batchCreateRankerJobs(request)
+      val second = service.batchCreateRankerJobs(request)
+
+      assertThat(second.rankerJobsList).isEqualTo(first.rankerJobsList)
+    }
+
+  @Test
+  fun `getRankerJob returns existing resource`() = runBlocking {
+    val created: RankerJob =
+      service.createRankerJob(
+        createRankerJobRequest {
+          dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
+          rawImpressionUploadResourceId = RAW_IMPRESSION_UPLOAD_RESOURCE_ID
+          rankerJob = rankerJob {
+            cmmsModelLine = CMMS_MODEL_LINE
+            poolOffsets += POOL_OFFSETS
+          }
+        }
+      )
+
+    val job: RankerJob =
+      service.getRankerJob(
+        getRankerJobRequest {
+          dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
+          rawImpressionUploadResourceId = RAW_IMPRESSION_UPLOAD_RESOURCE_ID
+          rankerJobResourceId = created.rankerJobResourceId
+        }
+      )
+
+    assertThat(job).isEqualTo(created)
+  }
+
+  @Test
+  fun `getRankerJob throws NOT_FOUND when not found`() = runBlocking {
+    val exception: StatusRuntimeException =
+      assertFailsWith<StatusRuntimeException> {
+        service.getRankerJob(
+          getRankerJobRequest {
+            dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
+            rawImpressionUploadResourceId = RAW_IMPRESSION_UPLOAD_RESOURCE_ID
+            rankerJobResourceId = "nonexistent-job"
+          }
+        )
+      }
+
+    assertThat(exception.status.code).isEqualTo(Status.Code.NOT_FOUND)
+  }
+
+  @Test
+  fun `getRankerJob throws INVALID_ARGUMENT if ranker_job_resource_id not set`() = runBlocking {
+    val exception: StatusRuntimeException =
+      assertFailsWith<StatusRuntimeException> {
+        service.getRankerJob(
+          getRankerJobRequest {
+            dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
+            rawImpressionUploadResourceId = RAW_IMPRESSION_UPLOAD_RESOURCE_ID
+          }
+        )
+      }
+
+    assertThat(exception.status.code).isEqualTo(Status.Code.INVALID_ARGUMENT)
+  }
+
+  @Test
+  fun `listRankerJobs returns resources`() = runBlocking {
+    createRanker(0L)
+    createRanker(1L)
+
+    val response: ListRankerJobsResponse =
+      service.listRankerJobs(
+        listRankerJobsRequest {
+          dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
+          rawImpressionUploadResourceId = RAW_IMPRESSION_UPLOAD_RESOURCE_ID
+        }
+      )
+
+    assertThat(response.rankerJobsList).hasSize(2)
+  }
+
+  @Test
+  fun `listRankerJobs respects page_size`() = runBlocking {
+    for (i in 0..2) {
+      createRanker(i.toLong())
+    }
+
+    val response: ListRankerJobsResponse =
+      service.listRankerJobs(
+        listRankerJobsRequest {
+          dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
+          rawImpressionUploadResourceId = RAW_IMPRESSION_UPLOAD_RESOURCE_ID
+          pageSize = 2
+        }
+      )
+
+    assertThat(response.rankerJobsList).hasSize(2)
+    assertThat(response.hasNextPageToken()).isTrue()
+  }
+
+  @Test
+  fun `listRankerJobs filters by state_in`() = runBlocking {
+    val created: RankerJob = createRanker(0L)
+    createRanker(1L)
+
+    service.markRankerJobSucceeded(
+      markRankerJobSucceededRequest {
+        dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
+        rawImpressionUploadResourceId = RAW_IMPRESSION_UPLOAD_RESOURCE_ID
+        rankerJobResourceId = created.rankerJobResourceId
+        etag = created.etag
+      }
+    )
+
+    val response: ListRankerJobsResponse =
+      service.listRankerJobs(
+        listRankerJobsRequest {
+          dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
+          rawImpressionUploadResourceId = RAW_IMPRESSION_UPLOAD_RESOURCE_ID
+          filter = ListRankerJobsRequestKt.filter { stateIn += RankerState.RANKER_STATE_SUCCEEDED }
+        }
+      )
+
+    assertThat(response.rankerJobsList).hasSize(1)
+    assertThat(response.rankerJobsList.first().rankerJobResourceId)
+      .isEqualTo(created.rankerJobResourceId)
+  }
+
+  @Test
+  fun `listRankerJobs filters by cmms_model_line`() = runBlocking {
+    createRanker(0L, cmmsModelLine = CMMS_MODEL_LINE)
+    createRanker(1L, cmmsModelLine = CMMS_MODEL_LINE_2)
+
+    val response: ListRankerJobsResponse =
+      service.listRankerJobs(
+        listRankerJobsRequest {
+          dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
+          rawImpressionUploadResourceId = RAW_IMPRESSION_UPLOAD_RESOURCE_ID
+          filter = ListRankerJobsRequestKt.filter { cmmsModelLine = CMMS_MODEL_LINE }
+        }
+      )
+
+    assertThat(response.rankerJobsList).hasSize(1)
+    assertThat(response.rankerJobsList.first().cmmsModelLine).isEqualTo(CMMS_MODEL_LINE)
+  }
+
+  @Test
+  fun `listRankerJobs paginates with page_token`() = runBlocking {
+    for (i in 0..2) {
+      createRanker(i.toLong())
+    }
+
+    val firstPage: ListRankerJobsResponse =
+      service.listRankerJobs(
+        listRankerJobsRequest {
+          dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
+          rawImpressionUploadResourceId = RAW_IMPRESSION_UPLOAD_RESOURCE_ID
+          pageSize = 2
+        }
+      )
+
+    assertThat(firstPage.rankerJobsList).hasSize(2)
+    assertThat(firstPage.hasNextPageToken()).isTrue()
+
+    val secondPage: ListRankerJobsResponse =
+      service.listRankerJobs(
+        listRankerJobsRequest {
+          dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
+          rawImpressionUploadResourceId = RAW_IMPRESSION_UPLOAD_RESOURCE_ID
+          pageSize = 2
+          pageToken = firstPage.nextPageToken
+        }
+      )
+
+    assertThat(secondPage.rankerJobsList).hasSize(1)
+    assertThat(secondPage.hasNextPageToken()).isFalse()
+  }
+
+  @Test
+  fun `markRankerJobSucceeded transitions CREATED to SUCCEEDED`() = runBlocking {
+    val created: RankerJob = createRanker(0L)
+
+    val response: MarkRankerJobSucceededResponse =
+      service.markRankerJobSucceeded(
+        markRankerJobSucceededRequest {
+          dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
+          rawImpressionUploadResourceId = RAW_IMPRESSION_UPLOAD_RESOURCE_ID
+          rankerJobResourceId = created.rankerJobResourceId
+          etag = created.etag
+        }
+      )
+
+    assertThat(response.rankerJob.state).isEqualTo(RankerState.RANKER_STATE_SUCCEEDED)
+  }
+
+  @Test
+  fun `markRankerJobSucceeded sets is_last_job true when it is the only job`() = runBlocking {
+    val created: RankerJob = createRanker(0L)
+
+    val response: MarkRankerJobSucceededResponse =
+      service.markRankerJobSucceeded(
+        markRankerJobSucceededRequest {
+          dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
+          rawImpressionUploadResourceId = RAW_IMPRESSION_UPLOAD_RESOURCE_ID
+          rankerJobResourceId = created.rankerJobResourceId
+          etag = created.etag
+        }
+      )
+
+    assertThat(response.isLastJob).isTrue()
+  }
+
+  @Test
+  fun `markRankerJobSucceeded sets is_last_job false when sibling still pending`() = runBlocking {
+    val created1: RankerJob = createRanker(0L)
+    createRanker(1L)
+
+    val response: MarkRankerJobSucceededResponse =
+      service.markRankerJobSucceeded(
+        markRankerJobSucceededRequest {
+          dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
+          rawImpressionUploadResourceId = RAW_IMPRESSION_UPLOAD_RESOURCE_ID
+          rankerJobResourceId = created1.rankerJobResourceId
+          etag = created1.etag
+        }
+      )
+
+    assertThat(response.isLastJob).isFalse()
+  }
+
+  @Test
+  fun `markRankerJobSucceeded sets is_last_job true on the last sibling`() = runBlocking {
+    val created1: RankerJob = createRanker(0L)
+    val created2: RankerJob = createRanker(1L)
+
+    service.markRankerJobSucceeded(
+      markRankerJobSucceededRequest {
+        dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
+        rawImpressionUploadResourceId = RAW_IMPRESSION_UPLOAD_RESOURCE_ID
+        rankerJobResourceId = created1.rankerJobResourceId
+        etag = created1.etag
+      }
+    )
+
+    val response: MarkRankerJobSucceededResponse =
+      service.markRankerJobSucceeded(
+        markRankerJobSucceededRequest {
+          dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
+          rawImpressionUploadResourceId = RAW_IMPRESSION_UPLOAD_RESOURCE_ID
+          rankerJobResourceId = created2.rankerJobResourceId
+          etag = created2.etag
+        }
+      )
+
+    assertThat(response.isLastJob).isTrue()
+  }
+
+  @Test
+  fun `markRankerJobSucceeded does not count a sibling for a different model line`() = runBlocking {
+    val created: RankerJob = createRanker(0L, cmmsModelLine = CMMS_MODEL_LINE)
+    createRanker(1L, cmmsModelLine = CMMS_MODEL_LINE_2)
+
+    val response: MarkRankerJobSucceededResponse =
+      service.markRankerJobSucceeded(
+        markRankerJobSucceededRequest {
+          dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
+          rawImpressionUploadResourceId = RAW_IMPRESSION_UPLOAD_RESOURCE_ID
+          rankerJobResourceId = created.rankerJobResourceId
+          etag = created.etag
+        }
+      )
+
+    assertThat(response.isLastJob).isTrue()
+  }
+
+  @Test
+  fun `markRankerJobSucceeded is idempotent with same request_id`() = runBlocking {
+    val requestId = UUID.randomUUID().toString()
+    val created: RankerJob = createRanker(0L)
+
+    val response1: MarkRankerJobSucceededResponse =
+      service.markRankerJobSucceeded(
+        markRankerJobSucceededRequest {
+          dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
+          rawImpressionUploadResourceId = RAW_IMPRESSION_UPLOAD_RESOURCE_ID
+          rankerJobResourceId = created.rankerJobResourceId
+          etag = created.etag
+          this.requestId = requestId
+        }
+      )
+
+    val response2: MarkRankerJobSucceededResponse =
+      service.markRankerJobSucceeded(
+        markRankerJobSucceededRequest {
+          dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
+          rawImpressionUploadResourceId = RAW_IMPRESSION_UPLOAD_RESOURCE_ID
+          rankerJobResourceId = created.rankerJobResourceId
+          etag = created.etag
+          this.requestId = requestId
+        }
+      )
+
+    assertThat(response2.rankerJob).isEqualTo(response1.rankerJob)
+    assertThat(response2.isLastJob).isEqualTo(response1.isLastJob)
+  }
+
+  @Test
+  fun `markRankerJobSucceeded throws ABORTED for etag mismatch`() = runBlocking {
+    val created: RankerJob = createRanker(0L)
+
+    val exception: StatusRuntimeException =
+      assertFailsWith<StatusRuntimeException> {
+        service.markRankerJobSucceeded(
+          markRankerJobSucceededRequest {
+            dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
+            rawImpressionUploadResourceId = RAW_IMPRESSION_UPLOAD_RESOURCE_ID
+            rankerJobResourceId = created.rankerJobResourceId
+            etag = "wrong-etag"
+          }
+        )
+      }
+
+    assertThat(exception.status.code).isEqualTo(Status.Code.ABORTED)
+  }
+
+  @Test
+  fun `markRankerJobSucceeded throws FAILED_PRECONDITION from SUCCEEDED state`() = runBlocking {
+    val created: RankerJob = createRanker(0L)
+
+    val response =
+      service.markRankerJobSucceeded(
+        markRankerJobSucceededRequest {
+          dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
+          rawImpressionUploadResourceId = RAW_IMPRESSION_UPLOAD_RESOURCE_ID
+          rankerJobResourceId = created.rankerJobResourceId
+          etag = created.etag
+        }
+      )
+
+    val exception: StatusRuntimeException =
+      assertFailsWith<StatusRuntimeException> {
+        service.markRankerJobSucceeded(
+          markRankerJobSucceededRequest {
+            dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
+            rawImpressionUploadResourceId = RAW_IMPRESSION_UPLOAD_RESOURCE_ID
+            rankerJobResourceId = created.rankerJobResourceId
+            etag = response.rankerJob.etag
+          }
+        )
+      }
+
+    assertThat(exception.status.code).isEqualTo(Status.Code.FAILED_PRECONDITION)
+  }
+
+  @Test
+  fun `markRankerJobSucceeded throws NOT_FOUND when not found`() = runBlocking {
+    val exception: StatusRuntimeException =
+      assertFailsWith<StatusRuntimeException> {
+        service.markRankerJobSucceeded(
+          markRankerJobSucceededRequest {
+            dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
+            rawImpressionUploadResourceId = RAW_IMPRESSION_UPLOAD_RESOURCE_ID
+            rankerJobResourceId = "nonexistent-job"
+            etag = "some-etag"
+          }
+        )
+      }
+
+    assertThat(exception.status.code).isEqualTo(Status.Code.NOT_FOUND)
+  }
+
+  @Test
+  fun `markRankerJobFailed transitions from CREATED to FAILED`() = runBlocking {
+    val created: RankerJob = createRanker(0L)
+
+    val job: RankerJob =
+      service.markRankerJobFailed(
+        markRankerJobFailedRequest {
+          dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
+          rawImpressionUploadResourceId = RAW_IMPRESSION_UPLOAD_RESOURCE_ID
+          rankerJobResourceId = created.rankerJobResourceId
+          etag = created.etag
+          errorMessage = "something went wrong"
+        }
+      )
+
+    assertThat(job.state).isEqualTo(RankerState.RANKER_STATE_FAILED)
+    assertThat(job.errorMessage).isEqualTo("something went wrong")
+  }
+
+  @Test
+  fun `markRankerJobFailed then markRankerJobSucceeded allows retry`() = runBlocking {
+    val created: RankerJob = createRanker(0L)
+
+    val failed: RankerJob =
+      service.markRankerJobFailed(
+        markRankerJobFailedRequest {
+          dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
+          rawImpressionUploadResourceId = RAW_IMPRESSION_UPLOAD_RESOURCE_ID
+          rankerJobResourceId = created.rankerJobResourceId
+          etag = created.etag
+          errorMessage = "transient"
+        }
+      )
+
+    val response: MarkRankerJobSucceededResponse =
+      service.markRankerJobSucceeded(
+        markRankerJobSucceededRequest {
+          dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
+          rawImpressionUploadResourceId = RAW_IMPRESSION_UPLOAD_RESOURCE_ID
+          rankerJobResourceId = created.rankerJobResourceId
+          etag = failed.etag
+        }
+      )
+
+    assertThat(response.rankerJob.state).isEqualTo(RankerState.RANKER_STATE_SUCCEEDED)
+  }
+
+  @Test
+  fun `markRankerJobFailed throws ABORTED for etag mismatch`() = runBlocking {
+    val created: RankerJob = createRanker(0L)
+
+    val exception: StatusRuntimeException =
+      assertFailsWith<StatusRuntimeException> {
+        service.markRankerJobFailed(
+          markRankerJobFailedRequest {
+            dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
+            rawImpressionUploadResourceId = RAW_IMPRESSION_UPLOAD_RESOURCE_ID
+            rankerJobResourceId = created.rankerJobResourceId
+            etag = "wrong-etag"
+            errorMessage = "something went wrong"
+          }
+        )
+      }
+
+    assertThat(exception.status.code).isEqualTo(Status.Code.ABORTED)
+  }
+
+  @Test
+  fun `listRankerJobs filters by create_time_in`() = runBlocking {
+    val created: RankerJob = createRanker(0L)
+
+    val withinResponse: ListRankerJobsResponse =
+      service.listRankerJobs(
+        listRankerJobsRequest {
+          dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
+          rawImpressionUploadResourceId = RAW_IMPRESSION_UPLOAD_RESOURCE_ID
+          filter =
+            ListRankerJobsRequestKt.filter {
+              createTimeIn = interval { startTime = created.createTime }
+            }
+        }
+      )
+    assertThat(withinResponse.rankerJobsList).hasSize(1)
+
+    val excludedResponse: ListRankerJobsResponse =
+      service.listRankerJobs(
+        listRankerJobsRequest {
+          dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
+          rawImpressionUploadResourceId = RAW_IMPRESSION_UPLOAD_RESOURCE_ID
+          filter =
+            ListRankerJobsRequestKt.filter {
+              createTimeIn = interval { endTime = created.createTime }
+            }
+        }
+      )
+    assertThat(excludedResponse.rankerJobsList).isEmpty()
+  }
+
+  @Test
+  fun `listRankerJobs lists across uploads when upload id omitted`() = runBlocking {
+    createRanker(0L)
+    createParentUpload(DATA_PROVIDER_RESOURCE_ID, SECOND_UPLOAD_RESOURCE_ID)
+    service.createRankerJob(
+      createRankerJobRequest {
+        dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
+        rawImpressionUploadResourceId = SECOND_UPLOAD_RESOURCE_ID
+        rankerJob = rankerJob {
+          cmmsModelLine = CMMS_MODEL_LINE
+          poolOffsets += POOL_OFFSETS
+        }
+      }
+    )
+
+    val response: ListRankerJobsResponse =
+      service.listRankerJobs(
+        listRankerJobsRequest { dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID }
+      )
+
+    assertThat(response.rankerJobsList).hasSize(2)
+  }
+
+  @Test
+  fun `batchCreateRankerJobs throws INVALID_ARGUMENT when exceeding max batch size`() =
+    runBlocking {
+      val exception: StatusRuntimeException =
+        assertFailsWith<StatusRuntimeException> {
+          service.batchCreateRankerJobs(
+            batchCreateRankerJobsRequest {
+              dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
+              rawImpressionUploadResourceId = RAW_IMPRESSION_UPLOAD_RESOURCE_ID
+              for (i in 0 until 51) {
+                requests += createRankerJobRequest {
+                  rankerJob = rankerJob {
+                    cmmsModelLine = CMMS_MODEL_LINE
+                    poolOffsets += i.toLong()
+                  }
+                }
+              }
+            }
+          )
+        }
+
+      assertThat(exception.status.code).isEqualTo(Status.Code.INVALID_ARGUMENT)
+      assertThat(exception.errorInfo)
+        .isEqualTo(
+          errorInfo {
+            domain = Errors.DOMAIN
+            reason = Errors.Reason.INVALID_FIELD_VALUE.name
+            metadata[Errors.Metadata.FIELD_NAME.key] = "requests"
+          }
+        )
+    }
+
+  @Test
+  fun `batchCreateRankerJobs throws INVALID_ARGUMENT for duplicate request_id`() = runBlocking {
+    val requestId = UUID.randomUUID().toString()
+
+    val exception: StatusRuntimeException =
+      assertFailsWith<StatusRuntimeException> {
+        service.batchCreateRankerJobs(
+          batchCreateRankerJobsRequest {
+            dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
+            rawImpressionUploadResourceId = RAW_IMPRESSION_UPLOAD_RESOURCE_ID
+            requests += createRankerJobRequest {
+              this.requestId = requestId
+              rankerJob = rankerJob {
+                cmmsModelLine = CMMS_MODEL_LINE
+                poolOffsets += POOL_OFFSETS
+              }
+            }
+            requests += createRankerJobRequest {
+              this.requestId = requestId
+              rankerJob = rankerJob {
+                cmmsModelLine = CMMS_MODEL_LINE
+                poolOffsets += POOL_OFFSETS
+              }
+            }
+          }
+        )
+      }
+
+    assertThat(exception.status.code).isEqualTo(Status.Code.INVALID_ARGUMENT)
+    assertThat(exception.errorInfo)
+      .isEqualTo(
+        errorInfo {
+          domain = Errors.DOMAIN
+          reason = Errors.Reason.INVALID_FIELD_VALUE.name
+          metadata[Errors.Metadata.FIELD_NAME.key] = "requests[1].request_id"
+        }
+      )
+  }
+
+  private suspend fun createRanker(
+    firstPoolOffset: Long,
+    cmmsModelLine: String = CMMS_MODEL_LINE,
+  ): RankerJob {
+    return service.createRankerJob(
+      createRankerJobRequest {
+        dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
+        rawImpressionUploadResourceId = RAW_IMPRESSION_UPLOAD_RESOURCE_ID
+        rankerJob = rankerJob {
+          this.cmmsModelLine = cmmsModelLine
+          poolOffsets += firstPoolOffset
+        }
+      }
+    )
+  }
+
+  companion object {
+    private const val DATA_PROVIDER_RESOURCE_ID = "dataProviders/dp1"
+    private const val RAW_IMPRESSION_UPLOAD_RESOURCE_ID = "uploads/upload1"
+    private const val SECOND_UPLOAD_RESOURCE_ID = "uploads/upload2"
+    private const val CMMS_MODEL_LINE = "modelProviders/mp1/modelSuites/ms1/modelLines/ml1"
+    private const val CMMS_MODEL_LINE_2 = "modelProviders/mp1/modelSuites/ms1/modelLines/ml2"
+    private val POOL_OFFSETS = listOf(0L, 1L, 2L)
+  }
+}

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/service/internal/testing/RankerJobServiceTest.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/service/internal/testing/RankerJobServiceTest.kt
@@ -78,6 +78,7 @@ abstract class RankerJobServiceTest {
     val job: RankerJob =
       service.createRankerJob(
         createRankerJobRequest {
+          requestId = UUID.randomUUID().toString()
           dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
           rawImpressionUploadResourceId = RAW_IMPRESSION_UPLOAD_RESOURCE_ID
           rankerJob = rankerJob {
@@ -136,6 +137,7 @@ abstract class RankerJobServiceTest {
       assertFailsWith<StatusRuntimeException> {
         service.createRankerJob(
           createRankerJobRequest {
+            requestId = UUID.randomUUID().toString()
             dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
             rawImpressionUploadResourceId = "uploads/missing"
             rankerJob = rankerJob {
@@ -156,6 +158,7 @@ abstract class RankerJobServiceTest {
         assertFailsWith<StatusRuntimeException> {
           service.createRankerJob(
             createRankerJobRequest {
+              requestId = UUID.randomUUID().toString()
               rawImpressionUploadResourceId = RAW_IMPRESSION_UPLOAD_RESOURCE_ID
               rankerJob = rankerJob {
                 cmmsModelLine = CMMS_MODEL_LINE
@@ -198,6 +201,7 @@ abstract class RankerJobServiceTest {
       assertFailsWith<StatusRuntimeException> {
         service.createRankerJob(
           createRankerJobRequest {
+            requestId = UUID.randomUUID().toString()
             dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
             rawImpressionUploadResourceId = RAW_IMPRESSION_UPLOAD_RESOURCE_ID
             rankerJob = rankerJob { poolOffsets += POOL_OFFSETS }
@@ -222,6 +226,7 @@ abstract class RankerJobServiceTest {
       assertFailsWith<StatusRuntimeException> {
         service.createRankerJob(
           createRankerJobRequest {
+            requestId = UUID.randomUUID().toString()
             dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
             rawImpressionUploadResourceId = RAW_IMPRESSION_UPLOAD_RESOURCE_ID
             rankerJob = rankerJob { cmmsModelLine = CMMS_MODEL_LINE }
@@ -269,6 +274,33 @@ abstract class RankerJobServiceTest {
   }
 
   @Test
+  fun `createRankerJob throws INVALID_ARGUMENT for empty request_id`() = runBlocking {
+    val exception: StatusRuntimeException =
+      assertFailsWith<StatusRuntimeException> {
+        service.createRankerJob(
+          createRankerJobRequest {
+            dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
+            rawImpressionUploadResourceId = RAW_IMPRESSION_UPLOAD_RESOURCE_ID
+            rankerJob = rankerJob {
+              cmmsModelLine = CMMS_MODEL_LINE
+              poolOffsets += POOL_OFFSETS
+            }
+          }
+        )
+      }
+
+    assertThat(exception.status.code).isEqualTo(Status.Code.INVALID_ARGUMENT)
+    assertThat(exception.errorInfo)
+      .isEqualTo(
+        errorInfo {
+          domain = Errors.DOMAIN
+          reason = Errors.Reason.REQUIRED_FIELD_NOT_SET.name
+          metadata[Errors.Metadata.FIELD_NAME.key] = "request_id"
+        }
+      )
+  }
+
+  @Test
   fun `batchCreateRankerJobs creates multiple`() =
     runBlocking<Unit> {
       val response =
@@ -277,12 +309,14 @@ abstract class RankerJobServiceTest {
             dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
             rawImpressionUploadResourceId = RAW_IMPRESSION_UPLOAD_RESOURCE_ID
             requests += createRankerJobRequest {
+              requestId = UUID.randomUUID().toString()
               rankerJob = rankerJob {
                 cmmsModelLine = CMMS_MODEL_LINE
                 poolOffsets += listOf(0L, 1L)
               }
             }
             requests += createRankerJobRequest {
+              requestId = UUID.randomUUID().toString()
               rankerJob = rankerJob {
                 cmmsModelLine = CMMS_MODEL_LINE
                 poolOffsets += listOf(2L, 3L)
@@ -323,6 +357,7 @@ abstract class RankerJobServiceTest {
     val created: RankerJob =
       service.createRankerJob(
         createRankerJobRequest {
+          requestId = UUID.randomUUID().toString()
           dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
           rawImpressionUploadResourceId = RAW_IMPRESSION_UPLOAD_RESOURCE_ID
           rankerJob = rankerJob {
@@ -724,6 +759,7 @@ abstract class RankerJobServiceTest {
     val job: RankerJob =
       service.markRankerJobFailed(
         markRankerJobFailedRequest {
+          requestId = UUID.randomUUID().toString()
           dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
           rawImpressionUploadResourceId = RAW_IMPRESSION_UPLOAD_RESOURCE_ID
           rankerJobResourceId = created.rankerJobResourceId
@@ -743,6 +779,7 @@ abstract class RankerJobServiceTest {
     val failed: RankerJob =
       service.markRankerJobFailed(
         markRankerJobFailedRequest {
+          requestId = UUID.randomUUID().toString()
           dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
           rawImpressionUploadResourceId = RAW_IMPRESSION_UPLOAD_RESOURCE_ID
           rankerJobResourceId = created.rankerJobResourceId
@@ -773,6 +810,7 @@ abstract class RankerJobServiceTest {
       assertFailsWith<StatusRuntimeException> {
         service.markRankerJobFailed(
           markRankerJobFailedRequest {
+            requestId = UUID.randomUUID().toString()
             dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
             rawImpressionUploadResourceId = RAW_IMPRESSION_UPLOAD_RESOURCE_ID
             rankerJobResourceId = created.rankerJobResourceId
@@ -783,6 +821,64 @@ abstract class RankerJobServiceTest {
       }
 
     assertThat(exception.status.code).isEqualTo(Status.Code.ABORTED)
+  }
+
+  @Test
+  fun `markRankerJobFailed throws INVALID_ARGUMENT for empty request_id`() = runBlocking {
+    val exception: StatusRuntimeException =
+      assertFailsWith<StatusRuntimeException> {
+        service.markRankerJobFailed(
+          markRankerJobFailedRequest {
+            dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
+            rawImpressionUploadResourceId = RAW_IMPRESSION_UPLOAD_RESOURCE_ID
+            rankerJobResourceId = "some-job"
+            etag = "some-etag"
+            errorMessage = "boom"
+          }
+        )
+      }
+
+    assertThat(exception.status.code).isEqualTo(Status.Code.INVALID_ARGUMENT)
+    assertThat(exception.errorInfo)
+      .isEqualTo(
+        errorInfo {
+          domain = Errors.DOMAIN
+          reason = Errors.Reason.REQUIRED_FIELD_NOT_SET.name
+          metadata[Errors.Metadata.FIELD_NAME.key] = "request_id"
+        }
+      )
+  }
+
+  @Test
+  fun `markRankerJobFailed is idempotent with same request_id`() = runBlocking {
+    val requestId = UUID.randomUUID().toString()
+    val created: RankerJob = createRanker(0L)
+
+    val failed1: RankerJob =
+      service.markRankerJobFailed(
+        markRankerJobFailedRequest {
+          dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
+          rawImpressionUploadResourceId = RAW_IMPRESSION_UPLOAD_RESOURCE_ID
+          rankerJobResourceId = created.rankerJobResourceId
+          etag = created.etag
+          errorMessage = "boom"
+          this.requestId = requestId
+        }
+      )
+
+    val failed2: RankerJob =
+      service.markRankerJobFailed(
+        markRankerJobFailedRequest {
+          dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
+          rawImpressionUploadResourceId = RAW_IMPRESSION_UPLOAD_RESOURCE_ID
+          rankerJobResourceId = created.rankerJobResourceId
+          etag = created.etag
+          errorMessage = "boom"
+          this.requestId = requestId
+        }
+      )
+
+    assertThat(failed2).isEqualTo(failed1)
   }
 
   @Test
@@ -822,6 +918,7 @@ abstract class RankerJobServiceTest {
     createParentUpload(DATA_PROVIDER_RESOURCE_ID, SECOND_UPLOAD_RESOURCE_ID)
     service.createRankerJob(
       createRankerJobRequest {
+        requestId = UUID.randomUUID().toString()
         dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
         rawImpressionUploadResourceId = SECOND_UPLOAD_RESOURCE_ID
         rankerJob = rankerJob {
@@ -850,6 +947,7 @@ abstract class RankerJobServiceTest {
               rawImpressionUploadResourceId = RAW_IMPRESSION_UPLOAD_RESOURCE_ID
               for (i in 0 until 51) {
                 requests += createRankerJobRequest {
+                  requestId = UUID.randomUUID().toString()
                   rankerJob = rankerJob {
                     cmmsModelLine = CMMS_MODEL_LINE
                     poolOffsets += i.toLong()
@@ -916,6 +1014,7 @@ abstract class RankerJobServiceTest {
   ): RankerJob {
     return service.createRankerJob(
       createRankerJobRequest {
+        requestId = UUID.randomUUID().toString()
         dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
         rawImpressionUploadResourceId = RAW_IMPRESSION_UPLOAD_RESOURCE_ID
         rankerJob = rankerJob {

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/service/internal/testing/RankerJobServiceTest.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/service/internal/testing/RankerJobServiceTest.kt
@@ -446,6 +446,43 @@ abstract class RankerJobServiceTest {
   }
 
   @Test
+  fun `listRankerJobs returns total_size ignoring pagination`() = runBlocking {
+    for (i in 0..2) {
+      createRanker(i.toLong())
+    }
+
+    val response: ListRankerJobsResponse =
+      service.listRankerJobs(
+        listRankerJobsRequest {
+          dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
+          rawImpressionUploadResourceId = RAW_IMPRESSION_UPLOAD_RESOURCE_ID
+          pageSize = 2
+        }
+      )
+
+    assertThat(response.rankerJobsList).hasSize(2)
+    assertThat(response.totalSize).isEqualTo(3)
+  }
+
+  @Test
+  fun `listRankerJobs total_size respects filter`() = runBlocking {
+    createRanker(0L, cmmsModelLine = CMMS_MODEL_LINE)
+    createRanker(1L, cmmsModelLine = CMMS_MODEL_LINE_2)
+
+    val response: ListRankerJobsResponse =
+      service.listRankerJobs(
+        listRankerJobsRequest {
+          dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
+          rawImpressionUploadResourceId = RAW_IMPRESSION_UPLOAD_RESOURCE_ID
+          filter = ListRankerJobsRequestKt.filter { cmmsModelLine = CMMS_MODEL_LINE }
+        }
+      )
+
+    assertThat(response.rankerJobsList).hasSize(1)
+    assertThat(response.totalSize).isEqualTo(1)
+  }
+
+  @Test
   fun `listRankerJobs filters by state_in`() = runBlocking {
     val created: RankerJob = createRanker(0L)
     createRanker(1L)

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/service/internal/testing/RankerJobServiceTest.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/service/internal/testing/RankerJobServiceTest.kt
@@ -925,6 +925,53 @@ abstract class RankerJobServiceTest {
   }
 
   @Test
+  fun `mark RPCs track succeeded and failed request_ids independently`() = runBlocking {
+    val requestId = UUID.randomUUID().toString()
+    val created: RankerJob = createRanker(0L)
+
+    // Mark FAILED then SUCCEEDED reusing the SAME request_id. Each Mark RPC keys idempotency on
+    // its own column, so the succeeded call must genuinely transition the job rather than replay
+    // the earlier failed mark.
+    val failed: RankerJob =
+      service.markRankerJobFailed(
+        markRankerJobFailedRequest {
+          dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
+          rawImpressionUploadResourceId = RAW_IMPRESSION_UPLOAD_RESOURCE_ID
+          rankerJobResourceId = created.rankerJobResourceId
+          etag = created.etag
+          errorMessage = "transient"
+          this.requestId = requestId
+        }
+      )
+    assertThat(failed.state).isEqualTo(RankerState.RANKER_STATE_FAILED)
+
+    val response: MarkRankerJobSucceededResponse =
+      service.markRankerJobSucceeded(
+        markRankerJobSucceededRequest {
+          dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
+          rawImpressionUploadResourceId = RAW_IMPRESSION_UPLOAD_RESOURCE_ID
+          rankerJobResourceId = created.rankerJobResourceId
+          etag = failed.etag
+          this.requestId = requestId
+        }
+      )
+    assertThat(response.rankerJob.state).isEqualTo(RankerState.RANKER_STATE_SUCCEEDED)
+
+    // The succeeded mark stays independently idempotent on its own request_id.
+    val replay: MarkRankerJobSucceededResponse =
+      service.markRankerJobSucceeded(
+        markRankerJobSucceededRequest {
+          dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
+          rawImpressionUploadResourceId = RAW_IMPRESSION_UPLOAD_RESOURCE_ID
+          rankerJobResourceId = created.rankerJobResourceId
+          etag = response.rankerJob.etag
+          this.requestId = requestId
+        }
+      )
+    assertThat(replay).isEqualTo(response)
+  }
+
+  @Test
   fun `listRankerJobs filters by create_time_in`() = runBlocking {
     val created: RankerJob = createRanker(0L)
 

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/service/internal/testing/RankerJobServiceTest.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/service/internal/testing/RankerJobServiceTest.kt
@@ -803,6 +803,49 @@ abstract class RankerJobServiceTest {
   }
 
   @Test
+  fun `markRankerJobSucceeded clears error_message when retrying from FAILED`() = runBlocking {
+    val created: RankerJob = createRanker(0L)
+
+    val failed: RankerJob =
+      service.markRankerJobFailed(
+        markRankerJobFailedRequest {
+          requestId = UUID.randomUUID().toString()
+          dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
+          rawImpressionUploadResourceId = RAW_IMPRESSION_UPLOAD_RESOURCE_ID
+          rankerJobResourceId = created.rankerJobResourceId
+          etag = created.etag
+          errorMessage = "transient"
+        }
+      )
+    assertThat(failed.errorMessage).isEqualTo("transient")
+
+    val response: MarkRankerJobSucceededResponse =
+      service.markRankerJobSucceeded(
+        markRankerJobSucceededRequest {
+          dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
+          rawImpressionUploadResourceId = RAW_IMPRESSION_UPLOAD_RESOURCE_ID
+          rankerJobResourceId = created.rankerJobResourceId
+          etag = failed.etag
+          requestId = UUID.randomUUID().toString()
+        }
+      )
+
+    assertThat(response.rankerJob.state).isEqualTo(RankerState.RANKER_STATE_SUCCEEDED)
+    assertThat(response.rankerJob.errorMessage).isEmpty()
+
+    // The cleared error_message must also be persisted, not just reflected in the response copy.
+    val fetched: RankerJob =
+      service.getRankerJob(
+        getRankerJobRequest {
+          dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
+          rawImpressionUploadResourceId = RAW_IMPRESSION_UPLOAD_RESOURCE_ID
+          rankerJobResourceId = created.rankerJobResourceId
+        }
+      )
+    assertThat(fetched.errorMessage).isEmpty()
+  }
+
+  @Test
   fun `markRankerJobFailed throws ABORTED for etag mismatch`() = runBlocking {
     val created: RankerJob = createRanker(0L)
 

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/service/v1alpha/BUILD.bazel
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/service/v1alpha/BUILD.bazel
@@ -124,6 +124,7 @@ kt_jvm_library(
     srcs = ["Services.kt"],
     deps = [
         ":impression_metadata_service",
+        ":ranker_job_service",
         ":raw_impression_metadata_batch_file_service",
         ":raw_impression_metadata_batch_service",
         ":raw_impression_upload_file_service",
@@ -131,6 +132,7 @@ kt_jvm_library(
         ":requisition_metadata_service",
         ":vid_labeling_job_service",
         "//src/main/proto/wfa/measurement/edpaggregator/v1alpha:impression_metadata_service_kt_jvm_grpc_proto",
+        "//src/main/proto/wfa/measurement/edpaggregator/v1alpha:ranker_job_service_kt_jvm_grpc_proto",
         "//src/main/proto/wfa/measurement/edpaggregator/v1alpha:raw_impression_metadata_batch_file_service_kt_jvm_grpc_proto",
         "//src/main/proto/wfa/measurement/edpaggregator/v1alpha:raw_impression_metadata_batch_service_kt_jvm_grpc_proto",
         "//src/main/proto/wfa/measurement/edpaggregator/v1alpha:raw_impression_upload_file_service_kt_jvm_grpc_proto",
@@ -138,6 +140,7 @@ kt_jvm_library(
         "//src/main/proto/wfa/measurement/edpaggregator/v1alpha:requisition_metadata_service_kt_jvm_grpc_proto",
         "//src/main/proto/wfa/measurement/edpaggregator/v1alpha:vid_labeling_job_service_kt_jvm_grpc_proto",
         "//src/main/proto/wfa/measurement/internal/edpaggregator:impression_metadata_service_kt_jvm_grpc_proto",
+        "//src/main/proto/wfa/measurement/internal/edpaggregator:ranker_job_service_kt_jvm_grpc_proto",
         "//src/main/proto/wfa/measurement/internal/edpaggregator:raw_impression_metadata_batch_file_service_kt_jvm_grpc_proto",
         "//src/main/proto/wfa/measurement/internal/edpaggregator:raw_impression_metadata_batch_service_kt_jvm_grpc_proto",
         "//src/main/proto/wfa/measurement/internal/edpaggregator:raw_impression_upload_file_service_kt_jvm_grpc_proto",
@@ -161,6 +164,25 @@ kt_jvm_library(
         "//src/main/proto/wfa/measurement/internal/edpaggregator:vid_labeling_job_kt_jvm_proto",
         "//src/main/proto/wfa/measurement/internal/edpaggregator:vid_labeling_job_service_kt_jvm_grpc_proto",
         "//src/main/proto/wfa/measurement/internal/edpaggregator:vid_labeling_state_kt_jvm_proto",
+        "@wfa_common_jvm//imports/java/io/grpc:api",
+        "@wfa_common_jvm//src/main/kotlin/org/wfanet/measurement/common",
+    ],
+)
+
+kt_jvm_library(
+    name = "ranker_job_service",
+    srcs = [
+        "RankerJobService.kt",
+    ],
+    deps = [
+        "//src/main/kotlin/org/wfanet/measurement/edpaggregator/service:errors",
+        "//src/main/kotlin/org/wfanet/measurement/edpaggregator/service:resource_key",
+        "//src/main/kotlin/org/wfanet/measurement/edpaggregator/service/internal:errors",
+        "//src/main/proto/wfa/measurement/edpaggregator/v1alpha:ranker_job_kt_jvm_proto",
+        "//src/main/proto/wfa/measurement/edpaggregator/v1alpha:ranker_job_service_kt_jvm_grpc_proto",
+        "//src/main/proto/wfa/measurement/internal/edpaggregator:ranker_job_kt_jvm_proto",
+        "//src/main/proto/wfa/measurement/internal/edpaggregator:ranker_job_service_kt_jvm_grpc_proto",
+        "//src/main/proto/wfa/measurement/internal/edpaggregator:ranker_state_kt_jvm_proto",
         "@wfa_common_jvm//imports/java/io/grpc:api",
         "@wfa_common_jvm//src/main/kotlin/org/wfanet/measurement/common",
     ],

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/service/v1alpha/ImpressionMetadataService.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/service/v1alpha/ImpressionMetadataService.kt
@@ -139,6 +139,9 @@ class ImpressionMetadataService(
           InternalErrors.Reason.VID_LABELING_JOB_NOT_FOUND,
           InternalErrors.Reason.VID_LABELING_JOB_STATE_INVALID,
           InternalErrors.Reason.VID_LABELING_JOB_ALREADY_EXISTS,
+          InternalErrors.Reason.RANKER_JOB_NOT_FOUND,
+          InternalErrors.Reason.RANKER_JOB_ALREADY_EXISTS,
+          InternalErrors.Reason.RANKER_JOB_STATE_INVALID,
           null -> Status.INTERNAL.withCause(e).asRuntimeException()
         }
       }
@@ -199,6 +202,9 @@ class ImpressionMetadataService(
           InternalErrors.Reason.VID_LABELING_JOB_NOT_FOUND,
           InternalErrors.Reason.VID_LABELING_JOB_STATE_INVALID,
           InternalErrors.Reason.VID_LABELING_JOB_ALREADY_EXISTS,
+          InternalErrors.Reason.RANKER_JOB_NOT_FOUND,
+          InternalErrors.Reason.RANKER_JOB_ALREADY_EXISTS,
+          InternalErrors.Reason.RANKER_JOB_STATE_INVALID,
           null -> Status.INTERNAL.withCause(e).asRuntimeException()
         }
       }
@@ -298,6 +304,9 @@ class ImpressionMetadataService(
           InternalErrors.Reason.VID_LABELING_JOB_NOT_FOUND,
           InternalErrors.Reason.VID_LABELING_JOB_STATE_INVALID,
           InternalErrors.Reason.VID_LABELING_JOB_ALREADY_EXISTS,
+          InternalErrors.Reason.RANKER_JOB_NOT_FOUND,
+          InternalErrors.Reason.RANKER_JOB_ALREADY_EXISTS,
+          InternalErrors.Reason.RANKER_JOB_STATE_INVALID,
           null -> Status.INTERNAL.withCause(e).asRuntimeException()
         }
       }
@@ -366,6 +375,9 @@ class ImpressionMetadataService(
           InternalErrors.Reason.VID_LABELING_JOB_NOT_FOUND,
           InternalErrors.Reason.VID_LABELING_JOB_STATE_INVALID,
           InternalErrors.Reason.VID_LABELING_JOB_ALREADY_EXISTS,
+          InternalErrors.Reason.RANKER_JOB_NOT_FOUND,
+          InternalErrors.Reason.RANKER_JOB_ALREADY_EXISTS,
+          InternalErrors.Reason.RANKER_JOB_STATE_INVALID,
           null -> Status.INTERNAL.withCause(e).asRuntimeException()
         }
       }
@@ -466,6 +478,9 @@ class ImpressionMetadataService(
           InternalErrors.Reason.VID_LABELING_JOB_NOT_FOUND,
           InternalErrors.Reason.VID_LABELING_JOB_STATE_INVALID,
           InternalErrors.Reason.VID_LABELING_JOB_ALREADY_EXISTS,
+          InternalErrors.Reason.RANKER_JOB_NOT_FOUND,
+          InternalErrors.Reason.RANKER_JOB_ALREADY_EXISTS,
+          InternalErrors.Reason.RANKER_JOB_STATE_INVALID,
           null -> Status.INTERNAL.withCause(e).asRuntimeException()
         }
       }
@@ -526,6 +541,9 @@ class ImpressionMetadataService(
         InternalErrors.Reason.VID_LABELING_JOB_NOT_FOUND,
         InternalErrors.Reason.VID_LABELING_JOB_STATE_INVALID,
         InternalErrors.Reason.VID_LABELING_JOB_ALREADY_EXISTS,
+        InternalErrors.Reason.RANKER_JOB_NOT_FOUND,
+        InternalErrors.Reason.RANKER_JOB_ALREADY_EXISTS,
+        InternalErrors.Reason.RANKER_JOB_STATE_INVALID,
         null -> Status.INTERNAL.withCause(e).asRuntimeException()
       }
     }
@@ -614,6 +632,9 @@ class ImpressionMetadataService(
           InternalErrors.Reason.VID_LABELING_JOB_NOT_FOUND,
           InternalErrors.Reason.VID_LABELING_JOB_STATE_INVALID,
           InternalErrors.Reason.VID_LABELING_JOB_ALREADY_EXISTS,
+          InternalErrors.Reason.RANKER_JOB_NOT_FOUND,
+          InternalErrors.Reason.RANKER_JOB_ALREADY_EXISTS,
+          InternalErrors.Reason.RANKER_JOB_STATE_INVALID,
           null -> Status.INTERNAL.withCause(e).asRuntimeException()
         }
       }
@@ -735,6 +756,9 @@ class ImpressionMetadataService(
           InternalErrors.Reason.VID_LABELING_JOB_NOT_FOUND,
           InternalErrors.Reason.VID_LABELING_JOB_STATE_INVALID,
           InternalErrors.Reason.VID_LABELING_JOB_ALREADY_EXISTS,
+          InternalErrors.Reason.RANKER_JOB_NOT_FOUND,
+          InternalErrors.Reason.RANKER_JOB_ALREADY_EXISTS,
+          InternalErrors.Reason.RANKER_JOB_STATE_INVALID,
           null -> Status.INTERNAL.withCause(e).asRuntimeException()
         }
       }
@@ -794,6 +818,9 @@ class ImpressionMetadataService(
           InternalErrors.Reason.VID_LABELING_JOB_NOT_FOUND,
           InternalErrors.Reason.VID_LABELING_JOB_STATE_INVALID,
           InternalErrors.Reason.VID_LABELING_JOB_ALREADY_EXISTS,
+          InternalErrors.Reason.RANKER_JOB_NOT_FOUND,
+          InternalErrors.Reason.RANKER_JOB_ALREADY_EXISTS,
+          InternalErrors.Reason.RANKER_JOB_STATE_INVALID,
           null -> Status.INTERNAL.withCause(e).asRuntimeException()
         }
       }

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/service/v1alpha/RankerJobService.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/service/v1alpha/RankerJobService.kt
@@ -327,13 +327,15 @@ class RankerJobService(
         .asStatusRuntimeException(Status.Code.INVALID_ARGUMENT)
     }
 
-    if (request.requestId.isNotEmpty()) {
-      try {
-        UUID.fromString(request.requestId)
-      } catch (e: IllegalArgumentException) {
-        throw InvalidFieldValueException("request_id", e)
-          .asStatusRuntimeException(Status.Code.INVALID_ARGUMENT)
-      }
+    if (request.requestId.isEmpty()) {
+      throw RequiredFieldNotSetException("request_id")
+        .asStatusRuntimeException(Status.Code.INVALID_ARGUMENT)
+    }
+    try {
+      UUID.fromString(request.requestId)
+    } catch (e: IllegalArgumentException) {
+      throw InvalidFieldValueException("request_id", e)
+        .asStatusRuntimeException(Status.Code.INVALID_ARGUMENT)
     }
 
     val internalResponse: InternalMarkSucceededResponse =

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/service/v1alpha/RankerJobService.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/service/v1alpha/RankerJobService.kt
@@ -439,6 +439,9 @@ class RankerJobService(
         InternalErrors.Reason.REQUISITION_METADATA_STATE_INVALID,
         InternalErrors.Reason.REQUIRED_FIELD_NOT_SET,
         InternalErrors.Reason.INVALID_FIELD_VALUE,
+        InternalErrors.Reason.VID_LABELING_JOB_NOT_FOUND,
+        InternalErrors.Reason.VID_LABELING_JOB_STATE_INVALID,
+        InternalErrors.Reason.VID_LABELING_JOB_ALREADY_EXISTS,
         null -> Status.INTERNAL.withCause(e).asRuntimeException()
       }
     }

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/service/v1alpha/RankerJobService.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/service/v1alpha/RankerJobService.kt
@@ -93,13 +93,15 @@ class RankerJobService(
       throw RequiredFieldNotSetException("ranker_job.pool_offsets")
         .asStatusRuntimeException(Status.Code.INVALID_ARGUMENT)
     }
-    if (request.requestId.isNotEmpty()) {
-      try {
-        UUID.fromString(request.requestId)
-      } catch (e: IllegalArgumentException) {
-        throw InvalidFieldValueException("request_id", e)
-          .asStatusRuntimeException(Status.Code.INVALID_ARGUMENT)
-      }
+    if (request.requestId.isEmpty()) {
+      throw RequiredFieldNotSetException("request_id")
+        .asStatusRuntimeException(Status.Code.INVALID_ARGUMENT)
+    }
+    try {
+      UUID.fromString(request.requestId)
+    } catch (e: IllegalArgumentException) {
+      throw InvalidFieldValueException("request_id", e)
+        .asStatusRuntimeException(Status.Code.INVALID_ARGUMENT)
     }
 
     val internalResponse: InternalRankerJob =
@@ -162,17 +164,19 @@ class RankerJobService(
         throw RequiredFieldNotSetException("requests.$index.ranker_job.pool_offsets")
           .asStatusRuntimeException(Status.Code.INVALID_ARGUMENT)
       }
-      if (createRequest.requestId.isNotEmpty()) {
-        try {
-          UUID.fromString(createRequest.requestId)
-        } catch (e: IllegalArgumentException) {
-          throw InvalidFieldValueException("requests.$index.request_id", e)
-            .asStatusRuntimeException(Status.Code.INVALID_ARGUMENT)
-        }
-        if (!seenRequestIds.add(createRequest.requestId)) {
-          throw InvalidFieldValueException("requests.$index.request_id")
-            .asStatusRuntimeException(Status.Code.INVALID_ARGUMENT)
-        }
+      if (createRequest.requestId.isEmpty()) {
+        throw RequiredFieldNotSetException("requests.$index.request_id")
+          .asStatusRuntimeException(Status.Code.INVALID_ARGUMENT)
+      }
+      try {
+        UUID.fromString(createRequest.requestId)
+      } catch (e: IllegalArgumentException) {
+        throw InvalidFieldValueException("requests.$index.request_id", e)
+          .asStatusRuntimeException(Status.Code.INVALID_ARGUMENT)
+      }
+      if (!seenRequestIds.add(createRequest.requestId)) {
+        throw InvalidFieldValueException("requests.$index.request_id")
+          .asStatusRuntimeException(Status.Code.INVALID_ARGUMENT)
       }
     }
 
@@ -375,6 +379,17 @@ class RankerJobService(
         .asStatusRuntimeException(Status.Code.INVALID_ARGUMENT)
     }
 
+    if (request.requestId.isEmpty()) {
+      throw RequiredFieldNotSetException("request_id")
+        .asStatusRuntimeException(Status.Code.INVALID_ARGUMENT)
+    }
+    try {
+      UUID.fromString(request.requestId)
+    } catch (e: IllegalArgumentException) {
+      throw InvalidFieldValueException("request_id", e)
+        .asStatusRuntimeException(Status.Code.INVALID_ARGUMENT)
+    }
+
     val internalResponse: InternalRankerJob =
       try {
         internalRankerJobStub.markRankerJobFailed(
@@ -384,6 +399,7 @@ class RankerJobService(
             rankerJobResourceId = jobKey.rankerJobId
             etag = request.etag
             errorMessage = request.errorMessage
+            requestId = request.requestId
           }
         )
       } catch (e: StatusException) {

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/service/v1alpha/RankerJobService.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/service/v1alpha/RankerJobService.kt
@@ -307,6 +307,7 @@ class RankerJobService(
 
     return listRankerJobsResponse {
       rankerJobs += internalResponse.rankerJobsList.map { it.toPublic() }
+      totalSize = internalResponse.totalSize
       if (internalResponse.hasNextPageToken()) {
         nextPageToken = internalResponse.nextPageToken.toByteArray().base64UrlEncode()
       }
@@ -442,6 +443,8 @@ class RankerJobService(
         InternalErrors.Reason.VID_LABELING_JOB_NOT_FOUND,
         InternalErrors.Reason.VID_LABELING_JOB_STATE_INVALID,
         InternalErrors.Reason.VID_LABELING_JOB_ALREADY_EXISTS,
+        InternalErrors.Reason.RAW_IMPRESSION_UPLOAD_FILE_NOT_FOUND,
+        InternalErrors.Reason.RAW_IMPRESSION_UPLOAD_FILE_ALREADY_EXISTS,
         null -> Status.INTERNAL.withCause(e).asRuntimeException()
       }
     }

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/service/v1alpha/RankerJobService.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/service/v1alpha/RankerJobService.kt
@@ -1,0 +1,475 @@
+// Copyright 2026 The Cross-Media Measurement Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.wfanet.measurement.edpaggregator.service.v1alpha
+
+import io.grpc.Status
+import io.grpc.StatusException
+import io.grpc.StatusRuntimeException
+import java.io.IOException
+import java.util.UUID
+import kotlin.coroutines.CoroutineContext
+import kotlin.coroutines.EmptyCoroutineContext
+import org.wfanet.measurement.common.api.ResourceKey
+import org.wfanet.measurement.common.base64UrlDecode
+import org.wfanet.measurement.common.base64UrlEncode
+import org.wfanet.measurement.edpaggregator.service.InvalidFieldValueException
+import org.wfanet.measurement.edpaggregator.service.RankerJobKey
+import org.wfanet.measurement.edpaggregator.service.RawImpressionUploadKey
+import org.wfanet.measurement.edpaggregator.service.RequiredFieldNotSetException
+import org.wfanet.measurement.edpaggregator.service.internal.Errors as InternalErrors
+import org.wfanet.measurement.edpaggregator.v1alpha.BatchCreateRankerJobsRequest
+import org.wfanet.measurement.edpaggregator.v1alpha.BatchCreateRankerJobsResponse
+import org.wfanet.measurement.edpaggregator.v1alpha.CreateRankerJobRequest
+import org.wfanet.measurement.edpaggregator.v1alpha.GetRankerJobRequest
+import org.wfanet.measurement.edpaggregator.v1alpha.ListRankerJobsRequest
+import org.wfanet.measurement.edpaggregator.v1alpha.ListRankerJobsResponse
+import org.wfanet.measurement.edpaggregator.v1alpha.MarkRankerJobFailedRequest
+import org.wfanet.measurement.edpaggregator.v1alpha.MarkRankerJobSucceededRequest
+import org.wfanet.measurement.edpaggregator.v1alpha.MarkRankerJobSucceededResponse
+import org.wfanet.measurement.edpaggregator.v1alpha.RankerJob
+import org.wfanet.measurement.edpaggregator.v1alpha.RankerJobServiceGrpcKt.RankerJobServiceCoroutineImplBase
+import org.wfanet.measurement.edpaggregator.v1alpha.batchCreateRankerJobsResponse
+import org.wfanet.measurement.edpaggregator.v1alpha.listRankerJobsResponse
+import org.wfanet.measurement.edpaggregator.v1alpha.markRankerJobSucceededResponse
+import org.wfanet.measurement.edpaggregator.v1alpha.rankerJob
+import org.wfanet.measurement.internal.edpaggregator.ListRankerJobsPageToken as InternalListPageToken
+import org.wfanet.measurement.internal.edpaggregator.ListRankerJobsRequestKt as InternalListRankerJobsRequestKt
+import org.wfanet.measurement.internal.edpaggregator.ListRankerJobsResponse as InternalListResponse
+import org.wfanet.measurement.internal.edpaggregator.MarkRankerJobSucceededResponse as InternalMarkSucceededResponse
+import org.wfanet.measurement.internal.edpaggregator.RankerJob as InternalRankerJob
+import org.wfanet.measurement.internal.edpaggregator.RankerJobServiceGrpcKt.RankerJobServiceCoroutineStub as InternalRankerJobServiceStub
+import org.wfanet.measurement.internal.edpaggregator.RankerState
+import org.wfanet.measurement.internal.edpaggregator.batchCreateRankerJobsRequest as internalBatchCreateRequest
+import org.wfanet.measurement.internal.edpaggregator.createRankerJobRequest as internalCreateRequest
+import org.wfanet.measurement.internal.edpaggregator.getRankerJobRequest as internalGetRequest
+import org.wfanet.measurement.internal.edpaggregator.listRankerJobsRequest as internalListRequest
+import org.wfanet.measurement.internal.edpaggregator.markRankerJobFailedRequest as internalMarkFailedRequest
+import org.wfanet.measurement.internal.edpaggregator.markRankerJobSucceededRequest as internalMarkSucceededRequest
+import org.wfanet.measurement.internal.edpaggregator.rankerJob as internalRankerJob
+
+/**
+ * Public v1alpha implementation of the [RankerJob] service.
+ *
+ * Validates and translates public RankerJob API requests into the internal RankerJob service,
+ * mapping resource names to internal resource IDs and internal error reasons to gRPC statuses.
+ */
+class RankerJobService(
+  private val internalRankerJobStub: InternalRankerJobServiceStub,
+  coroutineContext: CoroutineContext = EmptyCoroutineContext,
+) : RankerJobServiceCoroutineImplBase(coroutineContext) {
+
+  override suspend fun createRankerJob(request: CreateRankerJobRequest): RankerJob {
+    if (request.parent.isEmpty()) {
+      throw RequiredFieldNotSetException("parent")
+        .asStatusRuntimeException(Status.Code.INVALID_ARGUMENT)
+    }
+
+    val uploadKey =
+      RawImpressionUploadKey.fromName(request.parent)
+        ?: throw InvalidFieldValueException("parent")
+          .asStatusRuntimeException(Status.Code.INVALID_ARGUMENT)
+
+    if (!request.hasRankerJob()) {
+      throw RequiredFieldNotSetException("ranker_job")
+        .asStatusRuntimeException(Status.Code.INVALID_ARGUMENT)
+    }
+    if (request.rankerJob.cmmsModelLine.isEmpty()) {
+      throw RequiredFieldNotSetException("ranker_job.cmms_model_line")
+        .asStatusRuntimeException(Status.Code.INVALID_ARGUMENT)
+    }
+    if (request.rankerJob.poolOffsetsList.isEmpty()) {
+      throw RequiredFieldNotSetException("ranker_job.pool_offsets")
+        .asStatusRuntimeException(Status.Code.INVALID_ARGUMENT)
+    }
+    if (request.requestId.isNotEmpty()) {
+      try {
+        UUID.fromString(request.requestId)
+      } catch (e: IllegalArgumentException) {
+        throw InvalidFieldValueException("request_id", e)
+          .asStatusRuntimeException(Status.Code.INVALID_ARGUMENT)
+      }
+    }
+
+    val internalResponse: InternalRankerJob =
+      try {
+        internalRankerJobStub.createRankerJob(
+          internalCreateRequest {
+            dataProviderResourceId = uploadKey.dataProviderId
+            rawImpressionUploadResourceId = uploadKey.rawImpressionUploadId
+            rankerJob = internalRankerJob {
+              cmmsModelLine = request.rankerJob.cmmsModelLine
+              poolOffsets += request.rankerJob.poolOffsetsList
+            }
+            requestId = request.requestId
+          }
+        )
+      } catch (e: StatusException) {
+        throw handleInternalError(e)
+      }
+
+    return internalResponse.toPublic()
+  }
+
+  override suspend fun batchCreateRankerJobs(
+    request: BatchCreateRankerJobsRequest
+  ): BatchCreateRankerJobsResponse {
+    if (request.parent.isEmpty()) {
+      throw RequiredFieldNotSetException("parent")
+        .asStatusRuntimeException(Status.Code.INVALID_ARGUMENT)
+    }
+
+    val uploadKey =
+      RawImpressionUploadKey.fromName(request.parent)
+        ?: throw InvalidFieldValueException("parent")
+          .asStatusRuntimeException(Status.Code.INVALID_ARGUMENT)
+
+    if (request.requestsList.isEmpty()) {
+      throw RequiredFieldNotSetException("requests")
+        .asStatusRuntimeException(Status.Code.INVALID_ARGUMENT)
+    }
+    if (request.requestsList.size > MAX_BATCH_SIZE) {
+      throw InvalidFieldValueException("requests")
+        .asStatusRuntimeException(Status.Code.INVALID_ARGUMENT)
+    }
+
+    val seenRequestIds = mutableSetOf<String>()
+    request.requestsList.forEachIndexed { index, createRequest ->
+      if (createRequest.parent.isNotEmpty() && createRequest.parent != request.parent) {
+        throw InvalidFieldValueException("requests.$index.parent")
+          .asStatusRuntimeException(Status.Code.INVALID_ARGUMENT)
+      }
+      if (!createRequest.hasRankerJob()) {
+        throw RequiredFieldNotSetException("requests.$index.ranker_job")
+          .asStatusRuntimeException(Status.Code.INVALID_ARGUMENT)
+      }
+      if (createRequest.rankerJob.cmmsModelLine.isEmpty()) {
+        throw RequiredFieldNotSetException("requests.$index.ranker_job.cmms_model_line")
+          .asStatusRuntimeException(Status.Code.INVALID_ARGUMENT)
+      }
+      if (createRequest.rankerJob.poolOffsetsList.isEmpty()) {
+        throw RequiredFieldNotSetException("requests.$index.ranker_job.pool_offsets")
+          .asStatusRuntimeException(Status.Code.INVALID_ARGUMENT)
+      }
+      if (createRequest.requestId.isNotEmpty()) {
+        try {
+          UUID.fromString(createRequest.requestId)
+        } catch (e: IllegalArgumentException) {
+          throw InvalidFieldValueException("requests.$index.request_id", e)
+            .asStatusRuntimeException(Status.Code.INVALID_ARGUMENT)
+        }
+        if (!seenRequestIds.add(createRequest.requestId)) {
+          throw InvalidFieldValueException("requests.$index.request_id")
+            .asStatusRuntimeException(Status.Code.INVALID_ARGUMENT)
+        }
+      }
+    }
+
+    val internalResponse =
+      try {
+        internalRankerJobStub.batchCreateRankerJobs(
+          internalBatchCreateRequest {
+            dataProviderResourceId = uploadKey.dataProviderId
+            rawImpressionUploadResourceId = uploadKey.rawImpressionUploadId
+            requests +=
+              request.requestsList.map { createRequest ->
+                internalCreateRequest {
+                  dataProviderResourceId = uploadKey.dataProviderId
+                  rawImpressionUploadResourceId = uploadKey.rawImpressionUploadId
+                  rankerJob = internalRankerJob {
+                    cmmsModelLine = createRequest.rankerJob.cmmsModelLine
+                    poolOffsets += createRequest.rankerJob.poolOffsetsList
+                  }
+                  requestId = createRequest.requestId
+                }
+              }
+          }
+        )
+      } catch (e: StatusException) {
+        throw handleInternalError(e)
+      }
+
+    return batchCreateRankerJobsResponse {
+      rankerJobs += internalResponse.rankerJobsList.map { it.toPublic() }
+    }
+  }
+
+  override suspend fun getRankerJob(request: GetRankerJobRequest): RankerJob {
+    if (request.name.isEmpty()) {
+      throw RequiredFieldNotSetException("name")
+        .asStatusRuntimeException(Status.Code.INVALID_ARGUMENT)
+    }
+
+    val jobKey =
+      RankerJobKey.fromName(request.name)
+        ?: throw InvalidFieldValueException("name")
+          .asStatusRuntimeException(Status.Code.INVALID_ARGUMENT)
+
+    val internalResponse: InternalRankerJob =
+      try {
+        internalRankerJobStub.getRankerJob(
+          internalGetRequest {
+            dataProviderResourceId = jobKey.dataProviderId
+            rawImpressionUploadResourceId = jobKey.rawImpressionUploadId
+            rankerJobResourceId = jobKey.rankerJobId
+          }
+        )
+      } catch (e: StatusException) {
+        throw handleInternalError(e)
+      }
+
+    return internalResponse.toPublic()
+  }
+
+  override suspend fun listRankerJobs(request: ListRankerJobsRequest): ListRankerJobsResponse {
+    if (request.parent.isEmpty()) {
+      throw RequiredFieldNotSetException("parent")
+        .asStatusRuntimeException(Status.Code.INVALID_ARGUMENT)
+    }
+
+    val uploadKey =
+      RawImpressionUploadKey.fromName(request.parent)
+        ?: throw InvalidFieldValueException("parent")
+          .asStatusRuntimeException(Status.Code.INVALID_ARGUMENT)
+
+    if (request.pageSize < 0) {
+      throw InvalidFieldValueException("page_size")
+        .asStatusRuntimeException(Status.Code.INVALID_ARGUMENT)
+    }
+
+    val internalPageToken: InternalListPageToken? =
+      if (request.pageToken.isEmpty()) {
+        null
+      } else {
+        try {
+          InternalListPageToken.parseFrom(request.pageToken.base64UrlDecode())
+        } catch (e: IOException) {
+          throw InvalidFieldValueException("page_token", e)
+            .asStatusRuntimeException(Status.Code.INVALID_ARGUMENT)
+        }
+      }
+
+    if (request.hasFilter()) {
+      for (state in request.filter.stateInList) {
+        if (state == RankerJob.State.STATE_UNSPECIFIED || state == RankerJob.State.UNRECOGNIZED) {
+          throw InvalidFieldValueException("filter.state_in")
+            .asStatusRuntimeException(Status.Code.INVALID_ARGUMENT)
+        }
+      }
+    }
+
+    val internalResponse: InternalListResponse =
+      try {
+        internalRankerJobStub.listRankerJobs(
+          internalListRequest {
+            dataProviderResourceId = uploadKey.dataProviderId
+            rawImpressionUploadResourceId =
+              if (uploadKey.rawImpressionUploadId == ResourceKey.WILDCARD_ID) ""
+              else uploadKey.rawImpressionUploadId
+            this.pageSize = request.pageSize
+            if (internalPageToken != null) {
+              pageToken = internalPageToken
+            }
+            if (request.hasFilter()) {
+              filter =
+                InternalListRankerJobsRequestKt.filter {
+                  if (request.filter.stateInList.isNotEmpty()) {
+                    stateIn += request.filter.stateInList.map { it.toInternal() }
+                  }
+                  if (request.filter.hasCreateTimeIn()) {
+                    createTimeIn = request.filter.createTimeIn
+                  }
+                  if (request.filter.cmmsModelLine.isNotEmpty()) {
+                    cmmsModelLine = request.filter.cmmsModelLine
+                  }
+                }
+            }
+          }
+        )
+      } catch (e: StatusException) {
+        throw handleInternalError(e)
+      }
+
+    return listRankerJobsResponse {
+      rankerJobs += internalResponse.rankerJobsList.map { it.toPublic() }
+      if (internalResponse.hasNextPageToken()) {
+        nextPageToken = internalResponse.nextPageToken.toByteArray().base64UrlEncode()
+      }
+    }
+  }
+
+  override suspend fun markRankerJobSucceeded(
+    request: MarkRankerJobSucceededRequest
+  ): MarkRankerJobSucceededResponse {
+    if (request.name.isEmpty()) {
+      throw RequiredFieldNotSetException("name")
+        .asStatusRuntimeException(Status.Code.INVALID_ARGUMENT)
+    }
+
+    val jobKey =
+      RankerJobKey.fromName(request.name)
+        ?: throw InvalidFieldValueException("name")
+          .asStatusRuntimeException(Status.Code.INVALID_ARGUMENT)
+
+    if (request.etag.isEmpty()) {
+      throw RequiredFieldNotSetException("etag")
+        .asStatusRuntimeException(Status.Code.INVALID_ARGUMENT)
+    }
+
+    if (request.requestId.isNotEmpty()) {
+      try {
+        UUID.fromString(request.requestId)
+      } catch (e: IllegalArgumentException) {
+        throw InvalidFieldValueException("request_id", e)
+          .asStatusRuntimeException(Status.Code.INVALID_ARGUMENT)
+      }
+    }
+
+    val internalResponse: InternalMarkSucceededResponse =
+      try {
+        internalRankerJobStub.markRankerJobSucceeded(
+          internalMarkSucceededRequest {
+            dataProviderResourceId = jobKey.dataProviderId
+            rawImpressionUploadResourceId = jobKey.rawImpressionUploadId
+            rankerJobResourceId = jobKey.rankerJobId
+            etag = request.etag
+            requestId = request.requestId
+          }
+        )
+      } catch (e: StatusException) {
+        throw handleInternalError(e)
+      }
+
+    return markRankerJobSucceededResponse {
+      rankerJob = internalResponse.rankerJob.toPublic()
+      isLastJob = internalResponse.isLastJob
+    }
+  }
+
+  override suspend fun markRankerJobFailed(request: MarkRankerJobFailedRequest): RankerJob {
+    if (request.name.isEmpty()) {
+      throw RequiredFieldNotSetException("name")
+        .asStatusRuntimeException(Status.Code.INVALID_ARGUMENT)
+    }
+
+    val jobKey =
+      RankerJobKey.fromName(request.name)
+        ?: throw InvalidFieldValueException("name")
+          .asStatusRuntimeException(Status.Code.INVALID_ARGUMENT)
+
+    if (request.etag.isEmpty()) {
+      throw RequiredFieldNotSetException("etag")
+        .asStatusRuntimeException(Status.Code.INVALID_ARGUMENT)
+    }
+
+    val internalResponse: InternalRankerJob =
+      try {
+        internalRankerJobStub.markRankerJobFailed(
+          internalMarkFailedRequest {
+            dataProviderResourceId = jobKey.dataProviderId
+            rawImpressionUploadResourceId = jobKey.rawImpressionUploadId
+            rankerJobResourceId = jobKey.rankerJobId
+            etag = request.etag
+            errorMessage = request.errorMessage
+          }
+        )
+      } catch (e: StatusException) {
+        throw handleInternalError(e)
+      }
+
+    return internalResponse.toPublic()
+  }
+
+  companion object {
+    private const val MAX_BATCH_SIZE = 50
+
+    private fun handleInternalError(e: StatusException): StatusRuntimeException {
+      return when (InternalErrors.getReason(e)) {
+        InternalErrors.Reason.RANKER_JOB_NOT_FOUND,
+        InternalErrors.Reason.RAW_IMPRESSION_UPLOAD_NOT_FOUND ->
+          Status.NOT_FOUND.withCause(e).asRuntimeException()
+        InternalErrors.Reason.RANKER_JOB_ALREADY_EXISTS ->
+          Status.ALREADY_EXISTS.withCause(e).asRuntimeException()
+        InternalErrors.Reason.RANKER_JOB_STATE_INVALID ->
+          Status.FAILED_PRECONDITION.withCause(e).asRuntimeException()
+        InternalErrors.Reason.ETAG_MISMATCH -> Status.ABORTED.withCause(e).asRuntimeException()
+        InternalErrors.Reason.DATA_PROVIDER_MISMATCH,
+        InternalErrors.Reason.IMPRESSION_METADATA_NOT_FOUND,
+        InternalErrors.Reason.IMPRESSION_METADATA_ALREADY_EXISTS,
+        InternalErrors.Reason.IMPRESSION_METADATA_STATE_INVALID,
+        InternalErrors.Reason.RAW_IMPRESSION_METADATA_NOT_FOUND,
+        InternalErrors.Reason.RAW_IMPRESSION_METADATA_BATCH_NOT_FOUND,
+        InternalErrors.Reason.RAW_IMPRESSION_METADATA_BATCH_STATE_INVALID,
+        InternalErrors.Reason.RAW_IMPRESSION_METADATA_BATCH_FILE_NOT_FOUND,
+        InternalErrors.Reason.RAW_IMPRESSION_METADATA_BATCH_FILE_ALREADY_EXISTS,
+        InternalErrors.Reason.REQUISITION_METADATA_NOT_FOUND,
+        InternalErrors.Reason.REQUISITION_METADATA_NOT_FOUND_BY_CMMS_REQUISITION,
+        InternalErrors.Reason.REQUISITION_METADATA_ALREADY_EXISTS,
+        InternalErrors.Reason.REQUISITION_METADATA_ALREADY_EXISTS_BY_BLOB_URI,
+        InternalErrors.Reason.REQUISITION_METADATA_ALREADY_EXISTS_BY_CMMS_REQUISITION,
+        InternalErrors.Reason.REQUISITION_METADATA_STATE_INVALID,
+        InternalErrors.Reason.REQUIRED_FIELD_NOT_SET,
+        InternalErrors.Reason.INVALID_FIELD_VALUE,
+        null -> Status.INTERNAL.withCause(e).asRuntimeException()
+      }
+    }
+  }
+}
+
+/** Converts an internal [InternalRankerJob] to a public one. */
+internal fun InternalRankerJob.toPublic(): RankerJob {
+  val source = this
+  return rankerJob {
+    name =
+      RankerJobKey(
+          source.dataProviderResourceId,
+          source.rawImpressionUploadResourceId,
+          source.rankerJobResourceId,
+        )
+        .toName()
+    state = source.state.toPublic()
+    cmmsModelLine = source.cmmsModelLine
+    poolOffsets += source.poolOffsetsList
+    createTime = source.createTime
+    updateTime = source.updateTime
+    if (source.errorMessage.isNotEmpty()) {
+      errorMessage = source.errorMessage
+    }
+    if (source.etag.isNotEmpty()) {
+      etag = source.etag
+    }
+  }
+}
+
+/** Converts an internal [RankerState] to a public [RankerJob.State]. */
+internal fun RankerState.toPublic(): RankerJob.State {
+  return when (this) {
+    RankerState.RANKER_STATE_CREATED -> RankerJob.State.CREATED
+    RankerState.RANKER_STATE_SUCCEEDED -> RankerJob.State.SUCCEEDED
+    RankerState.RANKER_STATE_FAILED -> RankerJob.State.FAILED
+    RankerState.UNRECOGNIZED,
+    RankerState.RANKER_STATE_UNSPECIFIED -> error("Unrecognized state")
+  }
+}
+
+/** Converts a public [RankerJob.State] to an internal [RankerState]. */
+internal fun RankerJob.State.toInternal(): RankerState {
+  return when (this) {
+    RankerJob.State.CREATED -> RankerState.RANKER_STATE_CREATED
+    RankerJob.State.SUCCEEDED -> RankerState.RANKER_STATE_SUCCEEDED
+    RankerJob.State.FAILED -> RankerState.RANKER_STATE_FAILED
+    RankerJob.State.UNRECOGNIZED,
+    RankerJob.State.STATE_UNSPECIFIED -> error("Unrecognized state")
+  }
+}

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/service/v1alpha/RawImpressionMetadataBatchFileService.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/service/v1alpha/RawImpressionMetadataBatchFileService.kt
@@ -142,6 +142,9 @@ class RawImpressionMetadataBatchFileService(
           InternalErrors.Reason.VID_LABELING_JOB_NOT_FOUND,
           InternalErrors.Reason.VID_LABELING_JOB_STATE_INVALID,
           InternalErrors.Reason.VID_LABELING_JOB_ALREADY_EXISTS,
+          InternalErrors.Reason.RANKER_JOB_NOT_FOUND,
+          InternalErrors.Reason.RANKER_JOB_ALREADY_EXISTS,
+          InternalErrors.Reason.RANKER_JOB_STATE_INVALID,
           null -> Status.INTERNAL.withCause(e).asRuntimeException()
         }
       }
@@ -259,6 +262,9 @@ class RawImpressionMetadataBatchFileService(
           InternalErrors.Reason.VID_LABELING_JOB_NOT_FOUND,
           InternalErrors.Reason.VID_LABELING_JOB_STATE_INVALID,
           InternalErrors.Reason.VID_LABELING_JOB_ALREADY_EXISTS,
+          InternalErrors.Reason.RANKER_JOB_NOT_FOUND,
+          InternalErrors.Reason.RANKER_JOB_ALREADY_EXISTS,
+          InternalErrors.Reason.RANKER_JOB_STATE_INVALID,
           null -> Status.INTERNAL.withCause(e).asRuntimeException()
         }
       }
@@ -319,6 +325,9 @@ class RawImpressionMetadataBatchFileService(
           InternalErrors.Reason.VID_LABELING_JOB_NOT_FOUND,
           InternalErrors.Reason.VID_LABELING_JOB_STATE_INVALID,
           InternalErrors.Reason.VID_LABELING_JOB_ALREADY_EXISTS,
+          InternalErrors.Reason.RANKER_JOB_NOT_FOUND,
+          InternalErrors.Reason.RANKER_JOB_ALREADY_EXISTS,
+          InternalErrors.Reason.RANKER_JOB_STATE_INVALID,
           null -> Status.INTERNAL.withCause(e).asRuntimeException()
         }
       }
@@ -416,6 +425,9 @@ class RawImpressionMetadataBatchFileService(
           InternalErrors.Reason.VID_LABELING_JOB_NOT_FOUND,
           InternalErrors.Reason.VID_LABELING_JOB_STATE_INVALID,
           InternalErrors.Reason.VID_LABELING_JOB_ALREADY_EXISTS,
+          InternalErrors.Reason.RANKER_JOB_NOT_FOUND,
+          InternalErrors.Reason.RANKER_JOB_ALREADY_EXISTS,
+          InternalErrors.Reason.RANKER_JOB_STATE_INVALID,
           null -> Status.INTERNAL.withCause(e).asRuntimeException()
         }
       }
@@ -479,6 +491,9 @@ class RawImpressionMetadataBatchFileService(
           InternalErrors.Reason.VID_LABELING_JOB_NOT_FOUND,
           InternalErrors.Reason.VID_LABELING_JOB_STATE_INVALID,
           InternalErrors.Reason.VID_LABELING_JOB_ALREADY_EXISTS,
+          InternalErrors.Reason.RANKER_JOB_NOT_FOUND,
+          InternalErrors.Reason.RANKER_JOB_ALREADY_EXISTS,
+          InternalErrors.Reason.RANKER_JOB_STATE_INVALID,
           null -> Status.INTERNAL.withCause(e).asRuntimeException()
         }
       }
@@ -572,6 +587,9 @@ class RawImpressionMetadataBatchFileService(
           InternalErrors.Reason.VID_LABELING_JOB_NOT_FOUND,
           InternalErrors.Reason.VID_LABELING_JOB_STATE_INVALID,
           InternalErrors.Reason.VID_LABELING_JOB_ALREADY_EXISTS,
+          InternalErrors.Reason.RANKER_JOB_NOT_FOUND,
+          InternalErrors.Reason.RANKER_JOB_ALREADY_EXISTS,
+          InternalErrors.Reason.RANKER_JOB_STATE_INVALID,
           null -> Status.INTERNAL.withCause(e).asRuntimeException()
         }
       }

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/service/v1alpha/RawImpressionMetadataBatchService.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/service/v1alpha/RawImpressionMetadataBatchService.kt
@@ -117,6 +117,9 @@ class RawImpressionMetadataBatchService(
           InternalErrors.Reason.VID_LABELING_JOB_NOT_FOUND,
           InternalErrors.Reason.VID_LABELING_JOB_STATE_INVALID,
           InternalErrors.Reason.VID_LABELING_JOB_ALREADY_EXISTS,
+          InternalErrors.Reason.RANKER_JOB_NOT_FOUND,
+          InternalErrors.Reason.RANKER_JOB_ALREADY_EXISTS,
+          InternalErrors.Reason.RANKER_JOB_STATE_INVALID,
           null -> Status.INTERNAL.withCause(e).asRuntimeException()
         }
       }
@@ -173,6 +176,9 @@ class RawImpressionMetadataBatchService(
           InternalErrors.Reason.VID_LABELING_JOB_NOT_FOUND,
           InternalErrors.Reason.VID_LABELING_JOB_STATE_INVALID,
           InternalErrors.Reason.VID_LABELING_JOB_ALREADY_EXISTS,
+          InternalErrors.Reason.RANKER_JOB_NOT_FOUND,
+          InternalErrors.Reason.RANKER_JOB_ALREADY_EXISTS,
+          InternalErrors.Reason.RANKER_JOB_STATE_INVALID,
           null -> Status.INTERNAL.withCause(e).asRuntimeException()
         }
       }
@@ -261,6 +267,9 @@ class RawImpressionMetadataBatchService(
           InternalErrors.Reason.VID_LABELING_JOB_NOT_FOUND,
           InternalErrors.Reason.VID_LABELING_JOB_STATE_INVALID,
           InternalErrors.Reason.VID_LABELING_JOB_ALREADY_EXISTS,
+          InternalErrors.Reason.RANKER_JOB_NOT_FOUND,
+          InternalErrors.Reason.RANKER_JOB_ALREADY_EXISTS,
+          InternalErrors.Reason.RANKER_JOB_STATE_INVALID,
           null -> Status.INTERNAL.withCause(e).asRuntimeException()
         }
       }
@@ -323,6 +332,9 @@ class RawImpressionMetadataBatchService(
           InternalErrors.Reason.VID_LABELING_JOB_NOT_FOUND,
           InternalErrors.Reason.VID_LABELING_JOB_STATE_INVALID,
           InternalErrors.Reason.VID_LABELING_JOB_ALREADY_EXISTS,
+          InternalErrors.Reason.RANKER_JOB_NOT_FOUND,
+          InternalErrors.Reason.RANKER_JOB_ALREADY_EXISTS,
+          InternalErrors.Reason.RANKER_JOB_STATE_INVALID,
           null -> Status.INTERNAL.withCause(e).asRuntimeException()
         }
       }
@@ -380,6 +392,9 @@ class RawImpressionMetadataBatchService(
           InternalErrors.Reason.VID_LABELING_JOB_NOT_FOUND,
           InternalErrors.Reason.VID_LABELING_JOB_STATE_INVALID,
           InternalErrors.Reason.VID_LABELING_JOB_ALREADY_EXISTS,
+          InternalErrors.Reason.RANKER_JOB_NOT_FOUND,
+          InternalErrors.Reason.RANKER_JOB_ALREADY_EXISTS,
+          InternalErrors.Reason.RANKER_JOB_STATE_INVALID,
           null -> Status.INTERNAL.withCause(e).asRuntimeException()
         }
       }
@@ -437,6 +452,9 @@ class RawImpressionMetadataBatchService(
           InternalErrors.Reason.VID_LABELING_JOB_NOT_FOUND,
           InternalErrors.Reason.VID_LABELING_JOB_STATE_INVALID,
           InternalErrors.Reason.VID_LABELING_JOB_ALREADY_EXISTS,
+          InternalErrors.Reason.RANKER_JOB_NOT_FOUND,
+          InternalErrors.Reason.RANKER_JOB_ALREADY_EXISTS,
+          InternalErrors.Reason.RANKER_JOB_STATE_INVALID,
           null -> Status.INTERNAL.withCause(e).asRuntimeException()
         }
       }

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/service/v1alpha/RawImpressionUploadFileService.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/service/v1alpha/RawImpressionUploadFileService.kt
@@ -147,6 +147,9 @@ class RawImpressionUploadFileService(
           InternalErrors.Reason.VID_LABELING_JOB_NOT_FOUND,
           InternalErrors.Reason.VID_LABELING_JOB_STATE_INVALID,
           InternalErrors.Reason.VID_LABELING_JOB_ALREADY_EXISTS,
+          InternalErrors.Reason.RANKER_JOB_NOT_FOUND,
+          InternalErrors.Reason.RANKER_JOB_ALREADY_EXISTS,
+          InternalErrors.Reason.RANKER_JOB_STATE_INVALID,
           null -> Status.INTERNAL.withCause(e).asRuntimeException()
         }
       }
@@ -272,6 +275,9 @@ class RawImpressionUploadFileService(
           InternalErrors.Reason.VID_LABELING_JOB_NOT_FOUND,
           InternalErrors.Reason.VID_LABELING_JOB_STATE_INVALID,
           InternalErrors.Reason.VID_LABELING_JOB_ALREADY_EXISTS,
+          InternalErrors.Reason.RANKER_JOB_NOT_FOUND,
+          InternalErrors.Reason.RANKER_JOB_ALREADY_EXISTS,
+          InternalErrors.Reason.RANKER_JOB_STATE_INVALID,
           null -> Status.INTERNAL.withCause(e).asRuntimeException()
         }
       }
@@ -333,6 +339,9 @@ class RawImpressionUploadFileService(
           InternalErrors.Reason.VID_LABELING_JOB_NOT_FOUND,
           InternalErrors.Reason.VID_LABELING_JOB_STATE_INVALID,
           InternalErrors.Reason.VID_LABELING_JOB_ALREADY_EXISTS,
+          InternalErrors.Reason.RANKER_JOB_NOT_FOUND,
+          InternalErrors.Reason.RANKER_JOB_ALREADY_EXISTS,
+          InternalErrors.Reason.RANKER_JOB_STATE_INVALID,
           null -> Status.INTERNAL.withCause(e).asRuntimeException()
         }
       }
@@ -434,6 +443,9 @@ class RawImpressionUploadFileService(
           InternalErrors.Reason.VID_LABELING_JOB_NOT_FOUND,
           InternalErrors.Reason.VID_LABELING_JOB_STATE_INVALID,
           InternalErrors.Reason.VID_LABELING_JOB_ALREADY_EXISTS,
+          InternalErrors.Reason.RANKER_JOB_NOT_FOUND,
+          InternalErrors.Reason.RANKER_JOB_ALREADY_EXISTS,
+          InternalErrors.Reason.RANKER_JOB_STATE_INVALID,
           null -> Status.INTERNAL.withCause(e).asRuntimeException()
         }
       }
@@ -498,6 +510,9 @@ class RawImpressionUploadFileService(
           InternalErrors.Reason.VID_LABELING_JOB_NOT_FOUND,
           InternalErrors.Reason.VID_LABELING_JOB_STATE_INVALID,
           InternalErrors.Reason.VID_LABELING_JOB_ALREADY_EXISTS,
+          InternalErrors.Reason.RANKER_JOB_NOT_FOUND,
+          InternalErrors.Reason.RANKER_JOB_ALREADY_EXISTS,
+          InternalErrors.Reason.RANKER_JOB_STATE_INVALID,
           null -> Status.INTERNAL.withCause(e).asRuntimeException()
         }
       }
@@ -607,6 +622,9 @@ class RawImpressionUploadFileService(
           InternalErrors.Reason.VID_LABELING_JOB_NOT_FOUND,
           InternalErrors.Reason.VID_LABELING_JOB_STATE_INVALID,
           InternalErrors.Reason.VID_LABELING_JOB_ALREADY_EXISTS,
+          InternalErrors.Reason.RANKER_JOB_NOT_FOUND,
+          InternalErrors.Reason.RANKER_JOB_ALREADY_EXISTS,
+          InternalErrors.Reason.RANKER_JOB_STATE_INVALID,
           null -> Status.INTERNAL.withCause(e).asRuntimeException()
         }
       }

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/service/v1alpha/RawImpressionUploadService.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/service/v1alpha/RawImpressionUploadService.kt
@@ -123,6 +123,9 @@ class RawImpressionUploadService(
           InternalErrors.Reason.VID_LABELING_JOB_NOT_FOUND,
           InternalErrors.Reason.VID_LABELING_JOB_STATE_INVALID,
           InternalErrors.Reason.VID_LABELING_JOB_ALREADY_EXISTS,
+          InternalErrors.Reason.RANKER_JOB_NOT_FOUND,
+          InternalErrors.Reason.RANKER_JOB_ALREADY_EXISTS,
+          InternalErrors.Reason.RANKER_JOB_STATE_INVALID,
           null -> Status.INTERNAL.withCause(e).asRuntimeException()
         }
       }
@@ -179,6 +182,9 @@ class RawImpressionUploadService(
           InternalErrors.Reason.VID_LABELING_JOB_NOT_FOUND,
           InternalErrors.Reason.VID_LABELING_JOB_STATE_INVALID,
           InternalErrors.Reason.VID_LABELING_JOB_ALREADY_EXISTS,
+          InternalErrors.Reason.RANKER_JOB_NOT_FOUND,
+          InternalErrors.Reason.RANKER_JOB_ALREADY_EXISTS,
+          InternalErrors.Reason.RANKER_JOB_STATE_INVALID,
           null -> Status.INTERNAL.withCause(e).asRuntimeException()
         }
       }
@@ -281,6 +287,9 @@ class RawImpressionUploadService(
           InternalErrors.Reason.VID_LABELING_JOB_NOT_FOUND,
           InternalErrors.Reason.VID_LABELING_JOB_STATE_INVALID,
           InternalErrors.Reason.VID_LABELING_JOB_ALREADY_EXISTS,
+          InternalErrors.Reason.RANKER_JOB_NOT_FOUND,
+          InternalErrors.Reason.RANKER_JOB_ALREADY_EXISTS,
+          InternalErrors.Reason.RANKER_JOB_STATE_INVALID,
           null -> Status.INTERNAL.withCause(e).asRuntimeException()
         }
       }

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/service/v1alpha/RequisitionMetadataService.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/service/v1alpha/RequisitionMetadataService.kt
@@ -160,6 +160,9 @@ class RequisitionMetadataService(
           InternalErrors.Reason.VID_LABELING_JOB_NOT_FOUND,
           InternalErrors.Reason.VID_LABELING_JOB_STATE_INVALID,
           InternalErrors.Reason.VID_LABELING_JOB_ALREADY_EXISTS,
+          InternalErrors.Reason.RANKER_JOB_NOT_FOUND,
+          InternalErrors.Reason.RANKER_JOB_ALREADY_EXISTS,
+          InternalErrors.Reason.RANKER_JOB_STATE_INVALID,
           null -> Status.INTERNAL.withCause(e).asRuntimeException()
         }
       }
@@ -276,6 +279,9 @@ class RequisitionMetadataService(
           InternalErrors.Reason.VID_LABELING_JOB_NOT_FOUND,
           InternalErrors.Reason.VID_LABELING_JOB_STATE_INVALID,
           InternalErrors.Reason.VID_LABELING_JOB_ALREADY_EXISTS,
+          InternalErrors.Reason.RANKER_JOB_NOT_FOUND,
+          InternalErrors.Reason.RANKER_JOB_ALREADY_EXISTS,
+          InternalErrors.Reason.RANKER_JOB_STATE_INVALID,
           null -> Status.INTERNAL.withCause(e).asRuntimeException()
         }
       }
@@ -330,6 +336,9 @@ class RequisitionMetadataService(
           InternalErrors.Reason.VID_LABELING_JOB_NOT_FOUND,
           InternalErrors.Reason.VID_LABELING_JOB_STATE_INVALID,
           InternalErrors.Reason.VID_LABELING_JOB_ALREADY_EXISTS,
+          InternalErrors.Reason.RANKER_JOB_NOT_FOUND,
+          InternalErrors.Reason.RANKER_JOB_ALREADY_EXISTS,
+          InternalErrors.Reason.RANKER_JOB_STATE_INVALID,
           null -> Status.INTERNAL.withCause(e).asRuntimeException()
         }
       }
@@ -424,6 +433,9 @@ class RequisitionMetadataService(
           InternalErrors.Reason.VID_LABELING_JOB_NOT_FOUND,
           InternalErrors.Reason.VID_LABELING_JOB_STATE_INVALID,
           InternalErrors.Reason.VID_LABELING_JOB_ALREADY_EXISTS,
+          InternalErrors.Reason.RANKER_JOB_NOT_FOUND,
+          InternalErrors.Reason.RANKER_JOB_ALREADY_EXISTS,
+          InternalErrors.Reason.RANKER_JOB_STATE_INVALID,
           null -> Status.INTERNAL.withCause(e).asRuntimeException()
         }
       }
@@ -490,6 +502,9 @@ class RequisitionMetadataService(
           InternalErrors.Reason.VID_LABELING_JOB_NOT_FOUND,
           InternalErrors.Reason.VID_LABELING_JOB_STATE_INVALID,
           InternalErrors.Reason.VID_LABELING_JOB_ALREADY_EXISTS,
+          InternalErrors.Reason.RANKER_JOB_NOT_FOUND,
+          InternalErrors.Reason.RANKER_JOB_ALREADY_EXISTS,
+          InternalErrors.Reason.RANKER_JOB_STATE_INVALID,
           null -> Status.INTERNAL.withCause(e).asRuntimeException()
         }
       }
@@ -537,6 +552,9 @@ class RequisitionMetadataService(
         InternalErrors.Reason.VID_LABELING_JOB_NOT_FOUND,
         InternalErrors.Reason.VID_LABELING_JOB_STATE_INVALID,
         InternalErrors.Reason.VID_LABELING_JOB_ALREADY_EXISTS,
+        InternalErrors.Reason.RANKER_JOB_NOT_FOUND,
+        InternalErrors.Reason.RANKER_JOB_ALREADY_EXISTS,
+        InternalErrors.Reason.RANKER_JOB_STATE_INVALID,
         null -> Status.INTERNAL.withCause(e).asRuntimeException()
       }
     }
@@ -596,6 +614,9 @@ class RequisitionMetadataService(
           InternalErrors.Reason.VID_LABELING_JOB_NOT_FOUND,
           InternalErrors.Reason.VID_LABELING_JOB_STATE_INVALID,
           InternalErrors.Reason.VID_LABELING_JOB_ALREADY_EXISTS,
+          InternalErrors.Reason.RANKER_JOB_NOT_FOUND,
+          InternalErrors.Reason.RANKER_JOB_ALREADY_EXISTS,
+          InternalErrors.Reason.RANKER_JOB_STATE_INVALID,
           null -> Status.INTERNAL.withCause(e).asRuntimeException()
         }
       }
@@ -653,6 +674,9 @@ class RequisitionMetadataService(
           InternalErrors.Reason.VID_LABELING_JOB_NOT_FOUND,
           InternalErrors.Reason.VID_LABELING_JOB_STATE_INVALID,
           InternalErrors.Reason.VID_LABELING_JOB_ALREADY_EXISTS,
+          InternalErrors.Reason.RANKER_JOB_NOT_FOUND,
+          InternalErrors.Reason.RANKER_JOB_ALREADY_EXISTS,
+          InternalErrors.Reason.RANKER_JOB_STATE_INVALID,
           null -> Status.INTERNAL.withCause(e).asRuntimeException()
         }
       }
@@ -710,6 +734,9 @@ class RequisitionMetadataService(
           InternalErrors.Reason.VID_LABELING_JOB_NOT_FOUND,
           InternalErrors.Reason.VID_LABELING_JOB_STATE_INVALID,
           InternalErrors.Reason.VID_LABELING_JOB_ALREADY_EXISTS,
+          InternalErrors.Reason.RANKER_JOB_NOT_FOUND,
+          InternalErrors.Reason.RANKER_JOB_ALREADY_EXISTS,
+          InternalErrors.Reason.RANKER_JOB_STATE_INVALID,
           null -> Status.INTERNAL.withCause(e).asRuntimeException()
         }
       }
@@ -772,6 +799,9 @@ class RequisitionMetadataService(
           InternalErrors.Reason.VID_LABELING_JOB_NOT_FOUND,
           InternalErrors.Reason.VID_LABELING_JOB_STATE_INVALID,
           InternalErrors.Reason.VID_LABELING_JOB_ALREADY_EXISTS,
+          InternalErrors.Reason.RANKER_JOB_NOT_FOUND,
+          InternalErrors.Reason.RANKER_JOB_ALREADY_EXISTS,
+          InternalErrors.Reason.RANKER_JOB_STATE_INVALID,
           null -> Status.INTERNAL.withCause(e).asRuntimeException()
         }
       }
@@ -829,6 +859,9 @@ class RequisitionMetadataService(
           InternalErrors.Reason.VID_LABELING_JOB_NOT_FOUND,
           InternalErrors.Reason.VID_LABELING_JOB_STATE_INVALID,
           InternalErrors.Reason.VID_LABELING_JOB_ALREADY_EXISTS,
+          InternalErrors.Reason.RANKER_JOB_NOT_FOUND,
+          InternalErrors.Reason.RANKER_JOB_ALREADY_EXISTS,
+          InternalErrors.Reason.RANKER_JOB_STATE_INVALID,
           null -> Status.INTERNAL.withCause(e).asRuntimeException()
         }
       }

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/service/v1alpha/Services.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/service/v1alpha/Services.kt
@@ -21,6 +21,7 @@ import io.grpc.Channel
 import kotlin.coroutines.CoroutineContext
 import kotlin.coroutines.EmptyCoroutineContext
 import org.wfanet.measurement.edpaggregator.v1alpha.ImpressionMetadataServiceGrpcKt.ImpressionMetadataServiceCoroutineImplBase
+import org.wfanet.measurement.edpaggregator.v1alpha.RankerJobServiceGrpcKt.RankerJobServiceCoroutineImplBase
 import org.wfanet.measurement.edpaggregator.v1alpha.RawImpressionMetadataBatchFileServiceGrpcKt.RawImpressionMetadataBatchFileServiceCoroutineImplBase
 import org.wfanet.measurement.edpaggregator.v1alpha.RawImpressionMetadataBatchServiceGrpcKt.RawImpressionMetadataBatchServiceCoroutineImplBase
 import org.wfanet.measurement.edpaggregator.v1alpha.RawImpressionUploadFileServiceGrpcKt.RawImpressionUploadFileServiceCoroutineImplBase
@@ -28,6 +29,7 @@ import org.wfanet.measurement.edpaggregator.v1alpha.RawImpressionUploadServiceGr
 import org.wfanet.measurement.edpaggregator.v1alpha.RequisitionMetadataServiceGrpcKt.RequisitionMetadataServiceCoroutineImplBase
 import org.wfanet.measurement.edpaggregator.v1alpha.VidLabelingJobServiceGrpcKt.VidLabelingJobServiceCoroutineImplBase
 import org.wfanet.measurement.internal.edpaggregator.ImpressionMetadataServiceGrpcKt as InternalImpressionMetadataServiceGrpcKt
+import org.wfanet.measurement.internal.edpaggregator.RankerJobServiceGrpcKt as InternalRankerJobServiceGrpcKt
 import org.wfanet.measurement.internal.edpaggregator.RawImpressionMetadataBatchFileServiceGrpcKt as InternalRawImpressionMetadataBatchFileServiceGrpcKt
 import org.wfanet.measurement.internal.edpaggregator.RawImpressionMetadataBatchServiceGrpcKt as InternalRawImpressionMetadataBatchServiceGrpcKt
 import org.wfanet.measurement.internal.edpaggregator.RawImpressionUploadFileServiceGrpcKt as InternalRawImpressionUploadFileServiceGrpcKt
@@ -43,6 +45,7 @@ data class Services(
   val rawImpressionUpload: RawImpressionUploadServiceCoroutineImplBase,
   val rawImpressionUploadFile: RawImpressionUploadFileServiceCoroutineImplBase,
   val vidLabelingJob: VidLabelingJobServiceCoroutineImplBase,
+  val rankerJob: RankerJobServiceCoroutineImplBase,
 ) {
   fun toList(): List<BindableService> =
     listOf(
@@ -53,6 +56,7 @@ data class Services(
       rawImpressionUpload,
       rawImpressionUploadFile,
       vidLabelingJob,
+      rankerJob,
     )
 
   companion object {
@@ -84,6 +88,8 @@ data class Services(
         )
       val internalVidLabelingJobStub =
         InternalVidLabelingJobServiceGrpcKt.VidLabelingJobServiceCoroutineStub(internalApiChannel)
+      val internalRankerJobStub =
+        InternalRankerJobServiceGrpcKt.RankerJobServiceCoroutineStub(internalApiChannel)
 
       return Services(
         RequisitionMetadataService(internalRequisitionMetadataStub, coroutineContext),
@@ -93,6 +99,7 @@ data class Services(
         RawImpressionUploadService(internalUploadStub, coroutineContext),
         RawImpressionUploadFileService(internalUploadFileStub, coroutineContext),
         VidLabelingJobService(internalVidLabelingJobStub, coroutineContext),
+        RankerJobService(internalRankerJobStub, coroutineContext),
       )
     }
   }

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/service/v1alpha/VidLabelingJobService.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/service/v1alpha/VidLabelingJobService.kt
@@ -429,6 +429,9 @@ class VidLabelingJobService(
       InternalErrors.Reason.REQUISITION_METADATA_STATE_INVALID,
       InternalErrors.Reason.RAW_IMPRESSION_UPLOAD_FILE_NOT_FOUND,
       InternalErrors.Reason.RAW_IMPRESSION_UPLOAD_FILE_ALREADY_EXISTS,
+      InternalErrors.Reason.RANKER_JOB_NOT_FOUND,
+      InternalErrors.Reason.RANKER_JOB_ALREADY_EXISTS,
+      InternalErrors.Reason.RANKER_JOB_STATE_INVALID,
       null -> Status.INTERNAL.withCause(e).asRuntimeException()
       InternalErrors.Reason.RAW_IMPRESSION_UPLOAD_NOT_FOUND,
       InternalErrors.Reason.VID_LABELING_JOB_NOT_FOUND ->

--- a/src/main/proto/wfa/measurement/edpaggregator/v1alpha/ranker_job_service.proto
+++ b/src/main/proto/wfa/measurement/edpaggregator/v1alpha/ranker_job_service.proto
@@ -48,12 +48,21 @@ service RankerJobService {
   // Throws ABORTED if etag does not match the current resource
   // version (AIP-154). A retry with the same `request_id`
   // returns the original response without modifying state
-  // (AIP-155).
+  // (AIP-155); `request_id` must be derived deterministically so
+  // that retries share one (see its documentation), otherwise a
+  // retried call against an already-transitioned row fails with
+  // FAILED_PRECONDITION.
   rpc MarkRankerJobSucceeded(MarkRankerJobSucceededRequest)
       returns (MarkRankerJobSucceededResponse) {}
 
-  // Marks a `RankerJob` as `FAILED`. Throws
-  // FAILED_PRECONDITION if state is not CREATED or FAILED.
+  // Marks a `RankerJob` as `FAILED`. Throws FAILED_PRECONDITION
+  // if state is not CREATED or FAILED. Throws ABORTED if etag
+  // does not match the current resource version (AIP-154). A
+  // retry with the same `request_id` returns the original
+  // response without modifying state (AIP-155); `request_id` must
+  // be derived deterministically so that retries share one (see
+  // its documentation), otherwise a retried call against an
+  // already-transitioned row fails with FAILED_PRECONDITION.
   rpc MarkRankerJobFailed(MarkRankerJobFailedRequest) returns (RankerJob) {}
 }
 
@@ -200,9 +209,17 @@ message MarkRankerJobSucceededRequest {
   // The etag of the RankerJob for optimistic locking.
   string etag = 2 [(google.api.field_behavior) = REQUIRED];
 
-  // A request ID provided by the client to ensure idempotency
-  // on retry. A retry with the same `request_id` returns the
-  // original response without re-transitioning the resource.
+  // A request ID provided by the client to ensure idempotency on
+  // retry. A retry with the same `request_id` returns the original
+  // response without re-transitioning the resource.
+  //
+  // To survive retries (network blips, redeliveries, process
+  // restarts), derive this deterministically from the resource being
+  // marked — e.g. a UUID computed from its `name` and the operation —
+  // so that every attempt for the same logical mark uses the same
+  // `request_id` and shares one idempotent result. Generating a fresh
+  // UUID per attempt defeats AIP-155 and surfaces as
+  // FAILED_PRECONDITION on retry against an already-transitioned row.
   //
   // This field must be a UUID4 (RFC 4122) string.
   string request_id = 3 [
@@ -239,9 +256,17 @@ message MarkRankerJobFailedRequest {
   // Human-readable detail about the failure.
   string error_message = 3 [(google.api.field_behavior) = OPTIONAL];
 
-  // A request ID provided by the client to ensure idempotency
-  // on retry. A retry with the same `request_id` returns the
-  // original response without re-transitioning the resource.
+  // A request ID provided by the client to ensure idempotency on
+  // retry. A retry with the same `request_id` returns the original
+  // response without re-transitioning the resource.
+  //
+  // To survive retries (network blips, redeliveries, process
+  // restarts), derive this deterministically from the resource being
+  // marked — e.g. a UUID computed from its `name` and the operation —
+  // so that every attempt for the same logical mark uses the same
+  // `request_id` and shares one idempotent result. Generating a fresh
+  // UUID per attempt defeats AIP-155 and surfaces as
+  // FAILED_PRECONDITION on retry against an already-transitioned row.
   //
   // This field must be a UUID4 (RFC 4122) string.
   string request_id = 4 [

--- a/src/main/proto/wfa/measurement/edpaggregator/v1alpha/ranker_job_service.proto
+++ b/src/main/proto/wfa/measurement/edpaggregator/v1alpha/ranker_job_service.proto
@@ -46,23 +46,13 @@ service RankerJobService {
   // returns the signal to the caller. Throws
   // FAILED_PRECONDITION if state is not CREATED or FAILED.
   // Throws ABORTED if etag does not match the current resource
-  // version (AIP-154). A retry with the same `request_id`
-  // returns the original response without modifying state
-  // (AIP-155); `request_id` must be derived deterministically so
-  // that retries share one (see its documentation), otherwise a
-  // retried call against an already-transitioned row fails with
-  // FAILED_PRECONDITION.
+  // version (AIP-154).
   rpc MarkRankerJobSucceeded(MarkRankerJobSucceededRequest)
       returns (MarkRankerJobSucceededResponse) {}
 
   // Marks a `RankerJob` as `FAILED`. Throws FAILED_PRECONDITION
   // if state is not CREATED or FAILED. Throws ABORTED if etag
-  // does not match the current resource version (AIP-154). A
-  // retry with the same `request_id` returns the original
-  // response without modifying state (AIP-155); `request_id` must
-  // be derived deterministically so that retries share one (see
-  // its documentation), otherwise a retried call against an
-  // already-transitioned row fails with FAILED_PRECONDITION.
+  // does not match the current resource version (AIP-154).
   rpc MarkRankerJobFailed(MarkRankerJobFailedRequest) returns (RankerJob) {}
 }
 

--- a/src/main/proto/wfa/measurement/edpaggregator/v1alpha/ranker_job_service.proto
+++ b/src/main/proto/wfa/measurement/edpaggregator/v1alpha/ranker_job_service.proto
@@ -206,7 +206,7 @@ message MarkRankerJobSucceededRequest {
   //
   // This field must be a UUID4 (RFC 4122) string.
   string request_id = 3 [
-    (google.api.field_behavior) = OPTIONAL,
+    (google.api.field_behavior) = REQUIRED,
     (google.api.field_info).format = UUID4
   ];
 }

--- a/src/main/proto/wfa/measurement/edpaggregator/v1alpha/ranker_job_service.proto
+++ b/src/main/proto/wfa/measurement/edpaggregator/v1alpha/ranker_job_service.proto
@@ -74,7 +74,14 @@ message CreateRankerJobRequest {
 
   // A request ID provided by the client to ensure idempotency.
   //
-  // This field must be a UUID4 (RFC 4122) string.
+  // This field is REQUIRED, deviating from AIP-155 (which recommends request_id
+  // be optional): the job's resource name is assigned by the server, so the
+  // client has no other idempotency key. Without it, a retry after a lost
+  // response would create a second, orphaned job. Must be a UUID4 (RFC 4122)
+  // string.
+  // (-- api-linter: core::0133::request-required-fields=disabled
+  //     aip.dev/not-precedent: request_id is intentionally REQUIRED so the
+  //     server can deduplicate retries of this server-named resource. --)
   string request_id = 3 [
     (google.api.field_behavior) = REQUIRED,
     (google.api.field_info).format = UUID4
@@ -182,6 +189,10 @@ message ListRankerJobsResponse {
 
   // A token to retrieve the next page of results.
   string next_page_token = 2;
+
+  // The total number of ranker jobs matching the request, irrespective of
+  // pagination.
+  int32 total_size = 3;
 }
 
 // Request message for the `MarkRankerJobSucceeded` method.

--- a/src/main/proto/wfa/measurement/edpaggregator/v1alpha/ranker_job_service.proto
+++ b/src/main/proto/wfa/measurement/edpaggregator/v1alpha/ranker_job_service.proto
@@ -77,7 +77,7 @@ message CreateRankerJobRequest {
   //
   // This field must be a UUID4 (RFC 4122) string.
   string request_id = 3 [
-    (google.api.field_behavior) = OPTIONAL,
+    (google.api.field_behavior) = REQUIRED,
     (google.api.field_info).format = UUID4
   ];
 }
@@ -238,4 +238,14 @@ message MarkRankerJobFailedRequest {
 
   // Human-readable detail about the failure.
   string error_message = 3 [(google.api.field_behavior) = OPTIONAL];
+
+  // A request ID provided by the client to ensure idempotency
+  // on retry. A retry with the same `request_id` returns the
+  // original response without re-transitioning the resource.
+  //
+  // This field must be a UUID4 (RFC 4122) string.
+  string request_id = 4 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.field_info).format = UUID4
+  ];
 }

--- a/src/main/proto/wfa/measurement/internal/edpaggregator/ranker_job_service.proto
+++ b/src/main/proto/wfa/measurement/internal/edpaggregator/ranker_job_service.proto
@@ -138,6 +138,10 @@ message ListRankerJobsResponse {
 
   // A token to retrieve the next page of results.
   ListRankerJobsPageToken next_page_token = 2;
+
+  // The total number of ranker jobs matching the request, irrespective of
+  // pagination.
+  int32 total_size = 3;
 }
 
 // Page token for ListRankerJobs.

--- a/src/main/proto/wfa/measurement/internal/edpaggregator/ranker_job_service.proto
+++ b/src/main/proto/wfa/measurement/internal/edpaggregator/ranker_job_service.proto
@@ -195,4 +195,7 @@ message MarkRankerJobFailedRequest {
 
   // Human-readable detail about the failure.
   string error_message = 5;
+
+  // A request ID for retry idempotency.
+  string request_id = 6;
 }

--- a/src/main/proto/wfa/measurement/internal/edpaggregator/ranker_job_service.proto
+++ b/src/main/proto/wfa/measurement/internal/edpaggregator/ranker_job_service.proto
@@ -43,8 +43,6 @@ service RankerJobService {
   // Marks a `RankerJob` as `SUCCEEDED`. Throws
   // FAILED_PRECONDITION if state is not CREATED or FAILED.
   // Throws ABORTED if etag does not match (AIP-154).
-  // A retry with the same `request_id` returns the original
-  // response without modifying state (AIP-155).
   rpc MarkRankerJobSucceeded(MarkRankerJobSucceededRequest)
       returns (MarkRankerJobSucceededResponse);
 

--- a/src/test/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/spanner/BUILD.bazel
+++ b/src/test/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/spanner/BUILD.bazel
@@ -108,6 +108,19 @@ spanner_emulator_test(
 )
 
 spanner_emulator_test(
+    name = "SpannerRankerJobServiceTest",
+    srcs = ["SpannerRankerJobServiceTest.kt"],
+    test_class = "org.wfanet.measurement.edpaggregator.deploy.gcloud.spanner.SpannerRankerJobServiceTest",
+    deps = [
+        "//src/main/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/spanner:spanner_ranker_job_service",
+        "//src/main/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/spanner/testing:schemata",
+        "//src/main/kotlin/org/wfanet/measurement/edpaggregator/service/internal/testing:ranker_job_service_test",
+        "//src/main/proto/wfa/measurement/internal/edpaggregator:raw_impression_upload_state_kt_jvm_proto",
+        "@wfa_common_jvm//src/main/kotlin/org/wfanet/measurement/gcloud/spanner/testing",
+    ],
+)
+
+spanner_emulator_test(
     name = "SpannerVidLabelingJobServiceTest",
     srcs = ["SpannerVidLabelingJobServiceTest.kt"],
     test_class = "org.wfanet.measurement.edpaggregator.deploy.gcloud.spanner.SpannerVidLabelingJobServiceTest",

--- a/src/test/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/spanner/SpannerRankerJobServiceTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/spanner/SpannerRankerJobServiceTest.kt
@@ -1,0 +1,72 @@
+// Copyright 2026 The Cross-Media Measurement Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.wfanet.measurement.edpaggregator.deploy.gcloud.spanner
+
+import com.google.cloud.spanner.Mutation
+import com.google.cloud.spanner.Value
+import org.junit.ClassRule
+import org.junit.Rule
+import org.wfanet.measurement.common.IdGenerator
+import org.wfanet.measurement.edpaggregator.deploy.gcloud.spanner.testing.Schemata
+import org.wfanet.measurement.edpaggregator.service.internal.testing.RankerJobServiceTest
+import org.wfanet.measurement.gcloud.spanner.AsyncDatabaseClient
+import org.wfanet.measurement.gcloud.spanner.testing.SpannerEmulatorDatabaseRule
+import org.wfanet.measurement.gcloud.spanner.testing.SpannerEmulatorRule
+import org.wfanet.measurement.internal.edpaggregator.RankerJobServiceGrpcKt
+import org.wfanet.measurement.internal.edpaggregator.RawImpressionUploadState
+
+class SpannerRankerJobServiceTest : RankerJobServiceTest() {
+  @get:Rule
+  val spannerDatabase =
+    SpannerEmulatorDatabaseRule(spannerEmulator, Schemata.EDP_AGGREGATOR_CHANGELOG_PATH)
+
+  private var nextUploadId: Long = 1L
+
+  override fun newService(
+    idGenerator: IdGenerator
+  ): RankerJobServiceGrpcKt.RankerJobServiceCoroutineImplBase {
+    val databaseClient: AsyncDatabaseClient = spannerDatabase.databaseClient
+    return SpannerRankerJobService(databaseClient, idGenerator = idGenerator)
+  }
+
+  override suspend fun createParentUpload(
+    dataProviderResourceId: String,
+    rawImpressionUploadResourceId: String,
+  ) {
+    val uploadId = nextUploadId++
+    val mutation =
+      Mutation.newInsertBuilder("RawImpressionUpload")
+        .set("DataProviderResourceId")
+        .to(dataProviderResourceId)
+        .set("RawImpressionUploadId")
+        .to(uploadId)
+        .set("RawImpressionUploadResourceId")
+        .to(rawImpressionUploadResourceId)
+        .set("DoneBlobUri")
+        .to("gs://bucket/done")
+        .set("State")
+        .to(Value.protoEnum(RawImpressionUploadState.RAW_IMPRESSION_UPLOAD_STATE_CREATED))
+        .set("CreateTime")
+        .to(Value.COMMIT_TIMESTAMP)
+        .set("UpdateTime")
+        .to(Value.COMMIT_TIMESTAMP)
+        .build()
+    spannerDatabase.databaseClient.write(listOf(mutation))
+  }
+
+  companion object {
+    @get:ClassRule @JvmStatic val spannerEmulator = SpannerEmulatorRule()
+  }
+}

--- a/src/test/kotlin/org/wfanet/measurement/edpaggregator/service/v1alpha/BUILD.bazel
+++ b/src/test/kotlin/org/wfanet/measurement/edpaggregator/service/v1alpha/BUILD.bazel
@@ -153,6 +153,30 @@ spanner_emulator_test(
 )
 
 spanner_emulator_test(
+    name = "RankerJobServiceTest",
+    srcs = ["RankerJobServiceTest.kt"],
+    test_class = "org.wfanet.measurement.edpaggregator.service.v1alpha.RankerJobServiceTest",
+    deps = [
+        "//src/main/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/spanner:spanner_ranker_job_service",
+        "//src/main/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/spanner/testing:schemata",
+        "//src/main/kotlin/org/wfanet/measurement/edpaggregator/service:resource_key",
+        "//src/main/kotlin/org/wfanet/measurement/edpaggregator/service/v1alpha:ranker_job_service",
+        "//src/main/proto/wfa/measurement/edpaggregator/v1alpha:ranker_job_kt_jvm_proto",
+        "//src/main/proto/wfa/measurement/internal/edpaggregator:ranker_job_service_kt_jvm_grpc_proto",
+        "//src/main/proto/wfa/measurement/internal/edpaggregator:raw_impression_upload_state_kt_jvm_proto",
+        "@wfa_common_jvm//imports/java/com/google/common/truth",
+        "@wfa_common_jvm//imports/java/com/google/common/truth/extensions/proto",
+        "@wfa_common_jvm//imports/java/org/junit",
+        "@wfa_common_jvm//imports/kotlin/kotlin/test",
+        "@wfa_common_jvm//imports/kotlin/kotlinx/coroutines:core",
+        "@wfa_common_jvm//src/main/kotlin/org/wfanet/measurement/common/grpc/testing",
+        "@wfa_common_jvm//src/main/kotlin/org/wfanet/measurement/common/identity",
+        "@wfa_common_jvm//src/main/kotlin/org/wfanet/measurement/common/testing",
+        "@wfa_common_jvm//src/main/kotlin/org/wfanet/measurement/gcloud/spanner/testing",
+    ],
+)
+
+spanner_emulator_test(
     name = "VidLabelingJobServiceTest",
     srcs = ["VidLabelingJobServiceTest.kt"],
     test_class = "org.wfanet.measurement.edpaggregator.service.v1alpha.VidLabelingJobServiceTest",

--- a/src/test/kotlin/org/wfanet/measurement/edpaggregator/service/v1alpha/RankerJobServiceTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/edpaggregator/service/v1alpha/RankerJobServiceTest.kt
@@ -421,6 +421,35 @@ class RankerJobServiceTest {
     }
 
   @Test
+  fun `listRankerJobs returns total_size ignoring pagination`() =
+    runBlocking<Unit> {
+      createParentUpload(DATA_PROVIDER_ID, RAW_IMPRESSION_UPLOAD_ID)
+      for (offset in 0L..2L) {
+        service.createRankerJob(
+          createRankerJobRequest {
+            requestId = UUID.randomUUID().toString()
+            parent = UPLOAD_KEY.toName()
+            rankerJob = rankerJob {
+              cmmsModelLine = CMMS_MODEL_LINE
+              poolOffsets += listOf(offset)
+            }
+          }
+        )
+      }
+
+      val response =
+        service.listRankerJobs(
+          listRankerJobsRequest {
+            parent = UPLOAD_KEY.toName()
+            pageSize = 1
+          }
+        )
+
+      assertThat(response.rankerJobsList).hasSize(1)
+      assertThat(response.totalSize).isEqualTo(3)
+    }
+
+  @Test
   fun `listRankerJobs respects page size and pagination`() = runBlocking {
     createParentUpload(DATA_PROVIDER_ID, RAW_IMPRESSION_UPLOAD_ID)
     val created1 =

--- a/src/test/kotlin/org/wfanet/measurement/edpaggregator/service/v1alpha/RankerJobServiceTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/edpaggregator/service/v1alpha/RankerJobServiceTest.kt
@@ -155,6 +155,7 @@ class RankerJobServiceTest {
   @Test
   fun `createRankerJob throws INVALID_ARGUMENT for empty parent`() = runBlocking {
     val request = createRankerJobRequest {
+      requestId = UUID.randomUUID().toString()
       rankerJob = rankerJob {
         cmmsModelLine = CMMS_MODEL_LINE
         poolOffsets += POOL_OFFSETS
@@ -176,6 +177,7 @@ class RankerJobServiceTest {
   @Test
   fun `createRankerJob throws INVALID_ARGUMENT for malformed parent`() = runBlocking {
     val request = createRankerJobRequest {
+      requestId = UUID.randomUUID().toString()
       parent = "invalid-parent"
       rankerJob = rankerJob {
         cmmsModelLine = CMMS_MODEL_LINE
@@ -214,6 +216,7 @@ class RankerJobServiceTest {
   @Test
   fun `createRankerJob throws INVALID_ARGUMENT for empty cmmsModelLine`() = runBlocking {
     val request = createRankerJobRequest {
+      requestId = UUID.randomUUID().toString()
       parent = UPLOAD_KEY.toName()
       rankerJob = rankerJob { poolOffsets += POOL_OFFSETS }
     }
@@ -233,6 +236,7 @@ class RankerJobServiceTest {
   @Test
   fun `createRankerJob throws INVALID_ARGUMENT for empty pool_offsets`() = runBlocking {
     val request = createRankerJobRequest {
+      requestId = UUID.randomUUID().toString()
       parent = UPLOAD_KEY.toName()
       rankerJob = rankerJob { cmmsModelLine = CMMS_MODEL_LINE }
     }
@@ -279,12 +283,14 @@ class RankerJobServiceTest {
       val request = batchCreateRankerJobsRequest {
         parent = UPLOAD_KEY.toName()
         requests += createRankerJobRequest {
+          requestId = UUID.randomUUID().toString()
           rankerJob = rankerJob {
             cmmsModelLine = CMMS_MODEL_LINE
             poolOffsets += listOf(0L, 1L)
           }
         }
         requests += createRankerJobRequest {
+          requestId = UUID.randomUUID().toString()
           rankerJob = rankerJob {
             cmmsModelLine = CMMS_MODEL_LINE
             poolOffsets += listOf(2L, 3L)
@@ -303,6 +309,7 @@ class RankerJobServiceTest {
   fun `batchCreateRankerJobs throws INVALID_ARGUMENT for empty parent`() = runBlocking {
     val request = batchCreateRankerJobsRequest {
       requests += createRankerJobRequest {
+        requestId = UUID.randomUUID().toString()
         rankerJob = rankerJob {
           cmmsModelLine = CMMS_MODEL_LINE
           poolOffsets += POOL_OFFSETS
@@ -399,6 +406,7 @@ class RankerJobServiceTest {
       val created =
         service.createRankerJob(
           createRankerJobRequest {
+            requestId = UUID.randomUUID().toString()
             parent = UPLOAD_KEY.toName()
             rankerJob = rankerJob {
               cmmsModelLine = CMMS_MODEL_LINE
@@ -418,6 +426,7 @@ class RankerJobServiceTest {
     val created1 =
       service.createRankerJob(
         createRankerJobRequest {
+          requestId = UUID.randomUUID().toString()
           parent = UPLOAD_KEY.toName()
           rankerJob = rankerJob {
             cmmsModelLine = CMMS_MODEL_LINE
@@ -428,6 +437,7 @@ class RankerJobServiceTest {
     val created2 =
       service.createRankerJob(
         createRankerJobRequest {
+          requestId = UUID.randomUUID().toString()
           parent = UPLOAD_KEY.toName()
           rankerJob = rankerJob {
             cmmsModelLine = CMMS_MODEL_LINE
@@ -528,6 +538,7 @@ class RankerJobServiceTest {
     val created =
       service.createRankerJob(
         createRankerJobRequest {
+          requestId = UUID.randomUUID().toString()
           parent = UPLOAD_KEY.toName()
           rankerJob = rankerJob {
             cmmsModelLine = CMMS_MODEL_LINE
@@ -573,6 +584,7 @@ class RankerJobServiceTest {
     val created =
       service.createRankerJob(
         createRankerJobRequest {
+          requestId = UUID.randomUUID().toString()
           parent = UPLOAD_KEY.toName()
           rankerJob = rankerJob {
             cmmsModelLine = CMMS_MODEL_LINE
@@ -626,6 +638,7 @@ class RankerJobServiceTest {
     val created =
       service.createRankerJob(
         createRankerJobRequest {
+          requestId = UUID.randomUUID().toString()
           parent = UPLOAD_KEY.toName()
           rankerJob = rankerJob {
             cmmsModelLine = CMMS_MODEL_LINE
@@ -653,6 +666,7 @@ class RankerJobServiceTest {
     val created =
       service.createRankerJob(
         createRankerJobRequest {
+          requestId = UUID.randomUUID().toString()
           parent = UPLOAD_KEY.toName()
           rankerJob = rankerJob {
             cmmsModelLine = CMMS_MODEL_LINE
@@ -664,6 +678,7 @@ class RankerJobServiceTest {
     val failed =
       service.markRankerJobFailed(
         markRankerJobFailedRequest {
+          requestId = UUID.randomUUID().toString()
           name = created.name
           etag = created.etag
           errorMessage = "Something went wrong"
@@ -681,6 +696,7 @@ class RankerJobServiceTest {
       assertFailsWith<StatusRuntimeException> {
         service.markRankerJobFailed(
           markRankerJobFailedRequest {
+            requestId = UUID.randomUUID().toString()
             name = "invalid-name"
             etag = "some-etag"
           }
@@ -698,12 +714,37 @@ class RankerJobServiceTest {
   }
 
   @Test
+  fun `markRankerJobFailed throws INVALID_ARGUMENT for empty requestId`() = runBlocking {
+    val name = RankerJobKey(DATA_PROVIDER_ID, RAW_IMPRESSION_UPLOAD_ID, "rankerJob-some").toName()
+
+    val exception =
+      assertFailsWith<StatusRuntimeException> {
+        service.markRankerJobFailed(
+          markRankerJobFailedRequest {
+            this.name = name
+            etag = "some-etag"
+          }
+        )
+      }
+    assertThat(exception.status.code).isEqualTo(Status.Code.INVALID_ARGUMENT)
+    assertThat(exception.errorInfo)
+      .isEqualTo(
+        errorInfo {
+          domain = Errors.DOMAIN
+          reason = Errors.Reason.REQUIRED_FIELD_NOT_SET.name
+          metadata[Errors.Metadata.FIELD_NAME.key] = "request_id"
+        }
+      )
+  }
+
+  @Test
   fun `batchCreateRankerJobs throws INVALID_ARGUMENT when exceeding max batch size`() =
     runBlocking {
       val request = batchCreateRankerJobsRequest {
         parent = UPLOAD_KEY.toName()
         for (i in 0 until 51) {
           requests += createRankerJobRequest {
+            requestId = UUID.randomUUID().toString()
             rankerJob = rankerJob {
               cmmsModelLine = CMMS_MODEL_LINE
               poolOffsets += i.toLong()
@@ -765,6 +806,7 @@ class RankerJobServiceTest {
       val request = batchCreateRankerJobsRequest {
         parent = UPLOAD_KEY.toName()
         requests += createRankerJobRequest {
+          requestId = UUID.randomUUID().toString()
           parent = "dataProviders/other/rawImpressionUploads/other"
           rankerJob = rankerJob {
             cmmsModelLine = CMMS_MODEL_LINE
@@ -794,6 +836,7 @@ class RankerJobServiceTest {
       val firstJob =
         service.createRankerJob(
           createRankerJobRequest {
+            requestId = UUID.randomUUID().toString()
             parent = UPLOAD_KEY.toName()
             rankerJob = rankerJob {
               cmmsModelLine = CMMS_MODEL_LINE
@@ -804,6 +847,7 @@ class RankerJobServiceTest {
       val secondJob =
         service.createRankerJob(
           createRankerJobRequest {
+            requestId = UUID.randomUUID().toString()
             parent = RawImpressionUploadKey(DATA_PROVIDER_ID, SECOND_UPLOAD_ID).toName()
             rankerJob = rankerJob {
               cmmsModelLine = CMMS_MODEL_LINE
@@ -865,6 +909,7 @@ class RankerJobServiceTest {
       assertFailsWith<StatusRuntimeException> {
         service.markRankerJobFailed(
           markRankerJobFailedRequest {
+            requestId = UUID.randomUUID().toString()
             name = missingName
             etag = "some-etag"
           }

--- a/src/test/kotlin/org/wfanet/measurement/edpaggregator/service/v1alpha/RankerJobServiceTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/edpaggregator/service/v1alpha/RankerJobServiceTest.kt
@@ -541,6 +541,7 @@ class RankerJobServiceTest {
         markRankerJobSucceededRequest {
           name = created.name
           etag = created.etag
+          requestId = UUID.randomUUID().toString()
         }
       )
 
@@ -596,6 +597,30 @@ class RankerJobServiceTest {
   }
 
   @Test
+  fun `markRankerJobSucceeded throws INVALID_ARGUMENT for empty requestId`() = runBlocking {
+    val name = RankerJobKey(DATA_PROVIDER_ID, RAW_IMPRESSION_UPLOAD_ID, "rankerJob-some").toName()
+
+    val exception =
+      assertFailsWith<StatusRuntimeException> {
+        service.markRankerJobSucceeded(
+          markRankerJobSucceededRequest {
+            this.name = name
+            etag = "some-etag"
+          }
+        )
+      }
+    assertThat(exception.status.code).isEqualTo(Status.Code.INVALID_ARGUMENT)
+    assertThat(exception.errorInfo)
+      .isEqualTo(
+        errorInfo {
+          domain = Errors.DOMAIN
+          reason = Errors.Reason.REQUIRED_FIELD_NOT_SET.name
+          metadata[Errors.Metadata.FIELD_NAME.key] = "request_id"
+        }
+      )
+  }
+
+  @Test
   fun `markRankerJobSucceeded throws ABORTED for etag mismatch`() = runBlocking {
     createParentUpload(DATA_PROVIDER_ID, RAW_IMPRESSION_UPLOAD_ID)
     val created =
@@ -615,6 +640,7 @@ class RankerJobServiceTest {
           markRankerJobSucceededRequest {
             name = created.name
             etag = "wrong-etag"
+            requestId = UUID.randomUUID().toString()
           }
         )
       }
@@ -822,6 +848,7 @@ class RankerJobServiceTest {
           markRankerJobSucceededRequest {
             name = missingName
             etag = "some-etag"
+            requestId = UUID.randomUUID().toString()
           }
         )
       }

--- a/src/test/kotlin/org/wfanet/measurement/edpaggregator/service/v1alpha/RankerJobServiceTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/edpaggregator/service/v1alpha/RankerJobServiceTest.kt
@@ -1,0 +1,860 @@
+// Copyright 2026 The Cross-Media Measurement Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.wfanet.measurement.edpaggregator.service.v1alpha
+
+import com.google.cloud.spanner.Mutation
+import com.google.cloud.spanner.Value
+import com.google.common.truth.Truth.assertThat
+import com.google.common.truth.extensions.proto.ProtoTruth.assertThat
+import com.google.rpc.errorInfo
+import io.grpc.Status
+import io.grpc.StatusRuntimeException
+import java.time.Instant
+import java.util.UUID
+import kotlin.coroutines.EmptyCoroutineContext
+import kotlin.test.assertFailsWith
+import kotlin.test.assertNotNull
+import kotlinx.coroutines.runBlocking
+import org.junit.Before
+import org.junit.ClassRule
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TestRule
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+import org.wfanet.measurement.common.api.ResourceKey
+import org.wfanet.measurement.common.grpc.errorInfo
+import org.wfanet.measurement.common.grpc.testing.GrpcTestServerRule
+import org.wfanet.measurement.common.identity.externalIdToApiId
+import org.wfanet.measurement.common.testing.chainRulesSequentially
+import org.wfanet.measurement.common.toInstant
+import org.wfanet.measurement.edpaggregator.deploy.gcloud.spanner.SpannerRankerJobService
+import org.wfanet.measurement.edpaggregator.deploy.gcloud.spanner.testing.Schemata
+import org.wfanet.measurement.edpaggregator.service.Errors
+import org.wfanet.measurement.edpaggregator.service.RankerJobKey
+import org.wfanet.measurement.edpaggregator.service.RawImpressionUploadKey
+import org.wfanet.measurement.edpaggregator.v1alpha.RankerJob
+import org.wfanet.measurement.edpaggregator.v1alpha.batchCreateRankerJobsRequest
+import org.wfanet.measurement.edpaggregator.v1alpha.createRankerJobRequest
+import org.wfanet.measurement.edpaggregator.v1alpha.getRankerJobRequest
+import org.wfanet.measurement.edpaggregator.v1alpha.listRankerJobsRequest
+import org.wfanet.measurement.edpaggregator.v1alpha.markRankerJobFailedRequest
+import org.wfanet.measurement.edpaggregator.v1alpha.markRankerJobSucceededRequest
+import org.wfanet.measurement.edpaggregator.v1alpha.rankerJob
+import org.wfanet.measurement.gcloud.spanner.testing.SpannerEmulatorDatabaseRule
+import org.wfanet.measurement.gcloud.spanner.testing.SpannerEmulatorRule
+import org.wfanet.measurement.internal.edpaggregator.RankerJobServiceGrpcKt.RankerJobServiceCoroutineImplBase as InternalRankerJobServiceCoroutineImplBase
+import org.wfanet.measurement.internal.edpaggregator.RankerJobServiceGrpcKt.RankerJobServiceCoroutineStub as InternalRankerJobServiceCoroutineStub
+import org.wfanet.measurement.internal.edpaggregator.RawImpressionUploadState
+
+@RunWith(JUnit4::class)
+class RankerJobServiceTest {
+  private lateinit var internalService: InternalRankerJobServiceCoroutineImplBase
+  private lateinit var service: RankerJobService
+
+  private var nextUploadId: Long = 1L
+
+  val spannerDatabase =
+    SpannerEmulatorDatabaseRule(spannerEmulator, Schemata.EDP_AGGREGATOR_CHANGELOG_PATH)
+
+  val grpcTestServerRule = GrpcTestServerRule {
+    val spannerDatabaseClient = spannerDatabase.databaseClient
+    internalService = SpannerRankerJobService(spannerDatabaseClient, EmptyCoroutineContext)
+    addService(internalService)
+  }
+
+  @get:Rule
+  val serverRuleChain: TestRule = chainRulesSequentially(spannerDatabase, grpcTestServerRule)
+
+  @Before
+  fun initService() {
+    service = RankerJobService(InternalRankerJobServiceCoroutineStub(grpcTestServerRule.channel))
+  }
+
+  private suspend fun createParentUpload(
+    dataProviderResourceId: String,
+    rawImpressionUploadResourceId: String,
+  ) {
+    val uploadId = nextUploadId++
+    val mutation =
+      Mutation.newInsertBuilder("RawImpressionUpload")
+        .set("DataProviderResourceId")
+        .to(dataProviderResourceId)
+        .set("RawImpressionUploadId")
+        .to(uploadId)
+        .set("RawImpressionUploadResourceId")
+        .to(rawImpressionUploadResourceId)
+        .set("DoneBlobUri")
+        .to("gs://bucket/done")
+        .set("State")
+        .to(Value.protoEnum(RawImpressionUploadState.RAW_IMPRESSION_UPLOAD_STATE_CREATED))
+        .set("CreateTime")
+        .to(Value.COMMIT_TIMESTAMP)
+        .set("UpdateTime")
+        .to(Value.COMMIT_TIMESTAMP)
+        .build()
+    spannerDatabase.databaseClient.write(listOf(mutation))
+  }
+
+  @Test
+  fun `createRankerJob returns a job successfully`() = runBlocking {
+    createParentUpload(DATA_PROVIDER_ID, RAW_IMPRESSION_UPLOAD_ID)
+    val startTime = Instant.now()
+    val request = createRankerJobRequest {
+      parent = UPLOAD_KEY.toName()
+      rankerJob = rankerJob {
+        cmmsModelLine = CMMS_MODEL_LINE
+        poolOffsets += POOL_OFFSETS
+      }
+      requestId = REQUEST_ID
+    }
+
+    val job = service.createRankerJob(request)
+
+    val jobKey = assertNotNull(RankerJobKey.fromName(job.name))
+    assertThat(jobKey.dataProviderId).isEqualTo(DATA_PROVIDER_ID)
+    assertThat(jobKey.rawImpressionUploadId).isEqualTo(RAW_IMPRESSION_UPLOAD_ID)
+    assertThat(job.state).isEqualTo(RankerJob.State.CREATED)
+    assertThat(job.cmmsModelLine).isEqualTo(CMMS_MODEL_LINE)
+    assertThat(job.poolOffsetsList).containsExactlyElementsIn(POOL_OFFSETS).inOrder()
+    assertThat(job.createTime.toInstant()).isGreaterThan(startTime)
+    assertThat(job.updateTime).isEqualTo(job.createTime)
+    assertThat(job.etag).isNotEmpty()
+  }
+
+  @Test
+  fun `createRankerJob with requestId is idempotent`() = runBlocking {
+    createParentUpload(DATA_PROVIDER_ID, RAW_IMPRESSION_UPLOAD_ID)
+    val request = createRankerJobRequest {
+      parent = UPLOAD_KEY.toName()
+      rankerJob = rankerJob {
+        cmmsModelLine = CMMS_MODEL_LINE
+        poolOffsets += POOL_OFFSETS
+      }
+      requestId = REQUEST_ID
+    }
+    val existing = service.createRankerJob(request)
+
+    val duplicate = service.createRankerJob(request)
+
+    assertThat(duplicate).isEqualTo(existing)
+  }
+
+  @Test
+  fun `createRankerJob throws INVALID_ARGUMENT for empty parent`() = runBlocking {
+    val request = createRankerJobRequest {
+      rankerJob = rankerJob {
+        cmmsModelLine = CMMS_MODEL_LINE
+        poolOffsets += POOL_OFFSETS
+      }
+    }
+
+    val exception = assertFailsWith<StatusRuntimeException> { service.createRankerJob(request) }
+    assertThat(exception.status.code).isEqualTo(Status.Code.INVALID_ARGUMENT)
+    assertThat(exception.errorInfo)
+      .isEqualTo(
+        errorInfo {
+          domain = Errors.DOMAIN
+          reason = Errors.Reason.REQUIRED_FIELD_NOT_SET.name
+          metadata[Errors.Metadata.FIELD_NAME.key] = "parent"
+        }
+      )
+  }
+
+  @Test
+  fun `createRankerJob throws INVALID_ARGUMENT for malformed parent`() = runBlocking {
+    val request = createRankerJobRequest {
+      parent = "invalid-parent"
+      rankerJob = rankerJob {
+        cmmsModelLine = CMMS_MODEL_LINE
+        poolOffsets += POOL_OFFSETS
+      }
+    }
+
+    val exception = assertFailsWith<StatusRuntimeException> { service.createRankerJob(request) }
+    assertThat(exception.status.code).isEqualTo(Status.Code.INVALID_ARGUMENT)
+    assertThat(exception.errorInfo)
+      .isEqualTo(
+        errorInfo {
+          domain = Errors.DOMAIN
+          reason = Errors.Reason.INVALID_FIELD_VALUE.name
+          metadata[Errors.Metadata.FIELD_NAME.key] = "parent"
+        }
+      )
+  }
+
+  @Test
+  fun `createRankerJob throws INVALID_ARGUMENT for missing ranker_job`() = runBlocking {
+    val request = createRankerJobRequest { parent = UPLOAD_KEY.toName() }
+
+    val exception = assertFailsWith<StatusRuntimeException> { service.createRankerJob(request) }
+    assertThat(exception.status.code).isEqualTo(Status.Code.INVALID_ARGUMENT)
+    assertThat(exception.errorInfo)
+      .isEqualTo(
+        errorInfo {
+          domain = Errors.DOMAIN
+          reason = Errors.Reason.REQUIRED_FIELD_NOT_SET.name
+          metadata[Errors.Metadata.FIELD_NAME.key] = "ranker_job"
+        }
+      )
+  }
+
+  @Test
+  fun `createRankerJob throws INVALID_ARGUMENT for empty cmmsModelLine`() = runBlocking {
+    val request = createRankerJobRequest {
+      parent = UPLOAD_KEY.toName()
+      rankerJob = rankerJob { poolOffsets += POOL_OFFSETS }
+    }
+
+    val exception = assertFailsWith<StatusRuntimeException> { service.createRankerJob(request) }
+    assertThat(exception.status.code).isEqualTo(Status.Code.INVALID_ARGUMENT)
+    assertThat(exception.errorInfo)
+      .isEqualTo(
+        errorInfo {
+          domain = Errors.DOMAIN
+          reason = Errors.Reason.REQUIRED_FIELD_NOT_SET.name
+          metadata[Errors.Metadata.FIELD_NAME.key] = "ranker_job.cmms_model_line"
+        }
+      )
+  }
+
+  @Test
+  fun `createRankerJob throws INVALID_ARGUMENT for empty pool_offsets`() = runBlocking {
+    val request = createRankerJobRequest {
+      parent = UPLOAD_KEY.toName()
+      rankerJob = rankerJob { cmmsModelLine = CMMS_MODEL_LINE }
+    }
+
+    val exception = assertFailsWith<StatusRuntimeException> { service.createRankerJob(request) }
+    assertThat(exception.status.code).isEqualTo(Status.Code.INVALID_ARGUMENT)
+    assertThat(exception.errorInfo)
+      .isEqualTo(
+        errorInfo {
+          domain = Errors.DOMAIN
+          reason = Errors.Reason.REQUIRED_FIELD_NOT_SET.name
+          metadata[Errors.Metadata.FIELD_NAME.key] = "ranker_job.pool_offsets"
+        }
+      )
+  }
+
+  @Test
+  fun `createRankerJob throws INVALID_ARGUMENT for malformed requestId`() = runBlocking {
+    val request = createRankerJobRequest {
+      parent = UPLOAD_KEY.toName()
+      rankerJob = rankerJob {
+        cmmsModelLine = CMMS_MODEL_LINE
+        poolOffsets += POOL_OFFSETS
+      }
+      requestId = "invalid-request-id"
+    }
+
+    val exception = assertFailsWith<StatusRuntimeException> { service.createRankerJob(request) }
+    assertThat(exception.status.code).isEqualTo(Status.Code.INVALID_ARGUMENT)
+    assertThat(exception.errorInfo)
+      .isEqualTo(
+        errorInfo {
+          domain = Errors.DOMAIN
+          reason = Errors.Reason.INVALID_FIELD_VALUE.name
+          metadata[Errors.Metadata.FIELD_NAME.key] = "request_id"
+        }
+      )
+  }
+
+  @Test
+  fun `batchCreateRankerJobs returns jobs successfully`() =
+    runBlocking<Unit> {
+      createParentUpload(DATA_PROVIDER_ID, RAW_IMPRESSION_UPLOAD_ID)
+      val request = batchCreateRankerJobsRequest {
+        parent = UPLOAD_KEY.toName()
+        requests += createRankerJobRequest {
+          rankerJob = rankerJob {
+            cmmsModelLine = CMMS_MODEL_LINE
+            poolOffsets += listOf(0L, 1L)
+          }
+        }
+        requests += createRankerJobRequest {
+          rankerJob = rankerJob {
+            cmmsModelLine = CMMS_MODEL_LINE
+            poolOffsets += listOf(2L, 3L)
+          }
+        }
+      }
+
+      val response = service.batchCreateRankerJobs(request)
+
+      assertThat(response.rankerJobsList).hasSize(2)
+      assertThat(response.rankerJobsList.flatMap { it.poolOffsetsList }.sorted())
+        .containsExactly(0L, 1L, 2L, 3L)
+    }
+
+  @Test
+  fun `batchCreateRankerJobs throws INVALID_ARGUMENT for empty parent`() = runBlocking {
+    val request = batchCreateRankerJobsRequest {
+      requests += createRankerJobRequest {
+        rankerJob = rankerJob {
+          cmmsModelLine = CMMS_MODEL_LINE
+          poolOffsets += POOL_OFFSETS
+        }
+      }
+    }
+
+    val exception =
+      assertFailsWith<StatusRuntimeException> { service.batchCreateRankerJobs(request) }
+    assertThat(exception.status.code).isEqualTo(Status.Code.INVALID_ARGUMENT)
+    assertThat(exception.errorInfo)
+      .isEqualTo(
+        errorInfo {
+          domain = Errors.DOMAIN
+          reason = Errors.Reason.REQUIRED_FIELD_NOT_SET.name
+          metadata[Errors.Metadata.FIELD_NAME.key] = "parent"
+        }
+      )
+  }
+
+  @Test
+  fun `batchCreateRankerJobs throws INVALID_ARGUMENT for empty requests`() = runBlocking {
+    val request = batchCreateRankerJobsRequest { parent = UPLOAD_KEY.toName() }
+
+    val exception =
+      assertFailsWith<StatusRuntimeException> { service.batchCreateRankerJobs(request) }
+    assertThat(exception.status.code).isEqualTo(Status.Code.INVALID_ARGUMENT)
+    assertThat(exception.errorInfo)
+      .isEqualTo(
+        errorInfo {
+          domain = Errors.DOMAIN
+          reason = Errors.Reason.REQUIRED_FIELD_NOT_SET.name
+          metadata[Errors.Metadata.FIELD_NAME.key] = "requests"
+        }
+      )
+  }
+
+  @Test
+  fun `getRankerJob returns a job`() = runBlocking {
+    createParentUpload(DATA_PROVIDER_ID, RAW_IMPRESSION_UPLOAD_ID)
+    val created =
+      service.createRankerJob(
+        createRankerJobRequest {
+          parent = UPLOAD_KEY.toName()
+          rankerJob = rankerJob {
+            cmmsModelLine = CMMS_MODEL_LINE
+            poolOffsets += POOL_OFFSETS
+          }
+          requestId = REQUEST_ID
+        }
+      )
+
+    val job = service.getRankerJob(getRankerJobRequest { name = created.name })
+
+    assertThat(job).isEqualTo(created)
+  }
+
+  @Test
+  fun `getRankerJob throws INVALID_ARGUMENT for empty name`() = runBlocking {
+    val exception =
+      assertFailsWith<StatusRuntimeException> { service.getRankerJob(getRankerJobRequest {}) }
+    assertThat(exception.status.code).isEqualTo(Status.Code.INVALID_ARGUMENT)
+    assertThat(exception.errorInfo)
+      .isEqualTo(
+        errorInfo {
+          domain = Errors.DOMAIN
+          reason = Errors.Reason.REQUIRED_FIELD_NOT_SET.name
+          metadata[Errors.Metadata.FIELD_NAME.key] = "name"
+        }
+      )
+  }
+
+  @Test
+  fun `getRankerJob throws INVALID_ARGUMENT for malformed name`() = runBlocking {
+    val exception =
+      assertFailsWith<StatusRuntimeException> {
+        service.getRankerJob(getRankerJobRequest { name = "invalid-name" })
+      }
+    assertThat(exception.status.code).isEqualTo(Status.Code.INVALID_ARGUMENT)
+    assertThat(exception.errorInfo)
+      .isEqualTo(
+        errorInfo {
+          domain = Errors.DOMAIN
+          reason = Errors.Reason.INVALID_FIELD_VALUE.name
+          metadata[Errors.Metadata.FIELD_NAME.key] = "name"
+        }
+      )
+  }
+
+  @Test
+  fun `listRankerJobs returns jobs`() =
+    runBlocking<Unit> {
+      createParentUpload(DATA_PROVIDER_ID, RAW_IMPRESSION_UPLOAD_ID)
+      val created =
+        service.createRankerJob(
+          createRankerJobRequest {
+            parent = UPLOAD_KEY.toName()
+            rankerJob = rankerJob {
+              cmmsModelLine = CMMS_MODEL_LINE
+              poolOffsets += POOL_OFFSETS
+            }
+          }
+        )
+
+      val response = service.listRankerJobs(listRankerJobsRequest { parent = UPLOAD_KEY.toName() })
+
+      assertThat(response.rankerJobsList).containsExactly(created)
+    }
+
+  @Test
+  fun `listRankerJobs respects page size and pagination`() = runBlocking {
+    createParentUpload(DATA_PROVIDER_ID, RAW_IMPRESSION_UPLOAD_ID)
+    val created1 =
+      service.createRankerJob(
+        createRankerJobRequest {
+          parent = UPLOAD_KEY.toName()
+          rankerJob = rankerJob {
+            cmmsModelLine = CMMS_MODEL_LINE
+            poolOffsets += listOf(0L)
+          }
+        }
+      )
+    val created2 =
+      service.createRankerJob(
+        createRankerJobRequest {
+          parent = UPLOAD_KEY.toName()
+          rankerJob = rankerJob {
+            cmmsModelLine = CMMS_MODEL_LINE
+            poolOffsets += listOf(1L)
+          }
+        }
+      )
+    val sortedCreated = listOf(created1, created2).sortedBy { it.name }
+
+    val firstResponse =
+      service.listRankerJobs(
+        listRankerJobsRequest {
+          parent = UPLOAD_KEY.toName()
+          pageSize = 1
+        }
+      )
+
+    assertThat(firstResponse.rankerJobsList).hasSize(1)
+    assertThat(firstResponse.nextPageToken).isNotEmpty()
+
+    val secondResponse =
+      service.listRankerJobs(
+        listRankerJobsRequest {
+          parent = UPLOAD_KEY.toName()
+          pageSize = 1
+          pageToken = firstResponse.nextPageToken
+        }
+      )
+
+    assertThat(secondResponse.rankerJobsList).hasSize(1)
+    assertThat((firstResponse.rankerJobsList + secondResponse.rankerJobsList).sortedBy { it.name })
+      .isEqualTo(sortedCreated)
+  }
+
+  @Test
+  fun `listRankerJobs throws INVALID_ARGUMENT for empty parent`() = runBlocking {
+    val exception =
+      assertFailsWith<StatusRuntimeException> { service.listRankerJobs(listRankerJobsRequest {}) }
+    assertThat(exception.status.code).isEqualTo(Status.Code.INVALID_ARGUMENT)
+    assertThat(exception.errorInfo)
+      .isEqualTo(
+        errorInfo {
+          domain = Errors.DOMAIN
+          reason = Errors.Reason.REQUIRED_FIELD_NOT_SET.name
+          metadata[Errors.Metadata.FIELD_NAME.key] = "parent"
+        }
+      )
+  }
+
+  @Test
+  fun `listRankerJobs throws INVALID_ARGUMENT for negative page size`() = runBlocking {
+    val exception =
+      assertFailsWith<StatusRuntimeException> {
+        service.listRankerJobs(
+          listRankerJobsRequest {
+            parent = UPLOAD_KEY.toName()
+            pageSize = -1
+          }
+        )
+      }
+    assertThat(exception.status.code).isEqualTo(Status.Code.INVALID_ARGUMENT)
+    assertThat(exception.errorInfo)
+      .isEqualTo(
+        errorInfo {
+          domain = Errors.DOMAIN
+          reason = Errors.Reason.INVALID_FIELD_VALUE.name
+          metadata[Errors.Metadata.FIELD_NAME.key] = "page_size"
+        }
+      )
+  }
+
+  @Test
+  fun `listRankerJobs throws INVALID_ARGUMENT for malformed page token`() = runBlocking {
+    createParentUpload(DATA_PROVIDER_ID, RAW_IMPRESSION_UPLOAD_ID)
+    val exception =
+      assertFailsWith<StatusRuntimeException> {
+        service.listRankerJobs(
+          listRankerJobsRequest {
+            parent = UPLOAD_KEY.toName()
+            pageToken = "invalid-token"
+          }
+        )
+      }
+    assertThat(exception.status.code).isEqualTo(Status.Code.INVALID_ARGUMENT)
+    assertThat(exception.errorInfo)
+      .isEqualTo(
+        errorInfo {
+          domain = Errors.DOMAIN
+          reason = Errors.Reason.INVALID_FIELD_VALUE.name
+          metadata[Errors.Metadata.FIELD_NAME.key] = "page_token"
+        }
+      )
+  }
+
+  @Test
+  fun `markRankerJobSucceeded transitions state and reports is_last_job`() = runBlocking {
+    createParentUpload(DATA_PROVIDER_ID, RAW_IMPRESSION_UPLOAD_ID)
+    val created =
+      service.createRankerJob(
+        createRankerJobRequest {
+          parent = UPLOAD_KEY.toName()
+          rankerJob = rankerJob {
+            cmmsModelLine = CMMS_MODEL_LINE
+            poolOffsets += POOL_OFFSETS
+          }
+        }
+      )
+
+    val response =
+      service.markRankerJobSucceeded(
+        markRankerJobSucceededRequest {
+          name = created.name
+          etag = created.etag
+        }
+      )
+
+    assertThat(response.rankerJob.state).isEqualTo(RankerJob.State.SUCCEEDED)
+    assertThat(response.rankerJob.name).isEqualTo(created.name)
+    assertThat(response.isLastJob).isTrue()
+  }
+
+  @Test
+  fun `markRankerJobSucceeded throws INVALID_ARGUMENT for empty name`() = runBlocking {
+    val exception =
+      assertFailsWith<StatusRuntimeException> {
+        service.markRankerJobSucceeded(markRankerJobSucceededRequest { etag = "some-etag" })
+      }
+    assertThat(exception.status.code).isEqualTo(Status.Code.INVALID_ARGUMENT)
+    assertThat(exception.errorInfo)
+      .isEqualTo(
+        errorInfo {
+          domain = Errors.DOMAIN
+          reason = Errors.Reason.REQUIRED_FIELD_NOT_SET.name
+          metadata[Errors.Metadata.FIELD_NAME.key] = "name"
+        }
+      )
+  }
+
+  @Test
+  fun `markRankerJobSucceeded throws INVALID_ARGUMENT for empty etag`() = runBlocking {
+    createParentUpload(DATA_PROVIDER_ID, RAW_IMPRESSION_UPLOAD_ID)
+    val created =
+      service.createRankerJob(
+        createRankerJobRequest {
+          parent = UPLOAD_KEY.toName()
+          rankerJob = rankerJob {
+            cmmsModelLine = CMMS_MODEL_LINE
+            poolOffsets += POOL_OFFSETS
+          }
+        }
+      )
+
+    val exception =
+      assertFailsWith<StatusRuntimeException> {
+        service.markRankerJobSucceeded(markRankerJobSucceededRequest { name = created.name })
+      }
+    assertThat(exception.status.code).isEqualTo(Status.Code.INVALID_ARGUMENT)
+    assertThat(exception.errorInfo)
+      .isEqualTo(
+        errorInfo {
+          domain = Errors.DOMAIN
+          reason = Errors.Reason.REQUIRED_FIELD_NOT_SET.name
+          metadata[Errors.Metadata.FIELD_NAME.key] = "etag"
+        }
+      )
+  }
+
+  @Test
+  fun `markRankerJobSucceeded throws ABORTED for etag mismatch`() = runBlocking {
+    createParentUpload(DATA_PROVIDER_ID, RAW_IMPRESSION_UPLOAD_ID)
+    val created =
+      service.createRankerJob(
+        createRankerJobRequest {
+          parent = UPLOAD_KEY.toName()
+          rankerJob = rankerJob {
+            cmmsModelLine = CMMS_MODEL_LINE
+            poolOffsets += POOL_OFFSETS
+          }
+        }
+      )
+
+    val exception =
+      assertFailsWith<StatusRuntimeException> {
+        service.markRankerJobSucceeded(
+          markRankerJobSucceededRequest {
+            name = created.name
+            etag = "wrong-etag"
+          }
+        )
+      }
+    assertThat(exception.status.code).isEqualTo(Status.Code.ABORTED)
+  }
+
+  @Test
+  fun `markRankerJobFailed transitions state`() = runBlocking {
+    createParentUpload(DATA_PROVIDER_ID, RAW_IMPRESSION_UPLOAD_ID)
+    val created =
+      service.createRankerJob(
+        createRankerJobRequest {
+          parent = UPLOAD_KEY.toName()
+          rankerJob = rankerJob {
+            cmmsModelLine = CMMS_MODEL_LINE
+            poolOffsets += POOL_OFFSETS
+          }
+        }
+      )
+
+    val failed =
+      service.markRankerJobFailed(
+        markRankerJobFailedRequest {
+          name = created.name
+          etag = created.etag
+          errorMessage = "Something went wrong"
+        }
+      )
+
+    assertThat(failed.state).isEqualTo(RankerJob.State.FAILED)
+    assertThat(failed.name).isEqualTo(created.name)
+    assertThat(failed.errorMessage).isEqualTo("Something went wrong")
+  }
+
+  @Test
+  fun `markRankerJobFailed throws INVALID_ARGUMENT for malformed name`() = runBlocking {
+    val exception =
+      assertFailsWith<StatusRuntimeException> {
+        service.markRankerJobFailed(
+          markRankerJobFailedRequest {
+            name = "invalid-name"
+            etag = "some-etag"
+          }
+        )
+      }
+    assertThat(exception.status.code).isEqualTo(Status.Code.INVALID_ARGUMENT)
+    assertThat(exception.errorInfo)
+      .isEqualTo(
+        errorInfo {
+          domain = Errors.DOMAIN
+          reason = Errors.Reason.INVALID_FIELD_VALUE.name
+          metadata[Errors.Metadata.FIELD_NAME.key] = "name"
+        }
+      )
+  }
+
+  @Test
+  fun `batchCreateRankerJobs throws INVALID_ARGUMENT when exceeding max batch size`() =
+    runBlocking {
+      val request = batchCreateRankerJobsRequest {
+        parent = UPLOAD_KEY.toName()
+        for (i in 0 until 51) {
+          requests += createRankerJobRequest {
+            rankerJob = rankerJob {
+              cmmsModelLine = CMMS_MODEL_LINE
+              poolOffsets += i.toLong()
+            }
+          }
+        }
+      }
+
+      val exception =
+        assertFailsWith<StatusRuntimeException> { service.batchCreateRankerJobs(request) }
+      assertThat(exception.status.code).isEqualTo(Status.Code.INVALID_ARGUMENT)
+      assertThat(exception.errorInfo)
+        .isEqualTo(
+          errorInfo {
+            domain = Errors.DOMAIN
+            reason = Errors.Reason.INVALID_FIELD_VALUE.name
+            metadata[Errors.Metadata.FIELD_NAME.key] = "requests"
+          }
+        )
+    }
+
+  @Test
+  fun `batchCreateRankerJobs throws INVALID_ARGUMENT for duplicate request_id`() = runBlocking {
+    val duplicateId = UUID.randomUUID().toString()
+    val request = batchCreateRankerJobsRequest {
+      parent = UPLOAD_KEY.toName()
+      requests += createRankerJobRequest {
+        requestId = duplicateId
+        rankerJob = rankerJob {
+          cmmsModelLine = CMMS_MODEL_LINE
+          poolOffsets += POOL_OFFSETS
+        }
+      }
+      requests += createRankerJobRequest {
+        requestId = duplicateId
+        rankerJob = rankerJob {
+          cmmsModelLine = CMMS_MODEL_LINE
+          poolOffsets += POOL_OFFSETS
+        }
+      }
+    }
+
+    val exception =
+      assertFailsWith<StatusRuntimeException> { service.batchCreateRankerJobs(request) }
+    assertThat(exception.status.code).isEqualTo(Status.Code.INVALID_ARGUMENT)
+    assertThat(exception.errorInfo)
+      .isEqualTo(
+        errorInfo {
+          domain = Errors.DOMAIN
+          reason = Errors.Reason.INVALID_FIELD_VALUE.name
+          metadata[Errors.Metadata.FIELD_NAME.key] = "requests.1.request_id"
+        }
+      )
+  }
+
+  @Test
+  fun `batchCreateRankerJobs throws INVALID_ARGUMENT when sub-request parent mismatches`() =
+    runBlocking {
+      val request = batchCreateRankerJobsRequest {
+        parent = UPLOAD_KEY.toName()
+        requests += createRankerJobRequest {
+          parent = "dataProviders/other/rawImpressionUploads/other"
+          rankerJob = rankerJob {
+            cmmsModelLine = CMMS_MODEL_LINE
+            poolOffsets += POOL_OFFSETS
+          }
+        }
+      }
+
+      val exception =
+        assertFailsWith<StatusRuntimeException> { service.batchCreateRankerJobs(request) }
+      assertThat(exception.status.code).isEqualTo(Status.Code.INVALID_ARGUMENT)
+      assertThat(exception.errorInfo)
+        .isEqualTo(
+          errorInfo {
+            domain = Errors.DOMAIN
+            reason = Errors.Reason.INVALID_FIELD_VALUE.name
+            metadata[Errors.Metadata.FIELD_NAME.key] = "requests.0.parent"
+          }
+        )
+    }
+
+  @Test
+  fun `listRankerJobs lists across uploads with wildcard parent`() =
+    runBlocking<Unit> {
+      createParentUpload(DATA_PROVIDER_ID, RAW_IMPRESSION_UPLOAD_ID)
+      createParentUpload(DATA_PROVIDER_ID, SECOND_UPLOAD_ID)
+      val firstJob =
+        service.createRankerJob(
+          createRankerJobRequest {
+            parent = UPLOAD_KEY.toName()
+            rankerJob = rankerJob {
+              cmmsModelLine = CMMS_MODEL_LINE
+              poolOffsets += POOL_OFFSETS
+            }
+          }
+        )
+      val secondJob =
+        service.createRankerJob(
+          createRankerJobRequest {
+            parent = RawImpressionUploadKey(DATA_PROVIDER_ID, SECOND_UPLOAD_ID).toName()
+            rankerJob = rankerJob {
+              cmmsModelLine = CMMS_MODEL_LINE
+              poolOffsets += POOL_OFFSETS
+            }
+          }
+        )
+
+      val response =
+        service.listRankerJobs(
+          listRankerJobsRequest {
+            parent = RawImpressionUploadKey(DATA_PROVIDER_ID, ResourceKey.WILDCARD_ID).toName()
+          }
+        )
+
+      assertThat(response.rankerJobsList.map { it.name })
+        .containsExactly(firstJob.name, secondJob.name)
+    }
+
+  @Test
+  fun `getRankerJob throws NOT_FOUND for missing job`() = runBlocking {
+    createParentUpload(DATA_PROVIDER_ID, RAW_IMPRESSION_UPLOAD_ID)
+    val missingName =
+      RankerJobKey(DATA_PROVIDER_ID, RAW_IMPRESSION_UPLOAD_ID, "rj-missing").toName()
+
+    val exception =
+      assertFailsWith<StatusRuntimeException> {
+        service.getRankerJob(getRankerJobRequest { name = missingName })
+      }
+    assertThat(exception.status.code).isEqualTo(Status.Code.NOT_FOUND)
+  }
+
+  @Test
+  fun `markRankerJobSucceeded throws NOT_FOUND for missing job`() = runBlocking {
+    createParentUpload(DATA_PROVIDER_ID, RAW_IMPRESSION_UPLOAD_ID)
+    val missingName =
+      RankerJobKey(DATA_PROVIDER_ID, RAW_IMPRESSION_UPLOAD_ID, "rj-missing").toName()
+
+    val exception =
+      assertFailsWith<StatusRuntimeException> {
+        service.markRankerJobSucceeded(
+          markRankerJobSucceededRequest {
+            name = missingName
+            etag = "some-etag"
+          }
+        )
+      }
+    assertThat(exception.status.code).isEqualTo(Status.Code.NOT_FOUND)
+  }
+
+  @Test
+  fun `markRankerJobFailed throws NOT_FOUND for missing job`() = runBlocking {
+    createParentUpload(DATA_PROVIDER_ID, RAW_IMPRESSION_UPLOAD_ID)
+    val missingName =
+      RankerJobKey(DATA_PROVIDER_ID, RAW_IMPRESSION_UPLOAD_ID, "rj-missing").toName()
+
+    val exception =
+      assertFailsWith<StatusRuntimeException> {
+        service.markRankerJobFailed(
+          markRankerJobFailedRequest {
+            name = missingName
+            etag = "some-etag"
+          }
+        )
+      }
+    assertThat(exception.status.code).isEqualTo(Status.Code.NOT_FOUND)
+  }
+
+  companion object {
+    @get:ClassRule @JvmStatic val spannerEmulator = SpannerEmulatorRule()
+
+    private val DATA_PROVIDER_ID = externalIdToApiId(111L)
+    private const val RAW_IMPRESSION_UPLOAD_ID = "upload-1"
+    private const val SECOND_UPLOAD_ID = "upload-2"
+    private val UPLOAD_KEY = RawImpressionUploadKey(DATA_PROVIDER_ID, RAW_IMPRESSION_UPLOAD_ID)
+    private const val CMMS_MODEL_LINE = "modelProviders/mp1/modelSuites/ms1/modelLines/ml1"
+    private val POOL_OFFSETS = listOf(0L, 1L, 2L)
+    private val REQUEST_ID = UUID.randomUUID().toString()
+  }
+}


### PR DESCRIPTION
## Summary

  Implements the **Phase-1 `RankerJob`** resource API for the VID Labeler
  memoized-assignment pipeline: a public `v1alpha` service plus an internal Cloud
  Spanner service, resource keys, internal error reasons, and Spanner-emulator
  tests.

  The last `RankerJob` to succeed for a `(upload, model line)` reports
  `is_last_job`, so the caller can transition the parent
  `RawImpressionUploadModelLine` from `RANKING` → `LABELING` and trigger Phase 2.

  > Stacked on `getina/vid-labeling-spanner-schema` (schema PR #3989). Please set
  > that branch as the base when opening the PR, and merge it first.

  ## What's included

  - **Public API** (`service/v1alpha/RankerJobService.kt`): `CreateRankerJob`,
    `BatchCreateRankerJobs`, `GetRankerJob`, `ListRankerJobs`,
    `MarkRankerJobSucceeded`, `MarkRankerJobFailed`.
  - **Internal API** (`deploy/gcloud/spanner/SpannerRankerJobService.kt` +
    `db/RankerJob.kt`): Spanner-backed implementation with `request_id`
    idempotency and `etag` optimistic concurrency.
  - **Resource keys** (`service/RankerJobKey.kt`, incl. `RawImpressionUploadKey`),
    new internal error reasons in `service/internal/Errors.kt`, and service
    wiring (`Services.kt`, `InternalApiServices.kt`, `IdVariable.kt`, BUILD files).
  - **Tests**: abstract internal contract test + concrete Spanner-emulator test,
    and a public-API `v1alpha` test.

  ## Behavior notes
  
  - `MarkRankerJobSucceeded` is idempotent on `request_id`; `is_last_job` is
    computed from the current committed state of the sibling jobs, so the Phase-2
    (`RANKING` → `LABELING`) transition the caller drives MUST be idempotent.
  - Validation lives in the public layer (batch size ≤ 50, `request_id` UUID
    format + in-batch uniqueness, sub-request `parent`/`ranker_job` presence,
    `state_in` filter values), returning `INVALID_ARGUMENT` for client errors.
  - `ListRankerJobs` supports the AIP-159 wildcard `-` parent to list across all
    uploads for a data provider.

  ## ⚠️  Dependency on base schema PR #3989

  The `MarkRequestId STRING(36)` column that `MarkRankerJobSucceeded` idempotency
  relies on is intentionally **not** added here — it belongs to the base schema PR
  (`getina/vid-labeling-spanner-schema`, #3989) and is left as a `TODO` in
  `create-vid-labeling-schema.sql`. The code compiles, but the two
  Spanner-emulator test targets will pass only once that column is added in the
  base branch. (Verified green locally with the column present.)

  ## Testing
  
  - `ktfmt 0.54 --google-style`: clean.
  - `bazel build` of all main + test targets: passing.
  - `RankerJobServiceTest` (v1alpha) and `SpannerRankerJobServiceTest`: passing
    with the `MarkRequestId` column present (see dependency note above).


Issue: #3927 