### PR TITLE
feat(edpa): throttle VID recovery RPCs

### DIFF
--- a/docs/edpaggregator/deployment-guide.md
+++ b/docs/edpaggregator/deployment-guide.md
@@ -669,10 +669,10 @@ The checked-in topology permits 24 phase-worker VMs, one dispatcher function, on
 function, one internal API server, and one concurrently running operator retry process. If every
 eligible process saturates a throttle class, the aggregate ceilings are 4 Kingdom RPCs per second
 (two functions), 280 metadata reads per second (28 processes), 140 metadata mutations per second
-(28 processes), and 108 control-plane RPCs per second (27 processes; the dispatcher does not call
-the control plane). These are conservative per-class envelopes, not per-method bounds: each class
-contains multiple methods, and each method has its own caller set. Compare each method's measured
-traffic and configured server limit before tuning these values.
+(28 processes), and 112 control-plane RPCs per second (28 processes). These are conservative
+per-class envelopes, not per-method bounds: each class contains multiple methods, and each method
+has its own caller set. Compare each method's measured traffic and configured server limit before
+tuning these values.
 
 The Terraform module caps both the dispatcher and monitor at one instance. The checked-in Kingdom
 `RateLimitConfig` gives each VID Repository method its own 5-QPS average / 20-request burst bucket,

--- a/docs/edpaggregator/deployment-guide.md
+++ b/docs/edpaggregator/deployment-guide.md
@@ -660,15 +660,19 @@ entries only once your market has adopted VID labeling.
 
 Every VID Labeling process shares four client-side throttlers across its coroutines. The defaults
 pace Kingdom reads at **2 QPS** (one call every 500 milliseconds), EDP-Aggregator metadata reads at
-**2 QPS**, metadata mutations at **1 QPS**, and Secure Computation
-`WorkItems`/`WorkItemAttempts` calls at **2 QPS**. These are per-process limits, not measured
-downstream capacities or deployment-wide quotas.
+**10 QPS** (one call every 100 milliseconds), metadata mutations at **5 QPS** (one call every 200
+milliseconds), and Secure Computation `WorkItems`/`WorkItemAttempts` calls at **4 QPS** (one call
+every 250 milliseconds). These are per-process limits, not measured downstream capacities or
+deployment-wide quotas.
 
-The default topology permits 24 phase-worker VMs, one dispatcher, one monitor, one internal API
-server, and an operator retry process. At 28 processes, the read and write throttlers together are
-bounded at 84 metadata RPCs per second, below the existing 100-QPS EDPA per-method precedent, while
-control-plane traffic is bounded at 56 QPS. Treat those figures as a conservative planning envelope
-and tune them from production latency, saturation, and `RESOURCE_EXHAUSTED` metrics.
+The checked-in topology permits 24 phase-worker VMs, one dispatcher function, one monitor/dispatch
+function, one internal API server, and one concurrently running operator retry process. If every
+eligible process saturates a throttle class, the aggregate ceilings are 4 Kingdom RPCs per second
+(two functions), 280 metadata reads per second (28 processes), 140 metadata mutations per second
+(28 processes), and 108 control-plane RPCs per second (27 processes; the dispatcher does not call
+the control plane). These are conservative per-class envelopes, not per-method bounds: each class
+contains multiple methods, and each method has its own caller set. Compare each method's measured
+traffic and configured server limit before tuning these values.
 
 The Terraform module caps both the dispatcher and monitor at one instance. The checked-in Kingdom
 `RateLimitConfig` gives each VID Repository method its own 5-QPS average / 20-request burst bucket,
@@ -687,9 +691,10 @@ per_method_rate_limit {
 }
 ```
 
-Both VID Labeling scheduler jobs use a 600-second attempt deadline matching the monitor timeout. The
-GCS-triggered DataWatcher has a 540-second timeout and calls a dispatcher capped at 480 seconds, so
-the synchronous caller retains one minute of shutdown and response headroom.
+Both VID Labeling scheduler jobs use a 660-second attempt deadline, retaining 60 seconds of response
+headroom beyond the monitor function's 600-second timeout. The GCS-triggered DataWatcher has a
+540-second timeout and calls a dispatcher capped at 480 seconds, so that synchronous caller also
+retains one minute of shutdown and response headroom.
 
 The dispatcher and monitor accept these optional environment variables:
 
@@ -701,8 +706,8 @@ The dispatcher and monitor accept these optional environment variables:
 The TEE worker applications accept the corresponding command-line flags
 `--kingdom-rpc-min-interval`, `--metadata-read-rpc-min-interval`,
 `--metadata-write-rpc-min-interval`, and `--control-plane-rpc-min-interval`. The Secure Computation
-internal API server uses the latter three flags for its dead-letter listeners. Values are Java
-duration strings such as `500ms` or `1000ms` and must be positive.
+internal API server uses the latter three flags for its dead-letter listeners. Values are complete
+human-readable durations such as `500ms` or `1000ms` and must be positive.
 
 ---
 

--- a/docs/edpaggregator/deployment-guide.md
+++ b/docs/edpaggregator/deployment-guide.md
@@ -656,6 +656,54 @@ supply:
 Leave `vid_labeling_workers = {}` to skip the phase workers/queues; provide worker
 entries only once your market has adopted VID labeling.
 
+#### VID Labeling outbound RPC rate limits
+
+Every VID Labeling process shares four client-side throttlers across its coroutines. The defaults
+pace Kingdom reads at **2 QPS** (one call every 500 milliseconds), EDP-Aggregator metadata reads at
+**2 QPS**, metadata mutations at **1 QPS**, and Secure Computation
+`WorkItems`/`WorkItemAttempts` calls at **2 QPS**. These are per-process limits, not measured
+downstream capacities or deployment-wide quotas.
+
+The default topology permits 24 phase-worker VMs, one dispatcher, one monitor, one internal API
+server, and an operator retry process. At 28 processes, the read and write throttlers together are
+bounded at 84 metadata RPCs per second, below the existing 100-QPS EDPA per-method precedent, while
+control-plane traffic is bounded at 56 QPS. Treat those figures as a conservative planning envelope
+and tune them from production latency, saturation, and `RESOURCE_EXHAUSTED` metrics.
+
+The Terraform module caps both the dispatcher and monitor at one instance. The checked-in Kingdom
+`RateLimitConfig` gives each VID Repository method its own 5-QPS average / 20-request burst bucket,
+so the two functions' worst-case 4 QPS leaves 20 percent headroom without competing with
+ResultsFulfiller, RequisitionFetcher, EventGroupSync, or DataAvailabilitySync in the shared default
+bucket. The configured methods are `ModelLines/GetModelLine`, `ModelLines/ListModelLines`,
+`ModelRollouts/ListModelRollouts`, and `ModelShards/ListModelShards`; for example:
+
+```textproto
+per_method_rate_limit {
+  key: "wfa.measurement.api.v2alpha.ModelLines/ListModelLines"
+  value {
+    maximum_request_count: 20
+    average_request_rate: 5
+  }
+}
+```
+
+Both VID Labeling scheduler jobs use a 600-second attempt deadline matching the monitor timeout. The
+GCS-triggered DataWatcher has a 540-second timeout and calls a dispatcher capped at 480 seconds, so
+the synchronous caller retains one minute of shutdown and response headroom.
+
+The dispatcher and monitor accept these optional environment variables:
+
+* `VID_LABELING_KINGDOM_RPC_MIN_INTERVAL`
+* `VID_LABELING_METADATA_READ_RPC_MIN_INTERVAL`
+* `VID_LABELING_METADATA_WRITE_RPC_MIN_INTERVAL`
+* `VID_LABELING_CONTROL_PLANE_RPC_MIN_INTERVAL`
+
+The TEE worker applications accept the corresponding command-line flags
+`--kingdom-rpc-min-interval`, `--metadata-read-rpc-min-interval`,
+`--metadata-write-rpc-min-interval`, and `--control-plane-rpc-min-interval`. The Secure Computation
+internal API server uses the latter three flags for its dead-letter listeners. Values are Java
+duration strings such as `500ms` or `1000ms` and must be positive.
+
 ---
 
 ## Config file formats

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/BUILD.bazel
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/BUILD.bazel
@@ -70,14 +70,11 @@ kt_jvm_library(
 
 kt_jvm_library(
     name = "base_vid_labeling_tee_app_runner",
-    srcs = [
-        "BaseVidLabelingTeeAppRunner.kt",
-        "VidLabelingRpcDurationConverter.kt",
-    ],
+    srcs = ["BaseVidLabelingTeeAppRunner.kt"],
     deps = [
         ":base_tee_app_runner",
         ":storage_config",
-        ":vid_labeling_rpc_duration_parser",
+        ":vid_labeling_rpc_duration_converter",
         ":vid_labeling_rpc_throttlers",
         "@wfa_common_jvm//imports/java/com/google/crypto/tink",
         "@wfa_common_jvm//imports/java/com/google/protobuf",
@@ -87,6 +84,19 @@ kt_jvm_library(
         "@wfa_common_jvm//src/main/kotlin/org/wfanet/measurement/storage:client",
         "@wfa_common_jvm//src/main/kotlin/org/wfanet/measurement/storage:parquet_storage_client",
         "@wfa_common_jvm//src/main/kotlin/org/wfanet/measurement/storage:selected_storage_client",
+    ],
+)
+
+kt_jvm_library(
+    name = "vid_labeling_rpc_duration_converter",
+    srcs = ["VidLabelingRpcDurationConverter.kt"],
+    visibility = [
+        "//src/main/kotlin/org/wfanet/measurement/edpaggregator:__subpackages__",
+        "//src/main/kotlin/org/wfanet/measurement/securecomputation/deploy:__subpackages__",
+    ],
+    deps = [
+        ":vid_labeling_rpc_duration_parser",
+        "@wfa_common_jvm//imports/java/picocli",
     ],
 )
 

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/VidLabelingRpcDurationParser.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/VidLabelingRpcDurationParser.kt
@@ -25,7 +25,9 @@ object VidLabelingRpcDurationParser {
     require(HUMAN_READABLE_DURATION_PATTERN.matches(value)) {
       "Value must be a complete human-readable duration"
     }
-    return value.toDuration()
+    val duration: Duration = value.toDuration()
+    require(duration > Duration.ZERO) { "Value must be a positive human-readable duration" }
+    return duration
   }
 
   private val HUMAN_READABLE_DURATION_PATTERN = Regex("(?:\\d+(?:ns|ms|s|m|h|d))+")

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/tools/BUILD.bazel
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/tools/BUILD.bazel
@@ -50,6 +50,7 @@ kt_jvm_library(
     ],
     deps = [
         "//src/main/kotlin/org/wfanet/measurement/api/v2alpha:resource_key",
+        "//src/main/kotlin/org/wfanet/measurement/edpaggregator:vid_labeling_rpc_throttlers",
         "//src/main/kotlin/org/wfanet/measurement/edpaggregator/service:resource_key",
         "//src/main/kotlin/org/wfanet/measurement/edpaggregator/vidlabeling:request_ids",
         "//src/main/kotlin/org/wfanet/measurement/edpaggregator/vidlabeling:work_item_ids",
@@ -69,6 +70,7 @@ kt_jvm_library(
         "@wfa_common_jvm//src/main/kotlin/org/wfanet/measurement/common",
         "@wfa_common_jvm//src/main/kotlin/org/wfanet/measurement/common/crypto:signing_certs",
         "@wfa_common_jvm//src/main/kotlin/org/wfanet/measurement/common/grpc",
+        "@wfa_common_jvm//src/main/kotlin/org/wfanet/measurement/common/throttler",
         "@wfa_common_jvm//src/main/kotlin/org/wfanet/measurement/gcloud/pubsub:default_google_pub_sub_client",
         "@wfa_common_jvm//src/main/kotlin/org/wfanet/measurement/gcloud/pubsub:publisher",
         "@wfa_common_jvm//src/main/kotlin/org/wfanet/measurement/gcloud/pubsub:subscriber",

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/tools/BUILD.bazel
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/tools/BUILD.bazel
@@ -50,6 +50,7 @@ kt_jvm_library(
     ],
     deps = [
         "//src/main/kotlin/org/wfanet/measurement/api/v2alpha:resource_key",
+        "//src/main/kotlin/org/wfanet/measurement/edpaggregator:vid_labeling_rpc_duration_converter",
         "//src/main/kotlin/org/wfanet/measurement/edpaggregator:vid_labeling_rpc_throttlers",
         "//src/main/kotlin/org/wfanet/measurement/edpaggregator/service:resource_key",
         "//src/main/kotlin/org/wfanet/measurement/edpaggregator/vidlabeling:request_ids",

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/tools/FailedDispatchRetrier.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/tools/FailedDispatchRetrier.kt
@@ -20,6 +20,7 @@ import io.grpc.Status
 import io.grpc.StatusException
 import java.util.UUID
 import java.util.logging.Logger
+import org.wfanet.measurement.edpaggregator.VidLabelingRpcThrottlers
 import org.wfanet.measurement.edpaggregator.v1alpha.ListPoolAssignmentJobsRequestKt
 import org.wfanet.measurement.edpaggregator.v1alpha.ListRankerJobsRequestKt
 import org.wfanet.measurement.edpaggregator.v1alpha.ListVidLabelingJobsRequestKt
@@ -63,6 +64,7 @@ import org.wfanet.measurement.securecomputation.controlplane.v1alpha.workItem
  * @param rankerJobsStub stub for `RankerJobService` (Phase 1).
  * @param vidLabelingJobsStub stub for `VidLabelingJobService` (Phase 2).
  * @param workItemsStub stub for the Secure Computation control-plane `WorkItems` service.
+ * @param rpcThrottlers shared throttlers for metadata and control-plane RPCs.
  */
 class FailedDispatchRetrier(
   private val rawImpressionModelLinesStub: RawImpressionUploadModelLineServiceCoroutineStub,
@@ -70,6 +72,7 @@ class FailedDispatchRetrier(
   private val rankerJobsStub: RankerJobServiceCoroutineStub,
   private val vidLabelingJobsStub: VidLabelingJobServiceCoroutineStub,
   private val workItemsStub: WorkItemsCoroutineStub,
+  private val rpcThrottlers: VidLabelingRpcThrottlers,
 ) {
   /** Outcome of a [retryFailed] run. */
   data class RetryResult(
@@ -97,7 +100,11 @@ class FailedDispatchRetrier(
     fromPhase: RawImpressionUploadModelLine.State? = null,
   ): RetryResult {
     val modelLine =
-      rawImpressionModelLinesStub.findModelLine(rawImpressionUpload, cmmsModelLine)
+      rawImpressionModelLinesStub.findModelLine(
+        rawImpressionUpload,
+        cmmsModelLine,
+        rpcThrottlers.metadataRead,
+      )
         ?: throw IllegalArgumentException(
           "No RawImpressionUploadModelLine for $cmmsModelLine under $rawImpressionUpload"
         )
@@ -107,12 +114,19 @@ class FailedDispatchRetrier(
 
     // Re-trigger [fromPhase] if the operator specified one; otherwise the furthest phase reached
     // (the deepest one that created job rows).
-    val targetState = fromPhase ?: detectFurthestPhase(rawImpressionUpload, cmmsModelLine)
-    val oldWorkItemIds = workItemIdsForPhase(rawImpressionUpload, cmmsModelLine, targetState)
+    val phaseWorkItems =
+      if (fromPhase == null) {
+        detectFurthestPhaseWorkItems(rawImpressionUpload, cmmsModelLine)
+      } else {
+        PhaseWorkItems(
+          fromPhase,
+          workItemIdsForPhase(rawImpressionUpload, cmmsModelLine, fromPhase),
+        )
+      }
 
     // Re-publish before transitioning, so the work exists before the line is claimed.
     var republished = 0
-    for (oldId in oldWorkItemIds) {
+    for (oldId in phaseWorkItems.workItemIds) {
       if (republishWorkItem(oldId)) republished++
     }
 
@@ -123,7 +137,7 @@ class FailedDispatchRetrier(
       return RetryResult(modelLine.name, 0, modelLine.state)
     }
 
-    val updated = transition(modelLine, targetState)
+    val updated = transition(modelLine, phaseWorkItems.phase)
     return RetryResult(updated.name, republished, updated.state)
   }
 
@@ -132,20 +146,32 @@ class FailedDispatchRetrier(
    * job rows exist: `VidLabelingJob`s ⇒ `LABELING`, else `RankerJob`s ⇒ `RANKING`, else
    * `PoolAssignmentJob`s ⇒ `POOL_ASSIGNING`.
    */
-  private suspend fun detectFurthestPhase(
+  private suspend fun detectFurthestPhaseWorkItems(
     uploadName: String,
     cmmsModelLine: String,
-  ): RawImpressionUploadModelLine.State {
-    if (listVidLabelingJobNames(uploadName, cmmsModelLine).isNotEmpty()) {
-      return RawImpressionUploadModelLine.State.LABELING
+  ): PhaseWorkItems {
+    val vidLabelingJobNames = listVidLabelingJobNames(uploadName, cmmsModelLine)
+    if (vidLabelingJobNames.isNotEmpty()) {
+      return PhaseWorkItems(
+        RawImpressionUploadModelLine.State.LABELING,
+        vidLabelingJobNames.map { WorkItemIds.forVidLabeler(it) },
+      )
     }
-    if (listRankerJobNames(uploadName, cmmsModelLine).isNotEmpty()) {
-      return RawImpressionUploadModelLine.State.RANKING
+    val rankerJobNames = listRankerJobNames(uploadName, cmmsModelLine)
+    if (rankerJobNames.isNotEmpty()) {
+      return PhaseWorkItems(
+        RawImpressionUploadModelLine.State.RANKING,
+        rankerJobNames.map { WorkItemIds.forVidRankBuilder(it) },
+      )
     }
-    require(listPoolAssignmentJobShards(uploadName, cmmsModelLine).isNotEmpty()) {
+    val poolAssignmentJobShards = listPoolAssignmentJobShards(uploadName, cmmsModelLine)
+    require(poolAssignmentJobShards.isNotEmpty()) {
       "No jobs found for $cmmsModelLine under $uploadName; nothing to retry"
     }
-    return RawImpressionUploadModelLine.State.POOL_ASSIGNING
+    return PhaseWorkItems(
+      RawImpressionUploadModelLine.State.POOL_ASSIGNING,
+      poolAssignmentJobShards.map { WorkItemIds.forSubpoolAssigner(uploadName, cmmsModelLine, it) },
+    )
   }
 
   /** The origin WorkItem ids to republish to re-trigger [phase] for (upload, model line). */
@@ -191,13 +217,15 @@ class FailedDispatchRetrier(
     var pageToken = ""
     do {
       val response =
-        vidLabelingJobsStub.listVidLabelingJobs(
-          listVidLabelingJobsRequest {
-            parent = uploadName
-            filter = ListVidLabelingJobsRequestKt.filter { this.cmmsModelLine = cmmsModelLine }
-            this.pageToken = pageToken
-          }
-        )
+        rpcThrottlers.metadataRead.onReady {
+          vidLabelingJobsStub.listVidLabelingJobs(
+            listVidLabelingJobsRequest {
+              parent = uploadName
+              filter = ListVidLabelingJobsRequestKt.filter { this.cmmsModelLine = cmmsModelLine }
+              this.pageToken = pageToken
+            }
+          )
+        }
       response.vidLabelingJobsList.forEach { names.add(it.name) }
       pageToken = response.nextPageToken
     } while (pageToken.isNotEmpty())
@@ -209,13 +237,15 @@ class FailedDispatchRetrier(
     var pageToken = ""
     do {
       val response =
-        rankerJobsStub.listRankerJobs(
-          listRankerJobsRequest {
-            parent = uploadName
-            filter = ListRankerJobsRequestKt.filter { this.cmmsModelLine = cmmsModelLine }
-            this.pageToken = pageToken
-          }
-        )
+        rpcThrottlers.metadataRead.onReady {
+          rankerJobsStub.listRankerJobs(
+            listRankerJobsRequest {
+              parent = uploadName
+              filter = ListRankerJobsRequestKt.filter { this.cmmsModelLine = cmmsModelLine }
+              this.pageToken = pageToken
+            }
+          )
+        }
       response.rankerJobsList.forEach { names.add(it.name) }
       pageToken = response.nextPageToken
     } while (pageToken.isNotEmpty())
@@ -230,13 +260,15 @@ class FailedDispatchRetrier(
     var pageToken = ""
     do {
       val response =
-        poolAssignmentJobsStub.listPoolAssignmentJobs(
-          listPoolAssignmentJobsRequest {
-            parent = uploadName
-            filter = ListPoolAssignmentJobsRequestKt.filter { this.cmmsModelLine = cmmsModelLine }
-            this.pageToken = pageToken
-          }
-        )
+        rpcThrottlers.metadataRead.onReady {
+          poolAssignmentJobsStub.listPoolAssignmentJobs(
+            listPoolAssignmentJobsRequest {
+              parent = uploadName
+              filter = ListPoolAssignmentJobsRequestKt.filter { this.cmmsModelLine = cmmsModelLine }
+              this.pageToken = pageToken
+            }
+          )
+        }
       response.poolAssignmentJobsList.forEach { shards.add(it.shardIndex) }
       pageToken = response.nextPageToken
     } while (pageToken.isNotEmpty())
@@ -250,7 +282,9 @@ class FailedDispatchRetrier(
   private suspend fun republishWorkItem(oldWorkItemId: String): Boolean {
     val existing =
       try {
-        workItemsStub.getWorkItem(getWorkItemRequest { name = "workItems/$oldWorkItemId" })
+        rpcThrottlers.controlPlane.onReady {
+          workItemsStub.getWorkItem(getWorkItemRequest { name = "workItems/$oldWorkItemId" })
+        }
       } catch (e: StatusException) {
         if (e.status.code == Status.Code.NOT_FOUND) {
           throw IllegalStateException(
@@ -266,12 +300,14 @@ class FailedDispatchRetrier(
       workItemParams = existing.workItemParams
     }
     return try {
-      workItemsStub.createWorkItem(
-        createWorkItemRequest {
-          workItemId = newId
-          workItem = republished
-        }
-      )
+      rpcThrottlers.controlPlane.onReady {
+        workItemsStub.createWorkItem(
+          createWorkItemRequest {
+            workItemId = newId
+            workItem = republished
+          }
+        )
+      }
       logger.info("Re-published $oldWorkItemId as $newId (queue=${existing.queue}).")
       true
     } catch (e: StatusException) {
@@ -295,30 +331,41 @@ class FailedDispatchRetrier(
     // hits the AIP-155 replay short-circuit instead of failing INVALID_ARGUMENT.
     when (targetState) {
       RawImpressionUploadModelLine.State.POOL_ASSIGNING ->
-        rawImpressionModelLinesStub.markRawImpressionUploadModelLinePoolAssigning(
-          markRawImpressionUploadModelLinePoolAssigningRequest {
-            name = modelLine.name
-            etag = modelLine.etag
-          }
-        )
+        rpcThrottlers.metadataWrite.onReady {
+          rawImpressionModelLinesStub.markRawImpressionUploadModelLinePoolAssigning(
+            markRawImpressionUploadModelLinePoolAssigningRequest {
+              name = modelLine.name
+              etag = modelLine.etag
+            }
+          )
+        }
       RawImpressionUploadModelLine.State.RANKING ->
-        rawImpressionModelLinesStub.markRawImpressionUploadModelLineRanking(
-          markRawImpressionUploadModelLineRankingRequest {
-            name = modelLine.name
-            etag = modelLine.etag
-          }
-        )
+        rpcThrottlers.metadataWrite.onReady {
+          rawImpressionModelLinesStub.markRawImpressionUploadModelLineRanking(
+            markRawImpressionUploadModelLineRankingRequest {
+              name = modelLine.name
+              etag = modelLine.etag
+            }
+          )
+        }
       RawImpressionUploadModelLine.State.LABELING ->
-        rawImpressionModelLinesStub.markRawImpressionUploadModelLineLabeling(
-          markRawImpressionUploadModelLineLabelingRequest {
-            name = modelLine.name
-            etag = modelLine.etag
-          }
-        )
+        rpcThrottlers.metadataWrite.onReady {
+          rawImpressionModelLinesStub.markRawImpressionUploadModelLineLabeling(
+            markRawImpressionUploadModelLineLabelingRequest {
+              name = modelLine.name
+              etag = modelLine.etag
+            }
+          )
+        }
       else -> error("unreachable: targetState is a phase state")
     }
 
   companion object {
     private val logger: Logger = Logger.getLogger(FailedDispatchRetrier::class.java.name)
   }
+
+  private data class PhaseWorkItems(
+    val phase: RawImpressionUploadModelLine.State,
+    val workItemIds: List<String>,
+  )
 }

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/tools/ModelLineLookup.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/tools/ModelLineLookup.kt
@@ -16,6 +16,7 @@
 
 package org.wfanet.measurement.edpaggregator.tools
 
+import org.wfanet.measurement.common.throttler.Throttler
 import org.wfanet.measurement.edpaggregator.v1alpha.ListRawImpressionUploadModelLinesRequestKt
 import org.wfanet.measurement.edpaggregator.v1alpha.RawImpressionUploadModelLine
 import org.wfanet.measurement.edpaggregator.v1alpha.RawImpressionUploadModelLineServiceGrpcKt.RawImpressionUploadModelLineServiceCoroutineStub
@@ -25,24 +26,29 @@ import org.wfanet.measurement.edpaggregator.v1alpha.listRawImpressionUploadModel
  * Returns the single [RawImpressionUploadModelLine] under [uploadName] whose `cmms_model_line`
  * equals [cmmsModelLine], or null if none exists.
  *
+ * @param throttler optional throttler acquired once for every paginated RPC.
  * @throws IllegalArgumentException if more than one model line matches.
  */
 internal suspend fun RawImpressionUploadModelLineServiceCoroutineStub.findModelLine(
   uploadName: String,
   cmmsModelLine: String,
+  throttler: Throttler? = null,
 ): RawImpressionUploadModelLine? {
   var pageToken = ""
   var found: RawImpressionUploadModelLine? = null
   do {
+    val request = listRawImpressionUploadModelLinesRequest {
+      parent = uploadName
+      filter =
+        ListRawImpressionUploadModelLinesRequestKt.filter { this.cmmsModelLine = cmmsModelLine }
+      this.pageToken = pageToken
+    }
     val response =
-      listRawImpressionUploadModelLines(
-        listRawImpressionUploadModelLinesRequest {
-          parent = uploadName
-          filter =
-            ListRawImpressionUploadModelLinesRequestKt.filter { this.cmmsModelLine = cmmsModelLine }
-          this.pageToken = pageToken
-        }
-      )
+      if (throttler == null) {
+        listRawImpressionUploadModelLines(request)
+      } else {
+        throttler.onReady { listRawImpressionUploadModelLines(request) }
+      }
     for (line in response.rawImpressionUploadModelLinesList) {
       // The service filters by cmms_model_line, but guard against a server that ignores it.
       if (line.cmmsModelLine != cmmsModelLine) continue

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/tools/VidLabelingHeal.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/tools/VidLabelingHeal.kt
@@ -26,6 +26,7 @@ import org.wfanet.measurement.common.commandLineMain
 import org.wfanet.measurement.common.crypto.SigningCerts
 import org.wfanet.measurement.common.grpc.TlsFlags
 import org.wfanet.measurement.common.grpc.buildMutualTlsChannel
+import org.wfanet.measurement.edpaggregator.VidLabelingRpcThrottlers
 import org.wfanet.measurement.edpaggregator.v1alpha.PoolAssignmentJobServiceGrpcKt.PoolAssignmentJobServiceCoroutineStub
 import org.wfanet.measurement.edpaggregator.v1alpha.RankIndexBlobServiceGrpcKt.RankIndexBlobServiceCoroutineStub
 import org.wfanet.measurement.edpaggregator.v1alpha.RankerJobServiceGrpcKt.RankerJobServiceCoroutineStub
@@ -190,6 +191,27 @@ class MarkFailedCommand : EdpaApiCommand() {
 )
 class RetryFailedCommand : EdpaApiCommand() {
   @Option(
+    names = ["--metadata-read-rpc-min-interval"],
+    description = ["Minimum interval between outbound metadata read RPCs."],
+    defaultValue = "500ms",
+  )
+  private lateinit var metadataReadRpcMinInterval: Duration
+
+  @Option(
+    names = ["--metadata-write-rpc-min-interval"],
+    description = ["Minimum interval between outbound metadata write RPCs."],
+    defaultValue = "1000ms",
+  )
+  private lateinit var metadataWriteRpcMinInterval: Duration
+
+  @Option(
+    names = ["--control-plane-rpc-min-interval"],
+    description = ["Minimum interval between outbound Secure Computation control-plane RPCs."],
+    defaultValue = "500ms",
+  )
+  private lateinit var controlPlaneRpcMinInterval: Duration
+
+  @Option(
     names = ["--control-plane-api-target"],
     description = ["gRPC target (host:port) of the Secure Computation control-plane API."],
     required = true,
@@ -242,6 +264,11 @@ class RetryFailedCommand : EdpaApiCommand() {
             RankerJobServiceCoroutineStub(edpaChannel),
             VidLabelingJobServiceCoroutineStub(edpaChannel),
             WorkItemsCoroutineStub(controlPlaneChannel),
+            VidLabelingRpcThrottlers.fromMinimumIntervals(
+              metadataRead = metadataReadRpcMinInterval,
+              metadataWrite = metadataWriteRpcMinInterval,
+              controlPlane = controlPlaneRpcMinInterval,
+            ),
           )
         val result = retrier.retryFailed(rawImpressionUpload, modelLine, fromPhase)
         if (result.workItemsRepublished == 0) {

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/tools/VidLabelingHeal.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/tools/VidLabelingHeal.kt
@@ -193,21 +193,21 @@ class RetryFailedCommand : EdpaApiCommand() {
   @Option(
     names = ["--metadata-read-rpc-min-interval"],
     description = ["Minimum interval between outbound metadata read RPCs."],
-    defaultValue = "500ms",
+    defaultValue = "100ms",
   )
   private lateinit var metadataReadRpcMinInterval: Duration
 
   @Option(
     names = ["--metadata-write-rpc-min-interval"],
     description = ["Minimum interval between outbound metadata write RPCs."],
-    defaultValue = "1000ms",
+    defaultValue = "200ms",
   )
   private lateinit var metadataWriteRpcMinInterval: Duration
 
   @Option(
     names = ["--control-plane-rpc-min-interval"],
     description = ["Minimum interval between outbound Secure Computation control-plane RPCs."],
-    defaultValue = "500ms",
+    defaultValue = "250ms",
   )
   private lateinit var controlPlaneRpcMinInterval: Duration
 

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/tools/VidLabelingHeal.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/tools/VidLabelingHeal.kt
@@ -26,6 +26,7 @@ import org.wfanet.measurement.common.commandLineMain
 import org.wfanet.measurement.common.crypto.SigningCerts
 import org.wfanet.measurement.common.grpc.TlsFlags
 import org.wfanet.measurement.common.grpc.buildMutualTlsChannel
+import org.wfanet.measurement.edpaggregator.VidLabelingRpcDurationConverter
 import org.wfanet.measurement.edpaggregator.VidLabelingRpcThrottlers
 import org.wfanet.measurement.edpaggregator.v1alpha.PoolAssignmentJobServiceGrpcKt.PoolAssignmentJobServiceCoroutineStub
 import org.wfanet.measurement.edpaggregator.v1alpha.RankIndexBlobServiceGrpcKt.RankIndexBlobServiceCoroutineStub
@@ -194,6 +195,7 @@ class RetryFailedCommand : EdpaApiCommand() {
     names = ["--metadata-read-rpc-min-interval"],
     description = ["Minimum interval between outbound metadata read RPCs."],
     defaultValue = "100ms",
+    converter = [VidLabelingRpcDurationConverter::class],
   )
   private lateinit var metadataReadRpcMinInterval: Duration
 
@@ -201,6 +203,7 @@ class RetryFailedCommand : EdpaApiCommand() {
     names = ["--metadata-write-rpc-min-interval"],
     description = ["Minimum interval between outbound metadata write RPCs."],
     defaultValue = "200ms",
+    converter = [VidLabelingRpcDurationConverter::class],
   )
   private lateinit var metadataWriteRpcMinInterval: Duration
 
@@ -208,6 +211,7 @@ class RetryFailedCommand : EdpaApiCommand() {
     names = ["--control-plane-rpc-min-interval"],
     description = ["Minimum interval between outbound Secure Computation control-plane RPCs."],
     defaultValue = "250ms",
+    converter = [VidLabelingRpcDurationConverter::class],
   )
   private lateinit var controlPlaneRpcMinInterval: Duration
 

--- a/src/main/kotlin/org/wfanet/measurement/securecomputation/deploy/gcloud/deadletter/BUILD.bazel
+++ b/src/main/kotlin/org/wfanet/measurement/securecomputation/deploy/gcloud/deadletter/BUILD.bazel
@@ -11,6 +11,7 @@ kt_jvm_library(
     ],
     deps = [
         "//src/main/kotlin/org/wfanet/measurement/common/api/grpc:list_resources",
+        "//src/main/kotlin/org/wfanet/measurement/edpaggregator:vid_labeling_rpc_throttlers",
         "//src/main/kotlin/org/wfanet/measurement/edpaggregator/service:resource_key",
         "//src/main/kotlin/org/wfanet/measurement/edpaggregator/vidlabeling:request_ids",
         "//src/main/kotlin/org/wfanet/measurement/securecomputation/service:errors",

--- a/src/main/kotlin/org/wfanet/measurement/securecomputation/deploy/gcloud/deadletter/DeadLetterQueueListener.kt
+++ b/src/main/kotlin/org/wfanet/measurement/securecomputation/deploy/gcloud/deadletter/DeadLetterQueueListener.kt
@@ -26,6 +26,7 @@ import kotlinx.coroutines.flow.collect
 import org.wfanet.measurement.common.api.grpc.ResourceList
 import org.wfanet.measurement.common.api.grpc.listResources
 import org.wfanet.measurement.common.grpc.errorInfo
+import org.wfanet.measurement.edpaggregator.VidLabelingRpcThrottlers
 import org.wfanet.measurement.edpaggregator.service.VidLabelingJobKey
 import org.wfanet.measurement.edpaggregator.v1alpha.ListRawImpressionUploadModelLinesRequestKt
 import org.wfanet.measurement.edpaggregator.v1alpha.PoolAssignmentJob
@@ -79,6 +80,8 @@ import org.wfanet.measurement.securecomputation.service.Errors
  * @param vidLabelingJobsStub EDPA stub used to mark Phase-2 `VidLabelingJob`s FAILED.
  * @param rawImpressionUploadModelLinesStub EDPA stub used to resolve and mark the parent
  *   `RawImpressionUploadModelLine` FAILED.
+ * @param rpcThrottlers process-scoped throttlers shared by all outbound control-plane and EDPA
+ *   metadata RPCs.
  */
 class DeadLetterQueueListener(
   private val subscriptionId: String,
@@ -89,6 +92,7 @@ class DeadLetterQueueListener(
   private val rankerJobsStub: RankerJobServiceCoroutineStub,
   private val vidLabelingJobsStub: VidLabelingJobServiceCoroutineStub,
   private val rawImpressionUploadModelLinesStub: RawImpressionUploadModelLineServiceCoroutineStub,
+  private val rpcThrottlers: VidLabelingRpcThrottlers,
 ) : AutoCloseable {
 
   /** Starts the listener by subscribing to the dead letter queue. */
@@ -140,7 +144,9 @@ class DeadLetterQueueListener(
     logger.fine("Processing dead letter message for work item: ${workItem.name}")
 
     try {
-      workItemsStub.failWorkItem(failWorkItemRequest { workItemResourceId = workItem.name })
+      rpcThrottlers.controlPlane.onReady {
+        workItemsStub.failWorkItem(failWorkItemRequest { workItemResourceId = workItem.name })
+      }
       logger.fine("Successfully marked work item as failed: ${workItem.name}")
       // Mark the EDPA resource(s) referenced by this WorkItem FAILED. Best-effort: any failure is
       // logged and swallowed so the already-terminal dead-letter message is still acked below.
@@ -247,9 +253,11 @@ class DeadLetterQueueListener(
     if (name.isEmpty()) return
     try {
       val job =
-        poolAssignmentJobsStub.getPoolAssignmentJob(
-          getPoolAssignmentJobRequest { this.name = name }
-        )
+        rpcThrottlers.metadataRead.onReady {
+          poolAssignmentJobsStub.getPoolAssignmentJob(
+            getPoolAssignmentJobRequest { this.name = name }
+          )
+        }
       if (
         job.state == PoolAssignmentJob.State.SUCCEEDED ||
           job.state == PoolAssignmentJob.State.FAILED
@@ -257,16 +265,18 @@ class DeadLetterQueueListener(
         logger.info("PoolAssignmentJob $name already terminal (${job.state}); skipping FAILED mark")
         return
       }
-      poolAssignmentJobsStub.markPoolAssignmentJobFailed(
-        markPoolAssignmentJobFailedRequest {
-          this.name = name
-          this.etag = job.etag
-          this.errorMessage = errorMessage.take(MAX_ERROR_MESSAGE)
-          // AIP-155 idempotency on Pub/Sub redelivery: derived deterministically from the resource
-          // + operation so every attempt for the same mark shares one idempotent result.
-          requestId = RequestIds.forMarkPoolAssignmentJobFailed(name)
-        }
-      )
+      rpcThrottlers.metadataWrite.onReady {
+        poolAssignmentJobsStub.markPoolAssignmentJobFailed(
+          markPoolAssignmentJobFailedRequest {
+            this.name = name
+            this.etag = job.etag
+            this.errorMessage = errorMessage.take(MAX_ERROR_MESSAGE)
+            // AIP-155 idempotency on Pub/Sub redelivery: derived deterministically from the
+            // resource + operation so every attempt for the same mark shares one idempotent result.
+            requestId = RequestIds.forMarkPoolAssignmentJobFailed(name)
+          }
+        )
+      }
       logger.info("Marked PoolAssignmentJob $name FAILED from dead-letter queue")
     } catch (e: Exception) {
       logger.log(Level.WARNING, "Best-effort MarkPoolAssignmentJobFailed($name) failed", e)
@@ -281,21 +291,26 @@ class DeadLetterQueueListener(
   private suspend fun markRankerJobFailedBestEffort(name: String, errorMessage: String) {
     if (name.isEmpty()) return
     try {
-      val job = rankerJobsStub.getRankerJob(getRankerJobRequest { this.name = name })
+      val job =
+        rpcThrottlers.metadataRead.onReady {
+          rankerJobsStub.getRankerJob(getRankerJobRequest { this.name = name })
+        }
       if (job.state == RankerJob.State.SUCCEEDED || job.state == RankerJob.State.FAILED) {
         logger.info("RankerJob $name already terminal (${job.state}); skipping FAILED mark")
         return
       }
-      rankerJobsStub.markRankerJobFailed(
-        markRankerJobFailedRequest {
-          this.name = name
-          this.etag = job.etag
-          this.errorMessage = errorMessage.take(MAX_ERROR_MESSAGE)
-          // AIP-155 idempotency on Pub/Sub redelivery: derived deterministically from the resource
-          // + operation so every attempt for the same mark shares one idempotent result.
-          requestId = RequestIds.forMarkRankerJobFailed(name)
-        }
-      )
+      rpcThrottlers.metadataWrite.onReady {
+        rankerJobsStub.markRankerJobFailed(
+          markRankerJobFailedRequest {
+            this.name = name
+            this.etag = job.etag
+            this.errorMessage = errorMessage.take(MAX_ERROR_MESSAGE)
+            // AIP-155 idempotency on Pub/Sub redelivery: derived deterministically from the
+            // resource + operation so every attempt for the same mark shares one idempotent result.
+            requestId = RequestIds.forMarkRankerJobFailed(name)
+          }
+        )
+      }
       logger.info("Marked RankerJob $name FAILED from dead-letter queue")
     } catch (e: Exception) {
       logger.log(Level.WARNING, "Best-effort MarkRankerJobFailed($name) failed", e)
@@ -311,19 +326,24 @@ class DeadLetterQueueListener(
   private suspend fun markVidLabelingJobFailedBestEffort(name: String, errorMessage: String) {
     if (name.isEmpty()) return
     try {
-      val job = vidLabelingJobsStub.getVidLabelingJob(getVidLabelingJobRequest { this.name = name })
+      val job =
+        rpcThrottlers.metadataRead.onReady {
+          vidLabelingJobsStub.getVidLabelingJob(getVidLabelingJobRequest { this.name = name })
+        }
       if (job.state == VidLabelingJob.State.SUCCEEDED || job.state == VidLabelingJob.State.FAILED) {
         logger.info("VidLabelingJob $name already terminal (${job.state}); skipping FAILED mark")
         return
       }
-      vidLabelingJobsStub.markVidLabelingJobFailed(
-        markVidLabelingJobFailedRequest {
-          this.name = name
-          this.etag = job.etag
-          this.errorMessage = errorMessage.take(MAX_ERROR_MESSAGE)
-          requestId = RequestIds.forMarkVidLabelingJobFailed(name)
-        }
-      )
+      rpcThrottlers.metadataWrite.onReady {
+        vidLabelingJobsStub.markVidLabelingJobFailed(
+          markVidLabelingJobFailedRequest {
+            this.name = name
+            this.etag = job.etag
+            this.errorMessage = errorMessage.take(MAX_ERROR_MESSAGE)
+            requestId = RequestIds.forMarkVidLabelingJobFailed(name)
+          }
+        )
+      }
       logger.info("Marked VidLabelingJob $name FAILED from dead-letter queue")
     } catch (e: Exception) {
       logger.log(Level.WARNING, "Best-effort MarkVidLabelingJobFailed($name) failed", e)
@@ -361,18 +381,20 @@ class DeadLetterQueueListener(
         )
         return
       }
-      rawImpressionUploadModelLinesStub.markRawImpressionUploadModelLineFailed(
-        markRawImpressionUploadModelLineFailedRequest {
-          name = parent.name
-          // `etag` is REQUIRED. Reuse the one already returned by getParentModelLine's List (the
-          // RawImpressionUploadModelLine resource carries it) instead of an extra Get.
-          etag = parent.etag
-          this.errorMessage = errorMessage.take(MAX_ERROR_MESSAGE)
-          // AIP-155 idempotency on Pub/Sub redelivery: derived deterministically from the resource
-          // + operation so every attempt for the same mark shares one idempotent result.
-          requestId = RequestIds.forMarkRawImpressionUploadModelLineFailed(parent.name)
-        }
-      )
+      rpcThrottlers.metadataWrite.onReady {
+        rawImpressionUploadModelLinesStub.markRawImpressionUploadModelLineFailed(
+          markRawImpressionUploadModelLineFailedRequest {
+            name = parent.name
+            // `etag` is REQUIRED. Reuse the one already returned by getParentModelLine's List (the
+            // RawImpressionUploadModelLine resource carries it) instead of an extra Get.
+            etag = parent.etag
+            this.errorMessage = errorMessage.take(MAX_ERROR_MESSAGE)
+            // AIP-155 idempotency on Pub/Sub redelivery: derived deterministically from the
+            // resource + operation so every attempt for the same mark shares one idempotent result.
+            requestId = RequestIds.forMarkRawImpressionUploadModelLineFailed(parent.name)
+          }
+        )
+      }
       logger.info(
         "Marked RawImpressionUploadModelLine ${parent.name} FAILED from dead-letter queue"
       )
@@ -399,16 +421,18 @@ class DeadLetterQueueListener(
     rawImpressionUploadModelLinesStub
       .listResources { pageToken: String ->
         val response =
-          listRawImpressionUploadModelLines(
-            listRawImpressionUploadModelLinesRequest {
-              parent = rawImpressionUpload
-              filter =
-                ListRawImpressionUploadModelLinesRequestKt.filter {
-                  this.cmmsModelLine = cmmsModelLine
-                }
-              this.pageToken = pageToken
-            }
-          )
+          rpcThrottlers.metadataRead.onReady {
+            listRawImpressionUploadModelLines(
+              listRawImpressionUploadModelLinesRequest {
+                parent = rawImpressionUpload
+                filter =
+                  ListRawImpressionUploadModelLinesRequestKt.filter {
+                    this.cmmsModelLine = cmmsModelLine
+                  }
+                this.pageToken = pageToken
+              }
+            )
+          }
         ResourceList(response.rawImpressionUploadModelLinesList, response.nextPageToken)
       }
       .collect { page ->

--- a/src/main/kotlin/org/wfanet/measurement/securecomputation/deploy/gcloud/spanner/BUILD.bazel
+++ b/src/main/kotlin/org/wfanet/measurement/securecomputation/deploy/gcloud/spanner/BUILD.bazel
@@ -44,6 +44,7 @@ kt_jvm_library(
     deps = [
         ":services",
         "//src/main/kotlin/org/wfanet/measurement/common/grpc:service_flags",
+        "//src/main/kotlin/org/wfanet/measurement/edpaggregator:vid_labeling_rpc_throttlers",
         "//src/main/kotlin/org/wfanet/measurement/securecomputation/deploy/gcloud/deadletter:dead_letter_queue_listener",
         "//src/main/kotlin/org/wfanet/measurement/securecomputation/deploy/gcloud/publisher:google_work_item_publisher",
         "//src/main/kotlin/org/wfanet/measurement/securecomputation/service/internal:queue_mapping",

--- a/src/main/kotlin/org/wfanet/measurement/securecomputation/deploy/gcloud/spanner/BUILD.bazel
+++ b/src/main/kotlin/org/wfanet/measurement/securecomputation/deploy/gcloud/spanner/BUILD.bazel
@@ -41,9 +41,13 @@ kt_jvm_library(
 kt_jvm_library(
     name = "internal_api_server",
     srcs = ["InternalApiServer.kt"],
+    visibility = [
+        "//src/test/kotlin/org/wfanet/measurement/securecomputation/deploy/gcloud/spanner:__pkg__",
+    ],
     deps = [
         ":services",
         "//src/main/kotlin/org/wfanet/measurement/common/grpc:service_flags",
+        "//src/main/kotlin/org/wfanet/measurement/edpaggregator:vid_labeling_rpc_duration_converter",
         "//src/main/kotlin/org/wfanet/measurement/edpaggregator:vid_labeling_rpc_throttlers",
         "//src/main/kotlin/org/wfanet/measurement/securecomputation/deploy/gcloud/deadletter:dead_letter_queue_listener",
         "//src/main/kotlin/org/wfanet/measurement/securecomputation/deploy/gcloud/publisher:google_work_item_publisher",

--- a/src/main/kotlin/org/wfanet/measurement/securecomputation/deploy/gcloud/spanner/InternalApiServer.kt
+++ b/src/main/kotlin/org/wfanet/measurement/securecomputation/deploy/gcloud/spanner/InternalApiServer.kt
@@ -38,6 +38,7 @@ import org.wfanet.measurement.common.grpc.buildMutualTlsChannel
 import org.wfanet.measurement.common.grpc.withShutdownTimeout
 import org.wfanet.measurement.common.parseTextProto
 import org.wfanet.measurement.config.securecomputation.QueuesConfig
+import org.wfanet.measurement.edpaggregator.VidLabelingRpcThrottlers
 import org.wfanet.measurement.edpaggregator.v1alpha.PoolAssignmentJobServiceGrpcKt.PoolAssignmentJobServiceCoroutineStub
 import org.wfanet.measurement.edpaggregator.v1alpha.RankerJobServiceGrpcKt.RankerJobServiceCoroutineStub
 import org.wfanet.measurement.edpaggregator.v1alpha.RawImpressionUploadModelLineServiceGrpcKt.RawImpressionUploadModelLineServiceCoroutineStub
@@ -166,6 +167,27 @@ class InternalApiServer : Runnable {
   )
   private lateinit var channelShutdownTimeout: Duration
 
+  @CommandLine.Option(
+    names = ["--metadata-read-rpc-min-interval"],
+    defaultValue = "500ms",
+    description = ["Minimum interval between outbound EDPA metadata read RPCs from this process."],
+  )
+  private lateinit var metadataReadRpcMinInterval: Duration
+
+  @CommandLine.Option(
+    names = ["--metadata-write-rpc-min-interval"],
+    defaultValue = "1000ms",
+    description = ["Minimum interval between outbound EDPA metadata write RPCs from this process."],
+  )
+  private lateinit var metadataWriteRpcMinInterval: Duration
+
+  @CommandLine.Option(
+    names = ["--control-plane-rpc-min-interval"],
+    defaultValue = "500ms",
+    description = ["Minimum interval between outbound WorkItems RPCs from this process."],
+  )
+  private lateinit var controlPlaneRpcMinInterval: Duration
+
   override fun run() {
     val queuesConfig = parseTextProto(queuesConfigFile, QueuesConfig.getDefaultInstance())
     val queueMapping = QueueMapping(queuesConfig)
@@ -175,6 +197,12 @@ class InternalApiServer : Runnable {
     // them, so the EDPA cert/key/target flags are not required in that case.
     val edpaConnection: EdpaConnection? =
       if (deadLetterSubscriptionIds.isEmpty()) null else buildEdpaConnection()
+    val rpcThrottlers =
+      VidLabelingRpcThrottlers.fromMinimumIntervals(
+        metadataRead = metadataReadRpcMinInterval,
+        metadataWrite = metadataWriteRpcMinInterval,
+        controlPlane = controlPlaneRpcMinInterval,
+      )
 
     runBlocking {
       spannerFlags.usingSpanner { spanner ->
@@ -219,6 +247,7 @@ class InternalApiServer : Runnable {
                   // Non-null: edpaConnection is built whenever deadLetterSubscriptionIds is
                   // non-empty, which is exactly when this map iterates.
                   edpaStubs = checkNotNull(edpaConnection).stubs,
+                  rpcThrottlers = rpcThrottlers,
                 )
               async {
                 try {
@@ -320,6 +349,7 @@ class InternalApiServer : Runnable {
     subscriptionId: String,
     queueSubscriber: QueueSubscriber,
     edpaStubs: EdpaStubs,
+    rpcThrottlers: VidLabelingRpcThrottlers,
   ): DeadLetterQueueListener {
     return DeadLetterQueueListener(
       subscriptionId = subscriptionId,
@@ -330,6 +360,7 @@ class InternalApiServer : Runnable {
       rankerJobsStub = edpaStubs.rankerJobsStub,
       vidLabelingJobsStub = edpaStubs.vidLabelingJobsStub,
       rawImpressionUploadModelLinesStub = edpaStubs.rawImpressionUploadModelLinesStub,
+      rpcThrottlers = rpcThrottlers,
     )
   }
 

--- a/src/main/kotlin/org/wfanet/measurement/securecomputation/deploy/gcloud/spanner/InternalApiServer.kt
+++ b/src/main/kotlin/org/wfanet/measurement/securecomputation/deploy/gcloud/spanner/InternalApiServer.kt
@@ -38,6 +38,7 @@ import org.wfanet.measurement.common.grpc.buildMutualTlsChannel
 import org.wfanet.measurement.common.grpc.withShutdownTimeout
 import org.wfanet.measurement.common.parseTextProto
 import org.wfanet.measurement.config.securecomputation.QueuesConfig
+import org.wfanet.measurement.edpaggregator.VidLabelingRpcDurationConverter
 import org.wfanet.measurement.edpaggregator.VidLabelingRpcThrottlers
 import org.wfanet.measurement.edpaggregator.v1alpha.PoolAssignmentJobServiceGrpcKt.PoolAssignmentJobServiceCoroutineStub
 import org.wfanet.measurement.edpaggregator.v1alpha.RankerJobServiceGrpcKt.RankerJobServiceCoroutineStub
@@ -171,6 +172,7 @@ class InternalApiServer : Runnable {
     names = ["--metadata-read-rpc-min-interval"],
     defaultValue = "100ms",
     description = ["Minimum interval between outbound EDPA metadata read RPCs from this process."],
+    converter = [VidLabelingRpcDurationConverter::class],
   )
   private lateinit var metadataReadRpcMinInterval: Duration
 
@@ -178,6 +180,7 @@ class InternalApiServer : Runnable {
     names = ["--metadata-write-rpc-min-interval"],
     defaultValue = "200ms",
     description = ["Minimum interval between outbound EDPA metadata write RPCs from this process."],
+    converter = [VidLabelingRpcDurationConverter::class],
   )
   private lateinit var metadataWriteRpcMinInterval: Duration
 
@@ -185,6 +188,7 @@ class InternalApiServer : Runnable {
     names = ["--control-plane-rpc-min-interval"],
     defaultValue = "250ms",
     description = ["Minimum interval between outbound WorkItems RPCs from this process."],
+    converter = [VidLabelingRpcDurationConverter::class],
   )
   private lateinit var controlPlaneRpcMinInterval: Duration
 

--- a/src/main/kotlin/org/wfanet/measurement/securecomputation/deploy/gcloud/spanner/InternalApiServer.kt
+++ b/src/main/kotlin/org/wfanet/measurement/securecomputation/deploy/gcloud/spanner/InternalApiServer.kt
@@ -169,21 +169,21 @@ class InternalApiServer : Runnable {
 
   @CommandLine.Option(
     names = ["--metadata-read-rpc-min-interval"],
-    defaultValue = "500ms",
+    defaultValue = "100ms",
     description = ["Minimum interval between outbound EDPA metadata read RPCs from this process."],
   )
   private lateinit var metadataReadRpcMinInterval: Duration
 
   @CommandLine.Option(
     names = ["--metadata-write-rpc-min-interval"],
-    defaultValue = "1000ms",
+    defaultValue = "200ms",
     description = ["Minimum interval between outbound EDPA metadata write RPCs from this process."],
   )
   private lateinit var metadataWriteRpcMinInterval: Duration
 
   @CommandLine.Option(
     names = ["--control-plane-rpc-min-interval"],
-    defaultValue = "500ms",
+    defaultValue = "250ms",
     description = ["Minimum interval between outbound WorkItems RPCs from this process."],
   )
   private lateinit var controlPlaneRpcMinInterval: Duration

--- a/src/test/kotlin/org/wfanet/measurement/edpaggregator/tools/BUILD.bazel
+++ b/src/test/kotlin/org/wfanet/measurement/edpaggregator/tools/BUILD.bazel
@@ -140,5 +140,7 @@ kt_jvm_test(
         "//src/main/kotlin/org/wfanet/measurement/edpaggregator/tools:vid_labeling_heal",
         "@wfa_common_jvm//imports/java/com/google/common/truth",
         "@wfa_common_jvm//imports/java/org/junit",
+        "@wfa_common_jvm//imports/java/picocli",
+        "@wfa_common_jvm//imports/kotlin/kotlin/test",
     ],
 )

--- a/src/test/kotlin/org/wfanet/measurement/edpaggregator/tools/BUILD.bazel
+++ b/src/test/kotlin/org/wfanet/measurement/edpaggregator/tools/BUILD.bazel
@@ -93,6 +93,7 @@ kt_jvm_test(
     srcs = ["FailedDispatchRetrierTest.kt"],
     test_class = "org.wfanet.measurement.edpaggregator.tools.FailedDispatchRetrierTest",
     deps = [
+        "//src/main/kotlin/org/wfanet/measurement/edpaggregator/testing:vid_labeling_rpc_throttlers",
         "//src/main/kotlin/org/wfanet/measurement/edpaggregator/tools:vid_labeling_heal",
         "//src/main/proto/wfa/measurement/edpaggregator/v1alpha:pool_assignment_job_kt_jvm_proto",
         "//src/main/proto/wfa/measurement/edpaggregator/v1alpha:pool_assignment_job_service_kt_jvm_grpc_proto",

--- a/src/test/kotlin/org/wfanet/measurement/edpaggregator/tools/FailedDispatchRetrierTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/edpaggregator/tools/FailedDispatchRetrierTest.kt
@@ -26,10 +26,12 @@ import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 import org.mockito.kotlin.any
 import org.mockito.kotlin.never
+import org.mockito.kotlin.times
 import org.mockito.kotlin.verifyBlocking
 import org.mockito.kotlin.whenever
 import org.wfanet.measurement.common.grpc.testing.GrpcTestServerRule
 import org.wfanet.measurement.common.grpc.testing.mockService
+import org.wfanet.measurement.edpaggregator.testing.VidLabelingRpcThrottlersTestHelper
 import org.wfanet.measurement.edpaggregator.v1alpha.PoolAssignmentJobServiceGrpcKt
 import org.wfanet.measurement.edpaggregator.v1alpha.RankerJobServiceGrpcKt
 import org.wfanet.measurement.edpaggregator.v1alpha.RawImpressionUploadModelLine
@@ -61,6 +63,7 @@ class FailedDispatchRetrierTest {
     VidLabelingJobServiceGrpcKt.VidLabelingJobServiceCoroutineImplBase =
     mockService()
   private val workItemsService: WorkItemsGrpcKt.WorkItemsCoroutineImplBase = mockService()
+  private val recordingThrottlers = VidLabelingRpcThrottlersTestHelper.recording()
 
   @get:Rule
   val grpcTestServerRule = GrpcTestServerRule {
@@ -81,6 +84,7 @@ class FailedDispatchRetrierTest {
       RankerJobServiceGrpcKt.RankerJobServiceCoroutineStub(channel),
       VidLabelingJobServiceGrpcKt.VidLabelingJobServiceCoroutineStub(channel),
       WorkItemsGrpcKt.WorkItemsCoroutineStub(channel),
+      recordingThrottlers.throttlers,
     )
   }
 
@@ -118,6 +122,37 @@ class FailedDispatchRetrierTest {
 
     assertThat(result.newState).isEqualTo(RawImpressionUploadModelLine.State.LABELING)
     assertThat(result.workItemsRepublished).isEqualTo(1)
+    assertThat(recordingThrottlers.metadataRead.invocationCount).isEqualTo(2)
+    assertThat(recordingThrottlers.metadataWrite.invocationCount).isEqualTo(1)
+    assertThat(recordingThrottlers.controlPlane.invocationCount).isEqualTo(2)
+    assertThat(recordingThrottlers.kingdom.invocationCount).isEqualTo(0)
+  }
+
+  @Test
+  fun `retryFailed throttles every model-line page`() {
+    val result = runBlocking {
+      whenever(modelLineService.listRawImpressionUploadModelLines(any()))
+        .thenReturn(
+          listRawImpressionUploadModelLinesResponse { nextPageToken = "page-2" },
+          listRawImpressionUploadModelLinesResponse {
+            rawImpressionUploadModelLines += failedModelLine()
+          },
+        )
+      whenever(vidLabelingJobService.listVidLabelingJobs(any()))
+        .thenReturn(
+          listVidLabelingJobsResponse { vidLabelingJobs += vidLabelingJob { name = VID_JOB_NAME } }
+        )
+      whenever(workItemsService.getWorkItem(any())).thenReturn(workItem { queue = "q" })
+      whenever(workItemsService.createWorkItem(any())).thenReturn(workItem {})
+      whenever(modelLineService.markRawImpressionUploadModelLineLabeling(any()))
+        .thenReturn(failedModelLine().copy { state = RawImpressionUploadModelLine.State.LABELING })
+
+      retrier.retryFailed(UPLOAD_NAME, MODEL_LINE, RawImpressionUploadModelLine.State.LABELING)
+    }
+
+    assertThat(result.newState).isEqualTo(RawImpressionUploadModelLine.State.LABELING)
+    verifyBlocking(modelLineService, times(2)) { listRawImpressionUploadModelLines(any()) }
+    assertThat(recordingThrottlers.metadataRead.invocationCount).isEqualTo(3)
   }
 
   @Test

--- a/src/test/kotlin/org/wfanet/measurement/securecomputation/deploy/gcloud/deadletter/BUILD.bazel
+++ b/src/test/kotlin/org/wfanet/measurement/securecomputation/deploy/gcloud/deadletter/BUILD.bazel
@@ -6,6 +6,7 @@ kt_jvm_test(
     test_class = "org.wfanet.measurement.securecomputation.deploy.gcloud.deadletter.DeadLetterQueueListenerTest",
     deps = [
         "//src/main/kotlin/org/wfanet/measurement/common/grpc:error_info",
+        "//src/main/kotlin/org/wfanet/measurement/edpaggregator/testing:vid_labeling_rpc_throttlers",
         "//src/main/kotlin/org/wfanet/measurement/edpaggregator/vidlabeling:request_ids",
         "//src/main/kotlin/org/wfanet/measurement/securecomputation/deploy/gcloud/deadletter:dead_letter_queue_listener",
         "//src/main/kotlin/org/wfanet/measurement/securecomputation/deploy/gcloud/spanner:services",

--- a/src/test/kotlin/org/wfanet/measurement/securecomputation/deploy/gcloud/deadletter/DeadLetterQueueListenerTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/securecomputation/deploy/gcloud/deadletter/DeadLetterQueueListenerTest.kt
@@ -27,6 +27,7 @@ import kotlinx.coroutines.channels.Channel
 import org.junit.Test
 import org.mockito.kotlin.*
 import org.wfanet.measurement.common.pack
+import org.wfanet.measurement.edpaggregator.testing.VidLabelingRpcThrottlersTestHelper
 import org.wfanet.measurement.edpaggregator.v1alpha.MarkPoolAssignmentJobFailedRequest
 import org.wfanet.measurement.edpaggregator.v1alpha.MarkRankerJobFailedRequest
 import org.wfanet.measurement.edpaggregator.v1alpha.MarkRawImpressionUploadModelLineFailedRequest
@@ -720,6 +721,7 @@ class DeadLetterQueueListenerTest {
               rawImpressionUploadModelLines += parentModelLine()
             }
         }
+      val recordingThrottlers = VidLabelingRpcThrottlersTestHelper.recording()
 
       val listener =
         DeadLetterQueueListener(
@@ -731,6 +733,7 @@ class DeadLetterQueueListenerTest {
           rankerJobsStub = mock<RankerJobServiceCoroutineStub>(),
           vidLabelingJobsStub = mock<VidLabelingJobServiceCoroutineStub>(),
           rawImpressionUploadModelLinesStub = mockModelLinesStub,
+          rpcThrottlers = recordingThrottlers.throttlers,
         )
 
       val job = launch { listener.run() }
@@ -758,6 +761,10 @@ class DeadLetterQueueListenerTest {
 
       verify(mockWorkItemsStub, timeout(5000)).failWorkItem(any(), any())
       verify(mockQueueMessage, timeout(5000)).ack()
+      assertEquals(0, recordingThrottlers.kingdom.invocationCount)
+      assertEquals(2, recordingThrottlers.metadataRead.invocationCount)
+      assertEquals(2, recordingThrottlers.metadataWrite.invocationCount)
+      assertEquals(1, recordingThrottlers.controlPlane.invocationCount)
 
       messageChannel.close()
       job.cancel()
@@ -808,6 +815,7 @@ class DeadLetterQueueListenerTest {
           rankerJobsStub = mock<RankerJobServiceCoroutineStub>(),
           vidLabelingJobsStub = mockVidLabelingJobsStub,
           rawImpressionUploadModelLinesStub = mockModelLinesStub,
+          rpcThrottlers = VidLabelingRpcThrottlersTestHelper.alwaysReady(),
         )
 
       val job = launch { listener.run() }
@@ -886,6 +894,7 @@ class DeadLetterQueueListenerTest {
           rankerJobsStub = mock<RankerJobServiceCoroutineStub>(),
           vidLabelingJobsStub = mockVidLabelingJobsStub,
           rawImpressionUploadModelLinesStub = mockModelLinesStub,
+          rpcThrottlers = VidLabelingRpcThrottlersTestHelper.alwaysReady(),
         )
 
       val job = launch { listener.run() }
@@ -962,6 +971,7 @@ class DeadLetterQueueListenerTest {
         rankerJobsStub = mockRankerJobsStub,
         vidLabelingJobsStub = mock<VidLabelingJobServiceCoroutineStub>(),
         rawImpressionUploadModelLinesStub = mockModelLinesStub,
+        rpcThrottlers = VidLabelingRpcThrottlersTestHelper.alwaysReady(),
       )
 
     val job = launch { listener.run() }
@@ -1035,6 +1045,7 @@ class DeadLetterQueueListenerTest {
         rankerJobsStub = mock<RankerJobServiceCoroutineStub>(),
         vidLabelingJobsStub = mock<VidLabelingJobServiceCoroutineStub>(),
         rawImpressionUploadModelLinesStub = mockModelLinesStub,
+        rpcThrottlers = VidLabelingRpcThrottlersTestHelper.alwaysReady(),
       )
 
     val job = launch { listener.run() }
@@ -1068,6 +1079,7 @@ class DeadLetterQueueListenerTest {
       rankerJobsStub = mock(),
       vidLabelingJobsStub = mock(),
       rawImpressionUploadModelLinesStub = mock(),
+      rpcThrottlers = VidLabelingRpcThrottlersTestHelper.alwaysReady(),
     )
 
   private fun workItemForAppParams(appParams: com.google.protobuf.Any): WorkItem = workItem {

--- a/src/test/kotlin/org/wfanet/measurement/securecomputation/deploy/gcloud/spanner/BUILD.bazel
+++ b/src/test/kotlin/org/wfanet/measurement/securecomputation/deploy/gcloud/spanner/BUILD.bazel
@@ -2,6 +2,20 @@ load(
     "@wfa_common_jvm//src/main/kotlin/org/wfanet/measurement/gcloud/spanner/testing:macros.bzl",
     "spanner_emulator_test",
 )
+load("@wfa_rules_kotlin_jvm//kotlin:defs.bzl", "kt_jvm_test")
+
+kt_jvm_test(
+    name = "InternalApiServerTest",
+    srcs = ["InternalApiServerTest.kt"],
+    test_class = "org.wfanet.measurement.securecomputation.deploy.gcloud.spanner.InternalApiServerTest",
+    deps = [
+        "//src/main/kotlin/org/wfanet/measurement/securecomputation/deploy/gcloud/spanner:internal_api_server",
+        "@wfa_common_jvm//imports/java/com/google/common/truth",
+        "@wfa_common_jvm//imports/java/org/junit",
+        "@wfa_common_jvm//imports/java/picocli",
+        "@wfa_common_jvm//imports/kotlin/kotlin/test",
+    ],
+)
 
 spanner_emulator_test(
     name = "SecurecomputationSchemaTest",

--- a/src/test/kotlin/org/wfanet/measurement/securecomputation/deploy/gcloud/spanner/InternalApiServerTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/securecomputation/deploy/gcloud/spanner/InternalApiServerTest.kt
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.wfanet.measurement.edpaggregator.tools
+package org.wfanet.measurement.securecomputation.deploy.gcloud.spanner
 
 import com.google.common.truth.Truth.assertThat
 import kotlin.test.assertFailsWith
@@ -24,13 +24,12 @@ import org.junit.runners.JUnit4
 import picocli.CommandLine
 
 @RunWith(JUnit4::class)
-class VidLabelingHealTest {
+class InternalApiServerTest {
   @Test
   fun `command line rejects negative RPC interval`() {
     val exception =
       assertFailsWith<CommandLine.ParameterException> {
-        CommandLine(VidLabelingHeal())
-          .parseArgs("retry-failed", "--metadata-read-rpc-min-interval=-1s")
+        CommandLine(InternalApiServer()).parseArgs("--metadata-read-rpc-min-interval=-1s")
       }
 
     assertThat(exception).hasMessageThat().contains("complete human-readable duration")
@@ -40,36 +39,9 @@ class VidLabelingHealTest {
   fun `command line rejects partially malformed RPC interval`() {
     val exception =
       assertFailsWith<CommandLine.ParameterException> {
-        CommandLine(VidLabelingHeal())
-          .parseArgs("retry-failed", "--control-plane-rpc-min-interval=500msjunk")
+        CommandLine(InternalApiServer()).parseArgs("--control-plane-rpc-min-interval=500msjunk")
       }
 
     assertThat(exception).hasMessageThat().contains("complete human-readable duration")
-  }
-
-  @Test
-  fun `isAffirmative accepts y and yes case-insensitively, ignoring surrounding whitespace`() {
-    assertThat(isAffirmative("yes")).isTrue()
-    assertThat(isAffirmative("y")).isTrue()
-    assertThat(isAffirmative("YES")).isTrue()
-    assertThat(isAffirmative("Yes")).isTrue()
-    assertThat(isAffirmative("  yes  ")).isTrue()
-    assertThat(isAffirmative(" Y ")).isTrue()
-  }
-
-  @Test
-  fun `isAffirmative rejects anything that is not exactly y or yes`() {
-    assertThat(isAffirmative("no")).isFalse()
-    assertThat(isAffirmative("n")).isFalse()
-    assertThat(isAffirmative("yep")).isFalse()
-    assertThat(isAffirmative("yesss")).isFalse()
-    assertThat(isAffirmative("ye")).isFalse()
-    assertThat(isAffirmative("")).isFalse()
-    assertThat(isAffirmative("   ")).isFalse()
-  }
-
-  @Test
-  fun `isAffirmative treats null (no stdin or EOF) as a decline`() {
-    assertThat(isAffirmative(null)).isFalse()
   }
 }

--- a/src/test/kotlin/org/wfanet/measurement/securecomputation/deploy/gcloud/spanner/InternalApiServerTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/securecomputation/deploy/gcloud/spanner/InternalApiServerTest.kt
@@ -26,6 +26,16 @@ import picocli.CommandLine
 @RunWith(JUnit4::class)
 class InternalApiServerTest {
   @Test
+  fun `command line rejects zero RPC interval`() {
+    val exception =
+      assertFailsWith<CommandLine.ParameterException> {
+        CommandLine(InternalApiServer()).parseArgs("--metadata-read-rpc-min-interval=0s")
+      }
+
+    assertThat(exception).hasMessageThat().contains("positive human-readable duration")
+  }
+
+  @Test
   fun `command line rejects negative RPC interval`() {
     val exception =
       assertFailsWith<CommandLine.ParameterException> {


### PR DESCRIPTION
Throttle dead-letter and manual recovery RPCs and document the deployment-wide rate budget.

Issue: #4427