### PR TITLE
ci: set requisition-fetcher function timeout to 10m and cap to one instance

### DIFF
--- a/src/main/terraform/gcloud/modules/edp-aggregator/main.tf
+++ b/src/main/terraform/gcloud/modules/edp-aggregator/main.tf
@@ -202,9 +202,9 @@ module "vid_models_bucket" {
 }
 
 resource "google_storage_bucket_object" "upload_data_watcher_config" {
-  name   = var.data_watcher_config.destination
-  bucket = module.config_files_bucket.storage_bucket.name
-  source = var.data_watcher_config.local_path
+  name           = var.data_watcher_config.destination
+  bucket         = module.config_files_bucket.storage_bucket.name
+  source         = var.data_watcher_config.local_path
   source_md5hash = filemd5(var.data_watcher_config.local_path)
 }
 
@@ -215,9 +215,9 @@ resource "google_storage_bucket_object" "upload_data_watcher_delete_config" {
 }
 
 resource "google_storage_bucket_object" "upload_requisition_fetcher_config" {
-  name   = var.requisition_fetcher_config.destination
-  bucket = module.config_files_bucket.storage_bucket.name
-  source = var.requisition_fetcher_config.local_path
+  name           = var.requisition_fetcher_config.destination
+  bucket         = module.config_files_bucket.storage_bucket.name
+  source         = var.requisition_fetcher_config.local_path
   source_md5hash = filemd5(var.requisition_fetcher_config.local_path)
 }
 
@@ -321,7 +321,17 @@ module "requisition_fetcher_cloud_function" {
   secret_mappings                          = var.cloud_function_configs.requisition_fetcher.secret_mappings
   uber_jar_path                            = var.cloud_function_configs.requisition_fetcher.uber_jar_path
   secrets_to_access                        = [for key in local.requisition_fetcher_secrets_access : local.all_secrets[key].secret_id]
-  config_path                               = var.requisition_fetcher_config.local_path
+  config_path                              = var.requisition_fetcher_config.local_path
+
+  # The periodic drain ticker fires every FLUSH_INTERVAL (default 5m), so a single invocation must
+  # run longer than that for incremental draining to happen at all — the gen2 default of 60s would
+  # kill the function before the first tick. 600s (10m) lets several ticks fire while staying under
+  # the 15m scheduler interval, so a run always finishes before the next is triggered. Combined with
+  # max_instances = 1, that makes overlapping invocations over the same UNFULFILLED requisitions
+  # structurally impossible (the Cloud Scheduler -> Cloud Function path has no built-in overlap
+  # guard, unlike a K8s CronJob concurrencyPolicy).
+  timeout_seconds = 600
+  max_instances   = 1
 }
 
 module "requisition_fetcher_cloud_scheduler" {

--- a/src/main/terraform/gcloud/modules/http-cloud-function/main.tf
+++ b/src/main/terraform/gcloud/modules/http-cloud-function/main.tf
@@ -46,18 +46,22 @@ resource "terraform_data" "deploy_http_cloud_function" {
     var.extra_env_vars,
     var.secret_mappings,
     var.config_path != null ? filesha256(var.config_path) : "",
+    var.timeout_seconds,
+    var.max_instances,
   ]
 
   provisioner "local-exec" {
     interpreter = ["/bin/bash", "-c"]
     environment = {
-      FUNCTION_NAME           = var.function_name
-      ENTRY_POINT             = var.entry_point
-      CLOUD_REGION            = data.google_client_config.default.region
-      RUN_SERVICE_ACCOUNT     = google_service_account.http_cloud_function_service_account.email
-      EXTRA_ENV_VARS          = var.extra_env_vars
-      SECRET_MAPPINGS         = var.secret_mappings
-      UBER_JAR_DIRECTORY      = dirname(var.uber_jar_path)
+      FUNCTION_NAME       = var.function_name
+      ENTRY_POINT         = var.entry_point
+      CLOUD_REGION        = data.google_client_config.default.region
+      RUN_SERVICE_ACCOUNT = google_service_account.http_cloud_function_service_account.email
+      EXTRA_ENV_VARS      = var.extra_env_vars
+      SECRET_MAPPINGS     = var.secret_mappings
+      UBER_JAR_DIRECTORY  = dirname(var.uber_jar_path)
+      TIMEOUT_SECONDS     = var.timeout_seconds == null ? "" : tostring(var.timeout_seconds)
+      MAX_INSTANCES       = var.max_instances == null ? "" : tostring(var.max_instances)
     }
     command = <<-EOT
       #!/bin/bash
@@ -82,6 +86,14 @@ resource "terraform_data" "deploy_http_cloud_function" {
 
       if [[ -n "$SECRET_MAPPINGS" ]]; then
         args+=("--set-secrets=$SECRET_MAPPINGS")
+      fi
+
+      if [[ -n "$TIMEOUT_SECONDS" ]]; then
+        args+=("--timeout=$TIMEOUT_SECONDS")
+      fi
+
+      if [[ -n "$MAX_INSTANCES" ]]; then
+        args+=("--max-instances=$MAX_INSTANCES")
       fi
 
       gcloud $${args[@]}

--- a/src/main/terraform/gcloud/modules/http-cloud-function/variables.tf
+++ b/src/main/terraform/gcloud/modules/http-cloud-function/variables.tf
@@ -66,3 +66,17 @@ variable "config_path" {
   nullable    = true
   default     = null
 }
+
+variable "timeout_seconds" {
+  description = "Function request timeout in seconds. A single invocation is force-terminated after this. Null uses the gcloud default (60s for gen2)."
+  type        = number
+  nullable    = true
+  default     = null
+}
+
+variable "max_instances" {
+  description = "Maximum number of concurrent function instances. Set to 1 to prevent overlapping invocations. Null uses the gcloud default."
+  type        = number
+  nullable    = true
+  default     = null
+}


### PR DESCRIPTION
The RequisitionFetcher drains open report buffers on a periodic ticker (FLUSH_INTERVAL, default 5m), so a single invocation must run longer than that interval for incremental draining to happen at all. The Cloud Functions gen2 default request timeout of 60s would kill the function before the first tick, making the periodic drain inert. This adds optional timeout_seconds and max_instances knobs to the http-cloud-function module (null keeps the gcloud default, so other callers are unchanged) and sets the requisition-fetcher to timeout_seconds = 600 and max_instances = 1. 600s lets several ticks fire while staying under the 15m scheduler interval, and a single instance means a run always finishes before the next is triggered, so invocations cannot overlap on the same UNFULFILLED requisitions.

Issue: None