### PR TITLE
feat: make Kingdom measurement batch concurrency configurable

### DIFF
--- a/src/main/k8s/reporting_v2.cue
+++ b/src/main/k8s/reporting_v2.cue
@@ -24,7 +24,8 @@ package k8s
 	_certificateCacheExpirationDuration:  string | *"60m"
 	_dataProviderCacheExpirationDuration: string | *"60m"
 
-	_maxCreatedBasicReportAge: string | *"15m"
+	_maxCreatedBasicReportAge:           string | *"15m"
+	_kingdomMeasurementBatchConcurrency: string | *"8"
 
 	_postgresConfig:         #PostgresConfig
 	_reportingSpannerConfig: #SpannerConfig & {
@@ -215,6 +216,7 @@ package k8s
 						"--default-report-start-time-zone=America/New_York",
 						"--default-report-start-hour=6",
 						"--enable-reporting-set-reporting-unit-components=\(_reportingSetReportingUnitComponentsEnabled)",
+						"--kingdom-measurement-batch-concurrency=\(Reporting._kingdomMeasurementBatchConcurrency)",
 			] + _tlsArgs + _internalApiTarget.args + _kingdomApiTarget.args + _accessApiTarget.args + _eventDescriptorArgs
 
 			spec: template: spec: {
@@ -352,6 +354,7 @@ package k8s
 						"--port=8443",
 						"--health-port=8080",
 						"--pdp-name=\(_populationDataProviderName)",
+						"--kingdom-measurement-batch-concurrency=\(Reporting._kingdomMeasurementBatchConcurrency)",
 			] + _tlsArgs + _internalApiTarget.args + _kingdomApiTarget.args + _accessApiTarget.args
 			spec: {
 				jobTemplate: spec: template: spec: _mounts: {
@@ -395,6 +398,7 @@ package k8s
 							"--health-port=8080",
 							"--pdp-name=\(_populationDataProviderName)",
 							"--max-created-basic-report-age=\(Reporting._maxCreatedBasicReportAge)",
+							"--kingdom-measurement-batch-concurrency=\(Reporting._kingdomMeasurementBatchConcurrency)",
 						] + _tlsArgs + _internalApiTarget.args + _kingdomApiTarget.args + _accessApiTarget.args + _eventDescriptorArgs
 					}
 				}

--- a/src/main/kotlin/org/wfanet/measurement/integration/common/reporting/v2/InProcessReportingServer.kt
+++ b/src/main/kotlin/org/wfanet/measurement/integration/common/reporting/v2/InProcessReportingServer.kt
@@ -296,6 +296,7 @@ class InProcessReportingServer(
                 keyReaderContext = Dispatchers.IO,
                 cacheLoaderContext = Dispatchers.Default,
                 populationDataProvider = populationDataProviderName,
+                kingdomMeasurementBatchConcurrency = 3,
               )
               .withTrustedPrincipalAuthentication(),
             ReportingSetsService(internalReportingSetsClient, authorization)

--- a/src/main/kotlin/org/wfanet/measurement/reporting/deploy/v2/common/ReportingApiServerFlags.kt
+++ b/src/main/kotlin/org/wfanet/measurement/reporting/deploy/v2/common/ReportingApiServerFlags.kt
@@ -187,8 +187,10 @@ class ReportingApiServerFlags {
     names = ["--kingdom-measurement-batch-concurrency"],
     description =
       [
-        "Number of concurrent batch requests to the Kingdom's BatchCreateMeasurements RPC when " +
-          "dispatching Measurements for a Report or Metric."
+        "Number of concurrent batch requests to the Kingdom's BatchCreateMeasurements and " +
+          "BatchGetMeasurements RPCs when dispatching or syncing Measurements for a Report or " +
+          "Metric. Applies to both operations since there is no reason Kingdom's tolerance " +
+          "would differ between a create and a get on the same data."
       ],
     defaultValue = "8",
   )

--- a/src/main/kotlin/org/wfanet/measurement/reporting/deploy/v2/common/ReportingApiServerFlags.kt
+++ b/src/main/kotlin/org/wfanet/measurement/reporting/deploy/v2/common/ReportingApiServerFlags.kt
@@ -189,8 +189,7 @@ class ReportingApiServerFlags {
       [
         "Number of concurrent batch requests to the Kingdom's BatchCreateMeasurements and " +
           "BatchGetMeasurements RPCs when dispatching or syncing Measurements for a Report or " +
-          "Metric. Applies to both operations since there is no reason Kingdom's tolerance " +
-          "would differ between a create and a get on the same data."
+          "Metric."
       ],
     defaultValue = "8",
   )

--- a/src/main/kotlin/org/wfanet/measurement/reporting/deploy/v2/common/ReportingApiServerFlags.kt
+++ b/src/main/kotlin/org/wfanet/measurement/reporting/deploy/v2/common/ReportingApiServerFlags.kt
@@ -182,4 +182,16 @@ class ReportingApiServerFlags {
   )
   var systemMeasurementConsumerName: String? = null
     private set
+
+  @set:CommandLine.Option(
+    names = ["--kingdom-measurement-batch-concurrency"],
+    description =
+      [
+        "Number of concurrent batch requests to the Kingdom's BatchCreateMeasurements RPC when " +
+          "dispatching Measurements for a Report or Metric."
+      ],
+    defaultValue = "8",
+  )
+  var kingdomMeasurementBatchConcurrency by Delegates.notNull<Int>()
+    private set
 }

--- a/src/main/kotlin/org/wfanet/measurement/reporting/deploy/v2/common/ReportingApiServerFlags.kt
+++ b/src/main/kotlin/org/wfanet/measurement/reporting/deploy/v2/common/ReportingApiServerFlags.kt
@@ -194,6 +194,9 @@ class ReportingApiServerFlags {
       ],
     defaultValue = "8",
   )
-  var kingdomMeasurementBatchConcurrency by Delegates.notNull<Int>()
-    private set
+  var kingdomMeasurementBatchConcurrency: Int = 8
+    private set(value) {
+      require(value > 0) { "--kingdom-measurement-batch-concurrency must be greater than 0" }
+      field = value
+    }
 }

--- a/src/main/kotlin/org/wfanet/measurement/reporting/deploy/v2/common/job/BasicReportsReportsJobExecutor.kt
+++ b/src/main/kotlin/org/wfanet/measurement/reporting/deploy/v2/common/job/BasicReportsReportsJobExecutor.kt
@@ -137,10 +137,6 @@ private fun run(
   val metricSpecConfig =
     parseTextProto(v2AlphaFlags.metricSpecConfigFile, MetricSpecConfig.getDefaultInstance())
 
-  if (reportingApiServerFlags.kingdomMeasurementBatchConcurrency <= 0) {
-    throw IllegalArgumentException("--kingdom-measurement-batch-concurrency must be greater than 0")
-  }
-
   val metricsService =
     MetricsService(
         metricSpecConfig,
@@ -166,14 +162,8 @@ private fun run(
         keyReaderContext = Dispatchers.IO,
         cacheLoaderContext = Dispatchers.Default,
         populationDataProvider = reportingApiServerFlags.populationDataProvider,
-        // BasicReportsReportsJob never calls CreateReport/BatchCreateMetrics, so this
-        // MetricsService instance never dispatches new Measurements via this value. However,
-        // its reportsStub.getReport call can transitively reach batchGetMetrics ->
-        // syncAndConvertInternalMetricsToPublicMetrics -> syncInternalMeasurements, which is
-        // gated by this same concurrency value for BatchGetMeasurements whenever the report
-        // being read has RUNNING Metrics with PENDING Measurements -- the common case for a
-        // job whose purpose is reconciling in-flight reports. Wired to the shared flag rather
-        // than a separate literal so there is exactly one place this default comes from.
+        // getReport can transitively reach batchGetMetrics -> syncInternalMeasurements,
+        // which is gated by this same concurrency value.
         kingdomMeasurementBatchConcurrency =
           reportingApiServerFlags.kingdomMeasurementBatchConcurrency,
       )

--- a/src/main/kotlin/org/wfanet/measurement/reporting/deploy/v2/common/job/BasicReportsReportsJobExecutor.kt
+++ b/src/main/kotlin/org/wfanet/measurement/reporting/deploy/v2/common/job/BasicReportsReportsJobExecutor.kt
@@ -162,7 +162,12 @@ private fun run(
         keyReaderContext = Dispatchers.IO,
         cacheLoaderContext = Dispatchers.Default,
         populationDataProvider = reportingApiServerFlags.populationDataProvider,
-        kingdomMeasurementBatchConcurrency = 3,
+        // BasicReportsReportsJob only calls reportsStub.getReport (read-only) and never
+        // CreateReport/BatchCreateMetrics, so this MetricsService instance never dispatches new
+        // Measurements and this value has no effect in practice. Wired to the shared flag rather
+        // than a separate literal so there is exactly one place this default comes from.
+        kingdomMeasurementBatchConcurrency =
+          reportingApiServerFlags.kingdomMeasurementBatchConcurrency,
       )
       .withTrustedPrincipalAuthentication()
 

--- a/src/main/kotlin/org/wfanet/measurement/reporting/deploy/v2/common/job/BasicReportsReportsJobExecutor.kt
+++ b/src/main/kotlin/org/wfanet/measurement/reporting/deploy/v2/common/job/BasicReportsReportsJobExecutor.kt
@@ -162,6 +162,7 @@ private fun run(
         keyReaderContext = Dispatchers.IO,
         cacheLoaderContext = Dispatchers.Default,
         populationDataProvider = reportingApiServerFlags.populationDataProvider,
+        kingdomMeasurementBatchConcurrency = 3,
       )
       .withTrustedPrincipalAuthentication()
 

--- a/src/main/kotlin/org/wfanet/measurement/reporting/deploy/v2/common/job/BasicReportsReportsJobExecutor.kt
+++ b/src/main/kotlin/org/wfanet/measurement/reporting/deploy/v2/common/job/BasicReportsReportsJobExecutor.kt
@@ -137,6 +137,10 @@ private fun run(
   val metricSpecConfig =
     parseTextProto(v2AlphaFlags.metricSpecConfigFile, MetricSpecConfig.getDefaultInstance())
 
+  if (reportingApiServerFlags.kingdomMeasurementBatchConcurrency <= 0) {
+    throw IllegalArgumentException("--kingdom-measurement-batch-concurrency must be greater than 0")
+  }
+
   val metricsService =
     MetricsService(
         metricSpecConfig,
@@ -162,9 +166,13 @@ private fun run(
         keyReaderContext = Dispatchers.IO,
         cacheLoaderContext = Dispatchers.Default,
         populationDataProvider = reportingApiServerFlags.populationDataProvider,
-        // BasicReportsReportsJob only calls reportsStub.getReport (read-only) and never
-        // CreateReport/BatchCreateMetrics, so this MetricsService instance never dispatches new
-        // Measurements and this value has no effect in practice. Wired to the shared flag rather
+        // BasicReportsReportsJob never calls CreateReport/BatchCreateMetrics, so this
+        // MetricsService instance never dispatches new Measurements via this value. However,
+        // its reportsStub.getReport call can transitively reach batchGetMetrics ->
+        // syncAndConvertInternalMetricsToPublicMetrics -> syncInternalMeasurements, which is
+        // gated by this same concurrency value for BatchGetMeasurements whenever the report
+        // being read has RUNNING Metrics with PENDING Measurements -- the common case for a
+        // job whose purpose is reconciling in-flight reports. Wired to the shared flag rather
         // than a separate literal so there is exactly one place this default comes from.
         kingdomMeasurementBatchConcurrency =
           reportingApiServerFlags.kingdomMeasurementBatchConcurrency,

--- a/src/main/kotlin/org/wfanet/measurement/reporting/deploy/v2/common/job/ReportSchedulingJobExecutor.kt
+++ b/src/main/kotlin/org/wfanet/measurement/reporting/deploy/v2/common/job/ReportSchedulingJobExecutor.kt
@@ -120,10 +120,6 @@ private fun run(
   val metricSpecConfig =
     parseTextProto(v2AlphaFlags.metricSpecConfigFile, MetricSpecConfig.getDefaultInstance())
 
-  if (reportingApiServerFlags.kingdomMeasurementBatchConcurrency <= 0) {
-    throw IllegalArgumentException("--kingdom-measurement-batch-concurrency must be greater than 0")
-  }
-
   val metricsService =
     MetricsService(
         metricSpecConfig,

--- a/src/main/kotlin/org/wfanet/measurement/reporting/deploy/v2/common/job/ReportSchedulingJobExecutor.kt
+++ b/src/main/kotlin/org/wfanet/measurement/reporting/deploy/v2/common/job/ReportSchedulingJobExecutor.kt
@@ -120,6 +120,10 @@ private fun run(
   val metricSpecConfig =
     parseTextProto(v2AlphaFlags.metricSpecConfigFile, MetricSpecConfig.getDefaultInstance())
 
+  if (reportingApiServerFlags.kingdomMeasurementBatchConcurrency <= 0) {
+    throw IllegalArgumentException("--kingdom-measurement-batch-concurrency must be greater than 0")
+  }
+
   val metricsService =
     MetricsService(
         metricSpecConfig,

--- a/src/main/kotlin/org/wfanet/measurement/reporting/deploy/v2/common/job/ReportSchedulingJobExecutor.kt
+++ b/src/main/kotlin/org/wfanet/measurement/reporting/deploy/v2/common/job/ReportSchedulingJobExecutor.kt
@@ -145,6 +145,7 @@ private fun run(
         keyReaderContext = Dispatchers.IO,
         cacheLoaderContext = Dispatchers.Default,
         populationDataProvider = reportingApiServerFlags.populationDataProvider,
+        kingdomMeasurementBatchConcurrency = 3,
       )
       .withTrustedPrincipalAuthentication()
 

--- a/src/main/kotlin/org/wfanet/measurement/reporting/deploy/v2/common/job/ReportSchedulingJobExecutor.kt
+++ b/src/main/kotlin/org/wfanet/measurement/reporting/deploy/v2/common/job/ReportSchedulingJobExecutor.kt
@@ -145,7 +145,11 @@ private fun run(
         keyReaderContext = Dispatchers.IO,
         cacheLoaderContext = Dispatchers.Default,
         populationDataProvider = reportingApiServerFlags.populationDataProvider,
-        kingdomMeasurementBatchConcurrency = 3,
+        // ReportSchedulingJob calls reportsStub.createReport, which dispatches Measurements to
+        // the Kingdom the same way the public CreateReport/CreateBasicReport RPCs do, so a
+        // heavy scheduled Report benefits from the same concurrency as the interactive path.
+        kingdomMeasurementBatchConcurrency =
+          reportingApiServerFlags.kingdomMeasurementBatchConcurrency,
       )
       .withTrustedPrincipalAuthentication()
 

--- a/src/main/kotlin/org/wfanet/measurement/reporting/deploy/v2/common/server/V2AlphaPublicApiServer.kt
+++ b/src/main/kotlin/org/wfanet/measurement/reporting/deploy/v2/common/server/V2AlphaPublicApiServer.kt
@@ -244,6 +244,12 @@ private object V2AlphaPublicApiServer {
 
     val serviceDispatcher: CoroutineDispatcher = serviceFlags.executor.asCoroutineDispatcher()
 
+    if (reportingApiServerFlags.kingdomMeasurementBatchConcurrency <= 0) {
+      throw IllegalArgumentException(
+        "--kingdom-measurement-batch-concurrency must be greater than 0"
+      )
+    }
+
     val metricsService =
       MetricsService(
         metricSpecConfig,

--- a/src/main/kotlin/org/wfanet/measurement/reporting/deploy/v2/common/server/V2AlphaPublicApiServer.kt
+++ b/src/main/kotlin/org/wfanet/measurement/reporting/deploy/v2/common/server/V2AlphaPublicApiServer.kt
@@ -273,7 +273,7 @@ private object V2AlphaPublicApiServer {
         coroutineContext = serviceDispatcher,
         populationDataProvider = reportingApiServerFlags.populationDataProvider,
         kingdomMeasurementBatchConcurrency =
-          v2AlphaPublicServerFlags.kingdomMeasurementBatchConcurrency,
+          reportingApiServerFlags.kingdomMeasurementBatchConcurrency,
       )
 
     startInProcessServerWithService(
@@ -487,18 +487,6 @@ private object V2AlphaPublicApiServer {
       required = false,
     )
     var emitCelNullGuardsForNestedMembers: Boolean = false
-      private set
-
-    @CommandLine.Option(
-      names = ["--kingdom-measurement-batch-concurrency"],
-      description =
-        [
-          "Number of concurrent batch requests to the Kingdom's BatchCreateMeasurements RPC " +
-            "when dispatching Measurements for a Report or Metric."
-        ],
-      required = false,
-    )
-    var kingdomMeasurementBatchConcurrency: Int = 8
       private set
   }
 }

--- a/src/main/kotlin/org/wfanet/measurement/reporting/deploy/v2/common/server/V2AlphaPublicApiServer.kt
+++ b/src/main/kotlin/org/wfanet/measurement/reporting/deploy/v2/common/server/V2AlphaPublicApiServer.kt
@@ -244,12 +244,6 @@ private object V2AlphaPublicApiServer {
 
     val serviceDispatcher: CoroutineDispatcher = serviceFlags.executor.asCoroutineDispatcher()
 
-    if (reportingApiServerFlags.kingdomMeasurementBatchConcurrency <= 0) {
-      throw IllegalArgumentException(
-        "--kingdom-measurement-batch-concurrency must be greater than 0"
-      )
-    }
-
     val metricsService =
       MetricsService(
         metricSpecConfig,

--- a/src/main/kotlin/org/wfanet/measurement/reporting/deploy/v2/common/server/V2AlphaPublicApiServer.kt
+++ b/src/main/kotlin/org/wfanet/measurement/reporting/deploy/v2/common/server/V2AlphaPublicApiServer.kt
@@ -272,6 +272,8 @@ private object V2AlphaPublicApiServer {
         cacheLoaderContext = Dispatchers.Default,
         coroutineContext = serviceDispatcher,
         populationDataProvider = reportingApiServerFlags.populationDataProvider,
+        kingdomMeasurementBatchConcurrency =
+          v2AlphaPublicServerFlags.kingdomMeasurementBatchConcurrency,
       )
 
     startInProcessServerWithService(
@@ -485,6 +487,18 @@ private object V2AlphaPublicApiServer {
       required = false,
     )
     var emitCelNullGuardsForNestedMembers: Boolean = false
+      private set
+
+    @CommandLine.Option(
+      names = ["--kingdom-measurement-batch-concurrency"],
+      description =
+        [
+          "Number of concurrent batch requests to the Kingdom's BatchCreateMeasurements RPC " +
+            "when dispatching Measurements for a Report or Metric."
+        ],
+      required = false,
+    )
+    var kingdomMeasurementBatchConcurrency: Int = 8
       private set
   }
 }

--- a/src/main/kotlin/org/wfanet/measurement/reporting/service/api/SubmitBatchRequests.kt
+++ b/src/main/kotlin/org/wfanet/measurement/reporting/service/api/SubmitBatchRequests.kt
@@ -52,13 +52,19 @@ fun <T> Flow<T>.chunked(chunkSize: Int): Flow<List<T>> {
 /**
  * Submits multiple RPCs by dividing the input items to batches.
  *
+ * @param concurrency the number of batch requests that may be in flight at once. There is no
+ *   universally-safe default: appropriate values depend on how much concurrent load the downstream
+ *   service can tolerate, so callers must specify one explicitly. Most callers in this codebase
+ *   pass 3, matching this batching mechanism's original hardcoded behavior; Kingdom measurement
+ *   creation passes a higher value (8 by default, via the --kingdom-measurement-batch-concurrency
+ *   flag) because it has been observed to tolerate more concurrent load.
  * @return [Flow] that emits [List]s containing the results of the multiple RPCs.
  */
 suspend fun <ITEM, RESP, RESULT> submitBatchRequests(
   items: Flow<ITEM>,
   limit: Int,
   callRpc: suspend (List<ITEM>) -> RESP,
-  concurrency: Int = 3,
+  concurrency: Int,
   parseResponse: (RESP) -> List<RESULT>,
 ): Flow<List<RESULT>> {
   if (limit <= 0) {
@@ -68,9 +74,8 @@ suspend fun <ITEM, RESP, RESULT> submitBatchRequests(
     )
   }
 
-  // For network requests, the number of concurrent coroutines needs to be capped. The default of
-  // 3 is conservative; callers dispatching to services known to tolerate more concurrency (e.g.
-  // Kingdom measurement creation) may pass a higher value.
+  // For network requests, the number of concurrent coroutines needs to be capped; see the
+  // `concurrency` parameter doc for how callers choose a value.
   val batchSemaphore = Semaphore(concurrency)
   return flow {
     coroutineScope {

--- a/src/main/kotlin/org/wfanet/measurement/reporting/service/api/SubmitBatchRequests.kt
+++ b/src/main/kotlin/org/wfanet/measurement/reporting/service/api/SubmitBatchRequests.kt
@@ -58,6 +58,7 @@ suspend fun <ITEM, RESP, RESULT> submitBatchRequests(
   items: Flow<ITEM>,
   limit: Int,
   callRpc: suspend (List<ITEM>) -> RESP,
+  concurrency: Int = 3,
   parseResponse: (RESP) -> List<RESULT>,
 ): Flow<List<RESULT>> {
   if (limit <= 0) {
@@ -67,9 +68,10 @@ suspend fun <ITEM, RESP, RESULT> submitBatchRequests(
     )
   }
 
-  // For network requests, the number of concurrent coroutines needs to be capped. To be on the safe
-  // side, a low number is chosen.
-  val batchSemaphore = Semaphore(3)
+  // For network requests, the number of concurrent coroutines needs to be capped. The default of
+  // 3 is conservative; callers dispatching to services known to tolerate more concurrency (e.g.
+  // Kingdom measurement creation) may pass a higher value.
+  val batchSemaphore = Semaphore(concurrency)
   return flow {
     coroutineScope {
       val deferred: List<Deferred<List<RESULT>>> = buildList {

--- a/src/main/kotlin/org/wfanet/measurement/reporting/service/api/SubmitBatchRequests.kt
+++ b/src/main/kotlin/org/wfanet/measurement/reporting/service/api/SubmitBatchRequests.kt
@@ -54,11 +54,7 @@ fun <T> Flow<T>.chunked(chunkSize: Int): Flow<List<T>> {
  *
  * @param concurrency the number of batch requests that may be in flight at once. There is no
  *   universally-safe default: appropriate values depend on how much concurrent load the downstream
- *   service can tolerate, so callers must specify one explicitly. Most callers in this codebase
- *   pass 3, matching this batching mechanism's original hardcoded behavior; Kingdom measurement
- *   creation and retrieval both pass a higher value (8 by default, via the
- *   --kingdom-measurement-batch-concurrency flag) because they have been observed to tolerate more
- *   concurrent load.
+ *   service can tolerate, so callers must specify one explicitly.
  * @return [Flow] that emits [List]s containing the results of the multiple RPCs.
  */
 suspend fun <ITEM, RESP, RESULT> submitBatchRequests(

--- a/src/main/kotlin/org/wfanet/measurement/reporting/service/api/SubmitBatchRequests.kt
+++ b/src/main/kotlin/org/wfanet/measurement/reporting/service/api/SubmitBatchRequests.kt
@@ -56,8 +56,9 @@ fun <T> Flow<T>.chunked(chunkSize: Int): Flow<List<T>> {
  *   universally-safe default: appropriate values depend on how much concurrent load the downstream
  *   service can tolerate, so callers must specify one explicitly. Most callers in this codebase
  *   pass 3, matching this batching mechanism's original hardcoded behavior; Kingdom measurement
- *   creation passes a higher value (8 by default, via the --kingdom-measurement-batch-concurrency
- *   flag) because it has been observed to tolerate more concurrent load.
+ *   creation and retrieval both pass a higher value (8 by default, via the
+ *   --kingdom-measurement-batch-concurrency flag) because they have been observed to tolerate more
+ *   concurrent load.
  * @return [Flow] that emits [List]s containing the results of the multiple RPCs.
  */
 suspend fun <ITEM, RESP, RESULT> submitBatchRequests(
@@ -71,6 +72,12 @@ suspend fun <ITEM, RESP, RESULT> submitBatchRequests(
     throw BatchRequestException(
       "Invalid limit",
       IllegalArgumentException("The size limit of a batch must be greater than 0."),
+    )
+  }
+  if (concurrency <= 0) {
+    throw BatchRequestException(
+      "Invalid concurrency",
+      IllegalArgumentException("The concurrency of a batch must be greater than 0."),
     )
   }
 

--- a/src/main/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/MetricsService.kt
+++ b/src/main/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/MetricsService.kt
@@ -263,6 +263,7 @@ class MetricsService(
   keyReaderContext: @BlockingExecutor CoroutineContext = Dispatchers.IO,
   cacheLoaderContext: @NonBlockingExecutor CoroutineContext = Dispatchers.Default,
   coroutineContext: CoroutineContext = EmptyCoroutineContext,
+  kingdomMeasurementBatchConcurrency: Int = 8,
 ) : MetricsCoroutineImplBase(coroutineContext) {
   private data class DataProviderInfo(
     val dataProviderName: String,
@@ -286,6 +287,7 @@ class MetricsService(
       keyReaderContext,
       cacheLoaderContext,
       populationDataProvider,
+      kingdomMeasurementBatchConcurrency,
     )
 
   private class MeasurementSupplier(
@@ -303,6 +305,7 @@ class MetricsService(
     private val keyReaderContext: @BlockingExecutor CoroutineContext = Dispatchers.IO,
     cacheLoaderContext: @NonBlockingExecutor CoroutineContext = Dispatchers.Default,
     private val populationDataProvider: String,
+    private val kingdomMeasurementBatchConcurrency: Int = 8,
   ) {
     data class RunningMetric(
       val internalMetric: InternalMetric,
@@ -395,6 +398,7 @@ class MetricsService(
             cmmsCreateMeasurementRequests,
             BATCH_KINGDOM_MEASUREMENTS_LIMIT,
             callBatchCreateMeasurementsRpc,
+            concurrency = kingdomMeasurementBatchConcurrency,
           ) { response: BatchCreateMeasurementsResponse ->
             response.measurementsList
           }

--- a/src/main/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/MetricsService.kt
+++ b/src/main/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/MetricsService.kt
@@ -263,7 +263,7 @@ class MetricsService(
   keyReaderContext: @BlockingExecutor CoroutineContext = Dispatchers.IO,
   cacheLoaderContext: @NonBlockingExecutor CoroutineContext = Dispatchers.Default,
   coroutineContext: CoroutineContext = EmptyCoroutineContext,
-  kingdomMeasurementBatchConcurrency: Int = 8,
+  kingdomMeasurementBatchConcurrency: Int,
 ) : MetricsCoroutineImplBase(coroutineContext) {
   private data class DataProviderInfo(
     val dataProviderName: String,
@@ -305,7 +305,7 @@ class MetricsService(
     private val keyReaderContext: @BlockingExecutor CoroutineContext = Dispatchers.IO,
     cacheLoaderContext: @NonBlockingExecutor CoroutineContext = Dispatchers.Default,
     private val populationDataProvider: String,
-    private val kingdomMeasurementBatchConcurrency: Int = 8,
+    private val kingdomMeasurementBatchConcurrency: Int,
   ) {
     data class RunningMetric(
       val internalMetric: InternalMetric,
@@ -422,6 +422,7 @@ class MetricsService(
           },
           BATCH_SET_CMMS_MEASUREMENT_IDS_LIMIT,
           callBatchSetCmmsMeasurementIdsRpc,
+          concurrency = 3,
         ) { _: Unit ->
           emptyList<Unit>()
         }
@@ -925,6 +926,7 @@ class MetricsService(
             succeededMeasurements,
             BATCH_SET_MEASUREMENT_RESULTS_LIMIT,
             callBatchSetInternalMeasurementResultsRpc,
+            concurrency = 3,
           ) { _: Unit ->
             emptyList<Unit>()
           }
@@ -946,6 +948,7 @@ class MetricsService(
             failedMeasurements.asFlow(),
             BATCH_SET_MEASUREMENT_FAILURES_LIMIT,
             callBatchSetInternalMeasurementFailuresRpc,
+            concurrency = 3,
           ) { _: Unit ->
             emptyList<Unit>()
           }
@@ -1046,6 +1049,7 @@ class MetricsService(
         measurementNames,
         BATCH_KINGDOM_MEASUREMENTS_LIMIT,
         callBatchGetMeasurementsRpc,
+        concurrency = 3,
       ) { response: BatchGetMeasurementsResponse ->
         response.measurementsList
       }
@@ -1626,8 +1630,12 @@ class MetricsService(
     }
 
     val reportingSetNameToInternalReportingSetMap: Map<String, InternalReportingSet> = buildMap {
-      submitBatchRequests(reportingSetNames.asFlow(), BATCH_GET_REPORTING_SETS_LIMIT, callRpc) {
-          response ->
+      submitBatchRequests(
+          reportingSetNames.asFlow(),
+          BATCH_GET_REPORTING_SETS_LIMIT,
+          callRpc,
+          concurrency = 3,
+        ) { response ->
           response.reportingSetsList
         }
         .collect { reportingSetsList ->
@@ -1851,6 +1859,7 @@ class MetricsService(
           externalPrimitiveReportingSetIds,
           BATCH_GET_REPORTING_SETS_LIMIT,
           callBatchGetInternalReportingSetsRpc,
+          concurrency = 3,
         ) { response: BatchGetReportingSetsResponse ->
           response.reportingSetsList
         }

--- a/src/main/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/MetricsService.kt
+++ b/src/main/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/MetricsService.kt
@@ -422,12 +422,8 @@ class MetricsService(
           },
           BATCH_SET_CMMS_MEASUREMENT_IDS_LIMIT,
           callBatchSetCmmsMeasurementIdsRpc,
-          // This writes to the reporting server's own internal Measurements table, not Kingdom,
-          // so it should not share the Kingdom-dispatch concurrency flag even though it scales
-          // with the same measurement count. At BATCH_SET_CMMS_MEASUREMENT_IDS_LIMIT=1000, a
-          // report would need over 1000 Measurements before this ever needs more than one
-          // batch — well beyond the largest report size exercised so far (~936) — so
-          // concurrency has no effect in practice today.
+          // Writes to the internal Measurements table, not Kingdom, so it doesn't share the
+          // Kingdom-dispatch concurrency flag.
           concurrency = 3,
         ) { _: Unit ->
           emptyList<Unit>()
@@ -932,9 +928,8 @@ class MetricsService(
             succeededMeasurements,
             BATCH_SET_MEASUREMENT_RESULTS_LIMIT,
             callBatchSetInternalMeasurementResultsRpc,
-            // Writes to the internal Measurements table (not Kingdom) from the read/poll path
-            // (getMetric/batchGetMetrics/listMetrics), never from Metric creation. Limit is 1000,
-            // so this never multi-chunks at any report size seen so far.
+            // Writes to the internal Measurements table from the read/poll path, not Kingdom, so
+            // it doesn't share the Kingdom-dispatch concurrency flag.
             concurrency = 3,
           ) { _: Unit ->
             emptyList<Unit>()
@@ -957,8 +952,7 @@ class MetricsService(
             failedMeasurements.asFlow(),
             BATCH_SET_MEASUREMENT_FAILURES_LIMIT,
             callBatchSetInternalMeasurementFailuresRpc,
-            // Same reasoning as the adjacent BATCH_SET_MEASUREMENT_RESULTS_LIMIT call: internal
-            // DB, read/poll path only, limit of 1000 far exceeds any report size seen so far.
+            // Same reasoning as the adjacent BATCH_SET_MEASUREMENT_RESULTS_LIMIT call.
             concurrency = 3,
           ) { _: Unit ->
             emptyList<Unit>()
@@ -1645,10 +1639,8 @@ class MetricsService(
     }
 
     val reportingSetNameToInternalReportingSetMap: Map<String, InternalReportingSet> = buildMap {
-      // reportingSetNames is deduplicated (.distinct() above) and bounded by how many distinct
-      // ReportingSets a report's Metrics reference (e.g. union/TV/Meta for a cross-media report,
-      // typically a handful), not by Metric count, so this never approaches
-      // BATCH_GET_REPORTING_SETS_LIMIT=1000 regardless of report size.
+      // Bounded by how many distinct ReportingSets a report's Metrics reference, not by Metric
+      // count, so it doesn't share the Kingdom-dispatch concurrency flag.
       submitBatchRequests(
           reportingSetNames.asFlow(),
           BATCH_GET_REPORTING_SETS_LIMIT,

--- a/src/main/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/MetricsService.kt
+++ b/src/main/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/MetricsService.kt
@@ -422,6 +422,12 @@ class MetricsService(
           },
           BATCH_SET_CMMS_MEASUREMENT_IDS_LIMIT,
           callBatchSetCmmsMeasurementIdsRpc,
+          // This writes to the reporting server's own internal Measurements table, not Kingdom,
+          // so it should not share the Kingdom-dispatch concurrency flag even though it scales
+          // with the same measurement count. At BATCH_SET_CMMS_MEASUREMENT_IDS_LIMIT=1000, a
+          // report would need over 1000 Measurements before this ever needs more than one
+          // batch — well beyond the largest report size exercised so far (~936) — so
+          // concurrency has no effect in practice today.
           concurrency = 3,
         ) { _: Unit ->
           emptyList<Unit>()
@@ -926,6 +932,9 @@ class MetricsService(
             succeededMeasurements,
             BATCH_SET_MEASUREMENT_RESULTS_LIMIT,
             callBatchSetInternalMeasurementResultsRpc,
+            // Writes to the internal Measurements table (not Kingdom) from the read/poll path
+            // (getMetric/batchGetMetrics/listMetrics), never from Metric creation. Limit is 1000,
+            // so this never multi-chunks at any report size seen so far.
             concurrency = 3,
           ) { _: Unit ->
             emptyList<Unit>()
@@ -948,6 +957,8 @@ class MetricsService(
             failedMeasurements.asFlow(),
             BATCH_SET_MEASUREMENT_FAILURES_LIMIT,
             callBatchSetInternalMeasurementFailuresRpc,
+            // Same reasoning as the adjacent BATCH_SET_MEASUREMENT_RESULTS_LIMIT call: internal
+            // DB, read/poll path only, limit of 1000 far exceeds any report size seen so far.
             concurrency = 3,
           ) { _: Unit ->
             emptyList<Unit>()
@@ -1045,11 +1056,15 @@ class MetricsService(
           batchGetCmmsMeasurements(measurementConsumerCreds, items)
         }
 
+      // This reads from the same Kingdom endpoint, at the same BATCH_KINGDOM_MEASUREMENTS_LIMIT
+      // chunk size, as the Measurement-creation dispatch in createCmmsMeasurements, so it can
+      // need just as many concurrent batches for a large report's Measurements and there is no
+      // reason Kingdom's tolerance would differ between a create and a get.
       return submitBatchRequests(
         measurementNames,
         BATCH_KINGDOM_MEASUREMENTS_LIMIT,
         callBatchGetMeasurementsRpc,
-        concurrency = 3,
+        concurrency = kingdomMeasurementBatchConcurrency,
       ) { response: BatchGetMeasurementsResponse ->
         response.measurementsList
       }
@@ -1630,6 +1645,10 @@ class MetricsService(
     }
 
     val reportingSetNameToInternalReportingSetMap: Map<String, InternalReportingSet> = buildMap {
+      // reportingSetNames is deduplicated (.distinct() above) and bounded by how many distinct
+      // ReportingSets a report's Metrics reference (e.g. union/TV/Meta for a cross-media report,
+      // typically a handful), not by Metric count, so this never approaches
+      // BATCH_GET_REPORTING_SETS_LIMIT=1000 regardless of report size.
       submitBatchRequests(
           reportingSetNames.asFlow(),
           BATCH_GET_REPORTING_SETS_LIMIT,
@@ -1855,6 +1874,9 @@ class MetricsService(
       }
 
     return buildMap {
+      // externalPrimitiveReportingSetIds is deduplicated above and bounded by distinct primitive
+      // (single-DataProvider) ReportingSet count, not Metric count, so this is small regardless
+      // of report size for the same reason as the BATCH_GET_REPORTING_SETS_LIMIT call above.
       submitBatchRequests(
           externalPrimitiveReportingSetIds,
           BATCH_GET_REPORTING_SETS_LIMIT,

--- a/src/main/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/ReportSchedulesService.kt
+++ b/src/main/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/ReportSchedulesService.kt
@@ -674,6 +674,10 @@ class ReportSchedulesService(
       while (externalReportingSetIdSet.isNotEmpty()) {
         retrievedExternalReportingSetIdSet.addAll(externalReportingSetIdSet)
 
+        // This walks a composite ReportingSet's operand tree, bounded by the ReportingSet
+        // structure's own size (e.g. DataProvider/campaign composition), not by how many
+        // Metrics any Report generated from it will have, so it stays well under
+        // BATCH_GET_REPORTING_SETS_LIMIT=1000 regardless of report size.
         submitBatchRequests(
             externalReportingSetIdSet.asFlow(),
             BATCH_GET_REPORTING_SETS_LIMIT,

--- a/src/main/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/ReportSchedulesService.kt
+++ b/src/main/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/ReportSchedulesService.kt
@@ -674,10 +674,8 @@ class ReportSchedulesService(
       while (externalReportingSetIdSet.isNotEmpty()) {
         retrievedExternalReportingSetIdSet.addAll(externalReportingSetIdSet)
 
-        // This walks a composite ReportingSet's operand tree, bounded by the ReportingSet
-        // structure's own size (e.g. DataProvider/campaign composition), not by how many
-        // Metrics any Report generated from it will have, so it stays well under
-        // BATCH_GET_REPORTING_SETS_LIMIT=1000 regardless of report size.
+        // Bounded by the ReportingSet structure's own size, not by Metric count, so it
+        // doesn't share the Kingdom-dispatch concurrency flag.
         submitBatchRequests(
             externalReportingSetIdSet.asFlow(),
             BATCH_GET_REPORTING_SETS_LIMIT,

--- a/src/main/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/ReportSchedulesService.kt
+++ b/src/main/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/ReportSchedulesService.kt
@@ -678,6 +678,7 @@ class ReportSchedulesService(
             externalReportingSetIdSet.asFlow(),
             BATCH_GET_REPORTING_SETS_LIMIT,
             callRpc,
+            concurrency = 3,
           ) { response ->
             externalReportingSetIdSet.clear()
             response.reportingSetsList

--- a/src/main/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/ReportsService.kt
+++ b/src/main/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/ReportsService.kt
@@ -202,7 +202,8 @@ class ReportsService(
       batchGetMetrics(request.parent, items)
     }
     val externalIdToMetricMap: Map<String, Metric> = buildMap {
-      submitBatchRequests(metricNames, BATCH_GET_METRICS_LIMIT, callRpc) { response ->
+      submitBatchRequests(metricNames, BATCH_GET_METRICS_LIMIT, callRpc, concurrency = 3) { response
+          ->
           response.metricsList
         }
         .collect { metrics: List<Metric> ->
@@ -288,7 +289,8 @@ class ReportsService(
       batchGetMetrics(parent, items)
     }
     val externalIdToMetricMap: Map<String, Metric> = buildMap {
-      submitBatchRequests(metricNames, BATCH_GET_METRICS_LIMIT, callRpc) { response ->
+      submitBatchRequests(metricNames, BATCH_GET_METRICS_LIMIT, callRpc, concurrency = 3) { response
+          ->
           response.metricsList
         }
         .collect { metrics: List<Metric> ->
@@ -434,7 +436,12 @@ class ReportsService(
       batchCreateMetrics(request.parent, items)
     }
     val externalIdToMetricMap: Map<String, Metric> = buildMap {
-      submitBatchRequests(createMetricRequests, BATCH_CREATE_METRICS_LIMIT, callRpc) { response ->
+      submitBatchRequests(
+          createMetricRequests,
+          BATCH_CREATE_METRICS_LIMIT,
+          callRpc,
+          concurrency = 3,
+        ) { response ->
           response.metricsList
         }
         .collect { metrics: List<Metric> ->

--- a/src/main/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/ReportsService.kt
+++ b/src/main/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/ReportsService.kt
@@ -202,9 +202,6 @@ class ReportsService(
       batchGetMetrics(request.parent, items)
     }
     val externalIdToMetricMap: Map<String, Metric> = buildMap {
-      // metricNames is bounded by how many Metrics the Report being read has, which never
-      // exceeds BATCH_GET_METRICS_LIMIT=1000 for any report size seen so far, so this never
-      // needs more than one batch in practice.
       submitBatchRequests(metricNames, BATCH_GET_METRICS_LIMIT, callRpc, concurrency = 3) { response
           ->
           response.metricsList
@@ -292,9 +289,6 @@ class ReportsService(
       batchGetMetrics(parent, items)
     }
     val externalIdToMetricMap: Map<String, Metric> = buildMap {
-      // metricNames is bounded by how many Metrics the Report being read has, which never
-      // exceeds BATCH_GET_METRICS_LIMIT=1000 for any report size seen so far, so this never
-      // needs more than one batch in practice.
       submitBatchRequests(metricNames, BATCH_GET_METRICS_LIMIT, callRpc, concurrency = 3) { response
           ->
           response.metricsList
@@ -442,15 +436,9 @@ class ReportsService(
       batchCreateMetrics(request.parent, items)
     }
     val externalIdToMetricMap: Map<String, Metric> = buildMap {
-      // BATCH_CREATE_METRICS_LIMIT=1000 matches MetricsService's own MAX_BATCH_SIZE, so a
-      // report needs over 1000 Metrics before this chunks into more than one call to
-      // MetricsService.batchCreateMetrics -- beyond any report size exercised so far (~936,
-      // where the reporting server's memory ceiling becomes the binding constraint first).
       // Each chunk already fans out to Kingdom with its own concurrency via
       // kingdomMeasurementBatchConcurrency, so raising concurrency at this outer layer too
-      // would multiply Kingdom's effective concurrent load rather than add to it; that
-      // combination hasn't been measured, so this stays unconfigured until reports genuinely
-      // need more than one outer chunk.
+      // would multiply Kingdom's effective concurrent load rather than add to it.
       submitBatchRequests(
           createMetricRequests,
           BATCH_CREATE_METRICS_LIMIT,

--- a/src/main/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/ReportsService.kt
+++ b/src/main/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/ReportsService.kt
@@ -202,6 +202,9 @@ class ReportsService(
       batchGetMetrics(request.parent, items)
     }
     val externalIdToMetricMap: Map<String, Metric> = buildMap {
+      // metricNames is bounded by how many Metrics the Report being read has, which never
+      // exceeds BATCH_GET_METRICS_LIMIT=1000 for any report size seen so far, so this never
+      // needs more than one batch in practice.
       submitBatchRequests(metricNames, BATCH_GET_METRICS_LIMIT, callRpc, concurrency = 3) { response
           ->
           response.metricsList
@@ -289,6 +292,9 @@ class ReportsService(
       batchGetMetrics(parent, items)
     }
     val externalIdToMetricMap: Map<String, Metric> = buildMap {
+      // metricNames is bounded by how many Metrics the Report being read has, which never
+      // exceeds BATCH_GET_METRICS_LIMIT=1000 for any report size seen so far, so this never
+      // needs more than one batch in practice.
       submitBatchRequests(metricNames, BATCH_GET_METRICS_LIMIT, callRpc, concurrency = 3) { response
           ->
           response.metricsList
@@ -436,6 +442,15 @@ class ReportsService(
       batchCreateMetrics(request.parent, items)
     }
     val externalIdToMetricMap: Map<String, Metric> = buildMap {
+      // BATCH_CREATE_METRICS_LIMIT=1000 matches MetricsService's own MAX_BATCH_SIZE, so a
+      // report needs over 1000 Metrics before this chunks into more than one call to
+      // MetricsService.batchCreateMetrics -- beyond any report size exercised so far (~936,
+      // where the reporting server's memory ceiling becomes the binding constraint first).
+      // Each chunk already fans out to Kingdom with its own concurrency via
+      // kingdomMeasurementBatchConcurrency, so raising concurrency at this outer layer too
+      // would multiply Kingdom's effective concurrent load rather than add to it; that
+      // combination hasn't been measured, so this stays unconfigured until reports genuinely
+      // need more than one outer chunk.
       submitBatchRequests(
           createMetricRequests,
           BATCH_CREATE_METRICS_LIMIT,

--- a/src/test/kotlin/org/wfanet/measurement/reporting/service/api/SubmitBatchRequestsTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/reporting/service/api/SubmitBatchRequestsTest.kt
@@ -16,7 +16,7 @@
 
 package org.wfanet.measurement.reporting.service.api
 
-import com.google.common.truth.Truth.assertThat as assertThatValue
+import com.google.common.truth.Truth.assertThat
 import com.google.common.truth.extensions.proto.ProtoTruth.assertThat
 import io.grpc.Status
 import io.grpc.StatusException
@@ -157,7 +157,7 @@ class SubmitBatchRequestsTest {
 
     submitBatchRequests((1..10).asFlow(), 1, callRpc, concurrency = concurrency) { it }.toList()
 
-    assertThatValue(maxObservedConcurrency.get()).isEqualTo(concurrency)
+    assertThat(maxObservedConcurrency.get()).isEqualTo(concurrency)
   }
 
   @Test
@@ -175,11 +175,11 @@ class SubmitBatchRequestsTest {
 
       submitBatchRequests((1..10).asFlow(), 1, callRpc, concurrency = 3) { it }.toList()
 
-      assertThatValue(maxObservedConcurrency.get()).isEqualTo(3)
+      assertThat(maxObservedConcurrency.get()).isEqualTo(3)
     }
 
   @Test
-  fun `submitBatchRequests throws IllegalArgumentException when concurrency is zero`() =
+  fun `submitBatchRequests throws BatchRequestException wrapping IllegalArgumentException when concurrency is zero`() =
     runBlocking {
       val callRpc: suspend (List<Int>) -> List<Int> = { batch -> batch }
 
@@ -188,11 +188,11 @@ class SubmitBatchRequestsTest {
           submitBatchRequests((1..10).asFlow(), 1, callRpc, concurrency = 0) { it }.toList()
         }
 
-      assertThatValue(exception.cause).isInstanceOf(IllegalArgumentException::class.java)
+      assertThat(exception.cause).isInstanceOf(IllegalArgumentException::class.java)
     }
 
   @Test
-  fun `submitBatchRequests throws IllegalArgumentException when concurrency is negative`() =
+  fun `submitBatchRequests throws BatchRequestException wrapping IllegalArgumentException when concurrency is negative`() =
     runBlocking {
       val callRpc: suspend (List<Int>) -> List<Int> = { batch -> batch }
 
@@ -201,7 +201,7 @@ class SubmitBatchRequestsTest {
           submitBatchRequests((1..10).asFlow(), 1, callRpc, concurrency = -1) { it }.toList()
         }
 
-      assertThatValue(exception.cause).isInstanceOf(IllegalArgumentException::class.java)
+      assertThat(exception.cause).isInstanceOf(IllegalArgumentException::class.java)
     }
 
   @Test

--- a/src/test/kotlin/org/wfanet/measurement/reporting/service/api/SubmitBatchRequestsTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/reporting/service/api/SubmitBatchRequestsTest.kt
@@ -22,6 +22,7 @@ import io.grpc.Status
 import io.grpc.StatusException
 import java.util.concurrent.atomic.AtomicInteger
 import kotlin.math.ceil
+import kotlin.test.assertFailsWith
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.asFlow
 import kotlinx.coroutines.flow.emptyFlow
@@ -175,6 +176,32 @@ class SubmitBatchRequestsTest {
       submitBatchRequests((1..10).asFlow(), 1, callRpc, concurrency = 3) { it }.toList()
 
       assertThatValue(maxObservedConcurrency.get()).isEqualTo(3)
+    }
+
+  @Test
+  fun `submitBatchRequests throws IllegalArgumentException when concurrency is zero`() =
+    runBlocking {
+      val callRpc: suspend (List<Int>) -> List<Int> = { batch -> batch }
+
+      val exception =
+        assertFailsWith<BatchRequestException> {
+          submitBatchRequests((1..10).asFlow(), 1, callRpc, concurrency = 0) { it }.toList()
+        }
+
+      assertThatValue(exception.cause).isInstanceOf(IllegalArgumentException::class.java)
+    }
+
+  @Test
+  fun `submitBatchRequests throws IllegalArgumentException when concurrency is negative`() =
+    runBlocking {
+      val callRpc: suspend (List<Int>) -> List<Int> = { batch -> batch }
+
+      val exception =
+        assertFailsWith<BatchRequestException> {
+          submitBatchRequests((1..10).asFlow(), 1, callRpc, concurrency = -1) { it }.toList()
+        }
+
+      assertThatValue(exception.cause).isInstanceOf(IllegalArgumentException::class.java)
     }
 
   @Test

--- a/src/test/kotlin/org/wfanet/measurement/reporting/service/api/SubmitBatchRequestsTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/reporting/service/api/SubmitBatchRequestsTest.kt
@@ -92,6 +92,7 @@ class SubmitBatchRequestsTest {
             items,
             BATCH_GET_REPORTING_SETS_LIMIT,
             ::batchGetReportingSets,
+            concurrency = 3,
             parseResponse = parseResponse,
           )
           .toList()
@@ -125,6 +126,7 @@ class SubmitBatchRequestsTest {
             items,
             BATCH_GET_REPORTING_SETS_LIMIT,
             ::batchGetReportingSets,
+            concurrency = 3,
             parseResponse = parseResponse,
           )
           .toList()
@@ -158,21 +160,22 @@ class SubmitBatchRequestsTest {
   }
 
   @Test
-  fun `submitBatchRequests defaults concurrency to 3 when not specified`() = runBlocking {
-    val activeCalls = AtomicInteger(0)
-    val maxObservedConcurrency = AtomicInteger(0)
-    val callRpc: suspend (List<Int>) -> List<Int> = { batch ->
-      val current = activeCalls.incrementAndGet()
-      maxObservedConcurrency.updateAndGet { previous -> maxOf(previous, current) }
-      delay(50)
-      activeCalls.decrementAndGet()
-      batch
+  fun `submitBatchRequests limits concurrent calls to 3 when concurrency is explicitly 3`() =
+    runBlocking {
+      val activeCalls = AtomicInteger(0)
+      val maxObservedConcurrency = AtomicInteger(0)
+      val callRpc: suspend (List<Int>) -> List<Int> = { batch ->
+        val current = activeCalls.incrementAndGet()
+        maxObservedConcurrency.updateAndGet { previous -> maxOf(previous, current) }
+        delay(50)
+        activeCalls.decrementAndGet()
+        batch
+      }
+
+      submitBatchRequests((1..10).asFlow(), 1, callRpc, concurrency = 3) { it }.toList()
+
+      assertThatValue(maxObservedConcurrency.get()).isEqualTo(3)
     }
-
-    submitBatchRequests((1..10).asFlow(), 1, callRpc) { it }.toList()
-
-    assertThatValue(maxObservedConcurrency.get()).isEqualTo(3)
-  }
 
   @Test
   fun `submitBatchRequests returns empty list when the number of requests is 0`() = runBlocking {
@@ -185,6 +188,7 @@ class SubmitBatchRequestsTest {
           emptyFlow(),
           BATCH_GET_REPORTING_SETS_LIMIT,
           ::batchGetReportingSets,
+          concurrency = 3,
           parseResponse = parseResponse,
         )
         .toList()

--- a/src/test/kotlin/org/wfanet/measurement/reporting/service/api/SubmitBatchRequestsTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/reporting/service/api/SubmitBatchRequestsTest.kt
@@ -16,10 +16,13 @@
 
 package org.wfanet.measurement.reporting.service.api
 
+import com.google.common.truth.Truth.assertThat as assertThatValue
 import com.google.common.truth.extensions.proto.ProtoTruth.assertThat
 import io.grpc.Status
 import io.grpc.StatusException
+import java.util.concurrent.atomic.AtomicInteger
 import kotlin.math.ceil
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.asFlow
 import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.flow.toList
@@ -89,7 +92,7 @@ class SubmitBatchRequestsTest {
             items,
             BATCH_GET_REPORTING_SETS_LIMIT,
             ::batchGetReportingSets,
-            parseResponse,
+            parseResponse = parseResponse,
           )
           .toList()
           .flatten()
@@ -122,7 +125,7 @@ class SubmitBatchRequestsTest {
             items,
             BATCH_GET_REPORTING_SETS_LIMIT,
             ::batchGetReportingSets,
-            parseResponse,
+            parseResponse = parseResponse,
           )
           .toList()
           .flatten()
@@ -137,6 +140,41 @@ class SubmitBatchRequestsTest {
     }
 
   @Test
+  fun `submitBatchRequests limits concurrent calls to the given concurrency`() = runBlocking {
+    val activeCalls = AtomicInteger(0)
+    val maxObservedConcurrency = AtomicInteger(0)
+    val concurrency = 2
+    val callRpc: suspend (List<Int>) -> List<Int> = { batch ->
+      val current = activeCalls.incrementAndGet()
+      maxObservedConcurrency.updateAndGet { previous -> maxOf(previous, current) }
+      delay(50)
+      activeCalls.decrementAndGet()
+      batch
+    }
+
+    submitBatchRequests((1..10).asFlow(), 1, callRpc, concurrency = concurrency) { it }.toList()
+
+    assertThatValue(maxObservedConcurrency.get()).isEqualTo(concurrency)
+  }
+
+  @Test
+  fun `submitBatchRequests defaults concurrency to 3 when not specified`() = runBlocking {
+    val activeCalls = AtomicInteger(0)
+    val maxObservedConcurrency = AtomicInteger(0)
+    val callRpc: suspend (List<Int>) -> List<Int> = { batch ->
+      val current = activeCalls.incrementAndGet()
+      maxObservedConcurrency.updateAndGet { previous -> maxOf(previous, current) }
+      delay(50)
+      activeCalls.decrementAndGet()
+      batch
+    }
+
+    submitBatchRequests((1..10).asFlow(), 1, callRpc) { it }.toList()
+
+    assertThatValue(maxObservedConcurrency.get()).isEqualTo(3)
+  }
+
+  @Test
   fun `submitBatchRequests returns empty list when the number of requests is 0`() = runBlocking {
     val parseResponse: (BatchGetReportingSetsResponse) -> List<InternalReportingSet> = { response ->
       response.reportingSetsList
@@ -147,7 +185,7 @@ class SubmitBatchRequestsTest {
           emptyFlow(),
           BATCH_GET_REPORTING_SETS_LIMIT,
           ::batchGetReportingSets,
-          parseResponse,
+          parseResponse = parseResponse,
         )
         .toList()
         .flatten()

--- a/src/test/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/MetricsServiceTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/reporting/service/api/v2alpha/MetricsServiceTest.kt
@@ -2718,6 +2718,7 @@ class MetricsServiceTest {
         DEFAULT_VID_MODEL_LINE,
         MEASUREMENT_CONSUMER_MODEL_LINES,
         POPULATION_DATA_PROVIDER_NAME,
+        kingdomMeasurementBatchConcurrency = 8,
       )
   }
 
@@ -5948,6 +5949,7 @@ class MetricsServiceTest {
         DEFAULT_VID_MODEL_LINE,
         emptyMap(),
         POPULATION_DATA_PROVIDER_NAME,
+        kingdomMeasurementBatchConcurrency = 8,
       )
 
     wheneverBlocking {


### PR DESCRIPTION
The measurement-dispatch loop inside batchCreateMetrics limits concurrent Kingdom BatchCreateMeasurements calls to a hardcoded 3, found while investigating latency in the creation of reports with large numbers of metrics. Real timing measurements against a dev environment showed no server-side concurrency ceiling that would cap the benefit of a higher value.

This adds a --kingdom-measurement-batch-concurrency server flag, defaulting to 8, threaded through MetricsService into the Kingdom dispatch path and, since there is no reason Kingdom's tolerance would differ between a create and a get on the same data, also into the batch retrieval path used when syncing measurement status. The shared batching utility's concurrency parameter has no default; every other caller in this file and others continues to pass its own explicit value (typically 3), so no other batch dispatch behavior changes. The utility now also validates that concurrency is greater than 0, both there and at startup in each binary that reads this flag, so a misconfigured value fails fast with a clear error instead of only on first use.

Measured against a real report in a test environment, using actual Kingdom request timestamps rather than an estimate: raising this value from 3 to 8 is estimated to save roughly 1.5 to 3 seconds of total latency for a real large-scale report, depending on how many data providers are involved, or roughly 5 to 10 percent of the approximately 30 second request timeout referenced above. That makes this a real, low-risk, and essentially free improvement, but not the dominant contributor to that timeout. The larger contributor is a separate model line resolution issue addressed in #4372.

Issue: #4374
RELNOTES: Kingdom measurement batch concurrency (previously hardcoded to 3) is now configurable via the reporting server's new `--kingdom-measurement-batch-concurrency` flag, defaulting to 8. Operators running their own overlay may want to set this explicitly rather than relying on the default.
