### PR TITLE
ci: Compute run name from workflow inputs

### DIFF
--- a/.github/workflows/configure-aws-duchy.yml
+++ b/.github/workflows/configure-aws-duchy.yml
@@ -14,6 +14,12 @@
 
 name: "Configure AWS Duchy"
 
+run-name: >-
+  Configure AWS Duchy [${{ inputs.environment }}] |
+  apply=${{ inputs.apply }},
+  duchy=${{ inputs.duchy-name }},
+  image-tag=${{ inputs.image-tag }}
+
 on:
   workflow_call:
     inputs:

--- a/.github/workflows/configure-duchy.yml
+++ b/.github/workflows/configure-duchy.yml
@@ -14,6 +14,12 @@
 
 name: "Configure Duchy"
 
+run-name: >-
+  Configure Duchy [${{ inputs.environment }}] |
+  apply=${{ inputs.apply }},
+  duchy=${{ inputs.duchy-name }},
+  image-tag=${{ inputs.image-tag }}
+
 on:
   workflow_call:
     inputs:

--- a/.github/workflows/configure-edp-aggregator.yml
+++ b/.github/workflows/configure-edp-aggregator.yml
@@ -14,6 +14,11 @@
 
 name: "Configure Edp Aggregator Services"
 
+run-name: >-
+  Configure Edp Aggregator Services [${{ inputs.environment }}] |
+  apply=${{ inputs.apply }},
+  image-tag=${{ inputs.image-tag }}
+
 on:
   workflow_call:
     inputs:

--- a/.github/workflows/configure-kingdom.yml
+++ b/.github/workflows/configure-kingdom.yml
@@ -14,6 +14,11 @@
 
 name: "Configure Kingdom"
 
+run-name: >-
+  Configure Kingdom [${{ inputs.environment }}] |
+  apply=${{ inputs.apply }},
+  image-tag=${{ inputs.existing-image-tag }}
+
 on:
   workflow_call:
     inputs:

--- a/.github/workflows/configure-population-fulfiller.yml
+++ b/.github/workflows/configure-population-fulfiller.yml
@@ -14,6 +14,11 @@
 
 name: "Configure Population Requisition Fulfiller"
 
+run-name: >-
+  Configure Population Requisition Fulfiller [${{ inputs.environment }}] |
+  apply=${{ inputs.apply }},
+  image-tag=${{ inputs.existing-image-tag }}
+
 on:
   workflow_call:
     inputs:

--- a/.github/workflows/configure-reporting-v2.yml
+++ b/.github/workflows/configure-reporting-v2.yml
@@ -14,6 +14,11 @@
 
 name: "Configure Reporting V2"
 
+run-name: >-
+  Configure Reporting V2 [${{ inputs.environment }}] |
+  apply=${{ inputs.apply }},
+  image-tag=${{ inputs.existing-image-tag }}
+
 on:
   workflow_call:
     inputs:

--- a/.github/workflows/configure-secure-computation-control-plane.yml
+++ b/.github/workflows/configure-secure-computation-control-plane.yml
@@ -14,6 +14,11 @@
 
 name: "Configure Control Plane for Secure Computation"
 
+run-name: >-
+  Configure Control Plane for Secure Computation [${{ inputs.environment }}] |
+  apply=${{ inputs.apply }},
+  image-tag=${{ inputs.existing-image-tag }}
+
 on:
   workflow_call:
     inputs:

--- a/.github/workflows/configure-simulators.yml
+++ b/.github/workflows/configure-simulators.yml
@@ -14,6 +14,11 @@
 
 name: "Configure EDP simulators"
 
+run-name: >-
+  Configure EDP simulators [${{ inputs.environment }}] |
+  apply=${{ inputs.apply }},
+  image-tag=${{ inputs.existing-image-tag }}
+
 on:
   workflow_call:
     inputs:

--- a/.github/workflows/draft-new-release.yml
+++ b/.github/workflows/draft-new-release.yml
@@ -14,6 +14,12 @@
 
 name: Draft new release
 
+run-name: >-
+  Draft new release |
+  release=${{ inputs.existing-release-tag }},
+  milestone=${{ inputs.milestone-name }},
+  notes-start=${{ inputs.notes-start-commitish }}
+
 on:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/edpa-cloud-test.yml
+++ b/.github/workflows/edpa-cloud-test.yml
@@ -14,6 +14,8 @@
 
 name: Run EDP Aggregator Cloud Test
 
+run-name: Run EDP Aggregator Cloud Test [${{ inputs.environment }}]
+
 on:
   workflow_call:
     inputs:

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -14,6 +14,11 @@
 
 name: Prepare release
 
+run-name: >-
+  Prepare release |
+  nightly=${{ inputs.existing-nightly-build }},
+  release=${{ inputs.new-git-tag }}
+
 on:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/publish-cloud-run-function-uber-jars.yml
+++ b/.github/workflows/publish-cloud-run-function-uber-jars.yml
@@ -14,6 +14,8 @@
 
 name: Build and push uber jar to Github packages
 
+run-name: Build and push uber jar to Github packages | package-version=${{ inputs.package-version }}
+
 on:
   workflow_call:
     inputs:

--- a/.github/workflows/push-images.yml
+++ b/.github/workflows/push-images.yml
@@ -14,6 +14,8 @@
 
 name: Build and push container images
 
+run-name: Build and push container images | image-tag=${{ inputs.image-tag }}
+
 on:
   workflow_call:
     inputs:

--- a/.github/workflows/run-k8s-tests.yml
+++ b/.github/workflows/run-k8s-tests.yml
@@ -14,6 +14,8 @@
 
 name: Run Kubernetes tests
 
+run-name: Run Kubernetes tests [${{ inputs.environment }}]
+
 on:
   workflow_call:
     inputs:

--- a/.github/workflows/scan-images.yml
+++ b/.github/workflows/scan-images.yml
@@ -14,6 +14,12 @@
 
 name: Scan container images
 
+run-name: >-
+  Scan container images |
+  registry=${{ inputs.container-registry }},
+  prefix=${{ inputs.image-repo-prefix }},
+  image-tag=${{ inputs.image-tag }}
+
 on:
   workflow_call:
     inputs:

--- a/.github/workflows/terraform-cmms-v2.yml
+++ b/.github/workflows/terraform-cmms-v2.yml
@@ -14,6 +14,11 @@
 
 name: Terraform CMMS
 
+run-name: >-
+  Terraform CMMS [${{ inputs.environment }}] |
+  apply=${{ inputs.apply }},
+  image-tag=${{ inputs.image-tag }}
+
 on:
   workflow_call:
     inputs:

--- a/.github/workflows/update-cmms.yml
+++ b/.github/workflows/update-cmms.yml
@@ -14,6 +14,12 @@
 
 name: Update CMMS
 
+run-name: >-
+  Update CMMS [${{ inputs.environment }}] |
+  apply=${{ inputs.apply }},
+  test=${{ inputs.run-tests }},
+  image-tag=${{ inputs.existing-image-tag }}
+
 on:
   workflow_call:
     inputs:


### PR DESCRIPTION
Closes #4060

This PR expands some workflow run names using their input parameters. For example, a run of the `update-cmms` workflow will have a run name like:

```
Update CMMS [head] | apply=false, tests=true, image-tag=d1bb8105ab90952bfc91aa14f4f1c07328183ce6
```

Issue: #4060
