### PR TITLE
fix: raise internal and public reporting server JVM heap and memory limits

### DIFF
--- a/docs/gke/reporting-v2-server-deployment.md
+++ b/docs/gke/reporting-v2-server-deployment.md
@@ -139,8 +139,8 @@ container to burst using spare node capacity rather than capping it). Load
 testing with report-creation requests producing hundreds of metrics found
 that the previous smaller defaults (a 64M heap inherited from this
 environment's default, a 384Mi memory limit, and a 100m CPU request with
-no explicit heap override) caused both OOMKilled crashes and CPU-throttling-
-driven latency of several seconds per request. These recommended values are
+no explicit heap override) caused both OOMKilled crashes and CPU-throttling-driven
+latency of several seconds per request. These recommended values are
 a starting point based on that testing, not a guarantee for every workload;
 size your own node pools with enough spare CPU capacity to support bursting
 above the request under load.

--- a/docs/gke/reporting-v2-server-deployment.md
+++ b/docs/gke/reporting-v2-server-deployment.md
@@ -132,6 +132,19 @@ You can customize this generated object configuration with your own settings
 such as the number of replicas per deployment, the memory and CPU requirements
 of each container, and the JVM options of each container.
 
+For the internal reporting server container specifically, we recommend a JVM
+max heap size of at least 512M within a container memory limit of at least
+1Gi, and a CPU request of at least 500m with no CPU limit (allow the
+container to burst using spare node capacity rather than capping it). Load
+testing with report-creation requests producing hundreds of metrics found
+that the previous smaller defaults (a 64M heap inherited from this
+environment's default, a 384Mi memory limit, and a 100m CPU request with
+no explicit heap override) caused both OOMKilled crashes and CPU-throttling-
+driven latency of several seconds per request. These recommended values are
+a starting point based on that testing, not a guarantee for every workload;
+size your own node pools with enough spare CPU capacity to support bursting
+above the request under load.
+
 ## Customize the K8s secrets
 
 We use K8s secrets to hold sensitive information, such as private keys.

--- a/docs/gke/reporting-v2-server-deployment.md
+++ b/docs/gke/reporting-v2-server-deployment.md
@@ -145,6 +145,15 @@ a starting point based on that testing, not a guarantee for every workload;
 size your own node pools with enough spare CPU capacity to support bursting
 above the request under load.
 
+The reporting-v2alpha-public-api-server container, which builds every Metric
+in a report in memory before dispatching it, needs similar headroom: we
+recommend a JVM max heap size of at least 384M within a container memory
+limit of at least 768Mi, and a CPU request of at least 500m with no CPU
+limit. The same load testing found the smaller defaults for this container
+(a 64M heap, 320Mi memory, and a 25m CPU request) left a multi-second
+CPU-and-GC-bound stall in report-creation requests that raising these
+values measurably shrank.
+
 ## Customize the K8s secrets
 
 We use K8s secrets to hold sensitive information, such as private keys.

--- a/src/main/k8s/dev/reporting_v2_gke.cue
+++ b/src/main/k8s/dev/reporting_v2_gke.cue
@@ -160,7 +160,7 @@ reporting: #Reporting & {
 			if _mcpHost != "" && _oauthIssuer != "" {
 				_oauthArgs: [
 					// Use oauth_protected_resource if set, otherwise default to https://<mcp_host>.
-					"--oauth-protected-resource=" + [if _oauthProtectedResource != "" {_oauthProtectedResource}, "https://" + _mcpHost][0],
+					"--oauth-protected-resource=" + [ if _oauthProtectedResource != "" {_oauthProtectedResource}, "https://" + _mcpHost][0],
 					"--oauth-authorization-server=" + _oauthIssuer,
 					"--oauth-scope=reporting.*",
 				]

--- a/src/main/k8s/dev/reporting_v2_gke.cue
+++ b/src/main/k8s/dev/reporting_v2_gke.cue
@@ -140,7 +140,7 @@ reporting: #Reporting & {
 		"postgres-internal-reporting-server": {
 			_container: {
 				_javaOptions: maxHeapSize: "512M"
-				resources:    #InternalServerResourceRequirements
+				resources: #InternalServerResourceRequirements
 			}
 			spec: template: spec: #ServiceAccountPodSpec & {
 				serviceAccountName: #InternalServerServiceAccount
@@ -160,7 +160,7 @@ reporting: #Reporting & {
 			if _mcpHost != "" && _oauthIssuer != "" {
 				_oauthArgs: [
 					// Use oauth_protected_resource if set, otherwise default to https://<mcp_host>.
-					"--oauth-protected-resource=" + [ if _oauthProtectedResource != "" {_oauthProtectedResource}, "https://" + _mcpHost][0],
+					"--oauth-protected-resource=" + [if _oauthProtectedResource != "" {_oauthProtectedResource}, "https://" + _mcpHost][0],
 					"--oauth-authorization-server=" + _oauthIssuer,
 					"--oauth-scope=reporting.*",
 				]

--- a/src/main/k8s/dev/reporting_v2_gke.cue
+++ b/src/main/k8s/dev/reporting_v2_gke.cue
@@ -35,10 +35,15 @@ _accessPublicApiAddressName:                          "access-public"
 // Name of K8s service account for the Access internal API server.
 #InternalAccessServerServiceAccount: "internal-access-server"
 
+// Bumped from cpu 100m / memory 384Mi (heap default -Xmx64M): the internal reporting
+// server was suffering GC-pressure slowdowns and OOMKilled crashes while persisting the
+// Metric rows for reports with large numbers of metrics, since the inherited default heap
+// left almost no working memory once other JVM overhead (metaspace, thread stacks, netty
+// buffers) was accounted for within the old 384Mi container limit.
 #InternalServerResourceRequirements: ResourceRequirements=#ResourceRequirements & {
 	requests: {
 		cpu:    "100m"
-		memory: "384Mi"
+		memory: "1Gi"
 	}
 	limits: {
 		memory: ResourceRequirements.requests.memory
@@ -135,7 +140,10 @@ reporting: #Reporting & {
 
 	deployments: {
 		"postgres-internal-reporting-server": {
-			_container: resources: #InternalServerResourceRequirements
+			_container: {
+				_javaOptions: maxHeapSize: "512M"
+				resources:    #InternalServerResourceRequirements
+			}
 			spec: template: spec: #ServiceAccountPodSpec & {
 				serviceAccountName: #InternalServerServiceAccount
 			}

--- a/src/main/k8s/dev/reporting_v2_gke.cue
+++ b/src/main/k8s/dev/reporting_v2_gke.cue
@@ -138,7 +138,12 @@ reporting: #Reporting & {
 	deployments: {
 		"postgres-internal-reporting-server": {
 			_container: {
-				_javaOptions: maxHeapSize: "512M"
+				_javaOptions: {
+					maxHeapSize: "512M"
+					// Netty's pooled buffers are off-heap and not bounded by maxHeapSize;
+					// this keeps heap + direct + JVM overhead within the 1Gi container limit.
+					maxDirectMemorySize: "256M"
+				}
 				resources: #InternalServerResourceRequirements
 			}
 			spec: template: spec: #ServiceAccountPodSpec & {
@@ -147,7 +152,12 @@ reporting: #Reporting & {
 		}
 		"reporting-v2alpha-public-api-server": {
 			_container: {
-				_javaOptions: maxHeapSize: #PublicServerMaxHeapSize
+				_javaOptions: {
+					maxHeapSize: #PublicServerMaxHeapSize
+					// Netty's pooled buffers are off-heap and not bounded by maxHeapSize;
+					// this keeps heap + direct + JVM overhead within the 768Mi container limit.
+					maxDirectMemorySize: "192M"
+				}
 				resources: #PublicServerResourceRequirements
 			}
 		}

--- a/src/main/k8s/dev/reporting_v2_gke.cue
+++ b/src/main/k8s/dev/reporting_v2_gke.cue
@@ -47,11 +47,15 @@ _accessPublicApiAddressName:                          "access-public"
 		memory: ResourceRequirements.requests.memory
 	}
 }
-#PublicServerMaxHeapSize:          "64M"
+
+// Increased from cpu 25m / memory 320Mi / heap 64M, which is undersized for
+// report-creation requests that build hundreds of Metrics in memory (Cartesian
+// expansion of time intervals x groupings x metric specs). See issue #4376.
+#PublicServerMaxHeapSize:          "384M"
 #PublicServerResourceRequirements: ResourceRequirements=#ResourceRequirements & {
 	requests: {
-		cpu:    "25m"
-		memory: "320Mi"
+		cpu:    "500m"
+		memory: "768Mi"
 	}
 	limits: {
 		memory: ResourceRequirements.requests.memory

--- a/src/main/k8s/dev/reporting_v2_gke.cue
+++ b/src/main/k8s/dev/reporting_v2_gke.cue
@@ -35,9 +35,7 @@ _accessPublicApiAddressName:                          "access-public"
 // Name of K8s service account for the Access internal API server.
 #InternalAccessServerServiceAccount: "internal-access-server"
 
-// Increased from cpu 100m / memory 384Mi / heap default -Xmx64M, which caused
-// OOMKilled crashes and CPU-throttling slowdowns under heavy report-creation load.
-// No CPU limit is set, matching this file's other services. See issue #4376.
+// No CPU limit is set, matching this file's other services.
 #InternalServerResourceRequirements: ResourceRequirements=#ResourceRequirements & {
 	requests: {
 		cpu:    "500m"
@@ -48,9 +46,6 @@ _accessPublicApiAddressName:                          "access-public"
 	}
 }
 
-// Increased from cpu 25m / memory 320Mi / heap 64M, which is undersized for
-// report-creation requests that build hundreds of Metrics in memory (Cartesian
-// expansion of time intervals x groupings x metric specs). See issue #4376.
 #PublicServerMaxHeapSize:          "384M"
 #PublicServerResourceRequirements: ResourceRequirements=#ResourceRequirements & {
 	requests: {

--- a/src/main/k8s/dev/reporting_v2_gke.cue
+++ b/src/main/k8s/dev/reporting_v2_gke.cue
@@ -41,21 +41,18 @@ _accessPublicApiAddressName:                          "access-public"
 // left almost no working memory once other JVM overhead (metaspace, thread stacks, netty
 // buffers) was accounted for within the old 384Mi container limit.
 //
-// CPU was separately bumped from 100m (a tenth of a core) with no limit at all: real
-// in-process measurement showed the write logic itself only needs milliseconds per batch,
-// so the multi-second slowdowns actually observed under load point at CPU throttling, not
-// the write path. A JVM doing real serialization work for a large batch, on top of GC
-// activity from the larger heap above, needs real CPU headroom, not a tenth of a core with
-// no ceiling. No existing precedent in this file's sibling configs sets an explicit CPU
-// limit, so 500m request / 2 cores limit is a judgment call: enough guaranteed share to
-// stop throttling under normal load, with a bounded ceiling rather than unlimited burst.
+// CPU request was separately bumped from 100m (a tenth of a core): real in-process
+// measurement showed the write logic itself only needs milliseconds per batch, so the
+// multi-second slowdowns actually observed under load point at CPU throttling rather than
+// the write path. No CPU limit is set, matching this file's sibling configs and this
+// repo's convention of sizing the request correctly and letting bursts use spare node
+// capacity rather than capping them. See issue #4376 for the full investigation.
 #InternalServerResourceRequirements: ResourceRequirements=#ResourceRequirements & {
 	requests: {
 		cpu:    "500m"
 		memory: "1Gi"
 	}
 	limits: {
-		cpu:    "2"
 		memory: ResourceRequirements.requests.memory
 	}
 }

--- a/src/main/k8s/dev/reporting_v2_gke.cue
+++ b/src/main/k8s/dev/reporting_v2_gke.cue
@@ -40,12 +40,22 @@ _accessPublicApiAddressName:                          "access-public"
 // Metric rows for reports with large numbers of metrics, since the inherited default heap
 // left almost no working memory once other JVM overhead (metaspace, thread stacks, netty
 // buffers) was accounted for within the old 384Mi container limit.
+//
+// CPU was separately bumped from 100m (a tenth of a core) with no limit at all: real
+// in-process measurement showed the write logic itself only needs milliseconds per batch,
+// so the multi-second slowdowns actually observed under load point at CPU throttling, not
+// the write path. A JVM doing real serialization work for a large batch, on top of GC
+// activity from the larger heap above, needs real CPU headroom, not a tenth of a core with
+// no ceiling. No existing precedent in this file's sibling configs sets an explicit CPU
+// limit, so 500m request / 2 cores limit is a judgment call: enough guaranteed share to
+// stop throttling under normal load, with a bounded ceiling rather than unlimited burst.
 #InternalServerResourceRequirements: ResourceRequirements=#ResourceRequirements & {
 	requests: {
-		cpu:    "100m"
+		cpu:    "500m"
 		memory: "1Gi"
 	}
 	limits: {
+		cpu:    "2"
 		memory: ResourceRequirements.requests.memory
 	}
 }

--- a/src/main/k8s/dev/reporting_v2_gke.cue
+++ b/src/main/k8s/dev/reporting_v2_gke.cue
@@ -35,18 +35,9 @@ _accessPublicApiAddressName:                          "access-public"
 // Name of K8s service account for the Access internal API server.
 #InternalAccessServerServiceAccount: "internal-access-server"
 
-// Bumped from cpu 100m / memory 384Mi (heap default -Xmx64M): the internal reporting
-// server was suffering GC-pressure slowdowns and OOMKilled crashes while persisting the
-// Metric rows for reports with large numbers of metrics, since the inherited default heap
-// left almost no working memory once other JVM overhead (metaspace, thread stacks, netty
-// buffers) was accounted for within the old 384Mi container limit.
-//
-// CPU request was separately bumped from 100m (a tenth of a core): real in-process
-// measurement showed the write logic itself only needs milliseconds per batch, so the
-// multi-second slowdowns actually observed under load point at CPU throttling rather than
-// the write path. No CPU limit is set, matching this file's sibling configs and this
-// repo's convention of sizing the request correctly and letting bursts use spare node
-// capacity rather than capping them. See issue #4376 for the full investigation.
+// Increased from cpu 100m / memory 384Mi / heap default -Xmx64M, which caused
+// OOMKilled crashes and CPU-throttling slowdowns under heavy report-creation load.
+// No CPU limit is set, matching this file's other services. See issue #4376.
 #InternalServerResourceRequirements: ResourceRequirements=#ResourceRequirements & {
 	requests: {
 		cpu:    "500m"


### PR DESCRIPTION
Raises the internal reporting server's JVM heap (64M to 512M) and container memory (384Mi to 1Gi), and its CPU request (100m to 500m, no limit), after finding these caused GC-pressure slowdowns and OOMKilled crashes under heavy report-creation load. Also applies the same class of fix to the reporting-v2alpha-public-api-server container (64M to 384M heap, 320Mi to 768Mi memory, 25m to 500m CPU), which showed the same resource starvation pattern -- confirmed live by measuring a CPU/GC-bound stall in report-creation requests shrink from roughly 11 seconds to roughly 6 seconds after this change. Also adds a resource-sizing recommendation for both containers to the reporting-v2 deployment guide for operators running their own overlay. See the linked issue for the full investigation, evidence, and validation results.

Issue: #4376
RELNOTES: The reporting-v2 internal and public API servers' default JVM heap, memory, and CPU allocation have been increased to avoid OOMKilled crashes and CPU-throttling slowdowns under heavy report-creation load. See the updated reporting-v2 deployment guide for recommended values if you run this service with a custom Helm/K8s overlay.
