### PR TITLE
feat: Let the reporting server represent DETERMINISTIC_TRUNCATED_LAPLACE

### DIFF
--- a/src/main/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/MetricsService.kt
+++ b/src/main/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/MetricsService.kt
@@ -143,6 +143,7 @@ import org.wfanet.measurement.internal.reporting.v2.MetricKt as InternalMetricKt
 import org.wfanet.measurement.internal.reporting.v2.MetricKt.weightedMeasurement
 import org.wfanet.measurement.internal.reporting.v2.MetricSpec as InternalMetricSpec
 import org.wfanet.measurement.internal.reporting.v2.MetricsGrpcKt.MetricsCoroutineStub as InternalMetricsCoroutineStub
+import org.wfanet.measurement.internal.reporting.v2.NoiseMechanism as InternalNoiseMechanism
 import org.wfanet.measurement.internal.reporting.v2.ReportingSet as InternalReportingSet
 import org.wfanet.measurement.internal.reporting.v2.ReportingSetsGrpcKt.ReportingSetsCoroutineStub as InternalReportingSetsCoroutineStub
 import org.wfanet.measurement.internal.reporting.v2.StreamMetricsRequest
@@ -2445,6 +2446,20 @@ fun buildWeightedWatchDurationMeasurementVarianceParamsPerResult(
  * @throws MeasurementVarianceNotComputableException when methodology is not supported for watch
  *   duration or methodology missing variance information.
  */
+/**
+ * The truncation bound carried on the result, or null where the noise mechanism does not use one.
+ *
+ * Only DETERMINISTIC_TRUNCATED_LAPLACE parameterizes its noise this way.
+ */
+private fun InternalMeasurement.Result.Reach.truncationBoundOrNull(): Int? =
+  if (noiseMechanism == InternalNoiseMechanism.DETERMINISTIC_TRUNCATED_LAPLACE) truncationBound
+  else null
+
+/** @see [InternalMeasurement.Result.Reach.truncationBoundOrNull] */
+private fun InternalMeasurement.Result.Frequency.truncationBoundOrNull(): Int? =
+  if (noiseMechanism == InternalNoiseMechanism.DETERMINISTIC_TRUNCATED_LAPLACE) truncationBound
+  else null
+
 fun buildStatsMethodology(
   watchDurationResult: InternalMeasurement.Result.WatchDuration
 ): WatchDurationMethodology? {
@@ -2849,6 +2864,7 @@ fun buildWeightedFrequencyMeasurementVarianceParams(
             dpParams = frequencyPrivacyParams.toNoiserDpParams(),
             noiseMechanism = frequencyStatsNoiseMechanism,
             maximumFrequency = maximumFrequency,
+            truncationBound = frequencyResult.truncationBoundOrNull(),
           ),
       ),
     methodology = frequencyMethodology,
@@ -3107,6 +3123,7 @@ private fun buildWeightedReachMeasurementVarianceParams(
             vidSamplingInterval = vidSamplingInterval.toStatsVidSamplingInterval(),
             dpParams = privacyParams.toNoiserDpParams(),
             noiseMechanism = statsNoiseMechanism,
+            truncationBound = reachResult.truncationBoundOrNull(),
           ),
       ),
     methodology = methodology,

--- a/src/main/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/ProtoConversions.kt
+++ b/src/main/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/ProtoConversions.kt
@@ -688,6 +688,9 @@ private fun Measurement.Result.Frequency.toInternal(
       // variance depends on the sampling interval from MeasurementSpec rather than
       // frequency_vector_size, so no additional data from the result is needed.
       deterministicDistribution = DeterministicDistribution.getDefaultInstance()
+      if (cmmsProtocol.hasDeterministicTruncatedLaplaceNoiseParams()) {
+        truncationBound = cmmsProtocol.deterministicTruncatedLaplaceNoiseParams.truncationBound
+      }
     } else if (protocolConfig.protocolsList.any { it.hasDirect() }) {
       noiseMechanism = source.noiseMechanism.toInternal()
       @Suppress("WHEN_ENUM_CAN_BE_NULL_IN_JAVA")
@@ -739,6 +742,9 @@ private fun Measurement.Result.Reach.toInternal(
       // variance depends on the sampling interval from MeasurementSpec rather than
       // frequency_vector_size, so no additional data from the result is needed.
       deterministicCountDistinct = DeterministicCountDistinct.getDefaultInstance()
+      if (cmmsProtocol.hasDeterministicTruncatedLaplaceNoiseParams()) {
+        truncationBound = cmmsProtocol.deterministicTruncatedLaplaceNoiseParams.truncationBound
+      }
     } else if (protocolConfig.protocolsList.any { it.hasDirect() }) {
       noiseMechanism = source.noiseMechanism.toInternal()
       @Suppress("WHEN_ENUM_CAN_BE_NULL_IN_JAVA")
@@ -1047,7 +1053,8 @@ fun ProtocolConfig.NoiseMechanism.toInternal(): InternalNoiseMechanism {
       InternalNoiseMechanism.NOISE_MECHANISM_UNSPECIFIED
     ProtocolConfig.NoiseMechanism.CONTINUOUS_LAPLACE -> InternalNoiseMechanism.CONTINUOUS_LAPLACE
     ProtocolConfig.NoiseMechanism.CONTINUOUS_GAUSSIAN -> InternalNoiseMechanism.CONTINUOUS_GAUSSIAN
-    ProtocolConfig.NoiseMechanism.DETERMINISTIC_TRUNCATED_LAPLACE,
+    ProtocolConfig.NoiseMechanism.DETERMINISTIC_TRUNCATED_LAPLACE ->
+      InternalNoiseMechanism.DETERMINISTIC_TRUNCATED_LAPLACE
     ProtocolConfig.NoiseMechanism.UNRECOGNIZED -> {
       throw NoiseMechanismUnrecognizedException("Noise mechanism $this is not recognized.")
     }
@@ -1181,6 +1188,7 @@ fun InternalNoiseMechanism.toStatsNoiseMechanism(): StatsNoiseMechanism {
     NoiseMechanism.CONTINUOUS_LAPLACE -> StatsNoiseMechanism.LAPLACE
     NoiseMechanism.DISCRETE_GAUSSIAN,
     NoiseMechanism.CONTINUOUS_GAUSSIAN -> StatsNoiseMechanism.GAUSSIAN
+    NoiseMechanism.DETERMINISTIC_TRUNCATED_LAPLACE -> StatsNoiseMechanism.TRUNCATED_LAPLACE
     NoiseMechanism.NOISE_MECHANISM_UNSPECIFIED -> {
       throw NoiseMechanismUnspecifiedException("Internal noise mechanism should've been specified.")
     }

--- a/src/main/proto/wfa/measurement/internal/reporting/v2/measurement.proto
+++ b/src/main/proto/wfa/measurement/internal/reporting/v2/measurement.proto
@@ -81,6 +81,12 @@ message Measurement {
         HonestMajorityShareShuffle honest_majority_share_shuffle = 8;
         TrusTee trus_tee = 9;
       }
+
+      // Draws are truncated to `[-truncation_bound, truncation_bound]`. Must be
+      // positive. Set only when `noise_mechanism` is
+      // DETERMINISTIC_TRUNCATED_LAPLACE, the only mechanism that parameterizes
+      // its noise this way.
+      int32 truncation_bound = 10;
     }
     Reach reach = 1;
 
@@ -96,6 +102,12 @@ message Measurement {
         HonestMajorityShareShuffle honest_majority_share_shuffle = 7;
         TrusTee trus_tee = 8;
       }
+
+      // Draws are truncated to `[-truncation_bound, truncation_bound]`. Must be
+      // positive. Set only when `noise_mechanism` is
+      // DETERMINISTIC_TRUNCATED_LAPLACE, the only mechanism that parameterizes
+      // its noise this way.
+      int32 truncation_bound = 9;
     }
     Frequency frequency = 2;
 

--- a/src/main/proto/wfa/measurement/internal/reporting/v2/noise_mechanism.proto
+++ b/src/main/proto/wfa/measurement/internal/reporting/v2/noise_mechanism.proto
@@ -33,4 +33,5 @@ enum NoiseMechanism {
   CONTINUOUS_LAPLACE = 4;
   // Continuous Gaussian.
   CONTINUOUS_GAUSSIAN = 5;
+  DETERMINISTIC_TRUNCATED_LAPLACE = 6;
 }


### PR DESCRIPTION
Stacked on #4322, which adds the stats-layer variance. **Base is `deterministic-noise-variance`; retarget to `main` once that merges.**

The internal reporting `NoiseMechanism` enum had no value for the mechanism, so `ProtocolConfig.NoiseMechanism.toInternal` threw on it. A BasicReport could not use TrusTEE with deterministic noise at all.

**The bound has to be stored.** The variance needs it, and the reporting server does not retain the `ProtocolConfig` its results came from, only the results. `buildInternalMeasurementResult` already receives the full public `Measurement`, so the bound is read from its `ProtocolConfig` where results are converted for storage. No new call path.

**Where it sits.** Beside `noise_mechanism` on `Result.Reach` (field 10) and `Result.Frequency` (field 9), not on the internal `TrusTee` methodology message. TrusTEE results record `DeterministicCountDistinct` / `DeterministicDistribution` as their methodology and never populate `TrusTee`, so a field there would be dead. The bound is a property of the noise, not of the counting methodology.

**Not included.** No test yet exercises a DTLN measurement through the reporting server, because none can be created until #4311 lands the Kingdom-side selection. The unit-level variance is covered in #4322.

Issue: #4185