### PR TITLE
ci: align kingdom/duchy deploy config paths with renamed kustomization dirs

### DIFF
--- a/.github/workflows/configure-duchy.yml
+++ b/.github/workflows/configure-duchy.yml
@@ -177,7 +177,7 @@ jobs:
         AKID_TO_PRINCIPAL_MAP: ${{ vars.AKID_TO_PRINCIPAL_MAP }}
       run: >
         echo "$AKID_TO_PRINCIPAL_MAP" | sed $'s/\r$//'  >
-        "$KUSTOMIZATION_PATH/src/main/k8s/dev/config_files/authority_key_identifier_to_principal_map.textproto"
+        "$KUSTOMIZATION_PATH/src/main/k8s/dev/duchy_config_files/authority_key_identifier_to_principal_map.textproto"
 
     - name: Upload Kustomization artifact
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.github/workflows/configure-kingdom.yml
+++ b/.github/workflows/configure-kingdom.yml
@@ -140,13 +140,13 @@ jobs:
           AKID_TO_PRINCIPAL_MAP: ${{ vars.AKID_TO_PRINCIPAL_MAP }}
         run: >
           echo "$AKID_TO_PRINCIPAL_MAP" | sed $'s/\r$//'  >
-          "$KUSTOMIZATION_PATH/src/main/k8s/dev/config_files/authority_key_identifier_to_principal_map.textproto"
+          "$KUSTOMIZATION_PATH/src/main/k8s/dev/kingdom_config_files/authority_key_identifier_to_principal_map.textproto"
 
       - name: Copy rate limit config
         run: >
           cp
           src/main/k8s/testing/secretfiles/kingdom_rate_limit_config.textproto
-          "$KUSTOMIZATION_PATH/src/main/k8s/dev/config_files/rate_limit_config.textproto"
+          "$KUSTOMIZATION_PATH/src/main/k8s/dev/kingdom_config_files/rate_limit_config.textproto"
 
       # Run kubectl diff, treating the command as succeeded even if the exit
       # code is 1 as kubectl uses this code to indicate there's a diff.

--- a/.github/workflows/configure-population-fulfiller.yml
+++ b/.github/workflows/configure-population-fulfiller.yml
@@ -158,12 +158,6 @@ jobs:
           name: pdp-kustomization
           path: ${{ env.KUSTOMIZATION_PATH }}
 
-      - name: Copy rate limit config
-        run: >
-          cp
-          src/main/k8s/testing/secretfiles/kingdom_rate_limit_config.textproto
-          "$KUSTOMIZATION_PATH/src/main/k8s/dev/config_files/rate_limit_config.textproto"
-
       # Run kubectl diff, treating the command as succeeded even if the exit
       # code is 1 as kubectl uses this code to indicate there's a diff.
       - name: kubectl diff


### PR DESCRIPTION
# SUMMARY

#2469 renamed the dev config_files kustomization_dir to kingdom_config_files and added duchy_config_files. Update the kingdom and duchy configure workflows to write to the new paths, and drop the unused "Copy rate limit config" step from the population-fulfiller workflow (a client daemon that consumes no rate_limit_config).

Issue: #4293
Closes: #4293 