### PR TITLE
ci: trigger Claude review from Reviewable-published reviews

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -14,28 +14,45 @@
 
 name: Claude Code Review
 
+# Triggered by "@claude review" from two sources:
+# - issue_comment: a comment typed directly on the PR conversation on GitHub.
+# - pull_request_review: a review submitted via Reviewable (or GitHub's "Submit review"),
+#   which arrives as a review body rather than an issue comment. Reviewable-authored
+#   "@claude review" text is published as a review body, so without this event it would
+#   never trigger the workflow.
 on:
   issue_comment:
     types: [created]
+  pull_request_review:
+    types: [submitted]
 
 permissions:
   contents: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.issue.number  }}
+  # issue_comment exposes the PR number under issue.number; pull_request_review under
+  # pull_request.number. Fall back across both so the two event types for the same PR share a group.
+  group: ${{ github.workflow }}-${{ github.event.issue.number || github.event.pull_request.number }}
   cancel-in-progress: true
 
 jobs:
   review:
-    # 1. Ensure it's a Pull Request (not a regular issue)
-    # 2. Check if the comment contains '@claude review'
-    # 3. Restrict to authorized repository roles
+    # Trigger when either:
+    # - an issue_comment on a PR contains '@claude review', or
+    # - a submitted pull_request_review body contains '@claude review'.
+    # In both cases restrict to authorized repository roles.
     if: >
-      github.event.issue.pull_request &&
-      contains(github.event.comment.body, '@claude review') &&
-      (github.event.comment.author_association == 'MEMBER' ||
-       github.event.comment.author_association == 'OWNER' ||
-       github.event.comment.author_association == 'COLLABORATOR')
+      (github.event_name == 'issue_comment' &&
+       github.event.issue.pull_request &&
+       contains(github.event.comment.body, '@claude review') &&
+       (github.event.comment.author_association == 'MEMBER' ||
+        github.event.comment.author_association == 'OWNER' ||
+        github.event.comment.author_association == 'COLLABORATOR')) ||
+      (github.event_name == 'pull_request_review' &&
+       contains(github.event.review.body, '@claude review') &&
+       (github.event.review.author_association == 'MEMBER' ||
+        github.event.review.author_association == 'OWNER' ||
+        github.event.review.author_association == 'COLLABORATOR'))
     runs-on: ubuntu-latest
 
     permissions:
@@ -53,4 +70,6 @@ jobs:
           # The slash command's own frontmatter only covers the driver's Bash(gh ...) palette;
           # Task and read tools must be opened at the action layer or every subagent is denied.
           claude_args: --allowed-tools "Task,Read,Glob,Grep,Bash(gh pr view:*),Bash(gh pr diff:*),Bash(gh pr list:*),Bash(gh pr comment:*),Bash(gh search:*),Bash(gh issue view:*),Bash(gh issue list:*),mcp__github_inline_comment__create_inline_comment"
-          prompt: /code-review ${{ github.repository }}/pull/${{ github.event.issue.number }} --comment
+          # issue_comment exposes the PR number under issue.number; pull_request_review under
+          # pull_request.number. Fall back across both.
+          prompt: /code-review ${{ github.repository }}/pull/${{ github.event.issue.number || github.event.pull_request.number }} --comment


### PR DESCRIPTION
The Claude Code Review workflow only listened for issue_comment, so it never fired when @claude review was typed in Reviewable — Reviewable publishes that as a pull_request_review body, not an issue comment. This adds the pull_request_review submitted event with the same authorized-role guard, and falls back across issue.number / pull_request.number for the concurrency group and the review target. A bot-posted review cannot re-trigger it: the body has no @claude review text and its author_association is NONE.

Issue: None