### PR TITLE
feat: add Terraform + queues config for the VID Labeling pipeline

### DIFF
--- a/.github/workflows/terraform-cmms-v2.yml
+++ b/.github/workflows/terraform-cmms-v2.yml
@@ -73,6 +73,8 @@ jobs:
       EVENT_GROUP_SYNC_CONFIG_CONTENT: ${{ vars.EVENT_GROUP_SYNC_CONFIG_CONTENT }}
       DATA_AVAILABILITY_SYNC_CONFIG_CONTENT: ${{ vars.DATA_AVAILABILITY_SYNC_CONFIG_CONTENT }}
       DATA_AVAILABILITY_MONITOR_CONFIG_CONTENT: ${{ vars.DATA_AVAILABILITY_MONITOR_CONFIG_CONTENT }}
+      VID_LABELING_DISPATCHER_CONFIG_CONTENT: ${{ vars.VID_LABELING_DISPATCHER_CONFIG_CONTENT }}
+      VID_LABELING_MONITOR_CONFIG_CONTENT: ${{ vars.VID_LABELING_MONITOR_CONFIG_CONTENT }}
       RESULTS_FULFILLER_POPULATION_SPEC_CONTENT: ${{ vars.RESULTS_FULFILLER_POPULATION_SPEC_CONTENT }}
       RESULTS_FULFILLER_TRUSTED_CA_CONTENT: ${{ secrets.RESULTS_FULFILLER_TRUSTED_CA_CONTENT }}
       EDP_SIMULATOR_NAMES: '["edp1-simulator", "edp2-simulator", "edp3-simulator", "edp4-simulator", "edp5-simulator", "edp6-simulator"]'
@@ -142,6 +144,8 @@ jobs:
         echo "$EVENT_GROUP_SYNC_CONFIG_CONTENT" > "$CONFIG_DIR/event-group-sync-config.textproto"
         echo "$DATA_AVAILABILITY_SYNC_CONFIG_CONTENT" > "$CONFIG_DIR/data-availability-sync-config.textproto"
         echo "$DATA_AVAILABILITY_MONITOR_CONFIG_CONTENT" > "$CONFIG_DIR/data-availability-monitor-config.textproto"
+        echo "$VID_LABELING_DISPATCHER_CONFIG_CONTENT" > "$CONFIG_DIR/vid-labeling-dispatcher-config.textproto"
+        echo "$VID_LABELING_MONITOR_CONFIG_CONTENT" > "$CONFIG_DIR/vid-labeling-monitor-config.textproto"
         echo "$RESULTS_FULFILLER_POPULATION_SPEC_CONTENT" > "$CONFIG_DIR/results-fulfiller-population-spec.textproto"
         echo "$RESULTS_FULFILLER_TRUSTED_CA_CONTENT" > "$CONFIG_DIR/results-fulfiller-trusted-root-ca.pem"
         
@@ -187,6 +191,10 @@ jobs:
         coords[data-availability-sync]="org.wfanet.measurement.edpaggregator.deploy.gcloud.dataavailability:data-availability-sync:$ARTIFACT_VERSION:jar"
         coords[data-availability-cleanup]="org.wfanet.measurement.edpaggregator.deploy.gcloud.dataavailability:data-availability-cleanup:$ARTIFACT_VERSION:jar"
         coords[data-availability-monitor]="org.wfanet.measurement.edpaggregator.deploy.gcloud.dataavailability:data-availability-monitor:$ARTIFACT_VERSION:jar"
+        # TODO(@marcopremier): requires the function jars to be published to GitHub Packages
+        # (vid-labeling-dispatcher is on main; vid-labeling-monitor needs PR #4020 merged).
+        coords[vid-labeling-dispatcher]="org.wfanet.measurement.edpaggregator.deploy.gcloud.vidlabeling:vid-labeling-dispatcher:$ARTIFACT_VERSION:jar"
+        coords[vid-labeling-monitor]="org.wfanet.measurement.edpaggregator.deploy.gcloud.vidlabeling:vid-labeling-monitor:$ARTIFACT_VERSION:jar"
         
         LOCAL_REPO=$(mvn help:evaluate -Dexpression=settings.localRepository -q -DforceStdout)
 
@@ -291,6 +299,10 @@ jobs:
         DATA_AVAILABILITY_CLEANUP_ENV_VAR: ${{ vars.DATA_AVAILABILITY_CLEANUP_ENV_VAR }}
         DATA_AVAILABILITY_CLEANUP_SECRET_MAPPING: ${{ vars.DATA_AVAILABILITY_CLEANUP_SECRET_MAPPING }}
         DATA_AVAILABILITY_MONITOR_ENV_VAR: ${{ vars.DATA_AVAILABILITY_MONITOR_ENV_VAR }}
+        VID_LABELING_DISPATCHER_ENV_VAR: ${{ vars.VID_LABELING_DISPATCHER_ENV_VAR }}
+        VID_LABELING_DISPATCHER_SECRET_MAPPING: ${{ vars.VID_LABELING_DISPATCHER_SECRET_MAPPING }}
+        VID_LABELING_MONITOR_ENV_VAR: ${{ vars.VID_LABELING_MONITOR_ENV_VAR }}
+        VID_LABELING_MONITOR_SECRET_MAPPING: ${{ vars.VID_LABELING_MONITOR_SECRET_MAPPING }}
         RESULTS_FULFILLER_EVENT_DESCRIPTOR_BLOB_URI: ${{ vars.RESULTS_FULFILLER_EVENT_DESCRIPTOR_BLOB_URI }}
         RESULTS_FULFILLER_EVENT_TEMPLATE_TYPE_NAME: ${{ vars.RESULTS_FULFILLER_EVENT_TEMPLATE_TYPE_NAME }}
         RESULTS_FULFILLER_POPULATION_SPEC_BLOB_URI: ${{ vars.RESULTS_FULFILLER_POPULATION_SPEC_BLOB_URI }}
@@ -349,6 +361,14 @@ jobs:
         -var="data_availability_monitor_config_file_path=$CONFIG_DIR/data-availability-monitor-config.textproto"
         -var="data_availability_monitor_env_var=$DATA_AVAILABILITY_MONITOR_ENV_VAR"
         -var="data_availability_monitor_uber_jar_path=${{ steps.download-uber-jars.outputs.data_availability_monitor_source_path }}"
+        -var="vid_labeling_dispatcher_config_file_path=$CONFIG_DIR/vid-labeling-dispatcher-config.textproto"
+        -var="vid_labeling_dispatcher_env_var=$VID_LABELING_DISPATCHER_ENV_VAR"
+        -var="vid_labeling_dispatcher_secret_mapping=$VID_LABELING_DISPATCHER_SECRET_MAPPING"
+        -var="vid_labeling_dispatcher_uber_jar_path=${{ steps.download-uber-jars.outputs.vid_labeling_dispatcher_source_path }}"
+        -var="vid_labeling_monitor_config_file_path=$CONFIG_DIR/vid-labeling-monitor-config.textproto"
+        -var="vid_labeling_monitor_env_var=$VID_LABELING_MONITOR_ENV_VAR"
+        -var="vid_labeling_monitor_secret_mapping=$VID_LABELING_MONITOR_SECRET_MAPPING"
+        -var="vid_labeling_monitor_uber_jar_path=${{ steps.download-uber-jars.outputs.vid_labeling_monitor_source_path }}"
         -var="image_tag=$IMAGE_TAG"
         -var="results_fulfiller_event_proto_descriptor_path=${{ steps.build-test-event-descriptors.outputs.event_proto_descriptors_path }}"
         -var="results_fulfiller_event_proto_descriptor_blob_uri=$RESULTS_FULFILLER_EVENT_DESCRIPTOR_BLOB_URI"

--- a/src/main/docker/images.bzl
+++ b/src/main/docker/images.bzl
@@ -378,6 +378,21 @@ SECURE_COMPUTATION_TEE_APP_IMAGES = [
         image = "//src/main/kotlin/org/wfanet/measurement/edpaggregator/resultsfulfiller:results_fulfiller_image",
         repository = _PREFIX + "/edp-aggregator/results_fulfiller",
     ),
+    struct(
+        name = "gcloud_subpool_assigner_app",
+        image = "//src/main/kotlin/org/wfanet/measurement/edpaggregator/subpoolassigner:subpool_assigner_image",
+        repository = _PREFIX + "/edp-aggregator/subpool_assigner",
+    ),
+    struct(
+        name = "gcloud_vid_rank_builder_app",
+        image = "//src/main/kotlin/org/wfanet/measurement/edpaggregator/vidrankbuilder:vid_rank_builder_image",
+        repository = _PREFIX + "/edp-aggregator/vid_rank_builder",
+    ),
+    struct(
+        name = "gcloud_vid_labeler_app",
+        image = "//src/main/kotlin/org/wfanet/measurement/edpaggregator/vidlabeler:vid_labeler_image",
+        repository = _PREFIX + "/edp-aggregator/vid_labeler",
+    ),
 ]
 
 ALL_SECURE_COMPUTATION_GKE_IMAGES = SECURE_COMPUTATION_COMMON_IMAGES + SECURE_COMPUTATION_GKE_IMAGES

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/subpoolassigner/BUILD.bazel
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/subpoolassigner/BUILD.bazel
@@ -1,4 +1,6 @@
+load("@rules_java//java:defs.bzl", "java_binary")
 load("@wfa_rules_kotlin_jvm//kotlin:defs.bzl", "kt_jvm_library")
+load("//src/main/docker:macros.bzl", "java_image")
 
 package(default_visibility = [
     "//src/main/kotlin/org/wfanet/measurement/edpaggregator:__subpackages__",
@@ -143,4 +145,24 @@ kt_jvm_library(
         "@wfa_common_jvm//src/main/kotlin/org/wfanet/measurement/common",
         "@wfa_common_jvm//src/main/kotlin/org/wfanet/measurement/gcloud/pubsub:google_pub_sub_client",
     ],
+)
+
+java_binary(
+    name = "SubpoolAssigner",
+    main_class = "org.wfanet.measurement.edpaggregator.subpoolassigner.SubpoolAssignerAppRunner",
+    runtime_deps = [
+        ":subpool_assigner_app_runner",
+    ],
+)
+
+java_image(
+    name = "subpool_assigner_image",
+    base = "@java_image_base_root",
+    binary = ":SubpoolAssigner",
+    labels = {
+        "tee.launch_policy.allow_env_override": "EDPA_CONFIG_STORAGE_BUCKET,JAVA_TOOL_OPTIONS,OTEL_SERVICE_NAME,OTEL_METRICS_EXPORTER,OTEL_TRACES_EXPORTER,OTEL_LOGS_EXPORTER,OTEL_EXPORTER_GOOGLE_CLOUD_PROJECT_ID,OTEL_METRIC_EXPORT_INTERVAL",
+        "tee.launch_policy.log_redirect": "always",
+    },
+    main_class = "org.wfanet.measurement.edpaggregator.subpoolassigner.SubpoolAssignerAppRunner",
+    visibility = ["//src:docker_image_deployment"],
 )

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/vidrankbuilder/BUILD.bazel
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/vidrankbuilder/BUILD.bazel
@@ -1,4 +1,6 @@
+load("@rules_java//java:defs.bzl", "java_binary")
 load("@wfa_rules_kotlin_jvm//kotlin:defs.bzl", "kt_jvm_library")
+load("//src/main/docker:macros.bzl", "java_image")
 
 package(default_visibility = [
     "//src/main/kotlin/org/wfanet/measurement/edpaggregator:__subpackages__",
@@ -159,4 +161,24 @@ kt_jvm_library(
         "@wfa_common_jvm//src/main/kotlin/org/wfanet/measurement/gcloud/pubsub:google_pub_sub_client",
         "@wfa_common_jvm//src/main/kotlin/org/wfanet/measurement/storage:client",
     ],
+)
+
+java_binary(
+    name = "VidRankBuilder",
+    main_class = "org.wfanet.measurement.edpaggregator.vidrankbuilder.VidRankBuilderAppRunner",
+    runtime_deps = [
+        ":vid_rank_builder_app_runner",
+    ],
+)
+
+java_image(
+    name = "vid_rank_builder_image",
+    base = "@java_image_base_root",
+    binary = ":VidRankBuilder",
+    labels = {
+        "tee.launch_policy.allow_env_override": "EDPA_CONFIG_STORAGE_BUCKET,JAVA_TOOL_OPTIONS,OTEL_SERVICE_NAME,OTEL_METRICS_EXPORTER,OTEL_TRACES_EXPORTER,OTEL_LOGS_EXPORTER,OTEL_EXPORTER_GOOGLE_CLOUD_PROJECT_ID,OTEL_METRIC_EXPORT_INTERVAL",
+        "tee.launch_policy.log_redirect": "always",
+    },
+    main_class = "org.wfanet.measurement.edpaggregator.vidrankbuilder.VidRankBuilderAppRunner",
+    visibility = ["//src:docker_image_deployment"],
 )

--- a/src/main/proto/wfa/measurement/securecomputation/controlplane/v1alpha/queues_config.textproto
+++ b/src/main/proto/wfa/measurement/securecomputation/controlplane/v1alpha/queues_config.textproto
@@ -5,3 +5,18 @@ queueInfos {
   queue_resource_id: "results-fulfiller-queue"
   app_params_type_url: "type.googleapis.com/wfa.measurement.securecomputation.controlplane.v1alpha.WorkItem.WorkItemParams"
 }
+
+queueInfos {
+  queue_resource_id: "subpool-assigner-queue"
+  app_params_type_url: "type.googleapis.com/wfa.measurement.securecomputation.controlplane.v1alpha.WorkItem.WorkItemParams"
+}
+
+queueInfos {
+  queue_resource_id: "vid-rank-builder-queue"
+  app_params_type_url: "type.googleapis.com/wfa.measurement.securecomputation.controlplane.v1alpha.WorkItem.WorkItemParams"
+}
+
+queueInfos {
+  queue_resource_id: "vid-labeler-queue"
+  app_params_type_url: "type.googleapis.com/wfa.measurement.securecomputation.controlplane.v1alpha.WorkItem.WorkItemParams"
+}

--- a/src/main/terraform/gcloud/cmms/edp_aggregator.tf
+++ b/src/main/terraform/gcloud/cmms/edp_aggregator.tf
@@ -309,15 +309,35 @@ locals {
     destination = "vid-labeling-monitor-config.textproto"
   }
 
+  # Health cadence: staleness alerting, stuck-phase recovery, and data-quality
+  # checks (VidLabelingMonitor.runHealth, selected by ?mode=health). Runs once
+  # daily, matching the DataAvailabilityMonitor, so recovery attempts are spaced
+  # a day apart and never race an in-flight last-out (see staleness_threshold's
+  # 24h floor). Health is duration-based, so a faster cadence buys nothing.
   vid_labeling_monitor_scheduler_config = {
-    schedule                  = "*/5 * * * *" # Every 5 minutes
+    schedule                  = "0 6 * * *" # Daily at 06:00
     time_zone                 = "UTC"
     name                      = "vid-labeling-monitor-scheduler"
-    function_url              = "https://${data.google_client_config.default.region}-${data.google_client_config.default.project}.cloudfunctions.net/vid-labeling-monitor"
-    scheduler_sa_display_name = "VID Labeling Monitor Scheduler"
-    scheduler_sa_description  = "Service account for Cloud Scheduler to trigger the VID labeling monitor"
-    scheduler_job_description = "Scheduled job to sequence VID labeling dispatch and monitor pipeline health"
+    function_url              = "https://${data.google_client_config.default.region}-${data.google_client_config.default.project}.cloudfunctions.net/vid-labeling-monitor?mode=health"
+    scheduler_sa_display_name = "VID Labeling Monitor Health Scheduler"
+    scheduler_sa_description  = "Service account for Cloud Scheduler to trigger VID labeling monitor health checks"
+    scheduler_job_description = "Daily job running VID labeling staleness, stuck-phase recovery, and data-quality checks"
     scheduler_job_name        = "vid-labeling-monitor"
+  }
+
+  # Dispatch cadence: publish WorkItems for newly-registered uploads
+  # (VidLabelingMonitor.runDispatch, selected by ?mode=dispatch). Runs every 6h
+  # so new uploads start promptly; dispatch is user-visible latency, so it wants
+  # a fast clock independent of the slow health cadence.
+  vid_labeling_dispatch_scheduler_config = {
+    schedule                  = "0 */6 * * *" # Every 6 hours
+    time_zone                 = "UTC"
+    name                      = "vid-labeling-dispatch-scheduler"
+    function_url              = "https://${data.google_client_config.default.region}-${data.google_client_config.default.project}.cloudfunctions.net/vid-labeling-monitor?mode=dispatch"
+    scheduler_sa_display_name = "VID Labeling Dispatch Scheduler"
+    scheduler_sa_description  = "Service account for Cloud Scheduler to trigger VID labeling dispatch"
+    scheduler_job_description = "Six-hourly job dispatching VID labeling WorkItems for newly-registered uploads"
+    scheduler_job_name        = "vid-labeling-dispatcher"
   }
 
   # Shared TEE-app flags (from BaseTeeAppRunner) reused by the three VID Labeling
@@ -478,5 +498,6 @@ module "edp_aggregator" {
   vid_labeling_dispatcher_config                  = local.vid_labeling_dispatcher_config
   vid_labeling_monitor_config                     = local.vid_labeling_monitor_config
   vid_labeling_monitor_scheduler_config           = local.vid_labeling_monitor_scheduler_config
+  vid_labeling_dispatch_scheduler_config          = local.vid_labeling_dispatch_scheduler_config
   spanner_instance                              = google_spanner_instance.spanner_instance
 }

--- a/src/main/terraform/gcloud/cmms/edp_aggregator.tf
+++ b/src/main/terraform/gcloud/cmms/edp_aggregator.tf
@@ -332,7 +332,7 @@ locals {
   vid_labeling_dispatch_scheduler_config = {
     schedule                  = "0 */6 * * *" # Every 6 hours
     time_zone                 = "UTC"
-    name                      = "vid-labeling-dispatch-scheduler"
+    name                      = "vid-labeling-dispatch-sched"
     function_url              = "https://${data.google_client_config.default.region}-${data.google_client_config.default.project}.cloudfunctions.net/vid-labeling-monitor?mode=dispatch"
     scheduler_sa_display_name = "VID Labeling Dispatch Scheduler"
     scheduler_sa_description  = "Service account for Cloud Scheduler to trigger VID labeling dispatch"

--- a/src/main/terraform/gcloud/cmms/edp_aggregator.tf
+++ b/src/main/terraform/gcloud/cmms/edp_aggregator.tf
@@ -377,7 +377,7 @@ locals {
         max_replicas                  = 8
         machine_type                  = "n2d-highmem-16"
         disk_type                     = "pd-balanced"
-        java_tool_options             = "-Xmx96G"
+        java_tool_options             = "-Xmx96G -Djdk.util.jar.enableMultiRelease=false"
         docker_image                  = "ghcr.io/world-federation-of-advertisers/edp-aggregator/subpool_assigner:${var.image_tag}"
         tee_signed_image_repo         = "ghcr.io/world-federation-of-advertisers/edp-aggregator/subpool_assigner"
         mig_distribution_policy_zones = ["us-central1-a"]
@@ -404,7 +404,7 @@ locals {
         max_replicas                  = 8
         machine_type                  = "n2d-highmem-16"
         disk_type                     = "pd-balanced"
-        java_tool_options             = "-Xmx96G"
+        java_tool_options             = "-Xmx96G -Djdk.util.jar.enableMultiRelease=false"
         docker_image                  = "ghcr.io/world-federation-of-advertisers/edp-aggregator/vid_rank_builder:${var.image_tag}"
         tee_signed_image_repo         = "ghcr.io/world-federation-of-advertisers/edp-aggregator/vid_rank_builder"
         mig_distribution_policy_zones = ["us-central1-a"]
@@ -431,7 +431,7 @@ locals {
         max_replicas                  = 8
         machine_type                  = "n2d-highmem-16"
         disk_type                     = "pd-balanced"
-        java_tool_options             = "-Xmx96G"
+        java_tool_options             = "-Xmx96G -Djdk.util.jar.enableMultiRelease=false"
         docker_image                  = "ghcr.io/world-federation-of-advertisers/edp-aggregator/vid_labeler:${var.image_tag}"
         tee_signed_image_repo         = "ghcr.io/world-federation-of-advertisers/edp-aggregator/vid_labeler"
         mig_distribution_policy_zones = ["us-central1-a"]

--- a/src/main/terraform/gcloud/cmms/edp_aggregator.tf
+++ b/src/main/terraform/gcloud/cmms/edp_aggregator.tf
@@ -283,6 +283,140 @@ locals {
       secret_mappings     = ""
       uber_jar_path       = var.data_availability_monitor_uber_jar_path
     }
+    vid_labeling_dispatcher = {
+      function_name       = "vid-labeling-dispatcher"
+      entry_point         = "org.wfanet.measurement.edpaggregator.deploy.gcloud.vidlabeling.VidLabelingDispatcherFunction"
+      extra_env_vars      = "${var.vid_labeling_dispatcher_env_var},CONFIG_BLOB_KEY=${local.vid_labeling_dispatcher_config.destination},EDPA_CONFIG_STORAGE_BUCKET=gs://${var.edpa_config_files_bucket_name}"
+      secret_mappings     = var.vid_labeling_dispatcher_secret_mapping
+      uber_jar_path       = var.vid_labeling_dispatcher_uber_jar_path
+    }
+    vid_labeling_monitor = {
+      function_name       = "vid-labeling-monitor"
+      entry_point         = "org.wfanet.measurement.edpaggregator.deploy.gcloud.vidlabeling.VidLabelingMonitorFunction"
+      extra_env_vars      = "${var.vid_labeling_monitor_env_var},CONFIG_BLOB_KEY=${local.vid_labeling_monitor_config.destination},EDPA_CONFIG_STORAGE_BUCKET=gs://${var.edpa_config_files_bucket_name}"
+      secret_mappings     = var.vid_labeling_monitor_secret_mapping
+      uber_jar_path       = var.vid_labeling_monitor_uber_jar_path
+    }
+  }
+
+  vid_labeling_dispatcher_config = {
+    local_path  = var.vid_labeling_dispatcher_config_file_path
+    destination = "vid-labeling-dispatcher-config.textproto"
+  }
+
+  vid_labeling_monitor_config = {
+    local_path  = var.vid_labeling_monitor_config_file_path
+    destination = "vid-labeling-monitor-config.textproto"
+  }
+
+  vid_labeling_monitor_scheduler_config = {
+    schedule                  = "*/5 * * * *" # Every 5 minutes
+    time_zone                 = "UTC"
+    name                      = "vid-labeling-monitor-scheduler"
+    function_url              = "https://${data.google_client_config.default.region}-${data.google_client_config.default.project}.cloudfunctions.net/vid-labeling-monitor"
+    scheduler_sa_display_name = "VID Labeling Monitor Scheduler"
+    scheduler_sa_description  = "Service account for Cloud Scheduler to trigger the VID labeling monitor"
+    scheduler_job_description = "Scheduled job to sequence VID labeling dispatch and monitor pipeline health"
+    scheduler_job_name        = "vid-labeling-monitor"
+  }
+
+  # Shared TEE-app flags (from BaseTeeAppRunner) reused by the three VID Labeling
+  # workers. Per-app flags (subscription id, downstream queue) are appended in
+  # vid_labeling_workers below.
+  vid_labeling_common_app_flags = [
+    "--edpa-tls-cert-secret-id", "edpa-tee-app-tls-pem",
+    "--edpa-tls-cert-file-path", "/tmp/edpa_certs/edpa_tee_app_tls.pem",
+    "--edpa-tls-key-secret-id", "edpa-tee-app-tls-key",
+    "--edpa-tls-key-file-path", "/tmp/edpa_certs/edpa_tee_app_tls.key",
+    "--secure-computation-cert-collection-secret-id", "securecomputation-root-ca",
+    "--secure-computation-cert-collection-file-path", "/tmp/edpa_certs/secure_computation_root.pem",
+    "--metadata-storage-cert-collection-secret-id", "edpaggregator-root-ca",
+    "--metadata-storage-cert-collection-file-path", "/tmp/edpa_certs/edp_aggregator_root.pem",
+    "--secure-computation-public-api-target", var.secure_computation_public_api_target,
+    "--metadata-storage-public-api-target", var.metadata_storage_public_api_target,
+    "--google-project-id", data.google_client_config.default.project,
+  ]
+
+  # Phase 0/1/2 TEE applications. Queue resource ids match queues_config.textproto
+  # and each app's --*-queue / --subscription-id flags.
+  vid_labeling_workers = {
+    subpool_assigner = {
+      queue = {
+        topic_name            = "subpool-assigner-queue"
+        subscription_name     = "subpool-assigner-subscription"
+        ack_deadline_seconds  = 600
+        max_delivery_attempts = 5
+      }
+      worker = {
+        instance_template_name        = "subpool-assigner-template"
+        base_instance_name            = "subpool-assigner"
+        managed_instance_group_name   = "subpool-assigner-mig"
+        mig_service_account_name      = "subpool-assigner-sa"
+        single_instance_assignment    = 1
+        min_replicas                  = 0
+        max_replicas                  = 64
+        machine_type                  = "c4d-standard-32"
+        java_tool_options             = "-Xmx96G"
+        docker_image                  = "ghcr.io/world-federation-of-advertisers/edp-aggregator/subpool_assigner:${var.image_tag}"
+        tee_signed_image_repo         = "ghcr.io/world-federation-of-advertisers/edp-aggregator/subpool_assigner"
+        mig_distribution_policy_zones = ["us-central1-a"]
+        app_flags = concat(local.vid_labeling_common_app_flags, [
+          "--subscription-id", "subpool-assigner-subscription",
+          "--vid-rank-builder-queue", "vid-rank-builder-queue",
+        ])
+      }
+    }
+    vid_rank_builder = {
+      queue = {
+        topic_name            = "vid-rank-builder-queue"
+        subscription_name     = "vid-rank-builder-subscription"
+        ack_deadline_seconds  = 600
+        max_delivery_attempts = 5
+      }
+      worker = {
+        instance_template_name        = "vid-rank-builder-template"
+        base_instance_name            = "vid-rank-builder"
+        managed_instance_group_name   = "vid-rank-builder-mig"
+        mig_service_account_name      = "vid-rank-builder-sa"
+        single_instance_assignment    = 1
+        min_replicas                  = 0
+        max_replicas                  = 64
+        machine_type                  = "n2d-highmem-16"
+        java_tool_options             = "-Xmx96G"
+        docker_image                  = "ghcr.io/world-federation-of-advertisers/edp-aggregator/vid_rank_builder:${var.image_tag}"
+        tee_signed_image_repo         = "ghcr.io/world-federation-of-advertisers/edp-aggregator/vid_rank_builder"
+        mig_distribution_policy_zones = ["us-central1-a"]
+        app_flags = concat(local.vid_labeling_common_app_flags, [
+          "--subscription-id", "vid-rank-builder-subscription",
+          "--vid-labeler-queue", "vid-labeler-queue",
+        ])
+      }
+    }
+    vid_labeler = {
+      queue = {
+        topic_name            = "vid-labeler-queue"
+        subscription_name     = "vid-labeler-subscription"
+        ack_deadline_seconds  = 600
+        max_delivery_attempts = 5
+      }
+      worker = {
+        instance_template_name        = "vid-labeler-template"
+        base_instance_name            = "vid-labeler"
+        managed_instance_group_name   = "vid-labeler-mig"
+        mig_service_account_name      = "vid-labeler-sa"
+        single_instance_assignment    = 1
+        min_replicas                  = 0
+        max_replicas                  = 64
+        machine_type                  = "n2d-highmem-16"
+        java_tool_options             = "-Xmx96G"
+        docker_image                  = "ghcr.io/world-federation-of-advertisers/edp-aggregator/vid_labeler:${var.image_tag}"
+        tee_signed_image_repo         = "ghcr.io/world-federation-of-advertisers/edp-aggregator/vid_labeler"
+        mig_distribution_policy_zones = ["us-central1-a"]
+        app_flags = concat(local.vid_labeling_common_app_flags, [
+          "--subscription-id", "vid-labeler-subscription",
+        ])
+      }
+    }
   }
 
 }
@@ -335,5 +469,11 @@ module "edp_aggregator" {
   data_availability_monitor_service_account_name = "edpa-data-avail-monitor"
   data_availability_monitor_config                = local.data_availability_monitor_config
   data_availability_monitor_scheduler_config      = local.data_availability_monitor_scheduler_config
+  vid_labeling_workers                            = local.vid_labeling_workers
+  vid_labeling_dispatcher_service_account_name    = "edpa-vid-labeling-dispatcher"
+  vid_labeling_monitor_service_account_name       = "edpa-vid-labeling-monitor"
+  vid_labeling_dispatcher_config                  = local.vid_labeling_dispatcher_config
+  vid_labeling_monitor_config                     = local.vid_labeling_monitor_config
+  vid_labeling_monitor_scheduler_config           = local.vid_labeling_monitor_scheduler_config
   spanner_instance                              = google_spanner_instance.spanner_instance
 }

--- a/src/main/terraform/gcloud/cmms/edp_aggregator.tf
+++ b/src/main/terraform/gcloud/cmms/edp_aggregator.tf
@@ -354,8 +354,9 @@ locals {
         mig_service_account_name      = "subpool-assigner-sa"
         single_instance_assignment    = 1
         min_replicas                  = 0
-        max_replicas                  = 64
-        machine_type                  = "c4d-standard-32"
+        max_replicas                  = 8
+        machine_type                  = "n2d-highmem-16"
+        disk_type                     = "pd-balanced"
         java_tool_options             = "-Xmx96G"
         docker_image                  = "ghcr.io/world-federation-of-advertisers/edp-aggregator/subpool_assigner:${var.image_tag}"
         tee_signed_image_repo         = "ghcr.io/world-federation-of-advertisers/edp-aggregator/subpool_assigner"
@@ -380,8 +381,9 @@ locals {
         mig_service_account_name      = "vid-rank-builder-sa"
         single_instance_assignment    = 1
         min_replicas                  = 0
-        max_replicas                  = 64
+        max_replicas                  = 8
         machine_type                  = "n2d-highmem-16"
+        disk_type                     = "pd-balanced"
         java_tool_options             = "-Xmx96G"
         docker_image                  = "ghcr.io/world-federation-of-advertisers/edp-aggregator/vid_rank_builder:${var.image_tag}"
         tee_signed_image_repo         = "ghcr.io/world-federation-of-advertisers/edp-aggregator/vid_rank_builder"
@@ -406,8 +408,9 @@ locals {
         mig_service_account_name      = "vid-labeler-sa"
         single_instance_assignment    = 1
         min_replicas                  = 0
-        max_replicas                  = 64
+        max_replicas                  = 8
         machine_type                  = "n2d-highmem-16"
+        disk_type                     = "pd-balanced"
         java_tool_options             = "-Xmx96G"
         docker_image                  = "ghcr.io/world-federation-of-advertisers/edp-aggregator/vid_labeler:${var.image_tag}"
         tee_signed_image_repo         = "ghcr.io/world-federation-of-advertisers/edp-aggregator/vid_labeler"

--- a/src/main/terraform/gcloud/cmms/edp_aggregator.tf
+++ b/src/main/terraform/gcloud/cmms/edp_aggregator.tf
@@ -376,7 +376,6 @@ locals {
         min_replicas                  = 0
         max_replicas                  = 8
         machine_type                  = "n2d-highmem-16"
-        disk_type                     = "pd-balanced"
         java_tool_options             = "-Xmx96G -Djdk.util.jar.enableMultiRelease=false"
         docker_image                  = "ghcr.io/world-federation-of-advertisers/edp-aggregator/subpool_assigner:${var.image_tag}"
         tee_signed_image_repo         = "ghcr.io/world-federation-of-advertisers/edp-aggregator/subpool_assigner"
@@ -403,7 +402,6 @@ locals {
         min_replicas                  = 0
         max_replicas                  = 8
         machine_type                  = "n2d-highmem-16"
-        disk_type                     = "pd-balanced"
         java_tool_options             = "-Xmx96G -Djdk.util.jar.enableMultiRelease=false"
         docker_image                  = "ghcr.io/world-federation-of-advertisers/edp-aggregator/vid_rank_builder:${var.image_tag}"
         tee_signed_image_repo         = "ghcr.io/world-federation-of-advertisers/edp-aggregator/vid_rank_builder"
@@ -430,7 +428,6 @@ locals {
         min_replicas                  = 0
         max_replicas                  = 8
         machine_type                  = "n2d-highmem-16"
-        disk_type                     = "pd-balanced"
         java_tool_options             = "-Xmx96G -Djdk.util.jar.enableMultiRelease=false"
         docker_image                  = "ghcr.io/world-federation-of-advertisers/edp-aggregator/vid_labeler:${var.image_tag}"
         tee_signed_image_repo         = "ghcr.io/world-federation-of-advertisers/edp-aggregator/vid_labeler"

--- a/src/main/terraform/gcloud/cmms/variables.tf
+++ b/src/main/terraform/gcloud/cmms/variables.tf
@@ -409,3 +409,43 @@ variable "reporting_spanner_instance" {
   nullable    = false
   description = "Reporting Spanner instance name"
 }
+
+variable "vid_labeling_dispatcher_env_var" {
+  description = "VidLabelingDispatcher extra env variables"
+  type        = string
+}
+
+variable "vid_labeling_dispatcher_secret_mapping" {
+  description = "VidLabelingDispatcher secret mapping"
+  type        = string
+}
+
+variable "vid_labeling_dispatcher_uber_jar_path" {
+  description = "Path to VidLabelingDispatcher uber jar."
+  type        = string
+}
+
+variable "vid_labeling_dispatcher_config_file_path" {
+  description = "Path to VidLabelingDispatcher config file."
+  type        = string
+}
+
+variable "vid_labeling_monitor_env_var" {
+  description = "VidLabelingMonitor extra env variables"
+  type        = string
+}
+
+variable "vid_labeling_monitor_secret_mapping" {
+  description = "VidLabelingMonitor secret mapping"
+  type        = string
+}
+
+variable "vid_labeling_monitor_uber_jar_path" {
+  description = "Path to VidLabelingMonitor uber jar."
+  type        = string
+}
+
+variable "vid_labeling_monitor_config_file_path" {
+  description = "Path to VidLabelingMonitor config file."
+  type        = string
+}

--- a/src/main/terraform/gcloud/modules/edp-aggregator/main.tf
+++ b/src/main/terraform/gcloud/modules/edp-aggregator/main.tf
@@ -739,6 +739,17 @@ resource "google_pubsub_topic_iam_member" "vid_labeling_publisher" {
   member = var.pubsub_iam_service_account_member
 }
 
+# Allow the Secure Computation control plane to consume each phase's dead-letter
+# subscription so its dead-letter listener can mark the EDPA pipeline resources
+# FAILED on Pub/Sub retry exhaustion.
+resource "google_pubsub_subscription_iam_member" "vid_labeling_dead_letter_subscriber" {
+  for_each = var.vid_labeling_workers
+
+  subscription = module.vid_labeling_queue[each.key].dead_letter_subscription.name
+  role         = "roles/pubsub.subscriber"
+  member       = var.pubsub_iam_service_account_member
+}
+
 module "vid_labeling_tee_app" {
   source   = "../mig"
   for_each = var.vid_labeling_workers

--- a/src/main/terraform/gcloud/modules/edp-aggregator/main.tf
+++ b/src/main/terraform/gcloud/modules/edp-aggregator/main.tf
@@ -149,6 +149,8 @@ locals {
     "data_watcher_delete"       = module.data_watcher_delete_cloud_function.cloud_function_service_account.email
     "data_availability_cleanup" = module.data_availability_cleanup_cloud_function.cloud_function_service_account.email
     "data_availability_monitor" = module.data_availability_monitor_cloud_function.cloud_function_service_account.email
+    "vid_labeling_dispatcher"   = module.vid_labeling_dispatcher_cloud_function.cloud_function_service_account.email
+    "vid_labeling_monitor"      = module.vid_labeling_monitor_cloud_function.cloud_function_service_account.email
   }
 
   otel_metadata = {
@@ -678,4 +680,198 @@ resource "google_storage_bucket_iam_member" "data_availability_monitor_config_st
   bucket = module.config_files_bucket.storage_bucket.name
   role   = "roles/storage.objectViewer"
   member = "serviceAccount:${module.data_availability_monitor_cloud_function.cloud_function_service_account.email}"
+}
+
+# ============================================================================
+# VID Labeling pipeline (memoized VID assignment).
+#
+# Phase 0 (SubpoolAssigner), Phase 1 (VidRankBuilder) and Phase 2 (VidLabeler)
+# run as Confidential Space TEE applications on Managed Instance Groups, each
+# fed by its own Pub/Sub work queue (the pubsub module auto-creates the
+# dead-letter queue). WorkItems are created through the Secure Computation
+# control plane, which publishes to the queues, so the control-plane internal
+# service account is granted publisher on each topic (same as result_fulfiller).
+#
+# The VidLabelingDispatcher (invoked by the DataWatcher on a "done" blob) and
+# the scheduled VidLabelingMonitor run as HTTP Cloud Functions.
+# ============================================================================
+
+locals {
+  # Cert / root-CA secrets the VID Labeling cloud functions need to open mTLS
+  # gRPC channels: edpa-tee-app TLS (client identity) + the SecureComputation root
+  # (control_plane_connection) + the EdpAggregator root (raw_impression_metadata_storage_connection).
+  # The monitor additionally calls the VID Repository (ModelRollouts/ModelShards/ModelLines)
+  # using the per-EDP TLS certs against the Kingdom root (trusted-root-ca).
+  vid_labeling_function_secrets_access = concat(
+    [
+      "edpa_tee_app_tls_key",
+      "edpa_tee_app_tls_pem",
+      "secure_computation_root_ca",
+      "metadata_storage_root_ca",
+      "trusted_root_ca_collection",
+    ],
+    local.edp_tls_keys,
+  )
+}
+
+module "vid_labeling_queue" {
+  source   = "../pubsub"
+  for_each = var.vid_labeling_workers
+
+  topic_name            = each.value.queue.topic_name
+  subscription_name     = each.value.queue.subscription_name
+  ack_deadline_seconds  = each.value.queue.ack_deadline_seconds
+  max_delivery_attempts = each.value.queue.max_delivery_attempts
+}
+
+resource "google_pubsub_topic_iam_member" "vid_labeling_publisher" {
+  for_each = var.vid_labeling_workers
+
+  topic  = module.vid_labeling_queue[each.key].pubsub_topic.id
+  role   = "roles/pubsub.publisher"
+  member = var.pubsub_iam_service_account_member
+}
+
+module "vid_labeling_tee_app" {
+  source   = "../mig"
+  for_each = var.vid_labeling_workers
+
+  depends_on = [module.secrets]
+
+  instance_template_name        = each.value.worker.instance_template_name
+  base_instance_name            = each.value.worker.base_instance_name
+  managed_instance_group_name   = each.value.worker.managed_instance_group_name
+  subscription_id               = module.vid_labeling_queue[each.key].pubsub_subscription.name
+  mig_service_account_name      = each.value.worker.mig_service_account_name
+  single_instance_assignment    = each.value.worker.single_instance_assignment
+  min_replicas                  = each.value.worker.min_replicas
+  max_replicas                  = each.value.worker.max_replicas
+  machine_type                  = each.value.worker.machine_type
+  java_tool_options             = each.value.worker.java_tool_options
+  docker_image                  = each.value.worker.docker_image
+  mig_distribution_policy_zones = each.value.worker.mig_distribution_policy_zones
+  terraform_service_account     = var.terraform_service_account
+  secrets_to_access             = local.common_secrets_to_access
+  tee_cmd                       = each.value.worker.app_flags
+  disk_image_family             = var.results_fulfiller_disk_image_family
+  config_storage_bucket         = module.config_files_bucket.storage_bucket.name
+  subnetwork_name               = google_compute_subnetwork.private_subnetwork.name
+  tee_signed_image_repo         = each.value.worker.tee_signed_image_repo
+  extra_metadata                = local.otel_metadata
+}
+
+resource "google_storage_bucket_iam_member" "vid_labeling_storage_viewer" {
+  for_each = var.vid_labeling_workers
+
+  bucket = module.edp_aggregator_bucket.storage_bucket.name
+  role   = "roles/storage.objectViewer"
+  member = "serviceAccount:${module.vid_labeling_tee_app[each.key].mig_service_account.email}"
+}
+
+resource "google_storage_bucket_iam_member" "vid_labeling_storage_creator" {
+  for_each = var.vid_labeling_workers
+
+  bucket = module.edp_aggregator_bucket.storage_bucket.name
+  role   = "roles/storage.objectCreator"
+  member = "serviceAccount:${module.vid_labeling_tee_app[each.key].mig_service_account.email}"
+}
+
+resource "google_storage_bucket_iam_member" "vid_labeling_config_storage_viewer" {
+  for_each = var.vid_labeling_workers
+
+  bucket = module.config_files_bucket.storage_bucket.name
+  role   = "roles/storage.objectViewer"
+  member = "serviceAccount:${module.vid_labeling_tee_app[each.key].mig_service_account.email}"
+}
+
+# ---- VidLabelingDispatcher (HTTP Cloud Function, invoked by the DataWatcher) ----
+resource "google_storage_bucket_object" "upload_vid_labeling_dispatcher_config" {
+  name           = var.vid_labeling_dispatcher_config.destination
+  bucket         = module.config_files_bucket.storage_bucket.name
+  source         = var.vid_labeling_dispatcher_config.local_path
+  source_md5hash = filemd5(var.vid_labeling_dispatcher_config.local_path)
+}
+
+module "vid_labeling_dispatcher_cloud_function" {
+  source = "../http-cloud-function"
+
+  depends_on = [
+    module.secrets,
+    google_storage_bucket_object.upload_vid_labeling_dispatcher_config,
+  ]
+
+  http_cloud_function_service_account_name = var.vid_labeling_dispatcher_service_account_name
+  terraform_service_account                = var.terraform_service_account
+  function_name                            = var.cloud_function_configs.vid_labeling_dispatcher.function_name
+  entry_point                              = var.cloud_function_configs.vid_labeling_dispatcher.entry_point
+  extra_env_vars                           = var.cloud_function_configs.vid_labeling_dispatcher.extra_env_vars
+  secret_mappings                          = var.cloud_function_configs.vid_labeling_dispatcher.secret_mappings
+  uber_jar_path                            = var.cloud_function_configs.vid_labeling_dispatcher.uber_jar_path
+  secrets_to_access                        = [for key in local.vid_labeling_function_secrets_access : local.all_secrets[key].secret_id]
+}
+
+# The DataWatcher invokes the dispatcher over HTTP when a "done" blob lands.
+resource "google_cloud_run_service_iam_member" "vid_labeling_dispatcher_invoker" {
+  depends_on = [module.vid_labeling_dispatcher_cloud_function]
+  service    = var.cloud_function_configs.vid_labeling_dispatcher.function_name
+  role       = "roles/run.invoker"
+  member     = "serviceAccount:${module.data_watcher_cloud_function.cloud_function_service_account.email}"
+}
+
+resource "google_storage_bucket_iam_member" "vid_labeling_dispatcher_storage_viewer" {
+  bucket = module.edp_aggregator_bucket.storage_bucket.name
+  role   = "roles/storage.objectViewer"
+  member = "serviceAccount:${module.vid_labeling_dispatcher_cloud_function.cloud_function_service_account.email}"
+}
+
+resource "google_storage_bucket_iam_member" "vid_labeling_dispatcher_config_storage_viewer" {
+  bucket = module.config_files_bucket.storage_bucket.name
+  role   = "roles/storage.objectViewer"
+  member = "serviceAccount:${module.vid_labeling_dispatcher_cloud_function.cloud_function_service_account.email}"
+}
+
+# ---- VidLabelingMonitor (HTTP Cloud Function, triggered by Cloud Scheduler) ----
+resource "google_storage_bucket_object" "upload_vid_labeling_monitor_config" {
+  name           = var.vid_labeling_monitor_config.destination
+  bucket         = module.config_files_bucket.storage_bucket.name
+  source         = var.vid_labeling_monitor_config.local_path
+  source_md5hash = filemd5(var.vid_labeling_monitor_config.local_path)
+}
+
+module "vid_labeling_monitor_cloud_function" {
+  source = "../http-cloud-function"
+
+  depends_on = [
+    module.secrets,
+    google_storage_bucket_object.upload_vid_labeling_monitor_config,
+  ]
+
+  http_cloud_function_service_account_name = var.vid_labeling_monitor_service_account_name
+  terraform_service_account                = var.terraform_service_account
+  function_name                            = var.cloud_function_configs.vid_labeling_monitor.function_name
+  entry_point                              = var.cloud_function_configs.vid_labeling_monitor.entry_point
+  extra_env_vars                           = var.cloud_function_configs.vid_labeling_monitor.extra_env_vars
+  secret_mappings                          = var.cloud_function_configs.vid_labeling_monitor.secret_mappings
+  uber_jar_path                            = var.cloud_function_configs.vid_labeling_monitor.uber_jar_path
+  secrets_to_access                        = [for key in local.vid_labeling_function_secrets_access : local.all_secrets[key].secret_id]
+}
+
+module "vid_labeling_monitor_cloud_scheduler" {
+  source                    = "../cloud-scheduler"
+  terraform_service_account = var.terraform_service_account
+  scheduler_config          = var.vid_labeling_monitor_scheduler_config
+  depends_on                = [module.vid_labeling_monitor_cloud_function]
+}
+
+resource "google_storage_bucket_iam_member" "vid_labeling_monitor_storage_viewer" {
+  depends_on = [module.vid_labeling_monitor_cloud_function]
+  bucket     = module.edp_aggregator_bucket.storage_bucket.name
+  role       = "roles/storage.objectViewer"
+  member     = "serviceAccount:${module.vid_labeling_monitor_cloud_function.cloud_function_service_account.email}"
+}
+
+resource "google_storage_bucket_iam_member" "vid_labeling_monitor_config_storage_viewer" {
+  bucket = module.config_files_bucket.storage_bucket.name
+  role   = "roles/storage.objectViewer"
+  member = "serviceAccount:${module.vid_labeling_monitor_cloud_function.cloud_function_service_account.email}"
 }

--- a/src/main/terraform/gcloud/modules/edp-aggregator/main.tf
+++ b/src/main/terraform/gcloud/modules/edp-aggregator/main.tf
@@ -876,6 +876,13 @@ module "vid_labeling_monitor_cloud_scheduler" {
   depends_on                = [module.vid_labeling_monitor_cloud_function]
 }
 
+module "vid_labeling_dispatch_cloud_scheduler" {
+  source                    = "../cloud-scheduler"
+  terraform_service_account = var.terraform_service_account
+  scheduler_config          = var.vid_labeling_dispatch_scheduler_config
+  depends_on                = [module.vid_labeling_monitor_cloud_function]
+}
+
 resource "google_storage_bucket_iam_member" "vid_labeling_monitor_storage_viewer" {
   depends_on = [module.vid_labeling_monitor_cloud_function]
   bucket     = module.edp_aggregator_bucket.storage_bucket.name

--- a/src/main/terraform/gcloud/modules/edp-aggregator/main.tf
+++ b/src/main/terraform/gcloud/modules/edp-aggregator/main.tf
@@ -194,6 +194,13 @@ module "config_files_bucket" {
   location = var.edp_aggregator_buckets_location
 }
 
+module "vid_models_bucket" {
+  source = "../storage-bucket"
+
+  name     = "vid-models-storage"
+  location = var.edp_aggregator_buckets_location
+}
+
 resource "google_storage_bucket_object" "upload_data_watcher_config" {
   name   = var.data_watcher_config.destination
   bucket = module.config_files_bucket.storage_bucket.name
@@ -780,6 +787,14 @@ resource "google_storage_bucket_iam_member" "vid_labeling_config_storage_viewer"
   for_each = var.vid_labeling_workers
 
   bucket = module.config_files_bucket.storage_bucket.name
+  role   = "roles/storage.objectViewer"
+  member = "serviceAccount:${module.vid_labeling_tee_app[each.key].mig_service_account.email}"
+}
+
+resource "google_storage_bucket_iam_member" "vid_labeling_model_storage_viewer" {
+  for_each = var.vid_labeling_workers
+
+  bucket = module.vid_models_bucket.storage_bucket.name
   role   = "roles/storage.objectViewer"
   member = "serviceAccount:${module.vid_labeling_tee_app[each.key].mig_service_account.email}"
 }

--- a/src/main/terraform/gcloud/modules/edp-aggregator/main.tf
+++ b/src/main/terraform/gcloud/modules/edp-aggregator/main.tf
@@ -754,6 +754,7 @@ module "vid_labeling_tee_app" {
   min_replicas                  = each.value.worker.min_replicas
   max_replicas                  = each.value.worker.max_replicas
   machine_type                  = each.value.worker.machine_type
+  disk_type                     = each.value.worker.disk_type
   java_tool_options             = each.value.worker.java_tool_options
   docker_image                  = each.value.worker.docker_image
   mig_distribution_policy_zones = each.value.worker.mig_distribution_policy_zones

--- a/src/main/terraform/gcloud/modules/edp-aggregator/main.tf
+++ b/src/main/terraform/gcloud/modules/edp-aggregator/main.tf
@@ -768,19 +768,16 @@ module "vid_labeling_tee_app" {
   extra_metadata                = local.otel_metadata
 }
 
-resource "google_storage_bucket_iam_member" "vid_labeling_storage_viewer" {
+# The VID Labeling TEE apps read raw impressions and read/write/delete their own pipeline outputs
+# and intermediate blobs on this bucket: subpool-map and rank-index temp blobs are deleted after
+# each merge (SubpoolFingerprintsStore/RankIndexStore.delete), and labeled outputs are overwritten
+# on retry. That requires object delete in addition to create/read, so grant objectUser (create +
+# read + delete + list) rather than the create+read-only objectCreator/objectViewer pair.
+resource "google_storage_bucket_iam_member" "vid_labeling_storage_object_user" {
   for_each = var.vid_labeling_workers
 
   bucket = module.edp_aggregator_bucket.storage_bucket.name
-  role   = "roles/storage.objectViewer"
-  member = "serviceAccount:${module.vid_labeling_tee_app[each.key].mig_service_account.email}"
-}
-
-resource "google_storage_bucket_iam_member" "vid_labeling_storage_creator" {
-  for_each = var.vid_labeling_workers
-
-  bucket = module.edp_aggregator_bucket.storage_bucket.name
-  role   = "roles/storage.objectCreator"
+  role   = "roles/storage.objectUser"
   member = "serviceAccount:${module.vid_labeling_tee_app[each.key].mig_service_account.email}"
 }
 

--- a/src/main/terraform/gcloud/modules/edp-aggregator/variables.tf
+++ b/src/main/terraform/gcloud/modules/edp-aggregator/variables.tf
@@ -510,7 +510,22 @@ variable "vid_labeling_monitor_config" {
 }
 
 variable "vid_labeling_monitor_scheduler_config" {
-  description = "Configuration for Google Cloud Scheduler to trigger the VidLabelingMonitor."
+  description = "Configuration for Google Cloud Scheduler to trigger the VidLabelingMonitor health cadence (?mode=health)."
+  type = object({
+    schedule                  = string
+    time_zone                 = string
+    name                      = string
+    function_url              = string
+    scheduler_sa_display_name = string
+    scheduler_sa_description  = string
+    scheduler_job_description = string
+    scheduler_job_name        = optional(string)
+  })
+  nullable = false
+}
+
+variable "vid_labeling_dispatch_scheduler_config" {
+  description = "Configuration for Google Cloud Scheduler to trigger the VidLabelingMonitor dispatch cadence (?mode=dispatch)."
   type = object({
     schedule                  = string
     time_zone                 = string

--- a/src/main/terraform/gcloud/modules/edp-aggregator/variables.tf
+++ b/src/main/terraform/gcloud/modules/edp-aggregator/variables.tf
@@ -451,3 +451,74 @@ variable "data_availability_monitor_scheduler_config" {
   })
   nullable = false
 }
+
+variable "vid_labeling_workers" {
+  description = "Map of VID Labeling TEE apps (Phase 0/1/2): one Pub/Sub work queue and one Confidential Space MIG worker each."
+  type = map(object({
+    queue = object({
+      topic_name            = string
+      subscription_name     = string
+      ack_deadline_seconds  = number
+      max_delivery_attempts = number
+    })
+    worker = object({
+      instance_template_name        = string
+      base_instance_name            = string
+      managed_instance_group_name   = string
+      mig_service_account_name      = string
+      single_instance_assignment    = number
+      min_replicas                  = number
+      max_replicas                  = number
+      machine_type                  = string
+      java_tool_options             = optional(string)
+      docker_image                  = string
+      tee_signed_image_repo         = string
+      mig_distribution_policy_zones = list(string)
+      app_flags                     = list(string)
+    })
+  }))
+  default = {}
+}
+
+variable "vid_labeling_dispatcher_service_account_name" {
+  description = "Name of the VidLabelingDispatcher service account."
+  type        = string
+  nullable    = false
+}
+
+variable "vid_labeling_monitor_service_account_name" {
+  description = "Name of the VidLabelingMonitor service account."
+  type        = string
+  nullable    = false
+}
+
+variable "vid_labeling_dispatcher_config" {
+  description = "An object containing the local path of the VidLabelingDispatcher config file and its destination path in Cloud Storage."
+  type = object({
+    local_path  = string
+    destination = string
+  })
+}
+
+variable "vid_labeling_monitor_config" {
+  description = "An object containing the local path of the VidLabelingMonitor config file and its destination path in Cloud Storage."
+  type = object({
+    local_path  = string
+    destination = string
+  })
+}
+
+variable "vid_labeling_monitor_scheduler_config" {
+  description = "Configuration for Google Cloud Scheduler to trigger the VidLabelingMonitor."
+  type = object({
+    schedule                  = string
+    time_zone                 = string
+    name                      = string
+    function_url              = string
+    scheduler_sa_display_name = string
+    scheduler_sa_description  = string
+    scheduler_job_description = string
+    scheduler_job_name        = optional(string)
+  })
+  nullable = false
+}

--- a/src/main/terraform/gcloud/modules/edp-aggregator/variables.tf
+++ b/src/main/terraform/gcloud/modules/edp-aggregator/variables.tf
@@ -470,7 +470,7 @@ variable "vid_labeling_workers" {
       min_replicas                  = number
       max_replicas                  = number
       machine_type                  = string
-      disk_type                     = optional(string, "hyperdisk-balanced")
+      disk_type                     = optional(string, "pd-ssd")
       java_tool_options             = optional(string)
       docker_image                  = string
       tee_signed_image_repo         = string

--- a/src/main/terraform/gcloud/modules/edp-aggregator/variables.tf
+++ b/src/main/terraform/gcloud/modules/edp-aggregator/variables.tf
@@ -470,6 +470,7 @@ variable "vid_labeling_workers" {
       min_replicas                  = number
       max_replicas                  = number
       machine_type                  = string
+      disk_type                     = optional(string, "hyperdisk-balanced")
       java_tool_options             = optional(string)
       docker_image                  = string
       tee_signed_image_repo         = string

--- a/src/main/terraform/gcloud/modules/mig/main.tf
+++ b/src/main/terraform/gcloud/modules/mig/main.tf
@@ -117,9 +117,14 @@ resource "google_compute_instance_template" "confidential_vm_template" {
   }
 
   disk {
-    boot                   = true
-    source_image           = data.google_compute_image.confidential_space.self_link
-    disk_type              = "pd-ssd"
+    boot         = true
+    source_image = data.google_compute_image.confidential_space.self_link
+    disk_type    = var.disk_type
+    # provisioned_iops/throughput are only valid for hyperdisk-* disk types; other
+    # types (e.g. pd-balanced, required by machine families without hyperdisk support
+    # such as N2D) reject them, so they must be omitted (null) unless using hyperdisk.
+    provisioned_iops       = var.disk_type == "hyperdisk-balanced" ? 5000 : null
+    provisioned_throughput = var.disk_type == "hyperdisk-balanced" ? 1250 : null
   }
 
   shielded_instance_config {

--- a/src/main/terraform/gcloud/modules/mig/variables.tf
+++ b/src/main/terraform/gcloud/modules/mig/variables.tf
@@ -81,9 +81,9 @@ variable "machine_type" {
 }
 
 variable "disk_type" {
-  description = "The boot disk type. Use a hyperdisk-* type only for machine families that support it; use pd-balanced for families that do not (e.g. N2D)."
+  description = "The boot disk type. Defaults to pd-ssd (n2d-compatible, used fleet-wide since the n2d migration). Override with a hyperdisk-* type only for machine families that support it, or pd-balanced for others."
   type        = string
-  default     = "hyperdisk-balanced"
+  default     = "pd-ssd"
   nullable    = false
 }
 

--- a/src/main/terraform/gcloud/modules/mig/variables.tf
+++ b/src/main/terraform/gcloud/modules/mig/variables.tf
@@ -80,6 +80,13 @@ variable "machine_type" {
   nullable    = false
 }
 
+variable "disk_type" {
+  description = "The boot disk type. Use a hyperdisk-* type only for machine families that support it; use pd-balanced for families that do not (e.g. N2D)."
+  type        = string
+  default     = "hyperdisk-balanced"
+  nullable    = false
+}
+
 variable "docker_image" {
   description = "The docker image to be deployed."
   type        = string

--- a/src/main/terraform/gcloud/modules/pubsub/outputs.tf
+++ b/src/main/terraform/gcloud/modules/pubsub/outputs.tf
@@ -21,3 +21,8 @@ output "pubsub_subscription" {
   value       = google_pubsub_subscription.subscription
   description = "The created Pub/Sub subscription"
 }
+
+output "dead_letter_subscription" {
+  value       = google_pubsub_subscription.dead_letter_subscription
+  description = "The created dead-letter Pub/Sub subscription"
+}


### PR DESCRIPTION
# SUMMARY

Infrastructure-as-code to deploy the VID Labeling pipeline (Phases 0–2) on the
EDP Aggregator, plus the Secure Computation queue registration. Terraform-only —
no pipeline source or protos (those land in the PRs below this in the stack).

Adds:
- **`src/main/terraform/gcloud/modules/edp-aggregator/`** — the `edp-aggregator`
  module: 3 Confidential Space TEE MIGs (Phase-0 `SubpoolAssigner`, Phase-1
  `VidRankBuilder`, Phase-2 `VidLabeler`), their Pub/Sub topics + subscriptions,
  and the Dispatcher/Monitor Cloud Functions wiring.
- **`src/main/terraform/gcloud/cmms/edp_aggregator.tf` / `variables.tf`** — the
  CMMS-level instantiation: per-MIG machine types / replica bounds / images and
  each app's CLI flags (`--subscription-id`, `--vid-rank-builder-queue`,
  `--vid-labeler-queue`).
- **`queues_config.textproto`** — registers the four work queues
  (`results-fulfiller-queue`, `subpool-assigner-queue`, `vid-rank-builder-queue`,
  `vid-labeler-queue`) with the Secure Computation control plane.
- **`.github/workflows/terraform-cmms-v2.yml`** — CI for the Terraform.

## Stack

Sits on #4093 (base-runner + Phase-0 seam wiring). The pipeline source it
deploys is provided by the PRs below: #4020 / #3990 (dispatcher + monitor),
#4081 (Phase-0 dispatch), #4072 / #4083 (Phase-2), #4009 (Phase-1), #4093 (base
runner). The dispatcher/monitor uber-jars are published by #4065 (stacked above).

## Notes / validation

- Queue names are consistent across `queues_config.textproto`, the Terraform
  topics/subscriptions, and the runners' `--*-queue` flags.
- No bazel build (infra-only).
- Follow-up "point D" items (e.g. autoscaling tuning) tracked separately.

Issue: #3926
