### PR TITLE
fix: carry video_ad.viewed_fraction through the raw-impression round trip

### DIFF
--- a/src/main/kotlin/org/wfanet/measurement/loadtest/edpaggregator/testing/RawImpressionsWriter.kt
+++ b/src/main/kotlin/org/wfanet/measurement/loadtest/edpaggregator/testing/RawImpressionsWriter.kt
@@ -59,6 +59,15 @@ object RawImpressionColumns {
   /** Person age group as the event-template enum value name (e.g. "YEARS_18_TO_34"). */
   const val PERSON_AGE_GROUP = "person_age_group"
 
+  /**
+   * Fraction of the video ad that was viewed, in `[0, 1]`.
+   *
+   * Projected because the measurement filter predicates on it. A column the filter reads but the
+   * schema omits comes back as the field default, which silently fails the predicate for every
+   * labeled impression rather than raising.
+   */
+  const val VIDEO_AD_VIEWED_FRACTION = "video_ad_viewed_fraction"
+
   /** The entity_type used for the person entity key. */
   const val ENTITY_TYPE_PERSON = "person"
 

--- a/src/test/kotlin/org/wfanet/measurement/integration/k8s/SeedRawImpressionsRule.kt
+++ b/src/test/kotlin/org/wfanet/measurement/integration/k8s/SeedRawImpressionsRule.kt
@@ -243,12 +243,20 @@ class SeedRawImpressionsRule(
     }
   }
 
-  /** Demographic columns projected from the event message (enum value names). */
+  /**
+   * Event columns projected from the event message.
+   *
+   * Must cover every field the measurement's filter expression reads, otherwise the labeled
+   * impression carries the field default and the filter drops it. Demographics are written as enum
+   * value names; `viewed_fraction` is a double.
+   */
   private fun testEventColumns(event: TestEvent): Map<String, ParquetValue> =
     mapOf(
       RawImpressionColumns.PERSON_GENDER to parquetValue { stringValue = event.person.gender.name },
       RawImpressionColumns.PERSON_AGE_GROUP to
         parquetValue { stringValue = event.person.ageGroup.name },
+      RawImpressionColumns.VIDEO_AD_VIEWED_FRACTION to
+        parquetValue { doubleValue = event.videoAd.viewedFraction },
     )
 
   private fun deleteExistingRawImpressions(storage: Storage) {


### PR DESCRIPTION
The EDPA cloud test's measurement filter predicates on `video_ad.viewed_fraction`, but the raw-impression schema never projected it, so every pipelined-day impression was rebuilt with the field's `0.0` default and dropped by the filter — leaving edp7 contributing six days where the expected result assumed seven, which failed the frequency assertion roughly one run in eight.

The matching `event_template_field_mapping` entry is environment config and must be added per environment; dev is done, qa and head are tracked in the issue.

Issue: #4355

