### PR TITLE
fix(edpaggregator): Count occupied backfill rank collisions

### DIFF
--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/vidrankbuilder/RankAllocator.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/vidrankbuilder/RankAllocator.kt
@@ -322,6 +322,7 @@ class RankAllocator(
     if (hasOld) {
       dayOnly.put(keyHi, keyLo, oldRank)
       backfillReusedOldRank++
+      backfillRankCollisions++
       return oldRank
     }
     dayOnly.put(keyHi, keyLo, newRank)

--- a/src/test/kotlin/org/wfanet/measurement/edpaggregator/vidrankbuilder/RankAllocatorTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/edpaggregator/vidrankbuilder/RankAllocatorTest.kt
@@ -246,7 +246,7 @@ class RankAllocatorTest {
     assertThat(allocator.get(1L, 0)).isEqualTo(0) // cumulative gets a fresh free rank instead
     assertThat(allocator.allocated).isEqualTo(1)
     assertThat(allocator.backfillReusedOldRank).isEqualTo(1)
-    assertThat(allocator.backfillRankCollisions).isEqualTo(0) // not in the latest snapshot
+    assertThat(allocator.backfillRankCollisions).isEqualTo(1)
   }
 
   @Test

--- a/src/test/kotlin/org/wfanet/measurement/edpaggregator/vidrankbuilder/SubpoolRankerTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/edpaggregator/vidrankbuilder/SubpoolRankerTest.kt
@@ -562,7 +562,7 @@ class SubpoolRankerTest {
 
       assertThat(result.backfill).isTrue()
       assertThat(result.backfillReusedOldRank).isEqualTo(1)
-      assertThat(result.backfillRankCollisions).isEqualTo(0) // F1 is not in the latest snapshot
+      assertThat(result.backfillRankCollisions).isEqualTo(1)
       // The backfilled day is labeled with the original rank 5 (shared with Bob — accepted
       // undercount)...
       assertThat(readDayOnly().mapValues { it.value.first }).containsExactly(1L to 0, 5)


### PR DESCRIPTION
Count a backfill collision when a fingerprint's historical rank is occupied by a different fingerprint in the latest cumulative snapshot. This keeps the existing DAY_ONLY and cumulative rank behavior while making the documented undercount visible through metrics and warning logs.

Tests:
- `//src/test/kotlin/org/wfanet/measurement/edpaggregator/vidrankbuilder:RankAllocatorTest`
- `//src/test/kotlin/org/wfanet/measurement/edpaggregator/vidrankbuilder:SubpoolRankerTest`

Issue: #4442