### PR TITLE
feat(edpa): Track replacement upload revisions

### DIFF
--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/spanner/BUILD.bazel
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/spanner/BUILD.bazel
@@ -60,12 +60,14 @@ kt_jvm_library(
     srcs = ["SpannerRawImpressionUploadService.kt"],
     deps = [
         "//src/main/kotlin/org/wfanet/measurement/common:id_generator",
+        "//src/main/kotlin/org/wfanet/measurement/common/api:etags",
         "//src/main/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/spanner/db",
         "//src/main/kotlin/org/wfanet/measurement/edpaggregator/service/internal:errors",
         "//src/main/proto/wfa/measurement/internal/edpaggregator:raw_impression_upload_kt_jvm_proto",
         "//src/main/proto/wfa/measurement/internal/edpaggregator:raw_impression_upload_service_kt_jvm_grpc_proto",
         "//src/main/proto/wfa/measurement/internal/edpaggregator:raw_impression_upload_state_kt_jvm_proto",
         "@wfa_common_jvm//imports/java/com/google/protobuf/util",
+        "@wfa_common_jvm//src/main/kotlin/org/wfanet/measurement/common",
         "@wfa_common_jvm//src/main/kotlin/org/wfanet/measurement/gcloud/spanner",
     ],
 )

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/spanner/BUILD.bazel
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/spanner/BUILD.bazel
@@ -65,6 +65,7 @@ kt_jvm_library(
         "//src/main/proto/wfa/measurement/internal/edpaggregator:raw_impression_upload_kt_jvm_proto",
         "//src/main/proto/wfa/measurement/internal/edpaggregator:raw_impression_upload_service_kt_jvm_grpc_proto",
         "//src/main/proto/wfa/measurement/internal/edpaggregator:raw_impression_upload_state_kt_jvm_proto",
+        "@wfa_common_jvm//imports/java/com/google/protobuf/util",
         "@wfa_common_jvm//src/main/kotlin/org/wfanet/measurement/gcloud/spanner",
     ],
 )

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/spanner/SpannerRawImpressionUploadService.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/spanner/SpannerRawImpressionUploadService.kt
@@ -28,6 +28,7 @@ import kotlinx.coroutines.flow.map
 import org.wfanet.measurement.common.IdGenerator
 import org.wfanet.measurement.common.generateNewId
 import org.wfanet.measurement.edpaggregator.deploy.gcloud.spanner.db.RawImpressionUploadResult
+import org.wfanet.measurement.edpaggregator.deploy.gcloud.spanner.db.findLatestUploadByDoneBlobUri
 import org.wfanet.measurement.edpaggregator.deploy.gcloud.spanner.db.findUploadByCreateRequestId
 import org.wfanet.measurement.edpaggregator.deploy.gcloud.spanner.db.getRawImpressionUploadByResourceId
 import org.wfanet.measurement.edpaggregator.deploy.gcloud.spanner.db.insertRawImpressionUpload
@@ -116,6 +117,31 @@ class SpannerRawImpressionUploadService(
             return@run existing.rawImpressionUpload
           }
 
+          val previous =
+            txn.findLatestUploadByDoneBlobUri(
+              request.dataProviderResourceId,
+              request.rawImpressionUpload.doneBlobUri,
+            )
+          if (
+            request.rawImpressionUpload.doneBlobGeneration != 0L &&
+              previous != null &&
+              previous.rawImpressionUpload.doneBlobGeneration >=
+                request.rawImpressionUpload.doneBlobGeneration
+          ) {
+            throw RawImpressionUploadAlreadyExistsException(
+                request.dataProviderResourceId,
+                requestId,
+                previous.rawImpressionUpload.doneBlobUri,
+                request.rawImpressionUpload.doneBlobUri,
+                previous.rawImpressionUpload.doneBlobGeneration,
+                request.rawImpressionUpload.doneBlobGeneration,
+              )
+              .asStatusRuntimeException(Status.Code.ALREADY_EXISTS)
+          }
+          val replacesResourceId =
+            if (request.rawImpressionUpload.doneBlobGeneration == 0L) ""
+            else previous?.rawImpressionUpload?.rawImpressionUploadResourceId.orEmpty()
+
           val rawImpressionUploadId: Long =
             idGenerator.generateNewId { id ->
               txn.rawImpressionUploadExists(request.dataProviderResourceId, id)
@@ -131,6 +157,7 @@ class SpannerRawImpressionUploadService(
             requestId,
             RawImpressionUploadState.RAW_IMPRESSION_UPLOAD_STATE_CREATED,
             request.rawImpressionUpload.doneBlobGeneration,
+            replacesResourceId,
           )
 
           rawImpressionUpload {
@@ -138,6 +165,7 @@ class SpannerRawImpressionUploadService(
             rawImpressionUploadResourceId = resolvedResourceId
             doneBlobUri = request.rawImpressionUpload.doneBlobUri
             doneBlobGeneration = request.rawImpressionUpload.doneBlobGeneration
+            replacesRawImpressionUploadResourceId = replacesResourceId
             state = RawImpressionUploadState.RAW_IMPRESSION_UPLOAD_STATE_CREATED
           }
         }

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/spanner/SpannerRawImpressionUploadService.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/spanner/SpannerRawImpressionUploadService.kt
@@ -123,8 +123,7 @@ class SpannerRawImpressionUploadService(
               request.rawImpressionUpload.doneBlobUri,
             )
           if (
-            request.rawImpressionUpload.doneBlobGeneration != 0L &&
-              previous != null &&
+            previous != null &&
               previous.rawImpressionUpload.doneBlobGeneration >=
                 request.rawImpressionUpload.doneBlobGeneration
           ) {
@@ -138,9 +137,7 @@ class SpannerRawImpressionUploadService(
               )
               .asStatusRuntimeException(Status.Code.ALREADY_EXISTS)
           }
-          val replacesResourceId =
-            if (request.rawImpressionUpload.doneBlobGeneration == 0L) ""
-            else previous?.rawImpressionUpload?.rawImpressionUploadResourceId.orEmpty()
+          val replacesResourceId = previous?.rawImpressionUpload?.rawImpressionUploadResourceId
 
           val rawImpressionUploadId: Long =
             idGenerator.generateNewId { id ->
@@ -165,7 +162,9 @@ class SpannerRawImpressionUploadService(
             rawImpressionUploadResourceId = resolvedResourceId
             doneBlobUri = request.rawImpressionUpload.doneBlobUri
             doneBlobGeneration = request.rawImpressionUpload.doneBlobGeneration
-            replacesRawImpressionUploadResourceId = replacesResourceId
+            if (replacesResourceId != null) {
+              replacesRawImpressionUploadResourceId = replacesResourceId
+            }
             state = RawImpressionUploadState.RAW_IMPRESSION_UPLOAD_STATE_CREATED
           }
         }

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/spanner/SpannerRawImpressionUploadService.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/spanner/SpannerRawImpressionUploadService.kt
@@ -27,10 +27,13 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.collectIndexed
 import kotlinx.coroutines.flow.map
 import org.wfanet.measurement.common.IdGenerator
+import org.wfanet.measurement.common.api.ETags
 import org.wfanet.measurement.common.generateNewId
+import org.wfanet.measurement.common.toInstant
 import org.wfanet.measurement.edpaggregator.deploy.gcloud.spanner.db.RawImpressionUploadResult
 import org.wfanet.measurement.edpaggregator.deploy.gcloud.spanner.db.findLatestUploadByDoneBlobUri
 import org.wfanet.measurement.edpaggregator.deploy.gcloud.spanner.db.findUploadByCreateRequestId
+import org.wfanet.measurement.edpaggregator.deploy.gcloud.spanner.db.findUploadByMarkRegistrationCompleteRequestId
 import org.wfanet.measurement.edpaggregator.deploy.gcloud.spanner.db.getRawImpressionUploadByResourceId
 import org.wfanet.measurement.edpaggregator.deploy.gcloud.spanner.db.insertRawImpressionUpload
 import org.wfanet.measurement.edpaggregator.deploy.gcloud.spanner.db.rawImpressionUploadExists
@@ -38,6 +41,7 @@ import org.wfanet.measurement.edpaggregator.deploy.gcloud.spanner.db.rawImpressi
 import org.wfanet.measurement.edpaggregator.deploy.gcloud.spanner.db.readRawImpressionUploads
 import org.wfanet.measurement.edpaggregator.deploy.gcloud.spanner.db.updateRawImpressionUploadRegistrationComplete
 import org.wfanet.measurement.edpaggregator.deploy.gcloud.spanner.db.updateRawImpressionUploadState
+import org.wfanet.measurement.edpaggregator.service.internal.EtagMismatchException
 import org.wfanet.measurement.edpaggregator.service.internal.InvalidFieldValueException
 import org.wfanet.measurement.edpaggregator.service.internal.RawImpressionUploadAlreadyExistsException
 import org.wfanet.measurement.edpaggregator.service.internal.RawImpressionUploadNotFoundException
@@ -234,6 +238,7 @@ class SpannerRawImpressionUploadService(
     return result.copy {
       createTime = commitTimestamp
       updateTime = commitTimestamp
+      etag = ETags.computeETag(commitTimestamp.toInstant())
     }
   }
 
@@ -266,19 +271,51 @@ class SpannerRawImpressionUploadService(
     val (result, changed) =
       try {
         transactionRunner.run { txn ->
+          val replay =
+            txn.findUploadByMarkRegistrationCompleteRequestId(
+              request.dataProviderResourceId,
+              request.requestId,
+            )
+          if (replay != null) {
+            if (
+              replay.rawImpressionUpload.rawImpressionUploadResourceId !=
+                request.rawImpressionUploadResourceId
+            ) {
+              throw Status.ALREADY_EXISTS.withDescription(
+                  "request_id was already used for another RawImpressionUpload"
+                )
+                .asRuntimeException()
+            }
+            return@run replay.rawImpressionUpload to false
+          }
+
           val existing =
             txn.getRawImpressionUploadByResourceId(
               request.dataProviderResourceId,
               request.rawImpressionUploadResourceId,
             )
+          if (request.etag.isEmpty()) {
+            throw RequiredFieldNotSetException("etag")
+              .asStatusRuntimeException(Status.Code.INVALID_ARGUMENT)
+          }
+          if (request.etag != existing.rawImpressionUpload.etag) {
+            throw EtagMismatchException(request.etag, existing.rawImpressionUpload.etag)
+              .asStatusRuntimeException(Status.Code.ABORTED)
+          }
           if (existing.rawImpressionUpload.registrationComplete) {
-            return@run existing.rawImpressionUpload to false
+            throw Status.FAILED_PRECONDITION.withDescription(
+                "RawImpressionUpload registration is already complete"
+              )
+              .asRuntimeException()
           }
           if (
             existing.rawImpressionUpload.state ==
               RawImpressionUploadState.RAW_IMPRESSION_UPLOAD_STATE_FAILED
           ) {
-            return@run existing.rawImpressionUpload to false
+            throw Status.FAILED_PRECONDITION.withDescription(
+                "Cannot complete registration for a failed RawImpressionUpload"
+              )
+              .asRuntimeException()
           }
           val completedState =
             if (
@@ -296,6 +333,7 @@ class SpannerRawImpressionUploadService(
           txn.updateRawImpressionUploadRegistrationComplete(
             request.dataProviderResourceId,
             existing.rawImpressionUploadId,
+            request.requestId,
             completedState,
           )
           existing.rawImpressionUpload.copy {
@@ -307,9 +345,18 @@ class SpannerRawImpressionUploadService(
         }
       } catch (e: RawImpressionUploadNotFoundException) {
         throw e.asStatusRuntimeException(Status.Code.NOT_FOUND)
+      } catch (e: SpannerException) {
+        if (e.errorCode == ErrorCode.ALREADY_EXISTS) {
+          throw Status.ALREADY_EXISTS.withCause(e).asRuntimeException()
+        }
+        throw e
       }
     return if (changed) {
-      result.copy { updateTime = transactionRunner.getCommitTimestamp().toProto() }
+      val commitTimestamp = transactionRunner.getCommitTimestamp().toProto()
+      result.copy {
+        updateTime = commitTimestamp
+        etag = ETags.computeETag(commitTimestamp.toInstant())
+      }
     } else {
       result
     }

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/spanner/SpannerRawImpressionUploadService.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/spanner/SpannerRawImpressionUploadService.kt
@@ -18,6 +18,7 @@ import com.google.cloud.spanner.ErrorCode
 import com.google.cloud.spanner.Options
 import com.google.cloud.spanner.SpannerException
 import com.google.protobuf.Timestamp
+import com.google.protobuf.util.Timestamps
 import io.grpc.Status
 import java.util.UUID
 import kotlin.coroutines.CoroutineContext
@@ -33,7 +34,10 @@ import org.wfanet.measurement.edpaggregator.deploy.gcloud.spanner.db.findUploadB
 import org.wfanet.measurement.edpaggregator.deploy.gcloud.spanner.db.getRawImpressionUploadByResourceId
 import org.wfanet.measurement.edpaggregator.deploy.gcloud.spanner.db.insertRawImpressionUpload
 import org.wfanet.measurement.edpaggregator.deploy.gcloud.spanner.db.rawImpressionUploadExists
+import org.wfanet.measurement.edpaggregator.deploy.gcloud.spanner.db.rawImpressionUploadHasModelLines
 import org.wfanet.measurement.edpaggregator.deploy.gcloud.spanner.db.readRawImpressionUploads
+import org.wfanet.measurement.edpaggregator.deploy.gcloud.spanner.db.updateRawImpressionUploadRegistrationComplete
+import org.wfanet.measurement.edpaggregator.deploy.gcloud.spanner.db.updateRawImpressionUploadState
 import org.wfanet.measurement.edpaggregator.service.internal.InvalidFieldValueException
 import org.wfanet.measurement.edpaggregator.service.internal.RawImpressionUploadAlreadyExistsException
 import org.wfanet.measurement.edpaggregator.service.internal.RawImpressionUploadNotFoundException
@@ -45,6 +49,7 @@ import org.wfanet.measurement.internal.edpaggregator.ListRawImpressionUploadsPag
 import org.wfanet.measurement.internal.edpaggregator.ListRawImpressionUploadsPageTokenKt
 import org.wfanet.measurement.internal.edpaggregator.ListRawImpressionUploadsRequest
 import org.wfanet.measurement.internal.edpaggregator.ListRawImpressionUploadsResponse
+import org.wfanet.measurement.internal.edpaggregator.MarkRawImpressionUploadRegistrationCompleteRequest
 import org.wfanet.measurement.internal.edpaggregator.RawImpressionUpload
 import org.wfanet.measurement.internal.edpaggregator.RawImpressionUploadServiceGrpcKt.RawImpressionUploadServiceCoroutineImplBase
 import org.wfanet.measurement.internal.edpaggregator.RawImpressionUploadState
@@ -78,6 +83,13 @@ class SpannerRawImpressionUploadService(
       throw InvalidFieldValueException("raw_impression_upload.done_blob_generation")
         .asStatusRuntimeException(Status.Code.INVALID_ARGUMENT)
     }
+    if (
+      request.rawImpressionUpload.hasDoneBlobCreateTime() &&
+        !Timestamps.isValid(request.rawImpressionUpload.doneBlobCreateTime)
+    ) {
+      throw InvalidFieldValueException("raw_impression_upload.done_blob_create_time")
+        .asStatusRuntimeException(Status.Code.INVALID_ARGUMENT)
+    }
     val requestId: String = request.requestId
     if (requestId.isEmpty()) {
       throw RequiredFieldNotSetException("request_id")
@@ -102,7 +114,12 @@ class SpannerRawImpressionUploadService(
             if (
               existing.rawImpressionUpload.doneBlobUri != request.rawImpressionUpload.doneBlobUri ||
                 existing.rawImpressionUpload.doneBlobGeneration !=
-                  request.rawImpressionUpload.doneBlobGeneration
+                  request.rawImpressionUpload.doneBlobGeneration ||
+                existing.rawImpressionUpload.hasDoneBlobCreateTime() !=
+                  request.rawImpressionUpload.hasDoneBlobCreateTime() ||
+                (existing.rawImpressionUpload.hasDoneBlobCreateTime() &&
+                  existing.rawImpressionUpload.doneBlobCreateTime !=
+                    request.rawImpressionUpload.doneBlobCreateTime)
             ) {
               throw RawImpressionUploadAlreadyExistsException(
                   request.dataProviderResourceId,
@@ -124,8 +141,12 @@ class SpannerRawImpressionUploadService(
             )
           if (
             previous != null &&
-              previous.rawImpressionUpload.doneBlobGeneration >=
-                request.rawImpressionUpload.doneBlobGeneration
+              (!request.rawImpressionUpload.hasDoneBlobCreateTime() ||
+                (previous.rawImpressionUpload.hasDoneBlobCreateTime() &&
+                  Timestamps.compare(
+                    previous.rawImpressionUpload.doneBlobCreateTime,
+                    request.rawImpressionUpload.doneBlobCreateTime,
+                  ) >= 0))
           ) {
             throw RawImpressionUploadAlreadyExistsException(
                 request.dataProviderResourceId,
@@ -136,6 +157,20 @@ class SpannerRawImpressionUploadService(
                 request.rawImpressionUpload.doneBlobGeneration,
               )
               .asStatusRuntimeException(Status.Code.ALREADY_EXISTS)
+          }
+          if (
+            previous?.rawImpressionUpload?.state ==
+              RawImpressionUploadState.RAW_IMPRESSION_UPLOAD_STATE_CREATED &&
+              !previous.rawImpressionUpload.registrationComplete
+          ) {
+            // The previous dispatcher invocation did not finish registration. Supersede it in the
+            // same transaction that claims this newer generation. Any concurrent attempt to add
+            // model lines to the previous upload will conflict and then observe FAILED.
+            txn.updateRawImpressionUploadState(
+              request.dataProviderResourceId,
+              previous.rawImpressionUploadId,
+              RawImpressionUploadState.RAW_IMPRESSION_UPLOAD_STATE_FAILED,
+            )
           }
           val replacesResourceId = previous?.rawImpressionUpload?.rawImpressionUploadResourceId
 
@@ -154,6 +189,9 @@ class SpannerRawImpressionUploadService(
             requestId,
             RawImpressionUploadState.RAW_IMPRESSION_UPLOAD_STATE_CREATED,
             request.rawImpressionUpload.doneBlobGeneration,
+            request.rawImpressionUpload.doneBlobCreateTime.takeIf {
+              request.rawImpressionUpload.hasDoneBlobCreateTime()
+            },
             replacesResourceId,
           )
 
@@ -162,10 +200,14 @@ class SpannerRawImpressionUploadService(
             rawImpressionUploadResourceId = resolvedResourceId
             doneBlobUri = request.rawImpressionUpload.doneBlobUri
             doneBlobGeneration = request.rawImpressionUpload.doneBlobGeneration
+            if (request.rawImpressionUpload.hasDoneBlobCreateTime()) {
+              doneBlobCreateTime = request.rawImpressionUpload.doneBlobCreateTime
+            }
             if (replacesResourceId != null) {
               replacesRawImpressionUploadResourceId = replacesResourceId
             }
             state = RawImpressionUploadState.RAW_IMPRESSION_UPLOAD_STATE_CREATED
+            registrationComplete = false
           }
         }
       } catch (e: SpannerException) {
@@ -192,6 +234,84 @@ class SpannerRawImpressionUploadService(
     return result.copy {
       createTime = commitTimestamp
       updateTime = commitTimestamp
+    }
+  }
+
+  override suspend fun markRawImpressionUploadRegistrationComplete(
+    request: MarkRawImpressionUploadRegistrationCompleteRequest
+  ): RawImpressionUpload {
+    if (request.dataProviderResourceId.isEmpty()) {
+      throw RequiredFieldNotSetException("data_provider_resource_id")
+        .asStatusRuntimeException(Status.Code.INVALID_ARGUMENT)
+    }
+    if (request.rawImpressionUploadResourceId.isEmpty()) {
+      throw RequiredFieldNotSetException("raw_impression_upload_resource_id")
+        .asStatusRuntimeException(Status.Code.INVALID_ARGUMENT)
+    }
+    if (request.requestId.isEmpty()) {
+      throw RequiredFieldNotSetException("request_id")
+        .asStatusRuntimeException(Status.Code.INVALID_ARGUMENT)
+    }
+    try {
+      UUID.fromString(request.requestId)
+    } catch (e: IllegalArgumentException) {
+      throw InvalidFieldValueException("request_id", e)
+        .asStatusRuntimeException(Status.Code.INVALID_ARGUMENT)
+    }
+
+    val transactionRunner =
+      databaseClient.readWriteTransaction(
+        Options.tag("action=markRawImpressionUploadRegistrationComplete")
+      )
+    val (result, changed) =
+      try {
+        transactionRunner.run { txn ->
+          val existing =
+            txn.getRawImpressionUploadByResourceId(
+              request.dataProviderResourceId,
+              request.rawImpressionUploadResourceId,
+            )
+          if (existing.rawImpressionUpload.registrationComplete) {
+            return@run existing.rawImpressionUpload to false
+          }
+          if (
+            existing.rawImpressionUpload.state ==
+              RawImpressionUploadState.RAW_IMPRESSION_UPLOAD_STATE_FAILED
+          ) {
+            return@run existing.rawImpressionUpload to false
+          }
+          val completedState =
+            if (
+              existing.rawImpressionUpload.state !=
+                RawImpressionUploadState.RAW_IMPRESSION_UPLOAD_STATE_CREATED ||
+                txn.rawImpressionUploadHasModelLines(
+                  request.dataProviderResourceId,
+                  existing.rawImpressionUploadId,
+                )
+            ) {
+              null
+            } else {
+              RawImpressionUploadState.RAW_IMPRESSION_UPLOAD_STATE_COMPLETED
+            }
+          txn.updateRawImpressionUploadRegistrationComplete(
+            request.dataProviderResourceId,
+            existing.rawImpressionUploadId,
+            completedState,
+          )
+          existing.rawImpressionUpload.copy {
+            registrationComplete = true
+            if (completedState != null) {
+              state = completedState
+            }
+          } to true
+        }
+      } catch (e: RawImpressionUploadNotFoundException) {
+        throw e.asStatusRuntimeException(Status.Code.NOT_FOUND)
+      }
+    return if (changed) {
+      result.copy { updateTime = transactionRunner.getCommitTimestamp().toProto() }
+    } else {
+      result
     }
   }
 

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/spanner/db/BUILD.bazel
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/spanner/db/BUILD.bazel
@@ -53,6 +53,7 @@ kt_jvm_library(
         "//src/main/proto/wfa/measurement/internal/edpaggregator:vid_labeling_job_service_kt_jvm_grpc_proto",
         "//src/main/proto/wfa/measurement/internal/edpaggregator:vid_labeling_state_kt_jvm_proto",
         "@wfa_common_jvm//imports/java/com/google/cloud/spanner",
+        "@wfa_common_jvm//imports/java/com/google/protobuf",
         "@wfa_common_jvm//imports/kotlin/kotlinx/coroutines:core",
         "@wfa_common_jvm//src/main/kotlin/org/wfanet/measurement/common",
         "@wfa_common_jvm//src/main/kotlin/org/wfanet/measurement/gcloud/spanner",

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/spanner/db/RawImpressionUpload.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/spanner/db/RawImpressionUpload.kt
@@ -209,7 +209,7 @@ fun AsyncDatabaseClient.TransactionContext.insertRawImpressionUpload(
   createRequestId: String,
   state: RawImpressionUploadState,
   doneBlobGeneration: Long,
-  replacesRawImpressionUploadResourceId: String = "",
+  replacesRawImpressionUploadResourceId: String?,
 ) {
   bufferInsertMutation("RawImpressionUpload") {
     set("DataProviderResourceId").to(dataProviderResourceId)
@@ -220,7 +220,7 @@ fun AsyncDatabaseClient.TransactionContext.insertRawImpressionUpload(
     }
     set("DoneBlobUri").to(doneBlobUri)
     set("DoneBlobGeneration").to(doneBlobGeneration)
-    if (replacesRawImpressionUploadResourceId.isNotEmpty()) {
+    if (replacesRawImpressionUploadResourceId != null) {
       set("ReplacesRawImpressionUploadResourceId").to(replacesRawImpressionUploadResourceId)
     }
     set("State").to(state)

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/spanner/db/RawImpressionUpload.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/spanner/db/RawImpressionUpload.kt
@@ -51,6 +51,7 @@ suspend fun AsyncDatabaseClient.ReadContext.getRawImpressionUploadByResourceId(
       RawImpressionUploadResourceId,
       DoneBlobUri,
       DoneBlobGeneration,
+      ReplacesRawImpressionUploadResourceId,
       State,
       CreateTime,
       UpdateTime,
@@ -93,6 +94,7 @@ suspend fun AsyncDatabaseClient.ReadContext.findUploadByCreateRequestId(
       RawImpressionUploadResourceId,
       DoneBlobUri,
       DoneBlobGeneration,
+      ReplacesRawImpressionUploadResourceId,
       State,
       CreateTime,
       UpdateTime,
@@ -116,6 +118,76 @@ suspend fun AsyncDatabaseClient.ReadContext.findUploadByCreateRequestId(
   return buildRawImpressionUploadResult(row)
 }
 
+/** Finds the highest registered generation for a done-blob path. */
+suspend fun AsyncDatabaseClient.ReadContext.findLatestUploadByDoneBlobUri(
+  dataProviderResourceId: String,
+  doneBlobUri: String,
+): RawImpressionUploadResult? {
+  val generatedSql =
+    """
+    SELECT
+      DataProviderResourceId,
+      RawImpressionUploadId,
+      RawImpressionUploadResourceId,
+      DoneBlobUri,
+      DoneBlobGeneration,
+      ReplacesRawImpressionUploadResourceId,
+      State,
+      CreateTime,
+      UpdateTime,
+    FROM RawImpressionUpload@{
+      FORCE_INDEX=RawImpressionUploadByDoneBlobGeneration,
+      spanner_emulator.disable_query_null_filtered_index_check=true
+    }
+    WHERE DataProviderResourceId = @dataProviderResourceId
+      AND DoneBlobUri = @doneBlobUri
+      AND DoneBlobGeneration IS NOT NULL
+    ORDER BY DoneBlobGeneration DESC
+    LIMIT 1
+    """
+      .trimIndent()
+
+  val generatedRow =
+    executeQuery(
+        statement(generatedSql) {
+          bind("dataProviderResourceId").to(dataProviderResourceId)
+          bind("doneBlobUri").to(doneBlobUri)
+        }
+      )
+      .singleOrNullIfEmpty()
+  if (generatedRow != null) return buildRawImpressionUploadResult(generatedRow)
+
+  val legacySql =
+    """
+    SELECT
+      DataProviderResourceId,
+      RawImpressionUploadId,
+      RawImpressionUploadResourceId,
+      DoneBlobUri,
+      DoneBlobGeneration,
+      ReplacesRawImpressionUploadResourceId,
+      State,
+      CreateTime,
+      UpdateTime,
+    FROM RawImpressionUpload
+    WHERE DataProviderResourceId = @dataProviderResourceId
+      AND DoneBlobUri = @doneBlobUri
+      AND DoneBlobGeneration IS NULL
+    ORDER BY CreateTime DESC
+    LIMIT 1
+    """
+      .trimIndent()
+  val legacyRow =
+    executeQuery(
+        statement(legacySql) {
+          bind("dataProviderResourceId").to(dataProviderResourceId)
+          bind("doneBlobUri").to(doneBlobUri)
+        }
+      )
+      .singleOrNullIfEmpty() ?: return null
+  return buildRawImpressionUploadResult(legacyRow)
+}
+
 /** Checks whether an upload with the given internal ID exists. */
 suspend fun AsyncDatabaseClient.ReadContext.rawImpressionUploadExists(
   dataProviderResourceId: String,
@@ -137,6 +209,7 @@ fun AsyncDatabaseClient.TransactionContext.insertRawImpressionUpload(
   createRequestId: String,
   state: RawImpressionUploadState,
   doneBlobGeneration: Long,
+  replacesRawImpressionUploadResourceId: String = "",
 ) {
   bufferInsertMutation("RawImpressionUpload") {
     set("DataProviderResourceId").to(dataProviderResourceId)
@@ -147,6 +220,9 @@ fun AsyncDatabaseClient.TransactionContext.insertRawImpressionUpload(
     }
     set("DoneBlobUri").to(doneBlobUri)
     set("DoneBlobGeneration").to(doneBlobGeneration)
+    if (replacesRawImpressionUploadResourceId.isNotEmpty()) {
+      set("ReplacesRawImpressionUploadResourceId").to(replacesRawImpressionUploadResourceId)
+    }
     set("State").to(state)
     set("CreateTime").to(Value.COMMIT_TIMESTAMP)
     set("UpdateTime").to(Value.COMMIT_TIMESTAMP)
@@ -169,6 +245,7 @@ fun AsyncDatabaseClient.ReadContext.readRawImpressionUploads(
         RawImpressionUploadResourceId,
         DoneBlobUri,
         DoneBlobGeneration,
+        ReplacesRawImpressionUploadResourceId,
         State,
         CreateTime,
         UpdateTime,
@@ -250,6 +327,10 @@ private fun buildRawImpressionUploadResult(struct: Struct): RawImpressionUploadR
       doneBlobUri = struct.getString("DoneBlobUri")
       if (!struct.isNull("DoneBlobGeneration")) {
         doneBlobGeneration = struct.getLong("DoneBlobGeneration")
+      }
+      if (!struct.isNull("ReplacesRawImpressionUploadResourceId")) {
+        replacesRawImpressionUploadResourceId =
+          struct.getString("ReplacesRawImpressionUploadResourceId")
       }
       state = struct.getProtoEnum("State", RawImpressionUploadState::forNumber)
       createTime = struct.getTimestamp("CreateTime").toProto()

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/spanner/db/RawImpressionUpload.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/spanner/db/RawImpressionUpload.kt
@@ -22,7 +22,9 @@ import com.google.cloud.spanner.Value
 import com.google.protobuf.Timestamp
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
+import org.wfanet.measurement.common.api.ETags
 import org.wfanet.measurement.common.singleOrNullIfEmpty
+import org.wfanet.measurement.common.toInstant
 import org.wfanet.measurement.edpaggregator.service.internal.RawImpressionUploadNotFoundException
 import org.wfanet.measurement.gcloud.common.toGcloudTimestamp
 import org.wfanet.measurement.gcloud.spanner.AsyncDatabaseClient
@@ -38,6 +40,7 @@ import org.wfanet.measurement.internal.edpaggregator.rawImpressionUpload
 data class RawImpressionUploadResult(
   val rawImpressionUpload: RawImpressionUpload,
   val rawImpressionUploadId: Long,
+  val markRegistrationCompleteRequestId: String,
 )
 
 /** Reads a [RawImpressionUpload] by its resource IDs. */
@@ -56,6 +59,7 @@ suspend fun AsyncDatabaseClient.ReadContext.getRawImpressionUploadByResourceId(
       DoneBlobCreateTime,
       ReplacesRawImpressionUploadResourceId,
       RegistrationComplete,
+      MarkRegistrationCompleteRequestId,
       State,
       CreateTime,
       UpdateTime,
@@ -101,6 +105,7 @@ suspend fun AsyncDatabaseClient.ReadContext.findUploadByCreateRequestId(
       DoneBlobCreateTime,
       ReplacesRawImpressionUploadResourceId,
       RegistrationComplete,
+      MarkRegistrationCompleteRequestId,
       State,
       CreateTime,
       UpdateTime,
@@ -124,6 +129,46 @@ suspend fun AsyncDatabaseClient.ReadContext.findUploadByCreateRequestId(
   return buildRawImpressionUploadResult(row)
 }
 
+/** Finds an upload whose registration was completed using [requestId]. */
+suspend fun AsyncDatabaseClient.ReadContext.findUploadByMarkRegistrationCompleteRequestId(
+  dataProviderResourceId: String,
+  requestId: String,
+): RawImpressionUploadResult? {
+  val sql: String =
+    """
+    SELECT
+      DataProviderResourceId,
+      RawImpressionUploadId,
+      RawImpressionUploadResourceId,
+      DoneBlobUri,
+      DoneBlobGeneration,
+      DoneBlobCreateTime,
+      ReplacesRawImpressionUploadResourceId,
+      RegistrationComplete,
+      MarkRegistrationCompleteRequestId,
+      State,
+      CreateTime,
+      UpdateTime,
+    FROM RawImpressionUpload@{
+      FORCE_INDEX=RawImpressionUploadByMarkRegistrationCompleteRequestId,
+      spanner_emulator.disable_query_null_filtered_index_check=true
+    }
+    WHERE DataProviderResourceId = @dataProviderResourceId
+      AND MarkRegistrationCompleteRequestId = @requestId
+    """
+      .trimIndent()
+
+  val row =
+    executeQuery(
+        statement(sql) {
+          bind("dataProviderResourceId").to(dataProviderResourceId)
+          bind("requestId").to(requestId)
+        }
+      )
+      .singleOrNullIfEmpty() ?: return null
+  return buildRawImpressionUploadResult(row)
+}
+
 /** Finds the latest registered version for a done-blob path. */
 suspend fun AsyncDatabaseClient.ReadContext.findLatestUploadByDoneBlobUri(
   dataProviderResourceId: String,
@@ -140,6 +185,7 @@ suspend fun AsyncDatabaseClient.ReadContext.findLatestUploadByDoneBlobUri(
       DoneBlobCreateTime,
       ReplacesRawImpressionUploadResourceId,
       RegistrationComplete,
+      MarkRegistrationCompleteRequestId,
       State,
       CreateTime,
       UpdateTime,
@@ -176,6 +222,7 @@ suspend fun AsyncDatabaseClient.ReadContext.findLatestUploadByDoneBlobUri(
       DoneBlobCreateTime,
       ReplacesRawImpressionUploadResourceId,
       RegistrationComplete,
+      MarkRegistrationCompleteRequestId,
       State,
       CreateTime,
       UpdateTime,
@@ -263,6 +310,7 @@ fun AsyncDatabaseClient.ReadContext.readRawImpressionUploads(
         DoneBlobCreateTime,
         ReplacesRawImpressionUploadResourceId,
         RegistrationComplete,
+        MarkRegistrationCompleteRequestId,
         State,
         CreateTime,
         UpdateTime,
@@ -356,8 +404,14 @@ private fun buildRawImpressionUploadResult(struct: Struct): RawImpressionUploadR
       state = struct.getProtoEnum("State", RawImpressionUploadState::forNumber)
       createTime = struct.getTimestamp("CreateTime").toProto()
       updateTime = struct.getTimestamp("UpdateTime").toProto()
+      etag = ETags.computeETag(updateTime.toInstant())
     },
     struct.getLong("RawImpressionUploadId"),
+    if (struct.isNull("MarkRegistrationCompleteRequestId")) {
+      ""
+    } else {
+      struct.getString("MarkRegistrationCompleteRequestId")
+    },
   )
 }
 
@@ -365,12 +419,14 @@ private fun buildRawImpressionUploadResult(struct: Struct): RawImpressionUploadR
 fun AsyncDatabaseClient.TransactionContext.updateRawImpressionUploadRegistrationComplete(
   dataProviderResourceId: String,
   rawImpressionUploadId: Long,
+  requestId: String,
   state: RawImpressionUploadState? = null,
 ) {
   bufferUpdateMutation("RawImpressionUpload") {
     set("DataProviderResourceId").to(dataProviderResourceId)
     set("RawImpressionUploadId").to(rawImpressionUploadId)
     set("RegistrationComplete").to(true)
+    set("MarkRegistrationCompleteRequestId").to(requestId)
     if (state != null) {
       set("State").to(state)
     }

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/spanner/db/RawImpressionUpload.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/spanner/db/RawImpressionUpload.kt
@@ -19,6 +19,7 @@ import com.google.cloud.spanner.Options
 import com.google.cloud.spanner.Statement
 import com.google.cloud.spanner.Struct
 import com.google.cloud.spanner.Value
+import com.google.protobuf.Timestamp
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 import org.wfanet.measurement.common.singleOrNullIfEmpty
@@ -26,6 +27,7 @@ import org.wfanet.measurement.edpaggregator.service.internal.RawImpressionUpload
 import org.wfanet.measurement.gcloud.common.toGcloudTimestamp
 import org.wfanet.measurement.gcloud.spanner.AsyncDatabaseClient
 import org.wfanet.measurement.gcloud.spanner.bufferInsertMutation
+import org.wfanet.measurement.gcloud.spanner.bufferUpdateMutation
 import org.wfanet.measurement.gcloud.spanner.statement
 import org.wfanet.measurement.internal.edpaggregator.ListRawImpressionUploadsPageToken
 import org.wfanet.measurement.internal.edpaggregator.ListRawImpressionUploadsRequest
@@ -51,7 +53,9 @@ suspend fun AsyncDatabaseClient.ReadContext.getRawImpressionUploadByResourceId(
       RawImpressionUploadResourceId,
       DoneBlobUri,
       DoneBlobGeneration,
+      DoneBlobCreateTime,
       ReplacesRawImpressionUploadResourceId,
+      RegistrationComplete,
       State,
       CreateTime,
       UpdateTime,
@@ -94,7 +98,9 @@ suspend fun AsyncDatabaseClient.ReadContext.findUploadByCreateRequestId(
       RawImpressionUploadResourceId,
       DoneBlobUri,
       DoneBlobGeneration,
+      DoneBlobCreateTime,
       ReplacesRawImpressionUploadResourceId,
+      RegistrationComplete,
       State,
       CreateTime,
       UpdateTime,
@@ -118,7 +124,7 @@ suspend fun AsyncDatabaseClient.ReadContext.findUploadByCreateRequestId(
   return buildRawImpressionUploadResult(row)
 }
 
-/** Finds the highest registered generation for a done-blob path. */
+/** Finds the latest registered version for a done-blob path. */
 suspend fun AsyncDatabaseClient.ReadContext.findLatestUploadByDoneBlobUri(
   dataProviderResourceId: String,
   doneBlobUri: String,
@@ -131,18 +137,20 @@ suspend fun AsyncDatabaseClient.ReadContext.findLatestUploadByDoneBlobUri(
       RawImpressionUploadResourceId,
       DoneBlobUri,
       DoneBlobGeneration,
+      DoneBlobCreateTime,
       ReplacesRawImpressionUploadResourceId,
+      RegistrationComplete,
       State,
       CreateTime,
       UpdateTime,
     FROM RawImpressionUpload@{
-      FORCE_INDEX=RawImpressionUploadByDoneBlobGeneration,
+      FORCE_INDEX=RawImpressionUploadByDoneBlobCreateTime,
       spanner_emulator.disable_query_null_filtered_index_check=true
     }
     WHERE DataProviderResourceId = @dataProviderResourceId
       AND DoneBlobUri = @doneBlobUri
-      AND DoneBlobGeneration IS NOT NULL
-    ORDER BY DoneBlobGeneration DESC
+      AND DoneBlobCreateTime IS NOT NULL
+    ORDER BY DoneBlobCreateTime DESC
     LIMIT 1
     """
       .trimIndent()
@@ -165,14 +173,16 @@ suspend fun AsyncDatabaseClient.ReadContext.findLatestUploadByDoneBlobUri(
       RawImpressionUploadResourceId,
       DoneBlobUri,
       DoneBlobGeneration,
+      DoneBlobCreateTime,
       ReplacesRawImpressionUploadResourceId,
+      RegistrationComplete,
       State,
       CreateTime,
       UpdateTime,
     FROM RawImpressionUpload
     WHERE DataProviderResourceId = @dataProviderResourceId
       AND DoneBlobUri = @doneBlobUri
-      AND DoneBlobGeneration IS NULL
+      AND DoneBlobCreateTime IS NULL
     ORDER BY CreateTime DESC
     LIMIT 1
     """
@@ -209,6 +219,7 @@ fun AsyncDatabaseClient.TransactionContext.insertRawImpressionUpload(
   createRequestId: String,
   state: RawImpressionUploadState,
   doneBlobGeneration: Long,
+  doneBlobCreateTime: Timestamp?,
   replacesRawImpressionUploadResourceId: String?,
 ) {
   bufferInsertMutation("RawImpressionUpload") {
@@ -220,9 +231,13 @@ fun AsyncDatabaseClient.TransactionContext.insertRawImpressionUpload(
     }
     set("DoneBlobUri").to(doneBlobUri)
     set("DoneBlobGeneration").to(doneBlobGeneration)
+    if (doneBlobCreateTime != null) {
+      set("DoneBlobCreateTime").to(doneBlobCreateTime.toGcloudTimestamp())
+    }
     if (replacesRawImpressionUploadResourceId != null) {
       set("ReplacesRawImpressionUploadResourceId").to(replacesRawImpressionUploadResourceId)
     }
+    set("RegistrationComplete").to(false)
     set("State").to(state)
     set("CreateTime").to(Value.COMMIT_TIMESTAMP)
     set("UpdateTime").to(Value.COMMIT_TIMESTAMP)
@@ -245,7 +260,9 @@ fun AsyncDatabaseClient.ReadContext.readRawImpressionUploads(
         RawImpressionUploadResourceId,
         DoneBlobUri,
         DoneBlobGeneration,
+        DoneBlobCreateTime,
         ReplacesRawImpressionUploadResourceId,
+        RegistrationComplete,
         State,
         CreateTime,
         UpdateTime,
@@ -328,14 +345,35 @@ private fun buildRawImpressionUploadResult(struct: Struct): RawImpressionUploadR
       if (!struct.isNull("DoneBlobGeneration")) {
         doneBlobGeneration = struct.getLong("DoneBlobGeneration")
       }
+      if (!struct.isNull("DoneBlobCreateTime")) {
+        doneBlobCreateTime = struct.getTimestamp("DoneBlobCreateTime").toProto()
+      }
       if (!struct.isNull("ReplacesRawImpressionUploadResourceId")) {
         replacesRawImpressionUploadResourceId =
           struct.getString("ReplacesRawImpressionUploadResourceId")
       }
+      registrationComplete = struct.getBoolean("RegistrationComplete")
       state = struct.getProtoEnum("State", RawImpressionUploadState::forNumber)
       createTime = struct.getTimestamp("CreateTime").toProto()
       updateTime = struct.getTimestamp("UpdateTime").toProto()
     },
     struct.getLong("RawImpressionUploadId"),
   )
+}
+
+/** Marks registration of an upload's children complete. */
+fun AsyncDatabaseClient.TransactionContext.updateRawImpressionUploadRegistrationComplete(
+  dataProviderResourceId: String,
+  rawImpressionUploadId: Long,
+  state: RawImpressionUploadState? = null,
+) {
+  bufferUpdateMutation("RawImpressionUpload") {
+    set("DataProviderResourceId").to(dataProviderResourceId)
+    set("RawImpressionUploadId").to(rawImpressionUploadId)
+    set("RegistrationComplete").to(true)
+    if (state != null) {
+      set("State").to(state)
+    }
+    set("UpdateTime").to(Value.COMMIT_TIMESTAMP)
+  }
 }

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/spanner/db/RawImpressionUploadModelLine.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/spanner/db/RawImpressionUploadModelLine.kt
@@ -89,6 +89,29 @@ suspend fun AsyncDatabaseClient.ReadContext.rawImpressionUploadModelLineExists(
   ) != null
 }
 
+/** Returns whether [rawImpressionUploadId] has any registered model-line children. */
+suspend fun AsyncDatabaseClient.ReadContext.rawImpressionUploadHasModelLines(
+  dataProviderResourceId: String,
+  rawImpressionUploadId: Long,
+): Boolean {
+  val sql =
+    """
+    SELECT RawImpressionUploadModelLineId
+    FROM RawImpressionUploadModelLine
+    WHERE DataProviderResourceId = @dataProviderResourceId
+      AND RawImpressionUploadId = @rawImpressionUploadId
+    LIMIT 1
+    """
+      .trimIndent()
+  return executeQuery(
+      statement(sql) {
+        bind("dataProviderResourceId").to(dataProviderResourceId)
+        bind("rawImpressionUploadId").to(rawImpressionUploadId)
+      }
+    )
+    .singleOrNullIfEmpty() != null
+}
+
 /**
  * Returns the parent [RawImpressionUpload]'s current [RawImpressionUploadState], or `null` if the
  * row is missing.

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/vidlabeling/VidLabelingDispatcherFunction.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/vidlabeling/VidLabelingDispatcherFunction.kt
@@ -396,7 +396,11 @@ class VidLabelingDispatcherFunction : HttpFunction {
             }
             val generation = attributes.lastModifiedTime().toMillis()
             check(generation > 0L) { "Raw impression file has no modification time: $blobKey" }
-            RawImpressionBlobMetadata(generation = generation, sizeBytes = attributes.size())
+            RawImpressionBlobMetadata(
+              generation = generation,
+              sizeBytes = attributes.size(),
+              createTime = attributes.creationTime().toInstant(),
+            )
           }
         }
       }
@@ -417,7 +421,11 @@ class VidLabelingDispatcherFunction : HttpFunction {
             checkNotNull(storage.get(BlobId.of(doneBlobUri.bucket, blobKey))) {
               "Raw impression blob disappeared before registration: $blobKey"
             }
-          RawImpressionBlobMetadata(generation = blob.generation, sizeBytes = blob.size)
+          RawImpressionBlobMetadata(
+            generation = blob.generation,
+            sizeBytes = blob.size,
+            createTime = blob.createTimeOffsetDateTime.toInstant(),
+          )
         }
       }
     }

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/service/internal/testing/RawImpressionUploadServiceTest.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/service/internal/testing/RawImpressionUploadServiceTest.kt
@@ -96,7 +96,10 @@ abstract class RawImpressionUploadServiceTest {
       service.createRawImpressionUpload(
         createRawImpressionUploadRequest {
           dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
-          rawImpressionUpload = rawImpressionUpload { doneBlobUri = DONE_BLOB_URI }
+          rawImpressionUpload = rawImpressionUpload {
+            doneBlobUri = DONE_BLOB_URI
+            doneBlobGeneration = 1L
+          }
           requestId = UUID.randomUUID().toString()
         }
       )

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/service/internal/testing/RawImpressionUploadServiceTest.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/service/internal/testing/RawImpressionUploadServiceTest.kt
@@ -91,6 +91,63 @@ abstract class RawImpressionUploadServiceTest {
   }
 
   @Test
+  fun `createRawImpressionUpload persists replaced upload resource ID`(): Unit = runBlocking {
+    val original =
+      service.createRawImpressionUpload(
+        createRawImpressionUploadRequest {
+          dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
+          rawImpressionUpload = rawImpressionUpload { doneBlobUri = DONE_BLOB_URI }
+          requestId = UUID.randomUUID().toString()
+        }
+      )
+
+    val replacement =
+      service.createRawImpressionUpload(
+        createRawImpressionUploadRequest {
+          dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
+          rawImpressionUpload = rawImpressionUpload {
+            doneBlobUri = DONE_BLOB_URI
+            doneBlobGeneration = 2L
+          }
+          requestId = UUID.randomUUID().toString()
+        }
+      )
+
+    assertThat(replacement.replacesRawImpressionUploadResourceId)
+      .isEqualTo(original.rawImpressionUploadResourceId)
+  }
+
+  @Test
+  fun `createRawImpressionUpload rejects a stale done blob generation`(): Unit = runBlocking {
+    service.createRawImpressionUpload(
+      createRawImpressionUploadRequest {
+        dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
+        rawImpressionUpload = rawImpressionUpload {
+          doneBlobUri = DONE_BLOB_URI
+          doneBlobGeneration = 2L
+        }
+        requestId = UUID.randomUUID().toString()
+      }
+    )
+
+    val exception =
+      assertFailsWith<StatusRuntimeException> {
+        service.createRawImpressionUpload(
+          createRawImpressionUploadRequest {
+            dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
+            rawImpressionUpload = rawImpressionUpload {
+              doneBlobUri = DONE_BLOB_URI
+              doneBlobGeneration = 1L
+            }
+            requestId = UUID.randomUUID().toString()
+          }
+        )
+      }
+
+    assertThat(exception.status.code).isEqualTo(Status.Code.ALREADY_EXISTS)
+  }
+
+  @Test
   fun `createRawImpressionUpload is idempotent with same request_id`(): Unit = runBlocking {
     val requestId: String = UUID.randomUUID().toString()
 

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/service/internal/testing/RawImpressionUploadServiceTest.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/service/internal/testing/RawImpressionUploadServiceTest.kt
@@ -77,6 +77,7 @@ abstract class RawImpressionUploadServiceTest {
     assertThat(upload.rawImpressionUploadResourceId).isNotEmpty()
     assertThat(upload.createTime.toInstant()).isGreaterThan(startTime)
     assertThat(upload.updateTime).isEqualTo(upload.createTime)
+    assertThat(upload.etag).isNotEmpty()
     // Verify the entire response, substituting the non-deterministic resource ID and timestamps.
     assertThat(upload)
       .isEqualTo(
@@ -89,6 +90,7 @@ abstract class RawImpressionUploadServiceTest {
           state = RawImpressionUploadState.RAW_IMPRESSION_UPLOAD_STATE_CREATED
           createTime = upload.createTime
           updateTime = upload.updateTime
+          etag = upload.etag
         }
       )
   }
@@ -154,6 +156,7 @@ abstract class RawImpressionUploadServiceTest {
         markRawImpressionUploadRegistrationCompleteRequest {
           dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
           rawImpressionUploadResourceId = original.rawImpressionUploadResourceId
+          etag = original.etag
           requestId = UUID.randomUUID().toString()
         }
       )
@@ -212,19 +215,142 @@ abstract class RawImpressionUploadServiceTest {
       }
     )
 
-    val finalized =
+    val exception =
+      assertFailsWith<StatusRuntimeException> {
+        service.markRawImpressionUploadRegistrationComplete(
+          markRawImpressionUploadRegistrationCompleteRequest {
+            dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
+            rawImpressionUploadResourceId = original.rawImpressionUploadResourceId
+            etag = original.etag
+            requestId = UUID.randomUUID().toString()
+          }
+        )
+      }
+
+    assertThat(exception.status.code).isEqualTo(Status.Code.ABORTED)
+    val fetched =
+      service.getRawImpressionUpload(
+        getRawImpressionUploadRequest {
+          dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
+          rawImpressionUploadResourceId = original.rawImpressionUploadResourceId
+        }
+      )
+    assertThat(fetched.state).isEqualTo(RawImpressionUploadState.RAW_IMPRESSION_UPLOAD_STATE_FAILED)
+    assertThat(fetched.registrationComplete).isFalse()
+  }
+
+  @Test
+  fun `markRawImpressionUploadRegistrationComplete is idempotent by request ID`(): Unit =
+    runBlocking {
+      val upload = createUpload()
+      val request = markRawImpressionUploadRegistrationCompleteRequest {
+        dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
+        rawImpressionUploadResourceId = upload.rawImpressionUploadResourceId
+        etag = upload.etag
+        requestId = UUID.randomUUID().toString()
+      }
+
+      val completed = service.markRawImpressionUploadRegistrationComplete(request)
+      val replayed = service.markRawImpressionUploadRegistrationComplete(request)
+
+      assertThat(replayed).isEqualTo(completed)
+    }
+
+  @Test
+  fun `markRawImpressionUploadRegistrationComplete rejects stale etag`(): Unit = runBlocking {
+    val upload = createUpload()
+
+    val exception =
+      assertFailsWith<StatusRuntimeException> {
+        service.markRawImpressionUploadRegistrationComplete(
+          markRawImpressionUploadRegistrationCompleteRequest {
+            dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
+            rawImpressionUploadResourceId = upload.rawImpressionUploadResourceId
+            etag = "stale-etag"
+            requestId = UUID.randomUUID().toString()
+          }
+        )
+      }
+
+    assertThat(exception.status.code).isEqualTo(Status.Code.ABORTED)
+  }
+
+  @Test
+  fun `markRawImpressionUploadRegistrationComplete rejects missing etag`(): Unit = runBlocking {
+    val upload = createUpload()
+
+    val exception =
+      assertFailsWith<StatusRuntimeException> {
+        service.markRawImpressionUploadRegistrationComplete(
+          markRawImpressionUploadRegistrationCompleteRequest {
+            dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
+            rawImpressionUploadResourceId = upload.rawImpressionUploadResourceId
+            requestId = UUID.randomUUID().toString()
+          }
+        )
+      }
+
+    assertThat(exception.status.code).isEqualTo(Status.Code.INVALID_ARGUMENT)
+  }
+
+  @Test
+  fun `markRawImpressionUploadRegistrationComplete rejects reused request ID`(): Unit =
+    runBlocking {
+      val first = createUpload()
+      val second = createUpload()
+      val requestId = UUID.randomUUID().toString()
       service.markRawImpressionUploadRegistrationComplete(
         markRawImpressionUploadRegistrationCompleteRequest {
           dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
-          rawImpressionUploadResourceId = original.rawImpressionUploadResourceId
-          requestId = UUID.randomUUID().toString()
+          rawImpressionUploadResourceId = first.rawImpressionUploadResourceId
+          etag = first.etag
+          this.requestId = requestId
         }
       )
 
-    assertThat(finalized.state)
-      .isEqualTo(RawImpressionUploadState.RAW_IMPRESSION_UPLOAD_STATE_FAILED)
-    assertThat(finalized.registrationComplete).isFalse()
-  }
+      val exception =
+        assertFailsWith<StatusRuntimeException> {
+          service.markRawImpressionUploadRegistrationComplete(
+            markRawImpressionUploadRegistrationCompleteRequest {
+              dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
+              rawImpressionUploadResourceId = second.rawImpressionUploadResourceId
+              etag = second.etag
+              this.requestId = requestId
+            }
+          )
+        }
+
+      assertThat(exception.status.code).isEqualTo(Status.Code.ALREADY_EXISTS)
+    }
+
+  @Test
+  fun `markRawImpressionUploadRegistrationComplete rejects a different request after completion`() =
+    runBlocking {
+      val upload = createUpload()
+      val completed =
+        service.markRawImpressionUploadRegistrationComplete(
+          markRawImpressionUploadRegistrationCompleteRequest {
+            dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
+            rawImpressionUploadResourceId = upload.rawImpressionUploadResourceId
+            etag = upload.etag
+            requestId = UUID.randomUUID().toString()
+          }
+        )
+
+      val exception =
+        assertFailsWith<StatusRuntimeException> {
+          service.markRawImpressionUploadRegistrationComplete(
+            markRawImpressionUploadRegistrationCompleteRequest {
+              dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
+              rawImpressionUploadResourceId = upload.rawImpressionUploadResourceId
+              etag = completed.etag
+              requestId = UUID.randomUUID().toString()
+            }
+          )
+        }
+
+      assertThat(exception.status.code).isEqualTo(Status.Code.FAILED_PRECONDITION)
+    }
 
   @Test
   fun `createRawImpressionUpload rejects an older done blob with a higher generation`(): Unit =

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/service/internal/testing/RawImpressionUploadServiceTest.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/service/internal/testing/RawImpressionUploadServiceTest.kt
@@ -41,6 +41,7 @@ import org.wfanet.measurement.internal.edpaggregator.RawImpressionUploadState
 import org.wfanet.measurement.internal.edpaggregator.createRawImpressionUploadRequest
 import org.wfanet.measurement.internal.edpaggregator.getRawImpressionUploadRequest
 import org.wfanet.measurement.internal.edpaggregator.listRawImpressionUploadsRequest
+import org.wfanet.measurement.internal.edpaggregator.markRawImpressionUploadRegistrationCompleteRequest
 import org.wfanet.measurement.internal.edpaggregator.rawImpressionUpload
 
 @RunWith(JUnit4::class)
@@ -67,6 +68,7 @@ abstract class RawImpressionUploadServiceTest {
           rawImpressionUpload = rawImpressionUpload {
             doneBlobUri = DONE_BLOB_URI
             doneBlobGeneration = DONE_BLOB_GENERATION
+            doneBlobCreateTime = DONE_BLOB_CREATE_TIME.toProtoTime()
           }
           requestId = UUID.randomUUID().toString()
         }
@@ -83,6 +85,7 @@ abstract class RawImpressionUploadServiceTest {
           rawImpressionUploadResourceId = upload.rawImpressionUploadResourceId
           doneBlobUri = DONE_BLOB_URI
           doneBlobGeneration = DONE_BLOB_GENERATION
+          doneBlobCreateTime = DONE_BLOB_CREATE_TIME.toProtoTime()
           state = RawImpressionUploadState.RAW_IMPRESSION_UPLOAD_STATE_CREATED
           createTime = upload.createTime
           updateTime = upload.updateTime
@@ -98,19 +101,20 @@ abstract class RawImpressionUploadServiceTest {
           dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
           rawImpressionUpload = rawImpressionUpload {
             doneBlobUri = DONE_BLOB_URI
-            doneBlobGeneration = 1L
+            doneBlobGeneration = 900L
+            doneBlobCreateTime = DONE_BLOB_CREATE_TIME.toProtoTime()
           }
           requestId = UUID.randomUUID().toString()
         }
       )
-
     val replacement =
       service.createRawImpressionUpload(
         createRawImpressionUploadRequest {
           dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
           rawImpressionUpload = rawImpressionUpload {
             doneBlobUri = DONE_BLOB_URI
-            doneBlobGeneration = 2L
+            doneBlobGeneration = 120L
+            doneBlobCreateTime = DONE_BLOB_CREATE_TIME.plusSeconds(1).toProtoTime()
           }
           requestId = UUID.randomUUID().toString()
         }
@@ -118,37 +122,175 @@ abstract class RawImpressionUploadServiceTest {
 
     assertThat(replacement.replacesRawImpressionUploadResourceId)
       .isEqualTo(original.rawImpressionUploadResourceId)
+    assertThat(
+        service
+          .getRawImpressionUpload(
+            getRawImpressionUploadRequest {
+              dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
+              rawImpressionUploadResourceId = original.rawImpressionUploadResourceId
+            }
+          )
+          .state
+      )
+      .isEqualTo(RawImpressionUploadState.RAW_IMPRESSION_UPLOAD_STATE_FAILED)
   }
 
   @Test
-  fun `createRawImpressionUpload rejects a stale done blob generation`(): Unit = runBlocking {
+  fun `completed registration is not failed by a replacement upload`(): Unit = runBlocking {
+    val original =
+      service.createRawImpressionUpload(
+        createRawImpressionUploadRequest {
+          dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
+          rawImpressionUpload = rawImpressionUpload {
+            doneBlobUri = DONE_BLOB_URI
+            doneBlobGeneration = 1L
+            doneBlobCreateTime = DONE_BLOB_CREATE_TIME.toProtoTime()
+          }
+          requestId = UUID.randomUUID().toString()
+        }
+      )
+    val completed =
+      service.markRawImpressionUploadRegistrationComplete(
+        markRawImpressionUploadRegistrationCompleteRequest {
+          dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
+          rawImpressionUploadResourceId = original.rawImpressionUploadResourceId
+          requestId = UUID.randomUUID().toString()
+        }
+      )
+
+    assertThat(completed.registrationComplete).isTrue()
+    assertThat(completed.state)
+      .isEqualTo(RawImpressionUploadState.RAW_IMPRESSION_UPLOAD_STATE_COMPLETED)
+
     service.createRawImpressionUpload(
       createRawImpressionUploadRequest {
         dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
         rawImpressionUpload = rawImpressionUpload {
           doneBlobUri = DONE_BLOB_URI
           doneBlobGeneration = 2L
+          doneBlobCreateTime = DONE_BLOB_CREATE_TIME.plusSeconds(1).toProtoTime()
         }
         requestId = UUID.randomUUID().toString()
       }
     )
 
-    val exception =
-      assertFailsWith<StatusRuntimeException> {
+    val fetched =
+      service.getRawImpressionUpload(
+        getRawImpressionUploadRequest {
+          dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
+          rawImpressionUploadResourceId = original.rawImpressionUploadResourceId
+        }
+      )
+    assertThat(fetched.registrationComplete).isTrue()
+    assertThat(fetched.state)
+      .isEqualTo(RawImpressionUploadState.RAW_IMPRESSION_UPLOAD_STATE_COMPLETED)
+  }
+
+  @Test
+  fun `finalizing a superseded upload does not resurrect it`(): Unit = runBlocking {
+    val original =
+      service.createRawImpressionUpload(
+        createRawImpressionUploadRequest {
+          dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
+          rawImpressionUpload = rawImpressionUpload {
+            doneBlobUri = DONE_BLOB_URI
+            doneBlobGeneration = 1L
+            doneBlobCreateTime = DONE_BLOB_CREATE_TIME.toProtoTime()
+          }
+          requestId = UUID.randomUUID().toString()
+        }
+      )
+    service.createRawImpressionUpload(
+      createRawImpressionUploadRequest {
+        dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
+        rawImpressionUpload = rawImpressionUpload {
+          doneBlobUri = DONE_BLOB_URI
+          doneBlobGeneration = 2L
+          doneBlobCreateTime = DONE_BLOB_CREATE_TIME.plusSeconds(1).toProtoTime()
+        }
+        requestId = UUID.randomUUID().toString()
+      }
+    )
+
+    val finalized =
+      service.markRawImpressionUploadRegistrationComplete(
+        markRawImpressionUploadRegistrationCompleteRequest {
+          dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
+          rawImpressionUploadResourceId = original.rawImpressionUploadResourceId
+          requestId = UUID.randomUUID().toString()
+        }
+      )
+
+    assertThat(finalized.state)
+      .isEqualTo(RawImpressionUploadState.RAW_IMPRESSION_UPLOAD_STATE_FAILED)
+    assertThat(finalized.registrationComplete).isFalse()
+  }
+
+  @Test
+  fun `createRawImpressionUpload rejects an older done blob with a higher generation`(): Unit =
+    runBlocking {
+      service.createRawImpressionUpload(
+        createRawImpressionUploadRequest {
+          dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
+          rawImpressionUpload = rawImpressionUpload {
+            doneBlobUri = DONE_BLOB_URI
+            doneBlobGeneration = 120L
+            doneBlobCreateTime = DONE_BLOB_CREATE_TIME.plusSeconds(1).toProtoTime()
+          }
+          requestId = UUID.randomUUID().toString()
+        }
+      )
+
+      val exception =
+        assertFailsWith<StatusRuntimeException> {
+          service.createRawImpressionUpload(
+            createRawImpressionUploadRequest {
+              dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
+              rawImpressionUpload = rawImpressionUpload {
+                doneBlobUri = DONE_BLOB_URI
+                doneBlobGeneration = 900L
+                doneBlobCreateTime = DONE_BLOB_CREATE_TIME.toProtoTime()
+              }
+              requestId = UUID.randomUUID().toString()
+            }
+          )
+        }
+
+      assertThat(exception.status.code).isEqualTo(Status.Code.ALREADY_EXISTS)
+    }
+
+  @Test
+  fun `createRawImpressionUpload accepts a newer done blob with a lower generation`(): Unit =
+    runBlocking {
+      val original =
         service.createRawImpressionUpload(
           createRawImpressionUploadRequest {
             dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
             rawImpressionUpload = rawImpressionUpload {
               doneBlobUri = DONE_BLOB_URI
-              doneBlobGeneration = 1L
+              doneBlobGeneration = 900L
+              doneBlobCreateTime = DONE_BLOB_CREATE_TIME.toProtoTime()
             }
             requestId = UUID.randomUUID().toString()
           }
         )
-      }
 
-    assertThat(exception.status.code).isEqualTo(Status.Code.ALREADY_EXISTS)
-  }
+      val replacement =
+        service.createRawImpressionUpload(
+          createRawImpressionUploadRequest {
+            dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
+            rawImpressionUpload = rawImpressionUpload {
+              doneBlobUri = DONE_BLOB_URI
+              doneBlobGeneration = 120L
+              doneBlobCreateTime = DONE_BLOB_CREATE_TIME.plusSeconds(1).toProtoTime()
+            }
+            requestId = UUID.randomUUID().toString()
+          }
+        )
+
+      assertThat(replacement.replacesRawImpressionUploadResourceId)
+        .isEqualTo(original.rawImpressionUploadResourceId)
+    }
 
   @Test
   fun `createRawImpressionUpload is idempotent with same request_id`(): Unit = runBlocking {
@@ -535,7 +677,7 @@ abstract class RawImpressionUploadServiceTest {
       service.listRawImpressionUploads(
         listRawImpressionUploadsRequest {
           dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
-          filter = ListRawImpressionUploadsRequestKt.filter { doneBlobUri = DONE_BLOB_URI }
+          filter = ListRawImpressionUploadsRequestKt.filter { doneBlobUri = expected.doneBlobUri }
         }
       )
 
@@ -773,21 +915,24 @@ abstract class RawImpressionUploadServiceTest {
 
   private var nextDoneBlobGeneration = DONE_BLOB_GENERATION
 
-  private suspend fun createUpload(): RawImpressionUpload =
-    service.createRawImpressionUpload(
+  private suspend fun createUpload(): RawImpressionUpload {
+    val generation = nextDoneBlobGeneration++
+    return service.createRawImpressionUpload(
       createRawImpressionUploadRequest {
         dataProviderResourceId = DATA_PROVIDER_RESOURCE_ID
         rawImpressionUpload = rawImpressionUpload {
-          doneBlobUri = DONE_BLOB_URI
-          doneBlobGeneration = nextDoneBlobGeneration++
+          doneBlobUri = "$DONE_BLOB_URI/$generation"
+          doneBlobGeneration = generation
         }
         requestId = UUID.randomUUID().toString()
       }
     )
+  }
 
   companion object {
     private const val DATA_PROVIDER_RESOURCE_ID = "data-provider-1"
     private const val DONE_BLOB_URI = "gs://test-bucket/2026-06-16/done"
     private const val DONE_BLOB_GENERATION = 1234L
+    private val DONE_BLOB_CREATE_TIME = Instant.parse("2026-06-16T00:00:00Z")
   }
 }

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/service/v1alpha/BUILD.bazel
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/service/v1alpha/BUILD.bazel
@@ -59,6 +59,7 @@ kt_jvm_library(
         "//src/main/proto/wfa/measurement/internal/edpaggregator:raw_impression_upload_kt_jvm_proto",
         "//src/main/proto/wfa/measurement/internal/edpaggregator:raw_impression_upload_service_kt_jvm_grpc_proto",
         "//src/main/proto/wfa/measurement/internal/edpaggregator:raw_impression_upload_state_kt_jvm_proto",
+        "@wfa_common_jvm//imports/java/com/google/protobuf/util",
         "@wfa_common_jvm//imports/java/io/grpc:api",
         "@wfa_common_jvm//src/main/kotlin/org/wfanet/measurement/common",
     ],

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/service/v1alpha/RawImpressionUploadService.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/service/v1alpha/RawImpressionUploadService.kt
@@ -112,7 +112,6 @@ class RawImpressionUploadService(
           InternalErrors.Reason.IMPRESSION_METADATA_NOT_FOUND,
           InternalErrors.Reason.IMPRESSION_METADATA_ALREADY_EXISTS,
           InternalErrors.Reason.IMPRESSION_METADATA_STATE_INVALID,
-          InternalErrors.Reason.RAW_IMPRESSION_UPLOAD_NOT_FOUND,
           InternalErrors.Reason.REQUISITION_METADATA_NOT_FOUND,
           InternalErrors.Reason.REQUISITION_METADATA_NOT_FOUND_BY_CMMS_REQUISITION,
           InternalErrors.Reason.REQUISITION_METADATA_ALREADY_EXISTS,
@@ -140,6 +139,12 @@ class RawImpressionUploadService(
           InternalErrors.Reason.POOL_ASSIGNMENT_JOB_STATE_INVALID,
           InternalErrors.Reason.POOL_ASSIGNMENT_JOB_ALREADY_EXISTS,
           null -> Status.INTERNAL.withCause(e).asRuntimeException()
+          InternalErrors.Reason.RAW_IMPRESSION_UPLOAD_NOT_FOUND ->
+            RawImpressionUploadNotFoundException(
+                request.rawImpressionUpload.replacesRawImpressionUpload,
+                e,
+              )
+              .asStatusRuntimeException(Status.Code.NOT_FOUND)
           InternalErrors.Reason.RAW_IMPRESSION_UPLOAD_ALREADY_EXISTS ->
             Status.ALREADY_EXISTS.withCause(e).asRuntimeException()
         }
@@ -344,6 +349,14 @@ fun InternalRawImpressionUpload.toPublic(): RawImpressionUpload {
     state = source.state.toPublic()
     doneBlobUri = source.doneBlobUri
     doneBlobGeneration = source.doneBlobGeneration
+    if (source.replacesRawImpressionUploadResourceId.isNotEmpty()) {
+      replacesRawImpressionUpload =
+        RawImpressionUploadKey(
+            source.dataProviderResourceId,
+            source.replacesRawImpressionUploadResourceId,
+          )
+          .toName()
+    }
     createTime = source.createTime
     updateTime = source.updateTime
   }

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/service/v1alpha/RawImpressionUploadService.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/service/v1alpha/RawImpressionUploadService.kt
@@ -14,6 +14,7 @@
 
 package org.wfanet.measurement.edpaggregator.service.v1alpha
 
+import com.google.protobuf.util.Timestamps
 import io.grpc.Status
 import io.grpc.StatusException
 import java.io.IOException
@@ -32,6 +33,7 @@ import org.wfanet.measurement.edpaggregator.v1alpha.CreateRawImpressionUploadReq
 import org.wfanet.measurement.edpaggregator.v1alpha.GetRawImpressionUploadRequest
 import org.wfanet.measurement.edpaggregator.v1alpha.ListRawImpressionUploadsRequest
 import org.wfanet.measurement.edpaggregator.v1alpha.ListRawImpressionUploadsResponse
+import org.wfanet.measurement.edpaggregator.v1alpha.MarkRawImpressionUploadRegistrationCompleteRequest
 import org.wfanet.measurement.edpaggregator.v1alpha.RawImpressionUpload
 import org.wfanet.measurement.edpaggregator.v1alpha.RawImpressionUploadServiceGrpcKt.RawImpressionUploadServiceCoroutineImplBase
 import org.wfanet.measurement.edpaggregator.v1alpha.listRawImpressionUploadsResponse
@@ -45,6 +47,7 @@ import org.wfanet.measurement.internal.edpaggregator.RawImpressionUploadState
 import org.wfanet.measurement.internal.edpaggregator.createRawImpressionUploadRequest as internalCreateUploadRequest
 import org.wfanet.measurement.internal.edpaggregator.getRawImpressionUploadRequest as internalGetUploadRequest
 import org.wfanet.measurement.internal.edpaggregator.listRawImpressionUploadsRequest as internalListUploadsRequest
+import org.wfanet.measurement.internal.edpaggregator.markRawImpressionUploadRegistrationCompleteRequest as internalMarkRegistrationCompleteRequest
 import org.wfanet.measurement.internal.edpaggregator.rawImpressionUpload as internalRawImpressionUpload
 
 class RawImpressionUploadService(
@@ -82,6 +85,13 @@ class RawImpressionUploadService(
       throw InvalidFieldValueException("raw_impression_upload.done_blob_generation")
         .asStatusRuntimeException(Status.Code.INVALID_ARGUMENT)
     }
+    if (
+      request.rawImpressionUpload.hasDoneBlobCreateTime() &&
+        !Timestamps.isValid(request.rawImpressionUpload.doneBlobCreateTime)
+    ) {
+      throw InvalidFieldValueException("raw_impression_upload.done_blob_create_time")
+        .asStatusRuntimeException(Status.Code.INVALID_ARGUMENT)
+    }
 
     if (request.requestId.isEmpty()) {
       throw RequiredFieldNotSetException("request_id")
@@ -102,6 +112,9 @@ class RawImpressionUploadService(
             rawImpressionUpload = internalRawImpressionUpload {
               doneBlobUri = request.rawImpressionUpload.doneBlobUri
               doneBlobGeneration = request.rawImpressionUpload.doneBlobGeneration
+              if (request.rawImpressionUpload.hasDoneBlobCreateTime()) {
+                doneBlobCreateTime = request.rawImpressionUpload.doneBlobCreateTime
+              }
             }
             requestId = request.requestId
           }
@@ -215,6 +228,47 @@ class RawImpressionUploadService(
       }
 
     return internalResponse.toPublic()
+  }
+
+  override suspend fun markRawImpressionUploadRegistrationComplete(
+    request: MarkRawImpressionUploadRegistrationCompleteRequest
+  ): RawImpressionUpload {
+    if (request.name.isEmpty()) {
+      throw RequiredFieldNotSetException("name")
+        .asStatusRuntimeException(Status.Code.INVALID_ARGUMENT)
+    }
+    val uploadKey =
+      RawImpressionUploadKey.fromName(request.name)
+        ?: throw InvalidFieldValueException("name")
+          .asStatusRuntimeException(Status.Code.INVALID_ARGUMENT)
+    if (request.requestId.isEmpty()) {
+      throw RequiredFieldNotSetException("request_id")
+        .asStatusRuntimeException(Status.Code.INVALID_ARGUMENT)
+    }
+    try {
+      UUID.fromString(request.requestId)
+    } catch (e: IllegalArgumentException) {
+      throw InvalidFieldValueException("request_id", e)
+        .asStatusRuntimeException(Status.Code.INVALID_ARGUMENT)
+    }
+
+    return try {
+      internalUploadStub
+        .markRawImpressionUploadRegistrationComplete(
+          internalMarkRegistrationCompleteRequest {
+            dataProviderResourceId = uploadKey.dataProviderId
+            rawImpressionUploadResourceId = uploadKey.rawImpressionUploadId
+            requestId = request.requestId
+          }
+        )
+        .toPublic()
+    } catch (e: StatusException) {
+      if (InternalErrors.getReason(e) == InternalErrors.Reason.RAW_IMPRESSION_UPLOAD_NOT_FOUND) {
+        throw RawImpressionUploadNotFoundException(request.name, e)
+          .asStatusRuntimeException(Status.Code.NOT_FOUND)
+      }
+      throw Status.INTERNAL.withCause(e).asRuntimeException()
+    }
   }
 
   override suspend fun listRawImpressionUploads(
@@ -349,6 +403,10 @@ fun InternalRawImpressionUpload.toPublic(): RawImpressionUpload {
     state = source.state.toPublic()
     doneBlobUri = source.doneBlobUri
     doneBlobGeneration = source.doneBlobGeneration
+    if (source.hasDoneBlobCreateTime()) {
+      doneBlobCreateTime = source.doneBlobCreateTime
+    }
+    registrationComplete = source.registrationComplete
     if (source.replacesRawImpressionUploadResourceId.isNotEmpty()) {
       replacesRawImpressionUpload =
         RawImpressionUploadKey(

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/service/v1alpha/RawImpressionUploadService.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/service/v1alpha/RawImpressionUploadService.kt
@@ -154,11 +154,9 @@ class RawImpressionUploadService(
           InternalErrors.Reason.POOL_ASSIGNMENT_JOB_ALREADY_EXISTS,
           null -> Status.INTERNAL.withCause(e).asRuntimeException()
           InternalErrors.Reason.RAW_IMPRESSION_UPLOAD_NOT_FOUND ->
-            RawImpressionUploadNotFoundException(
-                request.rawImpressionUpload.replacesRawImpressionUpload,
-                e,
-              )
-              .asStatusRuntimeException(Status.Code.NOT_FOUND)
+            Status.NOT_FOUND.withDescription("RawImpressionUpload not found")
+              .withCause(e)
+              .asRuntimeException()
           InternalErrors.Reason.RAW_IMPRESSION_UPLOAD_ALREADY_EXISTS ->
             Status.ALREADY_EXISTS.withCause(e).asRuntimeException()
         }

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/service/v1alpha/RawImpressionUploadService.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/service/v1alpha/RawImpressionUploadService.kt
@@ -24,6 +24,7 @@ import kotlin.coroutines.EmptyCoroutineContext
 import org.wfanet.measurement.api.v2alpha.DataProviderKey
 import org.wfanet.measurement.common.base64UrlDecode
 import org.wfanet.measurement.common.base64UrlEncode
+import org.wfanet.measurement.edpaggregator.service.EtagMismatchException
 import org.wfanet.measurement.edpaggregator.service.InvalidFieldValueException
 import org.wfanet.measurement.edpaggregator.service.RawImpressionUploadKey
 import org.wfanet.measurement.edpaggregator.service.RawImpressionUploadNotFoundException
@@ -241,6 +242,10 @@ class RawImpressionUploadService(
       RawImpressionUploadKey.fromName(request.name)
         ?: throw InvalidFieldValueException("name")
           .asStatusRuntimeException(Status.Code.INVALID_ARGUMENT)
+    if (request.etag.isEmpty()) {
+      throw RequiredFieldNotSetException("etag")
+        .asStatusRuntimeException(Status.Code.INVALID_ARGUMENT)
+    }
     if (request.requestId.isEmpty()) {
       throw RequiredFieldNotSetException("request_id")
         .asStatusRuntimeException(Status.Code.INVALID_ARGUMENT)
@@ -258,16 +263,29 @@ class RawImpressionUploadService(
           internalMarkRegistrationCompleteRequest {
             dataProviderResourceId = uploadKey.dataProviderId
             rawImpressionUploadResourceId = uploadKey.rawImpressionUploadId
+            etag = request.etag
             requestId = request.requestId
           }
         )
         .toPublic()
     } catch (e: StatusException) {
-      if (InternalErrors.getReason(e) == InternalErrors.Reason.RAW_IMPRESSION_UPLOAD_NOT_FOUND) {
-        throw RawImpressionUploadNotFoundException(request.name, e)
-          .asStatusRuntimeException(Status.Code.NOT_FOUND)
+      throw when (InternalErrors.getReason(e)) {
+        InternalErrors.Reason.RAW_IMPRESSION_UPLOAD_NOT_FOUND ->
+          RawImpressionUploadNotFoundException(request.name, e)
+            .asStatusRuntimeException(Status.Code.NOT_FOUND)
+        InternalErrors.Reason.ETAG_MISMATCH ->
+          EtagMismatchException.fromInternal(e).asStatusRuntimeException(Status.Code.ABORTED)
+        null ->
+          if (
+            e.status.code == Status.Code.ALREADY_EXISTS ||
+              e.status.code == Status.Code.FAILED_PRECONDITION
+          ) {
+            e.status.withCause(e).asRuntimeException()
+          } else {
+            Status.INTERNAL.withCause(e).asRuntimeException()
+          }
+        else -> Status.INTERNAL.withCause(e).asRuntimeException()
       }
-      throw Status.INTERNAL.withCause(e).asRuntimeException()
     }
   }
 
@@ -417,6 +435,7 @@ fun InternalRawImpressionUpload.toPublic(): RawImpressionUpload {
     }
     createTime = source.createTime
     updateTime = source.updateTime
+    etag = source.etag
   }
 }
 

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/vidlabeling/RequestIds.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/vidlabeling/RequestIds.kt
@@ -33,6 +33,10 @@ object RequestIds {
   fun forRawImpressionUpload(doneBlobPath: String, generation: Long): String =
     fromKey("rawImpressionUpload:$doneBlobPath:$generation")
 
+  /** `request_id` for completing registration of a `RawImpressionUpload`. */
+  fun forRawImpressionUploadRegistrationComplete(uploadName: String): String =
+    fromKey("rawImpressionUploadRegistrationComplete:$uploadName")
+
   /**
    * `request_id` for creating a `RawImpressionUploadFile`.
    *

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/vidlabeling/RequestIds.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/vidlabeling/RequestIds.kt
@@ -33,9 +33,9 @@ object RequestIds {
   fun forRawImpressionUpload(doneBlobPath: String, generation: Long): String =
     fromKey("rawImpressionUpload:$doneBlobPath:$generation")
 
-  /** `request_id` for completing registration of a `RawImpressionUpload`. */
-  fun forRawImpressionUploadRegistrationComplete(uploadName: String): String =
-    fromKey("rawImpressionUploadRegistrationComplete:$uploadName")
+  /** `request_id` for completing one observed version of a `RawImpressionUpload`. */
+  fun forRawImpressionUploadRegistrationComplete(uploadName: String, etag: String): String =
+    fromKey("rawImpressionUploadRegistrationComplete:$uploadName:$etag")
 
   /**
    * `request_id` for creating a `RawImpressionUploadFile`.

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/vidlabeling/VidLabelingDispatcher.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/vidlabeling/VidLabelingDispatcher.kt
@@ -149,6 +149,11 @@ class VidLabelingDispatcher(
       )
 
       val rawImpressionUpload = createRawImpressionUpload(doneBlobPath, doneBlobGeneration)
+      if (rawImpressionUpload == null) {
+        logger.info("Ignoring stale done-object generation $doneBlobGeneration for $doneBlobPath")
+        recordUploadDuration(startTime, UPLOAD_STATUS_SUCCESS)
+        return
+      }
 
       createRawImpressionUploadFiles(rawImpressionUpload.name, blobs, doneBlobUri)
 
@@ -319,7 +324,7 @@ class VidLabelingDispatcher(
   private suspend fun createRawImpressionUpload(
     doneBlobPath: String,
     generation: Long,
-  ): RawImpressionUpload {
+  ): RawImpressionUpload? {
     val request = createRawImpressionUploadRequest {
       parent = dataProviderName
       rawImpressionUpload = rawImpressionUpload {
@@ -342,10 +347,14 @@ class VidLabelingDispatcher(
       // ALREADY_EXISTS, yet findUploadByDoneBlobUri returns null for it — log that collision
       // explicitly (logger.severe) and rethrow instead of the opaque IllegalStateException below.
       findUploadByDoneBlob(doneBlobPath, generation)
-        ?: throw IllegalStateException(
-          "createRawImpressionUpload returned ALREADY_EXISTS but no RawImpressionUpload matches " +
-            doneBlobPath
-        )
+        ?: if ((findLatestUploadByDoneBlob(doneBlobPath)?.doneBlobGeneration ?: 0L) > generation) {
+          null
+        } else {
+          throw IllegalStateException(
+            "createRawImpressionUpload returned ALREADY_EXISTS but no RawImpressionUpload matches " +
+              doneBlobPath
+          )
+        }
     }
   }
 
@@ -380,6 +389,25 @@ class VidLabelingDispatcher(
       }
       .flattenConcat()
       .firstOrNull { it.doneBlobGeneration == generation }
+
+  /** Finds the latest registered revision at [doneBlobPath]. */
+  @OptIn(ExperimentalCoroutinesApi::class) // For `flattenConcat`.
+  private suspend fun findLatestUploadByDoneBlob(doneBlobPath: String): RawImpressionUpload? =
+    rawImpressionUploadStub
+      .listResources { pageToken: String ->
+        val response =
+          rawImpressionUploadStub.listRawImpressionUploads(
+            listRawImpressionUploadsRequest {
+              parent = dataProviderName
+              filter = rawUploadFilter { doneBlobUri = doneBlobPath }
+              if (pageToken.isNotEmpty()) this.pageToken = pageToken
+            }
+          )
+        ResourceList(response.rawImpressionUploadsList, response.nextPageToken)
+      }
+      .flattenConcat()
+      .toList()
+      .maxByOrNull { it.doneBlobGeneration }
 
   private fun LocalDate.toProtoDate(): Date = date {
     year = this@toProtoDate.year

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/vidlabeling/VidLabelingDispatcher.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/vidlabeling/VidLabelingDispatcher.kt
@@ -460,15 +460,19 @@ class VidLabelingDispatcher(
   ): Boolean = readBlobMetadata(doneBlobUri.key).generation == expectedGeneration
 
   private suspend fun markRegistrationComplete(upload: RawImpressionUpload) {
-    rpcThrottlers.metadataWrite.onReady {
-      rawImpressionUploadStub.markRawImpressionUploadRegistrationComplete(
-        markRawImpressionUploadRegistrationCompleteRequest {
-          name = upload.name
-          etag = upload.etag
-          requestId =
-            RequestIds.forRawImpressionUploadRegistrationComplete(upload.name, upload.etag)
-        }
-      )
+    try {
+      rpcThrottlers.metadataWrite.onReady {
+        rawImpressionUploadStub.markRawImpressionUploadRegistrationComplete(
+          markRawImpressionUploadRegistrationCompleteRequest {
+            name = upload.name
+            etag = upload.etag
+            requestId =
+              RequestIds.forRawImpressionUploadRegistrationComplete(upload.name, upload.etag)
+          }
+        )
+      }
+    } catch (e: StatusException) {
+      throw Exception("Error marking RawImpressionUpload ${upload.name} registration complete", e)
     }
   }
 

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/vidlabeling/VidLabelingDispatcher.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/vidlabeling/VidLabelingDispatcher.kt
@@ -124,8 +124,8 @@ class VidLabelingDispatcher(
    *
    * @param doneBlobPath the full storage URI of the "done" blob that triggered this upload.
    * @param doneBlobGeneration GCS object generation number of the done blob. Used to produce
-   *   idempotent request IDs that handle both Pub/Sub redelivery (same generation = same ID) and
-   *   EDP re-uploads to the same path (new generation = new ID).
+   *   idempotent request IDs that handle both DataWatcher redelivery (same generation = same ID)
+   *   and EDP re-uploads to the same path (new generation = new ID).
    * @throws IllegalArgumentException if [doneBlobPath] uses an unsupported URI scheme or
    *   [doneBlobGeneration] is null.
    */
@@ -170,6 +170,12 @@ class VidLabelingDispatcher(
         createRawImpressionUpload(doneBlobPath, doneBlobGeneration, doneBlobMetadata.createTime)
       if (rawImpressionUpload == null) {
         logger.info("Ignoring stale done-object generation $doneBlobGeneration for $doneBlobPath")
+        recordUploadDuration(startTime, UPLOAD_STATUS_SUCCESS)
+        return
+      }
+
+      if (rawImpressionUpload.registrationComplete) {
+        logger.info("RawImpressionUpload ${rawImpressionUpload.name} is already registered")
         recordUploadDuration(startTime, UPLOAD_STATUS_SUCCESS)
         return
       }
@@ -330,8 +336,8 @@ class VidLabelingDispatcher(
    * Creates a `RawImpressionUpload` resource to track this upload.
    *
    * Uses the done blob path and GCS generation number to produce an idempotent request ID. Same
-   * (path, generation) → same request ID → idempotent on Pub/Sub redelivery. New generation at the
-   * same path → new request ID → new upload for EDP re-uploads.
+   * (path, generation) → same request ID → idempotent on DataWatcher redelivery. New generation at
+   * the same path → new request ID → new upload for EDP re-uploads.
    *
    * On `ALREADY_EXISTS` (redelivery after the AIP-155 idempotency cache has expired, so the server
    * returns the error rather than the cached resource), looks up and returns the existing upload so
@@ -426,13 +432,19 @@ class VidLabelingDispatcher(
     rawImpressionUploadStub
       .listResources { pageToken: String ->
         val response =
-          rawImpressionUploadStub.listRawImpressionUploads(
-            listRawImpressionUploadsRequest {
-              parent = dataProviderName
-              filter = rawUploadFilter { doneBlobUri = doneBlobPath }
-              if (pageToken.isNotEmpty()) this.pageToken = pageToken
+          try {
+            rpcThrottlers.metadataRead.onReady {
+              rawImpressionUploadStub.listRawImpressionUploads(
+                listRawImpressionUploadsRequest {
+                  parent = dataProviderName
+                  filter = rawUploadFilter { doneBlobUri = doneBlobPath }
+                  if (pageToken.isNotEmpty()) this.pageToken = pageToken
+                }
+              )
             }
-          )
+          } catch (e: StatusException) {
+            throw Exception("Error listing RawImpressionUploads for $dataProviderName", e)
+          }
         ResourceList(response.rawImpressionUploadsList, response.nextPageToken)
       }
       .flattenConcat()
@@ -448,13 +460,16 @@ class VidLabelingDispatcher(
   ): Boolean = readBlobMetadata(doneBlobUri.key).generation == expectedGeneration
 
   private suspend fun markRegistrationComplete(upload: RawImpressionUpload) {
-    rawImpressionUploadStub.markRawImpressionUploadRegistrationComplete(
-      markRawImpressionUploadRegistrationCompleteRequest {
-        name = upload.name
-        etag = upload.etag
-        requestId = RequestIds.forRawImpressionUploadRegistrationComplete(upload.name, upload.etag)
-      }
-    )
+    rpcThrottlers.metadataWrite.onReady {
+      rawImpressionUploadStub.markRawImpressionUploadRegistrationComplete(
+        markRawImpressionUploadRegistrationCompleteRequest {
+          name = upload.name
+          etag = upload.etag
+          requestId =
+            RequestIds.forRawImpressionUploadRegistrationComplete(upload.name, upload.etag)
+        }
+      )
+    }
   }
 
   private fun LocalDate.toProtoDate(): Date = date {

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/vidlabeling/VidLabelingDispatcher.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/vidlabeling/VidLabelingDispatcher.kt
@@ -25,6 +25,7 @@ import io.grpc.StatusException
 import io.opentelemetry.api.common.AttributeKey
 import io.opentelemetry.api.common.Attributes
 import java.time.Clock
+import java.time.Instant
 import java.time.LocalDate
 import java.util.logging.Level
 import java.util.logging.Logger
@@ -44,6 +45,7 @@ import org.wfanet.measurement.api.v2alpha.listModelLinesRequest
 import org.wfanet.measurement.common.api.grpc.ResourceList
 import org.wfanet.measurement.common.api.grpc.flattenConcat
 import org.wfanet.measurement.common.api.grpc.listResources
+import org.wfanet.measurement.common.toProtoTime
 import org.wfanet.measurement.edpaggregator.BlobUris
 import org.wfanet.measurement.edpaggregator.VidLabelingRpcThrottlers
 import org.wfanet.measurement.edpaggregator.rawimpressions.generationMatchedBlobUri
@@ -59,6 +61,7 @@ import org.wfanet.measurement.edpaggregator.v1alpha.createRawImpressionUploadFil
 import org.wfanet.measurement.edpaggregator.v1alpha.createRawImpressionUploadModelLineRequest
 import org.wfanet.measurement.edpaggregator.v1alpha.createRawImpressionUploadRequest
 import org.wfanet.measurement.edpaggregator.v1alpha.listRawImpressionUploadsRequest
+import org.wfanet.measurement.edpaggregator.v1alpha.markRawImpressionUploadRegistrationCompleteRequest
 import org.wfanet.measurement.edpaggregator.v1alpha.rawImpressionUpload
 import org.wfanet.measurement.edpaggregator.v1alpha.rawImpressionUploadFile
 import org.wfanet.measurement.edpaggregator.v1alpha.rawImpressionUploadModelLine
@@ -89,7 +92,7 @@ import org.wfanet.measurement.storage.StorageClient
  * @param modelLineConfigs field mapping configuration keyed by model line resource name.
  * @param readEventDate reads a raw-impression file's UTC event date from its plaintext Parquet
  *   footer (no decryption needed).
- * @param readBlobMetadata reads the storage generation and size for a raw-impression file in one
+ * @param readBlobMetadata reads the storage generation, size, and creation time for a blob in one
  *   metadata lookup.
  * @param rpcThrottlers process-scoped rate limiters shared with the dispatch sequencer.
  * @param clock clock for determining active model line windows.
@@ -131,11 +134,26 @@ class VidLabelingDispatcher(
 
     try {
       val doneBlobUri: BlobUri = SelectedStorageClient.parseBlobUri(doneBlobPath)
-      val folderPrefix: String = doneBlobUri.key.substringBeforeLast("/")
+      val folderPrefix: String =
+        doneBlobUri.key.substringBeforeLast("/", missingDelimiterValue = "")
+      val listingPrefix = if (folderPrefix.isEmpty()) "" else "$folderPrefix/"
+
+      val doneBlobMetadata = readBlobMetadata(doneBlobUri.key)
+      if (doneBlobMetadata.generation != doneBlobGeneration) {
+        logger.info("Ignoring stale done-object generation $doneBlobGeneration for $doneBlobPath")
+        recordUploadDuration(startTime, UPLOAD_STATUS_SUCCESS)
+        return
+      }
 
       val blobs: List<StorageClient.Blob> =
-        storageClient.listBlobs(folderPrefix).filter { !isDoneMarker(it.blobKey) }.toList()
+        storageClient.listBlobs(listingPrefix).filter { !isDoneMarker(it.blobKey) }.toList()
       val blobKeys: List<String> = blobs.map { it.blobKey }
+
+      if (!isCurrentDoneBlobGeneration(doneBlobUri, doneBlobGeneration)) {
+        logger.info("Ignoring stale done-object generation $doneBlobGeneration for $doneBlobPath")
+        recordUploadDuration(startTime, UPLOAD_STATUS_SUCCESS)
+        return
+      }
 
       if (blobKeys.isEmpty()) {
         logger.info("No raw impression files found in $folderPrefix")
@@ -148,7 +166,8 @@ class VidLabelingDispatcher(
         Attributes.of(DATA_PROVIDER_ATTR, dataProviderName),
       )
 
-      val rawImpressionUpload = createRawImpressionUpload(doneBlobPath, doneBlobGeneration)
+      val rawImpressionUpload =
+        createRawImpressionUpload(doneBlobPath, doneBlobGeneration, doneBlobMetadata.createTime)
       if (rawImpressionUpload == null) {
         logger.info("Ignoring stale done-object generation $doneBlobGeneration for $doneBlobPath")
         recordUploadDuration(startTime, UPLOAD_STATUS_SUCCESS)
@@ -160,12 +179,14 @@ class VidLabelingDispatcher(
       val resolvedModelLineNames = resolveModelLines()
 
       if (resolvedModelLineNames.isEmpty()) {
+        markRegistrationComplete(rawImpressionUpload.name)
         logger.info("No active model lines resolved for $modelSuiteName")
         recordUploadDuration(startTime, UPLOAD_STATUS_SUCCESS)
         return
       }
 
       createRawImpressionUploadModelLines(rawImpressionUpload.name, resolvedModelLineNames)
+      markRegistrationComplete(rawImpressionUpload.name)
 
       logger.info(
         "Registered upload ${rawImpressionUpload.name} with ${blobKeys.size} files and " +
@@ -324,12 +345,14 @@ class VidLabelingDispatcher(
   private suspend fun createRawImpressionUpload(
     doneBlobPath: String,
     generation: Long,
+    createTime: Instant,
   ): RawImpressionUpload? {
     val request = createRawImpressionUploadRequest {
       parent = dataProviderName
       rawImpressionUpload = rawImpressionUpload {
         doneBlobUri = doneBlobPath
         doneBlobGeneration = generation
+        doneBlobCreateTime = createTime.toProtoTime()
       }
       requestId = RequestIds.forRawImpressionUpload(doneBlobPath, generation)
     }
@@ -346,15 +369,22 @@ class VidLabelingDispatcher(
       // deterministic-UUID collision in RequestIds.forRawImpressionUpload) also surfaces as
       // ALREADY_EXISTS, yet findUploadByDoneBlobUri returns null for it — log that collision
       // explicitly (logger.severe) and rethrow instead of the opaque IllegalStateException below.
-      findUploadByDoneBlob(doneBlobPath, generation)
-        ?: if ((findLatestUploadByDoneBlob(doneBlobPath)?.doneBlobGeneration ?: 0L) > generation) {
-          null
-        } else {
-          throw IllegalStateException(
-            "createRawImpressionUpload returned ALREADY_EXISTS but no RawImpressionUpload matches " +
-              doneBlobPath
-          )
-        }
+      val matchingUpload = findUploadByDoneBlob(doneBlobPath, generation)
+      if (matchingUpload != null) {
+        return matchingUpload
+      }
+      val latestUpload = findLatestUploadByDoneBlob(doneBlobPath)
+      if (
+        latestUpload != null &&
+          latestUpload.hasDoneBlobCreateTime() &&
+          Timestamps.compare(latestUpload.doneBlobCreateTime, createTime.toProtoTime()) >= 0
+      ) {
+        return null
+      }
+      throw IllegalStateException(
+        "createRawImpressionUpload returned ALREADY_EXISTS but no RawImpressionUpload matches " +
+          doneBlobPath
+      )
     }
   }
 
@@ -407,7 +437,24 @@ class VidLabelingDispatcher(
       }
       .flattenConcat()
       .toList()
-      .maxByOrNull { it.doneBlobGeneration }
+      .filter { it.hasDoneBlobCreateTime() }
+      .maxWithOrNull { left, right ->
+        Timestamps.compare(left.doneBlobCreateTime, right.doneBlobCreateTime)
+      }
+
+  private suspend fun isCurrentDoneBlobGeneration(
+    doneBlobUri: BlobUri,
+    expectedGeneration: Long,
+  ): Boolean = readBlobMetadata(doneBlobUri.key).generation == expectedGeneration
+
+  private suspend fun markRegistrationComplete(uploadName: String) {
+    rawImpressionUploadStub.markRawImpressionUploadRegistrationComplete(
+      markRawImpressionUploadRegistrationCompleteRequest {
+        name = uploadName
+        requestId = RequestIds.forRawImpressionUploadRegistrationComplete(uploadName)
+      }
+    )
+  }
 
   private fun LocalDate.toProtoDate(): Date = date {
     year = this@toProtoDate.year
@@ -576,4 +623,8 @@ class VidLabelingDispatcher(
   )
 }
 
-data class RawImpressionBlobMetadata(val generation: Long, val sizeBytes: Long)
+data class RawImpressionBlobMetadata(
+  val generation: Long,
+  val sizeBytes: Long,
+  val createTime: Instant,
+)

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/vidlabeling/VidLabelingDispatcher.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/vidlabeling/VidLabelingDispatcher.kt
@@ -179,14 +179,14 @@ class VidLabelingDispatcher(
       val resolvedModelLineNames = resolveModelLines()
 
       if (resolvedModelLineNames.isEmpty()) {
-        markRegistrationComplete(rawImpressionUpload.name)
+        markRegistrationComplete(rawImpressionUpload)
         logger.info("No active model lines resolved for $modelSuiteName")
         recordUploadDuration(startTime, UPLOAD_STATUS_SUCCESS)
         return
       }
 
       createRawImpressionUploadModelLines(rawImpressionUpload.name, resolvedModelLineNames)
-      markRegistrationComplete(rawImpressionUpload.name)
+      markRegistrationComplete(rawImpressionUpload)
 
       logger.info(
         "Registered upload ${rawImpressionUpload.name} with ${blobKeys.size} files and " +
@@ -447,11 +447,12 @@ class VidLabelingDispatcher(
     expectedGeneration: Long,
   ): Boolean = readBlobMetadata(doneBlobUri.key).generation == expectedGeneration
 
-  private suspend fun markRegistrationComplete(uploadName: String) {
+  private suspend fun markRegistrationComplete(upload: RawImpressionUpload) {
     rawImpressionUploadStub.markRawImpressionUploadRegistrationComplete(
       markRawImpressionUploadRegistrationCompleteRequest {
-        name = uploadName
-        requestId = RequestIds.forRawImpressionUploadRegistrationComplete(uploadName)
+        name = upload.name
+        etag = upload.etag
+        requestId = RequestIds.forRawImpressionUploadRegistrationComplete(upload.name, upload.etag)
       }
     )
   }

--- a/src/main/proto/wfa/measurement/edpaggregator/v1alpha/raw_impression_upload.proto
+++ b/src/main/proto/wfa/measurement/edpaggregator/v1alpha/raw_impression_upload.proto
@@ -76,4 +76,12 @@ message RawImpressionUpload {
     (google.api.field_behavior) = REQUIRED,
     (google.api.field_behavior) = IMMUTABLE
   ];
+
+  // The preceding upload revision for the same done-blob path, if any.
+  string replaces_raw_impression_upload = 7 [
+    (google.api.field_behavior) = OUTPUT_ONLY,
+    (google.api.resource_reference) = {
+      type: "edpaggregator.halo-cmm.org/RawImpressionUpload"
+    }
+  ];
 }

--- a/src/main/proto/wfa/measurement/edpaggregator/v1alpha/raw_impression_upload.proto
+++ b/src/main/proto/wfa/measurement/edpaggregator/v1alpha/raw_impression_upload.proto
@@ -84,4 +84,11 @@ message RawImpressionUpload {
       type: "edpaggregator.halo-cmm.org/RawImpressionUpload"
     }
   ];
+
+  // Creation time of the exact Cloud Storage `done` object version.
+  google.protobuf.Timestamp done_blob_create_time = 8
+      [(google.api.field_behavior) = IMMUTABLE];
+
+  // Whether registration of this upload's files and model lines finished.
+  bool registration_complete = 9 [(google.api.field_behavior) = OUTPUT_ONLY];
 }

--- a/src/main/proto/wfa/measurement/edpaggregator/v1alpha/raw_impression_upload.proto
+++ b/src/main/proto/wfa/measurement/edpaggregator/v1alpha/raw_impression_upload.proto
@@ -91,4 +91,7 @@ message RawImpressionUpload {
 
   // Whether registration of this upload's files and model lines finished.
   bool registration_complete = 9 [(google.api.field_behavior) = OUTPUT_ONLY];
+
+  // Entity tag for optimistic concurrency control.
+  string etag = 10 [(google.api.field_behavior) = OUTPUT_ONLY];
 }

--- a/src/main/proto/wfa/measurement/edpaggregator/v1alpha/raw_impression_upload_service.proto
+++ b/src/main/proto/wfa/measurement/edpaggregator/v1alpha/raw_impression_upload_service.proto
@@ -39,6 +39,28 @@ service RawImpressionUploadService {
   // Lists RawImpressionUpload resources for a data provider.
   rpc ListRawImpressionUploads(ListRawImpressionUploadsRequest)
       returns (ListRawImpressionUploadsResponse) {}
+
+  // Marks registration of an upload's files and model lines complete.
+  rpc MarkRawImpressionUploadRegistrationComplete(
+      MarkRawImpressionUploadRegistrationCompleteRequest)
+      returns (RawImpressionUpload) {}
+}
+
+// Request message for `MarkRawImpressionUploadRegistrationComplete`.
+message MarkRawImpressionUploadRegistrationCompleteRequest {
+  // Resource name of the RawImpressionUpload.
+  string name = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference) = {
+      type: "edpaggregator.halo-cmm.org/RawImpressionUpload"
+    }
+  ];
+
+  // A UUID4 request ID used to make the operation idempotent.
+  string request_id = 2 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.field_info).format = UUID4
+  ];
 }
 
 // Request message for the `CreateRawImpressionUpload` method.

--- a/src/main/proto/wfa/measurement/edpaggregator/v1alpha/raw_impression_upload_service.proto
+++ b/src/main/proto/wfa/measurement/edpaggregator/v1alpha/raw_impression_upload_service.proto
@@ -40,7 +40,8 @@ service RawImpressionUploadService {
   rpc ListRawImpressionUploads(ListRawImpressionUploadsRequest)
       returns (ListRawImpressionUploadsResponse) {}
 
-  // Marks registration of an upload's files and model lines complete.
+  // Marks registration of an upload's files and model lines complete. Throws
+  // `ABORTED` if `etag` does not match (AIP-154).
   rpc MarkRawImpressionUploadRegistrationComplete(
       MarkRawImpressionUploadRegistrationCompleteRequest)
       returns (RawImpressionUpload) {}
@@ -56,8 +57,12 @@ message MarkRawImpressionUploadRegistrationCompleteRequest {
     }
   ];
 
-  // A UUID4 request ID used to make the operation idempotent.
-  string request_id = 2 [
+  // The etag of the `RawImpressionUpload` for optimistic locking.
+  string etag = 2 [(google.api.field_behavior) = REQUIRED];
+
+  // A UUID4 request ID used to make the operation idempotent. The dispatcher
+  // derives this deterministically from `name` and the observed `etag`.
+  string request_id = 3 [
     (google.api.field_behavior) = REQUIRED,
     (google.api.field_info).format = UUID4
   ];

--- a/src/main/proto/wfa/measurement/internal/edpaggregator/raw_impression_upload.proto
+++ b/src/main/proto/wfa/measurement/internal/edpaggregator/raw_impression_upload.proto
@@ -49,4 +49,7 @@ message RawImpressionUpload {
   // Cloud Storage generation of the done blob. Zero means unknown for legacy
   // uploads.
   int64 done_blob_generation = 7;
+
+  // Resource ID of the preceding upload revision for the same done-blob path.
+  string replaces_raw_impression_upload_resource_id = 8;
 }

--- a/src/main/proto/wfa/measurement/internal/edpaggregator/raw_impression_upload.proto
+++ b/src/main/proto/wfa/measurement/internal/edpaggregator/raw_impression_upload.proto
@@ -58,4 +58,7 @@ message RawImpressionUpload {
 
   // Whether registration of this upload's files and model lines finished.
   bool registration_complete = 10;
+
+  // Entity tag for optimistic concurrency control.
+  string etag = 11;
 }

--- a/src/main/proto/wfa/measurement/internal/edpaggregator/raw_impression_upload.proto
+++ b/src/main/proto/wfa/measurement/internal/edpaggregator/raw_impression_upload.proto
@@ -52,4 +52,10 @@ message RawImpressionUpload {
 
   // Resource ID of the preceding upload revision for the same done-blob path.
   string replaces_raw_impression_upload_resource_id = 8;
+
+  // Creation time of the exact Cloud Storage `done` object version.
+  google.protobuf.Timestamp done_blob_create_time = 9;
+
+  // Whether registration of this upload's files and model lines finished.
+  bool registration_complete = 10;
 }

--- a/src/main/proto/wfa/measurement/internal/edpaggregator/raw_impression_upload_service.proto
+++ b/src/main/proto/wfa/measurement/internal/edpaggregator/raw_impression_upload_service.proto
@@ -38,6 +38,17 @@ service RawImpressionUploadService {
   // Lists RawImpressionUpload entries for a data provider.
   rpc ListRawImpressionUploads(ListRawImpressionUploadsRequest)
       returns (ListRawImpressionUploadsResponse);
+
+  // Marks registration of an upload's files and model lines complete.
+  rpc MarkRawImpressionUploadRegistrationComplete(
+      MarkRawImpressionUploadRegistrationCompleteRequest)
+      returns (RawImpressionUpload);
+}
+
+message MarkRawImpressionUploadRegistrationCompleteRequest {
+  string data_provider_resource_id = 1;
+  string raw_impression_upload_resource_id = 2;
+  string request_id = 3;
 }
 
 // Request message for CreateRawImpressionUpload.

--- a/src/main/proto/wfa/measurement/internal/edpaggregator/raw_impression_upload_service.proto
+++ b/src/main/proto/wfa/measurement/internal/edpaggregator/raw_impression_upload_service.proto
@@ -49,6 +49,7 @@ message MarkRawImpressionUploadRegistrationCompleteRequest {
   string data_provider_resource_id = 1;
   string raw_impression_upload_resource_id = 2;
   string request_id = 3;
+  string etag = 4;
 }
 
 // Request message for CreateRawImpressionUpload.

--- a/src/main/resources/edpaggregator/spanner/add-raw-impression-upload-done-blob-create-time.sql
+++ b/src/main/resources/edpaggregator/spanner/add-raw-impression-upload-done-blob-create-time.sql
@@ -1,0 +1,23 @@
+-- liquibase formatted sql
+
+-- Copyright 2026 The Cross-Media Measurement Authors
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+-- changeset marcopremier:add-raw-impression-upload-done-blob-create-time dbms:cloudspanner
+-- comment: Order replacement uploads by the done object's immutable creation time.
+
+ALTER TABLE RawImpressionUpload ADD COLUMN DoneBlobCreateTime TIMESTAMP;
+
+CREATE NULL_FILTERED INDEX RawImpressionUploadByDoneBlobCreateTime
+  ON RawImpressionUpload(DataProviderResourceId, DoneBlobUri, DoneBlobCreateTime DESC);

--- a/src/main/resources/edpaggregator/spanner/add-raw-impression-upload-registration-complete.sql
+++ b/src/main/resources/edpaggregator/spanner/add-raw-impression-upload-registration-complete.sql
@@ -1,0 +1,22 @@
+-- liquibase formatted sql
+
+-- Copyright 2026 The Cross-Media Measurement Authors
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+-- changeset marcopremier:add-raw-impression-upload-registration-complete dbms:cloudspanner
+-- comment: Track whether every file and model line for an upload has been registered.
+
+-- Existing CREATED uploads may represent interrupted registration, so legacy rows start
+-- incomplete. Non-CREATED legacy rows are treated as complete by the dispatcher.
+ALTER TABLE RawImpressionUpload ADD COLUMN RegistrationComplete BOOL NOT NULL DEFAULT (FALSE);

--- a/src/main/resources/edpaggregator/spanner/add-raw-impression-upload-registration-complete.sql
+++ b/src/main/resources/edpaggregator/spanner/add-raw-impression-upload-registration-complete.sql
@@ -20,3 +20,7 @@
 -- Existing CREATED uploads may represent interrupted registration, so legacy rows start
 -- incomplete. Non-CREATED legacy rows are treated as complete by the dispatcher.
 ALTER TABLE RawImpressionUpload ADD COLUMN RegistrationComplete BOOL NOT NULL DEFAULT (FALSE);
+ALTER TABLE RawImpressionUpload ADD COLUMN MarkRegistrationCompleteRequestId STRING(36);
+
+CREATE UNIQUE NULL_FILTERED INDEX RawImpressionUploadByMarkRegistrationCompleteRequestId
+  ON RawImpressionUpload(DataProviderResourceId, MarkRegistrationCompleteRequestId);

--- a/src/main/resources/edpaggregator/spanner/add-raw-impression-upload-replacement.sql
+++ b/src/main/resources/edpaggregator/spanner/add-raw-impression-upload-replacement.sql
@@ -1,0 +1,23 @@
+-- liquibase formatted sql
+
+-- Copyright 2026 The Cross-Media Measurement Authors
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+-- changeset marcopremier:add-raw-impression-upload-replacement dbms:cloudspanner
+-- comment: Link each replacement upload to the preceding revision of the same done path.
+
+ALTER TABLE RawImpressionUpload ADD COLUMN ReplacesRawImpressionUploadResourceId STRING(63);
+
+CREATE NULL_FILTERED INDEX RawImpressionUploadByReplacement
+  ON RawImpressionUpload(DataProviderResourceId, ReplacesRawImpressionUploadResourceId);

--- a/src/main/resources/edpaggregator/spanner/changelog.yaml
+++ b/src/main/resources/edpaggregator/spanner/changelog.yaml
@@ -64,3 +64,6 @@ databaseChangeLog:
   - include:
       file: add-raw-impression-upload-generations.sql
       relativeToChangeLogFile: true
+  - include:
+      file: add-raw-impression-upload-replacement.sql
+      relativeToChangeLogFile: true

--- a/src/main/resources/edpaggregator/spanner/changelog.yaml
+++ b/src/main/resources/edpaggregator/spanner/changelog.yaml
@@ -67,3 +67,9 @@ databaseChangeLog:
   - include:
       file: add-raw-impression-upload-replacement.sql
       relativeToChangeLogFile: true
+  - include:
+      file: add-raw-impression-upload-done-blob-create-time.sql
+      relativeToChangeLogFile: true
+  - include:
+      file: add-raw-impression-upload-registration-complete.sql
+      relativeToChangeLogFile: true

--- a/src/test/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/spanner/RawImpressionUploadPaginationTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/spanner/RawImpressionUploadPaginationTest.kt
@@ -60,6 +60,7 @@ class RawImpressionUploadPaginationTest {
           createRequestId = "",
           state = RawImpressionUploadState.RAW_IMPRESSION_UPLOAD_STATE_CREATED,
           doneBlobGeneration = DONE_BLOB_GENERATION,
+          replacesRawImpressionUploadResourceId = null,
         )
         txn.insertRawImpressionUpload(
           rawImpressionUploadId = 1L,
@@ -69,6 +70,7 @@ class RawImpressionUploadPaginationTest {
           createRequestId = "",
           state = RawImpressionUploadState.RAW_IMPRESSION_UPLOAD_STATE_CREATED,
           doneBlobGeneration = DONE_BLOB_GENERATION,
+          replacesRawImpressionUploadResourceId = null,
         )
       }
 

--- a/src/test/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/spanner/RawImpressionUploadPaginationTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/spanner/RawImpressionUploadPaginationTest.kt
@@ -60,6 +60,7 @@ class RawImpressionUploadPaginationTest {
           createRequestId = "",
           state = RawImpressionUploadState.RAW_IMPRESSION_UPLOAD_STATE_CREATED,
           doneBlobGeneration = DONE_BLOB_GENERATION,
+          doneBlobCreateTime = null,
           replacesRawImpressionUploadResourceId = null,
         )
         txn.insertRawImpressionUpload(
@@ -70,6 +71,7 @@ class RawImpressionUploadPaginationTest {
           createRequestId = "",
           state = RawImpressionUploadState.RAW_IMPRESSION_UPLOAD_STATE_CREATED,
           doneBlobGeneration = DONE_BLOB_GENERATION,
+          doneBlobCreateTime = null,
           replacesRawImpressionUploadResourceId = null,
         )
       }

--- a/src/test/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/vidlabeling/VidLabelingDispatcherFunctionTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/edpaggregator/deploy/gcloud/vidlabeling/VidLabelingDispatcherFunctionTest.kt
@@ -68,6 +68,7 @@ import org.wfanet.measurement.config.edpaggregator.vidLabelingConfigs
 import org.wfanet.measurement.edpaggregator.v1alpha.BatchCreateRawImpressionUploadFilesRequest
 import org.wfanet.measurement.edpaggregator.v1alpha.CreateRawImpressionUploadRequest
 import org.wfanet.measurement.edpaggregator.v1alpha.LabelerInputFieldMapping
+import org.wfanet.measurement.edpaggregator.v1alpha.MarkRawImpressionUploadRegistrationCompleteRequest
 import org.wfanet.measurement.edpaggregator.v1alpha.RawImpressionUpload
 import org.wfanet.measurement.edpaggregator.v1alpha.RawImpressionUploadFileServiceGrpcKt.RawImpressionUploadFileServiceCoroutineImplBase
 import org.wfanet.measurement.edpaggregator.v1alpha.RawImpressionUploadModelLineServiceGrpcKt.RawImpressionUploadModelLineServiceCoroutineImplBase
@@ -95,8 +96,18 @@ class VidLabelingDispatcherFunctionTest {
           RawImpressionUpload.newBuilder()
             .setName("${request.parent}/rawImpressionUploads/upload-1")
             .setDoneBlobUri("file:////edp/edp_name/timestamp/done")
+            .setEtag(UPLOAD_ETAG)
             .build()
         }
+      onBlocking { markRawImpressionUploadRegistrationComplete(any()) }
+        .thenReturn(
+          RawImpressionUpload.newBuilder()
+            .setName("$DATA_PROVIDER/rawImpressionUploads/upload-1")
+            .setDoneBlobUri("file:////edp/edp_name/timestamp/done")
+            .setRegistrationComplete(true)
+            .setEtag("completed-$UPLOAD_ETAG")
+            .build()
+        )
       // The fast-path sequencer lists uploads after registration; return none so it cleanly
       // no-ops in this Function-wiring test (dispatch behavior is covered by the unit tests).
       onBlocking { listRawImpressionUploads(any()) }.thenReturn(listRawImpressionUploadsResponse {})
@@ -270,6 +281,15 @@ class VidLabelingDispatcherFunctionTest {
     verifyBlocking(rawImpressionUploadModelLineServiceMock, times(1)) {
       batchCreateRawImpressionUploadModelLines(any())
     }
+    val registrationRequestCaptor =
+      argumentCaptor<MarkRawImpressionUploadRegistrationCompleteRequest>()
+    verifyBlocking(rawImpressionUploadServiceMock, times(1)) {
+      markRawImpressionUploadRegistrationComplete(registrationRequestCaptor.capture())
+    }
+    assertThat(registrationRequestCaptor.firstValue.name)
+      .isEqualTo("$DATA_PROVIDER/rawImpressionUploads/upload-1")
+    assertThat(registrationRequestCaptor.firstValue.etag).isEqualTo(UPLOAD_ETAG)
+    assertThat(registrationRequestCaptor.firstValue.requestId).isNotEmpty()
     verifyBlocking(modelLinesServiceMock, times(1)) { listModelLines(any()) }
   }
 
@@ -407,6 +427,7 @@ class VidLabelingDispatcherFunctionTest {
     private const val MODEL_SUITE = "modelProviders/mp1/modelSuites/ms1"
     private const val MODEL_LINE = "$MODEL_SUITE/modelLines/ml1"
     private const val MODEL_RELEASE = "$MODEL_SUITE/modelReleases/mr1"
+    private const val UPLOAD_ETAG = "upload-etag"
 
     private val FUNCTION_BINARY_PATH =
       Paths.get(

--- a/src/test/kotlin/org/wfanet/measurement/edpaggregator/service/v1alpha/RawImpressionUploadServiceTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/edpaggregator/service/v1alpha/RawImpressionUploadServiceTest.kt
@@ -124,7 +124,10 @@ class RawImpressionUploadServiceTest {
       service.createRawImpressionUpload(
         createRawImpressionUploadRequest {
           parent = DATA_PROVIDER_KEY.toName()
-          rawImpressionUpload = rawImpressionUpload { doneBlobUri = DONE_BLOB_URI }
+          rawImpressionUpload = rawImpressionUpload {
+            doneBlobUri = DONE_BLOB_URI
+            doneBlobGeneration = 1L
+          }
           requestId = UUID.randomUUID().toString()
         }
       )

--- a/src/test/kotlin/org/wfanet/measurement/edpaggregator/service/v1alpha/RawImpressionUploadServiceTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/edpaggregator/service/v1alpha/RawImpressionUploadServiceTest.kt
@@ -119,6 +119,36 @@ class RawImpressionUploadServiceTest {
   }
 
   @Test
+  fun `createRawImpressionUpload persists replacement relationship`(): Unit = runBlocking {
+    val original =
+      service.createRawImpressionUpload(
+        createRawImpressionUploadRequest {
+          parent = DATA_PROVIDER_KEY.toName()
+          rawImpressionUpload = rawImpressionUpload { doneBlobUri = DONE_BLOB_URI }
+          requestId = UUID.randomUUID().toString()
+        }
+      )
+
+    val replacement =
+      service.createRawImpressionUpload(
+        createRawImpressionUploadRequest {
+          parent = DATA_PROVIDER_KEY.toName()
+          rawImpressionUpload = rawImpressionUpload {
+            doneBlobUri = DONE_BLOB_URI
+            doneBlobGeneration = 2L
+          }
+          requestId = UUID.randomUUID().toString()
+        }
+      )
+
+    assertThat(replacement.replacesRawImpressionUpload).isEqualTo(original.name)
+    assertThat(
+        service.getRawImpressionUpload(getRawImpressionUploadRequest { name = replacement.name })
+      )
+      .isEqualTo(replacement)
+  }
+
+  @Test
   fun `createRawImpressionUpload with requestId is idempotent`(): Unit = runBlocking {
     val request = createRawImpressionUploadRequest {
       parent = DATA_PROVIDER_KEY.toName()

--- a/src/test/kotlin/org/wfanet/measurement/edpaggregator/service/v1alpha/RawImpressionUploadServiceTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/edpaggregator/service/v1alpha/RawImpressionUploadServiceTest.kt
@@ -51,6 +51,7 @@ import org.wfanet.measurement.edpaggregator.v1alpha.createRawImpressionUploadReq
 import org.wfanet.measurement.edpaggregator.v1alpha.getRawImpressionUploadRequest
 import org.wfanet.measurement.edpaggregator.v1alpha.listRawImpressionUploadsRequest
 import org.wfanet.measurement.edpaggregator.v1alpha.listRawImpressionUploadsResponse
+import org.wfanet.measurement.edpaggregator.v1alpha.markRawImpressionUploadRegistrationCompleteRequest
 import org.wfanet.measurement.edpaggregator.v1alpha.rawImpressionUpload
 import org.wfanet.measurement.gcloud.spanner.testing.SpannerEmulatorDatabaseRule
 import org.wfanet.measurement.gcloud.spanner.testing.SpannerEmulatorRule
@@ -89,6 +90,7 @@ class RawImpressionUploadServiceTest {
       rawImpressionUpload = rawImpressionUpload {
         doneBlobUri = DONE_BLOB_URI
         doneBlobGeneration = DONE_BLOB_GENERATION
+        doneBlobCreateTime = DONE_BLOB_CREATE_TIME.toProtoTime()
       }
       requestId = REQUEST_ID
     }
@@ -108,6 +110,7 @@ class RawImpressionUploadServiceTest {
           state = RawImpressionUpload.State.CREATED
           doneBlobUri = DONE_BLOB_URI
           doneBlobGeneration = DONE_BLOB_GENERATION
+          doneBlobCreateTime = DONE_BLOB_CREATE_TIME.toProtoTime()
           createTime = upload.createTime
           updateTime = upload.updateTime
         }
@@ -126,7 +129,8 @@ class RawImpressionUploadServiceTest {
           parent = DATA_PROVIDER_KEY.toName()
           rawImpressionUpload = rawImpressionUpload {
             doneBlobUri = DONE_BLOB_URI
-            doneBlobGeneration = 1L
+            doneBlobGeneration = 900L
+            doneBlobCreateTime = DONE_BLOB_CREATE_TIME.toProtoTime()
           }
           requestId = UUID.randomUUID().toString()
         }
@@ -138,7 +142,8 @@ class RawImpressionUploadServiceTest {
           parent = DATA_PROVIDER_KEY.toName()
           rawImpressionUpload = rawImpressionUpload {
             doneBlobUri = DONE_BLOB_URI
-            doneBlobGeneration = 2L
+            doneBlobGeneration = 120L
+            doneBlobCreateTime = DONE_BLOB_CREATE_TIME.plusSeconds(1).toProtoTime()
           }
           requestId = UUID.randomUUID().toString()
         }
@@ -150,6 +155,34 @@ class RawImpressionUploadServiceTest {
       )
       .isEqualTo(replacement)
   }
+
+  @Test
+  fun `markRawImpressionUploadRegistrationComplete finalizes upload registration`(): Unit =
+    runBlocking {
+      val upload =
+        service.createRawImpressionUpload(
+          createRawImpressionUploadRequest {
+            parent = DATA_PROVIDER_KEY.toName()
+            rawImpressionUpload = rawImpressionUpload {
+              doneBlobUri = DONE_BLOB_URI
+              doneBlobGeneration = DONE_BLOB_GENERATION
+              doneBlobCreateTime = DONE_BLOB_CREATE_TIME.toProtoTime()
+            }
+            requestId = UUID.randomUUID().toString()
+          }
+        )
+
+      val completed =
+        service.markRawImpressionUploadRegistrationComplete(
+          markRawImpressionUploadRegistrationCompleteRequest {
+            name = upload.name
+            requestId = UUID.randomUUID().toString()
+          }
+        )
+
+      assertThat(completed.registrationComplete).isTrue()
+      assertThat(completed.state).isEqualTo(RawImpressionUpload.State.COMPLETED)
+    }
 
   @Test
   fun `createRawImpressionUpload with requestId is idempotent`(): Unit = runBlocking {
@@ -345,6 +378,7 @@ class RawImpressionUploadServiceTest {
           rawImpressionUpload = rawImpressionUpload {
             doneBlobUri = DONE_BLOB_URI
             doneBlobGeneration = DONE_BLOB_GENERATION
+            doneBlobCreateTime = DONE_BLOB_CREATE_TIME.toProtoTime()
           }
           requestId = REQUEST_ID
         }
@@ -400,6 +434,7 @@ class RawImpressionUploadServiceTest {
           rawImpressionUpload = rawImpressionUpload {
             doneBlobUri = DONE_BLOB_URI
             doneBlobGeneration = DONE_BLOB_GENERATION
+            doneBlobCreateTime = DONE_BLOB_CREATE_TIME.toProtoTime()
           }
           requestId = UUID.randomUUID().toString()
         }
@@ -452,6 +487,7 @@ class RawImpressionUploadServiceTest {
           rawImpressionUpload = rawImpressionUpload {
             doneBlobUri = DONE_BLOB_URI
             doneBlobGeneration = DONE_BLOB_GENERATION
+            doneBlobCreateTime = DONE_BLOB_CREATE_TIME.toProtoTime()
           }
           requestId = UUID.randomUUID().toString()
         }
@@ -463,11 +499,12 @@ class RawImpressionUploadServiceTest {
           rawImpressionUpload = rawImpressionUpload {
             doneBlobUri = DONE_BLOB_URI
             doneBlobGeneration = DONE_BLOB_GENERATION + 1L
+            doneBlobCreateTime = DONE_BLOB_CREATE_TIME.plusSeconds(1).toProtoTime()
           }
           requestId = UUID.randomUUID().toString()
         }
       )
-    val sortedCreated = listOf(created1, created2).sortedBy { it.name }
+    val sortedCreatedNames = listOf(created1.name, created2.name).sorted()
 
     val firstResponse =
       service.listRawImpressionUploads(
@@ -492,9 +529,10 @@ class RawImpressionUploadServiceTest {
     assertThat(secondResponse.rawImpressionUploadsList).hasSize(1)
     assertThat(
         (firstResponse.rawImpressionUploadsList + secondResponse.rawImpressionUploadsList)
-          .sortedBy { it.name }
+          .map { it.name }
+          .sorted()
       )
-      .isEqualTo(sortedCreated)
+      .isEqualTo(sortedCreatedNames)
   }
 
   @Test
@@ -777,6 +815,7 @@ class RawImpressionUploadServiceTest {
     private val REQUEST_ID = UUID.randomUUID().toString()
     private const val DONE_BLOB_URI = "gs://test-bucket/2026-06-16/done"
     private const val DONE_BLOB_GENERATION = 1234L
+    private val DONE_BLOB_CREATE_TIME = Instant.parse("2026-06-16T00:00:00Z")
     // An enum number that is not part of RawImpressionUpload.State, forcing UNRECOGNIZED.
     private const val UNRECOGNIZED_STATE_VALUE = 999
   }

--- a/src/test/kotlin/org/wfanet/measurement/edpaggregator/service/v1alpha/RawImpressionUploadServiceTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/edpaggregator/service/v1alpha/RawImpressionUploadServiceTest.kt
@@ -102,6 +102,7 @@ class RawImpressionUploadServiceTest {
     assertThat(uploadKey.rawImpressionUploadId).isNotEmpty()
     assertThat(upload.createTime.toInstant()).isGreaterThan(startTime)
     assertThat(upload.updateTime).isEqualTo(upload.createTime)
+    assertThat(upload.etag).isNotEmpty()
     // Verify the entire response, substituting the non-deterministic resource name and timestamps.
     assertThat(upload)
       .isEqualTo(
@@ -113,6 +114,7 @@ class RawImpressionUploadServiceTest {
           doneBlobCreateTime = DONE_BLOB_CREATE_TIME.toProtoTime()
           createTime = upload.createTime
           updateTime = upload.updateTime
+          etag = upload.etag
         }
       )
     // Verify the upload was persisted by reading it back.
@@ -176,6 +178,7 @@ class RawImpressionUploadServiceTest {
         service.markRawImpressionUploadRegistrationComplete(
           markRawImpressionUploadRegistrationCompleteRequest {
             name = upload.name
+            etag = upload.etag
             requestId = UUID.randomUUID().toString()
           }
         )
@@ -183,6 +186,70 @@ class RawImpressionUploadServiceTest {
       assertThat(completed.registrationComplete).isTrue()
       assertThat(completed.state).isEqualTo(RawImpressionUpload.State.COMPLETED)
     }
+
+  @Test
+  fun `markRawImpressionUploadRegistrationComplete throws INVALID_ARGUMENT for missing etag`() =
+    runBlocking {
+      val upload =
+        service.createRawImpressionUpload(
+          createRawImpressionUploadRequest {
+            parent = DATA_PROVIDER_KEY.toName()
+            rawImpressionUpload = rawImpressionUpload {
+              doneBlobUri = DONE_BLOB_URI
+              doneBlobGeneration = DONE_BLOB_GENERATION
+            }
+            requestId = UUID.randomUUID().toString()
+          }
+        )
+
+      val exception =
+        assertFailsWith<StatusRuntimeException> {
+          service.markRawImpressionUploadRegistrationComplete(
+            markRawImpressionUploadRegistrationCompleteRequest {
+              name = upload.name
+              requestId = UUID.randomUUID().toString()
+            }
+          )
+        }
+
+      assertThat(exception.status.code).isEqualTo(Status.Code.INVALID_ARGUMENT)
+      assertThat(exception.errorInfo)
+        .isEqualTo(
+          errorInfo {
+            domain = Errors.DOMAIN
+            reason = Errors.Reason.REQUIRED_FIELD_NOT_SET.name
+            metadata[Errors.Metadata.FIELD_NAME.key] = "etag"
+          }
+        )
+    }
+
+  @Test
+  fun `markRawImpressionUploadRegistrationComplete forwards stale etag as ABORTED`() = runBlocking {
+    val upload =
+      service.createRawImpressionUpload(
+        createRawImpressionUploadRequest {
+          parent = DATA_PROVIDER_KEY.toName()
+          rawImpressionUpload = rawImpressionUpload {
+            doneBlobUri = DONE_BLOB_URI
+            doneBlobGeneration = DONE_BLOB_GENERATION
+          }
+          requestId = UUID.randomUUID().toString()
+        }
+      )
+
+    val exception =
+      assertFailsWith<StatusRuntimeException> {
+        service.markRawImpressionUploadRegistrationComplete(
+          markRawImpressionUploadRegistrationCompleteRequest {
+            name = upload.name
+            etag = "stale-etag"
+            requestId = UUID.randomUUID().toString()
+          }
+        )
+      }
+
+    assertThat(exception.status.code).isEqualTo(Status.Code.ABORTED)
+  }
 
   @Test
   fun `createRawImpressionUpload with requestId is idempotent`(): Unit = runBlocking {

--- a/src/test/kotlin/org/wfanet/measurement/edpaggregator/vidlabeling/RequestIdsTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/edpaggregator/vidlabeling/RequestIdsTest.kt
@@ -29,6 +29,8 @@ class RequestIdsTest {
   fun `request ids are stable across calls`() {
     assertThat(RequestIds.forRawImpressionUpload(DONE_BLOB, 1L))
       .isEqualTo(RequestIds.forRawImpressionUpload(DONE_BLOB, 1L))
+    assertThat(RequestIds.forRawImpressionUploadRegistrationComplete(UPLOAD))
+      .isEqualTo(RequestIds.forRawImpressionUploadRegistrationComplete(UPLOAD))
     assertThat(RequestIds.forRawImpressionUploadFile(UPLOAD, FILE_URI))
       .isEqualTo(RequestIds.forRawImpressionUploadFile(UPLOAD, FILE_URI))
     assertThat(RequestIds.forRawImpressionUploadModelLine(UPLOAD, MODEL_LINE))
@@ -69,6 +71,7 @@ class RequestIdsTest {
     val ids =
       listOf(
         RequestIds.forRawImpressionUpload(DONE_BLOB, 1L),
+        RequestIds.forRawImpressionUploadRegistrationComplete(UPLOAD),
         RequestIds.forRawImpressionUploadFile(UPLOAD, FILE_URI),
         RequestIds.forRawImpressionUploadModelLine(UPLOAD, MODEL_LINE),
         RequestIds.forPoolAssignmentJob(UPLOAD, MODEL_LINE, 0),

--- a/src/test/kotlin/org/wfanet/measurement/edpaggregator/vidlabeling/RequestIdsTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/edpaggregator/vidlabeling/RequestIdsTest.kt
@@ -29,8 +29,8 @@ class RequestIdsTest {
   fun `request ids are stable across calls`() {
     assertThat(RequestIds.forRawImpressionUpload(DONE_BLOB, 1L))
       .isEqualTo(RequestIds.forRawImpressionUpload(DONE_BLOB, 1L))
-    assertThat(RequestIds.forRawImpressionUploadRegistrationComplete(UPLOAD))
-      .isEqualTo(RequestIds.forRawImpressionUploadRegistrationComplete(UPLOAD))
+    assertThat(RequestIds.forRawImpressionUploadRegistrationComplete(UPLOAD, ETAG))
+      .isEqualTo(RequestIds.forRawImpressionUploadRegistrationComplete(UPLOAD, ETAG))
     assertThat(RequestIds.forRawImpressionUploadFile(UPLOAD, FILE_URI))
       .isEqualTo(RequestIds.forRawImpressionUploadFile(UPLOAD, FILE_URI))
     assertThat(RequestIds.forRawImpressionUploadModelLine(UPLOAD, MODEL_LINE))
@@ -41,6 +41,12 @@ class RequestIdsTest {
   fun `upload request id differs by generation`() {
     assertThat(RequestIds.forRawImpressionUpload(DONE_BLOB, 1L))
       .isNotEqualTo(RequestIds.forRawImpressionUpload(DONE_BLOB, 2L))
+  }
+
+  @Test
+  fun `registration completion request id differs by etag`() {
+    assertThat(RequestIds.forRawImpressionUploadRegistrationComplete(UPLOAD, ETAG))
+      .isNotEqualTo(RequestIds.forRawImpressionUploadRegistrationComplete(UPLOAD, "new-etag"))
   }
 
   @Test
@@ -71,7 +77,7 @@ class RequestIdsTest {
     val ids =
       listOf(
         RequestIds.forRawImpressionUpload(DONE_BLOB, 1L),
-        RequestIds.forRawImpressionUploadRegistrationComplete(UPLOAD),
+        RequestIds.forRawImpressionUploadRegistrationComplete(UPLOAD, ETAG),
         RequestIds.forRawImpressionUploadFile(UPLOAD, FILE_URI),
         RequestIds.forRawImpressionUploadModelLine(UPLOAD, MODEL_LINE),
         RequestIds.forPoolAssignmentJob(UPLOAD, MODEL_LINE, 0),

--- a/src/test/kotlin/org/wfanet/measurement/edpaggregator/vidlabeling/VidLabelingDispatcherTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/edpaggregator/vidlabeling/VidLabelingDispatcherTest.kt
@@ -522,8 +522,13 @@ class VidLabelingDispatcherTest {
       whenever(storageClient.listBlobs(any())).thenReturn(flowOf(blob))
       stubRawImpressionUploadCreation()
       whenever(modelLinesService.listModelLines(any())).thenReturn(listModelLinesResponse {})
+      val metadataWrite = RecordingThrottler()
 
-      val dispatcher = createDispatcher()
+      val dispatcher =
+        createDispatcher(
+          rpcThrottlers =
+            VidLabelingRpcThrottlersTestHelper.alwaysReady().copy(metadataWrite = metadataWrite)
+        )
       dispatcher.upload(DONE_BLOB_PATH, DONE_BLOB_GENERATION)
 
       verifyBlocking(rawImpressionUploadService) { createRawImpressionUpload(any()) }
@@ -534,6 +539,7 @@ class VidLabelingDispatcherTest {
       verifyBlocking(rawImpressionUploadService) {
         markRawImpressionUploadRegistrationComplete(any())
       }
+      assertThat(metadataWrite.onReadyCalls).isEqualTo(3)
     }
 
   @Test
@@ -601,20 +607,37 @@ class VidLabelingDispatcherTest {
   }
 
   @Test
-  fun `upload with same generation produces same request ID`() =
+  fun `upload with same generation succeeds when registration is already complete`() =
     runBlocking<Unit> {
       val blob = createMockBlob("$FOLDER_PREFIX/file1.parquet")
       whenever(storageClient.listBlobs(any())).thenReturn(flowOf(blob))
       stubRawImpressionUploadCreation()
       stubFullResolutionChain(MODEL_LINE_1)
+      val uploadName = "$DATA_PROVIDER_NAME/rawImpressionUploads/$RAW_IMPRESSION_UPLOAD_ID"
+      whenever(rawImpressionUploadService.createRawImpressionUpload(any()))
+        .thenReturn(
+          RawImpressionUpload.newBuilder()
+            .setName(uploadName)
+            .setDoneBlobUri(DONE_BLOB_PATH)
+            .setDoneBlobGeneration(123L)
+            .setEtag(UPLOAD_ETAG)
+            .build(),
+          RawImpressionUpload.newBuilder()
+            .setName(uploadName)
+            .setDoneBlobUri(DONE_BLOB_PATH)
+            .setDoneBlobGeneration(123L)
+            .setRegistrationComplete(true)
+            .setEtag("completed-$UPLOAD_ETAG")
+            .build(),
+        )
 
       val dispatcher =
         createDispatcher(
           readDoneBlobMetadata = { RawImpressionBlobMetadata(123L, 0L, DONE_BLOB_CREATE_TIME) }
         )
       dispatcher.upload(DONE_BLOB_PATH, doneBlobGeneration = 123L)
-
-      whenever(storageClient.listBlobs(any())).thenReturn(flowOf(blob))
+      // DataWatcher redelivers the same done-object generation after the first invocation has
+      // completed registration.
       dispatcher.upload(DONE_BLOB_PATH, doneBlobGeneration = 123L)
 
       val requestCaptor = argumentCaptor<CreateRawImpressionUploadRequest>()
@@ -627,6 +650,15 @@ class VidLabelingDispatcherTest {
         .containsExactly(123L, 123L)
       assertThat(requestCaptor.allValues.map { it.rawImpressionUpload.doneBlobCreateTime })
         .containsExactly(DONE_BLOB_CREATE_TIME.toProtoTime(), DONE_BLOB_CREATE_TIME.toProtoTime())
+      verifyBlocking(rawImpressionUploadFileService, times(1)) {
+        batchCreateRawImpressionUploadFiles(any())
+      }
+      verifyBlocking(rawImpressionUploadModelLineService, times(1)) {
+        batchCreateRawImpressionUploadModelLines(any())
+      }
+      verifyBlocking(rawImpressionUploadService, times(1)) {
+        markRawImpressionUploadRegistrationComplete(any())
+      }
     }
 
   @Test
@@ -847,12 +879,18 @@ class VidLabelingDispatcherTest {
                 .build()
           },
         )
+      val metadataRead = RecordingThrottler()
 
-      createDispatcher().upload(DONE_BLOB_PATH, DONE_BLOB_GENERATION)
+      createDispatcher(
+          rpcThrottlers =
+            VidLabelingRpcThrottlersTestHelper.alwaysReady().copy(metadataRead = metadataRead)
+        )
+        .upload(DONE_BLOB_PATH, DONE_BLOB_GENERATION)
 
       verifyBlocking(rawImpressionUploadFileService, never()) {
         batchCreateRawImpressionUploadFiles(any())
       }
+      assertThat(metadataRead.onReadyCalls).isEqualTo(2)
     }
 
   @Test

--- a/src/test/kotlin/org/wfanet/measurement/edpaggregator/vidlabeling/VidLabelingDispatcherTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/edpaggregator/vidlabeling/VidLabelingDispatcherTest.kt
@@ -289,6 +289,7 @@ class VidLabelingDispatcherTest {
         RawImpressionUpload.newBuilder()
           .setName("$DATA_PROVIDER_NAME/rawImpressionUploads/$RAW_IMPRESSION_UPLOAD_ID")
           .setDoneBlobUri(DONE_BLOB_PATH)
+          .setEtag(UPLOAD_ETAG)
           .build()
       )
     whenever(rawImpressionUploadFileService.batchCreateRawImpressionUploadFiles(any()))
@@ -304,6 +305,7 @@ class VidLabelingDispatcherTest {
         RawImpressionUpload.newBuilder()
           .setName("$DATA_PROVIDER_NAME/rawImpressionUploads/$RAW_IMPRESSION_UPLOAD_ID")
           .setRegistrationComplete(true)
+          .setEtag("completed-$UPLOAD_ETAG")
           .build()
       )
     // The post-registration fast path lists uploads; default to none so dispatch is a no-op unless
@@ -430,9 +432,13 @@ class VidLabelingDispatcherTest {
       // event_date is populated from each file's plaintext Parquet footer (readEventDate seam).
       assertThat(request.requestsList.map { it.rawImpressionUploadFile.eventDate })
         .containsExactly(EVENT_DATE_PROTO, EVENT_DATE_PROTO)
+      val completionCaptor = argumentCaptor<MarkRawImpressionUploadRegistrationCompleteRequest>()
       verifyBlocking(rawImpressionUploadService) {
-        markRawImpressionUploadRegistrationComplete(any())
+        markRawImpressionUploadRegistrationComplete(completionCaptor.capture())
       }
+      assertThat(completionCaptor.firstValue.etag).isEqualTo(UPLOAD_ETAG)
+      assertThat(completionCaptor.firstValue.requestId)
+        .isEqualTo(RequestIds.forRawImpressionUploadRegistrationComplete(uploadName, UPLOAD_ETAG))
     }
 
   @Test
@@ -800,6 +806,7 @@ class VidLabelingDispatcherTest {
                 .setName("$DATA_PROVIDER_NAME/rawImpressionUploads/$RAW_IMPRESSION_UPLOAD_ID")
                 .setDoneBlobUri(DONE_BLOB_PATH)
                 .setDoneBlobGeneration(DONE_BLOB_GENERATION)
+                .setEtag(UPLOAD_ETAG)
                 .build()
           }
         )
@@ -982,6 +989,7 @@ class VidLabelingDispatcherTest {
     private const val FOLDER_PREFIX = "/test-bucket/edp1/2024-01-15"
     private const val DONE_BLOB_PATH = "file://$FOLDER_PREFIX/done"
     private const val RAW_IMPRESSION_UPLOAD_ID = "upload-abc123"
+    private const val UPLOAD_ETAG = "upload-etag"
     private const val DONE_BLOB_GENERATION = 12345L
     private const val RAW_BLOB_GENERATION = 67890L
     private const val NUMBER_OF_SHARDS = 2

--- a/src/test/kotlin/org/wfanet/measurement/edpaggregator/vidlabeling/VidLabelingDispatcherTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/edpaggregator/vidlabeling/VidLabelingDispatcherTest.kt
@@ -611,6 +611,43 @@ class VidLabelingDispatcherTest {
     }
 
   @Test
+  fun `out of order done event does not register stale snapshot`() =
+    runBlocking<Unit> {
+      val blob = createMockBlob("$FOLDER_PREFIX/file1.parquet")
+      whenever(storageClient.listBlobs(any())).thenReturn(flowOf(blob))
+      stubRawImpressionUploadCreation()
+      stubFullResolutionChain(MODEL_LINE_1)
+      whenever(rawImpressionUploadService.createRawImpressionUpload(any())).thenAnswer {
+        throw StatusException(Status.ALREADY_EXISTS.withDescription("newer generation exists"))
+      }
+      whenever(rawImpressionUploadService.listRawImpressionUploads(any())).thenAnswer { invocation
+        ->
+        val request = invocation.getArgument<ListRawImpressionUploadsRequest>(0)
+        if (request.filter.doneBlobUri == DONE_BLOB_PATH) {
+          listRawImpressionUploadsResponse {
+            rawImpressionUploads +=
+              RawImpressionUpload.newBuilder()
+                .setName("$DATA_PROVIDER_NAME/rawImpressionUploads/newer")
+                .setDoneBlobUri(DONE_BLOB_PATH)
+                .setDoneBlobGeneration(200L)
+                .build()
+          }
+        } else {
+          listRawImpressionUploadsResponse {}
+        }
+      }
+
+      createDispatcher().upload(DONE_BLOB_PATH, doneBlobGeneration = 150L)
+
+      verifyBlocking(rawImpressionUploadFileService, never()) {
+        batchCreateRawImpressionUploadFiles(any())
+      }
+      verifyBlocking(rawImpressionUploadModelLineService, never()) {
+        batchCreateRawImpressionUploadModelLines(any())
+      }
+    }
+
+  @Test
   fun `upload chunks RawImpressionUploadFiles at batch size 100`() =
     runBlocking<Unit> {
       val blobs = (1..250).map { createMockBlob("$FOLDER_PREFIX/file$it.parquet") }
@@ -675,8 +712,14 @@ class VidLabelingDispatcherTest {
       stubFullResolutionChain(MODEL_LINE_1)
       // Dispatch (best-effort) fails, but registration already succeeded, so upload() must not
       // throw.
-      whenever(rawImpressionUploadService.listRawImpressionUploads(any())).thenAnswer {
-        throw StatusException(Status.UNAVAILABLE.withDescription("metadata store unavailable"))
+      whenever(rawImpressionUploadService.listRawImpressionUploads(any())).thenAnswer { invocation
+        ->
+        val request = invocation.getArgument<ListRawImpressionUploadsRequest>(0)
+        if (request.filter.doneBlobUri.isNotEmpty()) {
+          listRawImpressionUploadsResponse {}
+        } else {
+          throw StatusException(Status.UNAVAILABLE.withDescription("metadata store unavailable"))
+        }
       }
 
       val dispatcher = createDispatcher()

--- a/src/test/kotlin/org/wfanet/measurement/edpaggregator/vidlabeling/VidLabelingDispatcherTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/edpaggregator/vidlabeling/VidLabelingDispatcherTest.kt
@@ -46,6 +46,7 @@ import org.mockito.kotlin.atLeastOnce
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
 import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
 import org.mockito.kotlin.verifyBlocking
 import org.mockito.kotlin.whenever
 import org.wfanet.measurement.api.v2alpha.ModelLine
@@ -62,6 +63,7 @@ import org.wfanet.measurement.common.Instrumentation
 import org.wfanet.measurement.common.grpc.testing.GrpcTestServerRule
 import org.wfanet.measurement.common.grpc.testing.mockService
 import org.wfanet.measurement.common.throttler.Throttler
+import org.wfanet.measurement.common.toProtoTime
 import org.wfanet.measurement.edpaggregator.VidLabelingRpcThrottlers
 import org.wfanet.measurement.edpaggregator.rawimpressions.generationMatchedBlobUri
 import org.wfanet.measurement.edpaggregator.testing.VidLabelingRpcThrottlersTestHelper
@@ -70,6 +72,7 @@ import org.wfanet.measurement.edpaggregator.v1alpha.BatchCreateRawImpressionUplo
 import org.wfanet.measurement.edpaggregator.v1alpha.CreateRawImpressionUploadRequest
 import org.wfanet.measurement.edpaggregator.v1alpha.LabelerInputFieldMapping
 import org.wfanet.measurement.edpaggregator.v1alpha.ListRawImpressionUploadsRequest
+import org.wfanet.measurement.edpaggregator.v1alpha.MarkRawImpressionUploadRegistrationCompleteRequest
 import org.wfanet.measurement.edpaggregator.v1alpha.PoolAssignmentJobServiceGrpcKt
 import org.wfanet.measurement.edpaggregator.v1alpha.RawImpressionUpload
 import org.wfanet.measurement.edpaggregator.v1alpha.RawImpressionUploadFileServiceGrpcKt
@@ -231,7 +234,10 @@ class VidLabelingDispatcherTest {
     modelLineConfigs: Map<String, VidLabelerParams.ModelLineConfig> = DEFAULT_MODEL_LINE_CONFIGS,
     readEventDate: suspend (String) -> LocalDate = { EVENT_DATE },
     readBlobMetadata: suspend (String) -> RawImpressionBlobMetadata = {
-      RawImpressionBlobMetadata(RAW_BLOB_GENERATION, 100L)
+      RawImpressionBlobMetadata(RAW_BLOB_GENERATION, 100L, RAW_BLOB_CREATE_TIME)
+    },
+    readDoneBlobMetadata: suspend () -> RawImpressionBlobMetadata = {
+      RawImpressionBlobMetadata(DONE_BLOB_GENERATION, 0L, DONE_BLOB_CREATE_TIME)
     },
     metrics: VidLabelingDispatcherMetrics = VidLabelingDispatcherMetrics(),
     rpcThrottlers: VidLabelingRpcThrottlers = VidLabelingRpcThrottlersTestHelper.alwaysReady(),
@@ -248,7 +254,13 @@ class VidLabelingDispatcherTest {
       overrideModelLines = overrideModelLines,
       modelLineConfigs = modelLineConfigs,
       readEventDate = readEventDate,
-      readBlobMetadata = readBlobMetadata,
+      readBlobMetadata = { blobKey ->
+        if (blobKey.substringAfterLast("/").equals("done", ignoreCase = true)) {
+          readDoneBlobMetadata()
+        } else {
+          readBlobMetadata(blobKey)
+        }
+      },
       rpcThrottlers = rpcThrottlers,
       clock = fixedClock,
       metrics = metrics,
@@ -283,6 +295,17 @@ class VidLabelingDispatcherTest {
       .thenReturn(batchCreateRawImpressionUploadFilesResponse {})
     whenever(rawImpressionUploadModelLineService.batchCreateRawImpressionUploadModelLines(any()))
       .thenReturn(batchCreateRawImpressionUploadModelLinesResponse {})
+    whenever(
+        rawImpressionUploadService.markRawImpressionUploadRegistrationComplete(
+          any<MarkRawImpressionUploadRegistrationCompleteRequest>()
+        )
+      )
+      .thenReturn(
+        RawImpressionUpload.newBuilder()
+          .setName("$DATA_PROVIDER_NAME/rawImpressionUploads/$RAW_IMPRESSION_UPLOAD_ID")
+          .setRegistrationComplete(true)
+          .build()
+      )
     // The post-registration fast path lists uploads; default to none so dispatch is a no-op unless
     // a test overrides this.
     whenever(rawImpressionUploadService.listRawImpressionUploads(any()))
@@ -380,6 +403,7 @@ class VidLabelingDispatcherTest {
                 blob2.blobKey -> 222L
                 else -> error("Unexpected blob: $blobKey")
               },
+              RAW_BLOB_CREATE_TIME,
             )
           }
         )
@@ -406,6 +430,9 @@ class VidLabelingDispatcherTest {
       // event_date is populated from each file's plaintext Parquet footer (readEventDate seam).
       assertThat(request.requestsList.map { it.rawImpressionUploadFile.eventDate })
         .containsExactly(EVENT_DATE_PROTO, EVENT_DATE_PROTO)
+      verifyBlocking(rawImpressionUploadService) {
+        markRawImpressionUploadRegistrationComplete(any())
+      }
     }
 
   @Test
@@ -446,7 +473,9 @@ class VidLabelingDispatcherTest {
 
     val dispatcher =
       createDispatcher(
-        readBlobMetadata = { RawImpressionBlobMetadata(RAW_BLOB_GENERATION, 123L) },
+        readBlobMetadata = {
+          RawImpressionBlobMetadata(RAW_BLOB_GENERATION, 123L, RAW_BLOB_CREATE_TIME)
+        },
         readEventDate = {
           footerPath = it
           EVENT_DATE
@@ -495,6 +524,9 @@ class VidLabelingDispatcherTest {
       verifyBlocking(rawImpressionUploadFileService) { batchCreateRawImpressionUploadFiles(any()) }
       verifyBlocking(rawImpressionUploadModelLineService, never()) {
         batchCreateRawImpressionUploadModelLines(any())
+      }
+      verifyBlocking(rawImpressionUploadService) {
+        markRawImpressionUploadRegistrationComplete(any())
       }
     }
 
@@ -570,7 +602,10 @@ class VidLabelingDispatcherTest {
       stubRawImpressionUploadCreation()
       stubFullResolutionChain(MODEL_LINE_1)
 
-      val dispatcher = createDispatcher()
+      val dispatcher =
+        createDispatcher(
+          readDoneBlobMetadata = { RawImpressionBlobMetadata(123L, 0L, DONE_BLOB_CREATE_TIME) }
+        )
       dispatcher.upload(DONE_BLOB_PATH, doneBlobGeneration = 123L)
 
       whenever(storageClient.listBlobs(any())).thenReturn(flowOf(blob))
@@ -584,6 +619,8 @@ class VidLabelingDispatcherTest {
         .isEqualTo(requestCaptor.allValues[1].requestId)
       assertThat(requestCaptor.allValues.map { it.rawImpressionUpload.doneBlobGeneration })
         .containsExactly(123L, 123L)
+      assertThat(requestCaptor.allValues.map { it.rawImpressionUpload.doneBlobCreateTime })
+        .containsExactly(DONE_BLOB_CREATE_TIME.toProtoTime(), DONE_BLOB_CREATE_TIME.toProtoTime())
     }
 
   @Test
@@ -594,10 +631,17 @@ class VidLabelingDispatcherTest {
       stubRawImpressionUploadCreation()
       stubFullResolutionChain(MODEL_LINE_1)
 
-      val dispatcher = createDispatcher()
+      var liveGeneration = 123L
+      var liveCreateTime = DONE_BLOB_CREATE_TIME
+      val dispatcher =
+        createDispatcher(
+          readDoneBlobMetadata = { RawImpressionBlobMetadata(liveGeneration, 0L, liveCreateTime) }
+        )
       dispatcher.upload(DONE_BLOB_PATH, doneBlobGeneration = 123L)
 
       whenever(storageClient.listBlobs(any())).thenReturn(flowOf(blob))
+      liveGeneration = 456L
+      liveCreateTime = DONE_BLOB_CREATE_TIME.plusSeconds(1)
       dispatcher.upload(DONE_BLOB_PATH, doneBlobGeneration = 456L)
 
       val requestCaptor = argumentCaptor<CreateRawImpressionUploadRequest>()
@@ -611,40 +655,44 @@ class VidLabelingDispatcherTest {
     }
 
   @Test
-  fun `out of order done event does not register stale snapshot`() =
+  fun `upload ignores stale done event before listing files`() =
     runBlocking<Unit> {
       val blob = createMockBlob("$FOLDER_PREFIX/file1.parquet")
       whenever(storageClient.listBlobs(any())).thenReturn(flowOf(blob))
       stubRawImpressionUploadCreation()
       stubFullResolutionChain(MODEL_LINE_1)
-      whenever(rawImpressionUploadService.createRawImpressionUpload(any())).thenAnswer {
-        throw StatusException(Status.ALREADY_EXISTS.withDescription("newer generation exists"))
-      }
-      whenever(rawImpressionUploadService.listRawImpressionUploads(any())).thenAnswer { invocation
-        ->
-        val request = invocation.getArgument<ListRawImpressionUploadsRequest>(0)
-        if (request.filter.doneBlobUri == DONE_BLOB_PATH) {
-          listRawImpressionUploadsResponse {
-            rawImpressionUploads +=
-              RawImpressionUpload.newBuilder()
-                .setName("$DATA_PROVIDER_NAME/rawImpressionUploads/newer")
-                .setDoneBlobUri(DONE_BLOB_PATH)
-                .setDoneBlobGeneration(200L)
-                .build()
+
+      createDispatcher(
+          readDoneBlobMetadata = {
+            RawImpressionBlobMetadata(200L, 0L, DONE_BLOB_CREATE_TIME.plusSeconds(1))
           }
-        } else {
-          listRawImpressionUploadsResponse {}
-        }
-      }
+        )
+        .upload(DONE_BLOB_PATH, doneBlobGeneration = 150L)
 
-      createDispatcher().upload(DONE_BLOB_PATH, doneBlobGeneration = 150L)
+      verify(storageClient, never()).listBlobs(any())
+      verifyBlocking(rawImpressionUploadService, never()) { createRawImpressionUpload(any()) }
+    }
 
-      verifyBlocking(rawImpressionUploadFileService, never()) {
-        batchCreateRawImpressionUploadFiles(any())
-      }
-      verifyBlocking(rawImpressionUploadModelLineService, never()) {
-        batchCreateRawImpressionUploadModelLines(any())
-      }
+  @Test
+  fun `upload ignores done event when done object changes during listing`() =
+    runBlocking<Unit> {
+      val blob = createMockBlob("$FOLDER_PREFIX/file1.parquet")
+      whenever(storageClient.listBlobs(any())).thenReturn(flowOf(blob))
+      var metadataReadCount = 0
+
+      createDispatcher(
+          readDoneBlobMetadata = {
+            metadataReadCount++
+            if (metadataReadCount == 1) {
+              RawImpressionBlobMetadata(150L, 0L, DONE_BLOB_CREATE_TIME)
+            } else {
+              RawImpressionBlobMetadata(200L, 0L, DONE_BLOB_CREATE_TIME.plusSeconds(1))
+            }
+          }
+        )
+        .upload(DONE_BLOB_PATH, doneBlobGeneration = 150L)
+
+      verifyBlocking(rawImpressionUploadService, never()) { createRawImpressionUpload(any()) }
     }
 
   @Test
@@ -768,6 +816,35 @@ class VidLabelingDispatcherTest {
       verifyBlocking(rawImpressionUploadFileService) { batchCreateRawImpressionUploadFiles(any()) }
       verifyBlocking(rawImpressionUploadModelLineService) {
         batchCreateRawImpressionUploadModelLines(any())
+      }
+    }
+
+  @Test
+  fun `upload acks when a newer upload wins after the final done generation check`() =
+    runBlocking<Unit> {
+      val blob = createMockBlob("$FOLDER_PREFIX/file1.parquet")
+      whenever(storageClient.listBlobs(any())).thenReturn(flowOf(blob))
+      whenever(rawImpressionUploadService.createRawImpressionUpload(any())).thenAnswer {
+        throw StatusException(Status.ALREADY_EXISTS.withDescription("newer upload exists"))
+      }
+      whenever(rawImpressionUploadService.listRawImpressionUploads(any()))
+        .thenReturn(
+          listRawImpressionUploadsResponse {},
+          listRawImpressionUploadsResponse {
+            rawImpressionUploads +=
+              RawImpressionUpload.newBuilder()
+                .setName("$DATA_PROVIDER_NAME/rawImpressionUploads/newer-upload")
+                .setDoneBlobUri(DONE_BLOB_PATH)
+                .setDoneBlobGeneration(DONE_BLOB_GENERATION + 1L)
+                .setDoneBlobCreateTime(DONE_BLOB_CREATE_TIME.plusSeconds(1).toProtoTime())
+                .build()
+          },
+        )
+
+      createDispatcher().upload(DONE_BLOB_PATH, DONE_BLOB_GENERATION)
+
+      verifyBlocking(rawImpressionUploadFileService, never()) {
+        batchCreateRawImpressionUploadFiles(any())
       }
     }
 
@@ -913,6 +990,8 @@ class VidLabelingDispatcherTest {
     private const val POOL_ASSIGNER_QUEUE_NAME = "queues/pool-assigner"
 
     private val FIXED_NOW: Instant = Instant.parse("2026-06-03T12:00:00Z")
+    private val DONE_BLOB_CREATE_TIME: Instant = Instant.parse("2026-06-03T11:00:00Z")
+    private val RAW_BLOB_CREATE_TIME: Instant = Instant.parse("2026-06-03T10:00:00Z")
     private val EVENT_DATE: LocalDate = LocalDate.parse("2026-06-01")
     private val EVENT_DATE_PROTO = date {
       year = 2026

--- a/src/test/kotlin/org/wfanet/measurement/edpaggregator/vidlabeling/VidLabelingDispatcherTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/edpaggregator/vidlabeling/VidLabelingDispatcherTest.kt
@@ -543,6 +543,24 @@ class VidLabelingDispatcherTest {
     }
 
   @Test
+  fun `upload wraps registration completion RPC failure`() = runBlocking {
+    val blob = createMockBlob("$FOLDER_PREFIX/file1.parquet")
+    whenever(storageClient.listBlobs(any())).thenReturn(flowOf(blob))
+    stubRawImpressionUploadCreation()
+    whenever(modelLinesService.listModelLines(any())).thenReturn(listModelLinesResponse {})
+    whenever(rawImpressionUploadService.markRawImpressionUploadRegistrationComplete(any()))
+      .thenAnswer {
+        throw StatusException(Status.UNAVAILABLE.withDescription("metadata store unavailable"))
+      }
+
+    val exception =
+      assertFailsWith<Exception> { createDispatcher().upload(DONE_BLOB_PATH, DONE_BLOB_GENERATION) }
+
+    assertThat(exception).hasMessageThat().contains("Error marking RawImpressionUpload")
+    assertThat(exception).hasCauseThat().isInstanceOf(StatusException::class.java)
+  }
+
+  @Test
   fun `upload excludes done marker from file list`() = runBlocking {
     val blob = createMockBlob("$FOLDER_PREFIX/file1.parquet")
     val doneBlob = createMockBlob("$FOLDER_PREFIX/done")


### PR DESCRIPTION
Records an atomic revision chain when a new generation of the same done-object path is registered. The Spanner create transaction selects the current head, rejects stale generations, and links the new upload to its predecessor. Each accepted upload stores a complete immutable snapshot of the raw files present for that revision, including their GCS generations.

The dispatcher treats delayed stale done events as successful no-ops while preserving idempotent redelivery for the exact same generation.

Issue: #4428