### PR TITLE
feat(reporting): expose MCP server externally with in-server TLS

### DIFF
--- a/src/main/k8s/dev/reporting_v2_gke.cue
+++ b/src/main/k8s/dev/reporting_v2_gke.cue
@@ -122,5 +122,6 @@ reporting: #Reporting & {
 		"reporting-v2alpha-public-api-server": _ipAddressName: _publicApiAddressName
 		"reporting-grpc-gateway": _ipAddressName:              _publicApiAddressName
 		"access-public-api-server": _ipAddressName:            _accessPublicApiAddressName
+		"reporting-mcp-server": _ipAddressName:                "reporting-mcp"
 	}
 }

--- a/src/main/k8s/reporting_v2.cue
+++ b/src/main/k8s/reporting_v2.cue
@@ -133,16 +133,16 @@ package k8s
 				}]
 			}
 		}
-		// Internal-only (ClusterIP) for the initial deployment. External exposure
-		// following the `reporting-grpc-gateway` pattern (LoadBalancer + in-server
-		// TLS termination) is tracked in
-		// TODO(world-federation-of-advertisers/cross-media-measurement#3938).
-		"reporting-mcp-server": {
-			spec: ports: [{
-				port:        8080
-				targetPort:  8080
-				appProtocol: "http"
-			}]
+		// Externally exposed following the `reporting-grpc-gateway` pattern:
+		// LoadBalancer + in-server TLS termination.
+		"reporting-mcp-server": #ExternalService & {
+			spec: {
+				ports: [{
+					port:        443
+					targetPort:  8443
+					appProtocol: "https"
+				}]
+			}
 		}
 	}
 
@@ -255,18 +255,18 @@ package k8s
 			_container: {
 				args: [
 					"--host=0.0.0.0",
-					"--port=8080",
+					"--port=8443",
 					"--cert-collection-file=/var/run/secrets/files/reporting_root.pem",
 					_debugVerboseGrpcClientLoggingFlag,
 				] + _tlsArgs + _reportingApiTarget.args
 				ports: [{
-					containerPort: 8080
+					containerPort: 8443
 				}]
 				readinessProbe: {
 					httpGet: {
 						path:   "/healthz"
-						port:   8080
-						scheme: "HTTP"
+						port:   8443
+						scheme: "HTTPS"
 					}
 					failureThreshold:    12
 					timeoutSeconds:      2
@@ -438,16 +438,12 @@ package k8s
 		"reporting-mcp-server": {
 			// Egress: calls the Reporting public API.
 			_destinationMatchLabels: ["reporting-v2alpha-public-api-server-app"]
-			// Ingress: intentionally open to any in-cluster pod on 8080. There is no
-			// dedicated in-cluster client in this phase (the server is reached via
-			// kubectl port-forward for testing and by the planned cloud integration
-			// test), so no `_sourceMatchLabels` restriction is applied yet. External
-			// exposure is tracked in
-			// TODO(world-federation-of-advertisers/cross-media-measurement#3938).
+			// Ingress: open on 8443 (TLS), matching the reporting-grpc-gateway
+			// pattern for an externally-exposed service.
 			_ingresses: {
-				http: {
+				https: {
 					ports: [{
-						port: 8080
+						port: 8443
 					}]
 				}
 			}

--- a/src/main/k8s/reporting_v2.cue
+++ b/src/main/k8s/reporting_v2.cue
@@ -253,6 +253,8 @@ package k8s
 
 		"reporting-mcp-server": {
 			_container: {
+				// Set --allowed-host to the external hostname at deploy for DNS-rebinding
+				// protection, once the public address/DNS is provisioned.
 				args: [
 					"--host=0.0.0.0",
 					"--port=8443",

--- a/src/main/kotlin/org/wfanet/measurement/reporting/mcp/ReportingMcpServerDaemon.kt
+++ b/src/main/kotlin/org/wfanet/measurement/reporting/mcp/ReportingMcpServerDaemon.kt
@@ -102,6 +102,13 @@ class ReportingMcpServerDaemon : Runnable {
     // reporting-grpc-gateway). SigningKeyHandle intentionally hides the private
     // key, so re-read the cert + key from the PEM files to build a KeyStore for
     // Ktor's sslConnector.
+    //
+    // Unlike the gRPC services (whose clients override the cert hostname with
+    // --cert-host=localhost), external HTTPS clients verify the URL hostname
+    // against the certificate's SANs. The inter-service cert (reporting_tls.pem)
+    // is issued for localhost, so a public deployment must mount a server
+    // certificate whose SANs include the external hostname, provisioned with the
+    // DNS name at deploy time.
     val serverCertificate = readCertificate(tlsFlags.certFile)
     val serverPrivateKey =
       readPrivateKey(tlsFlags.privateKeyFile, serverCertificate.publicKey.algorithm)

--- a/src/main/kotlin/org/wfanet/measurement/reporting/mcp/ReportingMcpServerDaemon.kt
+++ b/src/main/kotlin/org/wfanet/measurement/reporting/mcp/ReportingMcpServerDaemon.kt
@@ -24,11 +24,16 @@ import io.grpc.ClientInterceptors
 import io.grpc.MethodDescriptor
 import io.ktor.server.cio.CIO
 import io.ktor.server.engine.embeddedServer
+import io.ktor.server.engine.sslConnector
+import java.security.KeyStore
+import java.security.cert.Certificate
 import java.time.Duration
 import java.util.concurrent.TimeUnit
 import kotlin.properties.Delegates
 import org.wfanet.measurement.common.commandLineMain
 import org.wfanet.measurement.common.crypto.SigningCerts
+import org.wfanet.measurement.common.crypto.readCertificate
+import org.wfanet.measurement.common.crypto.readPrivateKey
 import org.wfanet.measurement.common.grpc.TlsFlags
 import org.wfanet.measurement.common.grpc.buildMutualTlsChannel
 import org.wfanet.measurement.common.grpc.withVerboseLogging
@@ -38,6 +43,8 @@ import org.wfanet.measurement.reporting.v2alpha.EventGroupsGrpcKt.EventGroupsCor
 import org.wfanet.measurement.reporting.v2alpha.ImpressionQualificationFiltersGrpcKt.ImpressionQualificationFiltersCoroutineStub
 import org.wfanet.measurement.reporting.v2alpha.ReportingSetsGrpcKt.ReportingSetsCoroutineStub
 import picocli.CommandLine
+
+private const val TLS_KEY_ALIAS = "reporting-mcp-server"
 
 /** Builds the runtime dependencies from command-line flags and starts the MCP server. */
 @CommandLine.Command(
@@ -91,7 +98,39 @@ class ReportingMcpServerDaemon : Runnable {
           ImpressionQualificationFiltersCoroutineStub(deadlineChannel),
       )
 
-    embeddedServer(CIO, host = mcpServerFlags.host, port = mcpServerFlags.port) {
+    // Serve TLS in-server (LoadBalancer + in-server TLS termination, mirroring
+    // reporting-grpc-gateway). SigningKeyHandle intentionally hides the private
+    // key, so re-read the cert + key from the PEM files to build a KeyStore for
+    // Ktor's sslConnector.
+    val serverCertificate = readCertificate(tlsFlags.certFile)
+    val serverPrivateKey =
+      readPrivateKey(tlsFlags.privateKeyFile, serverCertificate.publicKey.algorithm)
+    val keyStorePassword = CharArray(0)
+    val keyStore =
+      KeyStore.getInstance("PKCS12").apply {
+        load(null, null)
+        setKeyEntry(
+          TLS_KEY_ALIAS,
+          serverPrivateKey,
+          keyStorePassword,
+          arrayOf<Certificate>(serverCertificate),
+        )
+      }
+
+    embeddedServer(
+        CIO,
+        configure = {
+          sslConnector(
+            keyStore = keyStore,
+            keyAlias = TLS_KEY_ALIAS,
+            keyStorePassword = { keyStorePassword },
+            privateKeyPassword = { keyStorePassword },
+          ) {
+            host = mcpServerFlags.host
+            port = mcpServerFlags.port
+          }
+        },
+      ) {
         installReportingMcp(apiClient, mcpServerFlags.allowedHosts)
       }
       .start(wait = true)
@@ -109,12 +148,8 @@ class McpServerFlags {
 
   @set:CommandLine.Option(
     names = ["--port"],
-    description =
-      [
-        "HTTP port for the MCP server. For external access, terminate TLS upstream " +
-          "(a LoadBalancer or proxy)."
-      ],
-    defaultValue = "8080",
+    description = ["HTTPS port for the MCP server. TLS is terminated in-server."],
+    defaultValue = "8443",
   )
   var port by Delegates.notNull<Int>()
 

--- a/src/main/terraform/gcloud/cmms/reporting_v2.tf
+++ b/src/main/terraform/gcloud/cmms/reporting_v2.tf
@@ -43,3 +43,7 @@ module "reporting_v2" {
 resource "google_compute_address" "reporting_v2alpha" {
   name = "reporting-v2alpha"
 }
+
+resource "google_compute_address" "reporting_mcp" {
+  name = "reporting-mcp"
+}


### PR DESCRIPTION
Exposes the Reporting MCP server externally, following the reporting-grpc-gateway pattern (LoadBalancer + in-server TLS termination), so internal users can reach it without a cluster tunnel. The Ktor server now terminates TLS on 8443 using the certificate it already loads (re-read from the PEM files to build a KeyStore, since SigningKeyHandle hides the private key). The Service becomes a LoadBalancer (443 -> 8443, https), and the readiness probe and network policy move to HTTPS on 8443. No change to the tools, prompts, or bearer-token passthrough.

Issue: #3938
