### PR TITLE
perf(edpaggregator): reduce per-event allocation and Phase-2 peak memory

### DIFF
--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/rawimpressions/LabelerInputMapper.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/rawimpressions/LabelerInputMapper.kt
@@ -17,6 +17,7 @@
 package org.wfanet.measurement.edpaggregator.rawimpressions
 
 import com.google.protobuf.Descriptors.Descriptor
+import com.google.protobuf.Descriptors.EnumValueDescriptor
 import com.google.protobuf.Descriptors.FieldDescriptor
 import com.google.protobuf.Descriptors.FieldDescriptor.JavaType
 import org.wfanet.measurement.edpaggregator.v1alpha.AgeRange
@@ -127,6 +128,26 @@ class LabelerInputMapper(mappings: List<LabelerInputFieldMapping>) {
           require(leaf.javaType == JavaType.ENUM) {
             "enum_lookup target '$fieldPath' must be an enum field"
           }
+          val enumType = leaf.enumType
+          // Resolve every lookup-table target (and the default) to its EnumValueDescriptor ONCE at
+          // construction, so the per-row applier does no findValueByName. A target that names a
+          // non-existent enum value fails fast here at startup instead of on the first matching
+          // row.
+          val rawToEnumValue: Map<String, EnumValueDescriptor> =
+            lookup.lookupTableMap.mapValues { (raw, enumName) ->
+              requireNotNull(enumType.findValueByName(enumName)) {
+                "enum_lookup maps '$raw' to '$enumName', which is not a ${enumType.name} value " +
+                  "($fieldPath)"
+              }
+            }
+          val defaultEnumValue: EnumValueDescriptor? =
+            lookup.defaultEnumValue
+              .takeIf { it.isNotEmpty() }
+              ?.let { enumName ->
+                requireNotNull(enumType.findValueByName(enumName)) {
+                  "enum_lookup default '$enumName' is not a ${enumType.name} value ($fieldPath)"
+                }
+              }
           record(columnKinds, column, setOf(KindCase.STRING_VALUE))
           Applier { row, builder ->
             val value = presentValue(row, column) ?: return@Applier
@@ -135,28 +156,34 @@ class LabelerInputMapper(mappings: List<LabelerInputFieldMapping>) {
             }
             val raw = value.stringValue
             if (raw.isEmpty()) return@Applier
-            val enumName =
-              lookup.lookupTableMap[raw]
-                ?: lookup.defaultEnumValue.takeIf { it.isNotEmpty() }
+            val enumValue =
+              rawToEnumValue[raw]
+                ?: defaultEnumValue
                 ?: throw IllegalArgumentException(
                   "Column '$column' value '$raw' has no entry in enum_lookup.lookup_table for " +
                     "'$fieldPath' (and no default_enum_value)"
                 )
-            val enumValue =
-              requireNotNull(leaf.enumType.findValueByName(enumName)) {
-                "enum_lookup maps '$raw' to '$enumName', which is not a ${leaf.enumType.name} " +
-                  "value ($fieldPath)"
-              }
             ProtoRowProjector.setLeaf(builder, path, enumValue)
           }
         }
         LabelerInputFieldMapping.SourceCase.AGE_RANGE -> {
           val ageRange = mapping.ageRange
           val path = ProtoRowProjector.resolvePath(ROOT, fieldPath, allowMessageLeaf = true)
+          // Resolve the age message's min_age/max_age FieldDescriptors ONCE (the leaf's message
+          // type
+          // is fixed), so the per-row applier does no findFieldByName.
+          val ageDescriptor =
+            requireNotNull(path.last().messageType) {
+              "age_range target '$fieldPath' must be a message field with min_age/max_age"
+            }
+          val minAgeField = requireField(ageDescriptor, "min_age")
+          val maxAgeField = requireField(ageDescriptor, "max_age")
           for (column in ageRangeColumns(ageRange, fieldPath)) {
             record(columnKinds, column, ageColumnKinds(ageRange))
           }
-          Applier { row, builder -> applyAgeRange(builder, path, ageRange, row) }
+          Applier { row, builder ->
+            applyAgeRange(builder, path, ageRange, row, minAgeField, maxAgeField)
+          }
         }
         LabelerInputFieldMapping.SourceCase.COMPOSITE_IDENTITY -> {
           val composite = mapping.compositeIdentity
@@ -223,6 +250,8 @@ class LabelerInputMapper(mappings: List<LabelerInputFieldMapping>) {
       path: List<FieldDescriptor>,
       ageRange: AgeRange,
       row: Map<String, ParquetValue>,
+      minAgeField: FieldDescriptor,
+      maxAgeField: FieldDescriptor,
     ) {
       val (minAge, maxAge) =
         when (ageRange.sourceCase) {
@@ -268,9 +297,8 @@ class LabelerInputMapper(mappings: List<LabelerInputFieldMapping>) {
         owner = owner.getFieldBuilder(path[i])
       }
       val ageBuilder = owner.getFieldBuilder(path.last())
-      val ageDescriptor = ageBuilder.descriptorForType
-      ageBuilder.setField(requireField(ageDescriptor, "min_age"), minAge)
-      ageBuilder.setField(requireField(ageDescriptor, "max_age"), maxAge)
+      ageBuilder.setField(minAgeField, minAge)
+      ageBuilder.setField(maxAgeField, maxAge)
       owner.setField(path.last(), ageBuilder.build())
     }
 

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/rawimpressions/LabelerInputMapper.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/rawimpressions/LabelerInputMapper.kt
@@ -131,8 +131,8 @@ class LabelerInputMapper(mappings: List<LabelerInputFieldMapping>) {
           val enumType = leaf.enumType
           // Resolve every lookup-table target (and the default) to its EnumValueDescriptor ONCE at
           // construction, so the per-row applier does no findValueByName. A target that names a
-          // non-existent enum value fails fast here at startup instead of on the first matching
-          // row.
+          // non-existent enum value fails fast here at startup instead of on the first
+          // matching row.
           val rawToEnumValue: Map<String, EnumValueDescriptor> =
             lookup.lookupTableMap.mapValues { (raw, enumName) ->
               requireNotNull(enumType.findValueByName(enumName)) {
@@ -170,8 +170,7 @@ class LabelerInputMapper(mappings: List<LabelerInputFieldMapping>) {
           val ageRange = mapping.ageRange
           val path = ProtoRowProjector.resolvePath(ROOT, fieldPath, allowMessageLeaf = true)
           // Resolve the age message's min_age/max_age FieldDescriptors ONCE (the leaf's message
-          // type
-          // is fixed), so the per-row applier does no findFieldByName.
+          // type is fixed), so the per-row applier does no findFieldByName.
           val ageDescriptor =
             requireNotNull(path.last().messageType) {
               "age_range target '$fieldPath' must be a message field with min_age/max_age"

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/rawimpressions/RankIndexStore.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/rawimpressions/RankIndexStore.kt
@@ -122,6 +122,47 @@ class RankIndexStore(storageClient: ConditionalOperationStorageClient, kmsClient
       }
       .buffer(recordBufferCapacity)
 
+  /**
+   * Opens [blobKey] with a SINGLE `getBlob`, returning its plaintext byte size together with a
+   * [readBlob]-equivalent record [Flow], or `null` when the blob is absent.
+   *
+   * A caller that needs both the size (e.g. to pre-size a map) and the contents would otherwise
+   * call [blobSize] and [readBlob], each doing its own `getBlob`. This resolves the blob handle
+   * once and reuses it for both. The returned flow streams the same `RankIndexMap` records as
+   * [readBlob] and enforces [expectedChecksum] identically (hashing the plaintext payload as it
+   * streams and throwing at end-of-stream on mismatch). Memory stays bounded: only the blob handle
+   * is resolved eagerly; record bytes stream lazily on collection.
+   */
+  suspend fun openBlob(
+    blobKey: String,
+    encryptedDek: EncryptedDek,
+    expectedChecksum: ByteString? = null,
+    recordBufferCapacity: Int = DEFAULT_READ_RECORD_BUFFER,
+  ): Pair<Long, Flow<RankIndexMap>>? {
+    val blob = encryptedClient(encryptedDek).getBlob(blobKey) ?: return null
+    val readFlow =
+      flow {
+          val digest =
+            if (expectedChecksum != null && !expectedChecksum.isEmpty) {
+              MessageDigest.getInstance("SHA-256")
+            } else {
+              null
+            }
+          blob.read().collect { record ->
+            digest?.update(record.asReadOnlyByteBuffer())
+            emit(RankIndexMap.parseFrom(record))
+          }
+          if (digest != null) {
+            val actual = ByteString.copyFrom(digest.digest())
+            check(actual == expectedChecksum) {
+              "RankIndexBlob $blobKey checksum mismatch; cumulative blob is corrupt"
+            }
+          }
+        }
+        .buffer(recordBufferCapacity)
+    return blob.size to readFlow
+  }
+
   /** Deletes [blobKey] from Cloud Storage if present (used to evict aged-out rank-index blobs). */
   suspend fun delete(blobKey: String) {
     storageClient.getBlob(blobKey)?.delete()
@@ -132,13 +173,10 @@ class RankIndexStore(storageClient: ConditionalOperationStorageClient, kmsClient
    * byte count as reported by the encrypted storage client, not the plaintext size. The Phase-2
    * index load uses it to pre-size its per-subpool map: on disk each entry is
    * ~[ON_DISK_BYTES_PER_ENTRY] bytes (12-byte fingerprint + 4-byte fixed32 rank + 2-byte last-seen
-   * day), so the entry count is approximately `size / ON_DISK_BYTES_PER_ENTRY` (a safe slight
-   * over-estimate given framing/encryption).
-   *
-   * TODO(world-federation-of-advertisers/cross-media-measurement#4234): the Phase-2 caller
-   *   pre-sizes with this and then reads the blob, so each subpool resolves the blob handle (and
-   *   unwraps the DEK) twice. #4234's `openBlob` resolves it once and returns the size and record
-   *   flow together, collapsing this to a single unwrap.
+   * day), so the entry count is approximately `size / ON_DISK_BYTES_PER_ENTRY`. This is only a
+   * sizing hint: RecordIO framing and StreamingAead padding make the true per-entry size vary, so
+   * it may under- or over-shoot the real count — the map auto-resizes if under-sized (the pre-size
+   * just aims to avoid that).
    */
   suspend fun blobSize(blobKey: String, encryptedDek: EncryptedDek): Long =
     encryptedClient(encryptedDek).getBlob(blobKey)?.size ?: 0L

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/rawimpressions/RankIndexStore.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/rawimpressions/RankIndexStore.kt
@@ -110,6 +110,9 @@ class RankIndexStore(storageClient: ConditionalOperationStorageClient, kmsClient
             null
           }
         blob.read().collect { record ->
+          // Hashing PLAINTEXT record bytes: the encrypted storage client has already decrypted at
+          // this point. If this ever swaps to a raw storage client, the hash target changes and
+          // expectedChecksum must be recomputed accordingly.
           digest?.update(record.asReadOnlyByteBuffer())
           emit(RankIndexMap.parseFrom(record))
         }
@@ -123,8 +126,8 @@ class RankIndexStore(storageClient: ConditionalOperationStorageClient, kmsClient
       .buffer(recordBufferCapacity)
 
   /**
-   * Opens [blobKey] with a SINGLE `getBlob`, returning its plaintext byte size together with a
-   * [readBlob]-equivalent record [Flow], or `null` when the blob is absent.
+   * Opens [blobKey] with a SINGLE `getBlob`, returning its on-disk (ciphertext) byte size together
+   * with a [readBlob]-equivalent record [Flow], or `null` when the blob is absent.
    *
    * A caller that needs both the size (e.g. to pre-size a map) and the contents would otherwise
    * call [blobSize] and [readBlob], each doing its own `getBlob`. This resolves the blob handle
@@ -149,6 +152,9 @@ class RankIndexStore(storageClient: ConditionalOperationStorageClient, kmsClient
               null
             }
           blob.read().collect { record ->
+            // Hashing PLAINTEXT record bytes: the encrypted storage client has already decrypted at
+            // this point. If this ever swaps to a raw storage client, the hash target changes and
+            // expectedChecksum must be recomputed accordingly.
             digest?.update(record.asReadOnlyByteBuffer())
             emit(RankIndexMap.parseFrom(record))
           }

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/subpoolassigner/PoolEmitLabeler.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/subpoolassigner/PoolEmitLabeler.kt
@@ -51,12 +51,16 @@ import org.wfanet.virtualpeople.common.LabelerInput
  */
 interface PoolEmitLabeler : AutoCloseable {
   /**
-   * Returns the pool offsets [input] routes to (one per virtual person the model emits for the
-   * event), or an empty list if the event routes to no ranked pool (e.g. it falls back to
-   * hash-based VID assignment and therefore has no subpool). Duplicate offsets are permitted —
+   * Invokes [onPoolOffset] once for each pool offset [input] routes to (one per virtual person the
+   * model emits for the event), in model-emission order, and returns how many offsets were emitted
+   * (0 when the event routes to no ranked pool — e.g. it falls back to hash-based VID assignment
+   * and therefore has no subpool). Duplicate offsets are permitted and are passed through —
    * [SubpoolFingerprintsAccumulator] dedupes per subpool.
+   *
+   * The callback form lets the consumer hand each primitive offset straight to the accumulator with
+   * no intermediate boxed `List<Long>` allocation on this per-event hot path.
    */
-  fun emit(input: LabelerInput): List<Long>
+  fun emit(input: LabelerInput, onPoolOffset: (Long) -> Unit): Int
 
   /**
    * Returns the configured ranked sub-range size (`RankedPopulationNode.ranked_size`) of the

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/subpoolassigner/SubpoolAssignmentSink.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/subpoolassigner/SubpoolAssignmentSink.kt
@@ -76,27 +76,51 @@ class SubpoolAssignmentSink(
     get() = unroutedCounter.get()
 
   override suspend fun processBatch(events: List<ParquetDigestedEvent>) {
+    // Tally this batch's outcomes in local vars, then fold them into the shared atomics /
+    // OpenTelemetry counters ONCE per batch instead of once per event. The final totals (read after
+    // the whole stream drains) and the cumulative counter sums are identical — only the update
+    // granularity changes (maxOf is associative, so the per-batch max reduces to the global max).
+    var labeledInBatch = 0L
+    var droppedInBatch = 0L
+    var unroutedInBatch = 0L
+    var maxTimestampInBatch = Long.MIN_VALUE
     for (event in events) {
       val input = mapper.project(event.row)
       if (!input.hasTimestampUsec() || !activeWindow.contains(input.timestampUsec)) {
-        droppedOutsideWindowCounter.incrementAndGet()
-        metrics.eventsDroppedOutsideWindowCounter.add(1)
+        droppedInBatch++
         continue
       }
-      val offsets = labeler.emit(input)
-      if (offsets.isEmpty()) {
+      // Hand each primitive pool offset straight to the accumulator (no boxed List<Long>); the
+      // return count says whether the event routed anywhere.
+      val routed =
+        labeler.emit(input) { offset ->
+          accumulator.add(offset, event.digest.high, event.digest.low)
+        }
+      if (routed == 0) {
         // Per-event logging is intentionally avoided on this hot path (potentially billions of
         // events); the aggregate [unrouted] tally and OTel counter carry the signal instead.
-        unroutedCounter.incrementAndGet()
-        metrics.eventsUnroutedCounter.add(1)
+        unroutedInBatch++
         continue
       }
-      for (offset in offsets) {
-        accumulator.add(offset, event.digest.high, event.digest.low)
+      labeledInBatch++
+      if (input.timestampUsec > maxTimestampInBatch) {
+        maxTimestampInBatch = input.timestampUsec
       }
-      labeledCounter.incrementAndGet()
-      maxTimestampUsecValue.accumulateAndGet(input.timestampUsec, ::maxOf)
-      metrics.eventsLabeledCounter.add(1)
+    }
+    if (droppedInBatch > 0L) {
+      droppedOutsideWindowCounter.addAndGet(droppedInBatch)
+      metrics.eventsDroppedOutsideWindowCounter.add(droppedInBatch)
+    }
+    if (unroutedInBatch > 0L) {
+      unroutedCounter.addAndGet(unroutedInBatch)
+      metrics.eventsUnroutedCounter.add(unroutedInBatch)
+    }
+    if (labeledInBatch > 0L) {
+      labeledCounter.addAndGet(labeledInBatch)
+      metrics.eventsLabeledCounter.add(labeledInBatch)
+    }
+    if (maxTimestampInBatch != Long.MIN_VALUE) {
+      maxTimestampUsecValue.accumulateAndGet(maxTimestampInBatch, ::maxOf)
     }
   }
 

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/subpoolassigner/SubpoolFingerprintsAccumulator.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/subpoolassigner/SubpoolFingerprintsAccumulator.kt
@@ -18,7 +18,6 @@ package org.wfanet.measurement.edpaggregator.subpoolassigner
 
 import com.google.protobuf.ByteString
 import com.google.protobuf.UnsafeByteOperations
-import java.util.concurrent.ConcurrentHashMap
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 import org.wfanet.measurement.edpaggregator.vidlabeler.utils.Bytes12IntMap
@@ -51,24 +50,69 @@ class SubpoolFingerprintsAccumulator {
     val map = Bytes12IntMap()
   }
 
-  private val buckets = ConcurrentHashMap<Long, Bucket>()
+  /**
+   * Immutable, atomically-published pairing of subpool offsets to their [Bucket]s: `ids[i]` is the
+   * subpool offset of `buckets[i]`. Subpools are few, so [add]'s hot path does a primitive linear
+   * scan over the `ids` [LongArray] — no `Long` boxing, no ConcurrentHashMap bin lookup. A single
+   * [Snapshot] reference is published (under [growthLock]) whenever a new subpool first appears, so
+   * a concurrent reader always sees a consistent `(ids, buckets)` pair; a bucket, once created,
+   * keeps its index and is never replaced.
+   */
+  private class Snapshot(val ids: LongArray, val buckets: Array<Bucket>)
+
+  @Volatile private var snapshot = Snapshot(LongArray(0), emptyArray())
+  private val growthLock = Any()
 
   /**
    * Records that the fingerprint `(keyHi, keyLo)` belongs to [subpoolId]. Idempotent per subpool.
    */
   fun add(subpoolId: Long, keyHi: Long, keyLo: Int) {
-    // Lock-free fast path: the bucket almost always already exists (subpools are few, adds are
-    // many), so avoid CHM's computeIfAbsent bin-lock on the hot path.
-    val bucket = buckets[subpoolId] ?: buckets.computeIfAbsent(subpoolId) { Bucket() }
+    val bucket = bucketFor(subpoolId)
     synchronized(bucket) { bucket.map.put(keyHi, keyLo, PRESENT) }
   }
 
+  /** The [Bucket] for [subpoolId], creating it (under [growthLock]) the first time it is seen. */
+  private fun bucketFor(subpoolId: Long): Bucket {
+    // Lock-free fast path: subpools almost always already exist (few subpools, many adds).
+    val current = snapshot
+    val index = indexOf(current.ids, subpoolId)
+    if (index >= 0) return current.buckets[index]
+    // Slow path: create the bucket (or find it, if a concurrent add just created it), then publish
+    // a
+    // new snapshot with the appended (id, bucket) pair.
+    synchronized(growthLock) {
+      val latest = snapshot
+      val existing = indexOf(latest.ids, subpoolId)
+      if (existing >= 0) return latest.buckets[existing]
+      val bucket = Bucket()
+      snapshot = Snapshot(latest.ids + subpoolId, latest.buckets + bucket)
+      return bucket
+    }
+  }
+
+  private fun indexOf(ids: LongArray, subpoolId: Long): Int {
+    for (i in ids.indices) {
+      if (ids[i] == subpoolId) return i
+    }
+    return -1
+  }
+
   /** The subpool offsets seen so far. */
-  fun subpoolIds(): Set<Long> = buckets.keys
+  fun subpoolIds(): Set<Long> {
+    val current = snapshot
+    val ids = LinkedHashSet<Long>(current.ids.size)
+    for (id in current.ids) {
+      ids.add(id)
+    }
+    return ids
+  }
 
   /** Number of distinct fingerprints accumulated for [subpoolId]. */
   fun size(subpoolId: Long): Long {
-    val bucket = buckets[subpoolId] ?: return 0L
+    val current = snapshot
+    val index = indexOf(current.ids, subpoolId)
+    if (index < 0) return 0L
+    val bucket = current.buckets[index]
     return synchronized(bucket) { bucket.map.size }
   }
 
@@ -82,7 +126,10 @@ class SubpoolFingerprintsAccumulator {
     subpoolId: Long,
     chunkFingerprints: Int = DEFAULT_CHUNK_FINGERPRINTS,
   ): Flow<ByteString> = flow {
-    val bucket = buckets[subpoolId] ?: return@flow
+    val current = snapshot
+    val index = indexOf(current.ids, subpoolId)
+    if (index < 0) return@flow
+    val bucket = current.buckets[index]
     val total = bucket.map.size
     if (total == 0L) return@flow
 
@@ -111,7 +158,14 @@ class SubpoolFingerprintsAccumulator {
 
   /** Drops [subpoolId]'s map, freeing its heap once the subpool's blob has been written. */
   fun remove(subpoolId: Long) {
-    buckets.remove(subpoolId)
+    synchronized(growthLock) {
+      val latest = snapshot
+      val index = indexOf(latest.ids, subpoolId)
+      if (index < 0) return
+      val keptIds = latest.ids.filterIndexed { i, _ -> i != index }.toLongArray()
+      val keptBuckets = latest.buckets.filterIndexed { i, _ -> i != index }.toTypedArray()
+      snapshot = Snapshot(keptIds, keptBuckets)
+    }
   }
 
   companion object {
@@ -121,9 +175,15 @@ class SubpoolFingerprintsAccumulator {
     private const val PRESENT = 1
 
     /**
-     * ~16M fingerprints (~192 MB) per chunk: one RecordIO record, one buffer in memory at a time.
+     * ~1M fingerprints (~12 MB) per chunk: one RecordIO record, one buffer in memory at a time.
+     *
+     * Phase-0 writes these per-(shard, subpool) records and the last-shard-out merge
+     * ([org.wfanet.measurement.edpaggregator.rawimpressions.SubpoolFingerprintsStore.mergeSubpool])
+     * streams them straight through unchanged (a pure record-by-record concatenation, no
+     * re-chunking), so the merged blob Phase-1 reads inherits this same ~1M-fingerprint record
+     * size.
      */
-    const val DEFAULT_CHUNK_FINGERPRINTS = 16 * 1024 * 1024
+    const val DEFAULT_CHUNK_FINGERPRINTS = 1 * 1024 * 1024
 
     private fun writeBigEndianLong(out: ByteArray, offset: Int, value: Long) {
       out[offset] = (value ushr 56).toByte()

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/subpoolassigner/SubpoolFingerprintsAccumulator.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/subpoolassigner/SubpoolFingerprintsAccumulator.kt
@@ -97,7 +97,10 @@ class SubpoolFingerprintsAccumulator {
     return -1
   }
 
-  /** The subpool offsets seen so far. */
+  /**
+   * The subpool offsets seen so far, as a snapshot. Subpools added after this call are not visible
+   * in the returned set (unlike the previous `ConcurrentHashMap.keys` live-view semantics).
+   */
   fun subpoolIds(): Set<Long> {
     val current = snapshot
     val ids = LinkedHashSet<Long>(current.ids.size)
@@ -156,7 +159,14 @@ class SubpoolFingerprintsAccumulator {
     }
   }
 
-  /** Drops [subpoolId]'s map, freeing its heap once the subpool's blob has been written. */
+  /**
+   * Drops [subpoolId]'s map, freeing its heap once the subpool's blob has been written.
+   *
+   * Callers MUST have quiesced all `add(subpoolId, ...)` before calling this — a concurrent add
+   * would land in an orphaned bucket that no later [subpoolIds] / [streamChunks] would see. Today
+   * enforced by `SubpoolAssigner.dispatchShard` joining all input-processing coroutines (via
+   * `streamBlobs` returning) before the sequential per-subpool write/remove loop.
+   */
   fun remove(subpoolId: Long) {
     synchronized(growthLock) {
       val latest = snapshot

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/subpoolassigner/SubpoolFingerprintsAccumulator.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/subpoolassigner/SubpoolFingerprintsAccumulator.kt
@@ -78,8 +78,7 @@ class SubpoolFingerprintsAccumulator {
     val index = indexOf(current.ids, subpoolId)
     if (index >= 0) return current.buckets[index]
     // Slow path: create the bucket (or find it, if a concurrent add just created it), then publish
-    // a
-    // new snapshot with the appended (id, bucket) pair.
+    // a new snapshot with the appended (id, bucket) pair.
     synchronized(growthLock) {
       val latest = snapshot
       val existing = indexOf(latest.ids, subpoolId)

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/subpoolassigner/VirtualPeoplePoolEmitLabeler.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/subpoolassigner/VirtualPeoplePoolEmitLabeler.kt
@@ -47,8 +47,13 @@ private constructor(
   private val labeler: Labeler,
   private val rankedSizeByPoolOffset: Map<Long, Int>,
 ) : PoolEmitLabeler {
-  override fun emit(input: LabelerInput): List<Long> =
-    labeler.label(input, LabelingMode.POOL_IDENTITY).poolAssignmentsList.map { it.poolOffset }
+  override fun emit(input: LabelerInput, onPoolOffset: (Long) -> Unit): Int {
+    val poolAssignments = labeler.label(input, LabelingMode.POOL_IDENTITY).poolAssignmentsList
+    for (poolAssignment in poolAssignments) {
+      onPoolOffset(poolAssignment.poolOffset)
+    }
+    return poolAssignments.size
+  }
 
   override fun rankedSize(poolOffset: Long): Int =
     requireNotNull(rankedSizeByPoolOffset[poolOffset]) {

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/vidlabeler/EntityKeyMapper.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/vidlabeler/EntityKeyMapper.kt
@@ -57,32 +57,34 @@ class EntityKeyMapper(
 
   /** Builds this row's entity keys from the mapped string columns. */
   fun map(row: Map<String, ParquetValue>): List<LabeledImpression.EntityKey> {
-    val required =
-      requiredFieldMapping.map { (entityType, column) ->
-        val id = readStringOrNull(row, column, entityType)
-        require(!id.isNullOrEmpty()) {
-          "required entity-key column '$column' (entity_type '$entityType') is null/empty; every " +
-            "impression must have a non-empty value for required entity types"
-        }
+    // One pre-sized list filled required-then-optional (same order as the previous
+    // `required + optional` concatenation), instead of two intermediate lists plus a concat.
+    val entityKeys =
+      ArrayList<LabeledImpression.EntityKey>(requiredFieldMapping.size + optionalFieldMapping.size)
+    for ((entityType, column) in requiredFieldMapping) {
+      val id = readStringOrNull(row, column, entityType)
+      require(!id.isNullOrEmpty()) {
+        "required entity-key column '$column' (entity_type '$entityType') is null/empty; every " +
+          "impression must have a non-empty value for required entity types"
+      }
+      entityKeys.add(
         entityKey {
           this.entityType = entityType
           this.entityId = id
         }
-      }
-    val optional =
-      optionalFieldMapping.mapNotNull { (entityType, column) ->
-        // A NULL / unset / empty-string cell means the impression is not associated with this
-        // entity_type (mirrors ResultsFulfiller.buildEventGroupEntityKeyMap dropping empty ids).
-        readStringOrNull(row, column, entityType)
-          ?.takeIf { it.isNotEmpty() }
-          ?.let { id ->
-            entityKey {
-              this.entityType = entityType
-              this.entityId = id
-            }
-          }
-      }
-    val entityKeys = required + optional
+      )
+    }
+    for ((entityType, column) in optionalFieldMapping) {
+      // A NULL / unset / empty-string cell means the impression is not associated with this
+      // entity_type (mirrors ResultsFulfiller.buildEventGroupEntityKeyMap dropping empty ids).
+      val id = readStringOrNull(row, column, entityType)?.takeIf { it.isNotEmpty() } ?: continue
+      entityKeys.add(
+        entityKey {
+          this.entityType = entityType
+          this.entityId = id
+        }
+      )
+    }
     require(entityKeys.isNotEmpty()) {
       "all entity-key columns are null/empty for this impression; at least one entity key is " +
         "required (required columns: ${requiredFieldMapping.values}, optional columns: " +

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/vidlabeler/ImpressionConverter.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/vidlabeler/ImpressionConverter.kt
@@ -16,6 +16,7 @@
 
 package org.wfanet.measurement.edpaggregator.vidlabeler
 
+import com.google.protobuf.util.Timestamps
 import org.wfanet.measurement.edpaggregator.rawimpressions.ParquetDigestedEvent
 import org.wfanet.measurement.edpaggregator.rawimpressions.RawImpressionFileMetadata
 import org.wfanet.measurement.edpaggregator.v1alpha.VidLabelerParams
@@ -61,12 +62,16 @@ fun interface ImpressionConverter {
  * @property entityKeys entity keys for this impression, read per-row from the model line's
  *   required/optional entity-key column mappings (see [EntityKeyMapper]); propagated to the labeled
  *   output and the per-blob `BlobDetails.entity_keys` union.
+ * @property eventTimeMicros [eventTime] as epoch-micros, carried alongside the typed [eventTime] so
+ *   the sink's active-window check does not re-derive it per row via `Timestamps.toMicros`.
+ *   Defaults to `Timestamps.toMicros(eventTime)`, so it is always exactly that value.
  */
 data class ConvertedImpression(
   val labelerInput: LabelerInput,
   val eventTime: com.google.protobuf.Timestamp,
   val event: com.google.protobuf.Any,
   val entityKeys: List<org.wfanet.measurement.edpaggregator.v1alpha.LabeledImpression.EntityKey>,
+  val eventTimeMicros: Long = Timestamps.toMicros(eventTime),
 ) {
   init {
     // Making entityKeys a required parameter only blocks accidental omission at the call site; an

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/vidlabeler/ImpressionConverter.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/vidlabeler/ImpressionConverter.kt
@@ -16,7 +16,6 @@
 
 package org.wfanet.measurement.edpaggregator.vidlabeler
 
-import com.google.protobuf.util.Timestamps
 import org.wfanet.measurement.edpaggregator.rawimpressions.ParquetDigestedEvent
 import org.wfanet.measurement.edpaggregator.rawimpressions.RawImpressionFileMetadata
 import org.wfanet.measurement.edpaggregator.v1alpha.VidLabelerParams
@@ -54,24 +53,19 @@ fun interface ImpressionConverter {
 /**
  * The labeling-relevant fields extracted from one raw-impression row for one model line.
  *
- * @property labelerInput input fed to the [VidAssigner].
- * @property eventTime impression event time — used for active-window filtering and as the output
- *   `event_time`. A typed `Timestamp` so the converter contract carries the unit instead of a bare
- *   epoch-micros `Long`.
+ * @property labelerInput input fed to the [VidAssigner]. Its `timestamp_usec` is the single source
+ *   of the impression's event time: the sink filters the active window on it directly and derives
+ *   the output `event_time` from it via `Timestamps.fromMicros`, so no separate timestamp field can
+ *   drift out of sync with it.
  * @property event the Event payload to embed in the labeled output.
  * @property entityKeys entity keys for this impression, read per-row from the model line's
  *   required/optional entity-key column mappings (see [EntityKeyMapper]); propagated to the labeled
  *   output and the per-blob `BlobDetails.entity_keys` union.
- * @property eventTimeMicros [eventTime] as epoch-micros, carried alongside the typed [eventTime] so
- *   the sink's active-window check does not re-derive it per row via `Timestamps.toMicros`.
- *   Defaults to `Timestamps.toMicros(eventTime)`, so it is always exactly that value.
  */
 data class ConvertedImpression(
   val labelerInput: LabelerInput,
-  val eventTime: com.google.protobuf.Timestamp,
   val event: com.google.protobuf.Any,
   val entityKeys: List<org.wfanet.measurement.edpaggregator.v1alpha.LabeledImpression.EntityKey>,
-  val eventTimeMicros: Long = Timestamps.toMicros(eventTime),
 ) {
   init {
     // Making entityKeys a required parameter only blocks accidental omission at the call site; an

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/vidlabeler/MemoizedRankIndex.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/vidlabeler/MemoizedRankIndex.kt
@@ -37,6 +37,7 @@ import org.wfanet.measurement.edpaggregator.v1alpha.RankIndexBlobServiceGrpcKt.R
 import org.wfanet.measurement.edpaggregator.v1alpha.listRankIndexBlobsRequest
 import org.wfanet.measurement.edpaggregator.vidlabeler.utils.Bytes12IntMap
 import org.wfanet.measurement.edpaggregator.vidrankbuilder.EventIdDigestBytes
+import org.wfanet.virtualpeople.common.LabelerInput
 import org.wfanet.virtualpeople.common.RankAssignment
 import org.wfanet.virtualpeople.common.rankAssignment
 
@@ -55,11 +56,18 @@ import org.wfanet.virtualpeople.common.rankAssignment
  * is safe to call concurrently from the reader's CPU pool even though [Bytes12IntMap] is not safe
  * for concurrent *mutation*.
  *
- * @property mapsByPoolOffset the per-subpool `fingerprint -> rank` maps, keyed by `pool_offset`.
+ * The per-subpool state is held as two parallel arrays ([poolOffsets] + [maps]) rather than a
+ * `Map<Long, Bytes12IntMap>` so the per-impression probe iterates primitive indices with no map
+ * entry / iterator allocation on the hot path. Index `i` pairs `poolOffsets[i]` with `maps[i]`; the
+ * arrays share the load-time subpool order.
+ *
+ * @property poolOffsets the loaded subpools' `pool_offset`s, parallel to [maps].
+ * @property maps the per-subpool `fingerprint -> rank` maps, parallel to [poolOffsets].
  */
 class MemoizedRankIndex
 private constructor(
-  private val mapsByPoolOffset: Map<Long, Bytes12IntMap>,
+  private val poolOffsets: LongArray,
+  private val maps: Array<Bytes12IntMap>,
   /**
    * KEK URI shared by every loaded `RankIndexBlob` (the EDP's own KEK). Reused to wrap the
    * labeled-output DEK, so the output is encrypted with the same key as the rank-index blobs.
@@ -69,7 +77,7 @@ private constructor(
 
   /** Number of subpools loaded. Exposed for diagnostics / tests. */
   val subpoolCount: Int
-    get() = mapsByPoolOffset.size
+    get() = poolOffsets.size
 
   /**
    * Returns a [RankAssignment] for every subpool whose map holds [digest] — one `(pool_offset,
@@ -81,20 +89,57 @@ private constructor(
    * caller attaches all of them; the model's `RankedPopulationNode` leaf selects the one matching
    * its own `pool_offset` and ignores the rest. Returning only the first match would attach a rank
    * for the wrong subpool when the impression reaches a different one, which the leaf rejects.
+   *
+   * Kept for tests and callers that want the list; the hot labeling path uses
+   * [appendRankAssignments] to avoid the intermediate list + per-match message allocations.
    */
   fun lookup(digest: EventIdDigest): List<RankAssignment> = buildList {
-    for ((poolOffset, map) in mapsByPoolOffset) {
-      val rank = map.get(digest.high, digest.low)
+    for (i in poolOffsets.indices) {
+      val rank = maps[i].get(digest.high, digest.low)
       if (rank != Bytes12IntMap.NOT_PRESENT) {
         add(
           rankAssignment {
-            this.poolOffset = poolOffset
+            poolOffset = poolOffsets[i]
             localRank = rank.toLong()
           }
         )
       }
     }
   }
+
+  /**
+   * Appends a `RankAssignment` for every subpool whose map holds [digest] directly onto [builder]'s
+   * `rank_assignments`, and returns how many were appended. Equivalent to attaching [lookup]'s
+   * result but without allocating the intermediate list or the per-match [RankAssignment] messages
+   * (they are built in place). Probes every subpool in the same order as [lookup]; a return of `0`
+   * means the fingerprint is unranked (overflow / unseen).
+   */
+  fun appendRankAssignments(digest: EventIdDigest, builder: LabelerInput.Builder): Int {
+    var appended = 0
+    for (i in poolOffsets.indices) {
+      val rank = maps[i].get(digest.high, digest.low)
+      if (rank != Bytes12IntMap.NOT_PRESENT) {
+        builder.addRankAssignmentsBuilder().apply {
+          poolOffset = poolOffsets[i]
+          localRank = rank.toLong()
+        }
+        appended++
+      }
+    }
+    return appended
+  }
+
+  /**
+   * Content identity of a loaded index: the `(dataProvider, modelLine)` plus the sorted set of
+   * chosen `SNAPSHOT` blob URIs. `RankIndexBlob` URIs are per-write-unique (attempt UUID) and their
+   * content is immutable, so an identical set of chosen URIs would build a byte-identical index —
+   * which is what lets [MemoizedRankIndexCache] safely reuse one across WorkItems. A new Phase-1
+   * snapshot for any subpool produces a new chosen URI, hence a new [Key] and a rebuild.
+   */
+  data class Key(val dataProvider: String, val modelLine: String, val blobUris: List<String>)
+
+  /** The cheap listing result of [resolveLatestBlobs]: the cache [key] and the chosen blobs. */
+  class ResolvedBlobs(val key: Key, val blobs: List<RankIndexBlob>)
 
   companion object {
     private val logger = Logger.getLogger(MemoizedRankIndex::class.java.name)
@@ -112,7 +157,12 @@ private constructor(
     fun fromMaps(
       mapsByPoolOffset: Map<Long, Bytes12IntMap>,
       kekUri: String = "test-kek-uri",
-    ): MemoizedRankIndex = MemoizedRankIndex(mapsByPoolOffset, kekUri)
+    ): MemoizedRankIndex =
+      MemoizedRankIndex(
+        mapsByPoolOffset.keys.toLongArray(),
+        mapsByPoolOffset.values.toTypedArray(),
+        kekUri,
+      )
 
     /**
      * Loads the current rank index for [modelLine] under [dataProvider].
@@ -145,7 +195,30 @@ private constructor(
       readerParallelism: Int = DEFAULT_READER_PARALLELISM,
       metrics: MemoizedRankIndexMetrics = MemoizedRankIndexMetrics(),
     ): MemoizedRankIndex {
-      val startMark = TimeSource.Monotonic.markNow()
+      val resolved = resolveLatestBlobs(rankIndexBlobsStub, dataProvider, modelLine)
+      return buildFrom(
+        rankIndexStore,
+        dataProvider,
+        modelLine,
+        resolved.blobs,
+        readerParallelism,
+        metrics,
+      )
+    }
+
+    /**
+     * The cheap discovery half of [load]: lists every non-deleted `SNAPSHOT` blob for the
+     * `(dataProvider, modelLine)` across all uploads, keeps per `pool_offset` the one with the
+     * greatest `create_time` (tie-broken by name), and returns those chosen blobs together with a
+     * content-identity [Key]. No blob bytes are downloaded here — this is the part that runs on
+     * EVERY WorkItem so [MemoizedRankIndexCache] can detect a changed snapshot set. Throws if no
+     * SNAPSHOT exists (the same fail-loud contract [load] had).
+     */
+    suspend fun resolveLatestBlobs(
+      rankIndexBlobsStub: RankIndexBlobServiceCoroutineStub,
+      dataProvider: String,
+      modelLine: String,
+    ): ResolvedBlobs {
       val latestByPoolOffset = LinkedHashMap<Long, RankIndexBlob>()
       rankIndexBlobsStub
         .listResources { pageToken: String ->
@@ -181,9 +254,33 @@ private constructor(
           "Phase-1 must produce a cumulative snapshot before Phase-2 labeling"
       }
 
+      val blobs = latestByPoolOffset.values.toList()
+      val key = Key(dataProvider, modelLine, blobs.map { it.blobUri }.sorted())
+      return ResolvedBlobs(key, blobs)
+    }
+
+    /**
+     * The expensive build half of [load]: decrypts + decodes each chosen [blobs] entry into a
+     * [Bytes12IntMap] (up to [readerParallelism] at a time) and assembles the [MemoizedRankIndex].
+     * Records the cold-start / per-subpool metrics. Split out so [MemoizedRankIndexCache] can skip
+     * it on a key match while still running the cheap [resolveLatestBlobs] every WorkItem.
+     *
+     * Memory: the entire cumulative index is held in heap for the WorkItem's lifetime (~6 GiB
+     * steady-state on the 128 GB VID-labeler VM). Size the VM for the model line's fingerprint
+     * count.
+     */
+    suspend fun buildFrom(
+      rankIndexStore: RankIndexStore,
+      dataProvider: String,
+      modelLine: String,
+      blobs: List<RankIndexBlob>,
+      readerParallelism: Int = DEFAULT_READER_PARALLELISM,
+      metrics: MemoizedRankIndexMetrics = MemoizedRankIndexMetrics(),
+    ): MemoizedRankIndex {
+      val startMark = TimeSource.Monotonic.markNow()
       val semaphore = Semaphore(readerParallelism.coerceAtLeast(1))
       val loaded: Map<Long, LoadedSubpool> = coroutineScope {
-        latestByPoolOffset.values
+        blobs
           .map { blob ->
             async {
               semaphore.withPermit { blob.poolOffset to readSubpoolMap(rankIndexStore, blob) }
@@ -192,11 +289,15 @@ private constructor(
           .awaitAll()
           .toMap()
       }
-      val maps: Map<Long, Bytes12IntMap> = loaded.mapValues { (_, subpool) -> subpool.map }
+      // Parallel arrays in the load-time subpool order (loaded is an ordered LinkedHashMap), so
+      // poolOffsets[i] pairs with subpoolMaps[i]. Held as arrays (not a Map) for an allocation-free
+      // per-impression probe.
+      val poolOffsets: LongArray = loaded.keys.toLongArray()
+      val subpoolMaps: Array<Bytes12IntMap> = loaded.values.map { it.map }.toTypedArray()
 
       val baseAttributes =
         Attributes.of(metrics.DATA_PROVIDER_ATTR, dataProvider, metrics.MODEL_LINE_ATTR, modelLine)
-      metrics.subpoolCountGauge.set(maps.size.toLong(), baseAttributes)
+      metrics.subpoolCountGauge.set(poolOffsets.size.toLong(), baseAttributes)
       metrics.coldStartDurationHistogram.record(
         startMark.elapsedNow().inWholeMilliseconds / 1000.0,
         baseAttributes,
@@ -209,12 +310,12 @@ private constructor(
       }
 
       // Every rank-index blob is wrapped with the EDP's single KEK; resolve it (and assert it is
-      // present + consistent) so the labeled output can be wrapped with the same key. The empty-
-      // index check above already guarantees there is at least one blob to resolve it from.
-      val kekUri = resolveKekUri(latestByPoolOffset.values, modelLine)
+      // present + consistent) so the labeled output can be wrapped with the same key. The caller
+      // (resolveLatestBlobs) already guarantees there is at least one blob to resolve it from.
+      val kekUri = resolveKekUri(blobs, modelLine)
 
-      logger.info("Loaded memoized rank index for $modelLine: ${maps.size} subpool(s)")
-      return MemoizedRankIndex(maps, kekUri)
+      logger.info("Loaded memoized rank index for $modelLine: ${poolOffsets.size} subpool(s)")
+      return MemoizedRankIndex(poolOffsets, subpoolMaps, kekUri)
     }
 
     /**
@@ -237,14 +338,18 @@ private constructor(
       rankIndexStore: RankIndexStore,
       blob: RankIndexBlob,
     ): LoadedSubpool {
-      val estimatedEntries =
-        (rankIndexStore.blobSize(blob.blobUri, blob.encryptedDek) /
-            RankIndexStore.ON_DISK_BYTES_PER_ENTRY)
-          .coerceAtLeast(Bytes12IntMap.MIN_CAPACITY)
-      val map = Bytes12IntMap(estimatedEntries)
+      // Open the blob ONCE: openBlob does the single getBlob and hands back both the byte size (for
+      // pre-sizing) and the record flow (for content), instead of a getBlob for blobSize plus a
+      // second getBlob inside readBlob. An absent blob (null) is handled exactly as before: no
+      // records are read, so the ranked_size check below fails with the same error.
+      val opened = rankIndexStore.openBlob(blob.blobUri, blob.encryptedDek, blob.blobChecksum)
+      val estimatedEntries = (opened?.first ?: 0L) / RankIndexStore.ON_DISK_BYTES_PER_ENTRY
+      // Size the map to hold estimatedEntries WITHOUT resizing: capacity = entries / load-factor
+      // (0.75) == entries * 4 / 3, floored at the minimum. The map is lookup-only (never iterated),
+      // so a different capacity cannot change any observable result — only avoids resizes at load.
+      val map = Bytes12IntMap((estimatedEntries * 4 / 3).coerceAtLeast(Bytes12IntMap.MIN_CAPACITY))
       var rankedSize = -1
-      rankIndexStore.readBlob(blob.blobUri, blob.encryptedDek, blob.blobChecksum).collect { record
-        ->
+      opened?.second?.collect { record ->
         if (rankedSize == -1) {
           rankedSize = record.rankedSize
         } else {

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/vidlabeler/MemoizedRankIndex.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/vidlabeler/MemoizedRankIndex.kt
@@ -289,8 +289,12 @@ private constructor(
           .awaitAll()
           .toMap()
       }
-      // Parallel arrays in the load-time subpool order (loaded is an ordered LinkedHashMap), so
-      // poolOffsets[i] pairs with subpoolMaps[i]. Held as arrays (not a Map) for an allocation-free
+      // Parallel arrays in the load-time subpool order (loaded is an ordered LinkedHashMap from
+      // awaitAll().toMap()), so poolOffsets[i] pairs with subpoolMaps[i]. Both lookup() and
+      // appendRankAssignments() walk poolOffsets.indices in exactly this order; that stability
+      // relies on loaded staying insertion-ordered and would silently change if the map type
+      // changed. The model leaf selects by pool_offset, so any order is still correct — this only
+      // affects reproducible load-time ordering. Held as arrays (not a Map) for an allocation-free
       // per-impression probe.
       val poolOffsets: LongArray = loaded.keys.toLongArray()
       val subpoolMaps: Array<Bytes12IntMap> = loaded.values.map { it.map }.toTypedArray()

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/vidlabeler/ParquetImpressionConverter.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/vidlabeler/ParquetImpressionConverter.kt
@@ -19,6 +19,7 @@ package org.wfanet.measurement.edpaggregator.vidlabeler
 import com.google.protobuf.Any
 import com.google.protobuf.Descriptors
 import com.google.protobuf.util.Timestamps
+import java.util.concurrent.ConcurrentHashMap
 import org.wfanet.measurement.edpaggregator.rawimpressions.LabelerInputMapper
 import org.wfanet.measurement.edpaggregator.rawimpressions.ParquetDigestedEvent
 import org.wfanet.measurement.edpaggregator.v1alpha.VidLabelerParams
@@ -45,47 +46,63 @@ import org.wfanet.measurement.edpaggregator.v1alpha.VidLabelerParams
  */
 class ParquetImpressionConverter(private val eventDescriptor: Descriptors.Descriptor) :
   ImpressionConverter {
-  // The converter is built per (WorkItem, model line), so config is fixed; build the mappers once
-  // on first use and reuse them for every row (path resolution is the expensive part).
-  @Volatile private var cachedConfig: VidLabelerParams.ModelLineConfig? = null
-  private lateinit var labelerInputMapper: LabelerInputMapper
-  private lateinit var eventMessageMapper: EventMessageMapper
-  private lateinit var entityKeyMapper: EntityKeyMapper
+  // The event Any type_url is identical for every row (it is a function of the event descriptor
+  // only), so cache it once instead of recomputing it in Any.pack per row.
+  private val eventTypeUrl: String = TYPE_URL_PREFIX + eventDescriptor.fullName
 
-  @Synchronized
-  private fun mappersFor(
-    config: VidLabelerParams.ModelLineConfig
-  ): Triple<LabelerInputMapper, EventMessageMapper, EntityKeyMapper> {
-    if (cachedConfig !== config) {
-      labelerInputMapper = LabelerInputMapper(config.labelerInputFieldMappingList)
-      eventMessageMapper = EventMessageMapper(eventDescriptor, config.eventTemplateFieldMappingMap)
-      entityKeyMapper =
-        EntityKeyMapper(
-          config.requiredEntityKeyFieldMappingMap,
-          config.optionalEntityKeyFieldMappingMap,
-        )
-      cachedConfig = config
+  // A converter instance may see more than one ModelLineConfig: the non-memoized path builds ONE
+  // converter and calls convert() once per bundled model line's config. Cache the (path-resolved)
+  // mappers per config in a lock-free ConcurrentHashMap — computeIfAbsent builds each config's
+  // mappers exactly once. The mappers are a pure function of the config value and are all
+  // stateless / thread-safe once built, so reuse (even across threads and across value-equal
+  // configs) is behavior-identical to rebuilding.
+  private val mappersByConfig = ConcurrentHashMap<VidLabelerParams.ModelLineConfig, Mappers>()
+
+  private fun mappersFor(config: VidLabelerParams.ModelLineConfig): Mappers =
+    mappersByConfig.computeIfAbsent(config) { cfg ->
+      Mappers(
+        LabelerInputMapper(cfg.labelerInputFieldMappingList),
+        EventMessageMapper(eventDescriptor, cfg.eventTemplateFieldMappingMap),
+        EntityKeyMapper(cfg.requiredEntityKeyFieldMappingMap, cfg.optionalEntityKeyFieldMappingMap),
+      )
     }
-    return Triple(labelerInputMapper, eventMessageMapper, entityKeyMapper)
-  }
 
   override fun convert(
     event: ParquetDigestedEvent,
     config: VidLabelerParams.ModelLineConfig,
   ): ConvertedImpression? {
-    val (inputMapper, messageMapper, entityKeyMapper) = mappersFor(config)
+    val mappers = mappersFor(config)
 
-    val labelerInput = inputMapper.project(event.row)
-    val eventTime = Timestamps.fromMicros(labelerInput.timestampUsec)
-    val eventMessage = Any.pack(messageMapper.project(event.row))
+    val labelerInput = mappers.inputMapper.project(event.row)
+    val eventTimeMicros = labelerInput.timestampUsec
+    val eventTime = Timestamps.fromMicros(eventTimeMicros)
+    // Byte-identical to Any.pack(message): the type_url is "type.googleapis.com/<fullName>" and the
+    // value is message.toByteString(); the type_url is cached because it never varies per row.
+    val eventMessage =
+      Any.newBuilder()
+        .setTypeUrl(eventTypeUrl)
+        .setValue(mappers.messageMapper.project(event.row).toByteString())
+        .build()
     // entity_keys are read per row from the mapped columns.
-    val entityKeys = entityKeyMapper.map(event.row)
+    val entityKeys = mappers.entityKeyMapper.map(event.row)
 
     return ConvertedImpression(
       labelerInput = labelerInput,
       eventTime = eventTime,
       event = eventMessage,
       entityKeys = entityKeys,
+      eventTimeMicros = eventTimeMicros,
     )
+  }
+
+  /** The per-config, path-resolved mappers, built once per config and reused for every row. */
+  private class Mappers(
+    val inputMapper: LabelerInputMapper,
+    val messageMapper: EventMessageMapper,
+    val entityKeyMapper: EntityKeyMapper,
+  )
+
+  private companion object {
+    private const val TYPE_URL_PREFIX = "type.googleapis.com/"
   }
 }

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/vidlabeler/ParquetImpressionConverter.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/vidlabeler/ParquetImpressionConverter.kt
@@ -18,7 +18,6 @@ package org.wfanet.measurement.edpaggregator.vidlabeler
 
 import com.google.protobuf.Any
 import com.google.protobuf.Descriptors
-import com.google.protobuf.util.Timestamps
 import java.util.concurrent.ConcurrentHashMap
 import org.wfanet.measurement.edpaggregator.rawimpressions.LabelerInputMapper
 import org.wfanet.measurement.edpaggregator.rawimpressions.ParquetDigestedEvent
@@ -74,8 +73,6 @@ class ParquetImpressionConverter(private val eventDescriptor: Descriptors.Descri
     val mappers = mappersFor(config)
 
     val labelerInput = mappers.inputMapper.project(event.row)
-    val eventTimeMicros = labelerInput.timestampUsec
-    val eventTime = Timestamps.fromMicros(eventTimeMicros)
     // Byte-identical to Any.pack(message): the type_url is "type.googleapis.com/<fullName>" and the
     // value is message.toByteString(); the type_url is cached because it never varies per row.
     val eventMessage =
@@ -88,10 +85,8 @@ class ParquetImpressionConverter(private val eventDescriptor: Descriptors.Descri
 
     return ConvertedImpression(
       labelerInput = labelerInput,
-      eventTime = eventTime,
       event = eventMessage,
       entityKeys = entityKeys,
-      eventTimeMicros = eventTimeMicros,
     )
   }
 

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/vidlabeler/VidLabelingSink.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/vidlabeler/VidLabelingSink.kt
@@ -20,7 +20,6 @@ import com.google.crypto.tink.KmsClient
 import com.google.crypto.tink.aead.AeadConfig
 import com.google.crypto.tink.streamingaead.StreamingAeadConfig
 import com.google.protobuf.Timestamp
-import com.google.protobuf.util.Timestamps
 import com.google.type.interval
 import io.opentelemetry.api.common.Attributes
 import java.security.MessageDigest
@@ -56,7 +55,6 @@ import org.wfanet.measurement.edpaggregator.v1alpha.labeledImpression
 import org.wfanet.measurement.edpaggregator.vidlabeler.utils.ActiveWindow
 import org.wfanet.measurement.storage.MesosRecordIoStorageClient
 import org.wfanet.measurement.storage.SelectedStorageClient
-import org.wfanet.virtualpeople.common.copy
 
 /**
  * Per-input-file [RawImpressionSource.BlobSink] that labels one raw-impression file's
@@ -143,92 +141,101 @@ class VidLabelingSink(
   private val writers = ConcurrentHashMap<OutputGroupKey, GroupWriter>()
 
   override suspend fun processBatch(events: List<ParquetDigestedEvent>) {
-    // Label first (CPU work, and the canonical Labeler is stateless), then stream each produced
-    // record into its group's writer. processBatch is invoked concurrently for this blob.
-    val produced = ArrayList<GroupedImpression>()
-    for (digestedEvent in events) {
-      for (context in modelLineContexts) {
+    // Label (CPU work; the canonical Labeler is stateless) and stream each produced record straight
+    // into its group's writer. processBatch is invoked concurrently for this blob. Iterating model
+    // lines in the OUTER loop lets each context precompute its metric Attributes and resolve its
+    // GroupWriter once per batch (rather than per row) and stream records inline (no batch-wide
+    // buffer of produced impressions). Per-writer record order within a batch is preserved — events
+    // stream in order into each context's single writer — while order across concurrent batches is
+    // non-deterministic, exactly as before (records go to a per-model-line writer, so swapping the
+    // loop nesting cannot change any one blob's contents).
+    for (context in modelLineContexts) {
+      // Attributes depend only on (modelLine, reason), fixed for this context: build them once.
+      val labelAttrs = labelAttributes(context.modelLine)
+      val converterSkipAttrs =
+        dropAttributes(context.modelLine, VidLabelerMetrics.DROP_REASON_CONVERTER_SKIP)
+      val outsideWindowAttrs =
+        dropAttributes(context.modelLine, VidLabelerMetrics.DROP_REASON_OUTSIDE_WINDOW)
+      val noAssignmentAttrs =
+        dropAttributes(context.modelLine, VidLabelerMetrics.DROP_REASON_NO_ASSIGNMENT)
+      val rankIndex = context.rankIndex
+      // Resolved lazily on this context's first produced record, then reused for the batch, so a
+      // context that produces nothing opens no output blob (an empty blob would fail commit()).
+      var writer: GroupWriter? = null
+      for (digestedEvent in events) {
         try {
           val converted = impressionConverter.convert(digestedEvent, context.config)
           if (converted == null) {
-            metrics.impressionsDroppedCounter.add(
-              1,
-              dropAttributes(context.modelLine, VidLabelerMetrics.DROP_REASON_CONVERTER_SKIP),
-            )
+            metrics.impressionsDroppedCounter.add(1, converterSkipAttrs)
             continue
           }
-          if (!context.activeWindow.contains(Timestamps.toMicros(converted.eventTime))) {
-            metrics.impressionsDroppedCounter.add(
-              1,
-              dropAttributes(context.modelLine, VidLabelerMetrics.DROP_REASON_OUTSIDE_WINDOW),
-            )
+          if (!context.activeWindow.contains(converted.eventTimeMicros)) {
+            metrics.impressionsDroppedCounter.add(1, outsideWindowAttrs)
             continue
           }
 
-          // Memoized path: attach the impression's pre-computed rank(s) (keyed by its
-          // EventIdDigest) so the model's RankedPopulationNode leaf derives a collision-free VID
-          // via Feistel. All of the fingerprint's per-subpool ranks are attached (a fingerprint
-          // can route to several subpools across impressions); the leaf selects the one matching
-          // its own pool_offset. No match (overflow / unseen) leaves the input untouched and the
-          // leaf falls back to hashing.
-          val ranks = context.rankIndex?.lookup(digestedEvent.digest).orEmpty()
-          val labelerInput =
-            if (ranks.isEmpty()) {
-              converted.labelerInput
-            } else {
-              converted.labelerInput.copy { rankAssignments += ranks }
-            }
+          // Memoized path: append the impression's pre-computed rank(s) (keyed by its
+          // EventIdDigest)
+          // directly onto the LabelerInput builder so the model's RankedPopulationNode leaf derives
+          // a collision-free VID via Feistel. All matching per-subpool ranks are attached (a
+          // fingerprint can route to several subpools across impressions); the leaf selects the one
+          // matching its own pool_offset. No match (overflow / unseen) leaves the input untouched
+          // and the leaf falls back to hashing. The non-memoized path (rankIndex == null) never
+          // probes and never reads the digest.
           // TODO(world-federation-of-advertisers/cross-media-measurement#4073): Once
           // virtual-people-common#75 (memoized_rank_fallback signal) and
           // virtual-people-core-serving#89 (RankedPopulationNode hash fallback) are merged, count
           // VirtualPersonActivity.memoized_rank_fallback across output.peopleList (coviewing-safe)
           // into a per-(dataProvider, modelLine) counter here to surface silent degradation to
           // hash-based VID assignment when subpools saturate.
+          val labelerInput =
+            if (rankIndex == null) {
+              converted.labelerInput
+            } else {
+              val builder = converted.labelerInput.toBuilder()
+              if (rankIndex.appendRankAssignments(digestedEvent.digest, builder) == 0) {
+                converted.labelerInput // miss: leave the input untouched, exactly as before
+              } else {
+                builder.build()
+              }
+            }
 
           val output = context.assigner.assign(labelerInput)
           if (output.peopleCount == 0) {
-            metrics.impressionsDroppedCounter.add(
-              1,
-              dropAttributes(context.modelLine, VidLabelerMetrics.DROP_REASON_NO_ASSIGNMENT),
-            )
+            metrics.impressionsDroppedCounter.add(1, noAssignmentAttrs)
             continue
           }
 
-          val key = OutputGroupKey(context.modelLine)
+          // computeIfAbsent is atomic per key, so concurrent processBatch calls for different
+          // groups
+          // never block each other; send() then suspends on the group's channel if it is full,
+          // applying backpressure that bounds the heap.
+          val groupWriter =
+            writer
+              ?: writers
+                .computeIfAbsent(OutputGroupKey(context.modelLine)) { GroupWriter(it) }
+                .also { writer = it }
           // A LabelerOutput can assign multiple virtual people to a single impression; emit one
           // LabeledImpression per assigned VID rather than only the first.
           for (person in output.peopleList) {
-            produced.add(
-              GroupedImpression(
-                key,
-                labeledImpression {
-                  eventTime = converted.eventTime
-                  vid = person.virtualPersonId
-                  event = converted.event
-                  entityKeys += converted.entityKeys
-                },
-              )
+            groupWriter.send(
+              labeledImpression {
+                eventTime = converted.eventTime
+                vid = person.virtualPersonId
+                event = converted.event
+                entityKeys += converted.entityKeys
+              }
             )
           }
-          metrics.impressionsLabeledCounter.add(
-            output.peopleList.size.toLong(),
-            labelAttributes(context.modelLine),
-          )
+          metrics.impressionsLabeledCounter.add(output.peopleList.size.toLong(), labelAttrs)
         } catch (e: CancellationException) {
           // Cooperative cancellation is not a labeling error; rethrow without inflating the metric.
           throw e
         } catch (e: Exception) {
-          metrics.labelingErrorsCounter.add(1, labelAttributes(context.modelLine))
+          metrics.labelingErrorsCounter.add(1, labelAttrs)
           throw e
         }
       }
-    }
-
-    for ((key, impression) in produced) {
-      // computeIfAbsent is atomic per key, so concurrent processBatch calls for different groups
-      // never block each other; send() then suspends on the group's channel if it is full,
-      // applying backpressure that bounds the heap.
-      writers.computeIfAbsent(key) { GroupWriter(it) }.send(impression)
     }
   }
 
@@ -482,6 +489,3 @@ data class ModelLineContext(
  * by model line and carry the per-blob entity-key union on `BlobDetails.entity_keys`.
  */
 private data class OutputGroupKey(val modelLine: String)
-
-/** A labeled impression paired with the output group it belongs to, for channel hand-off. */
-private data class GroupedImpression(val key: OutputGroupKey, val impression: LabeledImpression)

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/vidlabeler/VidLabelingSink.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/vidlabeler/VidLabelingSink.kt
@@ -148,7 +148,9 @@ class VidLabelingSink(
     // buffer of produced impressions). Per-writer record order within a batch is preserved — events
     // stream in order into each context's single writer — while order across concurrent batches is
     // non-deterministic, exactly as before (records go to a per-model-line writer, so swapping the
-    // loop nesting cannot change any one blob's contents).
+    // loop nesting cannot change any one blob's contents). Each writer's blob is independently
+    // ordered by event; there is NO cross-writer ordering guarantee (before or after this change),
+    // so nothing may rely on how the writers' outputs interleave.
     for (context in modelLineContexts) {
       // Attributes depend only on (modelLine, reason), fixed for this context: build them once.
       val labelAttrs = labelAttributes(context.modelLine)

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/vidlabeler/VidLabelingSink.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/vidlabeler/VidLabelingSink.kt
@@ -20,6 +20,7 @@ import com.google.crypto.tink.KmsClient
 import com.google.crypto.tink.aead.AeadConfig
 import com.google.crypto.tink.streamingaead.StreamingAeadConfig
 import com.google.protobuf.Timestamp
+import com.google.protobuf.util.Timestamps
 import com.google.type.interval
 import io.opentelemetry.api.common.Attributes
 import java.security.MessageDigest
@@ -171,7 +172,7 @@ class VidLabelingSink(
             metrics.impressionsDroppedCounter.add(1, converterSkipAttrs)
             continue
           }
-          if (!context.activeWindow.contains(converted.eventTimeMicros)) {
+          if (!context.activeWindow.contains(converted.labelerInput.timestampUsec)) {
             metrics.impressionsDroppedCounter.add(1, outsideWindowAttrs)
             continue
           }
@@ -222,7 +223,7 @@ class VidLabelingSink(
           for (person in output.peopleList) {
             groupWriter.send(
               labeledImpression {
-                eventTime = converted.eventTime
+                eventTime = Timestamps.fromMicros(converted.labelerInput.timestampUsec)
                 vid = person.virtualPersonId
                 event = converted.event
                 entityKeys += converted.entityKeys

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/vidlabeler/VidLabelingSink.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/vidlabeler/VidLabelingSink.kt
@@ -178,13 +178,12 @@ class VidLabelingSink(
           }
 
           // Memoized path: append the impression's pre-computed rank(s) (keyed by its
-          // EventIdDigest)
-          // directly onto the LabelerInput builder so the model's RankedPopulationNode leaf derives
-          // a collision-free VID via Feistel. All matching per-subpool ranks are attached (a
-          // fingerprint can route to several subpools across impressions); the leaf selects the one
-          // matching its own pool_offset. No match (overflow / unseen) leaves the input untouched
-          // and the leaf falls back to hashing. The non-memoized path (rankIndex == null) never
-          // probes and never reads the digest.
+          // EventIdDigest) directly onto the LabelerInput builder so the model's
+          // RankedPopulationNode leaf derives a collision-free VID via Feistel. All matching
+          // per-subpool ranks are attached (a fingerprint can route to several subpools across
+          // impressions); the leaf selects the one matching its own pool_offset. No match
+          // (overflow / unseen) leaves the input untouched and the leaf falls back to hashing. The
+          // non-memoized path (rankIndex == null) never probes and never reads the digest.
           // TODO(world-federation-of-advertisers/cross-media-measurement#4073): Once
           // virtual-people-common#75 (memoized_rank_fallback signal) and
           // virtual-people-core-serving#89 (RankedPopulationNode hash fallback) are merged, count

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/vidlabeler/VidLabelingSink.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/vidlabeler/VidLabelingSink.kt
@@ -210,9 +210,8 @@ class VidLabelingSink(
           }
 
           // computeIfAbsent is atomic per key, so concurrent processBatch calls for different
-          // groups
-          // never block each other; send() then suspends on the group's channel if it is full,
-          // applying backpressure that bounds the heap.
+          // groups never block each other; send() then suspends on the group's channel if it is
+          // full, applying backpressure that bounds the heap.
           val groupWriter =
             writer
               ?: writers

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/vidrankbuilder/RankAllocator.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/vidrankbuilder/RankAllocator.kt
@@ -56,19 +56,28 @@ import org.wfanet.measurement.edpaggregator.vidlabeler.utils.Bytes12IntMap
  * @param eventDay epoch-day stamped as `last_seen` for every fingerprint touched this dispatch
  *   (typically the dispatch's `max_event_date`). Also the default `last_seen` for entries loaded
  *   from a legacy `SNAPSHOT` that predates the field.
- * @param initialCapacity initial slot count for **both** the [cumulative] and [dayOnly] maps. The
- *   caller passes this dispatch's subpool-map fingerprint count so the maps start near their final
- *   size instead of the 16-slot default, avoiding the `~log2(N)` resizes during load. This is an
- *   exact fit for [dayOnly] (it holds at most one entry per today fingerprint) and for cold
- *   subpools; for a mature subpool [cumulative] is loaded from a prior `SNAPSHOT` larger than one
- *   day's map, so it still resizes up to its real size — see
- *   world-federation-of-advertisers/cross-media-measurement#4015.
+ * @param initialCapacity initial slot count for the [dayOnly] map (and, by default, the
+ *   [cumulative] map). The caller passes this dispatch's subpool-map fingerprint count so the maps
+ *   start near their final size instead of the 16-slot default, avoiding the `~log2(N)` resizes
+ *   during load. This is an exact fit for [dayOnly] (it holds at most one entry per today
+ *   fingerprint) and for cold subpools.
+ * @param cumulativeCapacity initial slot count for the [cumulative] map. Defaults to
+ *   [initialCapacity]; a warm/backfill caller passes the prior-snapshot-plus-today entry count so
+ *   [cumulative] does not resize up during load — see
+ *   world-federation-of-advertisers/cross-media-measurement#4015. Sizing only affects capacity, not
+ *   the stored `(fp -> rank)` mapping, ranks, or `last_seen`.
+ * @param estimatedTotalRanks estimated distinct-rank count (prior + today, capped at [rankedSize]);
+ *   used only to pre-size the [taken] [BitSet]. Over- or under-estimating is safe: the `BitSet`
+ *   auto-grows and its contents/`nextClearBit` results do not depend on its initial size. Defaults
+ *   to [rankedSize] (the previous fixed sizing).
  */
 class RankAllocator(
   val poolOffset: Long,
   val rankedSize: Int,
   private val eventDay: Int,
   initialCapacity: Long = Bytes12IntMap.DEFAULT_INITIAL_CAPACITY,
+  cumulativeCapacity: Long = initialCapacity,
+  estimatedTotalRanks: Int = rankedSize,
 ) {
   init {
     require(rankedSize >= 0) { "rankedSize must be >= 0, got $rankedSize" }
@@ -77,9 +86,13 @@ class RankAllocator(
     }
   }
 
-  private val cumulative = Bytes12IntMap(initialCapacity)
+  private val cumulative = Bytes12IntMap(cumulativeCapacity)
   private val dayOnly = Bytes12IntMap(initialCapacity)
-  private val taken = BitSet(rankedSize.coerceAtLeast(1))
+  private val taken = BitSet(estimatedTotalRanks.coerceAtLeast(1))
+  // Sized to [rankedSize] (not the estimated rank count): the MAX rank value loaded from a prior
+  // snapshot can exceed the live-entry count (retention frees low ranks while a high rank
+  // survives),
+  // so a shorter array would index out of bounds. Kept fixed-size for safety.
   private val lastSeen = ShortArray(rankedSize)
   private var cursor = 0
 
@@ -180,19 +193,27 @@ class RankAllocator(
    * @return the number of ranks freed.
    */
   fun freeAgedRanks(cutoffEpochDay: Int, todayFps: Bytes12IntMap): Long {
-    val freeHi = ArrayList<Long>()
-    val freeLo = ArrayList<Int>()
+    // Growable primitive long[]/int[] (not boxed ArrayList<Long>/ArrayList<Int>); the iteration
+    // order over [cumulative] is unchanged, so the freed set is identical.
+    var freeHi = LongArray(INITIAL_FREE_BUFFER)
+    var freeLo = IntArray(INITIAL_FREE_BUFFER)
+    var freeCount = 0
     cumulative.forEach { keyHi, keyLo, rank ->
       if (
         rank in 0 until rankedSize &&
           (lastSeen[rank].toInt() and 0xFFFF) < cutoffEpochDay &&
           !todayFps.containsKey(keyHi, keyLo)
       ) {
-        freeHi.add(keyHi)
-        freeLo.add(keyLo)
+        if (freeCount == freeHi.size) {
+          freeHi = freeHi.copyOf(freeHi.size * 2)
+          freeLo = freeLo.copyOf(freeLo.size * 2)
+        }
+        freeHi[freeCount] = keyHi
+        freeLo[freeCount] = keyLo
+        freeCount++
       }
     }
-    for (i in freeHi.indices) {
+    for (i in 0 until freeCount) {
       val rank = cumulative.remove(freeHi[i], freeLo[i])
       if (rank != Bytes12IntMap.NOT_PRESENT) {
         if (rank in 0 until rankedSize) taken.clear(rank)
@@ -384,5 +405,8 @@ class RankAllocator(
   companion object {
     /** ~1M entries (~18 MB of fps+ranks+last_seen) per record: one buffer in memory at a time. */
     const val DEFAULT_CHUNK_ENTRIES = 1 * 1024 * 1024
+
+    /** Initial size of the growable primitive buffer of doomed keys in [freeAgedRanks]. */
+    private const val INITIAL_FREE_BUFFER = 16
   }
 }

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/vidrankbuilder/RankAllocator.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/vidrankbuilder/RankAllocator.kt
@@ -91,8 +91,7 @@ class RankAllocator(
   private val taken = BitSet(estimatedTotalRanks.coerceAtLeast(1))
   // Sized to [rankedSize] (not the estimated rank count): the MAX rank value loaded from a prior
   // snapshot can exceed the live-entry count (retention frees low ranks while a high rank
-  // survives),
-  // so a shorter array would index out of bounds. Kept fixed-size for safety.
+  // survives), so a shorter array would index out of bounds. Kept fixed-size for safety.
   private val lastSeen = ShortArray(rankedSize)
   private var cursor = 0
 

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/vidrankbuilder/RankAllocator.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/vidrankbuilder/RankAllocator.kt
@@ -406,7 +406,11 @@ class RankAllocator(
     /** ~1M entries (~18 MB of fps+ranks+last_seen) per record: one buffer in memory at a time. */
     const val DEFAULT_CHUNK_ENTRIES = 1 * 1024 * 1024
 
-    /** Initial size of the growable primitive buffer of doomed keys in [freeAgedRanks]. */
-    private const val INITIAL_FREE_BUFFER = 16
+    /**
+     * Initial size of the growable primitive buffer of doomed keys in [freeAgedRanks]. Sized to
+     * skip the first several grow-and-copy doublings on a real retention cutover (starting at 16
+     * would double ~6 times to reach this); still trivially small when fewer keys age out.
+     */
+    private const val INITIAL_FREE_BUFFER = 1024
   }
 }

--- a/src/test/kotlin/org/wfanet/measurement/edpaggregator/rawimpressions/LabelerInputMapperTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/edpaggregator/rawimpressions/LabelerInputMapperTest.kt
@@ -171,6 +171,41 @@ class LabelerInputMapperTest {
   }
 
   @Test
+  fun `rejects a lookup_table entry naming a non-existent enum value at construction`() {
+    // The lookup target is resolved to its EnumValueDescriptor once at construction, so an entry
+    // that names a non-existent enum value fails fast at startup (not on the first matching row).
+    val ex =
+      assertFailsWith<IllegalArgumentException> {
+        mapperOf(
+          labelerInputFieldMapping {
+            fieldPath = GENDER_PATH
+            enumLookup = enumLookup {
+              column = "g"
+              lookupTable["M"] = "NOT_A_GENDER"
+            }
+          }
+        )
+      }
+    assertThat(ex).hasMessageThat().contains("NOT_A_GENDER")
+  }
+
+  @Test
+  fun `rejects a default_enum_value naming a non-existent enum value at construction`() {
+    assertFailsWith<IllegalArgumentException> {
+      mapperOf(
+        labelerInputFieldMapping {
+          fieldPath = GENDER_PATH
+          enumLookup = enumLookup {
+            column = "g"
+            lookupTable["M"] = "GENDER_MALE"
+            defaultEnumValue = "NOT_A_GENDER"
+          }
+        }
+      )
+    }
+  }
+
+  @Test
   fun `rejects an enum_lookup targeting a non-enum field at construction`() {
     assertFailsWith<IllegalArgumentException> {
       mapperOf(

--- a/src/test/kotlin/org/wfanet/measurement/edpaggregator/rawimpressions/RankIndexStoreTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/edpaggregator/rawimpressions/RankIndexStoreTest.kt
@@ -103,6 +103,44 @@ class RankIndexStoreTest {
   }
 
   @Test
+  fun `openBlob returns the byte size and streams the same records as readBlob`() = runBlocking {
+    val store = RankIndexStore(storageClient, kmsClient)
+    val dek = store.generateDek(kekUri)
+    store.writeBlob("snapshot/subpool-7", dek, flowOf(record(7L, 100, 0, 1), record(7L, 100, 2)))
+
+    val opened = store.openBlob("snapshot/subpool-7", dek)
+    assertThat(opened).isNotNull()
+    val (size, flow) = opened!!
+    // Size matches the underlying (encrypted) blob's size — the same value blobSize returns.
+    assertThat(size).isEqualTo(store.blobSize("snapshot/subpool-7", dek))
+    assertThat(size).isGreaterThan(0L)
+    // Records stream identically to readBlob.
+    val viaOpen = flow.toList()
+    val viaRead = store.readBlob("snapshot/subpool-7", dek).toList()
+    assertThat(viaOpen).isEqualTo(viaRead)
+    assertThat(viaOpen.flatMap { it.ranksList }).containsExactly(0, 1, 2).inOrder()
+  }
+
+  @Test
+  fun `openBlob enforces the checksum on the returned flow`() = runBlocking {
+    val store = RankIndexStore(storageClient, kmsClient)
+    val dek = store.generateDek(kekUri)
+    store.writeBlob("snapshot/subpool-7", dek, flowOf(record(7L, 100, 0, 1, 2)))
+    val wrongChecksum = ByteString.copyFromUtf8("not-the-real-checksum")
+
+    val (_, flow) = store.openBlob("snapshot/subpool-7", dek, expectedChecksum = wrongChecksum)!!
+    assertFailsWith<IllegalStateException> { flow.toList() }
+    Unit
+  }
+
+  @Test
+  fun `openBlob returns null for an absent blob`() = runBlocking {
+    val store = RankIndexStore(storageClient, kmsClient)
+    val dek = store.generateDek(kekUri)
+    assertThat(store.openBlob("snapshot/does-not-exist", dek)).isNull()
+  }
+
+  @Test
   fun `delete removes a blob`() = runBlocking {
     val store = RankIndexStore(storageClient, kmsClient)
     val dek = store.generateDek(kekUri)

--- a/src/test/kotlin/org/wfanet/measurement/edpaggregator/subpoolassigner/SubpoolAssignerTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/edpaggregator/subpoolassigner/SubpoolAssignerTest.kt
@@ -549,7 +549,7 @@ class SubpoolAssignerTest {
     }
 
   private object FakePoolEmitLabeler : PoolEmitLabeler {
-    override fun emit(input: LabelerInput): List<Long> = emptyList()
+    override fun emit(input: LabelerInput, onPoolOffset: (Long) -> Unit): Int = 0
 
     // Distinct per offset so a key-swap / dropped-offset regression in the rankedSize stamping is
     // observable (a constant would hide it).

--- a/src/test/kotlin/org/wfanet/measurement/edpaggregator/subpoolassigner/SubpoolAssignmentSinkTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/edpaggregator/subpoolassigner/SubpoolAssignmentSinkTest.kt
@@ -215,7 +215,11 @@ class SubpoolAssignmentSinkTest {
 
   private class FakePoolEmitLabeler(private val routing: (LabelerInput) -> List<Long>) :
     PoolEmitLabeler {
-    override fun emit(input: LabelerInput): List<Long> = routing(input)
+    override fun emit(input: LabelerInput, onPoolOffset: (Long) -> Unit): Int {
+      val offsets = routing(input)
+      offsets.forEach(onPoolOffset)
+      return offsets.size
+    }
 
     override fun rankedSize(poolOffset: Long): Int = 0
   }

--- a/src/test/kotlin/org/wfanet/measurement/edpaggregator/subpoolassigner/VirtualPeoplePoolEmitLabelerTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/edpaggregator/subpoolassigner/VirtualPeoplePoolEmitLabelerTest.kt
@@ -43,7 +43,9 @@ class VirtualPeoplePoolEmitLabelerTest {
     // Loads without throwing: the blob is a Riegeli record list, so the pre-fix single-node
     // `CompiledNode.parseFrom(modelBlob)` threw here; the list reader succeeds.
     val labeler = VirtualPeoplePoolEmitLabeler.fromCompiledNodeBlob(modelBlob)
-    val offsets = labeler.emit(labelerInput { eventId = eventId { id = "any-event" } })
+    val offsets = buildList {
+      labeler.emit(labelerInput { eventId = eventId { id = "any-event" } }) { add(it) }
+    }
 
     // `single_id_model` is a single-VID model with no `RankedPopulationNode`, so POOL_IDENTITY
     // emits no pool offsets. The point of this test is that the Riegeli list is read and the

--- a/src/test/kotlin/org/wfanet/measurement/edpaggregator/vidlabeler/MemoizedRankIndexTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/edpaggregator/vidlabeler/MemoizedRankIndexTest.kt
@@ -47,7 +47,9 @@ import org.wfanet.measurement.edpaggregator.v1alpha.copy
 import org.wfanet.measurement.edpaggregator.v1alpha.listRankIndexBlobsResponse
 import org.wfanet.measurement.edpaggregator.v1alpha.rankIndexBlob
 import org.wfanet.measurement.edpaggregator.v1alpha.rankIndexMap
+import org.wfanet.measurement.edpaggregator.vidlabeler.utils.Bytes12IntMap
 import org.wfanet.measurement.storage.testing.InMemoryStorageClient
+import org.wfanet.virtualpeople.common.LabelerInput
 
 private const val DP = "dataProviders/dp"
 private const val MODEL_LINE = "modelProviders/mp/modelSuites/ms/modelLines/ml1"
@@ -145,6 +147,30 @@ class MemoizedRankIndexTest {
 
     assertThat(index.lookup(digestOf(fpX)).map { it.poolOffset to it.localRank })
       .containsExactly(10L to 3L, 20L to 8L)
+  }
+
+  @Test
+  fun `appendRankAssignments matches lookup and returns the appended count`() {
+    val fpX = fp(0x33)
+    val digest = digestOf(fpX)
+    // The same fingerprint is ranked in two subpools.
+    val mapA = Bytes12IntMap().apply { put(digest.high, digest.low, 3) }
+    val mapB = Bytes12IntMap().apply { put(digest.high, digest.low, 8) }
+    val index = MemoizedRankIndex.fromMaps(linkedMapOf(10L to mapA, 20L to mapB))
+
+    val builder = LabelerInput.newBuilder()
+    val appended = index.appendRankAssignments(digest, builder)
+
+    assertThat(appended).isEqualTo(2)
+    // Appended assignments match lookup() exactly, in the same order.
+    assertThat(builder.rankAssignmentsList.map { it.poolOffset to it.localRank })
+      .containsExactlyElementsIn(index.lookup(digest).map { it.poolOffset to it.localRank })
+      .inOrder()
+
+    // A miss appends nothing and returns 0.
+    val missBuilder = LabelerInput.newBuilder()
+    assertThat(index.appendRankAssignments(digestOf(fp(0x99)), missBuilder)).isEqualTo(0)
+    assertThat(missBuilder.rankAssignmentsList).isEmpty()
   }
 
   @Test

--- a/src/test/kotlin/org/wfanet/measurement/edpaggregator/vidlabeler/ParquetImpressionConverterTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/edpaggregator/vidlabeler/ParquetImpressionConverterTest.kt
@@ -121,6 +121,66 @@ class ParquetImpressionConverterTest {
   }
 
   @Test
+  fun `convert sets eventTimeMicros equal to the labeler input timestamp`() {
+    val converter = ParquetImpressionConverter(eventDescriptor)
+    val row =
+      mapOf(
+        "eid" to parquetValue { stringValue = "event-1" },
+        "ts" to parquetValue { int64Value = 1_700_000_000_000_000L },
+        "cr_col" to parquetValue { stringValue = "c-1" },
+      )
+
+    val converted = converter.convert(digestedEvent(row), config)!!
+
+    assertThat(converted.eventTimeMicros).isEqualTo(1_700_000_000_000_000L)
+    // Always exactly Timestamps.toMicros(eventTime) — what the sink previously recomputed per row.
+    assertThat(converted.eventTimeMicros).isEqualTo(Timestamps.toMicros(converted.eventTime))
+  }
+
+  @Test
+  fun `convert reuses cached mappers and is race-free under concurrent calls`() {
+    val converter = ParquetImpressionConverter(eventDescriptor)
+    val row =
+      mapOf(
+        "eid" to parquetValue { stringValue = "event-1" },
+        "ts" to parquetValue { int64Value = 1_700_000_000_000_000L },
+        "gender" to parquetValue { stringValue = "MALE" },
+        "age" to parquetValue { stringValue = "YEARS_18_TO_34" },
+        "cr_col" to parquetValue { stringValue = "c-1" },
+        "pl_col" to parquetValue { stringValue = "p-9" },
+      )
+    // Reference result from a warm-up convert (populates the per-config mapper cache).
+    val reference = converter.convert(digestedEvent(row), config)!!
+
+    val threads = 8
+    val perThread = 200
+    val pool = java.util.concurrent.Executors.newFixedThreadPool(threads)
+    val results = java.util.concurrent.ConcurrentLinkedQueue<ConvertedImpression>()
+    val errors = java.util.concurrent.ConcurrentLinkedQueue<Throwable>()
+    try {
+      (0 until threads)
+        .map {
+          pool.submit {
+            try {
+              repeat(perThread) { results.add(converter.convert(digestedEvent(row), config)!!) }
+            } catch (t: Throwable) {
+              errors.add(t)
+            }
+          }
+        }
+        .forEach { it.get() }
+    } finally {
+      pool.shutdown()
+    }
+
+    assertThat(errors).isEmpty()
+    assertThat(results).hasSize(threads * perThread)
+    // Every concurrent conversion of the same row+config yields an identical ConvertedImpression,
+    // proving the lock-free per-config mapper cache is race-free.
+    assertThat(results.all { it == reference }).isTrue()
+  }
+
+  @Test
   fun `convert throws when all entity-key columns are null`() {
     val converter = ParquetImpressionConverter(eventDescriptor)
     // No cr_col / pl_col columns -> every mapped entity column is unset.

--- a/src/test/kotlin/org/wfanet/measurement/edpaggregator/vidlabeler/ParquetImpressionConverterTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/edpaggregator/vidlabeler/ParquetImpressionConverterTest.kt
@@ -17,7 +17,6 @@
 package org.wfanet.measurement.edpaggregator.vidlabeler
 
 import com.google.common.truth.Truth.assertThat
-import com.google.protobuf.util.Timestamps
 import kotlin.test.assertFailsWith
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -77,7 +76,7 @@ class ParquetImpressionConverterTest {
 
     assertThat(converted).isNotNull()
     assertThat(converted!!.labelerInput.eventId.id).isEqualTo("event-1")
-    assertThat(converted.eventTime).isEqualTo(Timestamps.fromMicros(1_700_000_000_000_000L))
+    assertThat(converted.labelerInput.timestampUsec).isEqualTo(1_700_000_000_000_000L)
 
     val event = converted.event.unpack(TestEvent::class.java)
     assertThat(event.person.gender).isEqualTo(Person.Gender.MALE)
@@ -118,23 +117,6 @@ class ParquetImpressionConverterTest {
     assertThat(event).isEqualTo(TestEvent.getDefaultInstance())
     assertThat(converted.event.typeUrl)
       .isEqualTo("type.googleapis.com/" + TestEvent.getDescriptor().fullName)
-  }
-
-  @Test
-  fun `convert sets eventTimeMicros equal to the labeler input timestamp`() {
-    val converter = ParquetImpressionConverter(eventDescriptor)
-    val row =
-      mapOf(
-        "eid" to parquetValue { stringValue = "event-1" },
-        "ts" to parquetValue { int64Value = 1_700_000_000_000_000L },
-        "cr_col" to parquetValue { stringValue = "c-1" },
-      )
-
-    val converted = converter.convert(digestedEvent(row), config)!!
-
-    assertThat(converted.eventTimeMicros).isEqualTo(1_700_000_000_000_000L)
-    // Always exactly Timestamps.toMicros(eventTime) — what the sink previously recomputed per row.
-    assertThat(converted.eventTimeMicros).isEqualTo(Timestamps.toMicros(converted.eventTime))
   }
 
   @Test

--- a/src/test/kotlin/org/wfanet/measurement/edpaggregator/vidlabeler/VidLabelingSinkTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/edpaggregator/vidlabeler/VidLabelingSinkTest.kt
@@ -262,7 +262,10 @@ class VidLabelingSinkTest {
       // sharing the same impression time.
       assertThat(impressions).hasSize(3)
       assertThat(impressions.map { it.vid }).containsExactly(101L, 102L, 103L)
-      assertThat(impressions.map { it.eventTime }.toSet()).hasSize(1)
+      // The output event_time is derived from labelerInput.timestamp_usec via
+      // Timestamps.fromMicros.
+      assertThat(impressions.map { it.eventTime }.toSet())
+        .containsExactly(Timestamps.fromMicros(1_500L))
     }
 
   @Test
@@ -292,8 +295,10 @@ class VidLabelingSinkTest {
           converter =
             ImpressionConverter { event, _ ->
               ConvertedImpression(
-                labelerInput = LabelerInput.getDefaultInstance(),
-                eventTime = Timestamps.fromMicros(event.row.getValue(EVENT_TIME_COLUMN).int64Value),
+                labelerInput =
+                  LabelerInput.newBuilder()
+                    .setTimestampUsec(event.row.getValue(EVENT_TIME_COLUMN).int64Value)
+                    .build(),
                 event = Any.getDefaultInstance(),
                 entityKeys = emptyList(),
               )
@@ -464,8 +469,10 @@ class VidLabelingSinkTest {
       config: VidLabelerParams.ModelLineConfig,
     ): ConvertedImpression =
       ConvertedImpression(
-        labelerInput = LabelerInput.getDefaultInstance(),
-        eventTime = Timestamps.fromMicros(event.row.getValue(EVENT_TIME_COLUMN).int64Value),
+        labelerInput =
+          LabelerInput.newBuilder()
+            .setTimestampUsec(event.row.getValue(EVENT_TIME_COLUMN).int64Value)
+            .build(),
         event = Any.getDefaultInstance(),
         entityKeys =
           listOf(

--- a/src/test/kotlin/org/wfanet/measurement/edpaggregator/vidrankbuilder/RankAllocatorTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/edpaggregator/vidrankbuilder/RankAllocatorTest.kt
@@ -346,6 +346,51 @@ class RankAllocatorTest {
       .isEqualTo(Pair(Bytes12IntMap.MIN_CAPACITY, Bytes12IntMap.MIN_CAPACITY))
   }
 
+  @Test
+  fun `cumulativeCapacity pre-sizes the cumulative map independently (prior greater than today)`() {
+    // A warm/backfill caller sizes the cumulative to prior+today (>> today) while day-only stays at
+    // today's size; the two maps size independently.
+    val allocator =
+      RankAllocator(
+        poolOffset = 7L,
+        rankedSize = 100,
+        eventDay = EVENT_DAY,
+        initialCapacity = 100,
+        cumulativeCapacity = 10_000,
+      )
+    // 10_000 -> next power of two (16_384) for the cumulative; 100 -> 128 for day-only.
+    assertThat(allocator.mapCapacities()).isEqualTo(Pair(16_384L, 128L))
+  }
+
+  @Test
+  fun `pre-sizing and a small estimatedTotalRanks do not change loaded ranks (taken auto-grows)`() =
+    runBlocking<Unit> {
+      // A deliberately tiny estimatedTotalRanks (3) under-sizes the taken BitSet; it must auto-grow
+      // and produce identical ranks. Ranks 5 and 9 are taken, so a fresh assign takes rank 0.
+      val record =
+        buildRecord(
+          7L,
+          100,
+          entries = listOf(Entry(10L, 0, rank = 5, day = 30), Entry(20L, 0, rank = 9, day = 40)),
+        )
+      val allocator =
+        RankAllocator(
+          poolOffset = 7L,
+          rankedSize = 100,
+          eventDay = EVENT_DAY,
+          initialCapacity = 2,
+          cumulativeCapacity = 10_000,
+          estimatedTotalRanks = 3,
+        )
+
+      allocator.loadFrom(listOf(record).asFlow())
+
+      assertThat(allocator.get(10L, 0)).isEqualTo(5)
+      assertThat(allocator.get(20L, 0)).isEqualTo(9)
+      assertThat(allocator.lastSeenOf(9)).isEqualTo(40)
+      assertThat(allocator.assign(30L, 0)).isEqualTo(0)
+    }
+
   private data class Entry(val hi: Long, val lo: Int, val rank: Int, val day: Int)
 
   private fun packFingerprint(hi: Long, lo: Int): com.google.protobuf.ByteString {


### PR DESCRIPTION
## Benefit
  Stops the pipeline generating short-lived garbage for every one of billions of
  events, which **drops Phase-2 peak memory ~24% (heap ~99→84 GB, RSS ~141→106
  GB)**. That headroom is what lets the 4B run fit in the machine instead of
  OOMing, and the reduced GC churn shaves hot-path time. Output is unchanged.
  
  ## What
  - `MemoizedRankIndex` becomes parallel arrays (`LongArray` + `Array`, no boxed
    `Map<Long, …>`), and `appendRankAssignments` writes matches straight onto the
    `LabelerInput.Builder` (no intermediate list / per-match message).
  - Pool-emit path takes a primitive offset callback (`emit(input, onPoolOffset)`)
    instead of returning a per-event `List<Long>`; the subpool accumulator holds a
    primitive snapshot.
  - Mappers/converters resolve fixed enum/field descriptors once at construction,
    cache the event `type_url`, and tally metrics per batch instead of per event.
    
  ## Why it's safe
  Same labeled output — verified `appendRankAssignments` is equivalent to the
  prior lookup-and-build (the consumer filters by `pool_offset`, so record order
  is irrelevant).
  
  ## Tests
  `MemoizedRankIndexTest`, `SubpoolAssignmentSinkTest`,
  `VirtualPeoplePoolEmitLabelerTest`, `ParquetImpressionConverterTest`,
  `LabelerInputMapperTest` updated/green.

Issue: #4233 