### PR TITLE
fix: document and instrument ResultsFulfiller empty-metadata retry

### DIFF
--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/resultsfulfiller/ResultsFulfiller.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/resultsfulfiller/ResultsFulfiller.kt
@@ -157,8 +157,32 @@ class ResultsFulfiller(
     // fulfilled or refused already
     val requisitionsMetadata: List<RequisitionMetadata> = listRequisitionMetadata()
 
-    require(requisitionsMetadata.isNotEmpty()) {
-      "No requisition metadata found for group id: ${groupedRequisitions.groupId}"
+    // Empty metadata is almost always transient, not a permanent orphan. DataWatcher dispatches
+    // this work item on the blob write, but the RequisitionFetcher creates the RequisitionMetadata
+    // *after* writing the blob (writeBlob then batchCreateRequisitionMetadataForGroup), so a
+    // dispatch that wins the race against that metadata write reads zero rows here even though they
+    // land moments later. Throwing nacks the work item, which redelivers and self-heals once the
+    // metadata exists — do NOT skip-and-ack, which would abandon requisitions that are about to
+    // become fulfillable and leave the report permanently unfulfilled.
+    //
+    // The genuinely-orphaned case (fetcher crashed between blob and metadata, so metadata never
+    // arrives) is indistinguishable from the race at read time; it retries up to the queue's
+    // max_delivery_attempts and then dead-letters. Silencing that dead-letter noise requires gating
+    // dispatch on metadata existence (a done-marker) so empty metadata can only mean a true orphan;
+    // until then this stays a throw-and-retry. See #4119 (blocked by #4213).
+    //
+    // emptyMetadataRetries is the observability hook: a low steady rate is the normal race, a
+    // sustained climb on the same groupId is a stuck orphan worth investigating.
+    if (requisitionsMetadata.isEmpty()) {
+      metrics.emptyMetadataRetries.add(
+        1,
+        Attributes.of(ATTR_GROUP_ID_KEY, groupedRequisitions.groupId),
+      )
+      throw IllegalStateException(
+        "No requisition metadata for groupId=${groupedRequisitions.groupId}; the metadata write " +
+          "likely has not committed yet. Nacking to retry; if this persists for a groupId the blob " +
+          "may be a true orphan from a fetcher crash between blob and metadata writes."
+      )
     }
 
     val requisitionMetadataByName: Map<String, RequisitionMetadata> =

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/resultsfulfiller/ResultsFulfillerMetrics.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/resultsfulfiller/ResultsFulfillerMetrics.kt
@@ -95,6 +95,15 @@ class ResultsFulfillerMetrics(meter: Meter) {
       .setUnit("s")
       .build()
 
+  val emptyMetadataRetries: LongCounter =
+    meter
+      .counterBuilder("edpa.results_fulfiller.empty_metadata_retries")
+      .setDescription(
+        "Count of grouped-requisition blobs nacked for retry because their RequisitionMetadata " +
+          "was not found (usually the fetcher's metadata write racing behind the blob write)"
+      )
+      .build()
+
   companion object {
     private val statusKey = AttributeKey.stringKey("edpa.results_fulfiller.status")
 

--- a/src/test/kotlin/org/wfanet/measurement/edpaggregator/resultsfulfiller/ResultsFulfillerAppTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/edpaggregator/resultsfulfiller/ResultsFulfillerAppTest.kt
@@ -415,7 +415,7 @@ class ResultsFulfillerAppTest {
   }
 
   @Test
-  fun `runWork throws where requisition metadata is not found`() {
+  fun `runWork nacks work item when requisition metadata is not found`() {
     runBlocking {
       val subscriber =
         Subscriber(
@@ -522,7 +522,10 @@ class ResultsFulfillerAppTest {
           mapOf("some-model-line" to MODEL_LINE_INFO),
           metrics = ResultsFulfillerMetrics.create(),
         )
-      assertFailsWith<IllegalArgumentException> { app.runWork(Any.pack(workItemParams)) }
+      // Empty metadata is treated as transient (the fetcher writes metadata just after the blob,
+      // and DataWatcher dispatches on the blob), so runWork throws to nack the work item for retry
+      // rather than acking and abandoning fulfillable requisitions. See #4119 / #4213.
+      assertFailsWith<IllegalStateException> { app.runWork(Any.pack(workItemParams)) }
     }
   }
 

--- a/src/test/kotlin/org/wfanet/measurement/edpaggregator/resultsfulfiller/ResultsFulfillerTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/edpaggregator/resultsfulfiller/ResultsFulfillerTest.kt
@@ -1219,6 +1219,111 @@ class ResultsFulfillerTest {
   }
 
   @Test
+  fun `runWork nacks blob with no metadata for retry and counts it`() = runBlocking {
+    val impressionsTmpPath = Files.createTempDirectory(null).toFile()
+    val metadataTmpPath = Files.createTempDirectory(null).toFile()
+    val requisitionsTmpPath = Files.createTempDirectory(null).toFile()
+    val impressions =
+      List(130) {
+        LABELED_IMPRESSION.copy {
+          vid = it.toLong() + 1
+          eventTime = TIME_RANGE.start.toProtoTime()
+        }
+      }
+
+    val dates = FIRST_EVENT_DATE.datesUntil(LAST_EVENT_DATE.plusDays(1)).toList()
+    val impressionMetadataList = createImpressionMetadataList(dates, EVENT_GROUP_NAME)
+
+    whenever(impressionMetadataServiceMock.listImpressionMetadata(any()))
+      .thenReturn(listImpressionMetadataResponse { impressionMetadata += impressionMetadataList })
+
+    // Orphan blob: the RequisitionFetcher wrote the grouped-requisitions blob but has not (yet)
+    // created any RequisitionMetadata for it. ResultsFulfiller must skip and count it, not throw.
+    whenever(requisitionMetadataServiceMock.listRequisitionMetadata(any()))
+      .thenReturn(listRequisitionMetadataResponse {})
+
+    // Set up KMS
+    val kmsClient = FakeKmsClient()
+    val kekUri = FakeKmsClient.KEY_URI_PREFIX + "kek"
+    val kmsKeyHandle = KeysetHandle.generateNew(KeyTemplates.get("AES128_GCM"))
+    kmsClient.setAead(kekUri, kmsKeyHandle.getPrimitive(Aead::class.java))
+    createData(
+      kmsClient,
+      kekUri,
+      impressionsTmpPath,
+      metadataTmpPath,
+      requisitionsTmpPath,
+      impressions,
+      listOf(DIRECT_RNF_REQUISITION),
+    )
+    val impressionsMetadataService =
+      ImpressionDataSourceProvider(
+        impressionMetadataStub = impressionMetadataStub,
+        dataProvider = "dataProviders/123",
+        impressionsMetadataStorageConfig = StorageConfig(rootDirectory = metadataTmpPath),
+      )
+
+    val fulfillerSelector =
+      DefaultFulfillerSelector(
+        requisitionsStub = requisitionsStub,
+        requisitionFulfillmentStubMap = emptyMap<String, RequisitionFulfillmentCoroutineStub>(),
+        dataProviderCertificateKey = DATA_PROVIDER_CERTIFICATE_KEY,
+        dataProviderSigningKeyHandle = EDP_RESULT_SIGNING_KEY,
+        noiserSelector = ContinuousGaussianNoiseSelector(),
+        resultMinimumThresholds = null,
+        overrideImpressionMaxFrequencyPerUser = null,
+        supportedMultiPartyNoiseMechanisms = emptySet(),
+        trusTeeConfig =
+          TrusTeeConfig(
+            kmsClient = kmsClient,
+            workloadIdentityProvider = "test-wip",
+            impersonatedServiceAccount = "test-sa@example.com",
+            awsKmsParams = null,
+          ),
+        kekUriToKeyNameMap = emptyMap(),
+      )
+
+    val groupedRequisitions = loadGroupedRequisitions(requisitionsTmpPath)
+
+    val resultsFulfiller =
+      ResultsFulfiller(
+        dataProvider = EDP_NAME,
+        privateEncryptionKey = PRIVATE_ENCRYPTION_KEY,
+        requisitionMetadataStub = requisitionMetadataStub,
+        requisitionsStub = requisitionsStub,
+        groupedRequisitions = groupedRequisitions,
+        modelLineInfoMap = mapOf("some-model-line" to MODEL_LINE_INFO),
+        pipelineConfiguration = DEFAULT_PIPELINE_CONFIGURATION,
+        impressionDataSourceProvider = impressionsMetadataService,
+        impressionsStorageConfig = StorageConfig(rootDirectory = impressionsTmpPath),
+        kmsClient = kmsClient,
+        fulfillerSelector = fulfillerSelector,
+        metrics = metrics,
+      )
+
+    // Empty metadata is treated as transient: throw so the work item nacks and retries once the
+    // fetcher's metadata write commits, rather than acking and abandoning fulfillable requisitions.
+    assertFailsWith<IllegalStateException> { resultsFulfiller.fulfillRequisitions() }
+
+    // Nothing fulfilled or processed while metadata is absent.
+    verifyBlocking(requisitionsServiceMock, times(0)) { fulfillDirectRequisition(any()) }
+    verifyBlocking(requisitionMetadataServiceMock, times(0)) {
+      startProcessingRequisitionMetadata(any())
+    }
+    verifyBlocking(requisitionMetadataServiceMock, times(0)) { fulfillRequisitionMetadata(any()) }
+
+    // The retry is counted, tagged with the blob's group id.
+    val metricsByName = collectMetrics().associateBy { it.name }
+    val retryPoints =
+      metricsByName.getValue("edpa.results_fulfiller.empty_metadata_retries").longSumData.points
+    assertThat(retryPoints).hasSize(1)
+    val retryPoint = retryPoints.single()
+    assertThat(retryPoint.value).isEqualTo(1)
+    val groupIdKey = AttributeKey.stringKey("edpa.results_fulfiller.group_id")
+    assertThat(retryPoint.attributes.get(groupIdKey)).isEqualTo(groupedRequisitions.groupId)
+  }
+
+  @Test
   fun `runWork skips withdrawn requisitions`() = runBlocking {
     val impressionsTmpPath = Files.createTempDirectory(null).toFile()
     val metadataTmpPath = Files.createTempDirectory(null).toFile()

--- a/src/test/kotlin/org/wfanet/measurement/edpaggregator/resultsfulfiller/ResultsFulfillerTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/edpaggregator/resultsfulfiller/ResultsFulfillerTest.kt
@@ -1238,7 +1238,7 @@ class ResultsFulfillerTest {
       .thenReturn(listImpressionMetadataResponse { impressionMetadata += impressionMetadataList })
 
     // Orphan blob: the RequisitionFetcher wrote the grouped-requisitions blob but has not (yet)
-    // created any RequisitionMetadata for it. ResultsFulfiller must skip and count it, not throw.
+    // created any RequisitionMetadata for it. ResultsFulfiller must throw to nack for retry.
     whenever(requisitionMetadataServiceMock.listRequisitionMetadata(any()))
       .thenReturn(listRequisitionMetadataResponse {})
 


### PR DESCRIPTION
A grouped-requisitions blob can reach ResultsFulfiller before its RequisitionMetadata exists, because the RequisitionFetcher writes the blob before creating metadata and DataWatcher dispatch is triggered by the blob write. Previously this threw and dead-lettered the work item, which looked like a real failure even though the requisitions are still UNFULFILLED and reprocess on a later run. This replaces the throw with a warning log, an orphan_blobs_skipped counter tagged with the group id, and an early return.

Issue: #4119