### PR TITLE
perf(edpaggregator): cache the built index across WorkItems and skip …

### DIFF
--- a/src/main/k8s/testing/secretfiles/BUILD.bazel
+++ b/src/main/k8s/testing/secretfiles/BUILD.bazel
@@ -247,8 +247,6 @@ SECRET_FILES = [
     "edp7_enc_public.tink",
     "edp7_tls.key",
     "edp7_tls.pem",
-    "data_availability_tls.key",
-    "data_availability_tls.pem",
     "mp1_tls.pem",
     "mp1_tls.key",
     "mp1_cs_cert.der",

--- a/src/main/k8s/testing/secretfiles/BUILD.bazel
+++ b/src/main/k8s/testing/secretfiles/BUILD.bazel
@@ -247,6 +247,8 @@ SECRET_FILES = [
     "edp7_enc_public.tink",
     "edp7_tls.key",
     "edp7_tls.pem",
+    "data_availability_tls.key",
+    "data_availability_tls.pem",
     "mp1_tls.pem",
     "mp1_tls.key",
     "mp1_cs_cert.der",

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/rawimpressions/DigestedEvent.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/rawimpressions/DigestedEvent.kt
@@ -27,6 +27,7 @@ package org.wfanet.measurement.edpaggregator.rawimpressions
  * `LabelerInput` proto) via the `labeler_input_field_mapping`.
  *
  * @property row the decoded row.
- * @property digest the event-id [EventIdDigest]; distinct from the labeler's `acting_fingerprint`.
+ * @property digest the event-id [EventIdDigest], or null when it was not computed (the non-memoized
+ *   single-shard path skips the SHA-256); distinct from the labeler's `acting_fingerprint`.
  */
-data class DigestedEvent<R>(val row: R, val digest: EventIdDigest)
+data class DigestedEvent<R>(val row: R, val digest: EventIdDigest?)

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/rawimpressions/DigestedEvent.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/rawimpressions/DigestedEvent.kt
@@ -17,8 +17,8 @@
 package org.wfanet.measurement.edpaggregator.rawimpressions
 
 /**
- * One surviving raw impression event after shard-filtering, with its 12-byte [EventIdDigest]
- * pre-computed.
+ * A raw impression event that survived shard-filtering, tagged by whether its event-id
+ * [EventIdDigest] was computed.
  *
  * [row] is the reader's representation of the decoded row; the type parameter [R] keeps this
  * reusable across readers. For the parquet reader ([RawImpressionSource]) `R` is `Map<String,
@@ -27,7 +27,23 @@ package org.wfanet.measurement.edpaggregator.rawimpressions
  * `LabelerInput` proto) via the `labeler_input_field_mapping`.
  *
  * @property row the decoded row.
- * @property digest the event-id [EventIdDigest], or null when it was not computed (the non-memoized
- *   single-shard path skips the SHA-256); distinct from the labeler's `acting_fingerprint`.
  */
-data class DigestedEvent<R>(val row: R, val digest: EventIdDigest?)
+sealed interface RawEvent<R> {
+  val row: R
+}
+
+/**
+ * A [RawEvent] whose event-id [EventIdDigest] was computed. Memoized paths (Phase-0 subpool
+ * assignment and memoized Phase-2 labeling) require this variant, so the digest is non-null and the
+ * compiler proves it is present at those call sites.
+ *
+ * @property digest the event-id [EventIdDigest]; distinct from the labeler's `acting_fingerprint`.
+ */
+data class DigestedEvent<R>(override val row: R, val digest: EventIdDigest) : RawEvent<R>
+
+/**
+ * A [RawEvent] emitted without a digest: the non-memoized single-shard Phase-2 path skips the
+ * per-row SHA-256. Memoized consumers do not accept this variant, so routing one to a digest-keyed
+ * consumer is a compile error rather than a runtime NPE.
+ */
+data class UndigestedEvent<R>(override val row: R) : RawEvent<R>

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/rawimpressions/RawImpressionSource.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/rawimpressions/RawImpressionSource.kt
@@ -44,7 +44,11 @@ import org.wfanet.measurement.storage.ParquetValue
  * A shard-surviving parquet row + its event-id digest, delivered to a
  * [RawImpressionSource.BlobSink].
  */
+typealias ParquetRawEvent = RawEvent<Map<String, ParquetValue>>
+
 typealias ParquetDigestedEvent = DigestedEvent<Map<String, ParquetValue>>
+
+typealias ParquetUndigestedEvent = UndigestedEvent<Map<String, ParquetValue>>
 
 /**
  * Reads the local VM's shard of raw impressions for one upload in parallel and hands shard-filtered
@@ -144,7 +148,7 @@ typealias ParquetDigestedEvent = DigestedEvent<Map<String, ParquetValue>>
  *   (BINARY+STRING) or raw `BINARY` column; both are accepted. Downstream reads any other columns
  *   it needs (e.g. event time for per-model-line windowing) from [DigestedEvent.row].
  */
-class RawImpressionSource(
+class RawImpressionSource<E : ParquetRawEvent>(
   private val parquetStorageClient: ParquetStorageClient,
   private val rawImpressionUploadFilesStub: RawImpressionUploadFileServiceCoroutineStub,
   private val rawImpressionUpload: String,
@@ -183,6 +187,11 @@ class RawImpressionSource(
   // (Phase-0 subpool assignment and memoized Phase-2, which key on the digest). When [totalShards]
   // > 1 the digest is always computed regardless, since the shard filter needs it.
   private val needsDigest: Boolean = true,
+  // Builds the reader's event type from a decoded row and the (nullable) computed digest.
+  // Digested readers pass `{ row, digest -> DigestedEvent(row, checkNotNull(digest)) }`; the
+  // non-memoized single-shard reader passes `{ row, _ -> UndigestedEvent(row) }`. Concentrating
+  // the digest-presence check here lets the digested consumers get a compile-time-non-null digest.
+  private val toEvent: (Map<String, ParquetValue>, EventIdDigest?) -> E,
 ) {
   init {
     require(totalShards > 0) { "totalShards must be positive, got $totalShards" }
@@ -225,9 +234,9 @@ class RawImpressionSource(
    *   `Bytes12IntMap`); `commit`/`close` are no-ops and the whole map is uploaded once after
    *   [streamBlobs] returns.
    */
-  interface BlobSink {
+  interface BlobSink<E : ParquetRawEvent> {
     /** Processes one shard-filtered batch for this blob. Called concurrently. */
-    suspend fun processBatch(events: List<ParquetDigestedEvent>)
+    suspend fun processBatch(events: List<E>)
 
     /**
      * Finalizes + publishes this blob's output (Phase 2 upload; Phase 0 no-op). Called exactly
@@ -290,7 +299,7 @@ class RawImpressionSource(
   }
 
   suspend fun streamBlobs(
-    openSink: suspend (blobUri: String, footerMetadata: Map<String, String>) -> BlobSink
+    openSink: suspend (blobUri: String, footerMetadata: Map<String, String>) -> BlobSink<E>
   ) {
     val blobUris = discoverBlobUris()
     logger.info(
@@ -322,7 +331,7 @@ class RawImpressionSource(
    */
   private suspend fun processBlob(
     blobUri: String,
-    openSink: suspend (blobUri: String, footerMetadata: Map<String, String>) -> BlobSink,
+    openSink: suspend (blobUri: String, footerMetadata: Map<String, String>) -> BlobSink<E>,
     cpuDispatcher: CoroutineDispatcher,
     inFlight: Semaphore,
     progress: ProgressTracker,
@@ -396,12 +405,12 @@ class RawImpressionSource(
   private suspend fun readEventsFromBlob(
     blobUri: String,
     parquetBlob: ParquetStorageClient.ParquetBlob,
-    onBatch: suspend (List<ParquetDigestedEvent>) -> Unit,
+    onBatch: suspend (List<E>) -> Unit,
   ): FileCounts {
     var read = 0L
     var droppedOtherShard = 0L
     var emitted = 0L
-    var batch = ArrayList<ParquetDigestedEvent>(batchSize)
+    var batch = ArrayList<E>(batchSize)
     // Compute the digest only when a consumer needs it or the shard filter does (totalShards > 1).
     // On the non-memoized single-shard path both are false, so the SHA-256 per row is skipped and
     // the (never-read) digest is null; the shard filter is also skipped (it is a no-op at
@@ -415,12 +424,12 @@ class RawImpressionSource(
         } else {
           null
         }
-      if (computeDigest && !belongsToShard(digest!!)) {
+      if (digest != null && !belongsToShard(digest)) {
         droppedOtherShard++
         return@collect
       }
       emitted++
-      batch.add(DigestedEvent(row, digest))
+      batch.add(toEvent(row, digest))
       if (batch.size >= batchSize) {
         onBatch(batch)
         batch = ArrayList(batchSize)
@@ -565,6 +574,7 @@ class RawImpressionSource(
     private const val LIST_PAGE_SIZE = 1000
 
     /** Max concurrent `GetRawImpressionUploadFile` lookups when resolving a file list. */
-    private const val FILE_RESOLVE_CONCURRENCY = 8
+    private val FILE_RESOLVE_CONCURRENCY =
+      (System.getenv("FILE_RESOLVE_CONCURRENCY")?.toIntOrNull() ?: 8).coerceAtLeast(1)
   }
 }

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/rawimpressions/RawImpressionSource.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/rawimpressions/RawImpressionSource.kt
@@ -24,6 +24,8 @@ import kotlin.time.TimeSource
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.launch
@@ -173,6 +175,14 @@ class RawImpressionSource(
   // fingerprint-shard filter and NO whole-upload discovery. When null (Phase 0), discover all
   // of [rawImpressionUpload]'s files and apply the shard filter.
   private val inputFiles: List<String>? = null,
+  // Whether the event-id [EventIdDigest] is needed downstream. When false AND [totalShards] == 1
+  // (no shard filter to apply either), the per-row SHA-256 digest is skipped and a null digest
+  // is delivered — used by the non-memoized single-shard Phase-2 path, whose consumer never reads
+  // the digest. A null (rather than a placeholder value) makes any accidental future read fail fast
+  // instead of silently colliding. Defaults to true (compute), matching all prior callers
+  // (Phase-0 subpool assignment and memoized Phase-2, which key on the digest). When [totalShards]
+  // > 1 the digest is always computed regardless, since the shard filter needs it.
+  private val needsDigest: Boolean = true,
 ) {
   init {
     require(totalShards > 0) { "totalShards must be positive, got $totalShards" }
@@ -392,10 +402,20 @@ class RawImpressionSource(
     var droppedOtherShard = 0L
     var emitted = 0L
     var batch = ArrayList<ParquetDigestedEvent>(batchSize)
+    // Compute the digest only when a consumer needs it or the shard filter does (totalShards > 1).
+    // On the non-memoized single-shard path both are false, so the SHA-256 per row is skipped and
+    // the (never-read) digest is null; the shard filter is also skipped (it is a no-op at
+    // totalShards == 1, where belongsToShard is always true).
+    val computeDigest = needsDigest || totalShards > 1
     parquetBlob.readRows().collect { row ->
       read++
-      val digest = eventIdDigestExtractor.extract(readEventIdBytes(row, blobUri))
-      if (!belongsToShard(digest)) {
+      val digest =
+        if (computeDigest) {
+          eventIdDigestExtractor.extract(readEventIdBytes(row, blobUri))
+        } else {
+          null
+        }
+      if (computeDigest && !belongsToShard(digest!!)) {
         droppedOtherShard++
         return@collect
       }
@@ -422,14 +442,29 @@ class RawImpressionSource(
    */
   private suspend fun discoverBlobUris(): List<String> {
     if (inputFiles != null) {
-      return inputFiles.map { fileName ->
-        try {
-          rawImpressionUploadFilesStub
-            .getRawImpressionUploadFile(getRawImpressionUploadFileRequest { name = fileName })
-            .blobUri
-        } catch (e: StatusException) {
-          throw Exception("Error getting RawImpressionUploadFile $fileName", e)
-        }
+      // Resolve the file-list -> blob_uri lookups with bounded concurrency, collecting BY INDEX
+      // (awaitAll) so the resolved order is identical to the serial order. This is a separate,
+      // ephemeral scope that completes before any row-processing worker starts, so it never shares
+      // the CPU worker pool.
+      val resolveSemaphore = Semaphore(FILE_RESOLVE_CONCURRENCY)
+      return coroutineScope {
+        inputFiles
+          .map { fileName ->
+            async(readDispatcher) {
+              resolveSemaphore.withPermit {
+                try {
+                  rawImpressionUploadFilesStub
+                    .getRawImpressionUploadFile(
+                      getRawImpressionUploadFileRequest { name = fileName }
+                    )
+                    .blobUri
+                } catch (e: StatusException) {
+                  throw Exception("Error getting RawImpressionUploadFile $fileName", e)
+                }
+              }
+            }
+          }
+          .awaitAll()
       }
     }
     val blobUris = mutableListOf<String>()
@@ -528,5 +563,8 @@ class RawImpressionSource(
 
     /** Page size for listing the upload's files. */
     private const val LIST_PAGE_SIZE = 1000
+
+    /** Max concurrent `GetRawImpressionUploadFile` lookups when resolving a file list. */
+    private const val FILE_RESOLVE_CONCURRENCY = 8
   }
 }

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/subpoolassigner/SubpoolAssigner.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/subpoolassigner/SubpoolAssigner.kt
@@ -36,6 +36,7 @@ import org.wfanet.measurement.common.api.grpc.ResourceList
 import org.wfanet.measurement.common.api.grpc.listResources
 import org.wfanet.measurement.common.pack
 import org.wfanet.measurement.edpaggregator.rawimpressions.LabelerInputMapper
+import org.wfanet.measurement.edpaggregator.rawimpressions.ParquetDigestedEvent
 import org.wfanet.measurement.edpaggregator.rawimpressions.RawImpressionSource
 import org.wfanet.measurement.edpaggregator.rawimpressions.SubpoolFingerprintsStore
 import org.wfanet.measurement.edpaggregator.v1alpha.EncryptedDek
@@ -88,7 +89,7 @@ import org.wfanet.measurement.securecomputation.controlplane.v1alpha.workItem
  * terminal `FAILED` transition is owned by the DLQ listener on retry exhaustion.
  */
 class SubpoolAssigner(
-  private val rawImpressionSource: RawImpressionSource,
+  private val rawImpressionSource: RawImpressionSource<ParquetDigestedEvent>,
   private val mapper: LabelerInputMapper,
   private val labeler: PoolEmitLabeler,
   private val activeWindow: ActiveWindow,

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/subpoolassigner/SubpoolAssignerApp.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/subpoolassigner/SubpoolAssignerApp.kt
@@ -22,8 +22,10 @@ import com.google.protobuf.Parser
 import java.time.Instant
 import org.jetbrains.annotations.VisibleForTesting
 import org.wfanet.measurement.edpaggregator.StorageConfig
+import org.wfanet.measurement.edpaggregator.rawimpressions.DigestedEvent
 import org.wfanet.measurement.edpaggregator.rawimpressions.EventIdDigestExtractor
 import org.wfanet.measurement.edpaggregator.rawimpressions.LabelerInputMapper
+import org.wfanet.measurement.edpaggregator.rawimpressions.ParquetDigestedEvent
 import org.wfanet.measurement.edpaggregator.rawimpressions.RawImpressionSource
 import org.wfanet.measurement.edpaggregator.rawimpressions.SubpoolFingerprintsStore
 import org.wfanet.measurement.edpaggregator.v1alpha.LabelerInputFieldMapping
@@ -156,7 +158,7 @@ class SubpoolAssignerApp(
     val eventIdColumn = eventIdMapping.scalar.column
 
     val rawImpressionSource =
-      RawImpressionSource(
+      RawImpressionSource<ParquetDigestedEvent>(
         parquetStorageClient =
           buildParquetStorageClient(
             getRawImpressionsStorageConfig(params.rawImpressionStorageParams),
@@ -168,6 +170,7 @@ class SubpoolAssignerApp(
         shardIndex = params.shardIndex,
         totalShards = params.totalShards,
         eventIdDigestExtractor = eventIdDigestExtractor,
+        toEvent = { row, digest -> DigestedEvent(row, checkNotNull(digest)) },
       )
 
     val mapper = LabelerInputMapper(params.labelerInputFieldMappingList)

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/subpoolassigner/SubpoolAssignmentSink.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/subpoolassigner/SubpoolAssignmentSink.kt
@@ -47,7 +47,7 @@ class SubpoolAssignmentSink(
   private val accumulator: SubpoolFingerprintsAccumulator,
   private val activeWindow: ActiveWindow,
   private val metrics: SubpoolAssignerMetrics = SubpoolAssignerMetrics(),
-) : RawImpressionSource.BlobSink {
+) : RawImpressionSource.BlobSink<ParquetDigestedEvent> {
   private val labeledCounter = AtomicLong()
   private val droppedOutsideWindowCounter = AtomicLong()
   private val unroutedCounter = AtomicLong()
@@ -94,7 +94,7 @@ class SubpoolAssignmentSink(
       // return count says whether the event routed anywhere.
       val routed =
         labeler.emit(input) { offset ->
-          accumulator.add(offset, event.digest!!.high, event.digest!!.low)
+          accumulator.add(offset, event.digest.high, event.digest.low)
         }
       if (routed == 0) {
         // Per-event logging is intentionally avoided on this hot path (potentially billions of

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/subpoolassigner/SubpoolAssignmentSink.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/subpoolassigner/SubpoolAssignmentSink.kt
@@ -94,7 +94,7 @@ class SubpoolAssignmentSink(
       // return count says whether the event routed anywhere.
       val routed =
         labeler.emit(input) { offset ->
-          accumulator.add(offset, event.digest.high, event.digest.low)
+          accumulator.add(offset, event.digest!!.high, event.digest!!.low)
         }
       if (routed == 0) {
         // Per-event logging is intentionally avoided on this hot path (potentially billions of

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/vidlabeler/BUILD.bazel
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/vidlabeler/BUILD.bazel
@@ -26,6 +26,7 @@ kt_jvm_library(
     name = "memoized_rank_index",
     srcs = [
         "MemoizedRankIndex.kt",
+        "MemoizedRankIndexCache.kt",
         "MemoizedRankIndexMetrics.kt",
     ],
     deps = [

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/vidlabeler/ImpressionConverter.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/vidlabeler/ImpressionConverter.kt
@@ -16,7 +16,7 @@
 
 package org.wfanet.measurement.edpaggregator.vidlabeler
 
-import org.wfanet.measurement.edpaggregator.rawimpressions.ParquetDigestedEvent
+import org.wfanet.measurement.edpaggregator.rawimpressions.ParquetRawEvent
 import org.wfanet.measurement.edpaggregator.rawimpressions.RawImpressionFileMetadata
 import org.wfanet.measurement.edpaggregator.v1alpha.VidLabelerParams
 import org.wfanet.virtualpeople.common.LabelerInput
@@ -26,8 +26,8 @@ import org.wfanet.virtualpeople.common.LabelerInput
  * one model line.
  *
  * This is the seam between the raw-impression reader (which hands out rows keyed by **Parquet
- * column name** — see [ParquetDigestedEvent]) and the VirtualPeople [LabelerInput]. The conversion
- * is model-line-specific because the column→field mapping lives in
+ * column name** — see [ParquetRawEvent]) and the VirtualPeople [LabelerInput]. The conversion is
+ * model-line-specific because the column→field mapping lives in
  * [VidLabelerParams.ModelLineConfig.getLabelerInputFieldMappingList].
  *
  * It is injected (rather than implemented inline) so the labeling pipeline can be built and tested
@@ -45,7 +45,7 @@ fun interface ImpressionConverter {
    * @return the [ConvertedImpression], or `null` to skip this row for this model line.
    */
   fun convert(
-    event: ParquetDigestedEvent,
+    event: ParquetRawEvent,
     config: VidLabelerParams.ModelLineConfig,
   ): ConvertedImpression?
 }

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/vidlabeler/MemoizedRankIndexCache.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/vidlabeler/MemoizedRankIndexCache.kt
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2026 The Cross-Media Measurement Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wfanet.measurement.edpaggregator.vidlabeler
+
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+
+/**
+ * Process-scoped, size-1 cache of the most recently built [MemoizedRankIndex], keyed by its content
+ * identity ([MemoizedRankIndex.Key] — `(dataProvider, modelLine)` + the sorted chosen SNAPSHOT blob
+ * URIs).
+ *
+ * The memoized Phase-2 index for a large model line can be tens of GB, and building it dominates a
+ * WorkItem's wall-clock. Consecutive WorkItems for the same `(dataProvider, modelLine)` almost
+ * always resolve to the SAME chosen blobs (Phase-1 has not produced a new snapshot between them),
+ * so rebuilding the identical index each time is pure waste. The caller runs the cheap listing
+ * ([MemoizedRankIndex.resolveLatestBlobs]) on EVERY WorkItem — so a new Phase-1 snapshot is always
+ * detected — and only the expensive download+decode is skipped on a [Key] match.
+ *
+ * Reuse is behavior-preserving: a [MemoizedRankIndex] is immutable after construction, its lookups
+ * are a pure function of the chosen blobs, and `RankIndexBlob` URIs are per-write-unique over
+ * immutable content — so an equal [Key] would build a byte-identical index. A changed snapshot set
+ * yields a different [Key] and a rebuild.
+ *
+ * **Memory.** The cache holds exactly one index. On a miss it drops the old reference BEFORE
+ * building the new one, so the old (~tens of GB) index is GC-reclaimable while the new one is built
+ * and the peak stays a single index, not two.
+ *
+ * **Concurrency.** A [Mutex] serializes [getOrBuild], including across the (suspending) build: at
+ * most one index is built at a time, and concurrent callers for the same key wait and then observe
+ * the freshly cached index rather than each building their own (which would transiently hold two
+ * multi-GB indexes). This is the intended trade-off — the labeler is memory-bound on the index, so
+ * serializing its (re)build is preferable to duplicating it.
+ *
+ * One instance per process (wired at `VidLabelerAppRunner`, shared by every WorkItem), NOT one per
+ * WorkItem.
+ */
+class MemoizedRankIndexCache {
+  private val mutex = Mutex()
+  private var cachedKey: MemoizedRankIndex.Key? = null
+  private var cachedIndex: MemoizedRankIndex? = null
+
+  /**
+   * Returns the cached [MemoizedRankIndex] when it was built for [key], otherwise builds it via
+   * [build] (dropping any previously cached index first so peak memory stays one index) and caches
+   * it. Serialized across concurrent callers.
+   */
+  suspend fun getOrBuild(
+    key: MemoizedRankIndex.Key,
+    build: suspend () -> MemoizedRankIndex,
+  ): MemoizedRankIndex =
+    mutex.withLock {
+      val existing = cachedIndex
+      if (existing != null && cachedKey == key) {
+        return@withLock existing
+      }
+      // Miss: release the old index reference BEFORE building the new one so it can be reclaimed
+      // during the build and the peak stays a single index.
+      cachedIndex = null
+      cachedKey = null
+      val built = build()
+      cachedIndex = built
+      cachedKey = key
+      built
+    }
+}

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/vidlabeler/MemoizedRankIndexCache.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/vidlabeler/MemoizedRankIndexCache.kt
@@ -46,6 +46,13 @@ import kotlinx.coroutines.sync.withLock
  * multi-GB indexes). This is the intended trade-off — the labeler is memory-bound on the index, so
  * serializing its (re)build is preferable to duplicating it.
  *
+ * **Cross-key serialization.** Callers with DIFFERENT keys also serialize on the mutex — the second
+ * waits for the first's build to complete, then evicts it and rebuilds. Two concurrent WorkItems
+ * for two different (dataProvider, modelLine) pairs on the same VM therefore run their builds
+ * sequentially, not in parallel. Intentional: two multi-GB indexes in heap simultaneously would OOM
+ * the VM. (In practice the TEE app leases one WorkItem at a time, so this contention does not arise
+ * in production.)
+ *
  * One instance per process (wired at `VidLabelerAppRunner`, shared by every WorkItem), NOT one per
  * WorkItem.
  */

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/vidlabeler/MemoizedRankIndexCache.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/vidlabeler/MemoizedRankIndexCache.kt
@@ -71,12 +71,14 @@ class MemoizedRankIndexCache {
     build: suspend () -> MemoizedRankIndex,
   ): MemoizedRankIndex =
     mutex.withLock {
-      val existing = cachedIndex
-      if (existing != null && cachedKey == key) {
-        return@withLock existing
+      if (cachedKey == key) {
+        val cached = cachedIndex
+        if (cached != null) return@withLock cached
       }
-      // Miss: release the old index reference BEFORE building the new one so it can be reclaimed
-      // during the build and the peak stays a single index.
+      // Miss: drop the old index — the field AND any local — BEFORE building the new one so it can
+      // be reclaimed during the build and the peak stays a single index. Binding the old index to a
+      // local that outlives build() would pin it in heap and defeat that (two multi-GB indexes at
+      // once).
       cachedIndex = null
       cachedKey = null
       val built = build()

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/vidlabeler/ParquetImpressionConverter.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/vidlabeler/ParquetImpressionConverter.kt
@@ -20,7 +20,7 @@ import com.google.protobuf.Any
 import com.google.protobuf.Descriptors
 import java.util.concurrent.ConcurrentHashMap
 import org.wfanet.measurement.edpaggregator.rawimpressions.LabelerInputMapper
-import org.wfanet.measurement.edpaggregator.rawimpressions.ParquetDigestedEvent
+import org.wfanet.measurement.edpaggregator.rawimpressions.ParquetRawEvent
 import org.wfanet.measurement.edpaggregator.v1alpha.VidLabelerParams
 
 /**
@@ -67,7 +67,7 @@ class ParquetImpressionConverter(private val eventDescriptor: Descriptors.Descri
     }
 
   override fun convert(
-    event: ParquetDigestedEvent,
+    event: ParquetRawEvent,
     config: VidLabelerParams.ModelLineConfig,
   ): ConvertedImpression? {
     val mappers = mappersFor(config)

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/vidlabeler/VidLabeler.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/vidlabeler/VidLabeler.kt
@@ -23,6 +23,7 @@ import java.util.logging.Logger
 import kotlinx.coroutines.sync.Semaphore
 import org.wfanet.measurement.edpaggregator.StorageConfig
 import org.wfanet.measurement.edpaggregator.rawimpressions.ParquetRawEvent
+import org.wfanet.measurement.edpaggregator.rawimpressions.RawImpressionFileMetadata
 import org.wfanet.measurement.edpaggregator.rawimpressions.RawImpressionSource
 import org.wfanet.measurement.edpaggregator.v1alpha.VidLabelerParams
 import org.wfanet.measurement.edpaggregator.vidlabeler.utils.ActiveWindow
@@ -52,8 +53,8 @@ import org.wfanet.measurement.edpaggregator.vidlabeler.utils.ActiveWindow
  * @param outputStorageParams GCS project + blob prefix for labeled output.
  * @param storageConfig storage configuration built from [outputStorageParams].
  */
-class VidLabeler(
-  private val rawImpressionSource: RawImpressionSource<ParquetRawEvent>,
+class VidLabeler<E : ParquetRawEvent>(
+  private val rawImpressionSource: RawImpressionSource<E>,
   private val modelLineSpecs: List<ModelLineSpec>,
   private val overrideModelLines: List<String>,
   private val vidModelLoader: VidModelLoader,
@@ -64,6 +65,9 @@ class VidLabeler(
   private val storageConfig: StorageConfig,
   private val dataProvider: String,
   private val metrics: VidLabelerMetrics = VidLabelerMetrics(),
+  // Builds the per-file sink for this VM's event type: ::MemoizedVidLabelingSink (memoized)
+  // or ::PlainVidLabelingSink (hash-only). Chosen by the app; keeps this driver generic.
+  private val newSink: VidLabelingSinkFactory<E>,
 ) {
 
   // TODO(world-federation-of-advertisers/cross-media-measurement#4010): Add vid_labeling_job,
@@ -98,7 +102,7 @@ class VidLabeler(
     // output DEKs against the same KEK, so this caps concurrent KMS key setup across the
     // WorkItem's whole group fan-out (nModelLines x nFiles) and keeps the shared KEK under Cloud
     // KMS rate limits.
-    val encryptionKeySemaphore = Semaphore(VidLabelingSink.DEFAULT_ENCRYPTION_KEY_PARALLELISM)
+    val encryptionKeySemaphore = Semaphore(BaseVidLabelingSink.DEFAULT_ENCRYPTION_KEY_PARALLELISM)
 
     // Distinct event dates seen across this WorkItem's files, read from their footers as they
     // stream. streamBlobs reads files in parallel, so this must be a concurrent set.
@@ -113,18 +117,18 @@ class VidLabeler(
       // dedicated columns by the converter (EntityKeyMapper).
       val fileMetadata = RawImpressionFileMetadata.fromFooterMetadata(footerMetadata)
       observedEventDates.add(fileMetadata.eventDate)
-      VidLabelingSink(
-        inputBlobUri = blobUri,
-        modelLineContexts = contexts,
-        impressionConverter = impressionConverter,
-        fileMetadata = fileMetadata,
-        encryptKmsClient = encryptKmsClient,
-        encryptKekUri = encryptKekUri,
-        outputStorageParams = outputStorageParams,
-        storageConfig = storageConfig,
-        dataProvider = dataProvider,
-        metrics = metrics,
-        encryptionKeySemaphore = encryptionKeySemaphore,
+      newSink(
+        blobUri,
+        contexts,
+        impressionConverter,
+        fileMetadata,
+        encryptKmsClient,
+        encryptKekUri,
+        outputStorageParams,
+        storageConfig,
+        dataProvider,
+        metrics,
+        encryptionKeySemaphore,
       )
     }
     // TODO(world-federation-of-advertisers/cross-media-measurement#4010): Call

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/vidlabeler/VidLabeler.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/vidlabeler/VidLabeler.kt
@@ -22,7 +22,7 @@ import java.util.concurrent.ConcurrentHashMap
 import java.util.logging.Logger
 import kotlinx.coroutines.sync.Semaphore
 import org.wfanet.measurement.edpaggregator.StorageConfig
-import org.wfanet.measurement.edpaggregator.rawimpressions.RawImpressionFileMetadata
+import org.wfanet.measurement.edpaggregator.rawimpressions.ParquetRawEvent
 import org.wfanet.measurement.edpaggregator.rawimpressions.RawImpressionSource
 import org.wfanet.measurement.edpaggregator.v1alpha.VidLabelerParams
 import org.wfanet.measurement.edpaggregator.vidlabeler.utils.ActiveWindow
@@ -53,7 +53,7 @@ import org.wfanet.measurement.edpaggregator.vidlabeler.utils.ActiveWindow
  * @param storageConfig storage configuration built from [outputStorageParams].
  */
 class VidLabeler(
-  private val rawImpressionSource: RawImpressionSource,
+  private val rawImpressionSource: RawImpressionSource<ParquetRawEvent>,
   private val modelLineSpecs: List<ModelLineSpec>,
   private val overrideModelLines: List<String>,
   private val vidModelLoader: VidModelLoader,

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/vidlabeler/VidLabelerApp.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/vidlabeler/VidLabelerApp.kt
@@ -30,11 +30,14 @@ import org.wfanet.measurement.common.api.grpc.ResourceList
 import org.wfanet.measurement.common.api.grpc.listResources
 import org.wfanet.measurement.common.toInstant
 import org.wfanet.measurement.edpaggregator.StorageConfig
+import org.wfanet.measurement.edpaggregator.rawimpressions.DigestedEvent
 import org.wfanet.measurement.edpaggregator.rawimpressions.EventIdDigestExtractor
 import org.wfanet.measurement.edpaggregator.rawimpressions.LabelerInputMapper
+import org.wfanet.measurement.edpaggregator.rawimpressions.ParquetRawEvent
 import org.wfanet.measurement.edpaggregator.rawimpressions.RankIndexStore
 import org.wfanet.measurement.edpaggregator.rawimpressions.RawImpressionFileMetadata
 import org.wfanet.measurement.edpaggregator.rawimpressions.RawImpressionSource
+import org.wfanet.measurement.edpaggregator.rawimpressions.UndigestedEvent
 import org.wfanet.measurement.edpaggregator.service.VidLabelingJobKey
 import org.wfanet.measurement.edpaggregator.v1alpha.LabelerInputFieldMapping
 import org.wfanet.measurement.edpaggregator.v1alpha.RankIndexBlobServiceGrpcKt.RankIndexBlobServiceCoroutineStub
@@ -133,8 +136,11 @@ class VidLabelerApp(
   private val eventIdDigestExtractor: EventIdDigestExtractor = EventIdDigestExtractor(),
   // Process-scoped cache of the built memoized rank index, shared across WorkItems so consecutive
   // WorkItems for the same (dataProvider, modelLine) with an unchanged snapshot set reuse the index
-  // instead of rebuilding the (tens-of-GB) structure. Defaulted so the instance is process-scoped
-  // (one VidLabelerApp per process); the runner passes an explicit instance for clarity.
+  // instead of rebuilding the (tens-of-GB) structure. Defaults to a FRESH instance per constructor
+  // call, which gives tests isolated caches (no cross-test pollution). For production the runner
+  // passes an explicit process-scoped instance so the index is reused across WorkItems — DO NOT
+  // rely
+  // on the default to get that reuse; any second production path must pass the shared instance.
   private val memoizedRankIndexCache: MemoizedRankIndexCache = MemoizedRankIndexCache(),
   private val metrics: VidLabelerAppMetrics = VidLabelerAppMetrics(),
 ) :
@@ -342,7 +348,7 @@ class VidLabelerApp(
     // File-list mode: label exactly the RawImpressionUploadFiles carried on this WorkItem's
     // VidLabelingJob (the bin-packed batch), each read whole (no fingerprint-shard filter).
     val rawImpressionSource =
-      RawImpressionSource(
+      RawImpressionSource<ParquetRawEvent>(
         parquetStorageClient =
           buildParquetStorageClient(
             getStorageConfig(params.rawImpressionsStorageParams),
@@ -356,6 +362,7 @@ class VidLabelerApp(
         // The memoized path probes the rank index per impression by its event-id digest, so the
         // digest must be computed.
         needsDigest = true,
+        toEvent = { row, digest -> DigestedEvent(row, checkNotNull(digest)) },
       )
 
     // Schema-drift guard (#3993): fail fast if a mapped raw column is missing from the file schema
@@ -434,7 +441,7 @@ class VidLabelerApp(
     val eventIdColumn = resolveEventIdColumn(firstConfig)
 
     val rawImpressionSource =
-      RawImpressionSource(
+      RawImpressionSource<ParquetRawEvent>(
         parquetStorageClient =
           buildParquetStorageClient(
             getStorageConfig(params.rawImpressionsStorageParams),
@@ -448,6 +455,7 @@ class VidLabelerApp(
         // The non-memoized path has no rank index (rankIndex = null for every model line) and runs
         // single-shard (file-list mode), so no consumer reads the digest: skip the per-row SHA-256.
         needsDigest = false,
+        toEvent = { row, _ -> UndigestedEvent(row) },
       )
 
     require(params.hasModelStorageParams()) { "model_storage_params must be set" }

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/vidlabeler/VidLabelerApp.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/vidlabeler/VidLabelerApp.kt
@@ -131,6 +131,11 @@ class VidLabelerApp(
   private val buildImpressionConverter:
     suspend (modelLine: String, config: VidLabelerParams.ModelLineConfig) -> ImpressionConverter,
   private val eventIdDigestExtractor: EventIdDigestExtractor = EventIdDigestExtractor(),
+  // Process-scoped cache of the built memoized rank index, shared across WorkItems so consecutive
+  // WorkItems for the same (dataProvider, modelLine) with an unchanged snapshot set reuse the index
+  // instead of rebuilding the (tens-of-GB) structure. Defaulted so the instance is process-scoped
+  // (one VidLabelerApp per process); the runner passes an explicit instance for clarity.
+  private val memoizedRankIndexCache: MemoizedRankIndexCache = MemoizedRankIndexCache(),
   private val metrics: VidLabelerAppMetrics = VidLabelerAppMetrics(),
 ) :
   BaseTeeApplication(
@@ -320,8 +325,16 @@ class VidLabelerApp(
         buildVidRankMapStorageClient(getStorageConfig(mp.vidRankMapStorageParams)),
         kmsClient,
       )
+    // Resolve the current snapshot set every WorkItem (cheap listing); reuse the process-wide
+    // cached
+    // index when the exact same blobs would load, else build it (evicting the old one first). New
+    // Phase-1 output changes the chosen blob URIs -> a new cache key -> a rebuild.
+    val resolvedBlobs =
+      MemoizedRankIndex.resolveLatestBlobs(rankIndexBlobsStub, dataProvider, modelLine)
     val rankIndex =
-      MemoizedRankIndex.load(rankIndexBlobsStub, rankIndexStore, dataProvider, modelLine)
+      memoizedRankIndexCache.getOrBuild(resolvedBlobs.key) {
+        MemoizedRankIndex.buildFrom(rankIndexStore, dataProvider, modelLine, resolvedBlobs.blobs)
+      }
 
     // The raw event-id column is the raw-impression field mapped to LabelerInput's `event_id.id`.
     val eventIdColumn = resolveEventIdColumn(config)
@@ -340,6 +353,9 @@ class VidLabelerApp(
         eventIdColumn = eventIdColumn,
         eventIdDigestExtractor = eventIdDigestExtractor,
         inputFiles = inputFiles,
+        // The memoized path probes the rank index per impression by its event-id digest, so the
+        // digest must be computed.
+        needsDigest = true,
       )
 
     // Schema-drift guard (#3993): fail fast if a mapped raw column is missing from the file schema
@@ -429,6 +445,9 @@ class VidLabelerApp(
         eventIdColumn = eventIdColumn,
         eventIdDigestExtractor = eventIdDigestExtractor,
         inputFiles = inputFiles,
+        // The non-memoized path has no rank index (rankIndex = null for every model line) and runs
+        // single-shard (file-list mode), so no consumer reads the digest: skip the per-row SHA-256.
+        needsDigest = false,
       )
 
     require(params.hasModelStorageParams()) { "model_storage_params must be set" }

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/vidlabeler/VidLabelerApp.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/vidlabeler/VidLabelerApp.kt
@@ -33,7 +33,6 @@ import org.wfanet.measurement.edpaggregator.StorageConfig
 import org.wfanet.measurement.edpaggregator.rawimpressions.DigestedEvent
 import org.wfanet.measurement.edpaggregator.rawimpressions.EventIdDigestExtractor
 import org.wfanet.measurement.edpaggregator.rawimpressions.LabelerInputMapper
-import org.wfanet.measurement.edpaggregator.rawimpressions.ParquetRawEvent
 import org.wfanet.measurement.edpaggregator.rawimpressions.RankIndexStore
 import org.wfanet.measurement.edpaggregator.rawimpressions.RawImpressionFileMetadata
 import org.wfanet.measurement.edpaggregator.rawimpressions.RawImpressionSource
@@ -348,7 +347,7 @@ class VidLabelerApp(
     // File-list mode: label exactly the RawImpressionUploadFiles carried on this WorkItem's
     // VidLabelingJob (the bin-packed batch), each read whole (no fingerprint-shard filter).
     val rawImpressionSource =
-      RawImpressionSource<ParquetRawEvent>(
+      RawImpressionSource(
         parquetStorageClient =
           buildParquetStorageClient(
             getStorageConfig(params.rawImpressionsStorageParams),
@@ -406,6 +405,7 @@ class VidLabelerApp(
         // The labeled output is wrapped with the EDP's KEK, the same one the rank-index blobs were
         // written with; read it from the loaded RankIndexBlobs so there is no separate KEK field.
         encryptKekUri = rankIndex.kekUri,
+        newSink = ::MemoizedVidLabelingSink,
         outputStorageParams = params.vidLabeledImpressionsStorageParams,
         storageConfig = getStorageConfig(params.vidLabeledImpressionsStorageParams),
         dataProvider = dataProvider,
@@ -441,7 +441,7 @@ class VidLabelerApp(
     val eventIdColumn = resolveEventIdColumn(firstConfig)
 
     val rawImpressionSource =
-      RawImpressionSource<ParquetRawEvent>(
+      RawImpressionSource(
         parquetStorageClient =
           buildParquetStorageClient(
             getStorageConfig(params.rawImpressionsStorageParams),
@@ -508,6 +508,7 @@ class VidLabelerApp(
         impressionConverter = impressionConverter,
         encryptKmsClient = kmsClient,
         encryptKekUri = encryptKekUri,
+        newSink = ::PlainVidLabelingSink,
         outputStorageParams = params.vidLabeledImpressionsStorageParams,
         storageConfig = getStorageConfig(params.vidLabeledImpressionsStorageParams),
         dataProvider = dataProvider,

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/vidlabeler/VidLabelerApp.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/vidlabeler/VidLabelerApp.kt
@@ -138,8 +138,8 @@ class VidLabelerApp(
   // instead of rebuilding the (tens-of-GB) structure. Defaults to a FRESH instance per constructor
   // call, which gives tests isolated caches (no cross-test pollution). For production the runner
   // passes an explicit process-scoped instance so the index is reused across WorkItems — DO NOT
-  // rely
-  // on the default to get that reuse; any second production path must pass the shared instance.
+  // rely on the default to get that reuse; any second production path must pass the
+  // shared instance.
   private val memoizedRankIndexCache: MemoizedRankIndexCache = MemoizedRankIndexCache(),
   private val metrics: VidLabelerAppMetrics = VidLabelerAppMetrics(),
 ) :
@@ -331,15 +331,12 @@ class VidLabelerApp(
         kmsClient,
       )
     // Resolve the current snapshot set every WorkItem (cheap listing); reuse the process-wide
-    // cached
-    // index when the exact same blobs would load, else build it (evicting the old one first). New
-    // Phase-1 output changes the chosen blob URIs -> a new cache key -> a rebuild.
+    // cached index when the exact same blobs would load, else build it (evicting the old one
+    // first). New Phase-1 output changes the chosen blob URIs -> a new cache key -> a rebuild.
     // TODO: resolveLatestBlobs runs a metadata-list RPC on every WorkItem, even on a cache hit, so
-    // a
-    // metadata-service roll (UNAVAILABLE / DEADLINE_EXCEEDED) fails every WorkItem's fast path
-    // until
-    // it recovers. If it becomes a hotspot, cache the result with a short TTL to share one call
-    // across a burst of WorkItems, or retry-on-transient before falling through to a rebuild.
+    // a metadata-service roll (UNAVAILABLE / DEADLINE_EXCEEDED) fails every WorkItem's fast path
+    // until it recovers. If it becomes a hotspot, cache the result with a short TTL to share one
+    // call across a burst of WorkItems, or retry-on-transient before falling through to a rebuild.
     val resolvedBlobs =
       MemoizedRankIndex.resolveLatestBlobs(rankIndexBlobsStub, dataProvider, modelLine)
     val rankIndex =

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/vidlabeler/VidLabelerApp.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/vidlabeler/VidLabelerApp.kt
@@ -380,8 +380,8 @@ class VidLabelerApp(
 
     val activeWindow =
       ActiveWindow.of(
-        // active_start_time is required on ModelLineConfig (a model line always has an active
-        // start),
+        // active_start_time is required on ModelLineConfig (a model line always has an
+        // active start),
         // so ActiveWindow.of's non-null start parameter is satisfied directly; only the end is
         // optional and mapped to a null (open-ended) upper bound.
         config.activeStartTime.toInstant(),
@@ -509,8 +509,8 @@ class VidLabelerApp(
     return VidLabeler(
         rawImpressionSource = rawImpressionSource,
         modelLineSpecs = modelLineSpecs,
-        // The operator-header override filters the labeled set at the engine; empty = label all of
-        // model_lines.
+        // The operator-header override filters the labeled set at the engine; empty = label all
+        // of model_lines.
         overrideModelLines = params.overrideModelLinesList,
         vidModelLoader = vidModelLoader,
         impressionConverter = impressionConverter,
@@ -583,8 +583,8 @@ class VidLabelerApp(
     val completedModelLines = response.lastVidLabelingJobResult.completedModelLinesList
     // The date folder each completed model line's done marker goes in. Reuse the event dates the
     // labeler already read from each file's footer while streaming (no extra I/O); on the
-    // skip-relabel recovery path no labeling ran this delivery, so fall back to reading the
-    // footers.
+    // skip-relabel recovery path no labeling ran this delivery, so fall back to reading
+    // the footers.
     val eventDates = observedEventDates.ifEmpty { readEventDates(params, kmsClient, inputFiles) }
     if (completedModelLines.isNotEmpty()) {
       if (eventDates.isEmpty()) {
@@ -618,14 +618,12 @@ class VidLabelerApp(
       // truth-bearing signal. A persistent writeDoneBlob failure then leaves the model line in
       // LABELING (recoverable) instead of stranding a COMPLETED-but-unavailable upload: on Pub/Sub
       // redelivery the idempotent markVidLabelingJobSucceeded replay re-reports this completed
-      // model
-      // line (recomputed from sibling job states), so writeDoneBlob is retried; only once it
+      // model line (recomputed from sibling job states), so writeDoneBlob is retried; only once it
       // succeeds does markParentCompleted commit COMPLETED. Only this TEE reached last-job-out for
       // `completedModelLine`, so only it finalizes the (model line, date): it drops the single
       // `done` marker in that model line's shared-event-date folder — the one VidLabelingSink wrote
       // its labeled output to — and DataAvailabilitySync finalizes it. Independent per model line:
-      // a
-      // FAILED/stuck sibling no longer withholds this line's availability.
+      // a FAILED/stuck sibling no longer withholds this line's availability.
       if (eventDate != null) {
         writeDoneBlob(
           params.vidLabeledImpressionsStorageParams,

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/vidlabeler/VidLabelerApp.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/vidlabeler/VidLabelerApp.kt
@@ -334,6 +334,12 @@ class VidLabelerApp(
     // cached
     // index when the exact same blobs would load, else build it (evicting the old one first). New
     // Phase-1 output changes the chosen blob URIs -> a new cache key -> a rebuild.
+    // TODO: resolveLatestBlobs runs a metadata-list RPC on every WorkItem, even on a cache hit, so
+    // a
+    // metadata-service roll (UNAVAILABLE / DEADLINE_EXCEEDED) fails every WorkItem's fast path
+    // until
+    // it recovers. If it becomes a hotspot, cache the result with a short TTL to share one call
+    // across a burst of WorkItems, or retry-on-transient before falling through to a rebuild.
     val resolvedBlobs =
       MemoizedRankIndex.resolveLatestBlobs(rankIndexBlobsStub, dataProvider, modelLine)
     val rankIndex =
@@ -361,7 +367,12 @@ class VidLabelerApp(
         // The memoized path probes the rank index per impression by its event-id digest, so the
         // digest must be computed.
         needsDigest = true,
-        toEvent = { row, digest -> DigestedEvent(row, checkNotNull(digest)) },
+        toEvent = { row, digest ->
+          DigestedEvent(
+            row,
+            checkNotNull(digest) { "needsDigest=true must produce a digest for the memoized path" },
+          )
+        },
       )
 
     // Schema-drift guard (#3993): fail fast if a mapped raw column is missing from the file schema

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/vidlabeler/VidLabelerAppRunner.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/vidlabeler/VidLabelerAppRunner.kt
@@ -126,6 +126,10 @@ class VidLabelerAppRunner :
         buildImpressionConverter = { _, config ->
           ParquetImpressionConverter(eventDescriptor = resolveEventDescriptor(config))
         },
+        // Process-scoped: one cache shared across every WorkItem this container processes, so the
+        // memoized rank index is reused across WorkItems when the Phase-1 snapshot set is
+        // unchanged.
+        memoizedRankIndexCache = MemoizedRankIndexCache(),
       )
 
     runBlockingWithTelemetry { vidLabelerApp.run() }

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/vidlabeler/VidLabelingSink.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/vidlabeler/VidLabelingSink.kt
@@ -499,8 +499,7 @@ class MemoizedVidLabelingSink(
   ): LabelerInput {
     // Append the impression's pre-computed rank(s) (keyed by its EventIdDigest) directly onto the
     // LabelerInput builder so the model's RankedPopulationNode leaf derives a collision-free VID
-    // via
-    // Feistel. All matching per-subpool ranks are attached (a fingerprint can route to several
+    // via Feistel. All matching per-subpool ranks are attached (a fingerprint can route to several
     // subpools across impressions); the leaf selects the one matching its own pool_offset. No match
     // (overflow / unseen) leaves the input untouched and the leaf falls back to hashing; a model
     // line with no rank index falls back too.

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/vidlabeler/VidLabelingSink.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/vidlabeler/VidLabelingSink.kt
@@ -195,7 +195,7 @@ class VidLabelingSink(
               converted.labelerInput
             } else {
               val builder = converted.labelerInput.toBuilder()
-              if (rankIndex.appendRankAssignments(digestedEvent.digest, builder) == 0) {
+              if (rankIndex.appendRankAssignments(digestedEvent.digest!!, builder) == 0) {
                 converted.labelerInput // miss: leave the input untouched, exactly as before
               } else {
                 builder.build()

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/vidlabeler/VidLabelingSink.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/vidlabeler/VidLabelingSink.kt
@@ -252,8 +252,8 @@ abstract class BaseVidLabelingSink<E : ParquetRawEvent>(
   override suspend fun close() {
     // Abort any still-open writers. On the failure path commit() has not run, so cancelling here
     // tears down the open writeBlob streams. Any partially written data blob is harmless: it has no
-    // metadata sidecar, so no consumer can discover it, and a retry overwrites it (deterministic
-    // key).
+    // metadata sidecar, so no consumer can discover it, and a retry overwrites it
+    // (deterministic key).
     writerScope.cancel()
   }
 

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/vidlabeler/VidLabelingSink.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/vidlabeler/VidLabelingSink.kt
@@ -43,8 +43,10 @@ import org.wfanet.measurement.api.v2alpha.ModelLineKey
 import org.wfanet.measurement.common.crypto.tink.withEnvelopeEncryption
 import org.wfanet.measurement.edpaggregator.EncryptedStorage
 import org.wfanet.measurement.edpaggregator.StorageConfig
-import org.wfanet.measurement.edpaggregator.rawimpressions.DigestedEvent
+import org.wfanet.measurement.edpaggregator.rawimpressions.ParquetDigestedEvent
 import org.wfanet.measurement.edpaggregator.rawimpressions.ParquetRawEvent
+import org.wfanet.measurement.edpaggregator.rawimpressions.ParquetUndigestedEvent
+import org.wfanet.measurement.edpaggregator.rawimpressions.RawImpressionFileMetadata
 import org.wfanet.measurement.edpaggregator.rawimpressions.RawImpressionSource
 import org.wfanet.measurement.edpaggregator.v1alpha.EncryptedDek
 import org.wfanet.measurement.edpaggregator.v1alpha.LabeledImpression
@@ -56,6 +58,7 @@ import org.wfanet.measurement.edpaggregator.v1alpha.labeledImpression
 import org.wfanet.measurement.edpaggregator.vidlabeler.utils.ActiveWindow
 import org.wfanet.measurement.storage.MesosRecordIoStorageClient
 import org.wfanet.measurement.storage.SelectedStorageClient
+import org.wfanet.virtualpeople.common.LabelerInput
 
 /**
  * Per-input-file [RawImpressionSource.BlobSink] that labels one raw-impression file's
@@ -114,7 +117,7 @@ import org.wfanet.measurement.storage.SelectedStorageClient
  *   sink; the permit covers only the short key-setup phase, never the long streaming write, so it
  *   can never stall a started blob stream.
  */
-class VidLabelingSink(
+abstract class BaseVidLabelingSink<E : ParquetRawEvent>(
   private val inputBlobUri: String,
   private val modelLineContexts: List<ModelLineContext>,
   private val impressionConverter: ImpressionConverter,
@@ -126,7 +129,7 @@ class VidLabelingSink(
   private val dataProvider: String,
   private val metrics: VidLabelerMetrics,
   private val encryptionKeySemaphore: Semaphore,
-) : RawImpressionSource.BlobSink<ParquetRawEvent> {
+) : RawImpressionSource.BlobSink<E> {
 
   /**
    * Sink-owned scope for the per-group writer coroutines.
@@ -141,7 +144,7 @@ class VidLabelingSink(
   /** One streaming writer per model-line output group, created on the group's first record. */
   private val writers = ConcurrentHashMap<OutputGroupKey, GroupWriter>()
 
-  override suspend fun processBatch(events: List<ParquetRawEvent>) {
+  override suspend fun processBatch(events: List<E>) {
     // Label (CPU work; the canonical Labeler is stateless) and stream each produced record straight
     // into its group's writer. processBatch is invoked concurrently for this blob. Iterating model
     // lines in the OUTER loop lets each context precompute its metric Attributes and resolve its
@@ -161,13 +164,12 @@ class VidLabelingSink(
         dropAttributes(context.modelLine, VidLabelerMetrics.DROP_REASON_OUTSIDE_WINDOW)
       val noAssignmentAttrs =
         dropAttributes(context.modelLine, VidLabelerMetrics.DROP_REASON_NO_ASSIGNMENT)
-      val rankIndex = context.rankIndex
       // Resolved lazily on this context's first produced record, then reused for the batch, so a
       // context that produces nothing opens no output blob (an empty blob would fail commit()).
       var writer: GroupWriter? = null
-      for (digestedEvent in events) {
+      for (rawEvent in events) {
         try {
-          val converted = impressionConverter.convert(digestedEvent, context.config)
+          val converted = impressionConverter.convert(rawEvent, context.config)
           if (converted == null) {
             metrics.impressionsDroppedCounter.add(1, converterSkipAttrs)
             continue
@@ -177,33 +179,10 @@ class VidLabelingSink(
             continue
           }
 
-          // Memoized path: append the impression's pre-computed rank(s) (keyed by its
-          // EventIdDigest) directly onto the LabelerInput builder so the model's
-          // RankedPopulationNode leaf derives a collision-free VID via Feistel. All matching
-          // per-subpool ranks are attached (a fingerprint can route to several subpools across
-          // impressions); the leaf selects the one matching its own pool_offset. No match
-          // (overflow / unseen) leaves the input untouched and the leaf falls back to hashing. The
-          // non-memoized path (rankIndex == null) never probes and never reads the digest.
-          // TODO(world-federation-of-advertisers/cross-media-measurement#4073): Once
-          // virtual-people-common#75 (memoized_rank_fallback signal) and
-          // virtual-people-core-serving#89 (RankedPopulationNode hash fallback) are merged, count
-          // VirtualPersonActivity.memoized_rank_fallback across output.peopleList (coviewing-safe)
-          // into a per-(dataProvider, modelLine) counter here to surface silent degradation to
-          // hash-based VID assignment when subpools saturate.
-          val labelerInput =
-            if (rankIndex == null) {
-              converted.labelerInput
-            } else {
-              check(digestedEvent is DigestedEvent) {
-                "memoized model line received a digest-less event; check needsDigest wiring"
-              }
-              val builder = converted.labelerInput.toBuilder()
-              if (rankIndex.appendRankAssignments(digestedEvent.digest, builder) == 0) {
-                converted.labelerInput // miss: leave the input untouched, exactly as before
-              } else {
-                builder.build()
-              }
-            }
+          // Memoized vs. hash-only labeling differ ONLY here (see the subclasses'
+          // resolveLabelerInput). Everything else — convert, window filter, assign, stream-write —
+          // is identical and lives in this base, so neither subclass duplicates it.
+          val labelerInput = resolveLabelerInput(rawEvent, converted, context)
 
           val output = context.assigner.assign(labelerInput)
           if (output.peopleCount == 0) {
@@ -242,6 +221,18 @@ class VidLabelingSink(
       }
     }
   }
+
+  /**
+   * Resolves the [LabelerInput] to label for [event]. The memoized subclass appends the event's
+   * pre-computed ranks — it is typed to a
+   * [org.wfanet.measurement.edpaggregator.rawimpressions.DigestedEvent], so the digest is proven
+   * present at compile time; the hash-only subclass returns [converted]'s input unchanged.
+   */
+  protected abstract fun resolveLabelerInput(
+    event: E,
+    converted: ConvertedImpression,
+    context: ModelLineContext,
+  ): LabelerInput
 
   override suspend fun commit() {
     // Signal end-of-input to every writer, then await them so each data blob is fully written
@@ -447,7 +438,7 @@ class VidLabelingSink(
       StreamingAeadConfig.register()
     }
 
-    private val logger = Logger.getLogger(VidLabelingSink::class.java.name)
+    private val logger = Logger.getLogger(BaseVidLabelingSink::class.java.name)
 
     /**
      * Default permit count for the per-WorkItem [encryptionKeySemaphore]: the maximum number of
@@ -469,6 +460,123 @@ class VidLabelingSink(
     private const val WRITER_CHANNEL_CAPACITY = 256
   }
 }
+
+/**
+ * Memoized-path sink: typed to [ParquetDigestedEvent], so every event carries a non-null
+ * [org.wfanet.measurement.edpaggregator.rawimpressions.EventIdDigest]. The compiler proves the
+ * digest is present where the rank lookup reads it — a hash-only event can never reach this sink.
+ */
+class MemoizedVidLabelingSink(
+  inputBlobUri: String,
+  modelLineContexts: List<ModelLineContext>,
+  impressionConverter: ImpressionConverter,
+  fileMetadata: RawImpressionFileMetadata,
+  encryptKmsClient: KmsClient,
+  encryptKekUri: String,
+  outputStorageParams: VidLabelerParams.StorageParams,
+  storageConfig: StorageConfig,
+  dataProvider: String,
+  metrics: VidLabelerMetrics,
+  encryptionKeySemaphore: Semaphore,
+) :
+  BaseVidLabelingSink<ParquetDigestedEvent>(
+    inputBlobUri,
+    modelLineContexts,
+    impressionConverter,
+    fileMetadata,
+    encryptKmsClient,
+    encryptKekUri,
+    outputStorageParams,
+    storageConfig,
+    dataProvider,
+    metrics,
+    encryptionKeySemaphore,
+  ) {
+  override fun resolveLabelerInput(
+    event: ParquetDigestedEvent,
+    converted: ConvertedImpression,
+    context: ModelLineContext,
+  ): LabelerInput {
+    // Append the impression's pre-computed rank(s) (keyed by its EventIdDigest) directly onto the
+    // LabelerInput builder so the model's RankedPopulationNode leaf derives a collision-free VID
+    // via
+    // Feistel. All matching per-subpool ranks are attached (a fingerprint can route to several
+    // subpools across impressions); the leaf selects the one matching its own pool_offset. No match
+    // (overflow / unseen) leaves the input untouched and the leaf falls back to hashing; a model
+    // line with no rank index falls back too.
+    // TODO(world-federation-of-advertisers/cross-media-measurement#4073): Once
+    // virtual-people-common#75 (memoized_rank_fallback signal) and virtual-people-core-serving#89
+    // (RankedPopulationNode hash fallback) are merged, count
+    // VirtualPersonActivity.memoized_rank_fallback across output.peopleList (coviewing-safe) into a
+    // per-(dataProvider, modelLine) counter to surface silent degradation to hash-based VID
+    // assignment when subpools saturate.
+    val rankIndex = context.rankIndex ?: return converted.labelerInput
+    val builder = converted.labelerInput.toBuilder()
+    return if (rankIndex.appendRankAssignments(event.digest, builder) == 0) {
+      converted.labelerInput
+    } else {
+      builder.build()
+    }
+  }
+}
+
+/**
+ * Non-memoized (hash-only) sink: typed to [ParquetUndigestedEvent]. The per-row SHA-256 was skipped
+ * upstream, no rank lookup happens, and the digest is never read.
+ */
+class PlainVidLabelingSink(
+  inputBlobUri: String,
+  modelLineContexts: List<ModelLineContext>,
+  impressionConverter: ImpressionConverter,
+  fileMetadata: RawImpressionFileMetadata,
+  encryptKmsClient: KmsClient,
+  encryptKekUri: String,
+  outputStorageParams: VidLabelerParams.StorageParams,
+  storageConfig: StorageConfig,
+  dataProvider: String,
+  metrics: VidLabelerMetrics,
+  encryptionKeySemaphore: Semaphore,
+) :
+  BaseVidLabelingSink<ParquetUndigestedEvent>(
+    inputBlobUri,
+    modelLineContexts,
+    impressionConverter,
+    fileMetadata,
+    encryptKmsClient,
+    encryptKekUri,
+    outputStorageParams,
+    storageConfig,
+    dataProvider,
+    metrics,
+    encryptionKeySemaphore,
+  ) {
+  override fun resolveLabelerInput(
+    event: ParquetUndigestedEvent,
+    converted: ConvertedImpression,
+    context: ModelLineContext,
+  ): LabelerInput = converted.labelerInput
+}
+
+/**
+ * Builds a per-file [BaseVidLabelingSink] for event type [E]: `::MemoizedVidLabelingSink` for the
+ * memoized path, `::PlainVidLabelingSink` for the hash-only path. Lets [VidLabeler] stay generic in
+ * the event type while the concrete sink — and its compile-time digest guarantee — is chosen by the
+ * caller.
+ */
+typealias VidLabelingSinkFactory<E> =
+  (
+    inputBlobUri: String,
+    modelLineContexts: List<ModelLineContext>,
+    impressionConverter: ImpressionConverter,
+    fileMetadata: RawImpressionFileMetadata,
+    encryptKmsClient: KmsClient,
+    encryptKekUri: String,
+    outputStorageParams: VidLabelerParams.StorageParams,
+    storageConfig: StorageConfig,
+    dataProvider: String,
+    metrics: VidLabelerMetrics,
+    encryptionKeySemaphore: Semaphore,
+  ) -> RawImpressionSource.BlobSink<E>
 
 /**
  * A model line resolved to everything [VidLabelingSink] needs to label with it.

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/vidlabeler/VidLabelingSink.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/vidlabeler/VidLabelingSink.kt
@@ -43,8 +43,8 @@ import org.wfanet.measurement.api.v2alpha.ModelLineKey
 import org.wfanet.measurement.common.crypto.tink.withEnvelopeEncryption
 import org.wfanet.measurement.edpaggregator.EncryptedStorage
 import org.wfanet.measurement.edpaggregator.StorageConfig
-import org.wfanet.measurement.edpaggregator.rawimpressions.ParquetDigestedEvent
-import org.wfanet.measurement.edpaggregator.rawimpressions.RawImpressionFileMetadata
+import org.wfanet.measurement.edpaggregator.rawimpressions.DigestedEvent
+import org.wfanet.measurement.edpaggregator.rawimpressions.ParquetRawEvent
 import org.wfanet.measurement.edpaggregator.rawimpressions.RawImpressionSource
 import org.wfanet.measurement.edpaggregator.v1alpha.EncryptedDek
 import org.wfanet.measurement.edpaggregator.v1alpha.LabeledImpression
@@ -126,7 +126,7 @@ class VidLabelingSink(
   private val dataProvider: String,
   private val metrics: VidLabelerMetrics,
   private val encryptionKeySemaphore: Semaphore,
-) : RawImpressionSource.BlobSink {
+) : RawImpressionSource.BlobSink<ParquetRawEvent> {
 
   /**
    * Sink-owned scope for the per-group writer coroutines.
@@ -141,7 +141,7 @@ class VidLabelingSink(
   /** One streaming writer per model-line output group, created on the group's first record. */
   private val writers = ConcurrentHashMap<OutputGroupKey, GroupWriter>()
 
-  override suspend fun processBatch(events: List<ParquetDigestedEvent>) {
+  override suspend fun processBatch(events: List<ParquetRawEvent>) {
     // Label (CPU work; the canonical Labeler is stateless) and stream each produced record straight
     // into its group's writer. processBatch is invoked concurrently for this blob. Iterating model
     // lines in the OUTER loop lets each context precompute its metric Attributes and resolve its
@@ -194,8 +194,11 @@ class VidLabelingSink(
             if (rankIndex == null) {
               converted.labelerInput
             } else {
+              check(digestedEvent is DigestedEvent) {
+                "memoized model line received a digest-less event; check needsDigest wiring"
+              }
               val builder = converted.labelerInput.toBuilder()
-              if (rankIndex.appendRankAssignments(digestedEvent.digest!!, builder) == 0) {
+              if (rankIndex.appendRankAssignments(digestedEvent.digest, builder) == 0) {
                 converted.labelerInput // miss: leave the input untouched, exactly as before
               } else {
                 builder.build()

--- a/src/test/kotlin/org/wfanet/measurement/edpaggregator/rawimpressions/RawImpressionSourceTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/edpaggregator/rawimpressions/RawImpressionSourceTest.kt
@@ -129,7 +129,7 @@ class RawImpressionSourceTest {
     shardIndex: Int = 0,
     totalShards: Int = 1,
     extractor: EventIdDigestExtractor = EventIdDigestExtractor(),
-  ): RawImpressionSource =
+  ): RawImpressionSource<ParquetRawEvent> =
     RawImpressionSource(
       parquetStorageClient = client,
       rawImpressionUploadFilesStub = filesStub,
@@ -139,10 +139,11 @@ class RawImpressionSourceTest {
       totalShards = totalShards,
       eventIdDigestExtractor = extractor,
       metrics = testMetrics,
+      toEvent = { row, d -> if (d != null) DigestedEvent(row, d) else UndigestedEvent(row) },
     )
 
   /** Reads the decoded `event_id` (STRING or BINARY) from a [DigestedEvent]. */
-  private fun eventId(event: ParquetDigestedEvent): String {
+  private fun eventId(event: ParquetRawEvent): String {
     val v = event.row.getValue("event_id")
     return when (v.kindCase) {
       ParquetValue.KindCase.STRING_VALUE -> v.stringValue
@@ -160,22 +161,23 @@ class RawImpressionSourceTest {
     opened: ConcurrentLinkedQueue<String>? = null,
     committed: ConcurrentLinkedQueue<String>? = null,
     closed: ConcurrentLinkedQueue<String>? = null,
-  ): suspend (String, Map<String, String>) -> RawImpressionSource.BlobSink = { blobUri, _ ->
-    opened?.add(blobUri)
-    object : RawImpressionSource.BlobSink {
-      override suspend fun processBatch(events: List<ParquetDigestedEvent>) {
-        events.forEach { sink.add(eventId(it)) }
-      }
+  ): suspend (String, Map<String, String>) -> RawImpressionSource.BlobSink<ParquetRawEvent> =
+    { blobUri, _ ->
+      opened?.add(blobUri)
+      object : RawImpressionSource.BlobSink<ParquetRawEvent> {
+        override suspend fun processBatch(events: List<ParquetRawEvent>) {
+          events.forEach { sink.add(eventId(it)) }
+        }
 
-      override suspend fun commit() {
-        committed?.add(blobUri)
-      }
+        override suspend fun commit() {
+          committed?.add(blobUri)
+        }
 
-      override suspend fun close() {
-        closed?.add(blobUri)
+        override suspend fun close() {
+          closed?.add(blobUri)
+        }
       }
     }
-  }
 
   @Test
   fun `streamBlobs emits every row of the shard`(): Unit = runBlocking {
@@ -214,6 +216,7 @@ class RawImpressionSourceTest {
         eventIdDigestExtractor = EventIdDigestExtractor(),
         metrics = testMetrics,
         inputFiles = listOf("$UPLOAD/files/x", "$UPLOAD/files/y"),
+        toEvent = { row, d -> if (d != null) DigestedEvent(row, d) else UndigestedEvent(row) },
       )
     val sink = ConcurrentLinkedQueue<String>()
     subject.streamBlobs(collectingSink(sink))
@@ -345,16 +348,17 @@ class RawImpressionSourceTest {
           eventIdDigestExtractor = EventIdDigestExtractor(),
           metrics = testMetrics,
           needsDigest = false,
+          toEvent = { row, d -> if (d != null) DigestedEvent(row, d) else UndigestedEvent(row) },
         )
 
       val ids = ConcurrentLinkedQueue<String>()
       val digestPresent = ConcurrentLinkedQueue<Boolean>()
       subject.streamBlobs { _, _ ->
-        object : RawImpressionSource.BlobSink {
-          override suspend fun processBatch(events: List<ParquetDigestedEvent>) {
+        object : RawImpressionSource.BlobSink<ParquetRawEvent> {
+          override suspend fun processBatch(events: List<ParquetRawEvent>) {
             events.forEach {
               ids.add(eventId(it))
-              digestPresent.add(it.digest != null)
+              digestPresent.add(it is DigestedEvent)
             }
           }
 
@@ -413,6 +417,7 @@ class RawImpressionSourceTest {
         0,
         0,
         EventIdDigestExtractor(),
+        toEvent = { row, d -> if (d != null) DigestedEvent(row, d) else UndigestedEvent(row) },
       )
     }
     // shardIndex out of range.
@@ -425,6 +430,7 @@ class RawImpressionSourceTest {
         5,
         2,
         EventIdDigestExtractor(),
+        toEvent = { row, d -> if (d != null) DigestedEvent(row, d) else UndigestedEvent(row) },
       )
     }
     // maxOpenFiles must be positive.
@@ -437,16 +443,35 @@ class RawImpressionSourceTest {
         0,
         1,
         EventIdDigestExtractor(),
+        toEvent = { row, d -> if (d != null) DigestedEvent(row, d) else UndigestedEvent(row) },
         maxOpenFiles = 0,
       )
     }
     // rawImpressionUpload must be non-blank.
     assertFailsWith<IllegalArgumentException> {
-      RawImpressionSource(newClient(), filesStub, "  ", "event_id", 0, 1, EventIdDigestExtractor())
+      RawImpressionSource(
+        newClient(),
+        filesStub,
+        "  ",
+        "event_id",
+        0,
+        1,
+        EventIdDigestExtractor(),
+        toEvent = { row, d -> if (d != null) DigestedEvent(row, d) else UndigestedEvent(row) },
+      )
     }
     // eventIdColumn must be non-blank.
     assertFailsWith<IllegalArgumentException> {
-      RawImpressionSource(newClient(), filesStub, UPLOAD, "  ", 0, 1, EventIdDigestExtractor())
+      RawImpressionSource(
+        newClient(),
+        filesStub,
+        UPLOAD,
+        "  ",
+        0,
+        1,
+        EventIdDigestExtractor(),
+        toEvent = { row, d -> if (d != null) DigestedEvent(row, d) else UndigestedEvent(row) },
+      )
     }
   }
 

--- a/src/test/kotlin/org/wfanet/measurement/edpaggregator/rawimpressions/RawImpressionSourceTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/edpaggregator/rawimpressions/RawImpressionSourceTest.kt
@@ -332,6 +332,47 @@ class RawImpressionSourceTest {
   }
 
   @Test
+  fun `streamBlobs with needsDigest false skips the digest but still emits every row`(): Unit =
+    runBlocking {
+      val client = newClient()
+      writeFile(client, "nd/a.parquet", listOf(row("e1"), row("e2"), row("e3")))
+      val subject =
+        RawImpressionSource(
+          parquetStorageClient = client,
+          rawImpressionUploadFilesStub = filesStub,
+          rawImpressionUpload = UPLOAD,
+          eventIdColumn = "event_id",
+          eventIdDigestExtractor = EventIdDigestExtractor(),
+          metrics = testMetrics,
+          needsDigest = false,
+        )
+
+      val ids = ConcurrentLinkedQueue<String>()
+      val digestPresent = ConcurrentLinkedQueue<Boolean>()
+      subject.streamBlobs { _, _ ->
+        object : RawImpressionSource.BlobSink {
+          override suspend fun processBatch(events: List<ParquetDigestedEvent>) {
+            events.forEach {
+              ids.add(eventId(it))
+              digestPresent.add(it.digest != null)
+            }
+          }
+
+          override suspend fun commit() {}
+
+          override suspend fun close() {}
+        }
+      }
+
+      assertThat(ids.toList()).containsExactly("e1", "e2", "e3")
+      // The per-row SHA-256 was skipped: every event carries a null digest (never read on this
+      // path), so a future accidental read fails fast instead of silently colliding.
+      assertThat(digestPresent.toList()).containsExactly(false, false, false)
+      assertThat(counterValue(EMITTED)).isEqualTo(3)
+      assertThat(counterValue(DROPPED)).isEqualTo(0)
+    }
+
+  @Test
   fun `streamBlobs reads a raw BINARY (ByteString) event-id column`(): Unit = runBlocking {
     val client = newClient()
     writeFile(client, "b/a.parquet", listOf(rowWithBytesId("e1"), rowWithBytesId("e2")))

--- a/src/test/kotlin/org/wfanet/measurement/edpaggregator/subpoolassigner/SubpoolAssignerTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/edpaggregator/subpoolassigner/SubpoolAssignerTest.kt
@@ -42,6 +42,7 @@ import org.mockito.kotlin.times
 import org.mockito.kotlin.verifyBlocking
 import org.wfanet.measurement.common.crypto.tink.testing.FakeKmsClient
 import org.wfanet.measurement.edpaggregator.rawimpressions.LabelerInputMapper
+import org.wfanet.measurement.edpaggregator.rawimpressions.ParquetDigestedEvent
 import org.wfanet.measurement.edpaggregator.rawimpressions.RawImpressionSource
 import org.wfanet.measurement.edpaggregator.rawimpressions.SubpoolFingerprintsStore
 import org.wfanet.measurement.edpaggregator.v1alpha.EncryptedDek
@@ -159,7 +160,7 @@ class SubpoolAssignerTest {
     modelLinesStub: RawImpressionUploadModelLineServiceCoroutineStub,
     rankerStub: RankerJobServiceCoroutineStub = rankerStubMock(),
     workItemsStub: WorkItemsCoroutineStub = workItemsStubMock(),
-    source: RawImpressionSource = mock(),
+    source: RawImpressionSource<ParquetDigestedEvent> = mock(),
     accumulator: SubpoolFingerprintsAccumulator = SubpoolFingerprintsAccumulator(),
     totalShards: Int = 1,
   ) =

--- a/src/test/kotlin/org/wfanet/measurement/edpaggregator/vidlabeler/BUILD.bazel
+++ b/src/test/kotlin/org/wfanet/measurement/edpaggregator/vidlabeler/BUILD.bazel
@@ -14,6 +14,20 @@ kt_jvm_test(
 )
 
 kt_jvm_test(
+    name = "MemoizedRankIndexCacheTest",
+    srcs = ["MemoizedRankIndexCacheTest.kt"],
+    test_class = "org.wfanet.measurement.edpaggregator.vidlabeler.MemoizedRankIndexCacheTest",
+    deps = [
+        "//src/main/kotlin/org/wfanet/measurement/edpaggregator/vidlabeler:memoized_rank_index",
+        "//src/main/kotlin/org/wfanet/measurement/edpaggregator/vidlabeler/utils:bytes12_int_map",
+        "@wfa_common_jvm//imports/java/com/google/common/truth",
+        "@wfa_common_jvm//imports/java/org/junit",
+        "@wfa_common_jvm//imports/kotlin/kotlinx/coroutines:core",
+        "@wfa_virtual_people_common//src/main/proto/wfa/virtual_people/common:event_kt_jvm_proto",
+    ],
+)
+
+kt_jvm_test(
     name = "VirtualPeopleVidAssignerTest",
     srcs = ["VirtualPeopleVidAssignerTest.kt"],
     data = ["//src/main/resources/testing/labeler:single_id_model_riegeli"],

--- a/src/test/kotlin/org/wfanet/measurement/edpaggregator/vidlabeler/MemoizedRankIndexCacheTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/edpaggregator/vidlabeler/MemoizedRankIndexCacheTest.kt
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2026 The Cross-Media Measurement Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wfanet.measurement.edpaggregator.vidlabeler
+
+import com.google.common.truth.Truth.assertThat
+import java.util.concurrent.atomic.AtomicInteger
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.runBlocking
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+import org.wfanet.measurement.edpaggregator.vidlabeler.utils.Bytes12IntMap
+
+@RunWith(JUnit4::class)
+class MemoizedRankIndexCacheTest {
+  private fun index(rank: Int): MemoizedRankIndex =
+    MemoizedRankIndex.fromMaps(mapOf(0L to Bytes12IntMap().apply { put(1L, 1, rank) }))
+
+  private fun key(vararg uris: String): MemoizedRankIndex.Key =
+    MemoizedRankIndex.Key("dp", "ml", uris.toList())
+
+  @Test
+  fun `getOrBuild builds once and reuses the index on a key match`() =
+    runBlocking<Unit> {
+      val cache = MemoizedRankIndexCache()
+      val builds = AtomicInteger(0)
+
+      val first =
+        cache.getOrBuild(key("a")) {
+          builds.incrementAndGet()
+          index(1)
+        }
+      val second =
+        cache.getOrBuild(key("a")) {
+          builds.incrementAndGet()
+          index(2)
+        }
+
+      assertThat(builds.get()).isEqualTo(1)
+      assertThat(second).isSameInstanceAs(first)
+    }
+
+  @Test
+  fun `getOrBuild rebuilds on a changed key and does not retain the evicted index`() =
+    runBlocking<Unit> {
+      val cache = MemoizedRankIndexCache()
+      val builds = AtomicInteger(0)
+
+      val a1 =
+        cache.getOrBuild(key("a")) {
+          builds.incrementAndGet()
+          index(1)
+        }
+      val b =
+        cache.getOrBuild(key("b")) {
+          builds.incrementAndGet()
+          index(2)
+        }
+
+      assertThat(b).isNotSameInstanceAs(a1)
+      assertThat(builds.get()).isEqualTo(2)
+
+      // Size-1: the "a" entry was evicted when "b" was built, so requesting "a" again rebuilds
+      // rather than returning the original a1 (the old index is not retained).
+      val a2 =
+        cache.getOrBuild(key("a")) {
+          builds.incrementAndGet()
+          index(3)
+        }
+      assertThat(a2).isNotSameInstanceAs(a1)
+      assertThat(builds.get()).isEqualTo(3)
+    }
+
+  @Test
+  fun `getOrBuild serializes concurrent callers so the same key builds exactly once`() =
+    runBlocking<Unit> {
+      val cache = MemoizedRankIndexCache()
+      val builds = AtomicInteger(0)
+
+      val results =
+        (1..16)
+          .map {
+            async(Dispatchers.Default) {
+              cache.getOrBuild(key("a")) {
+                builds.incrementAndGet()
+                delay(50) // widen the overlap window so an unsynchronized cache would double-build
+                index(1)
+              }
+            }
+          }
+          .awaitAll()
+
+      // The Mutex serialized the callers: only the first built; the rest observed the cached index.
+      assertThat(builds.get()).isEqualTo(1)
+      assertThat(results.toSet()).hasSize(1)
+    }
+}

--- a/src/test/kotlin/org/wfanet/measurement/edpaggregator/vidlabeler/VidLabelerTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/edpaggregator/vidlabeler/VidLabelerTest.kt
@@ -27,7 +27,7 @@ import org.mockito.kotlin.any
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
 import org.wfanet.measurement.edpaggregator.StorageConfig
-import org.wfanet.measurement.edpaggregator.rawimpressions.ParquetRawEvent
+import org.wfanet.measurement.edpaggregator.rawimpressions.ParquetUndigestedEvent
 import org.wfanet.measurement.edpaggregator.rawimpressions.RawImpressionSource
 import org.wfanet.measurement.edpaggregator.v1alpha.VidLabelerParams
 import org.wfanet.measurement.edpaggregator.vidlabeler.utils.ActiveWindow
@@ -58,7 +58,7 @@ class VidLabelerTest {
       StubVidAssigner()
     }
 
-    val rawImpressionSource: RawImpressionSource<ParquetRawEvent> = mock()
+    val rawImpressionSource: RawImpressionSource<ParquetUndigestedEvent> = mock()
     whenever(rawImpressionSource.streamBlobs(any())).then {}
 
     val labeler =
@@ -74,6 +74,7 @@ class VidLabelerTest {
         outputStorageParams = VidLabelerParams.StorageParams.getDefaultInstance(),
         storageConfig = StorageConfig(),
         dataProvider = "dataProviders/edp-1",
+        newSink = ::PlainVidLabelingSink,
       )
 
     labeler.label()
@@ -91,7 +92,7 @@ class VidLabelerTest {
       StubVidAssigner()
     }
 
-    val rawImpressionSource: RawImpressionSource<ParquetRawEvent> = mock()
+    val rawImpressionSource: RawImpressionSource<ParquetUndigestedEvent> = mock()
     whenever(rawImpressionSource.streamBlobs(any())).then {}
 
     val labeler =
@@ -111,6 +112,7 @@ class VidLabelerTest {
         outputStorageParams = VidLabelerParams.StorageParams.getDefaultInstance(),
         storageConfig = StorageConfig(),
         dataProvider = "dataProviders/edp-1",
+        newSink = ::PlainVidLabelingSink,
       )
 
     labeler.label()
@@ -124,7 +126,7 @@ class VidLabelerTest {
   fun `label with override referencing absent model line throws`() = runBlocking {
     val vidModelLoader = VidModelLoader { _, _ -> StubVidAssigner() }
 
-    val rawImpressionSource: RawImpressionSource<ParquetRawEvent> = mock()
+    val rawImpressionSource: RawImpressionSource<ParquetUndigestedEvent> = mock()
 
     val labeler =
       VidLabeler(
@@ -138,6 +140,7 @@ class VidLabelerTest {
         outputStorageParams = VidLabelerParams.StorageParams.getDefaultInstance(),
         storageConfig = StorageConfig(),
         dataProvider = "dataProviders/edp-1",
+        newSink = ::PlainVidLabelingSink,
       )
 
     val exception = assertFailsWith<IllegalArgumentException> { labeler.label() }

--- a/src/test/kotlin/org/wfanet/measurement/edpaggregator/vidlabeler/VidLabelerTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/edpaggregator/vidlabeler/VidLabelerTest.kt
@@ -27,6 +27,7 @@ import org.mockito.kotlin.any
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
 import org.wfanet.measurement.edpaggregator.StorageConfig
+import org.wfanet.measurement.edpaggregator.rawimpressions.ParquetRawEvent
 import org.wfanet.measurement.edpaggregator.rawimpressions.RawImpressionSource
 import org.wfanet.measurement.edpaggregator.v1alpha.VidLabelerParams
 import org.wfanet.measurement.edpaggregator.vidlabeler.utils.ActiveWindow
@@ -57,7 +58,7 @@ class VidLabelerTest {
       StubVidAssigner()
     }
 
-    val rawImpressionSource: RawImpressionSource = mock()
+    val rawImpressionSource: RawImpressionSource<ParquetRawEvent> = mock()
     whenever(rawImpressionSource.streamBlobs(any())).then {}
 
     val labeler =
@@ -90,7 +91,7 @@ class VidLabelerTest {
       StubVidAssigner()
     }
 
-    val rawImpressionSource: RawImpressionSource = mock()
+    val rawImpressionSource: RawImpressionSource<ParquetRawEvent> = mock()
     whenever(rawImpressionSource.streamBlobs(any())).then {}
 
     val labeler =
@@ -123,7 +124,7 @@ class VidLabelerTest {
   fun `label with override referencing absent model line throws`() = runBlocking {
     val vidModelLoader = VidModelLoader { _, _ -> StubVidAssigner() }
 
-    val rawImpressionSource: RawImpressionSource = mock()
+    val rawImpressionSource: RawImpressionSource<ParquetRawEvent> = mock()
 
     val labeler =
       VidLabeler(

--- a/src/test/kotlin/org/wfanet/measurement/edpaggregator/vidlabeler/VidLabelingSinkTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/edpaggregator/vidlabeler/VidLabelingSinkTest.kt
@@ -91,9 +91,9 @@ class VidLabelingSinkTest {
       RawImpressionFileMetadata(eventDate = LocalDate.parse("2026-06-30")),
     encryptKmsClient: KmsClient = kmsClient,
     encryptionKeySemaphore: Semaphore =
-      Semaphore(VidLabelingSink.DEFAULT_ENCRYPTION_KEY_PARALLELISM),
+      Semaphore(BaseVidLabelingSink.DEFAULT_ENCRYPTION_KEY_PARALLELISM),
   ) =
-    VidLabelingSink(
+    MemoizedVidLabelingSink(
       inputBlobUri = "file:///raw/file-1.parquet",
       modelLineContexts = contexts,
       impressionConverter = converter,

--- a/src/test/kotlin/org/wfanet/measurement/edpaggregator/vidlabeler/VidLabelingSinkTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/edpaggregator/vidlabeler/VidLabelingSinkTest.kt
@@ -46,8 +46,9 @@ import org.wfanet.measurement.common.crypto.tink.withEnvelopeEncryption
 import org.wfanet.measurement.edpaggregator.StorageConfig
 import org.wfanet.measurement.edpaggregator.rawimpressions.DigestedEvent
 import org.wfanet.measurement.edpaggregator.rawimpressions.EventIdDigest
-import org.wfanet.measurement.edpaggregator.rawimpressions.ParquetDigestedEvent
 import org.wfanet.measurement.edpaggregator.rawimpressions.RawImpressionFileMetadata
+import org.wfanet.measurement.edpaggregator.rawimpressions.ParquetDigestedEvent
+import org.wfanet.measurement.edpaggregator.rawimpressions.ParquetRawEvent
 import org.wfanet.measurement.edpaggregator.v1alpha.BlobDetails
 import org.wfanet.measurement.edpaggregator.v1alpha.LabeledImpression
 import org.wfanet.measurement.edpaggregator.v1alpha.LabeledImpressionKt
@@ -465,7 +466,7 @@ class VidLabelingSinkTest {
    */
   private class FakeImpressionConverter : ImpressionConverter {
     override fun convert(
-      event: ParquetDigestedEvent,
+      event: ParquetRawEvent,
       config: VidLabelerParams.ModelLineConfig,
     ): ConvertedImpression =
       ConvertedImpression(
@@ -478,7 +479,7 @@ class VidLabelingSinkTest {
           listOf(
             LabeledImpressionKt.entityKey {
               entityType = "household"
-              entityId = "hh-${event.digest!!.high}"
+              entityId = "hh-${(event as DigestedEvent).digest.high}"
             },
             LabeledImpressionKt.entityKey {
               entityType = "person"

--- a/src/test/kotlin/org/wfanet/measurement/edpaggregator/vidlabeler/VidLabelingSinkTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/edpaggregator/vidlabeler/VidLabelingSinkTest.kt
@@ -478,7 +478,7 @@ class VidLabelingSinkTest {
           listOf(
             LabeledImpressionKt.entityKey {
               entityType = "household"
-              entityId = "hh-${event.digest.high}"
+              entityId = "hh-${event.digest!!.high}"
             },
             LabeledImpressionKt.entityKey {
               entityType = "person"

--- a/src/test/kotlin/org/wfanet/measurement/edpaggregator/vidlabeler/VidLabelingSinkTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/edpaggregator/vidlabeler/VidLabelingSinkTest.kt
@@ -46,9 +46,9 @@ import org.wfanet.measurement.common.crypto.tink.withEnvelopeEncryption
 import org.wfanet.measurement.edpaggregator.StorageConfig
 import org.wfanet.measurement.edpaggregator.rawimpressions.DigestedEvent
 import org.wfanet.measurement.edpaggregator.rawimpressions.EventIdDigest
-import org.wfanet.measurement.edpaggregator.rawimpressions.RawImpressionFileMetadata
 import org.wfanet.measurement.edpaggregator.rawimpressions.ParquetDigestedEvent
 import org.wfanet.measurement.edpaggregator.rawimpressions.ParquetRawEvent
+import org.wfanet.measurement.edpaggregator.rawimpressions.RawImpressionFileMetadata
 import org.wfanet.measurement.edpaggregator.v1alpha.BlobDetails
 import org.wfanet.measurement.edpaggregator.v1alpha.LabeledImpression
 import org.wfanet.measurement.edpaggregator.v1alpha.LabeledImpressionKt
@@ -479,7 +479,7 @@ class VidLabelingSinkTest {
           listOf(
             LabeledImpressionKt.entityKey {
               entityType = "household"
-              entityId = "hh-${(event as DigestedEvent).digest.high}"
+              entityId = "hh-${event.row.getValue(HOUSEHOLD_ID_COLUMN).int64Value}"
             },
             LabeledImpressionKt.entityKey {
               entityType = "person"
@@ -527,7 +527,8 @@ class VidLabelingSinkTest {
     DigestedEvent(
       row =
         mapOf(
-          EVENT_TIME_COLUMN to ParquetValue.newBuilder().setInt64Value(eventTimeMicros).build()
+          EVENT_TIME_COLUMN to ParquetValue.newBuilder().setInt64Value(eventTimeMicros).build(),
+          HOUSEHOLD_ID_COLUMN to ParquetValue.newBuilder().setInt64Value(idByte.toLong()).build(),
         ),
       digest = EventIdDigest(high = idByte.toLong(), low = idByte),
     )
@@ -543,5 +544,6 @@ class VidLabelingSinkTest {
     private const val VID = 42L
     private const val POOL_OFFSET = 10L
     private const val EVENT_TIME_COLUMN = "event_time_micros"
+    private const val HOUSEHOLD_ID_COLUMN = "household_id"
   }
 }


### PR DESCRIPTION
## What
  - **`MemoizedRankIndexCache` (new)** — process-scoped, size-1 cache keyed by
    content identity `(dataProvider, modelLine, sorted SNAPSHOT blob URIs)`. A
    cheap resolve runs every WorkItem; the expensive rebuild is skipped on a key
    match; the old index is dropped before the new one, so peak stays at one index.
    (Pays off when there are fewer VMs than WorkItems and consecutive jobs share a
    key.)
  - **`needsDigest`** — skip the per-row SHA-256 on the non-memoized single-shard
    path, which never reads the digest. The event carries a **null** digest (not a
    placeholder), so any future accidental read fails fast instead of silently
    colliding all events at `(0,0)`.
  - Concurrent file-list → `blob_uri` resolution (`FILE_RESOLVE_CONCURRENCY`).

  ## Why it's safe
  The cache only reuses an index for an identical content key; the null-digest
  change is compile-enforced against misuse.

  ## Tests
  New `MemoizedRankIndexCacheTest`; `RawImpressionSourceTest` covers
  `needsDigest`/null-digest and concurrent resolution.

Issue: #4233 