### PR TITLE
feat!: require request_id on PoolAssignmentJob Mark* and Create RPCs

### DIFF
--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/spanner/SpannerPoolAssignmentJobService.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/spanner/SpannerPoolAssignmentJobService.kt
@@ -98,23 +98,22 @@ class SpannerPoolAssignmentJobService(
     val createdJob: PoolAssignmentJob =
       try {
         transactionRunner.run { txn ->
-          if (request.requestId.isNotEmpty()) {
-            val existing =
-              txn.findPoolAssignmentJobByRequestId(
-                job.dataProviderResourceId,
-                job.rawImpressionUploadResourceId,
-                request.requestId,
-              )
-            if (existing != null) {
-              if (
-                existing.poolAssignmentJob.cmmsModelLine != job.cmmsModelLine ||
-                  existing.poolAssignmentJob.shardIndex != job.shardIndex
-              ) {
-                throw PoolAssignmentJobAlreadyExistsException()
-                  .asStatusRuntimeException(Status.Code.ALREADY_EXISTS)
-              }
-              return@run existing.poolAssignmentJob
+          // request_id is REQUIRED (validated above), so always attempt the idempotent replay.
+          val existing =
+            txn.findPoolAssignmentJobByRequestId(
+              job.dataProviderResourceId,
+              job.rawImpressionUploadResourceId,
+              request.requestId,
+            )
+          if (existing != null) {
+            if (
+              existing.poolAssignmentJob.cmmsModelLine != job.cmmsModelLine ||
+                existing.poolAssignmentJob.shardIndex != job.shardIndex
+            ) {
+              throw PoolAssignmentJobAlreadyExistsException()
+                .asStatusRuntimeException(Status.Code.ALREADY_EXISTS)
             }
+            return@run existing.poolAssignmentJob
           }
 
           val rawImpressionUploadId =
@@ -222,19 +221,21 @@ class SpannerPoolAssignmentJobService(
       }
 
       val requestId = subRequest.requestId
-      if (requestId.isNotEmpty()) {
-        try {
-          UUID.fromString(requestId)
-        } catch (e: IllegalArgumentException) {
-          throw InvalidFieldValueException("requests[$index].request_id", e)
-            .asStatusRuntimeException(Status.Code.INVALID_ARGUMENT)
-        }
-        if (!requestIdSet.add(requestId)) {
-          throw InvalidFieldValueException("requests[$index].request_id") {
-              "Duplicate request_id $requestId in batch"
-            }
-            .asStatusRuntimeException(Status.Code.INVALID_ARGUMENT)
-        }
+      if (requestId.isEmpty()) {
+        throw RequiredFieldNotSetException("requests[$index].request_id")
+          .asStatusRuntimeException(Status.Code.INVALID_ARGUMENT)
+      }
+      try {
+        UUID.fromString(requestId)
+      } catch (e: IllegalArgumentException) {
+        throw InvalidFieldValueException("requests[$index].request_id", e)
+          .asStatusRuntimeException(Status.Code.INVALID_ARGUMENT)
+      }
+      if (!requestIdSet.add(requestId)) {
+        throw InvalidFieldValueException("requests[$index].request_id") {
+            "Duplicate request_id $requestId in batch"
+          }
+          .asStatusRuntimeException(Status.Code.INVALID_ARGUMENT)
       }
     }
 
@@ -259,7 +260,8 @@ class SpannerPoolAssignmentJobService(
             txn.findPoolAssignmentJobsByRequestIds(
               dataProviderResourceId,
               rawImpressionUploadResourceId,
-              request.requestsList.mapNotNull { it.requestId.ifEmpty { null } },
+              // request_id is REQUIRED per element (validated above).
+              request.requestsList.map { it.requestId },
             )
 
           request.requestsList.map { subRequest ->
@@ -414,11 +416,9 @@ class SpannerPoolAssignmentJobService(
   /**
    * Marks a [PoolAssignmentJob] SUCCEEDED.
    *
-   * Idempotency contract gap: while `request_id` remains OPTIONAL, a caller that omits it gets
-   * non-idempotent behavior — on retry the replay short-circuit is skipped, the state is already
-   * SUCCEEDED (not in the valid previous states), and the call returns `FAILED_PRECONDITION`.
-   * Callers MUST pass a deterministic non-empty `request_id` until it is made REQUIRED. See
-   * [#4078](https://github.com/world-federation-of-advertisers/cross-media-measurement/issues/4078).
+   * `request_id` is REQUIRED: a retry with the same `request_id` replays the original response
+   * without re-transitioning the resource (AIP-155), so a Pub/Sub redelivery of the mark stays
+   * idempotent instead of surfacing `FAILED_PRECONDITION` against the already-SUCCEEDED row.
    */
   override suspend fun markPoolAssignmentJobSucceeded(
     request: MarkPoolAssignmentJobSucceededRequest
@@ -437,6 +437,16 @@ class SpannerPoolAssignmentJobService(
     }
     if (request.etag.isEmpty()) {
       throw RequiredFieldNotSetException("etag")
+        .asStatusRuntimeException(Status.Code.INVALID_ARGUMENT)
+    }
+    if (request.requestId.isEmpty()) {
+      throw RequiredFieldNotSetException("request_id")
+        .asStatusRuntimeException(Status.Code.INVALID_ARGUMENT)
+    }
+    try {
+      UUID.fromString(request.requestId)
+    } catch (e: IllegalArgumentException) {
+      throw InvalidFieldValueException("request_id", e)
         .asStatusRuntimeException(Status.Code.INVALID_ARGUMENT)
     }
     if (!request.hasEncryptedDek()) {
@@ -478,8 +488,7 @@ class SpannerPoolAssignmentJobService(
         // iff all siblings are now SUCCEEDED AND none reached SUCCEEDED after it.
         if (
           currentJob.state == State.POOL_ASSIGNMENT_STATE_SUCCEEDED &&
-            request.requestId.isNotEmpty() &&
-            result.markRequestId == request.requestId
+            result.markSucceededRequestId == request.requestId
         ) {
           val wasLastShard =
             txn.countNonSucceededPoolAssignmentJobs(
@@ -540,11 +549,8 @@ class SpannerPoolAssignmentJobService(
           poolAssignmentJobId = result.poolAssignmentJobId,
           state = State.POOL_ASSIGNMENT_STATE_SUCCEEDED,
         ) {
-          // Leave MarkSucceededRequestId NULL when no request_id is supplied; the NULL_FILTERED
-          // unique index would otherwise reject a second empty-string value in the group.
-          if (request.requestId.isNotEmpty()) {
-            set("MarkSucceededRequestId").to(request.requestId)
-          }
+          // request_id is REQUIRED, so stamp it unconditionally for AIP-155 replay detection.
+          set("MarkSucceededRequestId").to(request.requestId)
           // Persist the per-shard DEK that encrypts this shard's SubpoolFingerprints blobs.
           set("EncryptedDek").toProtoBytes(request.encryptedDek)
           // Clear any stale failure detail on the FAILED -> SUCCEEDED transition.
@@ -637,8 +643,14 @@ class SpannerPoolAssignmentJobService(
     }
   }
 
-  // TODO(world-federation-of-advertisers/cross-media-measurement#4078): Add AIP-155 request_id
-  // idempotency (replay check + MarkRequestId stamp), mirroring markPoolAssignmentJobSucceeded.
+  /**
+   * Marks a [PoolAssignmentJob] FAILED.
+   *
+   * `request_id` is REQUIRED: a retry with the same `request_id` replays the original response
+   * without re-transitioning the resource (AIP-155). Because `FAILED` is a valid previous state
+   * (the CREATED|FAILED self-loop), a Pub/Sub redelivery would otherwise re-stamp a fresh commit
+   * timestamp and rotate the etag, breaking a later CAS; the replay short-circuit prevents that.
+   */
   override suspend fun markPoolAssignmentJobFailed(
     request: MarkPoolAssignmentJobFailedRequest
   ): PoolAssignmentJob {
@@ -658,11 +670,23 @@ class SpannerPoolAssignmentJobService(
       throw RequiredFieldNotSetException("etag")
         .asStatusRuntimeException(Status.Code.INVALID_ARGUMENT)
     }
+    if (request.requestId.isEmpty()) {
+      throw RequiredFieldNotSetException("request_id")
+        .asStatusRuntimeException(Status.Code.INVALID_ARGUMENT)
+    }
+    try {
+      UUID.fromString(request.requestId)
+    } catch (e: IllegalArgumentException) {
+      throw InvalidFieldValueException("request_id", e)
+        .asStatusRuntimeException(Status.Code.INVALID_ARGUMENT)
+    }
 
     val transactionRunner =
       databaseClient.readWriteTransaction(Options.tag("action=markPoolAssignmentJobFailed"))
 
-    val updatedJob: PoolAssignmentJob =
+    data class TransactionResult(val job: PoolAssignmentJob, val isReplay: Boolean = false)
+
+    val txnResult: TransactionResult =
       transactionRunner.run { txn ->
         val result =
           txn.getPoolAssignmentJobByResourceId(
@@ -678,6 +702,15 @@ class SpannerPoolAssignmentJobService(
               .asStatusRuntimeException(Status.Code.NOT_FOUND)
 
         val currentJob = result.poolAssignmentJob
+
+        // AIP-155 idempotent replay: if this exact mark already ran (this MarkFailed's request_id
+        // is already stamped on the row), return the resource as-is instead of re-transitioning or
+        // throwing FAILED_PRECONDITION on a Pub/Sub redelivery. Matching the request_id alone is
+        // sufficient per AIP-155, even if the resource has since advanced to a later state; it also
+        // preserves the original error_message, since the update below is skipped.
+        if (result.markFailedRequestId == request.requestId) {
+          return@run TransactionResult(currentJob, isReplay = true)
+        }
 
         val validPreviousStates =
           setOf(State.POOL_ASSIGNMENT_STATE_CREATED, State.POOL_ASSIGNMENT_STATE_FAILED)
@@ -704,19 +737,28 @@ class SpannerPoolAssignmentJobService(
           poolAssignmentJobId = result.poolAssignmentJobId,
           state = State.POOL_ASSIGNMENT_STATE_FAILED,
         ) {
+          set("MarkFailedRequestId").to(request.requestId)
           set("ErrorMessage").to(request.errorMessage)
         }
 
-        currentJob.copy {
-          state = State.POOL_ASSIGNMENT_STATE_FAILED
-          errorMessage = request.errorMessage
-          clearUpdateTime()
-        }
+        TransactionResult(
+          currentJob.copy {
+            state = State.POOL_ASSIGNMENT_STATE_FAILED
+            errorMessage = request.errorMessage
+            clearUpdateTime()
+          }
+        )
       }
+
+    // isReplay=true returns the row as already committed (possibly in a later state); otherwise
+    // stamp the commit timestamp and etag onto the just-transitioned row.
+    if (txnResult.isReplay) {
+      return txnResult.job
+    }
 
     val commitTimestamp: Timestamp = transactionRunner.getCommitTimestamp().toProto()
 
-    return updatedJob.copy {
+    return txnResult.job.copy {
       updateTime = commitTimestamp
       etag = ETags.computeETag(commitTimestamp.toInstant())
     }
@@ -729,14 +771,6 @@ class SpannerPoolAssignmentJobService(
    * @throws InvalidFieldValueException if field values are invalid
    */
   private fun validateCreateRequest(request: CreatePoolAssignmentJobRequest) {
-    if (request.requestId.isNotEmpty()) {
-      try {
-        UUID.fromString(request.requestId)
-      } catch (e: IllegalArgumentException) {
-        throw InvalidFieldValueException("request_id", e)
-      }
-    }
-
     if (!request.hasPoolAssignmentJob()) {
       throw RequiredFieldNotSetException("pool_assignment_job")
     }
@@ -748,6 +782,14 @@ class SpannerPoolAssignmentJobService(
     }
     if (request.poolAssignmentJob.cmmsModelLine.isEmpty()) {
       throw RequiredFieldNotSetException("pool_assignment_job.cmms_model_line")
+    }
+    if (request.requestId.isEmpty()) {
+      throw RequiredFieldNotSetException("request_id")
+    }
+    try {
+      UUID.fromString(request.requestId)
+    } catch (e: IllegalArgumentException) {
+      throw InvalidFieldValueException("request_id", e)
     }
   }
 

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/spanner/SpannerPoolAssignmentJobService.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/spanner/SpannerPoolAssignmentJobService.kt
@@ -684,6 +684,9 @@ class SpannerPoolAssignmentJobService(
     val transactionRunner =
       databaseClient.readWriteTransaction(Options.tag("action=markPoolAssignmentJobFailed"))
 
+    // TODO(world-federation-of-advertisers/cross-media-measurement#4250): Consolidate the
+    // inline AIP-155 replay logic in the Mark* RPCs onto a shared request-id helper, as in
+    // SpannerRawImpressionUploadModelLineService.transitionState.
     data class TransactionResult(val job: PoolAssignmentJob, val isReplay: Boolean = false)
 
     val txnResult: TransactionResult =

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/spanner/db/PoolAssignmentJob.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/spanner/db/PoolAssignmentJob.kt
@@ -48,7 +48,8 @@ data class PoolAssignmentJobResult(
   val poolAssignmentJob: PoolAssignmentJob,
   val rawImpressionUploadId: Long,
   val poolAssignmentJobId: Long,
-  val markRequestId: String,
+  val markSucceededRequestId: String,
+  val markFailedRequestId: String,
 )
 
 /** Returns whether a [PoolAssignmentJob] with the specified keys exists. */
@@ -136,8 +137,6 @@ suspend fun AsyncDatabaseClient.ReadContext.findPoolAssignmentJobByRequestId(
   rawImpressionUploadResourceId: String,
   requestId: String,
 ): PoolAssignmentJobResult? {
-  if (requestId.isEmpty()) return null
-
   val sql = buildString {
     appendLine(PoolAssignmentJobEntity.BASE_SQL)
     appendLine(
@@ -473,9 +472,8 @@ fun AsyncDatabaseClient.TransactionContext.insertPoolAssignmentJob(
     set("PoolAssignmentJobResourceId").to(poolAssignmentJobResourceId)
     set("CmmsModelLine").to(cmmsModelLine)
     set("ShardIndex").to(shardIndex)
-    if (createRequestId.isNotEmpty()) {
-      set("CreateRequestId").to(createRequestId)
-    }
+    // request_id is REQUIRED on Create (enforced by the service), so set it unconditionally.
+    set("CreateRequestId").to(createRequestId)
     set("State").to(State.POOL_ASSIGNMENT_STATE_CREATED)
     set("CreateTime").to(Value.COMMIT_TIMESTAMP)
     set("UpdateTime").to(Value.COMMIT_TIMESTAMP)
@@ -515,6 +513,7 @@ private object PoolAssignmentJobEntity {
       PoolAssignmentJob.ShardIndex,
       PoolAssignmentJob.CreateRequestId,
       PoolAssignmentJob.MarkSucceededRequestId,
+      PoolAssignmentJob.MarkFailedRequestId,
       PoolAssignmentJob.State,
       PoolAssignmentJob.ErrorMessage,
       PoolAssignmentJob.EncryptedDek,
@@ -549,6 +548,7 @@ private object PoolAssignmentJobEntity {
       struct.getLong("PoolAssignmentJobId"),
       if (struct.isNull("MarkSucceededRequestId")) ""
       else struct.getString("MarkSucceededRequestId"),
+      if (struct.isNull("MarkFailedRequestId")) "" else struct.getString("MarkFailedRequestId"),
     )
   }
 }

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/service/internal/testing/PoolAssignmentJobServiceTest.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/service/internal/testing/PoolAssignmentJobServiceTest.kt
@@ -106,6 +106,7 @@ abstract class PoolAssignmentJobServiceTest {
     val job: PoolAssignmentJob =
       service.createPoolAssignmentJob(
         createPoolAssignmentJobRequest {
+          this.requestId = UUID.randomUUID().toString()
           poolAssignmentJob = poolAssignmentJob {
             dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
             rawImpressionUploadResourceId = RAW_IMPRESSION_UPLOAD_RESOURCE_ID
@@ -198,6 +199,7 @@ abstract class PoolAssignmentJobServiceTest {
         assertFailsWith<StatusRuntimeException> {
           service.createPoolAssignmentJob(
             createPoolAssignmentJobRequest {
+              this.requestId = UUID.randomUUID().toString()
               poolAssignmentJob = poolAssignmentJob {
                 rawImpressionUploadResourceId = RAW_IMPRESSION_UPLOAD_RESOURCE_ID
                 cmmsModelLine = CMMS_MODEL_LINE
@@ -226,6 +228,7 @@ abstract class PoolAssignmentJobServiceTest {
         assertFailsWith<StatusRuntimeException> {
           service.createPoolAssignmentJob(
             createPoolAssignmentJobRequest {
+              this.requestId = UUID.randomUUID().toString()
               poolAssignmentJob = poolAssignmentJob {
                 dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
                 cmmsModelLine = CMMS_MODEL_LINE
@@ -272,6 +275,7 @@ abstract class PoolAssignmentJobServiceTest {
       assertFailsWith<StatusRuntimeException> {
         service.createPoolAssignmentJob(
           createPoolAssignmentJobRequest {
+            this.requestId = UUID.randomUUID().toString()
             poolAssignmentJob = poolAssignmentJob {
               dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
               rawImpressionUploadResourceId = RAW_IMPRESSION_UPLOAD_RESOURCE_ID
@@ -321,6 +325,33 @@ abstract class PoolAssignmentJobServiceTest {
   }
 
   @Test
+  fun `createPoolAssignmentJob throws INVALID_ARGUMENT if request_id not set`() = runBlocking {
+    val exception: StatusRuntimeException =
+      assertFailsWith<StatusRuntimeException> {
+        service.createPoolAssignmentJob(
+          createPoolAssignmentJobRequest {
+            poolAssignmentJob = poolAssignmentJob {
+              dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
+              rawImpressionUploadResourceId = RAW_IMPRESSION_UPLOAD_RESOURCE_ID
+              cmmsModelLine = CMMS_MODEL_LINE
+              shardIndex = 0
+            }
+          }
+        )
+      }
+
+    assertThat(exception.status.code).isEqualTo(Status.Code.INVALID_ARGUMENT)
+    assertThat(exception.errorInfo)
+      .isEqualTo(
+        errorInfo {
+          domain = Errors.DOMAIN
+          reason = Errors.Reason.REQUIRED_FIELD_NOT_SET.name
+          metadata[Errors.Metadata.FIELD_NAME.key] = "request_id"
+        }
+      )
+  }
+
+  @Test
   fun `batchCreatePoolAssignmentJobs creates multiple`() =
     runBlocking<Unit> {
       val response =
@@ -329,6 +360,7 @@ abstract class PoolAssignmentJobServiceTest {
             dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
             rawImpressionUploadResourceId = RAW_IMPRESSION_UPLOAD_RESOURCE_ID
             requests += createPoolAssignmentJobRequest {
+              this.requestId = UUID.randomUUID().toString()
               poolAssignmentJob = poolAssignmentJob {
                 dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
                 rawImpressionUploadResourceId = RAW_IMPRESSION_UPLOAD_RESOURCE_ID
@@ -337,6 +369,7 @@ abstract class PoolAssignmentJobServiceTest {
               }
             }
             requests += createPoolAssignmentJobRequest {
+              this.requestId = UUID.randomUUID().toString()
               poolAssignmentJob = poolAssignmentJob {
                 dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
                 rawImpressionUploadResourceId = RAW_IMPRESSION_UPLOAD_RESOURCE_ID
@@ -356,6 +389,7 @@ abstract class PoolAssignmentJobServiceTest {
     val created: PoolAssignmentJob =
       service.createPoolAssignmentJob(
         createPoolAssignmentJobRequest {
+          this.requestId = UUID.randomUUID().toString()
           poolAssignmentJob = poolAssignmentJob {
             dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
             rawImpressionUploadResourceId = RAW_IMPRESSION_UPLOAD_RESOURCE_ID
@@ -429,6 +463,7 @@ abstract class PoolAssignmentJobServiceTest {
   fun `listPoolAssignmentJobs returns resources`() = runBlocking {
     service.createPoolAssignmentJob(
       createPoolAssignmentJobRequest {
+        this.requestId = UUID.randomUUID().toString()
         poolAssignmentJob = poolAssignmentJob {
           dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
           rawImpressionUploadResourceId = RAW_IMPRESSION_UPLOAD_RESOURCE_ID
@@ -439,6 +474,7 @@ abstract class PoolAssignmentJobServiceTest {
     )
     service.createPoolAssignmentJob(
       createPoolAssignmentJobRequest {
+        this.requestId = UUID.randomUUID().toString()
         poolAssignmentJob = poolAssignmentJob {
           dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
           rawImpressionUploadResourceId = RAW_IMPRESSION_UPLOAD_RESOURCE_ID
@@ -464,6 +500,7 @@ abstract class PoolAssignmentJobServiceTest {
     for (i in 0..2) {
       service.createPoolAssignmentJob(
         createPoolAssignmentJobRequest {
+          this.requestId = UUID.randomUUID().toString()
           poolAssignmentJob = poolAssignmentJob {
             dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
             rawImpressionUploadResourceId = RAW_IMPRESSION_UPLOAD_RESOURCE_ID
@@ -492,6 +529,7 @@ abstract class PoolAssignmentJobServiceTest {
     val created: PoolAssignmentJob =
       service.createPoolAssignmentJob(
         createPoolAssignmentJobRequest {
+          this.requestId = UUID.randomUUID().toString()
           poolAssignmentJob = poolAssignmentJob {
             dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
             rawImpressionUploadResourceId = RAW_IMPRESSION_UPLOAD_RESOURCE_ID
@@ -502,6 +540,7 @@ abstract class PoolAssignmentJobServiceTest {
       )
     service.createPoolAssignmentJob(
       createPoolAssignmentJobRequest {
+        this.requestId = UUID.randomUUID().toString()
         poolAssignmentJob = poolAssignmentJob {
           dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
           rawImpressionUploadResourceId = RAW_IMPRESSION_UPLOAD_RESOURCE_ID
@@ -513,6 +552,7 @@ abstract class PoolAssignmentJobServiceTest {
 
     service.markPoolAssignmentJobSucceeded(
       markPoolAssignmentJobSucceededRequest {
+        this.requestId = UUID.randomUUID().toString()
         dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
         rawImpressionUploadResourceId = RAW_IMPRESSION_UPLOAD_RESOURCE_ID
         poolAssignmentJobResourceId = created.poolAssignmentJobResourceId
@@ -542,6 +582,7 @@ abstract class PoolAssignmentJobServiceTest {
   fun `listPoolAssignmentJobs filters by cmms_model_line`() = runBlocking {
     service.createPoolAssignmentJob(
       createPoolAssignmentJobRequest {
+        this.requestId = UUID.randomUUID().toString()
         poolAssignmentJob = poolAssignmentJob {
           dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
           rawImpressionUploadResourceId = RAW_IMPRESSION_UPLOAD_RESOURCE_ID
@@ -552,6 +593,7 @@ abstract class PoolAssignmentJobServiceTest {
     )
     service.createPoolAssignmentJob(
       createPoolAssignmentJobRequest {
+        this.requestId = UUID.randomUUID().toString()
         poolAssignmentJob = poolAssignmentJob {
           dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
           rawImpressionUploadResourceId = RAW_IMPRESSION_UPLOAD_RESOURCE_ID
@@ -579,6 +621,7 @@ abstract class PoolAssignmentJobServiceTest {
     for (i in 0..2) {
       service.createPoolAssignmentJob(
         createPoolAssignmentJobRequest {
+          this.requestId = UUID.randomUUID().toString()
           poolAssignmentJob = poolAssignmentJob {
             dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
             rawImpressionUploadResourceId = RAW_IMPRESSION_UPLOAD_RESOURCE_ID
@@ -620,6 +663,7 @@ abstract class PoolAssignmentJobServiceTest {
     val created: PoolAssignmentJob =
       service.createPoolAssignmentJob(
         createPoolAssignmentJobRequest {
+          this.requestId = UUID.randomUUID().toString()
           poolAssignmentJob = poolAssignmentJob {
             dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
             rawImpressionUploadResourceId = RAW_IMPRESSION_UPLOAD_RESOURCE_ID
@@ -632,6 +676,7 @@ abstract class PoolAssignmentJobServiceTest {
     val response: MarkPoolAssignmentJobSucceededResponse =
       service.markPoolAssignmentJobSucceeded(
         markPoolAssignmentJobSucceededRequest {
+          this.requestId = UUID.randomUUID().toString()
           dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
           rawImpressionUploadResourceId = RAW_IMPRESSION_UPLOAD_RESOURCE_ID
           poolAssignmentJobResourceId = created.poolAssignmentJobResourceId
@@ -650,6 +695,7 @@ abstract class PoolAssignmentJobServiceTest {
     val created: PoolAssignmentJob =
       service.createPoolAssignmentJob(
         createPoolAssignmentJobRequest {
+          this.requestId = UUID.randomUUID().toString()
           poolAssignmentJob = poolAssignmentJob {
             dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
             rawImpressionUploadResourceId = RAW_IMPRESSION_UPLOAD_RESOURCE_ID
@@ -691,6 +737,7 @@ abstract class PoolAssignmentJobServiceTest {
     val created: PoolAssignmentJob =
       service.createPoolAssignmentJob(
         createPoolAssignmentJobRequest {
+          this.requestId = UUID.randomUUID().toString()
           poolAssignmentJob = poolAssignmentJob {
             dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
             rawImpressionUploadResourceId = RAW_IMPRESSION_UPLOAD_RESOURCE_ID
@@ -704,6 +751,7 @@ abstract class PoolAssignmentJobServiceTest {
       assertFailsWith<StatusRuntimeException> {
         service.markPoolAssignmentJobSucceeded(
           markPoolAssignmentJobSucceededRequest {
+            this.requestId = UUID.randomUUID().toString()
             dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
             rawImpressionUploadResourceId = RAW_IMPRESSION_UPLOAD_RESOURCE_ID
             poolAssignmentJobResourceId = created.poolAssignmentJobResourceId
@@ -722,6 +770,7 @@ abstract class PoolAssignmentJobServiceTest {
       val created: PoolAssignmentJob =
         service.createPoolAssignmentJob(
           createPoolAssignmentJobRequest {
+            this.requestId = UUID.randomUUID().toString()
             poolAssignmentJob = poolAssignmentJob {
               dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
               rawImpressionUploadResourceId = RAW_IMPRESSION_UPLOAD_RESOURCE_ID
@@ -734,6 +783,7 @@ abstract class PoolAssignmentJobServiceTest {
       val response =
         service.markPoolAssignmentJobSucceeded(
           markPoolAssignmentJobSucceededRequest {
+            this.requestId = UUID.randomUUID().toString()
             dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
             rawImpressionUploadResourceId = RAW_IMPRESSION_UPLOAD_RESOURCE_ID
             poolAssignmentJobResourceId = created.poolAssignmentJobResourceId
@@ -746,6 +796,7 @@ abstract class PoolAssignmentJobServiceTest {
         assertFailsWith<StatusRuntimeException> {
           service.markPoolAssignmentJobSucceeded(
             markPoolAssignmentJobSucceededRequest {
+              this.requestId = UUID.randomUUID().toString()
               dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
               rawImpressionUploadResourceId = RAW_IMPRESSION_UPLOAD_RESOURCE_ID
               poolAssignmentJobResourceId = created.poolAssignmentJobResourceId
@@ -763,6 +814,7 @@ abstract class PoolAssignmentJobServiceTest {
     val created: PoolAssignmentJob =
       service.createPoolAssignmentJob(
         createPoolAssignmentJobRequest {
+          this.requestId = UUID.randomUUID().toString()
           poolAssignmentJob = poolAssignmentJob {
             dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
             rawImpressionUploadResourceId = RAW_IMPRESSION_UPLOAD_RESOURCE_ID
@@ -775,6 +827,7 @@ abstract class PoolAssignmentJobServiceTest {
     val job: PoolAssignmentJob =
       service.markPoolAssignmentJobFailed(
         markPoolAssignmentJobFailedRequest {
+          this.requestId = UUID.randomUUID().toString()
           dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
           rawImpressionUploadResourceId = RAW_IMPRESSION_UPLOAD_RESOURCE_ID
           poolAssignmentJobResourceId = created.poolAssignmentJobResourceId
@@ -792,6 +845,7 @@ abstract class PoolAssignmentJobServiceTest {
     val created: PoolAssignmentJob =
       service.createPoolAssignmentJob(
         createPoolAssignmentJobRequest {
+          this.requestId = UUID.randomUUID().toString()
           poolAssignmentJob = poolAssignmentJob {
             dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
             rawImpressionUploadResourceId = RAW_IMPRESSION_UPLOAD_RESOURCE_ID
@@ -805,6 +859,7 @@ abstract class PoolAssignmentJobServiceTest {
       assertFailsWith<StatusRuntimeException> {
         service.markPoolAssignmentJobFailed(
           markPoolAssignmentJobFailedRequest {
+            this.requestId = UUID.randomUUID().toString()
             dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
             rawImpressionUploadResourceId = RAW_IMPRESSION_UPLOAD_RESOURCE_ID
             poolAssignmentJobResourceId = created.poolAssignmentJobResourceId
@@ -823,6 +878,7 @@ abstract class PoolAssignmentJobServiceTest {
       val created: PoolAssignmentJob =
         service.createPoolAssignmentJob(
           createPoolAssignmentJobRequest {
+            this.requestId = UUID.randomUUID().toString()
             poolAssignmentJob = poolAssignmentJob {
               dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
               rawImpressionUploadResourceId = RAW_IMPRESSION_UPLOAD_RESOURCE_ID
@@ -835,6 +891,7 @@ abstract class PoolAssignmentJobServiceTest {
       val response =
         service.markPoolAssignmentJobSucceeded(
           markPoolAssignmentJobSucceededRequest {
+            this.requestId = UUID.randomUUID().toString()
             dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
             rawImpressionUploadResourceId = RAW_IMPRESSION_UPLOAD_RESOURCE_ID
             poolAssignmentJobResourceId = created.poolAssignmentJobResourceId
@@ -847,6 +904,7 @@ abstract class PoolAssignmentJobServiceTest {
         assertFailsWith<StatusRuntimeException> {
           service.markPoolAssignmentJobFailed(
             markPoolAssignmentJobFailedRequest {
+              this.requestId = UUID.randomUUID().toString()
               dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
               rawImpressionUploadResourceId = RAW_IMPRESSION_UPLOAD_RESOURCE_ID
               poolAssignmentJobResourceId = created.poolAssignmentJobResourceId
@@ -860,11 +918,283 @@ abstract class PoolAssignmentJobServiceTest {
     }
 
   @Test
+  fun `markPoolAssignmentJobFailed is idempotent with same request_id`() = runBlocking {
+    val requestId = UUID.randomUUID().toString()
+    val created: PoolAssignmentJob =
+      service.createPoolAssignmentJob(
+        createPoolAssignmentJobRequest {
+          this.requestId = UUID.randomUUID().toString()
+          poolAssignmentJob = poolAssignmentJob {
+            dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
+            rawImpressionUploadResourceId = RAW_IMPRESSION_UPLOAD_RESOURCE_ID
+            cmmsModelLine = CMMS_MODEL_LINE
+            shardIndex = 0
+          }
+        }
+      )
+
+    val job1: PoolAssignmentJob =
+      service.markPoolAssignmentJobFailed(
+        markPoolAssignmentJobFailedRequest {
+          this.requestId = requestId
+          dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
+          rawImpressionUploadResourceId = RAW_IMPRESSION_UPLOAD_RESOURCE_ID
+          poolAssignmentJobResourceId = created.poolAssignmentJobResourceId
+          etag = created.etag
+          errorMessage = "something went wrong"
+        }
+      )
+
+    val job2: PoolAssignmentJob =
+      service.markPoolAssignmentJobFailed(
+        markPoolAssignmentJobFailedRequest {
+          this.requestId = requestId
+          dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
+          rawImpressionUploadResourceId = RAW_IMPRESSION_UPLOAD_RESOURCE_ID
+          poolAssignmentJobResourceId = created.poolAssignmentJobResourceId
+          etag = job1.etag
+          errorMessage = "something went wrong"
+        }
+      )
+
+    assertThat(job2).isEqualTo(job1)
+  }
+
+  @Test
+  fun `markPoolAssignmentJobFailed preserves original error_message on same-request_id replay`() =
+    runBlocking {
+      val requestId = UUID.randomUUID().toString()
+      val created: PoolAssignmentJob =
+        service.createPoolAssignmentJob(
+          createPoolAssignmentJobRequest {
+            this.requestId = UUID.randomUUID().toString()
+            poolAssignmentJob = poolAssignmentJob {
+              dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
+              rawImpressionUploadResourceId = RAW_IMPRESSION_UPLOAD_RESOURCE_ID
+              cmmsModelLine = CMMS_MODEL_LINE
+              shardIndex = 0
+            }
+          }
+        )
+
+      val job1: PoolAssignmentJob =
+        service.markPoolAssignmentJobFailed(
+          markPoolAssignmentJobFailedRequest {
+            this.requestId = requestId
+            dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
+            rawImpressionUploadResourceId = RAW_IMPRESSION_UPLOAD_RESOURCE_ID
+            poolAssignmentJobResourceId = created.poolAssignmentJobResourceId
+            etag = created.etag
+            errorMessage = "first failure"
+          }
+        )
+
+      // A replay with the same request_id but a different error_message returns the row with the
+      // ORIGINAL error_message (AIP-155: the first response is returned as-is).
+      val job2: PoolAssignmentJob =
+        service.markPoolAssignmentJobFailed(
+          markPoolAssignmentJobFailedRequest {
+            this.requestId = requestId
+            dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
+            rawImpressionUploadResourceId = RAW_IMPRESSION_UPLOAD_RESOURCE_ID
+            poolAssignmentJobResourceId = created.poolAssignmentJobResourceId
+            etag = job1.etag
+            errorMessage = "second failure"
+          }
+        )
+
+      assertThat(job2.errorMessage).isEqualTo("first failure")
+      assertThat(job2).isEqualTo(job1)
+    }
+
+  @Test
+  fun `markPoolAssignmentJobFailed replays after the resource advances to SUCCEEDED`() =
+    runBlocking {
+      val failRequestId = UUID.randomUUID().toString()
+      val created: PoolAssignmentJob =
+        service.createPoolAssignmentJob(
+          createPoolAssignmentJobRequest {
+            this.requestId = UUID.randomUUID().toString()
+            poolAssignmentJob = poolAssignmentJob {
+              dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
+              rawImpressionUploadResourceId = RAW_IMPRESSION_UPLOAD_RESOURCE_ID
+              cmmsModelLine = CMMS_MODEL_LINE
+              shardIndex = 0
+            }
+          }
+        )
+
+      val failed: PoolAssignmentJob =
+        service.markPoolAssignmentJobFailed(
+          markPoolAssignmentJobFailedRequest {
+            this.requestId = failRequestId
+            dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
+            rawImpressionUploadResourceId = RAW_IMPRESSION_UPLOAD_RESOURCE_ID
+            poolAssignmentJobResourceId = created.poolAssignmentJobResourceId
+            etag = created.etag
+            errorMessage = "transient failure"
+          }
+        )
+
+      // A later legitimate MarkSucceeded advances FAILED -> SUCCEEDED.
+      val succeeded =
+        service.markPoolAssignmentJobSucceeded(
+          markPoolAssignmentJobSucceededRequest {
+            this.requestId = UUID.randomUUID().toString()
+            dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
+            rawImpressionUploadResourceId = RAW_IMPRESSION_UPLOAD_RESOURCE_ID
+            poolAssignmentJobResourceId = created.poolAssignmentJobResourceId
+            etag = failed.etag
+            encryptedDek = ENCRYPTED_DEK
+          }
+        )
+
+      // A redelivery of the original MarkFailed replays as an idempotent no-op: it returns the row
+      // as-is (now SUCCEEDED) instead of throwing FAILED_PRECONDITION, and the stale etag is
+      // ignored because the replay short-circuits before the etag check.
+      val replayed: PoolAssignmentJob =
+        service.markPoolAssignmentJobFailed(
+          markPoolAssignmentJobFailedRequest {
+            this.requestId = failRequestId
+            dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
+            rawImpressionUploadResourceId = RAW_IMPRESSION_UPLOAD_RESOURCE_ID
+            poolAssignmentJobResourceId = created.poolAssignmentJobResourceId
+            etag = "stale-etag"
+            errorMessage = "transient failure"
+          }
+        )
+
+      assertThat(replayed.state).isEqualTo(PoolAssignmentState.POOL_ASSIGNMENT_STATE_SUCCEEDED)
+      assertThat(replayed).isEqualTo(succeeded.poolAssignmentJob)
+    }
+
+  @Test
+  fun `markPoolAssignmentJobFailed throws INVALID_ARGUMENT if request_id not set`() = runBlocking {
+    val created: PoolAssignmentJob =
+      service.createPoolAssignmentJob(
+        createPoolAssignmentJobRequest {
+          this.requestId = UUID.randomUUID().toString()
+          poolAssignmentJob = poolAssignmentJob {
+            dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
+            rawImpressionUploadResourceId = RAW_IMPRESSION_UPLOAD_RESOURCE_ID
+            cmmsModelLine = CMMS_MODEL_LINE
+            shardIndex = 0
+          }
+        }
+      )
+
+    val exception: StatusRuntimeException =
+      assertFailsWith<StatusRuntimeException> {
+        service.markPoolAssignmentJobFailed(
+          markPoolAssignmentJobFailedRequest {
+            dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
+            rawImpressionUploadResourceId = RAW_IMPRESSION_UPLOAD_RESOURCE_ID
+            poolAssignmentJobResourceId = created.poolAssignmentJobResourceId
+            etag = created.etag
+            errorMessage = "something went wrong"
+          }
+        )
+      }
+
+    assertThat(exception.status.code).isEqualTo(Status.Code.INVALID_ARGUMENT)
+    assertThat(exception.errorInfo)
+      .isEqualTo(
+        errorInfo {
+          domain = Errors.DOMAIN
+          reason = Errors.Reason.REQUIRED_FIELD_NOT_SET.name
+          metadata[Errors.Metadata.FIELD_NAME.key] = "request_id"
+        }
+      )
+  }
+
+  @Test
+  fun `markPoolAssignmentJobFailed throws INVALID_ARGUMENT for malformed request_id`() =
+    runBlocking {
+      val created: PoolAssignmentJob =
+        service.createPoolAssignmentJob(
+          createPoolAssignmentJobRequest {
+            this.requestId = UUID.randomUUID().toString()
+            poolAssignmentJob = poolAssignmentJob {
+              dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
+              rawImpressionUploadResourceId = RAW_IMPRESSION_UPLOAD_RESOURCE_ID
+              cmmsModelLine = CMMS_MODEL_LINE
+              shardIndex = 0
+            }
+          }
+        )
+
+      val exception: StatusRuntimeException =
+        assertFailsWith<StatusRuntimeException> {
+          service.markPoolAssignmentJobFailed(
+            markPoolAssignmentJobFailedRequest {
+              requestId = "not-a-valid-uuid"
+              dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
+              rawImpressionUploadResourceId = RAW_IMPRESSION_UPLOAD_RESOURCE_ID
+              poolAssignmentJobResourceId = created.poolAssignmentJobResourceId
+              etag = created.etag
+              errorMessage = "something went wrong"
+            }
+          )
+        }
+
+      assertThat(exception.status.code).isEqualTo(Status.Code.INVALID_ARGUMENT)
+      assertThat(exception.errorInfo)
+        .isEqualTo(
+          errorInfo {
+            domain = Errors.DOMAIN
+            reason = Errors.Reason.INVALID_FIELD_VALUE.name
+            metadata[Errors.Metadata.FIELD_NAME.key] = "request_id"
+          }
+        )
+    }
+
+  @Test
+  fun `markPoolAssignmentJobSucceeded throws INVALID_ARGUMENT if request_id not set`() =
+    runBlocking {
+      val created: PoolAssignmentJob =
+        service.createPoolAssignmentJob(
+          createPoolAssignmentJobRequest {
+            this.requestId = UUID.randomUUID().toString()
+            poolAssignmentJob = poolAssignmentJob {
+              dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
+              rawImpressionUploadResourceId = RAW_IMPRESSION_UPLOAD_RESOURCE_ID
+              cmmsModelLine = CMMS_MODEL_LINE
+              shardIndex = 0
+            }
+          }
+        )
+
+      val exception: StatusRuntimeException =
+        assertFailsWith<StatusRuntimeException> {
+          service.markPoolAssignmentJobSucceeded(
+            markPoolAssignmentJobSucceededRequest {
+              dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
+              rawImpressionUploadResourceId = RAW_IMPRESSION_UPLOAD_RESOURCE_ID
+              poolAssignmentJobResourceId = created.poolAssignmentJobResourceId
+              etag = created.etag
+              encryptedDek = ENCRYPTED_DEK
+            }
+          )
+        }
+
+      assertThat(exception.status.code).isEqualTo(Status.Code.INVALID_ARGUMENT)
+      assertThat(exception.errorInfo)
+        .isEqualTo(
+          errorInfo {
+            domain = Errors.DOMAIN
+            reason = Errors.Reason.REQUIRED_FIELD_NOT_SET.name
+            metadata[Errors.Metadata.FIELD_NAME.key] = "request_id"
+          }
+        )
+    }
+
+  @Test
   fun `markPoolAssignmentJobSucceeded throws NOT_FOUND when not found`() = runBlocking {
     val exception: StatusRuntimeException =
       assertFailsWith<StatusRuntimeException> {
         service.markPoolAssignmentJobSucceeded(
           markPoolAssignmentJobSucceededRequest {
+            this.requestId = UUID.randomUUID().toString()
             dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
             rawImpressionUploadResourceId = RAW_IMPRESSION_UPLOAD_RESOURCE_ID
             poolAssignmentJobResourceId = "nonexistent-job"
@@ -883,6 +1213,7 @@ abstract class PoolAssignmentJobServiceTest {
       val created: PoolAssignmentJob =
         service.createPoolAssignmentJob(
           createPoolAssignmentJobRequest {
+            this.requestId = UUID.randomUUID().toString()
             poolAssignmentJob = poolAssignmentJob {
               dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
               rawImpressionUploadResourceId = RAW_IMPRESSION_UPLOAD_RESOURCE_ID
@@ -896,6 +1227,7 @@ abstract class PoolAssignmentJobServiceTest {
         assertFailsWith<StatusRuntimeException> {
           service.markPoolAssignmentJobSucceeded(
             markPoolAssignmentJobSucceededRequest {
+              this.requestId = UUID.randomUUID().toString()
               dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
               rawImpressionUploadResourceId = RAW_IMPRESSION_UPLOAD_RESOURCE_ID
               poolAssignmentJobResourceId = created.poolAssignmentJobResourceId
@@ -920,6 +1252,7 @@ abstract class PoolAssignmentJobServiceTest {
     val created: PoolAssignmentJob =
       service.createPoolAssignmentJob(
         createPoolAssignmentJobRequest {
+          this.requestId = UUID.randomUUID().toString()
           poolAssignmentJob = poolAssignmentJob {
             dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
             rawImpressionUploadResourceId = RAW_IMPRESSION_UPLOAD_RESOURCE_ID
@@ -932,6 +1265,7 @@ abstract class PoolAssignmentJobServiceTest {
     val response: MarkPoolAssignmentJobSucceededResponse =
       service.markPoolAssignmentJobSucceeded(
         markPoolAssignmentJobSucceededRequest {
+          this.requestId = UUID.randomUUID().toString()
           dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
           rawImpressionUploadResourceId = RAW_IMPRESSION_UPLOAD_RESOURCE_ID
           poolAssignmentJobResourceId = created.poolAssignmentJobResourceId
@@ -959,6 +1293,7 @@ abstract class PoolAssignmentJobServiceTest {
       val shard0: PoolAssignmentJob =
         service.createPoolAssignmentJob(
           createPoolAssignmentJobRequest {
+            this.requestId = UUID.randomUUID().toString()
             poolAssignmentJob = poolAssignmentJob {
               dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
               rawImpressionUploadResourceId = RAW_IMPRESSION_UPLOAD_RESOURCE_ID
@@ -970,6 +1305,7 @@ abstract class PoolAssignmentJobServiceTest {
       val shard1: PoolAssignmentJob =
         service.createPoolAssignmentJob(
           createPoolAssignmentJobRequest {
+            this.requestId = UUID.randomUUID().toString()
             poolAssignmentJob = poolAssignmentJob {
               dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
               rawImpressionUploadResourceId = RAW_IMPRESSION_UPLOAD_RESOURCE_ID
@@ -982,6 +1318,7 @@ abstract class PoolAssignmentJobServiceTest {
       // Non-last shard: the parent's merged DEK stays unset even though this shard has a DEK.
       service.markPoolAssignmentJobSucceeded(
         markPoolAssignmentJobSucceededRequest {
+          this.requestId = UUID.randomUUID().toString()
           dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
           rawImpressionUploadResourceId = RAW_IMPRESSION_UPLOAD_RESOURCE_ID
           poolAssignmentJobResourceId = shard0.poolAssignmentJobResourceId
@@ -1001,6 +1338,7 @@ abstract class PoolAssignmentJobServiceTest {
       // Last shard out: this final shard's encrypted_dek is promoted onto the parent model line.
       service.markPoolAssignmentJobSucceeded(
         markPoolAssignmentJobSucceededRequest {
+          this.requestId = UUID.randomUUID().toString()
           dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
           rawImpressionUploadResourceId = RAW_IMPRESSION_UPLOAD_RESOURCE_ID
           poolAssignmentJobResourceId = shard1.poolAssignmentJobResourceId
@@ -1026,6 +1364,7 @@ abstract class PoolAssignmentJobServiceTest {
       val shard0: PoolAssignmentJob =
         service.createPoolAssignmentJob(
           createPoolAssignmentJobRequest {
+            this.requestId = UUID.randomUUID().toString()
             poolAssignmentJob = poolAssignmentJob {
               dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
               rawImpressionUploadResourceId = RAW_IMPRESSION_UPLOAD_RESOURCE_ID
@@ -1037,6 +1376,7 @@ abstract class PoolAssignmentJobServiceTest {
       val shard1: PoolAssignmentJob =
         service.createPoolAssignmentJob(
           createPoolAssignmentJobRequest {
+            this.requestId = UUID.randomUUID().toString()
             poolAssignmentJob = poolAssignmentJob {
               dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
               rawImpressionUploadResourceId = RAW_IMPRESSION_UPLOAD_RESOURCE_ID
@@ -1049,6 +1389,7 @@ abstract class PoolAssignmentJobServiceTest {
       val firstResponse: MarkPoolAssignmentJobSucceededResponse =
         service.markPoolAssignmentJobSucceeded(
           markPoolAssignmentJobSucceededRequest {
+            this.requestId = UUID.randomUUID().toString()
             dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
             rawImpressionUploadResourceId = RAW_IMPRESSION_UPLOAD_RESOURCE_ID
             poolAssignmentJobResourceId = shard0.poolAssignmentJobResourceId
@@ -1061,6 +1402,7 @@ abstract class PoolAssignmentJobServiceTest {
       val lastResponse: MarkPoolAssignmentJobSucceededResponse =
         service.markPoolAssignmentJobSucceeded(
           markPoolAssignmentJobSucceededRequest {
+            this.requestId = UUID.randomUUID().toString()
             dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
             rawImpressionUploadResourceId = RAW_IMPRESSION_UPLOAD_RESOURCE_ID
             poolAssignmentJobResourceId = shard1.poolAssignmentJobResourceId
@@ -1081,6 +1423,7 @@ abstract class PoolAssignmentJobServiceTest {
       val shard: PoolAssignmentJob =
         service.createPoolAssignmentJob(
           createPoolAssignmentJobRequest {
+            this.requestId = UUID.randomUUID().toString()
             poolAssignmentJob = poolAssignmentJob {
               dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
               rawImpressionUploadResourceId = RAW_IMPRESSION_UPLOAD_RESOURCE_ID
@@ -1093,6 +1436,7 @@ abstract class PoolAssignmentJobServiceTest {
       val response: MarkPoolAssignmentJobSucceededResponse =
         service.markPoolAssignmentJobSucceeded(
           markPoolAssignmentJobSucceededRequest {
+            this.requestId = UUID.randomUUID().toString()
             dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
             rawImpressionUploadResourceId = RAW_IMPRESSION_UPLOAD_RESOURCE_ID
             poolAssignmentJobResourceId = shard.poolAssignmentJobResourceId
@@ -1110,6 +1454,7 @@ abstract class PoolAssignmentJobServiceTest {
       val shard: PoolAssignmentJob =
         service.createPoolAssignmentJob(
           createPoolAssignmentJobRequest {
+            this.requestId = UUID.randomUUID().toString()
             poolAssignmentJob = poolAssignmentJob {
               dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
               rawImpressionUploadResourceId = RAW_IMPRESSION_UPLOAD_RESOURCE_ID
@@ -1122,6 +1467,7 @@ abstract class PoolAssignmentJobServiceTest {
       val response: MarkPoolAssignmentJobSucceededResponse =
         service.markPoolAssignmentJobSucceeded(
           markPoolAssignmentJobSucceededRequest {
+            this.requestId = UUID.randomUUID().toString()
             dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
             rawImpressionUploadResourceId = RAW_IMPRESSION_UPLOAD_RESOURCE_ID
             poolAssignmentJobResourceId = shard.poolAssignmentJobResourceId
@@ -1146,6 +1492,7 @@ abstract class PoolAssignmentJobServiceTest {
       val shard: PoolAssignmentJob =
         service.createPoolAssignmentJob(
           createPoolAssignmentJobRequest {
+            this.requestId = UUID.randomUUID().toString()
             poolAssignmentJob = poolAssignmentJob {
               dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
               rawImpressionUploadResourceId = RAW_IMPRESSION_UPLOAD_RESOURCE_ID
@@ -1200,6 +1547,7 @@ abstract class PoolAssignmentJobServiceTest {
       val shard0: PoolAssignmentJob =
         service.createPoolAssignmentJob(
           createPoolAssignmentJobRequest {
+            this.requestId = UUID.randomUUID().toString()
             poolAssignmentJob = poolAssignmentJob {
               dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
               rawImpressionUploadResourceId = RAW_IMPRESSION_UPLOAD_RESOURCE_ID
@@ -1211,6 +1559,7 @@ abstract class PoolAssignmentJobServiceTest {
       val shard1: PoolAssignmentJob =
         service.createPoolAssignmentJob(
           createPoolAssignmentJobRequest {
+            this.requestId = UUID.randomUUID().toString()
             poolAssignmentJob = poolAssignmentJob {
               dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
               rawImpressionUploadResourceId = RAW_IMPRESSION_UPLOAD_RESOURCE_ID
@@ -1236,6 +1585,7 @@ abstract class PoolAssignmentJobServiceTest {
       // Drain the group: shard1 is the last shard and reaches SUCCEEDED after shard0.
       service.markPoolAssignmentJobSucceeded(
         markPoolAssignmentJobSucceededRequest {
+          this.requestId = UUID.randomUUID().toString()
           dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
           rawImpressionUploadResourceId = RAW_IMPRESSION_UPLOAD_RESOURCE_ID
           poolAssignmentJobResourceId = shard1.poolAssignmentJobResourceId
@@ -1273,6 +1623,7 @@ abstract class PoolAssignmentJobServiceTest {
     val modelLineAShard0: PoolAssignmentJob =
       service.createPoolAssignmentJob(
         createPoolAssignmentJobRequest {
+          this.requestId = UUID.randomUUID().toString()
           poolAssignmentJob = poolAssignmentJob {
             dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
             rawImpressionUploadResourceId = RAW_IMPRESSION_UPLOAD_RESOURCE_ID
@@ -1284,6 +1635,7 @@ abstract class PoolAssignmentJobServiceTest {
     val modelLineAShard1: PoolAssignmentJob =
       service.createPoolAssignmentJob(
         createPoolAssignmentJobRequest {
+          this.requestId = UUID.randomUUID().toString()
           poolAssignmentJob = poolAssignmentJob {
             dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
             rawImpressionUploadResourceId = RAW_IMPRESSION_UPLOAD_RESOURCE_ID
@@ -1296,6 +1648,7 @@ abstract class PoolAssignmentJobServiceTest {
     // whole test, so it can neither trigger nor suppress model line A's last-shard result.
     service.createPoolAssignmentJob(
       createPoolAssignmentJobRequest {
+        this.requestId = UUID.randomUUID().toString()
         poolAssignmentJob = poolAssignmentJob {
           dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
           rawImpressionUploadResourceId = RAW_IMPRESSION_UPLOAD_RESOURCE_ID
@@ -1310,6 +1663,7 @@ abstract class PoolAssignmentJobServiceTest {
     val firstResponse: MarkPoolAssignmentJobSucceededResponse =
       service.markPoolAssignmentJobSucceeded(
         markPoolAssignmentJobSucceededRequest {
+          this.requestId = UUID.randomUUID().toString()
           dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
           rawImpressionUploadResourceId = RAW_IMPRESSION_UPLOAD_RESOURCE_ID
           poolAssignmentJobResourceId = modelLineAShard0.poolAssignmentJobResourceId
@@ -1324,6 +1678,7 @@ abstract class PoolAssignmentJobServiceTest {
     val lastResponse: MarkPoolAssignmentJobSucceededResponse =
       service.markPoolAssignmentJobSucceeded(
         markPoolAssignmentJobSucceededRequest {
+          this.requestId = UUID.randomUUID().toString()
           dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
           rawImpressionUploadResourceId = RAW_IMPRESSION_UPLOAD_RESOURCE_ID
           poolAssignmentJobResourceId = modelLineAShard1.poolAssignmentJobResourceId
@@ -1345,6 +1700,7 @@ abstract class PoolAssignmentJobServiceTest {
     val created: PoolAssignmentJob =
       service.createPoolAssignmentJob(
         createPoolAssignmentJobRequest {
+          this.requestId = UUID.randomUUID().toString()
           poolAssignmentJob = poolAssignmentJob {
             dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
             rawImpressionUploadResourceId = RAW_IMPRESSION_UPLOAD_RESOURCE_ID
@@ -1357,6 +1713,7 @@ abstract class PoolAssignmentJobServiceTest {
     val failed: PoolAssignmentJob =
       service.markPoolAssignmentJobFailed(
         markPoolAssignmentJobFailedRequest {
+          this.requestId = UUID.randomUUID().toString()
           dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
           rawImpressionUploadResourceId = RAW_IMPRESSION_UPLOAD_RESOURCE_ID
           poolAssignmentJobResourceId = created.poolAssignmentJobResourceId
@@ -1369,6 +1726,7 @@ abstract class PoolAssignmentJobServiceTest {
     val succeeded: MarkPoolAssignmentJobSucceededResponse =
       service.markPoolAssignmentJobSucceeded(
         markPoolAssignmentJobSucceededRequest {
+          this.requestId = UUID.randomUUID().toString()
           dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
           rawImpressionUploadResourceId = RAW_IMPRESSION_UPLOAD_RESOURCE_ID
           poolAssignmentJobResourceId = created.poolAssignmentJobResourceId
@@ -1389,7 +1747,7 @@ abstract class PoolAssignmentJobServiceTest {
         dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
         rawImpressionUploadResourceId = RAW_IMPRESSION_UPLOAD_RESOURCE_ID
         requests += createPoolAssignmentJobRequest {
-          requestId = UUID.randomUUID().toString()
+          this.requestId = UUID.randomUUID().toString()
           poolAssignmentJob = poolAssignmentJob {
             dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
             rawImpressionUploadResourceId = RAW_IMPRESSION_UPLOAD_RESOURCE_ID
@@ -1398,7 +1756,7 @@ abstract class PoolAssignmentJobServiceTest {
           }
         }
         requests += createPoolAssignmentJobRequest {
-          requestId = UUID.randomUUID().toString()
+          this.requestId = UUID.randomUUID().toString()
           poolAssignmentJob = poolAssignmentJob {
             dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
             rawImpressionUploadResourceId = RAW_IMPRESSION_UPLOAD_RESOURCE_ID
@@ -1465,6 +1823,7 @@ abstract class PoolAssignmentJobServiceTest {
               dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
               rawImpressionUploadResourceId = RAW_IMPRESSION_UPLOAD_RESOURCE_ID
               requests += createPoolAssignmentJobRequest {
+                this.requestId = UUID.randomUUID().toString()
                 poolAssignmentJob = poolAssignmentJob {
                   dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
                   rawImpressionUploadResourceId = RAW_IMPRESSION_UPLOAD_RESOURCE_ID
@@ -1473,6 +1832,7 @@ abstract class PoolAssignmentJobServiceTest {
                 }
               }
               requests += createPoolAssignmentJobRequest {
+                this.requestId = UUID.randomUUID().toString()
                 poolAssignmentJob = poolAssignmentJob {
                   dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
                   rawImpressionUploadResourceId = RAW_IMPRESSION_UPLOAD_RESOURCE_ID
@@ -1498,6 +1858,7 @@ abstract class PoolAssignmentJobServiceTest {
               rawImpressionUploadResourceId = RAW_IMPRESSION_UPLOAD_RESOURCE_ID
               for (i in 0..MAX_BATCH_SIZE) {
                 requests += createPoolAssignmentJobRequest {
+                  this.requestId = UUID.randomUUID().toString()
                   poolAssignmentJob = poolAssignmentJob {
                     dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
                     rawImpressionUploadResourceId = RAW_IMPRESSION_UPLOAD_RESOURCE_ID

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/service/v1alpha/PoolAssignmentJobService.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/service/v1alpha/PoolAssignmentJobService.kt
@@ -63,8 +63,6 @@ class PoolAssignmentJobService(
   coroutineContext: CoroutineContext = EmptyCoroutineContext,
 ) : PoolAssignmentJobServiceCoroutineImplBase(coroutineContext) {
 
-  // TODO(world-federation-of-advertisers/cross-media-measurement#4078): Flip request_id to REQUIRED
-  // + UUID4
   override suspend fun createPoolAssignmentJob(
     request: CreatePoolAssignmentJobRequest
   ): PoolAssignmentJob {
@@ -88,13 +86,15 @@ class PoolAssignmentJobService(
         .asStatusRuntimeException(Status.Code.INVALID_ARGUMENT)
     }
 
-    if (request.requestId.isNotEmpty()) {
-      try {
-        UUID.fromString(request.requestId)
-      } catch (e: IllegalArgumentException) {
-        throw InvalidFieldValueException("request_id", e)
-          .asStatusRuntimeException(Status.Code.INVALID_ARGUMENT)
-      }
+    if (request.requestId.isEmpty()) {
+      throw RequiredFieldNotSetException("request_id")
+        .asStatusRuntimeException(Status.Code.INVALID_ARGUMENT)
+    }
+    try {
+      UUID.fromString(request.requestId)
+    } catch (e: IllegalArgumentException) {
+      throw InvalidFieldValueException("request_id", e)
+        .asStatusRuntimeException(Status.Code.INVALID_ARGUMENT)
     }
 
     val internalResponse: InternalPoolAssignmentJob =
@@ -117,8 +117,6 @@ class PoolAssignmentJobService(
     return internalResponse.toPublic()
   }
 
-  // TODO(world-federation-of-advertisers/cross-media-measurement#4078): Flip per-element request_id
-  // to REQUIRED + UUID4
   override suspend fun batchCreatePoolAssignmentJobs(
     request: BatchCreatePoolAssignmentJobsRequest
   ): BatchCreatePoolAssignmentJobsResponse {
@@ -152,13 +150,15 @@ class PoolAssignmentJobService(
         throw RequiredFieldNotSetException("requests.$index.pool_assignment_job.cmms_model_line")
           .asStatusRuntimeException(Status.Code.INVALID_ARGUMENT)
       }
-      if (createRequest.requestId.isNotEmpty()) {
-        try {
-          UUID.fromString(createRequest.requestId)
-        } catch (e: IllegalArgumentException) {
-          throw InvalidFieldValueException("requests.$index.request_id", e)
-            .asStatusRuntimeException(Status.Code.INVALID_ARGUMENT)
-        }
+      if (createRequest.requestId.isEmpty()) {
+        throw RequiredFieldNotSetException("requests.$index.request_id")
+          .asStatusRuntimeException(Status.Code.INVALID_ARGUMENT)
+      }
+      try {
+        UUID.fromString(createRequest.requestId)
+      } catch (e: IllegalArgumentException) {
+        throw InvalidFieldValueException("requests.$index.request_id", e)
+          .asStatusRuntimeException(Status.Code.INVALID_ARGUMENT)
       }
     }
 
@@ -311,8 +311,6 @@ class PoolAssignmentJobService(
     }
   }
 
-  // TODO(world-federation-of-advertisers/cross-media-measurement#4078): Flip request_id to REQUIRED
-  // + UUID4
   override suspend fun markPoolAssignmentJobSucceeded(
     request: MarkPoolAssignmentJobSucceededRequest
   ): MarkPoolAssignmentJobSucceededResponse {
@@ -326,23 +324,11 @@ class PoolAssignmentJobService(
         ?: throw InvalidFieldValueException("name")
           .asStatusRuntimeException(Status.Code.INVALID_ARGUMENT)
 
-    if (request.etag.isEmpty()) {
-      throw RequiredFieldNotSetException("etag")
-        .asStatusRuntimeException(Status.Code.INVALID_ARGUMENT)
-    }
+    validateEtagAndRequestId(request.etag, request.requestId)
 
     if (!request.hasEncryptedDek()) {
       throw RequiredFieldNotSetException("encrypted_dek")
         .asStatusRuntimeException(Status.Code.INVALID_ARGUMENT)
-    }
-
-    if (request.requestId.isNotEmpty()) {
-      try {
-        UUID.fromString(request.requestId)
-      } catch (e: IllegalArgumentException) {
-        throw InvalidFieldValueException("request_id", e)
-          .asStatusRuntimeException(Status.Code.INVALID_ARGUMENT)
-      }
     }
 
     val internalResponse: InternalMarkSucceededResponse =
@@ -378,8 +364,6 @@ class PoolAssignmentJobService(
     }
   }
 
-  // TODO(world-federation-of-advertisers/cross-media-measurement#4078): Validate request_id (UUID4)
-  // and forward it to the internal request, mirroring markPoolAssignmentJobSucceeded.
   override suspend fun markPoolAssignmentJobFailed(
     request: MarkPoolAssignmentJobFailedRequest
   ): PoolAssignmentJob {
@@ -393,10 +377,7 @@ class PoolAssignmentJobService(
         ?: throw InvalidFieldValueException("name")
           .asStatusRuntimeException(Status.Code.INVALID_ARGUMENT)
 
-    if (request.etag.isEmpty()) {
-      throw RequiredFieldNotSetException("etag")
-        .asStatusRuntimeException(Status.Code.INVALID_ARGUMENT)
-    }
+    validateEtagAndRequestId(request.etag, request.requestId)
 
     val internalResponse: InternalPoolAssignmentJob =
       try {
@@ -407,6 +388,7 @@ class PoolAssignmentJobService(
             poolAssignmentJobResourceId = jobKey.poolAssignmentJobId
             etag = request.etag
             errorMessage = request.errorMessage
+            requestId = request.requestId
           }
         )
       } catch (e: StatusException) {
@@ -414,6 +396,23 @@ class PoolAssignmentJobService(
       }
 
     return internalResponse.toPublic()
+  }
+
+  private fun validateEtagAndRequestId(etag: String, requestId: String) {
+    if (etag.isEmpty()) {
+      throw RequiredFieldNotSetException("etag")
+        .asStatusRuntimeException(Status.Code.INVALID_ARGUMENT)
+    }
+    if (requestId.isEmpty()) {
+      throw RequiredFieldNotSetException("request_id")
+        .asStatusRuntimeException(Status.Code.INVALID_ARGUMENT)
+    }
+    try {
+      UUID.fromString(requestId)
+    } catch (e: IllegalArgumentException) {
+      throw InvalidFieldValueException("request_id", e)
+        .asStatusRuntimeException(Status.Code.INVALID_ARGUMENT)
+    }
   }
 
   companion object {

--- a/src/main/proto/wfa/measurement/edpaggregator/v1alpha/pool_assignment_job_service.proto
+++ b/src/main/proto/wfa/measurement/edpaggregator/v1alpha/pool_assignment_job_service.proto
@@ -57,7 +57,10 @@ service PoolAssignmentJobService {
   rpc MarkPoolAssignmentJobSucceeded(MarkPoolAssignmentJobSucceededRequest)
       returns (MarkPoolAssignmentJobSucceededResponse) {}
 
-  // Marks a `PoolAssignmentJob` as `FAILED`.
+  // Marks a `PoolAssignmentJob` as `FAILED`. Throws ABORTED if
+  // etag does not match the current resource version (AIP-154).
+  // A retry with the same `request_id` returns the original
+  // response without re-transitioning the resource (AIP-155).
   rpc MarkPoolAssignmentJobFailed(MarkPoolAssignmentJobFailedRequest)
       returns (PoolAssignmentJob) {}
 }
@@ -81,9 +84,16 @@ message CreatePoolAssignmentJobRequest {
 
   // A request ID provided by the client to ensure idempotency.
   //
-  // This field must be a UUID4 (RFC 4122) string.
+  // This field is REQUIRED, deviating from AIP-155 (which recommends request_id
+  // be optional): the job's resource name is assigned by the server, so the
+  // client has no other idempotency key. Without it, a retry after a lost
+  // response would create a second, orphaned job. Must be a UUID4 (RFC 4122)
+  // string.
+  // (-- api-linter: core::0133::request-required-fields=disabled
+  //     aip.dev/not-precedent: request_id is intentionally REQUIRED so the
+  //     server can deduplicate retries of this server-named resource. --)
   string request_id = 3 [
-    (google.api.field_behavior) = OPTIONAL,
+    (google.api.field_behavior) = REQUIRED,
     (google.api.field_info).format = UUID4
   ];
 }
@@ -215,7 +225,7 @@ message MarkPoolAssignmentJobSucceededRequest {
   //
   // This field must be a UUID4 (RFC 4122) string.
   string request_id = 3 [
-    (google.api.field_behavior) = OPTIONAL,
+    (google.api.field_behavior) = REQUIRED,
     (google.api.field_info).format = UUID4
   ];
 
@@ -291,4 +301,25 @@ message MarkPoolAssignmentJobFailedRequest {
 
   // Human-readable detail about the failure.
   string error_message = 3 [(google.api.field_behavior) = OPTIONAL];
+
+  // A request ID provided by the client to ensure idempotency on retry. A retry
+  // with the same `request_id` returns the original response without
+  // re-transitioning the resource.
+  //
+  // To survive retries (network blips, redeliveries, process restarts), derive
+  // this deterministically from the resource being marked -- e.g. a UUID
+  // computed from its `name` and the operation -- so that every attempt for the
+  // same logical mark uses the same `request_id` and shares one idempotent
+  // result. Generating a fresh UUID per attempt defeats AIP-155 and surfaces as
+  // FAILED_PRECONDITION on retry against an already-transitioned row.
+  //
+  // Note: on a same-`request_id` retry, the row is returned with the
+  // `error_message` from the first successful mark; a differing `error_message`
+  // in the retry is ignored (AIP-155: the first response is returned as-is).
+  //
+  // This field must be a UUID4 (RFC 4122) string.
+  string request_id = 4 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.field_info).format = UUID4
+  ];
 }

--- a/src/main/proto/wfa/measurement/internal/edpaggregator/pool_assignment_job_service.proto
+++ b/src/main/proto/wfa/measurement/internal/edpaggregator/pool_assignment_job_service.proto
@@ -220,4 +220,7 @@ message MarkPoolAssignmentJobFailedRequest {
 
   // Human-readable detail about the failure.
   string error_message = 5;
+
+  // A request ID provided by the client to ensure idempotency.
+  string request_id = 6;
 }

--- a/src/test/kotlin/org/wfanet/measurement/edpaggregator/service/v1alpha/PoolAssignmentJobServiceTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/edpaggregator/service/v1alpha/PoolAssignmentJobServiceTest.kt
@@ -218,6 +218,7 @@ class PoolAssignmentJobServiceTest {
   @Test
   fun `createPoolAssignmentJob throws INVALID_ARGUMENT for empty parent`() = runBlocking {
     val request = createPoolAssignmentJobRequest {
+      this.requestId = UUID.randomUUID().toString()
       poolAssignmentJob = poolAssignmentJob {
         cmmsModelLine = CMMS_MODEL_LINE
         shardIndex = 0
@@ -240,6 +241,7 @@ class PoolAssignmentJobServiceTest {
   @Test
   fun `createPoolAssignmentJob throws INVALID_ARGUMENT for malformed parent`() = runBlocking {
     val request = createPoolAssignmentJobRequest {
+      this.requestId = UUID.randomUUID().toString()
       parent = "invalid-parent"
       poolAssignmentJob = poolAssignmentJob {
         cmmsModelLine = CMMS_MODEL_LINE
@@ -281,6 +283,7 @@ class PoolAssignmentJobServiceTest {
   @Test
   fun `createPoolAssignmentJob throws INVALID_ARGUMENT for empty cmmsModelLine`() = runBlocking {
     val request = createPoolAssignmentJobRequest {
+      this.requestId = UUID.randomUUID().toString()
       parent = UPLOAD_KEY.toName()
       poolAssignmentJob = poolAssignmentJob { shardIndex = 0 }
     }
@@ -323,18 +326,43 @@ class PoolAssignmentJobServiceTest {
   }
 
   @Test
+  fun `createPoolAssignmentJob throws INVALID_ARGUMENT for missing requestId`() = runBlocking {
+    val request = createPoolAssignmentJobRequest {
+      parent = UPLOAD_KEY.toName()
+      poolAssignmentJob = poolAssignmentJob {
+        cmmsModelLine = CMMS_MODEL_LINE
+        shardIndex = 0
+      }
+    }
+
+    val exception =
+      assertFailsWith<StatusRuntimeException> { service.createPoolAssignmentJob(request) }
+    assertThat(exception.status.code).isEqualTo(Status.Code.INVALID_ARGUMENT)
+    assertThat(exception.errorInfo)
+      .isEqualTo(
+        errorInfo {
+          domain = Errors.DOMAIN
+          reason = Errors.Reason.REQUIRED_FIELD_NOT_SET.name
+          metadata[Errors.Metadata.FIELD_NAME.key] = "request_id"
+        }
+      )
+  }
+
+  @Test
   fun `batchCreatePoolAssignmentJobs returns jobs successfully`() =
     runBlocking<Unit> {
       createParentUpload(DATA_PROVIDER_ID, RAW_IMPRESSION_UPLOAD_ID)
       val request = batchCreatePoolAssignmentJobsRequest {
         parent = UPLOAD_KEY.toName()
         requests += createPoolAssignmentJobRequest {
+          this.requestId = UUID.randomUUID().toString()
           poolAssignmentJob = poolAssignmentJob {
             cmmsModelLine = CMMS_MODEL_LINE
             shardIndex = 0
           }
         }
         requests += createPoolAssignmentJobRequest {
+          this.requestId = UUID.randomUUID().toString()
           poolAssignmentJob = poolAssignmentJob {
             cmmsModelLine = CMMS_MODEL_LINE
             shardIndex = 1
@@ -353,6 +381,7 @@ class PoolAssignmentJobServiceTest {
   fun `batchCreatePoolAssignmentJobs throws INVALID_ARGUMENT for empty parent`() = runBlocking {
     val request = batchCreatePoolAssignmentJobsRequest {
       requests += createPoolAssignmentJobRequest {
+        this.requestId = UUID.randomUUID().toString()
         poolAssignmentJob = poolAssignmentJob {
           cmmsModelLine = CMMS_MODEL_LINE
           shardIndex = 0
@@ -451,6 +480,7 @@ class PoolAssignmentJobServiceTest {
       val created =
         service.createPoolAssignmentJob(
           createPoolAssignmentJobRequest {
+            this.requestId = UUID.randomUUID().toString()
             parent = UPLOAD_KEY.toName()
             poolAssignmentJob = poolAssignmentJob {
               cmmsModelLine = CMMS_MODEL_LINE
@@ -477,6 +507,7 @@ class PoolAssignmentJobServiceTest {
       val created1 =
         service.createPoolAssignmentJob(
           createPoolAssignmentJobRequest {
+            this.requestId = UUID.randomUUID().toString()
             parent = UPLOAD_KEY.toName()
             poolAssignmentJob = poolAssignmentJob {
               cmmsModelLine = CMMS_MODEL_LINE
@@ -487,6 +518,7 @@ class PoolAssignmentJobServiceTest {
       val created2 =
         service.createPoolAssignmentJob(
           createPoolAssignmentJobRequest {
+            this.requestId = UUID.randomUUID().toString()
             parent = uploadKey2.toName()
             poolAssignmentJob = poolAssignmentJob {
               cmmsModelLine = CMMS_MODEL_LINE
@@ -511,6 +543,7 @@ class PoolAssignmentJobServiceTest {
     val created1 =
       service.createPoolAssignmentJob(
         createPoolAssignmentJobRequest {
+          this.requestId = UUID.randomUUID().toString()
           parent = UPLOAD_KEY.toName()
           poolAssignmentJob = poolAssignmentJob {
             cmmsModelLine = CMMS_MODEL_LINE
@@ -521,6 +554,7 @@ class PoolAssignmentJobServiceTest {
     val created2 =
       service.createPoolAssignmentJob(
         createPoolAssignmentJobRequest {
+          this.requestId = UUID.randomUUID().toString()
           parent = UPLOAD_KEY.toName()
           poolAssignmentJob = poolAssignmentJob {
             cmmsModelLine = CMMS_MODEL_LINE
@@ -662,6 +696,7 @@ class PoolAssignmentJobServiceTest {
     val created =
       service.createPoolAssignmentJob(
         createPoolAssignmentJobRequest {
+          this.requestId = UUID.randomUUID().toString()
           parent = UPLOAD_KEY.toName()
           poolAssignmentJob = poolAssignmentJob {
             cmmsModelLine = CMMS_MODEL_LINE
@@ -673,6 +708,7 @@ class PoolAssignmentJobServiceTest {
     val response =
       service.markPoolAssignmentJobSucceeded(
         markPoolAssignmentJobSucceededRequest {
+          this.requestId = UUID.randomUUID().toString()
           name = created.name
           etag = created.etag
           encryptedDek = ENCRYPTED_DEK
@@ -709,6 +745,7 @@ class PoolAssignmentJobServiceTest {
     val created =
       service.createPoolAssignmentJob(
         createPoolAssignmentJobRequest {
+          this.requestId = UUID.randomUUID().toString()
           parent = UPLOAD_KEY.toName()
           poolAssignmentJob = poolAssignmentJob {
             cmmsModelLine = CMMS_MODEL_LINE
@@ -741,6 +778,7 @@ class PoolAssignmentJobServiceTest {
       val created =
         service.createPoolAssignmentJob(
           createPoolAssignmentJobRequest {
+            this.requestId = UUID.randomUUID().toString()
             parent = UPLOAD_KEY.toName()
             poolAssignmentJob = poolAssignmentJob {
               cmmsModelLine = CMMS_MODEL_LINE
@@ -753,6 +791,7 @@ class PoolAssignmentJobServiceTest {
         assertFailsWith<StatusRuntimeException> {
           service.markPoolAssignmentJobSucceeded(
             markPoolAssignmentJobSucceededRequest {
+              this.requestId = UUID.randomUUID().toString()
               name = created.name
               etag = created.etag
             }
@@ -770,11 +809,49 @@ class PoolAssignmentJobServiceTest {
     }
 
   @Test
+  fun `markPoolAssignmentJobSucceeded throws INVALID_ARGUMENT for missing requestId`() =
+    runBlocking {
+      createParentUpload(DATA_PROVIDER_ID, RAW_IMPRESSION_UPLOAD_ID)
+      val created =
+        service.createPoolAssignmentJob(
+          createPoolAssignmentJobRequest {
+            this.requestId = UUID.randomUUID().toString()
+            parent = UPLOAD_KEY.toName()
+            poolAssignmentJob = poolAssignmentJob {
+              cmmsModelLine = CMMS_MODEL_LINE
+              shardIndex = 0
+            }
+          }
+        )
+
+      val exception =
+        assertFailsWith<StatusRuntimeException> {
+          service.markPoolAssignmentJobSucceeded(
+            markPoolAssignmentJobSucceededRequest {
+              name = created.name
+              etag = created.etag
+              encryptedDek = ENCRYPTED_DEK
+            }
+          )
+        }
+      assertThat(exception.status.code).isEqualTo(Status.Code.INVALID_ARGUMENT)
+      assertThat(exception.errorInfo)
+        .isEqualTo(
+          errorInfo {
+            domain = Errors.DOMAIN
+            reason = Errors.Reason.REQUIRED_FIELD_NOT_SET.name
+            metadata[Errors.Metadata.FIELD_NAME.key] = "request_id"
+          }
+        )
+    }
+
+  @Test
   fun `markPoolAssignmentJobFailed transitions state`() = runBlocking {
     createParentUpload(DATA_PROVIDER_ID, RAW_IMPRESSION_UPLOAD_ID)
     val created =
       service.createPoolAssignmentJob(
         createPoolAssignmentJobRequest {
+          this.requestId = UUID.randomUUID().toString()
           parent = UPLOAD_KEY.toName()
           poolAssignmentJob = poolAssignmentJob {
             cmmsModelLine = CMMS_MODEL_LINE
@@ -786,6 +863,7 @@ class PoolAssignmentJobServiceTest {
     val failed =
       service.markPoolAssignmentJobFailed(
         markPoolAssignmentJobFailedRequest {
+          this.requestId = UUID.randomUUID().toString()
           name = created.name
           etag = created.etag
           errorMessage = "Something went wrong"
@@ -814,6 +892,7 @@ class PoolAssignmentJobServiceTest {
       assertFailsWith<StatusRuntimeException> {
         service.markPoolAssignmentJobFailed(
           markPoolAssignmentJobFailedRequest {
+            this.requestId = UUID.randomUUID().toString()
             name = "invalid-name"
             etag = "some-etag"
           }
@@ -829,6 +908,116 @@ class PoolAssignmentJobServiceTest {
         }
       )
   }
+
+  @Test
+  fun `markPoolAssignmentJobFailed throws INVALID_ARGUMENT for empty etag`() = runBlocking {
+    createParentUpload(DATA_PROVIDER_ID, RAW_IMPRESSION_UPLOAD_ID)
+    val created =
+      service.createPoolAssignmentJob(
+        createPoolAssignmentJobRequest {
+          this.requestId = UUID.randomUUID().toString()
+          parent = UPLOAD_KEY.toName()
+          poolAssignmentJob = poolAssignmentJob {
+            cmmsModelLine = CMMS_MODEL_LINE
+            shardIndex = 0
+          }
+        }
+      )
+
+    val exception =
+      assertFailsWith<StatusRuntimeException> {
+        service.markPoolAssignmentJobFailed(
+          markPoolAssignmentJobFailedRequest {
+            this.requestId = UUID.randomUUID().toString()
+            name = created.name
+            errorMessage = "Something went wrong"
+          }
+        )
+      }
+    assertThat(exception.status.code).isEqualTo(Status.Code.INVALID_ARGUMENT)
+    assertThat(exception.errorInfo)
+      .isEqualTo(
+        errorInfo {
+          domain = Errors.DOMAIN
+          reason = Errors.Reason.REQUIRED_FIELD_NOT_SET.name
+          metadata[Errors.Metadata.FIELD_NAME.key] = "etag"
+        }
+      )
+  }
+
+  @Test
+  fun `markPoolAssignmentJobFailed throws INVALID_ARGUMENT for missing requestId`() = runBlocking {
+    createParentUpload(DATA_PROVIDER_ID, RAW_IMPRESSION_UPLOAD_ID)
+    val created =
+      service.createPoolAssignmentJob(
+        createPoolAssignmentJobRequest {
+          this.requestId = UUID.randomUUID().toString()
+          parent = UPLOAD_KEY.toName()
+          poolAssignmentJob = poolAssignmentJob {
+            cmmsModelLine = CMMS_MODEL_LINE
+            shardIndex = 0
+          }
+        }
+      )
+
+    val exception =
+      assertFailsWith<StatusRuntimeException> {
+        service.markPoolAssignmentJobFailed(
+          markPoolAssignmentJobFailedRequest {
+            name = created.name
+            etag = created.etag
+            errorMessage = "Something went wrong"
+          }
+        )
+      }
+    assertThat(exception.status.code).isEqualTo(Status.Code.INVALID_ARGUMENT)
+    assertThat(exception.errorInfo)
+      .isEqualTo(
+        errorInfo {
+          domain = Errors.DOMAIN
+          reason = Errors.Reason.REQUIRED_FIELD_NOT_SET.name
+          metadata[Errors.Metadata.FIELD_NAME.key] = "request_id"
+        }
+      )
+  }
+
+  @Test
+  fun `markPoolAssignmentJobFailed throws INVALID_ARGUMENT for malformed requestId`() =
+    runBlocking {
+      createParentUpload(DATA_PROVIDER_ID, RAW_IMPRESSION_UPLOAD_ID)
+      val created =
+        service.createPoolAssignmentJob(
+          createPoolAssignmentJobRequest {
+            this.requestId = UUID.randomUUID().toString()
+            parent = UPLOAD_KEY.toName()
+            poolAssignmentJob = poolAssignmentJob {
+              cmmsModelLine = CMMS_MODEL_LINE
+              shardIndex = 0
+            }
+          }
+        )
+
+      val exception =
+        assertFailsWith<StatusRuntimeException> {
+          service.markPoolAssignmentJobFailed(
+            markPoolAssignmentJobFailedRequest {
+              requestId = "invalid-request-id"
+              name = created.name
+              etag = created.etag
+              errorMessage = "Something went wrong"
+            }
+          )
+        }
+      assertThat(exception.status.code).isEqualTo(Status.Code.INVALID_ARGUMENT)
+      assertThat(exception.errorInfo)
+        .isEqualTo(
+          errorInfo {
+            domain = Errors.DOMAIN
+            reason = Errors.Reason.INVALID_FIELD_VALUE.name
+            metadata[Errors.Metadata.FIELD_NAME.key] = "request_id"
+          }
+        )
+    }
 
   companion object {
     @get:ClassRule @JvmStatic val spannerEmulator = SpannerEmulatorRule()


### PR DESCRIPTION
## Summary

  makes `request_id` REQUIRED on `CreatePoolAssignmentJob`, `BatchCreatePoolAssignmentJobs`
  (per element), and `MarkPoolAssignmentJobSucceeded` for consistency across the resource.
  
  Resolves #4078. Same shape as the merged #4211 (`RawImpressionUploadModelLine` Mark*),
  so this follows that PR's approved pattern and review feedback.
  
  Previously `MarkPoolAssignmentJobFailed` had no `request_id` at all. Because `FAILED`
  is a valid previous state (the `CREATED|FAILED` self-loop), an at-least-once Pub/Sub
  redelivery of a MarkFailed would silently re-stamp a fresh commit timestamp and rotate
  the etag, breaking a later CAS for the real workflow. `MarkPoolAssignmentJobSucceeded`
  already carried `request_id` but only enforced it as OPTIONAL, so a caller that omitted
  it got non-idempotent behavior.
  
  ## Changes
  
  **Protos** (v1alpha + internal `pool_assignment_job_service.proto`)
  - Add `request_id` (REQUIRED, `UUID4`) to `MarkPoolAssignmentJobFailedRequest`, documenting
    that a same-`request_id` retry returns the original response as-is and a differing
    `error_message` on retry is ignored (AIP-155).
  - Flip `request_id` OPTIONAL → REQUIRED on `Create` and `MarkSucceeded`. The Create field
    gets the `core::0133::request-required-fields=disabled` api-linter directive and a KDoc
    noting the deliberate AIP-155 deviation (the resource name is server-assigned, so
    `request_id` is the client's only idempotency key).

  **Public service** (`PoolAssignmentJobService.kt`)
  - Extract a shared `validateEtagAndRequestId(etag, requestId)` helper (per #4211 review) and
    use it from both Mark RPCs; enforce REQUIRED + UUID4 on Create/BatchCreate; `markFailed`
    now validates and forwards `request_id`.

  **Internal Spanner service** (`SpannerPoolAssignmentJobService.kt`)
  - `markPoolAssignmentJobFailed`: AIP-155 replay short-circuit keyed on the `MarkFailedRequestId`
    column **alone** (returns the row as-is, before the etag/state checks, even if the resource
    has since advanced — e.g. a later MarkSucceeded — and preserves the original `error_message`).
    The replay flag is carried in the transaction's return value so it survives Spanner ABORTED
    retries. Stamps `MarkFailedRequestId` on the transition.
  - `markSucceeded` / `create` / `batchCreate`: enforce `request_id` REQUIRED + UUID4, and drop
    the now-unreachable OPTIONAL branches (unconditional `set(...RequestId)`, no empty-guard, and
    `map` instead of `mapNotNull { ifEmpty { null } }`).


  ## Notes

  - **No schema change** — the `MarkFailedRequestId STRING(36)` column and its
    `PoolAssignmentJobByMarkFailedRequestId` unique NULL_FILTERED index already landed in #3989.
  - **No producer changes** — the dispatcher (`RequestIds.forPoolAssignmentJob`) and
    `SubpoolAssigner` (deterministic `MarkSucceeded` id) already pass `request_id`; there is no
    production `MarkPoolAssignmentJobFailed` caller on `main` yet. This unblocks the DLQ listener's
    `TODO(#4078)` in #4089.

  ## Testing

  - Internal `PoolAssignmentJobServiceTest` (48 cases, via `SpannerPoolAssignmentJobServiceTest`):
    `request_id` threaded through every Create/Mark; added MarkFailed idempotent-replay,
    error_message-preservation, replay-after-advance (FAILED → SUCCEEDED), and missing/malformed
    `request_id` coverage for Create/MarkSucceeded/MarkFailed.
  - Public `PoolAssignmentJobServiceTest`: added missing/malformed `request_id` and empty-etag
    coverage for the Mark RPCs.
  - `SubpoolAssignerTest` and `VidLabelingDispatchSequencerTest` (producers) pass unchanged.
  - ktfmt 0.54 `--google-style`, clang-format, and api-linter 1.67.2 all clean.

BREAKING-CHANGE: request_id is now REQUIRED on PoolAssignmentJob Create, BatchCreate, MarkSucceeded, and MarkFailed RPCs.
Issue: #4078