### PR TITLE
feat!: Require max_file_batch_size_bytes in VidLabelingConfig

### DIFF
--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/vidlabeling/VidLabelingConfigValidation.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/vidlabeling/VidLabelingConfigValidation.kt
@@ -84,3 +84,19 @@ fun requireValidStalenessThreshold(config: VidLabelingConfig) {
       "last-out as if it were stuck"
   }
 }
+
+/**
+ * Fails fast (at Cloud Function boot / first tick) if [config]'s max_file_batch_size_bytes is unset
+ * or non-positive.
+ *
+ * The bin-packing cap is REQUIRED by both dispatch paths, but only the non-memoized one rejects it
+ * at dispatch, where `VidLabelingDispatchSequencer` bin-packs the upload's files itself. The
+ * memoized path forwards the value onto `SubpoolAssignerParams.max_file_batch_size_bytes`, where it
+ * is REQUIRED, so an unset value would otherwise only surface inside the TEE at the Phase-0
+ * last-shard-out, behind Pub/Sub retries and a DLQ FAILED cascade.
+ */
+fun requireValidMaxFileBatchSizeBytes(config: VidLabelingConfig) {
+  require(config.maxFileBatchSizeBytes > 0) {
+    "max_file_batch_size_bytes must be set (> 0) for data provider: ${config.dataProvider}"
+  }
+}

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/vidlabeling/VidLabelingConfigValidation.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/vidlabeling/VidLabelingConfigValidation.kt
@@ -86,14 +86,8 @@ fun requireValidStalenessThreshold(config: VidLabelingConfig) {
 }
 
 /**
- * Fails fast (at Cloud Function boot / first tick) if [config]'s max_file_batch_size_bytes is unset
- * or non-positive.
- *
- * The bin-packing cap is REQUIRED by both dispatch paths, but only the non-memoized one rejects it
- * at dispatch, where `VidLabelingDispatchSequencer` bin-packs the upload's files itself. The
- * memoized path forwards the value onto `SubpoolAssignerParams.max_file_batch_size_bytes`, where it
- * is REQUIRED, so an unset value would otherwise only surface inside the TEE at the Phase-0
- * last-shard-out, behind Pub/Sub retries and a DLQ FAILED cascade.
+ * Fails fast (at Cloud Function boot / first tick) if [config] omits max_file_batch_size_bytes,
+ * which the memoized path would otherwise only reject inside the TEE at Phase-0.
  */
 fun requireValidMaxFileBatchSizeBytes(config: VidLabelingConfig) {
   require(config.maxFileBatchSizeBytes > 0) {

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/vidlabeling/VidLabelingDispatcherFunction.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/vidlabeling/VidLabelingDispatcherFunction.kt
@@ -214,6 +214,8 @@ class VidLabelingDispatcherFunction : HttpFunction {
       }
       // Fail fast on per-model-line config the TEE would otherwise only reject at Phase-2.
       requireValidModelLineConfigs(config)
+      // Fail fast on the bin-packing cap the memoized path only rejects inside the TEE.
+      requireValidMaxFileBatchSizeBytes(config)
       val modelLineConfigs =
         VidLabelingFunctionHelpers.convertModelLineConfigs(config.modelLineConfigsMap)
 

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/vidlabeling/VidLabelingMonitorFunction.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/vidlabeling/VidLabelingMonitorFunction.kt
@@ -176,6 +176,8 @@ class VidLabelingMonitorFunction : HttpFunction {
     requireValidStalenessThreshold(config)
     // Fail fast on per-model-line config the TEE would otherwise only reject at Phase-2.
     requireValidModelLineConfigs(config)
+    // Fail fast on the bin-packing cap the memoized path only rejects inside the TEE.
+    requireValidMaxFileBatchSizeBytes(config)
 
     val grpcTelemetry = GrpcTelemetry.create(Instrumentation.openTelemetry)
 

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/vidlabeling/VidLabelingDispatchSequencer.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/vidlabeling/VidLabelingDispatchSequencer.kt
@@ -390,9 +390,8 @@ class VidLabelingDispatchSequencer(
       "model_storage_params missing for memoized model line ${modelLine.cmmsModelLine}; " +
         "set it on VidLabelingConfig for this DataProvider"
     }
-    // Mirrors the non-memoized guard in `dispatchNonMemoizedBundle`: the bin-packing cap is
-    // REQUIRED on `SubpoolAssignerParams`, so reject it here rather than publishing a WorkItem the
-    // TEE only rejects at the Phase-0 last-shard-out.
+    // The bin-packing cap is REQUIRED on `SubpoolAssignerParams`, so an unset one fails here
+    // rather than inside the TEE at the Phase-0 last-shard-out.
     require(subpoolAssignerParamsTemplate.maxFileBatchSizeBytes > 0) {
       "max_file_batch_size_bytes missing for memoized model line ${modelLine.cmmsModelLine}; " +
         "set it on VidLabelingConfig for this DataProvider"

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/vidlabeling/VidLabelingDispatchSequencer.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/vidlabeling/VidLabelingDispatchSequencer.kt
@@ -390,6 +390,13 @@ class VidLabelingDispatchSequencer(
       "model_storage_params missing for memoized model line ${modelLine.cmmsModelLine}; " +
         "set it on VidLabelingConfig for this DataProvider"
     }
+    // Mirrors the non-memoized guard in `dispatchNonMemoizedBundle`: the bin-packing cap is
+    // REQUIRED on `SubpoolAssignerParams`, so reject it here rather than publishing a WorkItem the
+    // TEE only rejects at the Phase-0 last-shard-out.
+    require(subpoolAssignerParamsTemplate.maxFileBatchSizeBytes > 0) {
+      "max_file_batch_size_bytes missing for memoized model line ${modelLine.cmmsModelLine}; " +
+        "set it on VidLabelingConfig for this DataProvider"
+    }
     val modelLineConfig =
       requireNotNull(modelLineConfigs[modelLine.cmmsModelLine]) {
         "No ModelLineConfig found for model line: ${modelLine.cmmsModelLine}"

--- a/src/main/proto/wfa/measurement/config/edpaggregator/vid_labeling_config.proto
+++ b/src/main/proto/wfa/measurement/config/edpaggregator/vid_labeling_config.proto
@@ -167,15 +167,9 @@ message VidLabelingConfig {
       [(google.api.field_behavior) = OPTIONAL];
 
   // Maximum total `RawImpressionUploadFile.size_bytes` packed into a single
-  // Phase-2 `VidLabelingJob` (the bin-packing threshold).
-  //
-  // REQUIRED by both dispatch paths, with no built-in default: too high a cap
-  // OOMs the Phase-2 VM and too low a cap under-utilizes it, so the operator
-  // MUST choose it explicitly. The non-memoized dispatcher enforces it (`> 0`)
-  // at dispatch; the memoized path forwards it verbatim onto
-  // `SubpoolAssignerParams.max_file_batch_size_bytes` (REQUIRED) so the Phase-1
-  // last-`RankerJob`-out bin-packs identically. Validated at Cloud Function
-  // boot by `requireValidMaxFileBatchSizeBytes`.
+  // Phase-2 `VidLabelingJob` (the bin-packing threshold). Required by both
+  // dispatch paths, with no default: too high a cap OOMs the Phase-2 VM and
+  // too low a cap under-utilizes it.
   int64 max_file_batch_size_bytes = 17 [(google.api.field_behavior) = REQUIRED];
 
   // Per-EDP folder segment for this EDP's VID-labeled impression output, placed

--- a/src/main/proto/wfa/measurement/config/edpaggregator/vid_labeling_config.proto
+++ b/src/main/proto/wfa/measurement/config/edpaggregator/vid_labeling_config.proto
@@ -167,10 +167,16 @@ message VidLabelingConfig {
       [(google.api.field_behavior) = OPTIONAL];
 
   // Maximum total `RawImpressionUploadFile.size_bytes` packed into a single
-  // non-memoized Phase-2 `VidLabelingJob` (the bin-packing threshold). OPTIONAL
-  // here like the memoized-only storage params above; the dispatcher enforces
-  // it (`> 0`) at the first non-memoized dispatch.
-  int64 max_file_batch_size_bytes = 17 [(google.api.field_behavior) = OPTIONAL];
+  // Phase-2 `VidLabelingJob` (the bin-packing threshold).
+  //
+  // REQUIRED by both dispatch paths, with no built-in default: too high a cap
+  // OOMs the Phase-2 VM and too low a cap under-utilizes it, so the operator
+  // MUST choose it explicitly. The non-memoized dispatcher enforces it (`> 0`)
+  // at dispatch; the memoized path forwards it verbatim onto
+  // `SubpoolAssignerParams.max_file_batch_size_bytes` (REQUIRED) so the Phase-1
+  // last-`RankerJob`-out bin-packs identically. Validated at Cloud Function
+  // boot by `requireValidMaxFileBatchSizeBytes`.
+  int64 max_file_batch_size_bytes = 17 [(google.api.field_behavior) = REQUIRED];
 
   // Per-EDP folder segment for this EDP's VID-labeled impression output, placed
   // between the storage bucket and the `model-line/<id>/<date>/` layout so each

--- a/src/test/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/vidlabeling/VidLabelingConfigValidationTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/vidlabeling/VidLabelingConfigValidationTest.kt
@@ -102,6 +102,36 @@ class VidLabelingConfigValidationTest {
     assertThat(exception).hasMessageThat().contains(DATA_PROVIDER)
   }
 
+  @Test
+  fun `max_file_batch_size_bytes passes when positive`() {
+    requireValidMaxFileBatchSizeBytes(configWithMaxFileBatchSizeBytes(1_000_000_000))
+  }
+
+  @Test
+  fun `max_file_batch_size_bytes throws when not set`() {
+    val exception =
+      assertFailsWith<IllegalArgumentException> {
+        requireValidMaxFileBatchSizeBytes(vidLabelingConfig { dataProvider = DATA_PROVIDER })
+      }
+    assertThat(exception).hasMessageThat().contains("max_file_batch_size_bytes must be set")
+    assertThat(exception).hasMessageThat().contains(DATA_PROVIDER)
+  }
+
+  @Test
+  fun `max_file_batch_size_bytes throws when negative`() {
+    val exception =
+      assertFailsWith<IllegalArgumentException> {
+        requireValidMaxFileBatchSizeBytes(configWithMaxFileBatchSizeBytes(-1))
+      }
+    assertThat(exception).hasMessageThat().contains("max_file_batch_size_bytes must be set")
+  }
+
+  private fun configWithMaxFileBatchSizeBytes(sizeBytes: Long): VidLabelingConfig =
+    vidLabelingConfig {
+      dataProvider = DATA_PROVIDER
+      maxFileBatchSizeBytes = sizeBytes
+    }
+
   private fun configWithStaleness(threshold: com.google.protobuf.Duration): VidLabelingConfig =
     vidLabelingConfig {
       dataProvider = DATA_PROVIDER

--- a/src/test/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/vidlabeling/VidLabelingDispatcherFunctionTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/vidlabeling/VidLabelingDispatcherFunctionTest.kt
@@ -325,6 +325,7 @@ class VidLabelingDispatcherFunctionTest {
   private fun fileSystemVidLabelingConfig() = vidLabelingConfig {
     dataProvider = DATA_PROVIDER
     edpImpressionPath = "edp7"
+    maxFileBatchSizeBytes = 1_000_000_000
     rawImpressionsStorageParams = storageParams {
       gcs = gcsStorage {
         projectId = "test-project"

--- a/src/test/kotlin/org/wfanet/measurement/edpaggregator/vidlabeling/VidLabelingDispatchSequencerTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/edpaggregator/vidlabeling/VidLabelingDispatchSequencerTest.kt
@@ -757,6 +757,30 @@ class VidLabelingDispatchSequencerTest {
     }
 
   @Test
+  fun `dispatchNext fails fast when a memoized model line lacks max_file_batch_size_bytes`() =
+    runBlocking<Unit> {
+      stubUploads(
+        created = listOf(upload("upload-1", RawImpressionUpload.State.CREATED, FIXED_NOW))
+      )
+      stubModelLines(createdModelLine())
+      stubShardResolution(memoized = true)
+      val templateMissingMaxFileBatchSize =
+        SUBPOOL_ASSIGNER_PARAMS_TEMPLATE.copy { maxFileBatchSizeBytes = 0 }
+
+      val exception =
+        assertFailsWith<Exception> {
+          createSequencer(subpoolAssignerParamsTemplate = templateMissingMaxFileBatchSize)
+            .dispatchNext()
+        }
+
+      assertThat(exception).hasMessageThat().contains("max_file_batch_size_bytes missing")
+      verifyBlocking(poolAssignmentJobService, never()) { batchCreatePoolAssignmentJobs(any()) }
+      verifyBlocking(rawImpressionUploadModelLineService, never()) {
+        markRawImpressionUploadModelLinePoolAssigning(any())
+      }
+    }
+
+  @Test
   fun `dispatchNext selects the oldest CREATED upload`() =
     runBlocking<Unit> {
       val older =


### PR DESCRIPTION
The field was annotated OPTIONAL, but both dispatch paths hard-require it. The non-memoized dispatcher rejects an unset value at dispatch, while the memoized path forwards it onto the REQUIRED SubpoolAssignerParams.max_file_batch_size_bytes, so an unset value there only surfaces inside the TEE at the Phase-0 last-shard-out, behind Pub/Sub retries and a DLQ FAILED cascade.

Mark the field REQUIRED, validate it at Cloud Function boot alongside the other checks in VidLabelingConfigValidation, and add the matching fail-fast to the memoized dispatch path so a directly constructed sequencer rejects an unset cap as well.

BREAKING-CHANGE: VidLabelingConfig.max_file_batch_size_bytes is now REQUIRED. Set it in every environment's VidLabelingConfig before rolling out this binary: the VID labeling dispatcher and monitor Cloud Functions now fail at boot when it is unset.
Issue: #4365
