### PR TITLE
perf: fix index-defeating query plan in MetricReader.readMetrics

### DIFF
--- a/src/main/kotlin/org/wfanet/measurement/reporting/deploy/v2/postgres/readers/MetricReader.kt
+++ b/src/main/kotlin/org/wfanet/measurement/reporting/deploy/v2/postgres/readers/MetricReader.kt
@@ -634,6 +634,11 @@ class MetricReader(private val readContext: ReadContext) {
   }
 
   fun readMetrics(request: StreamMetricsRequest): Flow<Result> {
+    // MeasurementConsumerId is resolved in a separate round trip and bound as a literal below,
+    // rather than filtering on CmmsMeasurementConsumerId directly: Postgres cannot use the
+    // (MeasurementConsumerId, ExternalMetricId) index for the ORDER BY + LIMIT when the id is
+    // resolved inline (join or CTE) instead of bound as a constant, and falls back to a full
+    // scan of Metrics that gets slower as the table grows.
     val sql =
       """
         $baseSqlSelect
@@ -669,7 +674,7 @@ class MetricReader(private val readContext: ReadContext) {
             CmmsModelLineName
           FROM MeasurementConsumers
             JOIN Metrics USING (MeasurementConsumerId)
-          WHERE CmmsMeasurementConsumerId = $1
+          WHERE MeasurementConsumers.MeasurementConsumerId = $1
             AND ExternalMetricId > $2
           ORDER BY ExternalMetricId ASC
           LIMIT $3
@@ -679,18 +684,23 @@ class MetricReader(private val readContext: ReadContext) {
       """
         .trimIndent()
 
-    val statement =
-      boundStatement(sql) {
-        bind("$1", request.filter.cmmsMeasurementConsumerId)
-        bind("$2", request.filter.externalMetricIdAfter)
-        if (request.limit > 0) {
-          bind("$3", request.limit)
-        } else {
-          bind("$3", 50)
-        }
-      }
-
     return flow {
+      val measurementConsumerId: InternalId =
+        MeasurementConsumerReader(readContext)
+          .getByCmmsId(request.filter.cmmsMeasurementConsumerId)
+          ?.measurementConsumerId ?: return@flow
+
+      val statement =
+        boundStatement(sql) {
+          bind("$1", measurementConsumerId)
+          bind("$2", request.filter.externalMetricIdAfter)
+          if (request.limit > 0) {
+            bind("$3", request.limit)
+          } else {
+            bind("$3", 50)
+          }
+        }
+
       val metricInfoMap = buildResultMap(statement)
 
       for (entry in metricInfoMap) {

--- a/src/main/kotlin/org/wfanet/measurement/reporting/service/internal/testing/v2/MetricsServiceTest.kt
+++ b/src/main/kotlin/org/wfanet/measurement/reporting/service/internal/testing/v2/MetricsServiceTest.kt
@@ -3410,6 +3410,23 @@ abstract class MetricsServiceTest<T : MetricsCoroutineImplBase> {
   }
 
   @Test
+  fun `streamMetrics returns empty flow when measurement consumer does not exist`() = runBlocking {
+    val retrievedMetrics =
+      service
+        .streamMetrics(
+          streamMetricsRequest {
+            filter =
+              StreamMetricsRequestKt.filter {
+                cmmsMeasurementConsumerId = CMMS_MEASUREMENT_CONSUMER_ID
+              }
+          }
+        )
+        .toList()
+
+    assertThat(retrievedMetrics).hasSize(0)
+  }
+
+  @Test
   fun `streamMetrics throws INVALID_ARGUMENT when MC filter missing`() = runBlocking {
     val exception =
       assertFailsWith<StatusRuntimeException> { service.streamMetrics(streamMetricsRequest {}) }


### PR DESCRIPTION
readMetrics resolved MeasurementConsumerId via an inline join on CmmsMeasurementConsumerId, which prevented Postgres from using the existing index for the query's ORDER BY + LIMIT and fell back to a full sequential scan of the Metrics table -- a cost that scales with table size. Resolves the id via a separate lookup and binds it as a literal instead, which restores the index scan. See the linked issue for the full investigation and verification.

Issue: #4381
