### PR TITLE
feat(edpa): Restore deleted impression metadata

### DIFF
--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/dataavailability/DataAvailabilityMonitor.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/dataavailability/DataAvailabilityMonitor.kt
@@ -28,6 +28,7 @@ import java.util.logging.Level
 import java.util.logging.Logger
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.flow.take
 import kotlinx.coroutines.flow.toList

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/dataavailability/DataAvailabilitySync.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/dataavailability/DataAvailabilitySync.kt
@@ -50,6 +50,7 @@ import org.wfanet.measurement.edpaggregator.v1alpha.ImpressionMetadata
 import org.wfanet.measurement.edpaggregator.v1alpha.ImpressionMetadataServiceGrpcKt
 import org.wfanet.measurement.edpaggregator.v1alpha.ListImpressionMetadataRequestKt.filter as listFilter
 import org.wfanet.measurement.edpaggregator.v1alpha.batchCreateImpressionMetadataRequest
+import org.wfanet.measurement.edpaggregator.v1alpha.batchUndeleteImpressionMetadataRequest
 import org.wfanet.measurement.edpaggregator.v1alpha.batchUpdateImpressionMetadataRequest
 import org.wfanet.measurement.edpaggregator.v1alpha.computeModelLineBoundsRequest
 import org.wfanet.measurement.edpaggregator.v1alpha.copy
@@ -381,18 +382,24 @@ class DataAvailabilitySync(
       // Partition into creates and updates
       val toCreate = mutableListOf<ImpressionMetadataWithBlobKey>()
       val toUpdate = mutableListOf<ImpressionMetadataWithBlobKey>()
+      val toRestore = mutableListOf<ImpressionMetadata>()
 
       for (item in impressionMetadataList) {
         val existing = existingByBlobUri[item.impressionMetadata.blobUri]
         if (existing == null) {
           toCreate.add(item)
-        } else if (hasContentChanged(item.impressionMetadata, existing)) {
-          toUpdate.add(
-            ImpressionMetadataWithBlobKey(
-              impressionMetadata = item.impressionMetadata.copy { name = existing.name },
-              impressionsBlobKey = item.impressionsBlobKey,
+        } else {
+          if (existing.state == ImpressionMetadata.State.DELETED) {
+            toRestore.add(existing)
+          }
+          if (hasContentChanged(item.impressionMetadata, existing)) {
+            toUpdate.add(
+              ImpressionMetadataWithBlobKey(
+                impressionMetadata = item.impressionMetadata.copy { name = existing.name },
+                impressionsBlobKey = item.impressionsBlobKey,
+              )
             )
-          )
+          }
         }
       }
 
@@ -437,6 +444,22 @@ class DataAvailabilitySync(
             .impressionMetadataList
         }
 
+      // Restore soft-deleted entries only after their latest content has been persisted. This
+      // prevents stale metadata from becoming visible if an update fails.
+      val restoreResponses =
+        toRestore.chunked(impressionMetadataBatchSize).flatMap { restoreChunk ->
+          throttler
+            .onReady {
+              impressionMetadataServiceStub.batchUndeleteImpressionMetadata(
+                batchUndeleteImpressionMetadataRequest {
+                  parent = dataProviderName
+                  names += restoreChunk.map { it.name }
+                }
+              )
+            }
+            .impressionMetadataList
+        }
+
       // Set GCS object metadata on every scanned metadata blob — not just newly
       // created/updated ones. A re-sync of a date whose metadata content is unchanged would
       // land in neither `createResponses` nor `updateResponses` (contentAwareRequestId
@@ -446,6 +469,7 @@ class DataAvailabilitySync(
       val resourceIdByBlobUri: Map<String, ImpressionMetadata> =
         (existingByBlobUri +
           createResponses.associateBy { it.blobUri } +
+          restoreResponses.associateBy { it.blobUri } +
           updateResponses.associateBy { it.blobUri })
       for (item in impressionMetadataList) {
         val blobUri = item.impressionMetadata.blobUri
@@ -490,6 +514,7 @@ class DataAvailabilitySync(
                   listImpressionMetadataRequest {
                     parent = dataProviderName
                     filter = listFilter { this.blobUris += blobUriChunk }
+                    showDeleted = true
                     if (pageToken.isNotEmpty()) {
                       this.pageToken = pageToken
                     }

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/spanner/SpannerImpressionMetadataService.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/spanner/SpannerImpressionMetadataService.kt
@@ -645,11 +645,11 @@ class SpannerImpressionMetadataService(
 
     val transactionRunner =
       databaseClient.readWriteTransaction(Options.tag("action=batchUndeleteImpressionMetadata"))
-    val restored = buildList {
+    val restored =
       transactionRunner.run { txn ->
         val existing =
           txn.getImpressionMetadataByResourceIds(dataProviderResourceId, resourceIds.toList())
-        request.requestsList.forEach { subRequest ->
+        request.requestsList.map { subRequest ->
           val result =
             existing[subRequest.impressionMetadataResourceId]
               ?: throw ImpressionMetadataNotFoundException(
@@ -666,10 +666,9 @@ class SpannerImpressionMetadataService(
             result.impressionMetadataId,
             State.IMPRESSION_METADATA_STATE_ACTIVE,
           )
-          add(result.impressionMetadata)
+          result.impressionMetadata
         }
       }
-    }
 
     val commitTimestamp = transactionRunner.getCommitTimestamp().toProto()
     return batchUndeleteImpressionMetadataResponse {

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/spanner/SpannerImpressionMetadataService.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/spanner/SpannerImpressionMetadataService.kt
@@ -38,6 +38,7 @@ import org.wfanet.measurement.edpaggregator.deploy.gcloud.spanner.db.readImpress
 import org.wfanet.measurement.edpaggregator.deploy.gcloud.spanner.db.readModelLinesBounds
 import org.wfanet.measurement.edpaggregator.deploy.gcloud.spanner.db.updateImpressionMetadataState
 import org.wfanet.measurement.edpaggregator.service.internal.DataProviderMismatchException
+import org.wfanet.measurement.edpaggregator.service.internal.ImpressionMetadataAlreadyExistsException
 import org.wfanet.measurement.edpaggregator.service.internal.ImpressionMetadataNotFoundException
 import org.wfanet.measurement.edpaggregator.service.internal.ImpressionMetadataStateInvalidException
 import org.wfanet.measurement.edpaggregator.service.internal.InvalidFieldValueException
@@ -47,6 +48,8 @@ import org.wfanet.measurement.internal.edpaggregator.BatchCreateImpressionMetada
 import org.wfanet.measurement.internal.edpaggregator.BatchCreateImpressionMetadataResponse
 import org.wfanet.measurement.internal.edpaggregator.BatchDeleteImpressionMetadataRequest
 import org.wfanet.measurement.internal.edpaggregator.BatchDeleteImpressionMetadataResponse
+import org.wfanet.measurement.internal.edpaggregator.BatchUndeleteImpressionMetadataRequest
+import org.wfanet.measurement.internal.edpaggregator.BatchUndeleteImpressionMetadataResponse
 import org.wfanet.measurement.internal.edpaggregator.BatchUpdateImpressionMetadataRequest
 import org.wfanet.measurement.internal.edpaggregator.BatchUpdateImpressionMetadataResponse
 import org.wfanet.measurement.internal.edpaggregator.ComputeModelLineBoundsRequest
@@ -65,6 +68,7 @@ import org.wfanet.measurement.internal.edpaggregator.UndeleteImpressionMetadataR
 import org.wfanet.measurement.internal.edpaggregator.UpdateImpressionMetadataRequest
 import org.wfanet.measurement.internal.edpaggregator.batchCreateImpressionMetadataResponse
 import org.wfanet.measurement.internal.edpaggregator.batchDeleteImpressionMetadataResponse
+import org.wfanet.measurement.internal.edpaggregator.batchUndeleteImpressionMetadataResponse
 import org.wfanet.measurement.internal.edpaggregator.batchUpdateImpressionMetadataResponse
 import org.wfanet.measurement.internal.edpaggregator.computeModelLineBoundsResponse
 import org.wfanet.measurement.internal.edpaggregator.copy
@@ -580,6 +584,106 @@ class SpannerImpressionMetadataService(
     }
   }
 
+  override suspend fun undeleteImpressionMetadata(
+    request: UndeleteImpressionMetadataRequest
+  ): ImpressionMetadata {
+    validateUndeleteRequest(request, "")
+
+    val transactionRunner =
+      databaseClient.readWriteTransaction(Options.tag("action=undeleteImpressionMetadata"))
+    val restored =
+      try {
+        transactionRunner.run { txn ->
+          val result =
+            txn.getImpressionMetadataByResourceId(
+              request.dataProviderResourceId,
+              request.impressionMetadataResourceId,
+            )
+          if (result.impressionMetadata.state != State.IMPRESSION_METADATA_STATE_DELETED) {
+            throw ImpressionMetadataAlreadyExistsException(result.impressionMetadata.blobUri)
+              .asStatusRuntimeException(Status.Code.ALREADY_EXISTS)
+          }
+          txn.updateImpressionMetadataState(
+            request.dataProviderResourceId,
+            result.impressionMetadataId,
+            State.IMPRESSION_METADATA_STATE_ACTIVE,
+          )
+          result.impressionMetadata
+        }
+      } catch (e: ImpressionMetadataNotFoundException) {
+        throw e.asStatusRuntimeException(Status.Code.NOT_FOUND)
+      }
+
+    val commitTimestamp = transactionRunner.getCommitTimestamp().toProto()
+    return restored.copy {
+      state = State.IMPRESSION_METADATA_STATE_ACTIVE
+      updateTime = commitTimestamp
+      etag = ETags.computeETag(commitTimestamp.toInstant())
+    }
+  }
+
+  override suspend fun batchUndeleteImpressionMetadata(
+    request: BatchUndeleteImpressionMetadataRequest
+  ): BatchUndeleteImpressionMetadataResponse {
+    if (request.requestsList.isEmpty()) {
+      return BatchUndeleteImpressionMetadataResponse.getDefaultInstance()
+    }
+
+    val dataProviderResourceId = request.requestsList.first().dataProviderResourceId
+    val resourceIds = mutableSetOf<String>()
+    request.requestsList.forEachIndexed { index, subRequest ->
+      validateUndeleteRequest(subRequest, "requests.$index.")
+      if (subRequest.dataProviderResourceId != dataProviderResourceId) {
+        throw InvalidFieldValueException("requests.$index.data_provider_resource_id")
+          .asStatusRuntimeException(Status.Code.INVALID_ARGUMENT)
+      }
+      if (!resourceIds.add(subRequest.impressionMetadataResourceId)) {
+        throw InvalidFieldValueException("requests.$index.impression_metadata_resource_id")
+          .asStatusRuntimeException(Status.Code.INVALID_ARGUMENT)
+      }
+    }
+
+    val transactionRunner =
+      databaseClient.readWriteTransaction(Options.tag("action=batchUndeleteImpressionMetadata"))
+    val restored = buildList {
+      transactionRunner.run { txn ->
+        val existing =
+          txn.getImpressionMetadataByResourceIds(dataProviderResourceId, resourceIds.toList())
+        request.requestsList.forEach { subRequest ->
+          val result =
+            existing[subRequest.impressionMetadataResourceId]
+              ?: throw ImpressionMetadataNotFoundException(
+                  dataProviderResourceId,
+                  subRequest.impressionMetadataResourceId,
+                )
+                .asStatusRuntimeException(Status.Code.NOT_FOUND)
+          if (result.impressionMetadata.state != State.IMPRESSION_METADATA_STATE_DELETED) {
+            throw ImpressionMetadataAlreadyExistsException(result.impressionMetadata.blobUri)
+              .asStatusRuntimeException(Status.Code.ALREADY_EXISTS)
+          }
+          txn.updateImpressionMetadataState(
+            dataProviderResourceId,
+            result.impressionMetadataId,
+            State.IMPRESSION_METADATA_STATE_ACTIVE,
+          )
+          add(result.impressionMetadata)
+        }
+      }
+    }
+
+    val commitTimestamp = transactionRunner.getCommitTimestamp().toProto()
+    return batchUndeleteImpressionMetadataResponse {
+      impressionMetadata +=
+        restored.map {
+          it.copy {
+            state = State.IMPRESSION_METADATA_STATE_ACTIVE
+            updateTime = commitTimestamp
+            etag = ETags.computeETag(commitTimestamp.toInstant())
+          }
+        }
+    }
+  }
+
   override suspend fun computeModelLineBounds(
     request: ComputeModelLineBoundsRequest
   ): ComputeModelLineBoundsResponse {
@@ -650,6 +754,20 @@ class SpannerImpressionMetadataService(
       throw RequiredFieldNotSetException(
         "${fieldPathPrefix}impression_metadata.event_group_reference_id or entity_keys"
       )
+    }
+  }
+
+  private fun validateUndeleteRequest(
+    request: UndeleteImpressionMetadataRequest,
+    fieldPathPrefix: String,
+  ) {
+    if (request.dataProviderResourceId.isEmpty()) {
+      throw RequiredFieldNotSetException("${fieldPathPrefix}data_provider_resource_id")
+        .asStatusRuntimeException(Status.Code.INVALID_ARGUMENT)
+    }
+    if (request.impressionMetadataResourceId.isEmpty()) {
+      throw RequiredFieldNotSetException("${fieldPathPrefix}impression_metadata_resource_id")
+        .asStatusRuntimeException(Status.Code.INVALID_ARGUMENT)
     }
   }
 

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/spanner/SpannerImpressionMetadataService.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/spanner/SpannerImpressionMetadataService.kt
@@ -584,44 +584,6 @@ class SpannerImpressionMetadataService(
     }
   }
 
-  override suspend fun undeleteImpressionMetadata(
-    request: UndeleteImpressionMetadataRequest
-  ): ImpressionMetadata {
-    validateUndeleteRequest(request, "")
-
-    val transactionRunner =
-      databaseClient.readWriteTransaction(Options.tag("action=undeleteImpressionMetadata"))
-    val restored =
-      try {
-        transactionRunner.run { txn ->
-          val result =
-            txn.getImpressionMetadataByResourceId(
-              request.dataProviderResourceId,
-              request.impressionMetadataResourceId,
-            )
-          if (result.impressionMetadata.state != State.IMPRESSION_METADATA_STATE_DELETED) {
-            throw ImpressionMetadataAlreadyExistsException(result.impressionMetadata.blobUri)
-              .asStatusRuntimeException(Status.Code.ALREADY_EXISTS)
-          }
-          txn.updateImpressionMetadataState(
-            request.dataProviderResourceId,
-            result.impressionMetadataId,
-            State.IMPRESSION_METADATA_STATE_ACTIVE,
-          )
-          result.impressionMetadata
-        }
-      } catch (e: ImpressionMetadataNotFoundException) {
-        throw e.asStatusRuntimeException(Status.Code.NOT_FOUND)
-      }
-
-    val commitTimestamp = transactionRunner.getCommitTimestamp().toProto()
-    return restored.copy {
-      state = State.IMPRESSION_METADATA_STATE_ACTIVE
-      updateTime = commitTimestamp
-      etag = ETags.computeETag(commitTimestamp.toInstant())
-    }
-  }
-
   override suspend fun batchUndeleteImpressionMetadata(
     request: BatchUndeleteImpressionMetadataRequest
   ): BatchUndeleteImpressionMetadataResponse {

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/service/internal/testing/ImpressionMetadataServiceTest.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/service/internal/testing/ImpressionMetadataServiceTest.kt
@@ -49,6 +49,7 @@ import org.wfanet.measurement.internal.edpaggregator.batchCreateImpressionMetada
 import org.wfanet.measurement.internal.edpaggregator.batchCreateImpressionMetadataResponse
 import org.wfanet.measurement.internal.edpaggregator.batchDeleteImpressionMetadataRequest
 import org.wfanet.measurement.internal.edpaggregator.batchDeleteImpressionMetadataResponse
+import org.wfanet.measurement.internal.edpaggregator.batchUndeleteImpressionMetadataRequest
 import org.wfanet.measurement.internal.edpaggregator.batchUpdateImpressionMetadataRequest
 import org.wfanet.measurement.internal.edpaggregator.computeModelLineBoundsRequest
 import org.wfanet.measurement.internal.edpaggregator.computeModelLineBoundsResponse
@@ -943,6 +944,94 @@ abstract class ImpressionMetadataServiceTest {
         )
       assertThat(got).isEqualTo(deleted)
     }
+
+  @Test
+  fun `undeleteImpressionMetadata restores a deleted resource`() = runBlocking {
+    service.createImpressionMetadata(
+      createImpressionMetadataRequest { impressionMetadata = IMPRESSION_METADATA }
+    )
+    service.deleteImpressionMetadata(
+      deleteImpressionMetadataRequest {
+        dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
+        impressionMetadataResourceId = IMPRESSION_METADATA_RESOURCE_ID
+      }
+    )
+
+    val restored =
+      service.undeleteImpressionMetadata(
+        undeleteImpressionMetadataRequest {
+          dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
+          impressionMetadataResourceId = IMPRESSION_METADATA_RESOURCE_ID
+        }
+      )
+
+    assertThat(restored.state).isEqualTo(State.IMPRESSION_METADATA_STATE_ACTIVE)
+  }
+
+  @Test
+  fun `undeleteImpressionMetadata throws ALREADY_EXISTS for active resource`() = runBlocking {
+    service.createImpressionMetadata(
+      createImpressionMetadataRequest { impressionMetadata = IMPRESSION_METADATA }
+    )
+
+    val exception =
+      assertFailsWith<StatusRuntimeException> {
+        service.undeleteImpressionMetadata(
+          undeleteImpressionMetadataRequest {
+            dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
+            impressionMetadataResourceId = IMPRESSION_METADATA_RESOURCE_ID
+          }
+        )
+      }
+
+    assertThat(exception.status.code).isEqualTo(Status.Code.ALREADY_EXISTS)
+  }
+
+  @Test
+  fun `batchUndeleteImpressionMetadata restores deleted resources`() = runBlocking {
+    val created =
+      service
+        .batchCreateImpressionMetadata(
+          batchCreateImpressionMetadataRequest {
+            dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
+            requests += createImpressionMetadataRequest { impressionMetadata = IMPRESSION_METADATA }
+            requests += createImpressionMetadataRequest {
+              impressionMetadata = IMPRESSION_METADATA_2
+            }
+          }
+        )
+        .impressionMetadataList
+    service.batchDeleteImpressionMetadata(
+      batchDeleteImpressionMetadataRequest {
+        requests +=
+          created.map {
+            deleteImpressionMetadataRequest {
+              dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
+              impressionMetadataResourceId = it.impressionMetadataResourceId
+            }
+          }
+      }
+    )
+
+    val restored =
+      service.batchUndeleteImpressionMetadata(
+        batchUndeleteImpressionMetadataRequest {
+          requests +=
+            created.map {
+              undeleteImpressionMetadataRequest {
+                dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
+                impressionMetadataResourceId = it.impressionMetadataResourceId
+              }
+            }
+        }
+      )
+
+    assertThat(restored.impressionMetadataList.map { it.state })
+      .containsExactly(
+        State.IMPRESSION_METADATA_STATE_ACTIVE,
+        State.IMPRESSION_METADATA_STATE_ACTIVE,
+      )
+  }
 
   @Test
   fun `deleteImpressionMetadata throws INVALID_ARGUMENT when dataProviderResourceId is missing`() =

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/service/internal/testing/ImpressionMetadataServiceTest.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/service/internal/testing/ImpressionMetadataServiceTest.kt
@@ -1031,6 +1031,7 @@ abstract class ImpressionMetadataServiceTest {
         State.IMPRESSION_METADATA_STATE_ACTIVE,
         State.IMPRESSION_METADATA_STATE_ACTIVE,
       )
+      .inOrder()
   }
 
   @Test

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/service/v1alpha/ImpressionMetadataService.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/service/v1alpha/ImpressionMetadataService.kt
@@ -745,40 +745,6 @@ class ImpressionMetadataService(
     }
   }
 
-  override suspend fun undeleteImpressionMetadata(
-    request: UndeleteImpressionMetadataRequest
-  ): ImpressionMetadata {
-    if (request.name.isEmpty()) {
-      throw RequiredFieldNotSetException("name")
-        .asStatusRuntimeException(Status.Code.INVALID_ARGUMENT)
-    }
-    val key =
-      ImpressionMetadataKey.fromName(request.name)
-        ?: throw InvalidFieldValueException("name")
-          .asStatusRuntimeException(Status.Code.INVALID_ARGUMENT)
-
-    return try {
-      internalImpressionMetadataStub
-        .undeleteImpressionMetadata(
-          internalUndeleteImpressionMetadataRequest {
-            dataProviderResourceId = key.dataProviderId
-            impressionMetadataResourceId = key.impressionMetadataId
-          }
-        )
-        .toImpressionMetadata()
-    } catch (e: StatusException) {
-      throw when (InternalErrors.getReason(e)) {
-        InternalErrors.Reason.IMPRESSION_METADATA_NOT_FOUND ->
-          ImpressionMetadataNotFoundException(request.name, e)
-            .asStatusRuntimeException(Status.Code.NOT_FOUND)
-        InternalErrors.Reason.IMPRESSION_METADATA_ALREADY_EXISTS ->
-          ImpressionMetadataAlreadyExistsException.fromInternal(e)
-            .asStatusRuntimeException(Status.Code.ALREADY_EXISTS)
-        else -> Status.INTERNAL.withCause(e).asRuntimeException()
-      }
-    }
-  }
-
   override suspend fun batchUndeleteImpressionMetadata(
     request: BatchUndeleteImpressionMetadataRequest
   ): BatchUndeleteImpressionMetadataResponse {

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/service/v1alpha/ImpressionMetadataService.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/service/v1alpha/ImpressionMetadataService.kt
@@ -38,6 +38,8 @@ import org.wfanet.measurement.edpaggregator.v1alpha.BatchCreateImpressionMetadat
 import org.wfanet.measurement.edpaggregator.v1alpha.BatchCreateImpressionMetadataResponse
 import org.wfanet.measurement.edpaggregator.v1alpha.BatchDeleteImpressionMetadataRequest
 import org.wfanet.measurement.edpaggregator.v1alpha.BatchDeleteImpressionMetadataResponse
+import org.wfanet.measurement.edpaggregator.v1alpha.BatchUndeleteImpressionMetadataRequest
+import org.wfanet.measurement.edpaggregator.v1alpha.BatchUndeleteImpressionMetadataResponse
 import org.wfanet.measurement.edpaggregator.v1alpha.BatchUpdateImpressionMetadataRequest
 import org.wfanet.measurement.edpaggregator.v1alpha.BatchUpdateImpressionMetadataResponse
 import org.wfanet.measurement.edpaggregator.v1alpha.ComputeModelLineBoundsRequest
@@ -55,6 +57,7 @@ import org.wfanet.measurement.edpaggregator.v1alpha.UndeleteImpressionMetadataRe
 import org.wfanet.measurement.edpaggregator.v1alpha.UpdateImpressionMetadataRequest
 import org.wfanet.measurement.edpaggregator.v1alpha.batchCreateImpressionMetadataResponse
 import org.wfanet.measurement.edpaggregator.v1alpha.batchDeleteImpressionMetadataResponse
+import org.wfanet.measurement.edpaggregator.v1alpha.batchUndeleteImpressionMetadataResponse
 import org.wfanet.measurement.edpaggregator.v1alpha.batchUpdateImpressionMetadataResponse
 import org.wfanet.measurement.edpaggregator.v1alpha.computeModelLineBoundsResponse
 import org.wfanet.measurement.edpaggregator.v1alpha.entityKey
@@ -62,6 +65,7 @@ import org.wfanet.measurement.edpaggregator.v1alpha.impressionMetadata
 import org.wfanet.measurement.edpaggregator.v1alpha.listImpressionMetadataResponse
 import org.wfanet.measurement.internal.edpaggregator.BatchCreateImpressionMetadataResponse as InternalBatchCreateImpressionMetadataResponse
 import org.wfanet.measurement.internal.edpaggregator.BatchDeleteImpressionMetadataResponse as InternalBatchDeleteImpressionMetadataResponse
+import org.wfanet.measurement.internal.edpaggregator.BatchUndeleteImpressionMetadataResponse as InternalBatchUndeleteImpressionMetadataResponse
 import org.wfanet.measurement.internal.edpaggregator.BatchUpdateImpressionMetadataResponse as InternalBatchUpdateImpressionMetadataResponse
 import org.wfanet.measurement.internal.edpaggregator.ComputeModelLineBoundsResponse as InternalComputeModelLineBoundsResponse
 import org.wfanet.measurement.internal.edpaggregator.CreateImpressionMetadataRequest as InternalCreateImpressionMetadataRequest
@@ -77,6 +81,7 @@ import org.wfanet.measurement.internal.edpaggregator.ListImpressionMetadataRespo
 import org.wfanet.measurement.internal.edpaggregator.UpdateImpressionMetadataRequest as InternalUpdateImpressionMetadataRequest
 import org.wfanet.measurement.internal.edpaggregator.batchCreateImpressionMetadataRequest as internalBatchCreateImpressionMetadataRequest
 import org.wfanet.measurement.internal.edpaggregator.batchDeleteImpressionMetadataRequest as internalBatchDeleteImpressionMetadataRequest
+import org.wfanet.measurement.internal.edpaggregator.batchUndeleteImpressionMetadataRequest as internalBatchUndeleteImpressionMetadataRequest
 import org.wfanet.measurement.internal.edpaggregator.batchUpdateImpressionMetadataRequest as internalBatchUpdateImpressionMetadataRequest
 import org.wfanet.measurement.internal.edpaggregator.computeModelLineBoundsRequest as internalComputeModelLineBoundsRequest
 import org.wfanet.measurement.internal.edpaggregator.createImpressionMetadataRequest as internalCreateImpressionMetadataRequest
@@ -735,6 +740,100 @@ class ImpressionMetadataService(
       }
 
     return batchDeleteImpressionMetadataResponse {
+      impressionMetadata +=
+        internalResponse.impressionMetadataList.map { it.toImpressionMetadata() }
+    }
+  }
+
+  override suspend fun undeleteImpressionMetadata(
+    request: UndeleteImpressionMetadataRequest
+  ): ImpressionMetadata {
+    if (request.name.isEmpty()) {
+      throw RequiredFieldNotSetException("name")
+        .asStatusRuntimeException(Status.Code.INVALID_ARGUMENT)
+    }
+    val key =
+      ImpressionMetadataKey.fromName(request.name)
+        ?: throw InvalidFieldValueException("name")
+          .asStatusRuntimeException(Status.Code.INVALID_ARGUMENT)
+
+    return try {
+      internalImpressionMetadataStub
+        .undeleteImpressionMetadata(
+          internalUndeleteImpressionMetadataRequest {
+            dataProviderResourceId = key.dataProviderId
+            impressionMetadataResourceId = key.impressionMetadataId
+          }
+        )
+        .toImpressionMetadata()
+    } catch (e: StatusException) {
+      throw when (InternalErrors.getReason(e)) {
+        InternalErrors.Reason.IMPRESSION_METADATA_NOT_FOUND ->
+          ImpressionMetadataNotFoundException(request.name, e)
+            .asStatusRuntimeException(Status.Code.NOT_FOUND)
+        InternalErrors.Reason.IMPRESSION_METADATA_ALREADY_EXISTS ->
+          ImpressionMetadataAlreadyExistsException.fromInternal(e)
+            .asStatusRuntimeException(Status.Code.ALREADY_EXISTS)
+        else -> Status.INTERNAL.withCause(e).asRuntimeException()
+      }
+    }
+  }
+
+  override suspend fun batchUndeleteImpressionMetadata(
+    request: BatchUndeleteImpressionMetadataRequest
+  ): BatchUndeleteImpressionMetadataResponse {
+    if (request.parent.isEmpty()) {
+      throw RequiredFieldNotSetException("parent")
+        .asStatusRuntimeException(Status.Code.INVALID_ARGUMENT)
+    }
+    val dataProviderKey =
+      DataProviderKey.fromName(request.parent)
+        ?: throw InvalidFieldValueException("parent")
+          .asStatusRuntimeException(Status.Code.INVALID_ARGUMENT)
+    if (request.namesList.isEmpty()) {
+      throw RequiredFieldNotSetException("names")
+        .asStatusRuntimeException(Status.Code.INVALID_ARGUMENT)
+    }
+
+    val names = mutableSetOf<String>()
+    val internalRequests =
+      request.namesList.mapIndexed { index, name ->
+        if (name.isEmpty()) {
+          throw RequiredFieldNotSetException("names.$index")
+            .asStatusRuntimeException(Status.Code.INVALID_ARGUMENT)
+        }
+        val key =
+          ImpressionMetadataKey.fromName(name)
+            ?: throw InvalidFieldValueException("names.$index")
+              .asStatusRuntimeException(Status.Code.INVALID_ARGUMENT)
+        if (key.dataProviderId != dataProviderKey.dataProviderId || !names.add(name)) {
+          throw InvalidFieldValueException("names.$index")
+            .asStatusRuntimeException(Status.Code.INVALID_ARGUMENT)
+        }
+        internalUndeleteImpressionMetadataRequest {
+          dataProviderResourceId = dataProviderKey.dataProviderId
+          impressionMetadataResourceId = key.impressionMetadataId
+        }
+      }
+
+    val internalResponse: InternalBatchUndeleteImpressionMetadataResponse =
+      try {
+        internalImpressionMetadataStub.batchUndeleteImpressionMetadata(
+          internalBatchUndeleteImpressionMetadataRequest { requests += internalRequests }
+        )
+      } catch (e: StatusException) {
+        throw when (InternalErrors.getReason(e)) {
+          InternalErrors.Reason.IMPRESSION_METADATA_NOT_FOUND ->
+            ImpressionMetadataNotFoundException.fromInternal(e)
+              .asStatusRuntimeException(Status.Code.NOT_FOUND)
+          InternalErrors.Reason.IMPRESSION_METADATA_ALREADY_EXISTS ->
+            ImpressionMetadataAlreadyExistsException.fromInternal(e)
+              .asStatusRuntimeException(Status.Code.ALREADY_EXISTS)
+          else -> Status.INTERNAL.withCause(e).asRuntimeException()
+        }
+      }
+
+    return batchUndeleteImpressionMetadataResponse {
       impressionMetadata +=
         internalResponse.impressionMetadataList.map { it.toImpressionMetadata() }
     }

--- a/src/main/proto/wfa/measurement/edpaggregator/v1alpha/impression_metadata_service.proto
+++ b/src/main/proto/wfa/measurement/edpaggregator/v1alpha/impression_metadata_service.proto
@@ -70,10 +70,6 @@ service ImpressionMetadataService {
   rpc BatchDeleteImpressionMetadata(BatchDeleteImpressionMetadataRequest)
       returns (BatchDeleteImpressionMetadataResponse) {}
 
-  // Restores a soft-deleted ImpressionMetadata entry.
-  rpc UndeleteImpressionMetadata(UndeleteImpressionMetadataRequest)
-      returns (ImpressionMetadata) {}
-
   // Restores multiple soft-deleted ImpressionMetadata entries in a single
   // request.
   rpc BatchUndeleteImpressionMetadata(BatchUndeleteImpressionMetadataRequest)
@@ -336,19 +332,6 @@ message BatchDeleteImpressionMetadataRequest {
 message BatchDeleteImpressionMetadataResponse {
   // The list of updated ImpressionMetadata, now marked as deleted.
   repeated ImpressionMetadata impression_metadata = 1;
-}
-
-// Request message for the `UndeleteImpressionMetadata` method.
-message UndeleteImpressionMetadataRequest {
-  // The resource name of the soft-deleted ImpressionMetadata to restore.
-  // Format:
-  // `dataProviders/{data_provider}/impressionMetadata/{impression_metadata}`
-  string name = 1 [
-    (google.api.field_behavior) = REQUIRED,
-    (google.api.resource_reference) = {
-      type: "edpaggregator.halo-cmm.org/ImpressionMetadata"
-    }
-  ];
 }
 
 // Request message for the `BatchUndeleteImpressionMetadata` method.

--- a/src/main/proto/wfa/measurement/edpaggregator/v1alpha/impression_metadata_service.proto
+++ b/src/main/proto/wfa/measurement/edpaggregator/v1alpha/impression_metadata_service.proto
@@ -70,6 +70,15 @@ service ImpressionMetadataService {
   rpc BatchDeleteImpressionMetadata(BatchDeleteImpressionMetadataRequest)
       returns (BatchDeleteImpressionMetadataResponse) {}
 
+  // Restores a soft-deleted ImpressionMetadata entry.
+  rpc UndeleteImpressionMetadata(UndeleteImpressionMetadataRequest)
+      returns (ImpressionMetadata) {}
+
+  // Restores multiple soft-deleted ImpressionMetadata entries in a single
+  // request.
+  rpc BatchUndeleteImpressionMetadata(BatchUndeleteImpressionMetadataRequest)
+      returns (BatchUndeleteImpressionMetadataResponse) {}
+
   // Computes the time bounds for all ModelLines for a DataProvider.
   //
   // This method returns, for each requested ModelLine, the interval spanning
@@ -326,6 +335,49 @@ message BatchDeleteImpressionMetadataRequest {
 //     "Metadatum".  --)
 message BatchDeleteImpressionMetadataResponse {
   // The list of updated ImpressionMetadata, now marked as deleted.
+  repeated ImpressionMetadata impression_metadata = 1;
+}
+
+// Request message for the `UndeleteImpressionMetadata` method.
+message UndeleteImpressionMetadataRequest {
+  // The resource name of the soft-deleted ImpressionMetadata to restore.
+  // Format:
+  // `dataProviders/{data_provider}/impressionMetadata/{impression_metadata}`
+  string name = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference) = {
+      type: "edpaggregator.halo-cmm.org/ImpressionMetadata"
+    }
+  ];
+}
+
+// Request message for the `BatchUndeleteImpressionMetadata` method.
+message BatchUndeleteImpressionMetadataRequest {
+  // The parent data provider resource name.
+  // Format: `dataProviders/{data_provider}`
+  string parent = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference) = {
+      child_type: "edpaggregator.halo-cmm.org/ImpressionMetadata"
+    }
+  ];
+
+  // The resource names of the ImpressionMetadata entries to restore.
+  repeated string names = 2 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference) = {
+      type: "edpaggregator.halo-cmm.org/ImpressionMetadata"
+    }
+  ];
+}
+
+// Response message for the `BatchUndeleteImpressionMetadata` method.
+// (-- api-linter: core::0235::response-resource-field=disabled
+//     aip.dev/not-precedent: Linter incorrectly singularizes "Metadata" to
+//     "Metadatum". --)
+message BatchUndeleteImpressionMetadataResponse {
+  // The restored ImpressionMetadata entries, in the same order as the names
+  // in the request.
   repeated ImpressionMetadata impression_metadata = 1;
 }
 

--- a/src/main/proto/wfa/measurement/internal/edpaggregator/impression_metadata_service.proto
+++ b/src/main/proto/wfa/measurement/internal/edpaggregator/impression_metadata_service.proto
@@ -61,6 +61,14 @@ service ImpressionMetadataService {
   rpc BatchDeleteImpressionMetadata(BatchDeleteImpressionMetadataRequest)
       returns (BatchDeleteImpressionMetadataResponse);
 
+  // Restores a soft-deleted ImpressionMetadata entry.
+  rpc UndeleteImpressionMetadata(UndeleteImpressionMetadataRequest)
+      returns (ImpressionMetadata);
+
+  // Restores multiple soft-deleted ImpressionMetadata entries.
+  rpc BatchUndeleteImpressionMetadata(BatchUndeleteImpressionMetadataRequest)
+      returns (BatchUndeleteImpressionMetadataResponse);
+
   // Computes the time bounds for all ModelLines for a DataProvider.
   rpc ComputeModelLineBounds(ComputeModelLineBoundsRequest)
       returns (ComputeModelLineBoundsResponse) {}
@@ -168,6 +176,19 @@ message BatchDeleteImpressionMetadataRequest {
 
 message BatchDeleteImpressionMetadataResponse {
   // The list of updated ImpressionMetadata, now marked as deleted.
+  repeated ImpressionMetadata impression_metadata = 1;
+}
+
+message UndeleteImpressionMetadataRequest {
+  string data_provider_resource_id = 1;
+  string impression_metadata_resource_id = 2;
+}
+
+message BatchUndeleteImpressionMetadataRequest {
+  repeated UndeleteImpressionMetadataRequest requests = 1;
+}
+
+message BatchUndeleteImpressionMetadataResponse {
   repeated ImpressionMetadata impression_metadata = 1;
 }
 

--- a/src/main/proto/wfa/measurement/internal/edpaggregator/impression_metadata_service.proto
+++ b/src/main/proto/wfa/measurement/internal/edpaggregator/impression_metadata_service.proto
@@ -61,10 +61,6 @@ service ImpressionMetadataService {
   rpc BatchDeleteImpressionMetadata(BatchDeleteImpressionMetadataRequest)
       returns (BatchDeleteImpressionMetadataResponse);
 
-  // Restores a soft-deleted ImpressionMetadata entry.
-  rpc UndeleteImpressionMetadata(UndeleteImpressionMetadataRequest)
-      returns (ImpressionMetadata);
-
   // Restores multiple soft-deleted ImpressionMetadata entries.
   rpc BatchUndeleteImpressionMetadata(BatchUndeleteImpressionMetadataRequest)
       returns (BatchUndeleteImpressionMetadataResponse);
@@ -177,11 +173,6 @@ message BatchDeleteImpressionMetadataRequest {
 message BatchDeleteImpressionMetadataResponse {
   // The list of updated ImpressionMetadata, now marked as deleted.
   repeated ImpressionMetadata impression_metadata = 1;
-}
-
-message UndeleteImpressionMetadataRequest {
-  string data_provider_resource_id = 1;
-  string impression_metadata_resource_id = 2;
 }
 
 message BatchUndeleteImpressionMetadataRequest {

--- a/src/test/kotlin/org/wfanet/measurement/edpaggregator/dataavailability/DataAvailabilityMonitorTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/edpaggregator/dataavailability/DataAvailabilityMonitorTest.kt
@@ -75,6 +75,12 @@ class DataAvailabilityMonitorTest {
                 "gs://$BUCKET_NAME/$EDP_IMPRESSION_PATH/model-line/${MODEL_LINE_A.modelLineId}/2026-03-10/metadata_campaign_123.json"
               state = V1AlphaImpressionMetadata.State.DELETED
             }
+            impressionMetadata += v1alphaImpressionMetadata {
+              name = "$DATA_PROVIDER_NAME/impressionMetadata/imp-active-1"
+              blobUri =
+                "gs://$BUCKET_NAME/$EDP_IMPRESSION_PATH/model-line/${MODEL_LINE_A.modelLineId}/2026-03-11/metadata_campaign_456.json"
+              state = V1AlphaImpressionMetadata.State.ACTIVE
+            }
           }
         }
     }

--- a/src/test/kotlin/org/wfanet/measurement/edpaggregator/dataavailability/DataAvailabilityMonitorTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/edpaggregator/dataavailability/DataAvailabilityMonitorTest.kt
@@ -75,12 +75,6 @@ class DataAvailabilityMonitorTest {
                 "gs://$BUCKET_NAME/$EDP_IMPRESSION_PATH/model-line/${MODEL_LINE_A.modelLineId}/2026-03-10/metadata_campaign_123.json"
               state = V1AlphaImpressionMetadata.State.DELETED
             }
-            impressionMetadata += v1alphaImpressionMetadata {
-              name = "$DATA_PROVIDER_NAME/impressionMetadata/imp-active-1"
-              blobUri =
-                "gs://$BUCKET_NAME/$EDP_IMPRESSION_PATH/model-line/${MODEL_LINE_A.modelLineId}/2026-03-11/metadata_campaign_456.json"
-              state = V1AlphaImpressionMetadata.State.ACTIVE
-            }
           }
         }
     }

--- a/src/test/kotlin/org/wfanet/measurement/edpaggregator/dataavailability/DataAvailabilitySyncTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/edpaggregator/dataavailability/DataAvailabilitySyncTest.kt
@@ -57,6 +57,7 @@ import org.wfanet.measurement.common.grpc.testing.mockService
 import org.wfanet.measurement.common.throttler.MinimumIntervalThrottler
 import org.wfanet.measurement.common.throttler.Throttler
 import org.wfanet.measurement.edpaggregator.v1alpha.BatchCreateImpressionMetadataRequest
+import org.wfanet.measurement.edpaggregator.v1alpha.BatchUndeleteImpressionMetadataRequest
 import org.wfanet.measurement.edpaggregator.v1alpha.BatchUpdateImpressionMetadataRequest
 import org.wfanet.measurement.edpaggregator.v1alpha.BlobDetails
 import org.wfanet.measurement.edpaggregator.v1alpha.ComputeModelLineBoundsRequest
@@ -66,6 +67,7 @@ import org.wfanet.measurement.edpaggregator.v1alpha.ImpressionMetadataServiceGrp
 import org.wfanet.measurement.edpaggregator.v1alpha.ImpressionMetadataServiceGrpcKt.ImpressionMetadataServiceCoroutineStub
 import org.wfanet.measurement.edpaggregator.v1alpha.ListImpressionMetadataRequest
 import org.wfanet.measurement.edpaggregator.v1alpha.batchCreateImpressionMetadataResponse
+import org.wfanet.measurement.edpaggregator.v1alpha.batchUndeleteImpressionMetadataResponse
 import org.wfanet.measurement.edpaggregator.v1alpha.batchUpdateImpressionMetadataResponse
 import org.wfanet.measurement.edpaggregator.v1alpha.blobDetails
 import org.wfanet.measurement.edpaggregator.v1alpha.computeModelLineBoundsResponse
@@ -141,6 +143,8 @@ class DataAvailabilitySyncTest {
               }
           }
         }
+      onBlocking { batchUndeleteImpressionMetadata(any<BatchUndeleteImpressionMetadataRequest>()) }
+        .thenAnswer { batchUndeleteImpressionMetadataResponse {} }
       onBlocking { computeModelLineBounds(any<ComputeModelLineBoundsRequest>()) }
         .thenAnswer { invocation ->
           val request = invocation.getArgument<ComputeModelLineBoundsRequest>(0)
@@ -2286,6 +2290,88 @@ class DataAvailabilitySyncTest {
       val secondRequestId = secondCaptor.firstValue.requestsList.single().requestId
       assertThat(secondRequestId).isNotEqualTo(firstRequestId)
     }
+
+  @Test
+  fun `sync restores deleted impression metadata at the same blob URI`() = runBlocking {
+    val fileSystemClient = FileSystemStorageClient(File(tempFolder.root.toString()))
+    val storageClient = FakeBlobMetadataStorageClient(fileSystemClient)
+    seedBlobDetails(storageClient, folderPrefix, listOf(300L to 400L))
+
+    var updatedBeforeRestore = false
+    wheneverBlocking {
+        impressionMetadataServiceMock.listImpressionMetadata(any<ListImpressionMetadataRequest>())
+      }
+      .thenAnswer { invocation ->
+        val request = invocation.getArgument<ListImpressionMetadataRequest>(0)
+        assertThat(request.showDeleted).isTrue()
+        listImpressionMetadataResponse {
+          impressionMetadata += impressionMetadata {
+            name = "dataProviders/dataProvider123/impressionMetadata/im-deleted"
+            blobUri = "$bucket/${folderPrefix}metadata-0.binpb"
+            blobTypeUrl =
+              "type.googleapis.com/wfa.measurement.securecomputation.impressions.BlobDetails"
+            eventGroupReferenceId = "some-event-group-reference-id"
+            modelLine = "modelProviders/provider1/modelSuites/suite1/modelLines/modelLine1"
+            interval = interval {
+              startTime = timestamp { seconds = 200 }
+              endTime = timestamp { seconds = 300 }
+            }
+            state = org.wfanet.measurement.edpaggregator.v1alpha.ImpressionMetadata.State.DELETED
+          }
+        }
+      }
+    wheneverBlocking {
+        impressionMetadataServiceMock.batchUpdateImpressionMetadata(
+          any<BatchUpdateImpressionMetadataRequest>()
+        )
+      }
+      .thenAnswer { invocation ->
+        updatedBeforeRestore = true
+        val request = invocation.getArgument<BatchUpdateImpressionMetadataRequest>(0)
+        batchUpdateImpressionMetadataResponse {
+          impressionMetadata += request.requestsList.map { it.impressionMetadata }
+        }
+      }
+    wheneverBlocking {
+        impressionMetadataServiceMock.batchUndeleteImpressionMetadata(
+          any<BatchUndeleteImpressionMetadataRequest>()
+        )
+      }
+      .thenAnswer {
+        assertThat(updatedBeforeRestore).isTrue()
+        batchUndeleteImpressionMetadataResponse {}
+      }
+
+    val dataAvailabilitySync =
+      DataAvailabilitySync(
+        "edp/edpa_edp",
+        storageClient,
+        dataProvidersStub,
+        impressionMetadataStub,
+        "dataProviders/dataProvider123",
+        MinimumIntervalThrottler(Clock.systemUTC(), Duration.ofMillis(1000)),
+        impressionMetadataBatchSize = DEFAULT_BATCH_SIZE,
+        modelLineMap = emptyMap(),
+        errorIfGapsExist = true,
+      )
+
+    dataAvailabilitySync.sync("$bucket/${folderPrefix}done")
+
+    val undeleteCaptor = argumentCaptor<BatchUndeleteImpressionMetadataRequest>()
+    verifyBlocking(impressionMetadataServiceMock) {
+      batchUndeleteImpressionMetadata(undeleteCaptor.capture())
+    }
+    assertThat(undeleteCaptor.firstValue.namesList.single())
+      .isEqualTo("dataProviders/dataProvider123/impressionMetadata/im-deleted")
+    val updateCaptor = argumentCaptor<BatchUpdateImpressionMetadataRequest>()
+    verifyBlocking(impressionMetadataServiceMock) {
+      batchUpdateImpressionMetadata(updateCaptor.capture())
+    }
+    assertThat(
+        updateCaptor.firstValue.requestsList.single().impressionMetadata.interval.startTime.seconds
+      )
+      .isEqualTo(300)
+  }
 
   /**
    * Seeds a directory (prefix) with BlobDetails files, one per interval. Returns the blob keys

--- a/src/test/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/spanner/BUILD.bazel
+++ b/src/test/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/spanner/BUILD.bazel
@@ -2,6 +2,7 @@ load(
     "@wfa_common_jvm//src/main/kotlin/org/wfanet/measurement/gcloud/spanner/testing:macros.bzl",
     "spanner_emulator_test",
 )
+load("@wfa_rules_kotlin_jvm//kotlin:defs.bzl", "kt_jvm_test")
 
 spanner_emulator_test(
     name = "EdpAggregatorSchemaTest",
@@ -23,6 +24,22 @@ spanner_emulator_test(
         "//src/main/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/spanner/testing:schemata",
         "//src/main/kotlin/org/wfanet/measurement/edpaggregator/service/internal/testing:impression_metadata_service_test",
         "@wfa_common_jvm//src/main/kotlin/org/wfanet/measurement/gcloud/spanner/testing",
+    ],
+)
+
+kt_jvm_test(
+    name = "SpannerImpressionMetadataServiceTransactionRetryTest",
+    srcs = ["SpannerImpressionMetadataServiceTransactionRetryTest.kt"],
+    test_class = "org.wfanet.measurement.edpaggregator.deploy.gcloud.spanner.SpannerImpressionMetadataServiceTransactionRetryTest",
+    deps = [
+        "//src/main/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/spanner:spanner_impression_metadata_service",
+        "//src/main/proto/wfa/measurement/internal/edpaggregator:impression_metadata_service_kt_jvm_grpc_proto",
+        "//src/main/proto/wfa/measurement/internal/edpaggregator:impression_metadata_state_kt_jvm_proto",
+        "@wfa_common_jvm//imports/java/com/google/cloud/spanner",
+        "@wfa_common_jvm//imports/java/com/google/common/truth",
+        "@wfa_common_jvm//imports/kotlin/kotlinx/coroutines:core",
+        "@wfa_common_jvm//imports/kotlin/org/mockito/kotlin",
+        "@wfa_common_jvm//src/main/kotlin/org/wfanet/measurement/gcloud/spanner",
     ],
 )
 

--- a/src/test/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/spanner/SpannerImpressionMetadataServiceTransactionRetryTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/spanner/SpannerImpressionMetadataServiceTransactionRetryTest.kt
@@ -1,0 +1,133 @@
+/*
+ * Copyright 2026 The Cross-Media Measurement Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wfanet.measurement.edpaggregator.deploy.gcloud.spanner
+
+import com.google.cloud.Timestamp
+import com.google.cloud.spanner.CommitResponse
+import com.google.cloud.spanner.Struct
+import com.google.cloud.spanner.Type
+import com.google.common.truth.Truth.assertThat
+import kotlinx.coroutines.flow.asFlow
+import kotlinx.coroutines.runBlocking
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+import org.mockito.kotlin.any
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import org.wfanet.measurement.gcloud.spanner.AsyncDatabaseClient
+import org.wfanet.measurement.gcloud.spanner.TransactionWork
+import org.wfanet.measurement.internal.edpaggregator.ImpressionMetadataState as State
+import org.wfanet.measurement.internal.edpaggregator.batchUndeleteImpressionMetadataRequest
+import org.wfanet.measurement.internal.edpaggregator.undeleteImpressionMetadataRequest
+
+@RunWith(JUnit4::class)
+class SpannerImpressionMetadataServiceTransactionRetryTest {
+  @Test
+  fun `batchUndeleteImpressionMetadata does not duplicate results after transaction retry`() =
+    runBlocking {
+      val rows =
+        listOf(
+          deletedImpressionMetadataRow(1L, "metadata-1"),
+          deletedImpressionMetadataRow(2L, "metadata-2"),
+        )
+      val transactionContext = mock<AsyncDatabaseClient.TransactionContext>()
+      whenever(transactionContext.executeQuery(any(), any())).thenReturn(rows.asFlow())
+      val transactionRunner = RetryingTransactionRunner(transactionContext)
+      val databaseClient = mock<AsyncDatabaseClient>()
+      whenever(databaseClient.readWriteTransaction(any())).thenReturn(transactionRunner)
+      val service = SpannerImpressionMetadataService(databaseClient)
+
+      val response =
+        service.batchUndeleteImpressionMetadata(
+          batchUndeleteImpressionMetadataRequest {
+            requests +=
+              listOf("metadata-1", "metadata-2").map { resourceId ->
+                undeleteImpressionMetadataRequest {
+                  dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
+                  impressionMetadataResourceId = resourceId
+                }
+              }
+          }
+        )
+
+      assertThat(transactionRunner.attempts).isEqualTo(2)
+      assertThat(response.impressionMetadataList.map { it.impressionMetadataResourceId })
+        .containsExactly("metadata-1", "metadata-2")
+        .inOrder()
+    }
+
+  private class RetryingTransactionRunner(
+    private val transactionContext: AsyncDatabaseClient.TransactionContext
+  ) : AsyncDatabaseClient.TransactionRunner {
+    var attempts = 0
+      private set
+
+    override suspend fun <R> run(doWork: TransactionWork<R>): R {
+      attempts++
+      doWork(transactionContext)
+      attempts++
+      return doWork(transactionContext)
+    }
+
+    override suspend fun getCommitTimestamp(): Timestamp = COMMIT_TIMESTAMP
+
+    override suspend fun getCommitResponse(): CommitResponse = error("Not used")
+
+    override fun close() {}
+  }
+
+  companion object {
+    private const val DATA_PROVIDER_RESOURCE_ID = "data-provider-1"
+    private val COMMIT_TIMESTAMP = Timestamp.ofTimeSecondsAndNanos(1234L, 0)
+    private val ENTITY_KEY_TYPE =
+      Type.struct(
+        Type.StructField.of("EntityType", Type.string()),
+        Type.StructField.of("EntityId", Type.string()),
+      )
+
+    private fun deletedImpressionMetadataRow(internalId: Long, resourceId: String): Struct =
+      Struct.newBuilder()
+        .set("DataProviderResourceId")
+        .to(DATA_PROVIDER_RESOURCE_ID)
+        .set("ImpressionMetadataId")
+        .to(internalId)
+        .set("ImpressionMetadataResourceId")
+        .to(resourceId)
+        .set("BlobUri")
+        .to("gs://bucket/$resourceId")
+        .set("BlobTypeUrl")
+        .to("type.googleapis.com/example.Impression")
+        .set("EventGroupReferenceId")
+        .to("event-group-1")
+        .set("CmmsModelLine")
+        .to("modelLines/1")
+        .set("IntervalStartTime")
+        .to(COMMIT_TIMESTAMP)
+        .set("IntervalEndTime")
+        .to(COMMIT_TIMESTAMP)
+        .set("State")
+        .to(State.IMPRESSION_METADATA_STATE_DELETED)
+        .set("CreateTime")
+        .to(COMMIT_TIMESTAMP)
+        .set("UpdateTime")
+        .to(COMMIT_TIMESTAMP)
+        .set("EntityKeys")
+        .toStructArray(ENTITY_KEY_TYPE, emptyList())
+        .build()
+  }
+}

--- a/src/test/kotlin/org/wfanet/measurement/edpaggregator/service/v1alpha/ImpressionMetadataServiceTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/edpaggregator/service/v1alpha/ImpressionMetadataServiceTest.kt
@@ -1416,6 +1416,7 @@ class ImpressionMetadataServiceTest {
 
     assertThat(response.impressionMetadataList.map { it.state })
       .containsExactly(ImpressionMetadata.State.ACTIVE, ImpressionMetadata.State.ACTIVE)
+      .inOrder()
   }
 
   @Test

--- a/src/test/kotlin/org/wfanet/measurement/edpaggregator/service/v1alpha/ImpressionMetadataServiceTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/edpaggregator/service/v1alpha/ImpressionMetadataServiceTest.kt
@@ -56,6 +56,7 @@ import org.wfanet.measurement.edpaggregator.v1alpha.batchCreateImpressionMetadat
 import org.wfanet.measurement.edpaggregator.v1alpha.batchCreateImpressionMetadataResponse
 import org.wfanet.measurement.edpaggregator.v1alpha.batchDeleteImpressionMetadataRequest
 import org.wfanet.measurement.edpaggregator.v1alpha.batchDeleteImpressionMetadataResponse
+import org.wfanet.measurement.edpaggregator.v1alpha.batchUndeleteImpressionMetadataRequest
 import org.wfanet.measurement.edpaggregator.v1alpha.computeModelLineBoundsRequest
 import org.wfanet.measurement.edpaggregator.v1alpha.computeModelLineBoundsResponse
 import org.wfanet.measurement.edpaggregator.v1alpha.copy
@@ -1393,6 +1394,43 @@ class ImpressionMetadataServiceTest {
           metadata[Errors.Metadata.FIELD_NAME.key] = "filter.state"
         }
       )
+  }
+
+  @Test
+  fun `batchUndeleteImpressionMetadata restores deleted metadata`() = runBlocking {
+    val created = createImpressionMetadata(IMPRESSION_METADATA, IMPRESSION_METADATA_2)
+    service.batchDeleteImpressionMetadata(
+      batchDeleteImpressionMetadataRequest {
+        parent = DATA_PROVIDER_KEY.toName()
+        names += created.map { it.name }
+      }
+    )
+
+    val response =
+      service.batchUndeleteImpressionMetadata(
+        batchUndeleteImpressionMetadataRequest {
+          parent = DATA_PROVIDER_KEY.toName()
+          names += created.map { it.name }
+        }
+      )
+
+    assertThat(response.impressionMetadataList.map { it.state })
+      .containsExactly(ImpressionMetadata.State.ACTIVE, ImpressionMetadata.State.ACTIVE)
+  }
+
+  @Test
+  fun `batchUndeleteImpressionMetadata rejects name under another parent`() = runBlocking {
+    val exception =
+      assertFailsWith<StatusRuntimeException> {
+        service.batchUndeleteImpressionMetadata(
+          batchUndeleteImpressionMetadataRequest {
+            parent = DATA_PROVIDER_KEY.toName()
+            names += "dataProviders/another/impressionMetadata/impression-1"
+          }
+        )
+      }
+
+    assertThat(exception.status.code).isEqualTo(Status.Code.INVALID_ARGUMENT)
   }
 
   @Test


### PR DESCRIPTION
Add AIP-164-style undelete operations for ImpressionMetadata, including a batched form for the sync pipeline. DataAvailabilitySync now lists active and deleted rows together, restores regenerated sidecars before refreshing changed content, and DataAvailabilityMonitor ignores active rows returned by show_deleted.

Issue: #4428