### PR TITLE
docs: note the concatenated multi-signature key-id tag for AWS KMS

### DIFF
--- a/docs/edpaggregator/aws-kms-setup.md
+++ b/docs/edpaggregator/aws-kms-setup.md
@@ -138,7 +138,11 @@ value goes in the trust policy (Step 3) and the EDP config (Step 5).
           "confidentialcomputing.googleapis.com:aud": "AUDIENCE",
           "aws:RequestTag/swname": "CONFIDENTIAL_SPACE",
           "aws:RequestTag/confidential_space.support_attributes": "LATEST=STABLE=USABLE",
-          "aws:RequestTag/container.signatures.key_ids": ["SIGNING_KEY_ID_1", "SIGNING_KEY_ID_2"],
+          "aws:RequestTag/container.signatures.key_ids": [
+            "SIGNING_KEY_ID_1",
+            "SIGNING_KEY_ID_2",
+            "SIGNING_KEY_ID_1=SIGNING_KEY_ID_2"
+          ],
           "aws:RequestTag/gce.project_id": ["OPERATOR_PROJECT_1", "OPERATOR_PROJECT_2"]
         }
       }
@@ -157,6 +161,23 @@ Notes:
   `e117571844aad697303b883969daec142b3dd12ac6c8a73cba620f029a653864`.
 * `gce.project_id` values are strings, and are the projects in which the operator runs
   the workloads.
+
+> **An image with more than one signature sends one concatenated tag value.**
+> `container.signatures.key_ids` is not a list. Confidential Space joins multiple
+> signature key IDs into a single `=`-separated string, sorted alphabetically — so an
+> image signed with both `SIGNING_KEY_ID_1` and `SIGNING_KEY_ID_2` presents
+> `SIGNING_KEY_ID_1=SIGNING_KEY_ID_2`, which matches neither key ID on its own. List
+> every combination the workload can legitimately present, as above. Omitting the
+> combined value fails with `Not authorized to perform sts:AssumeRoleWithWebIdentity`
+> only for the double-signed images, so it can pass in one environment and fail in
+> another that signs the same code with an additional key.
+>
+> Do **not** reach for `ForAnyValue:` / `ForAllValues:` here.
+> [`aws:RequestTag/tag-key` is a single-valued context key][aws-multivalue], and AWS
+> warns that set operators on single-valued keys can produce overly permissive
+> policies.
+
+[aws-multivalue]: https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_condition-single-vs-multi-valued-context-keys.html
 
 ## Step 4 — Grant the role `kms:Decrypt` on the key
 
@@ -212,7 +233,11 @@ event_data_provider_config {
    and AWS KMS `Decrypt` succeeds.
 
 > AWS CloudTrail's `AssumeRoleWithWebIdentity` events are the authoritative place to
-> see which trust policy conditions matched.
+> see which trust policy conditions matched. Note that CloudTrail records
+> `requestParameters` — including the session tags — only for calls that **succeed**;
+> on an `AccessDenied` they are redacted, so a denial shows which role and provider were
+> used but not which condition rejected it. Comparing against a successful call from
+> another environment is usually the fastest way to spot the differing claim.
 
 ---
 

--- a/docs/edpaggregator/aws-kms-setup.md
+++ b/docs/edpaggregator/aws-kms-setup.md
@@ -163,10 +163,11 @@ Notes:
   the workloads.
 
 > **An image with more than one signature sends one concatenated tag value.**
-> `container.signatures.key_ids` is not a list. Confidential Space joins multiple
-> signature key IDs into a single `=`-separated string, sorted alphabetically — so an
-> image signed with both `SIGNING_KEY_ID_1` and `SIGNING_KEY_ID_2` presents
-> `SIGNING_KEY_ID_1=SIGNING_KEY_ID_2`, which matches neither key ID on its own. List
+> The policy above lists the values the condition accepts, as any `StringEquals` policy
+> may; the tag the workload sends is a single string. Confidential Space joins multiple
+> signature key IDs with `=`, sorted alphabetically, so an image signed with both
+> `SIGNING_KEY_ID_1` and `SIGNING_KEY_ID_2` presents the one value
+> `SIGNING_KEY_ID_1=SIGNING_KEY_ID_2`, which equals neither key ID on its own. Enumerate
 > every combination the workload can legitimately present, as above. Omitting the
 > combined value fails with `Not authorized to perform sts:AssumeRoleWithWebIdentity`
 > only for the double-signed images, so it can pass in one environment and fail in


### PR DESCRIPTION
Confidential Space joins multiple container image signature key IDs into a single alphabetically sorted `=`-separated tag value rather than emitting a list, so an image carrying two signatures matches neither key ID on its own and AssumeRoleWithWebIdentity is denied. Because the same code can be signed with an extra key in one environment and not another, the trust policy can pass everywhere except where the additional signature is applied.

Lists the combined value in the example policy and warns against reaching for ForAnyValue/ForAllValues, which AWS documents as unsafe on the single-valued aws:RequestTag context key. Also records that CloudTrail redacts requestParameters on a denied call, so the session tags are only visible on calls that succeed.

Issue: #4309