### PR TITLE
feat!: require request_id on RawImpressionUploadModelLine Mark* and Create RPCs

### DIFF
--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/spanner/SpannerRawImpressionUploadModelLineService.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/spanner/SpannerRawImpressionUploadModelLineService.kt
@@ -222,19 +222,21 @@ class SpannerRawImpressionUploadModelLineService(
       }
 
       val requestId = subRequest.requestId
-      if (requestId.isNotEmpty()) {
-        try {
-          UUID.fromString(requestId)
-        } catch (e: IllegalArgumentException) {
-          throw InvalidFieldValueException("requests.$index.request_id", e)
-            .asStatusRuntimeException(Status.Code.INVALID_ARGUMENT)
-        }
-        if (!requestIdSet.add(requestId)) {
-          throw InvalidFieldValueException("requests.$index.request_id") {
-              "request id $requestId is duplicate in the batch of requests"
-            }
-            .asStatusRuntimeException(Status.Code.INVALID_ARGUMENT)
-        }
+      if (requestId.isEmpty()) {
+        throw RequiredFieldNotSetException("requests.$index.request_id")
+          .asStatusRuntimeException(Status.Code.INVALID_ARGUMENT)
+      }
+      try {
+        UUID.fromString(requestId)
+      } catch (e: IllegalArgumentException) {
+        throw InvalidFieldValueException("requests.$index.request_id", e)
+          .asStatusRuntimeException(Status.Code.INVALID_ARGUMENT)
+      }
+      if (!requestIdSet.add(requestId)) {
+        throw InvalidFieldValueException("requests.$index.request_id") {
+            "request id $requestId is duplicate in the batch of requests"
+          }
+          .asStatusRuntimeException(Status.Code.INVALID_ARGUMENT)
       }
     }
 
@@ -423,12 +425,15 @@ class SpannerRawImpressionUploadModelLineService(
       request.rawImpressionUploadResourceId,
       request.rawImpressionUploadModelLineResourceId,
       request.etag,
+      request.requestId,
       State.RAW_IMPRESSION_UPLOAD_MODEL_LINE_STATE_POOL_ASSIGNING,
       validPreviousStates =
         setOf(
           State.RAW_IMPRESSION_UPLOAD_MODEL_LINE_STATE_CREATED,
           State.RAW_IMPRESSION_UPLOAD_MODEL_LINE_STATE_FAILED,
         ),
+      markRequestIdColumn = "MarkPoolAssigningRequestId",
+      currentMarkRequestId = { it.markPoolAssigningRequestId },
     )
   }
 
@@ -440,12 +445,15 @@ class SpannerRawImpressionUploadModelLineService(
       request.rawImpressionUploadResourceId,
       request.rawImpressionUploadModelLineResourceId,
       request.etag,
+      request.requestId,
       State.RAW_IMPRESSION_UPLOAD_MODEL_LINE_STATE_RANKING,
       validPreviousStates =
         setOf(
           State.RAW_IMPRESSION_UPLOAD_MODEL_LINE_STATE_POOL_ASSIGNING,
           State.RAW_IMPRESSION_UPLOAD_MODEL_LINE_STATE_FAILED,
         ),
+      markRequestIdColumn = "MarkRankingRequestId",
+      currentMarkRequestId = { it.markRankingRequestId },
     )
   }
 
@@ -457,6 +465,7 @@ class SpannerRawImpressionUploadModelLineService(
       request.rawImpressionUploadResourceId,
       request.rawImpressionUploadModelLineResourceId,
       request.etag,
+      request.requestId,
       State.RAW_IMPRESSION_UPLOAD_MODEL_LINE_STATE_LABELING,
       validPreviousStates =
         setOf(
@@ -465,6 +474,8 @@ class SpannerRawImpressionUploadModelLineService(
           State.RAW_IMPRESSION_UPLOAD_MODEL_LINE_STATE_RANKING,
           State.RAW_IMPRESSION_UPLOAD_MODEL_LINE_STATE_FAILED,
         ),
+      markRequestIdColumn = "MarkLabelingRequestId",
+      currentMarkRequestId = { it.markLabelingRequestId },
     )
   }
 
@@ -476,8 +487,11 @@ class SpannerRawImpressionUploadModelLineService(
       request.rawImpressionUploadResourceId,
       request.rawImpressionUploadModelLineResourceId,
       request.etag,
+      request.requestId,
       State.RAW_IMPRESSION_UPLOAD_MODEL_LINE_STATE_COMPLETED,
       validPreviousStates = setOf(State.RAW_IMPRESSION_UPLOAD_MODEL_LINE_STATE_LABELING),
+      markRequestIdColumn = "MarkCompletedRequestId",
+      currentMarkRequestId = { it.markCompletedRequestId },
     )
   }
 
@@ -491,6 +505,7 @@ class SpannerRawImpressionUploadModelLineService(
         request.rawImpressionUploadResourceId,
         request.rawImpressionUploadModelLineResourceId,
         request.etag,
+        request.requestId,
         State.RAW_IMPRESSION_UPLOAD_MODEL_LINE_STATE_FAILED,
         validPreviousStates =
           setOf(
@@ -499,6 +514,8 @@ class SpannerRawImpressionUploadModelLineService(
             State.RAW_IMPRESSION_UPLOAD_MODEL_LINE_STATE_RANKING,
             State.RAW_IMPRESSION_UPLOAD_MODEL_LINE_STATE_LABELING,
           ),
+        markRequestIdColumn = "MarkFailedRequestId",
+        currentMarkRequestId = { it.markFailedRequestId },
       ) {
         set("ErrorMessage").to(request.errorMessage)
       }
@@ -517,8 +534,11 @@ class SpannerRawImpressionUploadModelLineService(
     rawImpressionUploadResourceId: String,
     rawImpressionUploadModelLineResourceId: String,
     expectedEtag: String,
+    requestId: String,
     nextState: State,
     validPreviousStates: Set<State>,
+    markRequestIdColumn: String,
+    currentMarkRequestId: (RawImpressionUploadModelLineResult) -> String,
     block: (com.google.cloud.spanner.Mutation.WriteBuilder.() -> Unit)? = null,
   ): RawImpressionUploadModelLine {
     if (dataProviderResourceId.isEmpty()) {
@@ -533,9 +553,20 @@ class SpannerRawImpressionUploadModelLineService(
       throw RequiredFieldNotSetException("raw_impression_upload_model_line_resource_id")
         .asStatusRuntimeException(Status.Code.INVALID_ARGUMENT)
     }
+    if (requestId.isEmpty()) {
+      throw RequiredFieldNotSetException("request_id")
+        .asStatusRuntimeException(Status.Code.INVALID_ARGUMENT)
+    }
+    try {
+      UUID.fromString(requestId)
+    } catch (e: IllegalArgumentException) {
+      throw InvalidFieldValueException("request_id", e)
+        .asStatusRuntimeException(Status.Code.INVALID_ARGUMENT)
+    }
 
     val transactionRunner =
       databaseClient.readWriteTransaction(Options.tag("action=transitionState"))
+    var isReplay = false
     val updatedModelLine =
       transactionRunner.run { txn ->
         val result =
@@ -550,6 +581,17 @@ class SpannerRawImpressionUploadModelLineService(
                 rawImpressionUploadModelLineResourceId,
               )
               .asStatusRuntimeException(Status.Code.NOT_FOUND)
+
+        // AIP-155 idempotent replay: if this exact mark already ran (row already in nextState and
+        // stamped with this request_id), return it as-is instead of re-transitioning or throwing
+        // FAILED_PRECONDITION on a Pub/Sub redelivery.
+        if (
+          result.rawImpressionUploadModelLine.state == nextState &&
+            currentMarkRequestId(result) == requestId
+        ) {
+          isReplay = true
+          return@run result.rawImpressionUploadModelLine
+        }
 
         if (expectedEtag.isEmpty()) {
           throw RequiredFieldNotSetException("etag")
@@ -602,6 +644,7 @@ class SpannerRawImpressionUploadModelLineService(
           nextState,
         ) {
           if (clearError) set("ErrorMessage").to(null as String?)
+          set(markRequestIdColumn).to(requestId)
           block?.invoke(this)
         }
 
@@ -655,6 +698,9 @@ class SpannerRawImpressionUploadModelLineService(
         result.rawImpressionUploadModelLine.copy { if (clearError) clearErrorMessage() }
       }
 
+    if (isReplay) {
+      return updatedModelLine
+    }
     val commitTimestamp: Timestamp = transactionRunner.getCommitTimestamp().toProto()
     return updatedModelLine.copy {
       state = nextState
@@ -670,12 +716,13 @@ class SpannerRawImpressionUploadModelLineService(
    * @throws InvalidFieldValueException if field values are invalid
    */
   private fun validateCreateRequest(request: CreateRawImpressionUploadModelLineRequest) {
-    if (request.requestId.isNotEmpty()) {
-      try {
-        UUID.fromString(request.requestId)
-      } catch (e: IllegalArgumentException) {
-        throw InvalidFieldValueException("request_id", e)
-      }
+    if (request.requestId.isEmpty()) {
+      throw RequiredFieldNotSetException("request_id")
+    }
+    try {
+      UUID.fromString(request.requestId)
+    } catch (e: IllegalArgumentException) {
+      throw InvalidFieldValueException("request_id", e)
     }
 
     if (request.dataProviderResourceId.isEmpty()) {

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/spanner/SpannerRawImpressionUploadModelLineService.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/spanner/SpannerRawImpressionUploadModelLineService.kt
@@ -564,9 +564,14 @@ class SpannerRawImpressionUploadModelLineService(
         .asStatusRuntimeException(Status.Code.INVALID_ARGUMENT)
     }
 
+    data class TransactionResult(
+      val modelLine: RawImpressionUploadModelLine,
+      val isReplay: Boolean = false,
+    )
+
     val transactionRunner =
       databaseClient.readWriteTransaction(Options.tag("action=transitionState"))
-    val updatedModelLine =
+    val txnResult =
       transactionRunner.run { txn ->
         val result =
           txn.getRawImpressionUploadModelLineByResourceIds(
@@ -588,7 +593,7 @@ class SpannerRawImpressionUploadModelLineService(
           result.rawImpressionUploadModelLine.state == nextState &&
             currentMarkRequestId(result) == requestId
         ) {
-          return@run result.rawImpressionUploadModelLine
+          return@run TransactionResult(result.rawImpressionUploadModelLine, isReplay = true)
         }
 
         if (expectedEtag.isEmpty()) {
@@ -693,19 +698,20 @@ class SpannerRawImpressionUploadModelLineService(
           }
           else -> {}
         }
-        result.rawImpressionUploadModelLine.copy { if (clearError) clearErrorMessage() }
+        TransactionResult(
+          result.rawImpressionUploadModelLine.copy { if (clearError) clearErrorMessage() }
+        )
       }
 
-    // A replay short-circuit returns the row already in [nextState]; a real transition returns the
-    // pre-transition row (state in validPreviousStates, never [nextState]). Discriminating on the
-    // returned state -- rather than a flag mutated inside the retryable transaction, which Spanner
-    // may re-run on ABORTED -- keeps the response correct across retries (mirrors
-    // createRawImpressionUploadModelLine's hasCreateTime check).
-    if (updatedModelLine.state == nextState) {
-      return updatedModelLine
+    // Carry the replay flag in the transaction's return value (not a var mutated inside the lambda)
+    // so it stays correct across Spanner ABORTED retries, matching SpannerRankerJobService /
+    // SpannerVidLabelingJobService. isReplay=true returns the row already committed in [nextState];
+    // otherwise stamp the commit timestamp and etag onto the just-transitioned row.
+    if (txnResult.isReplay) {
+      return txnResult.modelLine
     }
     val commitTimestamp: Timestamp = transactionRunner.getCommitTimestamp().toProto()
-    return updatedModelLine.copy {
+    return txnResult.modelLine.copy {
       state = nextState
       updateTime = commitTimestamp
       etag = ETags.computeETag(commitTimestamp.toInstant())

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/spanner/SpannerRawImpressionUploadModelLineService.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/spanner/SpannerRawImpressionUploadModelLineService.kt
@@ -535,8 +535,8 @@ class SpannerRawImpressionUploadModelLineService(
    * The outcome of a [transitionState] call.
    *
    * @property modelLine the resulting row
-   * @property isReplay true if this was an AIP-155 idempotent replay (the row was already in the
-   *   target state and stamped with this request_id), so [modelLine] is the row as first committed
+   * @property isReplay true if this was an AIP-155 idempotent replay (this mark's request_id was
+   *   already stamped on the row), so [modelLine] is the current committed row, not a re-transition
    */
   private data class TransactionResult(
     val modelLine: RawImpressionUploadModelLine,
@@ -602,13 +602,11 @@ class SpannerRawImpressionUploadModelLineService(
               )
               .asStatusRuntimeException(Status.Code.NOT_FOUND)
 
-        // AIP-155 idempotent replay: if this exact mark already ran (row already in nextState and
-        // stamped with this request_id), return it as-is instead of re-transitioning or throwing
-        // FAILED_PRECONDITION on a Pub/Sub redelivery.
-        if (
-          result.rawImpressionUploadModelLine.state == nextState &&
-            currentMarkRequestId(result) == requestId
-        ) {
+        // AIP-155 idempotent replay: if this exact mark already ran (this mark's request_id is
+        // already stamped on the row), return the resource as-is instead of re-transitioning or
+        // throwing FAILED_PRECONDITION on a Pub/Sub redelivery. Matching the request_id is
+        // sufficient per AIP-155, even if the resource has since advanced to a later state.
+        if (currentMarkRequestId(result) == requestId) {
           return@run TransactionResult(result.rawImpressionUploadModelLine, isReplay = true)
         }
 
@@ -721,8 +719,8 @@ class SpannerRawImpressionUploadModelLineService(
 
     // Carry the replay flag in the transaction's return value (not a var mutated inside the lambda)
     // so it stays correct across Spanner ABORTED retries, matching SpannerRankerJobService /
-    // SpannerVidLabelingJobService. isReplay=true returns the row already committed in [nextState];
-    // otherwise stamp the commit timestamp and etag onto the just-transitioned row.
+    // SpannerVidLabelingJobService. isReplay=true returns the row as already committed (possibly in
+    // a later state); otherwise stamp the commit timestamp and etag onto the just-transitioned row.
     if (txnResult.isReplay) {
       return txnResult
     }

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/spanner/SpannerRawImpressionUploadModelLineService.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/spanner/SpannerRawImpressionUploadModelLineService.kt
@@ -95,26 +95,24 @@ class SpannerRawImpressionUploadModelLineService(
     val modelLine: RawImpressionUploadModelLine =
       try {
         transactionRunner.run { txn ->
-          if (request.requestId.isNotEmpty()) {
-            val existing =
-              txn.findRawImpressionUploadModelLineByRequestId(
-                request.dataProviderResourceId,
-                request.rawImpressionUploadResourceId,
-                request.requestId,
-              )
-            if (existing != null) {
-              if (
-                existing.rawImpressionUploadModelLine.cmmsModelLine !=
-                  request.rawImpressionUploadModelLine.cmmsModelLine
-              ) {
-                throw Status.ALREADY_EXISTS.withDescription(
-                    "RawImpressionUploadModelLine already exists for request_id " +
-                      "${request.requestId} with a different cmms_model_line"
-                  )
-                  .asRuntimeException()
-              }
-              return@run existing.rawImpressionUploadModelLine
+          val existing =
+            txn.findRawImpressionUploadModelLineByRequestId(
+              request.dataProviderResourceId,
+              request.rawImpressionUploadResourceId,
+              request.requestId,
+            )
+          if (existing != null) {
+            if (
+              existing.rawImpressionUploadModelLine.cmmsModelLine !=
+                request.rawImpressionUploadModelLine.cmmsModelLine
+            ) {
+              throw Status.ALREADY_EXISTS.withDescription(
+                  "RawImpressionUploadModelLine already exists for request_id " +
+                    "${request.requestId} with a different cmms_model_line"
+                )
+                .asRuntimeException()
             }
+            return@run existing.rawImpressionUploadModelLine
           }
 
           val rawImpressionUploadId =
@@ -255,7 +253,7 @@ class SpannerRawImpressionUploadModelLineService(
             txn.findRawImpressionUploadModelLinesByRequestIds(
               dataProviderResourceId,
               rawImpressionUploadResourceId,
-              request.requestsList.mapNotNull { it.requestId.ifEmpty { null } },
+              request.requestsList.map { it.requestId },
             )
 
           request.requestsList.map { subRequest ->
@@ -421,85 +419,89 @@ class SpannerRawImpressionUploadModelLineService(
     request: MarkRawImpressionUploadModelLinePoolAssigningRequest
   ): RawImpressionUploadModelLine {
     return transitionState(
-      request.dataProviderResourceId,
-      request.rawImpressionUploadResourceId,
-      request.rawImpressionUploadModelLineResourceId,
-      request.etag,
-      request.requestId,
-      State.RAW_IMPRESSION_UPLOAD_MODEL_LINE_STATE_POOL_ASSIGNING,
-      validPreviousStates =
-        setOf(
-          State.RAW_IMPRESSION_UPLOAD_MODEL_LINE_STATE_CREATED,
-          State.RAW_IMPRESSION_UPLOAD_MODEL_LINE_STATE_FAILED,
-        ),
-      markRequestIdColumn = "MarkPoolAssigningRequestId",
-      currentMarkRequestId = { it.markPoolAssigningRequestId },
-    )
+        request.dataProviderResourceId,
+        request.rawImpressionUploadResourceId,
+        request.rawImpressionUploadModelLineResourceId,
+        request.etag,
+        request.requestId,
+        State.RAW_IMPRESSION_UPLOAD_MODEL_LINE_STATE_POOL_ASSIGNING,
+        validPreviousStates =
+          setOf(
+            State.RAW_IMPRESSION_UPLOAD_MODEL_LINE_STATE_CREATED,
+            State.RAW_IMPRESSION_UPLOAD_MODEL_LINE_STATE_FAILED,
+          ),
+        markRequestIdColumn = "MarkPoolAssigningRequestId",
+        currentMarkRequestId = { it.markPoolAssigningRequestId },
+      )
+      .modelLine
   }
 
   override suspend fun markRawImpressionUploadModelLineRanking(
     request: MarkRawImpressionUploadModelLineRankingRequest
   ): RawImpressionUploadModelLine {
     return transitionState(
-      request.dataProviderResourceId,
-      request.rawImpressionUploadResourceId,
-      request.rawImpressionUploadModelLineResourceId,
-      request.etag,
-      request.requestId,
-      State.RAW_IMPRESSION_UPLOAD_MODEL_LINE_STATE_RANKING,
-      validPreviousStates =
-        setOf(
-          State.RAW_IMPRESSION_UPLOAD_MODEL_LINE_STATE_POOL_ASSIGNING,
-          State.RAW_IMPRESSION_UPLOAD_MODEL_LINE_STATE_FAILED,
-        ),
-      markRequestIdColumn = "MarkRankingRequestId",
-      currentMarkRequestId = { it.markRankingRequestId },
-    )
+        request.dataProviderResourceId,
+        request.rawImpressionUploadResourceId,
+        request.rawImpressionUploadModelLineResourceId,
+        request.etag,
+        request.requestId,
+        State.RAW_IMPRESSION_UPLOAD_MODEL_LINE_STATE_RANKING,
+        validPreviousStates =
+          setOf(
+            State.RAW_IMPRESSION_UPLOAD_MODEL_LINE_STATE_POOL_ASSIGNING,
+            State.RAW_IMPRESSION_UPLOAD_MODEL_LINE_STATE_FAILED,
+          ),
+        markRequestIdColumn = "MarkRankingRequestId",
+        currentMarkRequestId = { it.markRankingRequestId },
+      )
+      .modelLine
   }
 
   override suspend fun markRawImpressionUploadModelLineLabeling(
     request: MarkRawImpressionUploadModelLineLabelingRequest
   ): RawImpressionUploadModelLine {
     return transitionState(
-      request.dataProviderResourceId,
-      request.rawImpressionUploadResourceId,
-      request.rawImpressionUploadModelLineResourceId,
-      request.etag,
-      request.requestId,
-      State.RAW_IMPRESSION_UPLOAD_MODEL_LINE_STATE_LABELING,
-      validPreviousStates =
-        setOf(
-          // Non-memoized uploads skip Phase 0/1 and go straight CREATED -> LABELING.
-          State.RAW_IMPRESSION_UPLOAD_MODEL_LINE_STATE_CREATED,
-          State.RAW_IMPRESSION_UPLOAD_MODEL_LINE_STATE_RANKING,
-          State.RAW_IMPRESSION_UPLOAD_MODEL_LINE_STATE_FAILED,
-        ),
-      markRequestIdColumn = "MarkLabelingRequestId",
-      currentMarkRequestId = { it.markLabelingRequestId },
-    )
+        request.dataProviderResourceId,
+        request.rawImpressionUploadResourceId,
+        request.rawImpressionUploadModelLineResourceId,
+        request.etag,
+        request.requestId,
+        State.RAW_IMPRESSION_UPLOAD_MODEL_LINE_STATE_LABELING,
+        validPreviousStates =
+          setOf(
+            // Non-memoized uploads skip Phase 0/1 and go straight CREATED -> LABELING.
+            State.RAW_IMPRESSION_UPLOAD_MODEL_LINE_STATE_CREATED,
+            State.RAW_IMPRESSION_UPLOAD_MODEL_LINE_STATE_RANKING,
+            State.RAW_IMPRESSION_UPLOAD_MODEL_LINE_STATE_FAILED,
+          ),
+        markRequestIdColumn = "MarkLabelingRequestId",
+        currentMarkRequestId = { it.markLabelingRequestId },
+      )
+      .modelLine
   }
 
   override suspend fun markRawImpressionUploadModelLineCompleted(
     request: MarkRawImpressionUploadModelLineCompletedRequest
   ): RawImpressionUploadModelLine {
     return transitionState(
-      request.dataProviderResourceId,
-      request.rawImpressionUploadResourceId,
-      request.rawImpressionUploadModelLineResourceId,
-      request.etag,
-      request.requestId,
-      State.RAW_IMPRESSION_UPLOAD_MODEL_LINE_STATE_COMPLETED,
-      validPreviousStates = setOf(State.RAW_IMPRESSION_UPLOAD_MODEL_LINE_STATE_LABELING),
-      markRequestIdColumn = "MarkCompletedRequestId",
-      currentMarkRequestId = { it.markCompletedRequestId },
-    )
+        request.dataProviderResourceId,
+        request.rawImpressionUploadResourceId,
+        request.rawImpressionUploadModelLineResourceId,
+        request.etag,
+        request.requestId,
+        State.RAW_IMPRESSION_UPLOAD_MODEL_LINE_STATE_COMPLETED,
+        validPreviousStates = setOf(State.RAW_IMPRESSION_UPLOAD_MODEL_LINE_STATE_LABELING),
+        markRequestIdColumn = "MarkCompletedRequestId",
+        currentMarkRequestId = { it.markCompletedRequestId },
+      )
+      .modelLine
   }
 
   override suspend fun markRawImpressionUploadModelLineFailed(
     request: MarkRawImpressionUploadModelLineFailedRequest
   ): RawImpressionUploadModelLine {
 
-    val modelLine =
+    val transitionResult =
       transitionState(
         request.dataProviderResourceId,
         request.rawImpressionUploadResourceId,
@@ -519,8 +521,27 @@ class SpannerRawImpressionUploadModelLineService(
       ) {
         set("ErrorMessage").to(request.errorMessage)
       }
-    return modelLine.copy { errorMessage = request.errorMessage }
+    // On an AIP-155 replay the stored (first) error_message is authoritative and returned as-is;
+    // only a fresh transition adopts this request's error_message (the row read before the write
+    // does not yet reflect it).
+    return if (transitionResult.isReplay) {
+      transitionResult.modelLine
+    } else {
+      transitionResult.modelLine.copy { errorMessage = request.errorMessage }
+    }
   }
+
+  /**
+   * The outcome of a [transitionState] call.
+   *
+   * @property modelLine the resulting row
+   * @property isReplay true if this was an AIP-155 idempotent replay (the row was already in the
+   *   target state and stamped with this request_id), so [modelLine] is the row as first committed
+   */
+  private data class TransactionResult(
+    val modelLine: RawImpressionUploadModelLine,
+    val isReplay: Boolean = false,
+  )
 
   /**
    * Transitions the state of a [RawImpressionUploadModelLine].
@@ -540,7 +561,7 @@ class SpannerRawImpressionUploadModelLineService(
     markRequestIdColumn: String,
     currentMarkRequestId: (RawImpressionUploadModelLineResult) -> String,
     block: (com.google.cloud.spanner.Mutation.WriteBuilder.() -> Unit)? = null,
-  ): RawImpressionUploadModelLine {
+  ): TransactionResult {
     if (dataProviderResourceId.isEmpty()) {
       throw RequiredFieldNotSetException("data_provider_resource_id")
         .asStatusRuntimeException(Status.Code.INVALID_ARGUMENT)
@@ -563,11 +584,6 @@ class SpannerRawImpressionUploadModelLineService(
       throw InvalidFieldValueException("request_id", e)
         .asStatusRuntimeException(Status.Code.INVALID_ARGUMENT)
     }
-
-    data class TransactionResult(
-      val modelLine: RawImpressionUploadModelLine,
-      val isReplay: Boolean = false,
-    )
 
     val transactionRunner =
       databaseClient.readWriteTransaction(Options.tag("action=transitionState"))
@@ -708,14 +724,16 @@ class SpannerRawImpressionUploadModelLineService(
     // SpannerVidLabelingJobService. isReplay=true returns the row already committed in [nextState];
     // otherwise stamp the commit timestamp and etag onto the just-transitioned row.
     if (txnResult.isReplay) {
-      return txnResult.modelLine
+      return txnResult
     }
     val commitTimestamp: Timestamp = transactionRunner.getCommitTimestamp().toProto()
-    return txnResult.modelLine.copy {
-      state = nextState
-      updateTime = commitTimestamp
-      etag = ETags.computeETag(commitTimestamp.toInstant())
-    }
+    return TransactionResult(
+      txnResult.modelLine.copy {
+        state = nextState
+        updateTime = commitTimestamp
+        etag = ETags.computeETag(commitTimestamp.toInstant())
+      }
+    )
   }
 
   /**

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/spanner/SpannerRawImpressionUploadModelLineService.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/spanner/SpannerRawImpressionUploadModelLineService.kt
@@ -566,7 +566,6 @@ class SpannerRawImpressionUploadModelLineService(
 
     val transactionRunner =
       databaseClient.readWriteTransaction(Options.tag("action=transitionState"))
-    var isReplay = false
     val updatedModelLine =
       transactionRunner.run { txn ->
         val result =
@@ -589,7 +588,6 @@ class SpannerRawImpressionUploadModelLineService(
           result.rawImpressionUploadModelLine.state == nextState &&
             currentMarkRequestId(result) == requestId
         ) {
-          isReplay = true
           return@run result.rawImpressionUploadModelLine
         }
 
@@ -698,7 +696,12 @@ class SpannerRawImpressionUploadModelLineService(
         result.rawImpressionUploadModelLine.copy { if (clearError) clearErrorMessage() }
       }
 
-    if (isReplay) {
+    // A replay short-circuit returns the row already in [nextState]; a real transition returns the
+    // pre-transition row (state in validPreviousStates, never [nextState]). Discriminating on the
+    // returned state -- rather than a flag mutated inside the retryable transaction, which Spanner
+    // may re-run on ABORTED -- keeps the response correct across retries (mirrors
+    // createRawImpressionUploadModelLine's hasCreateTime check).
+    if (updatedModelLine.state == nextState) {
       return updatedModelLine
     }
     val commitTimestamp: Timestamp = transactionRunner.getCommitTimestamp().toProto()

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/spanner/db/RawImpressionUploadModelLine.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/spanner/db/RawImpressionUploadModelLine.kt
@@ -42,15 +42,36 @@ import org.wfanet.measurement.internal.edpaggregator.RawImpressionUploadState
 import org.wfanet.measurement.internal.edpaggregator.rawImpressionUploadModelLine
 
 data class RawImpressionUploadModelLineResult(
+  /** The [RawImpressionUploadModelLine] read from Spanner. */
   val rawImpressionUploadModelLine: RawImpressionUploadModelLine,
+  /** Internal numeric ID of the parent `RawImpressionUpload` row. */
   val rawImpressionUploadId: Long,
+  /** Internal numeric ID of the `RawImpressionUploadModelLine` row. */
   val rawImpressionUploadModelLineId: Long,
-  // Per-mark AIP-155 request_id columns (empty when the transition hasn't happened). Used by the
-  // service to short-circuit an idempotent replay of the same mark.
+  /**
+   * AIP-155 `request_id` of the mark that moved this line to `POOL_ASSIGNING`, or empty if that
+   * transition hasn't happened. Used to short-circuit an idempotent replay of the same mark.
+   */
   val markPoolAssigningRequestId: String,
+  /**
+   * AIP-155 `request_id` of the mark that moved this line to `RANKING`, or empty if that transition
+   * hasn't happened. Used to short-circuit an idempotent replay of the same mark.
+   */
   val markRankingRequestId: String,
+  /**
+   * AIP-155 `request_id` of the mark that moved this line to `LABELING`, or empty if that
+   * transition hasn't happened. Used to short-circuit an idempotent replay of the same mark.
+   */
   val markLabelingRequestId: String,
+  /**
+   * AIP-155 `request_id` of the mark that moved this line to `COMPLETED`, or empty if that
+   * transition hasn't happened. Used to short-circuit an idempotent replay of the same mark.
+   */
   val markCompletedRequestId: String,
+  /**
+   * AIP-155 `request_id` of the mark that moved this line to `FAILED`, or empty if that transition
+   * hasn't happened. Used to short-circuit an idempotent replay of the same mark.
+   */
   val markFailedRequestId: String,
 )
 

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/spanner/db/RawImpressionUploadModelLine.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/spanner/db/RawImpressionUploadModelLine.kt
@@ -237,8 +237,6 @@ suspend fun AsyncDatabaseClient.ReadContext.findRawImpressionUploadModelLineByRe
   rawImpressionUploadResourceId: String,
   requestId: String,
 ): RawImpressionUploadModelLineResult? {
-  if (requestId.isEmpty()) return null
-
   val sql = buildString {
     appendLine(RawImpressionUploadModelLineEntity.BASE_SQL)
     appendLine(
@@ -409,9 +407,7 @@ fun AsyncDatabaseClient.TransactionContext.insertRawImpressionUploadModelLine(
     set("RawImpressionUploadModelLineId").to(rawImpressionUploadModelLineId)
     set("RawImpressionUploadModelLineResourceId").to(rawImpressionUploadModelLineResourceId)
     set("CmmsModelLine").to(cmmsModelLine)
-    if (createRequestId.isNotEmpty()) {
-      set("CreateRequestId").to(createRequestId)
-    }
+    set("CreateRequestId").to(createRequestId)
     set("State").to(State.RAW_IMPRESSION_UPLOAD_MODEL_LINE_STATE_CREATED)
     set("CreateTime").to(Value.COMMIT_TIMESTAMP)
     set("UpdateTime").to(Value.COMMIT_TIMESTAMP)

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/spanner/db/RawImpressionUploadModelLine.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/spanner/db/RawImpressionUploadModelLine.kt
@@ -47,11 +47,11 @@ data class RawImpressionUploadModelLineResult(
   val rawImpressionUploadModelLineId: Long,
   // Per-mark AIP-155 request_id columns (empty when the transition hasn't happened). Used by the
   // service to short-circuit an idempotent replay of the same mark.
-  val markPoolAssigningRequestId: String = "",
-  val markRankingRequestId: String = "",
-  val markLabelingRequestId: String = "",
-  val markCompletedRequestId: String = "",
-  val markFailedRequestId: String = "",
+  val markPoolAssigningRequestId: String,
+  val markRankingRequestId: String,
+  val markLabelingRequestId: String,
+  val markCompletedRequestId: String,
+  val markFailedRequestId: String,
 )
 
 /** Returns whether a [RawImpressionUploadModelLine] with the specified keys exists. */

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/spanner/db/RawImpressionUploadModelLine.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/spanner/db/RawImpressionUploadModelLine.kt
@@ -45,6 +45,13 @@ data class RawImpressionUploadModelLineResult(
   val rawImpressionUploadModelLine: RawImpressionUploadModelLine,
   val rawImpressionUploadId: Long,
   val rawImpressionUploadModelLineId: Long,
+  // Per-mark AIP-155 request_id columns (empty when the transition hasn't happened). Used by the
+  // service to short-circuit an idempotent replay of the same mark.
+  val markPoolAssigningRequestId: String = "",
+  val markRankingRequestId: String = "",
+  val markLabelingRequestId: String = "",
+  val markCompletedRequestId: String = "",
+  val markFailedRequestId: String = "",
 )
 
 /** Returns whether a [RawImpressionUploadModelLine] with the specified keys exists. */
@@ -449,12 +456,18 @@ private object RawImpressionUploadModelLineEntity {
       RawImpressionUploadModelLine.PoolOffsets,
       RawImpressionUploadModelLine.MaxEventDate,
       RawImpressionUploadModelLine.EncryptedMergedDek,
+      RawImpressionUploadModelLine.MarkPoolAssigningRequestId,
+      RawImpressionUploadModelLine.MarkRankingRequestId,
+      RawImpressionUploadModelLine.MarkLabelingRequestId,
+      RawImpressionUploadModelLine.MarkCompletedRequestId,
+      RawImpressionUploadModelLine.MarkFailedRequestId,
     FROM
       RawImpressionUploadModelLine
     """
       .trimIndent()
 
   fun buildResult(struct: Struct): RawImpressionUploadModelLineResult {
+    fun markId(column: String): String = if (struct.isNull(column)) "" else struct.getString(column)
     return RawImpressionUploadModelLineResult(
       rawImpressionUploadModelLine {
         dataProviderResourceId = struct.getString("DataProviderResourceId")
@@ -485,6 +498,11 @@ private object RawImpressionUploadModelLineEntity {
       },
       struct.getLong("RawImpressionUploadId"),
       struct.getLong("RawImpressionUploadModelLineId"),
+      markPoolAssigningRequestId = markId("MarkPoolAssigningRequestId"),
+      markRankingRequestId = markId("MarkRankingRequestId"),
+      markLabelingRequestId = markId("MarkLabelingRequestId"),
+      markCompletedRequestId = markId("MarkCompletedRequestId"),
+      markFailedRequestId = markId("MarkFailedRequestId"),
     )
   }
 }

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/service/internal/testing/RawImpressionUploadModelLineServiceTest.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/service/internal/testing/RawImpressionUploadModelLineServiceTest.kt
@@ -1686,6 +1686,69 @@ abstract class RawImpressionUploadModelLineServiceTest {
   }
 
   @Test
+  fun `markRawImpressionUploadModelLineRanking replays after the line advanced past RANKING`() =
+    runBlocking {
+      // AIP-155 stale success: a redelivered mark whose request_id already ran must return success
+      // reflecting the current committed state, even after the line advanced (RANKING -> LABELING),
+      // rather than FAILED_PRECONDITION.
+      val created = createModelLine()
+      val poolAssigning =
+        service.markRawImpressionUploadModelLinePoolAssigning(
+          markRawImpressionUploadModelLinePoolAssigningRequest {
+            dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
+            rawImpressionUploadResourceId = RAW_IMPRESSION_UPLOAD_RESOURCE_ID
+            rawImpressionUploadModelLineResourceId = created.rawImpressionUploadModelLineResourceId
+            etag = created.etag
+            requestId = UUID.randomUUID().toString()
+          }
+        )
+      val rankingRequestId = UUID.randomUUID().toString()
+      val ranking =
+        service.markRawImpressionUploadModelLineRanking(
+          markRawImpressionUploadModelLineRankingRequest {
+            dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
+            rawImpressionUploadResourceId = RAW_IMPRESSION_UPLOAD_RESOURCE_ID
+            rawImpressionUploadModelLineResourceId = created.rawImpressionUploadModelLineResourceId
+            etag = poolAssigning.etag
+            requestId = rankingRequestId
+          }
+        )
+      // The line moves on to LABELING before the Ranking mark is redelivered.
+      val labeling =
+        service.markRawImpressionUploadModelLineLabeling(
+          markRawImpressionUploadModelLineLabelingRequest {
+            dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
+            rawImpressionUploadResourceId = RAW_IMPRESSION_UPLOAD_RESOURCE_ID
+            rawImpressionUploadModelLineResourceId = created.rawImpressionUploadModelLineResourceId
+            etag = ranking.etag
+            requestId = UUID.randomUUID().toString()
+          }
+        )
+
+      // Pub/Sub redelivers the original Ranking mark (same request_id) after the advance.
+      val replay =
+        service.markRawImpressionUploadModelLineRanking(
+          markRawImpressionUploadModelLineRankingRequest {
+            dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
+            rawImpressionUploadResourceId = RAW_IMPRESSION_UPLOAD_RESOURCE_ID
+            rawImpressionUploadModelLineResourceId = created.rawImpressionUploadModelLineResourceId
+            etag = poolAssigning.etag
+            requestId = rankingRequestId
+          }
+        )
+
+      assertThat(labeling.state)
+        .isEqualTo(
+          RawImpressionUploadModelLineState.RAW_IMPRESSION_UPLOAD_MODEL_LINE_STATE_LABELING
+        )
+      assertThat(replay.state)
+        .isEqualTo(
+          RawImpressionUploadModelLineState.RAW_IMPRESSION_UPLOAD_MODEL_LINE_STATE_LABELING
+        )
+      assertThat(replay.etag).isEqualTo(labeling.etag)
+    }
+
+  @Test
   fun `markRawImpressionUploadModelLineLabeling is idempotent with same request_id`() =
     runBlocking {
       // Non-memoized path: CREATED -> LABELING directly.

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/service/internal/testing/RawImpressionUploadModelLineServiceTest.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/service/internal/testing/RawImpressionUploadModelLineServiceTest.kt
@@ -96,6 +96,7 @@ abstract class RawImpressionUploadModelLineServiceTest {
     val modelLine: RawImpressionUploadModelLine =
       service.createRawImpressionUploadModelLine(
         createRawImpressionUploadModelLineRequest {
+          requestId = UUID.randomUUID().toString()
           dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
           rawImpressionUploadResourceId = RAW_IMPRESSION_UPLOAD_RESOURCE_ID
           rawImpressionUploadModelLine = rawImpressionUploadModelLine {
@@ -184,6 +185,7 @@ abstract class RawImpressionUploadModelLineServiceTest {
         assertFailsWith<StatusRuntimeException> {
           service.createRawImpressionUploadModelLine(
             createRawImpressionUploadModelLineRequest {
+              requestId = UUID.randomUUID().toString()
               rawImpressionUploadResourceId = RAW_IMPRESSION_UPLOAD_RESOURCE_ID
               rawImpressionUploadModelLine = rawImpressionUploadModelLine {
                 cmmsModelLine = CMMS_MODEL_LINE
@@ -210,6 +212,7 @@ abstract class RawImpressionUploadModelLineServiceTest {
         assertFailsWith<StatusRuntimeException> {
           service.createRawImpressionUploadModelLine(
             createRawImpressionUploadModelLineRequest {
+              requestId = UUID.randomUUID().toString()
               dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
               rawImpressionUploadModelLine = rawImpressionUploadModelLine {
                 cmmsModelLine = CMMS_MODEL_LINE
@@ -236,6 +239,7 @@ abstract class RawImpressionUploadModelLineServiceTest {
         assertFailsWith<StatusRuntimeException> {
           service.createRawImpressionUploadModelLine(
             createRawImpressionUploadModelLineRequest {
+              requestId = UUID.randomUUID().toString()
               dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
               rawImpressionUploadResourceId = RAW_IMPRESSION_UPLOAD_RESOURCE_ID
             }
@@ -260,6 +264,7 @@ abstract class RawImpressionUploadModelLineServiceTest {
         assertFailsWith<StatusRuntimeException> {
           service.createRawImpressionUploadModelLine(
             createRawImpressionUploadModelLineRequest {
+              requestId = UUID.randomUUID().toString()
               dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
               rawImpressionUploadResourceId = RAW_IMPRESSION_UPLOAD_RESOURCE_ID
               rawImpressionUploadModelLine = rawImpressionUploadModelLine {}
@@ -316,11 +321,13 @@ abstract class RawImpressionUploadModelLineServiceTest {
             dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
             rawImpressionUploadResourceId = RAW_IMPRESSION_UPLOAD_RESOURCE_ID
             requests += createRawImpressionUploadModelLineRequest {
+              requestId = UUID.randomUUID().toString()
               rawImpressionUploadModelLine = rawImpressionUploadModelLine {
                 cmmsModelLine = CMMS_MODEL_LINE
               }
             }
             requests += createRawImpressionUploadModelLineRequest {
+              requestId = UUID.randomUUID().toString()
               rawImpressionUploadModelLine = rawImpressionUploadModelLine {
                 cmmsModelLine = CMMS_MODEL_LINE_2
               }
@@ -338,6 +345,7 @@ abstract class RawImpressionUploadModelLineServiceTest {
     val created: RawImpressionUploadModelLine =
       service.createRawImpressionUploadModelLine(
         createRawImpressionUploadModelLineRequest {
+          requestId = UUID.randomUUID().toString()
           dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
           rawImpressionUploadResourceId = RAW_IMPRESSION_UPLOAD_RESOURCE_ID
           rawImpressionUploadModelLine = rawImpressionUploadModelLine {
@@ -414,6 +422,7 @@ abstract class RawImpressionUploadModelLineServiceTest {
   fun `listRawImpressionUploadModelLines returns resources`() = runBlocking {
     service.createRawImpressionUploadModelLine(
       createRawImpressionUploadModelLineRequest {
+        requestId = UUID.randomUUID().toString()
         dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
         rawImpressionUploadResourceId = RAW_IMPRESSION_UPLOAD_RESOURCE_ID
         rawImpressionUploadModelLine = rawImpressionUploadModelLine {
@@ -423,6 +432,7 @@ abstract class RawImpressionUploadModelLineServiceTest {
     )
     service.createRawImpressionUploadModelLine(
       createRawImpressionUploadModelLineRequest {
+        requestId = UUID.randomUUID().toString()
         dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
         rawImpressionUploadResourceId = RAW_IMPRESSION_UPLOAD_RESOURCE_ID
         rawImpressionUploadModelLine = rawImpressionUploadModelLine {
@@ -447,6 +457,7 @@ abstract class RawImpressionUploadModelLineServiceTest {
     for (i in 1..3) {
       service.createRawImpressionUploadModelLine(
         createRawImpressionUploadModelLineRequest {
+          requestId = UUID.randomUUID().toString()
           dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
           rawImpressionUploadResourceId = RAW_IMPRESSION_UPLOAD_RESOURCE_ID
           rawImpressionUploadModelLine = rawImpressionUploadModelLine {
@@ -474,6 +485,7 @@ abstract class RawImpressionUploadModelLineServiceTest {
     val created: RawImpressionUploadModelLine =
       service.createRawImpressionUploadModelLine(
         createRawImpressionUploadModelLineRequest {
+          requestId = UUID.randomUUID().toString()
           dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
           rawImpressionUploadResourceId = RAW_IMPRESSION_UPLOAD_RESOURCE_ID
           rawImpressionUploadModelLine = rawImpressionUploadModelLine {
@@ -483,6 +495,7 @@ abstract class RawImpressionUploadModelLineServiceTest {
       )
     service.createRawImpressionUploadModelLine(
       createRawImpressionUploadModelLineRequest {
+        requestId = UUID.randomUUID().toString()
         dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
         rawImpressionUploadResourceId = RAW_IMPRESSION_UPLOAD_RESOURCE_ID
         rawImpressionUploadModelLine = rawImpressionUploadModelLine {
@@ -493,6 +506,7 @@ abstract class RawImpressionUploadModelLineServiceTest {
 
     service.markRawImpressionUploadModelLinePoolAssigning(
       markRawImpressionUploadModelLinePoolAssigningRequest {
+        requestId = UUID.randomUUID().toString()
         dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
         rawImpressionUploadResourceId = RAW_IMPRESSION_UPLOAD_RESOURCE_ID
         rawImpressionUploadModelLineResourceId = created.rawImpressionUploadModelLineResourceId
@@ -523,6 +537,7 @@ abstract class RawImpressionUploadModelLineServiceTest {
   fun `listRawImpressionUploadModelLines filters by cmms_model_line`() = runBlocking {
     service.createRawImpressionUploadModelLine(
       createRawImpressionUploadModelLineRequest {
+        requestId = UUID.randomUUID().toString()
         dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
         rawImpressionUploadResourceId = RAW_IMPRESSION_UPLOAD_RESOURCE_ID
         rawImpressionUploadModelLine = rawImpressionUploadModelLine {
@@ -532,6 +547,7 @@ abstract class RawImpressionUploadModelLineServiceTest {
     )
     service.createRawImpressionUploadModelLine(
       createRawImpressionUploadModelLineRequest {
+        requestId = UUID.randomUUID().toString()
         dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
         rawImpressionUploadResourceId = RAW_IMPRESSION_UPLOAD_RESOURCE_ID
         rawImpressionUploadModelLine = rawImpressionUploadModelLine {
@@ -560,6 +576,7 @@ abstract class RawImpressionUploadModelLineServiceTest {
     for (i in 1..3) {
       service.createRawImpressionUploadModelLine(
         createRawImpressionUploadModelLineRequest {
+          requestId = UUID.randomUUID().toString()
           dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
           rawImpressionUploadResourceId = RAW_IMPRESSION_UPLOAD_RESOURCE_ID
           rawImpressionUploadModelLine = rawImpressionUploadModelLine {
@@ -601,6 +618,7 @@ abstract class RawImpressionUploadModelLineServiceTest {
       val created: RawImpressionUploadModelLine =
         service.createRawImpressionUploadModelLine(
           createRawImpressionUploadModelLineRequest {
+            requestId = UUID.randomUUID().toString()
             dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
             rawImpressionUploadResourceId = RAW_IMPRESSION_UPLOAD_RESOURCE_ID
             rawImpressionUploadModelLine = rawImpressionUploadModelLine {
@@ -612,6 +630,7 @@ abstract class RawImpressionUploadModelLineServiceTest {
       val modelLine: RawImpressionUploadModelLine =
         service.markRawImpressionUploadModelLinePoolAssigning(
           markRawImpressionUploadModelLinePoolAssigningRequest {
+            requestId = UUID.randomUUID().toString()
             dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
             rawImpressionUploadResourceId = RAW_IMPRESSION_UPLOAD_RESOURCE_ID
             rawImpressionUploadModelLineResourceId = created.rawImpressionUploadModelLineResourceId
@@ -631,6 +650,7 @@ abstract class RawImpressionUploadModelLineServiceTest {
       val created: RawImpressionUploadModelLine =
         service.createRawImpressionUploadModelLine(
           createRawImpressionUploadModelLineRequest {
+            requestId = UUID.randomUUID().toString()
             dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
             rawImpressionUploadResourceId = RAW_IMPRESSION_UPLOAD_RESOURCE_ID
             rawImpressionUploadModelLine = rawImpressionUploadModelLine {
@@ -642,6 +662,7 @@ abstract class RawImpressionUploadModelLineServiceTest {
         assertFailsWith<StatusRuntimeException> {
           service.markRawImpressionUploadModelLinePoolAssigning(
             markRawImpressionUploadModelLinePoolAssigningRequest {
+              requestId = UUID.randomUUID().toString()
               dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
               rawImpressionUploadResourceId = RAW_IMPRESSION_UPLOAD_RESOURCE_ID
               rawImpressionUploadModelLineResourceId =
@@ -659,6 +680,7 @@ abstract class RawImpressionUploadModelLineServiceTest {
       val created: RawImpressionUploadModelLine =
         service.createRawImpressionUploadModelLine(
           createRawImpressionUploadModelLineRequest {
+            requestId = UUID.randomUUID().toString()
             dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
             rawImpressionUploadResourceId = RAW_IMPRESSION_UPLOAD_RESOURCE_ID
             rawImpressionUploadModelLine = rawImpressionUploadModelLine {
@@ -671,6 +693,7 @@ abstract class RawImpressionUploadModelLineServiceTest {
         assertFailsWith<StatusRuntimeException> {
           service.markRawImpressionUploadModelLinePoolAssigning(
             markRawImpressionUploadModelLinePoolAssigningRequest {
+              requestId = UUID.randomUUID().toString()
               dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
               rawImpressionUploadResourceId = RAW_IMPRESSION_UPLOAD_RESOURCE_ID
               rawImpressionUploadModelLineResourceId =
@@ -688,6 +711,7 @@ abstract class RawImpressionUploadModelLineServiceTest {
       val created: RawImpressionUploadModelLine =
         service.createRawImpressionUploadModelLine(
           createRawImpressionUploadModelLineRequest {
+            requestId = UUID.randomUUID().toString()
             dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
             rawImpressionUploadResourceId = RAW_IMPRESSION_UPLOAD_RESOURCE_ID
             rawImpressionUploadModelLine = rawImpressionUploadModelLine {
@@ -698,6 +722,7 @@ abstract class RawImpressionUploadModelLineServiceTest {
       val poolAssigning =
         service.markRawImpressionUploadModelLinePoolAssigning(
           markRawImpressionUploadModelLinePoolAssigningRequest {
+            requestId = UUID.randomUUID().toString()
             dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
             rawImpressionUploadResourceId = RAW_IMPRESSION_UPLOAD_RESOURCE_ID
             rawImpressionUploadModelLineResourceId = created.rawImpressionUploadModelLineResourceId
@@ -707,6 +732,7 @@ abstract class RawImpressionUploadModelLineServiceTest {
       val failed =
         service.markRawImpressionUploadModelLineFailed(
           markRawImpressionUploadModelLineFailedRequest {
+            requestId = UUID.randomUUID().toString()
             dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
             rawImpressionUploadResourceId = RAW_IMPRESSION_UPLOAD_RESOURCE_ID
             rawImpressionUploadModelLineResourceId = created.rawImpressionUploadModelLineResourceId
@@ -717,6 +743,7 @@ abstract class RawImpressionUploadModelLineServiceTest {
       val resumed =
         service.markRawImpressionUploadModelLinePoolAssigning(
           markRawImpressionUploadModelLinePoolAssigningRequest {
+            requestId = UUID.randomUUID().toString()
             dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
             rawImpressionUploadResourceId = RAW_IMPRESSION_UPLOAD_RESOURCE_ID
             rawImpressionUploadModelLineResourceId = created.rawImpressionUploadModelLineResourceId
@@ -736,6 +763,7 @@ abstract class RawImpressionUploadModelLineServiceTest {
       val created: RawImpressionUploadModelLine =
         service.createRawImpressionUploadModelLine(
           createRawImpressionUploadModelLineRequest {
+            requestId = UUID.randomUUID().toString()
             dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
             rawImpressionUploadResourceId = RAW_IMPRESSION_UPLOAD_RESOURCE_ID
             rawImpressionUploadModelLine = rawImpressionUploadModelLine {
@@ -745,6 +773,7 @@ abstract class RawImpressionUploadModelLineServiceTest {
         )
       service.markRawImpressionUploadModelLinePoolAssigning(
         markRawImpressionUploadModelLinePoolAssigningRequest {
+          requestId = UUID.randomUUID().toString()
           dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
           rawImpressionUploadResourceId = RAW_IMPRESSION_UPLOAD_RESOURCE_ID
           rawImpressionUploadModelLineResourceId = created.rawImpressionUploadModelLineResourceId
@@ -755,6 +784,7 @@ abstract class RawImpressionUploadModelLineServiceTest {
       val modelLine: RawImpressionUploadModelLine =
         service.markRawImpressionUploadModelLineRanking(
           markRawImpressionUploadModelLineRankingRequest {
+            requestId = UUID.randomUUID().toString()
             dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
             rawImpressionUploadResourceId = RAW_IMPRESSION_UPLOAD_RESOURCE_ID
             rawImpressionUploadModelLineResourceId = created.rawImpressionUploadModelLineResourceId
@@ -771,6 +801,7 @@ abstract class RawImpressionUploadModelLineServiceTest {
     val created: RawImpressionUploadModelLine =
       service.createRawImpressionUploadModelLine(
         createRawImpressionUploadModelLineRequest {
+          requestId = UUID.randomUUID().toString()
           dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
           rawImpressionUploadResourceId = RAW_IMPRESSION_UPLOAD_RESOURCE_ID
           rawImpressionUploadModelLine = rawImpressionUploadModelLine {
@@ -780,6 +811,7 @@ abstract class RawImpressionUploadModelLineServiceTest {
       )
     service.markRawImpressionUploadModelLinePoolAssigning(
       markRawImpressionUploadModelLinePoolAssigningRequest {
+        requestId = UUID.randomUUID().toString()
         dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
         rawImpressionUploadResourceId = RAW_IMPRESSION_UPLOAD_RESOURCE_ID
         rawImpressionUploadModelLineResourceId = created.rawImpressionUploadModelLineResourceId
@@ -788,6 +820,7 @@ abstract class RawImpressionUploadModelLineServiceTest {
     )
     service.markRawImpressionUploadModelLineRanking(
       markRawImpressionUploadModelLineRankingRequest {
+        requestId = UUID.randomUUID().toString()
         dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
         rawImpressionUploadResourceId = RAW_IMPRESSION_UPLOAD_RESOURCE_ID
         rawImpressionUploadModelLineResourceId = created.rawImpressionUploadModelLineResourceId
@@ -798,6 +831,7 @@ abstract class RawImpressionUploadModelLineServiceTest {
     val modelLine: RawImpressionUploadModelLine =
       service.markRawImpressionUploadModelLineLabeling(
         markRawImpressionUploadModelLineLabelingRequest {
+          requestId = UUID.randomUUID().toString()
           dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
           rawImpressionUploadResourceId = RAW_IMPRESSION_UPLOAD_RESOURCE_ID
           rawImpressionUploadModelLineResourceId = created.rawImpressionUploadModelLineResourceId
@@ -815,6 +849,7 @@ abstract class RawImpressionUploadModelLineServiceTest {
       val created: RawImpressionUploadModelLine =
         service.createRawImpressionUploadModelLine(
           createRawImpressionUploadModelLineRequest {
+            requestId = UUID.randomUUID().toString()
             dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
             rawImpressionUploadResourceId = RAW_IMPRESSION_UPLOAD_RESOURCE_ID
             rawImpressionUploadModelLine = rawImpressionUploadModelLine {
@@ -824,6 +859,7 @@ abstract class RawImpressionUploadModelLineServiceTest {
         )
       service.markRawImpressionUploadModelLinePoolAssigning(
         markRawImpressionUploadModelLinePoolAssigningRequest {
+          requestId = UUID.randomUUID().toString()
           dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
           rawImpressionUploadResourceId = RAW_IMPRESSION_UPLOAD_RESOURCE_ID
           rawImpressionUploadModelLineResourceId = created.rawImpressionUploadModelLineResourceId
@@ -832,6 +868,7 @@ abstract class RawImpressionUploadModelLineServiceTest {
       )
       service.markRawImpressionUploadModelLineRanking(
         markRawImpressionUploadModelLineRankingRequest {
+          requestId = UUID.randomUUID().toString()
           dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
           rawImpressionUploadResourceId = RAW_IMPRESSION_UPLOAD_RESOURCE_ID
           rawImpressionUploadModelLineResourceId = created.rawImpressionUploadModelLineResourceId
@@ -840,6 +877,7 @@ abstract class RawImpressionUploadModelLineServiceTest {
       )
       service.markRawImpressionUploadModelLineLabeling(
         markRawImpressionUploadModelLineLabelingRequest {
+          requestId = UUID.randomUUID().toString()
           dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
           rawImpressionUploadResourceId = RAW_IMPRESSION_UPLOAD_RESOURCE_ID
           rawImpressionUploadModelLineResourceId = created.rawImpressionUploadModelLineResourceId
@@ -850,6 +888,7 @@ abstract class RawImpressionUploadModelLineServiceTest {
       val modelLine: RawImpressionUploadModelLine =
         service.markRawImpressionUploadModelLineCompleted(
           markRawImpressionUploadModelLineCompletedRequest {
+            requestId = UUID.randomUUID().toString()
             dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
             rawImpressionUploadResourceId = RAW_IMPRESSION_UPLOAD_RESOURCE_ID
             rawImpressionUploadModelLineResourceId = created.rawImpressionUploadModelLineResourceId
@@ -868,6 +907,7 @@ abstract class RawImpressionUploadModelLineServiceTest {
     val created: RawImpressionUploadModelLine =
       service.createRawImpressionUploadModelLine(
         createRawImpressionUploadModelLineRequest {
+          requestId = UUID.randomUUID().toString()
           dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
           rawImpressionUploadResourceId = RAW_IMPRESSION_UPLOAD_RESOURCE_ID
           rawImpressionUploadModelLine = rawImpressionUploadModelLine {
@@ -879,6 +919,7 @@ abstract class RawImpressionUploadModelLineServiceTest {
     val modelLine: RawImpressionUploadModelLine =
       service.markRawImpressionUploadModelLineFailed(
         markRawImpressionUploadModelLineFailedRequest {
+          requestId = UUID.randomUUID().toString()
           dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
           rawImpressionUploadResourceId = RAW_IMPRESSION_UPLOAD_RESOURCE_ID
           rawImpressionUploadModelLineResourceId = created.rawImpressionUploadModelLineResourceId
@@ -898,6 +939,7 @@ abstract class RawImpressionUploadModelLineServiceTest {
       val created: RawImpressionUploadModelLine =
         service.createRawImpressionUploadModelLine(
           createRawImpressionUploadModelLineRequest {
+            requestId = UUID.randomUUID().toString()
             dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
             rawImpressionUploadResourceId = RAW_IMPRESSION_UPLOAD_RESOURCE_ID
             rawImpressionUploadModelLine = rawImpressionUploadModelLine {
@@ -907,6 +949,7 @@ abstract class RawImpressionUploadModelLineServiceTest {
         )
       service.markRawImpressionUploadModelLinePoolAssigning(
         markRawImpressionUploadModelLinePoolAssigningRequest {
+          requestId = UUID.randomUUID().toString()
           dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
           rawImpressionUploadResourceId = RAW_IMPRESSION_UPLOAD_RESOURCE_ID
           rawImpressionUploadModelLineResourceId = created.rawImpressionUploadModelLineResourceId
@@ -917,6 +960,7 @@ abstract class RawImpressionUploadModelLineServiceTest {
       val modelLine: RawImpressionUploadModelLine =
         service.markRawImpressionUploadModelLineFailed(
           markRawImpressionUploadModelLineFailedRequest {
+            requestId = UUID.randomUUID().toString()
             dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
             rawImpressionUploadResourceId = RAW_IMPRESSION_UPLOAD_RESOURCE_ID
             rawImpressionUploadModelLineResourceId = created.rawImpressionUploadModelLineResourceId
@@ -935,6 +979,7 @@ abstract class RawImpressionUploadModelLineServiceTest {
       val created: RawImpressionUploadModelLine =
         service.createRawImpressionUploadModelLine(
           createRawImpressionUploadModelLineRequest {
+            requestId = UUID.randomUUID().toString()
             dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
             rawImpressionUploadResourceId = RAW_IMPRESSION_UPLOAD_RESOURCE_ID
             rawImpressionUploadModelLine = rawImpressionUploadModelLine {
@@ -947,6 +992,7 @@ abstract class RawImpressionUploadModelLineServiceTest {
         assertFailsWith<StatusRuntimeException> {
           service.markRawImpressionUploadModelLineRanking(
             markRawImpressionUploadModelLineRankingRequest {
+              requestId = UUID.randomUUID().toString()
               dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
               rawImpressionUploadResourceId = RAW_IMPRESSION_UPLOAD_RESOURCE_ID
               rawImpressionUploadModelLineResourceId =
@@ -965,6 +1011,7 @@ abstract class RawImpressionUploadModelLineServiceTest {
       val created: RawImpressionUploadModelLine =
         service.createRawImpressionUploadModelLine(
           createRawImpressionUploadModelLineRequest {
+            requestId = UUID.randomUUID().toString()
             dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
             rawImpressionUploadResourceId = RAW_IMPRESSION_UPLOAD_RESOURCE_ID
             rawImpressionUploadModelLine = rawImpressionUploadModelLine {
@@ -977,6 +1024,7 @@ abstract class RawImpressionUploadModelLineServiceTest {
         assertFailsWith<StatusRuntimeException> {
           service.markRawImpressionUploadModelLineCompleted(
             markRawImpressionUploadModelLineCompletedRequest {
+              requestId = UUID.randomUUID().toString()
               dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
               rawImpressionUploadResourceId = RAW_IMPRESSION_UPLOAD_RESOURCE_ID
               rawImpressionUploadModelLineResourceId =
@@ -996,6 +1044,7 @@ abstract class RawImpressionUploadModelLineServiceTest {
         assertFailsWith<StatusRuntimeException> {
           service.markRawImpressionUploadModelLinePoolAssigning(
             markRawImpressionUploadModelLinePoolAssigningRequest {
+              requestId = UUID.randomUUID().toString()
               dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
               rawImpressionUploadResourceId = RAW_IMPRESSION_UPLOAD_RESOURCE_ID
               rawImpressionUploadModelLineResourceId = "nonexistent-resource-id"
@@ -1012,6 +1061,7 @@ abstract class RawImpressionUploadModelLineServiceTest {
     val created =
       service.createRawImpressionUploadModelLine(
         createRawImpressionUploadModelLineRequest {
+          requestId = UUID.randomUUID().toString()
           dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
           rawImpressionUploadResourceId = RAW_IMPRESSION_UPLOAD_RESOURCE_ID
           rawImpressionUploadModelLine = rawImpressionUploadModelLine {
@@ -1023,6 +1073,7 @@ abstract class RawImpressionUploadModelLineServiceTest {
       assertFailsWith<StatusRuntimeException> {
         service.markRawImpressionUploadModelLineRanking(
           markRawImpressionUploadModelLineRankingRequest {
+            requestId = UUID.randomUUID().toString()
             dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
             rawImpressionUploadResourceId = RAW_IMPRESSION_UPLOAD_RESOURCE_ID
             rawImpressionUploadModelLineResourceId = created.rawImpressionUploadModelLineResourceId
@@ -1038,6 +1089,7 @@ abstract class RawImpressionUploadModelLineServiceTest {
     val created =
       service.createRawImpressionUploadModelLine(
         createRawImpressionUploadModelLineRequest {
+          requestId = UUID.randomUUID().toString()
           dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
           rawImpressionUploadResourceId = RAW_IMPRESSION_UPLOAD_RESOURCE_ID
           rawImpressionUploadModelLine = rawImpressionUploadModelLine {
@@ -1049,6 +1101,7 @@ abstract class RawImpressionUploadModelLineServiceTest {
       assertFailsWith<StatusRuntimeException> {
         service.markRawImpressionUploadModelLineLabeling(
           markRawImpressionUploadModelLineLabelingRequest {
+            requestId = UUID.randomUUID().toString()
             dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
             rawImpressionUploadResourceId = RAW_IMPRESSION_UPLOAD_RESOURCE_ID
             rawImpressionUploadModelLineResourceId = created.rawImpressionUploadModelLineResourceId
@@ -1064,6 +1117,7 @@ abstract class RawImpressionUploadModelLineServiceTest {
     val created =
       service.createRawImpressionUploadModelLine(
         createRawImpressionUploadModelLineRequest {
+          requestId = UUID.randomUUID().toString()
           dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
           rawImpressionUploadResourceId = RAW_IMPRESSION_UPLOAD_RESOURCE_ID
           rawImpressionUploadModelLine = rawImpressionUploadModelLine {
@@ -1075,6 +1129,7 @@ abstract class RawImpressionUploadModelLineServiceTest {
       assertFailsWith<StatusRuntimeException> {
         service.markRawImpressionUploadModelLineCompleted(
           markRawImpressionUploadModelLineCompletedRequest {
+            requestId = UUID.randomUUID().toString()
             dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
             rawImpressionUploadResourceId = RAW_IMPRESSION_UPLOAD_RESOURCE_ID
             rawImpressionUploadModelLineResourceId = created.rawImpressionUploadModelLineResourceId
@@ -1090,6 +1145,7 @@ abstract class RawImpressionUploadModelLineServiceTest {
     val created =
       service.createRawImpressionUploadModelLine(
         createRawImpressionUploadModelLineRequest {
+          requestId = UUID.randomUUID().toString()
           dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
           rawImpressionUploadResourceId = RAW_IMPRESSION_UPLOAD_RESOURCE_ID
           rawImpressionUploadModelLine = rawImpressionUploadModelLine {
@@ -1101,6 +1157,7 @@ abstract class RawImpressionUploadModelLineServiceTest {
       assertFailsWith<StatusRuntimeException> {
         service.markRawImpressionUploadModelLineFailed(
           markRawImpressionUploadModelLineFailedRequest {
+            requestId = UUID.randomUUID().toString()
             dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
             rawImpressionUploadResourceId = RAW_IMPRESSION_UPLOAD_RESOURCE_ID
             rawImpressionUploadModelLineResourceId = created.rawImpressionUploadModelLineResourceId
@@ -1117,6 +1174,7 @@ abstract class RawImpressionUploadModelLineServiceTest {
       val created =
         service.createRawImpressionUploadModelLine(
           createRawImpressionUploadModelLineRequest {
+            requestId = UUID.randomUUID().toString()
             dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
             rawImpressionUploadResourceId = RAW_IMPRESSION_UPLOAD_RESOURCE_ID
             rawImpressionUploadModelLine = rawImpressionUploadModelLine {
@@ -1127,6 +1185,7 @@ abstract class RawImpressionUploadModelLineServiceTest {
       val poolAssigning =
         service.markRawImpressionUploadModelLinePoolAssigning(
           markRawImpressionUploadModelLinePoolAssigningRequest {
+            requestId = UUID.randomUUID().toString()
             dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
             rawImpressionUploadResourceId = RAW_IMPRESSION_UPLOAD_RESOURCE_ID
             rawImpressionUploadModelLineResourceId = created.rawImpressionUploadModelLineResourceId
@@ -1136,6 +1195,7 @@ abstract class RawImpressionUploadModelLineServiceTest {
       val ranking =
         service.markRawImpressionUploadModelLineRanking(
           markRawImpressionUploadModelLineRankingRequest {
+            requestId = UUID.randomUUID().toString()
             dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
             rawImpressionUploadResourceId = RAW_IMPRESSION_UPLOAD_RESOURCE_ID
             rawImpressionUploadModelLineResourceId = created.rawImpressionUploadModelLineResourceId
@@ -1146,6 +1206,7 @@ abstract class RawImpressionUploadModelLineServiceTest {
         assertFailsWith<StatusRuntimeException> {
           service.markRawImpressionUploadModelLinePoolAssigning(
             markRawImpressionUploadModelLinePoolAssigningRequest {
+              requestId = UUID.randomUUID().toString()
               dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
               rawImpressionUploadResourceId = RAW_IMPRESSION_UPLOAD_RESOURCE_ID
               rawImpressionUploadModelLineResourceId =
@@ -1163,6 +1224,7 @@ abstract class RawImpressionUploadModelLineServiceTest {
       assertFailsWith<StatusRuntimeException> {
         service.markRawImpressionUploadModelLineRanking(
           markRawImpressionUploadModelLineRankingRequest {
+            requestId = UUID.randomUUID().toString()
             dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
             rawImpressionUploadResourceId = RAW_IMPRESSION_UPLOAD_RESOURCE_ID
             rawImpressionUploadModelLineResourceId = "riuml-does-not-exist"
@@ -1184,6 +1246,7 @@ abstract class RawImpressionUploadModelLineServiceTest {
               rawImpressionUploadResourceId = RAW_IMPRESSION_UPLOAD_RESOURCE_ID
               for (i in 0 until 51) {
                 requests += createRawImpressionUploadModelLineRequest {
+                  requestId = UUID.randomUUID().toString()
                   rawImpressionUploadModelLine = rawImpressionUploadModelLine {
                     cmmsModelLine = "modelProviders/mp1/modelSuites/ms1/modelLines/ml$i"
                   }
@@ -1301,6 +1364,7 @@ abstract class RawImpressionUploadModelLineServiceTest {
     val created =
       service.createRawImpressionUploadModelLine(
         createRawImpressionUploadModelLineRequest {
+          requestId = UUID.randomUUID().toString()
           dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
           rawImpressionUploadResourceId = RAW_IMPRESSION_UPLOAD_RESOURCE_ID
           rawImpressionUploadModelLine = rawImpressionUploadModelLine {
@@ -1311,6 +1375,7 @@ abstract class RawImpressionUploadModelLineServiceTest {
 
     service.markRawImpressionUploadModelLinePoolAssigning(
       markRawImpressionUploadModelLinePoolAssigningRequest {
+        requestId = UUID.randomUUID().toString()
         dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
         rawImpressionUploadResourceId = RAW_IMPRESSION_UPLOAD_RESOURCE_ID
         rawImpressionUploadModelLineResourceId = created.rawImpressionUploadModelLineResourceId
@@ -1328,6 +1393,7 @@ abstract class RawImpressionUploadModelLineServiceTest {
       val created =
         service.createRawImpressionUploadModelLine(
           createRawImpressionUploadModelLineRequest {
+            requestId = UUID.randomUUID().toString()
             dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
             rawImpressionUploadResourceId = RAW_IMPRESSION_UPLOAD_RESOURCE_ID
             rawImpressionUploadModelLine = rawImpressionUploadModelLine {
@@ -1340,6 +1406,7 @@ abstract class RawImpressionUploadModelLineServiceTest {
       val modelLine =
         service.markRawImpressionUploadModelLineLabeling(
           markRawImpressionUploadModelLineLabelingRequest {
+            requestId = UUID.randomUUID().toString()
             dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
             rawImpressionUploadResourceId = RAW_IMPRESSION_UPLOAD_RESOURCE_ID
             rawImpressionUploadModelLineResourceId = created.rawImpressionUploadModelLineResourceId
@@ -1360,6 +1427,7 @@ abstract class RawImpressionUploadModelLineServiceTest {
     val created =
       service.createRawImpressionUploadModelLine(
         createRawImpressionUploadModelLineRequest {
+          requestId = UUID.randomUUID().toString()
           dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
           rawImpressionUploadResourceId = RAW_IMPRESSION_UPLOAD_RESOURCE_ID
           rawImpressionUploadModelLine = rawImpressionUploadModelLine {
@@ -1370,6 +1438,7 @@ abstract class RawImpressionUploadModelLineServiceTest {
 
     service.markRawImpressionUploadModelLineFailed(
       markRawImpressionUploadModelLineFailedRequest {
+        requestId = UUID.randomUUID().toString()
         dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
         rawImpressionUploadResourceId = RAW_IMPRESSION_UPLOAD_RESOURCE_ID
         rawImpressionUploadModelLineResourceId = created.rawImpressionUploadModelLineResourceId
@@ -1387,6 +1456,7 @@ abstract class RawImpressionUploadModelLineServiceTest {
     val modelLine1 =
       service.createRawImpressionUploadModelLine(
         createRawImpressionUploadModelLineRequest {
+          requestId = UUID.randomUUID().toString()
           dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
           rawImpressionUploadResourceId = RAW_IMPRESSION_UPLOAD_RESOURCE_ID
           rawImpressionUploadModelLine = rawImpressionUploadModelLine {
@@ -1397,6 +1467,7 @@ abstract class RawImpressionUploadModelLineServiceTest {
     val modelLine2 =
       service.createRawImpressionUploadModelLine(
         createRawImpressionUploadModelLineRequest {
+          requestId = UUID.randomUUID().toString()
           dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
           rawImpressionUploadResourceId = RAW_IMPRESSION_UPLOAD_RESOURCE_ID
           rawImpressionUploadModelLine = rawImpressionUploadModelLine {
@@ -1408,6 +1479,7 @@ abstract class RawImpressionUploadModelLineServiceTest {
     // Complete model line 1 (non-memoized: CREATED -> LABELING -> COMPLETED).
     service.markRawImpressionUploadModelLineLabeling(
       markRawImpressionUploadModelLineLabelingRequest {
+        requestId = UUID.randomUUID().toString()
         dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
         rawImpressionUploadResourceId = RAW_IMPRESSION_UPLOAD_RESOURCE_ID
         rawImpressionUploadModelLineResourceId = modelLine1.rawImpressionUploadModelLineResourceId
@@ -1416,6 +1488,7 @@ abstract class RawImpressionUploadModelLineServiceTest {
     )
     service.markRawImpressionUploadModelLineCompleted(
       markRawImpressionUploadModelLineCompletedRequest {
+        requestId = UUID.randomUUID().toString()
         dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
         rawImpressionUploadResourceId = RAW_IMPRESSION_UPLOAD_RESOURCE_ID
         rawImpressionUploadModelLineResourceId = modelLine1.rawImpressionUploadModelLineResourceId
@@ -1430,6 +1503,7 @@ abstract class RawImpressionUploadModelLineServiceTest {
     // Complete model line 2; now every model line is COMPLETED.
     service.markRawImpressionUploadModelLineLabeling(
       markRawImpressionUploadModelLineLabelingRequest {
+        requestId = UUID.randomUUID().toString()
         dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
         rawImpressionUploadResourceId = RAW_IMPRESSION_UPLOAD_RESOURCE_ID
         rawImpressionUploadModelLineResourceId = modelLine2.rawImpressionUploadModelLineResourceId
@@ -1438,6 +1512,7 @@ abstract class RawImpressionUploadModelLineServiceTest {
     )
     service.markRawImpressionUploadModelLineCompleted(
       markRawImpressionUploadModelLineCompletedRequest {
+        requestId = UUID.randomUUID().toString()
         dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
         rawImpressionUploadResourceId = RAW_IMPRESSION_UPLOAD_RESOURCE_ID
         rawImpressionUploadModelLineResourceId = modelLine2.rawImpressionUploadModelLineResourceId
@@ -1459,6 +1534,7 @@ abstract class RawImpressionUploadModelLineServiceTest {
       val first: RawImpressionUploadModelLine =
         service.createRawImpressionUploadModelLine(
           createRawImpressionUploadModelLineRequest {
+            requestId = UUID.randomUUID().toString()
             dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
             rawImpressionUploadResourceId = RAW_IMPRESSION_UPLOAD_RESOURCE_ID
             rawImpressionUploadModelLine = rawImpressionUploadModelLine {
@@ -1469,6 +1545,7 @@ abstract class RawImpressionUploadModelLineServiceTest {
       val second: RawImpressionUploadModelLine =
         service.createRawImpressionUploadModelLine(
           createRawImpressionUploadModelLineRequest {
+            requestId = UUID.randomUUID().toString()
             dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
             rawImpressionUploadResourceId = secondUpload
             rawImpressionUploadModelLine = rawImpressionUploadModelLine {
@@ -1480,6 +1557,7 @@ abstract class RawImpressionUploadModelLineServiceTest {
       // Put the first upload's model line in flight.
       service.markRawImpressionUploadModelLinePoolAssigning(
         markRawImpressionUploadModelLinePoolAssigningRequest {
+          requestId = UUID.randomUUID().toString()
           dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
           rawImpressionUploadResourceId = RAW_IMPRESSION_UPLOAD_RESOURCE_ID
           rawImpressionUploadModelLineResourceId = first.rawImpressionUploadModelLineResourceId
@@ -1492,6 +1570,7 @@ abstract class RawImpressionUploadModelLineServiceTest {
         assertFailsWith<StatusRuntimeException> {
           service.markRawImpressionUploadModelLinePoolAssigning(
             markRawImpressionUploadModelLinePoolAssigningRequest {
+              requestId = UUID.randomUUID().toString()
               dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
               rawImpressionUploadResourceId = secondUpload
               rawImpressionUploadModelLineResourceId = second.rawImpressionUploadModelLineResourceId
@@ -1513,6 +1592,277 @@ abstract class RawImpressionUploadModelLineServiceTest {
               RAW_IMPRESSION_UPLOAD_RESOURCE_ID
           }
         )
+    }
+
+  /** Creates a model line in the CREATED state with a fresh (valid) request_id. */
+  private suspend fun createModelLine(
+    cmmsModelLine: String = CMMS_MODEL_LINE
+  ): RawImpressionUploadModelLine =
+    service.createRawImpressionUploadModelLine(
+      createRawImpressionUploadModelLineRequest {
+        requestId = UUID.randomUUID().toString()
+        dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
+        rawImpressionUploadResourceId = RAW_IMPRESSION_UPLOAD_RESOURCE_ID
+        rawImpressionUploadModelLine = rawImpressionUploadModelLine {
+          this.cmmsModelLine = cmmsModelLine
+        }
+      }
+    )
+
+  @Test
+  fun `markRawImpressionUploadModelLinePoolAssigning is idempotent with same request_id`() =
+    runBlocking {
+      val created = createModelLine()
+      val requestId = UUID.randomUUID().toString()
+
+      val first =
+        service.markRawImpressionUploadModelLinePoolAssigning(
+          markRawImpressionUploadModelLinePoolAssigningRequest {
+            dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
+            rawImpressionUploadResourceId = RAW_IMPRESSION_UPLOAD_RESOURCE_ID
+            rawImpressionUploadModelLineResourceId = created.rawImpressionUploadModelLineResourceId
+            etag = created.etag
+            this.requestId = requestId
+          }
+        )
+      // A Pub/Sub redelivery replays the identical request (same etag, same request_id).
+      val second =
+        service.markRawImpressionUploadModelLinePoolAssigning(
+          markRawImpressionUploadModelLinePoolAssigningRequest {
+            dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
+            rawImpressionUploadResourceId = RAW_IMPRESSION_UPLOAD_RESOURCE_ID
+            rawImpressionUploadModelLineResourceId = created.rawImpressionUploadModelLineResourceId
+            etag = created.etag
+            this.requestId = requestId
+          }
+        )
+
+      assertThat(first.state)
+        .isEqualTo(
+          RawImpressionUploadModelLineState.RAW_IMPRESSION_UPLOAD_MODEL_LINE_STATE_POOL_ASSIGNING
+        )
+      assertThat(second).isEqualTo(first)
+    }
+
+  @Test
+  fun `markRawImpressionUploadModelLineRanking is idempotent with same request_id`() = runBlocking {
+    val created = createModelLine()
+    val poolAssigning =
+      service.markRawImpressionUploadModelLinePoolAssigning(
+        markRawImpressionUploadModelLinePoolAssigningRequest {
+          dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
+          rawImpressionUploadResourceId = RAW_IMPRESSION_UPLOAD_RESOURCE_ID
+          rawImpressionUploadModelLineResourceId = created.rawImpressionUploadModelLineResourceId
+          etag = created.etag
+          requestId = UUID.randomUUID().toString()
+        }
+      )
+    val requestId = UUID.randomUUID().toString()
+
+    val first =
+      service.markRawImpressionUploadModelLineRanking(
+        markRawImpressionUploadModelLineRankingRequest {
+          dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
+          rawImpressionUploadResourceId = RAW_IMPRESSION_UPLOAD_RESOURCE_ID
+          rawImpressionUploadModelLineResourceId = created.rawImpressionUploadModelLineResourceId
+          etag = poolAssigning.etag
+          this.requestId = requestId
+        }
+      )
+    val second =
+      service.markRawImpressionUploadModelLineRanking(
+        markRawImpressionUploadModelLineRankingRequest {
+          dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
+          rawImpressionUploadResourceId = RAW_IMPRESSION_UPLOAD_RESOURCE_ID
+          rawImpressionUploadModelLineResourceId = created.rawImpressionUploadModelLineResourceId
+          etag = poolAssigning.etag
+          this.requestId = requestId
+        }
+      )
+
+    assertThat(first.state)
+      .isEqualTo(RawImpressionUploadModelLineState.RAW_IMPRESSION_UPLOAD_MODEL_LINE_STATE_RANKING)
+    assertThat(second).isEqualTo(first)
+  }
+
+  @Test
+  fun `markRawImpressionUploadModelLineLabeling is idempotent with same request_id`() =
+    runBlocking {
+      // Non-memoized path: CREATED -> LABELING directly.
+      val created = createModelLine()
+      val requestId = UUID.randomUUID().toString()
+
+      val first =
+        service.markRawImpressionUploadModelLineLabeling(
+          markRawImpressionUploadModelLineLabelingRequest {
+            dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
+            rawImpressionUploadResourceId = RAW_IMPRESSION_UPLOAD_RESOURCE_ID
+            rawImpressionUploadModelLineResourceId = created.rawImpressionUploadModelLineResourceId
+            etag = created.etag
+            this.requestId = requestId
+          }
+        )
+      val second =
+        service.markRawImpressionUploadModelLineLabeling(
+          markRawImpressionUploadModelLineLabelingRequest {
+            dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
+            rawImpressionUploadResourceId = RAW_IMPRESSION_UPLOAD_RESOURCE_ID
+            rawImpressionUploadModelLineResourceId = created.rawImpressionUploadModelLineResourceId
+            etag = created.etag
+            this.requestId = requestId
+          }
+        )
+
+      assertThat(first.state)
+        .isEqualTo(
+          RawImpressionUploadModelLineState.RAW_IMPRESSION_UPLOAD_MODEL_LINE_STATE_LABELING
+        )
+      assertThat(second).isEqualTo(first)
+    }
+
+  @Test
+  fun `markRawImpressionUploadModelLineCompleted is idempotent with same request_id`() =
+    runBlocking {
+      val created = createModelLine()
+      val labeling =
+        service.markRawImpressionUploadModelLineLabeling(
+          markRawImpressionUploadModelLineLabelingRequest {
+            dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
+            rawImpressionUploadResourceId = RAW_IMPRESSION_UPLOAD_RESOURCE_ID
+            rawImpressionUploadModelLineResourceId = created.rawImpressionUploadModelLineResourceId
+            etag = created.etag
+            requestId = UUID.randomUUID().toString()
+          }
+        )
+      val requestId = UUID.randomUUID().toString()
+
+      val first =
+        service.markRawImpressionUploadModelLineCompleted(
+          markRawImpressionUploadModelLineCompletedRequest {
+            dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
+            rawImpressionUploadResourceId = RAW_IMPRESSION_UPLOAD_RESOURCE_ID
+            rawImpressionUploadModelLineResourceId = created.rawImpressionUploadModelLineResourceId
+            etag = labeling.etag
+            this.requestId = requestId
+          }
+        )
+      val second =
+        service.markRawImpressionUploadModelLineCompleted(
+          markRawImpressionUploadModelLineCompletedRequest {
+            dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
+            rawImpressionUploadResourceId = RAW_IMPRESSION_UPLOAD_RESOURCE_ID
+            rawImpressionUploadModelLineResourceId = created.rawImpressionUploadModelLineResourceId
+            etag = labeling.etag
+            this.requestId = requestId
+          }
+        )
+
+      assertThat(first.state)
+        .isEqualTo(
+          RawImpressionUploadModelLineState.RAW_IMPRESSION_UPLOAD_MODEL_LINE_STATE_COMPLETED
+        )
+      assertThat(second).isEqualTo(first)
+    }
+
+  @Test
+  fun `markRawImpressionUploadModelLineFailed is idempotent with same request_id`() = runBlocking {
+    val created = createModelLine()
+    val requestId = UUID.randomUUID().toString()
+
+    val first =
+      service.markRawImpressionUploadModelLineFailed(
+        markRawImpressionUploadModelLineFailedRequest {
+          dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
+          rawImpressionUploadResourceId = RAW_IMPRESSION_UPLOAD_RESOURCE_ID
+          rawImpressionUploadModelLineResourceId = created.rawImpressionUploadModelLineResourceId
+          etag = created.etag
+          this.requestId = requestId
+          errorMessage = "boom"
+        }
+      )
+    val second =
+      service.markRawImpressionUploadModelLineFailed(
+        markRawImpressionUploadModelLineFailedRequest {
+          dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
+          rawImpressionUploadResourceId = RAW_IMPRESSION_UPLOAD_RESOURCE_ID
+          rawImpressionUploadModelLineResourceId = created.rawImpressionUploadModelLineResourceId
+          etag = created.etag
+          this.requestId = requestId
+          errorMessage = "boom"
+        }
+      )
+
+    assertThat(first.state)
+      .isEqualTo(RawImpressionUploadModelLineState.RAW_IMPRESSION_UPLOAD_MODEL_LINE_STATE_FAILED)
+    assertThat(second).isEqualTo(first)
+  }
+
+  @Test
+  fun `markRawImpressionUploadModelLineFailed preserves original error_message on same-request_id replay`() =
+    runBlocking {
+      val created = createModelLine()
+      val requestId = UUID.randomUUID().toString()
+
+      val first =
+        service.markRawImpressionUploadModelLineFailed(
+          markRawImpressionUploadModelLineFailedRequest {
+            dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
+            rawImpressionUploadResourceId = RAW_IMPRESSION_UPLOAD_RESOURCE_ID
+            rawImpressionUploadModelLineResourceId = created.rawImpressionUploadModelLineResourceId
+            etag = created.etag
+            this.requestId = requestId
+            errorMessage = "first failure"
+          }
+        )
+      // Same request_id, different error_message: the replay returns the first response as-is.
+      val second =
+        service.markRawImpressionUploadModelLineFailed(
+          markRawImpressionUploadModelLineFailedRequest {
+            dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
+            rawImpressionUploadResourceId = RAW_IMPRESSION_UPLOAD_RESOURCE_ID
+            rawImpressionUploadModelLineResourceId = created.rawImpressionUploadModelLineResourceId
+            etag = created.etag
+            this.requestId = requestId
+            errorMessage = "second failure"
+          }
+        )
+
+      assertThat(first.errorMessage).isEqualTo("first failure")
+      assertThat(second.errorMessage).isEqualTo("first failure")
+    }
+
+  @Test
+  fun `markRawImpressionUploadModelLinePoolAssigning with different request_id after transition throws FAILED_PRECONDITION`() =
+    runBlocking {
+      val created = createModelLine()
+      service.markRawImpressionUploadModelLinePoolAssigning(
+        markRawImpressionUploadModelLinePoolAssigningRequest {
+          dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
+          rawImpressionUploadResourceId = RAW_IMPRESSION_UPLOAD_RESOURCE_ID
+          rawImpressionUploadModelLineResourceId = created.rawImpressionUploadModelLineResourceId
+          etag = created.etag
+          requestId = UUID.randomUUID().toString()
+        }
+      )
+
+      // A different request_id does NOT replay: the row is already POOL_ASSIGNING, which is not a
+      // valid previous state for PoolAssigning, so this is a state violation (etag is current, so
+      // it is not an etag mismatch).
+      val exception: StatusRuntimeException =
+        assertFailsWith<StatusRuntimeException> {
+          service.markRawImpressionUploadModelLinePoolAssigning(
+            markRawImpressionUploadModelLinePoolAssigningRequest {
+              dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
+              rawImpressionUploadResourceId = RAW_IMPRESSION_UPLOAD_RESOURCE_ID
+              rawImpressionUploadModelLineResourceId =
+                created.rawImpressionUploadModelLineResourceId
+              etag = currentEtag(created.rawImpressionUploadModelLineResourceId)
+              requestId = UUID.randomUUID().toString()
+            }
+          )
+        }
+
+      assertThat(exception.status.code).isEqualTo(Status.Code.FAILED_PRECONDITION)
     }
 
   companion object {

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/service/v1alpha/RawImpressionUploadModelLineService.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/service/v1alpha/RawImpressionUploadModelLineService.kt
@@ -339,20 +339,7 @@ class RawImpressionUploadModelLineService(
         ?: throw InvalidFieldValueException("name")
           .asStatusRuntimeException(Status.Code.INVALID_ARGUMENT)
 
-    if (request.etag.isEmpty()) {
-      throw RequiredFieldNotSetException("etag")
-        .asStatusRuntimeException(Status.Code.INVALID_ARGUMENT)
-    }
-    if (request.requestId.isEmpty()) {
-      throw RequiredFieldNotSetException("request_id")
-        .asStatusRuntimeException(Status.Code.INVALID_ARGUMENT)
-    }
-    try {
-      UUID.fromString(request.requestId)
-    } catch (e: IllegalArgumentException) {
-      throw InvalidFieldValueException("request_id", e)
-        .asStatusRuntimeException(Status.Code.INVALID_ARGUMENT)
-    }
+    validateEtagAndRequestId(request.etag, request.requestId)
     val internalResponse: InternalRawImpressionUploadModelLine =
       try {
         internalModelLineStub.markRawImpressionUploadModelLinePoolAssigning(
@@ -384,20 +371,7 @@ class RawImpressionUploadModelLineService(
         ?: throw InvalidFieldValueException("name")
           .asStatusRuntimeException(Status.Code.INVALID_ARGUMENT)
 
-    if (request.etag.isEmpty()) {
-      throw RequiredFieldNotSetException("etag")
-        .asStatusRuntimeException(Status.Code.INVALID_ARGUMENT)
-    }
-    if (request.requestId.isEmpty()) {
-      throw RequiredFieldNotSetException("request_id")
-        .asStatusRuntimeException(Status.Code.INVALID_ARGUMENT)
-    }
-    try {
-      UUID.fromString(request.requestId)
-    } catch (e: IllegalArgumentException) {
-      throw InvalidFieldValueException("request_id", e)
-        .asStatusRuntimeException(Status.Code.INVALID_ARGUMENT)
-    }
+    validateEtagAndRequestId(request.etag, request.requestId)
     val internalResponse: InternalRawImpressionUploadModelLine =
       try {
         internalModelLineStub.markRawImpressionUploadModelLineRanking(
@@ -429,20 +403,7 @@ class RawImpressionUploadModelLineService(
         ?: throw InvalidFieldValueException("name")
           .asStatusRuntimeException(Status.Code.INVALID_ARGUMENT)
 
-    if (request.etag.isEmpty()) {
-      throw RequiredFieldNotSetException("etag")
-        .asStatusRuntimeException(Status.Code.INVALID_ARGUMENT)
-    }
-    if (request.requestId.isEmpty()) {
-      throw RequiredFieldNotSetException("request_id")
-        .asStatusRuntimeException(Status.Code.INVALID_ARGUMENT)
-    }
-    try {
-      UUID.fromString(request.requestId)
-    } catch (e: IllegalArgumentException) {
-      throw InvalidFieldValueException("request_id", e)
-        .asStatusRuntimeException(Status.Code.INVALID_ARGUMENT)
-    }
+    validateEtagAndRequestId(request.etag, request.requestId)
     val internalResponse: InternalRawImpressionUploadModelLine =
       try {
         internalModelLineStub.markRawImpressionUploadModelLineLabeling(
@@ -474,20 +435,7 @@ class RawImpressionUploadModelLineService(
         ?: throw InvalidFieldValueException("name")
           .asStatusRuntimeException(Status.Code.INVALID_ARGUMENT)
 
-    if (request.etag.isEmpty()) {
-      throw RequiredFieldNotSetException("etag")
-        .asStatusRuntimeException(Status.Code.INVALID_ARGUMENT)
-    }
-    if (request.requestId.isEmpty()) {
-      throw RequiredFieldNotSetException("request_id")
-        .asStatusRuntimeException(Status.Code.INVALID_ARGUMENT)
-    }
-    try {
-      UUID.fromString(request.requestId)
-    } catch (e: IllegalArgumentException) {
-      throw InvalidFieldValueException("request_id", e)
-        .asStatusRuntimeException(Status.Code.INVALID_ARGUMENT)
-    }
+    validateEtagAndRequestId(request.etag, request.requestId)
     val internalResponse: InternalRawImpressionUploadModelLine =
       try {
         internalModelLineStub.markRawImpressionUploadModelLineCompleted(
@@ -519,20 +467,7 @@ class RawImpressionUploadModelLineService(
         ?: throw InvalidFieldValueException("name")
           .asStatusRuntimeException(Status.Code.INVALID_ARGUMENT)
 
-    if (request.etag.isEmpty()) {
-      throw RequiredFieldNotSetException("etag")
-        .asStatusRuntimeException(Status.Code.INVALID_ARGUMENT)
-    }
-    if (request.requestId.isEmpty()) {
-      throw RequiredFieldNotSetException("request_id")
-        .asStatusRuntimeException(Status.Code.INVALID_ARGUMENT)
-    }
-    try {
-      UUID.fromString(request.requestId)
-    } catch (e: IllegalArgumentException) {
-      throw InvalidFieldValueException("request_id", e)
-        .asStatusRuntimeException(Status.Code.INVALID_ARGUMENT)
-    }
+    validateEtagAndRequestId(request.etag, request.requestId)
     val internalResponse: InternalRawImpressionUploadModelLine =
       try {
         internalModelLineStub.markRawImpressionUploadModelLineFailed(
@@ -550,6 +485,29 @@ class RawImpressionUploadModelLineService(
       }
 
     return internalResponse.toPublic()
+  }
+
+  /**
+   * Validates the `etag` and `request_id` shared by every `Mark*` RPC.
+   *
+   * @throws io.grpc.StatusRuntimeException with [Status.Code.INVALID_ARGUMENT] if `etag` or
+   *   `request_id` is empty, or if `request_id` is not a valid UUID.
+   */
+  private fun validateEtagAndRequestId(etag: String, requestId: String) {
+    if (etag.isEmpty()) {
+      throw RequiredFieldNotSetException("etag")
+        .asStatusRuntimeException(Status.Code.INVALID_ARGUMENT)
+    }
+    if (requestId.isEmpty()) {
+      throw RequiredFieldNotSetException("request_id")
+        .asStatusRuntimeException(Status.Code.INVALID_ARGUMENT)
+    }
+    try {
+      UUID.fromString(requestId)
+    } catch (e: IllegalArgumentException) {
+      throw InvalidFieldValueException("request_id", e)
+        .asStatusRuntimeException(Status.Code.INVALID_ARGUMENT)
+    }
   }
 
   private fun handleInternalError(e: StatusException): StatusRuntimeException {

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/service/v1alpha/RawImpressionUploadModelLineService.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/service/v1alpha/RawImpressionUploadModelLineService.kt
@@ -91,13 +91,15 @@ class RawImpressionUploadModelLineService(
       ?: throw InvalidFieldValueException("raw_impression_upload_model_line.cmms_model_line")
         .asStatusRuntimeException(Status.Code.INVALID_ARGUMENT)
 
-    if (request.requestId.isNotEmpty()) {
-      try {
-        UUID.fromString(request.requestId)
-      } catch (e: IllegalArgumentException) {
-        throw InvalidFieldValueException("request_id", e)
-          .asStatusRuntimeException(Status.Code.INVALID_ARGUMENT)
-      }
+    if (request.requestId.isEmpty()) {
+      throw RequiredFieldNotSetException("request_id")
+        .asStatusRuntimeException(Status.Code.INVALID_ARGUMENT)
+    }
+    try {
+      UUID.fromString(request.requestId)
+    } catch (e: IllegalArgumentException) {
+      throw InvalidFieldValueException("request_id", e)
+        .asStatusRuntimeException(Status.Code.INVALID_ARGUMENT)
     }
 
     val internalResponse: InternalRawImpressionUploadModelLine =
@@ -148,17 +150,19 @@ class RawImpressionUploadModelLineService(
     val seenRequestIds = mutableSetOf<String>()
     val seenModelLines = mutableSetOf<String>()
     request.requestsList.forEachIndexed { index, createRequest ->
-      if (createRequest.requestId.isNotEmpty()) {
-        try {
-          UUID.fromString(createRequest.requestId)
-        } catch (e: IllegalArgumentException) {
-          throw InvalidFieldValueException("requests.$index.request_id", e)
-            .asStatusRuntimeException(Status.Code.INVALID_ARGUMENT)
-        }
-        if (!seenRequestIds.add(createRequest.requestId)) {
-          throw InvalidFieldValueException("requests.$index.request_id")
-            .asStatusRuntimeException(Status.Code.INVALID_ARGUMENT)
-        }
+      if (createRequest.requestId.isEmpty()) {
+        throw RequiredFieldNotSetException("requests.$index.request_id")
+          .asStatusRuntimeException(Status.Code.INVALID_ARGUMENT)
+      }
+      try {
+        UUID.fromString(createRequest.requestId)
+      } catch (e: IllegalArgumentException) {
+        throw InvalidFieldValueException("requests.$index.request_id", e)
+          .asStatusRuntimeException(Status.Code.INVALID_ARGUMENT)
+      }
+      if (!seenRequestIds.add(createRequest.requestId)) {
+        throw InvalidFieldValueException("requests.$index.request_id")
+          .asStatusRuntimeException(Status.Code.INVALID_ARGUMENT)
       }
       if (createRequest.parent.isNotEmpty() && createRequest.parent != request.parent) {
         throw InvalidFieldValueException("requests.$index.parent")
@@ -322,8 +326,6 @@ class RawImpressionUploadModelLineService(
     }
   }
 
-  // TODO(world-federation-of-advertisers/cross-media-measurement#4074): Add AIP-155 request_id
-  // idempotency
   override suspend fun markRawImpressionUploadModelLinePoolAssigning(
     request: MarkRawImpressionUploadModelLinePoolAssigningRequest
   ): RawImpressionUploadModelLine {
@@ -341,6 +343,16 @@ class RawImpressionUploadModelLineService(
       throw RequiredFieldNotSetException("etag")
         .asStatusRuntimeException(Status.Code.INVALID_ARGUMENT)
     }
+    if (request.requestId.isEmpty()) {
+      throw RequiredFieldNotSetException("request_id")
+        .asStatusRuntimeException(Status.Code.INVALID_ARGUMENT)
+    }
+    try {
+      UUID.fromString(request.requestId)
+    } catch (e: IllegalArgumentException) {
+      throw InvalidFieldValueException("request_id", e)
+        .asStatusRuntimeException(Status.Code.INVALID_ARGUMENT)
+    }
     val internalResponse: InternalRawImpressionUploadModelLine =
       try {
         internalModelLineStub.markRawImpressionUploadModelLinePoolAssigning(
@@ -349,6 +361,7 @@ class RawImpressionUploadModelLineService(
             rawImpressionUploadResourceId = modelLineKey.rawImpressionUploadId
             rawImpressionUploadModelLineResourceId = modelLineKey.rawImpressionUploadModelLineId
             etag = request.etag
+            requestId = request.requestId
           }
         )
       } catch (e: StatusException) {
@@ -358,8 +371,6 @@ class RawImpressionUploadModelLineService(
     return internalResponse.toPublic()
   }
 
-  // TODO(world-federation-of-advertisers/cross-media-measurement#4074): Add AIP-155 request_id
-  // idempotency
   override suspend fun markRawImpressionUploadModelLineRanking(
     request: MarkRawImpressionUploadModelLineRankingRequest
   ): RawImpressionUploadModelLine {
@@ -377,6 +388,16 @@ class RawImpressionUploadModelLineService(
       throw RequiredFieldNotSetException("etag")
         .asStatusRuntimeException(Status.Code.INVALID_ARGUMENT)
     }
+    if (request.requestId.isEmpty()) {
+      throw RequiredFieldNotSetException("request_id")
+        .asStatusRuntimeException(Status.Code.INVALID_ARGUMENT)
+    }
+    try {
+      UUID.fromString(request.requestId)
+    } catch (e: IllegalArgumentException) {
+      throw InvalidFieldValueException("request_id", e)
+        .asStatusRuntimeException(Status.Code.INVALID_ARGUMENT)
+    }
     val internalResponse: InternalRawImpressionUploadModelLine =
       try {
         internalModelLineStub.markRawImpressionUploadModelLineRanking(
@@ -385,6 +406,7 @@ class RawImpressionUploadModelLineService(
             rawImpressionUploadResourceId = modelLineKey.rawImpressionUploadId
             rawImpressionUploadModelLineResourceId = modelLineKey.rawImpressionUploadModelLineId
             etag = request.etag
+            requestId = request.requestId
           }
         )
       } catch (e: StatusException) {
@@ -394,8 +416,6 @@ class RawImpressionUploadModelLineService(
     return internalResponse.toPublic()
   }
 
-  // TODO(world-federation-of-advertisers/cross-media-measurement#4074): Add AIP-155 request_id
-  // idempotency
   override suspend fun markRawImpressionUploadModelLineLabeling(
     request: MarkRawImpressionUploadModelLineLabelingRequest
   ): RawImpressionUploadModelLine {
@@ -413,6 +433,16 @@ class RawImpressionUploadModelLineService(
       throw RequiredFieldNotSetException("etag")
         .asStatusRuntimeException(Status.Code.INVALID_ARGUMENT)
     }
+    if (request.requestId.isEmpty()) {
+      throw RequiredFieldNotSetException("request_id")
+        .asStatusRuntimeException(Status.Code.INVALID_ARGUMENT)
+    }
+    try {
+      UUID.fromString(request.requestId)
+    } catch (e: IllegalArgumentException) {
+      throw InvalidFieldValueException("request_id", e)
+        .asStatusRuntimeException(Status.Code.INVALID_ARGUMENT)
+    }
     val internalResponse: InternalRawImpressionUploadModelLine =
       try {
         internalModelLineStub.markRawImpressionUploadModelLineLabeling(
@@ -421,6 +451,7 @@ class RawImpressionUploadModelLineService(
             rawImpressionUploadResourceId = modelLineKey.rawImpressionUploadId
             rawImpressionUploadModelLineResourceId = modelLineKey.rawImpressionUploadModelLineId
             etag = request.etag
+            requestId = request.requestId
           }
         )
       } catch (e: StatusException) {
@@ -430,8 +461,6 @@ class RawImpressionUploadModelLineService(
     return internalResponse.toPublic()
   }
 
-  // TODO(world-federation-of-advertisers/cross-media-measurement#4074): Add AIP-155 request_id
-  // idempotency
   override suspend fun markRawImpressionUploadModelLineCompleted(
     request: MarkRawImpressionUploadModelLineCompletedRequest
   ): RawImpressionUploadModelLine {
@@ -449,6 +478,16 @@ class RawImpressionUploadModelLineService(
       throw RequiredFieldNotSetException("etag")
         .asStatusRuntimeException(Status.Code.INVALID_ARGUMENT)
     }
+    if (request.requestId.isEmpty()) {
+      throw RequiredFieldNotSetException("request_id")
+        .asStatusRuntimeException(Status.Code.INVALID_ARGUMENT)
+    }
+    try {
+      UUID.fromString(request.requestId)
+    } catch (e: IllegalArgumentException) {
+      throw InvalidFieldValueException("request_id", e)
+        .asStatusRuntimeException(Status.Code.INVALID_ARGUMENT)
+    }
     val internalResponse: InternalRawImpressionUploadModelLine =
       try {
         internalModelLineStub.markRawImpressionUploadModelLineCompleted(
@@ -457,6 +496,7 @@ class RawImpressionUploadModelLineService(
             rawImpressionUploadResourceId = modelLineKey.rawImpressionUploadId
             rawImpressionUploadModelLineResourceId = modelLineKey.rawImpressionUploadModelLineId
             etag = request.etag
+            requestId = request.requestId
           }
         )
       } catch (e: StatusException) {
@@ -466,8 +506,6 @@ class RawImpressionUploadModelLineService(
     return internalResponse.toPublic()
   }
 
-  // TODO(world-federation-of-advertisers/cross-media-measurement#4074): Add AIP-155 request_id
-  // idempotency
   override suspend fun markRawImpressionUploadModelLineFailed(
     request: MarkRawImpressionUploadModelLineFailedRequest
   ): RawImpressionUploadModelLine {
@@ -485,6 +523,16 @@ class RawImpressionUploadModelLineService(
       throw RequiredFieldNotSetException("etag")
         .asStatusRuntimeException(Status.Code.INVALID_ARGUMENT)
     }
+    if (request.requestId.isEmpty()) {
+      throw RequiredFieldNotSetException("request_id")
+        .asStatusRuntimeException(Status.Code.INVALID_ARGUMENT)
+    }
+    try {
+      UUID.fromString(request.requestId)
+    } catch (e: IllegalArgumentException) {
+      throw InvalidFieldValueException("request_id", e)
+        .asStatusRuntimeException(Status.Code.INVALID_ARGUMENT)
+    }
     val internalResponse: InternalRawImpressionUploadModelLine =
       try {
         internalModelLineStub.markRawImpressionUploadModelLineFailed(
@@ -493,6 +541,7 @@ class RawImpressionUploadModelLineService(
             rawImpressionUploadResourceId = modelLineKey.rawImpressionUploadId
             rawImpressionUploadModelLineResourceId = modelLineKey.rawImpressionUploadModelLineId
             etag = request.etag
+            requestId = request.requestId
             errorMessage = request.errorMessage
           }
         )

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/subpoolassigner/BUILD.bazel
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/subpoolassigner/BUILD.bazel
@@ -69,6 +69,7 @@ kt_jvm_library(
         "//src/main/kotlin/org/wfanet/measurement/edpaggregator/rawimpressions:raw_impression_source",
         "//src/main/kotlin/org/wfanet/measurement/edpaggregator/rawimpressions:subpool_fingerprints_store",
         "//src/main/kotlin/org/wfanet/measurement/edpaggregator/vidlabeler/utils:active_window",
+        "//src/main/kotlin/org/wfanet/measurement/edpaggregator/vidlabeling:request_ids",
         "//src/main/kotlin/org/wfanet/measurement/edpaggregator/vidlabeling:work_item_ids",
         "//src/main/proto/wfa/measurement/edpaggregator/v1alpha:encrypted_dek_kt_jvm_proto",
         "//src/main/proto/wfa/measurement/edpaggregator/v1alpha:pool_assignment_job_service_kt_jvm_grpc_proto",

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/subpoolassigner/BUILD.bazel
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/subpoolassigner/BUILD.bazel
@@ -67,6 +67,7 @@ kt_jvm_library(
         "//src/main/kotlin/org/wfanet/measurement/edpaggregator/rawimpressions:raw_impression_source",
         "//src/main/kotlin/org/wfanet/measurement/edpaggregator/rawimpressions:subpool_fingerprints_store",
         "//src/main/kotlin/org/wfanet/measurement/edpaggregator/vidlabeler/utils:active_window",
+        "//src/main/kotlin/org/wfanet/measurement/edpaggregator/vidlabeling:request_ids",
         "//src/main/proto/wfa/measurement/edpaggregator/v1alpha:encrypted_dek_kt_jvm_proto",
         "//src/main/proto/wfa/measurement/edpaggregator/v1alpha:pool_assignment_job_service_kt_jvm_grpc_proto",
         "//src/main/proto/wfa/measurement/edpaggregator/v1alpha:ranker_job_service_kt_jvm_grpc_proto",

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/subpoolassigner/SubpoolAssigner.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/subpoolassigner/SubpoolAssigner.kt
@@ -53,6 +53,7 @@ import org.wfanet.measurement.edpaggregator.v1alpha.markPoolAssignmentJobSucceed
 import org.wfanet.measurement.edpaggregator.v1alpha.markRawImpressionUploadModelLineRankingRequest
 import org.wfanet.measurement.edpaggregator.v1alpha.rankerJob
 import org.wfanet.measurement.edpaggregator.vidlabeler.utils.ActiveWindow
+import org.wfanet.measurement.edpaggregator.vidlabeling.RequestIds
 import org.wfanet.measurement.edpaggregator.vidlabeling.WorkItemIds
 import org.wfanet.measurement.securecomputation.controlplane.v1alpha.WorkItemKt.workItemParams
 import org.wfanet.measurement.securecomputation.controlplane.v1alpha.WorkItemsGrpcKt.WorkItemsCoroutineStub
@@ -406,6 +407,7 @@ class SubpoolAssigner(
         markRawImpressionUploadModelLineRankingRequest {
           name = parent.name
           etag = parent.etag
+          requestId = RequestIds.forMarkRawImpressionUploadModelLineRanking(parent.name)
         }
       )
     } catch (e: StatusException) {

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/subpoolassigner/SubpoolAssigner.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/subpoolassigner/SubpoolAssigner.kt
@@ -55,6 +55,7 @@ import org.wfanet.measurement.edpaggregator.v1alpha.markPoolAssignmentJobSucceed
 import org.wfanet.measurement.edpaggregator.v1alpha.markRawImpressionUploadModelLineRankingRequest
 import org.wfanet.measurement.edpaggregator.v1alpha.rankerJob
 import org.wfanet.measurement.edpaggregator.vidlabeler.utils.ActiveWindow
+import org.wfanet.measurement.edpaggregator.vidlabeling.RequestIds
 import org.wfanet.measurement.securecomputation.controlplane.v1alpha.WorkItemKt.workItemParams
 import org.wfanet.measurement.securecomputation.controlplane.v1alpha.WorkItemsGrpcKt.WorkItemsCoroutineStub
 import org.wfanet.measurement.securecomputation.controlplane.v1alpha.createWorkItemRequest
@@ -408,6 +409,7 @@ class SubpoolAssigner(
         markRawImpressionUploadModelLineRankingRequest {
           name = parent.name
           etag = parent.etag
+          requestId = RequestIds.forMarkRawImpressionUploadModelLineRanking(parent.name)
         }
       )
     } catch (e: StatusException) {

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/vidlabeler/VidLabelerApp.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/vidlabeler/VidLabelerApp.kt
@@ -608,6 +608,7 @@ class VidLabelerApp(
         markRawImpressionUploadModelLineCompletedRequest {
           name = parent.name
           etag = parent.etag
+          requestId = RequestIds.forMarkRawImpressionUploadModelLineCompleted(parent.name)
         }
       )
     } catch (e: StatusException) {

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/vidlabeler/VidLabelerApp.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/vidlabeler/VidLabelerApp.kt
@@ -617,6 +617,7 @@ class VidLabelerApp(
         markRawImpressionUploadModelLineCompletedRequest {
           name = parent.name
           etag = parent.etag
+          requestId = RequestIds.forMarkRawImpressionUploadModelLineCompleted(parent.name)
         }
       )
     } catch (e: StatusException) {

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/vidlabeling/RequestIds.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/vidlabeling/RequestIds.kt
@@ -74,5 +74,28 @@ object RequestIds {
   fun forMarkVidLabelingJobSucceeded(vidLabelingJobName: String): String =
     fromKey("markVidLabelingJobSucceeded:$vidLabelingJobName")
 
+  /**
+   * `request_id`s for the five `MarkRawImpressionUploadModelLine*` transitions.
+   *
+   * Keyed on the operation and [modelLineName] so a Pub/Sub redelivery of the same transition
+   * reuses the same id: the server replays it as an idempotent no-op (returning the already-marked
+   * row) instead of surfacing `FAILED_PRECONDITION`. Distinct per operation so each transition
+   * stamps its own per-mark request-id column.
+   */
+  fun forMarkRawImpressionUploadModelLinePoolAssigning(modelLineName: String): String =
+    fromKey("markRawImpressionUploadModelLinePoolAssigning:$modelLineName")
+
+  fun forMarkRawImpressionUploadModelLineRanking(modelLineName: String): String =
+    fromKey("markRawImpressionUploadModelLineRanking:$modelLineName")
+
+  fun forMarkRawImpressionUploadModelLineLabeling(modelLineName: String): String =
+    fromKey("markRawImpressionUploadModelLineLabeling:$modelLineName")
+
+  fun forMarkRawImpressionUploadModelLineCompleted(modelLineName: String): String =
+    fromKey("markRawImpressionUploadModelLineCompleted:$modelLineName")
+
+  fun forMarkRawImpressionUploadModelLineFailed(modelLineName: String): String =
+    fromKey("markRawImpressionUploadModelLineFailed:$modelLineName")
+
   private fun fromKey(key: String): String = UUID.nameUUIDFromBytes(key.toByteArray()).toString()
 }

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/vidlabeling/RequestIds.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/vidlabeling/RequestIds.kt
@@ -16,6 +16,7 @@
 
 package org.wfanet.measurement.edpaggregator.vidlabeling
 
+import java.security.MessageDigest
 import java.util.UUID
 
 /**
@@ -97,5 +98,19 @@ object RequestIds {
   fun forMarkRawImpressionUploadModelLineFailed(modelLineName: String): String =
     fromKey("markRawImpressionUploadModelLineFailed:$modelLineName")
 
-  private fun fromKey(key: String): String = UUID.nameUUIDFromBytes(key.toByteArray()).toString()
+  private fun fromKey(key: String): String {
+    // Render the deterministic (name-based) id in the RFC 4122 version-4 layout so the value
+    // conforms to the `(google.api.field_info).format = UUID4` annotation shared by every
+    // request_id
+    // field across the EDPA gRPC APIs. A random v4 UUID can't be reproduced on retry, so the 16
+    // bytes come from a SHA-256 hash of [key] with the version and variant bits set to 4 / IETF.
+    val bytes = MessageDigest.getInstance("SHA-256").digest(key.toByteArray())
+    bytes[6] = ((bytes[6].toInt() and 0x0f) or 0x40).toByte() // version 4
+    bytes[8] = ((bytes[8].toInt() and 0x3f) or 0x80).toByte() // IETF variant
+    var msb = 0L
+    var lsb = 0L
+    for (i in 0 until 8) msb = (msb shl 8) or (bytes[i].toLong() and 0xff)
+    for (i in 8 until 16) lsb = (lsb shl 8) or (bytes[i].toLong() and 0xff)
+    return UUID(msb, lsb).toString()
+  }
 }

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/vidlabeling/VidLabelingDispatchSequencer.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/vidlabeling/VidLabelingDispatchSequencer.kt
@@ -607,6 +607,7 @@ class VidLabelingDispatchSequencer(
         markRawImpressionUploadModelLineLabelingRequest {
           name = modelLineName
           this.etag = etag
+          requestId = RequestIds.forMarkRawImpressionUploadModelLineLabeling(modelLineName)
         }
       )
     } catch (e: StatusException) {
@@ -627,6 +628,7 @@ class VidLabelingDispatchSequencer(
         markRawImpressionUploadModelLinePoolAssigningRequest {
           name = modelLineName
           this.etag = etag
+          requestId = RequestIds.forMarkRawImpressionUploadModelLinePoolAssigning(modelLineName)
         }
       )
     } catch (e: StatusException) {

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/vidlabeling/VidLabelingDispatchSequencer.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/vidlabeling/VidLabelingDispatchSequencer.kt
@@ -611,6 +611,7 @@ class VidLabelingDispatchSequencer(
         markRawImpressionUploadModelLineLabelingRequest {
           name = modelLineName
           this.etag = etag
+          requestId = RequestIds.forMarkRawImpressionUploadModelLineLabeling(modelLineName)
         }
       )
     } catch (e: StatusException) {
@@ -631,6 +632,7 @@ class VidLabelingDispatchSequencer(
         markRawImpressionUploadModelLinePoolAssigningRequest {
           name = modelLineName
           this.etag = etag
+          requestId = RequestIds.forMarkRawImpressionUploadModelLinePoolAssigning(modelLineName)
         }
       )
     } catch (e: StatusException) {

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/vidrankbuilder/BUILD.bazel
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/vidrankbuilder/BUILD.bazel
@@ -91,6 +91,7 @@ kt_jvm_library(
         ":subpool_ranker",
         "//src/main/kotlin/org/wfanet/measurement/common/api/grpc:list_resources",
         "//src/main/kotlin/org/wfanet/measurement/edpaggregator/rawimpressions:raw_impression_file_bin_packer",
+        "//src/main/kotlin/org/wfanet/measurement/edpaggregator/vidlabeling:request_ids",
         "//src/main/kotlin/org/wfanet/measurement/edpaggregator/vidlabeling:work_item_ids",
         "//src/main/proto/wfa/measurement/edpaggregator/v1alpha:rank_index_blob_kt_jvm_proto",
         "//src/main/proto/wfa/measurement/edpaggregator/v1alpha:ranker_job_kt_jvm_proto",

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/vidrankbuilder/VidRankBuilder.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/vidrankbuilder/VidRankBuilder.kt
@@ -49,6 +49,7 @@ import org.wfanet.measurement.edpaggregator.v1alpha.markRankerJobSucceededReques
 import org.wfanet.measurement.edpaggregator.v1alpha.markRawImpressionUploadModelLineCompletedRequest
 import org.wfanet.measurement.edpaggregator.v1alpha.markRawImpressionUploadModelLineLabelingRequest
 import org.wfanet.measurement.edpaggregator.v1alpha.vidLabelingJob
+import org.wfanet.measurement.edpaggregator.vidlabeling.RequestIds
 import org.wfanet.measurement.edpaggregator.vidlabeling.WorkItemIds
 import org.wfanet.measurement.securecomputation.controlplane.v1alpha.WorkItemKt.workItemParams
 import org.wfanet.measurement.securecomputation.controlplane.v1alpha.WorkItemsGrpcKt.WorkItemsCoroutineStub
@@ -382,6 +383,7 @@ class VidRankBuilder(
         markRawImpressionUploadModelLineLabelingRequest {
           name = parent.name
           etag = parent.etag
+          requestId = RequestIds.forMarkRawImpressionUploadModelLineLabeling(parent.name)
         }
       )
     } catch (e: StatusException) {
@@ -409,6 +411,7 @@ class VidRankBuilder(
         markRawImpressionUploadModelLineCompletedRequest {
           name = parent.name
           etag = parent.etag
+          requestId = RequestIds.forMarkRawImpressionUploadModelLineCompleted(parent.name)
         }
       )
     } catch (e: StatusException) {

--- a/src/main/proto/wfa/measurement/edpaggregator/v1alpha/raw_impression_upload_model_line_service.proto
+++ b/src/main/proto/wfa/measurement/edpaggregator/v1alpha/raw_impression_upload_model_line_service.proto
@@ -384,6 +384,10 @@ message MarkRawImpressionUploadModelLineFailedRequest {
   // result. Generating a fresh UUID per attempt defeats AIP-155 and surfaces as
   // FAILED_PRECONDITION on retry against an already-transitioned row.
   //
+  // Note: on a same-`request_id` retry, the row is returned with the
+  // `error_message` from the first successful mark; a differing `error_message`
+  // in the retry is ignored (AIP-155: the first response is returned as-is).
+  //
   // This field must be a UUID4 (RFC 4122) string.
   string request_id = 4 [
     (google.api.field_behavior) = REQUIRED,

--- a/src/main/proto/wfa/measurement/edpaggregator/v1alpha/raw_impression_upload_model_line_service.proto
+++ b/src/main/proto/wfa/measurement/edpaggregator/v1alpha/raw_impression_upload_model_line_service.proto
@@ -106,9 +106,16 @@ message CreateRawImpressionUploadModelLineRequest {
 
   // A request ID provided by the client to ensure idempotency.
   //
-  // This field must be a UUID4 (RFC 4122) string.
+  // This field is REQUIRED, deviating from AIP-155 (which recommends request_id
+  // be optional): the model line's resource name is assigned by the server, so
+  // the client has no other idempotency key. Without it, a retry after a lost
+  // response would create a second, orphaned model line. Must be a UUID4 (RFC
+  // 4122) string.
+  // (-- api-linter: core::0133::request-required-fields=disabled
+  //     aip.dev/not-precedent: request_id is intentionally REQUIRED so the
+  //     server can deduplicate retries of this server-named resource. --)
   string request_id = 3 [
-    (google.api.field_behavior) = OPTIONAL,
+    (google.api.field_behavior) = REQUIRED,
     (google.api.field_info).format = UUID4
   ];
 }
@@ -234,6 +241,23 @@ message MarkRawImpressionUploadModelLinePoolAssigningRequest {
 
   // The etag of the `RawImpressionUploadModelLine` for optimistic locking.
   string etag = 2 [(google.api.field_behavior) = REQUIRED];
+
+  // A request ID provided by the client to ensure idempotency on retry. A retry
+  // with the same `request_id` returns the original response without
+  // re-transitioning the resource.
+  //
+  // To survive retries (network blips, redeliveries, process restarts), derive
+  // this deterministically from the resource being marked -- e.g. a UUID
+  // computed from its `name` and the operation -- so that every attempt for the
+  // same logical mark uses the same `request_id` and shares one idempotent
+  // result. Generating a fresh UUID per attempt defeats AIP-155 and surfaces as
+  // FAILED_PRECONDITION on retry against an already-transitioned row.
+  //
+  // This field must be a UUID4 (RFC 4122) string.
+  string request_id = 3 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.field_info).format = UUID4
+  ];
 }
 
 // Request message for the
@@ -249,6 +273,23 @@ message MarkRawImpressionUploadModelLineRankingRequest {
 
   // The etag of the `RawImpressionUploadModelLine` for optimistic locking.
   string etag = 2 [(google.api.field_behavior) = REQUIRED];
+
+  // A request ID provided by the client to ensure idempotency on retry. A retry
+  // with the same `request_id` returns the original response without
+  // re-transitioning the resource.
+  //
+  // To survive retries (network blips, redeliveries, process restarts), derive
+  // this deterministically from the resource being marked -- e.g. a UUID
+  // computed from its `name` and the operation -- so that every attempt for the
+  // same logical mark uses the same `request_id` and shares one idempotent
+  // result. Generating a fresh UUID per attempt defeats AIP-155 and surfaces as
+  // FAILED_PRECONDITION on retry against an already-transitioned row.
+  //
+  // This field must be a UUID4 (RFC 4122) string.
+  string request_id = 3 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.field_info).format = UUID4
+  ];
 }
 
 // Request message for the
@@ -264,6 +305,23 @@ message MarkRawImpressionUploadModelLineLabelingRequest {
 
   // The etag of the `RawImpressionUploadModelLine` for optimistic locking.
   string etag = 2 [(google.api.field_behavior) = REQUIRED];
+
+  // A request ID provided by the client to ensure idempotency on retry. A retry
+  // with the same `request_id` returns the original response without
+  // re-transitioning the resource.
+  //
+  // To survive retries (network blips, redeliveries, process restarts), derive
+  // this deterministically from the resource being marked -- e.g. a UUID
+  // computed from its `name` and the operation -- so that every attempt for the
+  // same logical mark uses the same `request_id` and shares one idempotent
+  // result. Generating a fresh UUID per attempt defeats AIP-155 and surfaces as
+  // FAILED_PRECONDITION on retry against an already-transitioned row.
+  //
+  // This field must be a UUID4 (RFC 4122) string.
+  string request_id = 3 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.field_info).format = UUID4
+  ];
 }
 
 // Request message for the
@@ -279,6 +337,23 @@ message MarkRawImpressionUploadModelLineCompletedRequest {
 
   // The etag of the `RawImpressionUploadModelLine` for optimistic locking.
   string etag = 2 [(google.api.field_behavior) = REQUIRED];
+
+  // A request ID provided by the client to ensure idempotency on retry. A retry
+  // with the same `request_id` returns the original response without
+  // re-transitioning the resource.
+  //
+  // To survive retries (network blips, redeliveries, process restarts), derive
+  // this deterministically from the resource being marked -- e.g. a UUID
+  // computed from its `name` and the operation -- so that every attempt for the
+  // same logical mark uses the same `request_id` and shares one idempotent
+  // result. Generating a fresh UUID per attempt defeats AIP-155 and surfaces as
+  // FAILED_PRECONDITION on retry against an already-transitioned row.
+  //
+  // This field must be a UUID4 (RFC 4122) string.
+  string request_id = 3 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.field_info).format = UUID4
+  ];
 }
 
 // Request message for the
@@ -297,4 +372,21 @@ message MarkRawImpressionUploadModelLineFailedRequest {
 
   // The etag of the `RawImpressionUploadModelLine` for optimistic locking.
   string etag = 3 [(google.api.field_behavior) = REQUIRED];
+
+  // A request ID provided by the client to ensure idempotency on retry. A retry
+  // with the same `request_id` returns the original response without
+  // re-transitioning the resource.
+  //
+  // To survive retries (network blips, redeliveries, process restarts), derive
+  // this deterministically from the resource being marked -- e.g. a UUID
+  // computed from its `name` and the operation -- so that every attempt for the
+  // same logical mark uses the same `request_id` and shares one idempotent
+  // result. Generating a fresh UUID per attempt defeats AIP-155 and surfaces as
+  // FAILED_PRECONDITION on retry against an already-transitioned row.
+  //
+  // This field must be a UUID4 (RFC 4122) string.
+  string request_id = 4 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.field_info).format = UUID4
+  ];
 }

--- a/src/main/proto/wfa/measurement/internal/edpaggregator/raw_impression_upload_model_line_service.proto
+++ b/src/main/proto/wfa/measurement/internal/edpaggregator/raw_impression_upload_model_line_service.proto
@@ -194,6 +194,9 @@ message MarkRawImpressionUploadModelLinePoolAssigningRequest {
 
   // Entity tag for optimistic concurrency control.
   string etag = 4;
+
+  // A request ID provided by the client to ensure idempotency on retry.
+  string request_id = 5;
 }
 
 // Request message for MarkRawImpressionUploadModelLineRanking.
@@ -209,6 +212,9 @@ message MarkRawImpressionUploadModelLineRankingRequest {
 
   // Entity tag for optimistic concurrency control.
   string etag = 4;
+
+  // A request ID provided by the client to ensure idempotency on retry.
+  string request_id = 5;
 }
 
 // Request message for MarkRawImpressionUploadModelLineLabeling.
@@ -224,6 +230,9 @@ message MarkRawImpressionUploadModelLineLabelingRequest {
 
   // Entity tag for optimistic concurrency control.
   string etag = 4;
+
+  // A request ID provided by the client to ensure idempotency on retry.
+  string request_id = 5;
 }
 
 // Request message for MarkRawImpressionUploadModelLineCompleted.
@@ -239,6 +248,9 @@ message MarkRawImpressionUploadModelLineCompletedRequest {
 
   // Entity tag for optimistic concurrency control.
   string etag = 4;
+
+  // A request ID provided by the client to ensure idempotency on retry.
+  string request_id = 5;
 }
 
 // Request message for MarkRawImpressionUploadModelLineFailed.
@@ -257,4 +269,7 @@ message MarkRawImpressionUploadModelLineFailedRequest {
 
   // Entity tag for optimistic concurrency control.
   string etag = 5;
+
+  // A request ID provided by the client to ensure idempotency on retry.
+  string request_id = 6;
 }

--- a/src/test/kotlin/org/wfanet/measurement/edpaggregator/service/v1alpha/RawImpressionUploadModelLineServiceTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/edpaggregator/service/v1alpha/RawImpressionUploadModelLineServiceTest.kt
@@ -318,11 +318,13 @@ class RawImpressionUploadModelLineServiceTest {
           rawImpressionUploadModelLine = rawImpressionUploadModelLine {
             cmmsModelLine = CMMS_MODEL_LINE
           }
+          requestId = UUID.randomUUID().toString()
         }
         requests += createRawImpressionUploadModelLineRequest {
           rawImpressionUploadModelLine = rawImpressionUploadModelLine {
             cmmsModelLine = CMMS_MODEL_LINE_2
           }
+          requestId = UUID.randomUUID().toString()
         }
       }
 
@@ -342,6 +344,7 @@ class RawImpressionUploadModelLineServiceTest {
           rawImpressionUploadModelLine = rawImpressionUploadModelLine {
             cmmsModelLine = CMMS_MODEL_LINE
           }
+          requestId = UUID.randomUUID().toString()
         }
       }
 
@@ -389,6 +392,7 @@ class RawImpressionUploadModelLineServiceTest {
           rawImpressionUploadModelLine = rawImpressionUploadModelLine {
             cmmsModelLine = "not-a-model-line"
           }
+          requestId = UUID.randomUUID().toString()
         }
       }
 
@@ -417,11 +421,13 @@ class RawImpressionUploadModelLineServiceTest {
           rawImpressionUploadModelLine = rawImpressionUploadModelLine {
             cmmsModelLine = CMMS_MODEL_LINE
           }
+          requestId = UUID.randomUUID().toString()
         }
         requests += createRawImpressionUploadModelLineRequest {
           rawImpressionUploadModelLine = rawImpressionUploadModelLine {
             cmmsModelLine = CMMS_MODEL_LINE
           }
+          requestId = UUID.randomUUID().toString()
         }
       }
 
@@ -545,6 +551,7 @@ class RawImpressionUploadModelLineServiceTest {
             rawImpressionUploadModelLine = rawImpressionUploadModelLine {
               cmmsModelLine = CMMS_MODEL_LINE
             }
+            requestId = UUID.randomUUID().toString()
           }
         )
 
@@ -568,6 +575,7 @@ class RawImpressionUploadModelLineServiceTest {
             rawImpressionUploadModelLine = rawImpressionUploadModelLine {
               cmmsModelLine = CMMS_MODEL_LINE
             }
+            requestId = UUID.randomUUID().toString()
           }
         )
       val created2 =
@@ -577,6 +585,7 @@ class RawImpressionUploadModelLineServiceTest {
             rawImpressionUploadModelLine = rawImpressionUploadModelLine {
               cmmsModelLine = CMMS_MODEL_LINE
             }
+            requestId = UUID.randomUUID().toString()
           }
         )
 
@@ -600,6 +609,7 @@ class RawImpressionUploadModelLineServiceTest {
           rawImpressionUploadModelLine = rawImpressionUploadModelLine {
             cmmsModelLine = CMMS_MODEL_LINE
           }
+          requestId = UUID.randomUUID().toString()
         }
       )
     val created2 =
@@ -609,6 +619,7 @@ class RawImpressionUploadModelLineServiceTest {
           rawImpressionUploadModelLine = rawImpressionUploadModelLine {
             cmmsModelLine = CMMS_MODEL_LINE_2
           }
+          requestId = UUID.randomUUID().toString()
         }
       )
     val sortedCreated = listOf(created1, created2).sortedBy { it.name }
@@ -735,6 +746,7 @@ class RawImpressionUploadModelLineServiceTest {
           rawImpressionUploadModelLine = rawImpressionUploadModelLine {
             cmmsModelLine = CMMS_MODEL_LINE
           }
+          requestId = UUID.randomUUID().toString()
         }
       )
 
@@ -743,6 +755,7 @@ class RawImpressionUploadModelLineServiceTest {
         markRawImpressionUploadModelLinePoolAssigningRequest {
           name = created.name
           etag = created.etag
+          requestId = UUID.randomUUID().toString()
         }
       )
 
@@ -801,6 +814,7 @@ class RawImpressionUploadModelLineServiceTest {
           rawImpressionUploadModelLine = rawImpressionUploadModelLine {
             cmmsModelLine = CMMS_MODEL_LINE
           }
+          requestId = UUID.randomUUID().toString()
         }
       )
     val poolAssigning =
@@ -808,6 +822,7 @@ class RawImpressionUploadModelLineServiceTest {
         markRawImpressionUploadModelLinePoolAssigningRequest {
           name = created.name
           etag = created.etag
+          requestId = UUID.randomUUID().toString()
         }
       )
 
@@ -816,6 +831,7 @@ class RawImpressionUploadModelLineServiceTest {
         markRawImpressionUploadModelLineRankingRequest {
           name = created.name
           etag = poolAssigning.etag
+          requestId = UUID.randomUUID().toString()
         }
       )
 
@@ -845,6 +861,7 @@ class RawImpressionUploadModelLineServiceTest {
           rawImpressionUploadModelLine = rawImpressionUploadModelLine {
             cmmsModelLine = CMMS_MODEL_LINE
           }
+          requestId = UUID.randomUUID().toString()
         }
       )
     val poolAssigning =
@@ -852,6 +869,7 @@ class RawImpressionUploadModelLineServiceTest {
         markRawImpressionUploadModelLinePoolAssigningRequest {
           name = created.name
           etag = created.etag
+          requestId = UUID.randomUUID().toString()
         }
       )
     val ranking =
@@ -859,6 +877,7 @@ class RawImpressionUploadModelLineServiceTest {
         markRawImpressionUploadModelLineRankingRequest {
           name = created.name
           etag = poolAssigning.etag
+          requestId = UUID.randomUUID().toString()
         }
       )
 
@@ -867,6 +886,7 @@ class RawImpressionUploadModelLineServiceTest {
         markRawImpressionUploadModelLineLabelingRequest {
           name = created.name
           etag = ranking.etag
+          requestId = UUID.randomUUID().toString()
         }
       )
 
@@ -896,6 +916,7 @@ class RawImpressionUploadModelLineServiceTest {
           rawImpressionUploadModelLine = rawImpressionUploadModelLine {
             cmmsModelLine = CMMS_MODEL_LINE
           }
+          requestId = UUID.randomUUID().toString()
         }
       )
     val poolAssigning =
@@ -903,6 +924,7 @@ class RawImpressionUploadModelLineServiceTest {
         markRawImpressionUploadModelLinePoolAssigningRequest {
           name = created.name
           etag = created.etag
+          requestId = UUID.randomUUID().toString()
         }
       )
     val ranking =
@@ -910,6 +932,7 @@ class RawImpressionUploadModelLineServiceTest {
         markRawImpressionUploadModelLineRankingRequest {
           name = created.name
           etag = poolAssigning.etag
+          requestId = UUID.randomUUID().toString()
         }
       )
     val labeling =
@@ -917,6 +940,7 @@ class RawImpressionUploadModelLineServiceTest {
         markRawImpressionUploadModelLineLabelingRequest {
           name = created.name
           etag = ranking.etag
+          requestId = UUID.randomUUID().toString()
         }
       )
 
@@ -925,6 +949,7 @@ class RawImpressionUploadModelLineServiceTest {
         markRawImpressionUploadModelLineCompletedRequest {
           name = created.name
           etag = labeling.etag
+          requestId = UUID.randomUUID().toString()
         }
       )
 
@@ -954,6 +979,7 @@ class RawImpressionUploadModelLineServiceTest {
           rawImpressionUploadModelLine = rawImpressionUploadModelLine {
             cmmsModelLine = CMMS_MODEL_LINE
           }
+          requestId = UUID.randomUUID().toString()
         }
       )
 
@@ -963,6 +989,7 @@ class RawImpressionUploadModelLineServiceTest {
           name = created.name
           etag = created.etag
           errorMessage = "Something went wrong"
+          requestId = UUID.randomUUID().toString()
         }
       )
 
@@ -1014,6 +1041,7 @@ class RawImpressionUploadModelLineServiceTest {
             rawImpressionUploadModelLine = rawImpressionUploadModelLine {
               cmmsModelLine = CMMS_MODEL_LINE
             }
+            requestId = UUID.randomUUID().toString()
           }
         )
       val exception =
@@ -1036,6 +1064,7 @@ class RawImpressionUploadModelLineServiceTest {
             rawImpressionUploadModelLine = rawImpressionUploadModelLine {
               cmmsModelLine = CMMS_MODEL_LINE
             }
+            requestId = UUID.randomUUID().toString()
           }
         )
       val exception =
@@ -1058,6 +1087,7 @@ class RawImpressionUploadModelLineServiceTest {
             rawImpressionUploadModelLine = rawImpressionUploadModelLine {
               cmmsModelLine = CMMS_MODEL_LINE
             }
+            requestId = UUID.randomUUID().toString()
           }
         )
       val exception =
@@ -1080,6 +1110,7 @@ class RawImpressionUploadModelLineServiceTest {
             rawImpressionUploadModelLine = rawImpressionUploadModelLine {
               cmmsModelLine = CMMS_MODEL_LINE
             }
+            requestId = UUID.randomUUID().toString()
           }
         )
       val exception =
@@ -1102,6 +1133,7 @@ class RawImpressionUploadModelLineServiceTest {
             rawImpressionUploadModelLine = rawImpressionUploadModelLine {
               cmmsModelLine = CMMS_MODEL_LINE
             }
+            requestId = UUID.randomUUID().toString()
           }
         )
       val exception =
@@ -1112,6 +1144,262 @@ class RawImpressionUploadModelLineServiceTest {
         }
       assertThat(exception.status.code).isEqualTo(Status.Code.INVALID_ARGUMENT)
     }
+
+  @Test
+  fun `createRawImpressionUploadModelLine throws INVALID_ARGUMENT for missing requestId`() =
+    runBlocking {
+      createParentUpload(DATA_PROVIDER_ID, RAW_IMPRESSION_UPLOAD_ID)
+      val request = createRawImpressionUploadModelLineRequest {
+        parent = UPLOAD_KEY.toName()
+        rawImpressionUploadModelLine = rawImpressionUploadModelLine {
+          cmmsModelLine = CMMS_MODEL_LINE
+        }
+      }
+
+      val exception =
+        assertFailsWith<StatusRuntimeException> {
+          service.createRawImpressionUploadModelLine(request)
+        }
+      assertThat(exception.status.code).isEqualTo(Status.Code.INVALID_ARGUMENT)
+      assertThat(exception.errorInfo)
+        .isEqualTo(
+          errorInfo {
+            domain = Errors.DOMAIN
+            reason = Errors.Reason.REQUIRED_FIELD_NOT_SET.name
+            metadata[Errors.Metadata.FIELD_NAME.key] = "request_id"
+          }
+        )
+    }
+
+  @Test
+  fun `batchCreateRawImpressionUploadModelLines throws INVALID_ARGUMENT for missing requestId`() =
+    runBlocking {
+      val request = batchCreateRawImpressionUploadModelLinesRequest {
+        parent = UPLOAD_KEY.toName()
+        requests += createRawImpressionUploadModelLineRequest {
+          rawImpressionUploadModelLine = rawImpressionUploadModelLine {
+            cmmsModelLine = CMMS_MODEL_LINE
+          }
+        }
+      }
+
+      val exception =
+        assertFailsWith<StatusRuntimeException> {
+          service.batchCreateRawImpressionUploadModelLines(request)
+        }
+      assertThat(exception.status.code).isEqualTo(Status.Code.INVALID_ARGUMENT)
+      assertThat(exception.errorInfo)
+        .isEqualTo(
+          errorInfo {
+            domain = Errors.DOMAIN
+            reason = Errors.Reason.REQUIRED_FIELD_NOT_SET.name
+            metadata[Errors.Metadata.FIELD_NAME.key] = "requests.0.request_id"
+          }
+        )
+    }
+
+  private suspend fun createModelLineForMark(): RawImpressionUploadModelLine {
+    createParentUpload(DATA_PROVIDER_ID, RAW_IMPRESSION_UPLOAD_ID)
+    return service.createRawImpressionUploadModelLine(
+      createRawImpressionUploadModelLineRequest {
+        parent = UPLOAD_KEY.toName()
+        rawImpressionUploadModelLine = rawImpressionUploadModelLine {
+          cmmsModelLine = CMMS_MODEL_LINE
+        }
+        requestId = UUID.randomUUID().toString()
+      }
+    )
+  }
+
+  private fun assertMissingRequestId(exception: StatusRuntimeException) {
+    assertThat(exception.status.code).isEqualTo(Status.Code.INVALID_ARGUMENT)
+    assertThat(exception.errorInfo)
+      .isEqualTo(
+        errorInfo {
+          domain = Errors.DOMAIN
+          reason = Errors.Reason.REQUIRED_FIELD_NOT_SET.name
+          metadata[Errors.Metadata.FIELD_NAME.key] = "request_id"
+        }
+      )
+  }
+
+  @Test
+  fun `markRawImpressionUploadModelLinePoolAssigning throws INVALID_ARGUMENT for missing requestId`() =
+    runBlocking {
+      val created = createModelLineForMark()
+      val exception =
+        assertFailsWith<StatusRuntimeException> {
+          service.markRawImpressionUploadModelLinePoolAssigning(
+            markRawImpressionUploadModelLinePoolAssigningRequest {
+              name = created.name
+              etag = created.etag
+            }
+          )
+        }
+      assertMissingRequestId(exception)
+    }
+
+  @Test
+  fun `markRawImpressionUploadModelLineRanking throws INVALID_ARGUMENT for missing requestId`() =
+    runBlocking {
+      val created = createModelLineForMark()
+      val exception =
+        assertFailsWith<StatusRuntimeException> {
+          service.markRawImpressionUploadModelLineRanking(
+            markRawImpressionUploadModelLineRankingRequest {
+              name = created.name
+              etag = created.etag
+            }
+          )
+        }
+      assertMissingRequestId(exception)
+    }
+
+  @Test
+  fun `markRawImpressionUploadModelLineLabeling throws INVALID_ARGUMENT for missing requestId`() =
+    runBlocking {
+      val created = createModelLineForMark()
+      val exception =
+        assertFailsWith<StatusRuntimeException> {
+          service.markRawImpressionUploadModelLineLabeling(
+            markRawImpressionUploadModelLineLabelingRequest {
+              name = created.name
+              etag = created.etag
+            }
+          )
+        }
+      assertMissingRequestId(exception)
+    }
+
+  @Test
+  fun `markRawImpressionUploadModelLineCompleted throws INVALID_ARGUMENT for missing requestId`() =
+    runBlocking {
+      val created = createModelLineForMark()
+      val exception =
+        assertFailsWith<StatusRuntimeException> {
+          service.markRawImpressionUploadModelLineCompleted(
+            markRawImpressionUploadModelLineCompletedRequest {
+              name = created.name
+              etag = created.etag
+            }
+          )
+        }
+      assertMissingRequestId(exception)
+    }
+
+  @Test
+  fun `markRawImpressionUploadModelLineFailed throws INVALID_ARGUMENT for missing requestId`() =
+    runBlocking {
+      val created = createModelLineForMark()
+      val exception =
+        assertFailsWith<StatusRuntimeException> {
+          service.markRawImpressionUploadModelLineFailed(
+            markRawImpressionUploadModelLineFailedRequest {
+              name = created.name
+              etag = created.etag
+              errorMessage = "boom"
+            }
+          )
+        }
+      assertMissingRequestId(exception)
+    }
+
+  @Test
+  fun `markRawImpressionUploadModelLinePoolAssigning replays idempotently`() = runBlocking {
+    val created = createModelLineForMark()
+    val request = markRawImpressionUploadModelLinePoolAssigningRequest {
+      name = created.name
+      etag = created.etag
+      requestId = UUID.randomUUID().toString()
+    }
+
+    val first = service.markRawImpressionUploadModelLinePoolAssigning(request)
+    val replay = service.markRawImpressionUploadModelLinePoolAssigning(request)
+
+    assertThat(first.state).isEqualTo(RawImpressionUploadModelLine.State.POOL_ASSIGNING)
+    assertThat(replay).isEqualTo(first)
+  }
+
+  @Test
+  fun `markRawImpressionUploadModelLineRanking replays idempotently`() = runBlocking {
+    val created = createModelLineForMark()
+    val poolAssigning =
+      service.markRawImpressionUploadModelLinePoolAssigning(
+        markRawImpressionUploadModelLinePoolAssigningRequest {
+          name = created.name
+          etag = created.etag
+          requestId = UUID.randomUUID().toString()
+        }
+      )
+    val request = markRawImpressionUploadModelLineRankingRequest {
+      name = created.name
+      etag = poolAssigning.etag
+      requestId = UUID.randomUUID().toString()
+    }
+
+    val first = service.markRawImpressionUploadModelLineRanking(request)
+    val replay = service.markRawImpressionUploadModelLineRanking(request)
+
+    assertThat(first.state).isEqualTo(RawImpressionUploadModelLine.State.RANKING)
+    assertThat(replay).isEqualTo(first)
+  }
+
+  @Test
+  fun `markRawImpressionUploadModelLineLabeling replays idempotently`() = runBlocking {
+    val created = createModelLineForMark()
+    val request = markRawImpressionUploadModelLineLabelingRequest {
+      name = created.name
+      etag = created.etag
+      requestId = UUID.randomUUID().toString()
+    }
+
+    val first = service.markRawImpressionUploadModelLineLabeling(request)
+    val replay = service.markRawImpressionUploadModelLineLabeling(request)
+
+    assertThat(first.state).isEqualTo(RawImpressionUploadModelLine.State.LABELING)
+    assertThat(replay).isEqualTo(first)
+  }
+
+  @Test
+  fun `markRawImpressionUploadModelLineCompleted replays idempotently`() = runBlocking {
+    val created = createModelLineForMark()
+    val labeling =
+      service.markRawImpressionUploadModelLineLabeling(
+        markRawImpressionUploadModelLineLabelingRequest {
+          name = created.name
+          etag = created.etag
+          requestId = UUID.randomUUID().toString()
+        }
+      )
+    val request = markRawImpressionUploadModelLineCompletedRequest {
+      name = created.name
+      etag = labeling.etag
+      requestId = UUID.randomUUID().toString()
+    }
+
+    val first = service.markRawImpressionUploadModelLineCompleted(request)
+    val replay = service.markRawImpressionUploadModelLineCompleted(request)
+
+    assertThat(first.state).isEqualTo(RawImpressionUploadModelLine.State.COMPLETED)
+    assertThat(replay).isEqualTo(first)
+  }
+
+  @Test
+  fun `markRawImpressionUploadModelLineFailed replays idempotently`() = runBlocking {
+    val created = createModelLineForMark()
+    val request = markRawImpressionUploadModelLineFailedRequest {
+      name = created.name
+      etag = created.etag
+      errorMessage = "Something went wrong"
+      requestId = UUID.randomUUID().toString()
+    }
+
+    val first = service.markRawImpressionUploadModelLineFailed(request)
+    val replay = service.markRawImpressionUploadModelLineFailed(request)
+
+    assertThat(first.state).isEqualTo(RawImpressionUploadModelLine.State.FAILED)
+    assertThat(replay).isEqualTo(first)
+  }
 
   @Test
   fun `toPublic surfaces phase-0 last-shard-out outputs`() {

--- a/src/test/kotlin/org/wfanet/measurement/edpaggregator/vidlabeling/RequestIdsTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/edpaggregator/vidlabeling/RequestIdsTest.kt
@@ -17,6 +17,7 @@
 package org.wfanet.measurement.edpaggregator.vidlabeling
 
 import com.google.common.truth.Truth.assertThat
+import java.util.UUID
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
@@ -60,6 +61,30 @@ class RequestIdsTest {
       .isNotEqualTo(RequestIds.forRawImpressionUploadModelLine(UPLOAD, SHARED))
   }
 
+  @Test
+  fun `request ids are formatted as UUID version 4`() {
+    // Every request_id proto field declares (google.api.field_info).format = UUID4, so the
+    // deterministic ids must render in the version-4 layout. Cover every helper family so no
+    // generator drifts to a different version.
+    val ids =
+      listOf(
+        RequestIds.forRawImpressionUpload(DONE_BLOB, 1L),
+        RequestIds.forRawImpressionUploadFile(UPLOAD, FILE_URI),
+        RequestIds.forRawImpressionUploadModelLine(UPLOAD, MODEL_LINE),
+        RequestIds.forPoolAssignmentJob(UPLOAD, MODEL_LINE, 0),
+        RequestIds.forVidLabelingJob(UPLOAD, listOf(MODEL_LINE), 0),
+        RequestIds.forMarkVidLabelingJobSucceeded(VID_LABELING_JOB),
+        RequestIds.forMarkRawImpressionUploadModelLinePoolAssigning(MODEL_LINE_NAME),
+        RequestIds.forMarkRawImpressionUploadModelLineRanking(MODEL_LINE_NAME),
+        RequestIds.forMarkRawImpressionUploadModelLineLabeling(MODEL_LINE_NAME),
+        RequestIds.forMarkRawImpressionUploadModelLineCompleted(MODEL_LINE_NAME),
+        RequestIds.forMarkRawImpressionUploadModelLineFailed(MODEL_LINE_NAME),
+      )
+    for (id in ids) {
+      assertThat(UUID.fromString(id).version()).isEqualTo(4)
+    }
+  }
+
   companion object {
     private const val DATA_PROVIDER = "dataProviders/edp123"
     private const val UPLOAD = "$DATA_PROVIDER/rawImpressionUploads/upload-1"
@@ -67,5 +92,7 @@ class RequestIdsTest {
     private const val FILE_URI = "gs://bucket/edp/2026-01-01/impressions_001"
     private const val MODEL_LINE = "modelProviders/mp1/modelSuites/ms1/modelLines/ml1"
     private const val SHARED = "shared-value"
+    private const val MODEL_LINE_NAME = "$UPLOAD/rawImpressionUploadModelLines/riuml-1"
+    private const val VID_LABELING_JOB = "$UPLOAD/vidLabelingJobs/vlj-1"
   }
 }


### PR DESCRIPTION
## Summary

  Adds AIP-155 `request_id` retry idempotency to the five
  `MarkRawImpressionUploadModelLine*` RPCs (`PoolAssigning`, `Ranking`, `Labeling`,
  `Completed`, `Failed`) and flips `CreateRawImpressionUploadModelLineRequest.request_id`
  from `OPTIONAL` to `REQUIRED`, matching the established pattern on `PoolAssignmentJob`,
  `RankerJob`, and `VidLabelingJob`.

  Without this, a Pub/Sub redelivery against an already-transitioned model line surfaced as
  `FAILED_PRECONDITION` instead of an idempotent no-op, stranding the caller's retry
  (dispatcher #3910, monitor #4020, VidRankBuilder #4009 all mark via `Sequencer`).


  ## Changes

  - **Protos** (`v1alpha` + `internal`): `string request_id [REQUIRED, UUID4]` on all 5
    `Mark*Request` messages; `Create.request_id` flipped to `REQUIRED` with a
    `core::0133::request-required-fields=disabled` suppression (deviating from AIP-155 for a
    server-named resource, mirroring `RankerJob`). Docstrings document deriving `request_id`
    deterministically from `(resource_name, operation)` so retries share one id.
  - **Public service**: validates `request_id` is a UUID4 before forwarding; the internal
    already-marked path now returns the row instead of `FAILED_PRECONDITION`.
  - **Internal service**: AIP-155 replay short-circuit in `transitionState` — if this mark's
    `request_id` is already stamped on the row, return the current committed resource as-is
    (per AIP-155 stale-success, even if it has since advanced to a later state); otherwise apply
    the transition and stamp the per-mark `Mark*RequestId` column. (The 5 columns + unique
    indexes already landed in #3989 — **no schema change**.)
  - **Callers** (dispatcher / sequencer / subpool-assigner / vid-labeler-app): derive a
    deterministic `request_id` via 5 new `RequestIds.forMarkRawImpressionUploadModelLine*`
    helpers.

  ## Testing

  - `RawImpressionUploadModelLineServiceTest` (runs the real Spanner emulator, so it exercises
    the internal replay logic): **56 tests pass**, including idempotent-replay across the 5
    Marks, replay after the line advanced to a later state, and missing-`request_id` coverage
    for `Create`, `BatchCreate`, and all 5 Marks.
  - `SubpoolAssignerTest`, `VidLabelerAppTest`, `VidLabelingDispatchSequencerTest`,
    `VidLabelingMonitorTest`, `VidLabelingDispatcherTest`: all pass.
  - Full `//src/main/.../edpaggregator/...` build passes; ktfmt `--google-style` + clang-format clean.


BREAKING-CHANGE: request_id is now REQUIRED on CreateRawImpressionUploadModelLine, BatchCreateRawImpressionUploadModelLines, and the five MarkRawImpressionUploadModelLine* RPCs; requests that omit it now fail with INVALID_ARGUMENT.
Issue: #4074