### PR TITLE
feat: add BasicReport references to reporting resources

### DIFF
--- a/src/main/proto/wfa/measurement/reporting/v2alpha/metric.proto
+++ b/src/main/proto/wfa/measurement/reporting/v2alpha/metric.proto
@@ -441,6 +441,15 @@ message Metric {
     (google.api.field_behavior) = IMMUTABLE
   ];
 
+  // The `BasicReport` that originated this `Metric`, if any.
+  string basic_report = 12 [
+    (google.api.resource_reference) = {
+      type: "reporting.halo-cmm.org/BasicReport"
+    },
+    (google.api.field_behavior) = OPTIONAL,
+    (google.api.field_behavior) = IMMUTABLE
+  ];
+
   // TODO(@tristanvuong2021): WIll be required in a future release. See
   // https://github.com/world-federation-of-advertisers/cross-media-measurement/issues/2345
   string model_line = 11

--- a/src/main/proto/wfa/measurement/reporting/v2alpha/report.proto
+++ b/src/main/proto/wfa/measurement/reporting/v2alpha/report.proto
@@ -48,6 +48,15 @@ message Report {
   // Resource name.
   string name = 1;
 
+  // The `BasicReport` that originated this `Report`, if any.
+  string basic_report = 11 [
+    (google.api.field_behavior) = OPTIONAL,
+    (google.api.field_behavior) = IMMUTABLE,
+    (google.api.resource_reference) = {
+      type: "reporting.halo-cmm.org/BasicReport"
+    }
+  ];
+
   // A map of arbitrary key-value pairs to support tagging of Reports
   // for upstream use by UIs and other rich clients.
   map<string, string> tags = 9 [(google.api.field_behavior) = IMMUTABLE];


### PR DESCRIPTION
Adds an optional, immutable BasicReport resource reference to the public Report and Metric messages for end-to-end trace correlation. These fields do not change the functional Reporting flow.

Both fields are needed by the tracing implementation because the existing service flow crosses public API boundaries: BasicReportsService passes the correlation key through CreateReport, then ReportsService passes it through CreateMetric so each generated MeasurementSpec can retain the same key. BasicReport already has its own resource name, so no other public Reporting API changes are needed.

This PR changes only the public Reporting API messages; persistence, telemetry, and Secure Computation changes remain in the stacked implementation PRs.

Issue: #4495