### PR TITLE
test(edpaggregator): add EventGroup migration integration tests

### DIFF
--- a/src/main/kotlin/org/wfanet/measurement/integration/common/InProcessEdpAggregatorComponents.kt
+++ b/src/main/kotlin/org/wfanet/measurement/integration/common/InProcessEdpAggregatorComponents.kt
@@ -52,13 +52,16 @@ import org.wfanet.measurement.api.v2alpha.ClientAccountsGrpcKt.ClientAccountsCor
 import org.wfanet.measurement.api.v2alpha.DataProvider
 import org.wfanet.measurement.api.v2alpha.DataProviderCertificateKey
 import org.wfanet.measurement.api.v2alpha.DataProvidersGrpcKt.DataProvidersCoroutineStub
+import org.wfanet.measurement.api.v2alpha.EventGroup as CmmsEventGroup
 import org.wfanet.measurement.api.v2alpha.EventGroupsGrpcKt.EventGroupsCoroutineStub
+import org.wfanet.measurement.api.v2alpha.ListEventGroupsRequestKt.filter as listEventGroupsFilter
 import org.wfanet.measurement.api.v2alpha.PopulationSpec
 import org.wfanet.measurement.api.v2alpha.Requisition
 import org.wfanet.measurement.api.v2alpha.RequisitionKt
 import org.wfanet.measurement.api.v2alpha.RequisitionsGrpcKt.RequisitionsCoroutineStub
 import org.wfanet.measurement.api.v2alpha.event_group_metadata.testing.SyntheticEventGroupSpec
 import org.wfanet.measurement.api.v2alpha.event_templates.testing.TestEvent
+import org.wfanet.measurement.api.v2alpha.listEventGroupsRequest
 import org.wfanet.measurement.api.v2alpha.refuseRequisitionRequest
 import org.wfanet.measurement.api.v2alpha.replaceDataProviderCapabilitiesRequest
 import org.wfanet.measurement.common.crypto.tink.testing.FakeKmsClient
@@ -748,6 +751,72 @@ class InProcessEdpAggregatorComponents(
         }
       }
       .toMap()
+  }
+
+  /**
+   * Re-runs [EventGroupSync] for a single EDP against the already-running in-process Kingdom, using
+   * the same real [EventGroupsCoroutineStub] the harness wires in [startDaemons]. Test-only seam
+   * for exercising repeated syncs (e.g. the #4175 reference-id -> entity_key migration) after the
+   * initial daemon startup. Returns the [MappedEventGroup]s emitted by the sync.
+   */
+  fun syncEventGroups(
+    edpAggregatorShortName: String,
+    sources: List<EventGroup>,
+    entityKeyTypes: List<String> = emptyList(),
+  ): List<MappedEventGroup> = runBlocking {
+    val edpResourceName = edpResourceNameMap.getValue(edpAggregatorShortName)
+    val eventGroupsClient =
+      EventGroupsCoroutineStub(publicApiChannel).withPrincipalName(edpResourceName)
+    val clientAccountsClient =
+      ClientAccountsCoroutineStub(publicApiChannel).withPrincipalName(edpResourceName)
+    EventGroupSync(
+        edpResourceName,
+        eventGroupsClient,
+        clientAccountsClient,
+        sources.asFlow(),
+        throttler,
+        entityKeyTypes = entityKeyTypes,
+        listEventGroupPageSize = 500,
+      )
+      .sync()
+      .toList()
+  }
+
+  /**
+   * Lists every CMMS [EventGroup] the given EDP owns on the in-process Kingdom, via the raw v2alpha
+   * `EventGroups.ListEventGroups` (not the Reporting API). Test-only seam for asserting the exact
+   * Kingdom row count and resource-name set, which is how "no EventGroup explosion / no duplicate
+   * rows" is proven independent of any Reporting-side filtering or de-duplication.
+   */
+  fun listCmmsEventGroups(edpAggregatorShortName: String): List<CmmsEventGroup> = runBlocking {
+    val edpResourceName = edpResourceNameMap.getValue(edpAggregatorShortName)
+    val eventGroupsClient =
+      EventGroupsCoroutineStub(publicApiChannel).withPrincipalName(edpResourceName)
+    val eventGroups = mutableListOf<CmmsEventGroup>()
+    var pageToken = ""
+    while (true) {
+      val response =
+        throttler.onReady {
+          eventGroupsClient.listEventGroups(
+            listEventGroupsRequest {
+              parent = edpResourceName
+              pageSize = 1000
+              this.pageToken = pageToken
+              // Kingdom defaults entity_type_in to ["campaign"] when unset; enumerate all entity
+              // types the tests use so migrated (creative-id / ad_group) rows are not hidden.
+              filter = listEventGroupsFilter {
+                entityTypeIn += "campaign"
+                entityTypeIn += "creative-id"
+                entityTypeIn += "ad_group"
+              }
+            }
+          )
+        }
+      eventGroups += response.eventGroupsList
+      if (response.nextPageToken.isEmpty()) break
+      pageToken = response.nextPageToken
+    }
+    eventGroups
   }
 
   fun stopDaemons() {

--- a/src/main/kotlin/org/wfanet/measurement/integration/common/InProcessEdpAggregatorComponents.kt
+++ b/src/main/kotlin/org/wfanet/measurement/integration/common/InProcessEdpAggregatorComponents.kt
@@ -783,12 +783,22 @@ class InProcessEdpAggregatorComponents(
   }
 
   /**
-   * Lists every CMMS [EventGroup] the given EDP owns on the in-process Kingdom, via the raw v2alpha
-   * `EventGroups.ListEventGroups` (not the Reporting API). Test-only seam for asserting the exact
-   * Kingdom row count and resource-name set, which is how "no EventGroup explosion / no duplicate
-   * rows" is proven independent of any Reporting-side filtering or de-duplication.
+   * Lists the CMMS [CmmsEventGroup]s the given EDP owns on the in-process Kingdom, filtered to
+   * [entityTypes], via the raw v2alpha `EventGroups.ListEventGroups` (not the Reporting API).
+   *
+   * [entityTypes] must enumerate every entity type the caller may have created: the Kingdom
+   * defaults `entity_type_in` to `["campaign"]` when unset, so a non-campaign row (e.g.
+   * `creative-id`) is hidden unless its type is listed here. Passing the caller's own type set
+   * keeps this lister from silently under-counting as new entity types are exercised.
+   *
+   * Test-only seam for asserting the exact Kingdom row count and resource-name set, which is how
+   * "no EventGroup explosion / no duplicate rows" is proven independent of any Reporting-side
+   * filtering or de-duplication.
    */
-  fun listCmmsEventGroups(edpAggregatorShortName: String): List<CmmsEventGroup> = runBlocking {
+  fun listCmmsEventGroups(
+    edpAggregatorShortName: String,
+    entityTypes: List<String>,
+  ): List<CmmsEventGroup> = runBlocking {
     val edpResourceName = edpResourceNameMap.getValue(edpAggregatorShortName)
     val eventGroupsClient =
       EventGroupsCoroutineStub(publicApiChannel).withPrincipalName(edpResourceName)
@@ -802,13 +812,7 @@ class InProcessEdpAggregatorComponents(
               parent = edpResourceName
               pageSize = 1000
               this.pageToken = pageToken
-              // Kingdom defaults entity_type_in to ["campaign"] when unset; enumerate all entity
-              // types the tests use so migrated (creative-id / ad_group) rows are not hidden.
-              filter = listEventGroupsFilter {
-                entityTypeIn += "campaign"
-                entityTypeIn += "creative-id"
-                entityTypeIn += "ad_group"
-              }
+              filter = listEventGroupsFilter { entityTypeIn += entityTypes }
             }
           )
         }

--- a/src/main/kotlin/org/wfanet/measurement/integration/common/reporting/v2/InProcessEdpAggregatorLifeOfAReportTest.kt
+++ b/src/main/kotlin/org/wfanet/measurement/integration/common/reporting/v2/InProcessEdpAggregatorLifeOfAReportTest.kt
@@ -94,12 +94,7 @@ import org.wfanet.measurement.config.reporting.measurementConsumerConfig
 import org.wfanet.measurement.config.reporting.measurementConsumerConfigs
 import org.wfanet.measurement.config.reporting.metricSpecConfig
 import org.wfanet.measurement.edpaggregator.eventgroups.v1alpha.EventGroup as EdpaEventGroup
-import org.wfanet.measurement.edpaggregator.eventgroups.v1alpha.EventGroupKt.MetadataKt.AdMetadataKt.campaignMetadata as edpaCampaignMetadata
-import org.wfanet.measurement.edpaggregator.eventgroups.v1alpha.EventGroupKt.MetadataKt.adMetadata as edpaAdMetadata
-import org.wfanet.measurement.edpaggregator.eventgroups.v1alpha.EventGroupKt.entityKey as edpaEntityKey
-import org.wfanet.measurement.edpaggregator.eventgroups.v1alpha.EventGroupKt.metadata as edpaEventGroupMetadata
 import org.wfanet.measurement.edpaggregator.eventgroups.v1alpha.MappedEventGroup
-import org.wfanet.measurement.edpaggregator.eventgroups.v1alpha.eventGroup as edpaEventGroup
 import org.wfanet.measurement.edpaggregator.resultsfulfiller.ModelLineInfo
 import org.wfanet.measurement.edpaggregator.v1alpha.ResultsFulfillerParams
 import org.wfanet.measurement.eventdataprovider.requisition.v2alpha.common.InMemoryVidIndexMap
@@ -1013,44 +1008,6 @@ abstract class InProcessEdpAggregatorLifeOfAReportTest(
     inProcessCmmsComponents.getMeasurementConsumerData().name
 
   /**
-   * Builds a valid EDPA-side source [EdpaEventGroup] for driving [EventGroupSync] directly in
-   * migration tests. Sets whichever of `event_group_reference_id` / `entity_key` is provided
-   * (mirroring how an EDP evolves a row across the #4175 migration), plus the fields
-   * `EventGroupSync.validateEventGroup` requires: media type, data-availability interval, and
-   * metadata. `campaign` names the campaign metadata so a mutation is observable across syncs.
-   */
-  protected fun buildMigrationSourceEventGroup(
-    referenceId: String?,
-    entityType: String?,
-    entityId: String?,
-    campaign: String,
-  ): EdpaEventGroup = edpaEventGroup {
-    if (!referenceId.isNullOrEmpty()) {
-      eventGroupReferenceId = referenceId
-    }
-    measurementConsumer = measurementConsumerName()
-    if (entityType != null && entityId != null) {
-      entityKey = edpaEntityKey {
-        this.entityType = entityType
-        this.entityId = entityId
-      }
-    }
-    eventGroupMetadata = edpaEventGroupMetadata {
-      adMetadata = edpaAdMetadata {
-        campaignMetadata = edpaCampaignMetadata {
-          brand = "migration-brand"
-          this.campaign = campaign
-        }
-      }
-    }
-    dataAvailabilityInterval = interval {
-      startTime = timestamp { seconds = 200 }
-      endTime = timestamp { seconds = 300 }
-    }
-    mediaTypes += EdpaEventGroup.MediaType.VIDEO
-  }
-
-  /**
    * Re-runs [EventGroupSync] for a single EDP against the running in-process Kingdom. Test-only
    * seam for driving repeated migration syncs after daemon startup.
    */
@@ -1066,12 +1023,17 @@ abstract class InProcessEdpAggregatorLifeOfAReportTest(
     )
 
   /**
-   * Lists the raw CMMS [CmmsEventGroup]s an EDP owns on the Kingdom (bypassing the Reporting API).
-   * Used to assert the exact Kingdom row count and resource-name set, proving no EventGroup
-   * explosion / duplicate rows during migration.
+   * Lists the raw CMMS [CmmsEventGroup]s an EDP owns on the Kingdom (bypassing the Reporting API),
+   * filtered to [entityTypes]. Used to assert the exact Kingdom row count and resource-name set,
+   * proving no EventGroup explosion / duplicate rows during migration. [entityTypes] must include
+   * every entity type the caller may have created, since the Kingdom hides non-`campaign` rows
+   * unless their type is listed.
    */
-  protected fun listCmmsEventGroups(edpAggregatorShortName: String): List<CmmsEventGroup> =
-    inProcessEdpAggregatorComponents.listCmmsEventGroups(edpAggregatorShortName)
+  protected fun listCmmsEventGroups(
+    edpAggregatorShortName: String,
+    entityTypes: List<String>,
+  ): List<CmmsEventGroup> =
+    inProcessEdpAggregatorComponents.listCmmsEventGroups(edpAggregatorShortName, entityTypes)
 
   protected suspend fun listReportingEventGroups(): List<EventGroup> {
     val measurementConsumerData = inProcessCmmsComponents.getMeasurementConsumerData()

--- a/src/main/kotlin/org/wfanet/measurement/integration/common/reporting/v2/InProcessEdpAggregatorLifeOfAReportTest.kt
+++ b/src/main/kotlin/org/wfanet/measurement/integration/common/reporting/v2/InProcessEdpAggregatorLifeOfAReportTest.kt
@@ -59,6 +59,7 @@ import org.wfanet.measurement.access.v1alpha.principal
 import org.wfanet.measurement.access.v1alpha.role
 import org.wfanet.measurement.api.v2alpha.DataProviderKt
 import org.wfanet.measurement.api.v2alpha.DataProvidersGrpcKt.DataProvidersCoroutineStub
+import org.wfanet.measurement.api.v2alpha.EventGroup as CmmsEventGroup
 import org.wfanet.measurement.api.v2alpha.EventMessageDescriptor
 import org.wfanet.measurement.api.v2alpha.Measurement
 import org.wfanet.measurement.api.v2alpha.MeasurementConsumerKey
@@ -92,6 +93,13 @@ import org.wfanet.measurement.config.reporting.encryptionKeyPairConfig
 import org.wfanet.measurement.config.reporting.measurementConsumerConfig
 import org.wfanet.measurement.config.reporting.measurementConsumerConfigs
 import org.wfanet.measurement.config.reporting.metricSpecConfig
+import org.wfanet.measurement.edpaggregator.eventgroups.v1alpha.EventGroup as EdpaEventGroup
+import org.wfanet.measurement.edpaggregator.eventgroups.v1alpha.EventGroupKt.MetadataKt.AdMetadataKt.campaignMetadata as edpaCampaignMetadata
+import org.wfanet.measurement.edpaggregator.eventgroups.v1alpha.EventGroupKt.MetadataKt.adMetadata as edpaAdMetadata
+import org.wfanet.measurement.edpaggregator.eventgroups.v1alpha.EventGroupKt.entityKey as edpaEntityKey
+import org.wfanet.measurement.edpaggregator.eventgroups.v1alpha.EventGroupKt.metadata as edpaEventGroupMetadata
+import org.wfanet.measurement.edpaggregator.eventgroups.v1alpha.MappedEventGroup
+import org.wfanet.measurement.edpaggregator.eventgroups.v1alpha.eventGroup as edpaEventGroup
 import org.wfanet.measurement.edpaggregator.resultsfulfiller.ModelLineInfo
 import org.wfanet.measurement.edpaggregator.v1alpha.ResultsFulfillerParams
 import org.wfanet.measurement.eventdataprovider.requisition.v2alpha.common.InMemoryVidIndexMap
@@ -999,6 +1007,71 @@ abstract class InProcessEdpAggregatorLifeOfAReportTest(
       .that(expectedProtocolFound)
       .isTrue()
   }
+
+  /** Resource name of the single MeasurementConsumer used by these tests. */
+  protected fun measurementConsumerName(): String =
+    inProcessCmmsComponents.getMeasurementConsumerData().name
+
+  /**
+   * Builds a valid EDPA-side source [EdpaEventGroup] for driving [EventGroupSync] directly in
+   * migration tests. Sets whichever of `event_group_reference_id` / `entity_key` is provided
+   * (mirroring how an EDP evolves a row across the #4175 migration), plus the fields
+   * `EventGroupSync.validateEventGroup` requires: media type, data-availability interval, and
+   * metadata. `campaign` names the campaign metadata so a mutation is observable across syncs.
+   */
+  protected fun buildMigrationSourceEventGroup(
+    referenceId: String?,
+    entityType: String?,
+    entityId: String?,
+    campaign: String,
+  ): EdpaEventGroup = edpaEventGroup {
+    if (!referenceId.isNullOrEmpty()) {
+      eventGroupReferenceId = referenceId
+    }
+    measurementConsumer = measurementConsumerName()
+    if (entityType != null && entityId != null) {
+      entityKey = edpaEntityKey {
+        this.entityType = entityType
+        this.entityId = entityId
+      }
+    }
+    eventGroupMetadata = edpaEventGroupMetadata {
+      adMetadata = edpaAdMetadata {
+        campaignMetadata = edpaCampaignMetadata {
+          brand = "migration-brand"
+          this.campaign = campaign
+        }
+      }
+    }
+    dataAvailabilityInterval = interval {
+      startTime = timestamp { seconds = 200 }
+      endTime = timestamp { seconds = 300 }
+    }
+    mediaTypes += EdpaEventGroup.MediaType.VIDEO
+  }
+
+  /**
+   * Re-runs [EventGroupSync] for a single EDP against the running in-process Kingdom. Test-only
+   * seam for driving repeated migration syncs after daemon startup.
+   */
+  protected fun syncEventGroups(
+    edpAggregatorShortName: String,
+    sources: List<EdpaEventGroup>,
+    entityKeyTypes: List<String> = emptyList(),
+  ): List<MappedEventGroup> =
+    inProcessEdpAggregatorComponents.syncEventGroups(
+      edpAggregatorShortName,
+      sources,
+      entityKeyTypes,
+    )
+
+  /**
+   * Lists the raw CMMS [CmmsEventGroup]s an EDP owns on the Kingdom (bypassing the Reporting API).
+   * Used to assert the exact Kingdom row count and resource-name set, proving no EventGroup
+   * explosion / duplicate rows during migration.
+   */
+  protected fun listCmmsEventGroups(edpAggregatorShortName: String): List<CmmsEventGroup> =
+    inProcessEdpAggregatorComponents.listCmmsEventGroups(edpAggregatorShortName)
 
   protected suspend fun listReportingEventGroups(): List<EventGroup> {
     val measurementConsumerData = inProcessCmmsComponents.getMeasurementConsumerData()

--- a/src/main/kotlin/org/wfanet/measurement/integration/common/reporting/v2/InProcessEdpAggregatorLifeOfAnEventGroupTest.kt
+++ b/src/main/kotlin/org/wfanet/measurement/integration/common/reporting/v2/InProcessEdpAggregatorLifeOfAnEventGroupTest.kt
@@ -17,9 +17,17 @@ package org.wfanet.measurement.integration.common.reporting.v2
 import com.google.common.truth.Truth.assertThat
 import com.google.common.truth.Truth.assertWithMessage
 import com.google.common.truth.extensions.proto.ProtoTruth.assertThat
+import com.google.protobuf.timestamp
+import com.google.type.interval
 import kotlinx.coroutines.runBlocking
 import org.junit.Test
 import org.wfanet.measurement.common.testing.ProviderRule
+import org.wfanet.measurement.edpaggregator.eventgroups.v1alpha.EventGroup as EdpaEventGroup
+import org.wfanet.measurement.edpaggregator.eventgroups.v1alpha.EventGroupKt.MetadataKt.AdMetadataKt.campaignMetadata as edpaCampaignMetadata
+import org.wfanet.measurement.edpaggregator.eventgroups.v1alpha.EventGroupKt.MetadataKt.adMetadata as edpaAdMetadata
+import org.wfanet.measurement.edpaggregator.eventgroups.v1alpha.EventGroupKt.entityKey as edpaEntityKey
+import org.wfanet.measurement.edpaggregator.eventgroups.v1alpha.EventGroupKt.metadata as edpaEventGroupMetadata
+import org.wfanet.measurement.edpaggregator.eventgroups.v1alpha.eventGroup as edpaEventGroup
 import org.wfanet.measurement.gcloud.spanner.testing.SpannerDatabaseAdmin
 import org.wfanet.measurement.integration.common.ALL_DUCHY_NAMES
 import org.wfanet.measurement.integration.common.AccessServicesFactory
@@ -56,6 +64,44 @@ abstract class InProcessEdpAggregatorLifeOfAnEventGroupTest(
     hmssEnabled,
     trusTeeEnabled,
   ) {
+
+  /**
+   * Builds a valid EDPA-side source [EdpaEventGroup] for driving [EventGroupSync] directly in these
+   * migration tests. Sets whichever of `event_group_reference_id` / `entity_key` is provided
+   * (mirroring how an EDP evolves a row across the #4175 migration), plus the fields
+   * `EventGroupSync.validateEventGroup` requires: media type, data-availability interval, and
+   * metadata. `campaign` names the campaign metadata so a mutation is observable across syncs.
+   */
+  private fun buildMigrationSourceEventGroup(
+    referenceId: String?,
+    entityType: String?,
+    entityId: String?,
+    campaign: String,
+  ): EdpaEventGroup = edpaEventGroup {
+    if (!referenceId.isNullOrEmpty()) {
+      eventGroupReferenceId = referenceId
+    }
+    measurementConsumer = measurementConsumerName()
+    if (entityType != null && entityId != null) {
+      entityKey = edpaEntityKey {
+        this.entityType = entityType
+        this.entityId = entityId
+      }
+    }
+    eventGroupMetadata = edpaEventGroupMetadata {
+      adMetadata = edpaAdMetadata {
+        campaignMetadata = edpaCampaignMetadata {
+          brand = "migration-brand"
+          this.campaign = campaign
+        }
+      }
+    }
+    dataAvailabilityInterval = interval {
+      startTime = timestamp { seconds = 200 }
+      endTime = timestamp { seconds = 300 }
+    }
+    mediaTypes += EdpaEventGroup.MediaType.VIDEO
+  }
 
   @Test
   fun `EDPA EventGroups with explicit entity_key round-trip to the Reporting API`() = runBlocking {
@@ -128,7 +174,7 @@ abstract class InProcessEdpAggregatorLifeOfAnEventGroupTest(
       // entity_type="campaign", so a campaign-blind fetch would miss it on the phase-2 re-sync.
       val entityKeyTypes = listOf("campaign", CREATIVE_ID_ENTITY_TYPE)
 
-      val baselineCount = listCmmsEventGroups(edp).size
+      val baselineCount = listCmmsEventGroups(edp, entityKeyTypes).size
 
       // Phase 1: refId-only — CREATE. One new Kingdom row.
       val phase1 =
@@ -148,7 +194,7 @@ abstract class InProcessEdpAggregatorLifeOfAnEventGroupTest(
       val resourceName = phase1.single().eventGroupResource
       assertThat(resourceName).isNotEmpty()
       assertThat(phase1.single().eventGroupReferenceId).isEqualTo(migRefId)
-      assertThat(listCmmsEventGroups(edp)).hasSize(baselineCount + 1)
+      assertThat(listCmmsEventGroups(edp, entityKeyTypes)).hasSize(baselineCount + 1)
 
       // Phase 2: add entity_key alongside refId — UPDATE (matched by refId, backfills entity_key).
       // No new row.
@@ -167,8 +213,8 @@ abstract class InProcessEdpAggregatorLifeOfAnEventGroupTest(
         )
       assertThat(phase2).hasSize(1)
       assertThat(phase2.single().eventGroupResource).isEqualTo(resourceName)
-      assertThat(listCmmsEventGroups(edp)).hasSize(baselineCount + 1)
-      val afterPhase2 = listCmmsEventGroups(edp).single { it.name == resourceName }
+      assertThat(listCmmsEventGroups(edp, entityKeyTypes)).hasSize(baselineCount + 1)
+      val afterPhase2 = listCmmsEventGroups(edp, entityKeyTypes).single { it.name == resourceName }
       assertThat(afterPhase2.entityKey.entityType).isEqualTo(CREATIVE_ID_ENTITY_TYPE)
       assertThat(afterPhase2.entityKey.entityId).isEqualTo(migEntityId)
 
@@ -190,7 +236,15 @@ abstract class InProcessEdpAggregatorLifeOfAnEventGroupTest(
         )
       assertThat(phase3).hasSize(1)
       assertThat(phase3.single().eventGroupResource).isEqualTo(resourceName)
-      assertThat(listCmmsEventGroups(edp)).hasSize(baselineCount + 1)
+      assertThat(listCmmsEventGroups(edp, entityKeyTypes)).hasSize(baselineCount + 1)
+
+      // Phase 3 dropped refId and renamed the campaign. Verify both mutations actually landed on
+      // the Kingdom row (the UPDATE applied), not just that identity was preserved.
+      val afterPhase3 = listCmmsEventGroups(edp, entityKeyTypes).single { it.name == resourceName }
+      assertThat(afterPhase3.eventGroupReferenceId).isEmpty()
+      assertThat(afterPhase3.entityKey.entityId).isEqualTo(migEntityId)
+      assertThat(afterPhase3.eventGroupMetadata.adMetadata.campaignMetadata.campaignName)
+        .isEqualTo("c1-final")
 
       // The Reporting API (what a user sees) shows exactly one row for the migrated EventGroup, and
       // it is the same Kingdom resource — no extras leaked through the Reporting read path.
@@ -215,7 +269,7 @@ abstract class InProcessEdpAggregatorLifeOfAnEventGroupTest(
         mapOf(refIds[0] to "fleet-id-A", refIds[1] to "fleet-id-B", refIds[2] to "fleet-id-C")
       val entityKeyTypes = listOf("campaign", CREATIVE_ID_ENTITY_TYPE)
 
-      val baselineCount = listCmmsEventGroups(edp).size
+      val baselineCount = listCmmsEventGroups(edp, entityKeyTypes).size
 
       fun sources(entityKeyed: Set<String>) =
         refIds.map { refId ->
@@ -239,15 +293,15 @@ abstract class InProcessEdpAggregatorLifeOfAnEventGroupTest(
       // Sync 1: all three refId-only — three CREATEs.
       val sync1 = syncEventGroups(edp, sources(entityKeyed = emptySet()), entityKeyTypes)
       assertThat(sync1).hasSize(3)
-      assertThat(listCmmsEventGroups(edp)).hasSize(baselineCount + 3)
+      assertThat(listCmmsEventGroups(edp, entityKeyTypes)).hasSize(baselineCount + 3)
       val migratedResourceNames = sync1.map { it.eventGroupResource }.toSet()
       assertThat(migratedResourceNames).hasSize(3)
 
       // Sync 2: only A migrates. B, C stay refId-only.
       syncEventGroups(edp, sources(entityKeyed = setOf(refIds[0])), entityKeyTypes)
-      assertThat(listCmmsEventGroups(edp)).hasSize(baselineCount + 3)
+      assertThat(listCmmsEventGroups(edp, entityKeyTypes)).hasSize(baselineCount + 3)
       assertThat(
-          listCmmsEventGroups(edp)
+          listCmmsEventGroups(edp, entityKeyTypes)
             .filter { it.name in migratedResourceNames }
             .count { it.entityKey.entityId.isNotEmpty() }
         )
@@ -255,9 +309,9 @@ abstract class InProcessEdpAggregatorLifeOfAnEventGroupTest(
 
       // Sync 3: A and B migrated. C still refId-only.
       syncEventGroups(edp, sources(entityKeyed = setOf(refIds[0], refIds[1])), entityKeyTypes)
-      assertThat(listCmmsEventGroups(edp)).hasSize(baselineCount + 3)
+      assertThat(listCmmsEventGroups(edp, entityKeyTypes)).hasSize(baselineCount + 3)
       assertThat(
-          listCmmsEventGroups(edp)
+          listCmmsEventGroups(edp, entityKeyTypes)
             .filter { it.name in migratedResourceNames }
             .count { it.entityKey.entityId.isNotEmpty() }
         )
@@ -265,9 +319,9 @@ abstract class InProcessEdpAggregatorLifeOfAnEventGroupTest(
 
       // Sync 4: all three migrated (dual-keyed).
       syncEventGroups(edp, sources(entityKeyed = refIds.toSet()), entityKeyTypes)
-      assertThat(listCmmsEventGroups(edp)).hasSize(baselineCount + 3)
+      assertThat(listCmmsEventGroups(edp, entityKeyTypes)).hasSize(baselineCount + 3)
       assertThat(
-          listCmmsEventGroups(edp)
+          listCmmsEventGroups(edp, entityKeyTypes)
             .filter { it.name in migratedResourceNames }
             .count { it.entityKey.entityId.isNotEmpty() }
         )
@@ -299,8 +353,8 @@ abstract class InProcessEdpAggregatorLifeOfAnEventGroupTest(
         ),
         entityKeyTypes,
       )
-      assertThat(listCmmsEventGroups(edp)).hasSize(baselineCount + 3)
-      assertThat(listCmmsEventGroups(edp).map { it.name }.toSet())
+      assertThat(listCmmsEventGroups(edp, entityKeyTypes)).hasSize(baselineCount + 3)
+      assertThat(listCmmsEventGroups(edp, entityKeyTypes).map { it.name }.toSet())
         .containsAtLeastElementsIn(migratedResourceNames)
 
       // Reporting API sees exactly the three migrated rows, one per resource name — no extras.
@@ -312,7 +366,7 @@ abstract class InProcessEdpAggregatorLifeOfAnEventGroupTest(
     }
 
   @Test
-  fun `EDPA EventGroup migration without entity_key_types re-creates the migrated row`() =
+  fun `EDPA EventGroup migration without entity_key_types silently fails to re-sync the migrated row (blocked by unique index)`() =
     runBlocking {
       // Guards the migration footgun documented on EventGroupSyncConfig.entity_key_types: when the
       // sync is NOT configured with entity_key_types, listEventGroups defaults to entity_type=
@@ -324,8 +378,12 @@ abstract class InProcessEdpAggregatorLifeOfAnEventGroupTest(
       val edp = "edp1"
       val migRefId = "mig-nofilter-ref"
       val migEntityId = "mig-nofilter-entity"
+      // The sync is deliberately left unconfigured (the footgun under test), but the raw
+      // lister must still enumerate every type the row could carry to observe true Kingdom
+      // state.
+      val presentEntityTypes = listOf("campaign", CREATIVE_ID_ENTITY_TYPE)
 
-      val baselineCount = listCmmsEventGroups(edp).size
+      val baselineCount = listCmmsEventGroups(edp, presentEntityTypes).size
 
       // Phase 1: refId-only — CREATE. Visible under the default campaign filter.
       val phase1 =
@@ -342,7 +400,7 @@ abstract class InProcessEdpAggregatorLifeOfAnEventGroupTest(
         )
       assertThat(phase1).hasSize(1)
       val resourceName = phase1.single().eventGroupResource
-      assertThat(listCmmsEventGroups(edp)).hasSize(baselineCount + 1)
+      assertThat(listCmmsEventGroups(edp, presentEntityTypes)).hasSize(baselineCount + 1)
 
       // Phase 2: migrate to entity_key. Matched by refId (still campaign-typed at fetch time), so
       // this UPDATE succeeds and backfills the creative-id entity_key. No new row yet.
@@ -360,7 +418,7 @@ abstract class InProcessEdpAggregatorLifeOfAnEventGroupTest(
         )
       assertThat(phase2).hasSize(1)
       assertThat(phase2.single().eventGroupResource).isEqualTo(resourceName)
-      assertThat(listCmmsEventGroups(edp)).hasSize(baselineCount + 1)
+      assertThat(listCmmsEventGroups(edp, presentEntityTypes)).hasSize(baselineCount + 1)
 
       // Phase 3: entity_key-only re-sync. The row is now creative-id-typed, invisible to the
       // campaign-only default fetch, so the sync tries to CREATE it again and the Kingdom rejects
@@ -382,6 +440,12 @@ abstract class InProcessEdpAggregatorLifeOfAnEventGroupTest(
       assertThat(phase3).isEmpty()
       // No duplicate landed (the unique index blocked it), but the item never synced: the mutation
       // (campaign renamed to "c1-final") did not apply.
-      assertThat(listCmmsEventGroups(edp)).hasSize(baselineCount + 1)
+      assertThat(listCmmsEventGroups(edp, presentEntityTypes)).hasSize(baselineCount + 1)
+      // The stored row still shows the pre-failure campaign ("c1"), proving the phase-3 mutation
+      // was not applied.
+      val afterPhase3 =
+        listCmmsEventGroups(edp, presentEntityTypes).single { it.name == resourceName }
+      assertThat(afterPhase3.eventGroupMetadata.adMetadata.campaignMetadata.campaignName)
+        .isEqualTo("c1")
     }
 }

--- a/src/main/kotlin/org/wfanet/measurement/integration/common/reporting/v2/InProcessEdpAggregatorLifeOfAnEventGroupTest.kt
+++ b/src/main/kotlin/org/wfanet/measurement/integration/common/reporting/v2/InProcessEdpAggregatorLifeOfAnEventGroupTest.kt
@@ -516,4 +516,150 @@ abstract class InProcessEdpAggregatorLifeOfAnEventGroupTest(
       assertThat(afterSync3.eventGroupMetadata.adMetadata.campaignMetadata.campaignName)
         .isEqualTo("c1")
     }
+
+  @Test
+  fun `EDPA EventGroup dropping refId while adding entity_key in one step duplicates the row`() =
+    runBlocking {
+      // Documents a migration-PROCEDURE footgun that is independent of entity_key_types: it happens
+      // even with the correct configuration (entity_key_types set below). The safe migration keeps
+      // event_group_reference_id while adding entity_key — the dual-keyed step lets the existing
+      // row
+      // be matched by refId and UPDATED to carry the entity_key (see the "preserves identity across
+      // syncs" test). If instead an EDP jumps straight from refId-only to entity_key-only in a
+      // single step, the new entity-keyed source shares no identifier with the existing refId-only
+      // row (match is by entity_key, then by refId, and neither is common to both), so the sync
+      // cannot correlate them: it CREATEs a second row and orphans the original. Because the old
+      // row
+      // never carried an entity_key, the unique EventGroupsByEntityKey index does not block the new
+      // CREATE, so a genuine duplicate lands — unlike the two misconfiguration cases above, which
+      // do
+      // not explode.
+      val edp = "edp1"
+      val migRefId = "jump-ref"
+      val migEntityId = "jump-entity"
+      // Correct configuration — the duplication below is not caused by a missing entity_key_types.
+      val entityKeyTypes = listOf("campaign", CREATIVE_ID_ENTITY_TYPE)
+
+      val baselineCount = listCmmsEventGroups(edp, entityKeyTypes).size
+
+      // Sync 1: refId-only — CREATE. Stored as a campaign-typed row keyed only by refId.
+      val sync1 =
+        syncEventGroups(
+          edp,
+          listOf(
+            buildMigrationSourceEventGroup(
+              referenceId = migRefId,
+              entityType = null,
+              entityId = null,
+              campaign = "c1",
+            )
+          ),
+          entityKeyTypes,
+        )
+      assertThat(sync1).hasSize(1)
+      val refIdResource = sync1.single().eventGroupResource
+      assertThat(listCmmsEventGroups(edp, entityKeyTypes)).hasSize(baselineCount + 1)
+
+      // Sync 2: entity_key-only, with refId dropped in the same step (no dual-keyed bridge). The
+      // source can't be matched to the existing refId-only row, so a second, entity-keyed row is
+      // created and the original is orphaned.
+      val sync2 =
+        syncEventGroups(
+          edp,
+          listOf(
+            buildMigrationSourceEventGroup(
+              referenceId = null,
+              entityType = CREATIVE_ID_ENTITY_TYPE,
+              entityId = migEntityId,
+              campaign = "c1",
+            )
+          ),
+          entityKeyTypes,
+        )
+      assertThat(sync2).hasSize(1)
+      val entityKeyResource = sync2.single().eventGroupResource
+      // A distinct resource from the refId-only row: the two are not correlated.
+      assertThat(entityKeyResource).isNotEqualTo(refIdResource)
+      // Both rows now exist for what should be a single logical EventGroup — the duplicate.
+      assertThat(listCmmsEventGroups(edp, entityKeyTypes)).hasSize(baselineCount + 2)
+    }
+
+  @Test
+  fun `EDPA EventGroup keeping refId while adding entity_key stalls (does not explode) when entity_key_types is unset`() =
+    runBlocking {
+      // The proper migration procedure — keep event_group_reference_id while adding entity_key
+      // (dual-keyed), so the existing row is matched by refId and UPDATED to carry the entity_key —
+      // still breaks when entity_key_types is left unset, but it does NOT explode: the unique
+      // EventGroupsByEntityKey index blocks the redundant CREATE, so the item stalls instead.
+      //
+      // The subtle part this pins: once the first dual-keyed sync backfills the entity_key, the row
+      // becomes non-"campaign"-typed and drops out of the campaign-default fetch. On the next sync
+      // the refId in the source no longer helps, because the row is no longer returned by the fetch
+      // at all, so it can be matched neither by entity_key nor by refId. The sync issues a CREATE
+      // that collides on the unique index and fails the item (no mapping emitted). No duplicate row
+      // is created — the migration is stuck, not exploded. Setting entity_key_types keeps the row
+      // visible so the re-sync is a no-op UPDATE instead.
+      val edp = "edp1"
+      val migRefId = "keep-ref"
+      val migEntityId = "keep-entity"
+
+      val listTypes = listOf("campaign", CREATIVE_ID_ENTITY_TYPE)
+      val baselineCount = listCmmsEventGroups(edp, listTypes).size
+
+      // Sync 1: refId-only, entity_key_types unset — CREATE (campaign-typed).
+      val sync1 =
+        syncEventGroups(
+          edp,
+          listOf(
+            buildMigrationSourceEventGroup(
+              referenceId = migRefId,
+              entityType = null,
+              entityId = null,
+              campaign = "c1",
+            )
+          ),
+        )
+      assertThat(sync1).hasSize(1)
+      val resourceName = sync1.single().eventGroupResource
+      assertThat(listCmmsEventGroups(edp, listTypes)).hasSize(baselineCount + 1)
+
+      // Sync 2: add entity_key while KEEPING refId. The row is still campaign-typed at fetch time,
+      // so it is matched by refId and UPDATED (entity_key backfilled). No new row.
+      val sync2 =
+        syncEventGroups(
+          edp,
+          listOf(
+            buildMigrationSourceEventGroup(
+              referenceId = migRefId,
+              entityType = CREATIVE_ID_ENTITY_TYPE,
+              entityId = migEntityId,
+              campaign = "c1",
+            )
+          ),
+        )
+      assertThat(sync2).hasSize(1)
+      assertThat(sync2.single().eventGroupResource).isEqualTo(resourceName)
+      assertThat(listCmmsEventGroups(edp, listTypes)).hasSize(baselineCount + 1)
+      val afterSync2 = listCmmsEventGroups(edp, listTypes).single { it.name == resourceName }
+      assertThat(afterSync2.entityKey.entityId).isEqualTo(migEntityId)
+
+      // Sync 3: identical dual-keyed source. The row is now creative-id-typed, so the campaign-
+      // default fetch misses it and the refId in the source can't rescue the match either. The sync
+      // issues a CREATE that the unique index rejects — the item stalls (no mapping), and crucially
+      // no duplicate row is created.
+      val sync3 =
+        syncEventGroups(
+          edp,
+          listOf(
+            buildMigrationSourceEventGroup(
+              referenceId = migRefId,
+              entityType = CREATIVE_ID_ENTITY_TYPE,
+              entityId = migEntityId,
+              campaign = "c1",
+            )
+          ),
+        )
+      assertThat(sync3).isEmpty()
+      assertThat(listCmmsEventGroups(edp, listTypes)).hasSize(baselineCount + 1)
+    }
 }

--- a/src/main/kotlin/org/wfanet/measurement/integration/common/reporting/v2/InProcessEdpAggregatorLifeOfAnEventGroupTest.kt
+++ b/src/main/kotlin/org/wfanet/measurement/integration/common/reporting/v2/InProcessEdpAggregatorLifeOfAnEventGroupTest.kt
@@ -448,4 +448,72 @@ abstract class InProcessEdpAggregatorLifeOfAnEventGroupTest(
       assertThat(afterPhase3.eventGroupMetadata.adMetadata.campaignMetadata.campaignName)
         .isEqualTo("c1")
     }
+
+  @Test
+  fun `EDPA EventGroup with non-campaign entity_type silently drops updates when entity_key_types is unset`() =
+    runBlocking {
+      // Documents the (undesirable) behavior of a MISCONFIGURED EventGroupSync — entity_key_types
+      // left unset — for an EventGroup created directly with a non-"campaign" entity_type (a
+      // publisher onboarding a new campaign/entity type, with no refId migration involved). This is
+      // the counterpart to the migration footgun above: the correct configuration sets
+      // entity_key_types so these rows stay visible to the sync (see the migration tests, which
+      // do).
+      //
+      // Because the row is entity-keyed from creation, its CREATE request_id is derived from the
+      // entity_key and is stable across syncs. The campaign-default fetch never sees the
+      // creative-id
+      // row, so every sync takes the CREATE path. The first CREATE lands the row; every later
+      // CREATE
+      // carries the same request_id, so the Kingdom idempotent-replays it and returns the ORIGINAL
+      // resource. Two consequences of the misconfiguration, both proven below:
+      //   1. No duplicate rows / no explosion and no ALREADY_EXISTS failure — idempotency absorbs
+      //      the redundant CREATE (unlike the migrated-then-dropped-refId case, where the differing
+      //      request_id hits the unique index instead).
+      //   2. Because every sync replays the original CREATE instead of issuing an UPDATE, later
+      //      changes to the source (here, a renamed campaign) are SILENTLY DROPPED — they never
+      //      reach the Kingdom row and no error signals the misconfiguration.
+      val edp = "edp1"
+      val entityId = "born-creative-entity"
+      val presentEntityTypes = listOf("campaign", CREATIVE_ID_ENTITY_TYPE)
+
+      val baselineCount = listCmmsEventGroups(edp, presentEntityTypes).size
+
+      fun source(campaign: String) =
+        listOf(
+          buildMigrationSourceEventGroup(
+            referenceId = null,
+            entityType = CREATIVE_ID_ENTITY_TYPE,
+            entityId = entityId,
+            campaign = campaign,
+          )
+        )
+
+      // Sync 1: entity_key_types unset (the misconfiguration). The row is new — CREATE succeeds.
+      val sync1 = syncEventGroups(edp, source("c1"))
+      assertThat(sync1).hasSize(1)
+      val resourceName = sync1.single().eventGroupResource
+      assertThat(resourceName).isNotEmpty()
+      assertThat(listCmmsEventGroups(edp, presentEntityTypes)).hasSize(baselineCount + 1)
+
+      // Sync 2: identical source. The campaign-default fetch still can't see the creative-id row,
+      // so
+      // the sync re-issues a CREATE with the same entity-key request_id; the Kingdom idempotent-
+      // replays and returns the same resource. No duplicate row, no failure.
+      val sync2 = syncEventGroups(edp, source("c1"))
+      assertThat(sync2).hasSize(1)
+      assertThat(sync2.single().eventGroupResource).isEqualTo(resourceName)
+      assertThat(listCmmsEventGroups(edp, presentEntityTypes)).hasSize(baselineCount + 1)
+
+      // Sync 3: the source renames the campaign to "c2". Still invisible to the fetch, so the sync
+      // replays the original CREATE instead of updating — the rename is silently dropped.
+      val sync3 = syncEventGroups(edp, source("c2"))
+      assertThat(sync3).hasSize(1)
+      assertThat(sync3.single().eventGroupResource).isEqualTo(resourceName)
+      assertThat(listCmmsEventGroups(edp, presentEntityTypes)).hasSize(baselineCount + 1)
+      // The stored row still shows the original campaign ("c1"); the "c2" update never landed.
+      val afterSync3 =
+        listCmmsEventGroups(edp, presentEntityTypes).single { it.name == resourceName }
+      assertThat(afterSync3.eventGroupMetadata.adMetadata.campaignMetadata.campaignName)
+        .isEqualTo("c1")
+    }
 }

--- a/src/main/kotlin/org/wfanet/measurement/integration/common/reporting/v2/InProcessEdpAggregatorLifeOfAnEventGroupTest.kt
+++ b/src/main/kotlin/org/wfanet/measurement/integration/common/reporting/v2/InProcessEdpAggregatorLifeOfAnEventGroupTest.kt
@@ -109,4 +109,279 @@ abstract class InProcessEdpAggregatorLifeOfAnEventGroupTest(
     assertThat(adGroupEventGroup.entityKey.entityId).isEqualTo(AD_GROUP_EDP_EVENT_GROUP_REF_ID)
     assertThat(adGroupEventGroup.eventGroupMetadata.entityMetadata).isEqualTo(ENTITY_METADATA)
   }
+
+  @Test
+  fun `EDPA EventGroup migrating from refId-only to entity_key preserves identity across syncs`() =
+    runBlocking {
+      // Drives the #4175 migration for a single EventGroup through the REAL in-process Kingdom
+      // (real request_id idempotency + real per-(DataProvider, MeasurementConsumer) uniqueness on
+      // the EventGroupsByEntityKey index), not a mock. Uses a fresh, dedicated identifier ("mig-*")
+      // that no other test touches. The sync is configured with entity_key_types covering the
+      // migrating type ("creative-id") — the required production configuration for a fleet that
+      // uses non-"campaign" entity types (see EventGroupSyncConfig.entity_key_types). The invariant
+      // proven at every phase: the migrating EventGroup maps to exactly one Kingdom resource name
+      // that never changes, so no duplicate / extra row is created.
+      val edp = "edp1"
+      val migRefId = "mig-eg-ref"
+      val migEntityId = "mig-eg-entity"
+      // Must include "campaign" too: the row is created refId-only, which the Kingdom defaults to
+      // entity_type="campaign", so a campaign-blind fetch would miss it on the phase-2 re-sync.
+      val entityKeyTypes = listOf("campaign", CREATIVE_ID_ENTITY_TYPE)
+
+      val baselineCount = listCmmsEventGroups(edp).size
+
+      // Phase 1: refId-only — CREATE. One new Kingdom row.
+      val phase1 =
+        syncEventGroups(
+          edp,
+          listOf(
+            buildMigrationSourceEventGroup(
+              referenceId = migRefId,
+              entityType = null,
+              entityId = null,
+              campaign = "c1",
+            )
+          ),
+          entityKeyTypes,
+        )
+      assertThat(phase1).hasSize(1)
+      val resourceName = phase1.single().eventGroupResource
+      assertThat(resourceName).isNotEmpty()
+      assertThat(phase1.single().eventGroupReferenceId).isEqualTo(migRefId)
+      assertThat(listCmmsEventGroups(edp)).hasSize(baselineCount + 1)
+
+      // Phase 2: add entity_key alongside refId — UPDATE (matched by refId, backfills entity_key).
+      // No new row.
+      val phase2 =
+        syncEventGroups(
+          edp,
+          listOf(
+            buildMigrationSourceEventGroup(
+              referenceId = migRefId,
+              entityType = CREATIVE_ID_ENTITY_TYPE,
+              entityId = migEntityId,
+              campaign = "c1",
+            )
+          ),
+          entityKeyTypes,
+        )
+      assertThat(phase2).hasSize(1)
+      assertThat(phase2.single().eventGroupResource).isEqualTo(resourceName)
+      assertThat(listCmmsEventGroups(edp)).hasSize(baselineCount + 1)
+      val afterPhase2 = listCmmsEventGroups(edp).single { it.name == resourceName }
+      assertThat(afterPhase2.entityKey.entityType).isEqualTo(CREATIVE_ID_ENTITY_TYPE)
+      assertThat(afterPhase2.entityKey.entityId).isEqualTo(migEntityId)
+
+      // Phase 3: drop refId entirely — entity_key only — UPDATE (matched by entity_key). No new
+      // row. This is the phase that regresses to a duplicate CREATE (ALREADY_EXISTS on
+      // EventGroupsByEntityKey) if the sync is misconfigured without entity_key_types.
+      val phase3 =
+        syncEventGroups(
+          edp,
+          listOf(
+            buildMigrationSourceEventGroup(
+              referenceId = null,
+              entityType = CREATIVE_ID_ENTITY_TYPE,
+              entityId = migEntityId,
+              campaign = "c1-final",
+            )
+          ),
+          entityKeyTypes,
+        )
+      assertThat(phase3).hasSize(1)
+      assertThat(phase3.single().eventGroupResource).isEqualTo(resourceName)
+      assertThat(listCmmsEventGroups(edp)).hasSize(baselineCount + 1)
+
+      // The Reporting API (what a user sees) shows exactly one row for the migrated EventGroup, and
+      // it is the same Kingdom resource — no extras leaked through the Reporting read path.
+      val reportingRows = listReportingEventGroups().filter { it.cmmsEventGroup == resourceName }
+      assertThat(reportingRows).hasSize(1)
+      assertThat(reportingRows.single().entityKey.entityType).isEqualTo(CREATIVE_ID_ENTITY_TYPE)
+      assertThat(reportingRows.single().entityKey.entityId).isEqualTo(migEntityId)
+    }
+
+  @Test
+  fun `EDPA EventGroup fleet migrating at different paces keeps Kingdom row count static`() =
+    runBlocking {
+      // Fleet-wide partial migration through the REAL Kingdom. Three dedicated EventGroups start
+      // refId-only and migrate to entity_key independently at different paces. The invariant across
+      // every sync: the Kingdom row count grows by exactly the number of distinct EventGroups (3)
+      // and never more — an EventGroup mid-migration is never duplicated, and EventGroups that
+      // migrate later don't disturb ones that already migrated. Configured with entity_key_types so
+      // migrated rows stay visible to subsequent syncs (the production-correct configuration).
+      val edp = "edp1"
+      val refIds = listOf("fleet-ref-A", "fleet-ref-B", "fleet-ref-C")
+      val entityIds =
+        mapOf(refIds[0] to "fleet-id-A", refIds[1] to "fleet-id-B", refIds[2] to "fleet-id-C")
+      val entityKeyTypes = listOf("campaign", CREATIVE_ID_ENTITY_TYPE)
+
+      val baselineCount = listCmmsEventGroups(edp).size
+
+      fun sources(entityKeyed: Set<String>) =
+        refIds.map { refId ->
+          if (refId in entityKeyed) {
+            buildMigrationSourceEventGroup(
+              referenceId = refId,
+              entityType = CREATIVE_ID_ENTITY_TYPE,
+              entityId = entityIds.getValue(refId),
+              campaign = "campaign",
+            )
+          } else {
+            buildMigrationSourceEventGroup(
+              referenceId = refId,
+              entityType = null,
+              entityId = null,
+              campaign = "campaign",
+            )
+          }
+        }
+
+      // Sync 1: all three refId-only — three CREATEs.
+      val sync1 = syncEventGroups(edp, sources(entityKeyed = emptySet()), entityKeyTypes)
+      assertThat(sync1).hasSize(3)
+      assertThat(listCmmsEventGroups(edp)).hasSize(baselineCount + 3)
+      val migratedResourceNames = sync1.map { it.eventGroupResource }.toSet()
+      assertThat(migratedResourceNames).hasSize(3)
+
+      // Sync 2: only A migrates. B, C stay refId-only.
+      syncEventGroups(edp, sources(entityKeyed = setOf(refIds[0])), entityKeyTypes)
+      assertThat(listCmmsEventGroups(edp)).hasSize(baselineCount + 3)
+      assertThat(
+          listCmmsEventGroups(edp)
+            .filter { it.name in migratedResourceNames }
+            .count { it.entityKey.entityId.isNotEmpty() }
+        )
+        .isEqualTo(1)
+
+      // Sync 3: A and B migrated. C still refId-only.
+      syncEventGroups(edp, sources(entityKeyed = setOf(refIds[0], refIds[1])), entityKeyTypes)
+      assertThat(listCmmsEventGroups(edp)).hasSize(baselineCount + 3)
+      assertThat(
+          listCmmsEventGroups(edp)
+            .filter { it.name in migratedResourceNames }
+            .count { it.entityKey.entityId.isNotEmpty() }
+        )
+        .isEqualTo(2)
+
+      // Sync 4: all three migrated (dual-keyed).
+      syncEventGroups(edp, sources(entityKeyed = refIds.toSet()), entityKeyTypes)
+      assertThat(listCmmsEventGroups(edp)).hasSize(baselineCount + 3)
+      assertThat(
+          listCmmsEventGroups(edp)
+            .filter { it.name in migratedResourceNames }
+            .count { it.entityKey.entityId.isNotEmpty() }
+        )
+        .isEqualTo(3)
+
+      // Sync 5: A and B drop refId (entity_key only); C keeps refId. Still matched by entity_key,
+      // so no duplicate rows.
+      syncEventGroups(
+        edp,
+        listOf(
+          buildMigrationSourceEventGroup(
+            null,
+            CREATIVE_ID_ENTITY_TYPE,
+            entityIds.getValue(refIds[0]),
+            "campaign",
+          ),
+          buildMigrationSourceEventGroup(
+            null,
+            CREATIVE_ID_ENTITY_TYPE,
+            entityIds.getValue(refIds[1]),
+            "campaign",
+          ),
+          buildMigrationSourceEventGroup(
+            refIds[2],
+            CREATIVE_ID_ENTITY_TYPE,
+            entityIds.getValue(refIds[2]),
+            "campaign",
+          ),
+        ),
+        entityKeyTypes,
+      )
+      assertThat(listCmmsEventGroups(edp)).hasSize(baselineCount + 3)
+      assertThat(listCmmsEventGroups(edp).map { it.name }.toSet())
+        .containsAtLeastElementsIn(migratedResourceNames)
+
+      // Reporting API sees exactly the three migrated rows, one per resource name — no extras.
+      val reportingMigrated =
+        listReportingEventGroups().filter { it.cmmsEventGroup in migratedResourceNames }
+      assertThat(reportingMigrated.map { it.cmmsEventGroup }.toSet())
+        .isEqualTo(migratedResourceNames)
+      assertThat(reportingMigrated).hasSize(3)
+    }
+
+  @Test
+  fun `EDPA EventGroup migration without entity_key_types re-creates the migrated row`() =
+    runBlocking {
+      // Guards the migration footgun documented on EventGroupSyncConfig.entity_key_types: when the
+      // sync is NOT configured with entity_key_types, listEventGroups defaults to entity_type=
+      // "campaign" only, so once an EventGroup migrates to a non-"campaign" entity type the next
+      // sync can no longer see it, treats it as new, and issues a CREATE that collides on the
+      // unique EventGroupsByEntityKey index. This test pins that behavior so the requirement to set
+      // entity_key_types is explicit and regressions are caught. It intentionally uses the default
+      // (empty) entityKeyTypes.
+      val edp = "edp1"
+      val migRefId = "mig-nofilter-ref"
+      val migEntityId = "mig-nofilter-entity"
+
+      val baselineCount = listCmmsEventGroups(edp).size
+
+      // Phase 1: refId-only — CREATE. Visible under the default campaign filter.
+      val phase1 =
+        syncEventGroups(
+          edp,
+          listOf(
+            buildMigrationSourceEventGroup(
+              referenceId = migRefId,
+              entityType = null,
+              entityId = null,
+              campaign = "c1",
+            )
+          ),
+        )
+      assertThat(phase1).hasSize(1)
+      val resourceName = phase1.single().eventGroupResource
+      assertThat(listCmmsEventGroups(edp)).hasSize(baselineCount + 1)
+
+      // Phase 2: migrate to entity_key. Matched by refId (still campaign-typed at fetch time), so
+      // this UPDATE succeeds and backfills the creative-id entity_key. No new row yet.
+      val phase2 =
+        syncEventGroups(
+          edp,
+          listOf(
+            buildMigrationSourceEventGroup(
+              referenceId = migRefId,
+              entityType = CREATIVE_ID_ENTITY_TYPE,
+              entityId = migEntityId,
+              campaign = "c1",
+            )
+          ),
+        )
+      assertThat(phase2).hasSize(1)
+      assertThat(phase2.single().eventGroupResource).isEqualTo(resourceName)
+      assertThat(listCmmsEventGroups(edp)).hasSize(baselineCount + 1)
+
+      // Phase 3: entity_key-only re-sync. The row is now creative-id-typed, invisible to the
+      // campaign-only default fetch, so the sync tries to CREATE it again and the Kingdom rejects
+      // the duplicate on EventGroupsByEntityKey. EventGroupSync records the per-item failure and
+      // emits no mapping — the write does not go through, so still no duplicate row lands, but the
+      // sync silently fails to progress the item. This is the misconfiguration signature.
+      val phase3 =
+        syncEventGroups(
+          edp,
+          listOf(
+            buildMigrationSourceEventGroup(
+              referenceId = null,
+              entityType = CREATIVE_ID_ENTITY_TYPE,
+              entityId = migEntityId,
+              campaign = "c1-final",
+            )
+          ),
+        )
+      assertThat(phase3).isEmpty()
+      // No duplicate landed (the unique index blocked it), but the item never synced: the mutation
+      // (campaign renamed to "c1-final") did not apply.
+      assertThat(listCmmsEventGroups(edp)).hasSize(baselineCount + 1)
+    }
 }


### PR DESCRIPTION
Adds integration tests to InProcessEdpAggregatorLifeOfAnEventGroupTest that drive the reference-id to entity_key EventGroup migration through the real in-process Kingdom, rather than a mock, so real request_id idempotency and the unique EventGroupsByEntityKey index are exercised. The tests verify no EventGroup explosion or duplicate rows when EventGroups migrate at different paces, asserting both on the raw Kingdom EventGroups list and through the Reporting API.

One test covers a single EventGroup migrating refId-only to dual-keyed to entity_key-only. One covers a fleet of three EventGroups migrating independently across five syncs with the Kingdom row count staying static. One pins the misconfiguration behavior documented on EventGroupSyncConfig.entity_key_types: when entity_key_types is unset, ListEventGroups defaults to entity_type campaign, so a migrated non-campaign EventGroup becomes invisible to the next sync and is re-created, colliding on the unique index.

Adds test-only seams to InProcessEdpAggregatorComponents (a re-runnable syncEventGroups and a raw listCmmsEventGroups) plus protected helpers on the parent test.

All tests pass locally against the emulator.

Issue: #4175