### PR TITLE
perf: replace wasteful join in CreateMetrics existence check

### DIFF
--- a/src/main/kotlin/org/wfanet/measurement/reporting/deploy/v2/postgres/readers/MetricReader.kt
+++ b/src/main/kotlin/org/wfanet/measurement/reporting/deploy/v2/postgres/readers/MetricReader.kt
@@ -25,6 +25,7 @@ import java.time.ZoneOffset
 import java.util.UUID
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.flow.flow
 import org.wfanet.measurement.common.db.r2dbc.BoundStatement
 import org.wfanet.measurement.common.db.r2dbc.ReadContext
@@ -546,6 +547,42 @@ class MetricReader(private val readContext: ReadContext) {
     readContext.executeQuery(statement).consume(translate).collect {}
 
     return reportingMetricMap
+  }
+
+  /**
+   * Returns whether any [Metric] with one of [externalMetricIds] already exists for
+   * [measurementConsumerId].
+   *
+   * Unlike [batchGetMetrics], this does not join in ReportingSets/Measurements/etc, since callers
+   * that only need existence would otherwise pay for that join just to discard the result.
+   */
+  suspend fun metricsExist(
+    measurementConsumerId: InternalId,
+    externalMetricIds: Collection<String>,
+  ): Boolean {
+    if (externalMetricIds.isEmpty()) {
+      return false
+    }
+
+    val statement =
+      valuesListBoundStatement(
+        valuesStartIndex = 1,
+        paramCount = 1,
+        """
+          SELECT 1
+          FROM Metrics
+          JOIN (VALUES ${ValuesListBoundStatement.VALUES_LIST_PLACEHOLDER})
+            AS c(ExternalMetricId) USING (ExternalMetricId)
+          WHERE MeasurementConsumerId = $1
+          LIMIT 1
+        """
+          .trimIndent(),
+      ) {
+        bind("$1", measurementConsumerId)
+        externalMetricIds.forEach { addValuesBinding { bindValuesParam(0, it) } }
+      }
+
+    return readContext.executeQuery(statement).consume { true }.firstOrNull() ?: false
   }
 
   fun batchGetMetrics(request: BatchGetMetricsRequest): Flow<Result> {

--- a/src/main/kotlin/org/wfanet/measurement/reporting/deploy/v2/postgres/readers/MetricReader.kt
+++ b/src/main/kotlin/org/wfanet/measurement/reporting/deploy/v2/postgres/readers/MetricReader.kt
@@ -550,11 +550,10 @@ class MetricReader(private val readContext: ReadContext) {
   }
 
   /**
-   * Returns whether any [Metric] with one of [externalMetricIds] already exists for
+   * Returns whether any [Metric] with one of [externalMetricIds] exists for
    * [measurementConsumerId].
    *
-   * Unlike [batchGetMetrics], this does not join in ReportingSets/Measurements/etc, since callers
-   * that only need existence would otherwise pay for that join just to discard the result.
+   * Reads only from Metrics; use [batchGetMetrics] when the matched rows are needed.
    */
   suspend fun metricsExist(
     measurementConsumerId: InternalId,

--- a/src/main/kotlin/org/wfanet/measurement/reporting/deploy/v2/postgres/writers/CreateMetrics.kt
+++ b/src/main/kotlin/org/wfanet/measurement/reporting/deploy/v2/postgres/writers/CreateMetrics.kt
@@ -31,13 +31,11 @@ import org.wfanet.measurement.common.toDuration
 import org.wfanet.measurement.common.toInstant
 import org.wfanet.measurement.common.toJson
 import org.wfanet.measurement.common.toProtoTime
-import org.wfanet.measurement.internal.reporting.v2.BatchGetMetricsRequest
 import org.wfanet.measurement.internal.reporting.v2.CreateMetricRequest
 import org.wfanet.measurement.internal.reporting.v2.Measurement
 import org.wfanet.measurement.internal.reporting.v2.Metric
 import org.wfanet.measurement.internal.reporting.v2.MetricSpec
 import org.wfanet.measurement.internal.reporting.v2.ReportingSet
-import org.wfanet.measurement.internal.reporting.v2.batchGetMetricsRequest
 import org.wfanet.measurement.internal.reporting.v2.copy
 import org.wfanet.measurement.reporting.deploy.v2.postgres.readers.MeasurementConsumerReader
 import org.wfanet.measurement.reporting.deploy.v2.postgres.readers.MetricReader
@@ -139,21 +137,12 @@ class CreateMetrics(private val requests: List<CreateMetricRequest>) :
         }
         .toSet()
 
-    if (externalIdsSet.isNotEmpty()) {
-      val batchGetMetricsRequest: BatchGetMetricsRequest = batchGetMetricsRequest {
-        this.cmmsMeasurementConsumerId = cmmsMeasurementConsumerId
-        externalMetricIds += externalIdsSet
-      }
-      // If there is any metrics found, it means there are metrics already existing with different
+    // Existence-only check: avoids the ReportingSets/Measurements/etc join that
+    // batchGetMetrics() pays for, since only presence -- not the matched rows -- is needed here.
+    if (MetricReader(transactionContext).metricsExist(measurementConsumerId, externalIdsSet)) {
+      // If there is any metric found, it means there are metrics already existing with different
       // request IDs or without request IDs.
-      if (
-        MetricReader(transactionContext)
-          .batchGetMetrics(batchGetMetricsRequest)
-          .toList()
-          .isNotEmpty()
-      ) {
-        throw MetricAlreadyExistsException()
-      }
+      throw MetricAlreadyExistsException()
     }
 
     val externalReportingSetIds = buildSet {

--- a/src/main/kotlin/org/wfanet/measurement/reporting/service/internal/testing/v2/MetricsServiceTest.kt
+++ b/src/main/kotlin/org/wfanet/measurement/reporting/service/internal/testing/v2/MetricsServiceTest.kt
@@ -984,6 +984,35 @@ abstract class MetricsServiceTest<T : MetricsCoroutineImplBase> {
     }
 
   @Test
+  fun `createMetric succeeds when different measurement consumers reuse the same external metric id`() =
+    runBlocking {
+      createMeasurementConsumer(CMMS_MEASUREMENT_CONSUMER_ID, measurementConsumersService)
+      val differentCmmsMeasurementConsumerId = CMMS_MEASUREMENT_CONSUMER_ID + 2
+      createMeasurementConsumer(differentCmmsMeasurementConsumerId, measurementConsumersService)
+
+      val createdMetric =
+        service.createMetric(
+          createCreateMetricRequest(
+            CMMS_MEASUREMENT_CONSUMER_ID,
+            reportingSetsService,
+            "sharedExternalMetricId",
+          )
+        )
+      val createdMetric2 =
+        service.createMetric(
+          createCreateMetricRequest(
+            differentCmmsMeasurementConsumerId,
+            reportingSetsService,
+            "sharedExternalMetricId",
+          )
+        )
+
+      assertThat(createdMetric.externalMetricId).isEqualTo(createdMetric2.externalMetricId)
+      assertThat(createdMetric.cmmsMeasurementConsumerId)
+        .isNotEqualTo(createdMetric2.cmmsMeasurementConsumerId)
+    }
+
+  @Test
   fun `createMetric throws NOT_FOUND when ReportingSet in basis not found`() = runBlocking {
     createMeasurementConsumer(CMMS_MEASUREMENT_CONSUMER_ID, measurementConsumersService)
     val createdReportingSet = createReportingSet(CMMS_MEASUREMENT_CONSUMER_ID, reportingSetsService)

--- a/src/main/kotlin/org/wfanet/measurement/reporting/service/internal/testing/v2/MetricsServiceTest.kt
+++ b/src/main/kotlin/org/wfanet/measurement/reporting/service/internal/testing/v2/MetricsServiceTest.kt
@@ -1809,6 +1809,44 @@ abstract class MetricsServiceTest<T : MetricsCoroutineImplBase> {
     }
 
   @Test
+  fun `batchCreateMetrics succeeds when different measurement consumers reuse the same external metric id`() =
+    runBlocking {
+      createMeasurementConsumer(CMMS_MEASUREMENT_CONSUMER_ID, measurementConsumersService)
+      val differentCmmsMeasurementConsumerId = CMMS_MEASUREMENT_CONSUMER_ID + 2
+      createMeasurementConsumer(differentCmmsMeasurementConsumerId, measurementConsumersService)
+
+      val response =
+        service.batchCreateMetrics(
+          batchCreateMetricsRequest {
+            cmmsMeasurementConsumerId = CMMS_MEASUREMENT_CONSUMER_ID
+            requests +=
+              createCreateMetricRequest(
+                CMMS_MEASUREMENT_CONSUMER_ID,
+                reportingSetsService,
+                "sharedExternalMetricId",
+              )
+          }
+        )
+      val response2 =
+        service.batchCreateMetrics(
+          batchCreateMetricsRequest {
+            cmmsMeasurementConsumerId = differentCmmsMeasurementConsumerId
+            requests +=
+              createCreateMetricRequest(
+                differentCmmsMeasurementConsumerId,
+                reportingSetsService,
+                "sharedExternalMetricId",
+              )
+          }
+        )
+
+      assertThat(response.metricsList.single().externalMetricId)
+        .isEqualTo(response2.metricsList.single().externalMetricId)
+      assertThat(response.metricsList.single().cmmsMeasurementConsumerId)
+        .isNotEqualTo(response2.metricsList.single().cmmsMeasurementConsumerId)
+    }
+
+  @Test
   fun `batchCreateMetrics throws INVALID_ARGUMENT when metrics have the same resource ID`() =
     runBlocking {
       createMeasurementConsumer(CMMS_MEASUREMENT_CONSUMER_ID, measurementConsumersService)


### PR DESCRIPTION
CreateMetrics called MetricReader.batchGetMetrics(...).toList().isNotEmpty() purely to test whether an external metric id already exists under a different request, but that method joins across ReportingSets, Measurements, MetricMeasurements, and several other tables to build full result rows the caller immediately discards. Adds a lightweight MetricReader.metricsExist() that touches only the Metrics table for this check. See the linked issue for the full investigation and verification.

Issue: #4381
