### PR TITLE
fix: use a per-environment name for the VID models storage bucket

### DIFF
--- a/src/main/terraform/gcloud/cmms/edp_aggregator.tf
+++ b/src/main/terraform/gcloud/cmms/edp_aggregator.tf
@@ -448,6 +448,7 @@ module "edp_aggregator" {
   pubsub_iam_service_account_member             = module.secure_computation.secure_computation_internal_iam_service_account_member
   edp_aggregator_bucket_name                    = var.secure_computation_storage_bucket_name
   config_files_bucket_name                      = var.edpa_config_files_bucket_name
+  vid_models_bucket_name                        = var.vid_models_storage_bucket_name
   edp_aggregator_buckets_location               = local.storage_bucket_location
   data_watcher_service_account_name             = "edpa-data-watcher"
   data_watcher_trigger_service_account_name     = "edpa-data-watcher-trigger"

--- a/src/main/terraform/gcloud/cmms/envs/dev.tfvars
+++ b/src/main/terraform/gcloud/cmms/envs/dev.tfvars
@@ -1,6 +1,7 @@
 spanner_processing_units                          = 100
 secure_computation_storage_bucket_name            = "secure-computation-storage-dev-bucket"
 edpa_config_files_bucket_name                     = "edpa-configs-storage-dev-bucket"
+vid_models_storage_bucket_name                    = "vid-models-storage-dev-bucket"
 key_ring_name                                     = "test-key-ring"
 results_fulfiller_event_proto_descriptor_blob_uri = "gs://edpa-configs-storage-dev-bucket/results_fulfiller_event_proto_descriptor.pb"
 results_fulfiller_event_template_type_name        = "wfa.measurement.api.v2alpha.event_templates.testing.TestEvent"

--- a/src/main/terraform/gcloud/cmms/envs/head.tfvars
+++ b/src/main/terraform/gcloud/cmms/envs/head.tfvars
@@ -1,6 +1,7 @@
 spanner_processing_units                          = 100
 secure_computation_storage_bucket_name            = "secure-computation-storage-head-bucket"
 edpa_config_files_bucket_name                     = "edpa-configs-storage-head-bucket"
+vid_models_storage_bucket_name                    = "vid-models-storage-head-bucket"
 key_ring_name                                     = "halo"
 results_fulfiller_event_proto_descriptor_blob_uri = "gs://edpa-configs-storage-head-bucket/results_fulfiller_event_proto_descriptor.pb"
 results_fulfiller_event_template_type_name        = "wfa.measurement.api.v2alpha.event_templates.testing.TestEvent"

--- a/src/main/terraform/gcloud/cmms/envs/qa.tfvars
+++ b/src/main/terraform/gcloud/cmms/envs/qa.tfvars
@@ -1,6 +1,7 @@
 spanner_processing_units                          = 1000
 secure_computation_storage_bucket_name            = "secure-computation-storage-qa-bucket"
 edpa_config_files_bucket_name                     = "edpa-configs-storage-qa-bucket"
+vid_models_storage_bucket_name                    = "vid-models-storage-qa-bucket"
 key_ring_name                                     = "halo"
 results_fulfiller_event_proto_descriptor_blob_uri = "gs://edpa-configs-storage-qa-bucket/results_fulfiller_event_proto_descriptor.pb"
 results_fulfiller_event_template_type_name        = "wfa.measurement.api.v2alpha.event_templates.testing.TestEvent"

--- a/src/main/terraform/gcloud/cmms/variables.tf
+++ b/src/main/terraform/gcloud/cmms/variables.tf
@@ -102,6 +102,12 @@ variable "edpa_config_files_bucket_name" {
   nullable    = false
 }
 
+variable "vid_models_storage_bucket_name" {
+  description = "Name of Google Cloud Storage bucket for the VID Labeling pipeline's compiled VID model blobs."
+  type        = string
+  nullable    = false
+}
+
 variable "terraform_service_account" {
   description = "Service account used by terraform that needs to attach the MIG service account to the VM."
   type        = string

--- a/src/main/terraform/gcloud/modules/edp-aggregator/main.tf
+++ b/src/main/terraform/gcloud/modules/edp-aggregator/main.tf
@@ -197,7 +197,7 @@ module "config_files_bucket" {
 module "vid_models_bucket" {
   source = "../storage-bucket"
 
-  name     = "vid-models-storage"
+  name     = var.vid_models_bucket_name
   location = var.edp_aggregator_buckets_location
 }
 

--- a/src/main/terraform/gcloud/modules/edp-aggregator/variables.tf
+++ b/src/main/terraform/gcloud/modules/edp-aggregator/variables.tf
@@ -168,6 +168,12 @@ variable "config_files_bucket_name" {
   nullable    = false
 }
 
+variable "vid_models_bucket_name" {
+  description = "Name of the Google Cloud Storage bucket holding the compiled VID model blobs read by the VID Labeling TEE apps."
+  type        = string
+  nullable    = false
+}
+
 variable "data_watcher_config" {
   description = "An object containing the local path of the data watcher config file and its destination path in Cloud Storage."
   type = object({


### PR DESCRIPTION
## Problem
  The `vid_models_bucket` added to the `edp-aggregator` Terraform module in #4087
  hardcodes its name to `"vid-models-storage"`. GCS bucket names are **globally
  unique**, so `terraform apply` fails with:

  Error 409: The requested bucket name is not available. The bucket namespace
  is shared by all users of the system. Please select a different name and try again.

  This is one of the two reasons the nightly `head` deploy failed on 2026-07-14
  ([run 29313328604](https://github.com/world-federation-of-advertisers/cross-media-measurement/actions/runs/29313328604/job/87024530942)).
  *(The other cause — the new `VID_LABELING_*` GitHub Environment variables being
  unset for `head`/`qa` — is separate and does not require a code change.)*

  ## Root cause
  `modules/edp-aggregator/main.tf` set `name = "vid-models-storage"` directly. The
  `storage-bucket` module applies `name = var.name` with no prefix, so the literal
  name lands in the global GCS namespace — it collides with any existing bucket of
  that name, and would also collide between the `head` / `qa` / `dev` environments,
  which all apply the same module. Every other bucket in this module is already
  environment-scoped via a passed-in `var.*_bucket_name`.

  ## Fix
  Thread the bucket name through as a variable, mirroring the existing
  `config_files_bucket_name` / `edp_aggregator_bucket_name` pattern:

  - `modules/edp-aggregator/main.tf` — `name = var.vid_models_bucket_name`
  - `modules/edp-aggregator/variables.tf` — declare `vid_models_bucket_name`
  - `cmms/variables.tf` — expose `vid_models_storage_bucket_name` at the root
  - `cmms/edp_aggregator.tf` — pass `vid_models_bucket_name = var.vid_models_storage_bucket_name`
  - `cmms/envs/{head,qa,dev}.tfvars` — set unique per-env values (`vid-models-storage-<env>-bucket`)

  ## Testing
  - `terraform -chdir=src/main/terraform/gcloud/cmms validate` → **Success**

Issue: #4226 