### PR TITLE
Raise default ListRequisitions page size to reduce rate-limit hits

### DIFF
--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/requisitionfetcher/RequisitionFetcher.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/requisitionfetcher/RequisitionFetcher.kt
@@ -864,8 +864,10 @@ class RequisitionFetcher(
     // The ListRequisitions rate limit bucket for this RPC is shared across all pages a
     // fetch cycle issues (see kingdom_rate_limit_config.textproto), so a small page size
     // makes a data provider with a large backlog exceed it purely from page count, not
-    // request rate. 500 is the API's stated maximum page size (larger values are coerced
-    // down), minimizing the number of pages needed per fetch cycle.
-    private const val KINGDOM_LIST_REQUISITIONS_DEFAULT_PAGE_SIZE: Int = 500
+    // request rate. Larger pages reduce page count but cost more per call: empirically,
+    // page sizes at and above 300 against dev regularly exceed the RPC deadline (each
+    // Requisition includes a full encrypted spec), while 200 consistently succeeds. 100
+    // keeps a margin below that empirically-observed cliff.
+    private const val KINGDOM_LIST_REQUISITIONS_DEFAULT_PAGE_SIZE: Int = 100
   }
 }

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/requisitionfetcher/RequisitionFetcher.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/requisitionfetcher/RequisitionFetcher.kt
@@ -861,6 +861,11 @@ class RequisitionFetcher(
     val DEFAULT_FLUSH_INTERVAL: Duration = Duration.ofMinutes(5)
     const val DEFAULT_CHANNEL_CAPACITY: Int = 4
     const val MIN_LIST_REQUISITIONS_PAGE_SIZE: Int = 1
-    private const val KINGDOM_LIST_REQUISITIONS_DEFAULT_PAGE_SIZE: Int = 10
+    // The ListRequisitions rate limit bucket for this RPC is shared across all pages a
+    // fetch cycle issues (see kingdom_rate_limit_config.textproto), so a small page size
+    // makes a data provider with a large backlog exceed it purely from page count, not
+    // request rate. 500 is the API's stated maximum page size (larger values are coerced
+    // down), minimizing the number of pages needed per fetch cycle.
+    private const val KINGDOM_LIST_REQUISITIONS_DEFAULT_PAGE_SIZE: Int = 500
   }
 }

--- a/src/test/kotlin/org/wfanet/measurement/edpaggregator/requisitionfetcher/RequisitionFetcherTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/edpaggregator/requisitionfetcher/RequisitionFetcherTest.kt
@@ -181,6 +181,7 @@ class RequisitionFetcherTest {
     maxTotalBufferedBytes: Long = RequisitionFetcher.DEFAULT_MAX_TOTAL_BUFFERED_BYTES,
     maxRequisitionsPerGroup: Int = RequisitionFetcher.DEFAULT_MAX_REQUISITIONS_PER_GROUP,
     metadataThrottler: Throttler = this.throttler,
+    responsePageSize: Int? = null,
   ): RequisitionFetcher {
     val validator =
       RequisitionsValidator(
@@ -208,6 +209,7 @@ class RequisitionFetcherTest {
       maxTotalBufferedBytes = maxTotalBufferedBytes,
       maxRequisitionsPerGroup = maxRequisitionsPerGroup,
       metrics = metrics,
+      responsePageSize = responsePageSize,
     )
   }
 
@@ -699,7 +701,7 @@ class RequisitionFetcherTest {
         listRequisitionsResponse { requisitions += r1 }
       }
 
-      createFetcher().fetchAndStoreRequisitions()
+      createFetcher(responsePageSize = 10).fetchAndStoreRequisitions()
 
       assertThat(captured).hasSize(4)
       assertThat(captured[0]).isEqualTo(10)
@@ -742,7 +744,7 @@ class RequisitionFetcherTest {
       }
     }
 
-    createFetcher().fetchAndStoreRequisitions()
+    createFetcher(responsePageSize = 10).fetchAndStoreRequisitions()
 
     assertThat(captured).containsExactly(10, 5, 5).inOrder()
   }


### PR DESCRIPTION
KINGDOM_LIST_REQUISITIONS_DEFAULT_PAGE_SIZE was 10. Kingdoms ListRequisitions rate limit bucket (20 burst, 5/sec average, see kingdom_rate_limit_config.textproto) is shared across every page a single fetch cycle issues, so a data provider with a nontrivial UNFULFILLED backlog can exceed it purely from page count -- e.g. ~9,000 requisitions needs ~90 sequential calls at page size 100.

Found while investigating an EDPA cloud test failure on dev: requisition-fetcher was intermittently failing with `UNAVAILABLE: Rate limit exceeded` while paginating through a data providers backlog.

Initially raised this to 500 (the APIs stated max page size), but empirically that regularly exceeds the RPC deadline against dev -- each Requisition includes a full encrypted spec, and page sizes at and above 300 consistently timed out while 200 consistently succeeded. Settled on 100 for margin below that observed cliff.

Decoupled the two page-size-halving tests from this default by adding an explicit `responsePageSize` test parameter, so they keep testing the halving mechanism itself rather than this specific tuned value.

Issue: NA