### PR TITLE
feat: Support TrusTeeV2 in the EDP fulfillment libraries

### DIFF
--- a/src/main/kotlin/org/wfanet/measurement/eventdataprovider/requisition/v2alpha/common/FrequencyVectorBuilder.kt
+++ b/src/main/kotlin/org/wfanet/measurement/eventdataprovider/requisition/v2alpha/common/FrequencyVectorBuilder.kt
@@ -109,6 +109,10 @@ class FrequencyVectorBuilder(
         measurementSpec.impression.maximumFrequencyPerUser
       } else if (measurementSpec.hasReach()) {
         resultMinimumThresholds?.reachMaxFrequencyPerUser ?: 1
+      } else if (measurementSpec.hasMulti()) {
+        // A multimeasurement carries no frequency cap. The TEE folds the histogram downstream, so
+        // the vector is built uncapped and only the cell width binds.
+        Byte.MAX_VALUE.toInt()
       } else {
         1
       }

--- a/src/main/kotlin/org/wfanet/measurement/eventdataprovider/requisition/v2alpha/common/FrequencyVectorBuilder.kt
+++ b/src/main/kotlin/org/wfanet/measurement/eventdataprovider/requisition/v2alpha/common/FrequencyVectorBuilder.kt
@@ -110,8 +110,9 @@ class FrequencyVectorBuilder(
       } else if (measurementSpec.hasReach()) {
         resultMinimumThresholds?.reachMaxFrequencyPerUser ?: 1
       } else if (measurementSpec.hasMulti()) {
-        // A multimeasurement carries no frequency cap. The TEE folds the histogram downstream, so
-        // the vector is built uncapped and only the cell width binds.
+        // A MultiMeasurementSpec carries no frequency cap. The TEE folds the histogram downstream,
+        // so the only bound is the cell: a frequency saturates at the largest signed byte, since a
+        // larger value would reach the TEE negative and be rejected.
         Byte.MAX_VALUE.toInt()
       } else {
         1

--- a/src/main/kotlin/org/wfanet/measurement/eventdataprovider/requisition/v2alpha/common/FrequencyVectorBuilder.kt
+++ b/src/main/kotlin/org/wfanet/measurement/eventdataprovider/requisition/v2alpha/common/FrequencyVectorBuilder.kt
@@ -41,15 +41,17 @@ val PopulationSpec.size: Long
  * [PopulationSpec] and that it is being used to determine indexes provided to the [increment] and
  * [incrementAll] methods.
  *
- * The [MeasurementSpec] is used in several ways. First, it must specify either a Reach or
- * ReachAndFrequency measurement. In the case of Reach, the FrequencyVectorBuilder will clamp all
- * frequency values at maximum of 1. In the case of a ReachAndFrequency measurement, the max
- * frequency parameter is used to clamp the frequency value. In both cases the vidSamplingInterval
- * is used to appropriately size the output vector and if the client does not do its own filtering,
- * filter the inputs to [increment] and [incrementAll].
+ * The [MeasurementSpec] is used in several ways. First, it must specify a Reach, ReachAndFrequency,
+ * or Multi measurement. In the case of Reach, the FrequencyVectorBuilder will clamp all frequency
+ * values at maximum of 1. In the case of a ReachAndFrequency measurement, the max frequency
+ * parameter is used to clamp the frequency value. A Multi measurement carries no frequency cap of
+ * its own, so values saturate at the largest signed 8-bit value the wire format holds. In every
+ * case the vidSamplingInterval is used to appropriately size the output vector and if the client
+ * does not do its own filtering, filter the inputs to [increment] and [incrementAll].
  *
  * @param populationSpec specification of the population being measured
- * @param measurementSpec a [MeasurementSpec] that specifies a Reach or ReachAndFrequency
+ * @param measurementSpec a [MeasurementSpec] that specifies a Reach, ReachAndFrequency, or Multi
+ *   measurement
  * @param strict If false the various increment methods ignore indexes that are out of bounds. If
  *   true, an out of bounds index will result in an exception being thrown. It is normal for indexes
  *   to be out of bounds of a given vid interval.

--- a/src/main/kotlin/org/wfanet/measurement/eventdataprovider/requisition/v2alpha/trustee/FulfillRequisitionRequestBuilder.kt
+++ b/src/main/kotlin/org/wfanet/measurement/eventdataprovider/requisition/v2alpha/trustee/FulfillRequisitionRequestBuilder.kt
@@ -51,6 +51,11 @@ import org.wfanet.measurement.consent.client.dataprovider.computeRequisitionFing
  * @param fulfillmentDetails Values to send alongside the frequency vector. Only valid for a
  *   `TrusTeeV2` requisition. Encrypted with the payload's Data Encryption Key when the payload is
  *   encrypted, and sent in plaintext when it is not.
+ *
+ * The caller is responsible for the [frequencyVector] matching the `MeasurementSpec`. A `TrusTeeV2`
+ * `Requisition` carries a `MultiMeasurementSpec`, whose vector is built uncapped; this class does
+ * not check the pairing.
+ *
  * @throws IllegalArgumentException if the requisition is malformed or the frequency vector is empty
  * @throws GeneralSecurityException if a cryptographic error happens
  */
@@ -185,21 +190,26 @@ class FulfillRequisitionRequestBuilder(
   /**
    * Encrypts [details] with the payload's Data Encryption Key, so that they carry the same
    * protection as the frequency vector they accompany.
+   *
+   * The type URL is used as associated data, which the reader must supply to decrypt. The frequency
+   * vector is encrypted under the same key with no associated data, so the two ciphertexts cannot
+   * be substituted for one another.
    */
   private fun encryptFulfillmentDetails(
     dekHandle: KeysetHandle,
     details: FulfillRequisitionRequest.Header.TrusTeeV2.FulfillmentDetails,
   ): EncryptedMessage {
+    val messageTypeUrl: String = ProtoReflection.getTypeUrl(details.descriptorForType)
     val ciphertextChunks: Sequence<ByteString> =
       StreamingEncryption.encryptChunked(
         dekHandle,
         details.toByteString(),
-        null,
-        RPC_CHUNK_SIZE_BYTES,
+        ByteString.copyFromUtf8(messageTypeUrl),
+        DETAILS_CHUNK_SIZE_BYTES,
       )
     return encryptedMessage {
       ciphertext = ciphertextChunks.fold(ByteString.EMPTY) { acc, chunk -> acc.concat(chunk) }
-      typeUrl = ProtoReflection.getTypeUrl(details.descriptorForType)
+      typeUrl = messageTypeUrl
     }
   }
 
@@ -248,6 +258,9 @@ class FulfillRequisitionRequestBuilder(
   companion object {
     private const val KEY_TEMPLATE = "AES256_GCM_HKDF_1MB"
     private const val RPC_CHUNK_SIZE_BYTES = 32 * 1024 // 32 KiB
+    // The details are held in a single field rather than streamed, so the chunk size only bounds
+    // the working buffer.
+    private const val DETAILS_CHUNK_SIZE_BYTES = 4 * 1024 // 4 KiB
 
     init {
       AeadConfig.register()

--- a/src/main/kotlin/org/wfanet/measurement/eventdataprovider/requisition/v2alpha/trustee/FulfillRequisitionRequestBuilder.kt
+++ b/src/main/kotlin/org/wfanet/measurement/eventdataprovider/requisition/v2alpha/trustee/FulfillRequisitionRequestBuilder.kt
@@ -24,15 +24,19 @@ import com.google.protobuf.ByteString
 import com.google.protobuf.kotlin.toByteString
 import java.io.ByteArrayOutputStream
 import org.wfanet.frequencycount.FrequencyVector
+import org.wfanet.measurement.api.v2alpha.EncryptedMessage
 import org.wfanet.measurement.api.v2alpha.EncryptionKey
 import org.wfanet.measurement.api.v2alpha.FulfillRequisitionRequest
 import org.wfanet.measurement.api.v2alpha.FulfillRequisitionRequestKt
 import org.wfanet.measurement.api.v2alpha.FulfillRequisitionRequestKt.HeaderKt.trusTee
+import org.wfanet.measurement.api.v2alpha.FulfillRequisitionRequestKt.HeaderKt.trusTeeV2
 import org.wfanet.measurement.api.v2alpha.FulfillRequisitionRequestKt.bodyChunk
 import org.wfanet.measurement.api.v2alpha.FulfillRequisitionRequestKt.header
 import org.wfanet.measurement.api.v2alpha.Requisition
+import org.wfanet.measurement.api.v2alpha.encryptedMessage
 import org.wfanet.measurement.api.v2alpha.encryptionKey
 import org.wfanet.measurement.api.v2alpha.fulfillRequisitionRequest
+import org.wfanet.measurement.common.ProtoReflection
 import org.wfanet.measurement.common.crypto.tink.StreamingEncryption
 import org.wfanet.measurement.consent.client.dataprovider.computeRequisitionFingerprint
 
@@ -44,6 +48,9 @@ import org.wfanet.measurement.consent.client.dataprovider.computeRequisitionFing
  * @param frequencyVector The payload for the fulfillment
  * @param encryptionParams The parameters for encryption. If null, the payload will not be
  *   encrypted.
+ * @param fulfillmentDetails Values to send alongside the frequency vector. Only valid for a
+ *   `TrusTeeV2` requisition. Encrypted with the payload's Data Encryption Key when the payload is
+ *   encrypted, and sent in plaintext when it is not.
  * @throws IllegalArgumentException if the requisition is malformed or the frequency vector is empty
  * @throws GeneralSecurityException if a cryptographic error happens
  */
@@ -53,6 +60,8 @@ class FulfillRequisitionRequestBuilder(
   // TODO(world-federation-of-advertisers/cross-media-measurement#2705): make it ByteArray
   private val frequencyVector: FrequencyVector,
   private val encryptionParams: EncryptionParams?,
+  private val fulfillmentDetails: FulfillRequisitionRequest.Header.TrusTeeV2.FulfillmentDetails? =
+    null,
 ) {
   /**
    * Parameters for optional encryption
@@ -75,12 +84,22 @@ class FulfillRequisitionRequestBuilder(
 
   private val frequencyVectorBytes: ByteArray
 
-  init {
-    val trusTeeProtocolList =
-      requisition.protocolConfig.protocolsList.filter { it.hasTrusTee() }.map { it.trusTee }
+  /** Whether this fulfills a `TrusTeeV2` [Requisition] rather than a `TrusTee` one. */
+  private val isTrusTeeV2: Boolean
 
-    require(trusTeeProtocolList.size == 1) {
-      "Expected to find exactly one config for TrusTee. Found: ${trusTeeProtocolList.size}"
+  init {
+    val trusTeeProtocolCount = requisition.protocolConfig.protocolsList.count { it.hasTrusTee() }
+    val trusTeeV2ProtocolCount =
+      requisition.protocolConfig.protocolsList.count { it.hasTrusTeeV2() }
+
+    require(trusTeeProtocolCount + trusTeeV2ProtocolCount == 1) {
+      "Expected to find exactly one config for TrusTee or TrusTeeV2. Found: " +
+        "${trusTeeProtocolCount + trusTeeV2ProtocolCount}"
+    }
+    isTrusTeeV2 = trusTeeV2ProtocolCount == 1
+
+    require(fulfillmentDetails == null || isTrusTeeV2) {
+      "fulfillmentDetails may only be set for a TrusTeeV2 Requisition"
     }
 
     require(frequencyVector.dataCount > 0) { "FrequencyVector must have size > 0" }
@@ -113,7 +132,9 @@ class FulfillRequisitionRequestBuilder(
     } else {
       val dekHandle = KeysetHandle.generateNew(KeyTemplates.get(KEY_TEMPLATE))
       val encryptedDek = encryptDek(dekHandle)
-      val headerRequest = buildEncryptedHeader(encryptedDek)
+      val encryptedDetails: EncryptedMessage? =
+        fulfillmentDetails?.let { encryptFulfillmentDetails(dekHandle, it) }
+      val headerRequest = buildEncryptedHeader(encryptedDek, encryptedDetails)
       yield(headerRequest)
 
       val bodyChunkRequests: Sequence<FulfillRequisitionRequest> =
@@ -137,44 +158,88 @@ class FulfillRequisitionRequestBuilder(
   }
 
   private fun buildUnencryptedHeader(): FulfillRequisitionRequest {
+    val trusTeeParams = trusTee {
+      dataFormat = FulfillRequisitionRequest.Header.TrusTee.DataFormat.FREQUENCY_VECTOR
+    }
+    val details = fulfillmentDetails
     return fulfillRequisitionRequest {
       header = header {
         name = requisition.name
         requisitionFingerprint = computeRequisitionFingerprint(requisition)
         nonce = requisitionNonce
         protocolConfig = requisition.protocolConfig
-        trusTee = trusTee {
-          dataFormat = FulfillRequisitionRequest.Header.TrusTee.DataFormat.FREQUENCY_VECTOR
+        if (isTrusTeeV2) {
+          trusTeeV2 = trusTeeV2 {
+            trusTee = trusTeeParams
+            if (details != null) {
+              fulfillmentDetails = details
+            }
+          }
+        } else {
+          trusTee = trusTeeParams
         }
       }
     }
   }
 
-  private fun buildEncryptedHeader(encryptedDek: ByteString): FulfillRequisitionRequest {
+  /**
+   * Encrypts [details] with the payload's Data Encryption Key, so that they carry the same
+   * protection as the frequency vector they accompany.
+   */
+  private fun encryptFulfillmentDetails(
+    dekHandle: KeysetHandle,
+    details: FulfillRequisitionRequest.Header.TrusTeeV2.FulfillmentDetails,
+  ): EncryptedMessage {
+    val ciphertextChunks: Sequence<ByteString> =
+      StreamingEncryption.encryptChunked(
+        dekHandle,
+        details.toByteString(),
+        null,
+        RPC_CHUNK_SIZE_BYTES,
+      )
+    return encryptedMessage {
+      ciphertext = ciphertextChunks.fold(ByteString.EMPTY) { acc, chunk -> acc.concat(chunk) }
+      typeUrl = ProtoReflection.getTypeUrl(details.descriptorForType)
+    }
+  }
+
+  private fun buildEncryptedHeader(
+    encryptedDek: ByteString,
+    encryptedDetails: EncryptedMessage?,
+  ): FulfillRequisitionRequest {
+    val trusTeeParams = trusTee {
+      dataFormat = FulfillRequisitionRequest.Header.TrusTee.DataFormat.ENCRYPTED_FREQUENCY_VECTOR
+      envelopeEncryption =
+        FulfillRequisitionRequestKt.HeaderKt.TrusTeeKt.envelopeEncryption {
+          this.encryptedDek = encryptionKey {
+            format = EncryptionKey.Format.TINK_ENCRYPTED_KEYSET
+            data = encryptedDek
+          }
+          kmsKekUri = encryptionParams!!.kmsKekUri
+          workloadIdentityProvider = encryptionParams.workloadIdentityProvider
+          impersonatedServiceAccount = encryptionParams.impersonatedServiceAccount
+          if (encryptionParams.awsKmsParams != null) {
+            awsKmsParams = encryptionParams.awsKmsParams
+          }
+        }
+      // TODO(world-federation-of-advertisers/cross-media-measurement#2624): generate
+      // populationSpec fingerprint
+    }
     return fulfillRequisitionRequest {
       header = header {
         name = requisition.name
         requisitionFingerprint = computeRequisitionFingerprint(requisition)
         nonce = requisitionNonce
         protocolConfig = requisition.protocolConfig
-        trusTee = trusTee {
-          dataFormat =
-            FulfillRequisitionRequest.Header.TrusTee.DataFormat.ENCRYPTED_FREQUENCY_VECTOR
-          envelopeEncryption =
-            FulfillRequisitionRequestKt.HeaderKt.TrusTeeKt.envelopeEncryption {
-              this.encryptedDek = encryptionKey {
-                format = EncryptionKey.Format.TINK_ENCRYPTED_KEYSET
-                data = encryptedDek
-              }
-              kmsKekUri = encryptionParams!!.kmsKekUri
-              workloadIdentityProvider = encryptionParams.workloadIdentityProvider
-              impersonatedServiceAccount = encryptionParams.impersonatedServiceAccount
-              if (encryptionParams.awsKmsParams != null) {
-                awsKmsParams = encryptionParams.awsKmsParams
-              }
+        if (isTrusTeeV2) {
+          trusTeeV2 = trusTeeV2 {
+            trusTee = trusTeeParams
+            if (encryptedDetails != null) {
+              encryptedFulfillmentDetails = encryptedDetails
             }
-          // TODO(world-federation-of-advertisers/cross-media-measurement#2624): generate
-          // populationSpec fingerprint
+          }
+        } else {
+          trusTee = trusTeeParams
         }
       }
     }
@@ -195,12 +260,14 @@ class FulfillRequisitionRequestBuilder(
       requisitionNonce: Long,
       frequencyVector: FrequencyVector,
       encryptionParams: EncryptionParams,
+      fulfillmentDetails: FulfillRequisitionRequest.Header.TrusTeeV2.FulfillmentDetails? = null,
     ): Sequence<FulfillRequisitionRequest> {
       return FulfillRequisitionRequestBuilder(
           requisition,
           requisitionNonce,
           frequencyVector,
           encryptionParams,
+          fulfillmentDetails,
         )
         .build()
     }
@@ -210,7 +277,15 @@ class FulfillRequisitionRequestBuilder(
       requisition: Requisition,
       requisitionNonce: Long,
       frequencyVector: FrequencyVector,
+      fulfillmentDetails: FulfillRequisitionRequest.Header.TrusTeeV2.FulfillmentDetails? = null,
     ): Sequence<FulfillRequisitionRequest> =
-      FulfillRequisitionRequestBuilder(requisition, requisitionNonce, frequencyVector, null).build()
+      FulfillRequisitionRequestBuilder(
+          requisition,
+          requisitionNonce,
+          frequencyVector,
+          null,
+          fulfillmentDetails,
+        )
+        .build()
   }
 }

--- a/src/test/kotlin/org/wfanet/measurement/eventdataprovider/requisition/v2alpha/common/FrequencyVectorBuilderTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/eventdataprovider/requisition/v2alpha/common/FrequencyVectorBuilderTest.kt
@@ -310,6 +310,22 @@ class FrequencyVectorBuilderTest {
   }
 
   @Test
+  fun `build saturates a multi measurement frequency at the largest signed byte`() {
+    val multiMeasurementSpec = measurementSpec {
+      vidSamplingInterval = FULL_SAMPLING_INTERVAL
+      multi = multiMeasurementSpec {}
+    }
+
+    val frequencyVector =
+      FrequencyVectorBuilder.build(SMALL_POPULATION_SPEC, multiMeasurementSpec) {
+        incrementBy(SMALL_POPULATION_VID_INDEX_MAP[STARTING_VID], 200)
+      }
+
+    // A larger value would reach the TEE as a negative byte.
+    assertThat(frequencyVector.dataList[0]).isEqualTo(Byte.MAX_VALUE.toInt())
+  }
+
+  @Test
   fun `build returns a frequency vector for reach over partial interval`() {
     val builder =
       FrequencyVectorBuilder(

--- a/src/test/kotlin/org/wfanet/measurement/eventdataprovider/requisition/v2alpha/common/FrequencyVectorBuilderTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/eventdataprovider/requisition/v2alpha/common/FrequencyVectorBuilderTest.kt
@@ -21,6 +21,7 @@ import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 import org.wfanet.frequencycount.frequencyVector
 import org.wfanet.measurement.api.v2alpha.MeasurementSpecKt.impression
+import org.wfanet.measurement.api.v2alpha.MeasurementSpecKt.multiMeasurementSpec
 import org.wfanet.measurement.api.v2alpha.MeasurementSpecKt.reach
 import org.wfanet.measurement.api.v2alpha.MeasurementSpecKt.reachAndFrequency
 import org.wfanet.measurement.api.v2alpha.MeasurementSpecKt.vidSamplingInterval
@@ -281,6 +282,31 @@ class FrequencyVectorBuilderTest {
 
     assertThat(frequencyVector)
       .isEqualTo(frequencyVector { data += listOf<Int>(3, 2, 0, 0, 0, 0, 0, 0, 3, 0) })
+  }
+
+  @Test
+  fun `build does not cap a frequency vector for a multi measurement`() {
+    val multiMeasurementSpec = measurementSpec {
+      vidSamplingInterval = FULL_SAMPLING_INTERVAL
+      multi = multiMeasurementSpec {}
+    }
+
+    val frequencyVector =
+      FrequencyVectorBuilder.build(SMALL_POPULATION_SPEC, multiMeasurementSpec) {
+        listOf(
+            STARTING_VID,
+            STARTING_VID,
+            STARTING_VID,
+            STARTING_VID + 1,
+            STARTING_VID + 8,
+            STARTING_VID + 8,
+          )
+          .map { incrementBy(SMALL_POPULATION_VID_INDEX_MAP[it], 2) }
+      }
+
+    // The same increments cap to 3 under a reachAndFrequency spec with maximumFrequency 3.
+    assertThat(frequencyVector)
+      .isEqualTo(frequencyVector { data += listOf<Int>(6, 2, 0, 0, 0, 0, 0, 0, 4, 0) })
   }
 
   @Test

--- a/src/test/kotlin/org/wfanet/measurement/eventdataprovider/requisition/v2alpha/trustee/FulfillRequisitionRequestBuilderTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/eventdataprovider/requisition/v2alpha/trustee/FulfillRequisitionRequestBuilderTest.kt
@@ -23,6 +23,7 @@ import com.google.crypto.tink.StreamingAead
 import com.google.crypto.tink.aead.AeadConfig
 import com.google.crypto.tink.streamingaead.StreamingAeadConfig
 import com.google.protobuf.ByteString
+import java.io.IOException
 import java.security.GeneralSecurityException
 import kotlin.test.assertFailsWith
 import org.junit.Test
@@ -396,8 +397,8 @@ class FulfillRequisitionRequestBuilderTest {
     val dekStreamingAead = dekKeysetHandle.getPrimitive(StreamingAead::class.java)
 
     // The payload is encrypted with no associated data, so the details ciphertext cannot stand in
-    // for it.
-    assertFailsWith<GeneralSecurityException> {
+    // for it. Tink surfaces the failed segment authentication as an IOException from the read.
+    assertFailsWith<IOException> {
       dekStreamingAead
         .newDecryptingStream(
           header.trusTeeV2.encryptedFulfillmentDetails.ciphertext.newInput(),

--- a/src/test/kotlin/org/wfanet/measurement/eventdataprovider/requisition/v2alpha/trustee/FulfillRequisitionRequestBuilderTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/eventdataprovider/requisition/v2alpha/trustee/FulfillRequisitionRequestBuilderTest.kt
@@ -299,8 +299,10 @@ class FulfillRequisitionRequestBuilderTest {
       FulfillRequisitionRequestBuilder.buildUnencrypted(V2_REQUISITION, NONCE, inputFrequencyVector)
         .toList()
 
+    val v1BodyChunks = v1Requests.filter { it.hasBodyChunk() }
+    assertThat(v1BodyChunks).isNotEmpty()
     assertThat(v2Requests.filter { it.hasBodyChunk() })
-      .containsExactlyElementsIn(v1Requests.filter { it.hasBodyChunk() })
+      .containsExactlyElementsIn(v1BodyChunks)
       .inOrder()
   }
 
@@ -344,11 +346,65 @@ class FulfillRequisitionRequestBuilderTest {
     val dekStreamingAead = dekKeysetHandle.getPrimitive(StreamingAead::class.java)
     val plaintext =
       dekStreamingAead
-        .newDecryptingStream(encryptedDetails.ciphertext.newInput(), byteArrayOf())
+        .newDecryptingStream(
+          encryptedDetails.ciphertext.newInput(),
+          encryptedDetails.typeUrl.toByteArray(),
+        )
         .use { it.readAllBytes() }
 
     assertThat(FulfillRequisitionRequest.Header.TrusTeeV2.FulfillmentDetails.parseFrom(plaintext))
       .isEqualTo(FULFILLMENT_DETAILS)
+  }
+
+  @Test
+  fun `buildEncrypted leaves FulfillmentDetails unset when none are supplied`() {
+    val requests =
+      FulfillRequisitionRequestBuilder.buildEncrypted(
+          V2_REQUISITION,
+          NONCE,
+          FREQUENCY_VECTOR,
+          ENCRYPTED_PARAMS,
+        )
+        .toList()
+
+    val header = requests.first { it.hasHeader() }.header
+    assertThat(header.hasTrusTeeV2()).isTrue()
+    assertThat(header.trusTeeV2.hasFulfillmentDetails()).isFalse()
+    assertThat(header.trusTeeV2.hasEncryptedFulfillmentDetails()).isFalse()
+    assertThat(header.trusTeeV2.trusTee.dataFormat)
+      .isEqualTo(FulfillRequisitionRequest.Header.TrusTee.DataFormat.ENCRYPTED_FREQUENCY_VECTOR)
+    assertThat(header.trusTeeV2.trusTee.envelopeEncryption.hasEncryptedDek()).isTrue()
+  }
+
+  @Test
+  fun `encrypted FulfillmentDetails cannot be decrypted as the payload`() {
+    val requests =
+      FulfillRequisitionRequestBuilder.buildEncrypted(
+          V2_REQUISITION,
+          NONCE,
+          FREQUENCY_VECTOR,
+          ENCRYPTED_PARAMS,
+          FULFILLMENT_DETAILS,
+        )
+        .toList()
+
+    val header = requests.first { it.hasHeader() }.header
+    val kekAead = KMS_CLIENT.getAead(KEK_URI)
+    val encryptedDek: ByteString = header.trusTeeV2.trusTee.envelopeEncryption.encryptedDek.data
+    val dekKeysetHandle =
+      KeysetHandle.read(BinaryKeysetReader.withInputStream(encryptedDek.newInput()), kekAead)
+    val dekStreamingAead = dekKeysetHandle.getPrimitive(StreamingAead::class.java)
+
+    // The payload is encrypted with no associated data, so the details ciphertext cannot stand in
+    // for it.
+    assertFailsWith<GeneralSecurityException> {
+      dekStreamingAead
+        .newDecryptingStream(
+          header.trusTeeV2.encryptedFulfillmentDetails.ciphertext.newInput(),
+          byteArrayOf(),
+        )
+        .use { it.readAllBytes() }
+    }
   }
 
   @Test

--- a/src/test/kotlin/org/wfanet/measurement/eventdataprovider/requisition/v2alpha/trustee/FulfillRequisitionRequestBuilderTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/eventdataprovider/requisition/v2alpha/trustee/FulfillRequisitionRequestBuilderTest.kt
@@ -26,6 +26,7 @@ import com.google.protobuf.ByteString
 import java.io.IOException
 import java.security.GeneralSecurityException
 import kotlin.test.assertFailsWith
+import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
@@ -46,6 +47,15 @@ import org.wfanet.measurement.consent.client.dataprovider.computeRequisitionFing
 
 @RunWith(JUnit4::class)
 class FulfillRequisitionRequestBuilderTest {
+  /**
+   * Restores the KEK [Aead], which the tests covering encryption failures replace with a throwing
+   * mock on the shared [KMS_CLIENT].
+   */
+  @Before
+  fun restoreKekAead() {
+    KMS_CLIENT.setAead(KEK_URI, KEK_AEAD)
+  }
+
   @Test
   fun `buildEncrypted fails when requisition has no TrusTee config`() {
     val exception =
@@ -445,12 +455,14 @@ class FulfillRequisitionRequestBuilderTest {
   companion object {
     private val KMS_CLIENT = FakeKmsClient()
     private const val KEK_URI = FakeKmsClient.KEY_URI_PREFIX + "kek"
+    private val KEK_AEAD: Aead
 
     init {
       AeadConfig.register()
       StreamingAeadConfig.register()
       val kmsKeyHandle = KeysetHandle.generateNew(KeyTemplates.get("AES256_GCM"))
-      KMS_CLIENT.setAead(KEK_URI, kmsKeyHandle.getPrimitive(Aead::class.java))
+      KEK_AEAD = kmsKeyHandle.getPrimitive(Aead::class.java)
+      KMS_CLIENT.setAead(KEK_URI, KEK_AEAD)
     }
 
     private const val NONCE = 12345L

--- a/src/test/kotlin/org/wfanet/measurement/eventdataprovider/requisition/v2alpha/trustee/FulfillRequisitionRequestBuilderTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/eventdataprovider/requisition/v2alpha/trustee/FulfillRequisitionRequestBuilderTest.kt
@@ -34,6 +34,8 @@ import org.mockito.kotlin.whenever
 import org.wfanet.frequencycount.FrequencyVector
 import org.wfanet.frequencycount.frequencyVector
 import org.wfanet.measurement.api.v2alpha.FulfillRequisitionRequest
+import org.wfanet.measurement.api.v2alpha.FulfillRequisitionRequestKt
+import org.wfanet.measurement.api.v2alpha.MeasurementKt
 import org.wfanet.measurement.api.v2alpha.ProtocolConfigKt
 import org.wfanet.measurement.api.v2alpha.copy
 import org.wfanet.measurement.api.v2alpha.protocolConfig
@@ -272,6 +274,117 @@ class FulfillRequisitionRequestBuilderTest {
     assertThat(payloadIntegers).isEqualTo(inputFrequencyVector.dataList)
   }
 
+  @Test
+  fun `buildUnencrypted sets TrusTeeV2 header for TrusTeeV2 Requisition`() {
+    val requests =
+      FulfillRequisitionRequestBuilder.buildUnencrypted(V2_REQUISITION, NONCE, FREQUENCY_VECTOR)
+        .toList()
+
+    val header = requests.first { it.hasHeader() }.header
+    assertThat(header.hasTrusTeeV2()).isTrue()
+    assertThat(header.hasTrusTee()).isFalse()
+    assertThat(header.trusTeeV2.trusTee.dataFormat)
+      .isEqualTo(FulfillRequisitionRequest.Header.TrusTee.DataFormat.FREQUENCY_VECTOR)
+    assertThat(header.trusTeeV2.hasFulfillmentDetails()).isFalse()
+  }
+
+  @Test
+  fun `buildUnencrypted produces same payload for TrusTee and TrusTeeV2`() {
+    val inputFrequencyVector = frequencyVector { data += listOf(1, 8, 27) }
+
+    val v1Requests =
+      FulfillRequisitionRequestBuilder.buildUnencrypted(REQUISITION, NONCE, inputFrequencyVector)
+        .toList()
+    val v2Requests =
+      FulfillRequisitionRequestBuilder.buildUnencrypted(V2_REQUISITION, NONCE, inputFrequencyVector)
+        .toList()
+
+    assertThat(v2Requests.filter { it.hasBodyChunk() })
+      .containsExactlyElementsIn(v1Requests.filter { it.hasBodyChunk() })
+      .inOrder()
+  }
+
+  @Test
+  fun `buildUnencrypted sets plaintext FulfillmentDetails`() {
+    val requests =
+      FulfillRequisitionRequestBuilder.buildUnencrypted(
+          V2_REQUISITION,
+          NONCE,
+          FREQUENCY_VECTOR,
+          FULFILLMENT_DETAILS,
+        )
+        .toList()
+
+    val header = requests.first { it.hasHeader() }.header
+    assertThat(header.trusTeeV2.fulfillmentDetails).isEqualTo(FULFILLMENT_DETAILS)
+    assertThat(header.trusTeeV2.hasEncryptedFulfillmentDetails()).isFalse()
+  }
+
+  @Test
+  fun `buildEncrypted encrypts FulfillmentDetails with the payload DEK`() {
+    val requests =
+      FulfillRequisitionRequestBuilder.buildEncrypted(
+          V2_REQUISITION,
+          NONCE,
+          FREQUENCY_VECTOR,
+          ENCRYPTED_PARAMS,
+          FULFILLMENT_DETAILS,
+        )
+        .toList()
+
+    val header = requests.first { it.hasHeader() }.header
+    assertThat(header.trusTeeV2.hasFulfillmentDetails()).isFalse()
+    val encryptedDetails = header.trusTeeV2.encryptedFulfillmentDetails
+    assertThat(encryptedDetails.typeUrl).endsWith("FulfillmentDetails")
+
+    val kekAead = KMS_CLIENT.getAead(KEK_URI)
+    val encryptedDek: ByteString = header.trusTeeV2.trusTee.envelopeEncryption.encryptedDek.data
+    val dekKeysetHandle =
+      KeysetHandle.read(BinaryKeysetReader.withInputStream(encryptedDek.newInput()), kekAead)
+    val dekStreamingAead = dekKeysetHandle.getPrimitive(StreamingAead::class.java)
+    val plaintext =
+      dekStreamingAead
+        .newDecryptingStream(encryptedDetails.ciphertext.newInput(), byteArrayOf())
+        .use { it.readAllBytes() }
+
+    assertThat(FulfillRequisitionRequest.Header.TrusTeeV2.FulfillmentDetails.parseFrom(plaintext))
+      .isEqualTo(FULFILLMENT_DETAILS)
+  }
+
+  @Test
+  fun `build fails when FulfillmentDetails set for a TrusTee Requisition`() {
+    val exception =
+      assertFailsWith<IllegalArgumentException> {
+        FulfillRequisitionRequestBuilder.buildUnencrypted(
+          REQUISITION,
+          NONCE,
+          FREQUENCY_VECTOR,
+          FULFILLMENT_DETAILS,
+        )
+      }
+
+    assertThat(exception.message).contains("fulfillmentDetails")
+  }
+
+  @Test
+  fun `build fails when Requisition has both TrusTee and TrusTeeV2 configs`() {
+    val exception =
+      assertFailsWith<IllegalArgumentException> {
+        FulfillRequisitionRequestBuilder.buildUnencrypted(
+          REQUISITION.copy {
+            protocolConfig =
+              protocolConfig.copy {
+                protocols += ProtocolConfigKt.protocol { trusTeeV2 = ProtocolConfigKt.trusTeeV2 {} }
+              }
+          },
+          NONCE,
+          FREQUENCY_VECTOR,
+        )
+      }
+
+    assertThat(exception.message).contains("Found: 2")
+  }
+
   companion object {
     private val KMS_CLIENT = FakeKmsClient()
     private const val KEK_URI = FakeKmsClient.KEY_URI_PREFIX + "kek"
@@ -293,6 +406,16 @@ class FulfillRequisitionRequestBuilderTest {
         protocols += ProtocolConfigKt.protocol { trusTee = ProtocolConfigKt.trusTee {} }
       }
     }
+    private val V2_REQUISITION = requisition {
+      name = "requisitions/test"
+      protocolConfig = protocolConfig {
+        protocols += ProtocolConfigKt.protocol { trusTeeV2 = ProtocolConfigKt.trusTeeV2 {} }
+      }
+    }
+    private val FULFILLMENT_DETAILS =
+      FulfillRequisitionRequestKt.HeaderKt.TrusTeeV2Kt.fulfillmentDetails {
+        impression = MeasurementKt.ResultKt.impression { value = 1234L }
+      }
     private val ENCRYPTED_PARAMS =
       FulfillRequisitionRequestBuilder.EncryptionParams(
         kmsClient = KMS_CLIENT,

--- a/src/test/kotlin/org/wfanet/measurement/eventdataprovider/requisition/v2alpha/trustee/FulfillRequisitionRequestBuilderTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/eventdataprovider/requisition/v2alpha/trustee/FulfillRequisitionRequestBuilderTest.kt
@@ -333,6 +333,9 @@ class FulfillRequisitionRequestBuilderTest {
     assertThat(header.trusTeeV2.hasEncryptedFulfillmentDetails()).isFalse()
   }
 
+  // TODO(world-federation-of-advertisers/cross-media-measurement#4475): Pin a fixed TrusTEE v2
+  // sample payload. These cases encrypt and decrypt with the same implementation, so the Phase 2.2
+  // reader still needs a fixture written against the same bytes.
   @Test
   fun `buildEncrypted encrypts FulfillmentDetails with the payload DEK`() {
     val requests =


### PR DESCRIPTION
Both published `eventdataprovider` artifacts gain TrusTEE v2 support, so a `DataProvider` can depend on them rather than reimplement the payload format.

`FrequencyVectorBuilder` had no branch for a `multi` `MeasurementSpec`, so it fell through to `maxFrequency = 1` and produced a reach bitmap with no error. The `multi` branch caps at the cell width instead, which is what the TEE folds.

`FulfillRequisitionRequestBuilder` matched `hasTrusTee()` alone, so a v2 requisition was refused. It now accepts either protocol, requires exactly one across both, and for v2 wraps the same `TrusTee` parameters in `Header.TrusTeeV2`. The payload bytes and the v1 header are unchanged, which the tests assert by comparing a v1 and a v2 fulfillment of the same vector.

`FulfillmentDetails` are an optional argument carrying the protection of the vector they accompany: plaintext beside a `FREQUENCY_VECTOR` payload, encrypted with the payload's own DEK beside an `ENCRYPTED_FREQUENCY_VECTOR` one. Setting them on a `TrusTee` requisition is rejected. Nothing computes a value for them yet.

## Where this sits in Phase 2.1

The plan in #4475 is five steps. This is the third.

| Step | State |
| --- | --- |
| Pin api 0.102.0 and reject the new cases in exhaustive `when`s | Merged, #4470 |
| Internal `trus_tee_v2_supported` and its conversions | Merged, #4470 |
| **The shared libraries: a `Header.TrusTeeV2` carrying `FulfillmentDetails`, and a non-clamping `multi` branch in `FrequencyVectorBuilder`** | **This PR** |
| The EDPA v2 branch: select on `hasTrusTeeV2()`, leave the vector uncapped, skip `ResultMinimumThresholder` | Next |
| The impression count: `ImpressionCountsParams` and `TrusTeeV2Config`, clip selection, the population sum, config-load validation | After that |

`EdpSimulator` consumes both artifacts and inherits the behavior. Exercising it against a v2 requisition belongs with the EDPA branch.

## Testing

No v2 requisition can be issued until the Kingdom and duchy support the protocol, so the tests construct them. Coverage: the v2 header shape, byte equality of the v1 and v2 payloads over the same vector, plaintext details, details encrypted under the payload DEK and decrypted with it, rejection of details on a v1 requisition, and rejection of a requisition carrying both protocols. The `multi` branch is covered by the increments that cap to 3 under a reach-and-frequency spec coming back uncapped.

Issue: #4475
