### PR TITLE
ci: publish VID Labeling dispatcher and monitor Cloud Function uber-jars

### DIFF
--- a/.github/workflows/publish-cloud-run-function-uber-jars.yml
+++ b/.github/workflows/publish-cloud-run-function-uber-jars.yml
@@ -141,3 +141,25 @@ jobs:
           artifact-id: data-availability-monitor
           artifact-group-id: org.wfanet.measurement.edpaggregator.deploy.gcloud.dataavailability
           bazel_target_label: //src/main/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/dataavailability:DataAvailabilityMonitorFunction_deploy.jar
+
+      - name: Build and Deploy VID Labeling Dispatcher
+        env:
+          MAVEN_USERNAME: ${{ github.actor }}
+          MAVEN_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+        uses: ./.github/actions/build-and-push-uber-jar
+        with:
+          package-version: ${{ steps.get-artifact-version.outputs.artifact-version }}
+          artifact-id: vid-labeling-dispatcher
+          artifact-group-id: org.wfanet.measurement.edpaggregator.deploy.gcloud.vidlabeling
+          bazel_target_label: //src/main/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/vidlabeling:VidLabelingDispatcherFunction_deploy.jar
+
+      - name: Build and Deploy VID Labeling Monitor
+        env:
+          MAVEN_USERNAME: ${{ github.actor }}
+          MAVEN_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+        uses: ./.github/actions/build-and-push-uber-jar
+        with:
+          package-version: ${{ steps.get-artifact-version.outputs.artifact-version }}
+          artifact-id: vid-labeling-monitor
+          artifact-group-id: org.wfanet.measurement.edpaggregator.deploy.gcloud.vidlabeling
+          bazel_target_label: //src/main/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/vidlabeling:VidLabelingMonitorFunction_deploy.jar

--- a/src/main/terraform/gcloud/cmms/edp_aggregator.tf
+++ b/src/main/terraform/gcloud/cmms/edp_aggregator.tf
@@ -379,7 +379,7 @@ locals {
         java_tool_options             = "-Xmx96G -Djdk.util.jar.enableMultiRelease=false"
         docker_image                  = "ghcr.io/world-federation-of-advertisers/edp-aggregator/subpool_assigner:${var.image_tag}"
         tee_signed_image_repo         = "ghcr.io/world-federation-of-advertisers/edp-aggregator/subpool_assigner"
-        mig_distribution_policy_zones = ["us-central1-a"]
+        mig_distribution_policy_zones = ["us-central1-a", "us-central1-b", "us-central1-c", "us-central1-f"]
         app_flags = concat(local.vid_labeling_common_app_flags, [
           "--subscription-id", "subpool-assigner-subscription",
           "--vid-rank-builder-queue", "vid-rank-builder-queue",
@@ -405,7 +405,7 @@ locals {
         java_tool_options             = "-Xmx96G -Djdk.util.jar.enableMultiRelease=false"
         docker_image                  = "ghcr.io/world-federation-of-advertisers/edp-aggregator/vid_rank_builder:${var.image_tag}"
         tee_signed_image_repo         = "ghcr.io/world-federation-of-advertisers/edp-aggregator/vid_rank_builder"
-        mig_distribution_policy_zones = ["us-central1-a"]
+        mig_distribution_policy_zones = ["us-central1-a", "us-central1-b", "us-central1-c", "us-central1-f"]
         app_flags = concat(local.vid_labeling_common_app_flags, [
           "--subscription-id", "vid-rank-builder-subscription",
           "--vid-labeler-queue", "vid-labeler-queue",
@@ -431,7 +431,7 @@ locals {
         java_tool_options             = "-Xmx96G -Djdk.util.jar.enableMultiRelease=false"
         docker_image                  = "ghcr.io/world-federation-of-advertisers/edp-aggregator/vid_labeler:${var.image_tag}"
         tee_signed_image_repo         = "ghcr.io/world-federation-of-advertisers/edp-aggregator/vid_labeler"
-        mig_distribution_policy_zones = ["us-central1-a"]
+        mig_distribution_policy_zones = ["us-central1-a", "us-central1-b", "us-central1-c", "us-central1-f"]
         app_flags = concat(local.vid_labeling_common_app_flags, [
           "--subscription-id", "vid-labeler-subscription",
         ])


### PR DESCRIPTION
## Summary
  
  Adds two `build-and-push-uber-jar` steps to
  `.github/workflows/publish-cloud-run-function-uber-jars.yml` so the VID Labeling
  Cloud Functions are published to GitHub Packages:
  
  | artifact-id | Bazel target |
  |---|---|
  | `vid-labeling-dispatcher` | `//src/main/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/vidlabeling:VidLabelingDispatcherFunction_deploy.jar` |
  | `vid-labeling-monitor` | `//src/main/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/vidlabeling:VidLabelingMonitorFunction_deploy.jar` |
  
  ## Why
  
  The VID Labeling pipeline Terraform (`terraform-cmms-v2`) deploys the
  `VidLabelingDispatcher` and `VidLabelingMonitor` HTTP Cloud Functions, and its
  `download-uber-jars` step fetches each function jar from GitHub Packages via
  `mvn dependency:get`. Those artifacts must be published first, so this adds the
  two missing steps — following the existing per-function pattern and using the
  `artifact-group-id` / `artifact-id` that the Terraform `coords` already expect.
  
  ## ⚠️  Do not merge yet — depends on #4020
  
  `VidLabelingMonitorFunction_deploy.jar` only exists once #4020
  (`jojijacob-vid-labeling-monitor`) is merged to `main`. A `DO_NOT_SUBMIT` marker
  is included above the monitor step so the **Check for DO_NOT_SUBMIT comments**
  gate fails this PR until it is merge-ready. (`vid-labeling-dispatcher` is already
  on `main`.)
  
  To unblock after #4020 lands:
  1. Rebase this branch on the updated `main` (so the monitor target exists).
  2. Remove the `DO_NOT_SUBMIT` comment.
  
  ## Notes
  
  - The workflow triggers only on `workflow_call` / `workflow_dispatch` (no
    `push`), so merging this does not auto-run a publish.
  - Pairs with the VID Labeling Terraform changes (branch
    `marcopremier/vid-labeler-terraform`).
    
  ## Testing
  
  - YAML validated (parses cleanly); no behavioral change until the workflow is
    manually dispatched or called.

Issue: #4064