### PR TITLE
fix: pre-create dashboard compliance metric descriptors

### DIFF
--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/dashboard/tools/BUILD.bazel
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/dashboard/tools/BUILD.bazel
@@ -38,6 +38,7 @@ kt_jvm_library(
         "DashboardComplianceCheckFunction.kt",
         "DashboardComplianceMetrics.kt",
     ],
+    visibility = ["//src/test/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/dashboard:__pkg__"],
     deps = [
         ":dashboard_compliance_runner",
         "//src/main/kotlin/org/wfanet/measurement/common:env_vars",

--- a/src/main/terraform/gcloud/cmms/BUILD.bazel
+++ b/src/main/terraform/gcloud/cmms/BUILD.bazel
@@ -1,0 +1,1 @@
+exports_files(["dashboard.tf"])

--- a/src/main/terraform/gcloud/cmms/dashboard.tf
+++ b/src/main/terraform/gcloud/cmms/dashboard.tf
@@ -1077,6 +1077,17 @@ module "dashboard_compliance_cloud_scheduler" {
   depends_on = [module.dashboard_compliance_cloud_function]
 }
 
+# The terraform SA pre-creates the metric descriptors below, which needs
+# monitoring.metricDescriptors.create. roles/monitoring.alertPolicyEditor does not
+# grant it; monitoring.metricWriter is the minimal role that does -- the same role
+# the function's runtime SA gets to export these metrics at runtime.
+resource "google_project_iam_member" "terraform_metric_writer" {
+  count   = local.deploy_dashboard_compliance_scheduler ? 1 : 0
+  project = data.google_client_config.default.project
+  role    = "roles/monitoring.metricWriter"
+  member  = "serviceAccount:${var.terraform_service_account}"
+}
+
 # Pre-create the custom metric descriptors the alert policy below filters on. Cloud
 # Monitoring only auto-registers these the first time the Cloud Function emits them, so on a
 # brand-new environment the alert policy would fail with "Cannot find metric(s)..." until the
@@ -1084,6 +1095,7 @@ module "dashboard_compliance_cloud_scheduler" {
 # single apply. Kinds/labels mirror what the OpenTelemetry exporter emits.
 resource "google_monitoring_metric_descriptor" "dashboard_compliance_failed_checks" {
   count        = local.deploy_dashboard_compliance_scheduler ? 1 : 0
+  depends_on   = [google_project_iam_member.terraform_metric_writer]
   type         = "workload.googleapis.com/edpa.dashboard_compliance.failed_checks"
   metric_kind  = "GAUGE"
   value_type   = "INT64"
@@ -1097,6 +1109,7 @@ resource "google_monitoring_metric_descriptor" "dashboard_compliance_failed_chec
 
 resource "google_monitoring_metric_descriptor" "dashboard_compliance_errors" {
   count        = local.deploy_dashboard_compliance_scheduler ? 1 : 0
+  depends_on   = [google_project_iam_member.terraform_metric_writer]
   type         = "workload.googleapis.com/edpa.dashboard_compliance.errors"
   metric_kind  = "CUMULATIVE"
   value_type   = "INT64"

--- a/src/main/terraform/gcloud/cmms/dashboard.tf
+++ b/src/main/terraform/gcloud/cmms/dashboard.tf
@@ -1077,13 +1077,47 @@ module "dashboard_compliance_cloud_scheduler" {
   depends_on = [module.dashboard_compliance_cloud_function]
 }
 
+# Pre-create the custom metric descriptors the alert policy below filters on. Cloud
+# Monitoring only auto-registers these the first time the Cloud Function emits them, so on a
+# brand-new environment the alert policy would fail with "Cannot find metric(s)..." until the
+# function had run once. Declaring them here lets a fresh deploy create the alert policy in a
+# single apply. Kinds/labels mirror what the OpenTelemetry exporter emits.
+resource "google_monitoring_metric_descriptor" "dashboard_compliance_failed_checks" {
+  count        = local.deploy_dashboard_compliance_scheduler ? 1 : 0
+  type         = "workload.googleapis.com/edpa.dashboard_compliance.failed_checks"
+  metric_kind  = "GAUGE"
+  value_type   = "INT64"
+  display_name = "edpa.dashboard_compliance.failed_checks"
+  description  = "Number of failed dashboard compliance checks in the most recent run"
+  labels { key = "instrumentation_source" }
+  labels { key = "service_name" }
+  labels { key = "instrumentation_version" }
+  labels { key = "edpa_dashboard_compliance_section" }
+}
+
+resource "google_monitoring_metric_descriptor" "dashboard_compliance_errors" {
+  count        = local.deploy_dashboard_compliance_scheduler ? 1 : 0
+  type         = "workload.googleapis.com/edpa.dashboard_compliance.errors"
+  metric_kind  = "CUMULATIVE"
+  value_type   = "INT64"
+  display_name = "edpa.dashboard_compliance.errors"
+  description  = "Number of DashboardComplianceCheckFunction execution errors"
+  labels { key = "instrumentation_source" }
+  labels { key = "service_name" }
+  labels { key = "instrumentation_version" }
+}
+
 # Metric-based alert policy. The function records failed-check counts per section to the
 # edpa.dashboard_compliance.failed_checks gauge and increments edpa.dashboard_compliance.errors
 # on a genuine crash; this policy fires on either. Channels are attached out-of-band (as with
 # the
 # gcs-bucket DLQ alert); with none configured the policy still records incidents but pages no one.
 resource "google_monitoring_alert_policy" "dashboard_compliance_failures" {
-  count        = local.deploy_dashboard_compliance_scheduler ? 1 : 0
+  count = local.deploy_dashboard_compliance_scheduler ? 1 : 0
+  depends_on = [
+    google_monitoring_metric_descriptor.dashboard_compliance_failed_checks,
+    google_monitoring_metric_descriptor.dashboard_compliance_errors,
+  ]
   display_name = "Dashboard Compliance Check Failures"
   combiner     = "OR"
 

--- a/src/test/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/dashboard/BUILD.bazel
+++ b/src/test/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/dashboard/BUILD.bazel
@@ -4,11 +4,13 @@ kt_jvm_test(
     name = "DashboardViewIsolationLocalTest",
     srcs = ["DashboardViewIsolationLocalTest.kt"],
     data = [
+        "//src/main/terraform/gcloud/cmms:dashboard.tf",
         "//src/main/terraform/gcloud/cmms/sql:mc_details.sql",
         "//src/main/terraform/gcloud/cmms/sql:report_detail.sql",
         "//src/main/terraform/gcloud/cmms/sql:requisition_overview.sql",
     ],
     deps = [
+        "//src/main/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/dashboard/tools:dashboard_compliance_check_function",
         "@wfa_common_jvm//imports/java/com/google/common/truth",
         "@wfa_common_jvm//imports/java/org/junit",
     ],

--- a/src/test/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/dashboard/DashboardViewIsolationLocalTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/dashboard/DashboardViewIsolationLocalTest.kt
@@ -20,6 +20,7 @@ import com.google.common.truth.Truth.assertThat
 import java.nio.file.Files
 import java.nio.file.Paths
 import org.junit.Test
+import org.wfanet.measurement.edpaggregator.deploy.gcloud.dashboard.tools.DashboardComplianceMetrics
 
 /** Validates dashboard SQL templates for correct EDP isolation structure. */
 class DashboardViewIsolationLocalTest {
@@ -35,6 +36,13 @@ class DashboardViewIsolationLocalTest {
     val runfilesDir = System.getenv("TEST_SRCDIR") ?: "."
     val workspace = System.getenv("TEST_WORKSPACE") ?: "__main__"
     val path = Paths.get(runfilesDir, workspace, "src/main/terraform/gcloud/cmms/sql", fileName)
+    return Files.readString(path)
+  }
+
+  private fun readTerraformFile(fileName: String): String {
+    val runfilesDir = System.getenv("TEST_SRCDIR") ?: "."
+    val workspace = System.getenv("TEST_WORKSPACE") ?: "__main__"
+    val path = Paths.get(runfilesDir, workspace, "src/main/terraform/gcloud/cmms", fileName)
     return Files.readString(path)
   }
 
@@ -72,6 +80,21 @@ class DashboardViewIsolationLocalTest {
       }
     }
     return result.toString()
+  }
+
+  @Test
+  fun metricDescriptorLabelsMatchEmittedAttributes() {
+    // The metric shape is declared both in DashboardComplianceMetrics and in the
+    // google_monitoring_metric_descriptor resources in dashboard.tf. If they drift, Cloud
+    // Monitoring rejects the exporter's writes and the isolation alert goes silently dead.
+    // Deriving the label from SECTION_ATTR means renaming the attribute breaks the build.
+    val terraform = readTerraformFile("dashboard.tf")
+    val sectionLabel = DashboardComplianceMetrics.SECTION_ATTR.key.replace('.', '_')
+
+    assertThat(terraform).contains("key = \"$sectionLabel\"")
+    for (label in listOf("instrumentation_source", "service_name", "instrumentation_version")) {
+      assertThat(terraform).contains("key = \"$label\"")
+    }
   }
 
   @Test


### PR DESCRIPTION
Pre-create the dashboard compliance metric descriptors and make the alert policy depend on them, so a fresh-environment deploy no longer fails with a 404 on a metric the Cloud Function has not emitted yet.

Issue: #4350
