### PR TITLE
feat(reporting): enable custom groups in CreateBasicReport via campaign-group synthesis

### DIFF
--- a/src/main/kotlin/org/wfanet/measurement/integration/common/reporting/v2/InProcessMultiEdpReportIntegrationTest.kt
+++ b/src/main/kotlin/org/wfanet/measurement/integration/common/reporting/v2/InProcessMultiEdpReportIntegrationTest.kt
@@ -614,7 +614,8 @@ abstract class InProcessMultiEdpReportIntegrationTest(
                           reach = true
                           percentReach = true
                         }
-                      cumulativeUnique = ResultGroupMetricSpecKt.uniqueMetricSetSpec { reach = true }
+                      cumulativeUnique =
+                        ResultGroupMetricSpecKt.uniqueMetricSetSpec { reach = true }
                     }
                 }
               }

--- a/src/main/kotlin/org/wfanet/measurement/integration/common/reporting/v2/InProcessMultiEdpReportIntegrationTest.kt
+++ b/src/main/kotlin/org/wfanet/measurement/integration/common/reporting/v2/InProcessMultiEdpReportIntegrationTest.kt
@@ -548,6 +548,108 @@ abstract class InProcessMultiEdpReportIntegrationTest(
       }
     }
 
+  @Test
+  fun `getBasicReport returns SUCCEEDED custom group basic report when basic report is completed`() =
+    runBlocking {
+      val measurementConsumerData = inProcessCmmsComponents.getMeasurementConsumerData()
+      val eventGroups = getMultiEdpEventGroups()
+      check(eventGroups.size > 1)
+
+      // One primitive custom group per EDP (empty campaign_group; disjoint DataProvider sets).
+      val customGroups: List<ReportingSet> =
+        eventGroups.mapIndexed { index, eventGroup ->
+          publicReportingSetsClient
+            .withCallCredentials(credentials)
+            .createReportingSet(
+              createReportingSetRequest {
+                parent = measurementConsumerData.name
+                reportingSet = reportingSet {
+                  displayName = "custom group $index"
+                  primitive =
+                    ReportingSetKt.primitive { cmmsEventGroups += eventGroup.cmmsEventGroup }
+                }
+                reportingSetId = "customgroup$index"
+              }
+            )
+        }
+
+      // Reuse the scaffolding (model line, reporting interval, IQF), but drop campaign_group so the
+      // server synthesizes one, and bucket by the custom-group ReportingSets.
+      val createBasicReportRequest =
+        buildCreateBasicReportRequest(eventGroups).copy {
+          basicReport =
+            basicReport.copy {
+              campaignGroup = ""
+              campaignGroupDisplayName = ""
+              resultGroupSpecs.clear()
+              resultGroupSpecs += resultGroupSpec {
+                title = "title"
+                reportingUnit = reportingUnit { components += customGroups.map { it.name } }
+                metricFrequency = metricFrequencySpec { total = true }
+                dimensionSpec = dimensionSpec {
+                  grouping =
+                    DimensionSpecKt.grouping { eventTemplateFields += "person.social_grade_group" }
+                  filters += eventFilter {
+                    terms += eventTemplateField {
+                      path = "person.age_group"
+                      value = EventTemplateFieldKt.fieldValue { enumValue = "YEARS_18_TO_34" }
+                    }
+                  }
+                }
+                resultGroupMetricSpec = resultGroupMetricSpec {
+                  populationSize = true
+                  reportingUnit =
+                    ResultGroupMetricSpecKt.reportingUnitMetricSetSpec {
+                      cumulative =
+                        ResultGroupMetricSpecKt.basicMetricSetSpec {
+                          reach = true
+                          percentReach = true
+                        }
+                      stackedIncrementalReach = true
+                    }
+                  component =
+                    ResultGroupMetricSpecKt.componentMetricSetSpec {
+                      cumulative =
+                        ResultGroupMetricSpecKt.basicMetricSetSpec {
+                          reach = true
+                          percentReach = true
+                        }
+                      cumulativeUnique = ResultGroupMetricSpecKt.uniqueMetricSetSpec { reach = true }
+                    }
+                }
+              }
+            }
+        }
+
+      val createdBasicReport =
+        publicBasicReportsClient
+          .withCallCredentials(credentials)
+          .createBasicReport(createBasicReportRequest)
+
+      // campaign_group is empty; the synthesized one is surfaced only via effective_campaign_group.
+      assertThat(createdBasicReport.campaignGroup).isEmpty()
+      assertThat(createdBasicReport.effectiveCampaignGroup).isNotEmpty()
+
+      executeBasicReportsReportsJob(createdBasicReport.name)
+      executeReportProcessorJob()
+
+      val retrievedCompletedBasicReport =
+        publicBasicReportsClient
+          .withCallCredentials(credentials)
+          .getBasicReport(getBasicReportRequest { name = createdBasicReport.name })
+
+      assertThat(retrievedCompletedBasicReport.state).isEqualTo(BasicReport.State.SUCCEEDED)
+
+      // Results are bucketed by the custom-group ReportingSet resource names.
+      val componentKeys =
+        retrievedCompletedBasicReport.resultGroupsList
+          .flatMap { it.resultsList }
+          .flatMap { it.metricSet.componentsList }
+          .map { it.key }
+          .toSet()
+      assertThat(componentKeys).containsAtLeastElementsIn(customGroups.map { it.name })
+    }
+
   private fun assertExpectedProtocolUsed(measurements: List<Measurement>) {
     assertWithMessage("measurements").that(measurements).isNotEmpty()
     var expectedProtocolFound = false

--- a/src/main/kotlin/org/wfanet/measurement/integration/common/reporting/v2/InProcessMultiEdpReportIntegrationTest.kt
+++ b/src/main/kotlin/org/wfanet/measurement/integration/common/reporting/v2/InProcessMultiEdpReportIntegrationTest.kt
@@ -639,8 +639,6 @@ abstract class InProcessMultiEdpReportIntegrationTest(
           .withCallCredentials(credentials)
           .getBasicReport(getBasicReportRequest { name = createdBasicReport.name })
 
-      assertThat(retrievedCompletedBasicReport.state).isEqualTo(BasicReport.State.SUCCEEDED)
-
       // Results are bucketed by the custom-group ReportingSet resource names.
       val componentKeys =
         retrievedCompletedBasicReport.resultGroupsList
@@ -649,6 +647,8 @@ abstract class InProcessMultiEdpReportIntegrationTest(
           .map { it.key }
           .toSet()
       assertThat(componentKeys).containsAtLeastElementsIn(customGroups.map { it.name })
+
+      assertThat(retrievedCompletedBasicReport.state).isEqualTo(BasicReport.State.SUCCEEDED)
     }
 
   private fun assertExpectedProtocolUsed(measurements: List<Measurement>) {

--- a/src/main/kotlin/org/wfanet/measurement/integration/common/reporting/v2/InProcessMultiEdpReportIntegrationTest.kt
+++ b/src/main/kotlin/org/wfanet/measurement/integration/common/reporting/v2/InProcessMultiEdpReportIntegrationTest.kt
@@ -552,12 +552,22 @@ abstract class InProcessMultiEdpReportIntegrationTest(
   fun `getBasicReport returns SUCCEEDED custom group basic report when basic report is completed`() =
     runBlocking {
       val measurementConsumerData = inProcessCmmsComponents.getMeasurementConsumerData()
-      val eventGroups = getMultiEdpEventGroups()
-      check(eventGroups.size > 1)
 
-      // One primitive custom group per EDP (empty campaign_group; disjoint DataProvider sets).
+      // One EventGroup per EDP (DataProvider); the harness creates exactly one per EDP.
+      val eventGroupPerEdp: List<EventGroup> =
+        listEventGroups().groupBy { it.cmmsDataProvider }.values.map { it.first() }
+      check(eventGroupPerEdp.size >= 4)
+
+      // Two custom groups, each spanning two EDPs, with disjoint EventGroups and distinct
+      // DataProvider sets ({edp0, edp1} and {edp2, edp3}). The groups cross publishers without
+      // overlapping, so no metric is double-counted -- the recommended client usage.
+      val customGroupEventGroups: List<List<String>> =
+        listOf(
+          listOf(eventGroupPerEdp[0].cmmsEventGroup, eventGroupPerEdp[1].cmmsEventGroup),
+          listOf(eventGroupPerEdp[2].cmmsEventGroup, eventGroupPerEdp[3].cmmsEventGroup),
+        )
       val customGroups: List<ReportingSet> =
-        eventGroups.mapIndexed { index, eventGroup ->
+        customGroupEventGroups.mapIndexed { index, cmmsEventGroupNames ->
           publicReportingSetsClient
             .withCallCredentials(credentials)
             .createReportingSet(
@@ -565,8 +575,7 @@ abstract class InProcessMultiEdpReportIntegrationTest(
                 parent = measurementConsumerData.name
                 reportingSet = reportingSet {
                   displayName = "custom group $index"
-                  primitive =
-                    ReportingSetKt.primitive { cmmsEventGroups += eventGroup.cmmsEventGroup }
+                  primitive = ReportingSetKt.primitive { cmmsEventGroups += cmmsEventGroupNames }
                 }
                 reportingSetId = "customgroup$index"
               }
@@ -576,7 +585,7 @@ abstract class InProcessMultiEdpReportIntegrationTest(
       // Reuse the scaffolding (model line, reporting interval, IQF), but drop campaign_group so the
       // server synthesizes one, and bucket by the custom-group ReportingSets.
       val createBasicReportRequest =
-        buildCreateBasicReportRequest(eventGroups).copy {
+        buildCreateBasicReportRequest(eventGroupPerEdp).copy {
           basicReport =
             basicReport.copy {
               campaignGroup = ""

--- a/src/main/kotlin/org/wfanet/measurement/integration/common/reporting/v2/InProcessMultiEdpReportIntegrationTest.kt
+++ b/src/main/kotlin/org/wfanet/measurement/integration/common/reporting/v2/InProcessMultiEdpReportIntegrationTest.kt
@@ -549,7 +549,7 @@ abstract class InProcessMultiEdpReportIntegrationTest(
     }
 
   @Test
-  fun `getBasicReport returns SUCCEEDED custom group basic report when basic report is completed`() =
+  fun `getBasicReport returns SUCCEEDED ReportingSet basic report when basic report is completed`() =
     runBlocking {
       val measurementConsumerData = inProcessCmmsComponents.getMeasurementConsumerData()
 
@@ -558,32 +558,32 @@ abstract class InProcessMultiEdpReportIntegrationTest(
         listEventGroups().groupBy { it.cmmsDataProvider }.values.map { it.first() }
       check(eventGroupPerEdp.size >= 4)
 
-      // Two custom groups, each spanning two EDPs, with disjoint EventGroups and distinct
-      // DataProvider sets ({edp0, edp1} and {edp2, edp3}). The groups cross publishers without
+      // Two ReportingSet components, each spanning two EDPs, with disjoint EventGroups and distinct
+      // DataProvider sets ({edp0, edp1} and {edp2, edp3}). The components cross publishers without
       // overlapping, so no metric is double-counted -- the recommended client usage.
-      val customGroupEventGroups: List<List<String>> =
+      val reportingSetComponentEventGroups: List<List<String>> =
         listOf(
           listOf(eventGroupPerEdp[0].cmmsEventGroup, eventGroupPerEdp[1].cmmsEventGroup),
           listOf(eventGroupPerEdp[2].cmmsEventGroup, eventGroupPerEdp[3].cmmsEventGroup),
         )
-      val customGroups: List<ReportingSet> =
-        customGroupEventGroups.mapIndexed { index, cmmsEventGroupNames ->
+      val reportingSetComponents: List<ReportingSet> =
+        reportingSetComponentEventGroups.mapIndexed { index, cmmsEventGroupNames ->
           publicReportingSetsClient
             .withCallCredentials(credentials)
             .createReportingSet(
               createReportingSetRequest {
                 parent = measurementConsumerData.name
                 reportingSet = reportingSet {
-                  displayName = "custom group $index"
+                  displayName = "ReportingSet component $index"
                   primitive = ReportingSetKt.primitive { cmmsEventGroups += cmmsEventGroupNames }
                 }
-                reportingSetId = "customgroup$index"
+                reportingSetId = "reportingset$index"
               }
             )
         }
 
       // Reuse the scaffolding (model line, reporting interval, IQF), but drop campaign_group so the
-      // server synthesizes one, and bucket by the custom-group ReportingSets.
+      // server synthesizes one, and bucket by the ReportingSet components.
       val createBasicReportRequest =
         buildCreateBasicReportRequest(eventGroupPerEdp).copy {
           basicReport =
@@ -593,7 +593,8 @@ abstract class InProcessMultiEdpReportIntegrationTest(
               resultGroupSpecs.clear()
               resultGroupSpecs += resultGroupSpec {
                 title = "title"
-                reportingUnit = reportingUnit { components += customGroups.map { it.name } }
+                reportingUnit =
+                  reportingUnit { components += reportingSetComponents.map { it.name } }
                 metricFrequency = metricFrequencySpec { total = true }
                 dimensionSpec = dimensionSpec {
                   grouping =
@@ -648,14 +649,14 @@ abstract class InProcessMultiEdpReportIntegrationTest(
           .withCallCredentials(credentials)
           .getBasicReport(getBasicReportRequest { name = createdBasicReport.name })
 
-      // Results are bucketed by the custom-group ReportingSet resource names.
+      // Results are bucketed by the ReportingSet component resource names.
       val componentKeys =
         retrievedCompletedBasicReport.resultGroupsList
           .flatMap { it.resultsList }
           .flatMap { it.metricSet.componentsList }
           .map { it.key }
           .toSet()
-      assertThat(componentKeys).containsAtLeastElementsIn(customGroups.map { it.name })
+      assertThat(componentKeys).containsAtLeastElementsIn(reportingSetComponents.map { it.name })
 
       assertThat(retrievedCompletedBasicReport.state).isEqualTo(BasicReport.State.SUCCEEDED)
     }

--- a/src/main/kotlin/org/wfanet/measurement/integration/common/reporting/v2/InProcessMultiEdpReportIntegrationTest.kt
+++ b/src/main/kotlin/org/wfanet/measurement/integration/common/reporting/v2/InProcessMultiEdpReportIntegrationTest.kt
@@ -593,8 +593,9 @@ abstract class InProcessMultiEdpReportIntegrationTest(
               resultGroupSpecs.clear()
               resultGroupSpecs += resultGroupSpec {
                 title = "title"
-                reportingUnit =
-                  reportingUnit { components += reportingSetComponents.map { it.name } }
+                reportingUnit = reportingUnit {
+                  components += reportingSetComponents.map { it.name }
+                }
                 metricFrequency = metricFrequencySpec { total = true }
                 dimensionSpec = dimensionSpec {
                   grouping =

--- a/src/main/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/BasicReportTransformations.kt
+++ b/src/main/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/BasicReportTransformations.kt
@@ -18,7 +18,6 @@ package org.wfanet.measurement.reporting.service.api.v2alpha
 
 import com.google.protobuf.Descriptors
 import org.wfanet.measurement.api.v2alpha.DataProvider
-import org.wfanet.measurement.api.v2alpha.EventGroup
 import org.wfanet.measurement.api.v2alpha.EventMessageDescriptor
 import org.wfanet.measurement.api.v2alpha.MediaType as CmmsMediaType
 import org.wfanet.measurement.internal.reporting.v2.EventTemplateField as InternalEventTemplateField

--- a/src/main/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/BasicReportTransformations.kt
+++ b/src/main/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/BasicReportTransformations.kt
@@ -68,8 +68,9 @@ private data class MetricCalculationSpecInfo(
  * @param campaignGroupName resource name of [ReportingSet] that is a campaign group
  * @param impressionQualificationFilterSpecsLists List of List of
  *   [ImpressionQualificationFilterSpec] for each [ReportingImpressionQualificationFilter]
- * @param dataProviderPrimitiveReportingSetMap Map of [DataProvider] resource name to primitive
- *   [ReportingSet] containing associated [EventGroup] resource names
+ * @param dataProviderPrimitiveReportingSetMap Map of reporting_unit component resource name to the
+ *   primitive [ReportingSet] used for it. In DataProvider mode the key is a [DataProvider] resource
+ *   name; in custom-group mode the key is a [ReportingSet] (custom group) resource name.
  * @param resultGroupSpecs List of [ResultGroupSpec] to transform
  * @param eventTemplateFieldsByPath Map of EventTemplate field path with respect to Event message to
  *   info for the field. Used for parsing [EventTemplateField]

--- a/src/main/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/BasicReportTransformations.kt
+++ b/src/main/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/BasicReportTransformations.kt
@@ -68,8 +68,8 @@ private data class MetricCalculationSpecInfo(
  * @param impressionQualificationFilterSpecsLists List of List of
  *   [ImpressionQualificationFilterSpec] for each [ReportingImpressionQualificationFilter]
  * @param dataProviderPrimitiveReportingSetMap Map of reporting_unit component resource name to the
- *   primitive [ReportingSet] used for it. In DataProvider mode the key is a [DataProvider] resource
- *   name; in custom-group mode the key is a [ReportingSet] (custom group) resource name.
+ *   primitive [ReportingSet] used for it. The key is a [DataProvider] resource name when the
+ *   component is a DataProvider, or a [ReportingSet] resource name when it is a ReportingSet.
  * @param resultGroupSpecs List of [ResultGroupSpec] to transform
  * @param eventTemplateFieldsByPath Map of EventTemplate field path with respect to Event message to
  *   info for the field. Used for parsing [EventTemplateField]

--- a/src/main/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/BasicReportsService.kt
+++ b/src/main/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/BasicReportsService.kt
@@ -68,6 +68,7 @@ import org.wfanet.measurement.internal.reporting.v2.ReportingSet as InternalRepo
 import org.wfanet.measurement.internal.reporting.v2.ReportingSetsGrpcKt.ReportingSetsCoroutineStub as InternalReportingSetsCoroutineStub
 import org.wfanet.measurement.internal.reporting.v2.StreamReportingSetsRequestKt
 import org.wfanet.measurement.internal.reporting.v2.batchGetReportingSetsRequest
+import org.wfanet.measurement.internal.reporting.v2.ensureSynthesizedCampaignGroupReportingSetRequest
 import org.wfanet.measurement.internal.reporting.v2.copy
 import org.wfanet.measurement.internal.reporting.v2.createBasicReportRequest
 import org.wfanet.measurement.internal.reporting.v2.createMetricCalculationSpecRequest
@@ -143,43 +144,75 @@ class BasicReportsService(
   }
 
   private data class ReportingSetMaps(
-    // Map of DataProvider resource name to Primitive ReportingSet
-    val primitiveReportingSetsByDataProvider: Map<String, ReportingSet>,
+    // Map of reporting_unit component resource name to the Primitive ReportingSet used for it. In
+    // DataProvider mode the key is a DataProvider resource name (mapping to a per-DataProvider
+    // auto-minted primitive); in custom-group mode the key is a ReportingSet resource name (mapping
+    // to the caller-supplied custom-group primitive itself).
+    val primitiveReportingSetsByComponent: Map<String, ReportingSet>,
     // Map of ReportingSet composite to ReportingSet resource name
     val nameByReportingSetComposite: Map<ReportingSet.Composite, String>,
+  )
+
+  /**
+   * The effective Campaign Group for a [CreateBasicReportRequest] and the derived facts the request
+   * flow needs, resolved from either a caller-supplied Campaign Group (DataProvider mode) or a
+   * server-synthesized one (custom-group mode).
+   */
+  private data class CampaignGroupResolution(
+    /** The effective Campaign Group [ReportingSet] (caller-supplied or server-synthesized). */
+    val campaignGroup: ReportingSet,
+    /** Key of [campaignGroup]. */
+    val campaignGroupKey: ReportingSetKey,
+    /** Whether [campaignGroup] was synthesized by the server (custom-group mode). */
+    val synthesized: Boolean,
+    /** Resource names of the DataProviders spanned by [campaignGroup]'s EventGroup universe. */
+    val dataProviderNames: Set<String>,
+    /**
+     * Custom-group components keyed by ReportingSet resource name. Empty in DataProvider mode; in
+     * custom-group mode these are the caller-supplied primitive ReportingSets used directly as the
+     * per-component primitives (no per-DataProvider auto-mint).
+     */
+    val customGroupPrimitiveReportingSetsByName: Map<String, ReportingSet>,
   )
 
   override suspend fun createBasicReport(request: CreateBasicReportRequest): BasicReport {
     val eventTemplateFieldsByPath = eventMessageDescriptor?.eventTemplateFieldsByPath ?: emptyMap()
 
-    if (request.basicReport.campaignGroup.isEmpty()) {
-      throw RequiredFieldNotSetException("basic_report.campaign_group")
-        .asStatusRuntimeException(Status.Code.INVALID_ARGUMENT)
-    }
-    val campaignGroupKey =
-      ReportingSetKey.fromName(request.basicReport.campaignGroup)
-        ?: throw InvalidFieldValueException("basic_report.campaign_group") { fieldPath ->
-            "$fieldPath is not a valid ReportingSet resource name"
+    // The Campaign Group is either supplied by the caller (DataProvider mode) or, when
+    // campaign_group is empty, synthesized by the server from the custom-group ReportingSet
+    // components (custom-group mode). Read the supplied Campaign Group (if any) up front so request
+    // validation can enforce the corresponding component-type rules; synthesis runs after
+    // validation.
+    val suppliedCampaignGroup: ReportingSet? =
+      if (request.basicReport.campaignGroup.isEmpty()) {
+        null
+      } else {
+        val campaignGroupKey =
+          ReportingSetKey.fromName(request.basicReport.campaignGroup)
+            ?: throw InvalidFieldValueException("basic_report.campaign_group") { fieldPath ->
+                "$fieldPath is not a valid ReportingSet resource name"
+              }
+              .asStatusRuntimeException(Status.Code.INVALID_ARGUMENT)
+        val campaignGroup: ReportingSet =
+          try {
+            getReportingSet(campaignGroupKey)
+          } catch (e: ReportingSetNotFoundException) {
+            throw e.asStatusRuntimeException(Status.Code.FAILED_PRECONDITION)
+          } catch (e: InternalReportingSetsException) {
+            throw Status.INTERNAL.withDescription(e.message).withCause(e).asRuntimeException()
           }
-          .asStatusRuntimeException(Status.Code.INVALID_ARGUMENT)
-    val campaignGroup: ReportingSet =
-      try {
-        getReportingSet(campaignGroupKey)
-      } catch (e: ReportingSetNotFoundException) {
-        throw e.asStatusRuntimeException(Status.Code.FAILED_PRECONDITION)
-      } catch (e: InternalReportingSetsException) {
-        throw Status.INTERNAL.withDescription(e.message).withCause(e).asRuntimeException()
+        if (campaignGroup.campaignGroup != campaignGroup.name) {
+          throw CampaignGroupInvalidException(request.basicReport.campaignGroup)
+            .asStatusRuntimeException(Status.Code.FAILED_PRECONDITION)
+        }
+        campaignGroup
       }
-    if (campaignGroup.campaignGroup != campaignGroup.name) {
-      throw CampaignGroupInvalidException(request.basicReport.campaignGroup)
-        .asStatusRuntimeException(Status.Code.FAILED_PRECONDITION)
-    }
 
     val (parentKey: MeasurementConsumerKey, requestImpressionQualificationFilterKeys) =
       try {
         CreateBasicReportRequestValidation.validateRequest(
           request,
-          campaignGroup,
+          suppliedCampaignGroup,
           defaultReportStartHour != null,
           eventTemplateFieldsByPath,
         )
@@ -193,6 +226,23 @@ class BasicReportsService(
         throw e.asStatusRuntimeException(Status.Code.FAILED_PRECONDITION)
       } catch (e: EventTemplateFieldInvalidException) {
         throw e.asStatusRuntimeException(Status.Code.INVALID_ARGUMENT)
+      }
+
+    // In custom-group mode the effective Campaign Group is synthesized from the (now validated)
+    // custom-group components. In DataProvider mode it is the supplied Campaign Group.
+    val campaignGroupResolution: CampaignGroupResolution =
+      if (suppliedCampaignGroup != null) {
+        resolveSuppliedCampaignGroup(suppliedCampaignGroup)
+      } else {
+        try {
+          synthesizeCampaignGroup(request, parentKey)
+        } catch (e: ReportingSetNotFoundException) {
+          throw e.asStatusRuntimeException(Status.Code.FAILED_PRECONDITION)
+        } catch (e: InvalidFieldValueException) {
+          throw e.asStatusRuntimeException(Status.Code.INVALID_ARGUMENT)
+        } catch (e: InternalReportingSetsException) {
+          throw Status.INTERNAL.withDescription(e.message).withCause(e).asRuntimeException()
+        }
       }
 
     val effectiveReportStart =
@@ -217,14 +267,14 @@ class BasicReportsService(
         request.basicReport.reportingInterval.reportStart
       }
 
-    val reportingSetMaps: ReportingSetMaps = buildReportingSetMaps(campaignGroup, campaignGroupKey)
+    val reportingSetMaps: ReportingSetMaps = buildReportingSetMaps(campaignGroupResolution)
     val effectiveModelLine: ModelLine? =
       try {
         getEffectiveModelLine(
           request.basicReport.modelLine,
           request.basicReport.reportingInterval,
           effectiveReportStart,
-          reportingSetMaps.primitiveReportingSetsByDataProvider.keys,
+          campaignGroupResolution.dataProviderNames,
           parentKey,
         )
       } catch (e: ModelLineNotActiveException) {
@@ -324,11 +374,8 @@ class BasicReportsService(
               request.basicReport.toInternal(
                 cmmsMeasurementConsumerId = parentKey.measurementConsumerId,
                 basicReportId = request.basicReportId,
-                campaignGroupId = campaignGroupKey.reportingSetId,
-                // TODO(world-federation-of-advertisers/cross-media-measurement#4071): Derive from
-                // campaign-group synthesis once ReportingSet (custom-group) reporting units are
-                // supported. The campaign group is always caller-supplied today.
-                campaignGroupSynthesized = false,
+                campaignGroupId = campaignGroupResolution.campaignGroupKey.reportingSetId,
+                campaignGroupSynthesized = campaignGroupResolution.synthesized,
                 createReportRequestId = createReportRequestId,
                 reportingImpressionQualificationFilters =
                   request.basicReport.impressionQualificationFiltersList,
@@ -371,11 +418,11 @@ class BasicReportsService(
     val reportingSetsMetricCalculationSpecDetailsMap:
       Map<ReportingSet, List<InternalMetricCalculationSpec.Details>> =
       buildReportingSetMetricCalculationSpecDetailsMap(
-        campaignGroupName = request.basicReport.campaignGroup,
+        campaignGroupName = campaignGroupResolution.campaignGroup.name,
         impressionQualificationFilterSpecsLists =
           impressionQualificationFilterSpecsByName.values + customFilterSpecs,
         dataProviderPrimitiveReportingSetMap =
-          reportingSetMaps.primitiveReportingSetsByDataProvider,
+          reportingSetMaps.primitiveReportingSetsByComponent,
         resultGroupSpecs = request.basicReport.resultGroupSpecsList,
         eventTemplateFieldsByPath = eventTemplateFieldsByPath,
       )
@@ -384,7 +431,7 @@ class BasicReportsService(
       try {
         buildReport(
           request.basicReport,
-          campaignGroupKey,
+          campaignGroupResolution.campaignGroupKey,
           reportingSetMaps.nameByReportingSetComposite,
           reportingSetsMetricCalculationSpecDetailsMap,
           effectiveModelLine?.name.orEmpty(),
@@ -715,21 +762,21 @@ class BasicReportsService(
   }
 
   /**
-   * Builds two different maps from ReportingSets for the specified CampaignGroup: one for
-   * DataProvider resource name to Primitive ReportingSet and the other for ReportingSet composite
-   * to ReportingSet resource name.
+   * Builds the [ReportingSetMaps] for the effective Campaign Group: a map of reporting_unit
+   * component resource name to Primitive ReportingSet, and a map of ReportingSet composite to
+   * ReportingSet resource name (for reusing composites already created under the Campaign Group).
+   *
+   * In DataProvider mode a primitive is reused or auto-minted per DataProvider spanned by the
+   * Campaign Group. In custom-group mode the caller-supplied custom groups are the per-component
+   * primitives directly, so no auto-mint occurs.
    */
   private suspend fun buildReportingSetMaps(
-    campaignGroup: ReportingSet,
-    campaignGroupKey: ReportingSetKey,
+    campaignGroupResolution: CampaignGroupResolution
   ): ReportingSetMaps {
-    val dataProviderEventGroupsMap: Map<String, List<String>> =
-      campaignGroup.primitive.cmmsEventGroupsList.groupBy {
-        EventGroupKey.fromName(it)!!.parentKey.toName()
-      }
+    val campaignGroupKey = campaignGroupResolution.campaignGroupKey
 
-    // Map of ReportingSetMapKey to ReportingSet. For determining whether a
-    // ReportingSet already exists.
+    // Existing ReportingSets under the effective Campaign Group, indexed for reuse: composites by
+    // their set expression, primitives by their EventGroup set.
     val campaignGroupReportingSetMap: Map<ReportingSetMapKey, ReportingSet> = buildMap {
       internalReportingSetsStub
         .streamReportingSets(
@@ -758,47 +805,6 @@ class BasicReportsService(
         }
     }
 
-    // Map of DataProvider resource names to primitive Reporting Sets.
-    val dataProviderPrimitiveReportingSetMap: Map<String, ReportingSet> = buildMap {
-      for (dataProviderName in dataProviderEventGroupsMap.keys) {
-        val reportingSetMapKey =
-          ReportingSetMapKey.Primitive(
-            cmmsEventGroups = dataProviderEventGroupsMap.getValue(dataProviderName).toSet()
-          )
-
-        if (campaignGroupReportingSetMap.containsKey(reportingSetMapKey)) {
-          put(dataProviderName, campaignGroupReportingSetMap.getValue(reportingSetMapKey))
-        } else {
-          val uuid = UUID.randomUUID()
-          val id = "a$uuid"
-
-          val primitiveReportingSet =
-            try {
-              internalReportingSetsStub
-                .createReportingSet(
-                  internalCreateReportingSetRequest {
-                    externalReportingSetId = id
-                    reportingSet = internalReportingSet {
-                      cmmsMeasurementConsumerId = campaignGroupKey.parentKey.measurementConsumerId
-                      this.externalCampaignGroupId = campaignGroupKey.reportingSetId
-                      primitive =
-                        ReportingSetKt.primitive {
-                            cmmsEventGroups += dataProviderEventGroupsMap.getValue(dataProviderName)
-                          }
-                          .toInternal()
-                    }
-                  }
-                )
-                .toReportingSet()
-            } catch (e: StatusException) {
-              throw Status.INTERNAL.withCause(e).asRuntimeException()
-            }
-
-          put(dataProviderName, primitiveReportingSet)
-        }
-      }
-    }
-
     // Map of ReportingSet Composite to ReportingSet resource name.
     val reportingSetCompositeToNameMap: Map<ReportingSet.Composite, String> = buildMap {
       campaignGroupReportingSetMap
@@ -806,7 +812,229 @@ class BasicReportsService(
         .forEach { put((it.key as ReportingSetMapKey.Composite).composite, it.value.name) }
     }
 
-    return ReportingSetMaps(dataProviderPrimitiveReportingSetMap, reportingSetCompositeToNameMap)
+    val primitiveReportingSetsByComponent: Map<String, ReportingSet> =
+      if (campaignGroupResolution.synthesized) {
+        // Custom-group mode: the caller-supplied custom groups are the per-component primitives.
+        campaignGroupResolution.customGroupPrimitiveReportingSetsByName
+      } else {
+        // DataProvider mode: reuse or auto-mint a primitive per DataProvider spanned by the
+        // Campaign Group's EventGroup universe.
+        val dataProviderEventGroupsMap: Map<String, List<String>> =
+          campaignGroupResolution.campaignGroup.primitive.cmmsEventGroupsList.groupBy {
+            EventGroupKey.fromName(it)!!.parentKey.toName()
+          }
+
+        buildMap {
+          for (dataProviderName in dataProviderEventGroupsMap.keys) {
+            val reportingSetMapKey =
+              ReportingSetMapKey.Primitive(
+                cmmsEventGroups = dataProviderEventGroupsMap.getValue(dataProviderName).toSet()
+              )
+
+            if (campaignGroupReportingSetMap.containsKey(reportingSetMapKey)) {
+              put(dataProviderName, campaignGroupReportingSetMap.getValue(reportingSetMapKey))
+            } else {
+              val id = "a${UUID.randomUUID()}"
+
+              val primitiveReportingSet =
+                try {
+                  internalReportingSetsStub
+                    .createReportingSet(
+                      internalCreateReportingSetRequest {
+                        externalReportingSetId = id
+                        reportingSet = internalReportingSet {
+                          cmmsMeasurementConsumerId =
+                            campaignGroupKey.parentKey.measurementConsumerId
+                          this.externalCampaignGroupId = campaignGroupKey.reportingSetId
+                          primitive =
+                            ReportingSetKt.primitive {
+                                cmmsEventGroups +=
+                                  dataProviderEventGroupsMap.getValue(dataProviderName)
+                              }
+                              .toInternal()
+                        }
+                      }
+                    )
+                    .toReportingSet()
+                } catch (e: StatusException) {
+                  throw Status.INTERNAL.withCause(e).asRuntimeException()
+                }
+
+              put(dataProviderName, primitiveReportingSet)
+            }
+          }
+        }
+      }
+
+    return ReportingSetMaps(primitiveReportingSetsByComponent, reportingSetCompositeToNameMap)
+  }
+
+  /**
+   * Resolves a caller-supplied Campaign Group (DataProvider mode) into a [CampaignGroupResolution].
+   */
+  private fun resolveSuppliedCampaignGroup(campaignGroup: ReportingSet): CampaignGroupResolution {
+    val campaignGroupKey = checkNotNull(ReportingSetKey.fromName(campaignGroup.name))
+    return CampaignGroupResolution(
+      campaignGroup = campaignGroup,
+      campaignGroupKey = campaignGroupKey,
+      synthesized = false,
+      dataProviderNames = dataProviderNames(campaignGroup),
+      customGroupPrimitiveReportingSetsByName = emptyMap(),
+    )
+  }
+
+  /**
+   * Synthesizes the Campaign Group for a custom-group [request] (empty `campaign_group`).
+   *
+   * Resolves the custom-group ReportingSet components across all ResultGroupSpecs, validates them
+   * (each must be a primitive ReportingSet, and no two may resolve to the same DataProvider set),
+   * and transactionally get-or-creates a primitive self-referencing Campaign Group whose EventGroup
+   * universe is the union of the custom groups' EventGroups. Concurrent and retried requests with
+   * the same universe converge on one shared ReportingSet.
+   *
+   * @throws ReportingSetNotFoundException if a custom-group component does not exist
+   * @throws InvalidFieldValueException if a component is not a primitive ReportingSet, or two
+   *   components resolve to the same DataProvider set
+   * @throws InternalReportingSetsException on other internal errors
+   */
+  private suspend fun synthesizeCampaignGroup(
+    request: CreateBasicReportRequest,
+    parentKey: MeasurementConsumerKey,
+  ): CampaignGroupResolution {
+    val componentsFieldPath = "basic_report.result_group_specs.reporting_unit.components"
+
+    // Distinct custom-group ReportingSet components across all ResultGroupSpecs.
+    val customGroupNames: Set<String> =
+      request.basicReport.resultGroupSpecsList.flatMap { it.reportingUnit.componentsList }.toSet()
+
+    val customGroupKeys: List<ReportingSetKey> =
+      customGroupNames.map { name ->
+        val key =
+          ReportingSetKey.fromName(name)
+            ?: throw InvalidFieldValueException(componentsFieldPath) { fieldPath ->
+              "$fieldPath is not a valid ReportingSet resource name"
+            }
+        if (key.cmmsMeasurementConsumerId != parentKey.measurementConsumerId) {
+          throw InvalidFieldValueException(componentsFieldPath) { fieldPath ->
+            "$fieldPath must reference ReportingSets owned by the parent MeasurementConsumer"
+          }
+        }
+        key
+      }
+
+    val customGroupsByName: Map<String, ReportingSet> = getReportingSets(parentKey, customGroupKeys)
+
+    // Each custom group must be a primitive ReportingSet, and no two may resolve to the same
+    // DataProvider set (which would silently collide in the post-processor).
+    val nameByDataProviderSet = mutableMapOf<Set<String>, String>()
+    for ((name, reportingSet) in customGroupsByName) {
+      if (!reportingSet.hasPrimitive()) {
+        throw InvalidFieldValueException(componentsFieldPath) { fieldPath ->
+          "$fieldPath must each reference a primitive ReportingSet; $name is not primitive"
+        }
+      }
+      val dataProviderSet = dataProviderNames(reportingSet)
+      val collidingName = nameByDataProviderSet.put(dataProviderSet, name)
+      if (collidingName != null) {
+        throw InvalidFieldValueException(componentsFieldPath) { fieldPath ->
+          "$fieldPath entries $name and $collidingName resolve to the same DataProvider set"
+        }
+      }
+    }
+
+    // Universe = union of all custom groups' EventGroups.
+    val eventGroupNames: List<String> =
+      customGroupsByName.values.flatMap { it.primitive.cmmsEventGroupsList }.distinct()
+
+    val synthesizedId = "a${UUID.randomUUID()}"
+    val ensuredInternalReportingSet =
+      try {
+        internalReportingSetsStub.ensureSynthesizedCampaignGroupReportingSet(
+          ensureSynthesizedCampaignGroupReportingSetRequest {
+            externalReportingSetId = synthesizedId
+            reportingSet = internalReportingSet {
+              cmmsMeasurementConsumerId = parentKey.measurementConsumerId
+              externalCampaignGroupId = synthesizedId
+              primitive =
+                ReportingSetKt.primitive { cmmsEventGroups += eventGroupNames }.toInternal()
+            }
+          }
+        )
+      } catch (e: StatusException) {
+        throw InternalReportingSetsException("Error synthesizing campaign group ReportingSet", e)
+      }
+
+    val synthesizedCampaignGroup = ensuredInternalReportingSet.toReportingSet()
+    return CampaignGroupResolution(
+      campaignGroup = synthesizedCampaignGroup,
+      campaignGroupKey =
+        ReportingSetKey(
+          ensuredInternalReportingSet.cmmsMeasurementConsumerId,
+          ensuredInternalReportingSet.externalReportingSetId,
+        ),
+      synthesized = true,
+      dataProviderNames = dataProviderNames(synthesizedCampaignGroup),
+      customGroupPrimitiveReportingSetsByName = customGroupsByName,
+    )
+  }
+
+  /** Resource names of the DataProviders spanned by [reportingSet]'s primitive EventGroups. */
+  private fun dataProviderNames(reportingSet: ReportingSet): Set<String> = buildSet {
+    for (eventGroupName in reportingSet.primitive.cmmsEventGroupsList) {
+      add(checkNotNull(EventGroupKey.fromName(eventGroupName)).parentKey.toName())
+    }
+  }
+
+  /**
+   * Batch-retrieves the [ReportingSet]s for [keys] under [parentKey], returned keyed by resource
+   * name.
+   *
+   * @throws ReportingSetNotFoundException if any ReportingSet does not exist
+   * @throws InternalReportingSetsException on other internal errors
+   */
+  private suspend fun getReportingSets(
+    parentKey: MeasurementConsumerKey,
+    keys: Collection<ReportingSetKey>,
+  ): Map<String, ReportingSet> {
+    return try {
+      internalReportingSetsStub
+        .batchGetReportingSets(
+          batchGetReportingSetsRequest {
+            cmmsMeasurementConsumerId = parentKey.measurementConsumerId
+            externalReportingSetIds += keys.map { it.reportingSetId }
+          }
+        )
+        .reportingSetsList
+        .associate {
+          val reportingSet = it.toReportingSet()
+          reportingSet.name to reportingSet
+        }
+    } catch (e: StatusException) {
+      throw when (ReportingInternalException.getErrorCode(e)) {
+        ErrorCode.REPORTING_SET_NOT_FOUND -> ReportingSetNotFoundException(keys.first().toName())
+        ErrorCode.MEASUREMENT_CONSUMER_NOT_FOUND,
+        ErrorCode.REPORTING_SET_ALREADY_EXISTS,
+        ErrorCode.CAMPAIGN_GROUP_INVALID,
+        ErrorCode.UNKNOWN_ERROR,
+        ErrorCode.MEASUREMENT_ALREADY_EXISTS,
+        ErrorCode.MEASUREMENT_NOT_FOUND,
+        ErrorCode.MEASUREMENT_CALCULATION_TIME_INTERVAL_NOT_FOUND,
+        ErrorCode.REPORT_NOT_FOUND,
+        ErrorCode.MEASUREMENT_STATE_INVALID,
+        ErrorCode.MEASUREMENT_CONSUMER_ALREADY_EXISTS,
+        ErrorCode.METRIC_ALREADY_EXISTS,
+        ErrorCode.REPORT_ALREADY_EXISTS,
+        ErrorCode.REPORT_SCHEDULE_ALREADY_EXISTS,
+        ErrorCode.REPORT_SCHEDULE_NOT_FOUND,
+        ErrorCode.REPORT_SCHEDULE_STATE_INVALID,
+        ErrorCode.REPORT_SCHEDULE_ITERATION_NOT_FOUND,
+        ErrorCode.REPORT_SCHEDULE_ITERATION_STATE_INVALID,
+        ErrorCode.METRIC_CALCULATION_SPEC_NOT_FOUND,
+        ErrorCode.METRIC_CALCULATION_SPEC_ALREADY_EXISTS,
+        ErrorCode.UNRECOGNIZED,
+        null -> InternalReportingSetsException("Error retrieving ReportingSets", e)
+      }
+    }
   }
 
   /**

--- a/src/main/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/BasicReportsService.kt
+++ b/src/main/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/BasicReportsService.kt
@@ -808,6 +808,11 @@ class BasicReportsService(
                 limit = 1000
               }
             )
+            // Only unfiltered ReportingSets are valid reuse targets, since minted and synthesized
+            // ReportingSets never have a filter. Filtered ReportingSets under the Campaign Group
+            // are silently skipped here.
+            // TODO(world-federation-of-advertisers/cross-media-measurement#4144): Reject filtered
+            //   ReportingSets at request time instead of silently ignoring them.
             .filter { it.filter.isEmpty() }
             .collect {
               val reportingSet = it.toReportingSet()
@@ -962,7 +967,8 @@ class BasicReportsService(
       val collidingName = nameByDataProviderSet.put(dataProviderSet, name)
       if (collidingName != null) {
         throw InvalidFieldValueException(componentsFieldPath) { fieldPath ->
-          "$fieldPath entries $name and $collidingName resolve to the same DataProvider set"
+          "$fieldPath entries $name and $collidingName resolve to the same DataProvider set; " +
+            "this would collide in per-DataProvider metric bucketing"
         }
       }
     }

--- a/src/main/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/BasicReportsService.kt
+++ b/src/main/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/BasicReportsService.kt
@@ -68,11 +68,11 @@ import org.wfanet.measurement.internal.reporting.v2.ReportingSet as InternalRepo
 import org.wfanet.measurement.internal.reporting.v2.ReportingSetsGrpcKt.ReportingSetsCoroutineStub as InternalReportingSetsCoroutineStub
 import org.wfanet.measurement.internal.reporting.v2.StreamReportingSetsRequestKt
 import org.wfanet.measurement.internal.reporting.v2.batchGetReportingSetsRequest
-import org.wfanet.measurement.internal.reporting.v2.ensureSynthesizedCampaignGroupReportingSetRequest
 import org.wfanet.measurement.internal.reporting.v2.copy
 import org.wfanet.measurement.internal.reporting.v2.createBasicReportRequest
 import org.wfanet.measurement.internal.reporting.v2.createMetricCalculationSpecRequest
 import org.wfanet.measurement.internal.reporting.v2.createReportingSetRequest as internalCreateReportingSetRequest
+import org.wfanet.measurement.internal.reporting.v2.ensureSynthesizedCampaignGroupReportingSetRequest
 import org.wfanet.measurement.internal.reporting.v2.getBasicReportRequest as internalGetBasicReportRequest
 import org.wfanet.measurement.internal.reporting.v2.getImpressionQualificationFilterRequest
 import org.wfanet.measurement.internal.reporting.v2.listBasicReportsRequest as internalListBasicReportsRequest
@@ -421,8 +421,7 @@ class BasicReportsService(
         campaignGroupName = campaignGroupResolution.campaignGroup.name,
         impressionQualificationFilterSpecsLists =
           impressionQualificationFilterSpecsByName.values + customFilterSpecs,
-        dataProviderPrimitiveReportingSetMap =
-          reportingSetMaps.primitiveReportingSetsByComponent,
+        dataProviderPrimitiveReportingSetMap = reportingSetMaps.primitiveReportingSetsByComponent,
         resultGroupSpecs = request.basicReport.resultGroupSpecsList,
         eventTemplateFieldsByPath = eventTemplateFieldsByPath,
       )

--- a/src/main/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/BasicReportsService.kt
+++ b/src/main/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/BasicReportsService.kt
@@ -36,6 +36,7 @@ import kotlinx.coroutines.flow.filter
 import org.wfanet.measurement.access.client.v1alpha.Authorization
 import org.wfanet.measurement.access.client.v1alpha.check
 import org.wfanet.measurement.access.client.v1alpha.withForwardedTrustedCredentials
+import org.wfanet.measurement.api.v2alpha.DataProviderKey
 import org.wfanet.measurement.api.v2alpha.EventGroupKey
 import org.wfanet.measurement.api.v2alpha.EventMessageDescriptor
 import org.wfanet.measurement.api.v2alpha.MeasurementConsumerKey
@@ -143,46 +144,62 @@ class BasicReportsService(
     data class Primitive(val cmmsEventGroups: Set<String>) : ReportingSetMapKey()
   }
 
-  private data class ReportingSetMaps(
-    // Map of reporting_unit component resource name to the Primitive ReportingSet used for it. In
-    // DataProvider mode the key is a DataProvider resource name (mapping to a per-DataProvider
-    // auto-minted primitive); in custom-group mode the key is a ReportingSet resource name (mapping
-    // to the caller-supplied custom-group primitive itself).
-    val primitiveReportingSetsByComponent: Map<String, ReportingSet>,
-    // Map of ReportingSet composite to ReportingSet resource name
-    val nameByReportingSetComposite: Map<ReportingSet.Composite, String>,
-  )
+  /**
+   * The primitive [ReportingSet] to use for each ReportingUnit component (keyed by the component's
+   * [ResourceKey]) plus the resource name of each existing composite [ReportingSet] under the
+   * Campaign Group (for reuse).
+   */
+  private sealed interface ReportingSetMaps<T : ResourceKey> {
+    /** Map of ReportingUnit component key to the Primitive [ReportingSet] used for it. */
+    val primitiveReportingSetsByComponentKey: Map<T, ReportingSet>
+    /** Map of composite [ReportingSet] to its resource name. */
+    val nameByReportingSetComposite: Map<ReportingSet.Composite, String>
+  }
+
+  /** [ReportingSetMaps] where the ReportingUnit components are DataProviders. */
+  private data class DataProviderReportingSetMaps(
+    override val primitiveReportingSetsByComponentKey: Map<DataProviderKey, ReportingSet>,
+    override val nameByReportingSetComposite: Map<ReportingSet.Composite, String>,
+  ) : ReportingSetMaps<DataProviderKey>
+
+  /** [ReportingSetMaps] where the ReportingUnit components are ReportingSets. */
+  private data class ReportingSetComponentReportingSetMaps(
+    override val primitiveReportingSetsByComponentKey: Map<ReportingSetKey, ReportingSet>,
+    override val nameByReportingSetComposite: Map<ReportingSet.Composite, String>,
+  ) : ReportingSetMaps<ReportingSetKey>
 
   /**
    * The effective Campaign Group for a [CreateBasicReportRequest] and the derived facts the request
-   * flow needs, resolved from either a caller-supplied Campaign Group (DataProvider mode) or a
-   * server-synthesized one (custom-group mode).
+   * flow needs, resolved from either a caller-supplied Campaign Group (when `campaign_group` is
+   * specified) or a server-synthesized one (when it is not).
    */
   private data class CampaignGroupResolution(
     /** The effective Campaign Group [ReportingSet] (caller-supplied or server-synthesized). */
     val campaignGroup: ReportingSet,
     /** Key of [campaignGroup]. */
     val campaignGroupKey: ReportingSetKey,
-    /** Whether [campaignGroup] was synthesized by the server (custom-group mode). */
-    val synthesized: Boolean,
     /** Resource names of the DataProviders spanned by [campaignGroup]'s EventGroup universe. */
     val dataProviderNames: Set<String>,
     /**
-     * Custom-group components keyed by ReportingSet resource name. Empty in DataProvider mode; in
-     * custom-group mode these are the caller-supplied primitive ReportingSets used directly as the
-     * per-component primitives (no per-DataProvider auto-mint).
+     * The ReportingUnit's ReportingSet components keyed by resource name. Empty when
+     * `campaign_group` was specified (components are DataProviders); otherwise these
+     * caller-supplied primitive ReportingSets are used directly as the per-component primitives (no
+     * per-DataProvider auto-mint), and the Campaign Group is synthesized from them.
      */
-    val customGroupPrimitiveReportingSetsByName: Map<String, ReportingSet>,
-  )
+    val reportingSetComponentsByName: Map<String, ReportingSet>,
+  ) {
+    /** Whether the Campaign Group was synthesized (i.e. `campaign_group` was not specified). */
+    val synthesized: Boolean
+      get() = reportingSetComponentsByName.isNotEmpty()
+  }
 
   override suspend fun createBasicReport(request: CreateBasicReportRequest): BasicReport {
     val eventTemplateFieldsByPath = eventMessageDescriptor?.eventTemplateFieldsByPath ?: emptyMap()
 
-    // The Campaign Group is either supplied by the caller (DataProvider mode) or, when
-    // campaign_group is empty, synthesized by the server from the custom-group ReportingSet
-    // components (custom-group mode). Read the supplied Campaign Group (if any) up front so request
-    // validation can enforce the corresponding component-type rules; synthesis runs after
-    // validation.
+    // The Campaign Group is either supplied by the caller (when campaign_group is specified) or,
+    // when campaign_group is empty, synthesized by the server from the ReportingSet components.
+    // Read the supplied Campaign Group (if any) up front so request validation can enforce the
+    // corresponding component-type rules; synthesis runs after validation.
     val suppliedCampaignGroup: ReportingSet? =
       if (request.basicReport.campaignGroup.isEmpty()) {
         null
@@ -228,8 +245,8 @@ class BasicReportsService(
         throw e.asStatusRuntimeException(Status.Code.INVALID_ARGUMENT)
       }
 
-    // In custom-group mode the effective Campaign Group is synthesized from the (now validated)
-    // custom-group components. In DataProvider mode it is the supplied Campaign Group.
+    // When campaign_group is not specified, the effective Campaign Group is synthesized from the
+    // (now validated) ReportingSet components. Otherwise it is the supplied Campaign Group.
     val campaignGroupResolution: CampaignGroupResolution =
       if (suppliedCampaignGroup != null) {
         resolveSuppliedCampaignGroup(suppliedCampaignGroup)
@@ -267,7 +284,7 @@ class BasicReportsService(
         request.basicReport.reportingInterval.reportStart
       }
 
-    val reportingSetMaps: ReportingSetMaps = buildReportingSetMaps(campaignGroupResolution)
+    val reportingSetMaps: ReportingSetMaps<*> = buildReportingSetMaps(campaignGroupResolution)
     val effectiveModelLine: ModelLine? =
       try {
         getEffectiveModelLine(
@@ -421,7 +438,8 @@ class BasicReportsService(
         campaignGroupName = campaignGroupResolution.campaignGroup.name,
         impressionQualificationFilterSpecsLists =
           impressionQualificationFilterSpecsByName.values + customFilterSpecs,
-        dataProviderPrimitiveReportingSetMap = reportingSetMaps.primitiveReportingSetsByComponent,
+        dataProviderPrimitiveReportingSetMap =
+          reportingSetMaps.primitiveReportingSetsByComponentKey.mapKeys { it.key.toName() },
         resultGroupSpecs = request.basicReport.resultGroupSpecsList,
         eventTemplateFieldsByPath = eventTemplateFieldsByPath,
       )
@@ -761,137 +779,144 @@ class BasicReportsService(
   }
 
   /**
-   * Builds the [ReportingSetMaps] for the effective Campaign Group: a map of reporting_unit
-   * component resource name to Primitive ReportingSet, and a map of ReportingSet composite to
-   * ReportingSet resource name (for reusing composites already created under the Campaign Group).
+   * Builds the [ReportingSetMaps] for the effective Campaign Group: the Primitive ReportingSet to
+   * use for each ReportingUnit component, and a map of composite ReportingSet to resource name (for
+   * reusing composites already created under the Campaign Group).
    *
-   * In DataProvider mode a primitive is reused or auto-minted per DataProvider spanned by the
-   * Campaign Group. In custom-group mode the caller-supplied custom groups are the per-component
-   * primitives directly, so no auto-mint occurs.
+   * When `campaign_group` was specified, a primitive is reused or auto-minted per DataProvider
+   * spanned by the Campaign Group. Otherwise the caller-supplied ReportingSet components are the
+   * per-component primitives directly, so no auto-mint occurs.
    */
   private suspend fun buildReportingSetMaps(
     campaignGroupResolution: CampaignGroupResolution
-  ): ReportingSetMaps {
+  ): ReportingSetMaps<*> {
     val campaignGroupKey = campaignGroupResolution.campaignGroupKey
 
     // Existing ReportingSets under the effective Campaign Group, indexed for reuse: composites by
     // their set expression, primitives by their EventGroup set.
-    val campaignGroupReportingSetMap: Map<ReportingSetMapKey, ReportingSet> = buildMap {
-      internalReportingSetsStub
-        .streamReportingSets(
-          streamReportingSetsRequest {
-            filter =
-              StreamReportingSetsRequestKt.filter {
-                cmmsMeasurementConsumerId = campaignGroupKey.cmmsMeasurementConsumerId
-                externalCampaignGroupId = campaignGroupKey.reportingSetId
+    val campaignGroupReportingSetMap: Map<ReportingSetMapKey, ReportingSet> =
+      try {
+        buildMap {
+          internalReportingSetsStub
+            .streamReportingSets(
+              streamReportingSetsRequest {
+                filter =
+                  StreamReportingSetsRequestKt.filter {
+                    cmmsMeasurementConsumerId = campaignGroupKey.cmmsMeasurementConsumerId
+                    externalCampaignGroupId = campaignGroupKey.reportingSetId
+                  }
+                limit = 1000
               }
-            limit = 1000
-          }
-        )
-        .filter { it.filter.isEmpty() }
-        .collect {
-          val reportingSet = it.toReportingSet()
-          if (reportingSet.hasComposite()) {
-            put(ReportingSetMapKey.Composite(composite = reportingSet.composite), reportingSet)
-          } else {
-            put(
-              ReportingSetMapKey.Primitive(
-                cmmsEventGroups = reportingSet.primitive.cmmsEventGroupsList.toSet()
-              ),
-              reportingSet,
             )
-          }
+            .filter { it.filter.isEmpty() }
+            .collect {
+              val reportingSet = it.toReportingSet()
+              if (reportingSet.hasComposite()) {
+                put(ReportingSetMapKey.Composite(composite = reportingSet.composite), reportingSet)
+              } else {
+                put(
+                  ReportingSetMapKey.Primitive(
+                    cmmsEventGroups = reportingSet.primitive.cmmsEventGroupsList.toSet()
+                  ),
+                  reportingSet,
+                )
+              }
+            }
         }
-    }
+      } catch (e: StatusException) {
+        throw Status.INTERNAL.withCause(e).asRuntimeException()
+      }
 
-    // Map of ReportingSet Composite to ReportingSet resource name.
+    // Map of composite ReportingSet to resource name.
     val reportingSetCompositeToNameMap: Map<ReportingSet.Composite, String> = buildMap {
       campaignGroupReportingSetMap
         .filter { it.key is ReportingSetMapKey.Composite }
         .forEach { put((it.key as ReportingSetMapKey.Composite).composite, it.value.name) }
     }
 
-    val primitiveReportingSetsByComponent: Map<String, ReportingSet> =
-      if (campaignGroupResolution.synthesized) {
-        // Custom-group mode: the caller-supplied custom groups are the per-component primitives.
-        campaignGroupResolution.customGroupPrimitiveReportingSetsByName
-      } else {
-        // DataProvider mode: reuse or auto-mint a primitive per DataProvider spanned by the
-        // Campaign Group's EventGroup universe.
-        val dataProviderEventGroupsMap: Map<String, List<String>> =
-          campaignGroupResolution.campaignGroup.primitive.cmmsEventGroupsList.groupBy {
-            EventGroupKey.fromName(it)!!.parentKey.toName()
-          }
-
-        buildMap {
-          for (dataProviderName in dataProviderEventGroupsMap.keys) {
-            val reportingSetMapKey =
-              ReportingSetMapKey.Primitive(
-                cmmsEventGroups = dataProviderEventGroupsMap.getValue(dataProviderName).toSet()
-              )
-
-            if (campaignGroupReportingSetMap.containsKey(reportingSetMapKey)) {
-              put(dataProviderName, campaignGroupReportingSetMap.getValue(reportingSetMapKey))
-            } else {
-              val id = "a${UUID.randomUUID()}"
-
-              val primitiveReportingSet =
-                try {
-                  internalReportingSetsStub
-                    .createReportingSet(
-                      internalCreateReportingSetRequest {
-                        externalReportingSetId = id
-                        reportingSet = internalReportingSet {
-                          cmmsMeasurementConsumerId =
-                            campaignGroupKey.parentKey.measurementConsumerId
-                          this.externalCampaignGroupId = campaignGroupKey.reportingSetId
-                          primitive =
-                            ReportingSetKt.primitive {
-                                cmmsEventGroups +=
-                                  dataProviderEventGroupsMap.getValue(dataProviderName)
-                              }
-                              .toInternal()
-                        }
-                      }
-                    )
-                    .toReportingSet()
-                } catch (e: StatusException) {
-                  throw Status.INTERNAL.withCause(e).asRuntimeException()
-                }
-
-              put(dataProviderName, primitiveReportingSet)
-            }
-          }
+    if (campaignGroupResolution.synthesized) {
+      // The caller-supplied ReportingSet components are the per-component primitives.
+      val primitiveReportingSetsByComponentKey: Map<ReportingSetKey, ReportingSet> =
+        campaignGroupResolution.reportingSetComponentsByName.mapKeys {
+          checkNotNull(ReportingSetKey.fromName(it.key))
         }
+      return ReportingSetComponentReportingSetMaps(
+        primitiveReportingSetsByComponentKey,
+        reportingSetCompositeToNameMap,
+      )
+    }
+
+    // Reuse or auto-mint a primitive per DataProvider spanned by the Campaign Group's EventGroup
+    // universe.
+    val eventGroupsByDataProviderKey: Map<DataProviderKey, List<String>> =
+      campaignGroupResolution.campaignGroup.primitive.cmmsEventGroupsList.groupBy {
+        checkNotNull(EventGroupKey.fromName(it)).parentKey
       }
 
-    return ReportingSetMaps(primitiveReportingSetsByComponent, reportingSetCompositeToNameMap)
+    val primitiveReportingSetsByComponentKey: Map<DataProviderKey, ReportingSet> = buildMap {
+      for ((dataProviderKey, eventGroupNames) in eventGroupsByDataProviderKey) {
+        val reportingSetMapKey =
+          ReportingSetMapKey.Primitive(cmmsEventGroups = eventGroupNames.toSet())
+
+        if (campaignGroupReportingSetMap.containsKey(reportingSetMapKey)) {
+          put(dataProviderKey, campaignGroupReportingSetMap.getValue(reportingSetMapKey))
+        } else {
+          val id = "a${UUID.randomUUID()}"
+
+          val primitiveReportingSet =
+            try {
+              internalReportingSetsStub
+                .createReportingSet(
+                  internalCreateReportingSetRequest {
+                    externalReportingSetId = id
+                    reportingSet = internalReportingSet {
+                      cmmsMeasurementConsumerId = campaignGroupKey.parentKey.measurementConsumerId
+                      this.externalCampaignGroupId = campaignGroupKey.reportingSetId
+                      primitive =
+                        ReportingSetKt.primitive { cmmsEventGroups += eventGroupNames }.toInternal()
+                    }
+                  }
+                )
+                .toReportingSet()
+            } catch (e: StatusException) {
+              throw Status.INTERNAL.withCause(e).asRuntimeException()
+            }
+
+          put(dataProviderKey, primitiveReportingSet)
+        }
+      }
+    }
+
+    return DataProviderReportingSetMaps(
+      primitiveReportingSetsByComponentKey,
+      reportingSetCompositeToNameMap,
+    )
   }
 
   /**
-   * Resolves a caller-supplied Campaign Group (DataProvider mode) into a [CampaignGroupResolution].
+   * Resolves a caller-supplied Campaign Group (when `campaign_group` is specified) into a
+   * [CampaignGroupResolution].
    */
   private fun resolveSuppliedCampaignGroup(campaignGroup: ReportingSet): CampaignGroupResolution {
     val campaignGroupKey = checkNotNull(ReportingSetKey.fromName(campaignGroup.name))
     return CampaignGroupResolution(
       campaignGroup = campaignGroup,
       campaignGroupKey = campaignGroupKey,
-      synthesized = false,
       dataProviderNames = dataProviderNames(campaignGroup),
-      customGroupPrimitiveReportingSetsByName = emptyMap(),
+      reportingSetComponentsByName = emptyMap(),
     )
   }
 
   /**
-   * Synthesizes the Campaign Group for a custom-group [request] (empty `campaign_group`).
+   * Synthesizes the Campaign Group for a [request] whose `campaign_group` is not specified.
    *
-   * Resolves the custom-group ReportingSet components across all ResultGroupSpecs, validates them
-   * (each must be a primitive ReportingSet, and no two may resolve to the same DataProvider set),
-   * and transactionally get-or-creates a primitive self-referencing Campaign Group whose EventGroup
-   * universe is the union of the custom groups' EventGroups. Concurrent and retried requests with
-   * the same universe converge on one shared ReportingSet.
+   * Resolves the ReportingSet components across all ResultGroupSpecs, validates them (each must be
+   * a primitive ReportingSet, and no two may resolve to the same DataProvider set), and
+   * transactionally get-or-creates a primitive self-referencing Campaign Group whose EventGroup
+   * universe is the union of the components' EventGroups. Concurrent and retried requests with the
+   * same universe converge on one shared ReportingSet.
    *
-   * @throws ReportingSetNotFoundException if a custom-group component does not exist
+   * @throws ReportingSetNotFoundException if a ReportingSet component does not exist
    * @throws InvalidFieldValueException if a component is not a primitive ReportingSet, or two
    *   components resolve to the same DataProvider set
    * @throws InternalReportingSetsException on other internal errors
@@ -902,12 +927,12 @@ class BasicReportsService(
   ): CampaignGroupResolution {
     val componentsFieldPath = "basic_report.result_group_specs.reporting_unit.components"
 
-    // Distinct custom-group ReportingSet components across all ResultGroupSpecs.
-    val customGroupNames: Set<String> =
+    // Distinct ReportingSet components across all ResultGroupSpecs.
+    val componentNames: Set<String> =
       request.basicReport.resultGroupSpecsList.flatMap { it.reportingUnit.componentsList }.toSet()
 
-    val customGroupKeys: List<ReportingSetKey> =
-      customGroupNames.map { name ->
+    val componentKeys: List<ReportingSetKey> =
+      componentNames.map { name ->
         val key =
           ReportingSetKey.fromName(name)
             ?: throw InvalidFieldValueException(componentsFieldPath) { fieldPath ->
@@ -921,12 +946,13 @@ class BasicReportsService(
         key
       }
 
-    val customGroupsByName: Map<String, ReportingSet> = getReportingSets(parentKey, customGroupKeys)
+    val reportingSetComponentsByName: Map<String, ReportingSet> =
+      getReportingSets(parentKey, componentKeys)
 
-    // Each custom group must be a primitive ReportingSet, and no two may resolve to the same
+    // Each component must be a primitive ReportingSet, and no two may resolve to the same
     // DataProvider set (which would silently collide in the post-processor).
     val nameByDataProviderSet = mutableMapOf<Set<String>, String>()
-    for ((name, reportingSet) in customGroupsByName) {
+    for ((name, reportingSet) in reportingSetComponentsByName) {
       if (!reportingSet.hasPrimitive()) {
         throw InvalidFieldValueException(componentsFieldPath) { fieldPath ->
           "$fieldPath must each reference a primitive ReportingSet; $name is not primitive"
@@ -941,9 +967,9 @@ class BasicReportsService(
       }
     }
 
-    // Universe = union of all custom groups' EventGroups.
+    // Universe = union of all components' EventGroups.
     val eventGroupNames: List<String> =
-      customGroupsByName.values.flatMap { it.primitive.cmmsEventGroupsList }.distinct()
+      reportingSetComponentsByName.values.flatMap { it.primitive.cmmsEventGroupsList }.distinct()
 
     val synthesizedId = "a${UUID.randomUUID()}"
     val ensuredInternalReportingSet =
@@ -971,9 +997,8 @@ class BasicReportsService(
           ensuredInternalReportingSet.cmmsMeasurementConsumerId,
           ensuredInternalReportingSet.externalReportingSetId,
         ),
-      synthesized = true,
       dataProviderNames = dataProviderNames(synthesizedCampaignGroup),
-      customGroupPrimitiveReportingSetsByName = customGroupsByName,
+      reportingSetComponentsByName = reportingSetComponentsByName,
     )
   }
 

--- a/src/main/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/CreateBasicReportRequestValidation.kt
+++ b/src/main/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/CreateBasicReportRequestValidation.kt
@@ -88,10 +88,10 @@ object CreateBasicReportRequestValidation {
    * [request.basicReport.campaignGroup][org.wfanet.measurement.reporting.v2alpha.BasicReport.campaignGroup]
    * field.
    *
-   * @param campaignGroup the caller-supplied Campaign Group [ReportingSet] (DataProvider mode), or
-   *   `null` for custom-group mode where the Campaign Group is server-synthesized after validation.
-   *   In DataProvider mode every `reporting_unit` component must be a DataProvider within the
-   *   Campaign Group; in custom-group mode every component must be a ReportingSet.
+   * @param campaignGroup the caller-supplied Campaign Group [ReportingSet], or `null` when
+   *   `campaign_group` was not specified and the Campaign Group is server-synthesized after
+   *   validation. When it was specified, every `reporting_unit` component must be a DataProvider
+   *   within the Campaign Group; when it was not, every component must be a ReportingSet.
    * @throws InvalidFieldValueException
    * @throws RequiredFieldNotSetException
    * @throws DataProviderNotFoundForCampaignGroupException
@@ -165,6 +165,8 @@ object CreateBasicReportRequestValidation {
    * @param resultGroupSpecs [List] of [ResultGroupSpec] to validate
    * @param eventTemplateFieldsByPath Map of EventTemplate field path with respect to Event message
    *   to info for the field. Used for validating [EventTemplateField]
+   * @param campaignGroupInfo information about the supplied Campaign Group, or `null` when
+   *   `campaign_group` was not specified (ReportingUnit components must then be ReportingSets)
    * @throws [RequiredFieldNotSetException] when validation fails
    * @throws [InvalidFieldValueException] when validation fails
    * @throws FieldUnimplementedException
@@ -300,20 +302,17 @@ object CreateBasicReportRequestValidation {
   /**
    * Validates [reportingUnit] within the context of a [CreateBasicReportRequest].
    *
-   * There are two mutually exclusive component modes, selected by whether a Campaign Group was
-   * supplied on the request:
-   * - DataProvider mode ([campaignGroupInfo] non-null): every component must be a DataProvider
-   *   resource name belonging to the Campaign Group.
-   * - Custom-group mode ([campaignGroupInfo] `null`): every component must be a ReportingSet
-   *   resource name. The referenced ReportingSets are resolved and further validated (primitive,
-   *   Measurement Consumer-owned, distinct DataProvider sets) server-side in `BasicReportsService`,
-   *   where they are fetched for Campaign Group synthesis.
-   *
-   * DataProvider and ReportingSet components must not be mixed within a single `reporting_unit`.
+   * The component type is selected by whether `campaign_group` was specified on the request:
+   * - When it was ([campaignGroupInfo] non-null): every component must be a DataProvider resource
+   *   name belonging to the Campaign Group.
+   * - When it was not ([campaignGroupInfo] `null`): every component must be a ReportingSet resource
+   *   name. The referenced ReportingSets are resolved and further validated (primitive, Measurement
+   *   Consumer-owned, distinct DataProvider sets) server-side in `BasicReportsService`, where they
+   *   are fetched for Campaign Group synthesis.
    *
    * @param fieldPath Path of [reportingUnit] relative to the request message
-   * @param campaignGroupInfo Information about the supplied Campaign Group, or `null` for
-   *   custom-group mode
+   * @param campaignGroupInfo Information about the supplied Campaign Group, or `null` when
+   *   `campaign_group` was not specified
    */
   private fun validateReportingUnit(
     reportingUnit: ReportingUnit,
@@ -331,25 +330,21 @@ object CreateBasicReportRequestValidation {
     }
 
     if (campaignGroupInfo == null) {
-      // Custom-group mode: every component must be a ReportingSet resource name. A DataProvider
-      // component here means the caller either mixed component types or left campaign_group empty
-      // for a DataProvider report.
+      // When campaign_group is not specified, every component must be a ReportingSet.
       components.forEachIndexed { index, component ->
         ReportingSetKey.fromName(component)
           ?: throw InvalidFieldValueException("$fieldPath.components[$index]") { fieldPath ->
-            "$fieldPath is not a valid ReportingSet resource name; DataProvider and ReportingSet " +
-              "components must not be mixed, and campaign_group must be set for DataProvider " +
-              "components"
+            "$fieldPath is not a valid ReportingSet resource name; when campaign_group is not " +
+              "specified, all ReportingUnit components must be ReportingSets"
           }
       }
     } else {
-      // DataProvider mode: every component must be a DataProvider within the Campaign Group.
+      // When campaign_group is specified, every component must be a DataProvider within it.
       components.forEachIndexed { index, component ->
         DataProviderKey.fromName(component)
           ?: throw InvalidFieldValueException("$fieldPath.components[$index]") { fieldPath ->
-            "$fieldPath is not a valid data provider name; DataProvider and ReportingSet " +
-              "components must not be mixed, and campaign_group must be empty for ReportingSet " +
-              "components"
+            "$fieldPath is not a valid DataProvider resource name; when campaign_group is " +
+              "specified, all ReportingUnit components must be DataProviders"
           }
 
         if (!campaignGroupInfo.dataProviderNames.contains(component)) {

--- a/src/main/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/CreateBasicReportRequestValidation.kt
+++ b/src/main/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/CreateBasicReportRequestValidation.kt
@@ -56,6 +56,12 @@ import org.wfanet.measurement.reporting.v2alpha.ResultGroupSpec
 object CreateBasicReportRequestValidation {
   private val RESOURCE_ID_REGEX = ResourceIds.AIP_122_REGEX
 
+  /**
+   * Maximum number of components allowed in a single `reporting_unit`. Guards against accidentally
+   * large requests; can be tightened later without back-compat concerns.
+   */
+  private const val MAX_REPORTING_UNIT_COMPONENTS = 25
+
   data class ParsedFields(
     val parentKey: MeasurementConsumerKey,
     val impressionQualificationFilterKeys: Set<ImpressionQualificationFilterKey>,
@@ -82,6 +88,10 @@ object CreateBasicReportRequestValidation {
    * [request.basicReport.campaignGroup][org.wfanet.measurement.reporting.v2alpha.BasicReport.campaignGroup]
    * field.
    *
+   * @param campaignGroup the caller-supplied Campaign Group [ReportingSet] (DataProvider mode), or
+   *   `null` for custom-group mode where the Campaign Group is server-synthesized after validation.
+   *   In DataProvider mode every `reporting_unit` component must be a DataProvider within the
+   *   Campaign Group; in custom-group mode every component must be a ReportingSet.
    * @throws InvalidFieldValueException
    * @throws RequiredFieldNotSetException
    * @throws DataProviderNotFoundForCampaignGroupException
@@ -90,7 +100,7 @@ object CreateBasicReportRequestValidation {
    */
   fun validateRequest(
     request: CreateBasicReportRequest,
-    campaignGroup: ReportingSet,
+    campaignGroup: ReportingSet?,
     hasDefaultReportStartHour: Boolean,
     eventTemplateFieldsByPath: Map<String, EventMessageDescriptor.EventTemplateFieldInfo>,
   ): ParsedFields {
@@ -143,7 +153,7 @@ object CreateBasicReportRequestValidation {
     validateResultGroupSpecs(
       request.basicReport.resultGroupSpecsList,
       eventTemplateFieldsByPath,
-      CampaignGroupInfo(campaignGroup),
+      if (campaignGroup != null) CampaignGroupInfo(campaignGroup) else null,
     )
 
     return ParsedFields(parentKey, impressionQualificationFilterKeyByName)
@@ -162,7 +172,7 @@ object CreateBasicReportRequestValidation {
   private fun validateResultGroupSpecs(
     resultGroupSpecs: List<ResultGroupSpec>,
     eventTemplateFieldsByPath: Map<String, EventMessageDescriptor.EventTemplateFieldInfo>,
-    campaignGroupInfo: CampaignGroupInfo,
+    campaignGroupInfo: CampaignGroupInfo?,
   ) {
     val fieldPath = "basic_report.result_group_specs"
     if (resultGroupSpecs.isEmpty()) {
@@ -290,26 +300,61 @@ object CreateBasicReportRequestValidation {
   /**
    * Validates [reportingUnit] within the context of a [CreateBasicReportRequest].
    *
+   * There are two mutually exclusive component modes, selected by whether a Campaign Group was
+   * supplied on the request:
+   * - DataProvider mode ([campaignGroupInfo] non-null): every component must be a DataProvider
+   *   resource name belonging to the Campaign Group.
+   * - Custom-group mode ([campaignGroupInfo] `null`): every component must be a ReportingSet
+   *   resource name. The referenced ReportingSets are resolved and further validated (primitive,
+   *   Measurement Consumer-owned, distinct DataProvider sets) server-side in `BasicReportsService`,
+   *   where they are fetched for Campaign Group synthesis.
+   *
+   * DataProvider and ReportingSet components must not be mixed within a single `reporting_unit`.
+   *
    * @param fieldPath Path of [reportingUnit] relative to the request message
-   * @param campaignGroupInfo Information about the Campaign Group for the BasicReport
+   * @param campaignGroupInfo Information about the supplied Campaign Group, or `null` for
+   *   custom-group mode
    */
   private fun validateReportingUnit(
     reportingUnit: ReportingUnit,
     fieldPath: String,
-    campaignGroupInfo: CampaignGroupInfo,
+    campaignGroupInfo: CampaignGroupInfo?,
   ) {
-    if (reportingUnit.componentsList.isEmpty()) {
+    val components = reportingUnit.componentsList
+    if (components.isEmpty()) {
       throw InvalidFieldValueException("$fieldPath.components")
     }
+    if (components.size > MAX_REPORTING_UNIT_COMPONENTS) {
+      throw InvalidFieldValueException("$fieldPath.components") { fieldPath ->
+        "$fieldPath must not contain more than $MAX_REPORTING_UNIT_COMPONENTS components"
+      }
+    }
 
-    reportingUnit.componentsList.forEachIndexed { index, component ->
-      DataProviderKey.fromName(component)
-        ?: throw InvalidFieldValueException("$fieldPath.components[$index]") { fieldPath ->
-          "$fieldPath is not a valid data provider name"
+    if (campaignGroupInfo == null) {
+      // Custom-group mode: every component must be a ReportingSet resource name. A DataProvider
+      // component here means either the caller mixed component types or omitted campaign_group for a
+      // DataProvider report.
+      components.forEachIndexed { index, component ->
+        ReportingSetKey.fromName(component)
+          ?: throw InvalidFieldValueException("$fieldPath.components[$index]") { fieldPath ->
+            "$fieldPath is not a valid ReportingSet resource name; DataProvider and ReportingSet " +
+              "components must not be mixed, and campaign_group must be set for DataProvider " +
+              "components"
+          }
+      }
+    } else {
+      // DataProvider mode: every component must be a DataProvider within the Campaign Group.
+      components.forEachIndexed { index, component ->
+        DataProviderKey.fromName(component)
+          ?: throw InvalidFieldValueException("$fieldPath.components[$index]") { fieldPath ->
+            "$fieldPath is not a valid data provider name; DataProvider and ReportingSet " +
+              "components must not be mixed, and campaign_group must be empty for ReportingSet " +
+              "components"
+          }
+
+        if (!campaignGroupInfo.dataProviderNames.contains(component)) {
+          throw DataProviderNotFoundForCampaignGroupException(component, campaignGroupInfo.name)
         }
-
-      if (!campaignGroupInfo.dataProviderNames.contains(component)) {
-        throw DataProviderNotFoundForCampaignGroupException(component, campaignGroupInfo.name)
       }
     }
   }

--- a/src/main/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/CreateBasicReportRequestValidation.kt
+++ b/src/main/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/CreateBasicReportRequestValidation.kt
@@ -332,8 +332,8 @@ object CreateBasicReportRequestValidation {
 
     if (campaignGroupInfo == null) {
       // Custom-group mode: every component must be a ReportingSet resource name. A DataProvider
-      // component here means either the caller mixed component types or omitted campaign_group for a
-      // DataProvider report.
+      // component here means the caller either mixed component types or left campaign_group empty
+      // for a DataProvider report.
       components.forEachIndexed { index, component ->
         ReportingSetKey.fromName(component)
           ?: throw InvalidFieldValueException("$fieldPath.components[$index]") { fieldPath ->

--- a/src/main/kotlin/org/wfanet/measurement/reporting/service/internal/Normalization.kt
+++ b/src/main/kotlin/org/wfanet/measurement/reporting/service/internal/Normalization.kt
@@ -69,10 +69,10 @@ object Normalization {
    * calculation), so order-only differences must not produce distinct dim keys.
    *
    * Both component variants are normalized: `dataProviderKeys` (BasicReport DataProvider mode) is
-   * sorted by `cmmsDataProviderId`, and `reportingSetKeys` (BasicReport custom-group mode) is sorted
-   * by `externalReportingSetId`. Any new component variant must extend this `when` rather than rely
-   * on a silent passthrough -- that would un-normalize the input and reintroduce the order-sensitive
-   * dim-key bug PR #4057 was written to prevent.
+   * sorted by `cmmsDataProviderId`, and `reportingSetKeys` (BasicReport custom-group mode) is
+   * sorted by `externalReportingSetId`. Any new component variant must extend this `when` rather
+   * than rely on a silent passthrough -- that would un-normalize the input and reintroduce the
+   * order-sensitive dim-key bug PR #4057 was written to prevent.
    */
   fun normalizeReportingUnit(reportingUnit: ReportingUnit): ReportingUnit {
     @Suppress("WHEN_ENUM_CAN_BE_NULL_IN_JAVA") // Proto enum fields are never null.

--- a/src/main/kotlin/org/wfanet/measurement/reporting/service/internal/Normalization.kt
+++ b/src/main/kotlin/org/wfanet/measurement/reporting/service/internal/Normalization.kt
@@ -68,9 +68,9 @@ object Normalization {
    * `ReportingUnit.components` is semantically a set (order does not affect downstream metric
    * calculation), so order-only differences must not produce distinct dim keys.
    *
-   * Both component variants are normalized: `dataProviderKeys` (BasicReport DataProvider mode) is
-   * sorted by `cmmsDataProviderId`, and `reportingSetKeys` (BasicReport custom-group mode) is
-   * sorted by `externalReportingSetId`. Any new component variant must extend this `when` rather
+   * Both component variants are normalized: `dataProviderKeys` (DataProvider components) is sorted
+   * by `cmmsDataProviderId`, and `reportingSetKeys` (ReportingSet components) is sorted by
+   * `externalReportingSetId`. Any new component variant must extend this `when` rather
    * than rely on a silent passthrough -- that would un-normalize the input and reintroduce the
    * order-sensitive dim-key bug PR #4057 was written to prevent.
    */

--- a/src/main/kotlin/org/wfanet/measurement/reporting/service/internal/Normalization.kt
+++ b/src/main/kotlin/org/wfanet/measurement/reporting/service/internal/Normalization.kt
@@ -68,12 +68,11 @@ object Normalization {
    * `ReportingUnit.components` is semantically a set (order does not affect downstream metric
    * calculation), so order-only differences must not produce distinct dim keys.
    *
-   * Only the `dataProviderKeys` variant is implemented today (the BasicReport path). The
-   * `reportingSetKeys` variant is reserved for AdvancedReport and currently has no caller; a future
-   * AdvancedReport normalization path must extend this function rather than rely on the
-   * silent-passthrough that the old early `if (hasDataProviderKeys())` shape allowed -- that would
-   * silently un-normalize AdvancedReport input and reintroduce the order-sensitive dim-key bug
-   * PR #4057 was written to prevent.
+   * Both component variants are normalized: `dataProviderKeys` (BasicReport DataProvider mode) is
+   * sorted by `cmmsDataProviderId`, and `reportingSetKeys` (BasicReport custom-group mode) is sorted
+   * by `externalReportingSetId`. Any new component variant must extend this `when` rather than rely
+   * on a silent passthrough -- that would un-normalize the input and reintroduce the order-sensitive
+   * dim-key bug PR #4057 was written to prevent.
    */
   fun normalizeReportingUnit(reportingUnit: ReportingUnit): ReportingUnit {
     @Suppress("WHEN_ENUM_CAN_BE_NULL_IN_JAVA") // Proto enum fields are never null.
@@ -88,12 +87,17 @@ object Normalization {
                 }
             }
         }
-      ReportingUnit.ComponentsCase.COMPONENTS_NOT_SET -> reportingUnit
       ReportingUnit.ComponentsCase.REPORTING_SET_KEYS ->
-        throw IllegalArgumentException(
-          "normalizeReportingUnit does not yet handle the reportingSetKeys variant; " +
-            "extend this function (sort by a stable key) when adding an AdvancedReport caller."
-        )
+        reportingUnit.copy {
+          reportingSetKeys =
+            ReportingUnitKt.reportingSetKeys {
+              reportingSetKeys +=
+                reportingUnit.reportingSetKeys.reportingSetKeysList.sortedBy {
+                  it.externalReportingSetId
+                }
+            }
+        }
+      ReportingUnit.ComponentsCase.COMPONENTS_NOT_SET -> reportingUnit
     }
   }
 

--- a/src/main/kotlin/org/wfanet/measurement/reporting/service/internal/Normalization.kt
+++ b/src/main/kotlin/org/wfanet/measurement/reporting/service/internal/Normalization.kt
@@ -70,9 +70,9 @@ object Normalization {
    *
    * Both component variants are normalized: `dataProviderKeys` (DataProvider components) is sorted
    * by `cmmsDataProviderId`, and `reportingSetKeys` (ReportingSet components) is sorted by
-   * `externalReportingSetId`. Any new component variant must extend this `when` rather
-   * than rely on a silent passthrough -- that would un-normalize the input and reintroduce the
-   * order-sensitive dim-key bug PR #4057 was written to prevent.
+   * `externalReportingSetId`. Any new component variant must extend this `when` rather than rely on
+   * a silent passthrough -- that would un-normalize the input and reintroduce the order-sensitive
+   * dim-key bug PR #4057 was written to prevent.
    */
   fun normalizeReportingUnit(reportingUnit: ReportingUnit): ReportingUnit {
     @Suppress("WHEN_ENUM_CAN_BE_NULL_IN_JAVA") // Proto enum fields are never null.

--- a/src/test/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/BasicReportsServiceTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/BasicReportsServiceTest.kt
@@ -455,10 +455,10 @@ class BasicReportsServiceTest {
   }
 
   /**
-   * Creates a primitive custom-group [ReportingSet] (empty `campaign_group`) with a single
-   * EventGroup, returning its resource name.
+   * Creates a primitive [ReportingSet] component (empty `campaign_group`) with a single EventGroup,
+   * returning its resource name.
    */
-  private suspend fun createPrimitiveCustomGroup(
+  private suspend fun createPrimitiveReportingSet(
     measurementConsumerKey: MeasurementConsumerKey,
     externalReportingSetId: String,
     cmmsDataProviderId: String,
@@ -484,10 +484,10 @@ class BasicReportsServiceTest {
   }
 
   /**
-   * Builds a custom-group ([reportingUnit] with ReportingSet components)
-   * [CreateBasicReportRequest].
+   * Builds a [CreateBasicReportRequest] whose [reportingUnit] has ReportingSet components (empty
+   * `campaign_group`).
    */
-  private fun customGroupBasicReportRequest(
+  private fun reportingSetComponentBasicReportRequest(
     measurementConsumerKey: MeasurementConsumerKey,
     basicReportId: String,
     componentNames: List<String>,
@@ -498,7 +498,7 @@ class BasicReportsServiceTest {
       }
     return createBasicReportRequest {
       parent = measurementConsumerKey.toName()
-      // campaign_group intentionally left empty (custom-group mode).
+      // campaign_group intentionally left empty (server synthesizes it).
       this.basicReport =
         BASIC_REPORT.copy {
           resultGroupSpecs.clear()
@@ -509,7 +509,7 @@ class BasicReportsServiceTest {
   }
 
   @Test
-  fun `createBasicReport synthesizes campaign group for custom group reporting units`(): Unit =
+  fun `createBasicReport synthesizes campaign group for ReportingSet reporting units`(): Unit =
     runBlocking {
       val measurementConsumerKey = MeasurementConsumerKey(CMMS_MEASUREMENT_CONSUMER_ID)
       measurementConsumersService.createMeasurementConsumer(
@@ -518,17 +518,17 @@ class BasicReportsServiceTest {
         }
       )
 
-      // Two primitive custom groups with disjoint DataProvider sets.
-      val customGroup1 =
-        createPrimitiveCustomGroup(measurementConsumerKey, "customgroup1", "dp1", "eg1")
-      val customGroup2 =
-        createPrimitiveCustomGroup(measurementConsumerKey, "customgroup2", "dp2", "eg2")
+      // Two primitive ReportingSet components with disjoint DataProvider sets.
+      val reportingSetComponent1 =
+        createPrimitiveReportingSet(measurementConsumerKey, "reportingset1", "dp1", "eg1")
+      val reportingSetComponent2 =
+        createPrimitiveReportingSet(measurementConsumerKey, "reportingset2", "dp2", "eg2")
 
       val request =
-        customGroupBasicReportRequest(
+        reportingSetComponentBasicReportRequest(
           measurementConsumerKey,
           "a1234",
-          listOf(customGroup1, customGroup2),
+          listOf(reportingSetComponent1, reportingSetComponent2),
         )
 
       val response =
@@ -540,7 +540,7 @@ class BasicReportsServiceTest {
       assertThat(response.effectiveCampaignGroup).isNotEmpty()
 
       // The synthesized campaign group is a primitive, self-referencing ReportingSet whose
-      // EventGroups are the union of the custom groups' EventGroups.
+      // EventGroups are the union of the components' EventGroups.
       val synthesizedKey = checkNotNull(ReportingSetKey.fromName(response.effectiveCampaignGroup))
       val synthesized =
         internalReportingSetsService
@@ -565,17 +565,17 @@ class BasicReportsServiceTest {
           },
         )
 
-      // The created internal Report buckets metrics by the custom-group ReportingSets themselves
-      // (and mints the union composite referencing them, exercising the empty-campaign_group
-      // composite path).
+      // The created internal Report buckets metrics by the ReportingSet components themselves (and
+      // mints the union composite referencing them, exercising the empty-campaign_group composite
+      // path).
       val createReportRequest =
         argumentCaptor { verify(reportsServiceMock).createReport(capture()) }.firstValue
       assertThat(createReportRequest.report.reportingMetricEntriesList.map { it.key })
-        .containsAtLeast(customGroup1, customGroup2)
+        .containsAtLeast(reportingSetComponent1, reportingSetComponent2)
     }
 
   @Test
-  fun `createBasicReport reuses synthesized campaign group for identical custom groups`(): Unit =
+  fun `createBasicReport reuses the synthesized campaign group for identical components`(): Unit =
     runBlocking {
       val measurementConsumerKey = MeasurementConsumerKey(CMMS_MEASUREMENT_CONSUMER_ID)
       measurementConsumersService.createMeasurementConsumer(
@@ -583,22 +583,22 @@ class BasicReportsServiceTest {
           cmmsMeasurementConsumerId = measurementConsumerKey.measurementConsumerId
         }
       )
-      val customGroup1 =
-        createPrimitiveCustomGroup(measurementConsumerKey, "customgroup1", "dp1", "eg1")
-      val customGroup2 =
-        createPrimitiveCustomGroup(measurementConsumerKey, "customgroup2", "dp2", "eg2")
-      val componentNames = listOf(customGroup1, customGroup2)
+      val reportingSetComponent1 =
+        createPrimitiveReportingSet(measurementConsumerKey, "reportingset1", "dp1", "eg1")
+      val reportingSetComponent2 =
+        createPrimitiveReportingSet(measurementConsumerKey, "reportingset2", "dp2", "eg2")
+      val componentNames = listOf(reportingSetComponent1, reportingSetComponent2)
 
       val firstResponse =
         withPrincipalAndScopes(PRINCIPAL, SCOPES) {
           service.createBasicReport(
-            customGroupBasicReportRequest(measurementConsumerKey, "a1234", componentNames)
+            reportingSetComponentBasicReportRequest(measurementConsumerKey, "a1234", componentNames)
           )
         }
       val secondResponse =
         withPrincipalAndScopes(PRINCIPAL, SCOPES) {
           service.createBasicReport(
-            customGroupBasicReportRequest(measurementConsumerKey, "a5678", componentNames)
+            reportingSetComponentBasicReportRequest(measurementConsumerKey, "a5678", componentNames)
           )
         }
 
@@ -615,14 +615,14 @@ class BasicReportsServiceTest {
         cmmsMeasurementConsumerId = measurementConsumerKey.measurementConsumerId
       }
     )
-    val customGroup =
-      createPrimitiveCustomGroup(measurementConsumerKey, "customgroup1", "dp1", "eg1")
+    val reportingSetComponent =
+      createPrimitiveReportingSet(measurementConsumerKey, "reportingset1", "dp1", "eg1")
 
     val request =
-      customGroupBasicReportRequest(
+      reportingSetComponentBasicReportRequest(
         measurementConsumerKey,
         "a1234",
-        listOf(DATA_PROVIDER_KEY.toName(), customGroup),
+        listOf(DATA_PROVIDER_KEY.toName(), reportingSetComponent),
       )
 
     val exception =
@@ -633,7 +633,7 @@ class BasicReportsServiceTest {
   }
 
   @Test
-  fun `createBasicReport throws INVALID_ARGUMENT when custom groups share a DataProvider set`():
+  fun `createBasicReport throws INVALID_ARGUMENT when ReportingSets share a DataProvider set`():
     Unit = runBlocking {
     val measurementConsumerKey = MeasurementConsumerKey(CMMS_MEASUREMENT_CONSUMER_ID)
     measurementConsumersService.createMeasurementConsumer(
@@ -641,17 +641,17 @@ class BasicReportsServiceTest {
         cmmsMeasurementConsumerId = measurementConsumerKey.measurementConsumerId
       }
     )
-    // Both custom groups resolve to the same DataProvider set ({dp1}).
-    val customGroup1 =
-      createPrimitiveCustomGroup(measurementConsumerKey, "customgroup1", "dp1", "eg1")
-    val customGroup2 =
-      createPrimitiveCustomGroup(measurementConsumerKey, "customgroup2", "dp1", "eg2")
+    // Both ReportingSets resolve to the same DataProvider set ({dp1}).
+    val reportingSetComponent1 =
+      createPrimitiveReportingSet(measurementConsumerKey, "reportingset1", "dp1", "eg1")
+    val reportingSetComponent2 =
+      createPrimitiveReportingSet(measurementConsumerKey, "reportingset2", "dp1", "eg2")
 
     val request =
-      customGroupBasicReportRequest(
+      reportingSetComponentBasicReportRequest(
         measurementConsumerKey,
         "a1234",
-        listOf(customGroup1, customGroup2),
+        listOf(reportingSetComponent1, reportingSetComponent2),
       )
 
     val exception =
@@ -662,7 +662,7 @@ class BasicReportsServiceTest {
   }
 
   @Test
-  fun `createBasicReport throws FAILED_PRECONDITION when a custom group does not exist`(): Unit =
+  fun `createBasicReport throws FAILED_PRECONDITION when a ReportingSet does not exist`(): Unit =
     runBlocking {
       val measurementConsumerKey = MeasurementConsumerKey(CMMS_MEASUREMENT_CONSUMER_ID)
       measurementConsumersService.createMeasurementConsumer(
@@ -672,7 +672,7 @@ class BasicReportsServiceTest {
       )
 
       val request =
-        customGroupBasicReportRequest(
+        reportingSetComponentBasicReportRequest(
           measurementConsumerKey,
           "a1234",
           listOf(ReportingSetKey(measurementConsumerKey, "nonexistent").toName()),
@@ -686,7 +686,7 @@ class BasicReportsServiceTest {
     }
 
   @Test
-  fun `createBasicReport throws INVALID_ARGUMENT when a custom group is composite`(): Unit =
+  fun `createBasicReport throws INVALID_ARGUMENT when a ReportingSet is composite`(): Unit =
     runBlocking {
       val measurementConsumerKey = MeasurementConsumerKey(CMMS_MEASUREMENT_CONSUMER_ID)
       measurementConsumersService.createMeasurementConsumer(
@@ -695,9 +695,9 @@ class BasicReportsServiceTest {
         }
       )
 
-      // A primitive ReportingSet plus a composite (UNION) custom group referencing it. Composite
-      // custom groups are rejected: custom-group components must be primitive.
-      createPrimitiveCustomGroup(measurementConsumerKey, "primitive1", "dp1", "eg1")
+      // A primitive ReportingSet plus a composite (UNION) ReportingSet referencing it. Composite
+      // components are rejected: ReportingSet components must be primitive.
+      createPrimitiveReportingSet(measurementConsumerKey, "primitive1", "dp1", "eg1")
       internalReportingSetsService.createReportingSet(
         createReportingSetRequest {
           reportingSet = internalReportingSet {
@@ -723,7 +723,7 @@ class BasicReportsServiceTest {
       )
 
       val request =
-        customGroupBasicReportRequest(
+        reportingSetComponentBasicReportRequest(
           measurementConsumerKey,
           "a1234",
           listOf(ReportingSetKey(measurementConsumerKey, "compositegroup").toName()),
@@ -749,8 +749,9 @@ class BasicReportsServiceTest {
     // 26 components exceeds the cap of 25. The cap is enforced during request validation, before
     // any ReportingSet is resolved, so the components need not exist.
     val componentNames =
-      (1..26).map { ReportingSetKey(measurementConsumerKey, "customgroup$it").toName() }
-    val request = customGroupBasicReportRequest(measurementConsumerKey, "a1234", componentNames)
+      (1..26).map { ReportingSetKey(measurementConsumerKey, "reportingset$it").toName() }
+    val request =
+      reportingSetComponentBasicReportRequest(measurementConsumerKey, "a1234", componentNames)
 
     val exception =
       assertFailsWith<StatusRuntimeException> {
@@ -4135,8 +4136,8 @@ class BasicReportsServiceTest {
   @Test
   fun `createBasicReport throws INVALID_ARGUMENT when campaignGroup empty and components are DataProviders`() =
     runBlocking {
-      // An empty campaign_group selects custom-group mode, where reporting_unit components must be
-      // ReportingSets. BASIC_REPORT uses a DataProvider component, so this is rejected.
+      // When campaign_group is not specified, reporting_unit components must be ReportingSets.
+      // BASIC_REPORT uses a DataProvider component, so this is rejected.
       val measurementConsumerKey = MeasurementConsumerKey(CMMS_MEASUREMENT_CONSUMER_ID)
 
       measurementConsumersService.createMeasurementConsumer(

--- a/src/test/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/BasicReportsServiceTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/BasicReportsServiceTest.kt
@@ -132,6 +132,7 @@ import org.wfanet.measurement.internal.reporting.v2.basicReportDetails
 import org.wfanet.measurement.internal.reporting.v2.basicReportResultDetails
 import org.wfanet.measurement.internal.reporting.v2.batchCreateReportingSetResultsRequest
 import org.wfanet.measurement.internal.reporting.v2.copy
+import org.wfanet.measurement.internal.reporting.v2.batchGetReportingSetsRequest
 import org.wfanet.measurement.internal.reporting.v2.createBasicReportRequest as internalCreateBasicReportRequest
 import org.wfanet.measurement.internal.reporting.v2.createReportResultRequest
 import org.wfanet.measurement.internal.reporting.v2.createReportingSetRequest
@@ -185,6 +186,7 @@ import org.wfanet.measurement.reporting.v2alpha.ReportsGrpcKt.ReportsCoroutineIm
 import org.wfanet.measurement.reporting.v2alpha.ReportsGrpcKt.ReportsCoroutineStub
 import org.wfanet.measurement.reporting.v2alpha.ResultGroupKt
 import org.wfanet.measurement.reporting.v2alpha.ResultGroupMetricSpecKt
+import org.wfanet.measurement.reporting.v2alpha.CreateBasicReportRequest
 import org.wfanet.measurement.reporting.v2alpha.basicReport
 import org.wfanet.measurement.reporting.v2alpha.copy
 import org.wfanet.measurement.reporting.v2alpha.createBasicReportRequest
@@ -451,6 +453,305 @@ class BasicReportsServiceTest {
       )
     assertThat(response.createTime.seconds).isAtLeast(1)
   }
+
+  /**
+   * Creates a primitive custom-group [ReportingSet] (empty `campaign_group`) with a single
+   * EventGroup, returning its resource name.
+   */
+  private suspend fun createPrimitiveCustomGroup(
+    measurementConsumerKey: MeasurementConsumerKey,
+    externalReportingSetId: String,
+    cmmsDataProviderId: String,
+    cmmsEventGroupId: String,
+  ): String {
+    internalReportingSetsService.createReportingSet(
+      createReportingSetRequest {
+        reportingSet = internalReportingSet {
+          cmmsMeasurementConsumerId = measurementConsumerKey.measurementConsumerId
+          primitive =
+            ReportingSetKt.primitive {
+              eventGroupKeys +=
+                ReportingSetKt.PrimitiveKt.eventGroupKey {
+                  this.cmmsDataProviderId = cmmsDataProviderId
+                  this.cmmsEventGroupId = cmmsEventGroupId
+                }
+            }
+        }
+        this.externalReportingSetId = externalReportingSetId
+      }
+    )
+    return ReportingSetKey(measurementConsumerKey, externalReportingSetId).toName()
+  }
+
+  /** Builds a custom-group ([reportingUnit] with ReportingSet components) [CreateBasicReportRequest]. */
+  private fun customGroupBasicReportRequest(
+    measurementConsumerKey: MeasurementConsumerKey,
+    basicReportId: String,
+    componentNames: List<String>,
+  ): CreateBasicReportRequest {
+    val resultGroupSpec =
+      BASIC_REPORT.resultGroupSpecsList.single().copy {
+        reportingUnit = reportingUnit { components += componentNames }
+      }
+    return createBasicReportRequest {
+      parent = measurementConsumerKey.toName()
+      // campaign_group intentionally left empty (custom-group mode).
+      this.basicReport =
+        BASIC_REPORT.copy {
+          resultGroupSpecs.clear()
+          resultGroupSpecs += resultGroupSpec
+        }
+      this.basicReportId = basicReportId
+    }
+  }
+
+  @Test
+  fun `createBasicReport synthesizes campaign group for custom group reporting units`(): Unit =
+    runBlocking {
+      val measurementConsumerKey = MeasurementConsumerKey(CMMS_MEASUREMENT_CONSUMER_ID)
+      measurementConsumersService.createMeasurementConsumer(
+        measurementConsumer {
+          cmmsMeasurementConsumerId = measurementConsumerKey.measurementConsumerId
+        }
+      )
+
+      // Two primitive custom groups with disjoint DataProvider sets.
+      val customGroup1 =
+        createPrimitiveCustomGroup(measurementConsumerKey, "customgroup1", "dp1", "eg1")
+      val customGroup2 =
+        createPrimitiveCustomGroup(measurementConsumerKey, "customgroup2", "dp2", "eg2")
+
+      val request =
+        customGroupBasicReportRequest(
+          measurementConsumerKey,
+          "a1234",
+          listOf(customGroup1, customGroup2),
+        )
+
+      val response =
+        withPrincipalAndScopes(PRINCIPAL, SCOPES) { service.createBasicReport(request) }
+
+      // campaign_group is empty; the server-synthesized campaign group is surfaced only via
+      // effective_campaign_group.
+      assertThat(response.campaignGroup).isEmpty()
+      assertThat(response.effectiveCampaignGroup).isNotEmpty()
+
+      // The synthesized campaign group is a primitive, self-referencing ReportingSet whose
+      // EventGroups are the union of the custom groups' EventGroups.
+      val synthesizedKey = checkNotNull(ReportingSetKey.fromName(response.effectiveCampaignGroup))
+      val synthesized =
+        internalReportingSetsService
+          .batchGetReportingSets(
+            batchGetReportingSetsRequest {
+              cmmsMeasurementConsumerId = measurementConsumerKey.measurementConsumerId
+              externalReportingSetIds += synthesizedKey.reportingSetId
+            }
+          )
+          .reportingSetsList
+          .single()
+      assertThat(synthesized.externalCampaignGroupId).isEqualTo(synthesizedKey.reportingSetId)
+      assertThat(synthesized.primitive.eventGroupKeysList)
+        .containsExactly(
+          ReportingSetKt.PrimitiveKt.eventGroupKey {
+            cmmsDataProviderId = "dp1"
+            cmmsEventGroupId = "eg1"
+          },
+          ReportingSetKt.PrimitiveKt.eventGroupKey {
+            cmmsDataProviderId = "dp2"
+            cmmsEventGroupId = "eg2"
+          },
+        )
+
+      // The created internal Report buckets metrics by the custom-group ReportingSets themselves
+      // (and mints the union composite referencing them, exercising the empty-campaign_group
+      // composite path).
+      val createReportRequest =
+        argumentCaptor { verify(reportsServiceMock).createReport(capture()) }.firstValue
+      assertThat(createReportRequest.report.reportingMetricEntriesList.map { it.key })
+        .containsAtLeast(customGroup1, customGroup2)
+    }
+
+  @Test
+  fun `createBasicReport reuses synthesized campaign group for identical custom groups`(): Unit =
+    runBlocking {
+      val measurementConsumerKey = MeasurementConsumerKey(CMMS_MEASUREMENT_CONSUMER_ID)
+      measurementConsumersService.createMeasurementConsumer(
+        measurementConsumer {
+          cmmsMeasurementConsumerId = measurementConsumerKey.measurementConsumerId
+        }
+      )
+      val customGroup1 =
+        createPrimitiveCustomGroup(measurementConsumerKey, "customgroup1", "dp1", "eg1")
+      val customGroup2 =
+        createPrimitiveCustomGroup(measurementConsumerKey, "customgroup2", "dp2", "eg2")
+      val componentNames = listOf(customGroup1, customGroup2)
+
+      val firstResponse =
+        withPrincipalAndScopes(PRINCIPAL, SCOPES) {
+          service.createBasicReport(
+            customGroupBasicReportRequest(measurementConsumerKey, "a1234", componentNames)
+          )
+        }
+      val secondResponse =
+        withPrincipalAndScopes(PRINCIPAL, SCOPES) {
+          service.createBasicReport(
+            customGroupBasicReportRequest(measurementConsumerKey, "a5678", componentNames)
+          )
+        }
+
+      assertThat(secondResponse.effectiveCampaignGroup)
+        .isEqualTo(firstResponse.effectiveCampaignGroup)
+    }
+
+  @Test
+  fun `createBasicReport throws INVALID_ARGUMENT when components mix DataProvider and ReportingSet`():
+    Unit = runBlocking {
+    val measurementConsumerKey = MeasurementConsumerKey(CMMS_MEASUREMENT_CONSUMER_ID)
+    measurementConsumersService.createMeasurementConsumer(
+      measurementConsumer {
+        cmmsMeasurementConsumerId = measurementConsumerKey.measurementConsumerId
+      }
+    )
+    val customGroup =
+      createPrimitiveCustomGroup(measurementConsumerKey, "customgroup1", "dp1", "eg1")
+
+    val request =
+      customGroupBasicReportRequest(
+        measurementConsumerKey,
+        "a1234",
+        listOf(DATA_PROVIDER_KEY.toName(), customGroup),
+      )
+
+    val exception =
+      assertFailsWith<StatusRuntimeException> {
+        withPrincipalAndScopes(PRINCIPAL, SCOPES) { service.createBasicReport(request) }
+      }
+    assertThat(exception).status().code().isEqualTo(Status.Code.INVALID_ARGUMENT)
+  }
+
+  @Test
+  fun `createBasicReport throws INVALID_ARGUMENT when custom groups share a DataProvider set`():
+    Unit = runBlocking {
+    val measurementConsumerKey = MeasurementConsumerKey(CMMS_MEASUREMENT_CONSUMER_ID)
+    measurementConsumersService.createMeasurementConsumer(
+      measurementConsumer {
+        cmmsMeasurementConsumerId = measurementConsumerKey.measurementConsumerId
+      }
+    )
+    // Both custom groups resolve to the same DataProvider set ({dp1}).
+    val customGroup1 =
+      createPrimitiveCustomGroup(measurementConsumerKey, "customgroup1", "dp1", "eg1")
+    val customGroup2 =
+      createPrimitiveCustomGroup(measurementConsumerKey, "customgroup2", "dp1", "eg2")
+
+    val request =
+      customGroupBasicReportRequest(
+        measurementConsumerKey,
+        "a1234",
+        listOf(customGroup1, customGroup2),
+      )
+
+    val exception =
+      assertFailsWith<StatusRuntimeException> {
+        withPrincipalAndScopes(PRINCIPAL, SCOPES) { service.createBasicReport(request) }
+      }
+    assertThat(exception).status().code().isEqualTo(Status.Code.INVALID_ARGUMENT)
+  }
+
+  @Test
+  fun `createBasicReport throws FAILED_PRECONDITION when a custom group does not exist`(): Unit =
+    runBlocking {
+      val measurementConsumerKey = MeasurementConsumerKey(CMMS_MEASUREMENT_CONSUMER_ID)
+      measurementConsumersService.createMeasurementConsumer(
+        measurementConsumer {
+          cmmsMeasurementConsumerId = measurementConsumerKey.measurementConsumerId
+        }
+      )
+
+      val request =
+        customGroupBasicReportRequest(
+          measurementConsumerKey,
+          "a1234",
+          listOf(ReportingSetKey(measurementConsumerKey, "nonexistent").toName()),
+        )
+
+      val exception =
+        assertFailsWith<StatusRuntimeException> {
+          withPrincipalAndScopes(PRINCIPAL, SCOPES) { service.createBasicReport(request) }
+        }
+      assertThat(exception).status().code().isEqualTo(Status.Code.FAILED_PRECONDITION)
+    }
+
+  @Test
+  fun `createBasicReport throws INVALID_ARGUMENT when a custom group is composite`(): Unit =
+    runBlocking {
+      val measurementConsumerKey = MeasurementConsumerKey(CMMS_MEASUREMENT_CONSUMER_ID)
+      measurementConsumersService.createMeasurementConsumer(
+        measurementConsumer {
+          cmmsMeasurementConsumerId = measurementConsumerKey.measurementConsumerId
+        }
+      )
+
+      // A primitive ReportingSet plus a composite (UNION) custom group referencing it. Composite
+      // custom groups are rejected: custom-group components must be primitive.
+      createPrimitiveCustomGroup(measurementConsumerKey, "primitive1", "dp1", "eg1")
+      internalReportingSetsService.createReportingSet(
+        createReportingSetRequest {
+          reportingSet = internalReportingSet {
+            cmmsMeasurementConsumerId = measurementConsumerKey.measurementConsumerId
+            composite =
+              ReportingSetKt.setExpression {
+                operation = ReportingSet.SetExpression.Operation.UNION
+                lhs = ReportingSetKt.SetExpressionKt.operand { externalReportingSetId = "primitive1" }
+              }
+            weightedSubsetUnions +=
+              ReportingSetKt.weightedSubsetUnion {
+                primitiveReportingSetBases +=
+                  ReportingSetKt.primitiveReportingSetBasis { externalReportingSetId = "primitive1" }
+                binaryRepresentation = 1
+                weight = 1
+              }
+          }
+          externalReportingSetId = "compositegroup"
+        }
+      )
+
+      val request =
+        customGroupBasicReportRequest(
+          measurementConsumerKey,
+          "a1234",
+          listOf(ReportingSetKey(measurementConsumerKey, "compositegroup").toName()),
+        )
+
+      val exception =
+        assertFailsWith<StatusRuntimeException> {
+          withPrincipalAndScopes(PRINCIPAL, SCOPES) { service.createBasicReport(request) }
+        }
+      assertThat(exception).status().code().isEqualTo(Status.Code.INVALID_ARGUMENT)
+    }
+
+  @Test
+  fun `createBasicReport throws INVALID_ARGUMENT when reporting unit exceeds component cap`(): Unit =
+    runBlocking {
+      val measurementConsumerKey = MeasurementConsumerKey(CMMS_MEASUREMENT_CONSUMER_ID)
+      measurementConsumersService.createMeasurementConsumer(
+        measurementConsumer {
+          cmmsMeasurementConsumerId = measurementConsumerKey.measurementConsumerId
+        }
+      )
+
+      // 26 components exceeds the cap of 25. The cap is enforced during request validation, before
+      // any ReportingSet is resolved, so the components need not exist.
+      val componentNames =
+        (1..26).map { ReportingSetKey(measurementConsumerKey, "customgroup$it").toName() }
+      val request = customGroupBasicReportRequest(measurementConsumerKey, "a1234", componentNames)
+
+      val exception =
+        assertFailsWith<StatusRuntimeException> {
+          withPrincipalAndScopes(PRINCIPAL, SCOPES) { service.createBasicReport(request) }
+        }
+      assertThat(exception).status().code().isEqualTo(Status.Code.INVALID_ARGUMENT)
+    }
 
   @Test
   fun `createBasicReport creates report and persists its report id`(): Unit = runBlocking {
@@ -3826,48 +4127,40 @@ class BasicReportsServiceTest {
   }
 
   @Test
-  fun `createBasicReport throws INVALID_ARGUMENT when campaignGroup is missing`() = runBlocking {
-    val measurementConsumerKey = MeasurementConsumerKey(CMMS_MEASUREMENT_CONSUMER_ID)
-    val campaignGroupKey = ReportingSetKey(measurementConsumerKey, "1234")
+  fun `createBasicReport throws INVALID_ARGUMENT when campaignGroup empty and components are DataProviders`() =
+    runBlocking {
+      // An empty campaign_group selects custom-group mode, where reporting_unit components must be
+      // ReportingSets. BASIC_REPORT uses a DataProvider component, so this is rejected.
+      val measurementConsumerKey = MeasurementConsumerKey(CMMS_MEASUREMENT_CONSUMER_ID)
 
-    measurementConsumersService.createMeasurementConsumer(
-      measurementConsumer {
-        cmmsMeasurementConsumerId = measurementConsumerKey.measurementConsumerId
-      }
-    )
-
-    internalReportingSetsService.createReportingSet(
-      createReportingSetRequest {
-        reportingSet =
-          INTERNAL_CAMPAIGN_GROUP.copy {
-            cmmsMeasurementConsumerId = measurementConsumerKey.measurementConsumerId
-            externalCampaignGroupId = campaignGroupKey.reportingSetId
-          }
-        externalReportingSetId = campaignGroupKey.reportingSetId
-      }
-    )
-
-    val request = createBasicReportRequest {
-      parent = measurementConsumerKey.toName()
-      basicReport = BASIC_REPORT
-      basicReportId = "a1234"
-    }
-    val exception =
-      assertFailsWith<StatusRuntimeException> {
-        withPrincipalAndScopes(PRINCIPAL, SCOPES) { service.createBasicReport(request) }
-      }
-
-    assertThat(exception).status().code().isEqualTo(Status.Code.INVALID_ARGUMENT)
-    assertThat(exception)
-      .errorInfo()
-      .isEqualTo(
-        errorInfo {
-          domain = Errors.DOMAIN
-          reason = Errors.Reason.REQUIRED_FIELD_NOT_SET.name
-          metadata[Errors.Metadata.FIELD_NAME.key] = "basic_report.campaign_group"
+      measurementConsumersService.createMeasurementConsumer(
+        measurementConsumer {
+          cmmsMeasurementConsumerId = measurementConsumerKey.measurementConsumerId
         }
       )
-  }
+
+      val request = createBasicReportRequest {
+        parent = measurementConsumerKey.toName()
+        basicReport = BASIC_REPORT
+        basicReportId = "a1234"
+      }
+      val exception =
+        assertFailsWith<StatusRuntimeException> {
+          withPrincipalAndScopes(PRINCIPAL, SCOPES) { service.createBasicReport(request) }
+        }
+
+      assertThat(exception).status().code().isEqualTo(Status.Code.INVALID_ARGUMENT)
+      assertThat(exception)
+        .errorInfo()
+        .isEqualTo(
+          errorInfo {
+            domain = Errors.DOMAIN
+            reason = Errors.Reason.INVALID_FIELD_VALUE.name
+            metadata[Errors.Metadata.FIELD_NAME.key] =
+              "basic_report.result_group_specs[0].reporting_unit.components[0]"
+          }
+        )
+    }
 
   @Test
   fun `createBasicReport throws INVALID_ARGUMENT when campaignGroup is invalid`() = runBlocking {

--- a/src/test/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/BasicReportsServiceTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/BasicReportsServiceTest.kt
@@ -131,8 +131,8 @@ import org.wfanet.measurement.internal.reporting.v2.basicReport as internalBasic
 import org.wfanet.measurement.internal.reporting.v2.basicReportDetails
 import org.wfanet.measurement.internal.reporting.v2.basicReportResultDetails
 import org.wfanet.measurement.internal.reporting.v2.batchCreateReportingSetResultsRequest
-import org.wfanet.measurement.internal.reporting.v2.copy
 import org.wfanet.measurement.internal.reporting.v2.batchGetReportingSetsRequest
+import org.wfanet.measurement.internal.reporting.v2.copy
 import org.wfanet.measurement.internal.reporting.v2.createBasicReportRequest as internalCreateBasicReportRequest
 import org.wfanet.measurement.internal.reporting.v2.createReportResultRequest
 import org.wfanet.measurement.internal.reporting.v2.createReportingSetRequest
@@ -173,6 +173,7 @@ import org.wfanet.measurement.reporting.deploy.v2.postgres.testing.Schemata as P
 import org.wfanet.measurement.reporting.service.api.Errors
 import org.wfanet.measurement.reporting.service.internal.ImpressionQualificationFilterMapping
 import org.wfanet.measurement.reporting.v2alpha.BasicReport
+import org.wfanet.measurement.reporting.v2alpha.CreateBasicReportRequest
 import org.wfanet.measurement.reporting.v2alpha.CreateReportRequest
 import org.wfanet.measurement.reporting.v2alpha.DimensionSpec
 import org.wfanet.measurement.reporting.v2alpha.DimensionSpecKt
@@ -186,7 +187,6 @@ import org.wfanet.measurement.reporting.v2alpha.ReportsGrpcKt.ReportsCoroutineIm
 import org.wfanet.measurement.reporting.v2alpha.ReportsGrpcKt.ReportsCoroutineStub
 import org.wfanet.measurement.reporting.v2alpha.ResultGroupKt
 import org.wfanet.measurement.reporting.v2alpha.ResultGroupMetricSpecKt
-import org.wfanet.measurement.reporting.v2alpha.CreateBasicReportRequest
 import org.wfanet.measurement.reporting.v2alpha.basicReport
 import org.wfanet.measurement.reporting.v2alpha.copy
 import org.wfanet.measurement.reporting.v2alpha.createBasicReportRequest
@@ -483,7 +483,10 @@ class BasicReportsServiceTest {
     return ReportingSetKey(measurementConsumerKey, externalReportingSetId).toName()
   }
 
-  /** Builds a custom-group ([reportingUnit] with ReportingSet components) [CreateBasicReportRequest]. */
+  /**
+   * Builds a custom-group ([reportingUnit] with ReportingSet components)
+   * [CreateBasicReportRequest].
+   */
   private fun customGroupBasicReportRequest(
     measurementConsumerKey: MeasurementConsumerKey,
     basicReportId: String,
@@ -702,12 +705,15 @@ class BasicReportsServiceTest {
             composite =
               ReportingSetKt.setExpression {
                 operation = ReportingSet.SetExpression.Operation.UNION
-                lhs = ReportingSetKt.SetExpressionKt.operand { externalReportingSetId = "primitive1" }
+                lhs =
+                  ReportingSetKt.SetExpressionKt.operand { externalReportingSetId = "primitive1" }
               }
             weightedSubsetUnions +=
               ReportingSetKt.weightedSubsetUnion {
                 primitiveReportingSetBases +=
-                  ReportingSetKt.primitiveReportingSetBasis { externalReportingSetId = "primitive1" }
+                  ReportingSetKt.primitiveReportingSetBasis {
+                    externalReportingSetId = "primitive1"
+                  }
                 binaryRepresentation = 1
                 weight = 1
               }
@@ -731,27 +737,27 @@ class BasicReportsServiceTest {
     }
 
   @Test
-  fun `createBasicReport throws INVALID_ARGUMENT when reporting unit exceeds component cap`(): Unit =
-    runBlocking {
-      val measurementConsumerKey = MeasurementConsumerKey(CMMS_MEASUREMENT_CONSUMER_ID)
-      measurementConsumersService.createMeasurementConsumer(
-        measurementConsumer {
-          cmmsMeasurementConsumerId = measurementConsumerKey.measurementConsumerId
-        }
-      )
+  fun `createBasicReport throws INVALID_ARGUMENT when reporting unit exceeds component cap`():
+    Unit = runBlocking {
+    val measurementConsumerKey = MeasurementConsumerKey(CMMS_MEASUREMENT_CONSUMER_ID)
+    measurementConsumersService.createMeasurementConsumer(
+      measurementConsumer {
+        cmmsMeasurementConsumerId = measurementConsumerKey.measurementConsumerId
+      }
+    )
 
-      // 26 components exceeds the cap of 25. The cap is enforced during request validation, before
-      // any ReportingSet is resolved, so the components need not exist.
-      val componentNames =
-        (1..26).map { ReportingSetKey(measurementConsumerKey, "customgroup$it").toName() }
-      val request = customGroupBasicReportRequest(measurementConsumerKey, "a1234", componentNames)
+    // 26 components exceeds the cap of 25. The cap is enforced during request validation, before
+    // any ReportingSet is resolved, so the components need not exist.
+    val componentNames =
+      (1..26).map { ReportingSetKey(measurementConsumerKey, "customgroup$it").toName() }
+    val request = customGroupBasicReportRequest(measurementConsumerKey, "a1234", componentNames)
 
-      val exception =
-        assertFailsWith<StatusRuntimeException> {
-          withPrincipalAndScopes(PRINCIPAL, SCOPES) { service.createBasicReport(request) }
-        }
-      assertThat(exception).status().code().isEqualTo(Status.Code.INVALID_ARGUMENT)
-    }
+    val exception =
+      assertFailsWith<StatusRuntimeException> {
+        withPrincipalAndScopes(PRINCIPAL, SCOPES) { service.createBasicReport(request) }
+      }
+    assertThat(exception).status().code().isEqualTo(Status.Code.INVALID_ARGUMENT)
+  }
 
   @Test
   fun `createBasicReport creates report and persists its report id`(): Unit = runBlocking {

--- a/src/test/kotlin/org/wfanet/measurement/reporting/service/internal/NormalizationTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/reporting/service/internal/NormalizationTest.kt
@@ -22,7 +22,6 @@ import com.google.type.DayOfWeek
 import java.util.logging.ConsoleHandler
 import java.util.logging.Level
 import java.util.logging.Logger
-import kotlin.test.assertFailsWith
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
@@ -263,22 +262,30 @@ class NormalizationTest {
   }
 
   @Test
-  fun `normalizeReportingUnit throws on reportingSetKeys variant`() {
+  fun `normalizeReportingUnit sorts reportingSetKeys by externalReportingSetId`() {
     val reportingUnit = reportingUnit {
       reportingSetKeys =
         ReportingUnitKt.reportingSetKeys {
           reportingSetKeys += reportingSetKey {
             cmmsMeasurementConsumerId = "mc-1"
-            externalReportingSetId = "rs-1"
+            externalReportingSetId = "rs_zebra"
+          }
+          reportingSetKeys += reportingSetKey {
+            cmmsMeasurementConsumerId = "mc-1"
+            externalReportingSetId = "rs_alpha"
+          }
+          reportingSetKeys += reportingSetKey {
+            cmmsMeasurementConsumerId = "mc-1"
+            externalReportingSetId = "rs_mango"
           }
         }
     }
 
-    val exception =
-      assertFailsWith<IllegalArgumentException> {
-        Normalization.normalizeReportingUnit(reportingUnit)
-      }
-    assertThat(exception).hasMessageThat().contains("reportingSetKeys")
+    val normalized = Normalization.normalizeReportingUnit(reportingUnit)
+
+    assertThat(normalized.reportingSetKeys.reportingSetKeysList.map { it.externalReportingSetId })
+      .containsExactly("rs_alpha", "rs_mango", "rs_zebra")
+      .inOrder()
   }
 
   init {


### PR DESCRIPTION
## What

Enables custom-group (ReportingSet) reporting units in `CreateBasicReport`. When
`campaign_group` is empty, the server synthesizes it from the custom-group
components instead of requiring a caller-supplied one — completing the
custom-groups workstream (final PR of epic #4067).

## Changes

- **Synthesis:** empty `campaign_group` → resolve the custom-group components,
  union their EventGroups, and transactionally get-or-create a primitive
  self-referencing campaign group via `EnsureSynthesizedCampaignGroupReportingSet`
  (reused across concurrent/retried requests). Surfaced only via
  `effective_campaign_group`; `campaign_group` stays empty.
- **Data flow:** `buildReportingSetMaps` is now mode-aware — custom groups are
  used directly as the per-component primitives (no per-DataProvider auto-mint).
  The existing transformation path mints the union / incremental-prefix /
  unit-minus-component composites over them unchanged.
- **Validation:** components must be all-DataProvider *or* all-ReportingSet (no
  mixing); custom groups must be **primitive**, Measurement Consumer-owned, and
  resolve to **distinct DataProvider sets** (closes the post-processor collision);
  component cap of 25. Removes the two feature gates.
- **Normalization:** `normalizeReportingUnit` now sorts the `reportingSetKeys`
  variant (previously threw), so the result-group-spec collision dedup works for
  custom groups.

Custom-group components are restricted to **primitive** ReportingSets: a
union-only composite is equivalent to its flattened primitive, so this loses no
capability while keeping synthesis and composite-minting flat.

Issue: #4071