### PR TITLE
feat: Support DETERMINISTIC_TRUNCATED_LAPLACE in variance and the reporting server

### DIFF
--- a/src/main/kotlin/org/wfanet/measurement/computation/BUILD.bazel
+++ b/src/main/kotlin/org/wfanet/measurement/computation/BUILD.bazel
@@ -6,6 +6,7 @@ package(default_visibility = [
     "//src/main/kotlin/org/wfanet/measurement/edpaggregator/resultsfulfiller/compute/protocols/direct:__subpackages__",
     "//src/main/kotlin/org/wfanet/measurement/edpaggregator/resultsfulfiller/fulfillers:__subpackages__",
     "//src/main/kotlin/org/wfanet/measurement/eventdataprovider/requisition/v2alpha/common:__pkg__",
+    "//src/main/kotlin/org/wfanet/measurement/measurementconsumer/stats:__pkg__",
     "//src/test/kotlin/org/wfanet/measurement/computation:__subpackages__",
     "//src/test/kotlin/org/wfanet/measurement/duchy/mill/trustee:__subpackages__",
     "//src/test/kotlin/org/wfanet/measurement/edpaggregator/resultsfulfiller:__subpackages__",
@@ -40,6 +41,7 @@ kt_jvm_library(
     name = "deterministic_truncated_laplace_noise_sampler",
     srcs = ["DeterministicTruncatedLaplaceNoiseSampler.kt"],
     deps = [
+        ":deterministic_truncated_laplace_params",
         ":deterministic_uniform_sampler",
         ":truncated_laplace_noise_distribution",
     ],

--- a/src/main/kotlin/org/wfanet/measurement/computation/DeterministicTruncatedLaplaceNoiseSampler.kt
+++ b/src/main/kotlin/org/wfanet/measurement/computation/DeterministicTruncatedLaplaceNoiseSampler.kt
@@ -60,19 +60,17 @@ class DeterministicTruncatedLaplaceNoiseSampler(
      * threshold at which the mechanism is ([epsilon], [delta])-DP, proved there for all ([epsilon],
      * [delta]) and [sensitivity], so no regime check is needed.
      *
-     * [StrictMath] keeps T bit-reproducible across JVMs, matching the draw it bounds and any
-     * variance derived from it.
+     * T comes from [DeterministicTruncatedLaplaceParams.truncationBoundFor], which is also what the
+     * reporting server uses, and is bit-reproducible across JVMs.
      */
     fun forDifferentialPrivacy(
       epsilon: Double,
       delta: Double,
       sensitivity: Double,
     ): DeterministicTruncatedLaplaceNoiseSampler {
-      require(epsilon > 0.0) { "epsilon must be positive, got $epsilon" }
-      require(delta > 0.0 && delta < 1.0) { "delta must be in (0, 1), got $delta" }
-      require(sensitivity > 0.0) { "sensitivity must be positive, got $sensitivity" }
       val scale = sensitivity / epsilon
-      val bound = scale * StrictMath.log(1.0 + (StrictMath.exp(epsilon) - 1.0) / (2.0 * delta))
+      val bound =
+        DeterministicTruncatedLaplaceParams.truncationBoundFor(epsilon, delta, sensitivity)
       return DeterministicTruncatedLaplaceNoiseSampler(
         TruncatedLaplaceNoiseDistribution(scale, bound)
       )

--- a/src/main/kotlin/org/wfanet/measurement/computation/DeterministicTruncatedLaplaceParams.kt
+++ b/src/main/kotlin/org/wfanet/measurement/computation/DeterministicTruncatedLaplaceParams.kt
@@ -29,4 +29,25 @@ package org.wfanet.measurement.computation
 object DeterministicTruncatedLaplaceParams {
   const val EPSILON = 1.0
   const val DELTA = 1.0 / 1000.0
+
+  /** The truncation bound a draw of L1 [sensitivity] takes under these parameters. */
+  fun truncationBound(sensitivity: Double): Double = truncationBoundFor(EPSILON, DELTA, sensitivity)
+
+  /**
+   * The smallest bound at which a Laplace of scale `sensitivity / epsilon`, truncated to `[-bound,
+   * bound]`, is ([epsilon], [delta])-differentially private.
+   *
+   * Geng et al., "Privacy and Utility Tradeoff in Approximate Differential Privacy"
+   * (arXiv:1810.00877), Definition 3, proved for all ([epsilon], [delta]) and [sensitivity].
+   *
+   * Anything deriving a variance from this noise must use the same threshold, so both the sampler
+   * and the reporting server call this rather than restating the formula.
+   */
+  fun truncationBoundFor(epsilon: Double, delta: Double, sensitivity: Double): Double {
+    require(epsilon > 0.0) { "epsilon must be positive, got $epsilon" }
+    require(delta > 0.0 && delta < 1.0) { "delta must be in (0, 1), got $delta" }
+    require(sensitivity > 0.0) { "sensitivity must be positive, got $sensitivity" }
+    return (sensitivity / epsilon) *
+      StrictMath.log(1.0 + (StrictMath.exp(epsilon) - 1.0) / (2.0 * delta))
+  }
 }

--- a/src/main/kotlin/org/wfanet/measurement/loadtest/measurementconsumer/MeasurementConsumerSimulator.kt
+++ b/src/main/kotlin/org/wfanet/measurement/loadtest/measurementconsumer/MeasurementConsumerSimulator.kt
@@ -1456,7 +1456,8 @@ private fun NoiseMechanism.toStatsNoiseMechanism(): StatsNoiseMechanism {
     NoiseMechanism.CONTINUOUS_LAPLACE -> StatsNoiseMechanism.LAPLACE
     NoiseMechanism.DISCRETE_GAUSSIAN,
     NoiseMechanism.CONTINUOUS_GAUSSIAN -> StatsNoiseMechanism.GAUSSIAN
-    NoiseMechanism.DETERMINISTIC_TRUNCATED_LAPLACE,
+    NoiseMechanism.DETERMINISTIC_TRUNCATED_LAPLACE ->
+      StatsNoiseMechanism.DETERMINISTIC_TRUNCATED_LAPLACE
     NoiseMechanism.NOISE_MECHANISM_UNSPECIFIED,
     NoiseMechanism.UNRECOGNIZED -> {
       error("Invalid NoiseMechanism.")

--- a/src/main/kotlin/org/wfanet/measurement/measurementconsumer/stats/BUILD.bazel
+++ b/src/main/kotlin/org/wfanet/measurement/measurementconsumer/stats/BUILD.bazel
@@ -39,6 +39,7 @@ kt_jvm_library(
         ":measurement_statistics",
         ":metric_statistics",
         "//imports/java/org/apache/commons/numbers/core",
+        "//src/main/kotlin/org/wfanet/measurement/computation:deterministic_truncated_laplace_params",
         "//src/main/kotlin/org/wfanet/measurement/eventdataprovider/noiser",
     ],
 )

--- a/src/main/kotlin/org/wfanet/measurement/measurementconsumer/stats/MeasurementStatistics.kt
+++ b/src/main/kotlin/org/wfanet/measurement/measurementconsumer/stats/MeasurementStatistics.kt
@@ -24,6 +24,11 @@ enum class NoiseMechanism {
   NONE,
   LAPLACE,
   GAUSSIAN,
+  /**
+   * Laplace drawn deterministically from the data and confined to a bound derived from the privacy
+   * params compiled into the attested images. Its variance is specific to those params.
+   */
+  DETERMINISTIC_TRUNCATED_LAPLACE,
 }
 
 data class VidSamplingInterval(val start: Double, val width: Double)

--- a/src/main/kotlin/org/wfanet/measurement/measurementconsumer/stats/Variances.kt
+++ b/src/main/kotlin/org/wfanet/measurement/measurementconsumer/stats/Variances.kt
@@ -427,7 +427,12 @@ object VariancesImpl : Variances {
     return (untruncated - truncatedTail) / normalizer
   }
 
-  /** Computes the noise variance based on the [DpParams] and the [NoiseMechanism]. */
+  /**
+   * Computes the noise variance based on the [DpParams] and the [NoiseMechanism].
+   *
+   * [dpParams] is unused for [NoiseMechanism.DETERMINISTIC_TRUNCATED_LAPLACE], whose privacy params
+   * are compiled into the images that draw the noise.
+   */
   private fun computeDirectNoiseVariance(
     dpParams: DpParams,
     noiseMechanism: NoiseMechanism,

--- a/src/main/kotlin/org/wfanet/measurement/measurementconsumer/stats/Variances.kt
+++ b/src/main/kotlin/org/wfanet/measurement/measurementconsumer/stats/Variances.kt
@@ -16,12 +16,14 @@
 
 package org.wfanet.measurement.measurementconsumer.stats
 
+import kotlin.math.exp
 import kotlin.math.max
 import kotlin.math.min
 import kotlin.math.pow
 import kotlin.random.Random
 import kotlin.random.asJavaRandom
 import org.apache.commons.numbers.core.Precision
+import org.wfanet.measurement.computation.DeterministicTruncatedLaplaceParams
 import org.wfanet.measurement.eventdataprovider.noiser.DpParams
 import org.wfanet.measurement.eventdataprovider.noiser.GaussianNoiser
 import org.wfanet.measurement.eventdataprovider.noiser.LaplaceNoiser
@@ -84,6 +86,21 @@ interface Variances {
 /** Default implementation of [Variances]. */
 object VariancesImpl : Variances {
   private const val TOLERANCE = 1E-6
+
+  /**
+   * L1 sensitivity of a deterministic truncated-Laplace draw: adding or removing one VID changes a
+   * reach or per-bucket count by 1.
+   */
+  private const val DETERMINISTIC_TRUNCATED_LAPLACE_SENSITIVITY = 1.0
+  /**
+   * Scale and truncation bound of a unit-sensitivity deterministic truncated-Laplace draw, taken
+   * from the params compiled into the attested images and the same threshold the sampler applies,
+   * so the reported variance cannot describe noise other than what is drawn.
+   */
+  private val DETERMINISTIC_TRUNCATED_LAPLACE_SCALE =
+    DETERMINISTIC_TRUNCATED_LAPLACE_SENSITIVITY / DeterministicTruncatedLaplaceParams.EPSILON
+  private val DETERMINISTIC_TRUNCATED_LAPLACE_BOUND =
+    DeterministicTruncatedLaplaceParams.truncationBound(DETERMINISTIC_TRUNCATED_LAPLACE_SENSITIVITY)
   private val EQUIVALENCE = Precision.doubleEquivalenceOfEpsilon(TOLERANCE)
 
   /**
@@ -386,6 +403,30 @@ object VariancesImpl : Variances {
     }
   }
 
+  /**
+   * Variance of a Laplace(0, b) distribution confined to `[-bound, bound]`, where `b` is [scale].
+   *
+   * The truncated density is the Laplace density renormalized by `Z = 1 - exp(-bound / b)`, so
+   *
+   * ```
+   * Var = [2b^2 - exp(-bound/b) * (bound^2 + 2*bound*b + 2b^2)] / Z
+   * ```
+   *
+   * The mean is zero by symmetry. As `bound` grows this tends to `2b^2`, the untruncated Laplace
+   * variance, and truncation only ever reduces it.
+   */
+  private fun truncatedLaplaceVariance(scale: Double, bound: Double): Double {
+    require(scale > 0.0) { "Laplace scale must be positive, got $scale" }
+    require(bound > 0.0) { "Truncation bound must be positive, got $bound" }
+    val boundOverScale: Double = bound / scale
+    val tailMass: Double = exp(-boundOverScale)
+    val normalizer: Double = 1.0 - tailMass
+    val untruncated: Double = 2.0 * scale * scale
+    val truncatedTail: Double =
+      tailMass * (bound * bound + 2.0 * bound * scale + 2.0 * scale * scale)
+    return (untruncated - truncatedTail) / normalizer
+  }
+
   /** Computes the noise variance based on the [DpParams] and the [NoiseMechanism]. */
   private fun computeDirectNoiseVariance(
     dpParams: DpParams,
@@ -399,6 +440,15 @@ object VariancesImpl : Variances {
       NoiseMechanism.GAUSSIAN -> {
         GaussianNoiser(dpParams, Random.asJavaRandom()).variance
       }
+      NoiseMechanism.DETERMINISTIC_TRUNCATED_LAPLACE -> {
+        // The noise is deterministic in the data, so this is the variance of the draw treating the
+        // seed as unknown: the uncertainty a consumer has before seeing the result. epsilon and the
+        // truncation bound are the system's compiled params, not taken from the measurement.
+        truncatedLaplaceVariance(
+          scale = DETERMINISTIC_TRUNCATED_LAPLACE_SCALE,
+          bound = DETERMINISTIC_TRUNCATED_LAPLACE_BOUND,
+        )
+      }
     }
   }
 
@@ -411,6 +461,11 @@ object VariancesImpl : Variances {
       NoiseMechanism.NONE -> 0.0
       NoiseMechanism.LAPLACE -> {
         error("Laplace is not supported for distributed noises.")
+      }
+      NoiseMechanism.DETERMINISTIC_TRUNCATED_LAPLACE -> {
+        // Drawn by the party holding the data, never by the duchy workers, so it contributes no
+        // distributed noise.
+        error("Truncated Laplace is not supported for distributed noises.")
       }
       NoiseMechanism.GAUSSIAN -> {
         // By passing 1 to contributorCount, the function called below outputs the total distributed

--- a/src/main/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/ProtoConversions.kt
+++ b/src/main/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/ProtoConversions.kt
@@ -1047,7 +1047,8 @@ fun ProtocolConfig.NoiseMechanism.toInternal(): InternalNoiseMechanism {
       InternalNoiseMechanism.NOISE_MECHANISM_UNSPECIFIED
     ProtocolConfig.NoiseMechanism.CONTINUOUS_LAPLACE -> InternalNoiseMechanism.CONTINUOUS_LAPLACE
     ProtocolConfig.NoiseMechanism.CONTINUOUS_GAUSSIAN -> InternalNoiseMechanism.CONTINUOUS_GAUSSIAN
-    ProtocolConfig.NoiseMechanism.DETERMINISTIC_TRUNCATED_LAPLACE,
+    ProtocolConfig.NoiseMechanism.DETERMINISTIC_TRUNCATED_LAPLACE ->
+      InternalNoiseMechanism.DETERMINISTIC_TRUNCATED_LAPLACE
     ProtocolConfig.NoiseMechanism.UNRECOGNIZED -> {
       throw NoiseMechanismUnrecognizedException("Noise mechanism $this is not recognized.")
     }
@@ -1181,6 +1182,8 @@ fun InternalNoiseMechanism.toStatsNoiseMechanism(): StatsNoiseMechanism {
     NoiseMechanism.CONTINUOUS_LAPLACE -> StatsNoiseMechanism.LAPLACE
     NoiseMechanism.DISCRETE_GAUSSIAN,
     NoiseMechanism.CONTINUOUS_GAUSSIAN -> StatsNoiseMechanism.GAUSSIAN
+    NoiseMechanism.DETERMINISTIC_TRUNCATED_LAPLACE ->
+      StatsNoiseMechanism.DETERMINISTIC_TRUNCATED_LAPLACE
     NoiseMechanism.NOISE_MECHANISM_UNSPECIFIED -> {
       throw NoiseMechanismUnspecifiedException("Internal noise mechanism should've been specified.")
     }

--- a/src/main/proto/wfa/measurement/internal/reporting/v2/noise_mechanism.proto
+++ b/src/main/proto/wfa/measurement/internal/reporting/v2/noise_mechanism.proto
@@ -33,4 +33,6 @@ enum NoiseMechanism {
   CONTINUOUS_LAPLACE = 4;
   // Continuous Gaussian.
   CONTINUOUS_GAUSSIAN = 5;
+  // Truncated Laplace drawn deterministically from the data.
+  DETERMINISTIC_TRUNCATED_LAPLACE = 6;
 }

--- a/src/test/kotlin/org/wfanet/measurement/measurementconsumer/stats/VariancesTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/measurementconsumer/stats/VariancesTest.kt
@@ -27,6 +27,54 @@ import org.wfanet.measurement.eventdataprovider.noiser.DpParams
 @RunWith(JUnit4::class)
 class VariancesTest {
   @Test
+  fun `computeMeasurementVariance returns the truncated Laplace variance for deterministic reach`() {
+    // The system's compiled params: Laplace(0, b) with b = sensitivity/epsilon = 1.0, confined to
+    // the Geng et al. threshold B = b * ln(1 + (e^epsilon - 1) / (2 * delta)) = 6.7571, the same
+    // bound the sampler derives. The closed form is
+    // [2b^2 - exp(-B/b)(B^2 + 2Bb + 2b^2)] / (1 - exp(-B/b)), below the untruncated 2b^2 = 2.0.
+    val reachMeasurementParams =
+      ReachMeasurementParams(
+        VidSamplingInterval(0.0, 1.0),
+        DpParams(1.0, 1.0),
+        NoiseMechanism.DETERMINISTIC_TRUNCATED_LAPLACE,
+      )
+
+    val variance =
+      VariancesImpl.computeMeasurementVariance(
+        DeterministicMethodology,
+        ReachMeasurementVarianceParams(0L, reachMeasurementParams),
+      )
+
+    val expected = 1.9311259178
+    assertThat(variance).isWithin(computeErrorTolerance(variance, expected)).of(expected)
+    assertThat(variance).isLessThan(2.0)
+  }
+
+  @Test
+  fun `computeMeasurementVariance scales the truncated Laplace variance by impression cap`() {
+    // The impression draw is taken at sensitivity maximumFrequencyPerUser, and both the scale and
+    // the bound scale linearly with sensitivity, so its variance is the unit-sensitivity variance
+    // times the cap squared. With no sampling and zero impressions only the noise term remains.
+    val maximumFrequencyPerUser = 3
+    val variance =
+      VariancesImpl.computeMeasurementVariance(
+        DeterministicMethodology,
+        ImpressionMeasurementVarianceParams(
+          0L,
+          ImpressionMeasurementParams(
+            VidSamplingInterval(0.0, 1.0),
+            DpParams(1.0, 1.0),
+            maximumFrequencyPerUser,
+            NoiseMechanism.DETERMINISTIC_TRUNCATED_LAPLACE,
+          ),
+        ),
+      )
+
+    val expected = 1.9311259178 * maximumFrequencyPerUser * maximumFrequencyPerUser
+    assertThat(variance).isWithin(computeErrorTolerance(variance, expected)).of(expected)
+  }
+
+  @Test
   fun `computeMeasurementVariance returns a value for deterministic reach when reach is small and vid sampling interval width is large`() {
     val reach = 0L
     val vidSamplingIntervalWidth = 1.0


### PR DESCRIPTION
`DETERMINISTIC_TRUNCATED_LAPLACE` had no representation above the duchy. The stats layer threw on it, so no measurement using deterministic noise could have its accuracy checked, and the internal reporting enum had no value for it, so a BasicReport could not use it at all.

## The variance

For a Laplace(0, b) confined to `[-B, B]`, with `b = sensitivity/epsilon`:

```
Var = [2b^2 - exp(-B/b)(B^2 + 2Bb + 2b^2)] / (1 - exp(-B/b))
```

The mean is zero by symmetry, and this tends to `2b^2` as the bound grows. The noise is deterministic in the data, so this is the variance of the draw treating the seed as unknown: the uncertainty a consumer has before seeing the result. Checked against numerical integration of the same truncated density.

Truncation is worth modelling rather than falling back on the untruncated `2b^2`. At the compiled parameters the bound is 6.7571 and the unit-sensitivity variance is 1.9311 against `2b^2 = 2.0`; at a tighter bound of 2 it would be 0.7479.

## The params are compiled in

Epsilon and delta for this mechanism are the system's privacy parameters, compiled into the attested images rather than set by the measurement consumer, and the truncation bound follows from them by the Geng et al. threshold. Both the sampler and the reporting server call `DeterministicTruncatedLaplaceParams.truncationBoundFor`, so the variance cannot describe noise other than what is drawn. That derivation moves into the params object in this PR; it previously lived on the sampler, and a mirrored copy of its old value in `VariancesImpl` is exactly how the two came apart.

Because the params are fixed, nothing is carried per result: no `truncation_bound` on the internal reporting `Result.Reach` / `Result.Frequency`, no `truncationBound` on the stats measurement params, and no plumbing through `MeasurementConsumerSimulator` or `MetricsService`.

## Sensitivity

The reported variance is for a unit-sensitivity draw. Both the scale and the bound scale linearly with sensitivity, so the variance scales by its square, which is what the impression path already applies as `maximumFrequencyPerUser^2 * noiseVariance`. Covered by a test.

## Which measurements reach this path

TrusTEE results carry `DeterministicCountDistinct` or `DeterministicDistribution`, so they route here. Direct results do too, once the EDP Aggregator can select the mechanism in #4321, and get the same number: the same mechanism at the same compiled params, one draw per released quantity.

Duchy workers never sample this noise, under TrusTEE or under the HMSS design, so `computeDistributedNoiseVariance` rejects it.

## Not included

No test exercises a measurement end to end, because none can be created until #4311 lands the Kingdom-side selection. The variance itself is covered by unit tests against the closed form.

Issue: #4185
