### PR TITLE
fix(securecomputation): forward X-DataWatcher-Generation to HTTP endp…

### DIFF
--- a/src/main/kotlin/org/wfanet/measurement/securecomputation/datawatcher/DataWatcher.kt
+++ b/src/main/kotlin/org/wfanet/measurement/securecomputation/datawatcher/DataWatcher.kt
@@ -266,7 +266,12 @@ class DataWatcher(
     private const val DATA_WATCHER_PATH_HEADER: String = "X-DataWatcher-Path"
     private const val DATA_WATCHER_GENERATION_HEADER: String = "X-DataWatcher-Generation"
 
-    /** Reserved objectMetadata key DataWatcherFunction uses to carry the GCS object generation. */
+    /**
+     * Reserved objectMetadata key DataWatcherFunction uses to carry the GCS object generation. If
+     * an EDP happens to set this key on their object's metadata, DataWatcherFunction overwrites it
+     * with the true generation on ingest (right-wins map merge) -- do not rely on EDP-set values
+     * under this key surviving.
+     */
     const val GENERATION_METADATA_KEY: String = "__datawatcher_object_generation__"
     private const val IMPRESSION_METADATA_RESOURCE_ID_HEADER: String =
       "X-Impression-Metadata-Resource-Id"

--- a/src/main/kotlin/org/wfanet/measurement/securecomputation/datawatcher/DataWatcher.kt
+++ b/src/main/kotlin/org/wfanet/measurement/securecomputation/datawatcher/DataWatcher.kt
@@ -152,6 +152,15 @@ class DataWatcher(
       )
     }
 
+    // The VidLabelingDispatcher requires the source blob's GCS generation (for idempotent
+    // request ids); DataWatcherFunction stashes it in objectMetadata under GENERATION_METADATA_KEY.
+    if (GENERATION_METADATA_KEY in objectMetadata) {
+      requestBuilder.header(
+        DATA_WATCHER_GENERATION_HEADER,
+        objectMetadata.getValue(GENERATION_METADATA_KEY),
+      )
+    }
+
     val request =
       requestBuilder
         .POST(HttpRequest.BodyPublishers.ofString(httpEndpointConfig.appParams.toJson()))
@@ -255,6 +264,10 @@ class DataWatcher(
   companion object {
     private val logger: Logger = Logger.getLogger(DataWatcher::class.java.name)
     private const val DATA_WATCHER_PATH_HEADER: String = "X-DataWatcher-Path"
+    private const val DATA_WATCHER_GENERATION_HEADER: String = "X-DataWatcher-Generation"
+
+    /** Reserved objectMetadata key DataWatcherFunction uses to carry the GCS object generation. */
+    const val GENERATION_METADATA_KEY: String = "__datawatcher_object_generation__"
     private const val IMPRESSION_METADATA_RESOURCE_ID_HEADER: String =
       "X-Impression-Metadata-Resource-Id"
 

--- a/src/main/kotlin/org/wfanet/measurement/securecomputation/deploy/gcloud/datawatcher/DataWatcherFunction.kt
+++ b/src/main/kotlin/org/wfanet/measurement/securecomputation/deploy/gcloud/datawatcher/DataWatcherFunction.kt
@@ -84,8 +84,10 @@ class DataWatcherFunction(
         }
       }
 
-      // Extract custom metadata from the GCS object
-      val objectMetadata: Map<String, String> = data.metadataMap
+      // Extract custom metadata from the GCS object, plus the object generation (the
+      // VidLabelingDispatcher requires it as the X-DataWatcher-Generation header).
+      val objectMetadata: Map<String, String> =
+        data.metadataMap + (DataWatcher.GENERATION_METADATA_KEY to data.generation.toString())
 
       Tracing.withW3CTraceContext(event) {
         Tracing.trace(

--- a/src/test/kotlin/org/wfanet/measurement/securecomputation/datawatcher/DataWatcherTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/securecomputation/datawatcher/DataWatcherTest.kt
@@ -389,6 +389,71 @@ class DataWatcherTest() {
       server.stop()
     }
   }
+
+  @Test
+  fun `forwards object generation as X-DataWatcher-Generation header to webhook sink`() {
+    runBlocking {
+      val appParams =
+        Struct.newBuilder()
+          .putFields("some-key", Value.newBuilder().setStringValue("some-value").build())
+          .build()
+      val localPort = ServerSocket(0).use { it.localPort }
+      val config = watchedPath {
+        sourcePathRegex = "test-schema://test-bucket/path-to-watch/(.*)"
+        this.httpEndpointSink = httpEndpointSink {
+          endpointUri = "http://localhost:$localPort"
+          this.appParams = appParams
+        }
+      }
+      val server = TestServer()
+      server.start(localPort)
+
+      val dataWatcher =
+        DataWatcher(
+          workItemsStub = workItemsStub,
+          dataWatcherConfigs = listOf(config),
+          idTokenProvider = mockIdTokenProvider,
+        )
+
+      val objectMetadata = mapOf(DataWatcher.GENERATION_METADATA_KEY to "42")
+      dataWatcher.receivePath("test-schema://test-bucket/path-to-watch/some-data", objectMetadata)
+
+      assertThat(server.getLastRequestHeader("X-DataWatcher-Generation")).isEqualTo("42")
+      server.stop()
+    }
+  }
+
+  @Test
+  fun `omits X-DataWatcher-Generation header when object generation absent`() {
+    runBlocking {
+      val appParams =
+        Struct.newBuilder()
+          .putFields("some-key", Value.newBuilder().setStringValue("some-value").build())
+          .build()
+      val localPort = ServerSocket(0).use { it.localPort }
+      val config = watchedPath {
+        sourcePathRegex = "test-schema://test-bucket/path-to-watch/(.*)"
+        this.httpEndpointSink = httpEndpointSink {
+          endpointUri = "http://localhost:$localPort"
+          this.appParams = appParams
+        }
+      }
+      val server = TestServer()
+      server.start(localPort)
+
+      val dataWatcher =
+        DataWatcher(
+          workItemsStub = workItemsStub,
+          dataWatcherConfigs = listOf(config),
+          idTokenProvider = mockIdTokenProvider,
+        )
+
+      dataWatcher.receivePath("test-schema://test-bucket/path-to-watch/some-data", emptyMap())
+
+      assertThat(server.getLastRequestHeader("X-DataWatcher-Generation")).isNull()
+      server.stop()
+    }
+  }
 }
 
 private class TestServer() {

--- a/src/test/kotlin/org/wfanet/measurement/securecomputation/deploy/gcloud/datawatcher/BUILD.bazel
+++ b/src/test/kotlin/org/wfanet/measurement/securecomputation/deploy/gcloud/datawatcher/BUILD.bazel
@@ -63,3 +63,19 @@ kt_jvm_test(
         "@wfa_common_jvm//src/main/kotlin/org/wfanet/measurement/common",
     ],
 )
+
+kt_jvm_test(
+    name = "DataWatcherFunctionTest",
+    srcs = ["DataWatcherFunctionTest.kt"],
+    test_class = "org.wfanet.measurement.securecomputation.deploy.gcloud.datawatcher.DataWatcherFunctionTest",
+    deps = [
+        "//src/main/kotlin/org/wfanet/measurement/edpaggregator/telemetry",
+        "//src/main/kotlin/org/wfanet/measurement/securecomputation/datawatcher:data_watcher",
+        "//src/main/kotlin/org/wfanet/measurement/securecomputation/deploy/gcloud/datawatcher:data_watcher_function",
+        "@wfa_common_jvm//imports/java/com/google/common/truth",
+        "@wfa_common_jvm//imports/java/io/cloudevents/core",
+        "@wfa_common_jvm//imports/java/org/junit",
+        "@wfa_common_jvm//imports/kotlin/kotlin/test",
+        "@wfa_common_jvm//src/main/kotlin/org/wfanet/measurement/common",
+    ],
+)

--- a/src/test/kotlin/org/wfanet/measurement/securecomputation/deploy/gcloud/datawatcher/DataWatcherFunctionTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/securecomputation/deploy/gcloud/datawatcher/DataWatcherFunctionTest.kt
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2025 The Cross-Media Measurement Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wfanet.measurement.securecomputation.deploy.gcloud.datawatcher
+
+import com.google.common.truth.Truth.assertThat
+import io.cloudevents.CloudEvent
+import io.cloudevents.CloudEventData
+import io.cloudevents.SpecVersion
+import java.net.URI
+import java.time.OffsetDateTime
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+import org.wfanet.measurement.edpaggregator.telemetry.EdpaTelemetry
+import org.wfanet.measurement.securecomputation.datawatcher.DataWatcher
+
+@RunWith(JUnit4::class)
+class DataWatcherFunctionTest {
+
+  @Test
+  fun `stashes the object generation in metadata for DataWatcher`() {
+    val capturedMetadata = mutableListOf<Map<String, String>>()
+    val pathReceiver: suspend (String, Map<String, String>) -> Unit = { _, metadata ->
+      capturedMetadata += metadata
+    }
+
+    val cloudEventData =
+      """
+      {
+        "bucket": "test-bucket",
+        "name": "path/to/blob",
+        "size": "1",
+        "generation": "42",
+        "metadata": { "impression-metadata-resource-id": "res-123" }
+      }
+      """
+        .trimIndent()
+
+    DataWatcherFunction(pathReceiver).accept(TestCloudEvent(cloudEventData.toByteArray()))
+
+    assertThat(capturedMetadata).hasSize(1)
+    // The GCS object generation is stashed under the reserved key so DataWatcher can forward it as
+    // the X-DataWatcher-Generation header.
+    assertThat(capturedMetadata.single()).containsEntry(DataWatcher.GENERATION_METADATA_KEY, "42")
+    // Existing custom object metadata is preserved alongside the generation.
+    assertThat(capturedMetadata.single())
+      .containsEntry("impression-metadata-resource-id", "res-123")
+  }
+
+  private class TestCloudEvent(private val dataBytes: ByteArray) : CloudEvent {
+    private val data =
+      object : CloudEventData {
+        override fun toBytes(): ByteArray = dataBytes
+      }
+
+    override fun getSpecVersion(): SpecVersion = SpecVersion.V1
+
+    override fun getId(): String = EVENT_ID
+
+    override fun getSource(): URI = URI.create(EVENT_SOURCE)
+
+    override fun getType(): String = EVENT_TYPE
+
+    override fun getDataContentType(): String? = "application/json"
+
+    override fun getDataSchema(): URI? = null
+
+    override fun getSubject(): String? = null
+
+    override fun getTime(): OffsetDateTime? = null
+
+    override fun getData(): CloudEventData = data
+
+    override fun getExtension(name: String): Any? = null
+
+    override fun getExtensionNames(): Set<String> = emptySet()
+
+    override fun getAttribute(name: String): Any? =
+      when (name.lowercase()) {
+        "id" -> EVENT_ID
+        "source" -> URI.create(EVENT_SOURCE)
+        "type" -> EVENT_TYPE
+        "datacontenttype" -> "application/json"
+        else -> null
+      }
+  }
+
+  companion object {
+    init {
+      // Disable OTLP exporters for testing before EdpaTelemetry initializes.
+      System.setProperty("otel.metrics.exporter", "none")
+      System.setProperty("otel.traces.exporter", "none")
+      System.setProperty("otel.logs.exporter", "none")
+
+      EdpaTelemetry.ensureInitialized()
+    }
+
+    private const val EVENT_ID = "generation-test"
+    private const val EVENT_SOURCE = "//storage.googleapis.com/projects/_/buckets/test-bucket"
+    private const val EVENT_TYPE = "google.cloud.storage.object.v1.finalized"
+  }
+}


### PR DESCRIPTION
  ## Summary
  
  The VID Labeling pipeline is triggered by `DataWatcher` → `VidLabelingDispatcher`:
  when a labeler writes a `done` blob to Cloud Storage, `DataWatcherFunction` (the
  GCS-event Cloud Function) fires and `DataWatcher.sendToHttpEndpoint` POSTs to the
  dispatcher's HTTP endpoint.
  
  The dispatcher **requires** the source blob's GCS object **generation** as the
  `X-DataWatcher-Generation` header — it uses it to build idempotent
  `RawImpressionUpload` request ids 
  (`RequestIds.forRawImpressionUpload(doneBlobPath, generation)`). But
  `sendToHttpEndpoint` only forwarded `X-DataWatcher-Path`, so every trigger was
  rejected with *"Missing required header: X-DataWatcher-Generation"* — no
  `RawImpressionUpload` was ever created and the pipeline had no working entry point.
  
  ## Changes
  
  - `DataWatcherFunction` stashes the GCS object generation (`data.generation`) into
    `objectMetadata` under a reserved key `GENERATION_METADATA_KEY`.
  - `DataWatcher.sendToHttpEndpoint` forwards it as the `X-DataWatcher-Generation`
    header (a no-op for endpoint sinks that don't require it).
    
  ## Why the generation
  
  Keying the request id on `(path, generation)` makes upload creation idempotent:
  - redelivery of the same GCS event (same generation) → same id → no duplicate upload;
  - an overwritten `done` blob (new generation) → distinct id → a new 
    `RawImpressionUpload` (relabel/reprocess).
    
  ## Deployment
  
  Requires a `DataWatcher` Cloud Function redeploy.

Issue: #4171