### PR TITLE
fix: Correct ImpressionMetadata show_deleted semantics

### DIFF
--- a/docs/edpaggregator/metadata-operator-guide.md
+++ b/docs/edpaggregator/metadata-operator-guide.md
@@ -196,7 +196,7 @@ There are 6 secondary indexes (verified against the live schema):
 | `ImpressionMetadataByBlobUri` (unique) | no | Lookup / cleanup by exact blob URI. Entry on every create. |
 | `ImpressionMetadataByBlobUriPrefix` (non-unique) | no | Prefix lookup by blob URI. `BlobUri` is `NOT NULL`, so an entry on every create. |
 | `ImpressionMetadataByUpdateRequestId` (unique) | yes | Idempotency on update. `UpdateRequestId` is NULL on create, so no cost on the create path (only on update). |
-| `ImpressionMetadataByListFilterAndPagination` | no | Backs `ListImpressionMetadata` (model line + event group + interval) and pagination. Entry on every create. |
+| `ImpressionMetadataByListFilterAndPagination` | no | Backs `ListImpressionMetadata` (model line + event group + state + interval) and pagination. Entry on every create. |
 
 Entity keys live in an interleaved child table, `ImpressionMetadataEntityKeys`
 (`DataProviderResourceId`, `ImpressionMetadataId`, `EntityType`, `EntityId`),
@@ -211,10 +211,10 @@ list filter.
 `IntervalStartTime`, `IntervalEndTime`, `CreateTime`,
 `ImpressionMetadataResourceId`). The public filter exposes `model_line`,
 `event_group_reference_id`, `interval_overlaps`, `blob_uri_prefix`,
-`entity_keys`, and `blob_uris` (plus a `show_deleted` flag that governs whether
-soft-`DELETED` rows are returned — `State` is an index column, not a caller-set
-filter field). A filter that supplies the leading index columns (model line,
-then event group, then interval) is a range scan; one that omits them cannot use
+`entity_keys`, `blob_uris`, and `state` (plus a `show_deleted` flag that controls
+whether soft-`DELETED` rows are eligible to be returned). A filter that supplies
+the leading index columns (model line, then event group, then state, then
+interval) is a range scan; one that omits them cannot use
 the index efficiently.
 
 ## ImpressionMetadata service: behavior at scale

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/dataavailability/DataAvailabilityMonitor.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/dataavailability/DataAvailabilityMonitor.kt
@@ -28,6 +28,7 @@ import java.util.logging.Level
 import java.util.logging.Logger
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.flow.take
 import kotlinx.coroutines.flow.toList
@@ -414,6 +415,7 @@ class DataAvailabilityMonitor(
                 this.pageToken = pageToken
                 filter = listImpressionMetadataRequestFilter {
                   modelLine = modelLineName
+                  state = V1AlphaImpressionMetadata.State.DELETED
                   intervalOverlaps = spuriousInterval
                 }
               }
@@ -422,20 +424,22 @@ class DataAvailabilityMonitor(
         }
         .flattenConcat()
 
-    deletedEntries.collect { entry ->
-      val blobKey = SelectedStorageClient.parseBlobUri(entry.blobUri).key
-      val blob = storageClient.getBlob(blobKey)
-      blob?.let {
-        spuriousCount++
-        if (spuriousCount <= 10) {
-          logger.log(
-            Level.WARNING,
-            "Spurious deletion detected for model line $modelLineName: " +
-              "entry ${entry.name} is deleted but blob exists at ${entry.blobUri}",
-          )
-        }
-      } ?: legitimateCount++
-    }
+    deletedEntries
+      .filter { it.state == V1AlphaImpressionMetadata.State.DELETED }
+      .collect { entry ->
+        val blobKey = SelectedStorageClient.parseBlobUri(entry.blobUri).key
+        val blob = storageClient.getBlob(blobKey)
+        blob?.let {
+          spuriousCount++
+          if (spuriousCount <= 10) {
+            logger.log(
+              Level.WARNING,
+              "Spurious deletion detected for model line $modelLineName: " +
+                "entry ${entry.name} is deleted but blob exists at ${entry.blobUri}",
+            )
+          }
+        } ?: legitimateCount++
+      }
 
     logger.log(
       Level.INFO,

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/dataavailability/DataAvailabilityMonitor.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/dataavailability/DataAvailabilityMonitor.kt
@@ -28,7 +28,6 @@ import java.util.logging.Level
 import java.util.logging.Logger
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.flow.take
 import kotlinx.coroutines.flow.toList
@@ -424,22 +423,24 @@ class DataAvailabilityMonitor(
         }
         .flattenConcat()
 
-    deletedEntries
-      .filter { it.state == V1AlphaImpressionMetadata.State.DELETED }
-      .collect { entry ->
-        val blobKey = SelectedStorageClient.parseBlobUri(entry.blobUri).key
-        val blob = storageClient.getBlob(blobKey)
-        blob?.let {
-          spuriousCount++
-          if (spuriousCount <= 10) {
-            logger.log(
-              Level.WARNING,
-              "Spurious deletion detected for model line $modelLineName: " +
-                "entry ${entry.name} is deleted but blob exists at ${entry.blobUri}",
-            )
-          }
-        } ?: legitimateCount++
+    deletedEntries.collect { entry ->
+      // Fail closed if the service violates the requested state filter.
+      check(entry.state == V1AlphaImpressionMetadata.State.DELETED) {
+        "ListImpressionMetadata returned ${entry.state} for a DELETED state filter"
       }
+      val blobKey = SelectedStorageClient.parseBlobUri(entry.blobUri).key
+      val blob = storageClient.getBlob(blobKey)
+      blob?.let {
+        spuriousCount++
+        if (spuriousCount <= 10) {
+          logger.log(
+            Level.WARNING,
+            "Spurious deletion detected for model line $modelLineName: " +
+              "entry ${entry.name} is deleted but blob exists at ${entry.blobUri}",
+          )
+        }
+      } ?: legitimateCount++
+    }
 
     logger.log(
       Level.INFO,

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/service/v1alpha/ImpressionMetadataService.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/service/v1alpha/ImpressionMetadataService.kt
@@ -699,6 +699,17 @@ class ImpressionMetadataService(
       }
     }
 
+    if (request.filter.state == ImpressionMetadata.State.UNRECOGNIZED) {
+      throw InvalidFieldValueException("filter.state")
+        .asStatusRuntimeException(Status.Code.INVALID_ARGUMENT)
+    }
+    if (request.filter.state == ImpressionMetadata.State.DELETED && !request.showDeleted) {
+      throw InvalidFieldValueException("filter.state") { fieldName ->
+          "$fieldName cannot be DELETED unless show_deleted is true"
+        }
+        .asStatusRuntimeException(Status.Code.INVALID_ARGUMENT)
+    }
+
     val pageSize =
       if (request.pageSize == 0) {
         DEFAULT_PAGE_SIZE
@@ -738,10 +749,12 @@ class ImpressionMetadataService(
         }
 
         state =
-          if (!request.showDeleted) {
-            InternalImpressionMetadataState.IMPRESSION_METADATA_STATE_ACTIVE
-          } else {
-            InternalImpressionMetadataState.IMPRESSION_METADATA_STATE_DELETED
+          when {
+            request.filter.state != ImpressionMetadata.State.STATE_UNSPECIFIED ->
+              request.filter.state.toInternal()
+            request.showDeleted ->
+              InternalImpressionMetadataState.IMPRESSION_METADATA_STATE_UNSPECIFIED
+            else -> InternalImpressionMetadataState.IMPRESSION_METADATA_STATE_ACTIVE
           }
       }
 

--- a/src/main/kotlin/org/wfanet/measurement/edpaggregator/service/v1alpha/ImpressionMetadataService.kt
+++ b/src/main/kotlin/org/wfanet/measurement/edpaggregator/service/v1alpha/ImpressionMetadataService.kt
@@ -699,16 +699,28 @@ class ImpressionMetadataService(
       }
     }
 
-    if (request.filter.state == ImpressionMetadata.State.UNRECOGNIZED) {
-      throw InvalidFieldValueException("filter.state")
-        .asStatusRuntimeException(Status.Code.INVALID_ARGUMENT)
-    }
-    if (request.filter.state == ImpressionMetadata.State.DELETED && !request.showDeleted) {
-      throw InvalidFieldValueException("filter.state") { fieldName ->
-          "$fieldName cannot be DELETED unless show_deleted is true"
+    val internalState =
+      when (request.filter.state) {
+        ImpressionMetadata.State.STATE_UNSPECIFIED ->
+          if (request.showDeleted) {
+            InternalImpressionMetadataState.IMPRESSION_METADATA_STATE_UNSPECIFIED
+          } else {
+            InternalImpressionMetadataState.IMPRESSION_METADATA_STATE_ACTIVE
+          }
+        ImpressionMetadata.State.ACTIVE -> request.filter.state.toInternal()
+        ImpressionMetadata.State.DELETED -> {
+          if (!request.showDeleted) {
+            throw InvalidFieldValueException("filter.state") { fieldName ->
+                "$fieldName cannot be DELETED unless show_deleted is true"
+              }
+              .asStatusRuntimeException(Status.Code.INVALID_ARGUMENT)
+          }
+          request.filter.state.toInternal()
         }
-        .asStatusRuntimeException(Status.Code.INVALID_ARGUMENT)
-    }
+        ImpressionMetadata.State.UNRECOGNIZED ->
+          throw InvalidFieldValueException("filter.state")
+            .asStatusRuntimeException(Status.Code.INVALID_ARGUMENT)
+      }
 
     val pageSize =
       if (request.pageSize == 0) {
@@ -748,14 +760,7 @@ class ImpressionMetadataService(
           blobUris += request.filter.blobUrisList
         }
 
-        state =
-          when {
-            request.filter.state != ImpressionMetadata.State.STATE_UNSPECIFIED ->
-              request.filter.state.toInternal()
-            request.showDeleted ->
-              InternalImpressionMetadataState.IMPRESSION_METADATA_STATE_UNSPECIFIED
-            else -> InternalImpressionMetadataState.IMPRESSION_METADATA_STATE_ACTIVE
-          }
+        state = internalState
       }
 
     val internalResponse: InternalListImpressionMetadataResponse =

--- a/src/main/proto/wfa/measurement/edpaggregator/v1alpha/impression_metadata_service.proto
+++ b/src/main/proto/wfa/measurement/edpaggregator/v1alpha/impression_metadata_service.proto
@@ -247,9 +247,16 @@ message ListImpressionMetadataRequest {
     // Filter by exact blob URIs. Only entries whose `blob_uri` matches
     // one of the given values are returned.
     repeated string blob_uris = 6 [(google.api.field_behavior) = OPTIONAL];
+
+    // State to filter by.
+    // `DELETED` may only be specified when `show_deleted` is true.
+    // (-- api-linter: core::0216::state-field-output-only=disabled
+    //     aip.dev/not-precedent: This is a filter input field, not a resource
+    //     state field. --)
+    ImpressionMetadata.State state = 7 [(google.api.field_behavior) = OPTIONAL];
   }
 
-  // A flag indicating whether to include soft DELETED entries.
+  // Whether to include soft-deleted entries in addition to active entries.
   bool show_deleted = 5 [(google.api.field_behavior) = OPTIONAL];
 }
 

--- a/src/test/kotlin/org/wfanet/measurement/edpaggregator/dataavailability/DataAvailabilityMonitorTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/edpaggregator/dataavailability/DataAvailabilityMonitorTest.kt
@@ -64,13 +64,22 @@ class DataAvailabilityMonitorTest {
   private val impressionMetadataServiceMock: ImpressionMetadataServiceCoroutineImplBase =
     mockService {
       onBlocking { listImpressionMetadata(org.mockito.kotlin.any<ListImpressionMetadataRequest>()) }
-        .thenAnswer { _ ->
+        .thenAnswer { invocation ->
+          val request = invocation.getArgument<ListImpressionMetadataRequest>(0)
+          assertThat(request.showDeleted).isTrue()
+          assertThat(request.filter.state).isEqualTo(V1AlphaImpressionMetadata.State.DELETED)
           listImpressionMetadataResponse {
             impressionMetadata += v1alphaImpressionMetadata {
               name = "$DATA_PROVIDER_NAME/impressionMetadata/imp-deleted-1"
               blobUri =
                 "gs://$BUCKET_NAME/$EDP_IMPRESSION_PATH/model-line/${MODEL_LINE_A.modelLineId}/2026-03-10/metadata_campaign_123.json"
               state = V1AlphaImpressionMetadata.State.DELETED
+            }
+            impressionMetadata += v1alphaImpressionMetadata {
+              name = "$DATA_PROVIDER_NAME/impressionMetadata/imp-active-1"
+              blobUri =
+                "gs://$BUCKET_NAME/$EDP_IMPRESSION_PATH/model-line/${MODEL_LINE_A.modelLineId}/2026-03-11/metadata_campaign_456.json"
+              state = V1AlphaImpressionMetadata.State.ACTIVE
             }
           }
         }

--- a/src/test/kotlin/org/wfanet/measurement/edpaggregator/dataavailability/DataAvailabilityMonitorTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/edpaggregator/dataavailability/DataAvailabilityMonitorTest.kt
@@ -85,29 +85,10 @@ class DataAvailabilityMonitorTest {
         .thenAnswer { _ -> listImpressionMetadataResponse {} }
     }
 
-  private val unexpectedStateServiceMock: ImpressionMetadataServiceCoroutineImplBase = mockService {
-    onBlocking { listImpressionMetadata(org.mockito.kotlin.any<ListImpressionMetadataRequest>()) }
-      .thenAnswer { invocation ->
-        val request = invocation.getArgument<ListImpressionMetadataRequest>(0)
-        assertThat(request.showDeleted).isTrue()
-        assertThat(request.filter.state).isEqualTo(V1AlphaImpressionMetadata.State.DELETED)
-        listImpressionMetadataResponse {
-          impressionMetadata += v1alphaImpressionMetadata {
-            name = "$DATA_PROVIDER_NAME/impressionMetadata/imp-active-1"
-            blobUri =
-              "gs://$BUCKET_NAME/$EDP_IMPRESSION_PATH/model-line/${MODEL_LINE_A.modelLineId}/2026-03-11/metadata_campaign_456.json"
-            state = V1AlphaImpressionMetadata.State.ACTIVE
-          }
-        }
-      }
-  }
-
   @get:Rule
   val grpcTestServerRule = GrpcTestServerRule { addService(impressionMetadataServiceMock) }
 
   @get:Rule val grpcTestServerRule2 = GrpcTestServerRule { addService(noDeletedEntriesServiceMock) }
-
-  @get:Rule val grpcTestServerRule3 = GrpcTestServerRule { addService(unexpectedStateServiceMock) }
 
   private val impressionMetadataStubForTest: ImpressionMetadataServiceCoroutineStub by lazy {
     ImpressionMetadataServiceCoroutineStub(grpcTestServerRule.channel)
@@ -115,10 +96,6 @@ class DataAvailabilityMonitorTest {
 
   private val noDeletedEntriesStub: ImpressionMetadataServiceCoroutineStub by lazy {
     ImpressionMetadataServiceCoroutineStub(grpcTestServerRule2.channel)
-  }
-
-  private val unexpectedStateStub: ImpressionMetadataServiceCoroutineStub by lazy {
-    ImpressionMetadataServiceCoroutineStub(grpcTestServerRule3.channel)
   }
 
   companion object {
@@ -1332,37 +1309,62 @@ class DataAvailabilityMonitorTest {
     }
 
   @Test
-  fun `checkFullStatus rejects active entry returned for deleted state filter`(): Unit =
-    runBlocking {
-      val storageClient = createStorageClient()
-      ensureDirectories(MODEL_LINE_A.modelLineId, "2026-03-15")
-      createDoneBlob(storageClient, MODEL_LINE_A.modelLineId, "2026-03-15")
-      createDataFile(storageClient, MODEL_LINE_A.modelLineId, "2026-03-15")
-
-      val monitor =
-        DataAvailabilityMonitor(
-          storageClient = storageClient,
-          edpImpressionPath = EDP_IMPRESSION_PATH,
-          activeModelLines = setOf(MODEL_LINE_A),
-          impressionMetadataStub = unexpectedStateStub,
-          dataProviderName = DATA_PROVIDER_NAME,
-        )
-
-      val exception =
-        assertFailsWith<IllegalStateException> {
-          monitor.checkFullStatus(
-            maxStaleDays = 3,
-            timeZone = TIME_ZONE,
-            clock = { TODAY },
-            unprocessedDoneThreshold = Duration.ofHours(24),
-            spuriousDeletionLookbackDays = 90,
-          )
+  fun `checkFullStatus rejects active entry returned for deleted state filter`() {
+    val unexpectedStateServiceMock: ImpressionMetadataServiceCoroutineImplBase = mockService {
+      onBlocking { listImpressionMetadata(org.mockito.kotlin.any<ListImpressionMetadataRequest>()) }
+        .thenAnswer { invocation ->
+          val request = invocation.getArgument<ListImpressionMetadataRequest>(0)
+          assertThat(request.showDeleted).isTrue()
+          assertThat(request.filter.state).isEqualTo(V1AlphaImpressionMetadata.State.DELETED)
+          listImpressionMetadataResponse {
+            impressionMetadata += v1alphaImpressionMetadata {
+              name = "$DATA_PROVIDER_NAME/impressionMetadata/imp-active-1"
+              blobUri =
+                "gs://$BUCKET_NAME/$EDP_IMPRESSION_PATH/model-line/${MODEL_LINE_A.modelLineId}/2026-03-11/metadata_campaign_456.json"
+              state = V1AlphaImpressionMetadata.State.ACTIVE
+            }
+          }
         }
-
-      assertThat(exception)
-        .hasMessageThat()
-        .contains("ListImpressionMetadata returned ACTIVE for a DELETED state filter")
     }
+    val testRule = GrpcTestServerRule { addService(unexpectedStateServiceMock) }
+    val statement =
+      object : org.junit.runners.model.Statement() {
+        override fun evaluate() {
+          runBlocking {
+            val storageClient = createStorageClient()
+            ensureDirectories(MODEL_LINE_A.modelLineId, "2026-03-15")
+            createDoneBlob(storageClient, MODEL_LINE_A.modelLineId, "2026-03-15")
+            createDataFile(storageClient, MODEL_LINE_A.modelLineId, "2026-03-15")
+
+            val monitor =
+              DataAvailabilityMonitor(
+                storageClient = storageClient,
+                edpImpressionPath = EDP_IMPRESSION_PATH,
+                activeModelLines = setOf(MODEL_LINE_A),
+                impressionMetadataStub = ImpressionMetadataServiceCoroutineStub(testRule.channel),
+                dataProviderName = DATA_PROVIDER_NAME,
+              )
+
+            val exception =
+              assertFailsWith<IllegalStateException> {
+                monitor.checkFullStatus(
+                  maxStaleDays = 3,
+                  timeZone = TIME_ZONE,
+                  clock = { TODAY },
+                  unprocessedDoneThreshold = Duration.ofHours(24),
+                  spuriousDeletionLookbackDays = 90,
+                )
+              }
+
+            assertThat(exception)
+              .hasMessageThat()
+              .contains("ListImpressionMetadata returned ACTIVE for a DELETED state filter")
+          }
+        }
+      }
+
+    testRule.apply(statement, org.junit.runner.Description.EMPTY).evaluate()
+  }
 
   @Test
   fun `checkFullStatus detects spurious deletion when blob still exists`(): Unit = runBlocking {

--- a/src/test/kotlin/org/wfanet/measurement/edpaggregator/dataavailability/DataAvailabilityMonitorTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/edpaggregator/dataavailability/DataAvailabilityMonitorTest.kt
@@ -85,31 +85,29 @@ class DataAvailabilityMonitorTest {
         .thenAnswer { _ -> listImpressionMetadataResponse {} }
     }
 
-  private val unexpectedStateServiceMock: ImpressionMetadataServiceCoroutineImplBase =
-    mockService {
-      onBlocking { listImpressionMetadata(org.mockito.kotlin.any<ListImpressionMetadataRequest>()) }
-        .thenAnswer { invocation ->
-          val request = invocation.getArgument<ListImpressionMetadataRequest>(0)
-          assertThat(request.showDeleted).isTrue()
-          assertThat(request.filter.state).isEqualTo(V1AlphaImpressionMetadata.State.DELETED)
-          listImpressionMetadataResponse {
-            impressionMetadata += v1alphaImpressionMetadata {
-              name = "$DATA_PROVIDER_NAME/impressionMetadata/imp-active-1"
-              blobUri =
-                "gs://$BUCKET_NAME/$EDP_IMPRESSION_PATH/model-line/${MODEL_LINE_A.modelLineId}/2026-03-11/metadata_campaign_456.json"
-              state = V1AlphaImpressionMetadata.State.ACTIVE
-            }
+  private val unexpectedStateServiceMock: ImpressionMetadataServiceCoroutineImplBase = mockService {
+    onBlocking { listImpressionMetadata(org.mockito.kotlin.any<ListImpressionMetadataRequest>()) }
+      .thenAnswer { invocation ->
+        val request = invocation.getArgument<ListImpressionMetadataRequest>(0)
+        assertThat(request.showDeleted).isTrue()
+        assertThat(request.filter.state).isEqualTo(V1AlphaImpressionMetadata.State.DELETED)
+        listImpressionMetadataResponse {
+          impressionMetadata += v1alphaImpressionMetadata {
+            name = "$DATA_PROVIDER_NAME/impressionMetadata/imp-active-1"
+            blobUri =
+              "gs://$BUCKET_NAME/$EDP_IMPRESSION_PATH/model-line/${MODEL_LINE_A.modelLineId}/2026-03-11/metadata_campaign_456.json"
+            state = V1AlphaImpressionMetadata.State.ACTIVE
           }
         }
-    }
+      }
+  }
 
   @get:Rule
   val grpcTestServerRule = GrpcTestServerRule { addService(impressionMetadataServiceMock) }
 
   @get:Rule val grpcTestServerRule2 = GrpcTestServerRule { addService(noDeletedEntriesServiceMock) }
 
-  @get:Rule
-  val grpcTestServerRule3 = GrpcTestServerRule { addService(unexpectedStateServiceMock) }
+  @get:Rule val grpcTestServerRule3 = GrpcTestServerRule { addService(unexpectedStateServiceMock) }
 
   private val impressionMetadataStubForTest: ImpressionMetadataServiceCoroutineStub by lazy {
     ImpressionMetadataServiceCoroutineStub(grpcTestServerRule.channel)

--- a/src/test/kotlin/org/wfanet/measurement/edpaggregator/dataavailability/DataAvailabilityMonitorTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/edpaggregator/dataavailability/DataAvailabilityMonitorTest.kt
@@ -75,12 +75,6 @@ class DataAvailabilityMonitorTest {
                 "gs://$BUCKET_NAME/$EDP_IMPRESSION_PATH/model-line/${MODEL_LINE_A.modelLineId}/2026-03-10/metadata_campaign_123.json"
               state = V1AlphaImpressionMetadata.State.DELETED
             }
-            impressionMetadata += v1alphaImpressionMetadata {
-              name = "$DATA_PROVIDER_NAME/impressionMetadata/imp-active-1"
-              blobUri =
-                "gs://$BUCKET_NAME/$EDP_IMPRESSION_PATH/model-line/${MODEL_LINE_A.modelLineId}/2026-03-11/metadata_campaign_456.json"
-              state = V1AlphaImpressionMetadata.State.ACTIVE
-            }
           }
         }
     }
@@ -91,10 +85,31 @@ class DataAvailabilityMonitorTest {
         .thenAnswer { _ -> listImpressionMetadataResponse {} }
     }
 
+  private val unexpectedStateServiceMock: ImpressionMetadataServiceCoroutineImplBase =
+    mockService {
+      onBlocking { listImpressionMetadata(org.mockito.kotlin.any<ListImpressionMetadataRequest>()) }
+        .thenAnswer { invocation ->
+          val request = invocation.getArgument<ListImpressionMetadataRequest>(0)
+          assertThat(request.showDeleted).isTrue()
+          assertThat(request.filter.state).isEqualTo(V1AlphaImpressionMetadata.State.DELETED)
+          listImpressionMetadataResponse {
+            impressionMetadata += v1alphaImpressionMetadata {
+              name = "$DATA_PROVIDER_NAME/impressionMetadata/imp-active-1"
+              blobUri =
+                "gs://$BUCKET_NAME/$EDP_IMPRESSION_PATH/model-line/${MODEL_LINE_A.modelLineId}/2026-03-11/metadata_campaign_456.json"
+              state = V1AlphaImpressionMetadata.State.ACTIVE
+            }
+          }
+        }
+    }
+
   @get:Rule
   val grpcTestServerRule = GrpcTestServerRule { addService(impressionMetadataServiceMock) }
 
   @get:Rule val grpcTestServerRule2 = GrpcTestServerRule { addService(noDeletedEntriesServiceMock) }
+
+  @get:Rule
+  val grpcTestServerRule3 = GrpcTestServerRule { addService(unexpectedStateServiceMock) }
 
   private val impressionMetadataStubForTest: ImpressionMetadataServiceCoroutineStub by lazy {
     ImpressionMetadataServiceCoroutineStub(grpcTestServerRule.channel)
@@ -102,6 +117,10 @@ class DataAvailabilityMonitorTest {
 
   private val noDeletedEntriesStub: ImpressionMetadataServiceCoroutineStub by lazy {
     ImpressionMetadataServiceCoroutineStub(grpcTestServerRule2.channel)
+  }
+
+  private val unexpectedStateStub: ImpressionMetadataServiceCoroutineStub by lazy {
+    ImpressionMetadataServiceCoroutineStub(grpcTestServerRule3.channel)
   }
 
   companion object {
@@ -1312,6 +1331,39 @@ class DataAvailabilityMonitorTest {
           spuriousDeletionLookbackDays = 90,
         )
       }
+    }
+
+  @Test
+  fun `checkFullStatus rejects active entry returned for deleted state filter`(): Unit =
+    runBlocking {
+      val storageClient = createStorageClient()
+      ensureDirectories(MODEL_LINE_A.modelLineId, "2026-03-15")
+      createDoneBlob(storageClient, MODEL_LINE_A.modelLineId, "2026-03-15")
+      createDataFile(storageClient, MODEL_LINE_A.modelLineId, "2026-03-15")
+
+      val monitor =
+        DataAvailabilityMonitor(
+          storageClient = storageClient,
+          edpImpressionPath = EDP_IMPRESSION_PATH,
+          activeModelLines = setOf(MODEL_LINE_A),
+          impressionMetadataStub = unexpectedStateStub,
+          dataProviderName = DATA_PROVIDER_NAME,
+        )
+
+      val exception =
+        assertFailsWith<IllegalStateException> {
+          monitor.checkFullStatus(
+            maxStaleDays = 3,
+            timeZone = TIME_ZONE,
+            clock = { TODAY },
+            unprocessedDoneThreshold = Duration.ofHours(24),
+            spuriousDeletionLookbackDays = 90,
+          )
+        }
+
+      assertThat(exception)
+        .hasMessageThat()
+        .contains("ListImpressionMetadata returned ACTIVE for a DELETED state filter")
     }
 
   @Test

--- a/src/test/kotlin/org/wfanet/measurement/edpaggregator/service/v1alpha/ImpressionMetadataServiceTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/edpaggregator/service/v1alpha/ImpressionMetadataServiceTest.kt
@@ -1193,9 +1193,9 @@ class ImpressionMetadataServiceTest {
     }
 
   @Test
-  fun `listImpressionMetadata returns deleted ImpressionMetadata when show deleted is set to true`() =
+  fun `listImpressionMetadata includes deleted ImpressionMetadata when show deleted is true`() =
     runBlocking {
-      val created = createImpressionMetadata(IMPRESSION_METADATA)
+      val created = createImpressionMetadata(IMPRESSION_METADATA, IMPRESSION_METADATA_2)
       val deleted =
         service.deleteImpressionMetadata(deleteImpressionMetadataRequest { name = created[0].name })
 
@@ -1208,8 +1208,55 @@ class ImpressionMetadataServiceTest {
         )
 
       assertThat(response)
-        .isEqualTo(listImpressionMetadataResponse { impressionMetadata += deleted })
+        .isEqualTo(
+          listImpressionMetadataResponse {
+            impressionMetadata += listOf(deleted, created[1]).sortedBy { it.name }
+          }
+        )
     }
+
+  @Test
+  fun `listImpressionMetadata filters deleted ImpressionMetadata by state`() = runBlocking {
+    val created = createImpressionMetadata(IMPRESSION_METADATA, IMPRESSION_METADATA_2)
+    val deleted =
+      service.deleteImpressionMetadata(deleteImpressionMetadataRequest { name = created[0].name })
+
+    val response =
+      service.listImpressionMetadata(
+        listImpressionMetadataRequest {
+          parent = DATA_PROVIDER_KEY.toName()
+          showDeleted = true
+          filter =
+            ListImpressionMetadataRequestKt.filter { state = ImpressionMetadata.State.DELETED }
+        }
+      )
+
+    assertThat(response).isEqualTo(listImpressionMetadataResponse { impressionMetadata += deleted })
+  }
+
+  @Test
+  fun `listImpressionMetadata rejects deleted state without show deleted`() = runBlocking {
+    val exception =
+      assertFailsWith<StatusRuntimeException> {
+        service.listImpressionMetadata(
+          listImpressionMetadataRequest {
+            parent = DATA_PROVIDER_KEY.toName()
+            filter =
+              ListImpressionMetadataRequestKt.filter { state = ImpressionMetadata.State.DELETED }
+          }
+        )
+      }
+
+    assertThat(exception.status.code).isEqualTo(Status.Code.INVALID_ARGUMENT)
+    assertThat(exception.errorInfo)
+      .isEqualTo(
+        errorInfo {
+          domain = Errors.DOMAIN
+          reason = Errors.Reason.INVALID_FIELD_VALUE.name
+          metadata[Errors.Metadata.FIELD_NAME.key] = "filter.state"
+        }
+      )
+  }
 
   @Test
   fun `listImpressionMetadata throws INVALID_ARGUMENT when parent is not set`() = runBlocking {

--- a/src/test/kotlin/org/wfanet/measurement/edpaggregator/service/v1alpha/ImpressionMetadataServiceTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/edpaggregator/service/v1alpha/ImpressionMetadataServiceTest.kt
@@ -1235,6 +1235,26 @@ class ImpressionMetadataServiceTest {
   }
 
   @Test
+  fun `listImpressionMetadata filters active ImpressionMetadata when show deleted is true`() =
+    runBlocking {
+      val created = createImpressionMetadata(IMPRESSION_METADATA, IMPRESSION_METADATA_2)
+      service.deleteImpressionMetadata(deleteImpressionMetadataRequest { name = created[0].name })
+
+      val response =
+        service.listImpressionMetadata(
+          listImpressionMetadataRequest {
+            parent = DATA_PROVIDER_KEY.toName()
+            showDeleted = true
+            filter =
+              ListImpressionMetadataRequestKt.filter { state = ImpressionMetadata.State.ACTIVE }
+          }
+        )
+
+      assertThat(response)
+        .isEqualTo(listImpressionMetadataResponse { impressionMetadata += created[1] })
+    }
+
+  @Test
   fun `listImpressionMetadata rejects deleted state without show deleted`() = runBlocking {
     val exception =
       assertFailsWith<StatusRuntimeException> {


### PR DESCRIPTION
## Summary

Makes `show_deleted=true` include active and soft-deleted `ImpressionMetadata` resources, consistent with AIP-164 and sibling APIs. Adds an explicit state filter so deleted-only monitoring remains efficient, and updates the monitor plus regression tests.

## Validation

- API lint, changed-file lint, and the full Build and test workflow passed on exact head `6d824a3c2be6d330409d88f6f45c991be6b4dee5`.
- Halo dev E2E on the full stacked image created an active test resource and then soft-deleted it through the public API. The default list excluded the deleted resource; `show_deleted=true` returned both the deleted test resource and an active control resource; and `show_deleted=true` with the explicit `DELETED` state filter returned only the deleted resource. After recovery undeleted it, the default list returned it as `ACTIVE` again.

### State-filter follow-up validation (2026-09-08)

Final head `6680ee8cc86995bb818112ae32f338889f6f0bc7` maps every public state through an exhaustive `when`. Explicit `state=ACTIVE` with `show_deleted=true` remains valid and is covered by a public-service regression test. The monitor requests `DELETED` and fails closed before any storage lookup if a response violates that filter; a monitor regression test covers that contract violation.

Changed-file lint, API lint, and the exact-head full Build and test workflow passed: [run 34290665402](https://github.com/world-federation-of-advertisers/cross-media-measurement/actions/runs/34290665402). Both focused suites also passed on final stack head `77fd901497cd912c1451963fd94c57bfed6f15c5`.

### Final holistic revalidation (2026-09-08)

Exact head `0a2b8e101b8a2b410ef3bb3fdd3428aa3c1ecc6d` passed the full Build and test workflow: [run 34295236947](https://github.com/world-federation-of-advertisers/cross-media-measurement/actions/runs/34295236947). Changed-file lint and API lint also passed on that head.

The internal Spanner path was audited directly: non-`UNSPECIFIED` state adds `ImpressionMetadata.State = @state`, binds the internal enum number, combines it with the other predicates before `ORDER BY`/`LIMIT`, and `UNSPECIFIED` adds no state predicate. The focused Spanner emulator state-filter suite passed on the final stacked head, covering unfiltered active+deleted, `ACTIVE`, and `DELETED`. Public tests additionally prove `state=ACTIVE, show_deleted=true` returns only active rows, and the monitor fails closed if a `DELETED` request returns another state. The operator guide now accurately documents the public `state` filter and index column order.

Issue: #4461
