### PR TITLE
feat: add SyncEventGroupActivities CLI tool

### DIFF
--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/tools/BUILD.bazel
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/tools/BUILD.bazel
@@ -1,0 +1,31 @@
+load("@rules_java//java:defs.bzl", "java_binary")
+load("@wfa_rules_kotlin_jvm//kotlin:defs.bzl", "kt_jvm_library")
+
+package(default_visibility = [
+    "//src/main/kotlin/org/wfanet/measurement/edpaggregator:__subpackages__",
+    "//src/test/kotlin/org/wfanet/measurement/edpaggregator:__subpackages__",
+])
+
+kt_jvm_library(
+    name = "sync_event_group_activities",
+    srcs = ["SyncEventGroupActivities.kt"],
+    deps = [
+        "//src/main/kotlin/org/wfanet/measurement/edpaggregator/eventgroupactivities:event_group_activity_sync",
+        "//src/main/proto/wfa/measurement/api/v2alpha:event_group_activities_service_kt_jvm_grpc_proto",
+        "//src/main/proto/wfa/measurement/config/edpaggregator:event_group_activity_sync_config_kt_jvm_proto",
+        "@wfa_common_jvm//imports/java/picocli",
+        "@wfa_common_jvm//imports/kotlin/kotlinx/coroutines:core",
+        "@wfa_common_jvm//src/main/kotlin/org/wfanet/measurement/common",
+        "@wfa_common_jvm//src/main/kotlin/org/wfanet/measurement/common/crypto:signing_certs",
+        "@wfa_common_jvm//src/main/kotlin/org/wfanet/measurement/common/grpc",
+        "@wfa_common_jvm//src/main/kotlin/org/wfanet/measurement/common/throttler",
+        "@wfa_common_jvm//src/main/kotlin/org/wfanet/measurement/storage:selected_storage_client",
+    ],
+)
+
+java_binary(
+    name = "SyncEventGroupActivities",
+    main_class = "org.wfanet.measurement.edpaggregator.tools.SyncEventGroupActivitiesKt",
+    tags = ["manual"],
+    runtime_deps = [":sync_event_group_activities"],
+)

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/tools/SyncEventGroupActivities.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/tools/SyncEventGroupActivities.kt
@@ -1,0 +1,202 @@
+/*
+ * Copyright 2026 The Cross-Media Measurement Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wfanet.measurement.edpaggregator.tools
+
+import io.grpc.ManagedChannel
+import java.io.File
+import java.io.FileInputStream
+import java.io.InputStream
+import java.time.Clock
+import java.time.Duration
+import java.util.concurrent.TimeUnit
+import java.util.logging.Logger
+import kotlin.system.exitProcess
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.runBlocking
+import org.wfanet.measurement.api.v2alpha.EventGroupActivitiesGrpcKt.EventGroupActivitiesCoroutineStub
+import org.wfanet.measurement.common.commandLineMain
+import org.wfanet.measurement.common.crypto.SigningCerts
+import org.wfanet.measurement.common.flatten
+import org.wfanet.measurement.common.grpc.TlsFlags
+import org.wfanet.measurement.common.grpc.buildMutualTlsChannel
+import org.wfanet.measurement.common.parseTextProto
+import org.wfanet.measurement.common.throttler.MinimumIntervalThrottler
+import org.wfanet.measurement.config.edpaggregator.EventGroupActivitySyncConfig
+import org.wfanet.measurement.config.edpaggregator.EventGroupActivitySyncConfig.InputCase
+import org.wfanet.measurement.edpaggregator.eventgroupactivities.EventGroupActivitySync
+import org.wfanet.measurement.edpaggregator.eventgroupactivities.SpotDataParser
+import org.wfanet.measurement.edpaggregator.eventgroupactivities.SpotRecord
+import org.wfanet.measurement.edpaggregator.eventgroupactivities.SyncMode
+import org.wfanet.measurement.edpaggregator.eventgroupactivities.SyncResult
+import org.wfanet.measurement.storage.SelectedStorageClient
+import picocli.CommandLine.Command
+import picocli.CommandLine.ITypeConverter
+import picocli.CommandLine.Mixin
+import picocli.CommandLine.Option
+
+/**
+ * Command that synchronizes `EventGroupActivity` resources for a DataProvider against the CMMS
+ * Public API from a JSON spot-data file.
+ *
+ * Per-environment values (DataProvider, spot-data input, Kingdom target) are supplied via an
+ * [EventGroupActivitySyncConfig] textproto passed with `--config-file`.
+ */
+@Command(
+  name = "SyncEventGroupActivities",
+  description = ["Syncs EventGroupActivities for a DataProvider from a JSON file"],
+  mixinStandardHelpOptions = true,
+)
+class SyncEventGroupActivities : Runnable {
+  @Mixin private lateinit var tlsFlags: TlsFlags
+
+  @Option(
+    names = ["--config-file"],
+    description = ["Path to an EventGroupActivitySyncConfig textproto"],
+    required = true,
+  )
+  private lateinit var configFile: File
+
+  @Option(
+    names = ["--throttler-minimum-interval"],
+    description =
+      [
+        "Minimum interval between gRPC calls. The sync makes one list call per EventGroup plus " +
+          "one batch call per 1000 created/deleted activities, so call volume is roughly " +
+          "proportional to the number of EventGroups."
+      ],
+    defaultValue = "100ms",
+  )
+  private lateinit var throttlerMinimumInterval: Duration
+
+  @Option(
+    names = ["--list-page-size"],
+    description = ["Page size used when listing existing EventGroupActivities"],
+    defaultValue = "50",
+  )
+  private var listPageSize: Int = 50
+
+  @Option(
+    names = ["--mode"],
+    description =
+      [
+        "How the sync writes to the Kingdom: " +
+          "sync (default: write creates and deletes to match input exactly), " +
+          "append (write creates only; leave Kingdom records absent from input untouched), " +
+          "or preview (make no mutating calls; log the planned diff)."
+      ],
+    converter = [SyncModeConverter::class],
+    defaultValue = "sync",
+  )
+  private var mode: SyncMode = SyncMode.SYNC
+
+  override fun run() {
+    val config: EventGroupActivitySyncConfig =
+      parseTextProto(configFile, EventGroupActivitySyncConfig.getDefaultInstance())
+    require(config.inputCase != InputCase.INPUT_NOT_SET) {
+      "config must set one of spot_data_blob_uri or local_file_path"
+    }
+    val dataProvider: String = config.dataProvider
+    val kingdomPublicApiTarget: String = config.kingdomPublicApiTarget
+    val kingdomPublicApiCertHost: String? = config.kingdomPublicApiCertHost.ifEmpty { null }
+
+    val clientCerts =
+      SigningCerts.fromPemFiles(
+        certificateFile = tlsFlags.certFile,
+        privateKeyFile = tlsFlags.privateKeyFile,
+        trustedCertCollectionFile = tlsFlags.certCollectionFile,
+      )
+    val channel: ManagedChannel =
+      buildMutualTlsChannel(kingdomPublicApiTarget, clientCerts, kingdomPublicApiCertHost)
+
+    val activitiesClient = EventGroupActivitiesCoroutineStub(channel)
+    val throttler = MinimumIntervalThrottler(Clock.systemUTC(), throttlerMinimumInterval)
+    val sync =
+      EventGroupActivitySync(
+        eventGroupActivitiesClient = activitiesClient,
+        throttler = throttler,
+        dataProviderName = dataProvider,
+        listPageSize = listPageSize,
+        mode = mode,
+      )
+
+    // Always shut down the channel; only exit non-zero AFTER the finally runs, since exitProcess
+    // would otherwise skip it. Skipped deletes (non-FULL delete modes) are intentional, so only
+    // runtime (RPC) failures drive the non-zero exit.
+    val hasFailures: Boolean =
+      try {
+        runBlocking {
+          val records: Flow<SpotRecord> = SpotDataParser.parseJson(readInput(config))
+          val result: SyncResult = sync.sync(records)
+
+          println("Sync result:")
+          println("  totalInputRecords: ${result.totalInputRecords}")
+          println("  eventGroupsSucceeded: ${result.eventGroupsSucceeded}")
+          println("  eventGroupsFailed: ${result.eventGroupsFailed}")
+          println("  activitiesCreated: ${result.activitiesCreated}")
+          println("  activitiesDeleted: ${result.activitiesDeleted}")
+          println("  activitiesUnchanged: ${result.activitiesUnchanged}")
+          println("  activitiesWouldDelete: ${result.activitiesWouldDelete}")
+          for (error in result.errors) {
+            logger.warning("Sync error [${error.eventGroup}]: ${error.message}")
+          }
+
+          result.eventGroupsFailed > 0
+        }
+      } finally {
+        channel.shutdown()
+        channel.awaitTermination(SHUTDOWN_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+      }
+
+    if (hasFailures) {
+      exitProcess(1)
+    }
+  }
+
+  /** Opens the input as a stream, from either the local file or the GCS blob per the config. */
+  private suspend fun readInput(config: EventGroupActivitySyncConfig): InputStream {
+    return when (config.inputCase) {
+      InputCase.LOCAL_FILE_PATH -> FileInputStream(File(config.localFilePath))
+      InputCase.SPOT_DATA_BLOB_URI -> {
+        val blobUri: String = config.spotDataBlobUri
+        val parsedBlobUri = SelectedStorageClient.parseBlobUri(blobUri)
+        val storageClient =
+          SelectedStorageClient(
+            blobUri = parsedBlobUri,
+            projectId = config.gcsProject.ifEmpty { null },
+          )
+        val blob =
+          storageClient.getBlob(parsedBlobUri.key) ?: error("Blob not found for URI: $blobUri")
+        blob.read().flatten().newInput()
+      }
+      InputCase.INPUT_NOT_SET ->
+        error("config must set one of spot_data_blob_uri or local_file_path")
+    }
+  }
+
+  companion object {
+    private val logger: Logger = Logger.getLogger(this::class.java.name)
+
+    /** Maximum time to wait for the gRPC channel to terminate during shutdown. */
+    private const val SHUTDOWN_TIMEOUT_SECONDS = 30L
+  }
+}
+
+private class SyncModeConverter : ITypeConverter<SyncMode> {
+  override fun convert(value: String): SyncMode = SyncMode.valueOf(value.uppercase())
+}
+
+fun main(args: Array<String>) = commandLineMain(SyncEventGroupActivities(), args)

--- a/src/main/proto/wfa/measurement/config/edpaggregator/BUILD.bazel
+++ b/src/main/proto/wfa/measurement/config/edpaggregator/BUILD.bazel
@@ -60,6 +60,20 @@ kt_jvm_proto_library(
 )
 
 proto_library(
+    name = "event_group_activity_sync_config_proto",
+    srcs = ["event_group_activity_sync_config.proto"],
+    strip_import_prefix = IMPORT_PREFIX,
+    deps = [
+        "@com_google_googleapis//google/api:resource_proto",
+    ],
+)
+
+kt_jvm_proto_library(
+    name = "event_group_activity_sync_config_kt_jvm_proto",
+    deps = [":event_group_activity_sync_config_proto"],
+)
+
+proto_library(
     name = "requisition_fetcher_config_proto",
     srcs = ["requisition_fetcher_config.proto"],
     strip_import_prefix = IMPORT_PREFIX,

--- a/src/main/proto/wfa/measurement/config/edpaggregator/event_group_activity_sync_config.proto
+++ b/src/main/proto/wfa/measurement/config/edpaggregator/event_group_activity_sync_config.proto
@@ -1,0 +1,50 @@
+// Copyright 2026 The Cross-Media Measurement Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package wfa.measurement.config.edpaggregator;
+
+import "google/api/resource.proto";
+
+option java_package = "org.wfanet.measurement.config.edpaggregator";
+option java_multiple_files = true;
+option java_outer_classname = "EventGroupActivitySyncConfigProto";
+
+// Per-environment configuration for a single EDP's event group activity sync
+// CronJob. Loaded by `SyncEventGroupActivities` via `--config-file`. All
+// fields except those tagged as optional are required.
+message EventGroupActivitySyncConfig {
+  // Resource name of the DataProvider whose activities are synced. Required.
+  string data_provider = 1
+      [(google.api.resource_reference).type = "halo.wfanet.org/DataProvider"];
+
+  // Source of the JSON spot-data input. Exactly one must be set.
+  oneof input {
+    // GCS URI (gs://bucket/key) of the JSON spot-data input file.
+    string spot_data_blob_uri = 2;
+    // Local filesystem path.
+    string local_file_path = 6;
+  }
+
+  // GCP project to use when reading `spot_data_blob_uri`. Optional; ignored
+  // when `local_file_path` is set.
+  string gcs_project = 3;
+
+  // gRPC target (host:port) of the Kingdom public API. Required.
+  string kingdom_public_api_target = 4;
+
+  // Expected hostname in the Kingdom public API's TLS certificate. Optional.
+  string kingdom_public_api_cert_host = 5;
+}

--- a/src/test/kotlin/org/wfanet/measurement/edpaggregator/tools/BUILD.bazel
+++ b/src/test/kotlin/org/wfanet/measurement/edpaggregator/tools/BUILD.bazel
@@ -1,0 +1,28 @@
+load("@wfa_rules_kotlin_jvm//kotlin:defs.bzl", "kt_jvm_test")
+
+kt_jvm_test(
+    name = "SyncEventGroupActivitiesTest",
+    srcs = ["SyncEventGroupActivitiesTest.kt"],
+    data = [
+        "//src/main/k8s/testing/secretfiles:root_certs",
+        "//src/main/k8s/testing/secretfiles:secret_files",
+    ],
+    jvm_flags = ["-Dcom.google.testing.junit.runner.shouldInstallTestSecurityManager=false"],
+    test_class = "org.wfanet.measurement.edpaggregator.tools.SyncEventGroupActivitiesTest",
+    deps = [
+        "//src/main/kotlin/org/wfanet/measurement/edpaggregator/tools:sync_event_group_activities",
+        "//src/main/proto/wfa/measurement/api/v2alpha:event_group_activities_service_kt_jvm_grpc_proto",
+        "//src/main/proto/wfa/measurement/api/v2alpha:event_group_activity_kt_jvm_proto",
+        "@wfa_common_jvm//imports/java/com/google/common/truth",
+        "@wfa_common_jvm//imports/java/com/google/protobuf",
+        "@wfa_common_jvm//imports/java/io/grpc/netty",
+        "@wfa_common_jvm//imports/java/org/junit",
+        "@wfa_common_jvm//imports/kotlin/kotlin/test",
+        "@wfa_common_jvm//imports/kotlin/org/mockito/kotlin",
+        "@wfa_common_jvm//src/main/kotlin/org/wfanet/measurement/common",
+        "@wfa_common_jvm//src/main/kotlin/org/wfanet/measurement/common/crypto:signing_certs",
+        "@wfa_common_jvm//src/main/kotlin/org/wfanet/measurement/common/grpc",
+        "@wfa_common_jvm//src/main/kotlin/org/wfanet/measurement/common/grpc/testing",
+        "@wfa_common_jvm//src/main/kotlin/org/wfanet/measurement/common/testing",
+    ],
+)

--- a/src/test/kotlin/org/wfanet/measurement/edpaggregator/tools/SyncEventGroupActivitiesTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/edpaggregator/tools/SyncEventGroupActivitiesTest.kt
@@ -1,0 +1,269 @@
+/*
+ * Copyright 2026 The Cross-Media Measurement Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wfanet.measurement.edpaggregator.tools
+
+import com.google.common.truth.Truth.assertThat
+import com.google.protobuf.Empty
+import com.google.type.date
+import io.grpc.Server
+import io.grpc.ServerServiceDefinition
+import io.grpc.netty.NettyServerBuilder
+import java.io.File
+import java.nio.file.Path
+import java.nio.file.Paths
+import java.util.concurrent.TimeUnit.SECONDS
+import org.junit.After
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+import org.mockito.kotlin.any
+import org.mockito.kotlin.check
+import org.mockito.kotlin.never
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verifyBlocking
+import org.mockito.kotlin.wheneverBlocking
+import org.wfanet.measurement.api.v2alpha.BatchDeleteEventGroupActivitiesRequest
+import org.wfanet.measurement.api.v2alpha.BatchUpdateEventGroupActivitiesRequest
+import org.wfanet.measurement.api.v2alpha.EventGroupActivitiesGrpcKt.EventGroupActivitiesCoroutineImplBase
+import org.wfanet.measurement.api.v2alpha.ListEventGroupActivitiesRequest
+import org.wfanet.measurement.api.v2alpha.batchUpdateEventGroupActivitiesResponse
+import org.wfanet.measurement.api.v2alpha.eventGroupActivity
+import org.wfanet.measurement.api.v2alpha.listEventGroupActivitiesResponse
+import org.wfanet.measurement.common.crypto.SigningCerts
+import org.wfanet.measurement.common.getRuntimePath
+import org.wfanet.measurement.common.grpc.testing.mockService
+import org.wfanet.measurement.common.grpc.toServerTlsContext
+import org.wfanet.measurement.common.testing.CommandLineTesting
+import org.wfanet.measurement.common.testing.ExitInterceptingSecurityManager
+
+@RunWith(JUnit4::class)
+class SyncEventGroupActivitiesTest {
+  private val activitiesServiceMock: EventGroupActivitiesCoroutineImplBase = mockService {
+    onBlocking { listEventGroupActivities(any<ListEventGroupActivitiesRequest>()) }
+      .thenReturn(listEventGroupActivitiesResponse {})
+    onBlocking { batchUpdateEventGroupActivities(any<BatchUpdateEventGroupActivitiesRequest>()) }
+      .thenReturn(batchUpdateEventGroupActivitiesResponse {})
+    onBlocking { batchDeleteEventGroupActivities(any<BatchDeleteEventGroupActivitiesRequest>()) }
+      .thenReturn(Empty.getDefaultInstance())
+  }
+
+  private val serverCerts =
+    SigningCerts.fromPemFiles(
+      certificateFile = SECRETS_DIR.resolve("kingdom_tls.pem").toFile(),
+      privateKeyFile = SECRETS_DIR.resolve("kingdom_tls.key").toFile(),
+      trustedCertCollectionFile = SECRETS_DIR.resolve("kingdom_root.pem").toFile(),
+    )
+
+  private val services: List<ServerServiceDefinition> = listOf(activitiesServiceMock.bindService())
+
+  private val server: Server =
+    NettyServerBuilder.forPort(0)
+      .sslContext(serverCerts.toServerTlsContext())
+      .addServices(services)
+      .build()
+
+  @get:Rule val tempDir = TemporaryFolder()
+
+  @Before
+  fun initServer() {
+    server.start()
+  }
+
+  @After
+  fun shutdownServer() {
+    server.shutdown()
+    server.awaitTermination(1, SECONDS)
+  }
+
+  private val tlsArgs: Array<String>
+    get() =
+      arrayOf(
+        "--tls-cert-file=$SECRETS_DIR/kingdom_tls.pem",
+        "--tls-key-file=$SECRETS_DIR/kingdom_tls.key",
+        "--cert-collection-file=$SECRETS_DIR/kingdom_root.pem",
+      )
+
+  private fun protoDate(dateString: String) =
+    java.time.LocalDate.parse(dateString).let {
+      date {
+        year = it.year
+        month = it.monthValue
+        day = it.dayOfMonth
+      }
+    }
+
+  private fun writeInputFile(json: String): File {
+    val file = tempDir.newFile("input.json")
+    file.writeText(json)
+    return file
+  }
+
+  private fun writeConfigFile(textproto: String): File {
+    val file = tempDir.newFile("sync-config.textproto")
+    file.writeText(textproto)
+    return file
+  }
+
+  /** Writes a config whose input is the given local JSON [inputFile]. */
+  private fun writeLocalFileConfig(inputFile: File): File =
+    writeConfigFile(
+      """
+      data_provider: "$DATA_PROVIDER"
+      kingdom_public_api_target: "$HOST:${server.port}"
+      local_file_path: "${inputFile.path}"
+      """
+        .trimIndent()
+    )
+
+  @Test
+  fun `CLI fails when --config-file not provided`() {
+    val capturedOutput = CommandLineTesting.capturingOutput(tlsArgs, ::main)
+
+    CommandLineTesting.assertThat(capturedOutput).status().isNotEqualTo(0)
+  }
+
+  @Test
+  fun `CLI fails when config has no input set`() {
+    val configFile =
+      writeConfigFile(
+        """
+        data_provider: "$DATA_PROVIDER"
+        kingdom_public_api_target: "$HOST:${server.port}"
+        """
+          .trimIndent()
+      )
+    val args = tlsArgs + arrayOf("--config-file=${configFile.path}")
+
+    val capturedOutput = CommandLineTesting.capturingOutput(args, ::main)
+
+    CommandLineTesting.assertThat(capturedOutput).status().isNotEqualTo(0)
+  }
+
+  @Test
+  fun `CLI reads from local file successfully`() {
+    val inputFile =
+      writeInputFile(
+        """
+        [
+          {"parent": "$DATA_PROVIDER/eventGroups/eg1", "event_group_activity_date": "2026-01-01T00:00:00Z"},
+          {"parent": "$DATA_PROVIDER/eventGroups/eg1", "event_group_activity_date": "2026-01-02T00:00:00Z"}
+        ]
+        """
+          .trimIndent()
+      )
+    val configFile = writeLocalFileConfig(inputFile)
+    val args = tlsArgs + arrayOf("--config-file=${configFile.path}")
+
+    val capturedOutput = CommandLineTesting.capturingOutput(args, ::main)
+
+    CommandLineTesting.assertThat(capturedOutput).status().isEqualTo(0)
+    verifyBlocking(activitiesServiceMock, times(1)) { batchUpdateEventGroupActivities(any()) }
+  }
+
+  @Test
+  fun `CLI passes --list-page-size through to list requests`() {
+    val inputFile =
+      writeInputFile(
+        """
+        [{"parent": "$DATA_PROVIDER/eventGroups/eg1", "event_group_activity_date": "2026-01-01T00:00:00Z"}]
+        """
+          .trimIndent()
+      )
+    val configFile = writeLocalFileConfig(inputFile)
+    val args = tlsArgs + arrayOf("--config-file=${configFile.path}", "--list-page-size=17")
+
+    val capturedOutput = CommandLineTesting.capturingOutput(args, ::main)
+
+    CommandLineTesting.assertThat(capturedOutput).status().isEqualTo(0)
+    verifyBlocking(activitiesServiceMock, times(1)) {
+      listEventGroupActivities(check { request -> assertThat(request.pageSize).isEqualTo(17) })
+    }
+  }
+
+  @Test
+  fun `CLI with --mode=append applies creates but not deletes`() {
+    wheneverBlocking { activitiesServiceMock.listEventGroupActivities(any()) }
+      .thenReturn(
+        listEventGroupActivitiesResponse {
+          eventGroupActivities +=
+            (1..10).map { day ->
+              val dateString = "2026-01-%02d".format(day)
+              eventGroupActivity {
+                name = "$DATA_PROVIDER/eventGroups/eg1/eventGroupActivities/$dateString"
+                date = protoDate(dateString)
+              }
+            }
+        }
+      )
+    // Kingdom has 10 dates; file keeps 2 -> 8 would-be deletes, suppressed by skip-deletes mode.
+    val inputFile =
+      writeInputFile(
+        """
+        [
+          {"parent": "$DATA_PROVIDER/eventGroups/eg1", "event_group_activity_date": "2026-01-01T00:00:00Z"},
+          {"parent": "$DATA_PROVIDER/eventGroups/eg1", "event_group_activity_date": "2026-01-02T00:00:00Z"}
+        ]
+        """
+          .trimIndent()
+      )
+    val configFile = writeLocalFileConfig(inputFile)
+    val args = tlsArgs + arrayOf("--config-file=${configFile.path}", "--mode=append")
+
+    val capturedOutput = CommandLineTesting.capturingOutput(args, ::main)
+
+    // skip-deletes is intentional partial work, not a failure, so the CLI exits zero and applies
+    // no deletes.
+    CommandLineTesting.assertThat(capturedOutput).status().isEqualTo(0)
+    verifyBlocking(activitiesServiceMock, never()) { batchDeleteEventGroupActivities(any()) }
+  }
+
+  @Test
+  fun `CLI with --mode=preview prints plan without making API calls`() {
+    val inputFile =
+      writeInputFile(
+        """
+        [
+          {"parent": "$DATA_PROVIDER/eventGroups/eg1", "event_group_activity_date": "2026-01-01T00:00:00Z"}
+        ]
+        """
+          .trimIndent()
+      )
+    val configFile = writeLocalFileConfig(inputFile)
+    val args = tlsArgs + arrayOf("--config-file=${configFile.path}", "--mode=preview")
+
+    val capturedOutput = CommandLineTesting.capturingOutput(args, ::main)
+
+    CommandLineTesting.assertThat(capturedOutput).status().isEqualTo(0)
+    verifyBlocking(activitiesServiceMock, never()) { batchUpdateEventGroupActivities(any()) }
+    verifyBlocking(activitiesServiceMock, never()) { batchDeleteEventGroupActivities(any()) }
+  }
+
+  companion object {
+    init {
+      System.setSecurityManager(ExitInterceptingSecurityManager)
+    }
+
+    private const val HOST = "localhost"
+    private const val MODULE_REPO_NAME = "wfa_measurement_system"
+    private const val DATA_PROVIDER = "dataProviders/dp1"
+    private val SECRETS_DIR: Path =
+      getRuntimePath(Paths.get(MODULE_REPO_NAME, "src", "main", "k8s", "testing", "secretfiles"))!!
+  }
+}


### PR DESCRIPTION
## Summary
- `SyncEventGroupActivities` picocli CLI for operators/cron to run the reconciliation.
- Config via a required `--config-file` (`EventGroupActivitySyncConfig` textproto): DataProvider, spot-data input (`oneof`: `spot_data_blob_uri` GCS / `local_file_path`), Kingdom public API target + cert host, GCS project.
- Operational flags kept out of env config: `--mode` (sync/append/preview), `--list-page-size`, `--throttler-minimum-interval`; Kingdom public API over mTLS (`@Mixin TlsFlags`).
- Reads input, parses with `SpotDataParser`, runs `EventGroupActivitySync`, prints `SyncResult`, exits non-zero if any EventGroup fails.

## Test plan
- `bazel test //src/test/kotlin/org/wfanet/measurement/edpaggregator/tools:SyncEventGroupActivitiesTest` (passes)
- Covers: missing `--config-file` rejected, config with no input set rejected, local-file read, `--mode=preview` makes no mutating calls, `--mode=append` applies creates but not deletes, `--list-page-size` propagation.

Issue: #4105