### PR TITLE
fix(reporting): propagate exception message on GetBasicReport INTERNAL

### DIFF
--- a/src/main/kotlin/org/wfanet/measurement/reporting/deploy/v2/gcloud/spanner/SpannerBasicReportsService.kt
+++ b/src/main/kotlin/org/wfanet/measurement/reporting/deploy/v2/gcloud/spanner/SpannerBasicReportsService.kt
@@ -147,7 +147,36 @@ class SpannerBasicReportsService(
           )
           .filter { it.filter.isEmpty() }
 
-      basicReport.withResults(campaignGroup, campaignGroupReportingSets, reportingSetResults)
+      try {
+        basicReport.withResults(campaignGroup, campaignGroupReportingSets, reportingSetResults)
+      } catch (e: CancellationException) {
+        // Never wrap cancellation; the coroutine machinery relies on it propagating cleanly.
+        throw e
+      } catch (e: RuntimeException) {
+        // The transformation code (BasicReportProcessedResultsTransformation +
+        // BasicReportProtoConversions) can throw on unexpected internal-state shapes --
+        // NoSuchElementException from Map.getValue, IllegalStateException from check(),
+        // NullPointerException from `!!` on protobuf oneofs, etc. Without this wrapper the
+        // exception surfaces as `Status.INTERNAL` with an empty description, so the caller
+        // sees "INTERNAL" and nothing else -- the exception message and stack trace live
+        // only in server logs. Preserve the cause chain for server-side logging and expose
+        // the message on the wire so callers get a one-line clue about what broke.
+        // See #4133. `listBasicReports` handles the same class of failure per-item via
+        // `unreachableBasicReportCounter`; single-item GetBasicReport has no equivalent
+        // structure so we surface INTERNAL with a description instead.
+        val basicReportName =
+          BasicReportKey(
+              cmmsMeasurementConsumerId = basicReport.cmmsMeasurementConsumerId,
+              basicReportId = basicReport.externalBasicReportId,
+            )
+            .toName()
+        logger.log(Level.SEVERE, e) { "Failed to render BasicReport $basicReportName" }
+        throw Status.INTERNAL.withDescription(
+            "Internal error while assembling BasicReport: ${e.message}"
+          )
+          .withCause(e)
+          .asRuntimeException()
+      }
     }
   }
 


### PR DESCRIPTION
Stacked on #4131.

Unhandled exceptions inside SpannerBasicReportsService.getBasicReport's render path (BasicReportProcessedResultsTransformation, BasicReportProtoConversions) were surfacing to callers as Status.INTERNAL with an empty description. The exception message and stack trace lived only in server logs, so diagnosing a specific failing report from the caller side was impossible without server access -- the client just sees "INTERNAL". That's the specific pain point that made the bug fixed in #4131 require end-to-end reproduction to root-cause.

Wraps the withResults() call (the transformation entry point) in a try/catch that lets CancellationException propagate cleanly, catches RuntimeException, logs the full stack + BasicReport name server-side at SEVERE (matching the pattern listBasicReports already uses for its per-item catch), and rethrows as Status.INTERNAL.withDescription("Internal error while assembling BasicReport: <exception message>").withCause(e). The cause chain is preserved for server-side logging and the caller gets a one-line clue about what broke.

listBasicReports already handles this class of failure per-item via the unreachableBasicReportCounter path. Single-item getBasicReport has no equivalent structure, so INTERNAL-with-description is the right shape.

Not in scope: the Python cronjob's bare except in post_process_report_result_job._process_basic_report's pre-AddProcessedResultValues path. Different code path, different design decisions; issue #4133 flags it as a follow-up.

Issue: #4133
