### PR TITLE
Raise requisition-fetcher Cloud Function memory to 2048MB

### DIFF
--- a/src/main/terraform/gcloud/modules/edp-aggregator/main.tf
+++ b/src/main/terraform/gcloud/modules/edp-aggregator/main.tf
@@ -339,6 +339,12 @@ module "requisition_fetcher_cloud_function" {
   # rather than firing rejected requests mid-drain.
   timeout_seconds = 600
   max_instances   = 1
+  # 512MB (the module default) suffices for a small, steady-state UNFULFILLED backlog, but this
+  # data provider has accumulated a large one (see cross-media-measurement#4298 investigation),
+  # and every invocation streams the *entire* UNFULFILLED backlog with no persisted cursor before
+  # any of it is dropped from the buffer. Raised to give that streaming/grouping headroom; revisit
+  # downward once the backlog is drained and stays small, or raise further if it recurs.
+  memory = "2048MB"
 }
 
 module "requisition_fetcher_cloud_scheduler" {

--- a/src/main/terraform/gcloud/modules/http-cloud-function/main.tf
+++ b/src/main/terraform/gcloud/modules/http-cloud-function/main.tf
@@ -48,6 +48,7 @@ resource "terraform_data" "deploy_http_cloud_function" {
     var.config_path != null ? filesha256(var.config_path) : "",
     var.timeout_seconds,
     var.max_instances,
+    var.memory,
   ]
 
   provisioner "local-exec" {
@@ -62,6 +63,7 @@ resource "terraform_data" "deploy_http_cloud_function" {
       UBER_JAR_DIRECTORY  = dirname(var.uber_jar_path)
       TIMEOUT_SECONDS     = var.timeout_seconds == null ? "" : tostring(var.timeout_seconds)
       MAX_INSTANCES       = var.max_instances == null ? "" : tostring(var.max_instances)
+      MEMORY              = var.memory
     }
     command = <<-EOT
       #!/bin/bash
@@ -72,12 +74,11 @@ resource "terraform_data" "deploy_http_cloud_function" {
         "--gen2"
         "--runtime=java17"
         "--entry-point=$ENTRY_POINT"
-        # 512MB suffices for test environments. The requisition-fetcher groups a report's
-        # requisitions in memory before writing one blob; a data provider with large reports
-        # (or rare ~1MB requisitions) can need substantially more headroom — up to 8GiB (Cloud
-        # Functions 2nd gen max) — and its MAX_TOTAL_BUFFERED_BYTES should be raised to match.
-        # Size per environment rather than assuming this default holds for larger workloads.
-        "--memory=512MB"
+        # Callers that buffer large in-memory state before writing (e.g. the
+        # requisition-fetcher, which groups a report's requisitions before writing one blob)
+        # should raise this via the memory variable — up to 8GiB, the Cloud Functions 2nd gen
+        # max — and size MAX_TOTAL_BUFFERED_BYTES to match.
+        "--memory=$MEMORY"
         "--region=$CLOUD_REGION"
         "--run-service-account=$RUN_SERVICE_ACCOUNT"
         "--source=$UBER_JAR_DIRECTORY"

--- a/src/main/terraform/gcloud/modules/http-cloud-function/variables.tf
+++ b/src/main/terraform/gcloud/modules/http-cloud-function/variables.tf
@@ -80,3 +80,9 @@ variable "max_instances" {
   nullable    = true
   default     = null
 }
+
+variable "memory" {
+  description = "The amount of memory allocated to the Cloud Function (e.g. \"512MB\", \"2048MB\")."
+  type        = string
+  default     = "512MB"
+}


### PR DESCRIPTION
dev requisition-fetcher has been crashing with repeated OutOfMemoryError while streaming a large accumulated UNFULFILLED backlog for one data provider. It buffers requisitions in memory before writing each report's blob and has no persisted cursor across invocations, so every run re-streams the entire backlog from scratch. The in-memory buffering backstop tracks serialized proto size, which understates actual retained JVM heap for parsed protobuf messages, leaving too little real headroom in the 512MB default container.

Adds `memory` as an optional module variable on the shared http-cloud-function module (default 512MB, matching prior behavior for every other caller) and overrides it to 2048MB for requisition-fetcher only.

Issue: NA