### PR TITLE
fix: Add EncryptedDek.ProtobufFormat to VID labeling proto bundle

### DIFF
--- a/src/main/resources/edpaggregator/spanner/create-vid-labeling-schema.sql
+++ b/src/main/resources/edpaggregator/spanner/create-vid-labeling-schema.sql
@@ -33,7 +33,8 @@ ALTER PROTO BUNDLE INSERT (
   `wfa.measurement.internal.edpaggregator.RankerState`,
   `wfa.measurement.internal.edpaggregator.VidLabelingState`,
   `wfa.measurement.internal.edpaggregator.BlobType`,
-  `wfa.measurement.internal.edpaggregator.EncryptedDek`
+  `wfa.measurement.internal.edpaggregator.EncryptedDek`,
+  `wfa.measurement.internal.edpaggregator.EncryptedDek.ProtobufFormat`
 );
 
 -- =============================================================================


### PR DESCRIPTION
Adds the nested enum `EncryptedDek.ProtobufFormat` as an explicit member of the proto bundle in changeset 11 of `create-vid-labeling-schema.sql`. Cloud Spanner requires every type referenced by a bundled message to itself be a bundle member, so without it the edp-aggregator schema rollout fails on real Spanner.

## Cloud verification (halo-cmm-dev)

EDP Aggregator cloud test on this commit, run against the dev environment - passed:
https://github.com/world-federation-of-advertisers/cross-media-measurement/actions/runs/28397378510

Separately, applied the full schema (the real `UpdateSchema` rollout tool, same binary the `update-edp-aggregator-schema` container runs) against real Cloud Spanner on `dev-instance` to confirm the migration itself. The emulator used in CI does not enforce nested-type bundle membership, so this needed real Spanner. All 11 changesets applied, including the previously-failing one:
```
Running Changeset: edpaggregator/spanner/create-vid-labeling-schema.sql::11::getina
INFO: ChangeSet edpaggregator/spanner/create-vid-labeling-schema.sql::11::getina ran successfully in 10221ms
INFO: Update command completed successfully.
```

Resulting proto bundle (note the nested enum is now a member):
```
CREATE PROTO BUNDLE (
  ...
  wfa.measurement.internal.edpaggregator.EncryptedDek,
  wfa.measurement.internal.edpaggregator.EncryptedDek.ProtobufFormat,
  ...
);
```

Issue: #4116