### PR TITLE
feat: add vid labeling config edp impression path

### DIFF
--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/vidlabeling/BUILD.bazel
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/vidlabeling/BUILD.bazel
@@ -16,10 +16,26 @@ kt_jvm_library(
 )
 
 kt_jvm_library(
+    name = "vid_labeling_function_helpers",
+    srcs = ["VidLabelingFunctionHelpers.kt"],
+    deps = [
+        "//imports/java/io/opentelemetry/instrumentation/grpc",
+        "//src/main/proto/wfa/measurement/config/edpaggregator:vid_labeling_config_kt_jvm_proto",
+        "//src/main/proto/wfa/measurement/edpaggregator/v1alpha:subpool_assigner_params_kt_jvm_proto",
+        "//src/main/proto/wfa/measurement/edpaggregator/v1alpha:transport_layer_security_params_kt_jvm_proto",
+        "//src/main/proto/wfa/measurement/edpaggregator/v1alpha:vid_labeler_params_kt_jvm_proto",
+        "@wfa_common_jvm//imports/java/io/grpc:api",
+        "@wfa_common_jvm//src/main/kotlin/org/wfanet/measurement/common/crypto:signing_certs",
+        "@wfa_common_jvm//src/main/kotlin/org/wfanet/measurement/common/grpc",
+    ],
+)
+
+kt_jvm_library(
     name = "vid_labeling_dispatcher_function",
     srcs = ["VidLabelingDispatcherFunction.kt"],
     deps = [
         ":vid_labeling_config_validation",
+        ":vid_labeling_function_helpers",
         "//imports/java/io/opentelemetry/api:context",
         "//imports/java/io/opentelemetry/extension:kotlin",
         "//imports/java/io/opentelemetry/instrumentation/grpc",
@@ -39,9 +55,6 @@ kt_jvm_library(
         "//src/main/proto/wfa/measurement/edpaggregator/v1alpha:raw_impression_upload_file_service_kt_jvm_grpc_proto",
         "//src/main/proto/wfa/measurement/edpaggregator/v1alpha:raw_impression_upload_model_line_service_kt_jvm_grpc_proto",
         "//src/main/proto/wfa/measurement/edpaggregator/v1alpha:raw_impression_upload_service_kt_jvm_grpc_proto",
-        "//src/main/proto/wfa/measurement/edpaggregator/v1alpha:subpool_assigner_params_kt_jvm_proto",
-        "//src/main/proto/wfa/measurement/edpaggregator/v1alpha:transport_layer_security_params_kt_jvm_proto",
-        "//src/main/proto/wfa/measurement/edpaggregator/v1alpha:vid_labeler_params_kt_jvm_proto",
         "//src/main/proto/wfa/measurement/edpaggregator/v1alpha:vid_labeling_dispatcher_params_kt_jvm_proto",
         "//src/main/proto/wfa/measurement/edpaggregator/v1alpha:vid_labeling_job_service_kt_jvm_grpc_proto",
         "//src/main/proto/wfa/measurement/securecomputation/controlplane/v1alpha:work_items_service_kt_jvm_grpc_proto",
@@ -51,8 +64,6 @@ kt_jvm_library(
         "@wfa_common_jvm//imports/java/org/apache/hadoop:hadoop_client_api",
         "@wfa_common_jvm//imports/kotlin/kotlinx/coroutines:core",
         "@wfa_common_jvm//src/main/kotlin/org/wfanet/measurement/common",
-        "@wfa_common_jvm//src/main/kotlin/org/wfanet/measurement/common/crypto:signing_certs",
-        "@wfa_common_jvm//src/main/kotlin/org/wfanet/measurement/common/grpc",
         "@wfa_common_jvm//src/main/kotlin/org/wfanet/measurement/gcloud/gcs",
         "@wfa_common_jvm//src/main/kotlin/org/wfanet/measurement/storage:client",
         "@wfa_common_jvm//src/main/kotlin/org/wfanet/measurement/storage:parquet_storage_client",
@@ -77,6 +88,7 @@ kt_jvm_library(
     srcs = ["VidLabelingMonitorFunction.kt"],
     deps = [
         ":vid_labeling_config_validation",
+        ":vid_labeling_function_helpers",
         "//imports/java/io/opentelemetry/instrumentation/grpc",
         "//src/main/kotlin/org/wfanet/measurement/common:env_vars",
         "//src/main/kotlin/org/wfanet/measurement/common/edpaggregator:edp_aggregator_config",
@@ -93,9 +105,6 @@ kt_jvm_library(
         "//src/main/proto/wfa/measurement/edpaggregator/v1alpha:raw_impression_upload_file_service_kt_jvm_grpc_proto",
         "//src/main/proto/wfa/measurement/edpaggregator/v1alpha:raw_impression_upload_model_line_service_kt_jvm_grpc_proto",
         "//src/main/proto/wfa/measurement/edpaggregator/v1alpha:raw_impression_upload_service_kt_jvm_grpc_proto",
-        "//src/main/proto/wfa/measurement/edpaggregator/v1alpha:subpool_assigner_params_kt_jvm_proto",
-        "//src/main/proto/wfa/measurement/edpaggregator/v1alpha:transport_layer_security_params_kt_jvm_proto",
-        "//src/main/proto/wfa/measurement/edpaggregator/v1alpha:vid_labeler_params_kt_jvm_proto",
         "//src/main/proto/wfa/measurement/edpaggregator/v1alpha:vid_labeling_job_service_kt_jvm_grpc_proto",
         "//src/main/proto/wfa/measurement/securecomputation/controlplane/v1alpha:work_items_service_kt_jvm_grpc_proto",
         "@wfa_common_jvm//imports/java/com/google/cloud/functions:functions_framework_api",

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/vidlabeling/VidLabelingDispatcherFunction.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/vidlabeling/VidLabelingDispatcherFunction.kt
@@ -440,14 +440,22 @@ class VidLabelingDispatcherFunction : HttpFunction {
       require(config.vidLabeledImpressionsStorageParams.hasGcs()) {
         "VidLabelingConfig vid_labeled_impressions_storage_params must use GCS"
       }
+      require(config.edpImpressionPath.isNotEmpty()) {
+        "VidLabelingConfig.edp_impression_path is required"
+      }
 
       return vidLabelerParams {
         dataProvider = config.dataProvider
         vidLabeledImpressionsStorageParams =
           VidLabelerParamsKt.storageParams {
             gcsProjectId = config.vidLabeledImpressionsStorageParams.gcs.projectId
+            // Per-EDP folder segment so each EDP's labeled output lives under its own
+            // folder: gs://<bucket>/<edp_impression_path>/model-line/<id>/<date>/. Required,
+            // and must match this EDP's DataAvailabilitySyncConfig edp_impression_path so the
+            // writer and the registrar agree on the location.
             impressionsBlobPrefix =
-              "gs://${config.vidLabeledImpressionsStorageParams.gcs.bucketName}"
+              "gs://${config.vidLabeledImpressionsStorageParams.gcs.bucketName}" +
+                "/${config.edpImpressionPath}"
           }
         rawImpressionsStorageParams =
           VidLabelerParamsKt.storageParams {

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/vidlabeling/VidLabelingDispatcherFunction.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/vidlabeling/VidLabelingDispatcherFunction.kt
@@ -21,15 +21,10 @@ import com.google.cloud.functions.HttpRequest
 import com.google.cloud.functions.HttpResponse
 import com.google.cloud.storage.StorageOptions
 import com.google.protobuf.util.JsonFormat
-import io.grpc.Channel
-import io.grpc.ClientInterceptors
-import io.grpc.ManagedChannel
 import io.opentelemetry.context.Context
 import io.opentelemetry.extension.kotlin.asContextElement
 import io.opentelemetry.instrumentation.grpc.v1_6.GrpcTelemetry
 import java.io.File
-import java.time.Duration
-import java.util.concurrent.ConcurrentHashMap
 import java.util.logging.Level
 import java.util.logging.Logger
 import kotlinx.coroutines.runBlocking
@@ -40,11 +35,7 @@ import org.wfanet.measurement.api.v2alpha.ModelRolloutsGrpcKt
 import org.wfanet.measurement.api.v2alpha.ModelShardsGrpcKt
 import org.wfanet.measurement.common.EnvVars
 import org.wfanet.measurement.common.Instrumentation
-import org.wfanet.measurement.common.crypto.SigningCerts
 import org.wfanet.measurement.common.edpaggregator.EdpAggregatorConfig
-import org.wfanet.measurement.common.grpc.buildMutualTlsChannel
-import org.wfanet.measurement.common.grpc.withShutdownTimeout
-import org.wfanet.measurement.config.edpaggregator.TransportLayerSecurityParams as ConfigTransportLayerSecurityParams
 import org.wfanet.measurement.config.edpaggregator.VidLabelingConfig
 import org.wfanet.measurement.config.edpaggregator.VidLabelingConfigs
 import org.wfanet.measurement.edpaggregator.rawimpressions.gcsHadoopConfiguration
@@ -55,15 +46,8 @@ import org.wfanet.measurement.edpaggregator.v1alpha.PoolAssignmentJobServiceGrpc
 import org.wfanet.measurement.edpaggregator.v1alpha.RawImpressionUploadFileServiceGrpcKt
 import org.wfanet.measurement.edpaggregator.v1alpha.RawImpressionUploadModelLineServiceGrpcKt
 import org.wfanet.measurement.edpaggregator.v1alpha.RawImpressionUploadServiceGrpcKt
-import org.wfanet.measurement.edpaggregator.v1alpha.SubpoolAssignerParams
-import org.wfanet.measurement.edpaggregator.v1alpha.SubpoolAssignerParamsKt
-import org.wfanet.measurement.edpaggregator.v1alpha.VidLabelerParams
-import org.wfanet.measurement.edpaggregator.v1alpha.VidLabelerParamsKt
 import org.wfanet.measurement.edpaggregator.v1alpha.VidLabelingDispatcherParams
 import org.wfanet.measurement.edpaggregator.v1alpha.VidLabelingJobServiceGrpcKt
-import org.wfanet.measurement.edpaggregator.v1alpha.subpoolAssignerParams
-import org.wfanet.measurement.edpaggregator.v1alpha.transportLayerSecurityParams
-import org.wfanet.measurement.edpaggregator.v1alpha.vidLabelerParams
 import org.wfanet.measurement.edpaggregator.vidlabeling.VidLabelingDispatchSequencer
 import org.wfanet.measurement.edpaggregator.vidlabeling.VidLabelingDispatcher
 import org.wfanet.measurement.gcloud.gcs.GcsStorageClient
@@ -72,13 +56,6 @@ import org.wfanet.measurement.storage.ParquetStorageClient
 import org.wfanet.measurement.storage.SelectedStorageClient
 import org.wfanet.measurement.storage.StorageClient
 import org.wfanet.measurement.storage.filesystem.FileSystemStorageClient
-
-/** Channel cache key using TLS params, target, and optional hostname override. */
-private data class ChannelKey(
-  val tls: ConfigTransportLayerSecurityParams,
-  val target: String,
-  val hostName: String?,
-)
 
 /**
  * Cloud Function that registers VID labeling uploads in the EDP Aggregator metadata store.
@@ -166,7 +143,7 @@ class VidLabelingDispatcherFunction : HttpFunction {
 
       val modelLinesStub =
         ModelLinesGrpcKt.ModelLinesCoroutineStub(
-          createInstrumentedChannel(
+          VidLabelingFunctionHelpers.createInstrumentedChannel(
             config.modelLinesConnection,
             modelLinesTarget,
             modelLinesCertHost,
@@ -176,7 +153,7 @@ class VidLabelingDispatcherFunction : HttpFunction {
 
       val modelRolloutsStub =
         ModelRolloutsGrpcKt.ModelRolloutsCoroutineStub(
-          createInstrumentedChannel(
+          VidLabelingFunctionHelpers.createInstrumentedChannel(
             config.modelRolloutsConnection,
             modelRolloutsTarget,
             modelRolloutsCertHost,
@@ -186,7 +163,7 @@ class VidLabelingDispatcherFunction : HttpFunction {
 
       val modelShardsStub =
         ModelShardsGrpcKt.ModelShardsCoroutineStub(
-          createInstrumentedChannel(
+          VidLabelingFunctionHelpers.createInstrumentedChannel(
             config.modelShardsConnection,
             modelShardsTarget,
             modelShardsCertHost,
@@ -195,7 +172,7 @@ class VidLabelingDispatcherFunction : HttpFunction {
         )
 
       val rawImpressionUploadChannel =
-        createInstrumentedChannel(
+        VidLabelingFunctionHelpers.createInstrumentedChannel(
           config.rawImpressionMetadataStorageConnection,
           rawImpressionUploadTarget,
           rawImpressionUploadCertHost,
@@ -224,7 +201,7 @@ class VidLabelingDispatcherFunction : HttpFunction {
         VidLabelingJobServiceGrpcKt.VidLabelingJobServiceCoroutineStub(rawImpressionUploadChannel)
       val workItemsStub =
         WorkItemsGrpcKt.WorkItemsCoroutineStub(
-          createInstrumentedChannel(
+          VidLabelingFunctionHelpers.createInstrumentedChannel(
             config.controlPlaneConnection,
             controlPlaneTarget,
             controlPlaneCertHost,
@@ -237,7 +214,8 @@ class VidLabelingDispatcherFunction : HttpFunction {
       }
       // Fail fast on per-model-line config the TEE would otherwise only reject at Phase-2.
       requireValidModelLineConfigs(config)
-      val modelLineConfigs = convertModelLineConfigs(config.modelLineConfigsMap)
+      val modelLineConfigs =
+        VidLabelingFunctionHelpers.convertModelLineConfigs(config.modelLineConfigsMap)
 
       val dispatchSequencer =
         VidLabelingDispatchSequencer(
@@ -249,8 +227,10 @@ class VidLabelingDispatcherFunction : HttpFunction {
           modelShardsStub = modelShardsStub,
           modelLinesStub = modelLinesStub,
           dataProviderName = config.dataProvider,
-          vidLabelerParamsTemplate = buildVidLabelerParamsTemplate(config),
-          subpoolAssignerParamsTemplate = buildSubpoolAssignerParamsTemplate(config),
+          vidLabelerParamsTemplate =
+            VidLabelingFunctionHelpers.buildVidLabelerParamsTemplate(config),
+          subpoolAssignerParamsTemplate =
+            VidLabelingFunctionHelpers.buildSubpoolAssignerParamsTemplate(config),
           queueName = vidLabelerQueueName,
           poolAssignerQueueName = poolAssignerQueueName,
           numberOfShards = config.numberOfShards,
@@ -293,7 +273,6 @@ class VidLabelingDispatcherFunction : HttpFunction {
 
   companion object {
     private val logger: Logger = Logger.getLogger(this::class.java.name)
-    private const val DEFAULT_CHANNEL_SHUTDOWN_DURATION_SECONDS: Long = 3L
     private const val DATA_WATCHER_PATH_HEADER: String = "X-DataWatcher-Path"
     private const val DATA_WATCHER_GENERATION_HEADER: String = "X-DataWatcher-Generation"
     private const val OVERRIDE_MODEL_LINES_HEADER: String = "X-Override-Model-Lines"
@@ -314,11 +293,6 @@ class VidLabelingDispatcherFunction : HttpFunction {
     private val vidLabelerQueueName: String = EnvVars.checkNotNullOrEmpty("VID_LABELER_QUEUE_NAME")
     private val poolAssignerQueueName: String =
       EnvVars.checkNotNullOrEmpty("POOL_ASSIGNER_QUEUE_NAME")
-    private val channelShutdownDuration =
-      Duration.ofSeconds(
-        System.getenv("CHANNEL_SHUTDOWN_DURATION_SECONDS")?.toLong()
-          ?: DEFAULT_CHANNEL_SHUTDOWN_DURATION_SECONDS
-      )
 
     private val fileSystemPath: String? = System.getenv("VID_LABELING_DISPATCHER_FILE_SYSTEM_PATH")
 
@@ -336,8 +310,6 @@ class VidLabelingDispatcherFunction : HttpFunction {
     private val vidLabelingConfigsByDataProvider: Map<String, VidLabelingConfig> by lazy {
       vidLabelingConfigs.configsList.associateBy { it.dataProvider }
     }
-
-    private val channelCache = ConcurrentHashMap<ChannelKey, ManagedChannel>()
 
     /**
      * Builds a [ParquetStorageClient] over the raw-impression storage for footer-only reads (no
@@ -378,186 +350,6 @@ class VidLabelingDispatcherFunction : HttpFunction {
             .service,
           doneBlobUri.bucket,
         )
-      }
-    }
-
-    private fun createPublicChannel(
-      connectionParams: ConfigTransportLayerSecurityParams,
-      target: String,
-      hostName: String?,
-    ): ManagedChannel {
-      val signingCerts =
-        SigningCerts.fromPemFiles(
-          certificateFile = checkNotNull(File(connectionParams.certFilePath)),
-          privateKeyFile = checkNotNull(File(connectionParams.privateKeyFilePath)),
-          trustedCertCollectionFile = checkNotNull(File(connectionParams.certCollectionFilePath)),
-        )
-      return buildMutualTlsChannel(target, signingCerts, hostName)
-        .withShutdownTimeout(channelShutdownDuration)
-    }
-
-    private fun getOrCreateChannel(
-      connectionParams: ConfigTransportLayerSecurityParams,
-      target: String,
-      hostName: String?,
-    ): ManagedChannel {
-      val channelKey = ChannelKey(connectionParams, target, hostName)
-      return channelCache.computeIfAbsent(channelKey) {
-        logger.info("Creating new channel for $target")
-        createPublicChannel(connectionParams, target, hostName)
-      }
-    }
-
-    private fun createInstrumentedChannel(
-      connectionParams: ConfigTransportLayerSecurityParams,
-      target: String,
-      hostName: String?,
-      grpcTelemetry: GrpcTelemetry,
-    ): Channel {
-      val channel = getOrCreateChannel(connectionParams, target, hostName)
-      return ClientInterceptors.intercept(channel, grpcTelemetry.newClientInterceptor())
-    }
-
-    private fun convertModelLineConfigs(
-      configModelLines: Map<String, VidLabelingConfig.ModelLineConfig>
-    ): Map<String, VidLabelerParams.ModelLineConfig> {
-      return configModelLines.mapValues { (_, configModelLine) ->
-        VidLabelerParamsKt.modelLineConfig {
-          labelerInputFieldMapping.addAll(configModelLine.labelerInputFieldMappingList)
-          eventTemplateFieldMapping.putAll(configModelLine.eventTemplateFieldMappingMap)
-          eventTemplateDescriptorBlobUri = configModelLine.eventTemplateDescriptorBlobUri
-          eventTemplateType = configModelLine.eventTemplateType
-          requiredEntityKeyFieldMapping.putAll(configModelLine.requiredEntityKeyFieldMappingMap)
-          optionalEntityKeyFieldMapping.putAll(configModelLine.optionalEntityKeyFieldMappingMap)
-        }
-      }
-    }
-
-    private fun buildVidLabelerParamsTemplate(config: VidLabelingConfig): VidLabelerParams {
-      require(config.rawImpressionsStorageParams.hasGcs()) {
-        "VidLabelingConfig raw_impressions_storage_params must use GCS"
-      }
-      require(config.vidLabeledImpressionsStorageParams.hasGcs()) {
-        "VidLabelingConfig vid_labeled_impressions_storage_params must use GCS"
-      }
-      require(config.edpImpressionPath.isNotEmpty()) {
-        "VidLabelingConfig.edp_impression_path is required"
-      }
-
-      return vidLabelerParams {
-        dataProvider = config.dataProvider
-        vidLabeledImpressionsStorageParams =
-          VidLabelerParamsKt.storageParams {
-            gcsProjectId = config.vidLabeledImpressionsStorageParams.gcs.projectId
-            // Per-EDP folder segment so each EDP's labeled output lives under its own
-            // folder: gs://<bucket>/<edp_impression_path>/model-line/<id>/<date>/. Required,
-            // and must match this EDP's DataAvailabilitySyncConfig edp_impression_path so the
-            // writer and the registrar agree on the location.
-            impressionsBlobPrefix =
-              "gs://${config.vidLabeledImpressionsStorageParams.gcs.bucketName}" +
-                "/${config.edpImpressionPath}"
-          }
-        rawImpressionsStorageParams =
-          VidLabelerParamsKt.storageParams {
-            gcsProjectId = config.rawImpressionsStorageParams.gcs.projectId
-            impressionsBlobPrefix = "gs://${config.rawImpressionsStorageParams.gcs.bucketName}"
-          }
-        vidRepoConnection = transportLayerSecurityParams {
-          clientCertResourcePath = config.vidRepoConnection.certFilePath
-          clientPrivateKeyResourcePath = config.vidRepoConnection.privateKeyFilePath
-        }
-        // The compiled model lives in its own Cloud Storage project. Optional on VidLabelingConfig
-        // (only EDPs that actually label need it); when set, thread it onto every WorkItem so the
-        // TEE reads the model from its own project on both the memoized and non-memoized paths.
-        if (config.modelStorageParams.hasGcs()) {
-          modelStorageParams =
-            VidLabelerParamsKt.storageParams {
-              gcsProjectId = config.modelStorageParams.gcs.projectId
-              impressionsBlobPrefix = "gs://${config.modelStorageParams.gcs.bucketName}"
-            }
-        }
-      }
-    }
-
-    // TODO(world-federation-of-advertisers/cross-media-measurement#4020): De-duplicate this
-    // template builder (with buildVidLabelerParamsTemplate and convertModelLineConfigs) into a
-    // shared helper once the helper-extraction thread on #4020 (this branch's parent) is
-    // addressed, rather than copying it across the dispatcher and monitor Function classes.
-    /**
-     * Builds the template [SubpoolAssignerParams] carrying the storage + connection fields shared
-     * by every memoized Phase-0 WorkItem. The per-shard fields (model line, shard index, active
-     * window, pool assignment job) are filled in by the sequencer.
-     */
-    private fun buildSubpoolAssignerParamsTemplate(
-      config: VidLabelingConfig
-    ): SubpoolAssignerParams {
-      require(config.rawImpressionsStorageParams.hasGcs()) {
-        "VidLabelingConfig raw_impressions_storage_params must use GCS"
-      }
-      require(config.vidLabeledImpressionsStorageParams.hasGcs()) {
-        "VidLabelingConfig vid_labeled_impressions_storage_params must use GCS"
-      }
-      // vid_rank_map/subpool_map storage are consumed only by the memoized Phase-0 path and are
-      // therefore optional in VidLabelingConfig; validate them only when set. An EDP whose model
-      // lines are all non-memoized may omit them, and this template is then never consumed.
-      if (config.hasVidRankMapStorageParams()) {
-        require(config.vidRankMapStorageParams.hasGcs()) {
-          "VidLabelingConfig vid_rank_map_storage_params must use GCS"
-        }
-      }
-      if (config.hasSubpoolMapStorageParams()) {
-        require(config.subpoolMapStorageParams.hasGcs()) {
-          "VidLabelingConfig subpool_map_storage_params must use GCS"
-        }
-      }
-      if (config.hasModelStorageParams()) {
-        require(config.modelStorageParams.hasGcs()) {
-          "VidLabelingConfig model_storage_params must use GCS"
-        }
-      }
-
-      return subpoolAssignerParams {
-        dataProvider = config.dataProvider
-        rawImpressionStorageParams =
-          SubpoolAssignerParamsKt.storageParams {
-            gcsProjectId = config.rawImpressionsStorageParams.gcs.projectId
-            blobPrefix = "gs://${config.rawImpressionsStorageParams.gcs.bucketName}"
-          }
-        vidLabeledImpressionsStorageParams =
-          SubpoolAssignerParamsKt.storageParams {
-            gcsProjectId = config.vidLabeledImpressionsStorageParams.gcs.projectId
-            blobPrefix = "gs://${config.vidLabeledImpressionsStorageParams.gcs.bucketName}"
-          }
-        if (config.hasVidRankMapStorageParams()) {
-          vidRankMapStorageParams =
-            SubpoolAssignerParamsKt.storageParams {
-              gcsProjectId = config.vidRankMapStorageParams.gcs.projectId
-              blobPrefix = "gs://${config.vidRankMapStorageParams.gcs.bucketName}"
-            }
-        }
-        if (config.hasSubpoolMapStorageParams()) {
-          subpoolMapStorageParams =
-            SubpoolAssignerParamsKt.storageParams {
-              gcsProjectId = config.subpoolMapStorageParams.gcs.projectId
-              blobPrefix = "gs://${config.subpoolMapStorageParams.gcs.bucketName}"
-            }
-        }
-        if (config.hasModelStorageParams()) {
-          modelStorageParams =
-            SubpoolAssignerParamsKt.storageParams {
-              gcsProjectId = config.modelStorageParams.gcs.projectId
-              blobPrefix = "gs://${config.modelStorageParams.gcs.bucketName}"
-            }
-        }
-        rawImpressionMetadataStorageConnection = transportLayerSecurityParams {
-          clientCertResourcePath = config.rawImpressionMetadataStorageConnection.certFilePath
-          clientPrivateKeyResourcePath =
-            config.rawImpressionMetadataStorageConnection.privateKeyFilePath
-        }
-        // Forward the bin-packing threshold onto the memoized Phase-0 path so the Phase-1 ranker's
-        // last-job-out fan-out bin-packs identically to the non-memoized dispatcher. REQUIRED on
-        // SubpoolAssignerParams; SubpoolAssignerApp validates it > 0.
-        maxFileBatchSizeBytes = config.maxFileBatchSizeBytes
       }
     }
   }

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/vidlabeling/VidLabelingFunctionHelpers.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/vidlabeling/VidLabelingFunctionHelpers.kt
@@ -1,0 +1,237 @@
+/*
+ * Copyright 2026 The Cross-Media Measurement Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wfanet.measurement.edpaggregator.deploy.gcloud.vidlabeling
+
+import io.grpc.Channel
+import io.grpc.ClientInterceptors
+import io.grpc.ManagedChannel
+import io.opentelemetry.instrumentation.grpc.v1_6.GrpcTelemetry
+import java.io.File
+import java.time.Duration
+import java.util.concurrent.ConcurrentHashMap
+import java.util.logging.Logger
+import org.wfanet.measurement.common.crypto.SigningCerts
+import org.wfanet.measurement.common.grpc.buildMutualTlsChannel
+import org.wfanet.measurement.common.grpc.withShutdownTimeout
+import org.wfanet.measurement.config.edpaggregator.TransportLayerSecurityParams as ConfigTransportLayerSecurityParams
+import org.wfanet.measurement.config.edpaggregator.VidLabelingConfig
+import org.wfanet.measurement.edpaggregator.v1alpha.SubpoolAssignerParams
+import org.wfanet.measurement.edpaggregator.v1alpha.SubpoolAssignerParamsKt
+import org.wfanet.measurement.edpaggregator.v1alpha.VidLabelerParams
+import org.wfanet.measurement.edpaggregator.v1alpha.VidLabelerParamsKt
+import org.wfanet.measurement.edpaggregator.v1alpha.subpoolAssignerParams
+import org.wfanet.measurement.edpaggregator.v1alpha.transportLayerSecurityParams
+import org.wfanet.measurement.edpaggregator.v1alpha.vidLabelerParams
+
+/** Channel cache key using TLS params, target, and optional hostname override. */
+data class ChannelKey(
+  val tls: ConfigTransportLayerSecurityParams,
+  val target: String,
+  val hostName: String?,
+)
+
+/**
+ * Shared helpers for the VID labeling Cloud Functions.
+ *
+ * Holds the gRPC channel cache and the [VidLabelerParams]/[SubpoolAssignerParams] template builders
+ * used identically by [VidLabelingDispatcherFunction] and [VidLabelingMonitorFunction].
+ */
+object VidLabelingFunctionHelpers {
+  private val logger: Logger = Logger.getLogger(this::class.java.name)
+  private const val DEFAULT_CHANNEL_SHUTDOWN_DURATION_SECONDS: Long = 3L
+  private val channelShutdownDuration =
+    Duration.ofSeconds(
+      System.getenv("CHANNEL_SHUTDOWN_DURATION_SECONDS")?.toLong()
+        ?: DEFAULT_CHANNEL_SHUTDOWN_DURATION_SECONDS
+    )
+
+  private val channelCache = ConcurrentHashMap<ChannelKey, ManagedChannel>()
+
+  private fun createPublicChannel(
+    connectionParams: ConfigTransportLayerSecurityParams,
+    target: String,
+    hostName: String?,
+  ): ManagedChannel {
+    val signingCerts =
+      SigningCerts.fromPemFiles(
+        certificateFile = checkNotNull(File(connectionParams.certFilePath)),
+        privateKeyFile = checkNotNull(File(connectionParams.privateKeyFilePath)),
+        trustedCertCollectionFile = checkNotNull(File(connectionParams.certCollectionFilePath)),
+      )
+    return buildMutualTlsChannel(target, signingCerts, hostName)
+      .withShutdownTimeout(channelShutdownDuration)
+  }
+
+  private fun getOrCreateChannel(
+    connectionParams: ConfigTransportLayerSecurityParams,
+    target: String,
+    hostName: String?,
+  ): ManagedChannel {
+    val channelKey = ChannelKey(connectionParams, target, hostName)
+    return channelCache.computeIfAbsent(channelKey) {
+      logger.info("Creating new channel for $target")
+      createPublicChannel(connectionParams, target, hostName)
+    }
+  }
+
+  fun createInstrumentedChannel(
+    connectionParams: ConfigTransportLayerSecurityParams,
+    target: String,
+    hostName: String?,
+    grpcTelemetry: GrpcTelemetry,
+  ): Channel {
+    val channel = getOrCreateChannel(connectionParams, target, hostName)
+    return ClientInterceptors.intercept(channel, grpcTelemetry.newClientInterceptor())
+  }
+
+  fun convertModelLineConfigs(
+    configModelLines: Map<String, VidLabelingConfig.ModelLineConfig>
+  ): Map<String, VidLabelerParams.ModelLineConfig> {
+    return configModelLines.mapValues { (_, configModelLine) ->
+      VidLabelerParamsKt.modelLineConfig {
+        labelerInputFieldMapping.addAll(configModelLine.labelerInputFieldMappingList)
+        eventTemplateFieldMapping.putAll(configModelLine.eventTemplateFieldMappingMap)
+        eventTemplateDescriptorBlobUri = configModelLine.eventTemplateDescriptorBlobUri
+        eventTemplateType = configModelLine.eventTemplateType
+        requiredEntityKeyFieldMapping.putAll(configModelLine.requiredEntityKeyFieldMappingMap)
+        optionalEntityKeyFieldMapping.putAll(configModelLine.optionalEntityKeyFieldMappingMap)
+      }
+    }
+  }
+
+  fun buildVidLabelerParamsTemplate(config: VidLabelingConfig): VidLabelerParams {
+    require(config.rawImpressionsStorageParams.hasGcs()) {
+      "VidLabelingConfig raw_impressions_storage_params must use GCS"
+    }
+    require(config.vidLabeledImpressionsStorageParams.hasGcs()) {
+      "VidLabelingConfig vid_labeled_impressions_storage_params must use GCS"
+    }
+    require(config.edpImpressionPath.isNotEmpty()) {
+      "VidLabelingConfig.edp_impression_path is required"
+    }
+
+    return vidLabelerParams {
+      dataProvider = config.dataProvider
+      vidLabeledImpressionsStorageParams =
+        VidLabelerParamsKt.storageParams {
+          gcsProjectId = config.vidLabeledImpressionsStorageParams.gcs.projectId
+          // Per-EDP folder segment so each EDP's labeled output lives under its own
+          // folder: gs://<bucket>/<edp_impression_path>/model-line/<id>/<date>/. Required,
+          // and must match this EDP's DataAvailabilitySyncConfig edp_impression_path so the
+          // writer and the registrar agree on the location.
+          impressionsBlobPrefix =
+            "gs://${config.vidLabeledImpressionsStorageParams.gcs.bucketName}" +
+              "/${config.edpImpressionPath}"
+        }
+      rawImpressionsStorageParams =
+        VidLabelerParamsKt.storageParams {
+          gcsProjectId = config.rawImpressionsStorageParams.gcs.projectId
+          impressionsBlobPrefix = "gs://${config.rawImpressionsStorageParams.gcs.bucketName}"
+        }
+      vidRepoConnection = transportLayerSecurityParams {
+        clientCertResourcePath = config.vidRepoConnection.certFilePath
+        clientPrivateKeyResourcePath = config.vidRepoConnection.privateKeyFilePath
+      }
+      // The compiled model lives in its own Cloud Storage project. Optional on VidLabelingConfig
+      // (only EDPs that actually label need it); when set, thread it onto every WorkItem so the
+      // TEE reads the model from its own project on both the memoized and non-memoized paths.
+      if (config.modelStorageParams.hasGcs()) {
+        modelStorageParams =
+          VidLabelerParamsKt.storageParams {
+            gcsProjectId = config.modelStorageParams.gcs.projectId
+            impressionsBlobPrefix = "gs://${config.modelStorageParams.gcs.bucketName}"
+          }
+      }
+    }
+  }
+
+  /**
+   * Builds the template [SubpoolAssignerParams] carrying the storage + connection fields shared by
+   * every memoized Phase-0 WorkItem. The per-shard fields (model line, shard index, active window,
+   * pool assignment job) are filled in by the sequencer.
+   */
+  fun buildSubpoolAssignerParamsTemplate(config: VidLabelingConfig): SubpoolAssignerParams {
+    require(config.rawImpressionsStorageParams.hasGcs()) {
+      "VidLabelingConfig raw_impressions_storage_params must use GCS"
+    }
+    require(config.vidLabeledImpressionsStorageParams.hasGcs()) {
+      "VidLabelingConfig vid_labeled_impressions_storage_params must use GCS"
+    }
+    // vid_rank_map/subpool_map storage are consumed only by the memoized Phase-0 path and are
+    // therefore optional in VidLabelingConfig; validate them only when set. An EDP whose model
+    // lines are all non-memoized may omit them, and this template is then never consumed.
+    if (config.hasVidRankMapStorageParams()) {
+      require(config.vidRankMapStorageParams.hasGcs()) {
+        "VidLabelingConfig vid_rank_map_storage_params must use GCS"
+      }
+    }
+    if (config.hasSubpoolMapStorageParams()) {
+      require(config.subpoolMapStorageParams.hasGcs()) {
+        "VidLabelingConfig subpool_map_storage_params must use GCS"
+      }
+    }
+    if (config.hasModelStorageParams()) {
+      require(config.modelStorageParams.hasGcs()) {
+        "VidLabelingConfig model_storage_params must use GCS"
+      }
+    }
+
+    return subpoolAssignerParams {
+      dataProvider = config.dataProvider
+      rawImpressionStorageParams =
+        SubpoolAssignerParamsKt.storageParams {
+          gcsProjectId = config.rawImpressionsStorageParams.gcs.projectId
+          blobPrefix = "gs://${config.rawImpressionsStorageParams.gcs.bucketName}"
+        }
+      vidLabeledImpressionsStorageParams =
+        SubpoolAssignerParamsKt.storageParams {
+          gcsProjectId = config.vidLabeledImpressionsStorageParams.gcs.projectId
+          blobPrefix = "gs://${config.vidLabeledImpressionsStorageParams.gcs.bucketName}"
+        }
+      if (config.hasVidRankMapStorageParams()) {
+        vidRankMapStorageParams =
+          SubpoolAssignerParamsKt.storageParams {
+            gcsProjectId = config.vidRankMapStorageParams.gcs.projectId
+            blobPrefix = "gs://${config.vidRankMapStorageParams.gcs.bucketName}"
+          }
+      }
+      if (config.hasSubpoolMapStorageParams()) {
+        subpoolMapStorageParams =
+          SubpoolAssignerParamsKt.storageParams {
+            gcsProjectId = config.subpoolMapStorageParams.gcs.projectId
+            blobPrefix = "gs://${config.subpoolMapStorageParams.gcs.bucketName}"
+          }
+      }
+      if (config.hasModelStorageParams()) {
+        modelStorageParams =
+          SubpoolAssignerParamsKt.storageParams {
+            gcsProjectId = config.modelStorageParams.gcs.projectId
+            blobPrefix = "gs://${config.modelStorageParams.gcs.bucketName}"
+          }
+      }
+      rawImpressionMetadataStorageConnection = transportLayerSecurityParams {
+        clientCertResourcePath = config.rawImpressionMetadataStorageConnection.certFilePath
+        clientPrivateKeyResourcePath =
+          config.rawImpressionMetadataStorageConnection.privateKeyFilePath
+      }
+      // Forward the bin-packing threshold onto the memoized Phase-0 path so the Phase-1 ranker's
+      // last-job-out fan-out bin-packs identically to the non-memoized dispatcher. REQUIRED on
+      // SubpoolAssignerParams; SubpoolAssignerApp validates it > 0.
+      maxFileBatchSizeBytes = config.maxFileBatchSizeBytes
+    }
+  }
+}

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/vidlabeling/VidLabelingMonitorFunction.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/vidlabeling/VidLabelingMonitorFunction.kt
@@ -345,6 +345,7 @@ class VidLabelingMonitorFunction : HttpFunction {
         VidLabelingConfigs.getDefaultInstance(),
       )
     }
+
     /** Builds a bucket-rooted [StorageClient] for the data-quality crawl. */
     private fun createStorageClient(bucketName: String, projectId: String): StorageClient {
       return GcsStorageClient(
@@ -359,6 +360,5 @@ class VidLabelingMonitorFunction : HttpFunction {
         bucketName,
       )
     }
-
   }
 }

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/vidlabeling/VidLabelingMonitorFunction.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/vidlabeling/VidLabelingMonitorFunction.kt
@@ -435,14 +435,22 @@ class VidLabelingMonitorFunction : HttpFunction {
       require(config.vidLabeledImpressionsStorageParams.hasGcs()) {
         "VidLabelingConfig vid_labeled_impressions_storage_params must use GCS"
       }
+      require(config.edpImpressionPath.isNotEmpty()) {
+        "VidLabelingConfig.edp_impression_path is required"
+      }
 
       return vidLabelerParams {
         dataProvider = config.dataProvider
         vidLabeledImpressionsStorageParams =
           VidLabelerParamsKt.storageParams {
             gcsProjectId = config.vidLabeledImpressionsStorageParams.gcs.projectId
+            // Per-EDP folder segment so each EDP's labeled output lives under its own
+            // folder: gs://<bucket>/<edp_impression_path>/model-line/<id>/<date>/. Required,
+            // and must match this EDP's DataAvailabilitySyncConfig edp_impression_path so the
+            // writer and the registrar agree on the location.
             impressionsBlobPrefix =
-              "gs://${config.vidLabeledImpressionsStorageParams.gcs.bucketName}"
+              "gs://${config.vidLabeledImpressionsStorageParams.gcs.bucketName}" +
+                "/${config.edpImpressionPath}"
           }
         rawImpressionsStorageParams =
           VidLabelerParamsKt.storageParams {

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/vidlabeling/VidLabelingMonitorFunction.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/vidlabeling/VidLabelingMonitorFunction.kt
@@ -20,13 +20,7 @@ import com.google.cloud.functions.HttpFunction
 import com.google.cloud.functions.HttpRequest
 import com.google.cloud.functions.HttpResponse
 import com.google.cloud.storage.StorageOptions
-import io.grpc.Channel
-import io.grpc.ClientInterceptors
-import io.grpc.ManagedChannel
 import io.opentelemetry.instrumentation.grpc.v1_6.GrpcTelemetry
-import java.io.File
-import java.time.Duration
-import java.util.concurrent.ConcurrentHashMap
 import java.util.logging.Level
 import java.util.logging.Logger
 import kotlinx.coroutines.runBlocking
@@ -35,12 +29,8 @@ import org.wfanet.measurement.api.v2alpha.ModelRolloutsGrpcKt
 import org.wfanet.measurement.api.v2alpha.ModelShardsGrpcKt
 import org.wfanet.measurement.common.EnvVars
 import org.wfanet.measurement.common.Instrumentation
-import org.wfanet.measurement.common.crypto.SigningCerts
 import org.wfanet.measurement.common.edpaggregator.EdpAggregatorConfig
-import org.wfanet.measurement.common.grpc.buildMutualTlsChannel
-import org.wfanet.measurement.common.grpc.withShutdownTimeout
 import org.wfanet.measurement.common.toDuration
-import org.wfanet.measurement.config.edpaggregator.TransportLayerSecurityParams as ConfigTransportLayerSecurityParams
 import org.wfanet.measurement.config.edpaggregator.VidLabelingConfig
 import org.wfanet.measurement.config.edpaggregator.VidLabelingConfigs
 import org.wfanet.measurement.edpaggregator.telemetry.EdpaTelemetry
@@ -49,26 +39,12 @@ import org.wfanet.measurement.edpaggregator.v1alpha.RankerJobServiceGrpcKt
 import org.wfanet.measurement.edpaggregator.v1alpha.RawImpressionUploadFileServiceGrpcKt
 import org.wfanet.measurement.edpaggregator.v1alpha.RawImpressionUploadModelLineServiceGrpcKt
 import org.wfanet.measurement.edpaggregator.v1alpha.RawImpressionUploadServiceGrpcKt
-import org.wfanet.measurement.edpaggregator.v1alpha.SubpoolAssignerParams
-import org.wfanet.measurement.edpaggregator.v1alpha.SubpoolAssignerParamsKt
-import org.wfanet.measurement.edpaggregator.v1alpha.VidLabelerParams
-import org.wfanet.measurement.edpaggregator.v1alpha.VidLabelerParamsKt
 import org.wfanet.measurement.edpaggregator.v1alpha.VidLabelingJobServiceGrpcKt
-import org.wfanet.measurement.edpaggregator.v1alpha.subpoolAssignerParams
-import org.wfanet.measurement.edpaggregator.v1alpha.transportLayerSecurityParams
-import org.wfanet.measurement.edpaggregator.v1alpha.vidLabelerParams
 import org.wfanet.measurement.edpaggregator.vidlabeling.VidLabelingDispatchSequencer
 import org.wfanet.measurement.edpaggregator.vidlabeling.VidLabelingMonitor
 import org.wfanet.measurement.gcloud.gcs.GcsStorageClient
 import org.wfanet.measurement.securecomputation.controlplane.v1alpha.WorkItemsGrpcKt
 import org.wfanet.measurement.storage.StorageClient
-
-/** Channel cache key using TLS params, target, and optional hostname override. */
-private data class ChannelKey(
-  val tls: ConfigTransportLayerSecurityParams,
-  val target: String,
-  val hostName: String?,
-)
 
 /**
  * Cloud Function that drives VID labeling dispatch sequencing and monitors pipeline health.
@@ -205,7 +181,7 @@ class VidLabelingMonitorFunction : HttpFunction {
 
     val workItemsStub =
       WorkItemsGrpcKt.WorkItemsCoroutineStub(
-        createInstrumentedChannel(
+        VidLabelingFunctionHelpers.createInstrumentedChannel(
           config.controlPlaneConnection,
           controlPlaneTarget,
           controlPlaneCertHost,
@@ -215,7 +191,7 @@ class VidLabelingMonitorFunction : HttpFunction {
 
     val modelRolloutsStub =
       ModelRolloutsGrpcKt.ModelRolloutsCoroutineStub(
-        createInstrumentedChannel(
+        VidLabelingFunctionHelpers.createInstrumentedChannel(
           config.modelRolloutsConnection,
           modelRolloutsTarget,
           modelRolloutsCertHost,
@@ -225,7 +201,7 @@ class VidLabelingMonitorFunction : HttpFunction {
 
     val modelShardsStub =
       ModelShardsGrpcKt.ModelShardsCoroutineStub(
-        createInstrumentedChannel(
+        VidLabelingFunctionHelpers.createInstrumentedChannel(
           config.modelShardsConnection,
           modelShardsTarget,
           modelShardsCertHost,
@@ -235,7 +211,7 @@ class VidLabelingMonitorFunction : HttpFunction {
 
     val modelLinesStub =
       ModelLinesGrpcKt.ModelLinesCoroutineStub(
-        createInstrumentedChannel(
+        VidLabelingFunctionHelpers.createInstrumentedChannel(
           config.modelLinesConnection,
           modelLinesTarget,
           modelLinesCertHost,
@@ -244,7 +220,7 @@ class VidLabelingMonitorFunction : HttpFunction {
       )
 
     val rawImpressionUploadChannel =
-      createInstrumentedChannel(
+      VidLabelingFunctionHelpers.createInstrumentedChannel(
         config.rawImpressionMetadataStorageConnection,
         rawImpressionUploadTarget,
         rawImpressionUploadCertHost,
@@ -283,12 +259,14 @@ class VidLabelingMonitorFunction : HttpFunction {
         modelShardsStub = modelShardsStub,
         modelLinesStub = modelLinesStub,
         dataProviderName = config.dataProvider,
-        vidLabelerParamsTemplate = buildVidLabelerParamsTemplate(config),
-        subpoolAssignerParamsTemplate = buildSubpoolAssignerParamsTemplate(config),
+        vidLabelerParamsTemplate = VidLabelingFunctionHelpers.buildVidLabelerParamsTemplate(config),
+        subpoolAssignerParamsTemplate =
+          VidLabelingFunctionHelpers.buildSubpoolAssignerParamsTemplate(config),
         queueName = vidLabelerQueueName,
         poolAssignerQueueName = poolAssignerQueueName,
         numberOfShards = config.numberOfShards,
-        modelLineConfigs = convertModelLineConfigs(config.modelLineConfigsMap),
+        modelLineConfigs =
+          VidLabelingFunctionHelpers.convertModelLineConfigs(config.modelLineConfigsMap),
         rawImpressionUploadFileStub = rawImpressionUploadFileStub,
         vidLabelingJobStub = vidLabelingJobStub,
         maxFileBatchSizeBytes = config.maxFileBatchSizeBytes,
@@ -333,7 +311,6 @@ class VidLabelingMonitorFunction : HttpFunction {
 
   companion object {
     private val logger: Logger = Logger.getLogger(this::class.java.name)
-    private const val DEFAULT_CHANNEL_SHUTDOWN_DURATION_SECONDS: Long = 3L
 
     private val controlPlaneTarget: String = EnvVars.checkNotNullOrEmpty("CONTROL_PLANE_TARGET")
     private val controlPlaneCertHost: String? = System.getenv("CONTROL_PLANE_CERT_HOST")
@@ -353,11 +330,6 @@ class VidLabelingMonitorFunction : HttpFunction {
     private val vidLabelerQueueName: String = EnvVars.checkNotNullOrEmpty("VID_LABELER_QUEUE_NAME")
     private val poolAssignerQueueName: String =
       EnvVars.checkNotNullOrEmpty("POOL_ASSIGNER_QUEUE_NAME")
-    private val channelShutdownDuration =
-      Duration.ofSeconds(
-        System.getenv("CHANNEL_SHUTDOWN_DURATION_SECONDS")?.toLong()
-          ?: DEFAULT_CHANNEL_SHUTDOWN_DURATION_SECONDS
-      )
 
     private val configBlobKey: String = EnvVars.checkNotNullOrEmpty("CONFIG_BLOB_KEY")
 
@@ -373,46 +345,6 @@ class VidLabelingMonitorFunction : HttpFunction {
         VidLabelingConfigs.getDefaultInstance(),
       )
     }
-
-    private val channelCache = ConcurrentHashMap<ChannelKey, ManagedChannel>()
-
-    private fun createPublicChannel(
-      connectionParams: ConfigTransportLayerSecurityParams,
-      target: String,
-      hostName: String?,
-    ): ManagedChannel {
-      val signingCerts =
-        SigningCerts.fromPemFiles(
-          certificateFile = checkNotNull(File(connectionParams.certFilePath)),
-          privateKeyFile = checkNotNull(File(connectionParams.privateKeyFilePath)),
-          trustedCertCollectionFile = checkNotNull(File(connectionParams.certCollectionFilePath)),
-        )
-      return buildMutualTlsChannel(target, signingCerts, hostName)
-        .withShutdownTimeout(channelShutdownDuration)
-    }
-
-    private fun getOrCreateChannel(
-      connectionParams: ConfigTransportLayerSecurityParams,
-      target: String,
-      hostName: String?,
-    ): ManagedChannel {
-      val channelKey = ChannelKey(connectionParams, target, hostName)
-      return channelCache.computeIfAbsent(channelKey) {
-        logger.info("Creating new channel for $target")
-        createPublicChannel(connectionParams, target, hostName)
-      }
-    }
-
-    private fun createInstrumentedChannel(
-      connectionParams: ConfigTransportLayerSecurityParams,
-      target: String,
-      hostName: String?,
-      grpcTelemetry: GrpcTelemetry,
-    ): Channel {
-      val channel = getOrCreateChannel(connectionParams, target, hostName)
-      return ClientInterceptors.intercept(channel, grpcTelemetry.newClientInterceptor())
-    }
-
     /** Builds a bucket-rooted [StorageClient] for the data-quality crawl. */
     private fun createStorageClient(bucketName: String, projectId: String): StorageClient {
       return GcsStorageClient(
@@ -428,147 +360,5 @@ class VidLabelingMonitorFunction : HttpFunction {
       )
     }
 
-    private fun buildVidLabelerParamsTemplate(config: VidLabelingConfig): VidLabelerParams {
-      require(config.rawImpressionsStorageParams.hasGcs()) {
-        "VidLabelingConfig raw_impressions_storage_params must use GCS"
-      }
-      require(config.vidLabeledImpressionsStorageParams.hasGcs()) {
-        "VidLabelingConfig vid_labeled_impressions_storage_params must use GCS"
-      }
-      require(config.edpImpressionPath.isNotEmpty()) {
-        "VidLabelingConfig.edp_impression_path is required"
-      }
-
-      return vidLabelerParams {
-        dataProvider = config.dataProvider
-        vidLabeledImpressionsStorageParams =
-          VidLabelerParamsKt.storageParams {
-            gcsProjectId = config.vidLabeledImpressionsStorageParams.gcs.projectId
-            // Per-EDP folder segment so each EDP's labeled output lives under its own
-            // folder: gs://<bucket>/<edp_impression_path>/model-line/<id>/<date>/. Required,
-            // and must match this EDP's DataAvailabilitySyncConfig edp_impression_path so the
-            // writer and the registrar agree on the location.
-            impressionsBlobPrefix =
-              "gs://${config.vidLabeledImpressionsStorageParams.gcs.bucketName}" +
-                "/${config.edpImpressionPath}"
-          }
-        rawImpressionsStorageParams =
-          VidLabelerParamsKt.storageParams {
-            gcsProjectId = config.rawImpressionsStorageParams.gcs.projectId
-            impressionsBlobPrefix = "gs://${config.rawImpressionsStorageParams.gcs.bucketName}"
-          }
-        vidRepoConnection = transportLayerSecurityParams {
-          clientCertResourcePath = config.vidRepoConnection.certFilePath
-          clientPrivateKeyResourcePath = config.vidRepoConnection.privateKeyFilePath
-        }
-        // The compiled model lives in its own Cloud Storage project. Optional on VidLabelingConfig
-        // (only EDPs that actually label need it); when set, thread it onto every WorkItem so the
-        // TEE reads the model from its own project on both the memoized and non-memoized paths.
-        if (config.modelStorageParams.hasGcs()) {
-          modelStorageParams =
-            VidLabelerParamsKt.storageParams {
-              gcsProjectId = config.modelStorageParams.gcs.projectId
-              impressionsBlobPrefix = "gs://${config.modelStorageParams.gcs.bucketName}"
-            }
-        }
-      }
-    }
-
-    // TODO(world-federation-of-advertisers/cross-media-measurement#4020): De-duplicate this
-    // template builder (with buildVidLabelerParamsTemplate and convertModelLineConfigs) into a
-    // shared helper once the helper-extraction thread on #4020 (this branch's parent) is
-    // addressed, rather than copying it across the dispatcher and monitor Function classes.
-    /**
-     * Builds the template [SubpoolAssignerParams] carrying the storage + connection fields shared
-     * by every memoized Phase-0 WorkItem. The per-shard fields (model line, shard index, active
-     * window, pool assignment job) are filled in by the sequencer.
-     */
-    private fun buildSubpoolAssignerParamsTemplate(
-      config: VidLabelingConfig
-    ): SubpoolAssignerParams {
-      require(config.rawImpressionsStorageParams.hasGcs()) {
-        "VidLabelingConfig raw_impressions_storage_params must use GCS"
-      }
-      require(config.vidLabeledImpressionsStorageParams.hasGcs()) {
-        "VidLabelingConfig vid_labeled_impressions_storage_params must use GCS"
-      }
-      // vid_rank_map/subpool_map storage are consumed only by the memoized Phase-0 path and are
-      // therefore optional in VidLabelingConfig; validate them only when set. An EDP whose model
-      // lines are all non-memoized may omit them, and this template is then never consumed.
-      if (config.hasVidRankMapStorageParams()) {
-        require(config.vidRankMapStorageParams.hasGcs()) {
-          "VidLabelingConfig vid_rank_map_storage_params must use GCS"
-        }
-      }
-      if (config.hasSubpoolMapStorageParams()) {
-        require(config.subpoolMapStorageParams.hasGcs()) {
-          "VidLabelingConfig subpool_map_storage_params must use GCS"
-        }
-      }
-      if (config.hasModelStorageParams()) {
-        require(config.modelStorageParams.hasGcs()) {
-          "VidLabelingConfig model_storage_params must use GCS"
-        }
-      }
-
-      return subpoolAssignerParams {
-        dataProvider = config.dataProvider
-        rawImpressionStorageParams =
-          SubpoolAssignerParamsKt.storageParams {
-            gcsProjectId = config.rawImpressionsStorageParams.gcs.projectId
-            blobPrefix = "gs://${config.rawImpressionsStorageParams.gcs.bucketName}"
-          }
-        vidLabeledImpressionsStorageParams =
-          SubpoolAssignerParamsKt.storageParams {
-            gcsProjectId = config.vidLabeledImpressionsStorageParams.gcs.projectId
-            blobPrefix = "gs://${config.vidLabeledImpressionsStorageParams.gcs.bucketName}"
-          }
-        if (config.hasVidRankMapStorageParams()) {
-          vidRankMapStorageParams =
-            SubpoolAssignerParamsKt.storageParams {
-              gcsProjectId = config.vidRankMapStorageParams.gcs.projectId
-              blobPrefix = "gs://${config.vidRankMapStorageParams.gcs.bucketName}"
-            }
-        }
-        if (config.hasSubpoolMapStorageParams()) {
-          subpoolMapStorageParams =
-            SubpoolAssignerParamsKt.storageParams {
-              gcsProjectId = config.subpoolMapStorageParams.gcs.projectId
-              blobPrefix = "gs://${config.subpoolMapStorageParams.gcs.bucketName}"
-            }
-        }
-        if (config.hasModelStorageParams()) {
-          modelStorageParams =
-            SubpoolAssignerParamsKt.storageParams {
-              gcsProjectId = config.modelStorageParams.gcs.projectId
-              blobPrefix = "gs://${config.modelStorageParams.gcs.bucketName}"
-            }
-        }
-        rawImpressionMetadataStorageConnection = transportLayerSecurityParams {
-          clientCertResourcePath = config.rawImpressionMetadataStorageConnection.certFilePath
-          clientPrivateKeyResourcePath =
-            config.rawImpressionMetadataStorageConnection.privateKeyFilePath
-        }
-        // Forward the bin-packing threshold onto the memoized Phase-0 path so the Phase-1 ranker's
-        // last-job-out fan-out bin-packs identically to the non-memoized dispatcher. REQUIRED on
-        // SubpoolAssignerParams; SubpoolAssignerApp validates it > 0.
-        maxFileBatchSizeBytes = config.maxFileBatchSizeBytes
-      }
-    }
-
-    private fun convertModelLineConfigs(
-      configModelLines: Map<String, VidLabelingConfig.ModelLineConfig>
-    ): Map<String, VidLabelerParams.ModelLineConfig> {
-      return configModelLines.mapValues { (_, configModelLine) ->
-        VidLabelerParamsKt.modelLineConfig {
-          labelerInputFieldMapping.addAll(configModelLine.labelerInputFieldMappingList)
-          eventTemplateFieldMapping.putAll(configModelLine.eventTemplateFieldMappingMap)
-          eventTemplateDescriptorBlobUri = configModelLine.eventTemplateDescriptorBlobUri
-          eventTemplateType = configModelLine.eventTemplateType
-          requiredEntityKeyFieldMapping.putAll(configModelLine.requiredEntityKeyFieldMappingMap)
-          optionalEntityKeyFieldMapping.putAll(configModelLine.optionalEntityKeyFieldMappingMap)
-        }
-      }
-    }
   }
 }

--- a/src/main/proto/wfa/measurement/config/edpaggregator/vid_labeling_config.proto
+++ b/src/main/proto/wfa/measurement/config/edpaggregator/vid_labeling_config.proto
@@ -171,6 +171,15 @@ message VidLabelingConfig {
   // here like the memoized-only storage params above; the dispatcher enforces
   // it (`> 0`) at the first non-memoized dispatch.
   int64 max_file_batch_size_bytes = 17 [(google.api.field_behavior) = OPTIONAL];
+
+  // Per-EDP folder segment for this EDP's VID-labeled impression output, placed
+  // between the storage bucket and the `model-line/<id>/<date>/` layout so each
+  // EDP writes to its own folder (e.g. `gs://<bucket>/<edp_impression_path>/
+  // model-line/...`). Keeps multiple EDPs that label the same model line in the
+  // same bucket from colliding in one folder. REQUIRED, and must match the
+  // `edp_impression_path` in this EDP's `DataAvailabilitySyncConfig` so the writer
+  // and the registrar agree on the location.
+  string edp_impression_path = 18 [(google.api.field_behavior) = REQUIRED];
 }
 
 // Wrapper containing VID Labeling configurations for all EDPs.

--- a/src/main/proto/wfa/measurement/config/edpaggregator/vid_labeling_config.proto
+++ b/src/main/proto/wfa/measurement/config/edpaggregator/vid_labeling_config.proto
@@ -177,8 +177,8 @@ message VidLabelingConfig {
   // EDP writes to its own folder (e.g. `gs://<bucket>/<edp_impression_path>/
   // model-line/...`). Keeps multiple EDPs that label the same model line in the
   // same bucket from colliding in one folder. REQUIRED, and must match the
-  // `edp_impression_path` in this EDP's `DataAvailabilitySyncConfig` so the writer
-  // and the registrar agree on the location.
+  // `edp_impression_path` in this EDP's `DataAvailabilitySyncConfig` so the
+  // writer and the registrar agree on the location.
   string edp_impression_path = 18 [(google.api.field_behavior) = REQUIRED];
 }
 

--- a/src/test/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/vidlabeling/VidLabelingDispatcherFunctionTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/vidlabeling/VidLabelingDispatcherFunctionTest.kt
@@ -324,6 +324,7 @@ class VidLabelingDispatcherFunctionTest {
 
   private fun fileSystemVidLabelingConfig() = vidLabelingConfig {
     dataProvider = DATA_PROVIDER
+    edpImpressionPath = "edp7"
     rawImpressionsStorageParams = storageParams {
       gcs = gcsStorage {
         projectId = "test-project"


### PR DESCRIPTION
## What
  Two related changes to the VID labeling Cloud Functions:
  
  1. **Per-EDP labeled-impression output** — add a required `edp_impression_path`
     (field 18) to `VidLabelingConfig` and use it in both `VidLabelingDispatcherFunction`
     and `VidLabelingMonitorFunction` to build the labeled-impression output prefix as
     `gs://<bucket>/<edp_impression_path>`, so each EDP's VID-labeled impressions live
     under their own folder.
  2. **De-duplicate the Cloud Function glue (#4027)** — extract the six byte-identical
     private helpers shared by the two Functions into a single `VidLabelingFunctionSupport`
     object. 
     
  ## Why (1)
  Today the pipeline writes every EDP's labeled output to
  `<impressions_blob_prefix>/model-line/<modelLineId>/<date>/`, where
  `impressions_blob_prefix` is derived only from
  `vid_labeled_impressions_storage_params.gcs.bucket_name`. With no per-EDP segment, two
  EDPs that label the **same model line in the same bucket** land in the same
  `model-line/<id>/<date>/` folder — sharing even the `done` marker — and
  `DataAvailabilitySync` (which crawls `<edp_impression_path>/model-line/<id>/` and
  registers everything under a single `dataProvider`) mis-attributes them. The registrar
  side already has a per-EDP `edp_impression_path` on `DataAvailabilitySyncConfig`, but the
  writer side (`VidLabelingConfig`) had no matching field, so the two could never agree on
  a per-EDP location.
  
  ## How (1)
  - New **required** `VidLabelingConfig.edp_impression_path` (field 18); both Functions
    `require(config.edpImpressionPath.isNotEmpty())` and build
    `impressions_blob_prefix = "gs://<bucket>/" + edp_impression_path`.
  - The VidLabeler TEE app already writes at `<impressions_blob_prefix>/model-line/...`
    (it only ever sees the composed prefix, never the config field), so no TEE change is
    needed — threading the per-EDP segment through the prefix is sufficient.
    
  ## What/Why/How (2) — #4027
  `VidLabelingDispatcherFunction` and `VidLabelingMonitorFunction` duplicated ~150 lines of
  glue: `ChannelKey`, the channel cache, `createPublicChannel`, `getOrCreateChannel`,
  `createInstrumentedChannel`, `convertModelLineConfigs`, `buildVidLabelerParamsTemplate`,
  and `buildSubpoolAssignerParamsTemplate`. This PR moves them into one
  `VidLabelingFunctionSupport` object in the same package; both Functions delegate.
  `createStorageClient` stays dispatcher-specific. Behavior-preserving — the moved bodies
  are verbatim. Access is confined to `edpaggregator` subpackages via the package
  `default_visibility`, since Kotlin `internal` cannot cross Bazel module boundaries.
  
  ## Deployment (config, per env — set `edp_impression_path` consistently)
  - `VID_LABELING_DISPATCHER_CONFIG_CONTENT` + `VID_LABELING_MONITOR_CONFIG_CONTENT`: set
    the new `edp_impression_path` per EDP.
  - `DATA_AVAILABILITY_SYNC_CONFIG_CONTENT`: set the existing `edp_impression_path` per EDP
    to the same value.
  - `DATA_WATCHER_CONFIG_CONTENT`: point the `data-availability` watched paths at
    `^gs://<bucket>/<edp>/model-line/[^/]+/[^/]+/done$`.
    
  ## Testing
  `bazelisk build //src/main/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/vidlabeling/...`
  passes (proto regen + both Functions + the new shared object compile).

Issue: #4243 
Issue: #4027 