### PR TITLE
feat: Let the Kingdom offer DETERMINISTIC_TRUNCATED_LAPLACE for Direct

### DIFF
--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/resultsfulfiller/ResultsFulfillerApp.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/resultsfulfiller/ResultsFulfillerApp.kt
@@ -156,11 +156,6 @@ class ResultsFulfillerApp(
       when (fulfillerParams.noiseParams.noiseType) {
         NoiseType.NONE -> NoNoiserSelector()
         NoiseType.CONTINUOUS_GAUSSIAN -> ContinuousGaussianNoiseSelector()
-        // TODO(@raimundoltdf): The Kingdom cannot offer this for Direct yet.
-        // V2alphaPublicApiServer rejects it for --direct-noise-mechanism, so it never reaches
-        // ProtocolConfig.Direct.noise_mechanisms and this selector refuses every requisition.
-        // Accepting it there needs the reporting server to map the mechanism first; both land in
-        // a follow-up.
         NoiseType.DETERMINISTIC_TRUNCATED_LAPLACE -> DeterministicTruncatedLaplaceNoiseSelector()
         else -> throw Exception("Invalid noise type ${fulfillerParams.noiseParams.noiseType}")
       }

--- a/src/main/kotlin/org/wfanet/measurement/integration/common/InProcessKingdom.kt
+++ b/src/main/kotlin/org/wfanet/measurement/integration/common/InProcessKingdom.kt
@@ -298,6 +298,7 @@ class InProcessKingdom(
         ProtocolConfig.NoiseMechanism.NONE,
         ProtocolConfig.NoiseMechanism.CONTINUOUS_LAPLACE,
         ProtocolConfig.NoiseMechanism.CONTINUOUS_GAUSSIAN,
+        ProtocolConfig.NoiseMechanism.DETERMINISTIC_TRUNCATED_LAPLACE,
       )
   }
 }

--- a/src/main/kotlin/org/wfanet/measurement/integration/common/reporting/v2/BUILD.bazel
+++ b/src/main/kotlin/org/wfanet/measurement/integration/common/reporting/v2/BUILD.bazel
@@ -50,6 +50,7 @@ kt_jvm_library(
         "//src/main/proto/wfa/measurement/reporting/v2alpha:reporting_sets_service_kt_jvm_grpc_proto",
         "//src/main/proto/wfa/measurement/reporting/v2alpha:reports_service_kt_jvm_grpc_proto",
         "@wfa_consent_signaling_client//src/main/kotlin/org/wfanet/measurement/consent/client/dataprovider",
+        "@wfa_consent_signaling_client//src/main/kotlin/org/wfanet/measurement/consent/client/measurementconsumer",
     ],
 )
 

--- a/src/main/kotlin/org/wfanet/measurement/integration/common/reporting/v2/BUILD.bazel
+++ b/src/main/kotlin/org/wfanet/measurement/integration/common/reporting/v2/BUILD.bazel
@@ -56,6 +56,7 @@ kt_jvm_library(
 kt_jvm_library(
     name = "in_process_edp_aggregator_life_of_a_report_test",
     srcs = [
+        "InProcessEdpAggregatorDirectDeterministicNoiseTest.kt",
         "InProcessEdpAggregatorDirectOnlyReportTest.kt",
         "InProcessEdpAggregatorLifeOfAReportTest.kt",
         "InProcessEdpAggregatorLifeOfAnEventGroupTest.kt",

--- a/src/main/kotlin/org/wfanet/measurement/integration/common/reporting/v2/InProcessEdpAggregatorDirectDeterministicNoiseTest.kt
+++ b/src/main/kotlin/org/wfanet/measurement/integration/common/reporting/v2/InProcessEdpAggregatorDirectDeterministicNoiseTest.kt
@@ -95,24 +95,30 @@ abstract class InProcessEdpAggregatorDirectDeterministicNoiseTest(
     val basicReportName = runBasicReport("deterministic-mechanism")
 
     val results = decryptedResults(getMeasurementsForBasicReport(basicReportName))
-    assertWithMessage("decrypted results").that(results).isNotEmpty()
 
-    for (result in results) {
-      if (result.hasReach()) {
-        assertWithMessage("reach noise mechanism")
-          .that(result.reach.noiseMechanism)
-          .isEqualTo(ProtocolConfig.NoiseMechanism.DETERMINISTIC_TRUNCATED_LAPLACE)
-      }
-      if (result.hasFrequency()) {
-        assertWithMessage("frequency noise mechanism")
-          .that(result.frequency.noiseMechanism)
-          .isEqualTo(ProtocolConfig.NoiseMechanism.DETERMINISTIC_TRUNCATED_LAPLACE)
-      }
-      if (result.hasImpression()) {
-        assertWithMessage("impression noise mechanism")
-          .that(result.impression.noiseMechanism)
-          .isEqualTo(ProtocolConfig.NoiseMechanism.DETERMINISTIC_TRUNCATED_LAPLACE)
-      }
+    // Each result type is asserted non-empty first, so a type dropping out of the report fails here
+    // rather than passing vacuously through its mechanism check.
+    val reachMechanisms = results.filter { it.hasReach() }.map { it.reach.noiseMechanism }
+    val frequencyMechanisms =
+      results.filter { it.hasFrequency() }.map { it.frequency.noiseMechanism }
+    val impressionMechanisms =
+      results.filter { it.hasImpression() }.map { it.impression.noiseMechanism }
+
+    assertWithMessage("reach results").that(reachMechanisms).isNotEmpty()
+    assertWithMessage("frequency results").that(frequencyMechanisms).isNotEmpty()
+    assertWithMessage("impression results").that(impressionMechanisms).isNotEmpty()
+
+    for ((label, mechanisms) in
+      listOf(
+        "reach" to reachMechanisms,
+        "frequency" to frequencyMechanisms,
+        "impression" to impressionMechanisms,
+      )) {
+      assertWithMessage("$label noise mechanisms")
+        .that(mechanisms)
+        .containsExactlyElementsIn(
+          List(mechanisms.size) { ProtocolConfig.NoiseMechanism.DETERMINISTIC_TRUNCATED_LAPLACE }
+        )
     }
   }
 

--- a/src/main/kotlin/org/wfanet/measurement/integration/common/reporting/v2/InProcessEdpAggregatorDirectDeterministicNoiseTest.kt
+++ b/src/main/kotlin/org/wfanet/measurement/integration/common/reporting/v2/InProcessEdpAggregatorDirectDeterministicNoiseTest.kt
@@ -1,0 +1,149 @@
+// Copyright 2026 The Cross-Media Measurement Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.wfanet.measurement.integration.common.reporting.v2
+
+import com.google.common.truth.Truth.assertThat
+import com.google.common.truth.Truth.assertWithMessage
+import kotlinx.coroutines.runBlocking
+import org.junit.Test
+import org.wfanet.measurement.common.testing.ProviderRule
+import org.wfanet.measurement.edpaggregator.v1alpha.ResultsFulfillerParams
+import org.wfanet.measurement.gcloud.spanner.testing.SpannerDatabaseAdmin
+import org.wfanet.measurement.integration.common.ALL_DUCHY_NAMES
+import org.wfanet.measurement.integration.common.AccessServicesFactory
+import org.wfanet.measurement.integration.common.InProcessDuchy
+import org.wfanet.measurement.kingdom.deploy.common.service.DataServices
+import org.wfanet.measurement.reporting.deploy.v2.common.service.Services
+import org.wfanet.measurement.reporting.v2alpha.BasicReport
+import org.wfanet.measurement.reporting.v2alpha.MetricFrequencySpec
+import org.wfanet.measurement.reporting.v2alpha.ResultGroup
+import org.wfanet.measurement.reporting.v2alpha.getBasicReportRequest
+import org.wfanet.measurement.system.v1alpha.ComputationLogEntriesGrpcKt.ComputationLogEntriesCoroutineStub
+
+/**
+ * Integration tests for Direct results noised with DETERMINISTIC_TRUNCATED_LAPLACE.
+ *
+ * The EDPs select the mechanism through `ResultsFulfillerParams.noise_type`, which is the whole
+ * migration surface: no schema or data changes, and reverting the setting runs the previous path on
+ * the next measurement. [InProcessEdpAggregatorDirectOnlyReportTest] runs the same reports with
+ * NoiseType.NONE, so the pair covers the flip in both directions.
+ *
+ * This is abstract so that different implementations of dependencies can all run the same tests.
+ */
+abstract class InProcessEdpAggregatorDirectDeterministicNoiseTest(
+  kingdomDataServicesRule: ProviderRule<DataServices>,
+  duchyDependenciesRule:
+    ProviderRule<(String, ComputationLogEntriesCoroutineStub) -> InProcessDuchy.DuchyDependencies>,
+  secureComputationDatabaseAdmin: SpannerDatabaseAdmin,
+  accessServicesFactory: AccessServicesFactory,
+  reportingDataServicesProviderRule: ProviderRule<Services>,
+  duchyNames: List<String> = ALL_DUCHY_NAMES,
+) :
+  InProcessEdpAggregatorLifeOfAReportTest(
+    kingdomDataServicesRule,
+    duchyDependenciesRule,
+    secureComputationDatabaseAdmin,
+    accessServicesFactory,
+    reportingDataServicesProviderRule,
+    duchyNames,
+    hmssEnabled = false,
+    trusTeeEnabled = false,
+    directNoiseType = ResultsFulfillerParams.NoiseParams.NoiseType.DETERMINISTIC_TRUNCATED_LAPLACE,
+  ) {
+
+  @Test
+  fun `direct results are within the noise bound of the unnoised values`() = runBlocking {
+    val cumulative = runReport("deterministic-bound")
+
+    assertWithinNoiseBound(
+      "reach",
+      cumulative.reach,
+      EXPECTED_SINGLE_EDP_SPEC2_REACH,
+      REACH_SENSITIVITY,
+    )
+    for ((index, expected) in EXPECTED_SINGLE_EDP_SPEC2_K_PLUS_REACH.withIndex()) {
+      assertWithinNoiseBound(
+        "${index + 1}+ reach",
+        cumulative.kPlusReachList[index],
+        expected,
+        K_PLUS_SENSITIVITY,
+      )
+    }
+  }
+
+  @Test
+  fun `rerunning the same report draws the same noise`() = runBlocking {
+    val first = runReport("deterministic-rerun-1")
+    val second = runReport("deterministic-rerun-2")
+
+    assertWithMessage("reach").that(second.reach).isEqualTo(first.reach)
+    assertWithMessage("impressions").that(second.impressions).isEqualTo(first.impressions)
+    assertWithMessage("k+ reach")
+      .that(second.kPlusReachList)
+      .containsExactlyElementsIn(first.kPlusReachList)
+      .inOrder()
+  }
+
+  /**
+   * Runs a single-EDP basic report over the reference-id-only event groups and returns its total.
+   */
+  private suspend fun runReport(label: String): ResultGroup.MetricSet.BasicMetricSet {
+    val eventGroups = getReferenceIdOnlyEventGroups()
+    check(eventGroups.isNotEmpty()) { "No reference-ID-only event groups found" }
+
+    val createdBasicReport =
+      reportingBasicReportsClient
+        .withCallCredentials(credentials)
+        .createBasicReport(
+          buildCreateBasicReportRequest(
+            eventGroups,
+            "$label-campaign",
+            "$label-basicreport",
+            includeIqfFilter = false,
+          )
+        )
+
+    executeBasicReportsReportsJob(createdBasicReport.name)
+    executeReportProcessorJob()
+
+    val completedBasicReport =
+      reportingBasicReportsClient
+        .withCallCredentials(credentials)
+        .getBasicReport(getBasicReportRequest { name = createdBasicReport.name })
+
+    assertThat(completedBasicReport.state).isEqualTo(BasicReport.State.SUCCEEDED)
+    assertStructuralResults(completedBasicReport)
+    assertExpectedProtocolUsed(getMeasurementsForBasicReport(completedBasicReport.name))
+
+    return completedBasicReport.resultGroupsList
+      .single()
+      .resultsList
+      .single { it.metadata.metricFrequency.selectorCase == MetricFrequencySpec.SelectorCase.TOTAL }
+      .metricSet
+      .reportingUnit
+      .cumulative
+  }
+
+  companion object {
+    /** One VID moves reach by 1. */
+    private const val REACH_SENSITIVITY = 1.0
+
+    /**
+     * A k+ value is a sum over frequency buckets, each carrying its own draw, normalized against a
+     * denominator that carries all of them. Bounding it by the histogram width is conservative.
+     */
+    private const val K_PLUS_SENSITIVITY = 5.0
+  }
+}

--- a/src/main/kotlin/org/wfanet/measurement/integration/common/reporting/v2/InProcessEdpAggregatorDirectDeterministicNoiseTest.kt
+++ b/src/main/kotlin/org/wfanet/measurement/integration/common/reporting/v2/InProcessEdpAggregatorDirectDeterministicNoiseTest.kt
@@ -18,6 +18,7 @@ import com.google.common.truth.Truth.assertThat
 import com.google.common.truth.Truth.assertWithMessage
 import kotlinx.coroutines.runBlocking
 import org.junit.Test
+import org.wfanet.measurement.api.v2alpha.ProtocolConfig
 import org.wfanet.measurement.common.testing.ProviderRule
 import org.wfanet.measurement.edpaggregator.v1alpha.ResultsFulfillerParams
 import org.wfanet.measurement.gcloud.spanner.testing.SpannerDatabaseAdmin
@@ -81,6 +82,38 @@ abstract class InProcessEdpAggregatorDirectDeterministicNoiseTest(
         K_PLUS_SENSITIVITY,
       )
     }
+    assertWithinNoiseBound(
+      "impressions",
+      cumulative.impressions,
+      EXPECTED_SINGLE_EDP_SPEC2_IMPRESSIONS,
+      IMPRESSION_SENSITIVITY,
+    )
+  }
+
+  @Test
+  fun `direct results record the deterministic mechanism`() = runBlocking {
+    val basicReportName = runBasicReport("deterministic-mechanism")
+
+    val results = decryptedResults(getMeasurementsForBasicReport(basicReportName))
+    assertWithMessage("decrypted results").that(results).isNotEmpty()
+
+    for (result in results) {
+      if (result.hasReach()) {
+        assertWithMessage("reach noise mechanism")
+          .that(result.reach.noiseMechanism)
+          .isEqualTo(ProtocolConfig.NoiseMechanism.DETERMINISTIC_TRUNCATED_LAPLACE)
+      }
+      if (result.hasFrequency()) {
+        assertWithMessage("frequency noise mechanism")
+          .that(result.frequency.noiseMechanism)
+          .isEqualTo(ProtocolConfig.NoiseMechanism.DETERMINISTIC_TRUNCATED_LAPLACE)
+      }
+      if (result.hasImpression()) {
+        assertWithMessage("impression noise mechanism")
+          .that(result.impression.noiseMechanism)
+          .isEqualTo(ProtocolConfig.NoiseMechanism.DETERMINISTIC_TRUNCATED_LAPLACE)
+      }
+    }
   }
 
   @Test
@@ -100,6 +133,22 @@ abstract class InProcessEdpAggregatorDirectDeterministicNoiseTest(
    * Runs a single-EDP basic report over the reference-id-only event groups and returns its total.
    */
   private suspend fun runReport(label: String): ResultGroup.MetricSet.BasicMetricSet {
+    val completedBasicReport =
+      reportingBasicReportsClient
+        .withCallCredentials(credentials)
+        .getBasicReport(getBasicReportRequest { name = runBasicReport(label) })
+
+    return completedBasicReport.resultGroupsList
+      .single()
+      .resultsList
+      .single { it.metadata.metricFrequency.selectorCase == MetricFrequencySpec.SelectorCase.TOTAL }
+      .metricSet
+      .reportingUnit
+      .cumulative
+  }
+
+  /** Runs a single-EDP basic report over the reference-id-only event groups, returning its name. */
+  private suspend fun runBasicReport(label: String): String {
     val eventGroups = getReferenceIdOnlyEventGroups()
     check(eventGroups.isNotEmpty()) { "No reference-ID-only event groups found" }
 
@@ -127,18 +176,18 @@ abstract class InProcessEdpAggregatorDirectDeterministicNoiseTest(
     assertStructuralResults(completedBasicReport)
     assertExpectedProtocolUsed(getMeasurementsForBasicReport(completedBasicReport.name))
 
-    return completedBasicReport.resultGroupsList
-      .single()
-      .resultsList
-      .single { it.metadata.metricFrequency.selectorCase == MetricFrequencySpec.SelectorCase.TOTAL }
-      .metricSet
-      .reportingUnit
-      .cumulative
+    return completedBasicReport.name
   }
 
   companion object {
     /** One VID moves reach by 1. */
     private const val REACH_SENSITIVITY = 1.0
+
+    /**
+     * One VID moves the impression count by the maximum frequency per user, which
+     * `impressionCountParams` in the metric spec config sets to 60.
+     */
+    private const val IMPRESSION_SENSITIVITY = 60.0
 
     /**
      * A k+ value is a sum over frequency buckets, each carrying its own draw, normalized against a

--- a/src/main/kotlin/org/wfanet/measurement/integration/common/reporting/v2/InProcessEdpAggregatorLifeOfAReportTest.kt
+++ b/src/main/kotlin/org/wfanet/measurement/integration/common/reporting/v2/InProcessEdpAggregatorLifeOfAReportTest.kt
@@ -88,6 +88,7 @@ import org.wfanet.measurement.common.getRuntimePath
 import org.wfanet.measurement.common.identity.withPrincipalName
 import org.wfanet.measurement.common.parseTextProto
 import org.wfanet.measurement.common.testing.ProviderRule
+import org.wfanet.measurement.consent.client.measurementconsumer.decryptResult
 import org.wfanet.measurement.common.testing.chainRulesSequentially
 import org.wfanet.measurement.computation.DeterministicTruncatedLaplaceParams
 import org.wfanet.measurement.config.reporting.EncryptionKeyPairConfigKt.keyPair
@@ -1044,6 +1045,22 @@ abstract class InProcessEdpAggregatorLifeOfAReportTest(
         .toName()
     return listMeasurements().filter {
       it.measurementSpec.unpack<MeasurementSpec>().reportingMetadata.report == reportName
+    }
+  }
+
+  /**
+   * Returns the [Measurement.Result]s [measurements] carry, decrypted with the
+   * MeasurementConsumer's key.
+   *
+   * A Direct result records the mechanism the EDP Aggregator actually applied. The protocol config
+   * carries only the mechanisms the Kingdom offered, so it cannot tell one selection from another.
+   */
+  protected fun decryptedResults(measurements: List<Measurement>): List<Measurement.Result> {
+    val encryptionKey = inProcessCmmsComponents.getMeasurementConsumerData().encryptionKey
+    return measurements.flatMap { measurement ->
+      measurement.resultsList.map { resultOutput ->
+        decryptResult(resultOutput.encryptedResult, encryptionKey).unpack()
+      }
     }
   }
 

--- a/src/main/kotlin/org/wfanet/measurement/integration/common/reporting/v2/InProcessEdpAggregatorLifeOfAReportTest.kt
+++ b/src/main/kotlin/org/wfanet/measurement/integration/common/reporting/v2/InProcessEdpAggregatorLifeOfAReportTest.kt
@@ -88,7 +88,6 @@ import org.wfanet.measurement.common.getRuntimePath
 import org.wfanet.measurement.common.identity.withPrincipalName
 import org.wfanet.measurement.common.parseTextProto
 import org.wfanet.measurement.common.testing.ProviderRule
-import org.wfanet.measurement.consent.client.measurementconsumer.decryptResult
 import org.wfanet.measurement.common.testing.chainRulesSequentially
 import org.wfanet.measurement.computation.DeterministicTruncatedLaplaceParams
 import org.wfanet.measurement.config.reporting.EncryptionKeyPairConfigKt.keyPair
@@ -99,6 +98,7 @@ import org.wfanet.measurement.config.reporting.encryptionKeyPairConfig
 import org.wfanet.measurement.config.reporting.measurementConsumerConfig
 import org.wfanet.measurement.config.reporting.measurementConsumerConfigs
 import org.wfanet.measurement.config.reporting.metricSpecConfig
+import org.wfanet.measurement.consent.client.measurementconsumer.decryptResult
 import org.wfanet.measurement.edpaggregator.eventgroups.v1alpha.EventGroup as EdpaEventGroup
 import org.wfanet.measurement.edpaggregator.eventgroups.v1alpha.MappedEventGroup
 import org.wfanet.measurement.edpaggregator.resultsfulfiller.ModelLineInfo

--- a/src/main/kotlin/org/wfanet/measurement/integration/common/reporting/v2/InProcessEdpAggregatorLifeOfAReportTest.kt
+++ b/src/main/kotlin/org/wfanet/measurement/integration/common/reporting/v2/InProcessEdpAggregatorLifeOfAReportTest.kt
@@ -36,6 +36,8 @@ import java.time.Duration
 import java.time.LocalDate
 import java.time.ZoneId
 import java.util.logging.Logger
+import kotlin.math.abs
+import kotlin.math.ceil
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.runBlocking
 import org.junit.Before
@@ -87,6 +89,7 @@ import org.wfanet.measurement.common.identity.withPrincipalName
 import org.wfanet.measurement.common.parseTextProto
 import org.wfanet.measurement.common.testing.ProviderRule
 import org.wfanet.measurement.common.testing.chainRulesSequentially
+import org.wfanet.measurement.computation.DeterministicTruncatedLaplaceParams
 import org.wfanet.measurement.config.reporting.EncryptionKeyPairConfigKt.keyPair
 import org.wfanet.measurement.config.reporting.EncryptionKeyPairConfigKt.principalKeyPairs
 import org.wfanet.measurement.config.reporting.MeasurementConsumerConfig
@@ -180,6 +183,13 @@ abstract class InProcessEdpAggregatorLifeOfAReportTest(
    * TrusTEE with that mechanism only when every DataProvider reports it.
    */
   private val deterministicTruncatedLaplaceSupported: Boolean = false,
+  /**
+   * The noise every EDP applies to its own Direct results. NONE keeps results exact, which the
+   * assertions on this class depend on; a subclass selecting a noising mechanism asserts against
+   * the noise envelope instead.
+   */
+  private val directNoiseType: ResultsFulfillerParams.NoiseParams.NoiseType =
+    ResultsFulfillerParams.NoiseParams.NoiseType.NONE,
 ) {
 
   protected val expectedProtocol: PublicProtocolConfig.Protocol.ProtocolCase =
@@ -401,10 +411,10 @@ abstract class InProcessEdpAggregatorLifeOfAReportTest(
           duchyMap,
           edpNoise =
             mapOf(
-              "edp1" to ResultsFulfillerParams.NoiseParams.NoiseType.NONE,
-              "edp2" to ResultsFulfillerParams.NoiseParams.NoiseType.NONE,
-              "edp3" to ResultsFulfillerParams.NoiseParams.NoiseType.NONE,
-              "edp4" to ResultsFulfillerParams.NoiseParams.NoiseType.NONE,
+              "edp1" to directNoiseType,
+              "edp2" to directNoiseType,
+              "edp3" to directNoiseType,
+              "edp4" to directNoiseType,
             ),
           edpMultiPartyNoiseTypes = multiPartyNoiseTypes,
         )
@@ -673,6 +683,27 @@ abstract class InProcessEdpAggregatorLifeOfAReportTest(
         }
       }
     }
+  }
+
+  /**
+   * Asserts [actual] is within one deterministic truncated-Laplace draw of [expected].
+   *
+   * The draw is truncated to a bound derived from the compiled privacy params and scaled by the
+   * quantity's L1 [sensitivity], so a single noised quantity cannot move further than that. The
+   * extra unit absorbs the truncation to `Long` when the result is scaled. Taking the bound from
+   * [DeterministicTruncatedLaplaceParams] rather than a recorded value keeps this in step with the
+   * params instead of with a particular seed.
+   */
+  protected fun assertWithinNoiseBound(
+    label: String,
+    actual: Long,
+    expected: Long,
+    sensitivity: Double,
+  ) {
+    val bound = ceil(DeterministicTruncatedLaplaceParams.truncationBound(sensitivity)).toLong()
+    assertWithMessage("$label: $actual is further than ${bound + 1} from $expected")
+      .that(abs(actual - expected))
+      .isAtMost(bound + 1)
   }
 
   /**

--- a/src/main/kotlin/org/wfanet/measurement/integration/common/reporting/v2/InProcessEdpAggregatorTrusTeeThresholdTest.kt
+++ b/src/main/kotlin/org/wfanet/measurement/integration/common/reporting/v2/InProcessEdpAggregatorTrusTeeThresholdTest.kt
@@ -16,13 +16,10 @@ package org.wfanet.measurement.integration.common.reporting.v2
 
 import com.google.common.truth.Truth.assertThat
 import com.google.common.truth.Truth.assertWithMessage
-import kotlin.math.abs
-import kotlin.math.ceil
 import kotlinx.coroutines.runBlocking
 import org.junit.Test
 import org.wfanet.measurement.api.v2alpha.ProtocolConfig
 import org.wfanet.measurement.common.testing.ProviderRule
-import org.wfanet.measurement.computation.DeterministicTruncatedLaplaceParams
 import org.wfanet.measurement.gcloud.spanner.testing.SpannerDatabaseAdmin
 import org.wfanet.measurement.integration.common.ALL_DUCHY_NAMES
 import org.wfanet.measurement.integration.common.AccessServicesFactory
@@ -94,27 +91,6 @@ abstract class InProcessEdpAggregatorTrusTeeThresholdTest(
       expectedEdpSpec1Reach = EXPECTED_EDP_SPEC1_REACH,
       expectedEdpSpec2Reach = EXPECTED_EDP_SPEC2_REACH,
     )
-  }
-
-  /**
-   * Asserts [actual] is within one deterministic truncated-Laplace draw of [expected].
-   *
-   * The draw is truncated to a bound derived from the compiled privacy params and scaled by the
-   * quantity's L1 [sensitivity], so a single noised quantity cannot move further than that. The
-   * extra unit absorbs the truncation to `Long` when the result is scaled. Taking the bound from
-   * [DeterministicTruncatedLaplaceParams] rather than a recorded value keeps this in step with the
-   * params instead of with a particular seed.
-   */
-  protected fun assertWithinNoiseBound(
-    label: String,
-    actual: Long,
-    expected: Long,
-    sensitivity: Double,
-  ) {
-    val bound = ceil(DeterministicTruncatedLaplaceParams.truncationBound(sensitivity)).toLong()
-    assertWithMessage("$label: $actual is further than ${bound + 1} from $expected")
-      .that(abs(actual - expected))
-      .isAtMost(bound + 1)
   }
 
   @Test

--- a/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/common/server/V2alphaPublicApiServer.kt
+++ b/src/main/kotlin/org/wfanet/measurement/kingdom/deploy/common/server/V2alphaPublicApiServer.kt
@@ -536,7 +536,8 @@ private class V2alphaFlags {
       when (noiseMechanism) {
         NoiseMechanism.NONE,
         NoiseMechanism.CONTINUOUS_LAPLACE,
-        NoiseMechanism.CONTINUOUS_GAUSSIAN -> {}
+        NoiseMechanism.CONTINUOUS_GAUSSIAN,
+        NoiseMechanism.DETERMINISTIC_TRUNCATED_LAPLACE -> {}
         NoiseMechanism.GEOMETRIC,
         // TODO(@riemanli): support DISCRETE_GAUSSIAN after having a clear definition of it.
         NoiseMechanism.DISCRETE_GAUSSIAN -> {
@@ -548,7 +549,6 @@ private class V2alphaFlags {
             ),
           )
         }
-        NoiseMechanism.DETERMINISTIC_TRUNCATED_LAPLACE,
         NoiseMechanism.NOISE_MECHANISM_UNSPECIFIED,
         NoiseMechanism.UNRECOGNIZED -> {
           throw CommandLine.ParameterException(

--- a/src/test/kotlin/org/wfanet/measurement/integration/common/reporting/v2/BUILD.bazel
+++ b/src/test/kotlin/org/wfanet/measurement/integration/common/reporting/v2/BUILD.bazel
@@ -72,6 +72,40 @@ java_test(
 )
 
 kt_jvm_library(
+    name = "gcloud_edp_aggregator_direct_deterministic_noise_test",
+    srcs = ["GCloudEdpAggregatorDirectDeterministicNoiseTest.kt"],
+    data = ["@cloud_spanner_emulator//:emulator"],
+    runtime_deps = [
+        "@wfa_common_jvm//imports/java/org/yaml:snakeyaml",
+    ],
+    deps = [
+        "//src/main/kotlin/org/wfanet/measurement/integration/common/reporting/v2:in_process_edp_aggregator_life_of_a_report_test",
+        "//src/main/kotlin/org/wfanet/measurement/integration/deploy/gcloud:internal_reporting_provider_rule",
+        "//src/main/kotlin/org/wfanet/measurement/integration/deploy/gcloud:kingdom_data_services_provider_rule",
+        "//src/main/kotlin/org/wfanet/measurement/integration/deploy/gcloud:spanner_access_services_factory",
+        "//src/main/kotlin/org/wfanet/measurement/integration/deploy/gcloud:spanner_duchy_dependency_provider_rule",
+        "//src/main/kotlin/org/wfanet/measurement/reporting/deploy/v2/postgres/testing",
+        "@wfa_common_jvm//src/main/kotlin/org/wfanet/measurement/common/db/r2dbc/postgres/testing:database_provider",
+    ],
+)
+
+# TODO(bazelbuild/rules_kotlin#1088): Use kt_jvm_test when fixed.
+java_test(
+    name = "GCloudEdpAggregatorDirectDeterministicNoiseTest",
+    size = "large",
+    timeout = "long",
+    tags = [
+        "cpu:2",
+        "no-remote-exec",
+    ],
+    test_class = "org.wfanet.measurement.integration.common.reporting.v2.GCloudEdpAggregatorDirectDeterministicNoiseTest",
+    runtime_deps = [
+        ":gcloud_edp_aggregator_direct_deterministic_noise_test",
+        "//imports/java/org/slf4j:simple",
+    ],
+)
+
+kt_jvm_library(
     name = "gcloud_edp_aggregator_hmss_report_test",
     srcs = ["GCloudEdpAggregatorHmssReportTest.kt"],
     data = ["@cloud_spanner_emulator//:emulator"],

--- a/src/test/kotlin/org/wfanet/measurement/integration/common/reporting/v2/GCloudEdpAggregatorDirectDeterministicNoiseTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/integration/common/reporting/v2/GCloudEdpAggregatorDirectDeterministicNoiseTest.kt
@@ -1,0 +1,60 @@
+// Copyright 2026 The Cross-Media Measurement Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.wfanet.measurement.integration.common.reporting.v2
+
+import org.junit.ClassRule
+import org.junit.Rule
+import org.junit.rules.Timeout
+import org.wfanet.measurement.common.db.r2dbc.postgres.testing.PostgresDatabaseProviderRule
+import org.wfanet.measurement.gcloud.spanner.testing.SpannerEmulatorRule
+import org.wfanet.measurement.integration.common.ALL_DUCHY_NAMES
+import org.wfanet.measurement.integration.common.IMPRESSION_QUALIFICATION_FILTER_MAPPING
+import org.wfanet.measurement.integration.deploy.gcloud.InternalReportingServicesProviderRule
+import org.wfanet.measurement.integration.deploy.gcloud.KingdomDataServicesProviderRule
+import org.wfanet.measurement.integration.deploy.gcloud.SpannerAccessServicesFactory
+import org.wfanet.measurement.integration.deploy.gcloud.SpannerDuchyDependencyProviderRule
+import org.wfanet.measurement.reporting.deploy.v2.postgres.testing.Schemata.REPORTING_CHANGELOG_PATH as POSTGRES_REPORTING_CHANGELOG_PATH
+
+/** Implementation of [InProcessEdpAggregatorDirectDeterministicNoiseTest] for GCloud backends. */
+class GCloudEdpAggregatorDirectDeterministicNoiseTest :
+  InProcessEdpAggregatorDirectDeterministicNoiseTest(
+    kingdomDataServicesRule = KingdomDataServicesProviderRule(spannerEmulator),
+    duchyDependenciesRule = SpannerDuchyDependencyProviderRule(spannerEmulator, ALL_DUCHY_NAMES),
+    secureComputationDatabaseAdmin = spannerEmulator,
+    accessServicesFactory = SpannerAccessServicesFactory(spannerEmulator),
+    reportingDataServicesProviderRule =
+      InternalReportingServicesProviderRule(
+        spannerEmulator,
+        reportingPostgresDatabaseProvider,
+        IMPRESSION_QUALIFICATION_FILTER_MAPPING,
+      ),
+  ) {
+
+  /**
+   * Rule to enforce test method timeout.
+   *
+   * TODO(Kotlin/kotlinx.coroutines#3865): Switch back to CoroutinesTimeout when fixed.
+   */
+  @get:Rule val timeout: Timeout = Timeout.seconds(180)
+
+  companion object {
+    @get:ClassRule @JvmStatic val spannerEmulator = SpannerEmulatorRule()
+
+    @get:ClassRule
+    @JvmStatic
+    val reportingPostgresDatabaseProvider =
+      PostgresDatabaseProviderRule(POSTGRES_REPORTING_CHANGELOG_PATH)
+  }
+}


### PR DESCRIPTION
`V2alphaPublicApiServer` rejected `DETERMINISTIC_TRUNCATED_LAPLACE` for `--direct-noise-mechanism`, so the mechanism never reached `ProtocolConfig.Direct.noise_mechanisms` and the EDP Aggregator's selector refused every requisition that asked for it. Accepting it there is the runtime change: a Kingdom operator can now configure the mechanism as a Direct option. `InProcessKingdom` offers it too, so the harness can select it.

The stale TODO in `ResultsFulfillerApp` said this was blocked on the reporting server mapping the mechanism. That landed in Phase 1 (#4322, #4323), so the TODO goes with it.

**Tests.** `InProcessEdpAggregatorDirectDeterministicNoiseTest` asserts three things: results land within one truncated-Laplace draw of the unnoised values, a re-run draws the same noise, and the decrypted `Measurement.Result`s record `DETERMINISTIC_TRUNCATED_LAPLACE` on reach, frequency, and impression. The last one matters because the first two pass under `NoiseType.NONE`. The protocol config carries the mechanisms the Kingdom offered rather than the one selected, so the result is the only place the applied mechanism appears.

`InProcessEdpAggregatorDirectOnlyReportTest` runs the same reports under `NoiseType.NONE`, so the pair covers the config flip in both directions with no schema or data change.

`assertWithinNoiseBound` moves from `InProcessEdpAggregatorTrusTeeThresholdTest` to the shared parent so the TrusTEE and Direct tests use one bound. Its existing callers are subclasses and inherit it unchanged. k+ reach is bounded by the histogram width rather than by one VID, matching `GCloudEdpAggregatorTrusTeeDeterministicNoiseReportTest`.

Issue: #4186