### PR TITLE
feat: add unlinked client accounts to the dashboard

### DIFF
--- a/docs/edpaggregator/dashboard/deployment-guide.md
+++ b/docs/edpaggregator/dashboard/deployment-guide.md
@@ -8,10 +8,10 @@ EDP Aggregator databases into BigQuery tables with per-EDP row-level isolation.
 
 The dashboard creates the following resources:
 
-*   **1 BigQuery dataset** (`dashboard`) containing 5 materialized tables
+*   **1 BigQuery dataset** (`dashboard`) containing 6 materialized tables
 *   **4 BigQuery connections** (3 Spanner with Data Boost, 1 Cloud SQL Postgres)
 *   **1 UDF** (`externalIdToApiId`) for internal-to-API ID conversion
-*   **5 hourly scheduled queries** using atomic MERGE to populate tables
+*   **6 hourly scheduled queries** using atomic MERGE to populate tables
 *   **Per-EDP service accounts** with table-level IAM and row access policies
 *   **Compliance check CLI** for ongoing security auditing
 
@@ -24,12 +24,13 @@ The dashboard creates the following resources:
 | `mc_details_edp` | Per-EDP | Event group details (own data only) |
 | `report_detail` | Platform only | Per-report event group associations with EDP count and report state |
 | `report_detail_edp` | Per-EDP | Per-report event group associations and report state (own data only) |
+| `unlinked_accounts` | Shared (row-filtered) | Advertiser client accounts observed with no MeasurementConsumer linkage; often empty |
 
 ### Security Model
 
-*   **Table-level IAM**: EDP service accounts have `dataViewer` on 3 tables
-    only (`requisition_overview`, `mc_details_edp`, `report_detail_edp`).
-    Platform-only tables return 403.
+*   **Table-level IAM**: EDP service accounts have `dataViewer` on 4 tables
+    only (`requisition_overview`, `mc_details_edp`, `report_detail_edp`,
+    `unlinked_accounts`). Platform-only tables return 403.
 *   **Row access policies**: Each EDP sees only rows matching their
     `DataProviderResourceId` or `CmmsDataProvider`. Policies survive scheduled
     query runs (MERGE is atomic and does not recreate the table).
@@ -272,7 +273,9 @@ FROM `<DASHBOARD_PROJECT>.dashboard.__TABLES__`
 ORDER BY table_id;
 ```
 
-All 5 tables should have rows after the scheduled queries complete.
+All tables except `unlinked_accounts` should have rows after the scheduled
+queries complete. `unlinked_accounts` is often empty — it only has rows when
+advertiser accounts are observed with no MeasurementConsumer linkage.
 
 ## Step 4: Run the Compliance Check
 
@@ -306,7 +309,10 @@ The compliance check verifies:
 *   **UDF validation**: `externalIdToApiId` produces valid output
 *   **Drift detection**: Expected tables, UDFs, schemas, row access policies,
     and connections all exist with correct configuration
-*   **Data correctness**: Tables are non-empty and data is fresh (< 3 hours old)
+*   **Data correctness**: Tables are non-empty and data is fresh (< 3 hours
+    old). `unlinked_accounts` is exempt from the non-empty and freshness
+    checks; a dedicated pipeline check instead compares its Kingdom source
+    row count to the dashboard row count to catch a silently-broken MERGE.
 
 ## Step 5: Set Up CI Integration
 

--- a/docs/edpaggregator/dashboard/onboarding-guide.md
+++ b/docs/edpaggregator/dashboard/onboarding-guide.md
@@ -7,7 +7,7 @@ BigQuery or Looker Studio.
 ## Overview
 
 Each EDP gets a dedicated Google Cloud service account that provides access to
-3 BigQuery tables. Row access policies ensure each EDP sees only their own data.
+4 BigQuery tables. Row access policies ensure each EDP sees only their own data.
 
 Deployment-specific values appear as placeholders throughout this guide:
 
@@ -34,6 +34,7 @@ server's `OpenIdProvidersConfig`.
 | `requisition_overview` | Requisition status, fulfillment times, report state, refusal reasons |
 | `mc_details_edp` | Event group details: entity keys, campaigns, brands, media types, data availability |
 | `report_detail_edp` | Per-report event group associations: which of their event groups are in each report |
+| `unlinked_accounts` | Advertiser client accounts observed in your event group data with no MeasurementConsumer linkage; often empty |
 
 ### What the EDP Cannot See
 
@@ -118,9 +119,9 @@ This creates:
 
 *   Service account `edp-<name>-dashboard@<DASHBOARD_PROJECT>.iam.gserviceaccount.com`
 *   `roles/bigquery.dataViewer` on `requisition_overview`, `mc_details_edp`,
-    `report_detail_edp`
+    `report_detail_edp`, `unlinked_accounts`
 *   `roles/bigquery.jobUser` on the project
-*   Row access policies on all 3 tables filtering to the EDP's resource ID
+*   Row access policies on all 4 tables filtering to the EDP's resource ID
 
 ### Step 4: Seed a BasicReport for the new EDP
 
@@ -198,7 +199,7 @@ Provide the EDP with their service account details:
 *   **Project ID**: The GCP project hosting the dashboard BigQuery dataset
 *   **Dataset**: `dashboard`
 *   **Accessible tables**: `requisition_overview`, `mc_details_edp`,
-    `report_detail_edp`
+    `report_detail_edp`, `unlinked_accounts`
 
 The EDP authenticates using their service account. See Option A below for the
 options in preference order — keyless (Workload Identity Federation or service
@@ -398,6 +399,20 @@ reuse a report or SA across EDPs.
 | `EntityTypes` | ARRAY\<STRING\> | Entity types for your event groups in this report |
 | `EntityIds` | ARRAY\<STRING\> | Entity IDs for your event groups in this report |
 
+#### `unlinked_accounts`
+
+Advertiser client accounts observed in your event group data that have no
+corresponding MeasurementConsumer linkage. Often empty: a row appears only
+while an account remains unlinked and is removed once it is linked.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `CmmsDataProvider` | STRING | Your EDP's API resource ID |
+| `ClientAccountReferenceId` | STRING | The unlinked account's reference ID |
+| `BrandName` | STRING | Brand from the observed event group's metadata (best-effort; may be empty) |
+| `ObservedEventGroup` | STRING | An event group where the account was observed (reference ID or entity key) |
+| `CreateTime` | TIMESTAMP | When the account was first recorded as unlinked |
+
 ## Operator Steps: Offboarding an EDP
 
 1.  Remove the EDP from the `edps` array in `DASHBOARD_CONFIG_CONTENT` (for a
@@ -418,7 +433,7 @@ access policy grants visibility, no service account to authenticate).
 ## Security Notes for EDPs
 
 *   Your service account has `bigquery.jobUser` at the project level, which
-    allows you to submit BigQuery queries. You can only read the 3 tables
+    allows you to submit BigQuery queries. You can only read the 4 tables
     granted to you via table-level IAM.
 *   Row access policies filter data at the BigQuery engine level. You see only
     rows where the EDP identifier column matches your resource ID.

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/dashboard/DashboardIsolationChecks.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/dashboard/DashboardIsolationChecks.kt
@@ -62,7 +62,7 @@ class DashboardIsolationChecks(
           // healthy rather than a failure. Every other table always has data for
           // an active EDP, so an empty result there is still a failure. The
           // cross-EDP assertion below still applies whenever rows do exist.
-          val emptyIsHealthy = tableName in EMPTY_IS_HEALTHY
+          val emptyIsHealthy = isEmptyResultHealthy(tableName)
           results.add(
             CheckResult(
               "${edp.name}: $tableName",
@@ -871,7 +871,7 @@ class DashboardIsolationChecks(
           .first()
           .get("cnt")
           .longValue
-      val healthy = !(staleSourceCount > 0 && destCount == 0L)
+      val healthy = unlinkedAccountsPipelineHealthy(staleSourceCount, destCount)
       listOf(
         CheckResult(
           "unlinked_accounts pipeline",
@@ -897,5 +897,16 @@ class DashboardIsolationChecks(
   companion object {
     // Tables that record an edge condition and are legitimately often empty.
     private val EMPTY_IS_HEALTHY = setOf("unlinked_accounts")
+
+    /** Whether an empty result for [tableName] is healthy (legitimately often empty). */
+    fun isEmptyResultHealthy(tableName: String): Boolean = tableName in EMPTY_IS_HEALTHY
+
+    /**
+     * Whether the unlinked_accounts pipeline is healthy given the count of source rows old enough
+     * that a scheduled MERGE should have picked them up and the dashboard table row count. Stale
+     * source rows with an empty dashboard table mean the MERGE is broken.
+     */
+    fun unlinkedAccountsPipelineHealthy(staleSourceCount: Long, destCount: Long): Boolean =
+      !(staleSourceCount > 0 && destCount == 0L)
   }
 }

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/dashboard/DashboardIsolationChecks.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/dashboard/DashboardIsolationChecks.kt
@@ -837,18 +837,18 @@ class DashboardIsolationChecks(
    * Detects a silently-broken `unlinked_accounts` MERGE.
    *
    * `unlinked_accounts` is exempt from both the empty-result isolation check and the staleness
-   * check because it is legitimately often empty. Those two exemptions together leave a blind
-   * spot: a broken federation connection, a type error, or a permissions change can leave the
-   * dashboard table empty forever and look identical to "legitimately empty". This distinguishes
-   * the two by comparing the federated Kingdom Spanner source row count to the dashboard table
-   * row count — if the source has rows but the dashboard table is empty, the scheduled MERGE is
-   * broken. It reuses the existing BigQuery client and EXTERNAL_QUERY federation, so it needs no
-   * new dependency.
+   * check because it is legitimately often empty. Those two exemptions together leave a blind spot:
+   * a broken federation connection, a type error, or a permissions change can leave the dashboard
+   * table empty forever and look identical to "legitimately empty". This distinguishes the two by
+   * comparing the federated Kingdom Spanner source row count to the dashboard table row count — if
+   * the source has rows but the dashboard table is empty, the scheduled MERGE is broken. It reuses
+   * the existing BigQuery client and EXTERNAL_QUERY federation, so it needs no new dependency.
    */
   fun checkUnlinkedAccountsPipeline(bq: BigQuery): List<CheckResult> {
     return try {
       val sourceCount =
-        bq.query(
+        bq
+          .query(
             QueryJobConfiguration.of(
               "SELECT COUNT(*) AS cnt FROM EXTERNAL_QUERY(" +
                 "'projects/$project/locations/$region/connections/kingdom-conn', " +
@@ -860,7 +860,8 @@ class DashboardIsolationChecks(
           .get("cnt")
           .longValue
       val destCount =
-        bq.query(
+        bq
+          .query(
             QueryJobConfiguration.of(
               "SELECT COUNT(*) AS cnt FROM `$project.$dataset.unlinked_accounts`"
             )

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/dashboard/DashboardIsolationChecks.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/dashboard/DashboardIsolationChecks.kt
@@ -361,9 +361,9 @@ class DashboardIsolationChecks(
           setOf(
             "CmmsDataProvider",
             "ClientAccountReferenceId",
-            "Brands",
+            "BrandName",
             "ObservedEventGroup",
-            "FirstObservedTime",
+            "CreateTime",
           ),
         "requisition_overview" to
           setOf(

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/dashboard/DashboardIsolationChecks.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/dashboard/DashboardIsolationChecks.kt
@@ -46,6 +46,7 @@ class DashboardIsolationChecks(
         "requisition_overview" to "DataProviderResourceId",
         "mc_details_edp" to "CmmsDataProvider",
         "report_detail_edp" to "CmmsDataProvider",
+        "unlinked_accounts" to "CmmsDataProvider",
       )) {
       val (tableName, column) = table
       try {
@@ -55,11 +56,20 @@ class DashboardIsolationChecks(
           )
         val ids = result.iterateAll().map { it[column].stringValue }.toSet()
         if (ids.isEmpty()) {
+          // unlinked_accounts records an edge/error condition and can legitimately
+          // be empty (an EDP with zero unlinked accounts, or a clean deployment
+          // with none). Empty means there is nothing to leak, so treat it as
+          // healthy rather than a failure. Every other table always has data for
+          // an active EDP, so an empty result there is still a failure. The
+          // cross-EDP assertion below still applies whenever rows do exist.
+          val emptyIsHealthy = tableName == "unlinked_accounts"
           results.add(
             CheckResult(
               "${edp.name}: $tableName",
-              false,
-              "${edp.name}: $tableName is empty (expected data after scheduled queries)",
+              emptyIsHealthy,
+              if (emptyIsHealthy)
+                "${edp.name}: $tableName is empty (no unlinked accounts; nothing to leak)"
+              else "${edp.name}: $tableName is empty (expected data after scheduled queries)",
             )
           )
         } else if (ids == setOf(edp.resourceId)) {
@@ -246,6 +256,7 @@ class DashboardIsolationChecks(
         "mc_details_edp",
         "report_detail",
         "report_detail_edp",
+        "unlinked_accounts",
       )
     try {
       val result =
@@ -310,7 +321,8 @@ class DashboardIsolationChecks(
         Regex("(?i).*total.?mcs.*"),
         Regex("(?i).*coverage.?percent.*"),
       )
-    val edpTables = listOf("requisition_overview", "mc_details_edp", "report_detail_edp")
+    val edpTables =
+      listOf("requisition_overview", "mc_details_edp", "report_detail_edp", "unlinked_accounts")
     try {
       val result =
         bq.query(
@@ -345,6 +357,14 @@ class DashboardIsolationChecks(
     // Check deployed table schemas match expected columns
     val expectedColumns =
       mapOf(
+        "unlinked_accounts" to
+          setOf(
+            "CmmsDataProvider",
+            "ClientAccountReferenceId",
+            "Brands",
+            "ObservedEventGroup",
+            "FirstObservedTime",
+          ),
         "requisition_overview" to
           setOf(
             "DataProviderResourceId",
@@ -475,6 +495,7 @@ class DashboardIsolationChecks(
         "requisition_overview" to "DataProviderResourceId",
         "mc_details_edp" to "CmmsDataProvider",
         "report_detail_edp" to "CmmsDataProvider",
+        "unlinked_accounts" to "CmmsDataProvider",
       )
     for ((tableName, column) in edpTableColumns) {
       try {
@@ -767,6 +788,10 @@ class DashboardIsolationChecks(
   fun checkFreshness(bq: BigQuery): List<CheckResult> {
     val results = mutableListOf<CheckResult>()
     val stalenessThresholdHours = 3
+    // unlinked_accounts is intentionally excluded from the staleness assertion:
+    // it records an edge/error condition and is often legitimately empty, and an
+    // hourly MERGE that affects zero rows does not bump lastModifiedTime. For this
+    // table "not recently modified" is a healthy state, not staleness.
     for (tableName in listOf("requisition_overview", "mc_details", "mc_details_edp")) {
       try {
         val table = bq.getTable(TableId.of(project, dataset, tableName))

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/dashboard/DashboardIsolationChecks.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/dashboard/DashboardIsolationChecks.kt
@@ -832,4 +832,62 @@ class DashboardIsolationChecks(
     }
     return results
   }
+
+  /**
+   * Detects a silently-broken `unlinked_accounts` MERGE.
+   *
+   * `unlinked_accounts` is exempt from both the empty-result isolation check and the staleness
+   * check because it is legitimately often empty. Those two exemptions together leave a blind
+   * spot: a broken federation connection, a type error, or a permissions change can leave the
+   * dashboard table empty forever and look identical to "legitimately empty". This distinguishes
+   * the two by comparing the federated Kingdom Spanner source row count to the dashboard table
+   * row count — if the source has rows but the dashboard table is empty, the scheduled MERGE is
+   * broken. It reuses the existing BigQuery client and EXTERNAL_QUERY federation, so it needs no
+   * new dependency.
+   */
+  fun checkUnlinkedAccountsPipeline(bq: BigQuery): List<CheckResult> {
+    return try {
+      val sourceCount =
+        bq.query(
+            QueryJobConfiguration.of(
+              "SELECT COUNT(*) AS cnt FROM EXTERNAL_QUERY(" +
+                "'projects/$project/locations/$region/connections/kingdom-conn', " +
+                "'''SELECT ClientAccountReferenceId FROM UnlinkedClientAccounts''')"
+            )
+          )
+          .iterateAll()
+          .first()
+          .get("cnt")
+          .longValue
+      val destCount =
+        bq.query(
+            QueryJobConfiguration.of(
+              "SELECT COUNT(*) AS cnt FROM `$project.$dataset.unlinked_accounts`"
+            )
+          )
+          .iterateAll()
+          .first()
+          .get("cnt")
+          .longValue
+      val healthy = !(sourceCount > 0 && destCount == 0L)
+      listOf(
+        CheckResult(
+          "unlinked_accounts pipeline",
+          healthy,
+          if (healthy) "unlinked_accounts: source=$sourceCount dest=$destCount (MERGE current)"
+          else
+            "unlinked_accounts: source has $sourceCount rows but dashboard is empty " +
+              "(MERGE broken?)",
+        )
+      )
+    } catch (e: BigQueryException) {
+      listOf(
+        CheckResult(
+          "unlinked_accounts pipeline",
+          false,
+          "unlinked_accounts pipeline health check failed: ${e.message}",
+        )
+      )
+    }
+  }
 }

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/dashboard/DashboardIsolationChecks.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/dashboard/DashboardIsolationChecks.kt
@@ -62,7 +62,7 @@ class DashboardIsolationChecks(
           // healthy rather than a failure. Every other table always has data for
           // an active EDP, so an empty result there is still a failure. The
           // cross-EDP assertion below still applies whenever rows do exist.
-          val emptyIsHealthy = tableName == "unlinked_accounts"
+          val emptyIsHealthy = tableName in EMPTY_IS_HEALTHY
           results.add(
             CheckResult(
               "${edp.name}: $tableName",
@@ -846,13 +846,14 @@ class DashboardIsolationChecks(
    */
   fun checkUnlinkedAccountsPipeline(bq: BigQuery): List<CheckResult> {
     return try {
-      val sourceCount =
+      val staleSourceCount =
         bq
           .query(
             QueryJobConfiguration.of(
               "SELECT COUNT(*) AS cnt FROM EXTERNAL_QUERY(" +
                 "'projects/$project/locations/$region/connections/kingdom-conn', " +
-                "'''SELECT ClientAccountReferenceId FROM UnlinkedClientAccounts''')"
+                "'''SELECT ClientAccountReferenceId FROM UnlinkedClientAccounts " +
+                "WHERE CreateTime < TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 2 HOUR)''')"
             )
           )
           .iterateAll()
@@ -870,15 +871,16 @@ class DashboardIsolationChecks(
           .first()
           .get("cnt")
           .longValue
-      val healthy = !(sourceCount > 0 && destCount == 0L)
+      val healthy = !(staleSourceCount > 0 && destCount == 0L)
       listOf(
         CheckResult(
           "unlinked_accounts pipeline",
           healthy,
-          if (healthy) "unlinked_accounts: source=$sourceCount dest=$destCount (MERGE current)"
+          if (healthy)
+            "unlinked_accounts: stale_source=$staleSourceCount dest=$destCount (MERGE current)"
           else
-            "unlinked_accounts: source has $sourceCount rows but dashboard is empty " +
-              "(MERGE broken?)",
+            "unlinked_accounts: $staleSourceCount source rows older than 2h but dashboard is " +
+              "empty (MERGE broken?)",
         )
       )
     } catch (e: BigQueryException) {
@@ -890,5 +892,10 @@ class DashboardIsolationChecks(
         )
       )
     }
+  }
+
+  companion object {
+    // Tables that record an edge condition and are legitimately often empty.
+    private val EMPTY_IS_HEALTHY = setOf("unlinked_accounts")
   }
 }

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/dashboard/tools/DashboardComplianceRunner.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/dashboard/tools/DashboardComplianceRunner.kt
@@ -98,9 +98,7 @@ object DashboardComplianceRunner {
     sections.add(Section("UDF Output Validation", checks.checkUdfOutputValidation(bq)))
     sections.add(Section("Drift Detection", checks.checkDriftDetection(bq, edps)))
     sections.add(Section("Data Freshness", checks.checkFreshness(bq)))
-    sections.add(
-      Section("Unlinked Accounts Pipeline", checks.checkUnlinkedAccountsPipeline(bq))
-    )
+    sections.add(Section("Unlinked Accounts Pipeline", checks.checkUnlinkedAccountsPipeline(bq)))
 
     return Report(sections)
   }

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/dashboard/tools/DashboardComplianceRunner.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/dashboard/tools/DashboardComplianceRunner.kt
@@ -98,6 +98,9 @@ object DashboardComplianceRunner {
     sections.add(Section("UDF Output Validation", checks.checkUdfOutputValidation(bq)))
     sections.add(Section("Drift Detection", checks.checkDriftDetection(bq, edps)))
     sections.add(Section("Data Freshness", checks.checkFreshness(bq)))
+    sections.add(
+      Section("Unlinked Accounts Pipeline", checks.checkUnlinkedAccountsPipeline(bq))
+    )
 
     return Report(sections)
   }

--- a/src/main/terraform/gcloud/cmms/dashboard.tf
+++ b/src/main/terraform/gcloud/cmms/dashboard.tf
@@ -548,9 +548,9 @@ resource "google_bigquery_table" "unlinked_accounts" {
     "mode": "NULLABLE"
   },
   {
-    "name": "Brands",
+    "name": "BrandName",
     "type": "STRING",
-    "mode": "REPEATED"
+    "mode": "NULLABLE"
   },
   {
     "name": "ObservedEventGroup",
@@ -558,7 +558,7 @@ resource "google_bigquery_table" "unlinked_accounts" {
     "mode": "NULLABLE"
   },
   {
-    "name": "FirstObservedTime",
+    "name": "CreateTime",
     "type": "TIMESTAMP",
     "mode": "NULLABLE"
   }

--- a/src/main/terraform/gcloud/cmms/dashboard.tf
+++ b/src/main/terraform/gcloud/cmms/dashboard.tf
@@ -529,6 +529,43 @@ resource "google_bigquery_table" "report_detail_edp" {
 EOF
 }
 
+resource "google_bigquery_table" "unlinked_accounts" {
+  dataset_id          = google_bigquery_dataset.dashboard.dataset_id
+  project             = data.google_client_config.default.project
+  table_id            = "unlinked_accounts"
+  deletion_protection = var.dashboard_deletion_protection
+
+  schema = <<EOF
+[
+  {
+    "name": "CmmsDataProvider",
+    "type": "STRING",
+    "mode": "NULLABLE"
+  },
+  {
+    "name": "ClientAccountReferenceId",
+    "type": "STRING",
+    "mode": "NULLABLE"
+  },
+  {
+    "name": "Brands",
+    "type": "STRING",
+    "mode": "REPEATED"
+  },
+  {
+    "name": "ObservedEventGroup",
+    "type": "STRING",
+    "mode": "NULLABLE"
+  },
+  {
+    "name": "FirstObservedTime",
+    "type": "TIMESTAMP",
+    "mode": "NULLABLE"
+  }
+]
+EOF
+}
+
 # Terraform SA needs serviceAccountUser on itself to create scheduled queries
 resource "google_service_account_iam_member" "terraform_sa_act_as_self" {
   service_account_id = "projects/${data.google_client_config.default.project}/serviceAccounts/${var.terraform_service_account}"
@@ -656,6 +693,25 @@ resource "google_bigquery_data_transfer_config" "report_detail_edp" {
   }
 }
 
+resource "google_bigquery_data_transfer_config" "unlinked_accounts" {
+  depends_on           = [google_service_account_iam_member.terraform_sa_act_as_self]
+  display_name         = "Dashboard: unlinked_accounts"
+  data_source_id       = "scheduled_query"
+  schedule             = "every 1 hours"
+  project              = data.google_client_config.default.project
+  location             = data.google_client_config.default.region
+  service_account_name = var.terraform_service_account
+
+  params = {
+    query = templatefile("${path.module}/sql/unlinked_accounts.sql", {
+      project_id = data.google_client_config.default.project
+      region     = data.google_client_config.default.region
+      dataset    = google_bigquery_dataset.dashboard.dataset_id
+      table_name = "unlinked_accounts"
+    })
+  }
+}
+
 # --- Per-EDP Service Accounts ---
 
 resource "google_service_account" "edp_dashboard" {
@@ -673,6 +729,15 @@ resource "google_bigquery_row_access_policy" "requisition_overview_platform" {
   project          = data.google_client_config.default.project
   dataset_id       = google_bigquery_dataset.dashboard.dataset_id
   table_id         = google_bigquery_table.requisition_overview.table_id
+  policy_id        = "platform_full_access"
+  filter_predicate = "TRUE"
+  grantees         = concat(["serviceAccount:${var.terraform_service_account}"], var.dashboard_operators)
+}
+
+resource "google_bigquery_row_access_policy" "unlinked_accounts_platform" {
+  project          = data.google_client_config.default.project
+  dataset_id       = google_bigquery_dataset.dashboard.dataset_id
+  table_id         = google_bigquery_table.unlinked_accounts.table_id
   policy_id        = "platform_full_access"
   filter_predicate = "TRUE"
   grantees         = concat(["serviceAccount:${var.terraform_service_account}"], var.dashboard_operators)
@@ -703,6 +768,16 @@ resource "google_bigquery_row_access_policy" "requisition_overview" {
   table_id         = google_bigquery_table.requisition_overview.table_id
   policy_id        = "${each.key}_filter"
   filter_predicate = "DataProviderResourceId = '${each.value}'"
+  grantees         = ["serviceAccount:${google_service_account.edp_dashboard[each.key].email}"]
+}
+
+resource "google_bigquery_row_access_policy" "unlinked_accounts" {
+  for_each         = var.data_provider_resource_ids
+  project          = data.google_client_config.default.project
+  dataset_id       = google_bigquery_dataset.dashboard.dataset_id
+  table_id         = google_bigquery_table.unlinked_accounts.table_id
+  policy_id        = "${each.key}_filter"
+  filter_predicate = "CmmsDataProvider = '${each.value}'"
   grantees         = ["serviceAccount:${google_service_account.edp_dashboard[each.key].email}"]
 }
 
@@ -865,6 +940,15 @@ resource "google_bigquery_table_iam_member" "requisition_overview_platform_viewe
   member     = each.value
 }
 
+resource "google_bigquery_table_iam_member" "unlinked_accounts_platform_viewer" {
+  for_each   = toset(var.dashboard_operators)
+  project    = data.google_client_config.default.project
+  dataset_id = google_bigquery_dataset.dashboard.dataset_id
+  table_id   = google_bigquery_table.unlinked_accounts.table_id
+  role       = "roles/bigquery.dataViewer"
+  member     = each.value
+}
+
 resource "google_bigquery_table_iam_member" "mc_details_platform_viewer" {
   for_each   = toset(var.dashboard_operators)
   project    = data.google_client_config.default.project
@@ -892,6 +976,15 @@ resource "google_bigquery_table_iam_member" "requisition_overview_viewer" {
   project    = data.google_client_config.default.project
   dataset_id = google_bigquery_dataset.dashboard.dataset_id
   table_id   = google_bigquery_table.requisition_overview.table_id
+  role       = "roles/bigquery.dataViewer"
+  member     = "serviceAccount:${google_service_account.edp_dashboard[each.key].email}"
+}
+
+resource "google_bigquery_table_iam_member" "unlinked_accounts_viewer" {
+  for_each   = var.data_provider_resource_ids
+  project    = data.google_client_config.default.project
+  dataset_id = google_bigquery_dataset.dashboard.dataset_id
+  table_id   = google_bigquery_table.unlinked_accounts.table_id
   role       = "roles/bigquery.dataViewer"
   member     = "serviceAccount:${google_service_account.edp_dashboard[each.key].email}"
 }

--- a/src/main/terraform/gcloud/cmms/dashboard.tf
+++ b/src/main/terraform/gcloud/cmms/dashboard.tf
@@ -929,8 +929,8 @@ resource "google_bigquery_dataset_iam_member" "terraform_data_editor" {
 
 # --- Table-level IAM ---
 
-# Operators get dataViewer on platform-only tables (mc_details, report_detail)
-# and the shared table (requisition_overview).
+# Operators get dataViewer on platform-only tables (mc_details, report_detail),
+# the shared table (requisition_overview), and unlinked_accounts.
 resource "google_bigquery_table_iam_member" "requisition_overview_platform_viewer" {
   for_each   = toset(var.dashboard_operators)
   project    = data.google_client_config.default.project
@@ -968,7 +968,7 @@ resource "google_bigquery_table_iam_member" "report_detail_platform_viewer" {
 }
 
 # EDP SAs get dataViewer on shared tables only (requisition_overview, mc_details_edp,
-# report_detail_edp). EDP SAs have no access to platform-only tables (mc_details,
+# report_detail_edp, unlinked_accounts). EDP SAs have no access to platform-only tables (mc_details,
 # report_detail) — they get 403.
 
 resource "google_bigquery_table_iam_member" "requisition_overview_viewer" {

--- a/src/main/terraform/gcloud/cmms/sql/BUILD.bazel
+++ b/src/main/terraform/gcloud/cmms/sql/BUILD.bazel
@@ -2,4 +2,5 @@ exports_files([
     "mc_details.sql",
     "report_detail.sql",
     "requisition_overview.sql",
+    "unlinked_accounts.sql",
 ])

--- a/src/main/terraform/gcloud/cmms/sql/unlinked_accounts.sql
+++ b/src/main/terraform/gcloud/cmms/sql/unlinked_accounts.sql
@@ -1,0 +1,48 @@
+-- Copyright 2026 The Cross-Media Measurement Authors
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+MERGE INTO `${project_id}.${dataset}.${table_name}` T
+USING (
+SELECT
+  `${project_id}.dashboard.externalIdToApiId`(dp.ExternalDataProviderId) AS CmmsDataProvider,
+  u.ClientAccountReferenceId,
+  u.Brands,
+  COALESCE(u.EventGroupReferenceId, CONCAT(u.EventGroupEntityKeyType, '/', u.EventGroupEntityKeyId)) AS ObservedEventGroup,
+  u.FirstObservedTime
+FROM (
+  SELECT * FROM EXTERNAL_QUERY(
+    'projects/${project_id}/locations/${region}/connections/kingdom-conn',
+    '''SELECT
+      u.DataProviderId,
+      u.ClientAccountReferenceId,
+      u.Brands,
+      u.EventGroupReferenceId,
+      u.EventGroupEntityKeyType,
+      u.EventGroupEntityKeyId,
+      u.FirstObservedTime
+    FROM UnlinkedClientAccounts u''')
+) u
+LEFT JOIN (
+  SELECT * FROM EXTERNAL_QUERY(
+    'projects/${project_id}/locations/${region}/connections/kingdom-conn',
+    '''SELECT
+      dp.DataProviderId,
+      dp.ExternalDataProviderId
+    FROM DataProviders dp''')
+) dp
+  ON u.DataProviderId = dp.DataProviderId
+) S
+ON FALSE
+WHEN NOT MATCHED THEN INSERT ROW
+WHEN NOT MATCHED BY SOURCE THEN DELETE;

--- a/src/main/terraform/gcloud/cmms/sql/unlinked_accounts.sql
+++ b/src/main/terraform/gcloud/cmms/sql/unlinked_accounts.sql
@@ -26,6 +26,7 @@ FROM (
     '''SELECT
       u.DataProviderId,
       u.ClientAccountReferenceId,
+      -- BrandName is best-effort: entity_metadata uses each EDP's own schema, so it may be NULL.
       JSON_VALUE(TO_JSON(u.EntityMetadata), '$.brand_name') AS BrandName,
       u.EventGroupReferenceId,
       u.EventGroupEntityKeyType,
@@ -33,7 +34,7 @@ FROM (
       u.CreateTime
     FROM UnlinkedClientAccounts u''')
 ) u
-LEFT JOIN (
+INNER JOIN (
   SELECT * FROM EXTERNAL_QUERY(
     'projects/${project_id}/locations/${region}/connections/kingdom-conn',
     '''SELECT

--- a/src/main/terraform/gcloud/cmms/sql/unlinked_accounts.sql
+++ b/src/main/terraform/gcloud/cmms/sql/unlinked_accounts.sql
@@ -17,20 +17,20 @@ USING (
 SELECT
   `${project_id}.dashboard.externalIdToApiId`(dp.ExternalDataProviderId) AS CmmsDataProvider,
   u.ClientAccountReferenceId,
-  u.Brands,
+  u.BrandName,
   COALESCE(u.EventGroupReferenceId, CONCAT(u.EventGroupEntityKeyType, '/', u.EventGroupEntityKeyId)) AS ObservedEventGroup,
-  u.FirstObservedTime
+  u.CreateTime
 FROM (
   SELECT * FROM EXTERNAL_QUERY(
     'projects/${project_id}/locations/${region}/connections/kingdom-conn',
     '''SELECT
       u.DataProviderId,
       u.ClientAccountReferenceId,
-      u.Brands,
+      JSON_VALUE(TO_JSON(u.EntityMetadata), '$.brand_name') AS BrandName,
       u.EventGroupReferenceId,
       u.EventGroupEntityKeyType,
       u.EventGroupEntityKeyId,
-      u.FirstObservedTime
+      u.CreateTime
     FROM UnlinkedClientAccounts u''')
 ) u
 LEFT JOIN (

--- a/src/test/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/dashboard/BUILD.bazel
+++ b/src/test/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/dashboard/BUILD.bazel
@@ -16,3 +16,13 @@ kt_jvm_test(
         "@wfa_common_jvm//imports/java/org/junit",
     ],
 )
+
+kt_jvm_test(
+    name = "DashboardIsolationChecksTest",
+    srcs = ["DashboardIsolationChecksTest.kt"],
+    deps = [
+        "//src/main/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/dashboard:dashboard_isolation_checks",
+        "@wfa_common_jvm//imports/java/com/google/common/truth",
+        "@wfa_common_jvm//imports/java/org/junit",
+    ],
+)

--- a/src/test/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/dashboard/BUILD.bazel
+++ b/src/test/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/dashboard/BUILD.bazel
@@ -8,6 +8,7 @@ kt_jvm_test(
         "//src/main/terraform/gcloud/cmms/sql:mc_details.sql",
         "//src/main/terraform/gcloud/cmms/sql:report_detail.sql",
         "//src/main/terraform/gcloud/cmms/sql:requisition_overview.sql",
+        "//src/main/terraform/gcloud/cmms/sql:unlinked_accounts.sql",
     ],
     deps = [
         "//src/main/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/dashboard/tools:dashboard_compliance_check_function",

--- a/src/test/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/dashboard/DashboardIsolationChecksTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/dashboard/DashboardIsolationChecksTest.kt
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2026 The Cross-Media Measurement Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wfanet.measurement.edpaggregator.deploy.gcloud.dashboard
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+
+@RunWith(JUnit4::class)
+class DashboardIsolationChecksTest {
+  @Test
+  fun `unlinkedAccountsPipelineHealthy is false when stale source rows exist but dashboard is empty`() {
+    assertThat(DashboardIsolationChecks.unlinkedAccountsPipelineHealthy(5, 0)).isFalse()
+  }
+
+  @Test
+  fun `unlinkedAccountsPipelineHealthy is true when the dashboard table is populated`() {
+    assertThat(DashboardIsolationChecks.unlinkedAccountsPipelineHealthy(5, 5)).isTrue()
+  }
+
+  @Test
+  fun `unlinkedAccountsPipelineHealthy is true when there are no stale source rows`() {
+    assertThat(DashboardIsolationChecks.unlinkedAccountsPipelineHealthy(0, 0)).isTrue()
+    assertThat(DashboardIsolationChecks.unlinkedAccountsPipelineHealthy(0, 5)).isTrue()
+  }
+
+  @Test
+  fun `isEmptyResultHealthy is true only for exempt tables`() {
+    assertThat(DashboardIsolationChecks.isEmptyResultHealthy("unlinked_accounts")).isTrue()
+    assertThat(DashboardIsolationChecks.isEmptyResultHealthy("requisition_overview")).isFalse()
+  }
+}

--- a/src/test/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/dashboard/DashboardViewIsolationLocalTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/dashboard/DashboardViewIsolationLocalTest.kt
@@ -29,7 +29,12 @@ class DashboardViewIsolationLocalTest {
     private val PLATFORM_ONLY_COLUMNS = setOf("CoveragePercent", "TotalMcs", "EdpCount")
 
     private val SQL_FILES =
-      listOf("mc_details.sql", "report_detail.sql", "requisition_overview.sql")
+      listOf(
+        "mc_details.sql",
+        "report_detail.sql",
+        "requisition_overview.sql",
+        "unlinked_accounts.sql",
+      )
   }
 
   private fun readSqlFile(fileName: String): String {
@@ -151,6 +156,20 @@ class DashboardViewIsolationLocalTest {
     val sql = readSqlFile("requisition_overview.sql")
     for (col in PLATFORM_ONLY_COLUMNS) {
       assertThat(sql).doesNotContain(col)
+    }
+  }
+
+  @Test
+  fun unlinkedAccountsIsEdpIsolated() {
+    // Guards against drift with the DashboardIsolationChecks mapping of
+    // "unlinked_accounts" to "CmmsDataProvider": the rendered SQL must select the
+    // isolation column the checker keys on and must not leak any platform-only
+    // columns.
+    val sql = readSqlFile("unlinked_accounts.sql")
+    val rendered = render(sql, platformEnabled = false)
+    assertThat(rendered).contains("CmmsDataProvider")
+    for (col in PLATFORM_ONLY_COLUMNS) {
+      assertThat(rendered).doesNotContain(col)
     }
   }
 

--- a/src/test/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/dashboard/DashboardViewIsolationLocalTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/dashboard/DashboardViewIsolationLocalTest.kt
@@ -171,6 +171,12 @@ class DashboardViewIsolationLocalTest {
     for (col in PLATFORM_ONLY_COLUMNS) {
       assertThat(rendered).doesNotContain(col)
     }
+    // The reworked Kingdom schema replaced Brands/FirstObservedTime with an
+    // EntityMetadata Struct and CreateTime, so the SQL must read the new columns.
+    assertThat(rendered).contains("BrandName")
+    assertThat(rendered).contains("CreateTime")
+    assertThat(rendered).doesNotContain("Brands")
+    assertThat(rendered).doesNotContain("FirstObservedTime")
   }
 
   @Test


### PR DESCRIPTION
Adds the unlinked_accounts BigQuery dashboard table, sourced from the Kingdom UnlinkedClientAccounts Spanner table via kingdom-conn (EXTERNAL_QUERY), joined to DataProviders for CmmsDataProvider. Includes the per-EDP row-access policy and a single ObservedEventGroup traceability column (event_group_reference_id or entity_key).

Issue: #4303
