### PR TITLE
refactor: consolidate dashboard config into DASHBOARD_CONFIG_CONTENT

### DIFF
--- a/.github/workflows/dashboard-isolation-test.yml
+++ b/.github/workflows/dashboard-isolation-test.yml
@@ -41,18 +41,21 @@ jobs:
       id-token: write
     environment: ${{ inputs.environment }}
     outputs:
-      edp_config: ${{ steps.load-edp-config.outputs.edp_config }}
+      edp_config: ${{ steps.load-config.outputs.edp_config }}
+      region: ${{ steps.load-config.outputs.region }}
     steps:
-      - name: Load EDP config from environment vars
-        id: load-edp-config
+      - name: Load dashboard config from environment vars
+        id: load-config
         env:
-          EDP_CONFIG: ${{ vars.DASHBOARD_EDP_CONFIG }}
+          DASHBOARD_CONFIG_CONTENT: ${{ vars.DASHBOARD_CONFIG_CONTENT }}
         run: |
-          if [ -z "$EDP_CONFIG" ]; then
-            echo "vars.DASHBOARD_EDP_CONFIG is empty for environment ${{ inputs.environment }}" >&2
+          set -euo pipefail
+          if [ -z "$DASHBOARD_CONFIG_CONTENT" ]; then
+            echo "vars.DASHBOARD_CONFIG_CONTENT is empty for environment ${{ inputs.environment }}" >&2
             exit 1
           fi
-          echo "edp_config=$EDP_CONFIG" >> "$GITHUB_OUTPUT"
+          echo "edp_config=$(jq -c '.edps' <<< "$DASHBOARD_CONFIG_CONTENT")" >> "$GITHUB_OUTPUT"
+          echo "region=$(jq -r '.bigquery_region' <<< "$DASHBOARD_CONFIG_CONTENT")" >> "$GITHUB_OUTPUT"
 
       - name: Authenticate to Google Cloud
         uses: google-github-actions/auth@c200f3691d83b41bf9bbd8638997a462592937ed # v2.1.13
@@ -63,7 +66,7 @@ jobs:
       - name: Trigger all dashboard scheduled queries
         env:
           PROJECT: ${{ vars.GOOGLE_CLOUD_PROJECT }}
-          REGION: ${{ vars.BIGQUERY_REGION }}
+          REGION: ${{ steps.load-config.outputs.region }}
         run: |
           set -euo pipefail
           RUN_TIME=$(date -u +%Y-%m-%dT%H:%M:%SZ)
@@ -177,7 +180,7 @@ jobs:
         id: run-tests
         env:
           GOOGLE_CLOUD_PROJECT: ${{ vars.GOOGLE_CLOUD_PROJECT }}
-          BIGQUERY_REGION: ${{ vars.BIGQUERY_REGION }}
+          BIGQUERY_REGION: ${{ needs.trigger-scheduled-queries.outputs.region }}
           EDP_NAME: ${{ matrix.edp.name }}
           EDP_RESOURCE_ID: ${{ matrix.edp.resource_id }}
           INSPECTOR_IMPERSONATE_SA: dashboard-compliance@${{ vars.GOOGLE_CLOUD_PROJECT }}.iam.gserviceaccount.com

--- a/.github/workflows/dashboard-isolation-test.yml
+++ b/.github/workflows/dashboard-isolation-test.yml
@@ -65,7 +65,7 @@ jobs:
 
       - name: Trigger all dashboard scheduled queries
         env:
-          PROJECT: ${{ vars.GOOGLE_CLOUD_PROJECT }}
+          PROJECT: ${{ vars.GCLOUD_PROJECT }}
           REGION: ${{ steps.load-config.outputs.region }}
         run: |
           set -euo pipefail
@@ -179,13 +179,13 @@ jobs:
       - name: Run Dashboard Isolation Tests
         id: run-tests
         env:
-          GOOGLE_CLOUD_PROJECT: ${{ vars.GOOGLE_CLOUD_PROJECT }}
+          GOOGLE_CLOUD_PROJECT: ${{ vars.GCLOUD_PROJECT }}
           BIGQUERY_REGION: ${{ needs.trigger-scheduled-queries.outputs.region }}
           EDP_NAME: ${{ matrix.edp.name }}
           EDP_RESOURCE_ID: ${{ matrix.edp.resource_id }}
-          INSPECTOR_IMPERSONATE_SA: dashboard-compliance@${{ vars.GOOGLE_CLOUD_PROJECT }}.iam.gserviceaccount.com
-          EDP_DELEGATES: dashboard-compliance@${{ vars.GOOGLE_CLOUD_PROJECT }}.iam.gserviceaccount.com
-          EDP_IMPERSONATE_SA: edp-${{ matrix.edp.name }}-dashboard@${{ vars.GOOGLE_CLOUD_PROJECT }}.iam.gserviceaccount.com
+          INSPECTOR_IMPERSONATE_SA: dashboard-compliance@${{ vars.GCLOUD_PROJECT }}.iam.gserviceaccount.com
+          EDP_DELEGATES: dashboard-compliance@${{ vars.GCLOUD_PROJECT }}.iam.gserviceaccount.com
+          EDP_IMPERSONATE_SA: edp-${{ matrix.edp.name }}-dashboard@${{ vars.GCLOUD_PROJECT }}.iam.gserviceaccount.com
         run: |
           bazel test \
           --test_env=GOOGLE_APPLICATION_CREDENTIALS \

--- a/.github/workflows/dashboard-isolation-test.yml
+++ b/.github/workflows/dashboard-isolation-test.yml
@@ -54,6 +54,11 @@ jobs:
             echo "vars.DASHBOARD_CONFIG_CONTENT is empty for environment ${{ inputs.environment }}" >&2
             exit 1
           fi
+          # Fail loudly on a malformed config rather than emitting literal "null" that
+          # propagates into later steps (e.g. locations/null). Mirrors terraform-cmms-v2.yml.
+          jq -e '(.edps | type == "array" and length > 0) and (.bigquery_region | type == "string" and length > 0)' \
+            <<< "$DASHBOARD_CONFIG_CONTENT" > /dev/null \
+            || { echo "DASHBOARD_CONFIG_CONTENT must set a non-empty 'edps' array and 'bigquery_region'" >&2; exit 1; }
           echo "edp_config=$(jq -c '.edps' <<< "$DASHBOARD_CONFIG_CONTENT")" >> "$GITHUB_OUTPUT"
           echo "region=$(jq -r '.bigquery_region' <<< "$DASHBOARD_CONFIG_CONTENT")" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/terraform-cmms-v2.yml
+++ b/.github/workflows/terraform-cmms-v2.yml
@@ -256,7 +256,7 @@ jobs:
       working-directory: ${{ env.GCLOUD_MODULE_PATH }}
       env:
         DASHBOARD_CONFIG_CONTENT: ${{ vars.DASHBOARD_CONFIG_CONTENT }}
-        SPANNER_PROJECT: ${{ vars.GOOGLE_CLOUD_PROJECT }}
+        SPANNER_PROJECT: ${{ vars.GCLOUD_PROJECT }}
         SPANNER_INSTANCE: ${{ vars.SPANNER_INSTANCE }}
       run: |
         set -euo pipefail

--- a/.github/workflows/terraform-cmms-v2.yml
+++ b/.github/workflows/terraform-cmms-v2.yml
@@ -261,7 +261,7 @@ jobs:
       run: |
         set -euo pipefail
         # Dashboard config (EDPs, operators, deletion protection) is consolidated
-        # into the single DASHBOARD_CONFIG_CONTENT JSON var (#4124). Terraform reads
+        # into the single DASHBOARD_CONFIG_CONTENT JSON var. Terraform reads
         # it natively as *.tfvars.json.
         # Fail loudly if any required key is missing rather than silently emitting
         # null (which Terraform would treat as unset, falling back to defaults).

--- a/.github/workflows/terraform-cmms-v2.yml
+++ b/.github/workflows/terraform-cmms-v2.yml
@@ -255,14 +255,27 @@ jobs:
     - name: Write dashboard tfvars
       working-directory: ${{ env.GCLOUD_MODULE_PATH }}
       env:
-        DATA_PROVIDER_RESOURCE_IDS: ${{ vars.DATA_PROVIDER_RESOURCE_IDS }}
-        DASHBOARD_OPERATORS: ${{ vars.DASHBOARD_OPERATORS }}
+        DASHBOARD_CONFIG_CONTENT: ${{ vars.DASHBOARD_CONFIG_CONTENT }}
         SPANNER_PROJECT: ${{ vars.GOOGLE_CLOUD_PROJECT }}
         SPANNER_INSTANCE: ${{ vars.SPANNER_INSTANCE }}
       run: |
+        set -euo pipefail
+        # Dashboard config (EDPs, operators, deletion protection) is consolidated
+        # into the single DASHBOARD_CONFIG_CONTENT JSON var (#4124). Terraform reads
+        # it natively as *.tfvars.json.
+        # Fail loudly if any required key is missing rather than silently emitting
+        # null (which Terraform would treat as unset, falling back to defaults).
+        jq -e 'has("bigquery_region") and has("deletion_protection")
+          and has("operators") and has("edps")' \
+          <<< "$DASHBOARD_CONFIG_CONTENT" > /dev/null \
+          || { echo "DASHBOARD_CONFIG_CONTENT is missing required keys" >&2; exit 1; }
+        jq '{
+          data_provider_resource_ids: ((.edps // [] | map({(.name): .resource_id}) | add) // {}),
+          dashboard_operators: .operators,
+          dashboard_deletion_protection: .deletion_protection
+        }' <<< "$DASHBOARD_CONFIG_CONTENT" > dashboard.auto.tfvars.json
+
         cat > dashboard.auto.tfvars << EOF
-        data_provider_resource_ids      = ${DATA_PROVIDER_RESOURCE_IDS}
-        dashboard_operators             = ${DASHBOARD_OPERATORS}
         edp_aggregator_spanner_project  = "${SPANNER_PROJECT}"
         edp_aggregator_spanner_instance = "${SPANNER_INSTANCE}"
         kingdom_spanner_project         = "${SPANNER_PROJECT}"

--- a/.github/workflows/terraform-cmms-v2.yml
+++ b/.github/workflows/terraform-cmms-v2.yml
@@ -263,12 +263,20 @@ jobs:
         # Dashboard config (EDPs, operators, deletion protection) is consolidated
         # into the single DASHBOARD_CONFIG_CONTENT JSON var. Terraform reads
         # it natively as *.tfvars.json.
-        # Fail loudly if any required key is missing rather than silently emitting
-        # null (which Terraform would treat as unset, falling back to defaults).
-        jq -e 'has("bigquery_region") and has("deletion_protection")
-          and has("operators") and has("edps")' \
+        # Fail loudly on a malformed config -- missing/mistyped keys, empty strings,
+        # or duplicate EDP names -- rather than silently emitting null (which Terraform
+        # treats as unset) or letting a duplicate name collapse in the map below.
+        jq -e '
+          (.bigquery_region | type == "string" and length > 0)
+          and (.deletion_protection | type == "boolean")
+          and (.operators | type == "array")
+          and (.edps | type == "array" and length > 0)
+          and (.edps | all((.name | type == "string" and length > 0)
+            and (.resource_id | type == "string" and length > 0)))
+          and ((.edps | map(.name)) as $names | ($names | length) == ($names | unique | length))
+        ' \
           <<< "$DASHBOARD_CONFIG_CONTENT" > /dev/null \
-          || { echo "DASHBOARD_CONFIG_CONTENT is missing required keys" >&2; exit 1; }
+          || { echo "DASHBOARD_CONFIG_CONTENT is malformed: need non-empty bigquery_region, boolean deletion_protection, operators array, and non-empty edps with unique non-empty name/resource_id" >&2; exit 1; }
         jq '{
           data_provider_resource_ids: ((.edps // [] | map({(.name): .resource_id}) | add) // {}),
           dashboard_operators: .operators,

--- a/.github/workflows/update-cmms.yml
+++ b/.github/workflows/update-cmms.yml
@@ -296,7 +296,7 @@ jobs:
       - name: Run Compliance Check
         env:
           DASHBOARD_CONFIG_CONTENT: ${{ vars.DASHBOARD_CONFIG_CONTENT }}
-          GOOGLE_CLOUD_PROJECT: ${{ vars.GOOGLE_CLOUD_PROJECT }}
+          GOOGLE_CLOUD_PROJECT: ${{ vars.GCLOUD_PROJECT }}
         run: |
           set -euo pipefail
           # Dashboard config is consolidated into DASHBOARD_CONFIG_CONTENT (#4124);

--- a/.github/workflows/update-cmms.yml
+++ b/.github/workflows/update-cmms.yml
@@ -295,16 +295,17 @@ jobs:
 
       - name: Run Compliance Check
         env:
-          DASHBOARD_EDP_CONFIG: ${{ vars.DASHBOARD_EDP_CONFIG }}
+          DASHBOARD_CONFIG_CONTENT: ${{ vars.DASHBOARD_CONFIG_CONTENT }}
           GOOGLE_CLOUD_PROJECT: ${{ vars.GOOGLE_CLOUD_PROJECT }}
-          BIGQUERY_REGION: ${{ vars.BIGQUERY_REGION }}
         run: |
-          EDP_ARGS=$(echo "$DASHBOARD_EDP_CONFIG" | jq -r '.[] | "--edp=\(.name):\(.resource_id)"' | tr '\n' ' ')
+          set -euo pipefail
+          # Dashboard config is consolidated into DASHBOARD_CONFIG_CONTENT (#4124);
+          # the check parses it against the DashboardConfig proto schema.
+          printf '%s' "$DASHBOARD_CONFIG_CONTENT" > "${RUNNER_TEMP}/dashboard-config.json"
           bazel run //src/main/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/dashboard/tools:DashboardComplianceCheck -- \
             --impersonate-service-account="dashboard-compliance@$GOOGLE_CLOUD_PROJECT.iam.gserviceaccount.com" \
             --project="$GOOGLE_CLOUD_PROJECT" \
-            --region="$BIGQUERY_REGION" \
-            $EDP_ARGS
+            --dashboard-config="${RUNNER_TEMP}/dashboard-config.json"
 
   send-slack-notification:
     uses: ./.github/workflows/slack-nightly-build-notification.yml

--- a/.github/workflows/update-cmms.yml
+++ b/.github/workflows/update-cmms.yml
@@ -299,7 +299,7 @@ jobs:
           GOOGLE_CLOUD_PROJECT: ${{ vars.GCLOUD_PROJECT }}
         run: |
           set -euo pipefail
-          # Dashboard config is consolidated into DASHBOARD_CONFIG_CONTENT (#4124);
+          # Dashboard config is consolidated into DASHBOARD_CONFIG_CONTENT;
           # the check parses it against the DashboardConfig proto schema.
           printf '%s' "$DASHBOARD_CONFIG_CONTENT" > "${RUNNER_TEMP}/dashboard-config.json"
           bazel run //src/main/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/dashboard/tools:DashboardComplianceCheck -- \

--- a/docs/edpaggregator/dashboard/deployment-guide.md
+++ b/docs/edpaggregator/dashboard/deployment-guide.md
@@ -120,8 +120,14 @@ Before deploying the dashboard, ensure the following are in place:
 
 ## Step 1: Configure Terraform Variables
 
-Add the following variables to your environment's `.tfvars` file or GitHub
-Actions environment variables.
+Dashboard configuration has two homes depending on how you deploy:
+
+*   **CI deploys** — the dashboard's EDPs, operators, region, and deletion
+    protection all live in the single `DASHBOARD_CONFIG_CONTENT` GitHub Actions
+    variable (see *GitHub Actions Environment Variables* below); the workflow
+    generates the Terraform vars from it.
+*   **Manual `terraform apply`** — provide them as the HCL variables in your
+    `.tfvars` file — see *Required Variables* and *Optional Variables* below.
 
 ### Required Variables
 
@@ -157,29 +163,56 @@ dashboard.
 
 ### Optional Variables
 
-```hcl
-# Set to false for dev environments to allow table recreation.
-# Defaults to true.
-dashboard_deletion_protection = false
+`dashboard_deletion_protection` defaults to `true`. On the CI path it comes from
+the `deletion_protection` field of `DASHBOARD_CONFIG_CONTENT`. The
+`envs/*.tfvars` files no longer set it, so a manual `terraform apply` now gets
+`true` — pass `false` (e.g. for dev/head) to allow table recreation:
+
+```shell
+terraform apply -var-file=envs/dev.tfvars -var=dashboard_deletion_protection=false
 ```
 
 ### GitHub Actions Environment Variables
 
 If using the CI workflow, set the following in your GitHub environment. The
-`terraform-cmms-v2.yml` workflow's "Write dashboard tfvars" step reads
-`DATA_PROVIDER_RESOURCE_IDS` and `DASHBOARD_OPERATORS` to generate the
-`dashboard.auto.tfvars` Terraform consumes; without them the deploy writes an
-empty/invalid tfvars and fails. `DASHBOARD_EDP_CONFIG` is used by the
-isolation test matrix; `DASHBOARD_DELETION_PROTECTION` is optional.
+`terraform-cmms-v2.yml` workflow's "Write dashboard tfvars" step reads the
+single `DASHBOARD_CONFIG_CONTENT` JSON var (per the `DashboardConfig` schema)
+to generate the `dashboard.auto.tfvars.json` Terraform consumes and to build
+the isolation-test matrix; without it the deploy fails.
 
-| Variable | Required | Description | Example |
-|----------|----------|-------------|---------|
-| `DATA_PROVIDER_RESOURCE_IDS` | yes | JSON object mapping EDP short name → DataProviderResourceId, consumed by the Terraform `data_provider_resource_ids` map var | `{"edp1":"AbCdEf_12345","edp2":"GhIjKl_67890"}` |
-| `DASHBOARD_OPERATORS` | yes | JSON array of `user:` / `group:` IAM members granted operator access (impersonation, platform-table reads) | `["group:edpa-dashboard-operators@example.com"]` |
-| `DASHBOARD_EDP_CONFIG` | yes | JSON array of EDP configs for the CI isolation test matrix | `[{"name":"edp1","resource_id":"AbCdEf_12345"},{"name":"edp2","resource_id":"GhIjKl_67890"}]` |
-| `DASHBOARD_DELETION_PROTECTION` | no (default `true`) | Set `"false"` in dev to allow table recreation | `"false"` |
+| Variable | Required | Description |
+|----------|----------|-------------|
+| `DASHBOARD_CONFIG_CONTENT` | yes | Single JSON object per the `DashboardConfig` proto. Consumed by Terraform (as `*.tfvars.json`), the compliance check, and the isolation-test matrix. See the field reference below. |
 
-Pre-existing CMMS environment variables (`GOOGLE_CLOUD_PROJECT`,
+`DASHBOARD_CONFIG_CONTENT` is one JSON object matching the `DashboardConfig`
+proto (src/main/proto/wfa/measurement/config/edpaggregator/dashboard_config.proto).
+The CI step requires **all four** top-level keys to be present — a missing key
+fails the deploy rather than silently falling back to a Terraform default:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `bigquery_region` | string | BigQuery region hosting the dashboard dataset (e.g. `"us-central1"`). Used by the compliance check and isolation-test matrix. |
+| `deletion_protection` | bool | Whether the dashboard BigQuery dataset has deletion protection. Set `false` in dev to allow table recreation; `true` in production. |
+| `operators` | string[] | IAM principals granted platform-wide access to the dashboard tables (`user:` / `group:`). Use Google Groups in production. |
+| `edps` | object[] | The EDPs the dashboard exposes; each is isolated to its own rows. |
+| `edps[].name` | string | Short EDP name used for per-EDP resource naming (e.g. `"meta"`): SA `edp-<name>-dashboard@`, row policy `<name>_filter`, and CI matrix entry. |
+| `edps[].resource_id` | string | The **bare** `DataProvider` resource ID — final path segment only (e.g. `"J3-pzhqS9Lo"`), **not** the full `dataProviders/...` name. Must match the value in Spanner / `EDPA_EDPS_CONFIG`. |
+
+Example (pretty-printed here; store it as compact JSON in the variable):
+
+```json
+{
+  "bigquery_region": "us-central1",
+  "deletion_protection": false,
+  "operators": ["group:edpa-dashboard-operators@example.com"],
+  "edps": [
+    {"name": "edp1", "resource_id": "AbCdEf_12345"},
+    {"name": "edp2", "resource_id": "GhIjKl_67890"}
+  ]
+}
+```
+
+Pre-existing CMMS environment variables (`GCLOUD_PROJECT`,
 `SPANNER_INSTANCE`, `POSTGRES_INSTANCE_NAME`, `POSTGRES_PASSWORD`) are
 already consumed by the broader workflow and do not need to be re-added for
 the dashboard.
@@ -209,8 +242,8 @@ After Terraform applies successfully, the tables are empty. The scheduled
 queries run hourly via MERGE. To populate tables immediately:
 
 `<REGION>` in the examples below is the GCP region the dashboard resources
-are deployed in — the CI reads it from the `BIGQUERY_REGION` GitHub
-environment variable. All dashboard tables, connections, and scheduled
+are deployed in — the CI reads it from the `bigquery_region` field of
+`DASHBOARD_CONFIG_CONTENT`. All dashboard tables, connections, and scheduled
 queries are created via `data.google_client_config.default.region` in
 `dashboard.tf`, so any GCP region GCP supports for BigQuery Data Transfer
 works.
@@ -254,11 +287,11 @@ role grants only what the check needs.
 bazel run //src/main/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/dashboard/tools:DashboardComplianceCheck -- \
   --impersonate-service-account=dashboard-compliance@MY_PROJECT.iam.gserviceaccount.com \
   --project=MY_PROJECT \
-  --region=<REGION> \
-  --edp=edp1:AbCdEf_12345 \
-  --edp=edp2:GhIjKl_67890 \
-  --edp=edp3:MnOpQr_24680
+  --dashboard-config=/path/to/dashboard-config.json
 ```
+
+where `dashboard-config.json` holds the environment's `DASHBOARD_CONFIG_CONTENT`
+(the EDPs and region are read from it).
 
 To impersonate, your account needs `roles/iam.serviceAccountTokenCreator` on
 the `dashboard-compliance` SA. The dashboard Terraform grants this to every
@@ -287,46 +320,45 @@ After Terraform deploys and other cloud tests generate data, the workflow:
     `dashboard-compliance@PROJECT.iam.gserviceaccount.com` (the least-privilege
     SA, not the broader operator/terraform SA)
 
-Ensure the GitHub environment has the required variables (`DASHBOARD_EDP_CONFIG`,
-`GOOGLE_CLOUD_PROJECT`, `BIGQUERY_REGION`, `TF_SERVICE_ACCOUNT`,
+Ensure the GitHub environment has the required variables
+(`DASHBOARD_CONFIG_CONTENT`, `GCLOUD_PROJECT`, `TF_SERVICE_ACCOUNT`,
 `WORKLOAD_IDENTITY_PROVIDER`).
 
 ## Ongoing Operations
 
 ### Adding a New EDP
 
-1.  Add the EDP to `data_provider_resource_ids` in your `.tfvars`:
-    ```hcl
-    data_provider_resource_ids = {
-      edp1 = "AbCdEf_12345"
-      edp2 = "GhIjKl_67890"
-      edp3 = "MnOpQr_24680"
-      edp4    = "StUvWx_13579"   # New EDP
-    }
+1.  Add the EDP to the `edps` array in the `DASHBOARD_CONFIG_CONTENT` GitHub
+    environment variable (the single source of truth):
+    ```json
+    {"name": "edp4", "resource_id": "StUvWx_13579"}
     ```
-2.  Update `DASHBOARD_EDP_CONFIG` in the GitHub environment to include the new
-    EDP.
-3.  Run `terraform apply`. This creates the new EDP's service account, row
-    access policies, and table-level IAM grants.
-4.  Run the compliance check to verify the new EDP's isolation.
+2.  Re-run the `Update CMMS` deploy workflow. The "Write dashboard tfvars" step regenerates
+    `data_provider_resource_ids` from `DASHBOARD_CONFIG_CONTENT`, then
+    `terraform apply` creates the new EDP's service account, row access
+    policies, and table-level IAM grants.
+3.  Run the compliance check to verify the new EDP's isolation.
 
 ### Removing an EDP
 
-1.  Remove the EDP from `data_provider_resource_ids` and
-    `DASHBOARD_EDP_CONFIG`.
-2.  Run `terraform apply`. This destroys the EDP's service account, row access
-    policies, and IAM grants.
+1.  Remove the EDP from the `edps` array in `DASHBOARD_CONFIG_CONTENT`.
+2.  Re-run the `Update CMMS` deploy workflow (or `terraform apply` for a manual deploy).
+    This destroys the EDP's service account, row access policies, and IAM
+    grants.
 3.  The EDP's historical data remains in the tables but is no longer accessible
     (no row access policy grants visibility).
 
 ### Updating Dashboard Operators
 
-1.  Update `dashboard_operators` in your `.tfvars`:
-    ```hcl
-    dashboard_operators = ["group:new-operators-group@example.com"]
+1.  Update the `operators` array in the `DASHBOARD_CONFIG_CONTENT` GitHub
+    environment variable (the single source of truth):
+    ```json
+    "operators": ["group:new-operators-group@example.com"]
     ```
-2.  Run `terraform apply`. This updates row access policies and impersonation
-    grants.
+2.  Re-run the `Update CMMS` deploy workflow. The "Write dashboard tfvars" step regenerates
+    `dashboard_operators` from `DASHBOARD_CONFIG_CONTENT`, then `terraform
+    apply` updates the row access policies and impersonation grants. (For a
+    manual apply, edit `dashboard_operators` in your `.tfvars` instead.)
 
 ### Monitoring
 
@@ -384,19 +416,17 @@ and must be re-applied.
 
 ### EDP sees zero rows
 
-Verify the EDP's `DataProviderResourceId` in `data_provider_resource_ids`
-matches the value produced by `externalIdToApiId` for that EDP's internal
-Spanner ID. A mismatch causes the row access policy filter to not match any
-rows.
+Verify the EDP's `resource_id` in `DASHBOARD_CONFIG_CONTENT` matches the
+value produced by `externalIdToApiId` for that EDP's internal Spanner ID (it
+flows into the generated `data_provider_resource_ids` and the row access policy
+filter). A mismatch causes the filter to not match any rows.
 
-Also verify `DASHBOARD_EDP_CONFIG`'s `resource_id` for the same EDP matches
-`data_provider_resource_ids`. If they disagree, terraform creates the SA
-against one resource ID (row policy filters to that ID) but the compliance /
-isolation tool authenticates against a different one (queries return only
-data matching the tool's ID). Symptom: `returns other EDPs' data` false-
-positive OR `report_detail_edp is empty` false-negative for that EDP. Fix by
-aligning both env vars to the ID in `EDPA_EDPS_CONFIG` and re-running
-terraform.
+Since `DASHBOARD_CONFIG_CONTENT` is the single source for both the Terraform
+vars and the compliance/isolation tools, a stale or wrong `resource_id` shows
+up as a `returns other EDPs' data` false-positive OR a `report_detail_edp is
+empty` false-negative for that EDP. Fix by aligning the EDP's `resource_id` in
+`DASHBOARD_CONFIG_CONTENT` with the value in `EDPA_EDPS_CONFIG` and re-running
+the deploy.
 
 ### `report_detail_edp is empty` on a freshly-onboarded EDP
 

--- a/docs/edpaggregator/dashboard/deployment-guide.md
+++ b/docs/edpaggregator/dashboard/deployment-guide.md
@@ -52,7 +52,7 @@ Before deploying the dashboard, ensure the following are in place:
     APIs (or force-provision service agents) until this is on. Requires a
     human with `roles/serviceusage.serviceUsageAdmin` (or Owner):
     ```shell
-    gcloud services enable serviceusage.googleapis.com --project=MY_PROJECT
+    gcloud services enable serviceusage.googleapis.com --project=<DASHBOARD_PROJECT>
     ```
     If you see `ERROR: (gcloud.beta.services.identity.create) PERMISSION_DENIED:
     Service Usage API has not been used in project ... before or it is disabled`
@@ -68,7 +68,7 @@ Before deploying the dashboard, ensure the following are in place:
     gcloud services enable \
       bigqueryconnection.googleapis.com \
       bigquerydatatransfer.googleapis.com \
-      --project=MY_PROJECT
+      --project=<DASHBOARD_PROJECT>
     ```
 4.  The Terraform service account has the following project-level roles
     (granted out-of-band — Terraform does not bootstrap its own credentials):
@@ -83,7 +83,7 @@ Before deploying the dashboard, ensure the following are in place:
         Terraform code adds a `terraform_role_admin` self-grant so subsequent
         applies maintain it automatically. Without this on the first apply,
         Terraform fails with: "Unable to verify whether custom project role
-        projects/<project>/roles/dashboardComplianceChecker already exists
+        projects/<DASHBOARD_PROJECT>/roles/dashboardComplianceChecker already exists
         and must be undeleted."
 
         **Security note for adopters.** The reference Terraform grants
@@ -99,17 +99,17 @@ Before deploying the dashboard, ensure the following are in place:
         `iam.roles.{get,list,create,update,undelete,delete}`, granted via
         `google_project_iam_member` with an IAM condition restricting the
         resource to
-        `resource.name.startsWith("projects/<project>/roles/dashboardComplianceChecker")`.
+        `resource.name.startsWith("projects/<DASHBOARD_PROJECT>/roles/dashboardComplianceChecker")`.
         The scoped-role refactor is tracked in
         [#4135](https://github.com/world-federation-of-advertisers/cross-media-measurement/issues/4135).
         The dev/head/qa reference environments accept the broader grant
         because their blast radius is bounded to test data and audit-logged
-        CI; production deployments should not follow this pattern without
+        CI; non-dev deployments should not follow this pattern without
         one of the above narrowings.
 5.  Proto bundles are registered in Kingdom and Reporting Spanner databases
     (required for `TO_JSON()` decoding).
 6.  The BigQuery Connection service agent
-    (`service-${project_number}@gcp-sa-bigqueryconnection.iam.gserviceaccount.com`)
+    (`service-<PROJECT_NUMBER>@gcp-sa-bigqueryconnection.iam.gserviceaccount.com`)
     exists. GCP creates this service-managed agent on demand the first time
     a project uses the BigQuery Connection API — but on-demand creation
     happens too late for Terraform, which tries to grant IAM to the agent in
@@ -142,7 +142,7 @@ data_provider_resource_ids = {
 
 # Users or groups granted full platform access to all dashboard tables
 # and the ability to impersonate EDP service accounts for testing.
-# Use Google Groups for production deployments.
+# Use Google Groups for shared/non-dev environments.
 dashboard_operators = ["group:edpa-dashboard-operators@example.com"]
 
 # Spanner project and instance for each database connection.
@@ -185,17 +185,17 @@ the isolation-test matrix; without it the deploy fails.
 | `DASHBOARD_CONFIG_CONTENT` | yes | Single JSON object per the `DashboardConfig` proto. Consumed by Terraform (as `*.tfvars.json`), the compliance check, and the isolation-test matrix. See the field reference below. |
 
 `DASHBOARD_CONFIG_CONTENT` is one JSON object matching the `DashboardConfig`
-proto (src/main/proto/wfa/measurement/config/edpaggregator/dashboard_config.proto).
+proto (`src/main/proto/wfa/measurement/config/edpaggregator/dashboard_config.proto`).
 The CI step requires **all four** top-level keys to be present — a missing key
 fails the deploy rather than silently falling back to a Terraform default:
 
 | Field | Type | Description |
 |-------|------|-------------|
 | `bigquery_region` | string | BigQuery region hosting the dashboard dataset (e.g. `"us-central1"`). Used by the compliance check and isolation-test matrix. |
-| `deletion_protection` | bool | Whether the dashboard BigQuery dataset has deletion protection. Set `false` in dev to allow table recreation; `true` in production. |
-| `operators` | string[] | IAM principals granted platform-wide access to the dashboard tables (`user:` / `group:`). Use Google Groups in production. |
+| `deletion_protection` | bool | Whether the dashboard BigQuery dataset has deletion protection. Set `false` in dev to allow table recreation; `true` for non-dev environments. |
+| `operators` | string[] | IAM principals granted platform-wide access to the dashboard tables (`user:` / `group:`). Use Google Groups for shared/non-dev environments. |
 | `edps` | object[] | The EDPs the dashboard exposes; each is isolated to its own rows. |
-| `edps[].name` | string | Short EDP name used for per-EDP resource naming (e.g. `"meta"`): SA `edp-<name>-dashboard@`, row policy `<name>_filter`, and CI matrix entry. |
+| `edps[].name` | string | Short EDP name used for per-EDP resource naming (e.g. `"meta"`): SA `edp-<name>-dashboard`, row policy `<name>_filter`, and CI matrix entry. |
 | `edps[].resource_id` | string | The **bare** `DataProvider` resource ID — final path segment only (e.g. `"J3-pzhqS9Lo"`), **not** the full `dataProviders/...` name. Must match the value in Spanner / `EDPA_EDPS_CONFIG`. |
 
 Example (pretty-printed here; store it as compact JSON in the variable):
@@ -252,7 +252,7 @@ works.
 
 ```shell
 # List dashboard transfer configs
-bq ls --transfer_config --transfer_location=<REGION> --project_id=MY_PROJECT \
+bq ls --transfer_config --transfer_location=<REGION> --project_id=<DASHBOARD_PROJECT> \
   --filter='dataSourceIds:scheduled_query'
 
 # Trigger a manual run for each config. CONFIG_RESOURCE_NAME is the
@@ -268,7 +268,7 @@ BigQuery scheduled queries — use `bq` as shown above.
 
 ```sql
 SELECT table_id, row_count, TIMESTAMP_MILLIS(last_modified_time) AS last_modified
-FROM `MY_PROJECT.dashboard.__TABLES__`
+FROM `<DASHBOARD_PROJECT>.dashboard.__TABLES__`
 ORDER BY table_id;
 ```
 
@@ -285,8 +285,8 @@ role grants only what the check needs.
 
 ```shell
 bazel run //src/main/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/dashboard/tools:DashboardComplianceCheck -- \
-  --impersonate-service-account=dashboard-compliance@MY_PROJECT.iam.gserviceaccount.com \
-  --project=MY_PROJECT \
+  --impersonate-service-account=dashboard-compliance@<DASHBOARD_PROJECT>.iam.gserviceaccount.com \
+  --project=<DASHBOARD_PROJECT> \
   --dashboard-config=/path/to/dashboard-config.json
 ```
 
@@ -310,14 +310,17 @@ The compliance check verifies:
 
 ## Step 5: Set Up CI Integration
 
-The dashboard isolation tests are wired into the `update-cmms.yml` workflow.
+The dashboard isolation tests are wired into the `Update CMMS` workflow.
 After Terraform deploys and other cloud tests generate data, the workflow:
 
 1.  Triggers all dashboard scheduled queries
 2.  Waits for completion
-3.  Runs `DashboardIsolationTest` for each EDP: the workflow authenticates as the terraform SA via Workload Identity Federation, then impersonates `edp-<name>-dashboard@PROJECT.iam.gserviceaccount.com` (chained through `dashboard-compliance@PROJECT.iam.gserviceaccount.com`) so each check runs with only the permissions that EDP would have in production
+3.  Runs `DashboardIsolationTest` for each EDP: the workflow authenticates as
+    the terraform SA via Workload Identity Federation, then impersonates
+    `edp-<name>-dashboard@<DASHBOARD_PROJECT>.iam.gserviceaccount.com` so each check
+    runs with only the permissions that EDP itself has
 4.  Runs `DashboardComplianceCheck` impersonating
-    `dashboard-compliance@PROJECT.iam.gserviceaccount.com` (the least-privilege
+    `dashboard-compliance@<DASHBOARD_PROJECT>.iam.gserviceaccount.com` (the least-privilege
     SA, not the broader operator/terraform SA)
 
 Ensure the GitHub environment has the required variables
@@ -326,27 +329,11 @@ Ensure the GitHub environment has the required variables
 
 ## Ongoing Operations
 
-### Adding a New EDP
+### Adding or Removing an EDP
 
-1.  Add the EDP to the `edps` array in the `DASHBOARD_CONFIG_CONTENT` GitHub
-    environment variable (the single source of truth):
-    ```json
-    {"name": "edp4", "resource_id": "StUvWx_13579"}
-    ```
-2.  Re-run the `Update CMMS` deploy workflow. The "Write dashboard tfvars" step regenerates
-    `data_provider_resource_ids` from `DASHBOARD_CONFIG_CONTENT`, then
-    `terraform apply` creates the new EDP's service account, row access
-    policies, and table-level IAM grants.
-3.  Run the compliance check to verify the new EDP's isolation.
-
-### Removing an EDP
-
-1.  Remove the EDP from the `edps` array in `DASHBOARD_CONFIG_CONTENT`.
-2.  Re-run the `Update CMMS` deploy workflow (or `terraform apply` for a manual deploy).
-    This destroys the EDP's service account, row access policies, and IAM
-    grants.
-3.  The EDP's historical data remains in the tables but is no longer accessible
-    (no row access policy grants visibility).
+See the EDP Onboarding Guide — *Operator Steps: Onboarding a New EDP* and
+*Operator Steps: Offboarding an EDP* — the single source for the EDP lifecycle
+(resource-ID lookup, seeding a BasicReport, sharing credentials).
 
 ### Updating Dashboard Operators
 
@@ -355,10 +342,10 @@ Ensure the GitHub environment has the required variables
     ```json
     "operators": ["group:new-operators-group@example.com"]
     ```
-2.  Re-run the `Update CMMS` deploy workflow. The "Write dashboard tfvars" step regenerates
-    `dashboard_operators` from `DASHBOARD_CONFIG_CONTENT`, then `terraform
-    apply` updates the row access policies and impersonation grants. (For a
-    manual apply, edit `dashboard_operators` in your `.tfvars` instead.)
+2.  Re-run the `Update CMMS` deploy workflow to update the platform row access
+    policies, table-level IAM, and impersonation grants. (For a manual apply,
+    edit `dashboard_operators` in your local `.tfvars` and `terraform apply`
+    directly.)
 
 ### Monitoring
 
@@ -369,10 +356,6 @@ Ensure the GitHub environment has the required variables
     service account and will not appear there. To also catch transfer- or
     config-level failures that never produce a query job, inspect the
     transfer run history with `bq show --transfer_run`.
-*   **Stale data**: The compliance check's staleness threshold is 3 hours. If
-    data is older, investigate scheduled query logs.
-*   **Row access policy drift**: The compliance check verifies policies exist
-    on every run.
 
 ### Scheduled compliance check
 
@@ -393,7 +376,15 @@ policy without notifications, so no one is paged until a channel is attached.
 
 The scheduled deploy is gated on `dashboard_compliance_uber_jar_path`: when
 that variable is unset, the Cloud Function, scheduler, and alert policy are not
-created.
+created. In CI it is set automatically (the deploy workflow downloads the
+published jar and passes it). For a manual `terraform apply`, build the jar
+yourself and pass it explicitly:
+
+```shell
+bazel build //src/main/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/dashboard/tools:DashboardComplianceCheckFunction_deploy.jar
+terraform apply -var-file=envs/dev.tfvars \
+  -var="dashboard_compliance_uber_jar_path=/abs/path/to/DashboardComplianceCheckFunction_deploy.jar"
+```
 
 ## Troubleshooting
 
@@ -411,22 +402,13 @@ manually (see Step 3). If tables remain empty after a triggered run, check:
 
 If the compliance check reports missing policies, run `terraform apply` to
 re-create them. MERGE-based scheduled queries preserve policies across runs.
-If you previously used `WRITE_TRUNCATE`, policies were dropped on each run
-and must be re-applied.
 
 ### EDP sees zero rows
 
-Verify the EDP's `resource_id` in `DASHBOARD_CONFIG_CONTENT` matches the
-value produced by `externalIdToApiId` for that EDP's internal Spanner ID (it
-flows into the generated `data_provider_resource_ids` and the row access policy
-filter). A mismatch causes the filter to not match any rows.
-
-Since `DASHBOARD_CONFIG_CONTENT` is the single source for both the Terraform
-vars and the compliance/isolation tools, a stale or wrong `resource_id` shows
-up as a `returns other EDPs' data` false-positive OR a `report_detail_edp is
-empty` false-negative for that EDP. Fix by aligning the EDP's `resource_id` in
-`DASHBOARD_CONFIG_CONTENT` with the value in `EDPA_EDPS_CONFIG` and re-running
-the deploy.
+Verify the EDP's `resource_id` in `DASHBOARD_CONFIG_CONTENT` matches the value
+`externalIdToApiId` produces for that EDP's internal Spanner ID — cross-check
+against `EDPA_EDPS_CONFIG`. It flows into the row access policy filter, so a
+wrong value matches no rows. Correct it and re-run the deploy.
 
 ### `report_detail_edp is empty` on a freshly-onboarded EDP
 
@@ -434,43 +416,25 @@ The compliance check `report_detail_edp is empty (expected data after
 scheduled queries)` and the corresponding isolation test both FAIL until the
 new EDP has at least one BasicReport in state `SUCCEEDED` that references one
 of its event groups. On fresh environments (and after adding any new EDPA
-EDP), you must seed a BasicReport manually &mdash; the CI `run-tests` job
+EDP), you must seed a BasicReport manually — the CI `run-tests` job
 only creates reports against simulator event groups (`sim-eg-*` prefix), not
 against EDPA-owned event groups. See the *Seed a BasicReport for the new
 EDP* step in the onboarding guide.
 
 ### `rerun-failed-jobs` doesn't re-trigger scheduled queries
 
-`rerun-failed-jobs` on `Update CMMS` only re-runs jobs whose prior attempt
-was `failure`. The `run-dashboard-isolation-test / trigger-scheduled-queries`
-job typically succeeds on its first run (kicking the queries off is
-independent of whether the queries return data), so subsequent
-`rerun-failed-jobs` calls preserve it as `success` and **do not re-fire the
-scheduled queries**. If the compliance/isolation checks are failing because
-`report_detail_edp` hasn't yet been refreshed to include a new BasicReport:
-
-1.  Verify the BasicReport is `state: SUCCEEDED` (via the Reporting API).
-2.  Check `bq show --format=prettyjson <project>:dashboard.report_detail_edp
-    | jq '{numRows, lastModifiedTime}'` &mdash; if `lastModifiedTime` is
-    before the BasicReport completed, the query hasn't cycled yet.
-3.  Wait for the natural hourly cycle, OR trigger the query manually via the
-    BigQuery Data Transfer REST API:
-    ```shell
-    curl -sS -X POST -H "Authorization: Bearer $(gcloud auth print-access-token)" \
-      -H 'Content-Type: application/json' \
-      --data "{\"requestedRunTime\":\"$(date -u +%Y-%m-%dT%H:%M:%SZ)\"}" \
-      "https://bigquerydatatransfer.googleapis.com/v1/projects/<project>/locations/<region>/transferConfigs/<config-id>:startManualRuns"
-    ```
-    (You need `roles/bigquerydatatransfer.admin` on the project; find
-    `<config-id>` via `bq ls --transfer_config --transfer_location=<region> --project_id=<project> --filter='dataSourceIds:scheduled_query'`.)
-4.  Once `report_detail_edp` has been refreshed, `gh api
-    .../actions/runs/<RUN_ID>/rerun-failed-jobs --method POST` will re-run
-    the remaining failing dashboard checks against the updated data.
+If a new EDP's compliance and isolation checks fail because `report_detail_edp`
+hasn't refreshed yet, `rerun-failed-jobs` on `Update CMMS` won't help: the
+`trigger-scheduled-queries` job already succeeded (firing the queries succeeds
+regardless of their output), so it isn't re-run and the checks re-run against
+stale data. Confirm the BasicReport is `SUCCEEDED`, refresh the data (wait for
+the next hourly cycle or trigger the query manually — see *Trigger Scheduled
+Queries Manually*), then re-run the failed jobs.
 
 ### Cross-project connection failures
 
 Verify the BigQuery Connection service agent
-(`service-{project_number}@gcp-sa-bigqueryconnection.iam.gserviceaccount.com`)
+(`service-<PROJECT_NUMBER>@gcp-sa-bigqueryconnection.iam.gserviceaccount.com`)
 has appropriate grants in the target project:
 
 *   `roles/spanner.databaseReaderWithDataBoost` on each target Spanner database

--- a/docs/edpaggregator/dashboard/onboarding-guide.md
+++ b/docs/edpaggregator/dashboard/onboarding-guide.md
@@ -39,8 +39,8 @@ server's `OpenIdProvidersConfig`.
 
 *   Other EDPs' event groups, entity keys, campaigns, or brand names
 *   Which other EDPs are in the same report
-*   How many other EDPs are in a report (`EdpCount` is platform-only)
-*   Platform-only tables (`mc_details`, `report_detail`) return 403
+*   How many other EDPs are in a report
+*   Platform-only tables
 *   Raw Spanner or Postgres data (no `EXTERNAL_QUERY` access)
 
 ## Operator Steps: Onboarding a New EDP
@@ -71,9 +71,6 @@ MeasurementSystem \
   get --name=dataProviders/AbCdEf_12345
 ```
 
-The resource ID is the last segment of the `DataProvider` resource name
-(e.g., for `dataProviders/AbCdEf_12345`, the ID is `AbCdEf_12345`).
-
 ### Step 2: Add the EDP to the Dashboard Config
 
 Add the EDP to the `edps` array of the `DASHBOARD_CONFIG_CONTENT` GitHub
@@ -86,8 +83,8 @@ the Terraform `data_provider_resource_ids` map from it:
 
 The `name` (e.g., `edp4`) is a short label used for:
 
-*   The service account name: `edp-edp4-dashboard@PROJECT.iam.gserviceaccount.com`
-*   Row access policy IDs: `edp4_filter`
+*   The service account name: `edp-<name>-dashboard@<DASHBOARD_PROJECT>.iam.gserviceaccount.com`
+*   Row access policy IDs: `<name>_filter`
 *   CI test matrix entries
 
 The full `edps` array then looks like:
@@ -101,46 +98,36 @@ The full `edps` array then looks like:
 ]
 ```
 
-### Step 3: Verify Resource IDs
+### Step 3: Apply Terraform
 
-Because `DASHBOARD_CONFIG_CONTENT` is the single source of truth, the same
-`edps` entry drives both the Terraform resources (Terraform's `for_each` over
-the generated `data_provider_resource_ids` creates the `edp-<name>-dashboard@`
-SAs and row access policies) and the compliance/isolation tools (which
-impersonate `edp-<name>-dashboard@` and expect that `resource_id`'s data). Make
-sure each `resource_id` is the **bare** ID correct for the target environment —
-cross-check against the environment's `EDPA_EDPS_CONFIG` (the proto that drives
-the actual EDPA pipeline). A wrong `resource_id` makes the row access policy
-filter everything out, so the compliance check reports `returns other EDPs'
-data` (false-positive leak) or `empty` (false negative).
+Apply the change one of two ways:
 
-### Step 4: Apply Terraform
+*   **CI (normal):** Re-run the `Update CMMS` deploy workflow. It regenerates
+    `data_provider_resource_ids` from `DASHBOARD_CONFIG_CONTENT` and runs
+    `terraform apply`.
+*   **Manual:** A local `.tfvars` is *not* regenerated from
+    `DASHBOARD_CONFIG_CONTENT`, so add the EDP to the `data_provider_resource_ids`
+    map in your `.tfvars` first, then apply:
 
-Re-run the `Update CMMS` deploy workflow. The "Write dashboard tfvars" step regenerates
-`data_provider_resource_ids` from `DASHBOARD_CONFIG_CONTENT`, then `terraform
-apply` runs. For a **manual** apply against a local `.tfvars` — which is *not*
-regenerated from `DASHBOARD_CONFIG_CONTENT` — add the EDP to
-`data_provider_resource_ids` in that file as well before applying:
-
-```shell
-terraform plan -var-file=my-env.tfvars
-terraform apply -var-file=my-env.tfvars
-```
+    ```shell
+    terraform plan -var-file=my-env.tfvars
+    terraform apply -var-file=my-env.tfvars
+    ```
 
 This creates:
 
-*   Service account `edp-edp4-dashboard@PROJECT.iam.gserviceaccount.com`
+*   Service account `edp-<name>-dashboard@<DASHBOARD_PROJECT>.iam.gserviceaccount.com`
 *   `roles/bigquery.dataViewer` on `requisition_overview`, `mc_details_edp`,
     `report_detail_edp`
 *   `roles/bigquery.jobUser` on the project
 *   Row access policies on all 3 tables filtering to the EDP's resource ID
 
-### Step 5: Seed a BasicReport for the new EDP
+### Step 4: Seed a BasicReport for the new EDP
 
 The dashboard's `report_detail_edp` scheduled query only populates a row for an
 EDP when at least one BasicReport in state `SUCCEEDED` references one of that
 EDP's event groups. On a fresh EDP with no reports yet, the compliance check
-`report_detail_edp is empty` and the isolation test both FAIL &mdash; a
+`report_detail_edp is empty` and the isolation test both FAIL — a
 false-negative that will keep failing every deploy until at least one
 BasicReport exists for the EDP.
 
@@ -164,7 +151,7 @@ To seed:
       --ttl=1h
     ```
 
-    The `--scope='*'` wildcard is required &mdash; the reporting API's
+    The `--scope='*'` wildcard is required — the reporting API's
     `Authorization.checkScopes()` returns `PERMISSION_DENIED` without it.
 
 2.  Look up an existing event group on the new EDP via the Reporting API:
@@ -182,62 +169,41 @@ To seed:
     = [dataProviders/<NEW_EDP_RESOURCE_ID>]`, and a single-day
     `reportingInterval` is sufficient.
 4.  Poll the BasicReport with `GET .../basicReports/{id}` until `state:
-    SUCCEEDED`. On qa this takes ~15&ndash;25 minutes (real TEE fulfillment);
-    on dev typically 2&ndash;5 minutes.
+    SUCCEEDED`. On qa this takes ~15–25 minutes (real TEE fulfillment);
+    on dev typically 2–5 minutes.
 5.  Wait for the next `report_detail_edp` scheduled-query cycle to pull the
-    Report in (hourly schedule) or trigger it manually &mdash; see the
-    deployment guide's *Triggering Scheduled Queries Manually* section.
-6.  Verify with `bq show MY_PROJECT:dashboard.report_detail_edp` that
+    Report in (hourly schedule) or trigger it manually — see the
+    deployment guide's *Trigger Scheduled Queries Manually* section.
+6.  Verify with `bq show <DASHBOARD_PROJECT>:dashboard.report_detail_edp` that
     `numRows` has grown and `lastModifiedTime` is after the BasicReport's
     completion time.
 
 The seed BasicReport can be trivial (single-day reporting interval, single
-event group, `impressionQualificationFilters/ami`) &mdash; it just needs to
+event group, `impressionQualificationFilters/ami`) — it just needs to
 exist and be `SUCCEEDED`. It stays in the environment permanently; no cleanup
 is required.
 
-### Step 6: Verify Isolation
+### Step 5: Verify Isolation
 
-Run the compliance check with the new EDP included, impersonating the
-least-privilege `dashboard-compliance` service account (matches the
-deployment guide's Step 4 and the CI pattern from #4128 — running without
-impersonation either fails outright or silently passes with broader-than-
-tested permissions):
+Run the compliance check with the new EDP in the config and confirm it passes
+for that EDP. See the deployment guide's *Run the Compliance Check* for the
+command, impersonation setup, and what it verifies.
 
-```shell
-bazel run //src/main/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/dashboard/tools:DashboardComplianceCheck -- \
-  --impersonate-service-account=dashboard-compliance@MY_PROJECT.iam.gserviceaccount.com \
-  --project=MY_PROJECT \
-  --dashboard-config=/path/to/dashboard-config.json
-```
-
-where `dashboard-config.json` holds the environment's `DASHBOARD_CONFIG_CONTENT`.
-
-To impersonate, your account needs `roles/iam.serviceAccountTokenCreator` on
-the `dashboard-compliance` SA. The dashboard Terraform grants this to every
-member of `dashboard_operators`.
-
-Verify all checks pass, including:
-
-*   `edp4: requisition_overview returns only own data`
-*   `edp4: correctly denied access to mc_details (403)`
-*   `edp4: correctly denied EXTERNAL_QUERY via kingdom-conn (403)`
-
-### Step 7: Share Credentials with the EDP
+### Step 6: Share Credentials with the EDP
 
 Provide the EDP with their service account details:
 
 *   **Service account email**:
-    `edp-edp4-dashboard@PROJECT.iam.gserviceaccount.com`
+    `edp-<name>-dashboard@<DASHBOARD_PROJECT>.iam.gserviceaccount.com`
 *   **Project ID**: The GCP project hosting the dashboard BigQuery dataset
 *   **Dataset**: `dashboard`
 *   **Accessible tables**: `requisition_overview`, `mc_details_edp`,
     `report_detail_edp`
 
-The EDP authenticates using their service account via one of the keyless options
-in Option A below (Workload Identity Federation or service account impersonation
-from their own GCP project). Service account keys are supported as a last resort
-but should be avoided — see the preference order in Option A.
+The EDP authenticates using their service account. See Option A below for the
+options in preference order — keyless (Workload Identity Federation or service
+account impersonation from their own GCP project) is preferred; downloaded
+service-account keys only as a last resort.
 
 ## EDP Steps: Accessing the Dashboard
 
@@ -252,7 +218,7 @@ In preference order:
 1.  **Service account impersonation** (the EDP has a Google identity in any
     GCP project). The operator grants the EDP's user/SA
     `roles/iam.serviceAccountTokenCreator` on
-    `edp-<name>-dashboard@PROJECT.iam.gserviceaccount.com`, then the EDP
+    `edp-<name>-dashboard@<DASHBOARD_PROJECT>.iam.gserviceaccount.com`, then the EDP
     impersonates it.
 2.  **Workload Identity Federation** (the EDP runs outside GCP, e.g. AWS or
     on-prem). The CMMS terraform already provisions
@@ -277,11 +243,11 @@ source_credentials, _ = default(
 )
 target_credentials = impersonated_credentials.Credentials(
     source_credentials=source_credentials,
-    target_principal='edp-edp4-dashboard@DASHBOARD_PROJECT.iam.gserviceaccount.com',
+    target_principal='edp-<name>-dashboard@<DASHBOARD_PROJECT>.iam.gserviceaccount.com',
     target_scopes=['https://www.googleapis.com/auth/bigquery'],
     lifetime=3600,
 )
-client = bigquery.Client(project='DASHBOARD_PROJECT', credentials=target_credentials)
+client = bigquery.Client(project='<DASHBOARD_PROJECT>', credentials=target_credentials)
 
 query = """
 SELECT
@@ -289,7 +255,7 @@ SELECT
     RequisitionState,
     CmmsCreateTime,
     FulfillmentDurationSeconds
-FROM `DASHBOARD_PROJECT.dashboard.requisition_overview`
+FROM `<DASHBOARD_PROJECT>.dashboard.requisition_overview`
 ORDER BY CmmsCreateTime DESC
 LIMIT 100
 """
@@ -304,18 +270,18 @@ for row in client.query(query).result():
 #   roles/iam.serviceAccountTokenCreator on the dashboard SA.
 
 export CLOUDSDK_AUTH_IMPERSONATE_SERVICE_ACCOUNT=\
-edp-edp4-dashboard@DASHBOARD_PROJECT.iam.gserviceaccount.com
+edp-<name>-dashboard@<DASHBOARD_PROJECT>.iam.gserviceaccount.com
 
-bq query --project_id=DASHBOARD_PROJECT --nouse_legacy_sql \
-  'SELECT * FROM `DASHBOARD_PROJECT.dashboard.requisition_overview` LIMIT 10'
+bq query --project_id=<DASHBOARD_PROJECT> --nouse_legacy_sql \
+  'SELECT * FROM `<DASHBOARD_PROJECT>.dashboard.requisition_overview` LIMIT 10'
 
-bq query --project_id=DASHBOARD_PROJECT --nouse_legacy_sql \
+bq query --project_id=<DASHBOARD_PROJECT> --nouse_legacy_sql \
   'SELECT CmmsDataProvider, EventGroupCount, EntityTypes, EntityIds, CampaignNames, MediaTypes
-   FROM `DASHBOARD_PROJECT.dashboard.mc_details_edp`'
+   FROM `<DASHBOARD_PROJECT>.dashboard.mc_details_edp`'
 
-bq query --project_id=DASHBOARD_PROJECT --nouse_legacy_sql \
+bq query --project_id=<DASHBOARD_PROJECT> --nouse_legacy_sql \
   'SELECT ExternalReportId, EventGroupCount, CmmsEventGroupIds, EntityTypes
-   FROM `DASHBOARD_PROJECT.dashboard.report_detail_edp`'
+   FROM `<DASHBOARD_PROJECT>.dashboard.report_detail_edp`'
 ```
 
 #### Last resort: service-account key
@@ -330,65 +296,52 @@ credentials = service_account.Credentials.from_service_account_file(
     'edp-dashboard-key.json',  # treat as a secret; rotate
     scopes=['https://www.googleapis.com/auth/bigquery'],
 )
-client = bigquery.Client(project='DASHBOARD_PROJECT', credentials=credentials)
+client = bigquery.Client(project='<DASHBOARD_PROJECT>', credentials=credentials)
 ```
 
 ### Option B: Looker Studio
 
-Looker Studio comes in two flavors with different authentication models —
-choose based on what you have access to:
+A central **report builder** builds the reports; each EDP only views. An EDP has
+nothing to configure — they just open the report link the builder shares (no
+account setup, service-account access, or IAM grants).
 
-#### Looker Studio Pro (recommended)
+Looker Studio runs the report's BigQuery data source under the EDP's
+`edp-<name>-dashboard` SA — the identity the dashboard's row access policies are
+written for. Every query then executes as the SA, so the policy is satisfied
+and the EDP sees only their own data, with no policy changes. This works the
+same in the free and Pro tiers.
 
-Pro lets a data source run as a service account, which is what the dashboard
-RAP grants. The EDP sees their own data without any policy changes.
+**Requirements:**
 
-1.  Open Looker Studio Pro and create a new report.
-2.  Add a BigQuery data source.
-3.  In the data source settings, configure it to run as
-    `edp-<name>-dashboard@DASHBOARD_PROJECT.iam.gserviceaccount.com`.
-4.  Select the project, dataset `dashboard`, and one of the accessible tables.
-5.  Build visualizations. Row access policies filter automatically.
+*   The report builder must sign in with a **Workspace / Cloud Identity
+    managed account**. Consumer `@gmail.com` accounts cannot select the
+    **Service account credentials** option.
+*   One-time IAM setup by an operator on
+    `edp-<name>-dashboard@<DASHBOARD_PROJECT>.iam.gserviceaccount.com`:
+    *   Grant the Looker Studio service agent (Google-managed, not a human)
+        `roles/iam.serviceAccountTokenCreator` on the SA — lets Looker Studio
+        impersonate the SA at runtime to run queries as it.
+    *   Grant the report builder's human Google account
+        `roles/iam.serviceAccountUser` (`actAs`) on the SA — a config-time
+        authorization to wire a data source to run as the SA; it does not mint
+        tokens or query as the SA itself. Grant per-SA (not project-wide) to
+        keep the footprint minimal.
 
-#### Free Looker Studio
+**Setup** (report builder, per EDP):
 
-The free tier authenticates with the **human's** Google identity, not a
-service account. Because only `edp-<name>-dashboard` is named in the row
-access policy, an EDP human user would see **0 rows** by default. To use the
-free tier, an operator must add the EDP's human Google accounts (or a Google
-Group) as grantees on the EDP's row access policy via `bq`:
+1.  Create a report and add a BigQuery data source.
+2.  Under data credentials, choose **Service account credentials** and enter
+    that EDP's SA:
+    `edp-<name>-dashboard@<DASHBOARD_PROJECT>.iam.gserviceaccount.com`.
+3.  Select the project, dataset `dashboard`, and an accessible table.
+4.  Build visualizations — row access policies filter automatically.
+5.  Share the report only with that EDP's designated viewers.
 
-```shell
-# Add EDP humans to each of the 3 EDP-visible tables' row access policies.
-# Re-run for every (table, EDP) pair where Free-tier access is needed.
-# --row_access_policy is a boolean toggle; identify the policy via
-# --policy_id + --target_table. --grantees is a single comma-separated list.
-# On update, re-supply the existing per-EDP predicate or it will be cleared.
-bq update --row_access_policy \
-  --project_id=DASHBOARD_PROJECT \
-  --policy_id=<EDP>_filter \
-  --target_table='dashboard.requisition_overview' \
-  --grantees='group:<edp-name>-dashboard-users@example.com,user:<analyst>@<edp-domain>' \
-  --filter_predicate='<existing per-EDP predicate>'
-```
-
-**Caveat — this is wiped on the next `terraform apply`.** The dashboard
-Terraform manages each row access policy via `google_bigquery_row_access_policy`
-with a fixed grantee list (the per-EDP service account only). When Terraform
-re-asserts the policy on the next deploy, manually-added human grantees are
-removed. Until the dashboard module accepts a `per_edp_human_grantees` input
-(not yet on the roadmap), free-tier setups require the operator to re-run
-the `bq update` commands above after every dashboard Terraform apply.
-**Prefer Looker Studio Pro whenever feasible** to avoid this drift.
-
-Once the policy is updated:
-
-1.  Open [Looker Studio](https://lookerstudio.google.com/) and create a new
-    report.
-2.  Add a BigQuery data source for the dashboard dataset.
-3.  Select "Viewer's credentials" so each viewer's identity is used for row
-    filtering.
-4.  Build visualizations.
+**Isolation warning:** a report runs as its configured SA for everyone who opens
+it, so the row access policy can't stop the wrong viewer from seeing data —
+cross-EDP isolation depends entirely on sharing scope. Build one report per EDP
+and share each only with that EDP; never use "anyone with the link," and never
+reuse a report or SA across EDPs.
 
 ### Available Fields
 
@@ -446,13 +399,20 @@ Once the policy is updated:
 
 ## Operator Steps: Offboarding an EDP
 
-1.  Remove the EDP from the `edps` array in `DASHBOARD_CONFIG_CONTENT`.
-2.  Re-run the `Update CMMS` deploy workflow (or `terraform apply` for a manual deploy, after
-    also removing the EDP from your local `.tfvars`). This destroys the EDP's
-    service account, row access policies, and table-level IAM grants.
-3.  The EDP's historical data remains in the tables but is inaccessible (no
-    row access policy grants visibility, no service account to authenticate).
-4.  Run the compliance check to verify the EDP no longer has access.
+1.  Remove the EDP from the `edps` array in `DASHBOARD_CONFIG_CONTENT` (for a
+    manual deploy, remove it from `data_provider_resource_ids` in your local
+    `.tfvars`).
+2.  Re-run the `Update CMMS` deploy workflow (or `terraform apply` for a manual
+    deploy). This destroys the EDP's service account, row access policies, and
+    table-level IAM grants.
+3.  Confirm the removal: the EDP's service account and row access policies
+    should be gone — check the apply output, or that
+    `gcloud iam service-accounts describe edp-<name>-dashboard@<DASHBOARD_PROJECT>.iam.gserviceaccount.com`
+    returns `NOT_FOUND`. The compliance check no longer covers a removed EDP, so
+    verify the destroy directly.
+
+The EDP's historical data remains in the tables but is inaccessible (no row
+access policy grants visibility, no service account to authenticate).
 
 ## Security Notes for EDPs
 

--- a/docs/edpaggregator/dashboard/onboarding-guide.md
+++ b/docs/edpaggregator/dashboard/onboarding-guide.md
@@ -74,29 +74,23 @@ MeasurementSystem \
 The resource ID is the last segment of the `DataProvider` resource name
 (e.g., for `dataProviders/AbCdEf_12345`, the ID is `AbCdEf_12345`).
 
-### Step 2: Add the EDP to Terraform Variables
+### Step 2: Add the EDP to the Dashboard Config
 
-Add the EDP to `data_provider_resource_ids` in your environment's `.tfvars`
-file:
+Add the EDP to the `edps` array of the `DASHBOARD_CONFIG_CONTENT` GitHub
+environment variable — the single source of truth. The CI workflow regenerates
+the Terraform `data_provider_resource_ids` map from it:
 
-```hcl
-data_provider_resource_ids = {
-  edp1 = "AbCdEf_12345"
-  edp2 = "GhIjKl_67890"
-  edp3 = "MnOpQr_24680"
-  edp4    = "StUvWx_13579"   # Add new EDP here
-}
+```json
+{"name": "edp4", "resource_id": "StUvWx_13579"}
 ```
 
-The key (e.g., `edp4`) is a short name used for:
+The `name` (e.g., `edp4`) is a short label used for:
 
 *   The service account name: `edp-edp4-dashboard@PROJECT.iam.gserviceaccount.com`
 *   Row access policy IDs: `edp4_filter`
 *   CI test matrix entries
 
-### Step 3: Update GitHub Actions Environment
-
-Add the new EDP to the `DASHBOARD_EDP_CONFIG` GitHub environment variable:
+The full `edps` array then looks like:
 
 ```json
 [
@@ -107,29 +101,26 @@ Add the new EDP to the `DASHBOARD_EDP_CONFIG` GitHub environment variable:
 ]
 ```
 
-**Critical: `DASHBOARD_EDP_CONFIG` and `data_provider_resource_ids` MUST
-match** on both keys AND resource IDs. Terraform's `for_each` over
-`data_provider_resource_ids` creates the `edp-<key>-dashboard@` SAs and row
-access policies (filtered by resource ID). The compliance and isolation tools
-iterate `DASHBOARD_EDP_CONFIG` to decide which `edp-<name>-dashboard@` SA to
-impersonate and which resource ID's data to expect. If the two disagree you
-get one of two failure modes:
+### Step 3: Verify Resource IDs
 
-*   **Keys don't match** &rarr; tool tries to impersonate an SA terraform
-    never created &rarr; `404 Not Found; Gaia id not found for email
-    edp-<name>-dashboard@PROJECT.iam.gserviceaccount.com`.
-*   **Resource IDs don't match** &rarr; SA authenticates fine but its row
-    access policy filters everything out &rarr; the compliance check reports
-    `returns other EDPs' data` (false-positive leak) or `empty` (false
-    negative).
-
-The common failure mode is a copy-paste from another environment's
-`data_provider_resource_ids` &mdash; the keys look right but the resource IDs
-are wrong for the target environment. Cross-check against the environment's
-`EDPA_EDPS_CONFIG` (the proto that drives the actual EDPA pipeline) as the
-source of truth for resource IDs.
+Because `DASHBOARD_CONFIG_CONTENT` is the single source of truth, the same
+`edps` entry drives both the Terraform resources (Terraform's `for_each` over
+the generated `data_provider_resource_ids` creates the `edp-<name>-dashboard@`
+SAs and row access policies) and the compliance/isolation tools (which
+impersonate `edp-<name>-dashboard@` and expect that `resource_id`'s data). Make
+sure each `resource_id` is the **bare** ID correct for the target environment —
+cross-check against the environment's `EDPA_EDPS_CONFIG` (the proto that drives
+the actual EDPA pipeline). A wrong `resource_id` makes the row access policy
+filter everything out, so the compliance check reports `returns other EDPs'
+data` (false-positive leak) or `empty` (false negative).
 
 ### Step 4: Apply Terraform
+
+Re-run the `Update CMMS` deploy workflow. The "Write dashboard tfvars" step regenerates
+`data_provider_resource_ids` from `DASHBOARD_CONFIG_CONTENT`, then `terraform
+apply` runs. For a **manual** apply against a local `.tfvars` — which is *not*
+regenerated from `DASHBOARD_CONFIG_CONTENT` — add the EDP to
+`data_provider_resource_ids` in that file as well before applying:
 
 ```shell
 terraform plan -var-file=my-env.tfvars
@@ -217,12 +208,10 @@ tested permissions):
 bazel run //src/main/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/dashboard/tools:DashboardComplianceCheck -- \
   --impersonate-service-account=dashboard-compliance@MY_PROJECT.iam.gserviceaccount.com \
   --project=MY_PROJECT \
-  --region=<REGION> \
-  --edp=edp1:AbCdEf_12345 \
-  --edp=edp2:GhIjKl_67890 \
-  --edp=edp3:MnOpQr_24680 \
-  --edp=edp4:StUvWx_13579
+  --dashboard-config=/path/to/dashboard-config.json
 ```
+
+where `dashboard-config.json` holds the environment's `DASHBOARD_CONFIG_CONTENT`.
 
 To impersonate, your account needs `roles/iam.serviceAccountTokenCreator` on
 the `dashboard-compliance` SA. The dashboard Terraform grants this to every
@@ -457,10 +446,10 @@ Once the policy is updated:
 
 ## Operator Steps: Offboarding an EDP
 
-1.  Remove the EDP from `data_provider_resource_ids` in `.tfvars` and from
-    `DASHBOARD_EDP_CONFIG` in the GitHub environment.
-2.  Run `terraform apply`. This destroys the EDP's service account, row access
-    policies, and table-level IAM grants.
+1.  Remove the EDP from the `edps` array in `DASHBOARD_CONFIG_CONTENT`.
+2.  Re-run the `Update CMMS` deploy workflow (or `terraform apply` for a manual deploy, after
+    also removing the EDP from your local `.tfvars`). This destroys the EDP's
+    service account, row access policies, and table-level IAM grants.
 3.  The EDP's historical data remains in the tables but is inaccessible (no
     row access policy grants visibility, no service account to authenticate).
 4.  Run the compliance check to verify the EDP no longer has access.

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/dashboard/tools/BUILD.bazel
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/dashboard/tools/BUILD.bazel
@@ -7,8 +7,11 @@ kt_jvm_library(
     visibility = ["//visibility:public"],
     deps = [
         "//src/main/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/dashboard:dashboard_isolation_checks",
+        "//src/main/proto/wfa/measurement/config/edpaggregator:dashboard_config_kt_jvm_proto",
         "@maven//:com_google_auth_google_auth_library_oauth2_http",
         "@maven//:com_google_cloud_google_cloud_bigquery",
+        "@wfa_common_jvm//imports/java/com/google/protobuf",
+        "@wfa_common_jvm//imports/java/com/google/protobuf/util",
     ],
 )
 

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/dashboard/tools/DashboardComplianceCheck.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/dashboard/tools/DashboardComplianceCheck.kt
@@ -16,8 +16,9 @@
 
 package org.wfanet.measurement.edpaggregator.deploy.gcloud.dashboard.tools
 
+import java.io.File
+import java.io.IOException
 import org.wfanet.measurement.common.commandLineMain
-import org.wfanet.measurement.edpaggregator.deploy.gcloud.dashboard.DashboardIsolationChecks.EdpConfig
 import picocli.CommandLine
 
 @CommandLine.Command(
@@ -26,6 +27,8 @@ import picocli.CommandLine
   sortOptions = false,
 )
 class DashboardComplianceCheck : Runnable {
+
+  @CommandLine.Spec private lateinit var spec: CommandLine.Model.CommandSpec
 
   @CommandLine.Option(names = ["--project"], required = true, description = ["GCP project ID"])
   private lateinit var project: String
@@ -39,15 +42,15 @@ class DashboardComplianceCheck : Runnable {
   private lateinit var dataset: String
 
   @CommandLine.Option(
-    names = ["--edp"],
+    names = ["--dashboard-config"],
     required = true,
-    description = ["EDP config as name:resourceId (repeatable)"],
-    split = ",",
+    description =
+      [
+        "Path to a DASHBOARD_CONFIG_CONTENT JSON file supplying the EDPs and BigQuery region, " +
+          "parsed against the DashboardConfig proto schema."
+      ],
   )
-  private lateinit var edpFlags: List<String>
-
-  @CommandLine.Option(names = ["--region"], required = true, description = ["BigQuery region"])
-  private lateinit var region: String
+  private lateinit var dashboardConfigFile: File
 
   @CommandLine.Option(
     names = ["--impersonate-service-account"],
@@ -56,22 +59,33 @@ class DashboardComplianceCheck : Runnable {
   )
   private var impersonateServiceAccount: String? = null
 
-  private val edps by lazy {
-    edpFlags.map { flag ->
-      val (name, resourceId) = flag.split(":", limit = 2)
-      EdpConfig(name, resourceId)
-    }
-  }
-
   override fun run() {
+    val config =
+      try {
+        DashboardComplianceRunner.parseDashboardConfig(dashboardConfigFile.readText())
+      } catch (e: IOException) {
+        throw CommandLine.ParameterException(
+          spec.commandLine(),
+          "Cannot read --dashboard-config file '${dashboardConfigFile.path}': ${e.message}",
+        )
+      } catch (e: IllegalArgumentException) {
+        throw CommandLine.ParameterException(spec.commandLine(), e.message)
+      }
+
     println("=== EDPA Dashboard Compliance Check ===")
     println("Project: $project")
     println("Dataset: $dataset")
-    println("EDPs: ${edps.map { it.name }}")
+    println("EDPs: ${config.edps.map { it.name }}")
     println()
 
     val report =
-      DashboardComplianceRunner.run(project, dataset, region, impersonateServiceAccount, edps)
+      DashboardComplianceRunner.run(
+        project,
+        dataset,
+        config.region,
+        impersonateServiceAccount,
+        config.edps,
+      )
 
     for (section in report.sections) {
       println("[${section.name}]")

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/dashboard/tools/DashboardComplianceCheck.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/dashboard/tools/DashboardComplianceCheck.kt
@@ -69,7 +69,10 @@ class DashboardComplianceCheck : Runnable {
           "Cannot read --dashboard-config file '${dashboardConfigFile.path}': ${e.message}",
         )
       } catch (e: IllegalArgumentException) {
-        throw CommandLine.ParameterException(spec.commandLine(), e.message)
+        throw CommandLine.ParameterException(
+          spec.commandLine(),
+          "Invalid --dashboard-config file '${dashboardConfigFile.path}': ${e.message ?: e}",
+        )
       }
 
     println("=== EDPA Dashboard Compliance Check ===")

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/dashboard/tools/DashboardComplianceRunner.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/dashboard/tools/DashboardComplianceRunner.kt
@@ -20,7 +20,10 @@ import com.google.auth.oauth2.GoogleCredentials
 import com.google.auth.oauth2.ImpersonatedCredentials
 import com.google.cloud.bigquery.BigQuery
 import com.google.cloud.bigquery.BigQueryOptions
+import com.google.protobuf.InvalidProtocolBufferException
+import com.google.protobuf.util.JsonFormat
 import java.util.logging.Logger
+import org.wfanet.measurement.config.edpaggregator.DashboardConfig
 import org.wfanet.measurement.edpaggregator.deploy.gcloud.dashboard.DashboardIsolationChecks
 import org.wfanet.measurement.edpaggregator.deploy.gcloud.dashboard.DashboardIsolationChecks.CheckResult
 import org.wfanet.measurement.edpaggregator.deploy.gcloud.dashboard.DashboardIsolationChecks.EdpConfig
@@ -39,6 +42,9 @@ object DashboardComplianceRunner {
   private val logger = Logger.getLogger(this::class.java.name)
 
   private val SCOPES = listOf("https://www.googleapis.com/auth/cloud-platform")
+
+  /** The EDPs and BigQuery region resolved from a DASHBOARD_CONFIG_CONTENT document. */
+  data class ResolvedConfig(val edps: List<EdpConfig>, val region: String)
 
   /** A named group of [CheckResult]s (mirrors the CLI's section layout). */
   data class Section(val name: String, val results: List<CheckResult>)
@@ -115,6 +121,32 @@ object DashboardComplianceRunner {
         }
         EdpConfig(parts[0], parts[1])
       }
+  }
+
+  /**
+   * Parses a DASHBOARD_CONFIG_CONTENT JSON document against the [DashboardConfig] proto schema and
+   * extracts the EDPs and BigQuery region.
+   *
+   * @throws IllegalArgumentException if the JSON is malformed or a required field (`edps`,
+   *   `bigquery_region`) is missing
+   */
+  fun parseDashboardConfig(json: String): ResolvedConfig {
+    val config =
+      try {
+        DashboardConfig.newBuilder()
+          .apply { JsonFormat.parser().ignoringUnknownFields().merge(json, this) }
+          .build()
+      } catch (e: InvalidProtocolBufferException) {
+        throw IllegalArgumentException("Malformed dashboard config JSON: ${e.message}", e)
+      }
+    require(config.edpsList.isNotEmpty()) {
+      "dashboard config must contain at least one entry in 'edps'"
+    }
+    require(config.bigqueryRegion.isNotEmpty()) { "dashboard config must set 'bigquery_region'" }
+    return ResolvedConfig(
+      config.edpsList.map { EdpConfig(it.name, it.resourceId) },
+      config.bigqueryRegion,
+    )
   }
 
   private fun buildBaseCredentials(impersonateServiceAccount: String?): GoogleCredentials {

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/dashboard/tools/DashboardComplianceRunner.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/dashboard/tools/DashboardComplianceRunner.kt
@@ -142,6 +142,12 @@ object DashboardComplianceRunner {
     require(config.edpsList.isNotEmpty()) {
       "dashboard config must contain at least one entry in 'edps'"
     }
+    for (edp in config.edpsList) {
+      require(edp.name.isNotEmpty()) { "dashboard config edp is missing 'name'" }
+      require(edp.resourceId.isNotEmpty()) {
+        "dashboard config edp '${edp.name}' is missing 'resource_id'"
+      }
+    }
     require(config.bigqueryRegion.isNotEmpty()) { "dashboard config must set 'bigquery_region'" }
     return ResolvedConfig(
       config.edpsList.map { EdpConfig(it.name, it.resourceId) },

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/dashboard/tools/DashboardComplianceRunner.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/dashboard/tools/DashboardComplianceRunner.kt
@@ -148,6 +148,11 @@ object DashboardComplianceRunner {
         "dashboard config edp '${edp.name}' is missing 'resource_id'"
       }
     }
+    val duplicateNames =
+      config.edpsList.groupingBy { it.name }.eachCount().filterValues { it > 1 }.keys
+    require(duplicateNames.isEmpty()) {
+      "dashboard config has duplicate edp names: $duplicateNames"
+    }
     require(config.bigqueryRegion.isNotEmpty()) { "dashboard config must set 'bigquery_region'" }
     return ResolvedConfig(
       config.edpsList.map { EdpConfig(it.name, it.resourceId) },

--- a/src/main/proto/wfa/measurement/config/edpaggregator/BUILD.bazel
+++ b/src/main/proto/wfa/measurement/config/edpaggregator/BUILD.bazel
@@ -174,3 +174,14 @@ kt_jvm_proto_library(
     name = "data_availability_monitor_config_kt_jvm_proto",
     deps = [":data_availability_monitor_config_proto"],
 )
+
+proto_library(
+    name = "dashboard_config_proto",
+    srcs = ["dashboard_config.proto"],
+    strip_import_prefix = IMPORT_PREFIX,
+)
+
+kt_jvm_proto_library(
+    name = "dashboard_config_kt_jvm_proto",
+    deps = [":dashboard_config_proto"],
+)

--- a/src/main/proto/wfa/measurement/config/edpaggregator/dashboard_config.proto
+++ b/src/main/proto/wfa/measurement/config/edpaggregator/dashboard_config.proto
@@ -46,7 +46,10 @@ message DashboardConfig {
     // Short EDP name used for per-EDP resource naming (e.g. "meta").
     string name = 1;
 
-    // The `DataProvider` resource ID (e.g. "J3-pzhqS9Lo").
+    // The bare `DataProvider` resource ID (final path segment only, e.g.
+    // "J3-pzhqS9Lo"), NOT the full resource name — do not include the
+    // "dataProviders/" prefix. Must match the DataProviderResourceId value
+    // stored in Spanner and used by the row access policy filters.
     string resource_id = 2;
   }
 }

--- a/src/main/proto/wfa/measurement/config/edpaggregator/dashboard_config.proto
+++ b/src/main/proto/wfa/measurement/config/edpaggregator/dashboard_config.proto
@@ -1,0 +1,52 @@
+// Copyright 2026 The Cross-Media Measurement Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package wfa.measurement.config.edpaggregator;
+
+option java_package = "org.wfanet.measurement.config.edpaggregator";
+option java_multiple_files = true;
+option java_outer_classname = "DashboardConfigProto";
+
+// Consolidated configuration for the reporting dashboard.
+//
+// Stored as a single `DASHBOARD_CONFIG_CONTENT` GitHub variable (JSON) per
+// environment, replacing the five separate dashboard variables. Consumed by
+// Terraform (natively as `*.tfvars.json`), by workflows (via `jq`), and by the
+// dashboard compliance check (parsed against this schema via `JsonFormat`).
+message DashboardConfig {
+  // BigQuery region hosting the dashboard dataset (e.g. "us-central1").
+  string bigquery_region = 1;
+
+  // Whether the dashboard BigQuery dataset has deletion protection enabled.
+  bool deletion_protection = 2;
+
+  // IAM principals granted platform-wide access to the dashboard tables
+  // (e.g. "user:alice@example.com").
+  repeated string operators = 3;
+
+  // The EDPs whose data the dashboard exposes; each is isolated to its own
+  // rows.
+  repeated Edp edps = 4;
+
+  // A single EDP: its short name and `DataProvider` resource ID.
+  message Edp {
+    // Short EDP name used for per-EDP resource naming (e.g. "meta").
+    string name = 1;
+
+    // The `DataProvider` resource ID (e.g. "J3-pzhqS9Lo").
+    string resource_id = 2;
+  }
+}

--- a/src/main/terraform/gcloud/cmms/envs/dev.tfvars
+++ b/src/main/terraform/gcloud/cmms/envs/dev.tfvars
@@ -7,4 +7,3 @@ results_fulfiller_event_proto_descriptor_blob_uri = "gs://edpa-configs-storage-d
 results_fulfiller_event_template_type_name        = "wfa.measurement.api.v2alpha.event_templates.testing.TestEvent"
 results_fulfiller_population_spec_blob_uri        = "gs://edpa-configs-storage-dev-bucket/results-fulfiller-population-spec-small.textproto"
 edpa_model_line_map                               = "modelProviders/Wt5MH8egH4w/modelSuites/NrAN9F9SunM/modelLines/B16R2tctG4A"
-dashboard_deletion_protection                     = false

--- a/src/main/terraform/gcloud/cmms/envs/head.tfvars
+++ b/src/main/terraform/gcloud/cmms/envs/head.tfvars
@@ -7,4 +7,3 @@ results_fulfiller_event_proto_descriptor_blob_uri = "gs://edpa-configs-storage-h
 results_fulfiller_event_template_type_name        = "wfa.measurement.api.v2alpha.event_templates.testing.TestEvent"
 results_fulfiller_population_spec_blob_uri        = "gs://edpa-configs-storage-head-bucket/results-fulfiller-population-spec.textproto"
 edpa_model_line_map                               = "modelProviders/PYauXl6kcsA/modelSuites/IvSb6madWtE/modelLines/DOfmLYTmbbY"
-dashboard_deletion_protection                     = false

--- a/src/main/terraform/gcloud/cmms/envs/qa.tfvars
+++ b/src/main/terraform/gcloud/cmms/envs/qa.tfvars
@@ -7,4 +7,3 @@ results_fulfiller_event_proto_descriptor_blob_uri = "gs://edpa-configs-storage-q
 results_fulfiller_event_template_type_name        = "wfa.measurement.api.v2alpha.event_templates.testing.TestEvent"
 results_fulfiller_population_spec_blob_uri        = "gs://edpa-configs-storage-qa-bucket/results-fulfiller-population-spec.textproto"
 edpa_model_line_map                               = "modelProviders/eaaPUbwUC5c/modelSuites/NMtDnLwcnNo/modelLines/AcQdbXsZIzw"
-dashboard_deletion_protection                     = true

--- a/src/test/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/dashboard/tools/DashboardComplianceRunnerTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/dashboard/tools/DashboardComplianceRunnerTest.kt
@@ -175,4 +175,26 @@ class DashboardComplianceRunnerTest {
       DashboardComplianceRunner.parseDashboardConfig("{not valid json")
     }
   }
+
+  @Test
+  fun `parseDashboardConfig throws when an edp is missing resource_id`() {
+    val exception =
+      assertThrows(IllegalArgumentException::class.java) {
+        DashboardComplianceRunner.parseDashboardConfig(
+          """{"bigquery_region": "us-central1", "edps": [{"name": "meta"}]}"""
+        )
+      }
+    assertThat(exception).hasMessageThat().contains("resource_id")
+  }
+
+  @Test
+  fun `parseDashboardConfig throws when an edp is missing name`() {
+    val exception =
+      assertThrows(IllegalArgumentException::class.java) {
+        DashboardComplianceRunner.parseDashboardConfig(
+          """{"bigquery_region": "us-central1", "edps": [{"resource_id": "abc"}]}"""
+        )
+      }
+    assertThat(exception).hasMessageThat().contains("name")
+  }
 }

--- a/src/test/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/dashboard/tools/DashboardComplianceRunnerTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/dashboard/tools/DashboardComplianceRunnerTest.kt
@@ -111,4 +111,68 @@ class DashboardComplianceRunnerTest {
       DashboardComplianceRunner.parseEdps(":AbC")
     }
   }
+
+  @Test
+  fun `parseDashboardConfig returns edps and region from valid config`() {
+    val json =
+      """
+      {
+        "bigquery_region": "us-central1",
+        "deletion_protection": false,
+        "operators": ["user:alice@example.com"],
+        "edps": [
+          {"name": "meta", "resource_id": "J3-pzhqS9Lo"},
+          {"name": "edp7", "resource_id": "T5RryPMNong"}
+        ]
+      }
+      """
+        .trimIndent()
+
+    val resolved = DashboardComplianceRunner.parseDashboardConfig(json)
+
+    assertThat(resolved.region).isEqualTo("us-central1")
+    assertThat(resolved.edps)
+      .containsExactly(EdpConfig("meta", "J3-pzhqS9Lo"), EdpConfig("edp7", "T5RryPMNong"))
+      .inOrder()
+  }
+
+  @Test
+  fun `parseDashboardConfig ignores unknown fields`() {
+    val json =
+      """{"bigquery_region": "us-central1", "future_field": "x", "edps": [{"name": "meta", "resource_id": "abc"}]}"""
+
+    val resolved = DashboardComplianceRunner.parseDashboardConfig(json)
+
+    assertThat(resolved.region).isEqualTo("us-central1")
+    assertThat(resolved.edps).containsExactly(EdpConfig("meta", "abc"))
+  }
+
+  @Test
+  fun `parseDashboardConfig throws when edps is empty`() {
+    val exception =
+      assertThrows(IllegalArgumentException::class.java) {
+        DashboardComplianceRunner.parseDashboardConfig(
+          """{"bigquery_region": "us-central1", "edps": []}"""
+        )
+      }
+    assertThat(exception).hasMessageThat().contains("edps")
+  }
+
+  @Test
+  fun `parseDashboardConfig throws when bigquery_region is missing`() {
+    val exception =
+      assertThrows(IllegalArgumentException::class.java) {
+        DashboardComplianceRunner.parseDashboardConfig(
+          """{"edps": [{"name": "meta", "resource_id": "abc"}]}"""
+        )
+      }
+    assertThat(exception).hasMessageThat().contains("bigquery_region")
+  }
+
+  @Test
+  fun `parseDashboardConfig throws on malformed json`() {
+    assertThrows(IllegalArgumentException::class.java) {
+      DashboardComplianceRunner.parseDashboardConfig("{not valid json")
+    }
+  }
 }

--- a/src/test/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/dashboard/tools/DashboardComplianceRunnerTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/dashboard/tools/DashboardComplianceRunnerTest.kt
@@ -197,4 +197,15 @@ class DashboardComplianceRunnerTest {
       }
     assertThat(exception).hasMessageThat().contains("name")
   }
+
+  @Test
+  fun `parseDashboardConfig throws on duplicate edp names`() {
+    val exception =
+      assertThrows(IllegalArgumentException::class.java) {
+        DashboardComplianceRunner.parseDashboardConfig(
+          """{"bigquery_region": "us-central1", "edps": [{"name": "meta", "resource_id": "a"}, {"name": "meta", "resource_id": "b"}]}"""
+        )
+      }
+    assertThat(exception).hasMessageThat().contains("duplicate")
+  }
 }


### PR DESCRIPTION
Consolidates the five per-environment dashboard GitHub variables into a single DASHBOARD_CONFIG_CONTENT JSON variable backed by a new DashboardConfig proto, read by Terraform (as *.tfvars.json), the dashboard workflows, and the DashboardComplianceCheck CLI (via --dashboard-config). Net: -5 variable slots per environment.

Operational: add DASHBOARD_CONFIG_CONTENT per environment before merge; delete the six old variables after.

Issue: #4124
