### PR TITLE
fix: verify done_blob_uri consistency on RawImpressionUpload create idempotency

### DIFF
--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/spanner/SpannerRawImpressionUploadService.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/spanner/SpannerRawImpressionUploadService.kt
@@ -32,6 +32,7 @@ import org.wfanet.measurement.edpaggregator.deploy.gcloud.spanner.db.insertRawIm
 import org.wfanet.measurement.edpaggregator.deploy.gcloud.spanner.db.rawImpressionUploadExists
 import org.wfanet.measurement.edpaggregator.deploy.gcloud.spanner.db.readRawImpressionUploads
 import org.wfanet.measurement.edpaggregator.service.internal.InvalidFieldValueException
+import org.wfanet.measurement.edpaggregator.service.internal.RawImpressionUploadAlreadyExistsException
 import org.wfanet.measurement.edpaggregator.service.internal.RawImpressionUploadNotFoundException
 import org.wfanet.measurement.edpaggregator.service.internal.RequiredFieldNotSetException
 import org.wfanet.measurement.gcloud.spanner.AsyncDatabaseClient
@@ -86,6 +87,10 @@ class SpannerRawImpressionUploadService(
         val existing: RawImpressionUploadResult? =
           txn.findUploadByCreateRequestId(request.dataProviderResourceId, requestId)
         if (existing != null) {
+          if (existing.rawImpressionUpload.doneBlobUri != request.rawImpressionUpload.doneBlobUri) {
+            throw RawImpressionUploadAlreadyExistsException(request.dataProviderResourceId)
+              .asStatusRuntimeException(Status.Code.ALREADY_EXISTS)
+          }
           return@run existing.rawImpressionUpload
         }
 

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/spanner/SpannerRawImpressionUploadService.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/spanner/SpannerRawImpressionUploadService.kt
@@ -88,7 +88,12 @@ class SpannerRawImpressionUploadService(
           txn.findUploadByCreateRequestId(request.dataProviderResourceId, requestId)
         if (existing != null) {
           if (existing.rawImpressionUpload.doneBlobUri != request.rawImpressionUpload.doneBlobUri) {
-            throw RawImpressionUploadAlreadyExistsException(request.dataProviderResourceId)
+            throw RawImpressionUploadAlreadyExistsException(
+                request.dataProviderResourceId,
+                requestId,
+                existing.rawImpressionUpload.doneBlobUri,
+                request.rawImpressionUpload.doneBlobUri,
+              )
               .asStatusRuntimeException(Status.Code.ALREADY_EXISTS)
           }
           return@run existing.rawImpressionUpload

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/service/internal/Errors.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/service/internal/Errors.kt
@@ -50,6 +50,7 @@ object Errors {
     POOL_ASSIGNMENT_JOB_NOT_FOUND,
     POOL_ASSIGNMENT_JOB_STATE_INVALID,
     POOL_ASSIGNMENT_JOB_ALREADY_EXISTS,
+    RAW_IMPRESSION_UPLOAD_ALREADY_EXISTS,
     RAW_IMPRESSION_UPLOAD_FILE_NOT_FOUND,
     RAW_IMPRESSION_UPLOAD_FILE_ALREADY_EXISTS,
     VID_LABELING_JOB_NOT_FOUND,
@@ -371,6 +372,17 @@ class RawImpressionUploadModelLineConcurrentException(
       Errors.Metadata.CONFLICTING_RAW_IMPRESSION_UPLOAD_RESOURCE_IDS to
         conflictingUploads.joinToString(",") { (id, _) -> id },
     ),
+    cause,
+  )
+
+class RawImpressionUploadAlreadyExistsException(
+  dataProviderResourceId: String,
+  cause: Throwable? = null,
+) :
+  ServiceException(
+    Errors.Reason.RAW_IMPRESSION_UPLOAD_ALREADY_EXISTS,
+    "RawImpressionUpload already exists for DataProvider $dataProviderResourceId",
+    mapOf(Errors.Metadata.DATA_PROVIDER_RESOURCE_ID to dataProviderResourceId),
     cause,
   )
 

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/service/internal/Errors.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/service/internal/Errors.kt
@@ -94,6 +94,7 @@ object Errors {
     POOL_ASSIGNMENT_JOB_RESOURCE_ID("poolAssignmentJobResourceId"),
     POOL_ASSIGNMENT_JOB_STATE("poolAssignmentJobState"),
     EXPECTED_POOL_ASSIGNMENT_JOB_STATES("expectedPoolAssignmentJobStates"),
+    CREATE_REQUEST_ID("createRequestId"),
     FILE_RESOURCE_ID("fileResourceId"),
     VID_LABELING_JOB_RESOURCE_ID("vidLabelingJobResourceId"),
     VID_LABELING_JOB_STATE("vidLabelingJobState"),
@@ -377,12 +378,20 @@ class RawImpressionUploadModelLineConcurrentException(
 
 class RawImpressionUploadAlreadyExistsException(
   dataProviderResourceId: String,
+  requestId: String,
+  existingDoneBlobUri: String,
+  incomingDoneBlobUri: String,
   cause: Throwable? = null,
 ) :
   ServiceException(
     Errors.Reason.RAW_IMPRESSION_UPLOAD_ALREADY_EXISTS,
-    "RawImpressionUpload already exists for DataProvider $dataProviderResourceId",
-    mapOf(Errors.Metadata.DATA_PROVIDER_RESOURCE_ID to dataProviderResourceId),
+    "RawImpressionUpload already exists for DataProvider $dataProviderResourceId with " +
+      "request_id $requestId: existing done_blob_uri=$existingDoneBlobUri, " +
+      "incoming done_blob_uri=$incomingDoneBlobUri",
+    mapOf(
+      Errors.Metadata.DATA_PROVIDER_RESOURCE_ID to dataProviderResourceId,
+      Errors.Metadata.CREATE_REQUEST_ID to requestId,
+    ),
     cause,
   )
 

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/service/internal/testing/RawImpressionUploadServiceTest.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/service/internal/testing/RawImpressionUploadServiceTest.kt
@@ -147,6 +147,7 @@ abstract class RawImpressionUploadServiceTest {
           domain = Errors.DOMAIN
           reason = Errors.Reason.RAW_IMPRESSION_UPLOAD_ALREADY_EXISTS.name
           metadata[Errors.Metadata.DATA_PROVIDER_RESOURCE_ID.key] = DATA_PROVIDER_RESOURCE_ID
+          metadata[Errors.Metadata.CREATE_REQUEST_ID.key] = requestId
         }
       )
   }

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/service/internal/testing/RawImpressionUploadServiceTest.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/service/internal/testing/RawImpressionUploadServiceTest.kt
@@ -118,6 +118,40 @@ abstract class RawImpressionUploadServiceTest {
   }
 
   @Test
+  fun `createRawImpressionUpload throws ALREADY_EXISTS when request_id reused with different done_blob_uri`():
+    Unit = runBlocking {
+    val requestId: String = UUID.randomUUID().toString()
+    service.createRawImpressionUpload(
+      createRawImpressionUploadRequest {
+        dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
+        rawImpressionUpload = rawImpressionUpload { doneBlobUri = DONE_BLOB_URI }
+        this.requestId = requestId
+      }
+    )
+
+    val exception: StatusRuntimeException =
+      assertFailsWith<StatusRuntimeException> {
+        service.createRawImpressionUpload(
+          createRawImpressionUploadRequest {
+            dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
+            rawImpressionUpload = rawImpressionUpload { doneBlobUri = "$DONE_BLOB_URI-different" }
+            this.requestId = requestId
+          }
+        )
+      }
+
+    assertThat(exception.status.code).isEqualTo(Status.Code.ALREADY_EXISTS)
+    assertThat(exception.errorInfo)
+      .isEqualTo(
+        errorInfo {
+          domain = Errors.DOMAIN
+          reason = Errors.Reason.RAW_IMPRESSION_UPLOAD_ALREADY_EXISTS.name
+          metadata[Errors.Metadata.DATA_PROVIDER_RESOURCE_ID.key] = DATA_PROVIDER_RESOURCE_ID
+        }
+      )
+  }
+
+  @Test
   fun `createRawImpressionUpload throws INVALID_ARGUMENT if data_provider_resource_id not set`():
     Unit = runBlocking {
     val exception: StatusRuntimeException =

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/service/v1alpha/ImpressionMetadataService.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/service/v1alpha/ImpressionMetadataService.kt
@@ -149,6 +149,7 @@ class ImpressionMetadataService(
           InternalErrors.Reason.RANK_INDEX_BLOB_NOT_FOUND,
           InternalErrors.Reason.RANK_INDEX_BLOB_ALREADY_EXISTS,
           InternalErrors.Reason.RAW_IMPRESSION_UPLOAD_MODEL_LINE_CONCURRENT,
+          InternalErrors.Reason.RAW_IMPRESSION_UPLOAD_ALREADY_EXISTS,
           null -> Status.INTERNAL.withCause(e).asRuntimeException()
         }
       }
@@ -219,6 +220,7 @@ class ImpressionMetadataService(
           InternalErrors.Reason.RANK_INDEX_BLOB_NOT_FOUND,
           InternalErrors.Reason.RANK_INDEX_BLOB_ALREADY_EXISTS,
           InternalErrors.Reason.RAW_IMPRESSION_UPLOAD_MODEL_LINE_CONCURRENT,
+          InternalErrors.Reason.RAW_IMPRESSION_UPLOAD_ALREADY_EXISTS,
           null -> Status.INTERNAL.withCause(e).asRuntimeException()
         }
       }
@@ -328,6 +330,7 @@ class ImpressionMetadataService(
           InternalErrors.Reason.RANK_INDEX_BLOB_NOT_FOUND,
           InternalErrors.Reason.RANK_INDEX_BLOB_ALREADY_EXISTS,
           InternalErrors.Reason.RAW_IMPRESSION_UPLOAD_MODEL_LINE_CONCURRENT,
+          InternalErrors.Reason.RAW_IMPRESSION_UPLOAD_ALREADY_EXISTS,
           null -> Status.INTERNAL.withCause(e).asRuntimeException()
         }
       }
@@ -406,6 +409,7 @@ class ImpressionMetadataService(
           InternalErrors.Reason.RANK_INDEX_BLOB_NOT_FOUND,
           InternalErrors.Reason.RANK_INDEX_BLOB_ALREADY_EXISTS,
           InternalErrors.Reason.RAW_IMPRESSION_UPLOAD_MODEL_LINE_CONCURRENT,
+          InternalErrors.Reason.RAW_IMPRESSION_UPLOAD_ALREADY_EXISTS,
           null -> Status.INTERNAL.withCause(e).asRuntimeException()
         }
       }
@@ -516,6 +520,7 @@ class ImpressionMetadataService(
           InternalErrors.Reason.RANK_INDEX_BLOB_NOT_FOUND,
           InternalErrors.Reason.RANK_INDEX_BLOB_ALREADY_EXISTS,
           InternalErrors.Reason.RAW_IMPRESSION_UPLOAD_MODEL_LINE_CONCURRENT,
+          InternalErrors.Reason.RAW_IMPRESSION_UPLOAD_ALREADY_EXISTS,
           null -> Status.INTERNAL.withCause(e).asRuntimeException()
         }
       }
@@ -586,6 +591,7 @@ class ImpressionMetadataService(
         InternalErrors.Reason.RANK_INDEX_BLOB_NOT_FOUND,
         InternalErrors.Reason.RANK_INDEX_BLOB_ALREADY_EXISTS,
         InternalErrors.Reason.RAW_IMPRESSION_UPLOAD_MODEL_LINE_CONCURRENT,
+        InternalErrors.Reason.RAW_IMPRESSION_UPLOAD_ALREADY_EXISTS,
         null -> Status.INTERNAL.withCause(e).asRuntimeException()
       }
     }
@@ -684,6 +690,7 @@ class ImpressionMetadataService(
           InternalErrors.Reason.RANK_INDEX_BLOB_NOT_FOUND,
           InternalErrors.Reason.RANK_INDEX_BLOB_ALREADY_EXISTS,
           InternalErrors.Reason.RAW_IMPRESSION_UPLOAD_MODEL_LINE_CONCURRENT,
+          InternalErrors.Reason.RAW_IMPRESSION_UPLOAD_ALREADY_EXISTS,
           null -> Status.INTERNAL.withCause(e).asRuntimeException()
         }
       }
@@ -815,6 +822,7 @@ class ImpressionMetadataService(
           InternalErrors.Reason.RANK_INDEX_BLOB_NOT_FOUND,
           InternalErrors.Reason.RANK_INDEX_BLOB_ALREADY_EXISTS,
           InternalErrors.Reason.RAW_IMPRESSION_UPLOAD_MODEL_LINE_CONCURRENT,
+          InternalErrors.Reason.RAW_IMPRESSION_UPLOAD_ALREADY_EXISTS,
           null -> Status.INTERNAL.withCause(e).asRuntimeException()
         }
       }
@@ -884,6 +892,7 @@ class ImpressionMetadataService(
           InternalErrors.Reason.RANK_INDEX_BLOB_NOT_FOUND,
           InternalErrors.Reason.RANK_INDEX_BLOB_ALREADY_EXISTS,
           InternalErrors.Reason.RAW_IMPRESSION_UPLOAD_MODEL_LINE_CONCURRENT,
+          InternalErrors.Reason.RAW_IMPRESSION_UPLOAD_ALREADY_EXISTS,
           null -> Status.INTERNAL.withCause(e).asRuntimeException()
         }
       }

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/service/v1alpha/PoolAssignmentJobService.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/service/v1alpha/PoolAssignmentJobService.kt
@@ -456,6 +456,7 @@ private fun handleInternalError(e: StatusException): StatusRuntimeException {
     InternalErrors.Reason.RAW_IMPRESSION_UPLOAD_MODEL_LINE_NOT_FOUND,
     InternalErrors.Reason.RAW_IMPRESSION_UPLOAD_MODEL_LINE_STATE_INVALID,
     InternalErrors.Reason.RAW_IMPRESSION_UPLOAD_MODEL_LINE_CONCURRENT,
+    InternalErrors.Reason.RAW_IMPRESSION_UPLOAD_ALREADY_EXISTS,
     null -> Status.INTERNAL.withCause(e).asRuntimeException()
     InternalErrors.Reason.RAW_IMPRESSION_UPLOAD_NOT_FOUND,
     InternalErrors.Reason.POOL_ASSIGNMENT_JOB_NOT_FOUND ->

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/service/v1alpha/RankIndexBlobService.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/service/v1alpha/RankIndexBlobService.kt
@@ -476,6 +476,7 @@ class RankIndexBlobService(
         InternalErrors.Reason.POOL_ASSIGNMENT_JOB_NOT_FOUND,
         InternalErrors.Reason.POOL_ASSIGNMENT_JOB_STATE_INVALID,
         InternalErrors.Reason.POOL_ASSIGNMENT_JOB_ALREADY_EXISTS,
+        InternalErrors.Reason.RAW_IMPRESSION_UPLOAD_ALREADY_EXISTS,
         null -> Status.INTERNAL.withCause(e).asRuntimeException()
       }
     }

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/service/v1alpha/RankerJobService.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/service/v1alpha/RankerJobService.kt
@@ -453,6 +453,7 @@ class RankerJobService(
         InternalErrors.Reason.POOL_ASSIGNMENT_JOB_NOT_FOUND,
         InternalErrors.Reason.POOL_ASSIGNMENT_JOB_STATE_INVALID,
         InternalErrors.Reason.POOL_ASSIGNMENT_JOB_ALREADY_EXISTS,
+        InternalErrors.Reason.RAW_IMPRESSION_UPLOAD_ALREADY_EXISTS,
         null -> Status.INTERNAL.withCause(e).asRuntimeException()
       }
     }

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/service/v1alpha/RawImpressionMetadataBatchFileService.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/service/v1alpha/RawImpressionMetadataBatchFileService.kt
@@ -153,6 +153,7 @@ class RawImpressionMetadataBatchFileService(
           InternalErrors.Reason.RANK_INDEX_BLOB_NOT_FOUND,
           InternalErrors.Reason.RANK_INDEX_BLOB_ALREADY_EXISTS,
           InternalErrors.Reason.RAW_IMPRESSION_UPLOAD_MODEL_LINE_CONCURRENT,
+          InternalErrors.Reason.RAW_IMPRESSION_UPLOAD_ALREADY_EXISTS,
           null -> Status.INTERNAL.withCause(e).asRuntimeException()
         }
       }
@@ -281,6 +282,7 @@ class RawImpressionMetadataBatchFileService(
           InternalErrors.Reason.RANK_INDEX_BLOB_NOT_FOUND,
           InternalErrors.Reason.RANK_INDEX_BLOB_ALREADY_EXISTS,
           InternalErrors.Reason.RAW_IMPRESSION_UPLOAD_MODEL_LINE_CONCURRENT,
+          InternalErrors.Reason.RAW_IMPRESSION_UPLOAD_ALREADY_EXISTS,
           null -> Status.INTERNAL.withCause(e).asRuntimeException()
         }
       }
@@ -352,6 +354,7 @@ class RawImpressionMetadataBatchFileService(
           InternalErrors.Reason.RANK_INDEX_BLOB_NOT_FOUND,
           InternalErrors.Reason.RANK_INDEX_BLOB_ALREADY_EXISTS,
           InternalErrors.Reason.RAW_IMPRESSION_UPLOAD_MODEL_LINE_CONCURRENT,
+          InternalErrors.Reason.RAW_IMPRESSION_UPLOAD_ALREADY_EXISTS,
           null -> Status.INTERNAL.withCause(e).asRuntimeException()
         }
       }
@@ -460,6 +463,7 @@ class RawImpressionMetadataBatchFileService(
           InternalErrors.Reason.RANK_INDEX_BLOB_NOT_FOUND,
           InternalErrors.Reason.RANK_INDEX_BLOB_ALREADY_EXISTS,
           InternalErrors.Reason.RAW_IMPRESSION_UPLOAD_MODEL_LINE_CONCURRENT,
+          InternalErrors.Reason.RAW_IMPRESSION_UPLOAD_ALREADY_EXISTS,
           null -> Status.INTERNAL.withCause(e).asRuntimeException()
         }
       }
@@ -534,6 +538,7 @@ class RawImpressionMetadataBatchFileService(
           InternalErrors.Reason.RANK_INDEX_BLOB_NOT_FOUND,
           InternalErrors.Reason.RANK_INDEX_BLOB_ALREADY_EXISTS,
           InternalErrors.Reason.RAW_IMPRESSION_UPLOAD_MODEL_LINE_CONCURRENT,
+          InternalErrors.Reason.RAW_IMPRESSION_UPLOAD_ALREADY_EXISTS,
           null -> Status.INTERNAL.withCause(e).asRuntimeException()
         }
       }
@@ -638,6 +643,7 @@ class RawImpressionMetadataBatchFileService(
           InternalErrors.Reason.RANK_INDEX_BLOB_NOT_FOUND,
           InternalErrors.Reason.RANK_INDEX_BLOB_ALREADY_EXISTS,
           InternalErrors.Reason.RAW_IMPRESSION_UPLOAD_MODEL_LINE_CONCURRENT,
+          InternalErrors.Reason.RAW_IMPRESSION_UPLOAD_ALREADY_EXISTS,
           null -> Status.INTERNAL.withCause(e).asRuntimeException()
         }
       }

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/service/v1alpha/RawImpressionMetadataBatchService.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/service/v1alpha/RawImpressionMetadataBatchService.kt
@@ -128,6 +128,7 @@ class RawImpressionMetadataBatchService(
           InternalErrors.Reason.RANK_INDEX_BLOB_NOT_FOUND,
           InternalErrors.Reason.RANK_INDEX_BLOB_ALREADY_EXISTS,
           InternalErrors.Reason.RAW_IMPRESSION_UPLOAD_MODEL_LINE_CONCURRENT,
+          InternalErrors.Reason.RAW_IMPRESSION_UPLOAD_ALREADY_EXISTS,
           null -> Status.INTERNAL.withCause(e).asRuntimeException()
         }
       }
@@ -195,6 +196,7 @@ class RawImpressionMetadataBatchService(
           InternalErrors.Reason.RANK_INDEX_BLOB_NOT_FOUND,
           InternalErrors.Reason.RANK_INDEX_BLOB_ALREADY_EXISTS,
           InternalErrors.Reason.RAW_IMPRESSION_UPLOAD_MODEL_LINE_CONCURRENT,
+          InternalErrors.Reason.RAW_IMPRESSION_UPLOAD_ALREADY_EXISTS,
           null -> Status.INTERNAL.withCause(e).asRuntimeException()
         }
       }
@@ -294,6 +296,7 @@ class RawImpressionMetadataBatchService(
           InternalErrors.Reason.RANK_INDEX_BLOB_NOT_FOUND,
           InternalErrors.Reason.RANK_INDEX_BLOB_ALREADY_EXISTS,
           InternalErrors.Reason.RAW_IMPRESSION_UPLOAD_MODEL_LINE_CONCURRENT,
+          InternalErrors.Reason.RAW_IMPRESSION_UPLOAD_ALREADY_EXISTS,
           null -> Status.INTERNAL.withCause(e).asRuntimeException()
         }
       }
@@ -367,6 +370,7 @@ class RawImpressionMetadataBatchService(
           InternalErrors.Reason.RANK_INDEX_BLOB_NOT_FOUND,
           InternalErrors.Reason.RANK_INDEX_BLOB_ALREADY_EXISTS,
           InternalErrors.Reason.RAW_IMPRESSION_UPLOAD_MODEL_LINE_CONCURRENT,
+          InternalErrors.Reason.RAW_IMPRESSION_UPLOAD_ALREADY_EXISTS,
           null -> Status.INTERNAL.withCause(e).asRuntimeException()
         }
       }
@@ -435,6 +439,7 @@ class RawImpressionMetadataBatchService(
           InternalErrors.Reason.RANK_INDEX_BLOB_NOT_FOUND,
           InternalErrors.Reason.RANK_INDEX_BLOB_ALREADY_EXISTS,
           InternalErrors.Reason.RAW_IMPRESSION_UPLOAD_MODEL_LINE_CONCURRENT,
+          InternalErrors.Reason.RAW_IMPRESSION_UPLOAD_ALREADY_EXISTS,
           null -> Status.INTERNAL.withCause(e).asRuntimeException()
         }
       }
@@ -503,6 +508,7 @@ class RawImpressionMetadataBatchService(
           InternalErrors.Reason.RANK_INDEX_BLOB_NOT_FOUND,
           InternalErrors.Reason.RANK_INDEX_BLOB_ALREADY_EXISTS,
           InternalErrors.Reason.RAW_IMPRESSION_UPLOAD_MODEL_LINE_CONCURRENT,
+          InternalErrors.Reason.RAW_IMPRESSION_UPLOAD_ALREADY_EXISTS,
           null -> Status.INTERNAL.withCause(e).asRuntimeException()
         }
       }

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/service/v1alpha/RawImpressionUploadFileService.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/service/v1alpha/RawImpressionUploadFileService.kt
@@ -158,6 +158,7 @@ class RawImpressionUploadFileService(
           InternalErrors.Reason.POOL_ASSIGNMENT_JOB_NOT_FOUND,
           InternalErrors.Reason.POOL_ASSIGNMENT_JOB_STATE_INVALID,
           InternalErrors.Reason.POOL_ASSIGNMENT_JOB_ALREADY_EXISTS,
+          InternalErrors.Reason.RAW_IMPRESSION_UPLOAD_ALREADY_EXISTS,
           null -> Status.INTERNAL.withCause(e).asRuntimeException()
         }
       }
@@ -294,6 +295,7 @@ class RawImpressionUploadFileService(
           InternalErrors.Reason.POOL_ASSIGNMENT_JOB_NOT_FOUND,
           InternalErrors.Reason.POOL_ASSIGNMENT_JOB_STATE_INVALID,
           InternalErrors.Reason.POOL_ASSIGNMENT_JOB_ALREADY_EXISTS,
+          InternalErrors.Reason.RAW_IMPRESSION_UPLOAD_ALREADY_EXISTS,
           null -> Status.INTERNAL.withCause(e).asRuntimeException()
         }
       }
@@ -366,6 +368,7 @@ class RawImpressionUploadFileService(
           InternalErrors.Reason.POOL_ASSIGNMENT_JOB_NOT_FOUND,
           InternalErrors.Reason.POOL_ASSIGNMENT_JOB_STATE_INVALID,
           InternalErrors.Reason.POOL_ASSIGNMENT_JOB_ALREADY_EXISTS,
+          InternalErrors.Reason.RAW_IMPRESSION_UPLOAD_ALREADY_EXISTS,
           null -> Status.INTERNAL.withCause(e).asRuntimeException()
         }
       }
@@ -478,6 +481,7 @@ class RawImpressionUploadFileService(
           InternalErrors.Reason.POOL_ASSIGNMENT_JOB_NOT_FOUND,
           InternalErrors.Reason.POOL_ASSIGNMENT_JOB_STATE_INVALID,
           InternalErrors.Reason.POOL_ASSIGNMENT_JOB_ALREADY_EXISTS,
+          InternalErrors.Reason.RAW_IMPRESSION_UPLOAD_ALREADY_EXISTS,
           null -> Status.INTERNAL.withCause(e).asRuntimeException()
         }
       }
@@ -553,6 +557,7 @@ class RawImpressionUploadFileService(
           InternalErrors.Reason.POOL_ASSIGNMENT_JOB_NOT_FOUND,
           InternalErrors.Reason.POOL_ASSIGNMENT_JOB_STATE_INVALID,
           InternalErrors.Reason.POOL_ASSIGNMENT_JOB_ALREADY_EXISTS,
+          InternalErrors.Reason.RAW_IMPRESSION_UPLOAD_ALREADY_EXISTS,
           null -> Status.INTERNAL.withCause(e).asRuntimeException()
         }
       }
@@ -673,6 +678,7 @@ class RawImpressionUploadFileService(
           InternalErrors.Reason.POOL_ASSIGNMENT_JOB_NOT_FOUND,
           InternalErrors.Reason.POOL_ASSIGNMENT_JOB_STATE_INVALID,
           InternalErrors.Reason.POOL_ASSIGNMENT_JOB_ALREADY_EXISTS,
+          InternalErrors.Reason.RAW_IMPRESSION_UPLOAD_ALREADY_EXISTS,
           null -> Status.INTERNAL.withCause(e).asRuntimeException()
         }
       }

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/service/v1alpha/RawImpressionUploadModelLineService.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/service/v1alpha/RawImpressionUploadModelLineService.kt
@@ -542,6 +542,7 @@ class RawImpressionUploadModelLineService(
       InternalErrors.Reason.POOL_ASSIGNMENT_JOB_NOT_FOUND,
       InternalErrors.Reason.POOL_ASSIGNMENT_JOB_STATE_INVALID,
       InternalErrors.Reason.POOL_ASSIGNMENT_JOB_ALREADY_EXISTS,
+      InternalErrors.Reason.RAW_IMPRESSION_UPLOAD_ALREADY_EXISTS,
       null -> Status.INTERNAL.withCause(e).asRuntimeException()
     }
   }

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/service/v1alpha/RawImpressionUploadService.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/service/v1alpha/RawImpressionUploadService.kt
@@ -135,6 +135,8 @@ class RawImpressionUploadService(
           InternalErrors.Reason.POOL_ASSIGNMENT_JOB_STATE_INVALID,
           InternalErrors.Reason.POOL_ASSIGNMENT_JOB_ALREADY_EXISTS,
           null -> Status.INTERNAL.withCause(e).asRuntimeException()
+          InternalErrors.Reason.RAW_IMPRESSION_UPLOAD_ALREADY_EXISTS ->
+            Status.ALREADY_EXISTS.withCause(e).asRuntimeException()
         }
       }
 
@@ -201,6 +203,7 @@ class RawImpressionUploadService(
           InternalErrors.Reason.POOL_ASSIGNMENT_JOB_NOT_FOUND,
           InternalErrors.Reason.POOL_ASSIGNMENT_JOB_STATE_INVALID,
           InternalErrors.Reason.POOL_ASSIGNMENT_JOB_ALREADY_EXISTS,
+          InternalErrors.Reason.RAW_IMPRESSION_UPLOAD_ALREADY_EXISTS,
           null -> Status.INTERNAL.withCause(e).asRuntimeException()
         }
       }
@@ -314,6 +317,7 @@ class RawImpressionUploadService(
           InternalErrors.Reason.POOL_ASSIGNMENT_JOB_NOT_FOUND,
           InternalErrors.Reason.POOL_ASSIGNMENT_JOB_STATE_INVALID,
           InternalErrors.Reason.POOL_ASSIGNMENT_JOB_ALREADY_EXISTS,
+          InternalErrors.Reason.RAW_IMPRESSION_UPLOAD_ALREADY_EXISTS,
           null -> Status.INTERNAL.withCause(e).asRuntimeException()
         }
       }

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/service/v1alpha/RequisitionMetadataService.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/service/v1alpha/RequisitionMetadataService.kt
@@ -170,6 +170,7 @@ class RequisitionMetadataService(
           InternalErrors.Reason.RANK_INDEX_BLOB_NOT_FOUND,
           InternalErrors.Reason.RANK_INDEX_BLOB_ALREADY_EXISTS,
           InternalErrors.Reason.RAW_IMPRESSION_UPLOAD_MODEL_LINE_CONCURRENT,
+          InternalErrors.Reason.RAW_IMPRESSION_UPLOAD_ALREADY_EXISTS,
           null -> Status.INTERNAL.withCause(e).asRuntimeException()
         }
       }
@@ -293,6 +294,7 @@ class RequisitionMetadataService(
           InternalErrors.Reason.RANK_INDEX_BLOB_NOT_FOUND,
           InternalErrors.Reason.RANK_INDEX_BLOB_ALREADY_EXISTS,
           InternalErrors.Reason.RAW_IMPRESSION_UPLOAD_MODEL_LINE_CONCURRENT,
+          InternalErrors.Reason.RAW_IMPRESSION_UPLOAD_ALREADY_EXISTS,
           null -> Status.INTERNAL.withCause(e).asRuntimeException()
         }
       }
@@ -357,6 +359,7 @@ class RequisitionMetadataService(
           InternalErrors.Reason.RANK_INDEX_BLOB_NOT_FOUND,
           InternalErrors.Reason.RANK_INDEX_BLOB_ALREADY_EXISTS,
           InternalErrors.Reason.RAW_IMPRESSION_UPLOAD_MODEL_LINE_CONCURRENT,
+          InternalErrors.Reason.RAW_IMPRESSION_UPLOAD_ALREADY_EXISTS,
           null -> Status.INTERNAL.withCause(e).asRuntimeException()
         }
       }
@@ -461,6 +464,7 @@ class RequisitionMetadataService(
           InternalErrors.Reason.RANK_INDEX_BLOB_NOT_FOUND,
           InternalErrors.Reason.RANK_INDEX_BLOB_ALREADY_EXISTS,
           InternalErrors.Reason.RAW_IMPRESSION_UPLOAD_MODEL_LINE_CONCURRENT,
+          InternalErrors.Reason.RAW_IMPRESSION_UPLOAD_ALREADY_EXISTS,
           null -> Status.INTERNAL.withCause(e).asRuntimeException()
         }
       }
@@ -537,6 +541,7 @@ class RequisitionMetadataService(
           InternalErrors.Reason.RANK_INDEX_BLOB_NOT_FOUND,
           InternalErrors.Reason.RANK_INDEX_BLOB_ALREADY_EXISTS,
           InternalErrors.Reason.RAW_IMPRESSION_UPLOAD_MODEL_LINE_CONCURRENT,
+          InternalErrors.Reason.RAW_IMPRESSION_UPLOAD_ALREADY_EXISTS,
           null -> Status.INTERNAL.withCause(e).asRuntimeException()
         }
       }
@@ -594,6 +599,7 @@ class RequisitionMetadataService(
         InternalErrors.Reason.RANK_INDEX_BLOB_NOT_FOUND,
         InternalErrors.Reason.RANK_INDEX_BLOB_ALREADY_EXISTS,
         InternalErrors.Reason.RAW_IMPRESSION_UPLOAD_MODEL_LINE_CONCURRENT,
+        InternalErrors.Reason.RAW_IMPRESSION_UPLOAD_ALREADY_EXISTS,
         null -> Status.INTERNAL.withCause(e).asRuntimeException()
       }
     }
@@ -666,6 +672,7 @@ class RequisitionMetadataService(
           InternalErrors.Reason.RANK_INDEX_BLOB_NOT_FOUND,
           InternalErrors.Reason.RANK_INDEX_BLOB_ALREADY_EXISTS,
           InternalErrors.Reason.RAW_IMPRESSION_UPLOAD_MODEL_LINE_CONCURRENT,
+          InternalErrors.Reason.RAW_IMPRESSION_UPLOAD_ALREADY_EXISTS,
           null -> Status.INTERNAL.withCause(e).asRuntimeException()
         }
       }
@@ -736,6 +743,7 @@ class RequisitionMetadataService(
           InternalErrors.Reason.RANK_INDEX_BLOB_NOT_FOUND,
           InternalErrors.Reason.RANK_INDEX_BLOB_ALREADY_EXISTS,
           InternalErrors.Reason.RAW_IMPRESSION_UPLOAD_MODEL_LINE_CONCURRENT,
+          InternalErrors.Reason.RAW_IMPRESSION_UPLOAD_ALREADY_EXISTS,
           null -> Status.INTERNAL.withCause(e).asRuntimeException()
         }
       }
@@ -806,6 +814,7 @@ class RequisitionMetadataService(
           InternalErrors.Reason.RANK_INDEX_BLOB_NOT_FOUND,
           InternalErrors.Reason.RANK_INDEX_BLOB_ALREADY_EXISTS,
           InternalErrors.Reason.RAW_IMPRESSION_UPLOAD_MODEL_LINE_CONCURRENT,
+          InternalErrors.Reason.RAW_IMPRESSION_UPLOAD_ALREADY_EXISTS,
           null -> Status.INTERNAL.withCause(e).asRuntimeException()
         }
       }
@@ -881,6 +890,7 @@ class RequisitionMetadataService(
           InternalErrors.Reason.RANK_INDEX_BLOB_NOT_FOUND,
           InternalErrors.Reason.RANK_INDEX_BLOB_ALREADY_EXISTS,
           InternalErrors.Reason.RAW_IMPRESSION_UPLOAD_MODEL_LINE_CONCURRENT,
+          InternalErrors.Reason.RAW_IMPRESSION_UPLOAD_ALREADY_EXISTS,
           null -> Status.INTERNAL.withCause(e).asRuntimeException()
         }
       }
@@ -951,6 +961,7 @@ class RequisitionMetadataService(
           InternalErrors.Reason.RANK_INDEX_BLOB_NOT_FOUND,
           InternalErrors.Reason.RANK_INDEX_BLOB_ALREADY_EXISTS,
           InternalErrors.Reason.RAW_IMPRESSION_UPLOAD_MODEL_LINE_CONCURRENT,
+          InternalErrors.Reason.RAW_IMPRESSION_UPLOAD_ALREADY_EXISTS,
           null -> Status.INTERNAL.withCause(e).asRuntimeException()
         }
       }

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/service/v1alpha/VidLabelingJobService.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/service/v1alpha/VidLabelingJobService.kt
@@ -440,6 +440,7 @@ class VidLabelingJobService(
       InternalErrors.Reason.POOL_ASSIGNMENT_JOB_NOT_FOUND,
       InternalErrors.Reason.POOL_ASSIGNMENT_JOB_STATE_INVALID,
       InternalErrors.Reason.POOL_ASSIGNMENT_JOB_ALREADY_EXISTS,
+      InternalErrors.Reason.RAW_IMPRESSION_UPLOAD_ALREADY_EXISTS,
       null -> Status.INTERNAL.withCause(e).asRuntimeException()
       InternalErrors.Reason.RAW_IMPRESSION_UPLOAD_NOT_FOUND,
       InternalErrors.Reason.VID_LABELING_JOB_NOT_FOUND ->


### PR DESCRIPTION
On a `request_id` idempotency match, `createRawImpressionUpload` returned the existing row without verifying field consistency; per AIP-155 it now throws `ALREADY_EXISTS` when the existing `done_blob_uri` differs from the request. This prevents a reused `request_id` with a different `done_blob_uri` from returning the wrong upload and a TEE labeling the wrong files.

Issue: #4117
