### PR TITLE
test: raise EVENT_GROUP_SYNC_TIMEOUT to 120s for cold starts

### DIFF
--- a/src/test/kotlin/org/wfanet/measurement/integration/k8s/EdpAggregatorCorrectnessTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/integration/k8s/EdpAggregatorCorrectnessTest.kt
@@ -252,7 +252,9 @@ class EdpAggregatorCorrectnessTest : AbstractEdpAggregatorCorrectnessTest(measur
     }
 
     companion object {
-      private const val EVENT_GROUP_SYNC_TIMEOUT = 30_000L
+      // 120s to absorb event-group-sync Cloud Function cold starts (JVM boot
+      // can consume the first several seconds after a fresh deploy).
+      private const val EVENT_GROUP_SYNC_TIMEOUT = 120_000L
       private const val EVENT_GROUP_SYNC_POLLING_INTERVAL = 3000L
     }
   }


### PR DESCRIPTION
Raises the EdpAggregatorCorrectnessTest event-group-sync client-side timeout from 30s to 120s to absorb Cloud Function cold starts (JVM boot can consume the first several seconds after a fresh deploy), which caused spurious timeouts even when the sync is a near no-op.

Issue: #4216