### PR TITLE
fix(edpa): Repair VID labeling healing retries

### DIFF
--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/spanner/SpannerRawImpressionUploadModelLineService.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/spanner/SpannerRawImpressionUploadModelLineService.kt
@@ -595,7 +595,10 @@ class SpannerRawImpressionUploadModelLineService(
     return if (transitionResult.isReplay) {
       transitionResult.modelLine
     } else {
-      transitionResult.modelLine.copy { errorMessage = request.errorMessage }
+      transitionResult.modelLine.copy {
+        errorMessage = request.errorMessage
+        failureAttemptId = request.requestId
+      }
     }
   }
 

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/spanner/db/RawImpressionUploadModelLine.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/spanner/db/RawImpressionUploadModelLine.kt
@@ -512,6 +512,7 @@ private object RawImpressionUploadModelLineEntity {
           encryptedMergedDek =
             struct.getProtoMessage("EncryptedMergedDek", EncryptedDek.getDefaultInstance())
         }
+        failureAttemptId = markId("MarkFailedRequestId")
       },
       struct.getLong("RawImpressionUploadId"),
       struct.getLong("RawImpressionUploadModelLineId"),

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/service/internal/testing/RawImpressionUploadModelLineServiceTest.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/service/internal/testing/RawImpressionUploadModelLineServiceTest.kt
@@ -744,6 +744,7 @@ abstract class RawImpressionUploadModelLineServiceTest {
   @Test
   fun `markRawImpressionUploadModelLinePoolAssigning succeeds from FAILED and clears error_message`() =
     runBlocking {
+      val failureAttemptId = UUID.randomUUID().toString()
       val created: RawImpressionUploadModelLine =
         service.createRawImpressionUploadModelLine(
           createRawImpressionUploadModelLineRequest {
@@ -768,7 +769,7 @@ abstract class RawImpressionUploadModelLineServiceTest {
       val failed =
         service.markRawImpressionUploadModelLineFailed(
           markRawImpressionUploadModelLineFailedRequest {
-            requestId = UUID.randomUUID().toString()
+            requestId = failureAttemptId
             dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
             rawImpressionUploadResourceId = RAW_IMPRESSION_UPLOAD_RESOURCE_ID
             rawImpressionUploadModelLineResourceId = created.rawImpressionUploadModelLineResourceId
@@ -791,6 +792,21 @@ abstract class RawImpressionUploadModelLineServiceTest {
           RawImpressionUploadModelLineState.RAW_IMPRESSION_UPLOAD_MODEL_LINE_STATE_POOL_ASSIGNING
         )
       assertThat(resumed.errorMessage).isEmpty()
+      assertThat(resumed.failureAttemptId).isEqualTo(failureAttemptId)
+
+      val nextFailureAttemptId = UUID.randomUUID().toString()
+      val failedAgain =
+        service.markRawImpressionUploadModelLineFailed(
+          markRawImpressionUploadModelLineFailedRequest {
+            requestId = nextFailureAttemptId
+            dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
+            rawImpressionUploadResourceId = RAW_IMPRESSION_UPLOAD_RESOURCE_ID
+            rawImpressionUploadModelLineResourceId = created.rawImpressionUploadModelLineResourceId
+            etag = resumed.etag
+            errorMessage = "retry failed"
+          }
+        )
+      assertThat(failedAgain.failureAttemptId).isEqualTo(nextFailureAttemptId)
     }
 
   @Test
@@ -940,6 +956,7 @@ abstract class RawImpressionUploadModelLineServiceTest {
 
   @Test
   fun `markRawImpressionUploadModelLineFailed transitions from CREATED to FAILED`() = runBlocking {
+    val failureAttemptId = UUID.randomUUID().toString()
     val created: RawImpressionUploadModelLine =
       service.createRawImpressionUploadModelLine(
         createRawImpressionUploadModelLineRequest {
@@ -955,7 +972,7 @@ abstract class RawImpressionUploadModelLineServiceTest {
     val modelLine: RawImpressionUploadModelLine =
       service.markRawImpressionUploadModelLineFailed(
         markRawImpressionUploadModelLineFailedRequest {
-          requestId = UUID.randomUUID().toString()
+          requestId = failureAttemptId
           dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
           rawImpressionUploadResourceId = RAW_IMPRESSION_UPLOAD_RESOURCE_ID
           rawImpressionUploadModelLineResourceId = created.rawImpressionUploadModelLineResourceId
@@ -967,6 +984,7 @@ abstract class RawImpressionUploadModelLineServiceTest {
     assertThat(modelLine.state)
       .isEqualTo(RawImpressionUploadModelLineState.RAW_IMPRESSION_UPLOAD_MODEL_LINE_STATE_FAILED)
     assertThat(modelLine.errorMessage).isEqualTo("something went wrong")
+    assertThat(modelLine.failureAttemptId).isEqualTo(failureAttemptId)
   }
 
   @Test

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/service/v1alpha/RawImpressionUploadModelLineService.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/service/v1alpha/RawImpressionUploadModelLineService.kt
@@ -585,6 +585,7 @@ fun InternalRawImpressionUploadModelLine.toPublic(): RawImpressionUploadModelLin
     if (source.hasEncryptedMergedDek()) {
       encryptedMergedDek = source.encryptedMergedDek.toPublic()
     }
+    failureAttemptId = source.failureAttemptId
   }
 }
 

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/tools/DispatchFailer.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/tools/DispatchFailer.kt
@@ -20,6 +20,7 @@ import java.util.logging.Logger
 import org.wfanet.measurement.edpaggregator.v1alpha.RawImpressionUploadModelLine
 import org.wfanet.measurement.edpaggregator.v1alpha.RawImpressionUploadModelLineServiceGrpcKt.RawImpressionUploadModelLineServiceCoroutineStub
 import org.wfanet.measurement.edpaggregator.v1alpha.markRawImpressionUploadModelLineFailedRequest
+import org.wfanet.measurement.edpaggregator.vidlabeling.RequestIds
 
 /**
  * Force-fails a stuck or hanging `RawImpressionUpload` — the operator recovery for a dispatch that
@@ -56,15 +57,13 @@ class DispatchFailer(
         logger.info("${modelLine.name} is ${modelLine.state} (not stuck); leaving as-is.")
         continue
       }
-      // TODO(world-federation-of-advertisers/cross-media-measurement#4211): once #4211 makes
-      // request_id REQUIRED on the Mark* RPCs, set
-      // requestId = RequestIds.forMarkRawImpressionUploadModelLineFailed(modelLine.name) so an
-      // operator re-run hits the AIP-155 replay short-circuit instead of failing INVALID_ARGUMENT.
       rawImpressionModelLinesStub.markRawImpressionUploadModelLineFailed(
         markRawImpressionUploadModelLineFailedRequest {
           name = modelLine.name
           errorMessage = reason
           etag = modelLine.etag
+          requestId =
+            RequestIds.forMarkRawImpressionUploadModelLineFailed(modelLine.name, modelLine.etag)
         }
       )
       failed.add(modelLine.name)

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/tools/EvictUploader.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/tools/EvictUploader.kt
@@ -34,6 +34,7 @@ import org.wfanet.measurement.edpaggregator.v1alpha.listRankIndexBlobsRequest
 import org.wfanet.measurement.edpaggregator.v1alpha.listRawImpressionUploadModelLinesRequest
 import org.wfanet.measurement.edpaggregator.v1alpha.listRawImpressionUploadsRequest
 import org.wfanet.measurement.edpaggregator.v1alpha.markRawImpressionUploadModelLineFailedRequest
+import org.wfanet.measurement.edpaggregator.vidlabeling.RequestIds
 
 /**
  * Evicts uploads that carry bad data for a model line, using the last-good-snapshot rebuild
@@ -161,16 +162,16 @@ class EvictUploader(
           getRawImpressionUploadModelLineRequest { name = entry.modelLineName }
         )
       if (current.state != RawImpressionUploadModelLine.State.FAILED) {
-        // TODO(world-federation-of-advertisers/cross-media-measurement#4211): once #4211 makes
-        // request_id REQUIRED on the Mark* RPCs, set
-        // requestId = RequestIds.forMarkRawImpressionUploadModelLineFailed(entry.modelLineName) so
-        // a
-        // re-run hits the AIP-155 replay short-circuit instead of failing INVALID_ARGUMENT.
         rawImpressionModelLinesStub.markRawImpressionUploadModelLineFailed(
           markRawImpressionUploadModelLineFailedRequest {
             name = entry.modelLineName
             errorMessage = reason
             etag = current.etag
+            requestId =
+              RequestIds.forMarkRawImpressionUploadModelLineFailed(
+                entry.modelLineName,
+                current.etag,
+              )
           }
         )
         failed.add(entry.modelLineName)

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/tools/FailedDispatchRetrier.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/tools/FailedDispatchRetrier.kt
@@ -18,7 +18,6 @@ package org.wfanet.measurement.edpaggregator.tools
 
 import io.grpc.Status
 import io.grpc.StatusException
-import java.util.UUID
 import java.util.logging.Logger
 import org.wfanet.measurement.edpaggregator.VidLabelingRpcThrottlers
 import org.wfanet.measurement.edpaggregator.v1alpha.ListPoolAssignmentJobsRequestKt
@@ -35,7 +34,9 @@ import org.wfanet.measurement.edpaggregator.v1alpha.listVidLabelingJobsRequest
 import org.wfanet.measurement.edpaggregator.v1alpha.markRawImpressionUploadModelLineLabelingRequest
 import org.wfanet.measurement.edpaggregator.v1alpha.markRawImpressionUploadModelLinePoolAssigningRequest
 import org.wfanet.measurement.edpaggregator.v1alpha.markRawImpressionUploadModelLineRankingRequest
+import org.wfanet.measurement.edpaggregator.vidlabeling.RequestIds
 import org.wfanet.measurement.edpaggregator.vidlabeling.WorkItemIds
+import org.wfanet.measurement.securecomputation.controlplane.v1alpha.WorkItem
 import org.wfanet.measurement.securecomputation.controlplane.v1alpha.WorkItemsGrpcKt.WorkItemsCoroutineStub
 import org.wfanet.measurement.securecomputation.controlplane.v1alpha.createWorkItemRequest
 import org.wfanet.measurement.securecomputation.controlplane.v1alpha.getWorkItemRequest
@@ -127,14 +128,7 @@ class FailedDispatchRetrier(
     // Re-publish before transitioning, so the work exists before the line is claimed.
     var republished = 0
     for (oldId in phaseWorkItems.workItemIds) {
-      if (republishWorkItem(oldId)) republished++
-    }
-
-    // If every target WorkItem already exists (a re-retry after a prior retry left them in place),
-    // do NOT advance the model line: transitioning with no fresh worker signal would masquerade as
-    // progress. Leave it FAILED so stuck-phase recovery or the operator can investigate.
-    if (republished == 0) {
-      return RetryResult(modelLine.name, 0, modelLine.state)
+      if (republishWorkItem(oldId, modelLine.etag)) republished++
     }
 
     val updated = transition(modelLine, phaseWorkItems.phase)
@@ -276,10 +270,11 @@ class FailedDispatchRetrier(
   }
 
   /**
-   * Re-publishes the WorkItem [oldWorkItemId] under a fresh deterministic id. Returns true if a new
-   * WorkItem was created, false if it already existed (an idempotent repeat retry).
+   * Re-publishes the WorkItem [oldWorkItemId] for the failed model-line version identified by
+   * [modelLineEtag]. Returns true if a new WorkItem was created, or false when the same retry
+   * attempt already created it.
    */
-  private suspend fun republishWorkItem(oldWorkItemId: String): Boolean {
+  private suspend fun republishWorkItem(oldWorkItemId: String, modelLineEtag: String): Boolean {
     val existing =
       try {
         rpcThrottlers.controlPlane.onReady {
@@ -294,28 +289,49 @@ class FailedDispatchRetrier(
         }
         throw e
       }
-    val newId = "rt-" + UUID.nameUUIDFromBytes("retry:$oldWorkItemId".toByteArray()).toString()
+    var newId = RequestIds.forRetriedWorkItem(oldWorkItemId, modelLineEtag)
     val republished = workItem {
       queue = existing.queue
       workItemParams = existing.workItemParams
     }
-    return try {
-      rpcThrottlers.controlPlane.onReady {
-        workItemsStub.createWorkItem(
-          createWorkItemRequest {
-            workItemId = newId
-            workItem = republished
+    while (true) {
+      try {
+        rpcThrottlers.controlPlane.onReady {
+          workItemsStub.createWorkItem(
+            createWorkItemRequest {
+              workItemId = newId
+              workItem = republished
+            }
+          )
+        }
+        logger.info("Re-published $oldWorkItemId as $newId (queue=${existing.queue}).")
+        return true
+      } catch (e: StatusException) {
+        if (e.status.code != Status.Code.ALREADY_EXISTS) throw e
+
+        val existingRetry =
+          rpcThrottlers.controlPlane.onReady {
+            workItemsStub.getWorkItem(getWorkItemRequest { name = "workItems/$newId" })
           }
-        )
-      }
-      logger.info("Re-published $oldWorkItemId as $newId (queue=${existing.queue}).")
-      true
-    } catch (e: StatusException) {
-      if (e.status.code == Status.Code.ALREADY_EXISTS) {
-        logger.info("Retry WorkItem $newId already exists; skipping (idempotent).")
-        false
-      } else {
-        throw e
+        when (existingRetry.state) {
+          WorkItem.State.QUEUED,
+          WorkItem.State.RUNNING,
+          WorkItem.State.SUCCEEDED -> {
+            logger.info(
+              "Retry WorkItem $newId already exists in ${existingRetry.state}; " +
+                "continuing the idempotent retry."
+            )
+            return false
+          }
+          WorkItem.State.FAILED -> {
+            val failureVersion =
+              "${existingRetry.updateTime.seconds}:${existingRetry.updateTime.nanos}"
+            newId = RequestIds.forRetriedWorkItem(newId, failureVersion)
+          }
+          WorkItem.State.STATE_UNSPECIFIED,
+          WorkItem.State.UNRECOGNIZED ->
+            error("Retry WorkItem $newId has invalid state ${existingRetry.state}.")
+        }
       }
     }
   }
@@ -324,11 +340,6 @@ class FailedDispatchRetrier(
     modelLine: RawImpressionUploadModelLine,
     targetState: RawImpressionUploadModelLine.State,
   ): RawImpressionUploadModelLine =
-    // TODO(world-federation-of-advertisers/cross-media-measurement#4211): once #4211 makes
-    // request_id REQUIRED on the Mark* RPCs, set requestId on each mark below via the matching
-    // RequestIds.forMarkRawImpressionUploadModelLine<Phase>(modelLine.name) helper so a repeat
-    // retry
-    // hits the AIP-155 replay short-circuit instead of failing INVALID_ARGUMENT.
     when (targetState) {
       RawImpressionUploadModelLine.State.POOL_ASSIGNING ->
         rpcThrottlers.metadataWrite.onReady {
@@ -336,6 +347,7 @@ class FailedDispatchRetrier(
             markRawImpressionUploadModelLinePoolAssigningRequest {
               name = modelLine.name
               etag = modelLine.etag
+              requestId = RequestIds.forHealingRetryPoolAssigning(modelLine.name, modelLine.etag)
             }
           )
         }
@@ -345,6 +357,7 @@ class FailedDispatchRetrier(
             markRawImpressionUploadModelLineRankingRequest {
               name = modelLine.name
               etag = modelLine.etag
+              requestId = RequestIds.forHealingRetryRanking(modelLine.name, modelLine.etag)
             }
           )
         }
@@ -354,6 +367,7 @@ class FailedDispatchRetrier(
             markRawImpressionUploadModelLineLabelingRequest {
               name = modelLine.name
               etag = modelLine.etag
+              requestId = RequestIds.forHealingRetryLabeling(modelLine.name, modelLine.etag)
             }
           )
         }

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/tools/FailedDispatchRetrier.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/tools/FailedDispatchRetrier.kt
@@ -81,17 +81,20 @@ class FailedDispatchRetrier(
     val workItemsRepublished: Int,
     /** The phase the model line was re-triggered at. */
     val newState: RawImpressionUploadModelLine.State,
+    /** Whether this invocation found a retry that a prior invocation already started. */
+    val wasAlreadyStarted: Boolean,
   )
 
   /**
-   * Re-triggers the `FAILED` `(rawImpressionUpload, cmmsModelLine)` and transitions it out of
-   * `FAILED`. Re-triggers [fromPhase] if given, otherwise the furthest phase the model line
-   * reached.
+   * Re-triggers the `(rawImpressionUpload, cmmsModelLine)` after its latest failure. If that retry
+   * was already started, returns its current model-line state without creating more WorkItems.
+   * Otherwise, re-triggers [fromPhase] if given, or the furthest phase the model line reached.
    *
    * @param fromPhase optional override of the phase to re-trigger from (`POOL_ASSIGNING`,
    *   `RANKING`, or `LABELING`); when null the furthest reached phase is auto-detected.
-   * @throws IllegalArgumentException if the model line is missing or not `FAILED`, [fromPhase] is
-   *   not a phase state, or no jobs exist for the target phase to re-publish.
+   * @throws IllegalArgumentException if the model line is missing, has no failure-attempt identity,
+   *   is neither `FAILED` nor the result of that failure's retry, [fromPhase] is not a phase state,
+   *   or no jobs exist for the target phase to re-publish.
    * @throws IllegalStateException if a job's original WorkItem no longer exists (its dispatch never
    *   enqueued), so it cannot be re-published standalone.
    */
@@ -109,8 +112,27 @@ class FailedDispatchRetrier(
         ?: throw IllegalArgumentException(
           "No RawImpressionUploadModelLine for $cmmsModelLine under $rawImpressionUpload"
         )
-    require(modelLine.state == RawImpressionUploadModelLine.State.FAILED) {
-      "${modelLine.name} is ${modelLine.state}, expected FAILED"
+    require(fromPhase == null || fromPhase in RETRY_PHASES) {
+      "--from-phase must be one of POOL_ASSIGNING, RANKING, LABELING; got $fromPhase"
+    }
+    require(modelLine.failureAttemptId.isNotEmpty()) {
+      "${modelLine.name} has no failure_attempt_id; expected a model line that has failed"
+    }
+
+    if (modelLine.state != RawImpressionUploadModelLine.State.FAILED) {
+      val existingPhase =
+        findExistingRetryPhase(
+          rawImpressionUpload,
+          cmmsModelLine,
+          modelLine.state,
+          modelLine.failureAttemptId,
+          fromPhase,
+        )
+      requireNotNull(existingPhase) {
+        "${modelLine.name} is ${modelLine.state}, expected FAILED or an existing retry for " +
+          "failure_attempt_id ${modelLine.failureAttemptId}"
+      }
+      return RetryResult(modelLine.name, 0, modelLine.state, wasAlreadyStarted = true)
     }
 
     // Re-trigger [fromPhase] if the operator specified one; otherwise the furthest phase reached
@@ -128,11 +150,80 @@ class FailedDispatchRetrier(
     // Re-publish before transitioning, so the work exists before the line is claimed.
     var republished = 0
     for (oldId in phaseWorkItems.workItemIds) {
-      if (republishWorkItem(oldId, modelLine.etag)) republished++
+      if (republishWorkItem(oldId, modelLine.failureAttemptId)) republished++
     }
 
-    val updated = transition(modelLine, phaseWorkItems.phase)
-    return RetryResult(updated.name, republished, updated.state)
+    val updated = transition(modelLine, phaseWorkItems.phase, modelLine.failureAttemptId)
+    return RetryResult(updated.name, republished, updated.state, wasAlreadyStarted = false)
+  }
+
+  /** Returns the phase of an existing retry for [failureAttemptId], or `null` if none exists. */
+  private suspend fun findExistingRetryPhase(
+    uploadName: String,
+    cmmsModelLine: String,
+    currentState: RawImpressionUploadModelLine.State,
+    failureAttemptId: String,
+    fromPhase: RawImpressionUploadModelLine.State?,
+  ): RawImpressionUploadModelLine.State? {
+    val possiblePhases =
+      when (currentState) {
+        RawImpressionUploadModelLine.State.POOL_ASSIGNING ->
+          listOf(RawImpressionUploadModelLine.State.POOL_ASSIGNING)
+        RawImpressionUploadModelLine.State.RANKING ->
+          listOf(
+            RawImpressionUploadModelLine.State.RANKING,
+            RawImpressionUploadModelLine.State.POOL_ASSIGNING,
+          )
+        RawImpressionUploadModelLine.State.LABELING,
+        RawImpressionUploadModelLine.State.COMPLETED -> RETRY_PHASES
+        RawImpressionUploadModelLine.State.CREATED,
+        RawImpressionUploadModelLine.State.FAILED,
+        RawImpressionUploadModelLine.State.STATE_UNSPECIFIED,
+        RawImpressionUploadModelLine.State.UNRECOGNIZED -> emptyList()
+      }
+    val candidatePhases =
+      if (fromPhase == null) possiblePhases else possiblePhases.filter { it == fromPhase }
+    for (phase in candidatePhases) {
+      val originalWorkItemIds = workItemIdsForPhaseOrEmpty(uploadName, cmmsModelLine, phase)
+      if (
+        originalWorkItemIds.isNotEmpty() &&
+          originalWorkItemIds.all { retryWorkItemIsActiveOrSucceeded(it, failureAttemptId) }
+      ) {
+        return phase
+      }
+    }
+    return null
+  }
+
+  private suspend fun retryWorkItemIsActiveOrSucceeded(
+    originalWorkItemId: String,
+    failureAttemptId: String,
+  ): Boolean {
+    var retryWorkItemId = RequestIds.forRetriedWorkItem(originalWorkItemId, failureAttemptId)
+    while (true) {
+      val retryWorkItem =
+        try {
+          rpcThrottlers.controlPlane.onReady {
+            workItemsStub.getWorkItem(getWorkItemRequest { name = "workItems/$retryWorkItemId" })
+          }
+        } catch (e: StatusException) {
+          if (e.status.code == Status.Code.NOT_FOUND) return false
+          throw e
+        }
+      when (retryWorkItem.state) {
+        WorkItem.State.QUEUED,
+        WorkItem.State.RUNNING,
+        WorkItem.State.SUCCEEDED -> return true
+        WorkItem.State.FAILED -> {
+          val failureVersion =
+            "${retryWorkItem.updateTime.seconds}:${retryWorkItem.updateTime.nanos}"
+          retryWorkItemId = RequestIds.forRetriedWorkItem(retryWorkItemId, failureVersion)
+        }
+        WorkItem.State.STATE_UNSPECIFIED,
+        WorkItem.State.UNRECOGNIZED ->
+          error("Retry WorkItem $retryWorkItemId has invalid state ${retryWorkItem.state}.")
+      }
+    }
   }
 
   /**
@@ -173,34 +264,29 @@ class FailedDispatchRetrier(
     uploadName: String,
     cmmsModelLine: String,
     phase: RawImpressionUploadModelLine.State,
+  ): List<String> {
+    val workItemIds = workItemIdsForPhaseOrEmpty(uploadName, cmmsModelLine, phase)
+    require(workItemIds.isNotEmpty()) {
+      "No jobs found for $cmmsModelLine under $uploadName; cannot retry from $phase"
+    }
+    return workItemIds
+  }
+
+  private suspend fun workItemIdsForPhaseOrEmpty(
+    uploadName: String,
+    cmmsModelLine: String,
+    phase: RawImpressionUploadModelLine.State,
   ): List<String> =
     when (phase) {
-      RawImpressionUploadModelLine.State.LABELING -> {
-        val names = listVidLabelingJobNames(uploadName, cmmsModelLine)
-        require(names.isNotEmpty()) {
-          "No VidLabelingJobs for $cmmsModelLine under $uploadName; cannot retry from LABELING"
+      RawImpressionUploadModelLine.State.LABELING ->
+        listVidLabelingJobNames(uploadName, cmmsModelLine).map { WorkItemIds.forVidLabeler(it) }
+      RawImpressionUploadModelLine.State.RANKING ->
+        listRankerJobNames(uploadName, cmmsModelLine).map { WorkItemIds.forVidRankBuilder(it) }
+      RawImpressionUploadModelLine.State.POOL_ASSIGNING ->
+        listPoolAssignmentJobShards(uploadName, cmmsModelLine).map {
+          WorkItemIds.forSubpoolAssigner(uploadName, cmmsModelLine, it)
         }
-        names.map { WorkItemIds.forVidLabeler(it) }
-      }
-      RawImpressionUploadModelLine.State.RANKING -> {
-        val names = listRankerJobNames(uploadName, cmmsModelLine)
-        require(names.isNotEmpty()) {
-          "No RankerJobs for $cmmsModelLine under $uploadName; cannot retry from RANKING"
-        }
-        names.map { WorkItemIds.forVidRankBuilder(it) }
-      }
-      RawImpressionUploadModelLine.State.POOL_ASSIGNING -> {
-        val shards = listPoolAssignmentJobShards(uploadName, cmmsModelLine)
-        require(shards.isNotEmpty()) {
-          "No PoolAssignmentJobs for $cmmsModelLine under $uploadName; cannot retry from " +
-            "POOL_ASSIGNING"
-        }
-        shards.map { WorkItemIds.forSubpoolAssigner(uploadName, cmmsModelLine, it) }
-      }
-      else ->
-        throw IllegalArgumentException(
-          "--from-phase must be one of POOL_ASSIGNING, RANKING, LABELING; got $phase"
-        )
+      else -> error("unreachable: $phase is not a retry phase")
     }
 
   private suspend fun listVidLabelingJobNames(
@@ -270,11 +356,11 @@ class FailedDispatchRetrier(
   }
 
   /**
-   * Re-publishes the WorkItem [oldWorkItemId] for the failed model-line version identified by
-   * [modelLineEtag]. Returns true if a new WorkItem was created, or false when the same retry
-   * attempt already created it.
+   * Re-publishes the WorkItem [oldWorkItemId] for the failure identified by [failureAttemptId].
+   * Returns true if a new WorkItem was created, or false when the same retry attempt already
+   * created it.
    */
-  private suspend fun republishWorkItem(oldWorkItemId: String, modelLineEtag: String): Boolean {
+  private suspend fun republishWorkItem(oldWorkItemId: String, failureAttemptId: String): Boolean {
     val existing =
       try {
         rpcThrottlers.controlPlane.onReady {
@@ -289,7 +375,7 @@ class FailedDispatchRetrier(
         }
         throw e
       }
-    var newId = RequestIds.forRetriedWorkItem(oldWorkItemId, modelLineEtag)
+    var newId = RequestIds.forRetriedWorkItem(oldWorkItemId, failureAttemptId)
     val republished = workItem {
       queue = existing.queue
       workItemParams = existing.workItemParams
@@ -339,6 +425,7 @@ class FailedDispatchRetrier(
   private suspend fun transition(
     modelLine: RawImpressionUploadModelLine,
     targetState: RawImpressionUploadModelLine.State,
+    failureAttemptId: String,
   ): RawImpressionUploadModelLine =
     when (targetState) {
       RawImpressionUploadModelLine.State.POOL_ASSIGNING ->
@@ -347,7 +434,7 @@ class FailedDispatchRetrier(
             markRawImpressionUploadModelLinePoolAssigningRequest {
               name = modelLine.name
               etag = modelLine.etag
-              requestId = RequestIds.forHealingRetryPoolAssigning(modelLine.name, modelLine.etag)
+              requestId = RequestIds.forHealingRetryPoolAssigning(modelLine.name, failureAttemptId)
             }
           )
         }
@@ -357,7 +444,7 @@ class FailedDispatchRetrier(
             markRawImpressionUploadModelLineRankingRequest {
               name = modelLine.name
               etag = modelLine.etag
-              requestId = RequestIds.forHealingRetryRanking(modelLine.name, modelLine.etag)
+              requestId = RequestIds.forHealingRetryRanking(modelLine.name, failureAttemptId)
             }
           )
         }
@@ -367,7 +454,7 @@ class FailedDispatchRetrier(
             markRawImpressionUploadModelLineLabelingRequest {
               name = modelLine.name
               etag = modelLine.etag
-              requestId = RequestIds.forHealingRetryLabeling(modelLine.name, modelLine.etag)
+              requestId = RequestIds.forHealingRetryLabeling(modelLine.name, failureAttemptId)
             }
           )
         }
@@ -375,6 +462,12 @@ class FailedDispatchRetrier(
     }
 
   companion object {
+    private val RETRY_PHASES =
+      listOf(
+        RawImpressionUploadModelLine.State.LABELING,
+        RawImpressionUploadModelLine.State.RANKING,
+        RawImpressionUploadModelLine.State.POOL_ASSIGNING,
+      )
     private val logger: Logger = Logger.getLogger(FailedDispatchRetrier::class.java.name)
   }
 

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/tools/VidLabelingHeal.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/tools/VidLabelingHeal.kt
@@ -275,18 +275,10 @@ class RetryFailedCommand : EdpaApiCommand() {
             ),
           )
         val result = retrier.retryFailed(rawImpressionUpload, modelLine, fromPhase)
-        if (result.workItemsRepublished == 0) {
-          System.err.println(
-            "WARN: all target WorkItems for ${result.modelLineName} already exist from a prior " +
-              "retry; the model line remains ${result.newState} and no new work was created. " +
-              "Investigate the prior retry's WorkItems (workItems/rt-<...>) before re-running."
-          )
-        } else {
-          println(
-            "Re-triggered ${result.modelLineName} at ${result.newState}: republished " +
-              "${result.workItemsRepublished} WorkItem(s)."
-          )
-        }
+        println(
+          "Re-triggered ${result.modelLineName} at ${result.newState}: created " +
+            "${result.workItemsRepublished} retry WorkItem(s)."
+        )
       }
     } finally {
       edpaChannel.shutdown()

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/tools/VidLabelingHeal.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/tools/VidLabelingHeal.kt
@@ -275,10 +275,17 @@ class RetryFailedCommand : EdpaApiCommand() {
             ),
           )
         val result = retrier.retryFailed(rawImpressionUpload, modelLine, fromPhase)
-        println(
-          "Re-triggered ${result.modelLineName} at ${result.newState}: created " +
-            "${result.workItemsRepublished} retry WorkItem(s)."
-        )
+        if (result.wasAlreadyStarted) {
+          println(
+            "Retry for ${result.modelLineName} was already started; current state is " +
+              "${result.newState}."
+          )
+        } else {
+          println(
+            "Re-triggered ${result.modelLineName} at ${result.newState}: created " +
+              "${result.workItemsRepublished} retry WorkItem(s)."
+          )
+        }
       }
     } finally {
       edpaChannel.shutdown()

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/vidlabeling/RequestIds.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/vidlabeling/RequestIds.kt
@@ -111,8 +111,24 @@ object RequestIds {
   fun forMarkRawImpressionUploadModelLineCompleted(modelLineName: String): String =
     fromKey("markRawImpressionUploadModelLineCompleted:$modelLineName")
 
-  fun forMarkRawImpressionUploadModelLineFailed(modelLineName: String): String =
-    fromKey("markRawImpressionUploadModelLineFailed:$modelLineName")
+  fun forMarkRawImpressionUploadModelLineFailed(modelLineName: String, etag: String): String =
+    fromKey("markRawImpressionUploadModelLineFailed:$modelLineName:$etag")
+
+  /** `request_id` for retrying a specific failed model-line version at Phase 0. */
+  fun forHealingRetryPoolAssigning(modelLineName: String, etag: String): String =
+    fromKey("healingRetryPoolAssigning:$modelLineName:$etag")
+
+  /** `request_id` for retrying a specific failed model-line version at Phase 1. */
+  fun forHealingRetryRanking(modelLineName: String, etag: String): String =
+    fromKey("healingRetryRanking:$modelLineName:$etag")
+
+  /** `request_id` for retrying a specific failed model-line version at Phase 2. */
+  fun forHealingRetryLabeling(modelLineName: String, etag: String): String =
+    fromKey("healingRetryLabeling:$modelLineName:$etag")
+
+  /** WorkItem id for retrying [originalWorkItemId] from a specific failed model-line version. */
+  fun forRetriedWorkItem(originalWorkItemId: String, modelLineEtag: String): String =
+    "rt-${fromKey("retryWorkItem:$originalWorkItemId:$modelLineEtag")}"
 
   private fun fromKey(key: String): String {
     // Render the deterministic (name-based) id in the RFC 4122 version-4 layout so the value

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/vidlabeling/RequestIds.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/vidlabeling/RequestIds.kt
@@ -114,21 +114,21 @@ object RequestIds {
   fun forMarkRawImpressionUploadModelLineFailed(modelLineName: String, etag: String): String =
     fromKey("markRawImpressionUploadModelLineFailed:$modelLineName:$etag")
 
-  /** `request_id` for retrying a specific failed model-line version at Phase 0. */
-  fun forHealingRetryPoolAssigning(modelLineName: String, etag: String): String =
-    fromKey("healingRetryPoolAssigning:$modelLineName:$etag")
+  /** `request_id` for retrying a specific model-line failure at Phase 0. */
+  fun forHealingRetryPoolAssigning(modelLineName: String, failureAttemptId: String): String =
+    fromKey("healingRetryPoolAssigning:$modelLineName:$failureAttemptId")
 
-  /** `request_id` for retrying a specific failed model-line version at Phase 1. */
-  fun forHealingRetryRanking(modelLineName: String, etag: String): String =
-    fromKey("healingRetryRanking:$modelLineName:$etag")
+  /** `request_id` for retrying a specific model-line failure at Phase 1. */
+  fun forHealingRetryRanking(modelLineName: String, failureAttemptId: String): String =
+    fromKey("healingRetryRanking:$modelLineName:$failureAttemptId")
 
-  /** `request_id` for retrying a specific failed model-line version at Phase 2. */
-  fun forHealingRetryLabeling(modelLineName: String, etag: String): String =
-    fromKey("healingRetryLabeling:$modelLineName:$etag")
+  /** `request_id` for retrying a specific model-line failure at Phase 2. */
+  fun forHealingRetryLabeling(modelLineName: String, failureAttemptId: String): String =
+    fromKey("healingRetryLabeling:$modelLineName:$failureAttemptId")
 
-  /** WorkItem id for retrying [originalWorkItemId] from a specific failed model-line version. */
-  fun forRetriedWorkItem(originalWorkItemId: String, modelLineEtag: String): String =
-    "rt-${fromKey("retryWorkItem:$originalWorkItemId:$modelLineEtag")}"
+  /** WorkItem id for retrying [originalWorkItemId] after a specific model-line failure. */
+  fun forRetriedWorkItem(originalWorkItemId: String, failureAttemptId: String): String =
+    "rt-${fromKey("retryWorkItem:$originalWorkItemId:$failureAttemptId")}"
 
   private fun fromKey(key: String): String {
     // Render the deterministic (name-based) id in the RFC 4122 version-4 layout so the value

--- a/src/main/kotlin/org/wfanet/measurement/securecomputation/deploy/gcloud/deadletter/DeadLetterQueueListener.kt
+++ b/src/main/kotlin/org/wfanet/measurement/securecomputation/deploy/gcloud/deadletter/DeadLetterQueueListener.kt
@@ -389,9 +389,10 @@ class DeadLetterQueueListener(
             // RawImpressionUploadModelLine resource carries it) instead of an extra Get.
             etag = parent.etag
             this.errorMessage = errorMessage.take(MAX_ERROR_MESSAGE)
-            // AIP-155 idempotency on Pub/Sub redelivery: derived deterministically from the
-            // resource + operation so every attempt for the same mark shares one idempotent result.
-            requestId = RequestIds.forMarkRawImpressionUploadModelLineFailed(parent.name)
+            // AIP-155 idempotency on Pub/Sub redelivery: the etag identifies the model-line version
+            // being failed, so a later failure after an operator retry receives a new request ID.
+            requestId =
+              RequestIds.forMarkRawImpressionUploadModelLineFailed(parent.name, parent.etag)
           }
         )
       }

--- a/src/main/proto/wfa/measurement/edpaggregator/v1alpha/raw_impression_upload_model_line.proto
+++ b/src/main/proto/wfa/measurement/edpaggregator/v1alpha/raw_impression_upload_model_line.proto
@@ -110,4 +110,9 @@ message RawImpressionUploadModelLine {
   // generated DEK.
   wfa.measurement.securecomputation.impressions.EncryptedDek
       encrypted_merged_dek = 10 [(google.api.field_behavior) = OUTPUT_ONLY];
+
+  // Identifier of the most recent transition to `FAILED`. Remains set until a
+  // later failure replaces it so clients can recognize retries of that
+  // failure after this resource transitions back to an active state.
+  string failure_attempt_id = 11 [(google.api.field_behavior) = OUTPUT_ONLY];
 }

--- a/src/main/proto/wfa/measurement/internal/edpaggregator/raw_impression_upload_model_line.proto
+++ b/src/main/proto/wfa/measurement/internal/edpaggregator/raw_impression_upload_model_line.proto
@@ -68,4 +68,9 @@ message RawImpressionUploadModelLine {
   // last shard's encrypted_dek, promoted on last-shard-out so a retrying
   // SubpoolAssigner reuses it.
   EncryptedDek encrypted_merged_dek = 12;
+
+  // Request ID of the most recent transition to FAILED. Remains set until a
+  // later failure replaces it, so retries can identify the failure attempt
+  // after this resource transitions back to an active state.
+  string failure_attempt_id = 13;
 }

--- a/src/test/kotlin/org/wfanet/measurement/edpaggregator/service/v1alpha/RawImpressionUploadModelLineServiceTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/edpaggregator/service/v1alpha/RawImpressionUploadModelLineServiceTest.kt
@@ -972,6 +972,7 @@ class RawImpressionUploadModelLineServiceTest {
 
   @Test
   fun `markRawImpressionUploadModelLineFailed transitions state`() = runBlocking {
+    val failureAttemptId = UUID.randomUUID().toString()
     createParentUpload(DATA_PROVIDER_ID, RAW_IMPRESSION_UPLOAD_ID)
     val created =
       service.createRawImpressionUploadModelLine(
@@ -990,13 +991,14 @@ class RawImpressionUploadModelLineServiceTest {
           name = created.name
           etag = created.etag
           errorMessage = "Something went wrong"
-          requestId = UUID.randomUUID().toString()
+          requestId = failureAttemptId
         }
       )
 
     assertThat(failed.state).isEqualTo(RawImpressionUploadModelLine.State.FAILED)
     assertThat(failed.name).isEqualTo(created.name)
     assertThat(failed.errorMessage).isEqualTo("Something went wrong")
+    assertThat(failed.failureAttemptId).isEqualTo(failureAttemptId)
   }
 
   @Test
@@ -1410,6 +1412,7 @@ class RawImpressionUploadModelLineServiceTest {
       rawImpressionUploadModelLineResourceId = "model-line-1"
       cmmsModelLine = CMMS_MODEL_LINE
       state = InternalModelLineState.RAW_IMPRESSION_UPLOAD_MODEL_LINE_STATE_POOL_ASSIGNING
+      failureAttemptId = "failure-attempt-1"
       poolOffsets += listOf(0L, 5L, 10L)
       maxEventDate = date {
         year = 2026
@@ -1427,6 +1430,7 @@ class RawImpressionUploadModelLineServiceTest {
     val publicModelLine = internalModelLine.toPublic()
 
     assertThat(publicModelLine.poolOffsetsList).containsExactly(0L, 5L, 10L).inOrder()
+    assertThat(publicModelLine.failureAttemptId).isEqualTo("failure-attempt-1")
     assertThat(publicModelLine.maxEventDate)
       .isEqualTo(
         date {

--- a/src/test/kotlin/org/wfanet/measurement/edpaggregator/tools/BUILD.bazel
+++ b/src/test/kotlin/org/wfanet/measurement/edpaggregator/tools/BUILD.bazel
@@ -106,6 +106,7 @@ kt_jvm_test(
         "//src/main/proto/wfa/measurement/securecomputation/controlplane/v1alpha:work_item_kt_jvm_proto",
         "//src/main/proto/wfa/measurement/securecomputation/controlplane/v1alpha:work_items_service_kt_jvm_grpc_proto",
         "@wfa_common_jvm//imports/java/com/google/common/truth",
+        "@wfa_common_jvm//imports/java/com/google/protobuf",
         "@wfa_common_jvm//imports/java/io/grpc/netty",
         "@wfa_common_jvm//imports/java/org/junit",
         "@wfa_common_jvm//imports/kotlin/kotlin/test",

--- a/src/test/kotlin/org/wfanet/measurement/edpaggregator/tools/DispatchFailerTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/edpaggregator/tools/DispatchFailerTest.kt
@@ -27,11 +27,13 @@ import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 import org.mockito.kotlin.any
 import org.mockito.kotlin.argThat
+import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.never
 import org.mockito.kotlin.verifyBlocking
 import org.mockito.kotlin.whenever
 import org.wfanet.measurement.common.grpc.testing.GrpcTestServerRule
 import org.wfanet.measurement.common.grpc.testing.mockService
+import org.wfanet.measurement.edpaggregator.v1alpha.MarkRawImpressionUploadModelLineFailedRequest
 import org.wfanet.measurement.edpaggregator.v1alpha.RawImpressionUploadModelLine
 import org.wfanet.measurement.edpaggregator.v1alpha.RawImpressionUploadModelLineServiceGrpcKt
 import org.wfanet.measurement.edpaggregator.v1alpha.listRawImpressionUploadModelLinesResponse
@@ -88,6 +90,11 @@ class DispatchFailerTest {
         }
       )
     }
+    val requestCaptor = argumentCaptor<MarkRawImpressionUploadModelLineFailedRequest>()
+    verifyBlocking(modelLineService) {
+      markRawImpressionUploadModelLineFailed(requestCaptor.capture())
+    }
+    assertThat(requestCaptor.firstValue.requestId).isNotEmpty()
   }
 
   @Test

--- a/src/test/kotlin/org/wfanet/measurement/edpaggregator/tools/EvictUploaderTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/edpaggregator/tools/EvictUploaderTest.kt
@@ -25,12 +25,15 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.never
+import org.mockito.kotlin.times
 import org.mockito.kotlin.verifyBlocking
 import org.mockito.kotlin.whenever
 import org.wfanet.measurement.common.grpc.testing.GrpcTestServerRule
 import org.wfanet.measurement.common.grpc.testing.mockService
 import org.wfanet.measurement.common.toProtoTime
+import org.wfanet.measurement.edpaggregator.v1alpha.MarkRawImpressionUploadModelLineFailedRequest
 import org.wfanet.measurement.edpaggregator.v1alpha.RankIndexBlob
 import org.wfanet.measurement.edpaggregator.v1alpha.RankIndexBlobServiceGrpcKt
 import org.wfanet.measurement.edpaggregator.v1alpha.RawImpressionUploadModelLine
@@ -139,6 +142,13 @@ class EvictUploaderTest {
     // Both cascade model lines are failed and each has its SNAPSHOT soft-deleted.
     assertThat(result.failedModelLines).containsExactly(modelLineName("up2"), modelLineName("up3"))
     assertThat(result.deletedSnapshots).isEqualTo(2)
+    val requestCaptor = argumentCaptor<MarkRawImpressionUploadModelLineFailedRequest>()
+    verifyBlocking(modelLineService, times(2)) {
+      markRawImpressionUploadModelLineFailed(requestCaptor.capture())
+    }
+    for (request in requestCaptor.allValues) {
+      assertThat(request.requestId).isNotEmpty()
+    }
   }
 
   @Test

--- a/src/test/kotlin/org/wfanet/measurement/edpaggregator/tools/FailedDispatchRetrierTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/edpaggregator/tools/FailedDispatchRetrierTest.kt
@@ -17,6 +17,7 @@
 package org.wfanet.measurement.edpaggregator.tools
 
 import com.google.common.truth.Truth.assertThat
+import com.google.protobuf.timestamp
 import io.grpc.Status
 import kotlin.test.assertFailsWith
 import kotlinx.coroutines.runBlocking
@@ -25,6 +26,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.never
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verifyBlocking
@@ -32,6 +34,9 @@ import org.mockito.kotlin.whenever
 import org.wfanet.measurement.common.grpc.testing.GrpcTestServerRule
 import org.wfanet.measurement.common.grpc.testing.mockService
 import org.wfanet.measurement.edpaggregator.testing.VidLabelingRpcThrottlersTestHelper
+import org.wfanet.measurement.edpaggregator.v1alpha.MarkRawImpressionUploadModelLineLabelingRequest
+import org.wfanet.measurement.edpaggregator.v1alpha.MarkRawImpressionUploadModelLinePoolAssigningRequest
+import org.wfanet.measurement.edpaggregator.v1alpha.MarkRawImpressionUploadModelLineRankingRequest
 import org.wfanet.measurement.edpaggregator.v1alpha.PoolAssignmentJobServiceGrpcKt
 import org.wfanet.measurement.edpaggregator.v1alpha.RankerJobServiceGrpcKt
 import org.wfanet.measurement.edpaggregator.v1alpha.RawImpressionUploadModelLine
@@ -46,6 +51,8 @@ import org.wfanet.measurement.edpaggregator.v1alpha.poolAssignmentJob
 import org.wfanet.measurement.edpaggregator.v1alpha.rankerJob
 import org.wfanet.measurement.edpaggregator.v1alpha.rawImpressionUploadModelLine
 import org.wfanet.measurement.edpaggregator.v1alpha.vidLabelingJob
+import org.wfanet.measurement.securecomputation.controlplane.v1alpha.CreateWorkItemRequest
+import org.wfanet.measurement.securecomputation.controlplane.v1alpha.WorkItem
 import org.wfanet.measurement.securecomputation.controlplane.v1alpha.WorkItemsGrpcKt
 import org.wfanet.measurement.securecomputation.controlplane.v1alpha.workItem
 
@@ -112,7 +119,13 @@ class FailedDispatchRetrierTest {
         .thenReturn(
           listVidLabelingJobsResponse { vidLabelingJobs += vidLabelingJob { name = VID_JOB_NAME } }
         )
-      whenever(workItemsService.getWorkItem(any())).thenReturn(workItem { queue = "q" })
+      whenever(workItemsService.getWorkItem(any()))
+        .thenReturn(
+          workItem {
+            queue = "q"
+            state = WorkItem.State.QUEUED
+          }
+        )
       whenever(workItemsService.createWorkItem(any())).thenReturn(workItem {})
       whenever(modelLineService.markRawImpressionUploadModelLineLabeling(any()))
         .thenReturn(failedModelLine().copy { state = RawImpressionUploadModelLine.State.LABELING })
@@ -126,6 +139,11 @@ class FailedDispatchRetrierTest {
     assertThat(recordingThrottlers.metadataWrite.invocationCount).isEqualTo(1)
     assertThat(recordingThrottlers.controlPlane.invocationCount).isEqualTo(2)
     assertThat(recordingThrottlers.kingdom.invocationCount).isEqualTo(0)
+    val requestCaptor = argumentCaptor<MarkRawImpressionUploadModelLineLabelingRequest>()
+    verifyBlocking(modelLineService) {
+      markRawImpressionUploadModelLineLabeling(requestCaptor.capture())
+    }
+    assertThat(requestCaptor.firstValue.requestId).isNotEmpty()
   }
 
   @Test
@@ -163,7 +181,13 @@ class FailedDispatchRetrierTest {
         .thenReturn(listVidLabelingJobsResponse {})
       whenever(rankerJobService.listRankerJobs(any()))
         .thenReturn(listRankerJobsResponse { rankerJobs += rankerJob { name = RANKER_JOB_NAME } })
-      whenever(workItemsService.getWorkItem(any())).thenReturn(workItem { queue = "q" })
+      whenever(workItemsService.getWorkItem(any()))
+        .thenReturn(
+          workItem {
+            queue = "q"
+            state = WorkItem.State.QUEUED
+          }
+        )
       whenever(workItemsService.createWorkItem(any())).thenReturn(workItem {})
       whenever(modelLineService.markRawImpressionUploadModelLineRanking(any()))
         .thenReturn(failedModelLine().copy { state = RawImpressionUploadModelLine.State.RANKING })
@@ -173,6 +197,11 @@ class FailedDispatchRetrierTest {
 
     assertThat(result.newState).isEqualTo(RawImpressionUploadModelLine.State.RANKING)
     assertThat(result.workItemsRepublished).isEqualTo(1)
+    val requestCaptor = argumentCaptor<MarkRawImpressionUploadModelLineRankingRequest>()
+    verifyBlocking(modelLineService) {
+      markRawImpressionUploadModelLineRanking(requestCaptor.capture())
+    }
+    assertThat(requestCaptor.firstValue.requestId).isNotEmpty()
   }
 
   @Test
@@ -200,6 +229,11 @@ class FailedDispatchRetrierTest {
 
     assertThat(result.newState).isEqualTo(RawImpressionUploadModelLine.State.POOL_ASSIGNING)
     assertThat(result.workItemsRepublished).isEqualTo(1)
+    val requestCaptor = argumentCaptor<MarkRawImpressionUploadModelLinePoolAssigningRequest>()
+    verifyBlocking(modelLineService) {
+      markRawImpressionUploadModelLinePoolAssigning(requestCaptor.capture())
+    }
+    assertThat(requestCaptor.firstValue.requestId).isNotEmpty()
   }
 
   @Test
@@ -242,25 +276,70 @@ class FailedDispatchRetrierTest {
   }
 
   @Test
-  fun `retryFailed does not advance the model line when all WorkItems already exist`() {
+  fun `retryFailed advances the model line when retry WorkItems already exist`() {
     val result = runBlocking {
       stubFailedModelLine()
       whenever(vidLabelingJobService.listVidLabelingJobs(any()))
         .thenReturn(
           listVidLabelingJobsResponse { vidLabelingJobs += vidLabelingJob { name = VID_JOB_NAME } }
         )
-      whenever(workItemsService.getWorkItem(any())).thenReturn(workItem { queue = "q" })
+      whenever(workItemsService.getWorkItem(any()))
+        .thenReturn(
+          workItem {
+            queue = "q"
+            state = WorkItem.State.QUEUED
+          }
+        )
       // Re-retry: the deterministic rt-<hash> WorkItem already exists from a prior retry.
       whenever(workItemsService.createWorkItem(any())).thenAnswer {
         throw Status.ALREADY_EXISTS.asRuntimeException()
       }
+      whenever(modelLineService.markRawImpressionUploadModelLineLabeling(any()))
+        .thenReturn(failedModelLine().copy { state = RawImpressionUploadModelLine.State.LABELING })
 
       retrier.retryFailed(UPLOAD_NAME, MODEL_LINE)
     }
 
     assertThat(result.workItemsRepublished).isEqualTo(0)
-    assertThat(result.newState).isEqualTo(RawImpressionUploadModelLine.State.FAILED)
-    verifyBlocking(modelLineService, never()) { markRawImpressionUploadModelLineLabeling(any()) }
+    assertThat(result.newState).isEqualTo(RawImpressionUploadModelLine.State.LABELING)
+    verifyBlocking(modelLineService) { markRawImpressionUploadModelLineLabeling(any()) }
+  }
+
+  @Test
+  fun `retryFailed creates a successor when the previous retry WorkItem failed`() {
+    val result = runBlocking {
+      stubFailedModelLine()
+      whenever(vidLabelingJobService.listVidLabelingJobs(any()))
+        .thenReturn(
+          listVidLabelingJobsResponse { vidLabelingJobs += vidLabelingJob { name = VID_JOB_NAME } }
+        )
+      whenever(workItemsService.getWorkItem(any()))
+        .thenReturn(
+          workItem { queue = "q" },
+          workItem {
+            queue = "q"
+            state = WorkItem.State.FAILED
+            updateTime = timestamp {
+              seconds = 123
+              nanos = 456
+            }
+          },
+        )
+      whenever(workItemsService.createWorkItem(any()))
+        .thenAnswer { throw Status.ALREADY_EXISTS.asRuntimeException() }
+        .thenReturn(workItem {})
+      whenever(modelLineService.markRawImpressionUploadModelLineLabeling(any()))
+        .thenReturn(failedModelLine().copy { state = RawImpressionUploadModelLine.State.LABELING })
+
+      retrier.retryFailed(UPLOAD_NAME, MODEL_LINE)
+    }
+
+    assertThat(result.workItemsRepublished).isEqualTo(1)
+    assertThat(result.newState).isEqualTo(RawImpressionUploadModelLine.State.LABELING)
+    val requestCaptor = argumentCaptor<CreateWorkItemRequest>()
+    verifyBlocking(workItemsService, times(2)) { createWorkItem(requestCaptor.capture()) }
+    assertThat(requestCaptor.allValues[1].workItemId)
+      .isNotEqualTo(requestCaptor.allValues[0].workItemId)
   }
 
   @Test

--- a/src/test/kotlin/org/wfanet/measurement/edpaggregator/tools/FailedDispatchRetrierTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/edpaggregator/tools/FailedDispatchRetrierTest.kt
@@ -51,7 +51,10 @@ import org.wfanet.measurement.edpaggregator.v1alpha.poolAssignmentJob
 import org.wfanet.measurement.edpaggregator.v1alpha.rankerJob
 import org.wfanet.measurement.edpaggregator.v1alpha.rawImpressionUploadModelLine
 import org.wfanet.measurement.edpaggregator.v1alpha.vidLabelingJob
+import org.wfanet.measurement.edpaggregator.vidlabeling.RequestIds
+import org.wfanet.measurement.edpaggregator.vidlabeling.WorkItemIds
 import org.wfanet.measurement.securecomputation.controlplane.v1alpha.CreateWorkItemRequest
+import org.wfanet.measurement.securecomputation.controlplane.v1alpha.GetWorkItemRequest
 import org.wfanet.measurement.securecomputation.controlplane.v1alpha.WorkItem
 import org.wfanet.measurement.securecomputation.controlplane.v1alpha.WorkItemsGrpcKt
 import org.wfanet.measurement.securecomputation.controlplane.v1alpha.workItem
@@ -100,6 +103,7 @@ class FailedDispatchRetrierTest {
     cmmsModelLine = MODEL_LINE
     state = RawImpressionUploadModelLine.State.FAILED
     etag = ETAG
+    failureAttemptId = FAILURE_ATTEMPT_ID
   }
 
   private suspend fun stubFailedModelLine() {
@@ -139,6 +143,7 @@ class FailedDispatchRetrierTest {
     assertThat(recordingThrottlers.metadataWrite.invocationCount).isEqualTo(1)
     assertThat(recordingThrottlers.controlPlane.invocationCount).isEqualTo(2)
     assertThat(recordingThrottlers.kingdom.invocationCount).isEqualTo(0)
+    assertThat(result.wasAlreadyStarted).isFalse()
     val requestCaptor = argumentCaptor<MarkRawImpressionUploadModelLineLabelingRequest>()
     verifyBlocking(modelLineService) {
       markRawImpressionUploadModelLineLabeling(requestCaptor.capture())
@@ -237,7 +242,7 @@ class FailedDispatchRetrierTest {
   }
 
   @Test
-  fun `retryFailed throws when the model line is not FAILED`() {
+  fun `retryFailed throws when failure identity is missing`() {
     val error =
       assertFailsWith<IllegalArgumentException> {
         runBlocking {
@@ -245,13 +250,119 @@ class FailedDispatchRetrierTest {
             .thenReturn(
               listRawImpressionUploadModelLinesResponse {
                 rawImpressionUploadModelLines +=
-                  failedModelLine().copy { state = RawImpressionUploadModelLine.State.RANKING }
+                  failedModelLine().copy {
+                    state = RawImpressionUploadModelLine.State.RANKING
+                    clearFailureAttemptId()
+                  }
               }
             )
           retrier.retryFailed(UPLOAD_NAME, MODEL_LINE)
         }
       }
-    assertThat(error).hasMessageThat().contains("expected FAILED")
+    assertThat(error).hasMessageThat().contains("has no failure_attempt_id")
+  }
+
+  @Test
+  fun `retryFailed returns existing retry when model line already left FAILED`() {
+    val result = runBlocking {
+      whenever(modelLineService.listRawImpressionUploadModelLines(any()))
+        .thenReturn(
+          listRawImpressionUploadModelLinesResponse {
+            rawImpressionUploadModelLines +=
+              failedModelLine().copy { state = RawImpressionUploadModelLine.State.LABELING }
+          }
+        )
+      whenever(vidLabelingJobService.listVidLabelingJobs(any()))
+        .thenReturn(
+          listVidLabelingJobsResponse { vidLabelingJobs += vidLabelingJob { name = VID_JOB_NAME } }
+        )
+      whenever(workItemsService.getWorkItem(any()))
+        .thenReturn(workItem { state = WorkItem.State.RUNNING })
+
+      retrier.retryFailed(UPLOAD_NAME, MODEL_LINE)
+    }
+
+    assertThat(result.newState).isEqualTo(RawImpressionUploadModelLine.State.LABELING)
+    assertThat(result.workItemsRepublished).isEqualTo(0)
+    assertThat(result.wasAlreadyStarted).isTrue()
+    val requestCaptor = argumentCaptor<GetWorkItemRequest>()
+    verifyBlocking(workItemsService) { getWorkItem(requestCaptor.capture()) }
+    assertThat(requestCaptor.firstValue.name)
+      .isEqualTo(
+        "workItems/${RequestIds.forRetriedWorkItem(WorkItemIds.forVidLabeler(VID_JOB_NAME), FAILURE_ATTEMPT_ID)}"
+      )
+    verifyBlocking(workItemsService, never()) { createWorkItem(any()) }
+    verifyBlocking(modelLineService, never()) { markRawImpressionUploadModelLineLabeling(any()) }
+  }
+
+  @Test
+  fun `retryFailed follows a failed retry WorkItem to its active successor`() {
+    val result = runBlocking {
+      whenever(modelLineService.listRawImpressionUploadModelLines(any()))
+        .thenReturn(
+          listRawImpressionUploadModelLinesResponse {
+            rawImpressionUploadModelLines +=
+              failedModelLine().copy { state = RawImpressionUploadModelLine.State.LABELING }
+          }
+        )
+      whenever(vidLabelingJobService.listVidLabelingJobs(any()))
+        .thenReturn(
+          listVidLabelingJobsResponse { vidLabelingJobs += vidLabelingJob { name = VID_JOB_NAME } }
+        )
+      whenever(workItemsService.getWorkItem(any()))
+        .thenReturn(
+          workItem {
+            state = WorkItem.State.FAILED
+            updateTime = timestamp {
+              seconds = 123
+              nanos = 456
+            }
+          },
+          workItem { state = WorkItem.State.QUEUED },
+        )
+
+      retrier.retryFailed(UPLOAD_NAME, MODEL_LINE)
+    }
+
+    assertThat(result.wasAlreadyStarted).isTrue()
+    val requestCaptor = argumentCaptor<GetWorkItemRequest>()
+    verifyBlocking(workItemsService, times(2)) { getWorkItem(requestCaptor.capture()) }
+    val firstRetryId =
+      RequestIds.forRetriedWorkItem(WorkItemIds.forVidLabeler(VID_JOB_NAME), FAILURE_ATTEMPT_ID)
+    assertThat(requestCaptor.allValues[0].name).isEqualTo("workItems/$firstRetryId")
+    assertThat(requestCaptor.allValues[1].name)
+      .isEqualTo("workItems/${RequestIds.forRetriedWorkItem(firstRetryId, "123:456")}")
+  }
+
+  @Test
+  fun `retryFailed rejects a non-FAILED model line without a matching retry`() {
+    val error =
+      assertFailsWith<IllegalArgumentException> {
+        runBlocking {
+          whenever(modelLineService.listRawImpressionUploadModelLines(any()))
+            .thenReturn(
+              listRawImpressionUploadModelLinesResponse {
+                rawImpressionUploadModelLines +=
+                  failedModelLine().copy { state = RawImpressionUploadModelLine.State.LABELING }
+              }
+            )
+          whenever(vidLabelingJobService.listVidLabelingJobs(any()))
+            .thenReturn(
+              listVidLabelingJobsResponse {
+                vidLabelingJobs += vidLabelingJob { name = VID_JOB_NAME }
+              }
+            )
+          whenever(workItemsService.getWorkItem(any())).thenAnswer {
+            throw Status.NOT_FOUND.asRuntimeException()
+          }
+
+          retrier.retryFailed(UPLOAD_NAME, MODEL_LINE, RawImpressionUploadModelLine.State.LABELING)
+        }
+      }
+
+    assertThat(error).hasMessageThat().contains("expected FAILED or an existing retry")
+    verifyBlocking(workItemsService, never()) { createWorkItem(any()) }
+    verifyBlocking(modelLineService, never()) { markRawImpressionUploadModelLineLabeling(any()) }
   }
 
   @Test
@@ -383,5 +494,6 @@ class FailedDispatchRetrierTest {
     private const val VID_JOB_NAME = "$UPLOAD_NAME/vidLabelingJobs/vlj1"
     private const val RANKER_JOB_NAME = "$UPLOAD_NAME/rankerJobs/rj1"
     private const val ETAG = "etag-1"
+    private const val FAILURE_ATTEMPT_ID = "failure-attempt-1"
   }
 }

--- a/src/test/kotlin/org/wfanet/measurement/edpaggregator/vidlabeling/RequestIdsTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/edpaggregator/vidlabeling/RequestIdsTest.kt
@@ -78,11 +78,25 @@ class RequestIdsTest {
         RequestIds.forMarkRawImpressionUploadModelLineRanking(MODEL_LINE_NAME),
         RequestIds.forMarkRawImpressionUploadModelLineLabeling(MODEL_LINE_NAME),
         RequestIds.forMarkRawImpressionUploadModelLineCompleted(MODEL_LINE_NAME),
-        RequestIds.forMarkRawImpressionUploadModelLineFailed(MODEL_LINE_NAME),
+        RequestIds.forMarkRawImpressionUploadModelLineFailed(MODEL_LINE_NAME, ETAG),
+        RequestIds.forHealingRetryPoolAssigning(MODEL_LINE_NAME, ETAG),
+        RequestIds.forHealingRetryRanking(MODEL_LINE_NAME, ETAG),
+        RequestIds.forHealingRetryLabeling(MODEL_LINE_NAME, ETAG),
+        RequestIds.forRetriedWorkItem(VID_LABELING_JOB, ETAG).removePrefix("rt-"),
       )
     for (id in ids) {
       assertThat(UUID.fromString(id).version()).isEqualTo(4)
     }
+  }
+
+  @Test
+  fun `healing request ids distinguish resource versions`() {
+    assertThat(RequestIds.forMarkRawImpressionUploadModelLineFailed(MODEL_LINE_NAME, ETAG))
+      .isNotEqualTo(
+        RequestIds.forMarkRawImpressionUploadModelLineFailed(MODEL_LINE_NAME, "new-etag")
+      )
+    assertThat(RequestIds.forRetriedWorkItem(VID_LABELING_JOB, ETAG))
+      .isNotEqualTo(RequestIds.forRetriedWorkItem(VID_LABELING_JOB, "new-etag"))
   }
 
   companion object {
@@ -94,5 +108,6 @@ class RequestIdsTest {
     private const val SHARED = "shared-value"
     private const val MODEL_LINE_NAME = "$UPLOAD/rawImpressionUploadModelLines/riuml-1"
     private const val VID_LABELING_JOB = "$UPLOAD/vidLabelingJobs/vlj-1"
+    private const val ETAG = "etag-1"
   }
 }

--- a/src/test/kotlin/org/wfanet/measurement/edpaggregator/vidlabeling/RequestIdsTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/edpaggregator/vidlabeling/RequestIdsTest.kt
@@ -79,10 +79,10 @@ class RequestIdsTest {
         RequestIds.forMarkRawImpressionUploadModelLineLabeling(MODEL_LINE_NAME),
         RequestIds.forMarkRawImpressionUploadModelLineCompleted(MODEL_LINE_NAME),
         RequestIds.forMarkRawImpressionUploadModelLineFailed(MODEL_LINE_NAME, ETAG),
-        RequestIds.forHealingRetryPoolAssigning(MODEL_LINE_NAME, ETAG),
-        RequestIds.forHealingRetryRanking(MODEL_LINE_NAME, ETAG),
-        RequestIds.forHealingRetryLabeling(MODEL_LINE_NAME, ETAG),
-        RequestIds.forRetriedWorkItem(VID_LABELING_JOB, ETAG).removePrefix("rt-"),
+        RequestIds.forHealingRetryPoolAssigning(MODEL_LINE_NAME, FAILURE_ATTEMPT_ID),
+        RequestIds.forHealingRetryRanking(MODEL_LINE_NAME, FAILURE_ATTEMPT_ID),
+        RequestIds.forHealingRetryLabeling(MODEL_LINE_NAME, FAILURE_ATTEMPT_ID),
+        RequestIds.forRetriedWorkItem(VID_LABELING_JOB, FAILURE_ATTEMPT_ID).removePrefix("rt-"),
       )
     for (id in ids) {
       assertThat(UUID.fromString(id).version()).isEqualTo(4)
@@ -90,13 +90,19 @@ class RequestIdsTest {
   }
 
   @Test
-  fun `healing request ids distinguish resource versions`() {
+  fun `mark-failed request ids distinguish resource versions`() {
     assertThat(RequestIds.forMarkRawImpressionUploadModelLineFailed(MODEL_LINE_NAME, ETAG))
       .isNotEqualTo(
         RequestIds.forMarkRawImpressionUploadModelLineFailed(MODEL_LINE_NAME, "new-etag")
       )
-    assertThat(RequestIds.forRetriedWorkItem(VID_LABELING_JOB, ETAG))
-      .isNotEqualTo(RequestIds.forRetriedWorkItem(VID_LABELING_JOB, "new-etag"))
+  }
+
+  @Test
+  fun `healing request ids distinguish failure attempts`() {
+    assertThat(RequestIds.forHealingRetryLabeling(MODEL_LINE_NAME, FAILURE_ATTEMPT_ID))
+      .isNotEqualTo(RequestIds.forHealingRetryLabeling(MODEL_LINE_NAME, "failure-attempt-2"))
+    assertThat(RequestIds.forRetriedWorkItem(VID_LABELING_JOB, FAILURE_ATTEMPT_ID))
+      .isNotEqualTo(RequestIds.forRetriedWorkItem(VID_LABELING_JOB, "failure-attempt-2"))
   }
 
   companion object {
@@ -109,5 +115,6 @@ class RequestIdsTest {
     private const val MODEL_LINE_NAME = "$UPLOAD/rawImpressionUploadModelLines/riuml-1"
     private const val VID_LABELING_JOB = "$UPLOAD/vidLabelingJobs/vlj-1"
     private const val ETAG = "etag-1"
+    private const val FAILURE_ATTEMPT_ID = "failure-attempt-1"
   }
 }

--- a/src/test/kotlin/org/wfanet/measurement/securecomputation/deploy/gcloud/deadletter/DeadLetterQueueListenerTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/securecomputation/deploy/gcloud/deadletter/DeadLetterQueueListenerTest.kt
@@ -755,7 +755,7 @@ class DeadLetterQueueListenerTest {
       assertEquals(PARENT_NAME, modelLineCaptor.firstValue.name)
       assertEquals(MODEL_LINE_ETAG, modelLineCaptor.firstValue.etag)
       assertEquals(
-        RequestIds.forMarkRawImpressionUploadModelLineFailed(PARENT_NAME),
+        RequestIds.forMarkRawImpressionUploadModelLineFailed(PARENT_NAME, MODEL_LINE_ETAG),
         modelLineCaptor.firstValue.requestId,
       )
 
@@ -838,7 +838,7 @@ class DeadLetterQueueListenerTest {
       assertEquals(PARENT_NAME, modelLineCaptor.firstValue.name)
       assertEquals(MODEL_LINE_ETAG, modelLineCaptor.firstValue.etag)
       assertEquals(
-        RequestIds.forMarkRawImpressionUploadModelLineFailed(PARENT_NAME),
+        RequestIds.forMarkRawImpressionUploadModelLineFailed(PARENT_NAME, MODEL_LINE_ETAG),
         modelLineCaptor.firstValue.requestId,
       )
 
@@ -916,7 +916,7 @@ class DeadLetterQueueListenerTest {
       assertEquals(PARENT_NAME, modelLineCaptor.firstValue.name)
       assertEquals(MODEL_LINE_ETAG, modelLineCaptor.firstValue.etag)
       assertEquals(
-        RequestIds.forMarkRawImpressionUploadModelLineFailed(PARENT_NAME),
+        RequestIds.forMarkRawImpressionUploadModelLineFailed(PARENT_NAME, MODEL_LINE_ETAG),
         modelLineCaptor.firstValue.requestId,
       )
 
@@ -989,7 +989,7 @@ class DeadLetterQueueListenerTest {
     assertEquals(PARENT_NAME, modelLineCaptor.firstValue.name)
     assertEquals(MODEL_LINE_ETAG, modelLineCaptor.firstValue.etag)
     assertEquals(
-      RequestIds.forMarkRawImpressionUploadModelLineFailed(PARENT_NAME),
+      RequestIds.forMarkRawImpressionUploadModelLineFailed(PARENT_NAME, MODEL_LINE_ETAG),
       modelLineCaptor.firstValue.requestId,
     )
 


### PR DESCRIPTION
Supply attempt-scoped request IDs for healing transitions and let retry-failed finish a transition after its retry WorkItems were already created.

Issue: #4428