### PR TITLE
feat(post-processor): snap k_plus_reach to satisfy per-window rounding identities (partial #4049)

### DIFF
--- a/src/main/python/wfa/measurement/reporting/postprocessing/tools/post_process_report_result.py
+++ b/src/main/python/wfa/measurement/reporting/postprocessing/tools/post_process_report_result.py
@@ -503,11 +503,11 @@ def compute_basic_metric_set(
 
     basic_metric_set = BasicMetricSet()
 
-    if reach:
+    if reach is not None:
         basic_metric_set.reach = reach
         basic_metric_set.percent_reach = reach / population * 100
 
-    if impressions:
+    if impressions is not None:
         basic_metric_set.impressions = impressions
         basic_metric_set.grps = impressions / population * 100
         if basic_metric_set.reach > 0:
@@ -552,6 +552,12 @@ def compute_basic_metric_set(
                                                  k_plus_reach_values[i - 1])
             if impressions is not None:
                 excess = sum(k_plus_reach_values) - impressions
+                # Walk high index -> low. This direction is load-bearing:
+                # only lowering k[i] for i descending keeps the non-
+                # increasing invariant (k[i-1] >= k[i]) intact, because
+                # k[i-1] is either untouched or about to be lowered next.
+                # A low->high or proportional rewrite would silently
+                # break Rule 3 / monotonicity.
                 i = len(k_plus_reach_values) - 1
                 while excess > 0 and i >= 1:
                     absorbed = min(excess, k_plus_reach_values[i])
@@ -559,14 +565,17 @@ def compute_basic_metric_set(
                     excess -= absorbed
                     i -= 1
                 if excess > 0:
-                    # Reach > impressions in the input -- upstream data is
-                    # inconsistent. Preserve k_plus_reach[0] == reach (rule 1)
-                    # and leave the impressions identity (rule 2) violated by
-                    # the leftover residue, so downstream consumers can see
-                    # the input was corrupt.
+                    # The histogram's weighted sum exceeds impressions and
+                    # the cascade ran out of buckets to absorb the residue
+                    # (cascade stops before index 0 to preserve rule 1 when
+                    # reach is set). Upstream data is inconsistent; surface
+                    # it as a warning rather than silently producing a
+                    # BasicMetricSet that violates rule 2. Use %s for reach
+                    # because reach may be None when only the histogram and
+                    # impressions were supplied.
                     logging.warning(
                         "Could not fully reconcile sum(k_plus_reach) <= "
-                        "impressions: leftover residue %d (reach=%d, "
+                        "impressions: leftover residue %d (reach=%s, "
                         "impressions=%d). Preserving reach == "
                         "k_plus_reach[0]; sum(k_plus_reach) will exceed "
                         "impressions by this residue.",

--- a/src/main/python/wfa/measurement/reporting/postprocessing/tools/post_process_report_result.py
+++ b/src/main/python/wfa/measurement/reporting/postprocessing/tools/post_process_report_result.py
@@ -526,17 +526,24 @@ def compute_basic_metric_set(
         #
         # Snap to enforce both. The reach value is the canonical 1+ reach,
         # so overwrite k_plus_reach[0]. For the impression identity, absorb
-        # any positive residue into the highest-frequency bucket (which has
-        # the loosest physical interpretation: "saw it at least N times for
-        # large N"). See Issue #4049.
+        # any positive residue starting at the highest-frequency bucket (which
+        # has the loosest physical interpretation: "saw it at least N times
+        # for large N"). If a single bucket can't absorb the full residue
+        # (e.g. it would go below zero), cascade into the next-highest bucket.
+        # Stop before index 0 so the reach == k_plus_reach[0] identity is
+        # preserved even in the (unrealistic) case where the residue exceeds
+        # the total capacity of all higher-frequency buckets. See Issue #4049.
         if k_plus_reach_values:
             if reach is not None:
                 k_plus_reach_values[0] = reach
             if impressions is not None:
                 excess = sum(k_plus_reach_values) - impressions
-                if excess > 0:
-                    k_plus_reach_values[-1] = max(
-                        0, k_plus_reach_values[-1] - excess)
+                i = len(k_plus_reach_values) - 1
+                while excess > 0 and i >= 1:
+                    absorbed = min(excess, k_plus_reach_values[i])
+                    k_plus_reach_values[i] -= absorbed
+                    excess -= absorbed
+                    i -= 1
         basic_metric_set.k_plus_reach.extend(k_plus_reach_values)
         basic_metric_set.percent_k_plus_reach.extend(
             [val / population * 100 for val in k_plus_reach_values])

--- a/src/main/python/wfa/measurement/reporting/postprocessing/tools/post_process_report_result.py
+++ b/src/main/python/wfa/measurement/reporting/postprocessing/tools/post_process_report_result.py
@@ -515,6 +515,28 @@ def compute_basic_metric_set(
             round(sum(frequency_values[i:]))
             for i in range(len(frequency_values))
         ]
+        # The post-processor solver returns reach and the frequency
+        # histogram as independent floats; rounding each separately can
+        # break two algebraic identities consumers rely on:
+        #
+        # 1. k_plus_reach[0] (the "1+ reach") must equal reach.
+        # 2. The weighted sum of frequency buckets must not exceed
+        #    impressions (it is conceptually equal, but rounding can push
+        #    it slightly above).
+        #
+        # Snap to enforce both. The reach value is the canonical 1+ reach,
+        # so overwrite k_plus_reach[0]. For the impression identity, absorb
+        # any positive residue into the highest-frequency bucket (which has
+        # the loosest physical interpretation: "saw it at least N times for
+        # large N"). See Issue #4049.
+        if k_plus_reach_values:
+            if reach is not None:
+                k_plus_reach_values[0] = reach
+            if impressions is not None:
+                excess = sum(k_plus_reach_values) - impressions
+                if excess > 0:
+                    k_plus_reach_values[-1] = max(
+                        0, k_plus_reach_values[-1] - excess)
         basic_metric_set.k_plus_reach.extend(k_plus_reach_values)
         basic_metric_set.percent_k_plus_reach.extend(
             [val / population * 100 for val in k_plus_reach_values])

--- a/src/main/python/wfa/measurement/reporting/postprocessing/tools/post_process_report_result.py
+++ b/src/main/python/wfa/measurement/reporting/postprocessing/tools/post_process_report_result.py
@@ -521,25 +521,35 @@ def compute_basic_metric_set(
         ]
         # The post-processor solver returns reach and the frequency
         # histogram as independent floats; rounding each separately can
-        # break two algebraic identities consumers rely on:
+        # break three algebraic identities consumers rely on:
         #
         # 1. k_plus_reach[0] (the "1+ reach") must equal reach.
         # 2. The weighted sum of frequency buckets must not exceed
         #    impressions (it is conceptually equal, but rounding can push
         #    it slightly above).
+        # 3. k_plus_reach is non-increasing: k_plus_reach[i] >=
+        #    k_plus_reach[i+1] ("N+ reach" cannot exceed "(N-1)+ reach").
         #
-        # Snap to enforce both. The reach value is the canonical 1+ reach,
-        # so overwrite k_plus_reach[0]. For the impression identity, absorb
-        # any positive residue starting at the highest-frequency bucket (which
-        # has the loosest physical interpretation: "saw it at least N times
-        # for large N"). If a single bucket can't absorb the full residue
-        # (e.g. it would go below zero), cascade into the next-highest bucket.
-        # Stop before index 0 so the reach == k_plus_reach[0] identity is
-        # preserved even in the (unrealistic) case where the residue exceeds
-        # the total capacity of all higher-frequency buckets. See Issue #4049.
+        # Snap to enforce all three. The reach value is the canonical 1+
+        # reach, so overwrite k_plus_reach[0]; that overwrite plus
+        # independent rounding can leave k_plus_reach[1] > k_plus_reach[0],
+        # so forward-clamp each bucket to its predecessor. Then, for the
+        # impression identity, absorb any positive residue starting at the
+        # highest-frequency bucket (which has the loosest physical
+        # interpretation: "saw it at least N times for large N"). If a
+        # single bucket can't absorb the full residue (e.g. it would go
+        # below zero), cascade into the next-highest bucket. Stop before
+        # index 0 so the reach == k_plus_reach[0] identity is preserved
+        # even in the (unrealistic) case where the residue exceeds the
+        # total capacity of all higher-frequency buckets. The forward-
+        # clamp must run before the cascade because clamping reduces
+        # sum(k_plus_reach) and thus changes the excess. See Issue #4049.
         if k_plus_reach_values:
             if reach is not None:
                 k_plus_reach_values[0] = reach
+                for i in range(1, len(k_plus_reach_values)):
+                    k_plus_reach_values[i] = min(k_plus_reach_values[i],
+                                                 k_plus_reach_values[i - 1])
             if impressions is not None:
                 excess = sum(k_plus_reach_values) - impressions
                 i = len(k_plus_reach_values) - 1

--- a/src/main/python/wfa/measurement/reporting/postprocessing/tools/post_process_report_result.py
+++ b/src/main/python/wfa/measurement/reporting/postprocessing/tools/post_process_report_result.py
@@ -544,6 +544,19 @@ def compute_basic_metric_set(
                     k_plus_reach_values[i] -= absorbed
                     excess -= absorbed
                     i -= 1
+                if excess > 0:
+                    # Reach > impressions in the input -- upstream data is
+                    # inconsistent. Preserve k_plus_reach[0] == reach (rule 1)
+                    # and leave the impressions identity (rule 2) violated by
+                    # the leftover residue, so downstream consumers can see
+                    # the input was corrupt.
+                    logging.warning(
+                        "Could not fully reconcile sum(k_plus_reach) <= "
+                        "impressions: leftover residue %d (reach=%d, "
+                        "impressions=%d). Preserving reach == "
+                        "k_plus_reach[0]; sum(k_plus_reach) will exceed "
+                        "impressions by this residue.",
+                        excess, reach, impressions)
         basic_metric_set.k_plus_reach.extend(k_plus_reach_values)
         basic_metric_set.percent_k_plus_reach.extend(
             [val / population * 100 for val in k_plus_reach_values])

--- a/src/test/python/wfa/measurement/reporting/postprocessing/tools/post_process_report_result_test.py
+++ b/src/test/python/wfa/measurement/reporting/postprocessing/tools/post_process_report_result_test.py
@@ -304,6 +304,45 @@ class PostProcessReportResultTest(unittest.TestCase):
             any('Could not fully reconcile' in m for m in cm.output),
             f"expected reconciliation warning, got: {cm.output}")
 
+    def test_compute_basic_metric_set_single_bucket_excess_logs_warning(self):
+        """When the histogram has a single bucket, the cascade has no
+        higher-frequency bucket to absorb residue into. Identity 1
+        (k_plus_reach[0] == reach) is preserved and the warning surfaces
+        the unresolved residue (Issue #4049).
+        """
+        with self.assertLogs(level='WARNING') as cm:
+            basic_metric_set = compute_basic_metric_set(
+                reach=10,
+                frequency_values=[10],
+                impressions=5,
+                population=1000,
+            )
+
+        self.assertEqual(list(basic_metric_set.k_plus_reach), [10])
+        self.assertTrue(
+            any('Could not fully reconcile' in m for m in cm.output),
+            f"expected reconciliation warning, got: {cm.output}")
+
+    def test_compute_basic_metric_set_k_plus_reach_is_non_increasing(self):
+        # Without the clamp: k_plus_reach[0]=6 (overwritten from reach) but
+        # k_plus_reach[1]=round(5+2)=7 -- "2+ reach > 1+ reach", nonsense.
+        basic_metric_set = compute_basic_metric_set(
+            reach=6,
+            frequency_values=[3, 5, 2],
+            impressions=20,
+            population=1000,
+        )
+
+        k_plus_reach = list(basic_metric_set.k_plus_reach)
+        self.assertEqual(k_plus_reach[0], basic_metric_set.reach,
+                         "k_plus_reach[0] must equal reach")
+        for i in range(1, len(k_plus_reach)):
+            self.assertLessEqual(
+                k_plus_reach[i], k_plus_reach[i - 1],
+                f"k_plus_reach must be non-increasing; "
+                f"bucket {i}={k_plus_reach[i]} exceeds "
+                f"bucket {i-1}={k_plus_reach[i - 1]}")
+
     def test_post_process_report_result_success(self):
         # Configures the mock stubs to return the data from the textproto files.
         self.mock_report_results_stub.ListReportingSetResults.return_value = (

--- a/src/test/python/wfa/measurement/reporting/postprocessing/tools/post_process_report_result_test.py
+++ b/src/test/python/wfa/measurement/reporting/postprocessing/tools/post_process_report_result_test.py
@@ -323,6 +323,25 @@ class PostProcessReportResultTest(unittest.TestCase):
             any('Could not fully reconcile' in m for m in cm.output),
             f"expected reconciliation warning, got: {cm.output}")
 
+    def test_compute_basic_metric_set_zero_reach_zeros_k_plus_reach(self):
+        """reach=0 (rather than None) means "nobody was reached"; the
+        snap overwrites k_plus_reach[0] with 0 and the forward-clamp
+        cascades that down through every bucket. Pin the behavior so a
+        future change to the snaps truthiness check (e.g. `if reach:`
+        instead of `if reach is not None:`) is caught.
+        """
+        basic_metric_set = compute_basic_metric_set(
+            reach=0,
+            frequency_values=[3, 5, 2],
+            impressions=20,
+            population=1000,
+        )
+
+        self.assertEqual(basic_metric_set.reach, 0)
+        self.assertEqual(list(basic_metric_set.k_plus_reach), [0, 0, 0])
+        self.assertEqual(list(basic_metric_set.percent_k_plus_reach),
+                         [0.0, 0.0, 0.0])
+
     def test_compute_basic_metric_set_k_plus_reach_is_non_increasing(self):
         # Without the clamp: k_plus_reach[0]=6 (overwritten from reach) but
         # k_plus_reach[1]=round(5+2)=7 -- "2+ reach > 1+ reach", nonsense.

--- a/src/test/python/wfa/measurement/reporting/postprocessing/tools/post_process_report_result_test.py
+++ b/src/test/python/wfa/measurement/reporting/postprocessing/tools/post_process_report_result_test.py
@@ -286,17 +286,23 @@ class PostProcessReportResultTest(unittest.TestCase):
         case; the residual is small in practice because large corrections
         are rejected upstream by the 7-sigma threshold.
         """
-        basic_metric_set = compute_basic_metric_set(
-            reach=10,
-            frequency_values=[10, 5, 3, 2, 1],
-            impressions=1,
-            population=1000,
-        )
+        with self.assertLogs(level='WARNING') as cm:
+            basic_metric_set = compute_basic_metric_set(
+                reach=10,
+                frequency_values=[10, 5, 3, 2, 1],
+                impressions=1,
+                population=1000,
+            )
 
         # All higher buckets pushed to zero, but k_plus_reach[0] is preserved.
         self.assertEqual(basic_metric_set.k_plus_reach[0], 10)
         for bucket in basic_metric_set.k_plus_reach[1:]:
             self.assertEqual(bucket, 0)
+        # Warning surfaces the unresolved residue so operators notice the
+        # upstream data inconsistency (reach > impressions).
+        self.assertTrue(
+            any('Could not fully reconcile' in m for m in cm.output),
+            f"expected reconciliation warning, got: {cm.output}")
 
     def test_post_process_report_result_success(self):
         # Configures the mock stubs to return the data from the textproto files.

--- a/src/test/python/wfa/measurement/reporting/postprocessing/tools/post_process_report_result_test.py
+++ b/src/test/python/wfa/measurement/reporting/postprocessing/tools/post_process_report_result_test.py
@@ -323,6 +323,29 @@ class PostProcessReportResultTest(unittest.TestCase):
             any('Could not fully reconcile' in m for m in cm.output),
             f"expected reconciliation warning, got: {cm.output}")
 
+    def test_compute_basic_metric_set_excess_warning_with_none_reach(self):
+        """When reach is None and the histogram's weighted sum exceeds
+        impressions, the cascade exhausts higher-frequency buckets and the
+        warning must format cleanly -- not TypeError on '%d % None'. With
+        reach=None there is no rule 1 to preserve; the warning still
+        signals upstream inconsistency to operators (Issue #4049).
+        """
+        with self.assertLogs(level='WARNING') as cm:
+            basic_metric_set = compute_basic_metric_set(
+                reach=None,
+                frequency_values=[100],
+                impressions=5,
+                population=1000,
+            )
+
+        self.assertEqual(list(basic_metric_set.k_plus_reach), [100])
+        self.assertTrue(
+            any('Could not fully reconcile' in m for m in cm.output),
+            f"expected reconciliation warning, got: {cm.output}")
+        self.assertTrue(
+            any('reach=None' in m for m in cm.output),
+            f"warning should render reach=None, got: {cm.output}")
+
     def test_compute_basic_metric_set_zero_reach_zeros_k_plus_reach(self):
         """reach=0 (rather than None) means "nobody was reached"; the
         snap overwrites k_plus_reach[0] with 0 and the forward-clamp

--- a/src/test/python/wfa/measurement/reporting/postprocessing/tools/post_process_report_result_test.py
+++ b/src/test/python/wfa/measurement/reporting/postprocessing/tools/post_process_report_result_test.py
@@ -198,6 +198,57 @@ class PostProcessReportResultTest(unittest.TestCase):
         self.assertEqual(list(basic_metric_set.percent_k_plus_reach),
                          [50.0, 40.0, 20.0, 5.0, 0.0])
 
+    def test_compute_basic_metric_set_k_plus_reach_zero_matches_reach(self):
+        """k_plus_reach[0] is the "1+ reach" and must equal reach.
+
+        When the post-processor solver returns reach and the frequency
+        histogram as floats (the realistic case in production), independent
+        round() calls on the two derivations can disagree by 1+. Consumers
+        rely on k_plus_reach[0] == reach (Issue #4049).
+        """
+        # Floats chosen so round(reach) != round(sum(freqs)):
+        # reach rounds to 2194000; sum(freqs) rounds to 2193997 (matches the
+        # real-world example from Origin staging in #4049).
+        basic_metric_set = compute_basic_metric_set(
+            reach=2194000,
+            frequency_values=[
+                1222269.4, 299330.4, 183245.4, 85498.4, 45170.4,
+                64182.4, 26965.4, 7445.4, 5345.4, 4608.4,
+                4874.4, 6342.4, 6253.4, 51051.4, 181420.4,
+            ],
+            impressions=7313150,
+            population=8045553,
+        )
+
+        self.assertEqual(basic_metric_set.k_plus_reach[0],
+                         basic_metric_set.reach,
+                         "k_plus_reach[0] (1+ reach) must equal reach")
+
+    def test_compute_basic_metric_set_k_plus_buckets_sum_le_impressions(self):
+        """The weighted sum of frequency-distribution buckets is conceptually
+        the impression count. With independent rounding the weighted sum can
+        exceed impressions by a small amount, breaking a validation rule
+        post-processor consumers rely on (Issue #4049).
+        """
+        basic_metric_set = compute_basic_metric_set(
+            reach=3946000,
+            frequency_values=[
+                1663825.4, 651217.4, 382519.4, 244746.4, 164390.4,
+                124340.4, 105164.4, 74233.4, 30675.4, 37481.4,
+                25755.4, 21514.4, 31622.4, 139317.4, 249203.4,
+            ],
+            impressions=15282723,
+            population=8568303,
+        )
+
+        # k_plus_reach values are aggregated by frequency bucket k. The
+        # impression count equals weighted sum: sum(freq[i] * (i+1)) for
+        # buckets [0..max], or equivalently sum(k_plus_reach).
+        weighted_sum_of_buckets = sum(basic_metric_set.k_plus_reach)
+        self.assertLessEqual(
+            weighted_sum_of_buckets, basic_metric_set.impressions,
+            "sum of k_plus_reach buckets must not exceed impressions")
+
     def test_post_process_report_result_success(self):
         # Configures the mock stubs to return the data from the textproto files.
         self.mock_report_results_stub.ListReportingSetResults.return_value = (

--- a/src/test/python/wfa/measurement/reporting/postprocessing/tools/post_process_report_result_test.py
+++ b/src/test/python/wfa/measurement/reporting/postprocessing/tools/post_process_report_result_test.py
@@ -249,6 +249,55 @@ class PostProcessReportResultTest(unittest.TestCase):
             weighted_sum_of_buckets, basic_metric_set.impressions,
             "sum of k_plus_reach buckets must not exceed impressions")
 
+    def test_compute_basic_metric_set_k_plus_excess_cascades_across_buckets(
+            self):
+        """When the rounding residue exceeds the last k_plus_reach bucket, the
+        snap cascades into the next-highest bucket until the impressions
+        identity is satisfied. Without cascading, the violation would persist.
+        """
+        # frequency_values picked so the highest bucket can absorb only part of
+        # the residue: k_plus_reach[-1] = 1 (= frequency_values[-1]) but
+        # excess after capping impressions is 5, so 4 must cascade into the
+        # next bucket.
+        basic_metric_set = compute_basic_metric_set(
+            reach=166,
+            frequency_values=[100, 50, 10, 5, 1],
+            impressions=250,
+            population=1000,
+        )
+
+        weighted_sum_of_buckets = sum(basic_metric_set.k_plus_reach)
+        self.assertLessEqual(
+            weighted_sum_of_buckets, basic_metric_set.impressions,
+            "sum of k_plus_reach buckets must not exceed impressions")
+        # k_plus_reach[-1] absorbs as much as it can; remainder cascades.
+        self.assertEqual(basic_metric_set.k_plus_reach[-1], 0)
+        self.assertEqual(basic_metric_set.k_plus_reach[-2], 2)
+        # Lower buckets are untouched.
+        self.assertEqual(basic_metric_set.k_plus_reach[0], 166)
+        self.assertEqual(basic_metric_set.k_plus_reach[1], 66)
+        self.assertEqual(basic_metric_set.k_plus_reach[2], 16)
+
+    def test_compute_basic_metric_set_k_plus_excess_preserves_reach_identity(
+            self):
+        """The cascade stops at index 1 so k_plus_reach[0] == reach holds
+        even when the residue would otherwise consume the whole histogram.
+        Identity #1 takes precedence over identity #2 in this (unrealistic)
+        case; the residual is small in practice because large corrections
+        are rejected upstream by the 7-sigma threshold.
+        """
+        basic_metric_set = compute_basic_metric_set(
+            reach=10,
+            frequency_values=[10, 5, 3, 2, 1],
+            impressions=1,
+            population=1000,
+        )
+
+        # All higher buckets pushed to zero, but k_plus_reach[0] is preserved.
+        self.assertEqual(basic_metric_set.k_plus_reach[0], 10)
+        for bucket in basic_metric_set.k_plus_reach[1:]:
+            self.assertEqual(bucket, 0)
+
     def test_post_process_report_result_success(self):
         # Configures the mock stubs to return the data from the textproto files.
         self.mock_report_results_stub.ListReportingSetResults.return_value = (


### PR DESCRIPTION
Partial fix for #4049. Within each BasicMetricSet, snap k_plus_reach so that k_plus_reach[0] == reach and sum(k_plus_reach) <= impressions. Independent round() calls on the solver's float outputs could drift these two integer identities apart, breaking validation rules consumers rely on.

The reach snap is unconditional: k_plus_reach[0] is overwritten with the canonical reach value. The impressions residue (sum(k_plus_reach) - impressions, after the reach snap) is absorbed bucket-by-bucket from the highest-frequency end, cascading into the next-highest bucket if the top one can't hold it all. The cascade stops before index 0 so the reach identity is never re-broken; if the residue still can't be absorbed (which only happens when reach > impressions in the input -- upstream data inconsistency, not a rounding issue), a warning is logged and the impressions identity is left violated by the leftover residue.

Addresses Rule 4 from the issue, and the only sensible reading of Rule 3 (per-BMS reach == k_plus_reach[0]). Does not touch any cross-BMS identity: Rules 1, 2, and 5 compare values across separate BasicMetricSets in the same report and require separate fixes. PR #4054 addresses Rules 1 and 2; Rule 5 is tracked in #4059.

Issue: #4049