### PR TITLE
feat: write unlinked client accounts from EventGroupSync

### DIFF
--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/eventgroups/BUILD.bazel
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/eventgroups/BUILD.bazel
@@ -20,6 +20,7 @@ kt_jvm_library(
         "//src/main/kotlin/org/wfanet/measurement/edpaggregator/eventgroups:event_group_sync",
         "//src/main/kotlin/org/wfanet/measurement/edpaggregator/telemetry",
         "//src/main/proto/wfa/measurement/api/v2alpha:client_accounts_service_kt_jvm_grpc_proto",
+        "//src/main/proto/wfa/measurement/api/v2alpha:unlinked_client_accounts_service_kt_jvm_grpc_proto",
         "//src/main/proto/wfa/measurement/config/edpaggregator:event_group_sync_config_kt_jvm_proto",
         "//src/main/proto/wfa/measurement/config/edpaggregator:storage_params_kt_jvm_proto",
         "//src/main/proto/wfa/measurement/config/edpaggregator:transport_layer_security_params_kt_jvm_proto",

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/eventgroups/EventGroupSyncFunction.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/eventgroups/EventGroupSyncFunction.kt
@@ -36,6 +36,7 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.runBlocking
 import org.wfanet.measurement.api.v2alpha.ClientAccountsGrpcKt.ClientAccountsCoroutineStub
 import org.wfanet.measurement.api.v2alpha.EventGroupsGrpcKt.EventGroupsCoroutineStub
+import org.wfanet.measurement.api.v2alpha.UnlinkedClientAccountsGrpcKt.UnlinkedClientAccountsCoroutineStub
 import org.wfanet.measurement.common.EnvVars
 import org.wfanet.measurement.common.Instrumentation
 import org.wfanet.measurement.common.crypto.SigningCerts
@@ -84,6 +85,7 @@ class EventGroupSyncFunction() : HttpFunction {
             )
           val eventGroupsClient = EventGroupsCoroutineStub(kingdomChannel)
           val clientAccountsClient = ClientAccountsCoroutineStub(kingdomChannel)
+          val unlinkedClientAccountsClient = UnlinkedClientAccountsCoroutineStub(kingdomChannel)
           val eventGroups: Flow<EventGroup> =
             Tracing.traceSuspending(
               spanName = "load_event_groups",
@@ -113,6 +115,7 @@ class EventGroupSyncFunction() : HttpFunction {
                   edpName = eventGroupSyncConfig.dataProvider,
                   eventGroupsStub = eventGroupsClient,
                   clientAccountsStub = clientAccountsClient,
+                  unlinkedClientAccountsStub = unlinkedClientAccountsClient,
                   eventGroups = eventGroups,
                   throttler = MinimumIntervalThrottler(Clock.systemUTC(), throttlerDuration),
                   listEventGroupPageSize,

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/eventgroups/EventGroupSyncFunction.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/eventgroups/EventGroupSyncFunction.kt
@@ -318,13 +318,24 @@ class EventGroupSyncFunction() : HttpFunction {
       certHost: String?,
       shutdownTimeout: Duration,
     ): Channel {
+      val cmmsConnection = eventGroupSyncConfig.cmmsConnection
+      val certificateFile = File(cmmsConnection.certFilePath)
+      val privateKeyFile = File(cmmsConnection.privateKeyFilePath)
+      val trustedCertCollectionFile = File(cmmsConnection.certCollectionFilePath)
+      require(certificateFile.isFile) {
+        "cmms_connection.cert_file_path must point to an existing file"
+      }
+      require(privateKeyFile.isFile) {
+        "cmms_connection.private_key_file_path must point to an existing file"
+      }
+      require(trustedCertCollectionFile.isFile) {
+        "cmms_connection.cert_collection_file_path must point to an existing file"
+      }
       val signingCerts =
         SigningCerts.fromPemFiles(
-          certificateFile = checkNotNull(File(eventGroupSyncConfig.cmmsConnection.certFilePath)),
-          privateKeyFile =
-            checkNotNull(File(eventGroupSyncConfig.cmmsConnection.privateKeyFilePath)),
-          trustedCertCollectionFile =
-            checkNotNull(File(eventGroupSyncConfig.cmmsConnection.certCollectionFilePath)),
+          certificateFile = certificateFile,
+          privateKeyFile = privateKeyFile,
+          trustedCertCollectionFile = trustedCertCollectionFile,
         )
 
       val publicChannel =

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/eventgroups/EventGroupSyncFunction.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/eventgroups/EventGroupSyncFunction.kt
@@ -323,13 +323,13 @@ class EventGroupSyncFunction() : HttpFunction {
       val privateKeyFile = File(cmmsConnection.privateKeyFilePath)
       val trustedCertCollectionFile = File(cmmsConnection.certCollectionFilePath)
       require(certificateFile.isFile) {
-        "cmms_connection.cert_file_path must point to an existing file"
+        "cmms_connection.cert_file_path must point to an existing file: ${certificateFile.path}"
       }
       require(privateKeyFile.isFile) {
-        "cmms_connection.private_key_file_path must point to an existing file"
+        "cmms_connection.private_key_file_path must point to an existing file: ${privateKeyFile.path}"
       }
       require(trustedCertCollectionFile.isFile) {
-        "cmms_connection.cert_collection_file_path must point to an existing file"
+        "cmms_connection.cert_collection_file_path must point to an existing file: ${trustedCertCollectionFile.path}"
       }
       val signingCerts =
         SigningCerts.fromPemFiles(

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/eventgroups/BUILD.bazel
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/eventgroups/BUILD.bazel
@@ -22,6 +22,8 @@ kt_jvm_library(
         "//src/main/proto/wfa/measurement/api/v2alpha:event_group_metadata_kt_jvm_proto",
         "//src/main/proto/wfa/measurement/api/v2alpha:event_groups_service_kt_jvm_grpc_proto",
         "//src/main/proto/wfa/measurement/api/v2alpha:media_type_kt_jvm_proto",
+        "//src/main/proto/wfa/measurement/api/v2alpha:unlinked_client_account_kt_jvm_proto",
+        "//src/main/proto/wfa/measurement/api/v2alpha:unlinked_client_accounts_service_kt_jvm_grpc_proto",
         "//src/main/proto/wfa/measurement/edpaggregator/eventgroups/v1alpha:event_group_kt_jvm_proto",
         "//src/main/proto/wfa/measurement/edpaggregator/eventgroups/v1alpha:event_group_map_kt_jvm_proto",
         "@wfa_common_jvm//imports/java/com/google/protobuf",

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/eventgroups/EventGroupSync.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/eventgroups/EventGroupSync.kt
@@ -16,8 +16,7 @@
 
 package org.wfanet.measurement.edpaggregator.eventgroups
 
-import com.google.protobuf.struct
-import com.google.protobuf.value
+import com.google.protobuf.Struct
 import io.grpc.Status
 import io.grpc.StatusException
 import io.opentelemetry.api.GlobalOpenTelemetry
@@ -248,24 +247,29 @@ class EventGroupSync(
    * `client_account_reference_id`.
    *
    * An entry is recorded only when a `client_account_reference_id` lookup completes and resolves to
-   * zero MeasurementConsumers (the confirmed-empty result). Distinct brands are unioned across
-   * every EventGroup that carries the same reference ID, and one observed EventGroup (its
-   * `entity_key` when present, otherwise its `event_group_reference_id`) is retained for
-   * traceability. Reconciled once at the end of the run via [reconcileUnlinkedClientAccounts].
+   * zero MeasurementConsumers (the confirmed-empty result). Every EventGroup carrying the same
+   * reference ID is retained as an observed candidate; the winning `observed_event_group` and the
+   * `entity_metadata` that belongs to it are chosen at flush time via [buildUnlinkedClientAccount].
+   * Reconciled once at the end of the run via [reconcileUnlinkedClientAccounts].
    */
   private val unlinkedClientAccounts = mutableMapOf<String, UnlinkedClientAccountAccumulator>()
 
+  /** One observed EventGroup and the `entity_metadata` that belongs to it. */
+  private data class ObservedEventGroup(
+    val entityKey: EventGroup.EntityKey?,
+    val eventGroupReferenceId: String?,
+    val entityMetadata: Struct?,
+  )
+
   /**
-   * Mutable accumulator for the distinct brands and observed-EventGroup candidates of an unlinked
-   * account.
+   * Mutable accumulator for the observed-EventGroup candidates of an unlinked account.
    *
-   * Both candidate collections are gathered as-is; the winning `observed_event_group` is chosen at
-   * flush time so the result is independent of the order EventGroups were observed in.
+   * Candidates are gathered as-is; the winning `observed_event_group` (and the `entity_metadata`
+   * that belongs to it) is chosen at flush time so the result is independent of the order
+   * EventGroups were observed in.
    */
   private class UnlinkedClientAccountAccumulator {
-    val brands = mutableSetOf<String>()
-    val eventGroupReferenceIds = mutableSetOf<String>()
-    val entityKeys = mutableSetOf<EventGroup.EntityKey>()
+    val observed = mutableListOf<ObservedEventGroup>()
   }
 
   /** Creates metric attributes with data provider name. */
@@ -324,7 +328,6 @@ class EventGroupSync(
       // Collect the EDP EventGroups as a stream rather than materializing the full decoded list.
       var observedEventGroupCount = 0
       eventGroups.collect { eventGroup ->
-        observedEventGroupCount++
         if (eventGroup.state == EventGroup.State.DELETED) {
           // A delete acts on an entity-keyed EventGroup, and only needs to act as a barrier when a
           // queued create/update targets that same EventGroup: flushing first keeps the buffered
@@ -397,6 +400,10 @@ class EventGroupSync(
           return@collect
         }
 
+        // Count only EventGroups that reach measurement-consumer resolution; deletes and
+        // validation failures return above, so counting them would let a delete-only run pass
+        // the reconcile guard and wipe the stored set.
+        observedEventGroupCount++
         val measurementConsumerKeys: Set<MeasurementConsumerKey> =
           try {
             resolveMeasurementConsumers(eventGroup)
@@ -948,8 +955,10 @@ class EventGroupSync(
       // transient Kingdom outage propagates out of this function and never reaches here — an RPC
       // error can therefore never record an account as unlinked. An account that resolves to >=1
       // MC (non-empty `lookedUpKeys`) is linked and is not captured (the cross-MC reconcile
-      // guarantee); neither is an EventGroup already linked via a direct `measurement_consumer`
-      // (`measurementConsumerKeys` already holds it, added above before the lookup).
+      // guarantee). An EventGroup with a well-formed direct `measurement_consumer` is likewise
+      // not captured (`measurementConsumerKeys` already holds it, added above before the
+      // lookup); note a malformed direct `measurement_consumer` was ignored above, so such an
+      // EventGroup can still be recorded as unlinked.
       if (lookedUpKeys.isEmpty() && measurementConsumerKeys.isEmpty()) {
         recordUnlinkedClientAccount(eventGroup, refId)
       }
@@ -971,24 +980,28 @@ class EventGroupSync(
   /**
    * Accumulates an unlinked-client-account observation for [refId].
    *
-   * Unions the EventGroup's brand (from `event_group_metadata.ad_metadata.campaign_metadata.brand`)
-   * into the account's distinct-brand set and collects the EventGroup as an observed candidate: its
-   * `entity_key` when present, otherwise its `event_group_reference_id`. The winning candidate is
-   * deliberately not chosen here so the result stays independent of observation order; see
+   * Collects the EventGroup as an observed candidate: its `entity_key` when present, its
+   * `event_group_reference_id`, and its own `entity_metadata` (forwarded verbatim, per the
+   * `UnlinkedClientAccount.entity_metadata` contract). The winning candidate is deliberately not
+   * chosen here so the result stays independent of observation order; see
    * [buildUnlinkedClientAccount]. Called only from the confirmed-empty lookup branch in
    * [resolveMeasurementConsumers].
    */
   private fun recordUnlinkedClientAccount(eventGroup: EventGroup, refId: String) {
     val accumulator = unlinkedClientAccounts.getOrPut(refId) { UnlinkedClientAccountAccumulator() }
-    val brand = eventGroup.eventGroupMetadata.adMetadata.campaignMetadata.brand
-    if (brand.isNotBlank()) {
-      accumulator.brands.add(brand)
-    }
-    if (eventGroup.hasEntityKey() && eventGroup.entityKey.entityId.isNotBlank()) {
-      accumulator.entityKeys.add(eventGroup.entityKey)
-    } else if (eventGroup.eventGroupReferenceId.isNotBlank()) {
-      accumulator.eventGroupReferenceIds.add(eventGroup.eventGroupReferenceId)
-    }
+    val metadata = eventGroup.eventGroupMetadata
+    accumulator.observed.add(
+      ObservedEventGroup(
+        entityKey =
+          if (eventGroup.hasEntityKey() && eventGroup.entityKey.entityId.isNotBlank()) {
+            eventGroup.entityKey
+          } else {
+            null
+          },
+        eventGroupReferenceId = eventGroup.eventGroupReferenceId.ifBlank { null },
+        entityMetadata = if (metadata.hasEntityMetadata()) metadata.entityMetadata else null,
+      )
+    )
   }
 
   /**
@@ -999,6 +1012,11 @@ class EventGroupSync(
    * `BatchCreateUnlinkedClientAccounts` for newly-observed reference IDs and
    * `BatchDeleteUnlinkedClientAccounts` for stored reference IDs no longer observed. Reference IDs
    * present in both sets are left untouched, preserving their server-assigned `create_time`.
+   *
+   * The delete side assumes each run observes this DataProvider's complete EventGroup set: any
+   * stored reference ID not observed this run is treated as no longer unlinked and deleted. A run
+   * that observed zero EventGroups skips the reconcile entirely (guarded below), so a partial or
+   * transient-empty read never wipes the stored set.
    *
    * This is a secondary reconcile: every EventGroup has already synced above, so each RPC is
    * best-effort — a failure is logged, increments [EventGroupSyncMetrics.unlinkedReconcileFailure],
@@ -1043,7 +1061,7 @@ class EventGroupSync(
     val toCreate: List<UnlinkedClientAccount> =
       observedByRefId.filterKeys { it !in existingByRefId }.values.toList()
     val toDelete: List<String> =
-      existingByRefId.filterKeys { it !in observedByRefId }.values.map { it.name }
+      existingByRefId.filterKeys { it !in observedByRefId }.toSortedMap().values.map { it.name }
 
     batchCreateUnlinkedClientAccounts(toCreate)
     batchDeleteUnlinkedClientAccounts(toDelete)
@@ -1052,28 +1070,32 @@ class EventGroupSync(
   /**
    * Builds the [UnlinkedClientAccount] observed for [refId] from its [accumulator].
    *
-   * `entity_metadata` folds the collected brands into a `Struct` with a single `brand_name` entry
-   * set to the lexicographically smallest brand, and is omitted entirely when no brand was
-   * observed.
-   *
    * `observed_event_group` prefers `entity_key` when any observed EventGroup carries one, falling
    * back to `event_group_reference_id`. Among candidates of the chosen kind the lexicographically
    * smallest is used, so repeated syncs over the same input produce the same value.
+   *
+   * `entity_metadata` carries the winning EventGroup's own `entity_metadata` verbatim (same schema
+   * as `EventGroupMetadata.entity_metadata`), and is omitted when the winner carried none.
    */
   private fun buildUnlinkedClientAccount(
     refId: String,
     accumulator: UnlinkedClientAccountAccumulator,
   ): UnlinkedClientAccount = unlinkedClientAccount {
     clientAccountReferenceId = refId
-    accumulator.brands.minOrNull()?.let { smallestBrand ->
-      entityMetadata = struct { fields["brand_name"] = value { stringValue = smallestBrand } }
-    }
-    val entityKeyCandidate =
-      accumulator.entityKeys.minWithOrNull(compareBy({ it.entityType }, { it.entityId }))
-    if (entityKeyCandidate != null) {
-      entityKey = entityKeyCandidate.toCmmsEntityKey()
-    } else {
-      accumulator.eventGroupReferenceIds.minOrNull()?.let { eventGroupReferenceId = it }
+    val winner: ObservedEventGroup? =
+      accumulator.observed
+        .filter { it.entityKey != null }
+        .minWithOrNull(compareBy({ it.entityKey!!.entityType }, { it.entityKey!!.entityId }))
+        ?: accumulator.observed
+          .filter { it.eventGroupReferenceId != null }
+          .minByOrNull { it.eventGroupReferenceId!! }
+    if (winner != null) {
+      if (winner.entityKey != null) {
+        entityKey = winner.entityKey.toCmmsEntityKey()
+      } else {
+        eventGroupReferenceId = winner.eventGroupReferenceId!!
+      }
+      winner.entityMetadata?.let { entityMetadata = it }
     }
   }
 

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/eventgroups/EventGroupSync.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/eventgroups/EventGroupSync.kt
@@ -45,8 +45,8 @@ import org.wfanet.measurement.api.v2alpha.EventGroupMetadataKt.AdMetadataKt as C
 import org.wfanet.measurement.api.v2alpha.EventGroupsGrpcKt.EventGroupsCoroutineStub
 import org.wfanet.measurement.api.v2alpha.ListClientAccountsRequestKt
 import org.wfanet.measurement.api.v2alpha.ListClientAccountsResponse
-import org.wfanet.measurement.api.v2alpha.ListUnlinkedClientAccountsResponse
 import org.wfanet.measurement.api.v2alpha.ListEventGroupsRequestKt.filter as listEventGroupsFilter
+import org.wfanet.measurement.api.v2alpha.ListUnlinkedClientAccountsResponse
 import org.wfanet.measurement.api.v2alpha.MeasurementConsumerClientAccountKey
 import org.wfanet.measurement.api.v2alpha.MeasurementConsumerKey
 import org.wfanet.measurement.api.v2alpha.MediaType as CmmsMediaType
@@ -1032,9 +1032,11 @@ class EventGroupSync(
     // Build the observed set from the accumulator, sorted by client_account_reference_id for a
     // deterministic payload.
     val observedByRefId: Map<String, UnlinkedClientAccount> =
-      unlinkedClientAccounts.entries.sortedBy { it.key }.associate { (refId, accumulator) ->
-        refId to buildUnlinkedClientAccount(refId, accumulator)
-      }
+      unlinkedClientAccounts.entries
+        .sortedBy { it.key }
+        .associate { (refId, accumulator) ->
+          refId to buildUnlinkedClientAccount(refId, accumulator)
+        }
 
     // Diff. Reference IDs present in both sets are left untouched (preserving `create_time`); only
     // the symmetric difference is written.
@@ -1051,7 +1053,8 @@ class EventGroupSync(
    * Builds the [UnlinkedClientAccount] observed for [refId] from its [accumulator].
    *
    * `entity_metadata` folds the collected brands into a `Struct` with a single `brand_name` entry
-   * set to the lexicographically smallest brand, and is omitted entirely when no brand was observed.
+   * set to the lexicographically smallest brand, and is omitted entirely when no brand was
+   * observed.
    *
    * `observed_event_group` prefers `entity_key` when any observed EventGroup carries one, falling
    * back to `event_group_reference_id`. Among candidates of the chosen kind the lexicographically
@@ -1102,10 +1105,12 @@ class EventGroupSync(
   }
 
   /**
-   * Creates [accounts] via `BatchCreateUnlinkedClientAccounts`, chunked to [MAX_UNLINKED_BATCH_SIZE].
+   * Creates [accounts] via `BatchCreateUnlinkedClientAccounts`, chunked to
+   * [MAX_UNLINKED_BATCH_SIZE].
    *
-   * Each chunk is best-effort per [reconcileUnlinkedClientAccounts]: a failure is logged, increments
-   * [EventGroupSyncMetrics.unlinkedReconcileFailure], and the run continues with the next chunk.
+   * Each chunk is best-effort per [reconcileUnlinkedClientAccounts]: a failure is logged,
+   * increments [EventGroupSyncMetrics.unlinkedReconcileFailure], and the run continues with the
+   * next chunk.
    */
   private suspend fun batchCreateUnlinkedClientAccounts(accounts: List<UnlinkedClientAccount>) {
     for (chunk in accounts.chunked(MAX_UNLINKED_BATCH_SIZE)) {
@@ -1151,8 +1156,9 @@ class EventGroupSync(
    * Deletes the accounts named by [names] via `BatchDeleteUnlinkedClientAccounts`, chunked to
    * [MAX_UNLINKED_BATCH_SIZE].
    *
-   * Each chunk is best-effort per [reconcileUnlinkedClientAccounts]: a failure is logged, increments
-   * [EventGroupSyncMetrics.unlinkedReconcileFailure], and the run continues with the next chunk.
+   * Each chunk is best-effort per [reconcileUnlinkedClientAccounts]: a failure is logged,
+   * increments [EventGroupSyncMetrics.unlinkedReconcileFailure], and the run continues with the
+   * next chunk.
    */
   private suspend fun batchDeleteUnlinkedClientAccounts(names: List<String>) {
     for (chunk in names.chunked(MAX_UNLINKED_BATCH_SIZE)) {

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/eventgroups/EventGroupSync.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/eventgroups/EventGroupSync.kt
@@ -47,6 +47,7 @@ import org.wfanet.measurement.api.v2alpha.ListEventGroupsRequestKt.filter as lis
 import org.wfanet.measurement.api.v2alpha.MeasurementConsumerClientAccountKey
 import org.wfanet.measurement.api.v2alpha.MeasurementConsumerKey
 import org.wfanet.measurement.api.v2alpha.MediaType as CmmsMediaType
+import org.wfanet.measurement.api.v2alpha.UnlinkedClientAccountsGrpcKt.UnlinkedClientAccountsCoroutineStub
 import org.wfanet.measurement.api.v2alpha.UpdateEventGroupRequest
 import org.wfanet.measurement.api.v2alpha.batchCreateEventGroupsRequest
 import org.wfanet.measurement.api.v2alpha.batchUpdateEventGroupsRequest
@@ -57,6 +58,8 @@ import org.wfanet.measurement.api.v2alpha.eventGroup as cmmsEventGroup
 import org.wfanet.measurement.api.v2alpha.eventGroupMetadata as cmmsEventGroupMetadata
 import org.wfanet.measurement.api.v2alpha.listClientAccountsRequest
 import org.wfanet.measurement.api.v2alpha.listEventGroupsRequest
+import org.wfanet.measurement.api.v2alpha.replaceUnlinkedClientAccountsRequest
+import org.wfanet.measurement.api.v2alpha.unlinkedClientAccount
 import org.wfanet.measurement.api.v2alpha.updateEventGroupRequest
 import org.wfanet.measurement.common.Instrumentation
 import org.wfanet.measurement.common.api.grpc.ResourceList
@@ -216,6 +219,7 @@ class EventGroupSync(
   private val edpName: String,
   private val eventGroupsStub: EventGroupsCoroutineStub,
   private val clientAccountsStub: ClientAccountsCoroutineStub,
+  private val unlinkedClientAccountsStub: UnlinkedClientAccountsCoroutineStub,
   private val eventGroups: Flow<EventGroup>,
   private val throttler: Throttler,
   private val listEventGroupPageSize: Int,
@@ -231,6 +235,31 @@ class EventGroupSync(
    * client account can map to multiple Measurement Consumers. Empty list if resolution failed.
    */
   private val clientAccountCache = mutableMapOf<String, List<MeasurementConsumerKey>>()
+
+  /**
+   * Accumulated unlinked client accounts observed during a single [sync] run, keyed by
+   * `client_account_reference_id`.
+   *
+   * An entry is recorded only when a `client_account_reference_id` lookup completes and resolves to
+   * zero MeasurementConsumers (the confirmed-empty result). Distinct brands are unioned across
+   * every EventGroup that carries the same reference ID, and one observed EventGroup (its
+   * `entity_key` when present, otherwise its `event_group_reference_id`) is retained for
+   * traceability. Flushed once at the end of the run via [flushUnlinkedClientAccounts].
+   */
+  private val unlinkedClientAccounts = mutableMapOf<String, UnlinkedClientAccountAccumulator>()
+
+  /**
+   * Mutable accumulator for the distinct brands and observed-EventGroup candidates of an unlinked
+   * account.
+   *
+   * Both candidate collections are gathered as-is; the winning `observed_event_group` is chosen at
+   * flush time so the result is independent of the order EventGroups were observed in.
+   */
+  private class UnlinkedClientAccountAccumulator {
+    val brands = mutableSetOf<String>()
+    val eventGroupReferenceIds = mutableSetOf<String>()
+    val entityKeys = mutableSetOf<EventGroup.EntityKey>()
+  }
 
   /** Creates metric attributes with data provider name. */
   private fun metricAttributes() =
@@ -286,7 +315,9 @@ class EventGroupSync(
       val pendingUpdates = mutableListOf<PendingWrite<UpdateEventGroupRequest>>()
 
       // Collect the EDP EventGroups as a stream rather than materializing the full decoded list.
+      var observedEventGroupCount = 0
       eventGroups.collect { eventGroup ->
+        observedEventGroupCount++
         if (eventGroup.state == EventGroup.State.DELETED) {
           // A delete acts on an entity-keyed EventGroup, and only needs to act as a barrier when a
           // queued create/update targets that same EventGroup: flushing first keeps the buffered
@@ -404,6 +435,12 @@ class EventGroupSync(
       // Flush any remaining buffered writes after the input stream is exhausted.
       flushCreates(pendingCreates)
       flushUpdates(pendingUpdates)
+
+      // Reconcile the full set of unlinked client accounts for this DataProvider. Passed the
+      // observed EventGroup count so a run that streamed zero EventGroups skips the reconcile
+      // instead of wiping the stored set; a run that did observe EventGroups still reconciles
+      // (even with zero entries) so accounts that became linked since the previous run are dropped.
+      flushUnlinkedClientAccounts(observedEventGroupCount)
     }
   }
 
@@ -899,6 +936,17 @@ class EventGroupSync(
           resolvedKeys
         }
 
+      // Record as unlinked only on a confirmed-empty lookup for an otherwise-unlinked EventGroup:
+      // the `listClientAccounts` RPC runs inside `getOrPut` above, so a StatusException from a
+      // transient Kingdom outage propagates out of this function and never reaches here — an RPC
+      // error can therefore never record an account as unlinked. An account that resolves to >=1
+      // MC (non-empty `lookedUpKeys`) is linked and is not captured (the cross-MC reconcile
+      // guarantee); neither is an EventGroup already linked via a direct `measurement_consumer`
+      // (`measurementConsumerKeys` already holds it, added above before the lookup).
+      if (lookedUpKeys.isEmpty() && measurementConsumerKeys.isEmpty()) {
+        recordUnlinkedClientAccount(eventGroup, refId)
+      }
+
       measurementConsumerKeys.addAll(lookedUpKeys)
     }
 
@@ -911,6 +959,101 @@ class EventGroupSync(
     }
 
     return measurementConsumerKeys
+  }
+
+  /**
+   * Accumulates an unlinked-client-account observation for [refId].
+   *
+   * Unions the EventGroup's brand (from `event_group_metadata.ad_metadata.campaign_metadata.brand`)
+   * into the account's distinct-brand set and collects the EventGroup as an observed candidate: its
+   * `entity_key` when present, otherwise its `event_group_reference_id`. The winning candidate is
+   * deliberately not chosen here so the result stays independent of observation order; see
+   * [flushUnlinkedClientAccounts]. Called only from the confirmed-empty lookup branch in
+   * [resolveMeasurementConsumers].
+   */
+  private fun recordUnlinkedClientAccount(eventGroup: EventGroup, refId: String) {
+    val accumulator = unlinkedClientAccounts.getOrPut(refId) { UnlinkedClientAccountAccumulator() }
+    val brand = eventGroup.eventGroupMetadata.adMetadata.campaignMetadata.brand
+    if (brand.isNotBlank()) {
+      accumulator.brands.add(brand)
+    }
+    if (eventGroup.hasEntityKey() && eventGroup.entityKey.entityId.isNotBlank()) {
+      accumulator.entityKeys.add(eventGroup.entityKey)
+    } else if (eventGroup.eventGroupReferenceId.isNotBlank()) {
+      accumulator.eventGroupReferenceIds.add(eventGroup.eventGroupReferenceId)
+    }
+  }
+
+  /**
+   * Reconciles the full set of unlinked client accounts for this DataProvider with a single
+   * `ReplaceUnlinkedClientAccounts` RPC.
+   *
+   * This is always issued at the end of a run — including with an empty set — so that the stored
+   * set is fully reconciled: accounts that resolved to a MeasurementConsumer in this run (and were
+   * therefore not accumulated) are dropped from storage.
+   */
+  private suspend fun flushUnlinkedClientAccounts(observedEventGroupCount: Int) {
+    if (observedEventGroupCount == 0) {
+      // A run that streamed zero EventGroups is treated as a no-op, not a signal that every account
+      // is now linked; reconciling an empty set here would wipe the stored unlinked accounts from a
+      // prior run on a transient empty read.
+      logger.warning {
+        "Skipping unlinked-client-account reconcile for $edpName: no EventGroups observed this run"
+      }
+      return
+    }
+    // Entries are sorted by client_account_reference_id for a deterministic request payload.
+    val accounts =
+      unlinkedClientAccounts.entries
+        .sortedBy { it.key }
+        .map { (refId, accumulator) ->
+          unlinkedClientAccount {
+            clientAccountReferenceId = refId
+            brands += accumulator.brands.sorted()
+            // `entity_key` is preferred when any observed EventGroup carries one, falling back to
+            // `event_group_reference_id`. Among candidates of the chosen kind the lexicographically
+            // smallest is used, so repeated syncs over the same input produce the same value.
+            if (accumulator.entityKeys.isNotEmpty()) {
+              entityKey =
+                accumulator.entityKeys
+                  .sortedWith(compareBy({ it.entityType }, { it.entityId }))
+                  .first()
+                  .toCmmsEntityKey()
+            } else if (accumulator.eventGroupReferenceIds.isNotEmpty()) {
+              eventGroupReferenceId = accumulator.eventGroupReferenceIds.sorted().first()
+            }
+          }
+        }
+    try {
+      throttler.onReady {
+        withSpan(
+          tracer,
+          "EventGroupSync.ReplaceUnlinkedClientAccounts",
+          Attributes.of(
+            AttributeKey.longKey("unlinked_client_account_count"),
+            accounts.size.toLong(),
+            AttributeKey.stringKey("data_provider_name"),
+            edpName,
+          ),
+          errorMessage = "ReplaceUnlinkedClientAccounts failed",
+        ) { _ ->
+          unlinkedClientAccountsStub.replaceUnlinkedClientAccounts(
+            replaceUnlinkedClientAccountsRequest {
+              parent = edpName
+              unlinkedClientAccounts += accounts
+            }
+          )
+        }
+      }
+    } catch (e: Exception) {
+      if (e is CancellationException) throw e
+      // Secondary reconcile: every EventGroup already synced above, so a failure here must not
+      // abort the run. Log and let the next reconcile run catch up.
+      logger.log(Level.SEVERE, e) {
+        "ReplaceUnlinkedClientAccounts failed for $edpName; leaving for the next reconcile run"
+      }
+      metrics.unlinkedReconcileFailure.add(1, metricAttributes())
+    }
   }
 
   /*

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/eventgroups/EventGroupSync.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/eventgroups/EventGroupSync.kt
@@ -16,6 +16,8 @@
 
 package org.wfanet.measurement.edpaggregator.eventgroups
 
+import com.google.protobuf.struct
+import com.google.protobuf.value
 import io.grpc.Status
 import io.grpc.StatusException
 import io.opentelemetry.api.GlobalOpenTelemetry
@@ -43,22 +45,27 @@ import org.wfanet.measurement.api.v2alpha.EventGroupMetadataKt.AdMetadataKt as C
 import org.wfanet.measurement.api.v2alpha.EventGroupsGrpcKt.EventGroupsCoroutineStub
 import org.wfanet.measurement.api.v2alpha.ListClientAccountsRequestKt
 import org.wfanet.measurement.api.v2alpha.ListClientAccountsResponse
+import org.wfanet.measurement.api.v2alpha.ListUnlinkedClientAccountsResponse
 import org.wfanet.measurement.api.v2alpha.ListEventGroupsRequestKt.filter as listEventGroupsFilter
 import org.wfanet.measurement.api.v2alpha.MeasurementConsumerClientAccountKey
 import org.wfanet.measurement.api.v2alpha.MeasurementConsumerKey
 import org.wfanet.measurement.api.v2alpha.MediaType as CmmsMediaType
+import org.wfanet.measurement.api.v2alpha.UnlinkedClientAccount
 import org.wfanet.measurement.api.v2alpha.UnlinkedClientAccountsGrpcKt.UnlinkedClientAccountsCoroutineStub
 import org.wfanet.measurement.api.v2alpha.UpdateEventGroupRequest
 import org.wfanet.measurement.api.v2alpha.batchCreateEventGroupsRequest
+import org.wfanet.measurement.api.v2alpha.batchCreateUnlinkedClientAccountsRequest
+import org.wfanet.measurement.api.v2alpha.batchDeleteUnlinkedClientAccountsRequest
 import org.wfanet.measurement.api.v2alpha.batchUpdateEventGroupsRequest
 import org.wfanet.measurement.api.v2alpha.copy
 import org.wfanet.measurement.api.v2alpha.createEventGroupRequest
+import org.wfanet.measurement.api.v2alpha.createUnlinkedClientAccountRequest
 import org.wfanet.measurement.api.v2alpha.deleteEventGroupRequest
 import org.wfanet.measurement.api.v2alpha.eventGroup as cmmsEventGroup
 import org.wfanet.measurement.api.v2alpha.eventGroupMetadata as cmmsEventGroupMetadata
 import org.wfanet.measurement.api.v2alpha.listClientAccountsRequest
 import org.wfanet.measurement.api.v2alpha.listEventGroupsRequest
-import org.wfanet.measurement.api.v2alpha.replaceUnlinkedClientAccountsRequest
+import org.wfanet.measurement.api.v2alpha.listUnlinkedClientAccountsRequest
 import org.wfanet.measurement.api.v2alpha.unlinkedClientAccount
 import org.wfanet.measurement.api.v2alpha.updateEventGroupRequest
 import org.wfanet.measurement.common.Instrumentation
@@ -244,7 +251,7 @@ class EventGroupSync(
    * zero MeasurementConsumers (the confirmed-empty result). Distinct brands are unioned across
    * every EventGroup that carries the same reference ID, and one observed EventGroup (its
    * `entity_key` when present, otherwise its `event_group_reference_id`) is retained for
-   * traceability. Flushed once at the end of the run via [flushUnlinkedClientAccounts].
+   * traceability. Reconciled once at the end of the run via [reconcileUnlinkedClientAccounts].
    */
   private val unlinkedClientAccounts = mutableMapOf<String, UnlinkedClientAccountAccumulator>()
 
@@ -440,7 +447,7 @@ class EventGroupSync(
       // observed EventGroup count so a run that streamed zero EventGroups skips the reconcile
       // instead of wiping the stored set; a run that did observe EventGroups still reconciles
       // (even with zero entries) so accounts that became linked since the previous run are dropped.
-      flushUnlinkedClientAccounts(observedEventGroupCount)
+      reconcileUnlinkedClientAccounts(observedEventGroupCount)
     }
   }
 
@@ -968,7 +975,7 @@ class EventGroupSync(
    * into the account's distinct-brand set and collects the EventGroup as an observed candidate: its
    * `entity_key` when present, otherwise its `event_group_reference_id`. The winning candidate is
    * deliberately not chosen here so the result stays independent of observation order; see
-   * [flushUnlinkedClientAccounts]. Called only from the confirmed-empty lookup branch in
+   * [buildUnlinkedClientAccount]. Called only from the confirmed-empty lookup branch in
    * [resolveMeasurementConsumers].
    */
   private fun recordUnlinkedClientAccount(eventGroup: EventGroup, refId: String) {
@@ -985,72 +992,199 @@ class EventGroupSync(
   }
 
   /**
-   * Reconciles the full set of unlinked client accounts for this DataProvider with a single
-   * `ReplaceUnlinkedClientAccounts` RPC.
+   * Reconciles the stored set of [UnlinkedClientAccount]s for this DataProvider against the set
+   * observed during this run.
    *
-   * This is always issued at the end of a run — including with an empty set — so that the stored
-   * set is fully reconciled: accounts that resolved to a MeasurementConsumer in this run (and were
-   * therefore not accumulated) are dropped from storage.
+   * Lists the currently-stored accounts, diffs them against the observed set, then issues
+   * `BatchCreateUnlinkedClientAccounts` for newly-observed reference IDs and
+   * `BatchDeleteUnlinkedClientAccounts` for stored reference IDs no longer observed. Reference IDs
+   * present in both sets are left untouched, preserving their server-assigned `create_time`.
+   *
+   * This is a secondary reconcile: every EventGroup has already synced above, so each RPC is
+   * best-effort — a failure is logged, increments [EventGroupSyncMetrics.unlinkedReconcileFailure],
+   * and is left for the next reconcile run rather than failing the sync.
    */
-  private suspend fun flushUnlinkedClientAccounts(observedEventGroupCount: Int) {
+  private suspend fun reconcileUnlinkedClientAccounts(observedEventGroupCount: Int) {
     if (observedEventGroupCount == 0) {
       // A run that streamed zero EventGroups is treated as a no-op, not a signal that every account
-      // is now linked; reconciling an empty set here would wipe the stored unlinked accounts from a
+      // is now linked; deleting the stored set here would wipe the stored unlinked accounts from a
       // prior run on a transient empty read.
       logger.warning {
         "Skipping unlinked-client-account reconcile for $edpName: no EventGroups observed this run"
       }
       return
     }
-    // Entries are sorted by client_account_reference_id for a deterministic request payload.
-    val accounts =
-      unlinkedClientAccounts.entries
-        .sortedBy { it.key }
-        .map { (refId, accumulator) ->
-          unlinkedClientAccount {
-            clientAccountReferenceId = refId
-            brands += accumulator.brands.sorted()
-            // `entity_key` is preferred when any observed EventGroup carries one, falling back to
-            // `event_group_reference_id`. Among candidates of the chosen kind the lexicographically
-            // smallest is used, so repeated syncs over the same input produce the same value.
-            val entityKeyCandidate =
-              accumulator.entityKeys.minWithOrNull(compareBy({ it.entityType }, { it.entityId }))
-            if (entityKeyCandidate != null) {
-              entityKey = entityKeyCandidate.toCmmsEntityKey()
-            } else {
-              accumulator.eventGroupReferenceIds.minOrNull()?.let { eventGroupReferenceId = it }
+
+    // List the currently-stored accounts, keyed by reference ID so each stored resource `name` is
+    // available for deletes. A failure here aborts only the reconcile, not the sync.
+    val existingByRefId: Map<String, UnlinkedClientAccount> =
+      try {
+        listUnlinkedClientAccounts().associateBy { it.clientAccountReferenceId }
+      } catch (e: Exception) {
+        if (e is CancellationException) throw e
+        logger.log(Level.SEVERE, e) {
+          "ListUnlinkedClientAccounts failed for $edpName; skipping reconcile for this run"
+        }
+        metrics.unlinkedReconcileFailure.add(1, metricAttributes())
+        return
+      }
+
+    // Build the observed set from the accumulator, sorted by client_account_reference_id for a
+    // deterministic payload.
+    val observedByRefId: Map<String, UnlinkedClientAccount> =
+      unlinkedClientAccounts.entries.sortedBy { it.key }.associate { (refId, accumulator) ->
+        refId to buildUnlinkedClientAccount(refId, accumulator)
+      }
+
+    // Diff. Reference IDs present in both sets are left untouched (preserving `create_time`); only
+    // the symmetric difference is written.
+    val toCreate: List<UnlinkedClientAccount> =
+      observedByRefId.filterKeys { it !in existingByRefId }.values.toList()
+    val toDelete: List<String> =
+      existingByRefId.filterKeys { it !in observedByRefId }.values.map { it.name }
+
+    batchCreateUnlinkedClientAccounts(toCreate)
+    batchDeleteUnlinkedClientAccounts(toDelete)
+  }
+
+  /**
+   * Builds the [UnlinkedClientAccount] observed for [refId] from its [accumulator].
+   *
+   * `entity_metadata` folds the collected brands into a `Struct` with a single `brand_name` entry
+   * set to the lexicographically smallest brand, and is omitted entirely when no brand was observed.
+   *
+   * `observed_event_group` prefers `entity_key` when any observed EventGroup carries one, falling
+   * back to `event_group_reference_id`. Among candidates of the chosen kind the lexicographically
+   * smallest is used, so repeated syncs over the same input produce the same value.
+   */
+  private fun buildUnlinkedClientAccount(
+    refId: String,
+    accumulator: UnlinkedClientAccountAccumulator,
+  ): UnlinkedClientAccount = unlinkedClientAccount {
+    clientAccountReferenceId = refId
+    accumulator.brands.minOrNull()?.let { smallestBrand ->
+      entityMetadata = struct { fields["brand_name"] = value { stringValue = smallestBrand } }
+    }
+    val entityKeyCandidate =
+      accumulator.entityKeys.minWithOrNull(compareBy({ it.entityType }, { it.entityId }))
+    if (entityKeyCandidate != null) {
+      entityKey = entityKeyCandidate.toCmmsEntityKey()
+    } else {
+      accumulator.eventGroupReferenceIds.minOrNull()?.let { eventGroupReferenceId = it }
+    }
+  }
+
+  /** Lists all stored [UnlinkedClientAccount]s for this DataProvider, paging through results. */
+  @OptIn(ExperimentalCoroutinesApi::class) // For `flattenConcat`.
+  private suspend fun listUnlinkedClientAccounts(): List<UnlinkedClientAccount> {
+    return unlinkedClientAccountsStub
+      .listResources { pageToken: String ->
+        val response: ListUnlinkedClientAccountsResponse =
+          throttler.onReady {
+            withSpan(
+              tracer,
+              "EventGroupSync.ListUnlinkedClientAccounts",
+              Attributes.of(AttributeKey.stringKey("data_provider_name"), edpName),
+              errorMessage = "ListUnlinkedClientAccounts failed",
+            ) { _ ->
+              unlinkedClientAccountsStub.listUnlinkedClientAccounts(
+                listUnlinkedClientAccountsRequest {
+                  parent = edpName
+                  this.pageToken = pageToken
+                }
+              )
             }
           }
-        }
-    try {
-      throttler.onReady {
-        withSpan(
-          tracer,
-          "EventGroupSync.ReplaceUnlinkedClientAccounts",
-          Attributes.of(
-            AttributeKey.longKey("unlinked_client_account_count"),
-            accounts.size.toLong(),
-            AttributeKey.stringKey("data_provider_name"),
-            edpName,
-          ),
-          errorMessage = "ReplaceUnlinkedClientAccounts failed",
-        ) { _ ->
-          unlinkedClientAccountsStub.replaceUnlinkedClientAccounts(
-            replaceUnlinkedClientAccountsRequest {
-              parent = edpName
-              unlinkedClientAccounts += accounts
-            }
-          )
-        }
+        ResourceList(response.unlinkedClientAccountsList, response.nextPageToken)
       }
-    } catch (e: Exception) {
-      if (e is CancellationException) throw e
-      // Secondary reconcile: every EventGroup already synced above, so a failure here must not
-      // abort the run. Log and let the next reconcile run catch up.
-      logger.log(Level.SEVERE, e) {
-        "ReplaceUnlinkedClientAccounts failed for $edpName; leaving for the next reconcile run"
+      .flattenConcat()
+      .toList()
+  }
+
+  /**
+   * Creates [accounts] via `BatchCreateUnlinkedClientAccounts`, chunked to [MAX_UNLINKED_BATCH_SIZE].
+   *
+   * Each chunk is best-effort per [reconcileUnlinkedClientAccounts]: a failure is logged, increments
+   * [EventGroupSyncMetrics.unlinkedReconcileFailure], and the run continues with the next chunk.
+   */
+  private suspend fun batchCreateUnlinkedClientAccounts(accounts: List<UnlinkedClientAccount>) {
+    for (chunk in accounts.chunked(MAX_UNLINKED_BATCH_SIZE)) {
+      try {
+        throttler.onReady {
+          withSpan(
+            tracer,
+            "EventGroupSync.BatchCreateUnlinkedClientAccounts",
+            Attributes.of(
+              AttributeKey.longKey("batch_size"),
+              chunk.size.toLong(),
+              AttributeKey.stringKey("data_provider_name"),
+              edpName,
+            ),
+            errorMessage = "BatchCreateUnlinkedClientAccounts failed",
+          ) { _ ->
+            unlinkedClientAccountsStub.batchCreateUnlinkedClientAccounts(
+              batchCreateUnlinkedClientAccountsRequest {
+                parent = edpName
+                requests +=
+                  chunk.map { account ->
+                    createUnlinkedClientAccountRequest {
+                      parent = edpName
+                      unlinkedClientAccount = account
+                    }
+                  }
+              }
+            )
+          }
+        }
+      } catch (e: Exception) {
+        if (e is CancellationException) throw e
+        logger.log(Level.SEVERE, e) {
+          "BatchCreateUnlinkedClientAccounts of ${chunk.size} accounts failed for $edpName;" +
+            " leaving for the next reconcile run"
+        }
+        metrics.unlinkedReconcileFailure.add(1, metricAttributes())
       }
-      metrics.unlinkedReconcileFailure.add(1, metricAttributes())
+    }
+  }
+
+  /**
+   * Deletes the accounts named by [names] via `BatchDeleteUnlinkedClientAccounts`, chunked to
+   * [MAX_UNLINKED_BATCH_SIZE].
+   *
+   * Each chunk is best-effort per [reconcileUnlinkedClientAccounts]: a failure is logged, increments
+   * [EventGroupSyncMetrics.unlinkedReconcileFailure], and the run continues with the next chunk.
+   */
+  private suspend fun batchDeleteUnlinkedClientAccounts(names: List<String>) {
+    for (chunk in names.chunked(MAX_UNLINKED_BATCH_SIZE)) {
+      try {
+        throttler.onReady {
+          withSpan(
+            tracer,
+            "EventGroupSync.BatchDeleteUnlinkedClientAccounts",
+            Attributes.of(
+              AttributeKey.longKey("batch_size"),
+              chunk.size.toLong(),
+              AttributeKey.stringKey("data_provider_name"),
+              edpName,
+            ),
+            errorMessage = "BatchDeleteUnlinkedClientAccounts failed",
+          ) { _ ->
+            unlinkedClientAccountsStub.batchDeleteUnlinkedClientAccounts(
+              batchDeleteUnlinkedClientAccountsRequest {
+                parent = edpName
+                this.names += chunk
+              }
+            )
+          }
+        }
+      } catch (e: Exception) {
+        if (e is CancellationException) throw e
+        logger.log(Level.SEVERE, e) {
+          "BatchDeleteUnlinkedClientAccounts of ${chunk.size} accounts failed for $edpName;" +
+            " leaving for the next reconcile run"
+        }
+        metrics.unlinkedReconcileFailure.add(1, metricAttributes())
+      }
     }
   }
 
@@ -1209,6 +1343,12 @@ class EventGroupSync(
   companion object {
     /** Maximum number of sub-requests per BatchCreate/BatchUpdate EventGroups RPC. */
     private const val MAX_BATCH_SIZE = 50
+
+    /**
+     * Maximum number of sub-requests per BatchCreate/BatchDelete UnlinkedClientAccounts RPC (server
+     * limit).
+     */
+    private const val MAX_UNLINKED_BATCH_SIZE = 1000
 
     /**
      * gRPC status codes for a failed batch RPC that are attributable to an individual sub-request

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/eventgroups/EventGroupSync.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/eventgroups/EventGroupSync.kt
@@ -1407,6 +1407,11 @@ class EventGroupSync(
       ) {
         "Either Event Group Reference Id or Entity Key with entity ID must be set"
       }
+      if (eventGroup.hasEntityKey() && eventGroup.entityKey.entityId.isNotBlank()) {
+        check(eventGroup.entityKey.entityType.isNotBlank()) {
+          "EventGroup.entity_key.entity_type must be non-blank when entity_id is set"
+        }
+      }
       if (eventGroup.measurementConsumer.isNotBlank()) {
         val mcKey = MeasurementConsumerKey.fromName(eventGroup.measurementConsumer)
         check(mcKey != null && mcKey.measurementConsumerId.isNotBlank()) {

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/eventgroups/EventGroupSync.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/eventgroups/EventGroupSync.kt
@@ -1013,14 +1013,12 @@ class EventGroupSync(
             // `entity_key` is preferred when any observed EventGroup carries one, falling back to
             // `event_group_reference_id`. Among candidates of the chosen kind the lexicographically
             // smallest is used, so repeated syncs over the same input produce the same value.
-            if (accumulator.entityKeys.isNotEmpty()) {
-              entityKey =
-                accumulator.entityKeys
-                  .sortedWith(compareBy({ it.entityType }, { it.entityId }))
-                  .first()
-                  .toCmmsEntityKey()
-            } else if (accumulator.eventGroupReferenceIds.isNotEmpty()) {
-              eventGroupReferenceId = accumulator.eventGroupReferenceIds.sorted().first()
+            val entityKeyCandidate =
+              accumulator.entityKeys.minWithOrNull(compareBy({ it.entityType }, { it.entityId }))
+            if (entityKeyCandidate != null) {
+              entityKey = entityKeyCandidate.toCmmsEntityKey()
+            } else {
+              accumulator.eventGroupReferenceIds.minOrNull()?.let { eventGroupReferenceId = it }
             }
           }
         }

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/eventgroups/EventGroupSyncMetrics.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/eventgroups/EventGroupSyncMetrics.kt
@@ -129,9 +129,10 @@ class EventGroupSyncMetrics(meter: Meter) {
   /**
    * Counter for failed unlinked-client-account reconciles.
    *
-   * Incremented when any end-of-run reconcile RPC (`ListUnlinkedClientAccounts`,
-   * `BatchCreateUnlinkedClientAccounts`, or `BatchDeleteUnlinkedClientAccounts`) fails. This is a
-   * secondary reconcile: the EventGroups themselves have already synced, so a failure here is
+   * Incremented once per failed end-of-run reconcile RPC: the single `ListUnlinkedClientAccounts`,
+   * plus each `BatchCreateUnlinkedClientAccounts` and `BatchDeleteUnlinkedClientAccounts` chunk
+   * (chunked at `MAX_UNLINKED_BATCH_SIZE`), so a single run can increment it more than once. This
+   * is a secondary reconcile: the EventGroups themselves have already synced, so a failure here is
    * logged and left for the next run rather than failing the sync.
    */
   val unlinkedReconcileFailure: LongCounter =

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/eventgroups/EventGroupSyncMetrics.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/eventgroups/EventGroupSyncMetrics.kt
@@ -125,4 +125,17 @@ class EventGroupSyncMetrics(meter: Meter) {
         "Number of ClientAccount reference IDs that are not mapped in the account table"
       )
       .build()
+
+  /**
+   * Counter for failed unlinked-client-account reconciles.
+   *
+   * Incremented when the end-of-run `ReplaceUnlinkedClientAccounts` call fails. This is a secondary
+   * reconcile: the EventGroups themselves have already synced, so a failure here is logged and left
+   * for the next run rather than failing the sync.
+   */
+  val unlinkedReconcileFailure: LongCounter =
+    meter
+      .counterBuilder("edpa.event_group.unlinked_reconcile_failure")
+      .setDescription("Number of failed unlinked-client-account reconciles")
+      .build()
 }

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/eventgroups/EventGroupSyncMetrics.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/eventgroups/EventGroupSyncMetrics.kt
@@ -131,8 +131,8 @@ class EventGroupSyncMetrics(meter: Meter) {
    *
    * Incremented when any end-of-run reconcile RPC (`ListUnlinkedClientAccounts`,
    * `BatchCreateUnlinkedClientAccounts`, or `BatchDeleteUnlinkedClientAccounts`) fails. This is a
-   * secondary reconcile: the EventGroups themselves have already synced, so a failure here is logged
-   * and left for the next run rather than failing the sync.
+   * secondary reconcile: the EventGroups themselves have already synced, so a failure here is
+   * logged and left for the next run rather than failing the sync.
    */
   val unlinkedReconcileFailure: LongCounter =
     meter

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/eventgroups/EventGroupSyncMetrics.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/eventgroups/EventGroupSyncMetrics.kt
@@ -129,9 +129,10 @@ class EventGroupSyncMetrics(meter: Meter) {
   /**
    * Counter for failed unlinked-client-account reconciles.
    *
-   * Incremented when the end-of-run `ReplaceUnlinkedClientAccounts` call fails. This is a secondary
-   * reconcile: the EventGroups themselves have already synced, so a failure here is logged and left
-   * for the next run rather than failing the sync.
+   * Incremented when any end-of-run reconcile RPC (`ListUnlinkedClientAccounts`,
+   * `BatchCreateUnlinkedClientAccounts`, or `BatchDeleteUnlinkedClientAccounts`) fails. This is a
+   * secondary reconcile: the EventGroups themselves have already synced, so a failure here is logged
+   * and left for the next run rather than failing the sync.
    */
   val unlinkedReconcileFailure: LongCounter =
     meter

--- a/src/main/kotlin/org/wfanet/measurement/integration/common/BUILD.bazel
+++ b/src/main/kotlin/org/wfanet/measurement/integration/common/BUILD.bazel
@@ -21,6 +21,7 @@ java_library(
         "//src/main/kotlin/org/wfanet/measurement/kingdom/service/api/v2alpha:accounts_service",
         "//src/main/kotlin/org/wfanet/measurement/kingdom/service/api/v2alpha:api_keys_service",
         "//src/main/kotlin/org/wfanet/measurement/kingdom/service/api/v2alpha:certificates_service",
+        "//src/main/kotlin/org/wfanet/measurement/kingdom/service/api/v2alpha:client_accounts_service",
         "//src/main/kotlin/org/wfanet/measurement/kingdom/service/api/v2alpha:data_providers_service",
         "//src/main/kotlin/org/wfanet/measurement/kingdom/service/api/v2alpha:event_group_activities_service",
         "//src/main/kotlin/org/wfanet/measurement/kingdom/service/api/v2alpha:event_group_metadata_descriptors_service",
@@ -37,6 +38,7 @@ java_library(
         "//src/main/kotlin/org/wfanet/measurement/kingdom/service/api/v2alpha:populations_service",
         "//src/main/kotlin/org/wfanet/measurement/kingdom/service/api/v2alpha:public_keys_service",
         "//src/main/kotlin/org/wfanet/measurement/kingdom/service/api/v2alpha:requisitions_service",
+        "//src/main/kotlin/org/wfanet/measurement/kingdom/service/api/v2alpha:unlinked_client_accounts_service",
     ],
 )
 

--- a/src/main/kotlin/org/wfanet/measurement/integration/common/InProcessEdpAggregatorComponents.kt
+++ b/src/main/kotlin/org/wfanet/measurement/integration/common/InProcessEdpAggregatorComponents.kt
@@ -59,6 +59,7 @@ import org.wfanet.measurement.api.v2alpha.PopulationSpec
 import org.wfanet.measurement.api.v2alpha.Requisition
 import org.wfanet.measurement.api.v2alpha.RequisitionKt
 import org.wfanet.measurement.api.v2alpha.RequisitionsGrpcKt.RequisitionsCoroutineStub
+import org.wfanet.measurement.api.v2alpha.UnlinkedClientAccountsGrpcKt.UnlinkedClientAccountsCoroutineStub
 import org.wfanet.measurement.api.v2alpha.event_group_metadata.testing.SyntheticEventGroupSpec
 import org.wfanet.measurement.api.v2alpha.event_templates.testing.TestEvent
 import org.wfanet.measurement.api.v2alpha.listEventGroupsRequest
@@ -316,6 +317,8 @@ class InProcessEdpAggregatorComponents(
         EventGroupsCoroutineStub(publicApiChannel).withPrincipalName(edpResourceName)
       val clientAccountsClient: ClientAccountsCoroutineStub =
         ClientAccountsCoroutineStub(publicApiChannel).withPrincipalName(edpResourceName)
+      val unlinkedClientAccountsClient: UnlinkedClientAccountsCoroutineStub =
+        UnlinkedClientAccountsCoroutineStub(publicApiChannel).withPrincipalName(edpResourceName)
       val edpPrivateKey = getDataProviderPrivateEncryptionKey(edpAggregatorShortName)
 
       val requisitionsValidator = RequisitionsValidator(edpPrivateKey)
@@ -354,6 +357,7 @@ class InProcessEdpAggregatorComponents(
           edpResourceName,
           eventGroupsClient,
           clientAccountsClient,
+          unlinkedClientAccountsClient,
           eventGroups.asFlow(),
           throttler,
           entityKeyTypes = emptyList(),
@@ -769,10 +773,13 @@ class InProcessEdpAggregatorComponents(
       EventGroupsCoroutineStub(publicApiChannel).withPrincipalName(edpResourceName)
     val clientAccountsClient =
       ClientAccountsCoroutineStub(publicApiChannel).withPrincipalName(edpResourceName)
+    val unlinkedClientAccountsClient =
+      UnlinkedClientAccountsCoroutineStub(publicApiChannel).withPrincipalName(edpResourceName)
     EventGroupSync(
         edpResourceName,
         eventGroupsClient,
         clientAccountsClient,
+        unlinkedClientAccountsClient,
         sources.asFlow(),
         throttler,
         entityKeyTypes = entityKeyTypes,

--- a/src/main/kotlin/org/wfanet/measurement/integration/common/InProcessKingdom.kt
+++ b/src/main/kotlin/org/wfanet/measurement/integration/common/InProcessKingdom.kt
@@ -29,6 +29,7 @@ import org.wfanet.measurement.duchy.herald.Herald
 import org.wfanet.measurement.internal.kingdom.AccountsGrpcKt.AccountsCoroutineStub as InternalAccountsCoroutineStub
 import org.wfanet.measurement.internal.kingdom.ApiKeysGrpcKt.ApiKeysCoroutineStub as InternalApiKeysCoroutineStub
 import org.wfanet.measurement.internal.kingdom.CertificatesGrpcKt.CertificatesCoroutineStub as InternalCertificatesCoroutineStub
+import org.wfanet.measurement.internal.kingdom.ClientAccountsGrpcKt.ClientAccountsCoroutineStub as InternalClientAccountsCoroutineStub
 import org.wfanet.measurement.internal.kingdom.ComputationParticipantsGrpcKt.ComputationParticipantsCoroutineStub as InternalComputationParticipantsCoroutineStub
 import org.wfanet.measurement.internal.kingdom.DataProvidersGrpcKt.DataProvidersCoroutineStub as InternalDataProvidersCoroutineStub
 import org.wfanet.measurement.internal.kingdom.EventGroupActivitiesGrpcKt.EventGroupActivitiesCoroutineStub as InternalEventGroupActivitiesCoroutineStub
@@ -48,11 +49,13 @@ import org.wfanet.measurement.internal.kingdom.PopulationsGrpcKt.PopulationsCoro
 import org.wfanet.measurement.internal.kingdom.PublicKeysGrpcKt.PublicKeysCoroutineStub as InternalPublicKeysCoroutineStub
 import org.wfanet.measurement.internal.kingdom.RecurringExchangesGrpcKt.RecurringExchangesCoroutineStub as InternalRecurringExchangesCoroutineStub
 import org.wfanet.measurement.internal.kingdom.RequisitionsGrpcKt.RequisitionsCoroutineStub as InternalRequisitionsCoroutineStub
+import org.wfanet.measurement.internal.kingdom.UnlinkedClientAccountsGrpcKt.UnlinkedClientAccountsCoroutineStub as InternalUnlinkedClientAccountsCoroutineStub
 import org.wfanet.measurement.kingdom.deploy.common.service.DataServices
 import org.wfanet.measurement.kingdom.deploy.common.service.toList
 import org.wfanet.measurement.kingdom.service.api.v2alpha.AccountsService
 import org.wfanet.measurement.kingdom.service.api.v2alpha.ApiKeysService
 import org.wfanet.measurement.kingdom.service.api.v2alpha.CertificatesService
+import org.wfanet.measurement.kingdom.service.api.v2alpha.ClientAccountsService
 import org.wfanet.measurement.kingdom.service.api.v2alpha.DataProvidersService
 import org.wfanet.measurement.kingdom.service.api.v2alpha.EventGroupActivitiesService
 import org.wfanet.measurement.kingdom.service.api.v2alpha.EventGroupMetadataDescriptorsService
@@ -69,6 +72,7 @@ import org.wfanet.measurement.kingdom.service.api.v2alpha.ModelSuitesService
 import org.wfanet.measurement.kingdom.service.api.v2alpha.PopulationsService
 import org.wfanet.measurement.kingdom.service.api.v2alpha.PublicKeysService
 import org.wfanet.measurement.kingdom.service.api.v2alpha.RequisitionsService
+import org.wfanet.measurement.kingdom.service.api.v2alpha.UnlinkedClientAccountsService
 import org.wfanet.measurement.kingdom.service.api.v2alpha.withAccountAuthenticationServerInterceptor
 import org.wfanet.measurement.kingdom.service.api.v2alpha.withApiKeyAuthenticationServerInterceptor
 import org.wfanet.measurement.kingdom.service.system.v1alpha.ComputationLogEntriesService as SystemComputationLogEntriesService
@@ -113,6 +117,12 @@ class InProcessKingdom(
   }
   private val internalEventGroupsClient by lazy {
     InternalEventGroupsCoroutineStub(internalApiChannel)
+  }
+  private val internalClientAccountsClient by lazy {
+    InternalClientAccountsCoroutineStub(internalApiChannel)
+  }
+  private val internalUnlinkedClientAccountsClient by lazy {
+    InternalUnlinkedClientAccountsCoroutineStub(internalApiChannel)
   }
   private val internalEventGroupActivitiesClient by lazy {
     InternalEventGroupActivitiesCoroutineStub(internalApiChannel)
@@ -189,6 +199,12 @@ class InProcessKingdom(
             .withMetadataPrincipalIdentities()
             .withApiKeyAuthenticationServerInterceptor(internalApiKeysClient),
           RequisitionsService(internalRequisitionsClient)
+            .withMetadataPrincipalIdentities()
+            .withApiKeyAuthenticationServerInterceptor(internalApiKeysClient),
+          ClientAccountsService(internalClientAccountsClient)
+            .withMetadataPrincipalIdentities()
+            .withApiKeyAuthenticationServerInterceptor(internalApiKeysClient),
+          UnlinkedClientAccountsService(internalUnlinkedClientAccountsClient)
             .withMetadataPrincipalIdentities()
             .withApiKeyAuthenticationServerInterceptor(internalApiKeysClient),
           ModelRolloutsService(internalModelRolloutsClient)

--- a/src/test/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/eventgroups/BUILD.bazel
+++ b/src/test/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/eventgroups/BUILD.bazel
@@ -17,6 +17,8 @@ kt_jvm_test(
         "//src/main/proto/wfa/measurement/api/v2alpha:event_group_metadata_kt_jvm_proto",
         "//src/main/proto/wfa/measurement/api/v2alpha:event_groups_service_kt_jvm_grpc_proto",
         "//src/main/proto/wfa/measurement/api/v2alpha:media_type_kt_jvm_proto",
+        "//src/main/proto/wfa/measurement/api/v2alpha:unlinked_client_account_kt_jvm_proto",
+        "//src/main/proto/wfa/measurement/api/v2alpha:unlinked_client_accounts_service_kt_jvm_grpc_proto",
         "//src/main/proto/wfa/measurement/config/edpaggregator:event_group_sync_config_kt_jvm_proto",
         "//src/main/proto/wfa/measurement/edpaggregator/eventgroups/v1alpha:event_group_kt_jvm_proto",
         "//src/main/proto/wfa/measurement/edpaggregator/eventgroups/v1alpha:event_group_map_kt_jvm_proto",

--- a/src/test/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/eventgroups/EventGroupSyncFunctionTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/eventgroups/EventGroupSyncFunctionTest.kt
@@ -64,6 +64,8 @@ import org.wfanet.measurement.api.v2alpha.EventGroupsGrpcKt.EventGroupsCoroutine
 import org.wfanet.measurement.api.v2alpha.ListClientAccountsRequest
 import org.wfanet.measurement.api.v2alpha.ListEventGroupsRequest
 import org.wfanet.measurement.api.v2alpha.MediaType as CmmsMediaType
+import org.wfanet.measurement.api.v2alpha.ReplaceUnlinkedClientAccountsRequest
+import org.wfanet.measurement.api.v2alpha.UnlinkedClientAccountsGrpcKt.UnlinkedClientAccountsCoroutineImplBase
 import org.wfanet.measurement.api.v2alpha.UpdateEventGroupRequest
 import org.wfanet.measurement.api.v2alpha.batchCreateEventGroupsResponse
 import org.wfanet.measurement.api.v2alpha.batchUpdateEventGroupsResponse
@@ -72,6 +74,7 @@ import org.wfanet.measurement.api.v2alpha.eventGroup as cmmsEventGroup
 import org.wfanet.measurement.api.v2alpha.eventGroupMetadata as cmmsEventGroupMetadata
 import org.wfanet.measurement.api.v2alpha.listClientAccountsResponse
 import org.wfanet.measurement.api.v2alpha.listEventGroupsResponse
+import org.wfanet.measurement.api.v2alpha.replaceUnlinkedClientAccountsResponse
 import org.wfanet.measurement.common.crypto.SigningCerts
 import org.wfanet.measurement.common.getRuntimePath
 import org.wfanet.measurement.common.grpc.CommonServer
@@ -203,10 +206,17 @@ class EventGroupSyncFunctionTest() {
       .thenReturn(listClientAccountsResponse {})
   }
 
+  private val unlinkedClientAccountsServiceMock: UnlinkedClientAccountsCoroutineImplBase =
+    mockService {
+      onBlocking { replaceUnlinkedClientAccounts(any<ReplaceUnlinkedClientAccountsRequest>()) }
+        .thenReturn(replaceUnlinkedClientAccountsResponse {})
+    }
+
   @get:Rule
   val grpcTestServerRule = GrpcTestServerRule {
     addService(eventGroupsServiceMock)
     addService(clientAccountsServiceMock)
+    addService(unlinkedClientAccountsServiceMock)
   }
 
   @get:Rule val tempFolder = TemporaryFolder()
@@ -220,7 +230,12 @@ class EventGroupSyncFunctionTest() {
           certs = serverCerts,
           clientAuth = ClientAuth.REQUIRE,
           nameForLogging = "EventGroupsServer",
-          services = listOf(eventGroupsServiceMock.bindService()),
+          services =
+            listOf(
+              eventGroupsServiceMock.bindService(),
+              clientAccountsServiceMock.bindService(),
+              unlinkedClientAccountsServiceMock.bindService(),
+            ),
         )
         .start()
     functionProcess =
@@ -345,6 +360,85 @@ class EventGroupSyncFunctionTest() {
           "reference-id-4" to "resource-name-for-reference-id-4",
         )
       )
+  }
+
+  @Test
+  fun `sync writes unlinked client accounts via ReplaceUnlinkedClientAccounts`() {
+    val unlinkedEventGroup = eventGroup {
+      eventGroupReferenceId = "reference-id-unlinked"
+      this.eventGroupMetadata = eventGroupMetadata {
+        this.adMetadata = adMetadata {
+          this.campaignMetadata = campaignMetadata {
+            brand = "brand-unlinked"
+            campaign = "campaign-unlinked"
+          }
+        }
+      }
+      clientAccountReferenceId = "client-ref-unlinked"
+      dataAvailabilityInterval = interval {
+        startTime = timestamp { seconds = 200 }
+        endTime = timestamp { seconds = 300 }
+      }
+      mediaTypes += listOf(MediaType.OTHER)
+    }
+    val config = eventGroupSyncConfig {
+      dataProvider = "dataProviders/some-data-provider"
+      eventGroupsBlobUri = "file:///some/path/campaigns-blob-uri.binpb"
+      eventGroupMapBlobUri = "file:///some/other/path/event-groups-map-uri"
+      this.cmmsConnection = transportLayerSecurityParams {
+        certFilePath = SECRETS_DIR.resolve("edp7_tls.pem").toString()
+        privateKeyFilePath = SECRETS_DIR.resolve("edp7_tls.key").toString()
+        certCollectionFilePath = SECRETS_DIR.resolve("kingdom_root.pem").toString()
+      }
+      eventGroupStorage = storageParams { fileSystem = fileSystemStorage {} }
+      eventGroupMapStorage = storageParams { fileSystem = fileSystemStorage {} }
+    }
+    val configBucketDir = File(tempFolder.root, "configbucket")
+    configBucketDir.mkdirs()
+    val runtimeConfig = eventGroupSyncConfigs { configs += config }
+    File(configBucketDir, "config.textproto")
+      .writeText(TextFormat.printer().printToString(runtimeConfig))
+
+    File("${tempFolder.root}/some/path").mkdirs()
+    File("${tempFolder.root}/some/other/path").mkdirs()
+    val port = runBlocking {
+      startFunction(
+        mapOf(
+          "EDPA_CONFIG_STORAGE_BUCKET" to "file://${configBucketDir.absolutePath}",
+          "CONFIG_BLOB_KEY" to "config.textproto",
+        )
+      )
+    }
+
+    val url = "http://localhost:$port"
+    val storageClient = FileSystemStorageClient(File(tempFolder.root.toString()))
+    runBlocking {
+      MesosRecordIoStorageClient(storageClient)
+        .writeBlob(
+          "some/path/campaigns-blob-uri.binpb",
+          listOf(unlinkedEventGroup).map { it.toByteString() }.asFlow(),
+        )
+    }
+
+    val client = HttpClient.newHttpClient()
+    val getRequest =
+      HttpRequest.newBuilder()
+        .uri(URI.create(url))
+        .POST(HttpRequest.BodyPublishers.ofString(config.toJson()))
+        .build()
+    val getResponse = client.send(getRequest, HttpResponse.BodyHandlers.ofString())
+    assertThat(getResponse.statusCode()).isEqualTo(200)
+
+    val captor = argumentCaptor<ReplaceUnlinkedClientAccountsRequest>()
+    verifyBlocking(unlinkedClientAccountsServiceMock, times(1)) {
+      replaceUnlinkedClientAccounts(captor.capture())
+    }
+    val request = captor.firstValue
+    assertThat(request.parent).isEqualTo("dataProviders/some-data-provider")
+    val account = request.unlinkedClientAccountsList.single()
+    assertThat(account.clientAccountReferenceId).isEqualTo("client-ref-unlinked")
+    assertThat(account.brandsList).containsExactly("brand-unlinked")
+    assertThat(account.eventGroupReferenceId).isEqualTo("reference-id-unlinked")
   }
 
   @Test

--- a/src/test/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/eventgroups/EventGroupSyncFunctionTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/eventgroups/EventGroupSyncFunctionTest.kt
@@ -20,6 +20,7 @@ import com.google.common.truth.Truth.assertThat
 import com.google.common.truth.extensions.proto.ProtoTruth.assertThat
 import com.google.protobuf.Any
 import com.google.protobuf.ByteString
+import com.google.protobuf.Empty
 import com.google.protobuf.TextFormat
 import com.google.protobuf.TypeRegistry
 import com.google.protobuf.kotlin.toByteString
@@ -54,6 +55,8 @@ import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verifyBlocking
 import org.wfanet.measurement.api.v2alpha.BatchCreateEventGroupsRequest
+import org.wfanet.measurement.api.v2alpha.BatchCreateUnlinkedClientAccountsRequest
+import org.wfanet.measurement.api.v2alpha.BatchDeleteUnlinkedClientAccountsRequest
 import org.wfanet.measurement.api.v2alpha.BatchUpdateEventGroupsRequest
 import org.wfanet.measurement.api.v2alpha.ClientAccountsGrpcKt.ClientAccountsCoroutineImplBase
 import org.wfanet.measurement.api.v2alpha.CreateEventGroupRequest
@@ -63,18 +66,19 @@ import org.wfanet.measurement.api.v2alpha.EventGroupMetadataKt.adMetadata as cmm
 import org.wfanet.measurement.api.v2alpha.EventGroupsGrpcKt.EventGroupsCoroutineImplBase
 import org.wfanet.measurement.api.v2alpha.ListClientAccountsRequest
 import org.wfanet.measurement.api.v2alpha.ListEventGroupsRequest
+import org.wfanet.measurement.api.v2alpha.ListUnlinkedClientAccountsRequest
 import org.wfanet.measurement.api.v2alpha.MediaType as CmmsMediaType
-import org.wfanet.measurement.api.v2alpha.ReplaceUnlinkedClientAccountsRequest
 import org.wfanet.measurement.api.v2alpha.UnlinkedClientAccountsGrpcKt.UnlinkedClientAccountsCoroutineImplBase
 import org.wfanet.measurement.api.v2alpha.UpdateEventGroupRequest
 import org.wfanet.measurement.api.v2alpha.batchCreateEventGroupsResponse
+import org.wfanet.measurement.api.v2alpha.batchCreateUnlinkedClientAccountsResponse
 import org.wfanet.measurement.api.v2alpha.batchUpdateEventGroupsResponse
 import org.wfanet.measurement.api.v2alpha.copy
 import org.wfanet.measurement.api.v2alpha.eventGroup as cmmsEventGroup
 import org.wfanet.measurement.api.v2alpha.eventGroupMetadata as cmmsEventGroupMetadata
 import org.wfanet.measurement.api.v2alpha.listClientAccountsResponse
 import org.wfanet.measurement.api.v2alpha.listEventGroupsResponse
-import org.wfanet.measurement.api.v2alpha.replaceUnlinkedClientAccountsResponse
+import org.wfanet.measurement.api.v2alpha.listUnlinkedClientAccountsResponse
 import org.wfanet.measurement.common.crypto.SigningCerts
 import org.wfanet.measurement.common.getRuntimePath
 import org.wfanet.measurement.common.grpc.CommonServer
@@ -208,8 +212,23 @@ class EventGroupSyncFunctionTest() {
 
   private val unlinkedClientAccountsServiceMock: UnlinkedClientAccountsCoroutineImplBase =
     mockService {
-      onBlocking { replaceUnlinkedClientAccounts(any<ReplaceUnlinkedClientAccountsRequest>()) }
-        .thenReturn(replaceUnlinkedClientAccountsResponse {})
+      onBlocking { listUnlinkedClientAccounts(any<ListUnlinkedClientAccountsRequest>()) }
+        .thenAnswer { listUnlinkedClientAccountsResponse {} }
+      onBlocking {
+          batchCreateUnlinkedClientAccounts(any<BatchCreateUnlinkedClientAccountsRequest>())
+        }
+        .thenAnswer { invocation ->
+          batchCreateUnlinkedClientAccountsResponse {
+            unlinkedClientAccounts +=
+              invocation.getArgument<BatchCreateUnlinkedClientAccountsRequest>(0).requestsList.map {
+                it.unlinkedClientAccount
+              }
+          }
+        }
+      onBlocking {
+          batchDeleteUnlinkedClientAccounts(any<BatchDeleteUnlinkedClientAccountsRequest>())
+        }
+        .thenAnswer { Empty.getDefaultInstance() }
     }
 
   @get:Rule
@@ -363,7 +382,7 @@ class EventGroupSyncFunctionTest() {
   }
 
   @Test
-  fun `sync writes unlinked client accounts via ReplaceUnlinkedClientAccounts`() {
+  fun `sync writes unlinked client accounts`() {
     val unlinkedEventGroup = eventGroup {
       eventGroupReferenceId = "reference-id-unlinked"
       this.eventGroupMetadata = eventGroupMetadata {
@@ -372,6 +391,9 @@ class EventGroupSyncFunctionTest() {
             brand = "brand-unlinked"
             campaign = "campaign-unlinked"
           }
+        }
+        this.entityMetadata = struct {
+          fields["brand_name"] = value { stringValue = "brand-unlinked" }
         }
       }
       clientAccountReferenceId = "client-ref-unlinked"
@@ -429,15 +451,16 @@ class EventGroupSyncFunctionTest() {
     val getResponse = client.send(getRequest, HttpResponse.BodyHandlers.ofString())
     assertThat(getResponse.statusCode()).isEqualTo(200)
 
-    val captor = argumentCaptor<ReplaceUnlinkedClientAccountsRequest>()
+    val captor = argumentCaptor<BatchCreateUnlinkedClientAccountsRequest>()
     verifyBlocking(unlinkedClientAccountsServiceMock, times(1)) {
-      replaceUnlinkedClientAccounts(captor.capture())
+      batchCreateUnlinkedClientAccounts(captor.capture())
     }
     val request = captor.firstValue
     assertThat(request.parent).isEqualTo("dataProviders/some-data-provider")
-    val account = request.unlinkedClientAccountsList.single()
+    val account = request.requestsList.single().unlinkedClientAccount
     assertThat(account.clientAccountReferenceId).isEqualTo("client-ref-unlinked")
-    assertThat(account.brandsList).containsExactly("brand-unlinked")
+    assertThat(account.entityMetadata.fieldsMap["brand_name"]?.stringValue)
+      .isEqualTo("brand-unlinked")
     assertThat(account.eventGroupReferenceId).isEqualTo("reference-id-unlinked")
   }
 

--- a/src/test/kotlin/org/wfanet/measurement/edpaggregator/eventgroups/BUILD.bazel
+++ b/src/test/kotlin/org/wfanet/measurement/edpaggregator/eventgroups/BUILD.bazel
@@ -14,6 +14,8 @@ kt_jvm_test(
         "//src/main/proto/wfa/measurement/api/v2alpha:event_group_metadata_kt_jvm_proto",
         "//src/main/proto/wfa/measurement/api/v2alpha:event_groups_service_kt_jvm_grpc_proto",
         "//src/main/proto/wfa/measurement/api/v2alpha:media_type_kt_jvm_proto",
+        "//src/main/proto/wfa/measurement/api/v2alpha:unlinked_client_account_kt_jvm_proto",
+        "//src/main/proto/wfa/measurement/api/v2alpha:unlinked_client_accounts_service_kt_jvm_grpc_proto",
         "//src/main/proto/wfa/measurement/edpaggregator/eventgroups/v1alpha:event_group_kt_jvm_proto",
         "//src/main/proto/wfa/measurement/edpaggregator/eventgroups/v1alpha:event_group_map_kt_jvm_proto",
         "@wfa_common_jvm//imports/java/com/google/common/truth",

--- a/src/test/kotlin/org/wfanet/measurement/edpaggregator/eventgroups/EventGroupSyncTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/edpaggregator/eventgroups/EventGroupSyncTest.kt
@@ -74,6 +74,9 @@ import org.wfanet.measurement.api.v2alpha.ListClientAccountsRequest
 import org.wfanet.measurement.api.v2alpha.ListEventGroupsRequest
 import org.wfanet.measurement.api.v2alpha.MeasurementConsumerClientAccountKey
 import org.wfanet.measurement.api.v2alpha.MediaType as CmmsMediaType
+import org.wfanet.measurement.api.v2alpha.ReplaceUnlinkedClientAccountsRequest
+import org.wfanet.measurement.api.v2alpha.UnlinkedClientAccountsGrpcKt.UnlinkedClientAccountsCoroutineImplBase
+import org.wfanet.measurement.api.v2alpha.UnlinkedClientAccountsGrpcKt.UnlinkedClientAccountsCoroutineStub
 import org.wfanet.measurement.api.v2alpha.UpdateEventGroupRequest
 import org.wfanet.measurement.api.v2alpha.batchCreateEventGroupsResponse
 import org.wfanet.measurement.api.v2alpha.batchUpdateEventGroupsResponse
@@ -82,6 +85,7 @@ import org.wfanet.measurement.api.v2alpha.eventGroup as cmmsEventGroup
 import org.wfanet.measurement.api.v2alpha.eventGroupMetadata as cmmsEventGroupMetadata
 import org.wfanet.measurement.api.v2alpha.listClientAccountsResponse
 import org.wfanet.measurement.api.v2alpha.listEventGroupsResponse
+import org.wfanet.measurement.api.v2alpha.replaceUnlinkedClientAccountsResponse
 import org.wfanet.measurement.common.Instrumentation
 import org.wfanet.measurement.common.grpc.testing.GrpcTestServerRule
 import org.wfanet.measurement.common.grpc.testing.mockService
@@ -284,6 +288,12 @@ class EventGroupSyncTest {
       }
   }
 
+  private val unlinkedClientAccountsServiceMock: UnlinkedClientAccountsCoroutineImplBase =
+    mockService {
+      onBlocking { replaceUnlinkedClientAccounts(any<ReplaceUnlinkedClientAccountsRequest>()) }
+        .thenAnswer { replaceUnlinkedClientAccountsResponse {} }
+    }
+
   private val eventGroupsStub: EventGroupsCoroutineStub by lazy {
     EventGroupsCoroutineStub(grpcTestServerRule.channel)
   }
@@ -292,10 +302,15 @@ class EventGroupSyncTest {
     ClientAccountsCoroutineStub(grpcTestServerRule.channel)
   }
 
+  private val unlinkedClientAccountsStub: UnlinkedClientAccountsCoroutineStub by lazy {
+    UnlinkedClientAccountsCoroutineStub(grpcTestServerRule.channel)
+  }
+
   @get:Rule
   val grpcTestServerRule = GrpcTestServerRule {
     addService(eventGroupsServiceMock)
     addService(clientAccountsServiceMock)
+    addService(unlinkedClientAccountsServiceMock)
   }
 
   @Test
@@ -324,6 +339,7 @@ class EventGroupSyncTest {
         "edp-name",
         eventGroupsStub,
         clientAccountsStub,
+        unlinkedClientAccountsStub,
         testCampaigns.asFlow(),
         MinimumIntervalThrottler(Clock.systemUTC(), Duration.ofMillis(1000)),
         100,
@@ -359,6 +375,7 @@ class EventGroupSyncTest {
         "edp-name",
         eventGroupsStub,
         clientAccountsStub,
+        unlinkedClientAccountsStub,
         testCampaigns.asFlow(),
         MinimumIntervalThrottler(Clock.systemUTC(), Duration.ofMillis(1000)),
         100,
@@ -443,6 +460,7 @@ class EventGroupSyncTest {
         "edp-name",
         eventGroupsStub,
         clientAccountsStub,
+        unlinkedClientAccountsStub,
         listOf(deletedEventGroup).asFlow(),
         MinimumIntervalThrottler(Clock.systemUTC(), Duration.ofMillis(1000)),
         100,
@@ -540,6 +558,7 @@ class EventGroupSyncTest {
         "edp-name",
         eventGroupsStub,
         clientAccountsStub,
+        unlinkedClientAccountsStub,
         listOf(deletedEventGroup, activeEventGroup).asFlow(),
         MinimumIntervalThrottler(Clock.systemUTC(), Duration.ofMillis(1000)),
         100,
@@ -577,6 +596,7 @@ class EventGroupSyncTest {
         "edp-name",
         eventGroupsStub,
         clientAccountsStub,
+        unlinkedClientAccountsStub,
         listOf(deletedEventGroup).asFlow(),
         MinimumIntervalThrottler(Clock.systemUTC(), Duration.ofMillis(1000)),
         100,
@@ -623,6 +643,7 @@ class EventGroupSyncTest {
           "dataProviders/test-edp-delete-metric",
           eventGroupsStub,
           clientAccountsStub,
+          unlinkedClientAccountsStub,
           listOf(deletedEventGroup).asFlow(),
           MinimumIntervalThrottler(Clock.systemUTC(), Duration.ofMillis(1000)),
           100,
@@ -660,6 +681,7 @@ class EventGroupSyncTest {
           "dataProviders/test-edp-no-delete-metric",
           eventGroupsStub,
           clientAccountsStub,
+          unlinkedClientAccountsStub,
           listOf(deletedEventGroup).asFlow(),
           MinimumIntervalThrottler(Clock.systemUTC(), Duration.ofMillis(1000)),
           100,
@@ -701,6 +723,7 @@ class EventGroupSyncTest {
         "edp-name",
         eventGroupsStub,
         clientAccountsStub,
+        unlinkedClientAccountsStub,
         testCampaigns.asFlow(),
         MinimumIntervalThrottler(Clock.systemUTC(), Duration.ofMillis(1000)),
         100,
@@ -744,6 +767,7 @@ class EventGroupSyncTest {
         "edp-name",
         eventGroupsStub,
         clientAccountsStub,
+        unlinkedClientAccountsStub,
         listOf(newStyleEventGroup).asFlow(),
         MinimumIntervalThrottler(Clock.systemUTC(), Duration.ofMillis(1000)),
         100,
@@ -789,6 +813,7 @@ class EventGroupSyncTest {
         "edp-name",
         eventGroupsStub,
         clientAccountsStub,
+        unlinkedClientAccountsStub,
         listOf(legacyEventGroup).asFlow(),
         MinimumIntervalThrottler(Clock.systemUTC(), Duration.ofMillis(1000)),
         100,
@@ -852,6 +877,7 @@ class EventGroupSyncTest {
         "edp-name",
         eventGroupsStub,
         clientAccountsStub,
+        unlinkedClientAccountsStub,
         listOf(legacyEventGroup, newStyleEventGroup).asFlow(),
         MinimumIntervalThrottler(Clock.systemUTC(), Duration.ofMillis(1000)),
         100,
@@ -923,6 +949,7 @@ class EventGroupSyncTest {
         "edp-name",
         eventGroupsStub,
         clientAccountsStub,
+        unlinkedClientAccountsStub,
         listOf(sourceEventGroup).asFlow(),
         MinimumIntervalThrottler(Clock.systemUTC(), Duration.ofMillis(1000)),
         100,
@@ -956,6 +983,7 @@ class EventGroupSyncTest {
         "edp-name",
         eventGroupsStub,
         clientAccountsStub,
+        unlinkedClientAccountsStub,
         CAMPAIGNS.asFlow(),
         MinimumIntervalThrottler(Clock.systemUTC(), Duration.ofMillis(1000)),
         100,
@@ -995,6 +1023,7 @@ class EventGroupSyncTest {
         "edp-name",
         eventGroupsStub,
         clientAccountsStub,
+        unlinkedClientAccountsStub,
         listOf(sourceEventGroup).asFlow(),
         MinimumIntervalThrottler(Clock.systemUTC(), Duration.ofMillis(1000)),
         100,
@@ -1070,6 +1099,7 @@ class EventGroupSyncTest {
     val testRule = GrpcTestServerRule {
       addService(eventGroupsMock)
       addService(clientAccountsServiceMock)
+      addService(unlinkedClientAccountsServiceMock)
     }
 
     val statement =
@@ -1098,6 +1128,7 @@ class EventGroupSyncTest {
               "edp-name",
               EventGroupsCoroutineStub(testRule.channel),
               ClientAccountsCoroutineStub(testRule.channel),
+              UnlinkedClientAccountsCoroutineStub(testRule.channel),
               listOf(sourceEventGroup).asFlow(),
               MinimumIntervalThrottler(Clock.systemUTC(), Duration.ofMillis(1000)),
               100,
@@ -1179,6 +1210,7 @@ class EventGroupSyncTest {
     val testRule = GrpcTestServerRule {
       addService(eventGroupsMock)
       addService(clientAccountsServiceMock)
+      addService(unlinkedClientAccountsServiceMock)
     }
 
     val statement =
@@ -1215,6 +1247,7 @@ class EventGroupSyncTest {
               "edp-name",
               EventGroupsCoroutineStub(testRule.channel),
               ClientAccountsCoroutineStub(testRule.channel),
+              UnlinkedClientAccountsCoroutineStub(testRule.channel),
               listOf(sourceEventGroup).asFlow(),
               MinimumIntervalThrottler(Clock.systemUTC(), Duration.ofMillis(1000)),
               100,
@@ -1288,6 +1321,7 @@ class EventGroupSyncTest {
     val testRule = GrpcTestServerRule {
       addService(eventGroupsMock)
       addService(clientAccountsServiceMock)
+      addService(unlinkedClientAccountsServiceMock)
     }
 
     val statement =
@@ -1324,6 +1358,7 @@ class EventGroupSyncTest {
               "edp-name",
               EventGroupsCoroutineStub(testRule.channel),
               ClientAccountsCoroutineStub(testRule.channel),
+              UnlinkedClientAccountsCoroutineStub(testRule.channel),
               listOf(sourceEventGroup).asFlow(),
               MinimumIntervalThrottler(Clock.systemUTC(), Duration.ofMillis(1000)),
               100,
@@ -1407,6 +1442,7 @@ class EventGroupSyncTest {
     val testRule = GrpcTestServerRule {
       addService(eventGroupsMock)
       addService(clientAccountsServiceMock)
+      addService(unlinkedClientAccountsServiceMock)
     }
 
     val statement =
@@ -1440,6 +1476,7 @@ class EventGroupSyncTest {
               "edp-name",
               EventGroupsCoroutineStub(testRule.channel),
               ClientAccountsCoroutineStub(testRule.channel),
+              UnlinkedClientAccountsCoroutineStub(testRule.channel),
               listOf(sourceEventGroup).asFlow(),
               MinimumIntervalThrottler(Clock.systemUTC(), Duration.ofMillis(1000)),
               100,
@@ -1525,6 +1562,7 @@ class EventGroupSyncTest {
     val testRule = GrpcTestServerRule {
       addService(eventGroupsMock)
       addService(clientAccountsServiceMock)
+      addService(unlinkedClientAccountsServiceMock)
     }
 
     val statement =
@@ -1558,6 +1596,7 @@ class EventGroupSyncTest {
               "edp-name",
               EventGroupsCoroutineStub(testRule.channel),
               ClientAccountsCoroutineStub(testRule.channel),
+              UnlinkedClientAccountsCoroutineStub(testRule.channel),
               listOf(sourceEventGroup).asFlow(),
               MinimumIntervalThrottler(Clock.systemUTC(), Duration.ofMillis(1000)),
               100,
@@ -1591,6 +1630,7 @@ class EventGroupSyncTest {
           "edp-name",
           eventGroupsStub,
           clientAccountsStub,
+          unlinkedClientAccountsStub,
           CAMPAIGNS.asFlow(),
           MinimumIntervalThrottler(Clock.systemUTC(), Duration.ofMillis(1000)),
           100,
@@ -1712,6 +1752,7 @@ class EventGroupSyncTest {
           "dataProviders/test-edp-123",
           eventGroupsStub,
           clientAccountsStub,
+          unlinkedClientAccountsStub,
           CAMPAIGNS.asFlow(),
           MinimumIntervalThrottler(Clock.systemUTC(), Duration.ofMillis(1000)),
           100,
@@ -1745,6 +1786,7 @@ class EventGroupSyncTest {
           "dataProviders/test-edp-456",
           eventGroupsStub,
           clientAccountsStub,
+          unlinkedClientAccountsStub,
           CAMPAIGNS.asFlow(),
           MinimumIntervalThrottler(Clock.systemUTC(), Duration.ofMillis(1000)),
           100,
@@ -1774,6 +1816,7 @@ class EventGroupSyncTest {
           "dataProviders/test-edp-789",
           eventGroupsStub,
           clientAccountsStub,
+          unlinkedClientAccountsStub,
           CAMPAIGNS.asFlow(),
           MinimumIntervalThrottler(Clock.systemUTC(), Duration.ofMillis(1000)),
           100,
@@ -1819,6 +1862,7 @@ class EventGroupSyncTest {
           "dataProviders/test-edp-error",
           eventGroupsStub,
           clientAccountsStub,
+          unlinkedClientAccountsStub,
           listOf(invalidEventGroup).asFlow(),
           MinimumIntervalThrottler(Clock.systemUTC(), Duration.ofMillis(1000)),
           100,
@@ -1858,6 +1902,7 @@ class EventGroupSyncTest {
           "dataProviders/test-edp-123",
           eventGroupsStub,
           clientAccountsStub,
+          unlinkedClientAccountsStub,
           CAMPAIGNS.asFlow(),
           MinimumIntervalThrottler(Clock.systemUTC(), Duration.ofMillis(1000)),
           100,
@@ -1887,6 +1932,7 @@ class EventGroupSyncTest {
           "dataProviders/test-edp-456",
           eventGroupsStub,
           clientAccountsStub,
+          unlinkedClientAccountsStub,
           CAMPAIGNS.asFlow(),
           MinimumIntervalThrottler(Clock.systemUTC(), Duration.ofMillis(1000)),
           100,
@@ -1936,6 +1982,7 @@ class EventGroupSyncTest {
           "dataProviders/test-edp-error",
           eventGroupsStub,
           clientAccountsStub,
+          unlinkedClientAccountsStub,
           listOf(invalidEventGroup).asFlow(),
           MinimumIntervalThrottler(Clock.systemUTC(), Duration.ofMillis(1000)),
           100,
@@ -1973,6 +2020,7 @@ class EventGroupSyncTest {
           "dataProviders/test-edp-parent-ok",
           eventGroupsStub,
           clientAccountsStub,
+          unlinkedClientAccountsStub,
           listOf(invalidEventGroup).asFlow(),
           MinimumIntervalThrottler(Clock.systemUTC(), Duration.ofMillis(1000)),
           100,
@@ -1999,6 +2047,7 @@ class EventGroupSyncTest {
           "dataProviders/test-edp-no-high-cardinality",
           eventGroupsStub,
           clientAccountsStub,
+          unlinkedClientAccountsStub,
           CAMPAIGNS.asFlow(),
           MinimumIntervalThrottler(Clock.systemUTC(), Duration.ofMillis(1000)),
           100,
@@ -2067,6 +2116,7 @@ class EventGroupSyncTest {
         "edp-name",
         eventGroupsStub,
         clientAccountsStub,
+        unlinkedClientAccountsStub,
         listOf(eventGroupWithClientRef).asFlow(),
         MinimumIntervalThrottler(Clock.systemUTC(), Duration.ofMillis(1000)),
         100,
@@ -2113,6 +2163,7 @@ class EventGroupSyncTest {
         "edp-name",
         eventGroupsStub,
         clientAccountsStub,
+        unlinkedClientAccountsStub,
         listOf(eventGroupWithBoth).asFlow(),
         MinimumIntervalThrottler(Clock.systemUTC(), Duration.ofMillis(1000)),
         100,
@@ -2167,6 +2218,7 @@ class EventGroupSyncTest {
         "edp-name",
         eventGroupsStub,
         clientAccountsStub,
+        unlinkedClientAccountsStub,
         listOf(eventGroupWithNoMatch).asFlow(),
         MinimumIntervalThrottler(Clock.systemUTC(), Duration.ofMillis(1000)),
         100,
@@ -2210,6 +2262,7 @@ class EventGroupSyncTest {
         "edp-name",
         eventGroupsStub,
         clientAccountsStub,
+        unlinkedClientAccountsStub,
         listOf(eventGroupWithMultiple).asFlow(),
         MinimumIntervalThrottler(Clock.systemUTC(), Duration.ofMillis(1000)),
         100,
@@ -2265,6 +2318,7 @@ class EventGroupSyncTest {
           "edp-name",
           eventGroupsStub,
           clientAccountsStub,
+          unlinkedClientAccountsStub,
           listOf(unmappableEventGroup).asFlow(),
           MinimumIntervalThrottler(Clock.systemUTC(), Duration.ofMillis(1000)),
           100,
@@ -2334,6 +2388,7 @@ class EventGroupSyncTest {
           "edp-name",
           eventGroupsStub,
           clientAccountsStub,
+          unlinkedClientAccountsStub,
           listOf(unmappableEventGroup, validEventGroup).asFlow(),
           MinimumIntervalThrottler(Clock.systemUTC(), Duration.ofMillis(1000)),
           100,
@@ -2384,6 +2439,7 @@ class EventGroupSyncTest {
         "edp-name",
         eventGroupsStub,
         clientAccountsStub,
+        unlinkedClientAccountsStub,
         listOf(eventGroupWithFailingLookup).asFlow(),
         MinimumIntervalThrottler(Clock.systemUTC(), Duration.ofMillis(1000)),
         100,
@@ -2419,6 +2475,7 @@ class EventGroupSyncTest {
           "edp-name",
           eventGroupsStub,
           clientAccountsStub,
+          unlinkedClientAccountsStub,
           listOf(malformedEventGroup).asFlow(),
           MinimumIntervalThrottler(Clock.systemUTC(), Duration.ofMillis(1000)),
           100,
@@ -2534,6 +2591,7 @@ class EventGroupSyncTest {
     val testRule = GrpcTestServerRule {
       addService(eventGroupsMock)
       addService(clientAccountsMock)
+      addService(unlinkedClientAccountsServiceMock)
     }
 
     val statement =
@@ -2562,6 +2620,7 @@ class EventGroupSyncTest {
               "edp-name",
               EventGroupsCoroutineStub(testRule.channel),
               ClientAccountsCoroutineStub(testRule.channel),
+              UnlinkedClientAccountsCoroutineStub(testRule.channel),
               listOf(eventGroupWithReducedMapping).asFlow(),
               MinimumIntervalThrottler(Clock.systemUTC(), Duration.ofMillis(1000)),
               100,
@@ -2703,6 +2762,7 @@ class EventGroupSyncTest {
           "edp-name",
           eventGroupsStub,
           clientAccountsStub,
+          unlinkedClientAccountsStub,
           listOf(deletedEventGroup).asFlow(),
           MinimumIntervalThrottler(Clock.systemUTC(), Duration.ofMillis(1000)),
           100,
@@ -2776,6 +2836,7 @@ class EventGroupSyncTest {
         "edp-name",
         eventGroupsStub,
         clientAccountsStub,
+        unlinkedClientAccountsStub,
         listOf(sourceEventGroup).asFlow(),
         MinimumIntervalThrottler(Clock.systemUTC(), Duration.ofMillis(1000)),
         100,
@@ -2855,6 +2916,7 @@ class EventGroupSyncTest {
         "edp-name",
         eventGroupsStub,
         clientAccountsStub,
+        unlinkedClientAccountsStub,
         listOf(sourceEventGroup).asFlow(),
         MinimumIntervalThrottler(Clock.systemUTC(), Duration.ofMillis(1000)),
         100,
@@ -2927,6 +2989,7 @@ class EventGroupSyncTest {
         "edp-name",
         eventGroupsStub,
         clientAccountsStub,
+        unlinkedClientAccountsStub,
         listOf(sourceEventGroup).asFlow(),
         MinimumIntervalThrottler(Clock.systemUTC(), Duration.ofMillis(1000)),
         100,
@@ -2996,6 +3059,7 @@ class EventGroupSyncTest {
         "edp-name",
         eventGroupsStub,
         clientAccountsStub,
+        unlinkedClientAccountsStub,
         sourceEventGroups.asFlow(),
         MinimumIntervalThrottler(Clock.systemUTC(), Duration.ofMillis(1000)),
         100,
@@ -3075,6 +3139,7 @@ class EventGroupSyncTest {
           "edp-name",
           eventGroupsStub,
           clientAccountsStub,
+          unlinkedClientAccountsStub,
           manyEventGroups.asFlow(),
           MinimumIntervalThrottler(Clock.systemUTC(), Duration.ofMillis(1000)),
           100,
@@ -3149,6 +3214,7 @@ class EventGroupSyncTest {
           "edp-name",
           eventGroupsStub,
           clientAccountsStub,
+          unlinkedClientAccountsStub,
           changedEventGroups.asFlow(),
           MinimumIntervalThrottler(Clock.systemUTC(), Duration.ofMillis(1000)),
           100,
@@ -3253,6 +3319,7 @@ class EventGroupSyncTest {
           "edp-name",
           eventGroupsStub,
           clientAccountsStub,
+          unlinkedClientAccountsStub,
           listOf(updateSource, deletedEventGroup).asFlow(),
           MinimumIntervalThrottler(Clock.systemUTC(), Duration.ofMillis(1000)),
           100,
@@ -3348,6 +3415,7 @@ class EventGroupSyncTest {
           "edp-name",
           eventGroupsStub,
           clientAccountsStub,
+          unlinkedClientAccountsStub,
           listOf(newCreate, deletedEventGroup).asFlow(),
           MinimumIntervalThrottler(Clock.systemUTC(), Duration.ofMillis(1000)),
           100,
@@ -3391,6 +3459,7 @@ class EventGroupSyncTest {
           "edp-name",
           eventGroupsStub,
           clientAccountsStub,
+          unlinkedClientAccountsStub,
           listOf(duplicated, duplicated).asFlow(),
           MinimumIntervalThrottler(Clock.systemUTC(), Duration.ofMillis(1000)),
           100,
@@ -3460,6 +3529,7 @@ class EventGroupSyncTest {
           "edp-name",
           eventGroupsStub,
           clientAccountsStub,
+          unlinkedClientAccountsStub,
           newGroups.asFlow(),
           MinimumIntervalThrottler(Clock.systemUTC(), Duration.ofMillis(1000)),
           100,
@@ -3543,6 +3613,7 @@ class EventGroupSyncTest {
           "edp-name",
           eventGroupsStub,
           clientAccountsStub,
+          unlinkedClientAccountsStub,
           changedGroups.asFlow(),
           MinimumIntervalThrottler(Clock.systemUTC(), Duration.ofMillis(1000)),
           100,
@@ -3633,6 +3704,7 @@ class EventGroupSyncTest {
         "edp-name",
         eventGroupsStub,
         clientAccountsStub,
+        unlinkedClientAccountsStub,
         listOf(sourceA, sourceB).asFlow(),
         MinimumIntervalThrottler(Clock.systemUTC(), Duration.ofMillis(1000)),
         100,
@@ -3715,6 +3787,7 @@ class EventGroupSyncTest {
         "edp-name",
         eventGroupsStub,
         clientAccountsStub,
+        unlinkedClientAccountsStub,
         listOf(refIdOnly, entityKeyOnly).asFlow(),
         MinimumIntervalThrottler(Clock.systemUTC(), Duration.ofMillis(1000)),
         100,
@@ -3799,6 +3872,7 @@ class EventGroupSyncTest {
         "edp-name",
         eventGroupsStub,
         clientAccountsStub,
+        unlinkedClientAccountsStub,
         listOf(legacyRefIdOfShapedName, entityKeyOfSameShape).asFlow(),
         MinimumIntervalThrottler(Clock.systemUTC(), Duration.ofMillis(1000)),
         100,
@@ -3878,6 +3952,7 @@ class EventGroupSyncTest {
         "edp-name",
         eventGroupsStub,
         clientAccountsStub,
+        unlinkedClientAccountsStub,
         listOf(duplicateEntityKeyA, duplicateEntityKeyB).asFlow(),
         MinimumIntervalThrottler(Clock.systemUTC(), Duration.ofMillis(1000)),
         100,
@@ -3962,6 +4037,7 @@ class EventGroupSyncTest {
         "edp-name",
         eventGroupsStub,
         clientAccountsStub,
+        unlinkedClientAccountsStub,
         listOf(newSourceRow).asFlow(),
         MinimumIntervalThrottler(Clock.systemUTC(), Duration.ofMillis(1000)),
         100,
@@ -4028,6 +4104,7 @@ class EventGroupSyncTest {
         "edp-name",
         eventGroupsStub,
         clientAccountsStub,
+        unlinkedClientAccountsStub,
         listOf(rowA, rowB).asFlow(),
         MinimumIntervalThrottler(Clock.systemUTC(), Duration.ofMillis(1000)),
         100,
@@ -4136,6 +4213,7 @@ class EventGroupSyncTest {
           edpName,
           eventGroupsStub,
           clientAccountsStub,
+          unlinkedClientAccountsStub,
           listOf(source).asFlow(),
           MinimumIntervalThrottler(Clock.systemUTC(), Duration.ofMillis(1000)),
           100,
@@ -4338,6 +4416,7 @@ class EventGroupSyncTest {
           edpName,
           eventGroupsStub,
           clientAccountsStub,
+          unlinkedClientAccountsStub,
           sources.toList().asFlow(),
           MinimumIntervalThrottler(Clock.systemUTC(), Duration.ofMillis(1000)),
           100,
@@ -4402,6 +4481,624 @@ class EventGroupSyncTest {
     // Total creates across all five syncs = 3 (only sync 1). All later syncs took the update or
     // no-op path.
     verifyBlocking(eventGroupsServiceMock, times(1)) { batchCreateEventGroups(any()) }
+  }
+
+  @Test
+  fun `sync captures unlinked client account and flushes via ReplaceUnlinkedClientAccounts`() {
+    val unlinkedEventGroup = eventGroup {
+      eventGroupReferenceId = "reference-id-unlinked"
+      this.eventGroupMetadata = eventGroupMetadata {
+        this.adMetadata = adMetadata {
+          this.campaignMetadata = campaignMetadata {
+            brand = "brand-unlinked"
+            campaign = "campaign-unlinked"
+          }
+        }
+      }
+      clientAccountReferenceId = "client-ref-nonexistent"
+      dataAvailabilityInterval = interval {
+        startTime = timestamp { seconds = 200 }
+        endTime = timestamp { seconds = 300 }
+      }
+      mediaTypes += listOf(MediaType.OTHER)
+    }
+    val eventGroupSync =
+      EventGroupSync(
+        "edp-name",
+        eventGroupsStub,
+        clientAccountsStub,
+        unlinkedClientAccountsStub,
+        listOf(unlinkedEventGroup).asFlow(),
+        MinimumIntervalThrottler(Clock.systemUTC(), Duration.ofMillis(1000)),
+        100,
+        entityKeyTypes = emptyList(),
+      )
+    runBlocking { eventGroupSync.sync().collect() }
+
+    val captor = argumentCaptor<ReplaceUnlinkedClientAccountsRequest>()
+    verifyBlocking(unlinkedClientAccountsServiceMock, times(1)) {
+      replaceUnlinkedClientAccounts(captor.capture())
+    }
+    val request = captor.firstValue
+    assertThat(request.parent).isEqualTo("edp-name")
+    val account = request.unlinkedClientAccountsList.single()
+    assertThat(account.clientAccountReferenceId).isEqualTo("client-ref-nonexistent")
+    assertThat(account.brandsList).containsExactly("brand-unlinked")
+    assertThat(account.eventGroupReferenceId).isEqualTo("reference-id-unlinked")
+  }
+
+  @Test
+  fun `sync does not record unlinked account when ClientAccounts lookup fails`() {
+    wheneverBlocking { clientAccountsServiceMock.listClientAccounts(any()) }
+      .thenThrow(StatusRuntimeException(Status.INTERNAL.withDescription("transient outage")))
+
+    val eventGroupWithFailingLookup = eventGroup {
+      eventGroupReferenceId = "reference-id-failing"
+      this.eventGroupMetadata = eventGroupMetadata {
+        this.adMetadata = adMetadata {
+          this.campaignMetadata = campaignMetadata {
+            brand = "brand-failing"
+            campaign = "campaign-failing"
+          }
+        }
+      }
+      clientAccountReferenceId = "client-ref-failing"
+      dataAvailabilityInterval = interval {
+        startTime = timestamp { seconds = 200 }
+        endTime = timestamp { seconds = 300 }
+      }
+      mediaTypes += listOf(MediaType.OTHER)
+    }
+    val eventGroupSync =
+      EventGroupSync(
+        "edp-name",
+        eventGroupsStub,
+        clientAccountsStub,
+        unlinkedClientAccountsStub,
+        listOf(eventGroupWithFailingLookup).asFlow(),
+        MinimumIntervalThrottler(Clock.systemUTC(), Duration.ofMillis(1000)),
+        100,
+        entityKeyTypes = emptyList(),
+      )
+
+    // A transient lookup failure must propagate as its gRPC StatusException rather than
+    // mislabel the account as unlinked.
+    assertFailsWith<StatusException> { runBlocking { eventGroupSync.sync().collect() } }
+    verifyBlocking(unlinkedClientAccountsServiceMock, times(0)) {
+      replaceUnlinkedClientAccounts(any())
+    }
+  }
+
+  @Test
+  fun `sync excludes linked client accounts from the unlinked set`() {
+    val linkedEventGroup = eventGroup {
+      eventGroupReferenceId = "reference-id-linked"
+      this.eventGroupMetadata = eventGroupMetadata {
+        this.adMetadata = adMetadata {
+          this.campaignMetadata = campaignMetadata {
+            brand = "brand-linked"
+            campaign = "campaign-linked"
+          }
+        }
+      }
+      clientAccountReferenceId = "client-ref-1"
+      dataAvailabilityInterval = interval {
+        startTime = timestamp { seconds = 200 }
+        endTime = timestamp { seconds = 300 }
+      }
+      mediaTypes += listOf(MediaType.OTHER)
+    }
+    val unlinkedEventGroup = eventGroup {
+      eventGroupReferenceId = "reference-id-unlinked"
+      this.eventGroupMetadata = eventGroupMetadata {
+        this.adMetadata = adMetadata {
+          this.campaignMetadata = campaignMetadata {
+            brand = "brand-unlinked"
+            campaign = "campaign-unlinked"
+          }
+        }
+      }
+      clientAccountReferenceId = "client-ref-nonexistent"
+      dataAvailabilityInterval = interval {
+        startTime = timestamp { seconds = 200 }
+        endTime = timestamp { seconds = 300 }
+      }
+      mediaTypes += listOf(MediaType.OTHER)
+    }
+    val eventGroupSync =
+      EventGroupSync(
+        "edp-name",
+        eventGroupsStub,
+        clientAccountsStub,
+        unlinkedClientAccountsStub,
+        listOf(linkedEventGroup, unlinkedEventGroup).asFlow(),
+        MinimumIntervalThrottler(Clock.systemUTC(), Duration.ofMillis(1000)),
+        100,
+        entityKeyTypes = emptyList(),
+      )
+    runBlocking { eventGroupSync.sync().collect() }
+
+    val captor = argumentCaptor<ReplaceUnlinkedClientAccountsRequest>()
+    verifyBlocking(unlinkedClientAccountsServiceMock, times(1)) {
+      replaceUnlinkedClientAccounts(captor.capture())
+    }
+    val refIds = captor.firstValue.unlinkedClientAccountsList.map { it.clientAccountReferenceId }
+    assertThat(refIds).containsExactly("client-ref-nonexistent")
+  }
+
+  @Test
+  fun `sync does not capture unlinked account when event group has a direct measurement consumer`() {
+    val eventGroupWithDirectMc = eventGroup {
+      eventGroupReferenceId = "reference-id-direct"
+      this.eventGroupMetadata = eventGroupMetadata {
+        this.adMetadata = adMetadata {
+          this.campaignMetadata = campaignMetadata {
+            brand = "brand-direct"
+            campaign = "campaign-direct"
+          }
+        }
+      }
+      measurementConsumer = "measurementConsumers/direct-consumer"
+      clientAccountReferenceId = "client-ref-nonexistent"
+      dataAvailabilityInterval = interval {
+        startTime = timestamp { seconds = 200 }
+        endTime = timestamp { seconds = 300 }
+      }
+      mediaTypes += listOf(MediaType.OTHER)
+    }
+    val eventGroupSync =
+      EventGroupSync(
+        "edp-name",
+        eventGroupsStub,
+        clientAccountsStub,
+        unlinkedClientAccountsStub,
+        listOf(eventGroupWithDirectMc).asFlow(),
+        MinimumIntervalThrottler(Clock.systemUTC(), Duration.ofMillis(1000)),
+        100,
+        entityKeyTypes = emptyList(),
+      )
+    runBlocking { eventGroupSync.sync().collect() }
+
+    val captor = argumentCaptor<ReplaceUnlinkedClientAccountsRequest>()
+    verifyBlocking(unlinkedClientAccountsServiceMock, times(1)) {
+      replaceUnlinkedClientAccounts(captor.capture())
+    }
+    // The event group is linked via its direct measurement_consumer, so the empty client-account
+    // lookup does not record it as unlinked.
+    assertThat(captor.firstValue.unlinkedClientAccountsList).isEmpty()
+  }
+
+  @Test
+  fun `sync captures unlinked account with empty brands when brand is blank`() {
+    val unlinkedEventGroup = eventGroup {
+      eventGroupReferenceId = "reference-id-no-brand"
+      this.eventGroupMetadata = eventGroupMetadata {
+        this.adMetadata = adMetadata {
+          this.campaignMetadata = campaignMetadata { campaign = "campaign-no-brand" }
+        }
+      }
+      clientAccountReferenceId = "client-ref-nonexistent"
+      dataAvailabilityInterval = interval {
+        startTime = timestamp { seconds = 200 }
+        endTime = timestamp { seconds = 300 }
+      }
+      mediaTypes += listOf(MediaType.OTHER)
+    }
+    val eventGroupSync =
+      EventGroupSync(
+        "edp-name",
+        eventGroupsStub,
+        clientAccountsStub,
+        unlinkedClientAccountsStub,
+        listOf(unlinkedEventGroup).asFlow(),
+        MinimumIntervalThrottler(Clock.systemUTC(), Duration.ofMillis(1000)),
+        100,
+        entityKeyTypes = emptyList(),
+      )
+    runBlocking { eventGroupSync.sync().collect() }
+
+    val captor = argumentCaptor<ReplaceUnlinkedClientAccountsRequest>()
+    verifyBlocking(unlinkedClientAccountsServiceMock, times(1)) {
+      replaceUnlinkedClientAccounts(captor.capture())
+    }
+    val account = captor.firstValue.unlinkedClientAccountsList.single()
+    assertThat(account.clientAccountReferenceId).isEqualTo("client-ref-nonexistent")
+    assertThat(account.brandsList).isEmpty()
+    assertThat(account.eventGroupReferenceId).isEqualTo("reference-id-no-brand")
+  }
+
+  @Test
+  fun `sync captures a separate entry per distinct client_account_reference_id`() {
+    val firstUnlinked = eventGroup {
+      eventGroupReferenceId = "reference-id-first"
+      this.eventGroupMetadata = eventGroupMetadata {
+        this.adMetadata = adMetadata {
+          this.campaignMetadata = campaignMetadata {
+            brand = "brand-first"
+            campaign = "campaign-first"
+          }
+        }
+      }
+      clientAccountReferenceId = "client-ref-nonexistent"
+      dataAvailabilityInterval = interval {
+        startTime = timestamp { seconds = 200 }
+        endTime = timestamp { seconds = 300 }
+      }
+      mediaTypes += listOf(MediaType.OTHER)
+    }
+    val secondUnlinked = eventGroup {
+      eventGroupReferenceId = "reference-id-second"
+      this.eventGroupMetadata = eventGroupMetadata {
+        this.adMetadata = adMetadata {
+          this.campaignMetadata = campaignMetadata {
+            brand = "brand-second"
+            campaign = "campaign-second"
+          }
+        }
+      }
+      clientAccountReferenceId = "client-ref-also-nonexistent"
+      dataAvailabilityInterval = interval {
+        startTime = timestamp { seconds = 200 }
+        endTime = timestamp { seconds = 300 }
+      }
+      mediaTypes += listOf(MediaType.OTHER)
+    }
+    val eventGroupSync =
+      EventGroupSync(
+        "edp-name",
+        eventGroupsStub,
+        clientAccountsStub,
+        unlinkedClientAccountsStub,
+        listOf(firstUnlinked, secondUnlinked).asFlow(),
+        MinimumIntervalThrottler(Clock.systemUTC(), Duration.ofMillis(1000)),
+        100,
+        entityKeyTypes = emptyList(),
+      )
+    runBlocking { eventGroupSync.sync().collect() }
+
+    val captor = argumentCaptor<ReplaceUnlinkedClientAccountsRequest>()
+    verifyBlocking(unlinkedClientAccountsServiceMock, times(1)) {
+      replaceUnlinkedClientAccounts(captor.capture())
+    }
+    val refIds = captor.firstValue.unlinkedClientAccountsList.map { it.clientAccountReferenceId }
+    assertThat(refIds).containsExactly("client-ref-nonexistent", "client-ref-also-nonexistent")
+  }
+
+  @Test
+  fun `sync captures unlinked account with entity_key when observed via entity-key event group`() {
+    val unlinkedEventGroup = eventGroup {
+      // No event_group_reference_id; identified by entity_key so it still validates.
+      this.eventGroupMetadata = eventGroupMetadata {
+        this.adMetadata = adMetadata {
+          this.campaignMetadata = campaignMetadata {
+            brand = "brand-entity-key"
+            campaign = "campaign-entity-key"
+          }
+        }
+      }
+      entityKey = entityKey {
+        entityType = "campaign"
+        entityId = "entity-observed"
+      }
+      clientAccountReferenceId = "client-ref-nonexistent"
+      dataAvailabilityInterval = interval {
+        startTime = timestamp { seconds = 200 }
+        endTime = timestamp { seconds = 300 }
+      }
+      mediaTypes += listOf(MediaType.OTHER)
+    }
+    val eventGroupSync =
+      EventGroupSync(
+        "edp-name",
+        eventGroupsStub,
+        clientAccountsStub,
+        unlinkedClientAccountsStub,
+        listOf(unlinkedEventGroup).asFlow(),
+        MinimumIntervalThrottler(Clock.systemUTC(), Duration.ofMillis(1000)),
+        100,
+        entityKeyTypes = emptyList(),
+      )
+    runBlocking { eventGroupSync.sync().collect() }
+
+    val captor = argumentCaptor<ReplaceUnlinkedClientAccountsRequest>()
+    verifyBlocking(unlinkedClientAccountsServiceMock, times(1)) {
+      replaceUnlinkedClientAccounts(captor.capture())
+    }
+    val account = captor.firstValue.unlinkedClientAccountsList.single()
+    assertThat(account.clientAccountReferenceId).isEqualTo("client-ref-nonexistent")
+    assertThat(account.brandsList).containsExactly("brand-entity-key")
+    assertThat(account.entityKey)
+      .isEqualTo(
+        cmmsEntityKey {
+          entityType = "campaign"
+          entityId = "entity-observed"
+        }
+      )
+    assertThat(account.eventGroupReferenceId).isEmpty()
+  }
+
+  @Test
+  fun `sync prefers entity_key over reference id and selects the lexicographically smallest`() {
+    // Observed via a ref-id-only EventGroup.
+    val refIdEventGroup = eventGroup {
+      eventGroupReferenceId = "reference-id-observed"
+      this.eventGroupMetadata = eventGroupMetadata {
+        this.adMetadata = adMetadata {
+          this.campaignMetadata = campaignMetadata {
+            brand = "brand-ref"
+            campaign = "campaign-ref"
+          }
+        }
+      }
+      clientAccountReferenceId = "client-ref-nonexistent"
+      dataAvailabilityInterval = interval {
+        startTime = timestamp { seconds = 200 }
+        endTime = timestamp { seconds = 300 }
+      }
+      mediaTypes += listOf(MediaType.OTHER)
+    }
+    // Two entity-key EventGroups observed out of sorted order; the smaller key must win regardless.
+    val higherEntityKeyEventGroup = eventGroup {
+      this.eventGroupMetadata = eventGroupMetadata {
+        this.adMetadata = adMetadata {
+          this.campaignMetadata = campaignMetadata {
+            brand = "brand-z"
+            campaign = "campaign-z"
+          }
+        }
+      }
+      entityKey = entityKey {
+        entityType = "campaign"
+        entityId = "entity-z"
+      }
+      clientAccountReferenceId = "client-ref-nonexistent"
+      dataAvailabilityInterval = interval {
+        startTime = timestamp { seconds = 200 }
+        endTime = timestamp { seconds = 300 }
+      }
+      mediaTypes += listOf(MediaType.OTHER)
+    }
+    val lowerEntityKeyEventGroup = eventGroup {
+      this.eventGroupMetadata = eventGroupMetadata {
+        this.adMetadata = adMetadata {
+          this.campaignMetadata = campaignMetadata {
+            brand = "brand-a"
+            campaign = "campaign-a"
+          }
+        }
+      }
+      entityKey = entityKey {
+        entityType = "campaign"
+        entityId = "entity-a"
+      }
+      clientAccountReferenceId = "client-ref-nonexistent"
+      dataAvailabilityInterval = interval {
+        startTime = timestamp { seconds = 200 }
+        endTime = timestamp { seconds = 300 }
+      }
+      mediaTypes += listOf(MediaType.OTHER)
+    }
+    val eventGroupSync =
+      EventGroupSync(
+        "edp-name",
+        eventGroupsStub,
+        clientAccountsStub,
+        unlinkedClientAccountsStub,
+        listOf(refIdEventGroup, higherEntityKeyEventGroup, lowerEntityKeyEventGroup).asFlow(),
+        MinimumIntervalThrottler(Clock.systemUTC(), Duration.ofMillis(1000)),
+        100,
+        entityKeyTypes = emptyList(),
+      )
+    runBlocking { eventGroupSync.sync().collect() }
+
+    val captor = argumentCaptor<ReplaceUnlinkedClientAccountsRequest>()
+    verifyBlocking(unlinkedClientAccountsServiceMock, times(1)) {
+      replaceUnlinkedClientAccounts(captor.capture())
+    }
+    val account = captor.firstValue.unlinkedClientAccountsList.single()
+    assertThat(account.clientAccountReferenceId).isEqualTo("client-ref-nonexistent")
+    // entity_key wins over the observed reference id, and the smallest key is chosen.
+    assertThat(account.entityKey)
+      .isEqualTo(
+        cmmsEntityKey {
+          entityType = "campaign"
+          entityId = "entity-a"
+        }
+      )
+    assertThat(account.eventGroupReferenceId).isEmpty()
+  }
+
+  @Test
+  fun `sync flushes unlinked accounts once with deduped brands`() {
+    val firstEventGroup = eventGroup {
+      eventGroupReferenceId = "reference-id-a"
+      this.eventGroupMetadata = eventGroupMetadata {
+        this.adMetadata = adMetadata {
+          this.campaignMetadata = campaignMetadata {
+            brand = "brand-a"
+            campaign = "campaign-a"
+          }
+        }
+      }
+      clientAccountReferenceId = "client-ref-nonexistent"
+      dataAvailabilityInterval = interval {
+        startTime = timestamp { seconds = 200 }
+        endTime = timestamp { seconds = 300 }
+      }
+      mediaTypes += listOf(MediaType.OTHER)
+    }
+    val secondEventGroup = eventGroup {
+      eventGroupReferenceId = "reference-id-b"
+      this.eventGroupMetadata = eventGroupMetadata {
+        this.adMetadata = adMetadata {
+          this.campaignMetadata = campaignMetadata {
+            brand = "brand-b"
+            campaign = "campaign-b"
+          }
+        }
+      }
+      clientAccountReferenceId = "client-ref-nonexistent"
+      dataAvailabilityInterval = interval {
+        startTime = timestamp { seconds = 200 }
+        endTime = timestamp { seconds = 300 }
+      }
+      mediaTypes += listOf(MediaType.OTHER)
+    }
+    val eventGroupSync =
+      EventGroupSync(
+        "edp-name",
+        eventGroupsStub,
+        clientAccountsStub,
+        unlinkedClientAccountsStub,
+        listOf(firstEventGroup, secondEventGroup).asFlow(),
+        MinimumIntervalThrottler(Clock.systemUTC(), Duration.ofMillis(1000)),
+        100,
+        entityKeyTypes = emptyList(),
+      )
+    runBlocking { eventGroupSync.sync().collect() }
+
+    // The lookup is cached, so the Kingdom is queried only once for the shared reference ID.
+    verifyBlocking(clientAccountsServiceMock, times(1)) { listClientAccounts(any()) }
+
+    val captor = argumentCaptor<ReplaceUnlinkedClientAccountsRequest>()
+    verifyBlocking(unlinkedClientAccountsServiceMock, times(1)) {
+      replaceUnlinkedClientAccounts(captor.capture())
+    }
+    val request = captor.firstValue
+    assertThat(request.parent).isEqualTo("edp-name")
+    val account = request.unlinkedClientAccountsList.single()
+    assertThat(account.clientAccountReferenceId).isEqualTo("client-ref-nonexistent")
+    assertThat(account.brandsList).containsExactly("brand-a", "brand-b")
+    assertThat(account.eventGroupReferenceId).isEqualTo("reference-id-a")
+  }
+
+  @Test
+  fun `sync always calls ReplaceUnlinkedClientAccounts even with no unlinked accounts`() {
+    val eventGroupSync =
+      EventGroupSync(
+        "edp-name",
+        eventGroupsStub,
+        clientAccountsStub,
+        unlinkedClientAccountsStub,
+        CAMPAIGNS.asFlow(),
+        MinimumIntervalThrottler(Clock.systemUTC(), Duration.ofMillis(1000)),
+        100,
+        entityKeyTypes = emptyList(),
+      )
+    runBlocking { eventGroupSync.sync().collect() }
+
+    val captor = argumentCaptor<ReplaceUnlinkedClientAccountsRequest>()
+    verifyBlocking(unlinkedClientAccountsServiceMock, times(1)) {
+      replaceUnlinkedClientAccounts(captor.capture())
+    }
+    assertThat(captor.firstValue.parent).isEqualTo("edp-name")
+    assertThat(captor.firstValue.unlinkedClientAccountsList).isEmpty()
+  }
+
+  @Test
+  fun `sync skips ReplaceUnlinkedClientAccounts when no event groups are observed`() {
+    val eventGroupSync =
+      EventGroupSync(
+        "edp-name",
+        eventGroupsStub,
+        clientAccountsStub,
+        unlinkedClientAccountsStub,
+        emptyList<EdpaEventGroup>().asFlow(),
+        MinimumIntervalThrottler(Clock.systemUTC(), Duration.ofMillis(1000)),
+        100,
+        entityKeyTypes = emptyList(),
+      )
+    runBlocking { eventGroupSync.sync().collect() }
+
+    // A run that streams zero event groups must not reconcile, so a transient empty read never
+    // wipes the stored unlinked accounts from a prior run.
+    verifyBlocking(unlinkedClientAccountsServiceMock, times(0)) {
+      replaceUnlinkedClientAccounts(any())
+    }
+  }
+
+  @Test
+  fun `sync does not fail the run when ReplaceUnlinkedClientAccounts fails`() {
+    wheneverBlocking { unlinkedClientAccountsServiceMock.replaceUnlinkedClientAccounts(any()) }
+      .thenThrow(
+        StatusRuntimeException(io.grpc.Status.UNAVAILABLE.withDescription("transient outage"))
+      )
+
+    val unlinkedEventGroup = eventGroup {
+      eventGroupReferenceId = "reference-id-unlinked"
+      this.eventGroupMetadata = eventGroupMetadata {
+        this.adMetadata = adMetadata {
+          this.campaignMetadata = campaignMetadata {
+            brand = "brand-unlinked"
+            campaign = "campaign-unlinked"
+          }
+        }
+      }
+      clientAccountReferenceId = "client-ref-nonexistent"
+      dataAvailabilityInterval = interval {
+        startTime = timestamp { seconds = 200 }
+        endTime = timestamp { seconds = 300 }
+      }
+      mediaTypes += listOf(MediaType.OTHER)
+    }
+    // A linked, directly-mapped event group in the same run that syncs successfully. Its sync must
+    // not be undone by the failing secondary reconcile.
+    val linkedEventGroup = eventGroup {
+      eventGroupReferenceId = "reference-id-linked"
+      measurementConsumer = "measurementConsumers/measurement-consumer-2"
+      this.eventGroupMetadata = eventGroupMetadata {
+        this.adMetadata = adMetadata {
+          this.campaignMetadata = campaignMetadata {
+            brand = "brand-linked"
+            campaign = "campaign-linked"
+          }
+        }
+      }
+      dataAvailabilityInterval = interval {
+        startTime = timestamp { seconds = 200 }
+        endTime = timestamp { seconds = 300 }
+      }
+      mediaTypes += listOf(MediaType.OTHER)
+    }
+    val eventGroupSync =
+      EventGroupSync(
+        "edp-name",
+        eventGroupsStub,
+        clientAccountsStub,
+        unlinkedClientAccountsStub,
+        listOf(unlinkedEventGroup, linkedEventGroup).asFlow(),
+        MinimumIntervalThrottler(Clock.systemUTC(), Duration.ofMillis(1000)),
+        100,
+        entityKeyTypes = emptyList(),
+      )
+
+    // The secondary reconcile failing must not abort a run whose event groups already synced; the
+    // run completes and the next reconcile catches up.
+    val result = runBlocking { eventGroupSync.sync().toList() }
+    verifyBlocking(unlinkedClientAccountsServiceMock, times(1)) {
+      replaceUnlinkedClientAccounts(any())
+    }
+
+    // Despite the reconcile failure, the linked event group in the same run still synced: its
+    // create RPC was issued and its MappedEventGroup was emitted.
+    val createCaptor = argumentCaptor<BatchCreateEventGroupsRequest>()
+    verifyBlocking(eventGroupsServiceMock, times(1)) {
+      batchCreateEventGroups(createCaptor.capture())
+    }
+    assertThat(
+        createCaptor.allValues
+          .flatMap { it.requestsList }
+          .map { it.eventGroup.eventGroupReferenceId }
+      )
+      .contains("reference-id-linked")
+    assertThat(result.map { it.eventGroupReferenceId }).contains("reference-id-linked")
+
+    // The failed secondary reconcile increments its dedicated counter.
+    val metrics = getMetrics()
+    val reconcileFailureMetric =
+      metrics.find { it.name == "edpa.event_group.unlinked_reconcile_failure" }
+    assertThat(reconcileFailureMetric).isNotNull()
+    assertThat(reconcileFailureMetric!!.longSumData.points.sumOf { it.value }).isEqualTo(1)
   }
 
   companion object {

--- a/src/test/kotlin/org/wfanet/measurement/edpaggregator/eventgroups/EventGroupSyncTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/edpaggregator/eventgroups/EventGroupSyncTest.kt
@@ -303,10 +303,9 @@ class EventGroupSyncTest {
         .thenAnswer { invocation ->
           batchCreateUnlinkedClientAccountsResponse {
             unlinkedClientAccounts +=
-              invocation
-                .getArgument<BatchCreateUnlinkedClientAccountsRequest>(0)
-                .requestsList
-                .map { it.unlinkedClientAccount }
+              invocation.getArgument<BatchCreateUnlinkedClientAccountsRequest>(0).requestsList.map {
+                it.unlinkedClientAccount
+              }
           }
         }
       onBlocking {
@@ -4692,7 +4691,9 @@ class EventGroupSyncTest {
     // The event group is linked via its direct measurement_consumer, so the empty client-account
     // lookup does not record it as unlinked. The reconcile still lists the stored set (empty here),
     // but has nothing to create or delete.
-    verifyBlocking(unlinkedClientAccountsServiceMock, times(1)) { listUnlinkedClientAccounts(any()) }
+    verifyBlocking(unlinkedClientAccountsServiceMock, times(1)) {
+      listUnlinkedClientAccounts(any())
+    }
     verifyBlocking(unlinkedClientAccountsServiceMock, times(0)) {
       batchCreateUnlinkedClientAccounts(any())
     }
@@ -5107,7 +5108,9 @@ class EventGroupSyncTest {
 
     // The reconcile lists the stored set (empty) and observes no unlinked accounts, so no
     // create/delete RPC is issued.
-    verifyBlocking(unlinkedClientAccountsServiceMock, times(1)) { listUnlinkedClientAccounts(any()) }
+    verifyBlocking(unlinkedClientAccountsServiceMock, times(1)) {
+      listUnlinkedClientAccounts(any())
+    }
     verifyBlocking(unlinkedClientAccountsServiceMock, times(0)) {
       batchCreateUnlinkedClientAccounts(any())
     }
@@ -5133,7 +5136,9 @@ class EventGroupSyncTest {
 
     // A run that streams zero event groups must not reconcile, so a transient empty read never
     // wipes the stored unlinked accounts from a prior run.
-    verifyBlocking(unlinkedClientAccountsServiceMock, times(0)) { listUnlinkedClientAccounts(any()) }
+    verifyBlocking(unlinkedClientAccountsServiceMock, times(0)) {
+      listUnlinkedClientAccounts(any())
+    }
     verifyBlocking(unlinkedClientAccountsServiceMock, times(0)) {
       batchCreateUnlinkedClientAccounts(any())
     }
@@ -5189,9 +5194,7 @@ class EventGroupSyncTest {
 
   @Test
   fun `sync does not fail the run when BatchCreateUnlinkedClientAccounts fails`() {
-    wheneverBlocking {
-        unlinkedClientAccountsServiceMock.batchCreateUnlinkedClientAccounts(any())
-      }
+    wheneverBlocking { unlinkedClientAccountsServiceMock.batchCreateUnlinkedClientAccounts(any()) }
       .thenThrow(
         StatusRuntimeException(io.grpc.Status.UNAVAILABLE.withDescription("transient outage"))
       )

--- a/src/test/kotlin/org/wfanet/measurement/edpaggregator/eventgroups/EventGroupSyncTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/edpaggregator/eventgroups/EventGroupSyncTest.kt
@@ -177,7 +177,7 @@ class EventGroupSyncTest {
                 name = "dataProviders/data-provider-1/eventGroups/resource-id-1"
                 measurementConsumer = "measurementConsumers/measurement-consumer-1"
                 eventGroupReferenceId = "reference-id-1"
-                mediaTypes += listOf("VIDEO", "DISPLAY").map { CmmsMediaType.valueOf(it) }
+                mediaTypes += listOf(CmmsMediaType.VIDEO, CmmsMediaType.DISPLAY)
                 eventGroupMetadata = cmmsEventGroupMetadata {
                   this.adMetadata = cmmsAdMetadata {
                     this.campaignMetadata = cmmsCampaignMetadata {
@@ -195,7 +195,7 @@ class EventGroupSyncTest {
                 name = "dataProviders/data-provider-2/eventGroups/resource-id-2"
                 measurementConsumer = "measurementConsumers/measurement-consumer-2"
                 eventGroupReferenceId = "reference-id-2"
-                mediaTypes += listOf("OTHER").map { CmmsMediaType.valueOf(it) }
+                mediaTypes += listOf(CmmsMediaType.OTHER)
                 eventGroupMetadata = cmmsEventGroupMetadata {
                   this.adMetadata = cmmsAdMetadata {
                     this.campaignMetadata = cmmsCampaignMetadata {
@@ -231,7 +231,7 @@ class EventGroupSyncTest {
                 name = "dataProviders/data-provider-3/eventGroups/resource-id-4"
                 measurementConsumer = "measurementConsumers/measurement-consumer-other"
                 eventGroupReferenceId = "reference-id-1"
-                mediaTypes += listOf("VIDEO", "DISPLAY").map { CmmsMediaType.valueOf(it) }
+                mediaTypes += listOf(CmmsMediaType.VIDEO, CmmsMediaType.DISPLAY)
                 eventGroupMetadata = cmmsEventGroupMetadata {
                   this.adMetadata = cmmsAdMetadata {
                     this.campaignMetadata = cmmsCampaignMetadata {
@@ -350,8 +350,7 @@ class EventGroupSyncTest {
         startTime = timestamp { seconds = 200 }
         endTime = timestamp { seconds = 300 }
       }
-      mediaTypes +=
-        listOf(MediaType.OTHER, MediaType.valueOf("VIDEO"), MediaType.valueOf("DISPLAY"))
+      mediaTypes += listOf(MediaType.OTHER, MediaType.VIDEO, MediaType.DISPLAY)
     }
     val testCampaigns = CAMPAIGNS + newCampaign
     val eventGroupSync =
@@ -386,8 +385,7 @@ class EventGroupSyncTest {
         startTime = timestamp { seconds = 200 }
         endTime = timestamp { seconds = 300 }
       }
-      mediaTypes +=
-        listOf(MediaType.OTHER, MediaType.valueOf("VIDEO"), MediaType.valueOf("DISPLAY"))
+      mediaTypes += listOf(MediaType.OTHER, MediaType.VIDEO, MediaType.DISPLAY)
     }
     val testCampaigns = listOf(newCampaign)
     val eventGroupSync =
@@ -422,7 +420,7 @@ class EventGroupSyncTest {
                 name = "dataProviders/data-provider-1/eventGroups/resource-id-1"
                 measurementConsumer = "measurementConsumers/measurement-consumer-1"
                 eventGroupReferenceId = "reference-id-1"
-                mediaTypes += listOf("VIDEO", "DISPLAY").map { CmmsMediaType.valueOf(it) }
+                mediaTypes += listOf(CmmsMediaType.VIDEO, CmmsMediaType.DISPLAY)
                 eventGroupMetadata = cmmsEventGroupMetadata {
                   this.adMetadata = cmmsAdMetadata {
                     this.campaignMetadata = cmmsCampaignMetadata {
@@ -444,7 +442,7 @@ class EventGroupSyncTest {
                 name = "dataProviders/data-provider-3/eventGroups/resource-id-4"
                 measurementConsumer = "measurementConsumers/measurement-consumer-other"
                 eventGroupReferenceId = "reference-id-1"
-                mediaTypes += listOf("VIDEO", "DISPLAY").map { CmmsMediaType.valueOf(it) }
+                mediaTypes += listOf(CmmsMediaType.VIDEO, CmmsMediaType.DISPLAY)
                 eventGroupMetadata = cmmsEventGroupMetadata {
                   this.adMetadata = cmmsAdMetadata {
                     this.campaignMetadata = cmmsCampaignMetadata {
@@ -507,7 +505,7 @@ class EventGroupSyncTest {
                 name = "dataProviders/data-provider-1/eventGroups/resource-id-1"
                 measurementConsumer = "measurementConsumers/measurement-consumer-1"
                 eventGroupReferenceId = "reference-id-1"
-                mediaTypes += listOf("VIDEO", "DISPLAY").map { CmmsMediaType.valueOf(it) }
+                mediaTypes += listOf(CmmsMediaType.VIDEO, CmmsMediaType.DISPLAY)
                 eventGroupMetadata = cmmsEventGroupMetadata {
                   this.adMetadata = cmmsAdMetadata {
                     this.campaignMetadata = cmmsCampaignMetadata {
@@ -529,7 +527,7 @@ class EventGroupSyncTest {
                 name = "dataProviders/data-provider-3/eventGroups/resource-id-4"
                 measurementConsumer = "measurementConsumers/measurement-consumer-other"
                 eventGroupReferenceId = "reference-id-1"
-                mediaTypes += listOf("VIDEO", "DISPLAY").map { CmmsMediaType.valueOf(it) }
+                mediaTypes += listOf(CmmsMediaType.VIDEO, CmmsMediaType.DISPLAY)
                 eventGroupMetadata = cmmsEventGroupMetadata {
                   this.adMetadata = cmmsAdMetadata {
                     this.campaignMetadata = cmmsCampaignMetadata {
@@ -571,7 +569,7 @@ class EventGroupSyncTest {
         startTime = timestamp { seconds = 200 }
         endTime = timestamp { seconds = 300 }
       }
-      mediaTypes += listOf(MediaType.valueOf("VIDEO"), MediaType.valueOf("DISPLAY"))
+      mediaTypes += listOf(MediaType.VIDEO, MediaType.DISPLAY)
     }
     val eventGroupSync =
       EventGroupSync(
@@ -636,7 +634,7 @@ class EventGroupSyncTest {
             name = "dataProviders/data-provider-1/eventGroups/resource-id-1"
             measurementConsumer = "measurementConsumers/measurement-consumer-1"
             eventGroupReferenceId = "reference-id-1"
-            mediaTypes += listOf("VIDEO", "DISPLAY").map { CmmsMediaType.valueOf(it) }
+            mediaTypes += listOf(CmmsMediaType.VIDEO, CmmsMediaType.DISPLAY)
             dataAvailabilityInterval = interval {
               startTime = timestamp { seconds = 200 }
               endTime = timestamp { seconds = 300 }
@@ -734,8 +732,7 @@ class EventGroupSyncTest {
         startTime = timestamp { seconds = 200 }
         endTime = timestamp { seconds = 300 }
       }
-      mediaTypes +=
-        listOf(MediaType.OTHER, MediaType.valueOf("VIDEO"), MediaType.valueOf("DISPLAY"))
+      mediaTypes += listOf(MediaType.OTHER, MediaType.VIDEO, MediaType.DISPLAY)
     }
     val testCampaigns = listOf(newCampaign)
     val eventGroupSync =
@@ -2400,7 +2397,7 @@ class EventGroupSyncTest {
           startTime = timestamp { seconds = 200 }
           endTime = timestamp { seconds = 300 }
         }
-        mediaTypes += listOf(MediaType.valueOf("VIDEO"), MediaType.valueOf("DISPLAY"))
+        mediaTypes += listOf(MediaType.VIDEO, MediaType.DISPLAY)
       }
 
       val eventGroupSync =
@@ -4514,6 +4511,9 @@ class EventGroupSyncTest {
             campaign = "campaign-unlinked"
           }
         }
+        this.entityMetadata = struct {
+          fields["brand_name"] = value { stringValue = "brand-unlinked" }
+        }
       }
       clientAccountReferenceId = "client-ref-nonexistent"
       dataAvailabilityInterval = interval {
@@ -4625,6 +4625,9 @@ class EventGroupSyncTest {
             campaign = "campaign-unlinked"
           }
         }
+        this.entityMetadata = struct {
+          fields["brand_name"] = value { stringValue = "brand-unlinked" }
+        }
       }
       clientAccountReferenceId = "client-ref-nonexistent"
       dataAvailabilityInterval = interval {
@@ -4703,7 +4706,7 @@ class EventGroupSyncTest {
   }
 
   @Test
-  fun `sync captures unlinked account with no entity_metadata when brand is blank`() {
+  fun `sync captures unlinked account with no entity_metadata when the EventGroup has none`() {
     val unlinkedEventGroup = eventGroup {
       eventGroupReferenceId = "reference-id-no-brand"
       this.eventGroupMetadata = eventGroupMetadata {
@@ -4809,6 +4812,9 @@ class EventGroupSyncTest {
             brand = "brand-entity-key"
             campaign = "campaign-entity-key"
           }
+        }
+        this.entityMetadata = struct {
+          fields["brand_name"] = value { stringValue = "brand-entity-key" }
         }
       }
       entityKey = entityKey {
@@ -4945,7 +4951,7 @@ class EventGroupSyncTest {
   }
 
   @Test
-  fun `sync folds observed brands into a single brand_name using the smallest brand`() {
+  fun `sync carries the winning observed EventGroup entity_metadata`() {
     val firstEventGroup = eventGroup {
       eventGroupReferenceId = "reference-id-a"
       this.eventGroupMetadata = eventGroupMetadata {
@@ -4955,6 +4961,7 @@ class EventGroupSyncTest {
             campaign = "campaign-a"
           }
         }
+        this.entityMetadata = struct { fields["brand_name"] = value { stringValue = "meta-a" } }
       }
       clientAccountReferenceId = "client-ref-nonexistent"
       dataAvailabilityInterval = interval {
@@ -4972,6 +4979,7 @@ class EventGroupSyncTest {
             campaign = "campaign-b"
           }
         }
+        this.entityMetadata = struct { fields["brand_name"] = value { stringValue = "meta-b" } }
       }
       clientAccountReferenceId = "client-ref-nonexistent"
       dataAvailabilityInterval = interval {
@@ -5004,10 +5012,10 @@ class EventGroupSyncTest {
     assertThat(request.parent).isEqualTo("edp-name")
     val account = request.requestsList.single().unlinkedClientAccount
     assertThat(account.clientAccountReferenceId).isEqualTo("client-ref-nonexistent")
-    // Both brands fold into a single brand_name entry set to the lexicographically smallest brand.
+    // entity_metadata is forwarded verbatim from the winning (smallest reference_id) EventGroup.
     assertThat(account.entityMetadata.fieldsMap.keys).containsExactly("brand_name")
     assertThat(account.entityMetadata.fieldsMap.getValue("brand_name").stringValue)
-      .isEqualTo("brand-a")
+      .isEqualTo("meta-a")
     assertThat(account.eventGroupReferenceId).isEqualTo("reference-id-a")
   }
 
@@ -5148,6 +5156,43 @@ class EventGroupSyncTest {
   }
 
   @Test
+  fun `sync does not reconcile unlinked accounts on a delete-only run`() {
+    val deletedEventGroup = eventGroup {
+      eventGroupReferenceId = "reference-id-1"
+      measurementConsumer = "measurementConsumers/measurement-consumer-1"
+      state = State.DELETED
+      entityKey = entityKey {
+        entityType = "campaign"
+        entityId = "reference-id-1"
+      }
+    }
+    val eventGroupSync =
+      EventGroupSync(
+        "edp-name",
+        eventGroupsStub,
+        clientAccountsStub,
+        unlinkedClientAccountsStub,
+        listOf(deletedEventGroup).asFlow(),
+        MinimumIntervalThrottler(Clock.systemUTC(), Duration.ofMillis(1000)),
+        100,
+        entityKeyTypes = emptyList(),
+      )
+    runBlocking { eventGroupSync.sync().collect() }
+
+    // Deletions never resolve an account, so observedEventGroupCount stays 0 and the reconcile is
+    // skipped: a delete-only run must not wipe the stored unlinked set.
+    verifyBlocking(unlinkedClientAccountsServiceMock, times(0)) {
+      listUnlinkedClientAccounts(any())
+    }
+    verifyBlocking(unlinkedClientAccountsServiceMock, times(0)) {
+      batchCreateUnlinkedClientAccounts(any())
+    }
+    verifyBlocking(unlinkedClientAccountsServiceMock, times(0)) {
+      batchDeleteUnlinkedClientAccounts(any())
+    }
+  }
+
+  @Test
   fun `sync creates unlinked accounts in multiple batches when exceeding MAX_UNLINKED_BATCH_SIZE`() {
     // 1001 distinct unlinked client accounts must be split into two BatchCreate RPCs (1000 + 1).
     val unlinkedEventGroups =
@@ -5193,6 +5238,248 @@ class EventGroupSyncTest {
   }
 
   @Test
+  fun `sync deletes all stored accounts when a run observes only linked event groups`() {
+    // A run that resolves event groups but observes zero unlinked accounts (all linked) still
+    // reconciles: every stored account is now linked, so all are deleted. This is the core reason
+    // the reconcile runs whenever observedEventGroupCount > 0, even with an empty observed set.
+    wheneverBlocking {
+        unlinkedClientAccountsServiceMock.listUnlinkedClientAccounts(
+          any<ListUnlinkedClientAccountsRequest>()
+        )
+      }
+      .thenAnswer {
+        listUnlinkedClientAccountsResponse {
+          unlinkedClientAccounts +=
+            listOf(
+              unlinkedClientAccount {
+                name = "dataProviders/edp-name/unlinkedClientAccounts/client-ref-1"
+                clientAccountReferenceId = "client-ref-1"
+              },
+              unlinkedClientAccount {
+                name = "dataProviders/edp-name/unlinkedClientAccounts/client-ref-2"
+                clientAccountReferenceId = "client-ref-2"
+              },
+            )
+        }
+      }
+    val linkedEventGroup = eventGroup {
+      eventGroupReferenceId = "reference-id-linked"
+      measurementConsumer = "measurementConsumers/measurement-consumer-2"
+      this.eventGroupMetadata = eventGroupMetadata {
+        this.adMetadata = adMetadata {
+          this.campaignMetadata = campaignMetadata {
+            brand = "brand-linked"
+            campaign = "campaign-linked"
+          }
+        }
+      }
+      dataAvailabilityInterval = interval {
+        startTime = timestamp { seconds = 200 }
+        endTime = timestamp { seconds = 300 }
+      }
+      mediaTypes += listOf(MediaType.OTHER)
+    }
+    val eventGroupSync =
+      EventGroupSync(
+        "edp-name",
+        eventGroupsStub,
+        clientAccountsStub,
+        unlinkedClientAccountsStub,
+        listOf(linkedEventGroup).asFlow(),
+        MinimumIntervalThrottler(Clock.systemUTC(), Duration.ofMillis(1000)),
+        100,
+        entityKeyTypes = emptyList(),
+      )
+    runBlocking { eventGroupSync.sync().collect() }
+
+    verifyBlocking(unlinkedClientAccountsServiceMock, times(0)) {
+      batchCreateUnlinkedClientAccounts(any())
+    }
+    val deleteCaptor = argumentCaptor<BatchDeleteUnlinkedClientAccountsRequest>()
+    verifyBlocking(unlinkedClientAccountsServiceMock, times(1)) {
+      batchDeleteUnlinkedClientAccounts(deleteCaptor.capture())
+    }
+    assertThat(deleteCaptor.firstValue.namesList)
+      .containsExactly(
+        "dataProviders/edp-name/unlinkedClientAccounts/client-ref-1",
+        "dataProviders/edp-name/unlinkedClientAccounts/client-ref-2",
+      )
+  }
+
+  @Test
+  fun `sync deletes stale accounts in multiple batches when exceeding MAX_UNLINKED_BATCH_SIZE`() {
+    // 1001 stored accounts, all now linked (empty observed set), must be deleted across two
+    // BatchDelete RPCs (1000 + 1) - symmetric with the create-side chunking.
+    wheneverBlocking {
+        unlinkedClientAccountsServiceMock.listUnlinkedClientAccounts(
+          any<ListUnlinkedClientAccountsRequest>()
+        )
+      }
+      .thenAnswer {
+        listUnlinkedClientAccountsResponse {
+          unlinkedClientAccounts +=
+            (0 until 1001).map { i ->
+              unlinkedClientAccount {
+                name = "dataProviders/edp-name/unlinkedClientAccounts/stored-%04d".format(i)
+                clientAccountReferenceId = "stored-%04d".format(i)
+              }
+            }
+        }
+      }
+    val linkedEventGroup = eventGroup {
+      eventGroupReferenceId = "reference-id-linked"
+      measurementConsumer = "measurementConsumers/measurement-consumer-2"
+      this.eventGroupMetadata = eventGroupMetadata {
+        this.adMetadata = adMetadata {
+          this.campaignMetadata = campaignMetadata {
+            brand = "brand-linked"
+            campaign = "campaign-linked"
+          }
+        }
+      }
+      dataAvailabilityInterval = interval {
+        startTime = timestamp { seconds = 200 }
+        endTime = timestamp { seconds = 300 }
+      }
+      mediaTypes += listOf(MediaType.OTHER)
+    }
+    val eventGroupSync =
+      EventGroupSync(
+        "edp-name",
+        eventGroupsStub,
+        clientAccountsStub,
+        unlinkedClientAccountsStub,
+        listOf(linkedEventGroup).asFlow(),
+        MinimumIntervalThrottler(Clock.systemUTC(), Duration.ofMillis(1000)),
+        100,
+        entityKeyTypes = emptyList(),
+      )
+    runBlocking { eventGroupSync.sync().collect() }
+
+    val deleteCaptor = argumentCaptor<BatchDeleteUnlinkedClientAccountsRequest>()
+    verifyBlocking(unlinkedClientAccountsServiceMock, times(2)) {
+      batchDeleteUnlinkedClientAccounts(deleteCaptor.capture())
+    }
+    assertThat(deleteCaptor.allValues.map { it.namesList.size }).containsExactly(1000, 1).inOrder()
+  }
+
+  @Test
+  fun `sync does not fail the run when BatchDeleteUnlinkedClientAccounts fails`() {
+    wheneverBlocking { unlinkedClientAccountsServiceMock.batchDeleteUnlinkedClientAccounts(any()) }
+      .thenThrow(
+        StatusRuntimeException(io.grpc.Status.UNAVAILABLE.withDescription("transient outage"))
+      )
+    wheneverBlocking {
+        unlinkedClientAccountsServiceMock.listUnlinkedClientAccounts(
+          any<ListUnlinkedClientAccountsRequest>()
+        )
+      }
+      .thenAnswer {
+        listUnlinkedClientAccountsResponse {
+          unlinkedClientAccounts += unlinkedClientAccount {
+            name = "dataProviders/edp-name/unlinkedClientAccounts/client-ref-stale"
+            clientAccountReferenceId = "client-ref-stale"
+          }
+        }
+      }
+    val linkedEventGroup = eventGroup {
+      eventGroupReferenceId = "reference-id-linked"
+      measurementConsumer = "measurementConsumers/measurement-consumer-2"
+      this.eventGroupMetadata = eventGroupMetadata {
+        this.adMetadata = adMetadata {
+          this.campaignMetadata = campaignMetadata {
+            brand = "brand-linked"
+            campaign = "campaign-linked"
+          }
+        }
+      }
+      dataAvailabilityInterval = interval {
+        startTime = timestamp { seconds = 200 }
+        endTime = timestamp { seconds = 300 }
+      }
+      mediaTypes += listOf(MediaType.OTHER)
+    }
+    val eventGroupSync =
+      EventGroupSync(
+        "edp-name",
+        eventGroupsStub,
+        clientAccountsStub,
+        unlinkedClientAccountsStub,
+        listOf(linkedEventGroup).asFlow(),
+        MinimumIntervalThrottler(Clock.systemUTC(), Duration.ofMillis(1000)),
+        100,
+        entityKeyTypes = emptyList(),
+      )
+    // The run completes despite the failing delete.
+    runBlocking { eventGroupSync.sync().toList() }
+    verifyBlocking(unlinkedClientAccountsServiceMock, times(1)) {
+      batchDeleteUnlinkedClientAccounts(any())
+    }
+    val metrics = getMetrics()
+    val reconcileFailureMetric =
+      metrics.find { it.name == "edpa.event_group.unlinked_reconcile_failure" }
+    assertThat(reconcileFailureMetric).isNotNull()
+    assertThat(reconcileFailureMetric!!.longSumData.points.sumOf { it.value }).isEqualTo(1)
+  }
+
+  @Test
+  fun `sync skips reconcile writes when ListUnlinkedClientAccounts fails`() {
+    wheneverBlocking {
+        unlinkedClientAccountsServiceMock.listUnlinkedClientAccounts(
+          any<ListUnlinkedClientAccountsRequest>()
+        )
+      }
+      .thenThrow(
+        StatusRuntimeException(io.grpc.Status.UNAVAILABLE.withDescription("transient outage"))
+      )
+    val unlinkedEventGroup = eventGroup {
+      eventGroupReferenceId = "reference-id-unlinked"
+      this.eventGroupMetadata = eventGroupMetadata {
+        this.adMetadata = adMetadata {
+          this.campaignMetadata = campaignMetadata {
+            brand = "brand-unlinked"
+            campaign = "campaign-unlinked"
+          }
+        }
+        this.entityMetadata = struct {
+          fields["brand_name"] = value { stringValue = "brand-unlinked" }
+        }
+      }
+      clientAccountReferenceId = "client-ref-nonexistent"
+      dataAvailabilityInterval = interval {
+        startTime = timestamp { seconds = 200 }
+        endTime = timestamp { seconds = 300 }
+      }
+      mediaTypes += listOf(MediaType.OTHER)
+    }
+    val eventGroupSync =
+      EventGroupSync(
+        "edp-name",
+        eventGroupsStub,
+        clientAccountsStub,
+        unlinkedClientAccountsStub,
+        listOf(unlinkedEventGroup).asFlow(),
+        MinimumIntervalThrottler(Clock.systemUTC(), Duration.ofMillis(1000)),
+        100,
+        entityKeyTypes = emptyList(),
+      )
+    runBlocking { eventGroupSync.sync().toList() }
+
+    // List failed, so neither create nor delete is attempted, and the failure is metered.
+    verifyBlocking(unlinkedClientAccountsServiceMock, times(0)) {
+      batchCreateUnlinkedClientAccounts(any())
+    }
+    verifyBlocking(unlinkedClientAccountsServiceMock, times(0)) {
+      batchDeleteUnlinkedClientAccounts(any())
+    }
+    val metrics = getMetrics()
+    val reconcileFailureMetric =
+      metrics.find { it.name == "edpa.event_group.unlinked_reconcile_failure" }
+    assertThat(reconcileFailureMetric).isNotNull()
+    assertThat(reconcileFailureMetric!!.longSumData.points.sumOf { it.value }).isEqualTo(1)
+  }
+
+  @Test
   fun `sync does not fail the run when BatchCreateUnlinkedClientAccounts fails`() {
     wheneverBlocking { unlinkedClientAccountsServiceMock.batchCreateUnlinkedClientAccounts(any()) }
       .thenThrow(
@@ -5207,6 +5494,9 @@ class EventGroupSyncTest {
             brand = "brand-unlinked"
             campaign = "campaign-unlinked"
           }
+        }
+        this.entityMetadata = struct {
+          fields["brand_name"] = value { stringValue = "brand-unlinked" }
         }
       }
       clientAccountReferenceId = "client-ref-nonexistent"
@@ -5294,7 +5584,7 @@ class EventGroupSyncTest {
             startTime = timestamp { seconds = 200 }
             endTime = timestamp { seconds = 300 }
           }
-          mediaTypes += listOf(MediaType.valueOf("VIDEO"), MediaType.valueOf("DISPLAY"))
+          mediaTypes += listOf(MediaType.VIDEO, MediaType.DISPLAY)
         },
         eventGroup {
           eventGroupReferenceId = "reference-id-2"
@@ -5345,7 +5635,7 @@ class EventGroupSyncTest {
             startTime = timestamp { seconds = 200 }
             endTime = timestamp { seconds = 300 }
           }
-          mediaTypes += listOf(MediaType.valueOf("VIDEO"), MediaType.valueOf("DISPLAY"))
+          mediaTypes += listOf(MediaType.VIDEO, MediaType.DISPLAY)
         },
       )
   }

--- a/src/test/kotlin/org/wfanet/measurement/edpaggregator/eventgroups/EventGroupSyncTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/edpaggregator/eventgroups/EventGroupSyncTest.kt
@@ -18,6 +18,7 @@ package org.wfanet.measurement.edpaggregator.eventgroups
 
 import com.google.common.truth.Truth.assertThat
 import com.google.common.truth.extensions.proto.ProtoTruth.assertThat
+import com.google.protobuf.Empty
 import com.google.protobuf.listValue
 import com.google.protobuf.struct
 import com.google.protobuf.timestamp
@@ -59,6 +60,8 @@ import org.mockito.kotlin.times
 import org.mockito.kotlin.verifyBlocking
 import org.mockito.kotlin.wheneverBlocking
 import org.wfanet.measurement.api.v2alpha.BatchCreateEventGroupsRequest
+import org.wfanet.measurement.api.v2alpha.BatchCreateUnlinkedClientAccountsRequest
+import org.wfanet.measurement.api.v2alpha.BatchDeleteUnlinkedClientAccountsRequest
 import org.wfanet.measurement.api.v2alpha.BatchUpdateEventGroupsRequest
 import org.wfanet.measurement.api.v2alpha.ClientAccountsGrpcKt.ClientAccountsCoroutineImplBase
 import org.wfanet.measurement.api.v2alpha.ClientAccountsGrpcKt.ClientAccountsCoroutineStub
@@ -72,20 +75,22 @@ import org.wfanet.measurement.api.v2alpha.EventGroupsGrpcKt.EventGroupsCoroutine
 import org.wfanet.measurement.api.v2alpha.EventGroupsGrpcKt.EventGroupsCoroutineStub
 import org.wfanet.measurement.api.v2alpha.ListClientAccountsRequest
 import org.wfanet.measurement.api.v2alpha.ListEventGroupsRequest
+import org.wfanet.measurement.api.v2alpha.ListUnlinkedClientAccountsRequest
 import org.wfanet.measurement.api.v2alpha.MeasurementConsumerClientAccountKey
 import org.wfanet.measurement.api.v2alpha.MediaType as CmmsMediaType
-import org.wfanet.measurement.api.v2alpha.ReplaceUnlinkedClientAccountsRequest
 import org.wfanet.measurement.api.v2alpha.UnlinkedClientAccountsGrpcKt.UnlinkedClientAccountsCoroutineImplBase
 import org.wfanet.measurement.api.v2alpha.UnlinkedClientAccountsGrpcKt.UnlinkedClientAccountsCoroutineStub
 import org.wfanet.measurement.api.v2alpha.UpdateEventGroupRequest
 import org.wfanet.measurement.api.v2alpha.batchCreateEventGroupsResponse
+import org.wfanet.measurement.api.v2alpha.batchCreateUnlinkedClientAccountsResponse
 import org.wfanet.measurement.api.v2alpha.batchUpdateEventGroupsResponse
 import org.wfanet.measurement.api.v2alpha.clientAccount
 import org.wfanet.measurement.api.v2alpha.eventGroup as cmmsEventGroup
 import org.wfanet.measurement.api.v2alpha.eventGroupMetadata as cmmsEventGroupMetadata
 import org.wfanet.measurement.api.v2alpha.listClientAccountsResponse
 import org.wfanet.measurement.api.v2alpha.listEventGroupsResponse
-import org.wfanet.measurement.api.v2alpha.replaceUnlinkedClientAccountsResponse
+import org.wfanet.measurement.api.v2alpha.listUnlinkedClientAccountsResponse
+import org.wfanet.measurement.api.v2alpha.unlinkedClientAccount
 import org.wfanet.measurement.common.Instrumentation
 import org.wfanet.measurement.common.grpc.testing.GrpcTestServerRule
 import org.wfanet.measurement.common.grpc.testing.mockService
@@ -290,8 +295,24 @@ class EventGroupSyncTest {
 
   private val unlinkedClientAccountsServiceMock: UnlinkedClientAccountsCoroutineImplBase =
     mockService {
-      onBlocking { replaceUnlinkedClientAccounts(any<ReplaceUnlinkedClientAccountsRequest>()) }
-        .thenAnswer { replaceUnlinkedClientAccountsResponse {} }
+      onBlocking { listUnlinkedClientAccounts(any<ListUnlinkedClientAccountsRequest>()) }
+        .thenAnswer { listUnlinkedClientAccountsResponse {} }
+      onBlocking {
+          batchCreateUnlinkedClientAccounts(any<BatchCreateUnlinkedClientAccountsRequest>())
+        }
+        .thenAnswer { invocation ->
+          batchCreateUnlinkedClientAccountsResponse {
+            unlinkedClientAccounts +=
+              invocation
+                .getArgument<BatchCreateUnlinkedClientAccountsRequest>(0)
+                .requestsList
+                .map { it.unlinkedClientAccount }
+          }
+        }
+      onBlocking {
+          batchDeleteUnlinkedClientAccounts(any<BatchDeleteUnlinkedClientAccountsRequest>())
+        }
+        .thenAnswer { Empty.getDefaultInstance() }
     }
 
   private val eventGroupsStub: EventGroupsCoroutineStub by lazy {
@@ -4484,7 +4505,7 @@ class EventGroupSyncTest {
   }
 
   @Test
-  fun `sync captures unlinked client account and flushes via ReplaceUnlinkedClientAccounts`() {
+  fun `sync captures unlinked client account and creates it via BatchCreateUnlinkedClientAccounts`() {
     val unlinkedEventGroup = eventGroup {
       eventGroupReferenceId = "reference-id-unlinked"
       this.eventGroupMetadata = eventGroupMetadata {
@@ -4515,16 +4536,21 @@ class EventGroupSyncTest {
       )
     runBlocking { eventGroupSync.sync().collect() }
 
-    val captor = argumentCaptor<ReplaceUnlinkedClientAccountsRequest>()
+    val createCaptor = argumentCaptor<BatchCreateUnlinkedClientAccountsRequest>()
     verifyBlocking(unlinkedClientAccountsServiceMock, times(1)) {
-      replaceUnlinkedClientAccounts(captor.capture())
+      batchCreateUnlinkedClientAccounts(createCaptor.capture())
     }
-    val request = captor.firstValue
+    val request = createCaptor.firstValue
     assertThat(request.parent).isEqualTo("edp-name")
-    val account = request.unlinkedClientAccountsList.single()
+    val account = request.requestsList.single().unlinkedClientAccount
     assertThat(account.clientAccountReferenceId).isEqualTo("client-ref-nonexistent")
-    assertThat(account.brandsList).containsExactly("brand-unlinked")
+    assertThat(account.entityMetadata.fieldsMap.getValue("brand_name").stringValue)
+      .isEqualTo("brand-unlinked")
     assertThat(account.eventGroupReferenceId).isEqualTo("reference-id-unlinked")
+    // Nothing was stored before, so there is nothing to delete.
+    verifyBlocking(unlinkedClientAccountsServiceMock, times(0)) {
+      batchDeleteUnlinkedClientAccounts(any())
+    }
   }
 
   @Test
@@ -4565,7 +4591,10 @@ class EventGroupSyncTest {
     // mislabel the account as unlinked.
     assertFailsWith<StatusException> { runBlocking { eventGroupSync.sync().collect() } }
     verifyBlocking(unlinkedClientAccountsServiceMock, times(0)) {
-      replaceUnlinkedClientAccounts(any())
+      batchCreateUnlinkedClientAccounts(any())
+    }
+    verifyBlocking(unlinkedClientAccountsServiceMock, times(0)) {
+      batchDeleteUnlinkedClientAccounts(any())
     }
   }
 
@@ -4618,11 +4647,12 @@ class EventGroupSyncTest {
       )
     runBlocking { eventGroupSync.sync().collect() }
 
-    val captor = argumentCaptor<ReplaceUnlinkedClientAccountsRequest>()
+    val createCaptor = argumentCaptor<BatchCreateUnlinkedClientAccountsRequest>()
     verifyBlocking(unlinkedClientAccountsServiceMock, times(1)) {
-      replaceUnlinkedClientAccounts(captor.capture())
+      batchCreateUnlinkedClientAccounts(createCaptor.capture())
     }
-    val refIds = captor.firstValue.unlinkedClientAccountsList.map { it.clientAccountReferenceId }
+    val refIds =
+      createCaptor.firstValue.requestsList.map { it.unlinkedClientAccount.clientAccountReferenceId }
     assertThat(refIds).containsExactly("client-ref-nonexistent")
   }
 
@@ -4659,17 +4689,20 @@ class EventGroupSyncTest {
       )
     runBlocking { eventGroupSync.sync().collect() }
 
-    val captor = argumentCaptor<ReplaceUnlinkedClientAccountsRequest>()
-    verifyBlocking(unlinkedClientAccountsServiceMock, times(1)) {
-      replaceUnlinkedClientAccounts(captor.capture())
-    }
     // The event group is linked via its direct measurement_consumer, so the empty client-account
-    // lookup does not record it as unlinked.
-    assertThat(captor.firstValue.unlinkedClientAccountsList).isEmpty()
+    // lookup does not record it as unlinked. The reconcile still lists the stored set (empty here),
+    // but has nothing to create or delete.
+    verifyBlocking(unlinkedClientAccountsServiceMock, times(1)) { listUnlinkedClientAccounts(any()) }
+    verifyBlocking(unlinkedClientAccountsServiceMock, times(0)) {
+      batchCreateUnlinkedClientAccounts(any())
+    }
+    verifyBlocking(unlinkedClientAccountsServiceMock, times(0)) {
+      batchDeleteUnlinkedClientAccounts(any())
+    }
   }
 
   @Test
-  fun `sync captures unlinked account with empty brands when brand is blank`() {
+  fun `sync captures unlinked account with no entity_metadata when brand is blank`() {
     val unlinkedEventGroup = eventGroup {
       eventGroupReferenceId = "reference-id-no-brand"
       this.eventGroupMetadata = eventGroupMetadata {
@@ -4697,13 +4730,13 @@ class EventGroupSyncTest {
       )
     runBlocking { eventGroupSync.sync().collect() }
 
-    val captor = argumentCaptor<ReplaceUnlinkedClientAccountsRequest>()
+    val createCaptor = argumentCaptor<BatchCreateUnlinkedClientAccountsRequest>()
     verifyBlocking(unlinkedClientAccountsServiceMock, times(1)) {
-      replaceUnlinkedClientAccounts(captor.capture())
+      batchCreateUnlinkedClientAccounts(createCaptor.capture())
     }
-    val account = captor.firstValue.unlinkedClientAccountsList.single()
+    val account = createCaptor.firstValue.requestsList.single().unlinkedClientAccount
     assertThat(account.clientAccountReferenceId).isEqualTo("client-ref-nonexistent")
-    assertThat(account.brandsList).isEmpty()
+    assertThat(account.hasEntityMetadata()).isFalse()
     assertThat(account.eventGroupReferenceId).isEqualTo("reference-id-no-brand")
   }
 
@@ -4756,11 +4789,12 @@ class EventGroupSyncTest {
       )
     runBlocking { eventGroupSync.sync().collect() }
 
-    val captor = argumentCaptor<ReplaceUnlinkedClientAccountsRequest>()
+    val createCaptor = argumentCaptor<BatchCreateUnlinkedClientAccountsRequest>()
     verifyBlocking(unlinkedClientAccountsServiceMock, times(1)) {
-      replaceUnlinkedClientAccounts(captor.capture())
+      batchCreateUnlinkedClientAccounts(createCaptor.capture())
     }
-    val refIds = captor.firstValue.unlinkedClientAccountsList.map { it.clientAccountReferenceId }
+    val refIds =
+      createCaptor.firstValue.requestsList.map { it.unlinkedClientAccount.clientAccountReferenceId }
     assertThat(refIds).containsExactly("client-ref-nonexistent", "client-ref-also-nonexistent")
   }
 
@@ -4800,13 +4834,14 @@ class EventGroupSyncTest {
       )
     runBlocking { eventGroupSync.sync().collect() }
 
-    val captor = argumentCaptor<ReplaceUnlinkedClientAccountsRequest>()
+    val createCaptor = argumentCaptor<BatchCreateUnlinkedClientAccountsRequest>()
     verifyBlocking(unlinkedClientAccountsServiceMock, times(1)) {
-      replaceUnlinkedClientAccounts(captor.capture())
+      batchCreateUnlinkedClientAccounts(createCaptor.capture())
     }
-    val account = captor.firstValue.unlinkedClientAccountsList.single()
+    val account = createCaptor.firstValue.requestsList.single().unlinkedClientAccount
     assertThat(account.clientAccountReferenceId).isEqualTo("client-ref-nonexistent")
-    assertThat(account.brandsList).containsExactly("brand-entity-key")
+    assertThat(account.entityMetadata.fieldsMap.getValue("brand_name").stringValue)
+      .isEqualTo("brand-entity-key")
     assertThat(account.entityKey)
       .isEqualTo(
         cmmsEntityKey {
@@ -4891,11 +4926,11 @@ class EventGroupSyncTest {
       )
     runBlocking { eventGroupSync.sync().collect() }
 
-    val captor = argumentCaptor<ReplaceUnlinkedClientAccountsRequest>()
+    val createCaptor = argumentCaptor<BatchCreateUnlinkedClientAccountsRequest>()
     verifyBlocking(unlinkedClientAccountsServiceMock, times(1)) {
-      replaceUnlinkedClientAccounts(captor.capture())
+      batchCreateUnlinkedClientAccounts(createCaptor.capture())
     }
-    val account = captor.firstValue.unlinkedClientAccountsList.single()
+    val account = createCaptor.firstValue.requestsList.single().unlinkedClientAccount
     assertThat(account.clientAccountReferenceId).isEqualTo("client-ref-nonexistent")
     // entity_key wins over the observed reference id, and the smallest key is chosen.
     assertThat(account.entityKey)
@@ -4909,13 +4944,13 @@ class EventGroupSyncTest {
   }
 
   @Test
-  fun `sync flushes unlinked accounts once with deduped brands`() {
+  fun `sync folds observed brands into a single brand_name using the smallest brand`() {
     val firstEventGroup = eventGroup {
       eventGroupReferenceId = "reference-id-a"
       this.eventGroupMetadata = eventGroupMetadata {
         this.adMetadata = adMetadata {
           this.campaignMetadata = campaignMetadata {
-            brand = "brand-a"
+            brand = "brand-b"
             campaign = "campaign-a"
           }
         }
@@ -4932,7 +4967,7 @@ class EventGroupSyncTest {
       this.eventGroupMetadata = eventGroupMetadata {
         this.adMetadata = adMetadata {
           this.campaignMetadata = campaignMetadata {
-            brand = "brand-b"
+            brand = "brand-a"
             campaign = "campaign-b"
           }
         }
@@ -4960,20 +4995,103 @@ class EventGroupSyncTest {
     // The lookup is cached, so the Kingdom is queried only once for the shared reference ID.
     verifyBlocking(clientAccountsServiceMock, times(1)) { listClientAccounts(any()) }
 
-    val captor = argumentCaptor<ReplaceUnlinkedClientAccountsRequest>()
+    val createCaptor = argumentCaptor<BatchCreateUnlinkedClientAccountsRequest>()
     verifyBlocking(unlinkedClientAccountsServiceMock, times(1)) {
-      replaceUnlinkedClientAccounts(captor.capture())
+      batchCreateUnlinkedClientAccounts(createCaptor.capture())
     }
-    val request = captor.firstValue
+    val request = createCaptor.firstValue
     assertThat(request.parent).isEqualTo("edp-name")
-    val account = request.unlinkedClientAccountsList.single()
+    val account = request.requestsList.single().unlinkedClientAccount
     assertThat(account.clientAccountReferenceId).isEqualTo("client-ref-nonexistent")
-    assertThat(account.brandsList).containsExactly("brand-a", "brand-b")
+    // Both brands fold into a single brand_name entry set to the lexicographically smallest brand.
+    assertThat(account.entityMetadata.fieldsMap.keys).containsExactly("brand_name")
+    assertThat(account.entityMetadata.fieldsMap.getValue("brand_name").stringValue)
+      .isEqualTo("brand-a")
     assertThat(account.eventGroupReferenceId).isEqualTo("reference-id-a")
   }
 
   @Test
-  fun `sync always calls ReplaceUnlinkedClientAccounts even with no unlinked accounts`() {
+  fun `sync deletes a stale stored account that is no longer observed`() {
+    // The stored set already contains an overlap account (still observed this run) and a stale
+    // account (no longer observed). Only the stale one should be deleted; the overlap is left
+    // untouched to preserve its create_time, and the newly-observed account is created.
+    wheneverBlocking {
+        unlinkedClientAccountsServiceMock.listUnlinkedClientAccounts(
+          any<ListUnlinkedClientAccountsRequest>()
+        )
+      }
+      .thenAnswer {
+        listUnlinkedClientAccountsResponse {
+          unlinkedClientAccounts +=
+            listOf(
+              unlinkedClientAccount {
+                name = "dataProviders/edp-name/unlinkedClientAccounts/client-ref-overlap"
+                clientAccountReferenceId = "client-ref-overlap"
+              },
+              unlinkedClientAccount {
+                name = "dataProviders/edp-name/unlinkedClientAccounts/client-ref-stale"
+                clientAccountReferenceId = "client-ref-stale"
+              },
+            )
+        }
+      }
+
+    fun unlinkedEventGroup(refId: String, clientRef: String) = eventGroup {
+      eventGroupReferenceId = refId
+      this.eventGroupMetadata = eventGroupMetadata {
+        this.adMetadata = adMetadata {
+          this.campaignMetadata = campaignMetadata {
+            brand = "brand-$refId"
+            campaign = "campaign-$refId"
+          }
+        }
+      }
+      clientAccountReferenceId = clientRef
+      dataAvailabilityInterval = interval {
+        startTime = timestamp { seconds = 200 }
+        endTime = timestamp { seconds = 300 }
+      }
+      mediaTypes += listOf(MediaType.OTHER)
+    }
+
+    val eventGroupSync =
+      EventGroupSync(
+        "edp-name",
+        eventGroupsStub,
+        clientAccountsStub,
+        unlinkedClientAccountsStub,
+        listOf(
+            unlinkedEventGroup("reference-id-overlap", "client-ref-overlap"),
+            unlinkedEventGroup("reference-id-new", "client-ref-nonexistent"),
+          )
+          .asFlow(),
+        MinimumIntervalThrottler(Clock.systemUTC(), Duration.ofMillis(1000)),
+        100,
+        entityKeyTypes = emptyList(),
+      )
+    runBlocking { eventGroupSync.sync().collect() }
+
+    // Only the newly-observed account is created; the overlap is left untouched.
+    val createCaptor = argumentCaptor<BatchCreateUnlinkedClientAccountsRequest>()
+    verifyBlocking(unlinkedClientAccountsServiceMock, times(1)) {
+      batchCreateUnlinkedClientAccounts(createCaptor.capture())
+    }
+    val createdRefIds =
+      createCaptor.firstValue.requestsList.map { it.unlinkedClientAccount.clientAccountReferenceId }
+    assertThat(createdRefIds).containsExactly("client-ref-nonexistent")
+
+    // Only the stale stored account is deleted, by resource name.
+    val deleteCaptor = argumentCaptor<BatchDeleteUnlinkedClientAccountsRequest>()
+    verifyBlocking(unlinkedClientAccountsServiceMock, times(1)) {
+      batchDeleteUnlinkedClientAccounts(deleteCaptor.capture())
+    }
+    assertThat(deleteCaptor.firstValue.parent).isEqualTo("edp-name")
+    assertThat(deleteCaptor.firstValue.namesList)
+      .containsExactly("dataProviders/edp-name/unlinkedClientAccounts/client-ref-stale")
+  }
+
+  @Test
+  fun `sync issues no reconcile writes when the observed and stored sets match`() {
     val eventGroupSync =
       EventGroupSync(
         "edp-name",
@@ -4987,16 +5105,19 @@ class EventGroupSyncTest {
       )
     runBlocking { eventGroupSync.sync().collect() }
 
-    val captor = argumentCaptor<ReplaceUnlinkedClientAccountsRequest>()
-    verifyBlocking(unlinkedClientAccountsServiceMock, times(1)) {
-      replaceUnlinkedClientAccounts(captor.capture())
+    // The reconcile lists the stored set (empty) and observes no unlinked accounts, so no
+    // create/delete RPC is issued.
+    verifyBlocking(unlinkedClientAccountsServiceMock, times(1)) { listUnlinkedClientAccounts(any()) }
+    verifyBlocking(unlinkedClientAccountsServiceMock, times(0)) {
+      batchCreateUnlinkedClientAccounts(any())
     }
-    assertThat(captor.firstValue.parent).isEqualTo("edp-name")
-    assertThat(captor.firstValue.unlinkedClientAccountsList).isEmpty()
+    verifyBlocking(unlinkedClientAccountsServiceMock, times(0)) {
+      batchDeleteUnlinkedClientAccounts(any())
+    }
   }
 
   @Test
-  fun `sync skips ReplaceUnlinkedClientAccounts when no event groups are observed`() {
+  fun `sync skips reconcile when no event groups are observed`() {
     val eventGroupSync =
       EventGroupSync(
         "edp-name",
@@ -5012,14 +5133,65 @@ class EventGroupSyncTest {
 
     // A run that streams zero event groups must not reconcile, so a transient empty read never
     // wipes the stored unlinked accounts from a prior run.
+    verifyBlocking(unlinkedClientAccountsServiceMock, times(0)) { listUnlinkedClientAccounts(any()) }
     verifyBlocking(unlinkedClientAccountsServiceMock, times(0)) {
-      replaceUnlinkedClientAccounts(any())
+      batchCreateUnlinkedClientAccounts(any())
+    }
+    verifyBlocking(unlinkedClientAccountsServiceMock, times(0)) {
+      batchDeleteUnlinkedClientAccounts(any())
     }
   }
 
   @Test
-  fun `sync does not fail the run when ReplaceUnlinkedClientAccounts fails`() {
-    wheneverBlocking { unlinkedClientAccountsServiceMock.replaceUnlinkedClientAccounts(any()) }
+  fun `sync creates unlinked accounts in multiple batches when exceeding MAX_UNLINKED_BATCH_SIZE`() {
+    // 1001 distinct unlinked client accounts must be split into two BatchCreate RPCs (1000 + 1).
+    val unlinkedEventGroups =
+      (0 until 1001).map { i ->
+        eventGroup {
+          eventGroupReferenceId = "reference-id-bulk-%04d".format(i)
+          this.eventGroupMetadata = eventGroupMetadata {
+            this.adMetadata = adMetadata {
+              this.campaignMetadata = campaignMetadata {
+                brand = "brand-bulk-%04d".format(i)
+                campaign = "campaign-bulk-%04d".format(i)
+              }
+            }
+          }
+          clientAccountReferenceId = "bulk-ref-%04d".format(i)
+          dataAvailabilityInterval = interval {
+            startTime = timestamp { seconds = 200 }
+            endTime = timestamp { seconds = 300 }
+          }
+          mediaTypes += listOf(MediaType.OTHER)
+        }
+      }
+    val eventGroupSync =
+      EventGroupSync(
+        "edp-name",
+        eventGroupsStub,
+        clientAccountsStub,
+        unlinkedClientAccountsStub,
+        unlinkedEventGroups.asFlow(),
+        MinimumIntervalThrottler(Clock.systemUTC(), Duration.ofMillis(1)),
+        100,
+        entityKeyTypes = emptyList(),
+      )
+    runBlocking { eventGroupSync.sync().collect() }
+
+    val createCaptor = argumentCaptor<BatchCreateUnlinkedClientAccountsRequest>()
+    verifyBlocking(unlinkedClientAccountsServiceMock, times(2)) {
+      batchCreateUnlinkedClientAccounts(createCaptor.capture())
+    }
+    val chunkSizes = createCaptor.allValues.map { it.requestsList.size }
+    assertThat(chunkSizes).containsExactly(1000, 1).inOrder()
+    assertThat(chunkSizes.sum()).isEqualTo(1001)
+  }
+
+  @Test
+  fun `sync does not fail the run when BatchCreateUnlinkedClientAccounts fails`() {
+    wheneverBlocking {
+        unlinkedClientAccountsServiceMock.batchCreateUnlinkedClientAccounts(any())
+      }
       .thenThrow(
         StatusRuntimeException(io.grpc.Status.UNAVAILABLE.withDescription("transient outage"))
       )
@@ -5076,7 +5248,7 @@ class EventGroupSyncTest {
     // run completes and the next reconcile catches up.
     val result = runBlocking { eventGroupSync.sync().toList() }
     verifyBlocking(unlinkedClientAccountsServiceMock, times(1)) {
-      replaceUnlinkedClientAccounts(any())
+      batchCreateUnlinkedClientAccounts(any())
     }
 
     // Despite the reconcile failure, the linked event group in the same run still synced: its

--- a/src/test/kotlin/org/wfanet/measurement/edpaggregator/eventgroups/EventGroupSyncTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/edpaggregator/eventgroups/EventGroupSyncTest.kt
@@ -208,7 +208,7 @@ class EventGroupSyncTest {
                 name = "dataProviders/data-provider-3/eventGroups/resource-id-3"
                 measurementConsumer = "measurementConsumers/measurement-consumer-2"
                 eventGroupReferenceId = "reference-id-3"
-                mediaTypes += listOf(CmmsMediaType.valueOf("OTHER"))
+                mediaTypes += listOf(CmmsMediaType.OTHER)
                 eventGroupMetadata = cmmsEventGroupMetadata {
                   this.adMetadata = cmmsAdMetadata {
                     this.campaignMetadata = cmmsCampaignMetadata {
@@ -331,7 +331,7 @@ class EventGroupSyncTest {
         endTime = timestamp { seconds = 300 }
       }
       mediaTypes +=
-        listOf(MediaType.valueOf("OTHER"), MediaType.valueOf("VIDEO"), MediaType.valueOf("DISPLAY"))
+        listOf(MediaType.OTHER, MediaType.valueOf("VIDEO"), MediaType.valueOf("DISPLAY"))
     }
     val testCampaigns = CAMPAIGNS + newCampaign
     val eventGroupSync =
@@ -367,7 +367,7 @@ class EventGroupSyncTest {
         endTime = timestamp { seconds = 300 }
       }
       mediaTypes +=
-        listOf(MediaType.valueOf("OTHER"), MediaType.valueOf("VIDEO"), MediaType.valueOf("DISPLAY"))
+        listOf(MediaType.OTHER, MediaType.valueOf("VIDEO"), MediaType.valueOf("DISPLAY"))
     }
     val testCampaigns = listOf(newCampaign)
     val eventGroupSync =
@@ -715,7 +715,7 @@ class EventGroupSyncTest {
         endTime = timestamp { seconds = 300 }
       }
       mediaTypes +=
-        listOf(MediaType.valueOf("OTHER"), MediaType.valueOf("VIDEO"), MediaType.valueOf("DISPLAY"))
+        listOf(MediaType.OTHER, MediaType.valueOf("VIDEO"), MediaType.valueOf("DISPLAY"))
     }
     val testCampaigns = listOf(newCampaign)
     val eventGroupSync =
@@ -1686,7 +1686,7 @@ class EventGroupSyncTest {
         startTime = timestamp { seconds = 200 }
         endTime = timestamp { seconds = 300 }
       }
-      mediaTypes += listOf(MediaType.valueOf("OTHER"))
+      mediaTypes += listOf(MediaType.OTHER)
     }
     assertFailsWith<IllegalStateException> { EventGroupSync.validateEventGroup(eventGroup) }
   }
@@ -1704,7 +1704,7 @@ class EventGroupSyncTest {
         }
       }
       measurementConsumer = "measurement-consumer-2"
-      mediaTypes += listOf(MediaType.valueOf("OTHER"))
+      mediaTypes += listOf(MediaType.OTHER)
     }
     assertFailsWith<IllegalStateException> { EventGroupSync.validateEventGroup(eventGroup) }
   }
@@ -1718,7 +1718,7 @@ class EventGroupSyncTest {
         startTime = timestamp { seconds = 200 }
         endTime = timestamp { seconds = 300 }
       }
-      mediaTypes += listOf(MediaType.valueOf("OTHER"))
+      mediaTypes += listOf(MediaType.OTHER)
     }
     assertFailsWith<IllegalStateException> { EventGroupSync.validateEventGroup(eventGroup) }
   }
@@ -1739,7 +1739,7 @@ class EventGroupSyncTest {
         startTime = timestamp { seconds = 200 }
         endTime = timestamp { seconds = 300 }
       }
-      mediaTypes += listOf(MediaType.valueOf("OTHER"))
+      mediaTypes += listOf(MediaType.OTHER)
     }
     assertFailsWith<IllegalStateException> { EventGroupSync.validateEventGroup(eventGroup) }
   }
@@ -1850,7 +1850,7 @@ class EventGroupSyncTest {
       val invalidEventGroup = eventGroup {
         eventGroupReferenceId = "invalid-ref-id"
         measurementConsumer = "" // Invalid - empty
-        mediaTypes += listOf(MediaType.valueOf("OTHER"))
+        mediaTypes += listOf(MediaType.OTHER)
         dataAvailabilityInterval = interval {
           startTime = timestamp { seconds = 200 }
           endTime = timestamp { seconds = 300 }
@@ -1970,7 +1970,7 @@ class EventGroupSyncTest {
       val invalidEventGroup = eventGroup {
         eventGroupReferenceId = "invalid-ref-id"
         measurementConsumer = "" // Invalid - empty
-        mediaTypes += listOf(MediaType.valueOf("OTHER"))
+        mediaTypes += listOf(MediaType.OTHER)
         dataAvailabilityInterval = interval {
           startTime = timestamp { seconds = 200 }
           endTime = timestamp { seconds = 300 }
@@ -2008,7 +2008,7 @@ class EventGroupSyncTest {
       val invalidEventGroup = eventGroup {
         eventGroupReferenceId = "invalid-ref-id"
         measurementConsumer = "" // Invalid - empty
-        mediaTypes += listOf(MediaType.valueOf("OTHER"))
+        mediaTypes += listOf(MediaType.OTHER)
         dataAvailabilityInterval = interval {
           startTime = timestamp { seconds = 200 }
           endTime = timestamp { seconds = 300 }
@@ -2108,7 +2108,7 @@ class EventGroupSyncTest {
         startTime = timestamp { seconds = 200 }
         endTime = timestamp { seconds = 300 }
       }
-      mediaTypes += listOf(MediaType.valueOf("OTHER"))
+      mediaTypes += listOf(MediaType.OTHER)
     }
 
     val eventGroupSync =
@@ -2155,7 +2155,7 @@ class EventGroupSyncTest {
         startTime = timestamp { seconds = 200 }
         endTime = timestamp { seconds = 300 }
       }
-      mediaTypes += listOf(MediaType.valueOf("OTHER"))
+      mediaTypes += listOf(MediaType.OTHER)
     }
 
     val eventGroupSync =
@@ -2210,7 +2210,7 @@ class EventGroupSyncTest {
         startTime = timestamp { seconds = 200 }
         endTime = timestamp { seconds = 300 }
       }
-      mediaTypes += listOf(MediaType.valueOf("OTHER"))
+      mediaTypes += listOf(MediaType.OTHER)
     }
 
     val eventGroupSync =
@@ -2254,7 +2254,7 @@ class EventGroupSyncTest {
         startTime = timestamp { seconds = 200 }
         endTime = timestamp { seconds = 300 }
       }
-      mediaTypes += listOf(MediaType.valueOf("OTHER"))
+      mediaTypes += listOf(MediaType.OTHER)
     }
 
     val eventGroupSync =
@@ -2310,7 +2310,7 @@ class EventGroupSyncTest {
           startTime = timestamp { seconds = 200 }
           endTime = timestamp { seconds = 300 }
         }
-        mediaTypes += listOf(MediaType.valueOf("OTHER"))
+        mediaTypes += listOf(MediaType.OTHER)
       }
 
       val eventGroupSync =
@@ -2362,7 +2362,7 @@ class EventGroupSyncTest {
           startTime = timestamp { seconds = 200 }
           endTime = timestamp { seconds = 300 }
         }
-        mediaTypes += listOf(MediaType.valueOf("OTHER"))
+        mediaTypes += listOf(MediaType.OTHER)
       }
 
       val validEventGroup = eventGroup {
@@ -2431,7 +2431,7 @@ class EventGroupSyncTest {
         startTime = timestamp { seconds = 200 }
         endTime = timestamp { seconds = 300 }
       }
-      mediaTypes += listOf(MediaType.valueOf("OTHER"))
+      mediaTypes += listOf(MediaType.OTHER)
     }
 
     val eventGroupSync =
@@ -2467,7 +2467,7 @@ class EventGroupSyncTest {
           startTime = timestamp { seconds = 200 }
           endTime = timestamp { seconds = 300 }
         }
-        mediaTypes += listOf(MediaType.valueOf("OTHER"))
+        mediaTypes += listOf(MediaType.OTHER)
       }
 
       val eventGroupSync =
@@ -2551,7 +2551,7 @@ class EventGroupSyncTest {
                   name = "dataProviders/data-provider-1/eventGroups/resource-id-100"
                   measurementConsumer = "measurementConsumers/measurement-consumer-1"
                   eventGroupReferenceId = "reference-id-reduced"
-                  mediaTypes += listOf(CmmsMediaType.valueOf("OTHER"))
+                  mediaTypes += listOf(CmmsMediaType.OTHER)
                   eventGroupMetadata = cmmsEventGroupMetadata {
                     this.adMetadata = cmmsAdMetadata {
                       this.campaignMetadata = cmmsCampaignMetadata {
@@ -2569,7 +2569,7 @@ class EventGroupSyncTest {
                   name = "dataProviders/data-provider-1/eventGroups/resource-id-101"
                   measurementConsumer = "measurementConsumers/measurement-consumer-2"
                   eventGroupReferenceId = "reference-id-reduced"
-                  mediaTypes += listOf(CmmsMediaType.valueOf("OTHER"))
+                  mediaTypes += listOf(CmmsMediaType.OTHER)
                   eventGroupMetadata = cmmsEventGroupMetadata {
                     this.adMetadata = cmmsAdMetadata {
                       this.campaignMetadata = cmmsCampaignMetadata {
@@ -2612,7 +2612,7 @@ class EventGroupSyncTest {
               startTime = timestamp { seconds = 200 }
               endTime = timestamp { seconds = 300 }
             }
-            mediaTypes += listOf(MediaType.valueOf("OTHER"))
+            mediaTypes += listOf(MediaType.OTHER)
           }
 
           val eventGroupSync =
@@ -2717,7 +2717,7 @@ class EventGroupSyncTest {
         startTime = timestamp { seconds = 200 }
         endTime = timestamp { seconds = 300 }
       }
-      mediaTypes += listOf(MediaType.valueOf("OTHER"))
+      mediaTypes += listOf(MediaType.OTHER)
     }
 
     // Should not throw an exception
@@ -2740,7 +2740,7 @@ class EventGroupSyncTest {
         startTime = timestamp { seconds = 200 }
         endTime = timestamp { seconds = 300 }
       }
-      mediaTypes += listOf(MediaType.valueOf("OTHER"))
+      mediaTypes += listOf(MediaType.OTHER)
     }
 
     val exception =
@@ -3101,7 +3101,7 @@ class EventGroupSyncTest {
         startTime = timestamp { seconds = 200 }
         endTime = timestamp { seconds = 300 }
       }
-      mediaTypes += listOf(MediaType.valueOf("OTHER"))
+      mediaTypes += listOf(MediaType.OTHER)
     }
 
     val exception =
@@ -5136,7 +5136,7 @@ class EventGroupSyncTest {
             startTime = timestamp { seconds = 200 }
             endTime = timestamp { seconds = 300 }
           }
-          mediaTypes += listOf(MediaType.valueOf("OTHER"))
+          mediaTypes += listOf(MediaType.OTHER)
         },
         eventGroup {
           eventGroupReferenceId = "reference-id-3"
@@ -5153,7 +5153,7 @@ class EventGroupSyncTest {
             startTime = timestamp { seconds = 200 }
             endTime = timestamp { seconds = 300 }
           }
-          mediaTypes += listOf(MediaType.valueOf("OTHER"))
+          mediaTypes += listOf(MediaType.OTHER)
         },
         eventGroup {
           eventGroupReferenceId = "reference-id-1"


### PR DESCRIPTION
EventGroupSync records client accounts that don't resolve to a MeasurementConsumer and reconciles them at the end of each sync via BatchCreate/BatchDelete UnlinkedClientAccounts over the existing kingdomChannel. Each account carries the observed EventGroup's entity_metadata and its entity_key or event_group_reference_id for traceability.

Issue: #4303
