### PR TITLE
feat(reporting): make MCP OAuth protected-resource configurable

### DIFF
--- a/src/main/k8s/dev/reporting_v2_gke.cue
+++ b/src/main/k8s/dev/reporting_v2_gke.cue
@@ -22,6 +22,7 @@ _reportingMcConfigSecretName:                         string       @tag("mc_conf
 _publicApiAddressName:                                string       @tag("public_api_address_name")
 _mcpHost:                                             *"" | string @tag("mcp_host")
 _oauthIssuer:                                         *"" | string @tag("oauth_issuer")
+_oauthProtectedResource:                              *"" | string @tag("oauth_protected_resource")
 _accessPublicApiAddressName:                          "access-public"
 
 #KingdomApiTarget: #GrpcTarget & {
@@ -152,7 +153,7 @@ reporting: #Reporting & {
 			}
 			if _mcpHost != "" && _oauthIssuer != "" {
 				_oauthArgs: [
-					"--oauth-protected-resource=https://" + _mcpHost,
+					"--oauth-protected-resource=" + [ if _oauthProtectedResource != "" {_oauthProtectedResource}, "https://" + _mcpHost][0],
 					"--oauth-authorization-server=" + _oauthIssuer,
 					"--oauth-scope=reporting.*",
 				]

--- a/src/main/k8s/dev/reporting_v2_gke.cue
+++ b/src/main/k8s/dev/reporting_v2_gke.cue
@@ -153,6 +153,7 @@ reporting: #Reporting & {
 			}
 			if _mcpHost != "" && _oauthIssuer != "" {
 				_oauthArgs: [
+					// Use oauth_protected_resource if set, otherwise default to https://<mcp_host>.
 					"--oauth-protected-resource=" + [ if _oauthProtectedResource != "" {_oauthProtectedResource}, "https://" + _mcpHost][0],
 					"--oauth-authorization-server=" + _oauthIssuer,
 					"--oauth-scope=reporting.*",


### PR DESCRIPTION
The MCP server advertises its OAuth 2.0 protected-resource identifier (RFC 9728) as its own host URL, which is the value MCP clients request an access token for. For the interactive login flow this identifier must match the authorization server API audience, configured separately per deployment, so issued tokens are valid for the Reporting API the server proxies to. This adds an oauth_protected_resource deploy tag to set that identifier, defaulting to the existing https://<mcp-host> so current deployments are unchanged.

Issue: #4042