### PR TITLE
fix: make requisition-fetcher resilient to a large UNFULFILLED backlog

### DIFF
--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/requisitionfetcher/RequisitionFetcher.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/requisitionfetcher/RequisitionFetcher.kt
@@ -861,6 +861,13 @@ class RequisitionFetcher(
     val DEFAULT_FLUSH_INTERVAL: Duration = Duration.ofMinutes(5)
     const val DEFAULT_CHANNEL_CAPACITY: Int = 4
     const val MIN_LIST_REQUISITIONS_PAGE_SIZE: Int = 1
-    private const val KINGDOM_LIST_REQUISITIONS_DEFAULT_PAGE_SIZE: Int = 10
+    // The ListRequisitions rate limit bucket for this RPC is shared across all pages a
+    // fetch cycle issues (see kingdom_rate_limit_config.textproto), so a small page size
+    // makes a data provider with a large backlog exceed it purely from page count, not
+    // request rate. Larger pages reduce page count but cost more per call: empirically,
+    // page sizes at and above 300 against dev regularly exceed the RPC deadline (each
+    // Requisition includes a full encrypted spec), while 200 consistently succeeds. 100
+    // keeps a margin below that empirically-observed cliff.
+    private const val KINGDOM_LIST_REQUISITIONS_DEFAULT_PAGE_SIZE: Int = 100
   }
 }

--- a/src/main/terraform/gcloud/modules/edp-aggregator/main.tf
+++ b/src/main/terraform/gcloud/modules/edp-aggregator/main.tf
@@ -339,6 +339,12 @@ module "requisition_fetcher_cloud_function" {
   # rather than firing rejected requests mid-drain.
   timeout_seconds = 600
   max_instances   = 1
+  # 512MB (the module default) suffices for a small, steady-state UNFULFILLED backlog, but this
+  # data provider has accumulated a large one (see cross-media-measurement#4298 investigation),
+  # and every invocation streams the *entire* UNFULFILLED backlog with no persisted cursor before
+  # any of it is dropped from the buffer. Raised to give that streaming/grouping headroom; revisit
+  # downward once the backlog is drained and stays small, or raise further if it recurs.
+  memory = "2048MB"
 }
 
 module "requisition_fetcher_cloud_scheduler" {

--- a/src/main/terraform/gcloud/modules/http-cloud-function/main.tf
+++ b/src/main/terraform/gcloud/modules/http-cloud-function/main.tf
@@ -48,6 +48,7 @@ resource "terraform_data" "deploy_http_cloud_function" {
     var.config_path != null ? filesha256(var.config_path) : "",
     var.timeout_seconds,
     var.max_instances,
+    var.memory,
   ]
 
   provisioner "local-exec" {
@@ -62,6 +63,7 @@ resource "terraform_data" "deploy_http_cloud_function" {
       UBER_JAR_DIRECTORY  = dirname(var.uber_jar_path)
       TIMEOUT_SECONDS     = var.timeout_seconds == null ? "" : tostring(var.timeout_seconds)
       MAX_INSTANCES       = var.max_instances == null ? "" : tostring(var.max_instances)
+      MEMORY              = var.memory
     }
     command = <<-EOT
       #!/bin/bash
@@ -72,12 +74,11 @@ resource "terraform_data" "deploy_http_cloud_function" {
         "--gen2"
         "--runtime=java17"
         "--entry-point=$ENTRY_POINT"
-        # 512MB suffices for test environments. The requisition-fetcher groups a report's
-        # requisitions in memory before writing one blob; a data provider with large reports
-        # (or rare ~1MB requisitions) can need substantially more headroom — up to 8GiB (Cloud
-        # Functions 2nd gen max) — and its MAX_TOTAL_BUFFERED_BYTES should be raised to match.
-        # Size per environment rather than assuming this default holds for larger workloads.
-        "--memory=512MB"
+        # Callers that buffer large in-memory state before writing (e.g. the
+        # requisition-fetcher, which groups a report's requisitions before writing one blob)
+        # should raise this via the memory variable — up to 8GiB, the Cloud Functions 2nd gen
+        # max — and size MAX_TOTAL_BUFFERED_BYTES to match.
+        "--memory=$MEMORY"
         "--region=$CLOUD_REGION"
         "--run-service-account=$RUN_SERVICE_ACCOUNT"
         "--source=$UBER_JAR_DIRECTORY"

--- a/src/main/terraform/gcloud/modules/http-cloud-function/variables.tf
+++ b/src/main/terraform/gcloud/modules/http-cloud-function/variables.tf
@@ -80,3 +80,9 @@ variable "max_instances" {
   nullable    = true
   default     = null
 }
+
+variable "memory" {
+  description = "The amount of memory allocated to the Cloud Function (e.g. \"512MB\", \"2048MB\")."
+  type        = string
+  default     = "512MB"
+}

--- a/src/test/kotlin/org/wfanet/measurement/edpaggregator/requisitionfetcher/RequisitionFetcherTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/edpaggregator/requisitionfetcher/RequisitionFetcherTest.kt
@@ -181,6 +181,7 @@ class RequisitionFetcherTest {
     maxTotalBufferedBytes: Long = RequisitionFetcher.DEFAULT_MAX_TOTAL_BUFFERED_BYTES,
     maxRequisitionsPerGroup: Int = RequisitionFetcher.DEFAULT_MAX_REQUISITIONS_PER_GROUP,
     metadataThrottler: Throttler = this.throttler,
+    responsePageSize: Int? = null,
   ): RequisitionFetcher {
     val validator =
       RequisitionsValidator(
@@ -208,6 +209,7 @@ class RequisitionFetcherTest {
       maxTotalBufferedBytes = maxTotalBufferedBytes,
       maxRequisitionsPerGroup = maxRequisitionsPerGroup,
       metrics = metrics,
+      responsePageSize = responsePageSize,
     )
   }
 
@@ -699,7 +701,7 @@ class RequisitionFetcherTest {
         listRequisitionsResponse { requisitions += r1 }
       }
 
-      createFetcher().fetchAndStoreRequisitions()
+      createFetcher(responsePageSize = 10).fetchAndStoreRequisitions()
 
       assertThat(captured).hasSize(4)
       assertThat(captured[0]).isEqualTo(10)
@@ -742,7 +744,7 @@ class RequisitionFetcherTest {
       }
     }
 
-    createFetcher().fetchAndStoreRequisitions()
+    createFetcher(responsePageSize = 10).fetchAndStoreRequisitions()
 
     assertThat(captured).containsExactly(10, 5, 5).inOrder()
   }

--- a/src/test/kotlin/org/wfanet/measurement/integration/k8s/EdpAggregatorCorrectnessTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/integration/k8s/EdpAggregatorCorrectnessTest.kt
@@ -412,7 +412,11 @@ class EdpAggregatorCorrectnessTest : AbstractEdpAggregatorCorrectnessTest(measur
             val request =
               HttpRequest.newBuilder()
                 .uri(URI.create(requisitionFetcherEndpoint))
-                .timeout(Duration.ofSeconds(120))
+                // The fetcher streams every UNFULFILLED requisition for its data provider on
+                // each invocation with no persisted cursor, so its response time scales with
+                // however large that data provider's backlog happens to be, not with the
+                // handful of requisitions this test just created.
+                .timeout(Duration.ofSeconds(REQUISITION_FETCHER_HTTP_TIMEOUT_SECONDS))
                 .header("Authorization", "Bearer $jwt")
                 .GET()
                 .build()
@@ -486,6 +490,7 @@ class EdpAggregatorCorrectnessTest : AbstractEdpAggregatorCorrectnessTest(measur
 
     companion object {
       private const val REQUISITIONS_SYNC_TIMEOUT = 60_000L * 5
+      private const val REQUISITION_FETCHER_HTTP_TIMEOUT_SECONDS = 300L
       private const val REQUISITIONS_SYNC_POLLING_INTERVAL = 5000L
 
       private val channels = mutableListOf<ManagedChannel>()


### PR DESCRIPTION
Combines three changes found while investigating an EDPA cloud test failure caused by a large accumulated UNFULFILLED backlog for one data provider (dev). Each addresses a different way that backlog broke the fetch cycle:

- **Cloud Function memory (512MB -> 2048MB)**: the fetcher buffers a report's requisitions in memory before writing one blob; a large backlog needs more headroom than the default, and the buffering backstop tracks serialized proto size, which understates actual retained JVM heap.
- **ListRequisitions page size (10 -> 100)**: Kingdom's ListRequisitions rate limit bucket is shared across every page a fetch cycle issues, so a large backlog can exceed it purely from page count. 100 was chosen empirically -- page sizes at and above 300 against dev regularly exceed the RPC deadline, while 200 consistently succeeded.
- **EdpAggregatorCorrectnessTest HTTP client timeout (120s -> 300s)**: triggerRequisitionFetcher() waits synchronously on the fetcher's HTTP response, whose duration scales with the data provider's entire backlog, not just the handful of requisitions the test just created.

Originally three separate PRs (now closed): #4391, #4393, #4394.

Issue: NA
