### PR TITLE
docs: Clarify report end interval semantics

### DIFF
--- a/src/main/proto/wfa/measurement/reporting/v2alpha/report.proto
+++ b/src/main/proto/wfa/measurement/reporting/v2alpha/report.proto
@@ -84,8 +84,9 @@ message Report {
     (google.api.field_behavior) = IMMUTABLE
   ];
 
-  // The interval over which Metrics are generated. The start is inclusive and
-  // the end is exclusive.
+  // The interval over which Metrics are generated. Its bounds are instants:
+  // `report_start` is inclusive, and the instant constructed from `report_end`
+  // is exclusive.
   message ReportingInterval {
     // The date and time of the start of the report. The year,
     // month, day, and time_offset are all required.
@@ -93,17 +94,20 @@ message Report {
     // be 24 hours based on the time of day specified here. If `time_zone` is
     // set, days will be based on the calendar and daylight savings will be
     // considered; if 5 AM is chosen, the day will start with 5 AM year-round.
-    // This side of the interval is closed.
+    // This instant is included in the report.
     google.type.DateTime report_start = 1 [
       (google.api.field_behavior) = REQUIRED,
       (google.api.field_behavior) = IMMUTABLE
     ];
 
-    // The date used to construct the exclusive end instant of the report.
+    // Date used to construct the report's exclusive end instant.
     //
-    // The end instant has the same time of day and `time_offset` setting as
-    // `report_start`, but uses this date. Only times before the end instant are
-    // included in the report.
+    // This is not an inclusive calendar date. The server combines this date
+    // with the time of day and `time_offset` from `report_start`.
+    //
+    // For example, if `report_start` is May 1 at 06:00 and `report_end` is May
+    // 2, timestamps before May 2 at 06:00 are included, while timestamps at or
+    // after that instant are excluded.
     google.type.Date report_end = 2 [
       (google.api.field_behavior) = REQUIRED,
       (google.api.field_behavior) = IMMUTABLE

--- a/src/main/proto/wfa/measurement/reporting/v2alpha/report.proto
+++ b/src/main/proto/wfa/measurement/reporting/v2alpha/report.proto
@@ -102,9 +102,8 @@ message Report {
     // The date used to construct the exclusive end instant of the report.
     //
     // The end instant has the same time of day and `time_offset` setting as
-    // `report_start`, but uses this date. Events at or after the end instant
-    // are excluded. The resulting report interval is half-open:
-    // [`report_start`, end).
+    // `report_start`, but uses this date. Only times before the end instant are
+    // included in the report.
     google.type.Date report_end = 2 [
       (google.api.field_behavior) = REQUIRED,
       (google.api.field_behavior) = IMMUTABLE

--- a/src/main/proto/wfa/measurement/reporting/v2alpha/report.proto
+++ b/src/main/proto/wfa/measurement/reporting/v2alpha/report.proto
@@ -84,8 +84,8 @@ message Report {
     (google.api.field_behavior) = IMMUTABLE
   ];
 
-  // The interval over which Metrics are generated. This interval is
-  // closed on both sides.
+  // The interval over which Metrics are generated. The start is inclusive and
+  // the end is exclusive.
   message ReportingInterval {
     // The date and time of the start of the report. The year,
     // month, day, and time_offset are all required.
@@ -99,8 +99,12 @@ message Report {
       (google.api.field_behavior) = IMMUTABLE
     ];
 
-    // The end date of the report. The time is considered to be the same as
-    // that specified in the report start. This side of the interval is closed.
+    // The date used to construct the exclusive end instant of the report.
+    //
+    // The end instant has the same time of day and `time_offset` setting as
+    // `report_start`, but uses this date. Events at or after the end instant
+    // are excluded. The resulting report interval is half-open:
+    // [`report_start`, end).
     google.type.Date report_end = 2 [
       (google.api.field_behavior) = REQUIRED,
       (google.api.field_behavior) = IMMUTABLE

--- a/src/main/proto/wfa/measurement/reporting/v2alpha/reporting_interval.proto
+++ b/src/main/proto/wfa/measurement/reporting/v2alpha/reporting_interval.proto
@@ -68,8 +68,7 @@ message ReportingInterval {
   // The date used to construct the exclusive end instant of the report.
   //
   // The end instant has the same time of day and `time_offset` setting as
-  // `effective_report_start`, but uses this date. Events at or after the end
-  // instant are excluded. The resulting report interval is half-open:
-  // [`effective_report_start`, end).
+  // `effective_report_start`, but uses this date. Only times before the end
+  // instant are included in the report.
   google.type.Date report_end = 2 [(google.api.field_behavior) = REQUIRED];
 }

--- a/src/main/proto/wfa/measurement/reporting/v2alpha/reporting_interval.proto
+++ b/src/main/proto/wfa/measurement/reporting/v2alpha/reporting_interval.proto
@@ -65,10 +65,11 @@ message ReportingInterval {
   google.type.DateTime effective_report_start = 3
       [(google.api.field_behavior) = OUTPUT_ONLY];
 
-  // The end date of the report.
+  // The date used to construct the exclusive end instant of the report.
   //
-  // The time is considered to be the same as that specified in the report
-  // start. This side of the interval is open with respect to the date specified
-  // here when taken together with the time specified by report_start.
+  // The end instant has the same time of day and `time_offset` setting as
+  // `effective_report_start`, but uses this date. Events at or after the end
+  // instant are excluded. The resulting report interval is half-open:
+  // [`effective_report_start`, end).
   google.type.Date report_end = 2 [(google.api.field_behavior) = REQUIRED];
 }

--- a/src/main/proto/wfa/measurement/reporting/v2alpha/reporting_interval.proto
+++ b/src/main/proto/wfa/measurement/reporting/v2alpha/reporting_interval.proto
@@ -25,7 +25,9 @@ option java_multiple_files = true;
 option java_outer_classname = "ReportingIntervalProto";
 option go_package = "github.com/world-federation-of-advertisers/cross-media-measurement/reporting/apiv2alpha/reportingpb";
 
-// The time interval over which Metrics are reported.
+// The time interval over which Metrics are reported. Its bounds are instants:
+// `effective_report_start` is inclusive, and the instant constructed from
+// `report_end` is exclusive.
 message ReportingInterval {
   // The start time of the report. Required.
   oneof report_start_time {
@@ -38,7 +40,7 @@ message ReportingInterval {
     // set, days will be based on the calendar and daylight savings will be
     // considered; if 5 AM is chosen, the day will start at 5 AM year-round.
     //
-    // This side of the interval is closed.
+    // This instant is included in the report.
     google.type.DateTime report_start = 1
         [(google.api.field_behavior) = IMMUTABLE];
 
@@ -65,10 +67,13 @@ message ReportingInterval {
   google.type.DateTime effective_report_start = 3
       [(google.api.field_behavior) = OUTPUT_ONLY];
 
-  // The date used to construct the exclusive end instant of the report.
+  // Date used to construct the report's exclusive end instant.
   //
-  // The end instant has the same time of day and `time_offset` setting as
-  // `effective_report_start`, but uses this date. Only times before the end
-  // instant are included in the report.
+  // This is not an inclusive calendar date. The server combines this date with
+  // the time of day and `time_offset` from `effective_report_start`.
+  //
+  // For example, if `effective_report_start` is May 1 at 06:00 and `report_end`
+  // is May 2, timestamps before May 2 at 06:00 are included, while timestamps
+  // at or after that instant are excluded.
   google.type.Date report_end = 2 [(google.api.field_behavior) = REQUIRED];
 }


### PR DESCRIPTION
Clarify that report interval bounds are instants and that `report_end` identifies the date used to construct an exclusive end instant from the report start's time of day and time-offset setting.

Apply the same terminology to both `ReportingInterval` definitions.

Issue: NA
