### PR TITLE
feat: Compile DETERMINISTIC_TRUNCATED_LAPLACE privacy params into the TrusTEE image

### DIFF
--- a/src/main/kotlin/org/wfanet/measurement/computation/BUILD.bazel
+++ b/src/main/kotlin/org/wfanet/measurement/computation/BUILD.bazel
@@ -78,6 +78,7 @@ kt_jvm_library(
     srcs = ["ResultNoiser.kt"],
     deps = [
         ":deterministic_truncated_laplace_noise_sampler",
+        ":deterministic_truncated_laplace_params",
         ":differential_privacy_params",
         "//imports/java/com/google/privacy:differential_privacy",
     ],

--- a/src/main/kotlin/org/wfanet/measurement/computation/BUILD.bazel
+++ b/src/main/kotlin/org/wfanet/measurement/computation/BUILD.bazel
@@ -80,7 +80,6 @@ kt_jvm_library(
         ":deterministic_truncated_laplace_noise_sampler",
         ":deterministic_truncated_laplace_params",
         ":differential_privacy_params",
-        ":truncated_laplace_noise_distribution",
         "//imports/java/com/google/privacy:differential_privacy",
     ],
 )

--- a/src/main/kotlin/org/wfanet/measurement/computation/BUILD.bazel
+++ b/src/main/kotlin/org/wfanet/measurement/computation/BUILD.bazel
@@ -22,6 +22,11 @@ kt_jvm_library(
 )
 
 kt_jvm_library(
+    name = "deterministic_truncated_laplace_params",
+    srcs = ["DeterministicTruncatedLaplaceParams.kt"],
+)
+
+kt_jvm_library(
     name = "truncated_laplace_noise_distribution",
     srcs = ["TruncatedLaplaceNoiseDistribution.kt"],
 )

--- a/src/main/kotlin/org/wfanet/measurement/computation/BUILD.bazel
+++ b/src/main/kotlin/org/wfanet/measurement/computation/BUILD.bazel
@@ -80,6 +80,7 @@ kt_jvm_library(
         ":deterministic_truncated_laplace_noise_sampler",
         ":deterministic_truncated_laplace_params",
         ":differential_privacy_params",
+        ":truncated_laplace_noise_distribution",
         "//imports/java/com/google/privacy:differential_privacy",
     ],
 )

--- a/src/main/kotlin/org/wfanet/measurement/computation/DeterministicTruncatedLaplaceNoiseSampler.kt
+++ b/src/main/kotlin/org/wfanet/measurement/computation/DeterministicTruncatedLaplaceNoiseSampler.kt
@@ -47,14 +47,25 @@ class DeterministicTruncatedLaplaceNoiseSampler(
   companion object {
     /**
      * A sampler drawing ([epsilon], [delta])-differentially private truncated-Laplace noise for a
-     * query of L1 [sensitivity]. The scale is `sensitivity / epsilon` and the truncation bound is
-     * the smallest that keeps the truncated tail mass within [delta]: `bound = scale * ln(1 +
-     * (e^epsilon - 1) / (2 * delta))` (see Geng et al., "Privacy and Utility Tradeoff in
-     * Approximate Differential Privacy", arXiv:1810.00877).
+     * query of L1 [sensitivity].
      *
-     * Scale and bound are derived together so they cannot drift apart at a call site. [StrictMath]
-     * keeps the bound bit-reproducible across JVMs, matching the draw it bounds and any variance
-     * derived from it.
+     * The noise is Laplace with scale `b = sensitivity / epsilon` (the scale that makes the
+     * untruncated Laplace epsilon-DP), truncated to `[-T, T]`. T is chosen by the two-sided
+     * tail-mass rule: truncate where the discarded mass equals [delta]. For a zero-mean Laplace
+     * `P(|Y| > T) = e^(-T/b)`, so setting that to [delta] gives `T = b * ln(1 / delta)`. Discarding
+     * at most [delta] of the mass makes the truncated mechanism differ from the epsilon-DP Laplace
+     * only on an event of probability at most [delta], which is ([epsilon], [delta])-DP. T is
+     * rounded up and bumped by 1 for a strictly-conservative integer threshold:
+     * ```
+     * T = ceil((sensitivity / epsilon) * ln(1 / delta)) + 1
+     * ```
+     *
+     * This is looser than the tight optimal threshold
+     * `(sensitivity / epsilon) * ln(1 + (e^epsilon - 1) / (2 * delta))` (Geng et al., "Privacy and
+     * Utility Tradeoff in Approximate Differential Privacy", arXiv:1810.00877, Definition 3), which
+     * accounts for only the uncovered end-interval mass and so adds less noise. The conservative
+     * tail-mass form is the value compiled into the attested image. [StrictMath] keeps T
+     * bit-reproducible across JVMs, matching the draw it bounds and any variance derived from it.
      */
     fun forDifferentialPrivacy(
       epsilon: Double,
@@ -65,7 +76,7 @@ class DeterministicTruncatedLaplaceNoiseSampler(
       require(delta > 0.0 && delta < 1.0) { "delta must be in (0, 1), got $delta" }
       require(sensitivity > 0.0) { "sensitivity must be positive, got $sensitivity" }
       val scale = sensitivity / epsilon
-      val bound = scale * StrictMath.log(1.0 + (StrictMath.exp(epsilon) - 1.0) / (2.0 * delta))
+      val bound = StrictMath.ceil(scale * StrictMath.log(1.0 / delta)) + 1.0
       return DeterministicTruncatedLaplaceNoiseSampler(
         TruncatedLaplaceNoiseDistribution(scale, bound)
       )

--- a/src/main/kotlin/org/wfanet/measurement/computation/DeterministicTruncatedLaplaceNoiseSampler.kt
+++ b/src/main/kotlin/org/wfanet/measurement/computation/DeterministicTruncatedLaplaceNoiseSampler.kt
@@ -49,9 +49,8 @@ class DeterministicTruncatedLaplaceNoiseSampler(
      * A sampler drawing ([epsilon], [delta])-differentially private truncated-Laplace noise for a
      * query of L1 [sensitivity]. The scale is `sensitivity / epsilon` and the truncation bound is
      * the smallest that keeps the truncated tail mass within [delta]: `bound = scale * ln(1 +
-     * (e^epsilon - 1) / (2 * delta))` (see the `LaplaceBoundedNoise` mechanism in IBM's
-     * differential-privacy-library, and Geng et al., "Privacy and Utility Tradeoff in Approximate
-     * Differential Privacy", arXiv:1810.00877).
+     * (e^epsilon - 1) / (2 * delta))` (see Geng et al., "Privacy and Utility Tradeoff in
+     * Approximate Differential Privacy", arXiv:1810.00877).
      *
      * Scale and bound are derived together so they cannot drift apart at a call site. [StrictMath]
      * keeps the bound bit-reproducible across JVMs, matching the draw it bounds and any variance

--- a/src/main/kotlin/org/wfanet/measurement/computation/DeterministicTruncatedLaplaceNoiseSampler.kt
+++ b/src/main/kotlin/org/wfanet/measurement/computation/DeterministicTruncatedLaplaceNoiseSampler.kt
@@ -47,14 +47,35 @@ class DeterministicTruncatedLaplaceNoiseSampler(
   companion object {
     /**
      * A sampler drawing ([epsilon], [delta])-differentially private truncated-Laplace noise for a
-     * query of L1 [sensitivity]. The scale is `sensitivity / epsilon` and the truncation bound is
-     * the smallest that keeps the truncated tail mass within [delta]: `bound = scale * ln(1 +
-     * (e^epsilon - 1) / (2 * delta))` (see Geng et al., "Privacy and Utility Tradeoff in
-     * Approximate Differential Privacy", arXiv:1810.00877).
+     * query of L1 [sensitivity].
      *
-     * Scale and bound are derived together so they cannot drift apart at a call site. [StrictMath]
-     * keeps the bound bit-reproducible across JVMs, matching the draw it bounds and any variance
-     * derived from it.
+     * The noise is Laplace with scale `b = sensitivity / epsilon` (the scale that makes the
+     * untruncated Laplace epsilon-DP), truncated to `[-T, T]`. T is chosen by the two-sided
+     * tail-mass rule: truncate where the discarded mass equals [delta]. For a zero-mean Laplace
+     * `P(|Y| > T) = e^(-T/b)`, so setting that to [delta] gives `T = b * ln(1 / delta)`. Discarding
+     * at most [delta] of the mass makes the truncated mechanism differ from the epsilon-DP Laplace
+     * only on an event of probability at most [delta], which is ([epsilon], [delta])-DP. T is
+     * rounded up and bumped by 1 for a strictly-conservative integer threshold:
+     * ```
+     * T = ceil((sensitivity / epsilon) * ln(1 / delta)) + 1
+     * ```
+     *
+     * This is looser than the tight optimal threshold `(sensitivity / epsilon) * ln(1 +
+     * (e^epsilon - 1) / (2 * delta))` (Geng et al., "Privacy and Utility Tradeoff in Approximate
+     * Differential Privacy", arXiv:1810.00877, Definition 3), which accounts for only the uncovered
+     * end-interval mass and so adds less noise. The conservative tail-mass form is the value
+     * compiled into the attested image.
+     *
+     * The tail-mass rule only meets the tight optimal for `epsilon <= ln(3 - 2 * delta)` (about 1.1
+     * for small [delta]). Above that the bare `ln(1 / delta)` term drops below the optimal, and the
+     * fixed `+ 1` closes the gap only at unit sensitivity; for [sensitivity] above 1 with epsilon
+     * past the crossover (the impression-threshold draw) it can under-truncate and fail to be
+     * ([epsilon], [delta])-DP. This function throws when the resulting bound is below the optimal,
+     * so an insufficient bound cannot pass silently. The compiled epsilon is 1, well below the
+     * crossover, so the bound is conservative for every sensitivity used here.
+     *
+     * [StrictMath] keeps T bit-reproducible across JVMs, matching the draw it bounds and any
+     * variance derived from it.
      */
     fun forDifferentialPrivacy(
       epsilon: Double,
@@ -65,7 +86,15 @@ class DeterministicTruncatedLaplaceNoiseSampler(
       require(delta > 0.0 && delta < 1.0) { "delta must be in (0, 1), got $delta" }
       require(sensitivity > 0.0) { "sensitivity must be positive, got $sensitivity" }
       val scale = sensitivity / epsilon
-      val bound = scale * StrictMath.log(1.0 + (StrictMath.exp(epsilon) - 1.0) / (2.0 * delta))
+      val bound = StrictMath.ceil(scale * StrictMath.log(1.0 / delta)) + 1.0
+      // The tail-mass + 1 rule can fall below the tight (epsilon, delta) threshold for epsilon
+      // above ~ln(3) with sensitivity > 1 (see above); refuse to emit non-private noise.
+      val optimalBound =
+        scale * StrictMath.log(1.0 + (StrictMath.exp(epsilon) - 1.0) / (2.0 * delta))
+      require(bound >= optimalBound) {
+        "truncation bound $bound is below the minimum $optimalBound for epsilon=$epsilon, " +
+          "delta=$delta, sensitivity=$sensitivity"
+      }
       return DeterministicTruncatedLaplaceNoiseSampler(
         TruncatedLaplaceNoiseDistribution(scale, bound)
       )

--- a/src/main/kotlin/org/wfanet/measurement/computation/DeterministicTruncatedLaplaceNoiseSampler.kt
+++ b/src/main/kotlin/org/wfanet/measurement/computation/DeterministicTruncatedLaplaceNoiseSampler.kt
@@ -28,12 +28,6 @@ class DeterministicTruncatedLaplaceNoiseSampler(
   private val distribution: TruncatedLaplaceNoiseDistribution,
   private val uniformSampler: DeterministicUniformSampler = DeterministicUniformSampler(),
 ) {
-  constructor(
-    epsilon: Double,
-    sensitivity: Double,
-    truncationBound: Double,
-  ) : this(TruncatedLaplaceNoiseDistribution(epsilon, sensitivity, truncationBound))
-
   /**
    * Returns the noise to release: a truncated-Laplace draw for [parts], rounded to an integer.
    *

--- a/src/main/kotlin/org/wfanet/measurement/computation/DeterministicTruncatedLaplaceNoiseSampler.kt
+++ b/src/main/kotlin/org/wfanet/measurement/computation/DeterministicTruncatedLaplaceNoiseSampler.kt
@@ -43,4 +43,33 @@ class DeterministicTruncatedLaplaceNoiseSampler(
    */
   fun sampleRounded(vararg parts: ByteArray): Long =
     StrictMath.rint(distribution.inverseCdf(uniformSampler.sample(*parts))).toLong()
+
+  companion object {
+    /**
+     * A sampler drawing ([epsilon], [delta])-differentially private truncated-Laplace noise for a
+     * query of L1 [sensitivity]. The scale is `sensitivity / epsilon` and the truncation bound is
+     * the smallest that keeps the truncated tail mass within [delta]:
+     * `bound = scale * ln(1 + (e^epsilon - 1) / (2 * delta))` (see the `LaplaceBoundedNoise`
+     * mechanism in IBM's differential-privacy-library, and Geng et al., "Privacy and Utility
+     * Tradeoff in Approximate Differential Privacy", arXiv:1810.00877).
+     *
+     * Scale and bound are derived together so they cannot drift apart at a call site. [StrictMath]
+     * keeps the bound bit-reproducible across JVMs, matching the draw it bounds and any variance
+     * derived from it.
+     */
+    fun forDifferentialPrivacy(
+      epsilon: Double,
+      delta: Double,
+      sensitivity: Double,
+    ): DeterministicTruncatedLaplaceNoiseSampler {
+      require(epsilon > 0.0) { "epsilon must be positive, got $epsilon" }
+      require(delta > 0.0 && delta < 1.0) { "delta must be in (0, 1), got $delta" }
+      require(sensitivity > 0.0) { "sensitivity must be positive, got $sensitivity" }
+      val scale = sensitivity / epsilon
+      val bound = scale * StrictMath.log(1.0 + (StrictMath.exp(epsilon) - 1.0) / (2.0 * delta))
+      return DeterministicTruncatedLaplaceNoiseSampler(
+        TruncatedLaplaceNoiseDistribution(scale, bound)
+      )
+    }
+  }
 }

--- a/src/main/kotlin/org/wfanet/measurement/computation/DeterministicTruncatedLaplaceNoiseSampler.kt
+++ b/src/main/kotlin/org/wfanet/measurement/computation/DeterministicTruncatedLaplaceNoiseSampler.kt
@@ -50,29 +50,15 @@ class DeterministicTruncatedLaplaceNoiseSampler(
      * query of L1 [sensitivity].
      *
      * The noise is Laplace with scale `b = sensitivity / epsilon` (the scale that makes the
-     * untruncated Laplace epsilon-DP), truncated to `[-T, T]`. T is chosen by the two-sided
-     * tail-mass rule: truncate where the discarded mass equals [delta]. For a zero-mean Laplace
-     * `P(|Y| > T) = e^(-T/b)`, so setting that to [delta] gives `T = b * ln(1 / delta)`. Discarding
-     * at most [delta] of the mass makes the truncated mechanism differ from the epsilon-DP Laplace
-     * only on an event of probability at most [delta], which is ([epsilon], [delta])-DP. T is
-     * rounded up and bumped by 1 for a strictly-conservative integer threshold:
+     * untruncated Laplace epsilon-DP), truncated to `[-T, T]` at the optimal threshold:
      * ```
-     * T = ceil((sensitivity / epsilon) * ln(1 / delta)) + 1
+     * T = (sensitivity / epsilon) * ln(1 + (e^epsilon - 1) / (2 * delta))
      * ```
      *
-     * This is looser than the tight optimal threshold `(sensitivity / epsilon) * ln(1 +
-     * (e^epsilon - 1) / (2 * delta))` (Geng et al., "Privacy and Utility Tradeoff in Approximate
-     * Differential Privacy", arXiv:1810.00877, Definition 3), which accounts for only the uncovered
-     * end-interval mass and so adds less noise. The conservative tail-mass form is the value
-     * compiled into the attested image.
-     *
-     * The tail-mass rule only meets the tight optimal for `epsilon <= ln(3 - 2 * delta)` (about 1.1
-     * for small [delta]). Above that the bare `ln(1 / delta)` term drops below the optimal, and the
-     * fixed `+ 1` closes the gap only at unit sensitivity; for [sensitivity] above 1 with epsilon
-     * past the crossover (the impression-threshold draw) it can under-truncate and fail to be
-     * ([epsilon], [delta])-DP. This function throws when the resulting bound is below the optimal,
-     * so an insufficient bound cannot pass silently. The compiled epsilon is 1, well below the
-     * crossover, so the bound is conservative for every sensitivity used here.
+     * This is Geng et al., "Privacy and Utility Tradeoff in Approximate Differential Privacy"
+     * (arXiv:1810.00877), Definition 3, where the truncated Laplace is proved to be the optimal
+     * ([epsilon], [delta])-DP additive-noise mechanism and this threshold is proved tight. It holds
+     * for every ([epsilon], [delta]) and [sensitivity], so no regime check is needed.
      *
      * [StrictMath] keeps T bit-reproducible across JVMs, matching the draw it bounds and any
      * variance derived from it.
@@ -86,15 +72,7 @@ class DeterministicTruncatedLaplaceNoiseSampler(
       require(delta > 0.0 && delta < 1.0) { "delta must be in (0, 1), got $delta" }
       require(sensitivity > 0.0) { "sensitivity must be positive, got $sensitivity" }
       val scale = sensitivity / epsilon
-      val bound = StrictMath.ceil(scale * StrictMath.log(1.0 / delta)) + 1.0
-      // The tail-mass + 1 rule can fall below the tight (epsilon, delta) threshold for epsilon
-      // above ~ln(3) with sensitivity > 1 (see above); refuse to emit non-private noise.
-      val optimalBound =
-        scale * StrictMath.log(1.0 + (StrictMath.exp(epsilon) - 1.0) / (2.0 * delta))
-      require(bound >= optimalBound) {
-        "truncation bound $bound is below the minimum $optimalBound for epsilon=$epsilon, " +
-          "delta=$delta, sensitivity=$sensitivity"
-      }
+      val bound = scale * StrictMath.log(1.0 + (StrictMath.exp(epsilon) - 1.0) / (2.0 * delta))
       return DeterministicTruncatedLaplaceNoiseSampler(
         TruncatedLaplaceNoiseDistribution(scale, bound)
       )

--- a/src/main/kotlin/org/wfanet/measurement/computation/DeterministicTruncatedLaplaceNoiseSampler.kt
+++ b/src/main/kotlin/org/wfanet/measurement/computation/DeterministicTruncatedLaplaceNoiseSampler.kt
@@ -50,15 +50,18 @@ class DeterministicTruncatedLaplaceNoiseSampler(
      * query of L1 [sensitivity].
      *
      * The noise is Laplace with scale `b = sensitivity / epsilon` (the scale that makes the
-     * untruncated Laplace epsilon-DP), truncated to `[-T, T]` at the optimal threshold:
+     * untruncated Laplace epsilon-DP), truncated to `[-T, T]`:
      * ```
      * T = (sensitivity / epsilon) * ln(1 + (e^epsilon - 1) / (2 * delta))
      * ```
      *
-     * This is Geng et al., "Privacy and Utility Tradeoff in Approximate Differential Privacy"
-     * (arXiv:1810.00877), Definition 3, where the truncated Laplace is proved to be the optimal
-     * ([epsilon], [delta])-DP additive-noise mechanism and this threshold is proved tight. It holds
-     * for every ([epsilon], [delta]) and [sensitivity], so no regime check is needed.
+     * This is the truncated Laplace mechanism of Geng et al., "Privacy and Utility Tradeoff in
+     * Approximate Differential Privacy" (arXiv:1810.00877), Definition 3. T is the smallest
+     * threshold at which the mechanism is ([epsilon], [delta])-DP, proved there for all
+     * ([epsilon], [delta]) and [sensitivity], so no regime check is needed. That paper also shows
+     * the mechanism minimizes noise amplitude and power among ([epsilon], [delta])-DP
+     * additive-noise mechanisms, but establishes that asymptotically in high-privacy regimes;
+     * nothing here relies on it.
      *
      * [StrictMath] keeps T bit-reproducible across JVMs, matching the draw it bounds and any
      * variance derived from it.

--- a/src/main/kotlin/org/wfanet/measurement/computation/DeterministicTruncatedLaplaceNoiseSampler.kt
+++ b/src/main/kotlin/org/wfanet/measurement/computation/DeterministicTruncatedLaplaceNoiseSampler.kt
@@ -31,7 +31,7 @@ class DeterministicTruncatedLaplaceNoiseSampler(
   constructor(
     epsilon: Double,
     sensitivity: Double,
-    truncationBound: Int,
+    truncationBound: Double,
   ) : this(TruncatedLaplaceNoiseDistribution(epsilon, sensitivity, truncationBound))
 
   /**

--- a/src/main/kotlin/org/wfanet/measurement/computation/DeterministicTruncatedLaplaceNoiseSampler.kt
+++ b/src/main/kotlin/org/wfanet/measurement/computation/DeterministicTruncatedLaplaceNoiseSampler.kt
@@ -47,25 +47,14 @@ class DeterministicTruncatedLaplaceNoiseSampler(
   companion object {
     /**
      * A sampler drawing ([epsilon], [delta])-differentially private truncated-Laplace noise for a
-     * query of L1 [sensitivity].
+     * query of L1 [sensitivity]. The scale is `sensitivity / epsilon` and the truncation bound is
+     * the smallest that keeps the truncated tail mass within [delta]: `bound = scale * ln(1 +
+     * (e^epsilon - 1) / (2 * delta))` (see Geng et al., "Privacy and Utility Tradeoff in
+     * Approximate Differential Privacy", arXiv:1810.00877).
      *
-     * The noise is Laplace with scale `b = sensitivity / epsilon` (the scale that makes the
-     * untruncated Laplace epsilon-DP), truncated to `[-T, T]`. T is chosen by the two-sided
-     * tail-mass rule: truncate where the discarded mass equals [delta]. For a zero-mean Laplace
-     * `P(|Y| > T) = e^(-T/b)`, so setting that to [delta] gives `T = b * ln(1 / delta)`. Discarding
-     * at most [delta] of the mass makes the truncated mechanism differ from the epsilon-DP Laplace
-     * only on an event of probability at most [delta], which is ([epsilon], [delta])-DP. T is
-     * rounded up and bumped by 1 for a strictly-conservative integer threshold:
-     * ```
-     * T = ceil((sensitivity / epsilon) * ln(1 / delta)) + 1
-     * ```
-     *
-     * This is looser than the tight optimal threshold
-     * `(sensitivity / epsilon) * ln(1 + (e^epsilon - 1) / (2 * delta))` (Geng et al., "Privacy and
-     * Utility Tradeoff in Approximate Differential Privacy", arXiv:1810.00877, Definition 3), which
-     * accounts for only the uncovered end-interval mass and so adds less noise. The conservative
-     * tail-mass form is the value compiled into the attested image. [StrictMath] keeps T
-     * bit-reproducible across JVMs, matching the draw it bounds and any variance derived from it.
+     * Scale and bound are derived together so they cannot drift apart at a call site. [StrictMath]
+     * keeps the bound bit-reproducible across JVMs, matching the draw it bounds and any variance
+     * derived from it.
      */
     fun forDifferentialPrivacy(
       epsilon: Double,
@@ -76,7 +65,7 @@ class DeterministicTruncatedLaplaceNoiseSampler(
       require(delta > 0.0 && delta < 1.0) { "delta must be in (0, 1), got $delta" }
       require(sensitivity > 0.0) { "sensitivity must be positive, got $sensitivity" }
       val scale = sensitivity / epsilon
-      val bound = StrictMath.ceil(scale * StrictMath.log(1.0 / delta)) + 1.0
+      val bound = scale * StrictMath.log(1.0 + (StrictMath.exp(epsilon) - 1.0) / (2.0 * delta))
       return DeterministicTruncatedLaplaceNoiseSampler(
         TruncatedLaplaceNoiseDistribution(scale, bound)
       )

--- a/src/main/kotlin/org/wfanet/measurement/computation/DeterministicTruncatedLaplaceNoiseSampler.kt
+++ b/src/main/kotlin/org/wfanet/measurement/computation/DeterministicTruncatedLaplaceNoiseSampler.kt
@@ -57,8 +57,8 @@ class DeterministicTruncatedLaplaceNoiseSampler(
      *
      * This is the truncated Laplace mechanism of Geng et al., "Privacy and Utility Tradeoff in
      * Approximate Differential Privacy" (arXiv:1810.00877), Definition 3. T is the smallest
-     * threshold at which the mechanism is ([epsilon], [delta])-DP, proved there for all
-     * ([epsilon], [delta]) and [sensitivity], so no regime check is needed.
+     * threshold at which the mechanism is ([epsilon], [delta])-DP, proved there for all ([epsilon],
+     * [delta]) and [sensitivity], so no regime check is needed.
      *
      * [StrictMath] keeps T bit-reproducible across JVMs, matching the draw it bounds and any
      * variance derived from it.

--- a/src/main/kotlin/org/wfanet/measurement/computation/DeterministicTruncatedLaplaceNoiseSampler.kt
+++ b/src/main/kotlin/org/wfanet/measurement/computation/DeterministicTruncatedLaplaceNoiseSampler.kt
@@ -58,10 +58,7 @@ class DeterministicTruncatedLaplaceNoiseSampler(
      * This is the truncated Laplace mechanism of Geng et al., "Privacy and Utility Tradeoff in
      * Approximate Differential Privacy" (arXiv:1810.00877), Definition 3. T is the smallest
      * threshold at which the mechanism is ([epsilon], [delta])-DP, proved there for all
-     * ([epsilon], [delta]) and [sensitivity], so no regime check is needed. That paper also shows
-     * the mechanism minimizes noise amplitude and power among ([epsilon], [delta])-DP
-     * additive-noise mechanisms, but establishes that asymptotically in high-privacy regimes;
-     * nothing here relies on it.
+     * ([epsilon], [delta]) and [sensitivity], so no regime check is needed.
      *
      * [StrictMath] keeps T bit-reproducible across JVMs, matching the draw it bounds and any
      * variance derived from it.

--- a/src/main/kotlin/org/wfanet/measurement/computation/DeterministicTruncatedLaplaceNoiseSampler.kt
+++ b/src/main/kotlin/org/wfanet/measurement/computation/DeterministicTruncatedLaplaceNoiseSampler.kt
@@ -48,10 +48,10 @@ class DeterministicTruncatedLaplaceNoiseSampler(
     /**
      * A sampler drawing ([epsilon], [delta])-differentially private truncated-Laplace noise for a
      * query of L1 [sensitivity]. The scale is `sensitivity / epsilon` and the truncation bound is
-     * the smallest that keeps the truncated tail mass within [delta]:
-     * `bound = scale * ln(1 + (e^epsilon - 1) / (2 * delta))` (see the `LaplaceBoundedNoise`
-     * mechanism in IBM's differential-privacy-library, and Geng et al., "Privacy and Utility
-     * Tradeoff in Approximate Differential Privacy", arXiv:1810.00877).
+     * the smallest that keeps the truncated tail mass within [delta]: `bound = scale * ln(1 +
+     * (e^epsilon - 1) / (2 * delta))` (see the `LaplaceBoundedNoise` mechanism in IBM's
+     * differential-privacy-library, and Geng et al., "Privacy and Utility Tradeoff in Approximate
+     * Differential Privacy", arXiv:1810.00877).
      *
      * Scale and bound are derived together so they cannot drift apart at a call site. [StrictMath]
      * keeps the bound bit-reproducible across JVMs, matching the draw it bounds and any variance

--- a/src/main/kotlin/org/wfanet/measurement/computation/DeterministicTruncatedLaplaceParams.kt
+++ b/src/main/kotlin/org/wfanet/measurement/computation/DeterministicTruncatedLaplaceParams.kt
@@ -21,12 +21,31 @@ package org.wfanet.measurement.computation
  *
  * These are compiled into the attested images that draw the noise (the TrusTEE image and the EDP
  * Aggregator image) rather than set by the measurement consumer, and the reporting server mirrors
- * them to derive the matching variance. [EPSILON] with a truncation bound of [TRUNCATION_BOUND]
- * encodes delta = 1/1000. [SENSITIVITY] is the L1 sensitivity: adding or removing one VID changes a
- * reach or per-bucket count by 1.
+ * them to derive the matching variance. The noise targets ([EPSILON], [DELTA])-differential privacy.
+ *
+ * The truncation bound is not a compiled constant: it is [truncationBound], a function of the
+ * per-draw L1 sensitivity. The released quantities have different sensitivities (reach and a
+ * frequency bucket move by 1 per VID, the capped impression count moves by the per-user cap), and a
+ * single bound would conform to [DELTA] at only one of them.
  */
 object DeterministicTruncatedLaplaceParams {
   const val EPSILON = 1.0
-  const val TRUNCATION_BOUND = 8
-  const val SENSITIVITY = 1.0
+  const val DELTA = 1.0 / 1000.0
+
+  /**
+   * The truncation bound for the truncated-Laplace mechanism at [sensitivity] and [epsilon]: the
+   * smallest bound that keeps the truncated tail mass within [DELTA].
+   *
+   * This is the truncated-Laplace relation
+   * `bound = (sensitivity / epsilon) * ln(1 + (e^epsilon - 1) / (2 * delta))` (see the
+   * `LaplaceBoundedNoise` mechanism in IBM's differential-privacy-library, and Geng et al.,
+   * "Privacy and Utility Tradeoff in Approximate Differential Privacy", arXiv:1810.00877). At
+   * [EPSILON] and [DELTA] it is ~6.76 per unit of sensitivity.
+   *
+   * Uses [StrictMath] so the bound is bit-reproducible across JVMs, matching the draw it bounds and
+   * the variance the reporting server derives from it.
+   */
+  fun truncationBound(epsilon: Double, sensitivity: Double): Double =
+    (sensitivity / epsilon) *
+      StrictMath.log(1.0 + (StrictMath.exp(epsilon) - 1.0) / (2.0 * DELTA))
 }

--- a/src/main/kotlin/org/wfanet/measurement/computation/DeterministicTruncatedLaplaceParams.kt
+++ b/src/main/kotlin/org/wfanet/measurement/computation/DeterministicTruncatedLaplaceParams.kt
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2026 The Cross-Media Measurement Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wfanet.measurement.computation
+
+/**
+ * The system's privacy parameters for deterministic truncated-Laplace noise.
+ *
+ * These are compiled into the attested images that draw the noise (the TrusTEE image and the EDP
+ * Aggregator image) rather than set by the measurement consumer, and the reporting server mirrors
+ * them to derive the matching variance. [EPSILON] with a truncation bound of [TRUNCATION_BOUND]
+ * encodes delta = 1/1000. [SENSITIVITY] is the L1 sensitivity: adding or removing one VID changes a
+ * reach or per-bucket count by 1.
+ */
+object DeterministicTruncatedLaplaceParams {
+  const val EPSILON = 1.0
+  const val TRUNCATION_BOUND = 8
+  const val SENSITIVITY = 1.0
+}

--- a/src/main/kotlin/org/wfanet/measurement/computation/DeterministicTruncatedLaplaceParams.kt
+++ b/src/main/kotlin/org/wfanet/measurement/computation/DeterministicTruncatedLaplaceParams.kt
@@ -22,9 +22,9 @@ package org.wfanet.measurement.computation
  * These are compiled into the attested images that draw the noise (the TrusTEE image and the EDP
  * Aggregator image) rather than set by the measurement consumer, and the reporting server mirrors
  * them to derive the matching variance. The noise targets ([EPSILON], [DELTA])-differential
- * privacy; each draw's distribution comes from
- * [TruncatedLaplaceNoiseDistribution.forDifferentialPrivacy] with these constants and the draw's L1
- * sensitivity.
+ * privacy; each draw's sampler comes from
+ * [DeterministicTruncatedLaplaceNoiseSampler.forDifferentialPrivacy] with these constants and the
+ * draw's L1 sensitivity.
  */
 object DeterministicTruncatedLaplaceParams {
   const val EPSILON = 1.0

--- a/src/main/kotlin/org/wfanet/measurement/computation/DeterministicTruncatedLaplaceParams.kt
+++ b/src/main/kotlin/org/wfanet/measurement/computation/DeterministicTruncatedLaplaceParams.kt
@@ -21,31 +21,11 @@ package org.wfanet.measurement.computation
  *
  * These are compiled into the attested images that draw the noise (the TrusTEE image and the EDP
  * Aggregator image) rather than set by the measurement consumer, and the reporting server mirrors
- * them to derive the matching variance. The noise targets ([EPSILON], [DELTA])-differential privacy.
- *
- * The truncation bound is not a compiled constant: it is [truncationBound], a function of the
- * per-draw L1 sensitivity. The released quantities have different sensitivities (reach and a
- * frequency bucket move by 1 per VID, the capped impression count moves by the per-user cap), and a
- * single bound would conform to [DELTA] at only one of them.
+ * them to derive the matching variance. The noise targets ([EPSILON], [DELTA])-differential privacy;
+ * each draw's distribution comes from [TruncatedLaplaceNoiseDistribution.forDifferentialPrivacy]
+ * with these constants and the draw's L1 sensitivity.
  */
 object DeterministicTruncatedLaplaceParams {
   const val EPSILON = 1.0
   const val DELTA = 1.0 / 1000.0
-
-  /**
-   * The truncation bound for the truncated-Laplace mechanism at [sensitivity] and [epsilon]: the
-   * smallest bound that keeps the truncated tail mass within [DELTA].
-   *
-   * This is the truncated-Laplace relation
-   * `bound = (sensitivity / epsilon) * ln(1 + (e^epsilon - 1) / (2 * delta))` (see the
-   * `LaplaceBoundedNoise` mechanism in IBM's differential-privacy-library, and Geng et al.,
-   * "Privacy and Utility Tradeoff in Approximate Differential Privacy", arXiv:1810.00877). At
-   * [EPSILON] and [DELTA] it is ~6.76 per unit of sensitivity.
-   *
-   * Uses [StrictMath] so the bound is bit-reproducible across JVMs, matching the draw it bounds and
-   * the variance the reporting server derives from it.
-   */
-  fun truncationBound(epsilon: Double, sensitivity: Double): Double =
-    (sensitivity / epsilon) *
-      StrictMath.log(1.0 + (StrictMath.exp(epsilon) - 1.0) / (2.0 * DELTA))
 }

--- a/src/main/kotlin/org/wfanet/measurement/computation/DeterministicTruncatedLaplaceParams.kt
+++ b/src/main/kotlin/org/wfanet/measurement/computation/DeterministicTruncatedLaplaceParams.kt
@@ -21,9 +21,10 @@ package org.wfanet.measurement.computation
  *
  * These are compiled into the attested images that draw the noise (the TrusTEE image and the EDP
  * Aggregator image) rather than set by the measurement consumer, and the reporting server mirrors
- * them to derive the matching variance. The noise targets ([EPSILON], [DELTA])-differential privacy;
- * each draw's distribution comes from [TruncatedLaplaceNoiseDistribution.forDifferentialPrivacy]
- * with these constants and the draw's L1 sensitivity.
+ * them to derive the matching variance. The noise targets ([EPSILON], [DELTA])-differential
+ * privacy; each draw's distribution comes from
+ * [TruncatedLaplaceNoiseDistribution.forDifferentialPrivacy] with these constants and the draw's L1
+ * sensitivity.
  */
 object DeterministicTruncatedLaplaceParams {
   const val EPSILON = 1.0

--- a/src/main/kotlin/org/wfanet/measurement/computation/ResultNoiser.kt
+++ b/src/main/kotlin/org/wfanet/measurement/computation/ResultNoiser.kt
@@ -103,24 +103,23 @@ class GaussianResultNoiser(
 class DeterministicTruncatedLaplaceResultNoiser(
   combinedFrequencyVector: IntArray,
   contributionCount: Int,
-  private val reachEpsilon: Double,
-  private val frequencyEpsilon: Double,
   private val maxFrequencyPerUser: Int = 1,
 ) : ResultNoiser {
   private val fingerprint: ByteArray = fingerprint(combinedFrequencyVector, contributionCount)
 
-  // The truncation bound is derived per draw from its sensitivity: reach and each frequency bucket
-  // have sensitivity 1, the capped impression count has sensitivity maxFrequencyPerUser. A shared
-  // bound would conform to the target delta at only one sensitivity.
-  private val reachSampler by lazy { sampler(reachEpsilon, UNIT_SENSITIVITY) }
-  private val frequencySampler by lazy { sampler(frequencyEpsilon, UNIT_SENSITIVITY) }
-  private val impressionSampler by lazy { sampler(reachEpsilon, maxFrequencyPerUser.toDouble()) }
+  // One sampler per released quantity, each calibrated to that quantity's L1 sensitivity: reach and
+  // each frequency bucket move by 1 per VID, the capped impression count by maxFrequencyPerUser.
+  private val reachSampler by lazy { sampler(UNIT_SENSITIVITY) }
+  private val frequencySampler by lazy { sampler(UNIT_SENSITIVITY) }
+  private val impressionSampler by lazy { sampler(maxFrequencyPerUser.toDouble()) }
 
-  private fun sampler(epsilon: Double, sensitivity: Double) =
+  private fun sampler(sensitivity: Double) =
     DeterministicTruncatedLaplaceNoiseSampler(
-      epsilon,
-      sensitivity,
-      DeterministicTruncatedLaplaceParams.truncationBound(epsilon, sensitivity),
+      TruncatedLaplaceNoiseDistribution.forDifferentialPrivacy(
+        DeterministicTruncatedLaplaceParams.EPSILON,
+        DeterministicTruncatedLaplaceParams.DELTA,
+        sensitivity,
+      )
     )
 
   override fun noiseReach(reachInSample: Long): Long =

--- a/src/main/kotlin/org/wfanet/measurement/computation/ResultNoiser.kt
+++ b/src/main/kotlin/org/wfanet/measurement/computation/ResultNoiser.kt
@@ -114,12 +114,10 @@ class DeterministicTruncatedLaplaceResultNoiser(
   private val impressionSampler by lazy { sampler(maxFrequencyPerUser.toDouble()) }
 
   private fun sampler(sensitivity: Double) =
-    DeterministicTruncatedLaplaceNoiseSampler(
-      TruncatedLaplaceNoiseDistribution.forDifferentialPrivacy(
-        DeterministicTruncatedLaplaceParams.EPSILON,
-        DeterministicTruncatedLaplaceParams.DELTA,
-        sensitivity,
-      )
+    DeterministicTruncatedLaplaceNoiseSampler.forDifferentialPrivacy(
+      DeterministicTruncatedLaplaceParams.EPSILON,
+      DeterministicTruncatedLaplaceParams.DELTA,
+      sensitivity,
     )
 
   override fun noiseReach(reachInSample: Long): Long =

--- a/src/main/kotlin/org/wfanet/measurement/computation/ResultNoiser.kt
+++ b/src/main/kotlin/org/wfanet/measurement/computation/ResultNoiser.kt
@@ -105,24 +105,23 @@ class DeterministicTruncatedLaplaceResultNoiser(
   contributionCount: Int,
   private val reachEpsilon: Double,
   private val frequencyEpsilon: Double,
-  private val truncationBound: Int,
   private val maxFrequencyPerUser: Int = 1,
 ) : ResultNoiser {
   private val fingerprint: ByteArray = fingerprint(combinedFrequencyVector, contributionCount)
 
-  private val reachSampler by lazy {
-    DeterministicTruncatedLaplaceNoiseSampler(reachEpsilon, UNIT_SENSITIVITY, truncationBound)
-  }
-  private val frequencySampler by lazy {
-    DeterministicTruncatedLaplaceNoiseSampler(frequencyEpsilon, UNIT_SENSITIVITY, truncationBound)
-  }
-  private val impressionSampler by lazy {
+  // The truncation bound is derived per draw from its sensitivity: reach and each frequency bucket
+  // have sensitivity 1, the capped impression count has sensitivity maxFrequencyPerUser. A shared
+  // bound would conform to the target delta at only one sensitivity.
+  private val reachSampler by lazy { sampler(reachEpsilon, UNIT_SENSITIVITY) }
+  private val frequencySampler by lazy { sampler(frequencyEpsilon, UNIT_SENSITIVITY) }
+  private val impressionSampler by lazy { sampler(reachEpsilon, maxFrequencyPerUser.toDouble()) }
+
+  private fun sampler(epsilon: Double, sensitivity: Double) =
     DeterministicTruncatedLaplaceNoiseSampler(
-      reachEpsilon,
-      maxFrequencyPerUser.toDouble(),
-      truncationBound,
+      epsilon,
+      sensitivity,
+      DeterministicTruncatedLaplaceParams.truncationBound(epsilon, sensitivity),
     )
-  }
 
   override fun noiseReach(reachInSample: Long): Long =
     reachInSample + reachSampler.sampleRounded(fingerprint, label(REACH_LABEL))

--- a/src/main/kotlin/org/wfanet/measurement/computation/TruncatedLaplaceNoiseDistribution.kt
+++ b/src/main/kotlin/org/wfanet/measurement/computation/TruncatedLaplaceNoiseDistribution.kt
@@ -15,32 +15,28 @@
 package org.wfanet.measurement.computation
 
 /**
- * A [Laplace distribution](https://en.wikipedia.org/wiki/Laplace_distribution) with mean 0 and
- * scale `sensitivity / epsilon`, [truncated](https://en.wikipedia.org/wiki/Truncated_distribution)
- * to `[-truncationBound, truncationBound]`.
+ * A [Laplace distribution](https://en.wikipedia.org/wiki/Laplace_distribution) with mean 0 and the
+ * given [scale], [truncated](https://en.wikipedia.org/wiki/Truncated_distribution) to
+ * `[-bound, bound]`.
+ *
+ * This is the noise primitive: it knows only [scale] and [bound], not the differential-privacy
+ * parameters they may have been calibrated from. Use [forDifferentialPrivacy] to derive a
+ * distribution from an (epsilon, delta, sensitivity) target.
  *
  * [inverseCdf] maps a uniform in `[0, 1)` to a draw by
  * [inverse transform sampling](https://en.wikipedia.org/wiki/Inverse_transform_sampling). Every
  * floating-point operation uses [StrictMath] (fdlibm, specified to be identical on every JVM), so
  * the draw is bit-reproducible across builds and hosts.
  *
- * @param epsilon the Laplace scale is `sensitivity / epsilon`.
- * @param sensitivity L1 sensitivity of the noised output: the most one VID can change it.
- * @param truncationBound draws are confined to `[-truncationBound, truncationBound]`.
+ * @param scale the Laplace scale (`sensitivity / epsilon` for a DP calibration).
+ * @param bound draws are confined to `[-bound, bound]`.
  */
-class TruncatedLaplaceNoiseDistribution(
-  epsilon: Double,
-  sensitivity: Double,
-  truncationBound: Double,
-) {
+class TruncatedLaplaceNoiseDistribution(private val scale: Double, private val bound: Double) {
   init {
-    require(epsilon > 0.0) { "epsilon must be positive, got $epsilon" }
-    require(sensitivity > 0.0) { "sensitivity must be positive, got $sensitivity" }
-    require(truncationBound > 0.0) { "truncationBound must be positive, got $truncationBound" }
+    require(scale > 0.0) { "scale must be positive, got $scale" }
+    require(bound > 0.0) { "bound must be positive, got $bound" }
   }
 
-  private val scale: Double = sensitivity / epsilon
-  private val bound: Double = truncationBound
   private val cdfLow: Double = laplaceCdf(-bound)
   private val cdfHigh: Double = laplaceCdf(bound)
 
@@ -66,4 +62,32 @@ class TruncatedLaplaceNoiseDistribution(
 
   private fun laplaceQuantile(p: Double): Double =
     if (p < 0.5) scale * StrictMath.log(2.0 * p) else -scale * StrictMath.log(2.0 * (1.0 - p))
+
+  companion object {
+    /**
+     * The truncated-Laplace mechanism: the distribution giving ([epsilon], [delta])-differential
+     * privacy for a query of L1 [sensitivity]. The scale is `sensitivity / epsilon` and the
+     * truncation bound is the smallest that keeps the truncated tail mass within [delta]:
+     * `bound = scale * ln(1 + (e^epsilon - 1) / (2 * delta))` (see the `LaplaceBoundedNoise`
+     * mechanism in IBM's differential-privacy-library, and Geng et al., "Privacy and Utility
+     * Tradeoff in Approximate Differential Privacy", arXiv:1810.00877).
+     *
+     * Deriving scale and bound together keeps them consistent: they are two views of the same
+     * (epsilon, delta, sensitivity) and cannot drift apart at a call site. [StrictMath] keeps the
+     * bound bit-reproducible across JVMs, matching the draw it bounds and any variance derived from
+     * it.
+     */
+    fun forDifferentialPrivacy(
+      epsilon: Double,
+      delta: Double,
+      sensitivity: Double,
+    ): TruncatedLaplaceNoiseDistribution {
+      require(epsilon > 0.0) { "epsilon must be positive, got $epsilon" }
+      require(delta > 0.0 && delta < 1.0) { "delta must be in (0, 1), got $delta" }
+      require(sensitivity > 0.0) { "sensitivity must be positive, got $sensitivity" }
+      val scale = sensitivity / epsilon
+      val bound = scale * StrictMath.log(1.0 + (StrictMath.exp(epsilon) - 1.0) / (2.0 * delta))
+      return TruncatedLaplaceNoiseDistribution(scale, bound)
+    }
+  }
 }

--- a/src/main/kotlin/org/wfanet/measurement/computation/TruncatedLaplaceNoiseDistribution.kt
+++ b/src/main/kotlin/org/wfanet/measurement/computation/TruncatedLaplaceNoiseDistribution.kt
@@ -31,16 +31,16 @@ package org.wfanet.measurement.computation
 class TruncatedLaplaceNoiseDistribution(
   epsilon: Double,
   sensitivity: Double,
-  truncationBound: Int,
+  truncationBound: Double,
 ) {
   init {
     require(epsilon > 0.0) { "epsilon must be positive, got $epsilon" }
     require(sensitivity > 0.0) { "sensitivity must be positive, got $sensitivity" }
-    require(truncationBound > 0) { "truncationBound must be positive, got $truncationBound" }
+    require(truncationBound > 0.0) { "truncationBound must be positive, got $truncationBound" }
   }
 
   private val scale: Double = sensitivity / epsilon
-  private val bound: Double = truncationBound.toDouble()
+  private val bound: Double = truncationBound
   private val cdfLow: Double = laplaceCdf(-bound)
   private val cdfHigh: Double = laplaceCdf(bound)
 

--- a/src/main/kotlin/org/wfanet/measurement/computation/TruncatedLaplaceNoiseDistribution.kt
+++ b/src/main/kotlin/org/wfanet/measurement/computation/TruncatedLaplaceNoiseDistribution.kt
@@ -20,8 +20,9 @@ package org.wfanet.measurement.computation
  * bound]`.
  *
  * This is the noise primitive: it knows only [scale] and [bound], not the differential-privacy
- * parameters they may have been calibrated from. Use [forDifferentialPrivacy] to derive a
- * distribution from an (epsilon, delta, sensitivity) target.
+ * parameters they may have been calibrated from. Use
+ * [DeterministicTruncatedLaplaceNoiseSampler.forDifferentialPrivacy] to build a sampler calibrated
+ * from an (epsilon, delta, sensitivity) target.
  *
  * [inverseCdf] maps a uniform in `[0, 1)` to a draw by
  * [inverse transform sampling](https://en.wikipedia.org/wiki/Inverse_transform_sampling). Every
@@ -62,32 +63,4 @@ class TruncatedLaplaceNoiseDistribution(private val scale: Double, private val b
 
   private fun laplaceQuantile(p: Double): Double =
     if (p < 0.5) scale * StrictMath.log(2.0 * p) else -scale * StrictMath.log(2.0 * (1.0 - p))
-
-  companion object {
-    /**
-     * The truncated-Laplace mechanism: the distribution giving ([epsilon], [delta])-differential
-     * privacy for a query of L1 [sensitivity]. The scale is `sensitivity / epsilon` and the
-     * truncation bound is the smallest that keeps the truncated tail mass within [delta]: `bound =
-     * scale * ln(1 + (e^epsilon - 1) / (2 * delta))` (see the `LaplaceBoundedNoise` mechanism in
-     * IBM's differential-privacy-library, and Geng et al., "Privacy and Utility Tradeoff in
-     * Approximate Differential Privacy", arXiv:1810.00877).
-     *
-     * Deriving scale and bound together keeps them consistent: they are two views of the same
-     * (epsilon, delta, sensitivity) and cannot drift apart at a call site. [StrictMath] keeps the
-     * bound bit-reproducible across JVMs, matching the draw it bounds and any variance derived from
-     * it.
-     */
-    fun forDifferentialPrivacy(
-      epsilon: Double,
-      delta: Double,
-      sensitivity: Double,
-    ): TruncatedLaplaceNoiseDistribution {
-      require(epsilon > 0.0) { "epsilon must be positive, got $epsilon" }
-      require(delta > 0.0 && delta < 1.0) { "delta must be in (0, 1), got $delta" }
-      require(sensitivity > 0.0) { "sensitivity must be positive, got $sensitivity" }
-      val scale = sensitivity / epsilon
-      val bound = scale * StrictMath.log(1.0 + (StrictMath.exp(epsilon) - 1.0) / (2.0 * delta))
-      return TruncatedLaplaceNoiseDistribution(scale, bound)
-    }
-  }
 }

--- a/src/main/kotlin/org/wfanet/measurement/computation/TruncatedLaplaceNoiseDistribution.kt
+++ b/src/main/kotlin/org/wfanet/measurement/computation/TruncatedLaplaceNoiseDistribution.kt
@@ -16,8 +16,8 @@ package org.wfanet.measurement.computation
 
 /**
  * A [Laplace distribution](https://en.wikipedia.org/wiki/Laplace_distribution) with mean 0 and the
- * given [scale], [truncated](https://en.wikipedia.org/wiki/Truncated_distribution) to
- * `[-bound, bound]`.
+ * given [scale], [truncated](https://en.wikipedia.org/wiki/Truncated_distribution) to `[-bound,
+ * bound]`.
  *
  * This is the noise primitive: it knows only [scale] and [bound], not the differential-privacy
  * parameters they may have been calibrated from. Use [forDifferentialPrivacy] to derive a
@@ -67,10 +67,10 @@ class TruncatedLaplaceNoiseDistribution(private val scale: Double, private val b
     /**
      * The truncated-Laplace mechanism: the distribution giving ([epsilon], [delta])-differential
      * privacy for a query of L1 [sensitivity]. The scale is `sensitivity / epsilon` and the
-     * truncation bound is the smallest that keeps the truncated tail mass within [delta]:
-     * `bound = scale * ln(1 + (e^epsilon - 1) / (2 * delta))` (see the `LaplaceBoundedNoise`
-     * mechanism in IBM's differential-privacy-library, and Geng et al., "Privacy and Utility
-     * Tradeoff in Approximate Differential Privacy", arXiv:1810.00877).
+     * truncation bound is the smallest that keeps the truncated tail mass within [delta]: `bound =
+     * scale * ln(1 + (e^epsilon - 1) / (2 * delta))` (see the `LaplaceBoundedNoise` mechanism in
+     * IBM's differential-privacy-library, and Geng et al., "Privacy and Utility Tradeoff in
+     * Approximate Differential Privacy", arXiv:1810.00877).
      *
      * Deriving scale and bound together keeps them consistent: they are two views of the same
      * (epsilon, delta, sensitivity) and cannot drift apart at a call site. [StrictMath] keeps the

--- a/src/main/kotlin/org/wfanet/measurement/duchy/mill/trustee/TrusTeeMill.kt
+++ b/src/main/kotlin/org/wfanet/measurement/duchy/mill/trustee/TrusTeeMill.kt
@@ -170,12 +170,6 @@ class TrusTeeMill(
   /** Converts internal [TrusTee.ComputationDetails] to the internal [TrusTeeParams]. */
   fun TrusTeeDetails.toTrusTeeParams(): TrusTeeParams {
     val isNoNoise = parameters.noiseMechanism == NoiseMechanism.NONE
-    if (parameters.noiseMechanism == NoiseMechanism.DETERMINISTIC_TRUNCATED_LAPLACE) {
-      val truncationBound = parameters.deterministicTruncatedLaplaceNoiseParams.truncationBound
-      require(truncationBound > 0) {
-        "truncation_bound must be greater than 0 for DETERMINISTIC_TRUNCATED_LAPLACE noise, got $truncationBound"
-      }
-    }
 
     val resultMinimumThresholds: ResultMinimumThresholds? =
       if (parameters.hasResultMinimumThresholds()) {
@@ -205,7 +199,6 @@ class TrusTeeMill(
           if (isNoNoise) null else parameters.reachDpParams,
           resultMinimumThresholds,
           parameters.noiseMechanism,
-          parameters.deterministicTruncatedLaplaceNoiseParams.truncationBound,
         )
       }
       TrusTeeDetails.Type.REACH_AND_FREQUENCY -> {
@@ -224,7 +217,6 @@ class TrusTeeMill(
           if (isNoNoise) null else parameters.frequencyDpParams,
           resultMinimumThresholds,
           parameters.noiseMechanism,
-          parameters.deterministicTruncatedLaplaceNoiseParams.truncationBound,
         )
       }
       TrusTeeDetails.Type.TYPE_UNSPECIFIED,

--- a/src/main/kotlin/org/wfanet/measurement/duchy/mill/trustee/processor/BUILD.bazel
+++ b/src/main/kotlin/org/wfanet/measurement/duchy/mill/trustee/processor/BUILD.bazel
@@ -17,6 +17,7 @@ kt_jvm_library(
     srcs = ["TrusTeeProcessorImpl.kt"],
     deps = [
         ":trus_tee_processor",
+        "//src/main/kotlin/org/wfanet/measurement/computation:deterministic_truncated_laplace_params",
         "//src/main/kotlin/org/wfanet/measurement/computation:histogram_computations",
         "//src/main/kotlin/org/wfanet/measurement/computation:reach_and_frequency",
         "//src/main/kotlin/org/wfanet/measurement/computation:reach_and_frequency_computations",

--- a/src/main/kotlin/org/wfanet/measurement/duchy/mill/trustee/processor/BUILD.bazel
+++ b/src/main/kotlin/org/wfanet/measurement/duchy/mill/trustee/processor/BUILD.bazel
@@ -17,7 +17,6 @@ kt_jvm_library(
     srcs = ["TrusTeeProcessorImpl.kt"],
     deps = [
         ":trus_tee_processor",
-        "//src/main/kotlin/org/wfanet/measurement/computation:deterministic_truncated_laplace_params",
         "//src/main/kotlin/org/wfanet/measurement/computation:histogram_computations",
         "//src/main/kotlin/org/wfanet/measurement/computation:reach_and_frequency",
         "//src/main/kotlin/org/wfanet/measurement/computation:reach_and_frequency_computations",

--- a/src/main/kotlin/org/wfanet/measurement/duchy/mill/trustee/processor/TrusTeeProcessor.kt
+++ b/src/main/kotlin/org/wfanet/measurement/duchy/mill/trustee/processor/TrusTeeProcessor.kt
@@ -23,11 +23,6 @@ import org.wfanet.measurement.internal.duchy.NoiseMechanism
 sealed interface TrusTeeParams {
   /** Mechanism used to generate noise. */
   val noiseMechanism: NoiseMechanism
-  /**
-   * Truncation bound for [NoiseMechanism.DETERMINISTIC_TRUNCATED_LAPLACE]. Unused by other
-   * mechanisms.
-   */
-  val truncationBound: Int
 }
 
 /** TrusTEE parameters for a Reach-only measurement. */
@@ -36,7 +31,6 @@ data class TrusTeeReachParams(
   val dpParams: DifferentialPrivacyParams?,
   val resultMinimumThresholds: ResultMinimumThresholds?,
   override val noiseMechanism: NoiseMechanism = NoiseMechanism.NOISE_MECHANISM_UNSPECIFIED,
-  override val truncationBound: Int = 0,
 ) : TrusTeeParams
 
 /** TrusTEE parameters for a Reach-and-Frequency measurement. */
@@ -47,7 +41,6 @@ data class TrusTeeReachAndFrequencyParams(
   val frequencyDpParams: DifferentialPrivacyParams?,
   val resultMinimumThresholds: ResultMinimumThresholds?,
   override val noiseMechanism: NoiseMechanism = NoiseMechanism.NOISE_MECHANISM_UNSPECIFIED,
-  override val truncationBound: Int = 0,
 ) : TrusTeeParams
 
 /**

--- a/src/main/kotlin/org/wfanet/measurement/duchy/mill/trustee/processor/TrusTeeProcessorImpl.kt
+++ b/src/main/kotlin/org/wfanet/measurement/duchy/mill/trustee/processor/TrusTeeProcessorImpl.kt
@@ -181,7 +181,6 @@ class TrusTeeProcessorImpl(override val trusTeeParams: TrusTeeParams) : TrusTeeP
         contributionCount,
         reachEpsilon = DeterministicTruncatedLaplaceParams.EPSILON,
         frequencyEpsilon = DeterministicTruncatedLaplaceParams.EPSILON,
-        truncationBound = DeterministicTruncatedLaplaceParams.TRUNCATION_BOUND,
         maxFrequencyPerUser = resultMinimumThresholds?.reachMaxFrequencyPerUser ?: 1,
       )
     }

--- a/src/main/kotlin/org/wfanet/measurement/duchy/mill/trustee/processor/TrusTeeProcessorImpl.kt
+++ b/src/main/kotlin/org/wfanet/measurement/duchy/mill/trustee/processor/TrusTeeProcessorImpl.kt
@@ -14,6 +14,7 @@
 
 package org.wfanet.measurement.duchy.mill.trustee.processor
 
+import org.wfanet.measurement.computation.DeterministicTruncatedLaplaceParams
 import org.wfanet.measurement.computation.DeterministicTruncatedLaplaceResultNoiser
 import org.wfanet.measurement.computation.DifferentialPrivacyParams
 import org.wfanet.measurement.computation.GaussianResultNoiser
@@ -178,9 +179,9 @@ class TrusTeeProcessorImpl(override val trusTeeParams: TrusTeeParams) : TrusTeeP
       return DeterministicTruncatedLaplaceResultNoiser(
         frequencyVector,
         contributionCount,
-        reachEpsilon = DETERMINISTIC_EPSILON,
-        frequencyEpsilon = DETERMINISTIC_EPSILON,
-        truncationBound = DETERMINISTIC_TRUNCATION_BOUND,
+        reachEpsilon = DeterministicTruncatedLaplaceParams.EPSILON,
+        frequencyEpsilon = DeterministicTruncatedLaplaceParams.EPSILON,
+        truncationBound = DeterministicTruncatedLaplaceParams.TRUNCATION_BOUND,
         maxFrequencyPerUser = resultMinimumThresholds?.reachMaxFrequencyPerUser ?: 1,
       )
     }
@@ -200,12 +201,6 @@ class TrusTeeProcessorImpl(override val trusTeeParams: TrusTeeParams) : TrusTeeP
   }
 
   companion object Factory : TrusTeeProcessor.Factory {
-    // The system's privacy parameters for DETERMINISTIC_TRUNCATED_LAPLACE, compiled into the
-    // attested TrusTEE image rather than set by the measurement consumer. epsilon = 1 with a
-    // truncation bound of 8 encodes delta = 1/1000.
-    private const val DETERMINISTIC_EPSILON = 1.0
-    private const val DETERMINISTIC_TRUNCATION_BOUND = 8
-
     override fun create(trusTeeParams: TrusTeeParams): TrusTeeProcessor {
       return TrusTeeProcessorImpl(trusTeeParams)
     }

--- a/src/main/kotlin/org/wfanet/measurement/duchy/mill/trustee/processor/TrusTeeProcessorImpl.kt
+++ b/src/main/kotlin/org/wfanet/measurement/duchy/mill/trustee/processor/TrusTeeProcessorImpl.kt
@@ -14,7 +14,6 @@
 
 package org.wfanet.measurement.duchy.mill.trustee.processor
 
-import org.wfanet.measurement.computation.DeterministicTruncatedLaplaceParams
 import org.wfanet.measurement.computation.DeterministicTruncatedLaplaceResultNoiser
 import org.wfanet.measurement.computation.DifferentialPrivacyParams
 import org.wfanet.measurement.computation.GaussianResultNoiser
@@ -179,8 +178,6 @@ class TrusTeeProcessorImpl(override val trusTeeParams: TrusTeeParams) : TrusTeeP
       return DeterministicTruncatedLaplaceResultNoiser(
         frequencyVector,
         contributionCount,
-        reachEpsilon = DeterministicTruncatedLaplaceParams.EPSILON,
-        frequencyEpsilon = DeterministicTruncatedLaplaceParams.EPSILON,
         maxFrequencyPerUser = resultMinimumThresholds?.reachMaxFrequencyPerUser ?: 1,
       )
     }

--- a/src/main/kotlin/org/wfanet/measurement/duchy/mill/trustee/processor/TrusTeeProcessorImpl.kt
+++ b/src/main/kotlin/org/wfanet/measurement/duchy/mill/trustee/processor/TrusTeeProcessorImpl.kt
@@ -128,8 +128,7 @@ class TrusTeeProcessorImpl(override val trusTeeParams: TrusTeeParams) : TrusTeeP
       is TrusTeeReachParams -> {
         // A reach-only measurement has a single set of DP params, and never draws a frequency
         // bucket: computeReach noises the reach and the threshold only.
-        val noiser =
-          noiser(frequencyVector, params.dpParams, params.dpParams, params.truncationBound)
+        val noiser = noiser(frequencyVector, params.dpParams, params.dpParams)
         val reach =
           ReachAndFrequencyComputations.computeReach(
             sampledReachAndFrequency,
@@ -141,13 +140,7 @@ class TrusTeeProcessorImpl(override val trusTeeParams: TrusTeeParams) : TrusTeeP
         ReachResult(reach = reach, methodology = DeterministicMethodology)
       }
       is TrusTeeReachAndFrequencyParams -> {
-        val noiser =
-          noiser(
-            frequencyVector,
-            params.reachDpParams,
-            params.frequencyDpParams,
-            params.truncationBound,
-          )
+        val noiser = noiser(frequencyVector, params.reachDpParams, params.frequencyDpParams)
         val reach =
           ReachAndFrequencyComputations.computeReach(
             sampledReachAndFrequency,
@@ -179,16 +172,15 @@ class TrusTeeProcessorImpl(override val trusTeeParams: TrusTeeParams) : TrusTeeP
     frequencyVector: IntArray,
     reachDpParams: InternalDifferentialPrivacyParams?,
     frequencyDpParams: InternalDifferentialPrivacyParams?,
-    truncationBound: Int,
   ): ResultNoiser {
     if (isDeterministicTruncatedLaplace) {
+      // Privacy params are compiled into the attested image, not taken from the measurement spec.
       return DeterministicTruncatedLaplaceResultNoiser(
         frequencyVector,
         contributionCount,
-        reachEpsilon = requireNotNull(reachDpParams) { REACH_DP_PARAMS_REQUIRED }.epsilon,
-        frequencyEpsilon =
-          requireNotNull(frequencyDpParams) { FREQUENCY_DP_PARAMS_REQUIRED }.epsilon,
-        truncationBound = truncationBound,
+        reachEpsilon = DETERMINISTIC_EPSILON,
+        frequencyEpsilon = DETERMINISTIC_EPSILON,
+        truncationBound = DETERMINISTIC_TRUNCATION_BOUND,
         maxFrequencyPerUser = resultMinimumThresholds?.reachMaxFrequencyPerUser ?: 1,
       )
     }
@@ -208,10 +200,11 @@ class TrusTeeProcessorImpl(override val trusTeeParams: TrusTeeParams) : TrusTeeP
   }
 
   companion object Factory : TrusTeeProcessor.Factory {
-    private const val REACH_DP_PARAMS_REQUIRED =
-      "Reach DP params are required for DETERMINISTIC_TRUNCATED_LAPLACE noise."
-    private const val FREQUENCY_DP_PARAMS_REQUIRED =
-      "Frequency DP params are required for DETERMINISTIC_TRUNCATED_LAPLACE noise."
+    // The system's privacy parameters for DETERMINISTIC_TRUNCATED_LAPLACE, compiled into the
+    // attested TrusTEE image rather than set by the measurement consumer. epsilon = 1 with a
+    // truncation bound of 8 encodes delta = 1/1000.
+    private const val DETERMINISTIC_EPSILON = 1.0
+    private const val DETERMINISTIC_TRUNCATION_BOUND = 8
 
     override fun create(trusTeeParams: TrusTeeParams): TrusTeeProcessor {
       return TrusTeeProcessorImpl(trusTeeParams)

--- a/src/main/proto/wfa/measurement/internal/duchy/protocol/trus_tee.proto
+++ b/src/main/proto/wfa/measurement/internal/duchy/protocol/trus_tee.proto
@@ -76,12 +76,6 @@ message TrusTee {
       int32 min_users = 2;
     }
 
-    // Parameters for DETERMINISTIC_TRUNCATED_LAPLACE noise.
-    message DeterministicTruncatedLaplaceNoiseParams {
-      // Draws are truncated to `[-truncation_bound, truncation_bound]`.
-      int32 truncation_bound = 1;
-    }
-
     // Parameters used in this computation.
     message Parameters {
       // The maximum frequency to reveal in the histogram.
@@ -96,9 +90,6 @@ message TrusTee {
       float vid_sampling_interval_width = 5;
       // Optional small-cell suppression parameters.
       ResultMinimumThresholds result_minimum_thresholds = 6;
-      // Required when `noise_mechanism` is DETERMINISTIC_TRUNCATED_LAPLACE.
-      DeterministicTruncatedLaplaceNoiseParams
-          deterministic_truncated_laplace_noise_params = 7;
     }
     Parameters parameters = 3;
   }

--- a/src/main/proto/wfa/measurement/internal/duchy/protocol/trus_tee.proto
+++ b/src/main/proto/wfa/measurement/internal/duchy/protocol/trus_tee.proto
@@ -90,8 +90,7 @@ message TrusTee {
       float vid_sampling_interval_width = 5;
       // Optional small-cell suppression parameters.
       ResultMinimumThresholds result_minimum_thresholds = 6;
-      // Was deterministic_truncated_laplace_noise_params; the truncation bound is now derived from
-      // the compiled privacy params (DeterministicTruncatedLaplaceParams), not persisted here.
+      // Field 7 (removed deterministic_truncated_laplace_noise_params).
       reserved 7;
     }
     Parameters parameters = 3;

--- a/src/main/proto/wfa/measurement/internal/duchy/protocol/trus_tee.proto
+++ b/src/main/proto/wfa/measurement/internal/duchy/protocol/trus_tee.proto
@@ -90,6 +90,9 @@ message TrusTee {
       float vid_sampling_interval_width = 5;
       // Optional small-cell suppression parameters.
       ResultMinimumThresholds result_minimum_thresholds = 6;
+      // Was deterministic_truncated_laplace_noise_params; the truncation bound is now derived from
+      // the compiled privacy params (DeterministicTruncatedLaplaceParams), not persisted here.
+      reserved 7;
     }
     Parameters parameters = 3;
   }

--- a/src/test/kotlin/org/wfanet/measurement/computation/BUILD.bazel
+++ b/src/test/kotlin/org/wfanet/measurement/computation/BUILD.bazel
@@ -40,6 +40,7 @@ kt_jvm_test(
         "//src/main/kotlin/org/wfanet/measurement/computation:deterministic_uniform_sampler",
         "//src/main/kotlin/org/wfanet/measurement/computation:truncated_laplace_noise_distribution",
         "@wfa_common_jvm//imports/java/com/google/common/truth",
+        "@wfa_common_jvm//imports/kotlin/kotlin/test",
     ],
 )
 

--- a/src/test/kotlin/org/wfanet/measurement/computation/DeterministicTruncatedLaplaceNoiseSamplerTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/computation/DeterministicTruncatedLaplaceNoiseSamplerTest.kt
@@ -95,7 +95,7 @@ class DeterministicTruncatedLaplaceNoiseSamplerTest {
   @Test
   fun `forDifferentialPrivacy calibrates the draw from the privacy params`() {
     // Golden rounded draws for the same seed at two sensitivities, computed off-code from
-    // scale = sensitivity / epsilon and bound = ceil(scale * ln(1 / delta)) + 1. Larger sensitivity
+    // scale = sensitivity / epsilon and the Geng et al. Definition 3 bound. Larger sensitivity
     // widens the scale, so the draw grows; the exact per-quantity bounds are pinned end-to-end by
     // DeterministicTruncatedLaplaceResultNoiserTest.
     val unit =
@@ -131,24 +131,14 @@ class DeterministicTruncatedLaplaceNoiseSamplerTest {
   }
 
   @Test
-  fun `forDifferentialPrivacy rejects params where the bound falls below the optimal`() {
-    // High epsilon with sensitivity > 1: the tail-mass + 1 threshold undershoots the tight
-    // (epsilon, delta) bound, so it would not be (epsilon, delta)-DP.
-    assertFailsWith<IllegalArgumentException> {
-      DeterministicTruncatedLaplaceNoiseSampler.forDifferentialPrivacy(2.0, 1.0 / 1000, 126.0)
-    }
-  }
-
-  @Test
-  fun `forDifferentialPrivacy accepts high sensitivity at the compiled epsilon of 1`() {
-    // At epsilon 1 the tail-mass bound stays above the tight optimal for every sensitivity, so a
-    // high-sensitivity draw (the impression threshold) is accepted, not rejected by the guard. The
-    // bound is ceil(126 * ln(1000)) + 1 = 872, so draws stay within +/-872.
+  fun `forDifferentialPrivacy bounds a high-sensitivity draw`() {
+    // The impression-threshold draw, at the largest sensitivity in use. The bound is
+    // 126 * ln(1 + (e - 1) / 0.002) = 851.39, so draws stay within +/-851.
     val sampler =
       DeterministicTruncatedLaplaceNoiseSampler.forDifferentialPrivacy(1.0, 1.0 / 1000, 126.0)
     val draw = sampler.sampleRounded(fingerprint, label)
-    assertThat(draw).isAtLeast(-872L)
-    assertThat(draw).isAtMost(872L)
+    assertThat(draw).isAtLeast(-851L)
+    assertThat(draw).isAtMost(851L)
   }
 
   companion object {

--- a/src/test/kotlin/org/wfanet/measurement/computation/DeterministicTruncatedLaplaceNoiseSamplerTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/computation/DeterministicTruncatedLaplaceNoiseSamplerTest.kt
@@ -95,9 +95,9 @@ class DeterministicTruncatedLaplaceNoiseSamplerTest {
   @Test
   fun `forDifferentialPrivacy calibrates the draw from the privacy params`() {
     // Golden rounded draws for the same seed at two sensitivities, computed off-code from
-    // scale = sensitivity / epsilon and bound = scale * ln(1 + (e^epsilon - 1) / (2 * delta)).
-    // Larger sensitivity widens the scale, so the draw grows; the exact per-quantity bounds are
-    // pinned end-to-end by DeterministicTruncatedLaplaceResultNoiserTest.
+    // scale = sensitivity / epsilon and bound = ceil(scale * ln(1 / delta)) + 1. Larger sensitivity
+    // widens the scale, so the draw grows; the exact per-quantity bounds are pinned end-to-end by
+    // DeterministicTruncatedLaplaceResultNoiserTest.
     val unit =
       DeterministicTruncatedLaplaceNoiseSampler.forDifferentialPrivacy(1.0, 1.0 / 1000, 1.0)
     val wide =
@@ -127,6 +127,15 @@ class DeterministicTruncatedLaplaceNoiseSamplerTest {
   fun `forDifferentialPrivacy rejects non-positive sensitivity`() {
     assertFailsWith<IllegalArgumentException> {
       DeterministicTruncatedLaplaceNoiseSampler.forDifferentialPrivacy(1.0, 1.0 / 1000, 0.0)
+    }
+  }
+
+  @Test
+  fun `forDifferentialPrivacy rejects params where the bound falls below the optimal`() {
+    // High epsilon with sensitivity > 1: the tail-mass + 1 threshold undershoots the tight
+    // (epsilon, delta) bound, so it would not be (epsilon, delta)-DP.
+    assertFailsWith<IllegalArgumentException> {
+      DeterministicTruncatedLaplaceNoiseSampler.forDifferentialPrivacy(2.0, 1.0 / 1000, 126.0)
     }
   }
 

--- a/src/test/kotlin/org/wfanet/measurement/computation/DeterministicTruncatedLaplaceNoiseSamplerTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/computation/DeterministicTruncatedLaplaceNoiseSamplerTest.kt
@@ -139,6 +139,18 @@ class DeterministicTruncatedLaplaceNoiseSamplerTest {
     }
   }
 
+  @Test
+  fun `forDifferentialPrivacy accepts high sensitivity at the compiled epsilon of 1`() {
+    // At epsilon 1 the tail-mass bound stays above the tight optimal for every sensitivity, so a
+    // high-sensitivity draw (the impression threshold) is accepted, not rejected by the guard. The
+    // bound is ceil(126 * ln(1000)) + 1 = 872, so draws stay within +/-872.
+    val sampler =
+      DeterministicTruncatedLaplaceNoiseSampler.forDifferentialPrivacy(1.0, 1.0 / 1000, 126.0)
+    val draw = sampler.sampleRounded(fingerprint, label)
+    assertThat(draw).isAtLeast(-872L)
+    assertThat(draw).isAtMost(872L)
+  }
+
   companion object {
     private const val SCALE = 1.0
     private const val BOUND = 8.0

--- a/src/test/kotlin/org/wfanet/measurement/computation/DeterministicTruncatedLaplaceNoiseSamplerTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/computation/DeterministicTruncatedLaplaceNoiseSamplerTest.kt
@@ -16,6 +16,7 @@ package org.wfanet.measurement.computation
 
 import com.google.common.truth.Truth.assertThat
 import kotlin.math.abs
+import kotlin.test.assertFailsWith
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
@@ -89,6 +90,44 @@ class DeterministicTruncatedLaplaceNoiseSamplerTest {
     val mean =
       (0 until 20000).map { sampler.sampleRounded("fv-$it".toByteArray(), label) }.average()
     assertThat(mean).isWithin(0.1).of(0.0)
+  }
+
+  @Test
+  fun `forDifferentialPrivacy calibrates the draw from the privacy params`() {
+    // Golden rounded draws for the same seed at two sensitivities, computed off-code from
+    // scale = sensitivity / epsilon and bound = scale * ln(1 + (e^epsilon - 1) / (2 * delta)).
+    // Larger sensitivity widens the scale, so the draw grows; the exact per-quantity bounds are
+    // pinned end-to-end by DeterministicTruncatedLaplaceResultNoiserTest.
+    val unit =
+      DeterministicTruncatedLaplaceNoiseSampler.forDifferentialPrivacy(1.0, 1.0 / 1000, 1.0)
+    val wide =
+      DeterministicTruncatedLaplaceNoiseSampler.forDifferentialPrivacy(1.0, 1.0 / 1000, 4.0)
+    assertThat(unit.sampleRounded(fingerprint, label)).isEqualTo(1L)
+    assertThat(wide.sampleRounded(fingerprint, label)).isEqualTo(2L)
+  }
+
+  @Test
+  fun `forDifferentialPrivacy rejects non-positive epsilon`() {
+    assertFailsWith<IllegalArgumentException> {
+      DeterministicTruncatedLaplaceNoiseSampler.forDifferentialPrivacy(0.0, 1.0 / 1000, 1.0)
+    }
+  }
+
+  @Test
+  fun `forDifferentialPrivacy rejects delta outside the open unit interval`() {
+    assertFailsWith<IllegalArgumentException> {
+      DeterministicTruncatedLaplaceNoiseSampler.forDifferentialPrivacy(1.0, 0.0, 1.0)
+    }
+    assertFailsWith<IllegalArgumentException> {
+      DeterministicTruncatedLaplaceNoiseSampler.forDifferentialPrivacy(1.0, 1.0, 1.0)
+    }
+  }
+
+  @Test
+  fun `forDifferentialPrivacy rejects non-positive sensitivity`() {
+    assertFailsWith<IllegalArgumentException> {
+      DeterministicTruncatedLaplaceNoiseSampler.forDifferentialPrivacy(1.0, 1.0 / 1000, 0.0)
+    }
   }
 
   companion object {

--- a/src/test/kotlin/org/wfanet/measurement/computation/DeterministicTruncatedLaplaceNoiseSamplerTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/computation/DeterministicTruncatedLaplaceNoiseSamplerTest.kt
@@ -95,9 +95,9 @@ class DeterministicTruncatedLaplaceNoiseSamplerTest {
   @Test
   fun `forDifferentialPrivacy calibrates the draw from the privacy params`() {
     // Golden rounded draws for the same seed at two sensitivities, computed off-code from
-    // scale = sensitivity / epsilon and bound = scale * ln(1 + (e^epsilon - 1) / (2 * delta)).
-    // Larger sensitivity widens the scale, so the draw grows; the exact per-quantity bounds are
-    // pinned end-to-end by DeterministicTruncatedLaplaceResultNoiserTest.
+    // scale = sensitivity / epsilon and bound = ceil(scale * ln(1 / delta)) + 1. Larger sensitivity
+    // widens the scale, so the draw grows; the exact per-quantity bounds are pinned end-to-end by
+    // DeterministicTruncatedLaplaceResultNoiserTest.
     val unit =
       DeterministicTruncatedLaplaceNoiseSampler.forDifferentialPrivacy(1.0, 1.0 / 1000, 1.0)
     val wide =

--- a/src/test/kotlin/org/wfanet/measurement/computation/DeterministicTruncatedLaplaceNoiseSamplerTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/computation/DeterministicTruncatedLaplaceNoiseSamplerTest.kt
@@ -22,7 +22,7 @@ import org.junit.runners.JUnit4
 
 @RunWith(JUnit4::class)
 class DeterministicTruncatedLaplaceNoiseSamplerTest {
-  private val distribution = TruncatedLaplaceNoiseDistribution(EPSILON, SENSITIVITY, BOUND)
+  private val distribution = TruncatedLaplaceNoiseDistribution(SCALE, BOUND)
   private val uniformSampler = DeterministicUniformSampler()
   private val sampler = DeterministicTruncatedLaplaceNoiseSampler(distribution, uniformSampler)
 
@@ -77,9 +77,9 @@ class DeterministicTruncatedLaplaceNoiseSamplerTest {
   }
 
   @Test
-  fun `higher sensitivity yields a larger-magnitude draw for the same parts`() {
-    val narrow = TruncatedLaplaceNoiseDistribution(EPSILON, sensitivity = 1.0, BOUND)
-    val wide = TruncatedLaplaceNoiseDistribution(EPSILON, sensitivity = 4.0, BOUND)
+  fun `larger scale yields a larger-magnitude draw for the same parts`() {
+    val narrow = TruncatedLaplaceNoiseDistribution(scale = 1.0, bound = BOUND)
+    val wide = TruncatedLaplaceNoiseDistribution(scale = 4.0, bound = BOUND)
     val u = uniformSampler.sample(fingerprint, label)
     assertThat(abs(wide.inverseCdf(u))).isGreaterThan(abs(narrow.inverseCdf(u)))
   }
@@ -92,8 +92,7 @@ class DeterministicTruncatedLaplaceNoiseSamplerTest {
   }
 
   companion object {
-    private const val EPSILON = 1.0
-    private const val SENSITIVITY = 1.0
+    private const val SCALE = 1.0
     private const val BOUND = 8.0
   }
 }

--- a/src/test/kotlin/org/wfanet/measurement/computation/DeterministicTruncatedLaplaceNoiseSamplerTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/computation/DeterministicTruncatedLaplaceNoiseSamplerTest.kt
@@ -95,9 +95,9 @@ class DeterministicTruncatedLaplaceNoiseSamplerTest {
   @Test
   fun `forDifferentialPrivacy calibrates the draw from the privacy params`() {
     // Golden rounded draws for the same seed at two sensitivities, computed off-code from
-    // scale = sensitivity / epsilon and bound = ceil(scale * ln(1 / delta)) + 1. Larger sensitivity
-    // widens the scale, so the draw grows; the exact per-quantity bounds are pinned end-to-end by
-    // DeterministicTruncatedLaplaceResultNoiserTest.
+    // scale = sensitivity / epsilon and bound = scale * ln(1 + (e^epsilon - 1) / (2 * delta)).
+    // Larger sensitivity widens the scale, so the draw grows; the exact per-quantity bounds are
+    // pinned end-to-end by DeterministicTruncatedLaplaceResultNoiserTest.
     val unit =
       DeterministicTruncatedLaplaceNoiseSampler.forDifferentialPrivacy(1.0, 1.0 / 1000, 1.0)
     val wide =

--- a/src/test/kotlin/org/wfanet/measurement/computation/DeterministicTruncatedLaplaceNoiseSamplerTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/computation/DeterministicTruncatedLaplaceNoiseSamplerTest.kt
@@ -94,6 +94,6 @@ class DeterministicTruncatedLaplaceNoiseSamplerTest {
   companion object {
     private const val EPSILON = 1.0
     private const val SENSITIVITY = 1.0
-    private const val BOUND = 8
+    private const val BOUND = 8.0
   }
 }

--- a/src/test/kotlin/org/wfanet/measurement/computation/DeterministicTruncatedLaplaceResultNoiserTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/computation/DeterministicTruncatedLaplaceResultNoiserTest.kt
@@ -44,8 +44,8 @@ class DeterministicTruncatedLaplaceResultNoiserTest {
   fun `impression count is capped and drawn on its own label`() {
     // Capped sum over [10, 4, 1] at 3 per user is 1*10 + 2*4 + 3*1 = 21; the draw on the impression
     // label at sensitivity 3 is -5, using the bound derived for that sensitivity (20.27, not the
-    // 6.76 of the unit-sensitivity draws). Distinct from the bucket labels, so it is not the weighted sum
-    // of the bucket draws.
+    // 6.76 of the unit-sensitivity draws). Distinct from the bucket labels, so it is not the
+    // weighted sum of the bucket draws.
     assertThat(noiser().noiseImpressionsFromFrequencyHistogram(longArrayOf(10, 4, 1)))
       .isEqualTo(16L)
   }

--- a/src/test/kotlin/org/wfanet/measurement/computation/DeterministicTruncatedLaplaceResultNoiserTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/computation/DeterministicTruncatedLaplaceResultNoiserTest.kt
@@ -43,8 +43,8 @@ class DeterministicTruncatedLaplaceResultNoiserTest {
   @Test
   fun `impression count is capped and drawn on its own label`() {
     // Capped sum over [10, 4, 1] at 3 per user is 1*10 + 2*4 + 3*1 = 21; the draw on the impression
-    // label at sensitivity 3 is -5, using the bound derived for that sensitivity (22, not the 8 of
-    // the unit-sensitivity draws). Distinct from the bucket labels, so it is not the weighted sum
+    // label at sensitivity 3 is -5, using the bound derived for that sensitivity (20.27, not the
+    // 6.76 of the unit-sensitivity draws). Distinct from the bucket labels, so it is not the weighted sum
     // of the bucket draws.
     assertThat(noiser().noiseImpressionsFromFrequencyHistogram(longArrayOf(10, 4, 1)))
       .isEqualTo(16L)

--- a/src/test/kotlin/org/wfanet/measurement/computation/DeterministicTruncatedLaplaceResultNoiserTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/computation/DeterministicTruncatedLaplaceResultNoiserTest.kt
@@ -43,9 +43,9 @@ class DeterministicTruncatedLaplaceResultNoiserTest {
   @Test
   fun `impression count is capped and drawn on its own label`() {
     // Capped sum over [10, 4, 1] at 3 per user is 1*10 + 2*4 + 3*1 = 21; the draw on the impression
-    // label at sensitivity 3 is -5, using the bound derived for that sensitivity (22, not the 8 of
-    // the unit-sensitivity draws). Distinct from the bucket labels, so it is not the weighted sum
-    // of the bucket draws.
+    // label at sensitivity 3 is -5, using the bound derived for that sensitivity (~20.3, not the
+    // ~6.76 of the unit-sensitivity draws). Distinct from the bucket labels, so it is not the
+    // weighted sum of the bucket draws.
     assertThat(noiser().noiseImpressionsFromFrequencyHistogram(longArrayOf(10, 4, 1)))
       .isEqualTo(16L)
   }

--- a/src/test/kotlin/org/wfanet/measurement/computation/DeterministicTruncatedLaplaceResultNoiserTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/computation/DeterministicTruncatedLaplaceResultNoiserTest.kt
@@ -43,9 +43,9 @@ class DeterministicTruncatedLaplaceResultNoiserTest {
   @Test
   fun `impression count is capped and drawn on its own label`() {
     // Capped sum over [10, 4, 1] at 3 per user is 1*10 + 2*4 + 3*1 = 21; the draw on the impression
-    // label at sensitivity 3 is -5, using the bound derived for that sensitivity (~20.3, not the
-    // ~6.76 of the unit-sensitivity draws). Distinct from the bucket labels, so it is not the
-    // weighted sum of the bucket draws.
+    // label at sensitivity 3 is -5, using the bound derived for that sensitivity (22, not the 8 of
+    // the unit-sensitivity draws). Distinct from the bucket labels, so it is not the weighted sum
+    // of the bucket draws.
     assertThat(noiser().noiseImpressionsFromFrequencyHistogram(longArrayOf(10, 4, 1)))
       .isEqualTo(16L)
   }

--- a/src/test/kotlin/org/wfanet/measurement/computation/DeterministicTruncatedLaplaceResultNoiserTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/computation/DeterministicTruncatedLaplaceResultNoiserTest.kt
@@ -31,12 +31,12 @@ class DeterministicTruncatedLaplaceResultNoiserTest {
   fun `reach and bucket draws match golden`() {
     // Goldens computed outside this codebase from the documented construction: SHA-256 over the
     // length-prefixed parts, top 53 bits as the uniform, then inverseCdf and round-half-to-even.
-    // The draws are +1, -2, -1, 0, so this fails against a noiser that returns zero.
+    // The draws are +1, -4, -2, 0, so this fails against a noiser that returns zero.
     val noiser = noiser()
 
     assertThat(noiser.noiseReach(15)).isEqualTo(16L)
-    assertThat(noiser.noiseFrequencyBucket(0, 10)).isEqualTo(8L)
-    assertThat(noiser.noiseFrequencyBucket(1, 4)).isEqualTo(3L)
+    assertThat(noiser.noiseFrequencyBucket(0, 10)).isEqualTo(6L)
+    assertThat(noiser.noiseFrequencyBucket(1, 4)).isEqualTo(2L)
     assertThat(noiser.noiseFrequencyBucket(2, 1)).isEqualTo(1L)
   }
 
@@ -96,8 +96,6 @@ class DeterministicTruncatedLaplaceResultNoiserTest {
   }
 
   companion object {
-    private const val REACH_EPSILON = 1.0
-    private const val FREQUENCY_EPSILON = 2.0
     private const val CONTRIBUTION_COUNT = 3
     private const val MAX_FREQUENCY_PER_USER = 3
     private val COMBINED = intArrayOf(0, 1, 2, 1, 3, 0, 2)
@@ -106,8 +104,6 @@ class DeterministicTruncatedLaplaceResultNoiserTest {
       DeterministicTruncatedLaplaceResultNoiser(
         COMBINED,
         CONTRIBUTION_COUNT,
-        REACH_EPSILON,
-        FREQUENCY_EPSILON,
         MAX_FREQUENCY_PER_USER,
       )
 

--- a/src/test/kotlin/org/wfanet/measurement/computation/DeterministicTruncatedLaplaceResultNoiserTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/computation/DeterministicTruncatedLaplaceResultNoiserTest.kt
@@ -43,10 +43,11 @@ class DeterministicTruncatedLaplaceResultNoiserTest {
   @Test
   fun `impression count is capped and drawn on its own label`() {
     // Capped sum over [10, 4, 1] at 3 per user is 1*10 + 2*4 + 3*1 = 21; the draw on the impression
-    // label at sensitivity 3 is -4. Distinct from the bucket labels, so it is not the weighted sum
-    // of the bucket draws.
+    // label at sensitivity 3 is -5, using the bound derived for that sensitivity (~20.3, not the
+    // ~6.76 of the unit-sensitivity draws). Distinct from the bucket labels, so it is not the
+    // weighted sum of the bucket draws.
     assertThat(noiser().noiseImpressionsFromFrequencyHistogram(longArrayOf(10, 4, 1)))
-      .isEqualTo(17L)
+      .isEqualTo(16L)
   }
 
   @Test
@@ -97,7 +98,6 @@ class DeterministicTruncatedLaplaceResultNoiserTest {
   companion object {
     private const val REACH_EPSILON = 1.0
     private const val FREQUENCY_EPSILON = 2.0
-    private const val BOUND = 8
     private const val CONTRIBUTION_COUNT = 3
     private const val MAX_FREQUENCY_PER_USER = 3
     private val COMBINED = intArrayOf(0, 1, 2, 1, 3, 0, 2)
@@ -108,7 +108,6 @@ class DeterministicTruncatedLaplaceResultNoiserTest {
         CONTRIBUTION_COUNT,
         REACH_EPSILON,
         FREQUENCY_EPSILON,
-        BOUND,
         MAX_FREQUENCY_PER_USER,
       )
 

--- a/src/test/kotlin/org/wfanet/measurement/computation/TruncatedLaplaceNoiseDistributionTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/computation/TruncatedLaplaceNoiseDistributionTest.kt
@@ -22,11 +22,11 @@ import org.junit.runners.JUnit4
 
 @RunWith(JUnit4::class)
 class TruncatedLaplaceNoiseDistributionTest {
-  private val distribution = TruncatedLaplaceNoiseDistribution(EPSILON, SENSITIVITY, BOUND)
+  private val distribution = TruncatedLaplaceNoiseDistribution(SCALE, BOUND)
 
   @Test
   fun `inverseCdf at zero is the lower bound`() {
-    assertThat(distribution.inverseCdf(0.0)).isWithin(1e-9).of(-BOUND.toDouble())
+    assertThat(distribution.inverseCdf(0.0)).isWithin(1e-9).of(-BOUND)
   }
 
   @Test
@@ -38,7 +38,7 @@ class TruncatedLaplaceNoiseDistributionTest {
   fun `inverseCdf near one stays within the upper bound`() {
     val draw = distribution.inverseCdf(0.999999999)
     assertThat(draw).isGreaterThan(0.0)
-    assertThat(draw).isAtMost(BOUND.toDouble())
+    assertThat(draw).isAtMost(BOUND)
   }
 
   @Test
@@ -58,8 +58,8 @@ class TruncatedLaplaceNoiseDistributionTest {
     var u = 0.0
     while (u < 1.0) {
       val draw = distribution.inverseCdf(u)
-      assertThat(draw).isAtLeast(-BOUND.toDouble())
-      assertThat(draw).isAtMost(BOUND.toDouble())
+      assertThat(draw).isAtLeast(-BOUND)
+      assertThat(draw).isAtMost(BOUND)
       u += 0.001
     }
   }
@@ -77,23 +77,16 @@ class TruncatedLaplaceNoiseDistributionTest {
   }
 
   @Test
-  fun `rejects non-positive epsilon`() {
+  fun `rejects non-positive scale`() {
     assertFailsWith<IllegalArgumentException> {
-      TruncatedLaplaceNoiseDistribution(epsilon = 0.0, SENSITIVITY, BOUND)
+      TruncatedLaplaceNoiseDistribution(scale = 0.0, bound = BOUND)
     }
   }
 
   @Test
-  fun `rejects non-positive sensitivity`() {
+  fun `rejects non-positive bound`() {
     assertFailsWith<IllegalArgumentException> {
-      TruncatedLaplaceNoiseDistribution(EPSILON, sensitivity = 0.0, BOUND)
-    }
-  }
-
-  @Test
-  fun `rejects non-positive truncation bound`() {
-    assertFailsWith<IllegalArgumentException> {
-      TruncatedLaplaceNoiseDistribution(EPSILON, SENSITIVITY, truncationBound = 0.0)
+      TruncatedLaplaceNoiseDistribution(scale = SCALE, bound = 0.0)
     }
   }
 
@@ -103,9 +96,50 @@ class TruncatedLaplaceNoiseDistributionTest {
     assertFailsWith<IllegalArgumentException> { distribution.inverseCdf(-0.1) }
   }
 
+  @Test
+  fun `forDifferentialPrivacy sets the bound from epsilon, delta and sensitivity`() {
+    // inverseCdf(0) equals -bound, so it reveals the calibrated bound. At epsilon 1, delta 1/1000,
+    // sensitivity 1, bound = ln(1 + (e - 1) / (2 * delta)).
+    val dp = TruncatedLaplaceNoiseDistribution.forDifferentialPrivacy(1.0, 1.0 / 1000, 1.0)
+    assertThat(dp.inverseCdf(0.0)).isWithin(1e-9).of(-6.7570962295802515)
+  }
+
+  @Test
+  fun `forDifferentialPrivacy scales scale and bound with sensitivity`() {
+    // Scale and bound are both proportional to sensitivity, so doubling it doubles both. inverseCdf
+    // is linear in scale, so every quantile doubles too.
+    val unit = TruncatedLaplaceNoiseDistribution.forDifferentialPrivacy(1.0, 1.0 / 1000, 1.0)
+    val doubled = TruncatedLaplaceNoiseDistribution.forDifferentialPrivacy(1.0, 1.0 / 1000, 2.0)
+    assertThat(doubled.inverseCdf(0.0)).isWithin(1e-9).of(-13.514192459160503)
+    assertThat(doubled.inverseCdf(0.3)).isWithin(1e-9).of(2.0 * unit.inverseCdf(0.3))
+  }
+
+  @Test
+  fun `forDifferentialPrivacy rejects non-positive epsilon`() {
+    assertFailsWith<IllegalArgumentException> {
+      TruncatedLaplaceNoiseDistribution.forDifferentialPrivacy(0.0, 1.0 / 1000, 1.0)
+    }
+  }
+
+  @Test
+  fun `forDifferentialPrivacy rejects delta outside the open unit interval`() {
+    assertFailsWith<IllegalArgumentException> {
+      TruncatedLaplaceNoiseDistribution.forDifferentialPrivacy(1.0, 0.0, 1.0)
+    }
+    assertFailsWith<IllegalArgumentException> {
+      TruncatedLaplaceNoiseDistribution.forDifferentialPrivacy(1.0, 1.0, 1.0)
+    }
+  }
+
+  @Test
+  fun `forDifferentialPrivacy rejects non-positive sensitivity`() {
+    assertFailsWith<IllegalArgumentException> {
+      TruncatedLaplaceNoiseDistribution.forDifferentialPrivacy(1.0, 1.0 / 1000, 0.0)
+    }
+  }
+
   companion object {
-    private const val EPSILON = 1.0
-    private const val SENSITIVITY = 1.0
+    private const val SCALE = 1.0
     private const val BOUND = 8.0
   }
 }

--- a/src/test/kotlin/org/wfanet/measurement/computation/TruncatedLaplaceNoiseDistributionTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/computation/TruncatedLaplaceNoiseDistributionTest.kt
@@ -93,7 +93,7 @@ class TruncatedLaplaceNoiseDistributionTest {
   @Test
   fun `rejects non-positive truncation bound`() {
     assertFailsWith<IllegalArgumentException> {
-      TruncatedLaplaceNoiseDistribution(EPSILON, SENSITIVITY, truncationBound = 0)
+      TruncatedLaplaceNoiseDistribution(EPSILON, SENSITIVITY, truncationBound = 0.0)
     }
   }
 
@@ -106,6 +106,6 @@ class TruncatedLaplaceNoiseDistributionTest {
   companion object {
     private const val EPSILON = 1.0
     private const val SENSITIVITY = 1.0
-    private const val BOUND = 8
+    private const val BOUND = 8.0
   }
 }

--- a/src/test/kotlin/org/wfanet/measurement/computation/TruncatedLaplaceNoiseDistributionTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/computation/TruncatedLaplaceNoiseDistributionTest.kt
@@ -96,48 +96,6 @@ class TruncatedLaplaceNoiseDistributionTest {
     assertFailsWith<IllegalArgumentException> { distribution.inverseCdf(-0.1) }
   }
 
-  @Test
-  fun `forDifferentialPrivacy sets the bound from epsilon, delta and sensitivity`() {
-    // inverseCdf(0) equals -bound, so it reveals the calibrated bound. At epsilon 1, delta 1/1000,
-    // sensitivity 1, bound = ln(1 + (e - 1) / (2 * delta)).
-    val dp = TruncatedLaplaceNoiseDistribution.forDifferentialPrivacy(1.0, 1.0 / 1000, 1.0)
-    assertThat(dp.inverseCdf(0.0)).isWithin(1e-9).of(-6.7570962295802515)
-  }
-
-  @Test
-  fun `forDifferentialPrivacy scales scale and bound with sensitivity`() {
-    // Scale and bound are both proportional to sensitivity, so doubling it doubles both. inverseCdf
-    // is linear in scale, so every quantile doubles too.
-    val unit = TruncatedLaplaceNoiseDistribution.forDifferentialPrivacy(1.0, 1.0 / 1000, 1.0)
-    val doubled = TruncatedLaplaceNoiseDistribution.forDifferentialPrivacy(1.0, 1.0 / 1000, 2.0)
-    assertThat(doubled.inverseCdf(0.0)).isWithin(1e-9).of(-13.514192459160503)
-    assertThat(doubled.inverseCdf(0.3)).isWithin(1e-9).of(2.0 * unit.inverseCdf(0.3))
-  }
-
-  @Test
-  fun `forDifferentialPrivacy rejects non-positive epsilon`() {
-    assertFailsWith<IllegalArgumentException> {
-      TruncatedLaplaceNoiseDistribution.forDifferentialPrivacy(0.0, 1.0 / 1000, 1.0)
-    }
-  }
-
-  @Test
-  fun `forDifferentialPrivacy rejects delta outside the open unit interval`() {
-    assertFailsWith<IllegalArgumentException> {
-      TruncatedLaplaceNoiseDistribution.forDifferentialPrivacy(1.0, 0.0, 1.0)
-    }
-    assertFailsWith<IllegalArgumentException> {
-      TruncatedLaplaceNoiseDistribution.forDifferentialPrivacy(1.0, 1.0, 1.0)
-    }
-  }
-
-  @Test
-  fun `forDifferentialPrivacy rejects non-positive sensitivity`() {
-    assertFailsWith<IllegalArgumentException> {
-      TruncatedLaplaceNoiseDistribution.forDifferentialPrivacy(1.0, 1.0 / 1000, 0.0)
-    }
-  }
-
   companion object {
     private const val SCALE = 1.0
     private const val BOUND = 8.0

--- a/src/test/kotlin/org/wfanet/measurement/duchy/mill/trustee/processor/TrusTeeProcessorImplTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/duchy/mill/trustee/processor/TrusTeeProcessorImplTest.kt
@@ -613,7 +613,6 @@ class TrusTeeProcessorImplTest {
         frequencyDpParams = DEFAULT_DP_PARAMS,
         resultMinimumThresholds = ResultMinimumThresholds(minUsers = 2, minImpressions = 1),
         noiseMechanism = NoiseMechanism.DETERMINISTIC_TRUNCATED_LAPLACE,
-        truncationBound = TRUNCATION_BOUND,
       )
     val aboveThreshold = byteArrayOf(1, 1, 1, 1, 1, 0, 0, 0, 0, 0) // reaches 5 users
     val subThreshold = byteArrayOf(0, 0, 0, 0, 0, 1, 0, 0, 0, 0) // reaches 1 user, below min_users
@@ -644,7 +643,6 @@ class TrusTeeProcessorImplTest {
       frequencyDpParams = DEFAULT_DP_PARAMS,
       resultMinimumThresholds = ResultMinimumThresholds(minUsers, minImpressions),
       noiseMechanism = NoiseMechanism.DETERMINISTIC_TRUNCATED_LAPLACE,
-      truncationBound = TRUNCATION_BOUND,
     )
 
   companion object {
@@ -673,8 +671,6 @@ class TrusTeeProcessorImplTest {
         resultMinimumThresholds = null,
       )
 
-    private const val TRUNCATION_BOUND = 8
-
     private val DETERMINISTIC_R_F_PARAMS =
       TrusTeeReachAndFrequencyParams(
         maximumFrequency = MAX_FREQUENCY,
@@ -683,7 +679,6 @@ class TrusTeeProcessorImplTest {
         frequencyDpParams = DEFAULT_DP_PARAMS,
         resultMinimumThresholds = null,
         noiseMechanism = NoiseMechanism.DETERMINISTIC_TRUNCATED_LAPLACE,
-        truncationBound = TRUNCATION_BOUND,
       )
 
     private val DETERMINISTIC_REACH_PARAMS =
@@ -692,7 +687,6 @@ class TrusTeeProcessorImplTest {
         dpParams = DEFAULT_DP_PARAMS,
         resultMinimumThresholds = null,
         noiseMechanism = NoiseMechanism.DETERMINISTIC_TRUNCATED_LAPLACE,
-        truncationBound = TRUNCATION_BOUND,
       )
   }
 }

--- a/src/test/kotlin/org/wfanet/measurement/duchy/mill/trustee/processor/TrusTeeProcessorImplTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/duchy/mill/trustee/processor/TrusTeeProcessorImplTest.kt
@@ -529,6 +529,42 @@ class TrusTeeProcessorImplTest {
   }
 
   @Test
+  fun `deterministic noise ignores the measurement spec privacy params`() {
+    // The property this mechanism exists to establish: the privacy params are compiled into the
+    // image, not taken from the spec. An MC asking for a huge epsilon must not get less noise. If
+    // the mechanism read the spec params, these two runs would diverge.
+    fun paramsWithEpsilon(specEpsilon: Double) =
+      TrusTeeReachAndFrequencyParams(
+        maximumFrequency = MAX_FREQUENCY,
+        vidSamplingIntervalWidth = FULL_SAMPLING_RATE,
+        reachDpParams =
+          differentialPrivacyParams {
+            epsilon = specEpsilon
+            delta = 0.99
+          },
+        frequencyDpParams =
+          differentialPrivacyParams {
+            epsilon = specEpsilon
+            delta = 0.99
+          },
+        resultMinimumThresholds = null,
+        noiseMechanism = NoiseMechanism.DETERMINISTIC_TRUNCATED_LAPLACE,
+      )
+
+    val vector = byteArrayOf(1, 2, 0, 1, 3)
+    fun run(specEpsilon: Double) =
+      TrusTeeProcessorImpl(paramsWithEpsilon(specEpsilon))
+        .apply { addFrequencyVector(vector) }
+        .computeResult() as ReachAndFrequencyResult
+
+    val huge = run(1_000_000.0)
+    val tiny = run(0.001)
+
+    assertThat(huge.reach).isEqualTo(tiny.reach)
+    assertThat(huge.frequency).isEqualTo(tiny.frequency)
+  }
+
+  @Test
   fun `computeResult with deterministic noise is independent of contribution order`() {
     // The noise is seeded from the combined vector and the contribution count, both independent of
     // the order contributions arrive in, so the same contributions in a different order yield


### PR DESCRIPTION
The MC sets epsilon in the MeasurementSpec, DTLN has no privacy budget manager, and nothing caps epsilon — so an MC could ask for a huge epsilon and get near-raw data in one query (determinism doesn't help; it's a single query, not repeats). Per the design discussion, the DTLN privacy params are **compiled into the attested TrusTEE image**, not set by the MC or carried in config.

- `TrusTeeProcessorImpl` builds the DTLN noiser with compiled **epsilon = 1** and **truncation bound = 8** (encoding **delta = 1/1000**), ignoring the spec/proto values.
- Remove `DeterministicTruncatedLaplaceNoiseParams` / `truncation_bound` from the duchy `trus_tee.proto` and from `TrusTeeParams`; the mill no longer threads it.
- `DeterministicTruncatedLaplaceResultNoiser` stays parameterized; the constants come from a single `DeterministicTruncatedLaplaceParams` object in the `computation` module, since the same values are needed by three separately-compiled components (this TrusTEE image, the EDP Aggregator Direct path, and the reporting server variance).

Follow-ups (separate PRs, once this lands): the EDPA Direct path (#4321) and the reporting-server variance (#4322) reference the same `DeterministicTruncatedLaplaceParams`; the Kingdom-side selection wiring (#4311) drops the matching config field and handles the MC's REQUIRED spec privacy params.

Issue: #4183
