### PR TITLE
perf: scale the memoized rank-index read and write paths

### DIFF
--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/rawimpressions/RankIndexStore.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/rawimpressions/RankIndexStore.kt
@@ -20,6 +20,7 @@ import com.google.crypto.tink.KmsClient
 import com.google.protobuf.ByteString
 import java.security.MessageDigest
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.buffer
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.map
 import org.wfanet.measurement.edpaggregator.v1alpha.EncryptedDek
@@ -98,32 +99,59 @@ class RankIndexStore(storageClient: ConditionalOperationStorageClient, kmsClient
     blobKey: String,
     encryptedDek: EncryptedDek,
     expectedChecksum: ByteString? = null,
-  ): Flow<RankIndexMap> = flow {
-    val blob = encryptedClient(encryptedDek).getBlob(blobKey) ?: return@flow
-    val digest =
-      if (expectedChecksum != null && !expectedChecksum.isEmpty) {
-        MessageDigest.getInstance("SHA-256")
-      } else {
-        null
+    recordBufferCapacity: Int = DEFAULT_READ_RECORD_BUFFER,
+  ): Flow<RankIndexMap> =
+    flow {
+        val blob = encryptedClient(encryptedDek).getBlob(blobKey) ?: return@flow
+        val digest =
+          if (expectedChecksum != null && !expectedChecksum.isEmpty) {
+            MessageDigest.getInstance("SHA-256")
+          } else {
+            null
+          }
+        blob.read().collect { record ->
+          digest?.update(record.asReadOnlyByteBuffer())
+          emit(RankIndexMap.parseFrom(record))
+        }
+        if (digest != null) {
+          val actual = ByteString.copyFrom(digest.digest())
+          check(actual == expectedChecksum) {
+            "RankIndexBlob $blobKey checksum mismatch; cumulative blob is corrupt"
+          }
+        }
       }
-    blob.read().collect { record ->
-      digest?.update(record.asReadOnlyByteBuffer())
-      emit(RankIndexMap.parseFrom(record))
-    }
-    if (digest != null) {
-      val actual = ByteString.copyFrom(digest.digest())
-      check(actual == expectedChecksum) {
-        "RankIndexBlob $blobKey checksum mismatch; cumulative blob is corrupt"
-      }
-    }
-  }
+      .buffer(recordBufferCapacity)
 
   /** Deletes [blobKey] from Cloud Storage if present (used to evict aged-out rank-index blobs). */
   suspend fun delete(blobKey: String) {
     storageClient.getBlob(blobKey)?.delete()
   }
 
+  /**
+   * Byte size of the SNAPSHOT blob at [blobKey], or 0 if absent. The Phase-2 index load uses this
+   * to pre-size its per-subpool map: on disk each entry is ~[ON_DISK_BYTES_PER_ENTRY] bytes
+   * (12-byte fingerprint + 4-byte fixed32 rank + 2-byte last-seen day), so the entry count is
+   * approximately `size / ON_DISK_BYTES_PER_ENTRY` (a safe slight over-estimate given
+   * framing/encryption).
+   */
+  suspend fun blobSize(blobKey: String, encryptedDek: EncryptedDek): Long =
+    encryptedClient(encryptedDek).getBlob(blobKey)?.size ?: 0L
+
   companion object {
+    /**
+     * Approximate on-disk bytes per rank-index entry: 12-byte fingerprint + 4-byte fixed32 rank +
+     * 2-byte last-seen day. Used to pre-size the Phase-2 load map from the blob byte size.
+     */
+    const val ON_DISK_BYTES_PER_ENTRY = 18L
+
+    /**
+     * Prefetch depth (in RankIndexMap records, ~18 MiB each at 1M entries/record) between the
+     * read/decrypt/parse producer and the map-insert consumer, so the GCS read runs ahead of
+     * inserts instead of stalling on them. Small on purpose: memory ~= capacity x ~18 MiB x
+     * concurrent readers (Phase-2 loads up to 6 subpools at once => ~430 MiB total at 4).
+     */
+    const val DEFAULT_READ_RECORD_BUFFER = 4
+
     /**
      * Storage key for a cumulative `SNAPSHOT` blob of [poolOffset], scoped to the (upload, model
      * line) run and to a single write [attemptId].

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/rawimpressions/RankIndexStore.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/rawimpressions/RankIndexStore.kt
@@ -135,9 +135,9 @@ class RankIndexStore(storageClient: ConditionalOperationStorageClient, kmsClient
    * day), so the entry count is approximately `size / ON_DISK_BYTES_PER_ENTRY` (a safe slight
    * over-estimate given framing/encryption).
    *
-   * TODO(world-federation-of-advertisers/cross-media-measurement#4235): the Phase-2 caller
+   * TODO(world-federation-of-advertisers/cross-media-measurement#4234): the Phase-2 caller
    *   pre-sizes with this and then reads the blob, so each subpool resolves the blob handle (and
-   *   unwraps the DEK) twice. #4235's `openBlob` resolves it once and returns the size and record
+   *   unwraps the DEK) twice. #4234's `openBlob` resolves it once and returns the size and record
    *   flow together, collapsing this to a single unwrap.
    */
   suspend fun blobSize(blobKey: String, encryptedDek: EncryptedDek): Long =

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/rawimpressions/RankIndexStore.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/rawimpressions/RankIndexStore.kt
@@ -128,11 +128,17 @@ class RankIndexStore(storageClient: ConditionalOperationStorageClient, kmsClient
   }
 
   /**
-   * Byte size of the SNAPSHOT blob at [blobKey], or 0 if absent. The Phase-2 index load uses this
-   * to pre-size its per-subpool map: on disk each entry is ~[ON_DISK_BYTES_PER_ENTRY] bytes
-   * (12-byte fingerprint + 4-byte fixed32 rank + 2-byte last-seen day), so the entry count is
-   * approximately `size / ON_DISK_BYTES_PER_ENTRY` (a safe slight over-estimate given
-   * framing/encryption).
+   * Byte size of the SNAPSHOT blob at [blobKey], or 0 if absent. This is the ciphertext (on-disk)
+   * byte count as reported by the encrypted storage client, not the plaintext size. The Phase-2
+   * index load uses it to pre-size its per-subpool map: on disk each entry is
+   * ~[ON_DISK_BYTES_PER_ENTRY] bytes (12-byte fingerprint + 4-byte fixed32 rank + 2-byte last-seen
+   * day), so the entry count is approximately `size / ON_DISK_BYTES_PER_ENTRY` (a safe slight
+   * over-estimate given framing/encryption).
+   *
+   * TODO(world-federation-of-advertisers/cross-media-measurement#4235): the Phase-2 caller
+   *   pre-sizes with this and then reads the blob, so each subpool resolves the blob handle (and
+   *   unwraps the DEK) twice. #4235's `openBlob` resolves it once and returns the size and record
+   *   flow together, collapsing this to a single unwrap.
    */
   suspend fun blobSize(blobKey: String, encryptedDek: EncryptedDek): Long =
     encryptedClient(encryptedDek).getBlob(blobKey)?.size ?: 0L

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/vidlabeler/BUILD.bazel
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/vidlabeler/BUILD.bazel
@@ -29,6 +29,7 @@ kt_jvm_library(
         "MemoizedRankIndexMetrics.kt",
     ],
     deps = [
+        "//src/main/kotlin/org/wfanet/measurement/edpaggregator/vidrankbuilder:event_id_digest_bytes",
         "//src/main/kotlin/org/wfanet/measurement/common/api:resource_key",
         "//src/main/kotlin/org/wfanet/measurement/common/api/grpc:list_resources",
         "//src/main/kotlin/org/wfanet/measurement/edpaggregator/rawimpressions:event_id_digest",

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/vidlabeler/BUILD.bazel
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/vidlabeler/BUILD.bazel
@@ -29,12 +29,12 @@ kt_jvm_library(
         "MemoizedRankIndexMetrics.kt",
     ],
     deps = [
-        "//src/main/kotlin/org/wfanet/measurement/edpaggregator/vidrankbuilder:event_id_digest_bytes",
         "//src/main/kotlin/org/wfanet/measurement/common/api:resource_key",
         "//src/main/kotlin/org/wfanet/measurement/common/api/grpc:list_resources",
         "//src/main/kotlin/org/wfanet/measurement/edpaggregator/rawimpressions:event_id_digest",
         "//src/main/kotlin/org/wfanet/measurement/edpaggregator/rawimpressions:rank_index_store",
         "//src/main/kotlin/org/wfanet/measurement/edpaggregator/vidlabeler/utils:bytes12_int_map",
+        "//src/main/kotlin/org/wfanet/measurement/edpaggregator/vidrankbuilder:event_id_digest_bytes",
         "//src/main/proto/wfa/measurement/edpaggregator/v1alpha:encrypted_dek_kt_jvm_proto",
         "//src/main/proto/wfa/measurement/edpaggregator/v1alpha:rank_index_blob_kt_jvm_proto",
         "//src/main/proto/wfa/measurement/edpaggregator/v1alpha:rank_index_blob_service_kt_jvm_grpc_proto",

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/vidlabeler/MemoizedRankIndex.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/vidlabeler/MemoizedRankIndex.kt
@@ -36,6 +36,7 @@ import org.wfanet.measurement.edpaggregator.v1alpha.RankIndexBlob
 import org.wfanet.measurement.edpaggregator.v1alpha.RankIndexBlobServiceGrpcKt.RankIndexBlobServiceCoroutineStub
 import org.wfanet.measurement.edpaggregator.v1alpha.listRankIndexBlobsRequest
 import org.wfanet.measurement.edpaggregator.vidlabeler.utils.Bytes12IntMap
+import org.wfanet.measurement.edpaggregator.vidrankbuilder.EventIdDigestBytes
 import org.wfanet.virtualpeople.common.RankAssignment
 import org.wfanet.virtualpeople.common.rankAssignment
 
@@ -236,7 +237,11 @@ private constructor(
       rankIndexStore: RankIndexStore,
       blob: RankIndexBlob,
     ): LoadedSubpool {
-      val map = Bytes12IntMap()
+      val estimatedEntries =
+        (rankIndexStore.blobSize(blob.blobUri, blob.encryptedDek) /
+            RankIndexStore.ON_DISK_BYTES_PER_ENTRY)
+          .coerceAtLeast(Bytes12IntMap.MIN_CAPACITY)
+      val map = Bytes12IntMap(estimatedEntries)
       var rankedSize = -1
       rankIndexStore.readBlob(blob.blobUri, blob.encryptedDek, blob.blobChecksum).collect { record
         ->
@@ -249,20 +254,24 @@ private constructor(
           }
         }
         val fingerprints = record.fingerprints
-        val ranks = record.ranksList
-        // `rank_index_map.proto`: `fingerprints` length MUST equal `ranks.size` * 12. Enforce it so
+        // `rank_index_map.proto`: `fingerprints` length MUST equal `ranks_count` * 12. Enforce it
+        // so
         // a malformed blob fails with a clear, attributable error instead of an opaque
         // IndexOutOfBoundsException (too short) or silently dropped trailing fingerprints (too
         // long).
-        check(fingerprints.size() == ranks.size * FINGERPRINT_BYTES) {
+        check(fingerprints.size() == record.ranksCount * FINGERPRINT_BYTES) {
           "Malformed rank index blob ${blob.blobUri}: ${fingerprints.size()} fingerprint bytes " +
-            "for ${ranks.size} ranks (expected ${ranks.size * FINGERPRINT_BYTES})"
+            "for ${record.ranksCount} ranks (expected ${record.ranksCount * FINGERPRINT_BYTES})"
         }
+        // Read fingerprint hi/lo + the primitive rank directly. The old per-entry
+        // `substring(...).toByteArray()` + boxed `ranksList` allocated ~2 objects per entry, which
+        // GC-thrashed the index load into a crawl at 4B scale (hundreds of millions of entries).
         var offset = 0
-        for (i in ranks.indices) {
+        for (i in 0 until record.ranksCount) {
           map.put(
-            fingerprints.substring(offset, offset + FINGERPRINT_BYTES).toByteArray(),
-            ranks[i],
+            EventIdDigestBytes.readHi(fingerprints, offset),
+            EventIdDigestBytes.readLo(fingerprints, offset + 8),
+            record.getRanks(i),
           )
           offset += FINGERPRINT_BYTES
         }

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/vidlabeler/MemoizedRankIndex.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/vidlabeler/MemoizedRankIndex.kt
@@ -255,8 +255,7 @@ private constructor(
         }
         val fingerprints = record.fingerprints
         // `rank_index_map.proto`: `fingerprints` length MUST equal `ranks_count` * 12. Enforce it
-        // so
-        // a malformed blob fails with a clear, attributable error instead of an opaque
+        // so a malformed blob fails with a clear, attributable error instead of an opaque
         // IndexOutOfBoundsException (too short) or silently dropped trailing fingerprints (too
         // long).
         check(fingerprints.size() == record.ranksCount * FINGERPRINT_BYTES) {

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/vidrankbuilder/RankAllocator.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/vidrankbuilder/RankAllocator.kt
@@ -371,8 +371,11 @@ class RankAllocator(
     rankedSize = this@RankAllocator.rankedSize
     fingerprints = UnsafeByteOperations.unsafeWrap(fps, 0, count * EventIdDigestBytes.WIDTH)
     val lastSeenBytes = ByteArray(count * LastSeenDayBytes.WIDTH)
+    // Bulk-add ranks in O(count). A per-element  on the packed repeated-field DSL
+    // list is O(count) each (repeated-field grow/copy), making this loop O(count^2) and stalling
+    // large no-overflow rank-index writes; addAll copies once.
+    this.ranks += if (count == ranks.size) ranks.asList() else ranks.asList().subList(0, count)
     for (i in 0 until count) {
-      this.ranks += ranks[i]
       LastSeenDayBytes.write(lastSeenBytes, i * LastSeenDayBytes.WIDTH, seen[i])
     }
     lastSeenDays = UnsafeByteOperations.unsafeWrap(lastSeenBytes)
@@ -380,6 +383,6 @@ class RankAllocator(
 
   companion object {
     /** ~16M entries (~288 MB of fps+ranks+last_seen) per record: one buffer in memory at a time. */
-    const val DEFAULT_CHUNK_ENTRIES = 16 * 1024 * 1024
+    const val DEFAULT_CHUNK_ENTRIES = 1 * 1024 * 1024
   }
 }

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/vidrankbuilder/RankAllocator.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/vidrankbuilder/RankAllocator.kt
@@ -371,9 +371,9 @@ class RankAllocator(
     rankedSize = this@RankAllocator.rankedSize
     fingerprints = UnsafeByteOperations.unsafeWrap(fps, 0, count * EventIdDigestBytes.WIDTH)
     val lastSeenBytes = ByteArray(count * LastSeenDayBytes.WIDTH)
-    // Bulk-add ranks in O(count). A per-element  on the packed repeated-field DSL
-    // list is O(count) each (repeated-field grow/copy), making this loop O(count^2) and stalling
-    // large no-overflow rank-index writes; addAll copies once.
+    // Bulk-add ranks in one call. Per-element `this.ranks += ranks[i]` allocated one boxed Int per
+    // entry and paid N virtual dispatches through DslList; addAll skips both, at the cost of the
+    // list-view copy in the subList branch.
     this.ranks += if (count == ranks.size) ranks.asList() else ranks.asList().subList(0, count)
     for (i in 0 until count) {
       LastSeenDayBytes.write(lastSeenBytes, i * LastSeenDayBytes.WIDTH, seen[i])
@@ -382,7 +382,7 @@ class RankAllocator(
   }
 
   companion object {
-    /** ~16M entries (~288 MB of fps+ranks+last_seen) per record: one buffer in memory at a time. */
+    /** ~1M entries (~18 MB of fps+ranks+last_seen) per record: one buffer in memory at a time. */
     const val DEFAULT_CHUNK_ENTRIES = 1 * 1024 * 1024
   }
 }


### PR DESCRIPTION
## Benefit
  Makes the memoized pipeline usable at volume. On the 700M stress test this
  **cuts Phase 2 from ~3 hours to ~15 minutes** and unblocks the large
  no-overflow Phase-1 writes that previously stalled. Output is byte-identical —
  this is pure throughput, no behavior change.
  
  ## What
  - **Phase-2 index load** — pre-size the per-subpool map from the blob's byte
    size (`size / ON_DISK_BYTES_PER_ENTRY`) so it never resizes mid-load, and
    prefetch the encrypted record stream (bounded read-ahead) so the GCS download
    overlaps map insertion instead of stalling on it. The load also reads the
    fingerprint hi/lo + primitive rank directly (no per-entry
    `substring`/`toByteArray`/boxed list).
  - **Phase-1 index write** — bulk-add ranks in O(n) (was O(n²): a per-element
    `+=` on a packed repeated field recopied the whole list each time), and stream
    the rank index in 1M-entry chunks so a single record no longer buffers ~400MB.
    
  ## Why it's safe
  No public output changes; the map contents and the written rank index are
  identical, just produced without the resize storm and the quadratic append.
  
  ## Tests
  Existing `RankAllocatorTest`, `MemoizedRankIndexTest`, `RankIndexStoreTest`,
  `SubpoolRankerTest` pass unchanged.

Issue: #4233 