### PR TITLE
feat: Offer TrusTEE noise mechanisms in preference order

### DIFF
--- a/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/common/TrusTeeProtocolConfig.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/common/TrusTeeProtocolConfig.kt
@@ -26,6 +26,14 @@ object TrusTeeProtocolConfig {
   lateinit var protocolConfig: ProtocolConfig.TrusTee
     private set
 
+  /**
+   * Noise mechanisms in preference order.
+   *
+   * Never empty. A config that specifies no preference yields [protocolConfig]'s own mechanism.
+   */
+  lateinit var noiseMechanismPreference: List<ProtocolConfig.NoiseMechanism>
+    private set
+
   lateinit var duchyId: String
 
   fun initializeFromFlags(flags: TrusTeeProtocolConfigFlags) {
@@ -36,14 +44,25 @@ object TrusTeeProtocolConfig {
       }
 
     protocolConfig = configMessage.protocolConfig
+    noiseMechanismPreference = configMessage.noiseMechanismPreferenceList.toPreference()
     duchyId = configMessage.duchyId
   }
 
-  fun setForTest(protocolConfig: ProtocolConfig.TrusTee, duchyId: String) {
+  fun setForTest(
+    protocolConfig: ProtocolConfig.TrusTee,
+    duchyId: String,
+    noiseMechanismPreference: List<ProtocolConfig.NoiseMechanism> = emptyList(),
+  ) {
     require(!TrusTeeProtocolConfig::protocolConfig.isInitialized)
 
     TrusTeeProtocolConfig.protocolConfig = protocolConfig
+    TrusTeeProtocolConfig.noiseMechanismPreference = noiseMechanismPreference.toPreference()
     TrusTeeProtocolConfig.duchyId = duchyId
+  }
+
+  private fun List<ProtocolConfig.NoiseMechanism>.toPreference():
+    List<ProtocolConfig.NoiseMechanism> {
+    return ifEmpty { listOf(protocolConfig.noiseMechanism) }
   }
 }
 

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/service/api/v2alpha/MeasurementsService.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/service/api/v2alpha/MeasurementsService.kt
@@ -86,6 +86,7 @@ import org.wfanet.measurement.internal.kingdom.batchCreateMeasurementsRequest
 import org.wfanet.measurement.internal.kingdom.batchGetDataProvidersRequest
 import org.wfanet.measurement.internal.kingdom.batchGetMeasurementsRequest
 import org.wfanet.measurement.internal.kingdom.cancelMeasurementRequest
+import org.wfanet.measurement.internal.kingdom.copy as internalCopy
 import org.wfanet.measurement.internal.kingdom.createMeasurementRequest as internalCreateMeasurementRequest
 import org.wfanet.measurement.internal.kingdom.getMeasurementRequest
 import org.wfanet.measurement.internal.kingdom.measurementKey
@@ -476,14 +477,35 @@ class MeasurementsService(
   }
 
   /**
-   * Whether every `DataProvider` supports the noise mechanism the TrusTEE config selects.
+   * The TrusTEE config to offer for a `Measurement` on these `DataProvider`s, or `null` if none of
+   * the configured noise mechanisms is supported by all of them.
+   *
+   * Walks [TrusTeeProtocolConfig.noiseMechanismPreference] in order and stamps the first supported
+   * mechanism, leaving the rest of the config, including `result_minimum_thresholds`, unchanged. A
+   * `DataProvider` that cannot do the preferred mechanism therefore keeps the `Measurement` on
+   * TrusTEE under a weaker one, rather than moving it to an MPC protocol.
+   */
+  private fun Collection<InternalDataProviderCapabilities>.selectTrusTeeProtocolConfig():
+    InternalProtocolConfig.TrusTee? {
+    val selectedNoiseMechanism =
+      TrusTeeProtocolConfig.noiseMechanismPreference.firstOrNull { supportNoiseMechanism(it) }
+        ?: return null
+    return TrusTeeProtocolConfig.protocolConfig.internalCopy {
+      noiseMechanism = selectedNoiseMechanism
+    }
+  }
+
+  /**
+   * Whether every `DataProvider` supports [noiseMechanism].
    *
    * The public API also declares `noise_mechanism_none_supported`, which is not propagated to the
    * internal API and not enforced anywhere in this repo, so NONE is treated as supported.
    */
-  private fun Collection<InternalDataProviderCapabilities>.supportTrusTeeNoiseMechanism(): Boolean {
+  private fun Collection<InternalDataProviderCapabilities>.supportNoiseMechanism(
+    noiseMechanism: InternalProtocolConfig.NoiseMechanism
+  ): Boolean {
     @Suppress("WHEN_ENUM_CAN_BE_NULL_IN_JAVA") // Proto enum fields are never null.
-    return when (TrusTeeProtocolConfig.protocolConfig.noiseMechanism) {
+    return when (noiseMechanism) {
       InternalProtocolConfig.NoiseMechanism.DETERMINISTIC_TRUNCATED_LAPLACE ->
         all { it.noiseMechanismDeterministicTruncatedLaplaceSupported }
       InternalProtocolConfig.NoiseMechanism.NONE,
@@ -521,14 +543,19 @@ class MeasurementsService(
               }
           }
         } else {
-          if (
-            (measurementConsumerName in trusTeeEnabledMeasurementConsumers || trusTeeEnabled) &&
-              dataProviderCapabilities.all { it.trusTeeSupported } &&
-              dataProviderCapabilities.supportTrusTeeNoiseMechanism()
-          ) {
+          val trusTeeProtocolConfig =
+            if (
+              (measurementConsumerName in trusTeeEnabledMeasurementConsumers || trusTeeEnabled) &&
+                dataProviderCapabilities.all { it.trusTeeSupported }
+            ) {
+              dataProviderCapabilities.selectTrusTeeProtocolConfig()
+            } else {
+              null
+            }
+          if (trusTeeProtocolConfig != null) {
             protocolConfig {
               externalProtocolConfigId = TrusTeeProtocolConfig.NAME
-              trusTee = TrusTeeProtocolConfig.protocolConfig
+              trusTee = trusTeeProtocolConfig
             }
           } else if (
             (measurementConsumerName in hmssEnabledMeasurementConsumers || hmssEnabled) &&
@@ -570,14 +597,19 @@ class MeasurementsService(
               }
           }
         } else {
-          if (
-            (measurementConsumerName in trusTeeEnabledMeasurementConsumers || trusTeeEnabled) &&
-              dataProviderCapabilities.all { it.trusTeeSupported } &&
-              dataProviderCapabilities.supportTrusTeeNoiseMechanism()
-          ) {
+          val trusTeeProtocolConfig =
+            if (
+              (measurementConsumerName in trusTeeEnabledMeasurementConsumers || trusTeeEnabled) &&
+                dataProviderCapabilities.all { it.trusTeeSupported }
+            ) {
+              dataProviderCapabilities.selectTrusTeeProtocolConfig()
+            } else {
+              null
+            }
+          if (trusTeeProtocolConfig != null) {
             protocolConfig {
               externalProtocolConfigId = TrusTeeProtocolConfig.NAME
-              trusTee = TrusTeeProtocolConfig.protocolConfig
+              trusTee = trusTeeProtocolConfig
             }
           } else if (
             (measurementConsumerName in hmssEnabledMeasurementConsumers || hmssEnabled) &&

--- a/src/main/proto/wfa/measurement/internal/kingdom/protocol_config_config.proto
+++ b/src/main/proto/wfa/measurement/internal/kingdom/protocol_config_config.proto
@@ -52,4 +52,13 @@ message TrusTeeProtocolConfigConfig {
   ProtocolConfig.TrusTee protocol_config = 1;
   // The id of the duchy executing the computation.
   string duchy_id = 2;
+  // Noise mechanisms in preference order.
+  //
+  // The Kingdom stamps the first mechanism that every `DataProvider` on the
+  // `Measurement` supports, leaving the rest of `protocol_config` unchanged. If
+  // no `DataProvider` supports any of them, TrusTee is not offered and
+  // selection falls through to the next protocol.
+  //
+  // When empty, only `protocol_config.noise_mechanism` is offered.
+  repeated ProtocolConfig.NoiseMechanism noise_mechanism_preference = 3;
 }

--- a/src/test/kotlin/org/wfanet/measurement/kingdom/service/api/v2alpha/MeasurementsServiceTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/kingdom/service/api/v2alpha/MeasurementsServiceTest.kt
@@ -991,9 +991,9 @@ class MeasurementsServiceTest {
   }
 
   @Test
-  fun `createMeasurement skips trusTEE when an EDP lacks the noise mechanism capability`() {
-    // The configured TrusTEE mechanism is DETERMINISTIC_TRUNCATED_LAPLACE, so an EDP that supports
-    // TrusTEE but not the mechanism must not get a TrusTEE protocol config.
+  fun `createMeasurement falls back to the next noise mechanism the EDPs support`() {
+    // The preference is DETERMINISTIC_TRUNCATED_LAPLACE then CONTINUOUS_GAUSSIAN. An EDP that
+    // supports TrusTEE but not the deterministic mechanism gets TrusTEE under the second.
     internalDataProvidersMock.stub {
       onBlocking { batchGetDataProviders(any()) }
         .thenReturn(
@@ -1026,13 +1026,17 @@ class MeasurementsServiceTest {
       runBlocking { trusTeeEnabledService.createMeasurement(request) }
     }
 
-    // TrusTEE is skipped, HMSS is unsupported on these EDPs, so selection falls to LLv2.
     val internalRequest =
       captureFirst<InternalCreateMeasurementRequest> {
         runBlocking { verify(internalMeasurementsMock).createMeasurement(capture()) }
       }
     assertThat(internalRequest.measurement.details.protocolConfig)
-      .isEqualTo(LLV2_INTERNAL_PROTOCOL_CONFIG)
+      .isEqualTo(
+        TRUS_TEE_INTERNAL_PROTOCOL_CONFIG.copy {
+          trusTee =
+            trusTee.copy { noiseMechanism = InternalNoiseMechanism.CONTINUOUS_GAUSSIAN }
+        }
+      )
   }
 
   @Test
@@ -3104,7 +3108,14 @@ class MeasurementsServiceTest {
         "worker2",
         "aggregator",
       )
-      TrusTeeProtocolConfig.setForTest(TRUS_TEE_INTERNAL_PROTOCOL_CONFIG.trusTee, "aggregator")
+      TrusTeeProtocolConfig.setForTest(
+        TRUS_TEE_INTERNAL_PROTOCOL_CONFIG.trusTee,
+        "aggregator",
+        listOf(
+          InternalNoiseMechanism.DETERMINISTIC_TRUNCATED_LAPLACE,
+          InternalNoiseMechanism.CONTINUOUS_GAUSSIAN,
+        ),
+      )
     }
 
     private val API_VERSION = Version.V2_ALPHA


### PR DESCRIPTION
Lets a deployment configure TrusTEE noise mechanisms in preference order, so a `DataProvider` that lacks the capability for the preferred mechanism keeps the `Measurement` on TrusTEE under a weaker one instead of moving it to an MPC protocol.

Today the capability gate added in #4311 is all-or-nothing: if any `DataProvider` cannot do the configured mechanism, TrusTEE is skipped and selection falls through to HMSS or LLv2. That changes the computation topology, not just the noise. A deployment that runs TrusTEE with a single aggregator Duchy has no MPC ring to fall through to.

**Shape.** `TrusTeeProtocolConfigConfig` gains `repeated ProtocolConfig.NoiseMechanism noise_mechanism_preference = 3`. The Kingdom walks it in order and stamps the first mechanism every `DataProvider` on the `Measurement` supports, leaving the rest of `protocol_config` unchanged. An empty list keeps `protocol_config.noise_mechanism` as the only option, so existing configs behave exactly as before.

A list of mechanisms rather than a second full `ProtocolConfig.TrusTee`: `result_minimum_thresholds` stays fixed across the preference order, so which thresholds a `Measurement` gets never depends on EDP capabilities. It also supports more than one level of fallback.

**Still falls through when nothing matches.** If no configured mechanism is supported by every `DataProvider`, TrusTEE is not offered and selection continues to HMSS or LLv2, unchanged from today. This PR does not make a TrusTEE-only deployment fail loudly at `CreateMeasurement`; the `Measurement` would still be created against a protocol its Duchies may not run, and fail at computation time. Making that a `FAILED_PRECONDITION` is a separate decision about whether the Kingdom should know a deployment is TrusTEE-only. Worth settling here if reviewers have a view.

**Testing.** `MeasurementsServiceTest` configures the preference as DETERMINISTIC_TRUNCATED_LAPLACE then CONTINUOUS_GAUSSIAN and covers both outcomes: the deterministic mechanism when every EDP reports the capability, and the Gaussian fallback when one does not. `TrusTeeProtocolConfig.setForTest` is set-once per JVM, so a single test class cannot also cover the empty-preference case; that path is exercised by every other TrusTEE test in the repo, all of which pass no preference.

Stacked on #4311, which adds the capability this reads. Retarget to `main` once that merges.

Issue: #4184
