### PR TITLE
fix(common): make TokenBucket cancellation-safe

### DIFF
--- a/src/main/kotlin/org/wfanet/measurement/common/ratelimit/TokenBucket.kt
+++ b/src/main/kotlin/org/wfanet/measurement/common/ratelimit/TokenBucket.kt
@@ -86,6 +86,7 @@ class TokenBucket(
         }
       }
     }
+    var permitAcquired = false
     try {
       while (acquirer.job.isActive) {
         refill()
@@ -99,9 +100,14 @@ class TokenBucket(
         }
       }
       acquirer.job.join()
+      permitAcquired = true
     } finally {
       synchronized(this) {
         if (acquirers.remove(acquirer)) {
+          releaseAcquirers()
+        } else if (acquirer.isGranted && !permitAcquired) {
+          acquirer.isGranted = false
+          tokenCount.updateAndGet { count -> (count + acquirer.permitCount).coerceAtMost(size) }
           releaseAcquirers()
         }
       }
@@ -157,6 +163,7 @@ class TokenBucket(
         // was actually granted the permit so that a canceled waiter cannot reduce capacity.
         if (acquirer.job.complete()) {
           check(tryConsumeTokens(acquirer.permitCount))
+          acquirer.isGranted = true
         }
       } else {
         break
@@ -164,5 +171,8 @@ class TokenBucket(
     }
   }
 
-  private data class Acquirer(val permitCount: Int, val job: CompletableJob)
+  private class Acquirer(val permitCount: Int, val job: CompletableJob) {
+    /** Whether tokens were removed from the bucket for this acquirer, guarded by the bucket. */
+    var isGranted: Boolean = false
+  }
 }

--- a/src/main/kotlin/org/wfanet/measurement/common/ratelimit/TokenBucket.kt
+++ b/src/main/kotlin/org/wfanet/measurement/common/ratelimit/TokenBucket.kt
@@ -23,6 +23,7 @@ import kotlin.time.ComparableTimeMark
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.seconds
 import kotlin.time.TimeSource
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CompletableJob
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.awaitCancellation
@@ -76,15 +77,35 @@ class TokenBucket(
 
     val acquirer = Acquirer(permitCount, Job(coroutineContext[Job]))
     synchronized(this) { acquirers.add(acquirer) }
-    while (acquirer.job.isActive) {
-      refill()
-
-      val tokensNeeded = permitCount - tokenCount.get()
-      if (tokensNeeded > 0) {
-        delay(refillTime * tokensNeeded)
+    acquirer.job.invokeOnCompletion { cause ->
+      if (cause is CancellationException) {
+        synchronized(this) {
+          if (acquirers.remove(acquirer)) {
+            releaseAcquirers()
+          }
+        }
       }
     }
-    acquirer.job.join()
+    try {
+      while (acquirer.job.isActive) {
+        refill()
+        if (!acquirer.job.isActive) {
+          break
+        }
+
+        val tokensNeeded = permitCount - tokenCount.get()
+        if (tokensNeeded > 0) {
+          delay(refillTime * tokensNeeded)
+        }
+      }
+      acquirer.job.join()
+    } finally {
+      synchronized(this) {
+        if (acquirers.remove(acquirer)) {
+          releaseAcquirers()
+        }
+      }
+    }
   }
 
   /**
@@ -125,9 +146,18 @@ class TokenBucket(
     while (acquirers.isNotEmpty()) {
       val acquirer: Acquirer = acquirers.first() // Peek.
 
-      if (tryConsumeTokens(acquirer.permitCount)) {
+      if (!acquirer.job.isActive) {
+        acquirers.removeFirst()
+        continue
+      }
+
+      if (tokenCount.get() >= acquirer.permitCount) {
         acquirers.removeFirst() // Dequeue.
-        acquirer.job.complete()
+        // Completing can lose a race with cancellation. Only consume the tokens if this acquirer
+        // was actually granted the permit so that a canceled waiter cannot reduce capacity.
+        if (acquirer.job.complete()) {
+          check(tryConsumeTokens(acquirer.permitCount))
+        }
       } else {
         break
       }

--- a/src/test/kotlin/org/wfanet/measurement/common/ratelimit/BUILD.bazel
+++ b/src/test/kotlin/org/wfanet/measurement/common/ratelimit/BUILD.bazel
@@ -11,5 +11,7 @@ kt_jvm_test(
         "@wfa_common_jvm//imports/java/com/google/common/truth",
         "@wfa_common_jvm//imports/java/org/junit",
         "@wfa_common_jvm//imports/kotlin/kotlin/test",
+        "@wfa_common_jvm//imports/kotlin/kotlinx/coroutines:core",
+        "@wfa_common_jvm//imports/kotlin/kotlinx/coroutines/test",
     ],
 )

--- a/src/test/kotlin/org/wfanet/measurement/common/ratelimit/TokenBucketTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/common/ratelimit/TokenBucketTest.kt
@@ -137,4 +137,23 @@ class TokenBucketTest {
 
     assertThat(next.isCompleted).isTrue()
   }
+
+  @Test
+  @OptIn(ExperimentalCoroutinesApi::class)
+  fun `acquire returns token when canceled after grant before resume`() = runTest {
+    val tokenBucket = TokenBucket(1, 1.0, testScheduler.timeSource)
+    assertThat(tokenBucket.tryAcquire()).isTrue()
+
+    val waiter = launch { tokenBucket.acquire() }
+    runCurrent()
+    testScheduler.advanceTimeBy(1.seconds)
+
+    // Trigger the refill and grant from outside the suspended waiter without resuming it.
+    assertThat(tokenBucket.tryAcquire()).isFalse()
+    waiter.cancel()
+    runCurrent()
+
+    assertThat(waiter.isCancelled).isTrue()
+    assertThat(tokenBucket.tryAcquire()).isTrue()
+  }
 }

--- a/src/test/kotlin/org/wfanet/measurement/common/ratelimit/TokenBucketTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/common/ratelimit/TokenBucketTest.kt
@@ -20,6 +20,11 @@ import com.google.common.truth.Truth.assertThat
 import kotlin.test.assertFailsWith
 import kotlin.time.Duration.Companion.seconds
 import kotlin.time.TestTimeSource
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
@@ -112,5 +117,24 @@ class TokenBucketTest {
   fun `constructor throws when fill rate is not positive`() {
     assertFailsWith<IllegalArgumentException> { TokenBucket(5, 0.0, testTimeSource) }
     assertFailsWith<IllegalArgumentException> { TokenBucket(5, -1.0, testTimeSource) }
+  }
+
+  @Test
+  @OptIn(ExperimentalCoroutinesApi::class)
+  fun `acquire skips canceled waiter`() = runTest {
+    val tokenBucket = TokenBucket(1, 1.0, testScheduler.timeSource)
+    assertThat(tokenBucket.tryAcquire()).isTrue()
+
+    val canceled = launch { tokenBucket.acquire() }
+    runCurrent()
+    assertThat(canceled.isActive).isTrue()
+    canceled.cancelAndJoin()
+
+    val next = launch { tokenBucket.acquire() }
+    runCurrent()
+    testScheduler.advanceTimeBy(1.seconds)
+    runCurrent()
+
+    assertThat(next.isCompleted).isTrue()
   }
 }


### PR DESCRIPTION
Remove cancelled waiters from the token bucket queue without consuming capacity or blocking later callers.

Issue: #4427