### PR TITLE
Raise requisition-fetcher HTTP timeout in EDPA correctness test

### DIFF
--- a/src/test/kotlin/org/wfanet/measurement/integration/k8s/EdpAggregatorCorrectnessTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/integration/k8s/EdpAggregatorCorrectnessTest.kt
@@ -412,7 +412,11 @@ class EdpAggregatorCorrectnessTest : AbstractEdpAggregatorCorrectnessTest(measur
             val request =
               HttpRequest.newBuilder()
                 .uri(URI.create(requisitionFetcherEndpoint))
-                .timeout(Duration.ofSeconds(120))
+                // The fetcher streams every UNFULFILLED requisition for its data provider on
+                // each invocation with no persisted cursor, so its response time scales with
+                // however large that data provider's backlog happens to be, not with the
+                // handful of requisitions this test just created.
+                .timeout(Duration.ofSeconds(REQUISITION_FETCHER_HTTP_TIMEOUT_SECONDS))
                 .header("Authorization", "Bearer $jwt")
                 .GET()
                 .build()
@@ -486,6 +490,7 @@ class EdpAggregatorCorrectnessTest : AbstractEdpAggregatorCorrectnessTest(measur
 
     companion object {
       private const val REQUISITIONS_SYNC_TIMEOUT = 60_000L * 5
+      private const val REQUISITION_FETCHER_HTTP_TIMEOUT_SECONDS = 300L
       private const val REQUISITIONS_SYNC_POLLING_INTERVAL = 5000L
 
       private val channels = mutableListOf<ManagedChannel>()


### PR DESCRIPTION
triggerRequisitionFetcher() calls the fetchers HTTP endpoint directly and waits synchronously for its response. The fetcher streams every UNFULFILLED requisition for its data provider on each invocation with no persisted cursor (see #4391), so its response time scales with that data providers entire backlog rather than the handful of requisitions this test just created. Under a nontrivial backlog, 120s was too tight and the test failed on `check(response.statusCode() == 200)` even though the fetcher was working correctly and just still running.

Raised to 300s to match the tests own outer REQUISITIONS_SYNC_TIMEOUT, with a comment explaining why.

Issue: NA